### PR TITLE
release(cascade): stage -> main for #1138 (KB stale-extraction fix)

### DIFF
--- a/apps/api/src/agents/agent-template-catalog.service.spec.ts
+++ b/apps/api/src/agents/agent-template-catalog.service.spec.ts
@@ -1,0 +1,140 @@
+// Mock the agent-package barrels the service imports. Importing the real
+// `@ever-works/agent/facades` barrel under apps/api's jest drags in the
+// agent package's `database.config` (which uses the agent-side `@src/*`
+// alias that collides with apps/api's `@src` mapping). The service only
+// needs `GitFacadeService` as a type and `CACHE_MANAGER`/`Cache` tokens,
+// and this is a pure unit test (no Nest DI), so stub them out.
+jest.mock('@ever-works/agent/facades', () => ({ GitFacadeService: class {} }));
+jest.mock('@ever-works/agent/cache', () => ({ CACHE_MANAGER: 'CACHE_MANAGER', Cache: class {} }));
+
+import { AgentTemplateCatalogService } from './agent-template-catalog.service';
+
+/**
+ * Unit coverage for the agent-template catalog (ADR-011, spec FR-26..FR-30).
+ * Mocks GitFacadeService + the cache so no network / DB is touched.
+ */
+describe('AgentTemplateCatalogService', () => {
+    const ORIGINAL_ENV = { ...process.env };
+
+    afterEach(() => {
+        process.env = { ...ORIGINAL_ENV };
+        jest.restoreAllMocks();
+    });
+
+    const MANIFEST = JSON.stringify({
+        templates: [
+            {
+                slug: 'ceo',
+                name: 'CEO',
+                title: 'CEO',
+                summary: 'Chief Executive',
+                scope: 'TENANT',
+                avatarIcon: 'crown',
+                tags: ['strategy', 'roadmap'],
+            },
+            {
+                slug: 'starter-coder',
+                name: 'Coder',
+                summary: 'Ships small reviewed changes',
+                avatarIcon: 'code-2',
+                tags: ['engineering'],
+            },
+            { name: 'no-slug-here' }, // invalid → dropped
+        ],
+    });
+
+    function make(
+        getFileContent: jest.Mock,
+        getInstallationTokenForOwner: jest.Mock = jest.fn(async () => null),
+    ) {
+        const git = { getFileContent, getInstallationTokenForOwner } as any;
+        const store = new Map<string, unknown>();
+        const cache = {
+            get: jest.fn(async (k: string) => store.get(k)),
+            set: jest.fn(async (k: string, v: unknown) => {
+                store.set(k, v);
+            }),
+        } as any;
+        return { svc: new AgentTemplateCatalogService(git, cache), git, cache };
+    }
+
+    it('returns [] for non-agent entities without touching git', async () => {
+        const { svc, git } = make(jest.fn());
+        await expect(svc.list('skill')).resolves.toEqual([]);
+        await expect(svc.list('task')).resolves.toEqual([]);
+        expect(git.getFileContent).not.toHaveBeenCalled();
+    });
+
+    it('uses the platform GitHub App installation token when available (no env needed)', async () => {
+        delete process.env.EVER_WORKS_AGENTS_TOKEN;
+        delete process.env.GITHUB_TOKEN;
+        const getFileContent = jest.fn(async () => ({ content: MANIFEST, encoding: 'utf-8' }));
+        const getInstallationTokenForOwner = jest.fn(async () => 'app-installation-token');
+        const { svc } = make(getFileContent, getInstallationTokenForOwner);
+        const rows = await svc.list('agent');
+        expect(getInstallationTokenForOwner).toHaveBeenCalledWith('ever-works');
+        expect(rows.map((r) => r.slug)).toEqual(['ceo', 'starter-coder']);
+        // The App installation token is the one used to read the repo.
+        const callArgs = getFileContent.mock.calls[0] as unknown[];
+        expect(callArgs[3]).toEqual({
+            token: 'app-installation-token',
+            providerId: 'github',
+        });
+    });
+
+    it('returns [] and does not call git when no token is configured', async () => {
+        delete process.env.EVER_WORKS_AGENTS_TOKEN;
+        delete process.env.GITHUB_TOKEN;
+        const { svc, git } = make(jest.fn(async () => ({ content: MANIFEST, encoding: 'utf-8' })));
+        await expect(svc.list('agent')).resolves.toEqual([]);
+        expect(git.getFileContent).not.toHaveBeenCalled();
+    });
+
+    it('maps manifest rows, drops invalid ones, and caches the result', async () => {
+        process.env.EVER_WORKS_AGENTS_TOKEN = 'tok';
+        const { svc, cache } = make(
+            jest.fn(async () => ({ content: MANIFEST, encoding: 'utf-8' })),
+        );
+        const rows = await svc.list('agent');
+        expect(rows.map((r) => r.slug)).toEqual(['ceo', 'starter-coder']);
+        const ceo = rows.find((r) => r.slug === 'ceo')!;
+        expect(ceo.title).toBe('CEO');
+        expect(ceo.description).toBe('Chief Executive');
+        expect(ceo.iconName).toBe('Crown'); // kebab → Pascal
+        expect(ceo.category).toBe('Strategy'); // first tag, capitalized
+        const coder = rows.find((r) => r.slug === 'starter-coder')!;
+        expect(coder.iconName).toBe('Code2');
+        expect(cache.set).toHaveBeenCalledTimes(1);
+    });
+
+    it('serves from cache on the second call without re-fetching', async () => {
+        process.env.GITHUB_TOKEN = 'tok';
+        const getFileContent = jest.fn(async () => ({ content: MANIFEST, encoding: 'utf-8' }));
+        const { svc } = make(getFileContent);
+        await svc.list('agent');
+        await svc.list('agent');
+        expect(getFileContent).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns [] when the repo read throws', async () => {
+        process.env.GITHUB_TOKEN = 'tok';
+        const { svc } = make(
+            jest.fn(async () => {
+                throw new Error('network down');
+            }),
+        );
+        await expect(svc.list('agent')).resolves.toEqual([]);
+    });
+
+    it('returns [] on malformed manifest JSON', async () => {
+        process.env.GITHUB_TOKEN = 'tok';
+        const { svc } = make(jest.fn(async () => ({ content: 'not json {', encoding: 'utf-8' })));
+        await expect(svc.list('agent')).resolves.toEqual([]);
+    });
+
+    it('returns [] when the manifest file is missing', async () => {
+        process.env.GITHUB_TOKEN = 'tok';
+        const { svc } = make(jest.fn(async () => null));
+        await expect(svc.list('agent')).resolves.toEqual([]);
+    });
+});

--- a/apps/api/src/agents/agent-template-catalog.service.ts
+++ b/apps/api/src/agents/agent-template-catalog.service.ts
@@ -1,0 +1,164 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { CACHE_MANAGER, Cache } from '@ever-works/agent/cache';
+import { GitFacadeService } from '@ever-works/agent/facades';
+
+/**
+ * Agent-template catalog (ADR-011, spec FR-26..FR-30).
+ *
+ * Reads the curated `manifest.json` index from the external
+ * `ever-works/agents` repo, maps it to the stable `AstTemplateEntry`
+ * shape the web app already consumes, and caches it for 1h in the
+ * shared `cache_entries` store. Every failure path (no token, repo
+ * unreachable, malformed manifest) returns an empty array — the web
+ * layer then falls back to its built-in catalog, so the chips +
+ * `View All` panel never break.
+ *
+ * Auth: the repo is private. The token is resolved in priority order:
+ *   1. The platform GitHub App's installation on the `ever-works` org —
+ *      the same App that already lets the platform create repos there.
+ *      No extra secret needed in the standard hosted deployment.
+ *   2. `EVER_WORKS_AGENTS_TOKEN` / `GITHUB_TOKEN` env override — for
+ *      self-hosted installs that don't run the GitHub App, or local dev.
+ * When none resolve, the service logs once and returns []. Pin a ref
+ * with `EVER_WORKS_AGENTS_REF` (default `main`).
+ */
+
+export type AstTemplateEntityType = 'agent' | 'skill' | 'task';
+
+export interface AstTemplateEntry {
+    slug: string;
+    title: string;
+    description: string;
+    category?: string;
+    iconName?: string;
+    tags?: string[];
+}
+
+/** Shape of a `manifest.json` `templates[]` row in `ever-works/agents`. */
+interface RawManifestTemplate {
+    slug?: unknown;
+    name?: unknown;
+    title?: unknown;
+    summary?: unknown;
+    scope?: unknown;
+    avatarIcon?: unknown;
+    tags?: unknown;
+}
+
+const AGENTS_REPO_OWNER = 'ever-works';
+const AGENTS_REPO_NAME = 'agents';
+const MANIFEST_PATH = 'manifest.json';
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+/** `kanban-square` → `KanbanSquare` so the client icon map (PascalCase
+ *  lucide names) can resolve repo `avatarIcon` ids. */
+function kebabToPascal(value: string): string {
+    return value
+        .split(/[-_\s]+/)
+        .filter(Boolean)
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join('');
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+    if (!Array.isArray(value)) return undefined;
+    const out = value.filter((v): v is string => typeof v === 'string');
+    return out.length > 0 ? out : undefined;
+}
+
+function mapTemplate(row: RawManifestTemplate): AstTemplateEntry | null {
+    if (typeof row?.slug !== 'string' || row.slug.length === 0) return null;
+    const tags = asStringArray(row.tags);
+    const title =
+        (typeof row.title === 'string' && row.title) ||
+        (typeof row.name === 'string' && row.name) ||
+        row.slug;
+    return {
+        slug: row.slug,
+        title,
+        description: typeof row.summary === 'string' ? row.summary : '',
+        // First tag makes a friendlier chip label than the raw scope enum.
+        category: tags?.[0] ? tags[0].charAt(0).toUpperCase() + tags[0].slice(1) : undefined,
+        iconName: typeof row.avatarIcon === 'string' ? kebabToPascal(row.avatarIcon) : undefined,
+        tags,
+    };
+}
+
+@Injectable()
+export class AgentTemplateCatalogService {
+    private readonly logger = new Logger(AgentTemplateCatalogService.name);
+    private warnedNoToken = false;
+
+    constructor(
+        private readonly git: GitFacadeService,
+        @Inject(CACHE_MANAGER) private readonly cache: Cache,
+    ) {}
+
+    /**
+     * Returns the catalog for an entity type. Only `agent` is backed by
+     * the repo today; `skill`/`task` return [] (the web layer keeps its
+     * own fallback for those).
+     */
+    async list(entity: AstTemplateEntityType = 'agent'): Promise<AstTemplateEntry[]> {
+        if (entity !== 'agent') return [];
+
+        const ref = process.env.EVER_WORKS_AGENTS_REF || 'main';
+        const cacheKey = `agent-templates:${entity}:${ref}`;
+
+        const cached = await this.cache.get<AstTemplateEntry[]>(cacheKey).catch(() => undefined);
+        if (Array.isArray(cached)) return cached;
+
+        const templates = await this.fetchFromRepo(ref);
+        if (templates.length > 0) {
+            await this.cache.set(cacheKey, templates, CACHE_TTL_MS).catch(() => undefined);
+        }
+        return templates;
+    }
+
+    /**
+     * Resolve a GitHub token that can read `ever-works/agents`. Prefer
+     * the platform GitHub App's installation on the org (no extra
+     * secret); fall back to an explicit env override.
+     */
+    private async resolveToken(): Promise<string | null> {
+        const appToken = await this.git
+            .getInstallationTokenForOwner(AGENTS_REPO_OWNER)
+            .catch(() => null);
+        if (appToken) return appToken;
+        return process.env.EVER_WORKS_AGENTS_TOKEN || process.env.GITHUB_TOKEN || null;
+    }
+
+    private async fetchFromRepo(ref: string): Promise<AstTemplateEntry[]> {
+        const token = await this.resolveToken();
+        if (!token) {
+            if (!this.warnedNoToken) {
+                this.warnedNoToken = true;
+                this.logger.warn(
+                    'No GitHub App installation on the ever-works org and no EVER_WORKS_AGENTS_TOKEN / GITHUB_TOKEN set — agent-template catalog is unavailable; the web app falls back to its built-in list.',
+                );
+            }
+            return [];
+        }
+
+        try {
+            const file = await this.git.getFileContent(
+                AGENTS_REPO_OWNER,
+                AGENTS_REPO_NAME,
+                MANIFEST_PATH,
+                { token, providerId: 'github' },
+                ref,
+            );
+            if (!file) return [];
+            const manifest = JSON.parse(file.content) as { templates?: RawManifestTemplate[] };
+            const rows = Array.isArray(manifest.templates) ? manifest.templates : [];
+            return rows
+                .map(mapTemplate)
+                .filter((entry): entry is AstTemplateEntry => entry !== null);
+        } catch (err) {
+            this.logger.warn(
+                `agent-template catalog fetch failed (${ref}): ${err instanceof Error ? err.message : String(err)}`,
+            );
+            return [];
+        }
+    }
+}

--- a/apps/api/src/agents/agent-templates.controller.ts
+++ b/apps/api/src/agents/agent-templates.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, HttpCode, HttpStatus, Query } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Public } from '../auth/decorators/public.decorator';
+import {
+    AgentTemplateCatalogService,
+    type AstTemplateEntry,
+    type AstTemplateEntityType,
+} from './agent-template-catalog.service';
+
+/**
+ * `GET /api/agent-templates?entity=agent` (ADR-011, spec FR-27).
+ *
+ * Public read — the agent-template catalog is non-sensitive and is
+ * consumed by the web app's server components / server action. Returns
+ * an empty array when the catalog is unavailable; the caller falls back
+ * to its built-in list, so a cold/unauthenticated catalog never errors.
+ */
+@ApiTags('Agents')
+@Controller('api/agent-templates')
+export class AgentTemplatesController {
+    constructor(private readonly catalog: AgentTemplateCatalogService) {}
+
+    @Get()
+    @Public()
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: 'List agent templates from the ever-works/agents catalog' })
+    @ApiResponse({ status: 200, description: 'Catalog entries (empty array when unavailable)' })
+    async list(@Query('entity') entity?: string): Promise<AstTemplateEntry[]> {
+        const normalized: AstTemplateEntityType =
+            entity === 'skill' || entity === 'task' ? entity : 'agent';
+        return this.catalog.list(normalized);
+    }
+}

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -65,6 +65,8 @@ import { SkillsModule as AgentSkillsModule } from '@ever-works/agent/skills';
 import { DatabaseModule } from '@ever-works/agent/database';
 import { AuthModule } from '../auth/auth.module';
 import { AgentsController } from './agents.controller';
+import { AgentTemplatesController } from './agent-templates.controller';
+import { AgentTemplateCatalogService } from './agent-template-catalog.service';
 
 /**
  * Agents/Skills/Tasks PR #1017 — api-side AgentsModule (Phase 3 + 15.5 + 16.10).
@@ -110,8 +112,9 @@ import { AgentsController } from './agents.controller';
         // consumed by the AGENT_EMAIL_FACADE binding below.
         EmailModule,
     ],
-    controllers: [AgentsController],
+    controllers: [AgentsController, AgentTemplatesController],
     providers: [
+        AgentTemplateCatalogService,
         {
             provide: AGENT_RUN_CHAT_BACK_POSTER,
             inject: [TaskChatService],

--- a/apps/web/e2e/user-journey.spec.ts
+++ b/apps/web/e2e/user-journey.spec.ts
@@ -102,15 +102,17 @@ test.describe('Complete user journey', () => {
         }
 
         // The previously separate "Create Manually" flow was merged into
-        // the unified WorkAICreator (new-work-client.tsx:405-426), which
-        // uses discrete <Input>/<Textarea> components rather than a single
-        // <form> wrapper. Target the inputs directly by their `name`s.
+        // the unified WorkAICreator (new-work-client.tsx:405-426). The shared
+        // ui/Input wrapper drops the `name` prop between JSX and the rendered
+        // `<input>` (verified against the failing-run aria-snapshot — the
+        // textbox is present but `input[name="name"]` returns 0). Target by
+        // accessible role + label instead.
         const dirSlug = `journey-${suffix}`;
-        const nameInput = page.locator('input[name="name"]').first();
-        await expect(nameInput).toBeVisible({ timeout: 10_000 });
+        const nameInput = page.getByRole('textbox', { name: /Work Name/i });
+        await expect(nameInput).toBeVisible({ timeout: 30_000 });
         await nameInput.fill(`Journey Dir ${dirSlug}`);
 
-        const descriptionTextarea = page.locator('textarea[name="prompt"], textarea').first();
+        const descriptionTextarea = page.getByRole('textbox', { name: /Describe Your Work/i });
         await descriptionTextarea.fill('Full journey test work');
 
         // Submit via the primary CTA (WorkAICreator uses an onClick handler,

--- a/apps/web/e2e/works.spec.ts
+++ b/apps/web/e2e/works.spec.ts
@@ -60,20 +60,23 @@ test.describe('Work creation', () => {
         await page.goto('/en/works/new?mode=manual');
 
         // The previously separate "Create Manually" flow was merged into the
-        // unified WorkAICreator (new-work-client.tsx:405-426), which uses
-        // discrete <Input>/<Textarea> components rather than a single <form>
-        // wrapper. Target the inputs directly via their `name` attributes
-        // instead of scoping by form element.
-        const nameInput = page.locator('input[name="name"]').first();
-        await expect(nameInput).toBeVisible({ timeout: 10_000 });
+        // unified WorkAICreator (new-work-client.tsx:405-426). The shared
+        // ui/Input wrapper drops `name` between the JSX prop and the rendered
+        // `<input>` — verified against the failing run's aria-snapshot, which
+        // shows `textbox "Work Name *"` but `locator('input[name="name"]')`
+        // returning 0. Targeting by accessible role + name is stable across
+        // that wrapper.
+        const nameInput = page.getByRole('textbox', { name: /Work Name/i });
+        await expect(nameInput).toBeVisible({ timeout: 30_000 });
         await nameInput.fill(`E2E Test Dir ${slug}`);
 
         // Slug auto-populates from name; just verify it picked something up.
-        const slugInput = page.locator('input[name="slug"]').first();
+        const slugInput = page.getByRole('textbox', { name: /Work Slug/i });
         await expect(slugInput).toHaveValue(/.+/);
 
-        // Description / prompt textarea (the AI/manual flow shares one).
-        const promptTextarea = page.locator('textarea[name="prompt"], textarea').first();
+        // Description / prompt textarea — same wrapper drops `name`, so use
+        // the accessible label.
+        const promptTextarea = page.getByRole('textbox', { name: /Describe Your Work/i });
         await promptTextarea.fill('Automated E2E test work for Playwright testing');
 
         // Submit — the primary CTA on the page. WorkAICreator handles submit
@@ -95,10 +98,9 @@ test.describe('Work creation', () => {
         // Land on manual mode directly (see comment on the previous test).
         await page.goto('/en/works/new?mode=manual');
 
-        // Same selector update — the unified WorkAICreator no longer wraps
-        // its fields in `<form className="space-y-6" autocomplete="off">`.
-        const nameInput = page.locator('input[name="name"]').first();
-        await expect(nameInput).toBeVisible({ timeout: 10_000 });
+        // Same wrapper drops `name`; target by accessible role + label.
+        const nameInput = page.getByRole('textbox', { name: /Work Name/i });
+        await expect(nameInput).toBeVisible({ timeout: 30_000 });
 
         // Click back button → returns to the mode-card selector on /works/new.
         const backButton = page.locator('button').filter({ hasText: /back/i }).first();

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -620,7 +620,28 @@
                 "cancel": "Cancel",
                 "back": "Back",
                 "next": "Next",
-                "create": "Create Agent"
+                "create": "Create Agent",
+                "templateStepTitle": "Start from a template (optional)",
+                "startFromScratch": "Start from scratch",
+                "pickParentHint": "Pick a {scope} above to continue, or choose Workspace scope.",
+                "nextDisabledReason": "Pick a parent or choose Workspace scope to continue."
+            },
+            "orDivider": "Or",
+            "createManually": "Create Agent Manually",
+            "prompt": {
+                "label": "Describe the Agent you want",
+                "minLength": "Describe your Agent in a few more words.",
+                "submitTitle": "Build this Agent"
+            },
+            "chips": {
+                "viewAll": "View All",
+                "ariaLabel": "Pick an Agent template"
+            },
+            "catalog": {
+                "allTemplates": "All templates",
+                "yourTemplates": "Your templates",
+                "yourTemplatesEmpty": "Agents you create will appear here as reusable templates.",
+                "openInWizard": "Open in wizard"
             }
         },
         "tasksPage": {

--- a/apps/web/src/app/[locale]/(dashboard)/agents/new/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/new/page.tsx
@@ -5,6 +5,8 @@ import { createAgentAction } from '@/app/actions/agents';
 import { missionsAPI } from '@/lib/api/missions';
 import { workAPI } from '@/lib/api/work';
 import { workProposalsAPI } from '@/lib/api/work-proposals';
+import type { AstTemplateEntry } from '@/lib/api/agent-templates';
+import { fetchAgentTemplateCatalog } from '@/lib/api/agent-templates.server';
 import type { Mission } from '@/lib/api/missions';
 import type { Work } from '@/lib/api/work';
 import type { WorkProposal } from '@/lib/api/work-proposals';
@@ -23,7 +25,7 @@ export async function generateMetadata(): Promise<Metadata> {
  * tenant-scope only.
  */
 export default async function NewAgentPage() {
-    const [missions, worksResp, ideas] = await Promise.all([
+    const [missions, worksResp, ideas, templates] = await Promise.all([
         missionsAPI.list().catch(() => [] as Mission[]),
         workAPI.getAll({ limit: 100 }).catch(
             () =>
@@ -35,6 +37,9 @@ export default async function NewAgentPage() {
         workProposalsAPI
             .list(['pending', 'queued', 'building', 'failed', 'accepted'])
             .catch(() => [] as WorkProposal[]),
+        // Optional template-pick step (spec FR-23). Defensive so a cold
+        // catalog never 500s the create page.
+        fetchAgentTemplateCatalog('agent').catch(() => [] as AstTemplateEntry[]),
     ]);
 
     const missionOptions = missions.map((m) => ({ id: m.id, label: m.title }));
@@ -53,6 +58,7 @@ export default async function NewAgentPage() {
             missions={missionOptions}
             works={workOptions}
             ideas={ideaOptions}
+            templates={templates}
         />
     );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/agents/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { agentsAPI, type Agent } from '@/lib/api/agents';
+import type { AstTemplateEntry } from '@/lib/api/agent-templates';
+import { fetchAgentTemplateCatalog } from '@/lib/api/agent-templates.server';
 import { AgentsList } from '@/components/agents';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -10,14 +12,33 @@ export async function generateMetadata(): Promise<Metadata> {
 
 /**
  * Agents/Skills/Tasks PR #1017 — Phase 5. `/agents` catalog page.
- * Server-fetches the user's Agent list once. Defensive
- * `.catch(() => [])` so a flaky API renders the empty-state
- * surface instead of a 500.
+ * Server-fetches the user's Agent list + the agent-template catalog
+ * once. Both fetches are defensive (`.catch`) so a flaky API / cold
+ * catalog renders the empty-state surface (and fallback chips)
+ * instead of a 500.
+ *
+ * agent-prompt-first-creation — the catalog feeds the quick-pick chips
+ * + `View All` panel below the prompt composer; the user's existing
+ * Agents are surfaced as "Your templates" (spec FR-29, Q2 default).
  */
 export default async function AgentsPage() {
-    const result = await agentsAPI.list({ limit: 50 }).catch(() => ({
-        data: [] as Agent[],
-        meta: { total: 0, limit: 50, offset: 0 },
+    const [result, templates] = await Promise.all([
+        agentsAPI.list({ limit: 50 }).catch(() => ({
+            data: [] as Agent[],
+            meta: { total: 0, limit: 50, offset: 0 },
+        })),
+        fetchAgentTemplateCatalog('agent').catch(() => [] as AstTemplateEntry[]),
+    ]);
+
+    // "Your templates" — the user's existing Agents as reusable
+    // starting points. Until an explicit save-as-template flow ships,
+    // this derives directly from the Agent list (spec Q2 default).
+    const userTemplates: AstTemplateEntry[] = result.data.map((a) => ({
+        slug: a.slug,
+        title: a.name,
+        description: a.title ?? a.capabilities ?? '',
+        iconName: a.avatarIcon ?? undefined,
     }));
-    return <AgentsList agents={result.data} />;
+
+    return <AgentsList agents={result.data} templates={templates} userTemplates={userTemplates} />;
 }

--- a/apps/web/src/components/agents/AgentTemplateChips.tsx
+++ b/apps/web/src/components/agents/AgentTemplateChips.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+    BookOpen,
+    Bot,
+    ClipboardList,
+    Code2,
+    Cpu,
+    Crown,
+    LayoutGrid,
+    PenLine,
+    Sparkles,
+    TrendingUp,
+    Wrench,
+    type LucideIcon,
+} from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { PromptChipsRow, type PromptChip } from '@/components/common/PromptChipsRow';
+import { ROUTES } from '@/lib/constants';
+import type { AstTemplateEntry } from '@/lib/api/agent-templates';
+
+/**
+ * Agent-template quick-pick chips + `View All` catalog, rendered below
+ * the prompt composer on `/agents` (spec FR-10…FR-19). The first chip
+ * is `View All`, which toggles an inline catalog of every repo template
+ * (`ever-works/agents`, ADR-011) plus the user's own templates. Every
+ * other chip is a template name (CEO, CTO, …); clicking one seeds the
+ * prompt via `onPick` so the user can elaborate, rather than creating
+ * an Agent immediately.
+ */
+
+/** Sentinel chip value for the `View All` toggle (never a real slug). */
+const VIEW_ALL = '__view_all__';
+
+/**
+ * Curated lucide icons referenced by the built-in fallback catalog +
+ * repo `agent.yml` `icon` fields. Imported explicitly (not via a
+ * dynamic barrel) to keep the bundle lean. Unknown names fall back to
+ * `Bot`.
+ */
+const ICON_BY_NAME: Record<string, LucideIcon> = {
+    Crown,
+    Cpu,
+    Wrench,
+    PenLine,
+    TrendingUp,
+    Sparkles,
+    ClipboardList,
+    Code2,
+    BookOpen,
+};
+
+function resolveIcon(name?: string): LucideIcon {
+    return (name && ICON_BY_NAME[name]) || Bot;
+}
+
+export interface AgentTemplateChipsProps {
+    /** Catalog templates (repo or built-in fallback). */
+    readonly templates: ReadonlyArray<AstTemplateEntry>;
+    /** The signed-in user's own templates ("Your templates" section). */
+    readonly userTemplates?: ReadonlyArray<AstTemplateEntry>;
+    /** Called when the user picks a template (chip or catalog card). */
+    readonly onPick: (template: AstTemplateEntry) => void;
+    readonly className?: string;
+}
+
+export function AgentTemplateChips({
+    templates,
+    userTemplates = [],
+    onPick,
+    className,
+}: AgentTemplateChipsProps) {
+    const t = useTranslations('dashboard.agentsPage');
+    const [expanded, setExpanded] = useState(false);
+
+    const chips = useMemo<ReadonlyArray<PromptChip<string>>>(
+        () => [
+            { value: VIEW_ALL, label: t('chips.viewAll'), Icon: LayoutGrid },
+            ...templates.map((tpl) => ({
+                value: tpl.slug,
+                label: tpl.title,
+                Icon: resolveIcon(tpl.iconName),
+            })),
+        ],
+        [t, templates],
+    );
+
+    const findBySlug = useCallback(
+        (slug: string) =>
+            templates.find((x) => x.slug === slug) ?? userTemplates.find((x) => x.slug === slug),
+        [templates, userTemplates],
+    );
+
+    const handleChange = useCallback(
+        (next: string | null) => {
+            // `View All` clicked while inactive → open. The row emits
+            // `null` when the active chip is re-clicked, which for us
+            // means `View All` was toggled off → collapse.
+            if (next === VIEW_ALL) {
+                setExpanded(true);
+                return;
+            }
+            if (next === null) {
+                setExpanded(false);
+                return;
+            }
+            const tpl = findBySlug(next);
+            if (tpl) {
+                onPick(tpl);
+                // If the catalog panel was open, collapse it so a chip
+                // pick behaves the same as a catalog-card pick.
+                setExpanded(false);
+            }
+        },
+        [findBySlug, onPick],
+    );
+
+    // Esc collapses the catalog panel (FR-19).
+    useEffect(() => {
+        if (!expanded) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') setExpanded(false);
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [expanded]);
+
+    const pickAndCollapse = useCallback(
+        (tpl: AstTemplateEntry) => {
+            onPick(tpl);
+            setExpanded(false);
+        },
+        [onPick],
+    );
+
+    return (
+        <div className={cn('space-y-3', className)}>
+            <PromptChipsRow
+                chips={chips}
+                value={expanded ? VIEW_ALL : null}
+                onChange={handleChange}
+                ariaLabel={t('chips.ariaLabel')}
+                testIdPrefix="agent-template-chip"
+            />
+
+            {expanded && (
+                <div
+                    className="rounded-lg border border-border/60 dark:border-border-dark/60 bg-card/60 dark:bg-card-primary-dark/40 p-4 space-y-5"
+                    data-testid="agent-template-catalog"
+                >
+                    <CatalogSection
+                        title={t('catalog.allTemplates')}
+                        openInWizardLabel={t('catalog.openInWizard')}
+                        entries={templates}
+                        onPick={pickAndCollapse}
+                    />
+                    <CatalogSection
+                        title={t('catalog.yourTemplates')}
+                        openInWizardLabel={t('catalog.openInWizard')}
+                        entries={userTemplates}
+                        emptyHint={t('catalog.yourTemplatesEmpty')}
+                        onPick={pickAndCollapse}
+                    />
+                </div>
+            )}
+        </div>
+    );
+}
+
+interface CatalogSectionProps {
+    readonly title: string;
+    readonly openInWizardLabel: string;
+    readonly entries: ReadonlyArray<AstTemplateEntry>;
+    readonly emptyHint?: string;
+    readonly onPick: (template: AstTemplateEntry) => void;
+}
+
+function CatalogSection({
+    title,
+    openInWizardLabel,
+    entries,
+    emptyHint,
+    onPick,
+}: CatalogSectionProps) {
+    return (
+        <section>
+            <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
+                {title}
+            </h3>
+            {entries.length === 0 ? (
+                emptyHint ? (
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark">{emptyHint}</p>
+                ) : null
+            ) : (
+                <div className="grid grid-cols-1 @lg/main:grid-cols-2 @3xl/main:grid-cols-3 gap-3">
+                    {entries.map((tpl) => {
+                        const Icon = resolveIcon(tpl.iconName);
+                        return (
+                            <div
+                                key={tpl.slug}
+                                className="group flex flex-col gap-2 rounded-lg border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-3"
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => onPick(tpl)}
+                                    className="flex flex-col gap-1 text-left"
+                                    data-testid={`agent-template-card-${tpl.slug}`}
+                                >
+                                    <span className="flex items-center gap-2">
+                                        <span className="grid size-7 shrink-0 place-items-center rounded-md bg-primary/10 text-primary">
+                                            <Icon className="size-4" aria-hidden="true" />
+                                        </span>
+                                        <span className="text-sm font-medium text-text dark:text-text-dark">
+                                            {tpl.title}
+                                        </span>
+                                        {tpl.category && (
+                                            <span className="ml-auto rounded-full bg-foreground/5 px-2 py-0.5 text-[10px] text-text-muted dark:bg-white/10 dark:text-text-muted-dark">
+                                                {tpl.category}
+                                            </span>
+                                        )}
+                                    </span>
+                                    <span className="text-xs text-text-muted dark:text-text-muted-dark line-clamp-2">
+                                        {tpl.description}
+                                    </span>
+                                </button>
+                                <Button
+                                    href={`${ROUTES.DASHBOARD_AGENT_NEW}?from=${encodeURIComponent(tpl.slug)}`}
+                                    variant="ghost"
+                                    size="sm"
+                                    className="self-start text-xs opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+                                >
+                                    {openInWizardLabel}
+                                </Button>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </section>
+    );
+}

--- a/apps/web/src/components/agents/AgentTemplateChips.unit.spec.tsx
+++ b/apps/web/src/components/agents/AgentTemplateChips.unit.spec.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ push: vi.fn() }),
+    Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+import { AgentTemplateChips } from './AgentTemplateChips';
+import type { AstTemplateEntry } from '@/lib/api/agent-templates';
+
+const TEMPLATES: AstTemplateEntry[] = [
+    { slug: 'ceo', title: 'CEO', description: 'Chief Executive', iconName: 'Crown' },
+    { slug: 'cto', title: 'CTO', description: 'Chief Technology Officer', iconName: 'Cpu' },
+];
+
+describe('AgentTemplateChips', () => {
+    it('renders a `View All` chip first, then a chip per template', () => {
+        const { container } = render(<AgentTemplateChips templates={TEMPLATES} onPick={vi.fn()} />);
+        const chips = Array.from(
+            container.querySelectorAll('button[role="option"]'),
+        ) as HTMLButtonElement[];
+        // View All + 2 templates.
+        expect(chips.length).toBe(3);
+        expect(
+            container.querySelector('[data-testid="agent-template-chip-__view_all__"]'),
+        ).not.toBeNull();
+        expect(container.querySelector('[data-testid="agent-template-chip-ceo"]')).not.toBeNull();
+        expect(container.querySelector('[data-testid="agent-template-chip-cto"]')).not.toBeNull();
+    });
+
+    it('calls onPick with the template when a template chip is clicked (no catalog expand)', () => {
+        const onPick = vi.fn();
+        const { container } = render(<AgentTemplateChips templates={TEMPLATES} onPick={onPick} />);
+        fireEvent.click(container.querySelector('[data-testid="agent-template-chip-cto"]')!);
+        expect(onPick).toHaveBeenCalledTimes(1);
+        expect(onPick.mock.calls[0][0].slug).toBe('cto');
+        // Catalog stays collapsed when picking a chip directly.
+        expect(container.querySelector('[data-testid="agent-template-catalog"]')).toBeNull();
+    });
+
+    it('toggles the `View All` catalog with both sections', () => {
+        const { container } = render(
+            <AgentTemplateChips
+                templates={TEMPLATES}
+                userTemplates={[{ slug: 'mine', title: 'My Agent', description: 'A saved one' }]}
+                onPick={vi.fn()}
+            />,
+        );
+        const viewAll = container.querySelector(
+            '[data-testid="agent-template-chip-__view_all__"]',
+        )!;
+        fireEvent.click(viewAll);
+        expect(container.querySelector('[data-testid="agent-template-catalog"]')).not.toBeNull();
+        // "All templates" + "Your templates" headings (mocked i18n echoes keys).
+        expect(screen.getByText('dashboard.agentsPage.catalog.allTemplates')).toBeTruthy();
+        expect(screen.getByText('dashboard.agentsPage.catalog.yourTemplates')).toBeTruthy();
+        // Re-click collapses (row emits null for the active chip).
+        fireEvent.click(viewAll);
+        expect(container.querySelector('[data-testid="agent-template-catalog"]')).toBeNull();
+    });
+
+    it('picking a card from the catalog calls onPick and collapses the panel', () => {
+        const onPick = vi.fn();
+        const { container } = render(<AgentTemplateChips templates={TEMPLATES} onPick={onPick} />);
+        fireEvent.click(
+            container.querySelector('[data-testid="agent-template-chip-__view_all__"]')!,
+        );
+        fireEvent.click(container.querySelector('[data-testid="agent-template-card-ceo"]')!);
+        expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ slug: 'ceo' }));
+        expect(container.querySelector('[data-testid="agent-template-catalog"]')).toBeNull();
+    });
+});

--- a/apps/web/src/components/agents/AgentsList.tsx
+++ b/apps/web/src/components/agents/AgentsList.tsx
@@ -1,42 +1,160 @@
 'use client';
 
+import { useState, useTransition } from 'react';
 import { Bot, Plus } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { ROUTES } from '@/lib/constants';
+import { useRouter } from '@/i18n/navigation';
+import {
+    PromptComposer,
+    buildAttachmentRefs,
+    type ComposerAttachment,
+} from '@/components/common/PromptComposer';
+import { useStartFromPrompt } from '@/lib/hooks/use-start-from-prompt';
 import { AgentCard } from './AgentCard';
+import { AgentTemplateChips } from './AgentTemplateChips';
 import { PageHeader } from '@/components/common/PageHeader';
 import type { Agent } from '@/lib/api/agents';
+import type { AstTemplateEntry } from '@/lib/api/agent-templates';
 
 /**
- * Agents/Skills/Tasks PR #1017 — Phase 5. Catalog list. Matches
- * MissionsList layout: top-right "+ New Agent" CTA, empty state
- * nudge, then a responsive grid of AgentCards.
+ * Agents catalog page client. Brings the Agents page to parity with
+ * Missions / Ideas / Works: a prompt-first `PromptComposer` at the top
+ * (type what you want → the chat AI builds it + a Canvas to edit),
+ * agent-template quick-pick chips below the input, and an `Or` block
+ * with `+ Create Agent Manually` (the relabelled former `+ New Agent`,
+ * moved out of the header per the operator request) for the manual
+ * wizard. The existing AgentCard grid stays below, unchanged.
  *
- * View-mode switcher (Cards/Table) lands in a later sub-tick —
- * v1 is cards-only so the page is useful immediately.
+ * Spec: docs/specs/features/agent-prompt-first-creation/spec.md
  */
-export function AgentsList({ agents }: { agents: Agent[] }) {
+
+/** Stable id so a chip pick can refocus the composer textarea. */
+const PROMPT_INPUT_ID = 'agents-prompt';
+
+/** Agent-flavoured placeholder cycle — mirrors the agent examples used
+ *  by the unified `/new` page so the surfaces feel like one primitive. */
+const AGENT_PLACEHOLDERS: ReadonlyArray<string> = [
+    'e.g. "Research assistant that fetches AI safety papers and summarizes them weekly"',
+    'e.g. "Content editor that rewrites our directory descriptions in a consistent voice"',
+    'e.g. "Release-notes drafter that watches a repo and proposes draft notes"',
+    'e.g. "PR triage agent that labels new community PRs and suggests reviewers"',
+];
+
+export interface AgentsListProps {
+    agents: Agent[];
+    /** Catalog templates for the chips + `View All` panel. */
+    templates?: ReadonlyArray<AstTemplateEntry>;
+    /** The user's own templates ("Your templates" section). */
+    userTemplates?: ReadonlyArray<AstTemplateEntry>;
+}
+
+export function AgentsList({ agents, templates = [], userTemplates = [] }: AgentsListProps) {
     const t = useTranslations('dashboard.agentsPage');
+    const router = useRouter();
+    const startFromPrompt = useStartFromPrompt();
+    const [prompt, setPrompt] = useState('');
+    const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
+    const [submitting, startSubmit] = useTransition();
+
+    const submit = () => {
+        const description = prompt.trim();
+        if (description.length < 10) {
+            toast.error(t('prompt.minLength'));
+            return;
+        }
+        startSubmit(() => {
+            // Same contract as the unified /new page's Agent chip: hand
+            // the prompt to the chat AI, then route to the Agent Canvas
+            // (the wizard) where the user can edit in parallel. No
+            // `?prompt=` — the chat already carries it.
+            startFromPrompt(description, {
+                intent: 'Agent',
+                attachments: buildAttachmentRefs(attachments),
+            });
+            router.push(ROUTES.DASHBOARD_AGENT_NEW);
+        });
+    };
+
+    // Clicking a template chip seeds the composer (spec Q1 default): if
+    // the box is empty, seed it with the template's one-liner; if the
+    // user already typed something, prepend the role label so their text
+    // is preserved. Then refocus the input so they can elaborate.
+    const handlePickTemplate = (tpl: AstTemplateEntry) => {
+        setPrompt((prev) => {
+            const trimmed = prev.trim();
+            if (!trimmed) return tpl.description || tpl.title;
+            return `${tpl.title} — ${trimmed}`;
+        });
+        if (typeof document !== 'undefined') {
+            requestAnimationFrame(() => {
+                document.getElementById(PROMPT_INPUT_ID)?.focus();
+            });
+        }
+    };
 
     return (
         <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
-            <PageHeader
-                icon={Bot}
-                title={t('title')}
-                subtitle={t('subtitle')}
-                tone="primary"
-                actions={
-                    <Button
-                        href={ROUTES.DASHBOARD_AGENT_NEW}
-                        size="sm"
-                        className="gap-1.5 shrink-0"
-                    >
-                        <Plus className="w-3.5 h-3.5" />
-                        {t('newAgent')}
-                    </Button>
-                }
-            />
+            <PageHeader icon={Bot} title={t('title')} subtitle={t('subtitle')} tone="primary" />
+
+            {/* Prompt-first surface — describe the Agent you want. Chips
+                with quick-pick templates + `View All` render below the
+                input (matches the /new + marketing layouts). */}
+            <div className="mb-4">
+                <label
+                    htmlFor={PROMPT_INPUT_ID}
+                    className="block text-xs font-medium uppercase tracking-wide text-text-muted dark:text-text-muted-dark mb-2"
+                >
+                    {t('prompt.label')}
+                </label>
+                <PromptComposer
+                    inputId={PROMPT_INPUT_ID}
+                    value={prompt}
+                    onChange={setPrompt}
+                    onSubmit={submit}
+                    submitting={submitting}
+                    placeholderExamples={AGENT_PLACEHOLDERS}
+                    ariaLabel={t('prompt.label')}
+                    submitTitle={t('prompt.submitTitle')}
+                    testId="agents-prompt"
+                    onAttachmentsChange={setAttachments}
+                    chipsBelow={
+                        <AgentTemplateChips
+                            templates={templates}
+                            userTemplates={userTemplates}
+                            onPick={handlePickTemplate}
+                        />
+                    }
+                />
+            </div>
+
+            {/* `Or` block — the manual wizard as the explicit alternative
+                to the prompt (former `+ New Agent`, relabelled + moved
+                out of the header). Mirrors the Works page treatment. */}
+            <div
+                className="my-6 flex items-center gap-3"
+                role="separator"
+                aria-label={t('orDivider')}
+            >
+                <span className="h-px flex-1 bg-border/60 dark:bg-border-dark/60" />
+                <span className="text-xs uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
+                    {t('orDivider')}
+                </span>
+                <span className="h-px flex-1 bg-border/60 dark:bg-border-dark/60" />
+            </div>
+            <div className="mb-8 flex justify-center">
+                <Button
+                    href={ROUTES.DASHBOARD_AGENT_NEW}
+                    variant="secondary"
+                    size="sm"
+                    className="gap-1.5"
+                >
+                    <Plus className="w-3.5 h-3.5" />
+                    {t('createManually')}
+                </Button>
+            </div>
 
             {agents.length === 0 ? (
                 <div className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-6">

--- a/apps/web/src/components/agents/NewAgentDialog.tsx
+++ b/apps/web/src/components/agents/NewAgentDialog.tsx
@@ -13,9 +13,16 @@ import type { AgentScope, CreateAgentInput } from '@/lib/api/agents';
 // never read searchParams. Pre-fill name + title from the fallback
 // template catalog so the templates flow has an actual on-ramp into
 // Agent creation.
-import { listAstTemplates } from '@/lib/api/agent-templates';
+import { listAstTemplates, type AstTemplateEntry } from '@/lib/api/agent-templates';
 
 type CreateAgentFn = (input: CreateAgentInput) => Promise<{ id: string }>;
+
+/**
+ * Wizard steps. `template` (optional) → `scope` → `details`. The
+ * `template` step is skipped when the dialog is `pinned` to a parent
+ * entity or when no templates are available, so it never shows empty.
+ */
+type WizardStep = 'template' | 'scope' | 'details';
 
 export interface ScopeParentOption {
     id: string;
@@ -23,12 +30,15 @@ export interface ScopeParentOption {
 }
 
 /**
- * Agents/Skills/Tasks PR #1017 — Phase 5. 2-step create form per
- * UX-DESIGN §10. Step 1 picks a scope (now including
- * Mission/Work/Idea — when the page passes the corresponding
- * catalog lists), step 2 collects a name + optional title.
- * Defaults the rest from CreateAgentDto so the server can fill in
- * the safe permissions baseline.
+ * Manual create wizard per UX-DESIGN §10, extended by
+ * agent-prompt-first-creation. Steps: an optional `template` step
+ * (shown only when templates are passed and the dialog isn't pinned)
+ * → `scope` (picks Tenant/Mission/Work/Idea — Mission/Work/Idea require
+ * the page to pass the corresponding catalog lists) → `details` (name +
+ * optional title). Defaults the rest from CreateAgentDto so the server
+ * fills the safe permissions baseline. The `scope` step never
+ * dead-ends: when a non-tenant scope has no parent candidates, the
+ * disabled Next is explained and Workspace scope always advances.
  */
 export interface NewAgentDialogPinnedScope {
     scope: Exclude<AgentScope, 'tenant'>;
@@ -55,6 +65,13 @@ export interface NewAgentDialogProps {
     missions?: ScopeParentOption[];
     works?: ScopeParentOption[];
     ideas?: ScopeParentOption[];
+    /**
+     * Optional agent-template catalog (spec FR-23). When non-empty and
+     * the dialog isn't `pinned`, the wizard opens on an optional
+     * template-pick step; picking one pre-fills name + title. Empty →
+     * the step is skipped entirely so it never renders blank.
+     */
+    templates?: AstTemplateEntry[];
 }
 
 export function NewAgentDialog({
@@ -63,11 +80,14 @@ export function NewAgentDialog({
     missions = [],
     works = [],
     ideas = [],
+    templates = [],
 }: NewAgentDialogProps) {
     const t = useTranslations('dashboard.agentsPage.newDialog');
     const router = useRouter();
     const searchParams = useSearchParams();
-    const [step, setStep] = useState<1 | 2>(pinned ? 2 : 1);
+    const [step, setStep] = useState<WizardStep>(
+        pinned ? 'details' : templates.length > 0 ? 'template' : 'scope',
+    );
     const [scope, setScope] = useState<AgentScope>(pinned?.scope ?? 'tenant');
     const [parentId, setParentId] = useState<string>(
         pinned?.missionId ?? pinned?.workId ?? pinned?.ideaId ?? '',
@@ -97,7 +117,7 @@ export function NewAgentDialog({
                     setTemplateSlug(from);
                     if (!name) setName(entry.title);
                     if (!title && entry.description) setTitle(entry.description.slice(0, 80));
-                    setStep(2);
+                    setStep('details');
                 }
             } catch {
                 // Best-effort — fall back to a blank form.
@@ -173,6 +193,19 @@ export function NewAgentDialog({
     const canAdvance =
         scope === 'tenant' || (!!parentId && parentOptions.some((o) => o.id === parentId));
 
+    // Optional template step (FR-23/24). Picking a template pre-fills
+    // name + title (without clobbering anything the user already
+    // typed); "Start from scratch" passes null. Either way we advance
+    // to the scope step.
+    const handlePickTemplate = (tpl: AstTemplateEntry | null) => {
+        if (tpl) {
+            setTemplateSlug(tpl.slug);
+            if (!name) setName(tpl.title);
+            if (!title && tpl.description) setTitle(tpl.description.slice(0, 80));
+        }
+        setStep('scope');
+    };
+
     const handleSubmit = () => {
         if (!name.trim()) return;
         if (scope !== 'tenant' && !parentId) {
@@ -213,7 +246,47 @@ export function NewAgentDialog({
                 </h1>
             </div>
 
-            {step === 1 && (
+            {step === 'template' && (
+                <section>
+                    <h2 className="text-sm font-medium text-text dark:text-text-dark mb-3">
+                        {t('templateStepTitle')}
+                    </h2>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                        {templates.map((tpl) => (
+                            <button
+                                key={tpl.slug}
+                                type="button"
+                                onClick={() => handlePickTemplate(tpl)}
+                                className="text-left rounded-lg border border-border/60 dark:border-border-dark/60 p-3 transition-colors hover:border-primary"
+                                data-testid={`agent-template-step-${tpl.slug}`}
+                            >
+                                <div className="text-sm font-medium text-text dark:text-text-dark">
+                                    {tpl.title}
+                                </div>
+                                <div className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark line-clamp-2">
+                                    {tpl.description}
+                                </div>
+                            </button>
+                        ))}
+                    </div>
+                    <div className="flex items-center justify-between gap-2 mt-6">
+                        <Button variant="ghost" size="sm" onClick={() => router.back()}>
+                            {t('cancel')}
+                        </Button>
+                        <Button
+                            size="sm"
+                            variant="secondary"
+                            onClick={() => handlePickTemplate(null)}
+                            className="gap-1.5"
+                        >
+                            {t('startFromScratch')}
+                            <ChevronRight className="w-3.5 h-3.5" />
+                        </Button>
+                    </div>
+                </section>
+            )}
+
+            {step === 'scope' && (
                 <section>
                     <h2 className="text-sm font-medium text-text dark:text-text-dark mb-3">
                         {t('step1Title')}
@@ -276,24 +349,48 @@ export function NewAgentDialog({
                         </div>
                     )}
 
-                    <div className="flex items-center justify-end gap-2 mt-6">
-                        <Button variant="ghost" size="sm" onClick={() => router.back()}>
-                            {t('cancel')}
-                        </Button>
-                        <Button
-                            size="sm"
-                            onClick={() => setStep(2)}
-                            disabled={!canAdvance}
-                            className="gap-1.5"
-                        >
-                            {t('next')}
-                            <ChevronRight className="w-3.5 h-3.5" />
-                        </Button>
+                    <div className="flex items-center justify-between gap-2 mt-6">
+                        {templates.length > 0 ? (
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setStep('template')}
+                                className="gap-1.5"
+                            >
+                                <ChevronLeft className="w-3.5 h-3.5" />
+                                {t('back')}
+                            </Button>
+                        ) : (
+                            <Button variant="ghost" size="sm" onClick={() => router.back()}>
+                                {t('cancel')}
+                            </Button>
+                        )}
+                        {/* Spec FR-20/21 — when a non-tenant scope has no
+                            valid parent, Next is disabled; surface WHY so
+                            the flow isn't a silent dead-end. Workspace
+                            scope always advances. */}
+                        <div className="flex flex-col items-end gap-1">
+                            {!canAdvance && (
+                                <p className="text-xs text-text-muted dark:text-text-muted-dark text-right">
+                                    {t('pickParentHint', { scope })}
+                                </p>
+                            )}
+                            <Button
+                                size="sm"
+                                onClick={() => setStep('details')}
+                                disabled={!canAdvance}
+                                title={canAdvance ? undefined : t('nextDisabledReason')}
+                                className="gap-1.5"
+                            >
+                                {t('next')}
+                                <ChevronRight className="w-3.5 h-3.5" />
+                            </Button>
+                        </div>
                     </div>
                 </section>
             )}
 
-            {step === 2 && (
+            {step === 'details' && (
                 <section>
                     {pinned && (
                         <div className="mb-4 rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-text-secondary dark:text-text-secondary-dark">
@@ -364,7 +461,7 @@ export function NewAgentDialog({
                             <Button
                                 variant="ghost"
                                 size="sm"
-                                onClick={() => setStep(1)}
+                                onClick={() => setStep('scope')}
                                 className="gap-1.5"
                             >
                                 <ChevronLeft className="w-3.5 h-3.5" />

--- a/apps/web/src/components/agents/NewAgentDialog.unit.spec.tsx
+++ b/apps/web/src/components/agents/NewAgentDialog.unit.spec.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: (ns: string) => (key: string) => `${ns}.${key}`,
+}));
+
+vi.mock('next/navigation', () => ({
+    useSearchParams: () => ({ get: () => null }),
+}));
+
+const routerPushMock = vi.fn();
+const routerBackMock = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ push: routerPushMock, back: routerBackMock }),
+    Link: ({ href, children }: { href: string; children: React.ReactNode }) => (
+        <a href={href}>{children}</a>
+    ),
+}));
+
+vi.mock('@/lib/api/agent-templates', () => ({
+    listAstTemplates: vi.fn(async () => []),
+}));
+
+import { NewAgentDialog } from './NewAgentDialog';
+import type { AstTemplateEntry } from '@/lib/api/agent-templates';
+
+const T = 'dashboard.agentsPage.newDialog';
+const createAgent = vi.fn(async () => ({ id: 'agent-1' }));
+
+const TEMPLATES: AstTemplateEntry[] = [
+    { slug: 'ceo', title: 'CEO', description: 'Chief Executive' },
+    { slug: 'cto', title: 'CTO', description: 'Chief Technology Officer' },
+];
+
+function nextButton(container: HTMLElement): HTMLButtonElement {
+    const btn = Array.from(container.querySelectorAll('button')).find((b) =>
+        b.textContent?.includes(`${T}.next`),
+    );
+    if (!btn) throw new Error('Next button not found');
+    return btn as HTMLButtonElement;
+}
+
+describe('NewAgentDialog — bug fix + template step', () => {
+    it('Workspace (tenant) happy path: Next is enabled and advances to details', () => {
+        const { container } = render(<NewAgentDialog createAgent={createAgent} />);
+        // No templates passed → opens on the scope step.
+        const next = nextButton(container);
+        expect(next.disabled).toBe(false);
+        fireEvent.click(next);
+        // Details step renders the name input.
+        expect(container.querySelector('input[type="text"]')).not.toBeNull();
+    });
+
+    it('non-tenant scope with no candidates does NOT dead-end: Next disabled + hint shown', () => {
+        const { container } = render(<NewAgentDialog createAgent={createAgent} />);
+        // Select the Mission scope (no missions passed → empty catalog).
+        const missionBtn = Array.from(container.querySelectorAll('button')).find((b) =>
+            b.textContent?.toLowerCase().includes('mission'),
+        );
+        fireEvent.click(missionBtn!);
+        const next = nextButton(container);
+        expect(next.disabled).toBe(true);
+        expect(next.getAttribute('title')).toBe(`${T}.nextDisabledReason`);
+        expect(screen.getByText(`${T}.pickParentHint`)).toBeTruthy();
+    });
+
+    it('opens on the optional template step when templates are provided', () => {
+        const { container } = render(
+            <NewAgentDialog createAgent={createAgent} templates={TEMPLATES} />,
+        );
+        expect(container.querySelector('[data-testid="agent-template-step-ceo"]')).not.toBeNull();
+        expect(screen.getByText(`${T}.startFromScratch`)).toBeTruthy();
+    });
+
+    it('picking a template prefills the name and advances through scope to details', () => {
+        const { container } = render(
+            <NewAgentDialog createAgent={createAgent} templates={TEMPLATES} />,
+        );
+        fireEvent.click(container.querySelector('[data-testid="agent-template-step-cto"]')!);
+        // Now on scope step (tenant default) → advance.
+        fireEvent.click(nextButton(container));
+        const nameInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+        expect(nameInput.value).toBe('CTO');
+    });
+
+    it('pinned scope skips the template step and lands on details', () => {
+        const { container } = render(
+            <NewAgentDialog
+                createAgent={createAgent}
+                templates={TEMPLATES}
+                pinned={{ scope: 'mission', missionId: 'm1', parentLabel: 'Cats Business' }}
+            />,
+        );
+        // No template cards; the name input is immediately present.
+        expect(container.querySelector('[data-testid="agent-template-step-ceo"]')).toBeNull();
+        expect(container.querySelector('input[type="text"]')).not.toBeNull();
+    });
+});

--- a/apps/web/src/components/agents/index.ts
+++ b/apps/web/src/components/agents/index.ts
@@ -1,4 +1,5 @@
 export { AgentCard } from './AgentCard';
 export { AgentsList } from './AgentsList';
+export { AgentTemplateChips } from './AgentTemplateChips';
 export { AgentDetailTabs } from './AgentDetailTabs';
 export { NewAgentDialog } from './NewAgentDialog';

--- a/apps/web/src/components/works/WorkAICreator.tsx
+++ b/apps/web/src/components/works/WorkAICreator.tsx
@@ -207,6 +207,7 @@ export function WorkAICreator({
                     <Input
                         label={`${t('workNameLabel')} *`}
                         type="text"
+                        name="name"
                         value={workName}
                         onChange={(e) => {
                             const nextName = e.target.value;
@@ -230,6 +231,7 @@ export function WorkAICreator({
                     <Input
                         label={t('slugLabel')}
                         type="text"
+                        name="slug"
                         value={slug}
                         onChange={(e) => {
                             setSlug(e.target.value);
@@ -244,6 +246,7 @@ export function WorkAICreator({
                     {/* AI Prompt */}
                     <Textarea
                         label={`${t('promptLabel')} *`}
+                        name="prompt"
                         value={prompt}
                         onChange={(e) => setPrompt(e.target.value)}
                         placeholder={t('promptPlaceholder')}

--- a/apps/web/src/lib/api/agent-templates.server.ts
+++ b/apps/web/src/lib/api/agent-templates.server.ts
@@ -1,0 +1,35 @@
+import 'server-only';
+import { serverFetch } from './server-api';
+import {
+    listAstTemplates,
+    type AstTemplateEntry,
+    type AstTemplateEntityType,
+} from './agent-templates';
+
+/**
+ * Server-only catalog fetch (spec FR-28). Calls the API's
+ * `GET /agent-templates?entity=…` (backed by `AgentTemplateCatalogService`
+ * reading `ever-works/agents`, ADR-011) and falls back to the built-in
+ * `listAstTemplates` list on any error or empty response.
+ *
+ * Lives in a `server-only` module — never import it from a client
+ * component. Client code (e.g. the wizard's `?from=` pre-fill) keeps
+ * importing the isomorphic `listAstTemplates` from `./agent-templates`
+ * directly, so the web client bundle stays free of `server-only`.
+ */
+export async function fetchAgentTemplateCatalog(
+    entity: AstTemplateEntityType = 'agent',
+): Promise<AstTemplateEntry[]> {
+    try {
+        const rows = await serverFetch<AstTemplateEntry[]>(
+            `/agent-templates?entity=${encodeURIComponent(entity)}`,
+        );
+        if (Array.isArray(rows) && rows.length > 0) {
+            return rows;
+        }
+    } catch {
+        // Cold/unauthenticated catalog, network blip, or non-array body —
+        // fall through to the built-in list so chips never render empty.
+    }
+    return listAstTemplates(entity);
+}

--- a/apps/web/src/lib/api/agent-templates.ts
+++ b/apps/web/src/lib/api/agent-templates.ts
@@ -32,6 +32,67 @@ export interface AstTemplateEntry {
 }
 
 const AGENT_TEMPLATES: AstTemplateEntry[] = [
+    // Named-role starters the operator asked to surface as quick-pick
+    // chips on /agents (CEO, CTO, Lead Engineer, Copywriter, Sales,
+    // Brand Specialist, …). These are the built-in FALLBACK shown until
+    // the `ever-works/agents` repo (ADR-011) is the live source — they
+    // keep the chip row populated even with a cold/unreachable catalog
+    // (spec E2). Additive: the original PM/Coder/Researcher starters
+    // stay below.
+    {
+        slug: 'ceo',
+        title: 'CEO',
+        description:
+            'Chief Executive — keeps every Mission laddering up to a clear goal, sets priorities, and nudges stalled work forward.',
+        category: 'Leadership',
+        tags: ['strategy', 'roadmap', 'coordination'],
+        iconName: 'Crown',
+    },
+    {
+        slug: 'cto',
+        title: 'CTO',
+        description:
+            'Chief Technology Officer — owns technical direction, reviews architecture decisions, and guards delivery quality.',
+        category: 'Leadership',
+        tags: ['architecture', 'engineering', 'review'],
+        iconName: 'Cpu',
+    },
+    {
+        slug: 'lead-engineer',
+        title: 'Lead Engineer',
+        description:
+            'Breaks features into tasks, implements the hard parts end-to-end, and unblocks the rest of the team. Requires git permissions.',
+        category: 'Engineering',
+        tags: ['git', 'pr', 'implementation'],
+        iconName: 'Wrench',
+    },
+    {
+        slug: 'copywriter',
+        title: 'Copywriter',
+        description:
+            'Writes and rewrites marketing + product copy in a consistent brand voice — landing pages, descriptions, release notes.',
+        category: 'Content',
+        tags: ['content', 'marketing', 'voice'],
+        iconName: 'PenLine',
+    },
+    {
+        slug: 'sales',
+        title: 'Sales',
+        description:
+            'Drafts outreach, qualifies inbound interest, and keeps a pipeline of follow-ups moving with timely nudges.',
+        category: 'Go-to-market',
+        tags: ['outreach', 'pipeline', 'crm'],
+        iconName: 'TrendingUp',
+    },
+    {
+        slug: 'brand-specialist',
+        title: 'Brand Specialist',
+        description:
+            'Guards brand consistency across copy, naming, and visuals — flags off-voice content and proposes on-brand alternatives.',
+        category: 'Content',
+        tags: ['brand', 'voice', 'design'],
+        iconName: 'Sparkles',
+    },
     {
         slug: 'starter-pm',
         title: 'Project Manager',
@@ -137,8 +198,28 @@ const FALLBACK: Record<AstTemplateEntityType, AstTemplateEntry[]> = {
  * pure-data path avoids the bundle pollution; the catalog-swap path
  * moves to a dedicated server action when ADR-010 lands.
  */
+/**
+ * Session-scoped catalog cache (spec FR-30). Keeps the template chips
+ * + `View All` catalog instant across re-renders and route revisits
+ * without refetching within the TTL. Keyed by entity type. On the
+ * client this persists for the tab session; on the server it's a
+ * per-process cache — both are correct because the agent-template
+ * catalog is a public, non-request-scoped resource (so this does not
+ * violate the "no shared module state for request data" rule). When
+ * the ADR-010/ADR-011 server-action swap lands, the fetch+fallback
+ * goes here behind the same cache; the return type stays stable.
+ */
+const CLIENT_CACHE_TTL_MS = 5 * 60_000;
+const catalogCache = new Map<AstTemplateEntityType, { at: number; data: AstTemplateEntry[] }>();
+
 export async function listAstTemplates(entity: AstTemplateEntityType): Promise<AstTemplateEntry[]> {
-    return FALLBACK[entity] ?? [];
+    const cached = catalogCache.get(entity);
+    if (cached && Date.now() - cached.at < CLIENT_CACHE_TTL_MS) {
+        return cached.data;
+    }
+    const data = FALLBACK[entity] ?? [];
+    catalogCache.set(entity, { at: Date.now(), data });
+    return data;
 }
 
 /**

--- a/apps/web/src/lib/api/agent-templates.unit.spec.ts
+++ b/apps/web/src/lib/api/agent-templates.unit.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { getAstTemplate, listAstTemplates } from './agent-templates';
+
+/**
+ * agent-prompt-first-creation — runnable coverage for the named-role
+ * starters that back the `/agents` quick-pick chips. (The sibling
+ * `agent-templates.spec.ts` predates the `*.unit.spec.ts` convention
+ * the web vitest config matches, so this file is the one that actually
+ * executes.)
+ */
+describe('agent-templates — named-role starters', () => {
+    it('exposes CEO/CTO/Lead Engineer/Copywriter/Sales/Brand Specialist as agent templates', async () => {
+        const agents = await listAstTemplates('agent');
+        const slugs = new Set(agents.map((a) => a.slug));
+        for (const role of [
+            'ceo',
+            'cto',
+            'lead-engineer',
+            'copywriter',
+            'sales',
+            'brand-specialist',
+        ]) {
+            expect(slugs.has(role)).toBe(true);
+        }
+    });
+
+    it('each named-role starter has a title, one-line description, and an icon', async () => {
+        for (const role of ['ceo', 'cto', 'lead-engineer']) {
+            const tpl = await getAstTemplate('agent', role);
+            expect(tpl).not.toBeNull();
+            expect(tpl?.title.length).toBeGreaterThan(0);
+            expect(tpl?.description.length).toBeGreaterThan(0);
+            expect(tpl?.iconName).toBeTruthy();
+        }
+    });
+
+    it('keeps the original PM/Coder/Researcher starters (additive, not a replacement)', async () => {
+        const slugs = new Set((await listAstTemplates('agent')).map((a) => a.slug));
+        expect(slugs.has('starter-pm')).toBe(true);
+        expect(slugs.has('starter-coder')).toBe(true);
+        expect(slugs.has('starter-researcher')).toBe(true);
+    });
+});

--- a/docs/specs/features/agent-prompt-first-creation/plan.md
+++ b/docs/specs/features/agent-prompt-first-creation/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Agent prompt-first creation & template chips
+
+Companion to [spec.md](./spec.md). This is the _how_. Reuse-first: every prompt-first primitive already exists and is used by Missions/Ideas/`/new` — we wire them onto `/agents`, add one new chips component, fix the wizard, and land the backend catalog service.
+
+## A. Frontend — prompt-first `/agents` page
+
+**Files**
+
+- `apps/web/src/app/[locale]/(dashboard)/agents/page.tsx` (server) — additionally fetch the template catalog and pass it down:
+    ```ts
+    const [agentsResult, templates] = await Promise.all([
+      agentsAPI.list({ limit: 50 }).catch(() => ({ data: [], meta: { total: 0, limit: 50, offset: 0 } })),
+      listAstTemplates('agent').catch(() => []),       // NFR-2: defensive
+    ]);
+    return <AgentsList agents={agentsResult.data} templates={templates} />;
+    ```
+- `apps/web/src/components/agents/AgentsList.tsx` (client) — becomes the prompt-first page client:
+    - Add `PromptComposer` (model: `IdeasPageClient.tsx`) with `placeholderExamples` = the agent placeholders from `NewPageClient`.
+    - `submit()` mirrors `NewPageClient`'s agent path: `startFromPrompt(description, { intent: 'Agent', attachments })` then `router.push(ROUTES.DASHBOARD_AGENT_NEW)`. Min-length guard `< 10`.
+    - `chipsBelow={<AgentTemplateChips … />}` (new component, §B).
+    - Move the `+ New Agent` button out of `PageHeader.actions`; render the `Or` block + `+ Create Agent Manually` below the composer.
+    - Keep the existing cards grid + empty-state untouched below.
+    - Auto-collapse the chat panel on mount (`useChatPanel().setOpen(false)`) like `NewPageClient`, so the prompt gets the column on first land.
+
+**`Or` block** — match the Works treatment. A thin presentational block: a centered `Or` rule (flex with `before:`/`after:` borders) and the `+ Create Agent Manually` `Button` (`href={ROUTES.DASHBOARD_AGENT_NEW}`, `variant="secondary"`, `Plus` icon). Keep it inline in `AgentsList` (small) rather than a new shared component, unless the Works `CreationBlockTrio` already exposes a reusable `Or` — if so, reuse it.
+
+## B. Frontend — `AgentTemplateChips` (new component)
+
+`apps/web/src/components/agents/AgentTemplateChips.tsx` (client).
+
+**Props**
+
+```ts
+interface AgentTemplateChipsProps {
+	templates: AstTemplateEntry[]; // repo/fallback catalog
+	userTemplates?: AstTemplateEntry[]; // "Your templates" (FR-16/29)
+	onPick: (tpl: AstTemplateEntry) => void; // seed the prompt (FR-13)
+}
+```
+
+**Behaviour**
+
+- Build a `PromptChip[]` array: `[{ value: VIEW_ALL, label: t('chips.viewAll'), Icon: LayoutGrid }, ...templates.map(tpl => ({ value: tpl.slug, label: tpl.title, Icon: resolveIcon(tpl.iconName) }))]`.
+- Render `<PromptChipsRow chips={chips} value={expanded ? VIEW_ALL : null} onChange={onChange} />`.
+- `onChange(v)`: if `v === VIEW_ALL` → toggle `expanded`; else if `v` → `onPick(bySlug(v))` (do **not** persist selection — value stays `null` so no sticky highlight).
+- When `expanded`, render the catalog panel: two `<section>`s ("All templates", "Your templates") each a card grid. Card click → `onPick(tpl)` + collapse (default), with a secondary "Open in wizard" link to `/agents/new?from=<slug>`. `Esc` collapses.
+- Icon resolution: a small map from the curated lucide names used in `agent-templates.ts` (`ClipboardList`, `Code2`, `BookOpen`, plus the role icons we add — `Crown`/`Briefcase` for CEO, `Cpu`/`Wrench` for CTO, etc.). Fallback `Bot`.
+
+**Chip seed semantics (spec Q1 default):** in `onPick`, the parent (`AgentsList`) sets the composer value: empty → `tpl.description` (or `"${tpl.title} — ${tpl.description}"`); non-empty → prepend `"${tpl.title} — "`. Then focus the input (`PromptComposer` exposes `inputId`; focus by id).
+
+## C. Frontend — catalog client helper + global cache
+
+`apps/web/src/lib/api/agent-templates.ts`:
+
+- Keep the stable `AstTemplateEntry` shape and `listAstTemplates(entity)` signature (FR-28).
+- **Extend the built-in fallback** `AGENT_TEMPLATES` with the named roles the operator listed — additive, keep PM/Coder/Researcher: add `CEO`, `CTO`, `Lead Engineer`, `Copywriter`, `Sales`, `Brand Specialist` (each with slug, title, description, category, iconName, tags). This guarantees the chips are populated _today_ (E2) before the repo lands.
+- Add a **module-level cache** (FR-30): `const cache = new Map<AstTemplateEntityType, { at: number; data: AstTemplateEntry[] }>()` with a short client TTL; `listAstTemplates` checks it first. (Server reads go through the service's `cache_entries`.)
+- Leave the documented swap-to-server-action path (per the existing file comment) — when the endpoint lands (§D) the fallback becomes the catch path.
+
+## D. Backend — `AgentTemplateService` + endpoint (ADR-011)
+
+**Service** `packages/agent/src/services/agent-template.service.ts` (or the agents module if one exists):
+
+- `listTemplates(entity='agent'): Promise<AstTemplateEntry[]>`.
+- Resolve source: `EVER_WORKS_AGENTS_PATH` (local clone) if set, else `git clone --depth 1 --branch $EVER_WORKS_AGENTS_REF(github.com/ever-works/agents)` into a temp dir (reuse `isomorphic-git`/existing git facade if it fits; otherwise a thin clone util). Use the official client / existing git util — **no hand-rolled HTTP** (NN #22).
+- Parse each top-level folder: read `agent.yml` for `title`/`description`/`category`/`icon`/`tags`; validate against a Zod schema; skip + warn on invalid folders.
+- Cache the parsed list in `cache_entries` keyed `agent-templates:agent:<ref>` with 1h TTL. Cache-first read; clone only on miss.
+- Resilience (NFR-3): timeout the clone; on failure return `[]` (controller layer or client falls back).
+
+**Endpoint** `apps/api/src/...` — `GET /agent-templates?entity=agent` → `AstTemplateEntry[]`. `@Public()` read is fine (catalog is public). Thin controller → service.
+
+**Web wiring** — a server action `listAstTemplatesFromCatalogAction(entity)` that `serverFetch('/agent-templates?entity=…')`; `listAstTemplates` calls it and falls back to the built-in list on error (keeps the client bundle clean per the existing file's webpack note).
+
+**Repo creation** — `ever-works/agents` may not exist yet. Creating/seeding it is a **shared-state action requiring operator approval** (spec Q4). The service + fallback are designed so the feature ships and works regardless; populating the repo flips chips from fallback to live with no code change.
+
+## E. Wizard — `NewAgentDialog.tsx`
+
+**Bug fix (FR-20/21/22)** — minimal, surgical:
+
+- Add an inline helper under the scope list / above the buttons when `!canAdvance && !pinned`: e.g. `t('pickParentHint', { scope })` ("Pick a {scope} to continue, or choose Workspace scope").
+- Add `title={canAdvance ? undefined : t('nextDisabledReason')}` to the Next `Button` so the disabled state is explained on hover/focus.
+- Do **not** touch the `canAdvance` happy path for `tenant`.
+- (The empty-scope hint already exists at `:245`; we make its consequence — disabled Next — legible.)
+
+**Optional template step (FR-23/24/25)** — extend the step machine:
+
+- Change `step` from `1 | 2` to a union `'template' | 'scope' | 'details'`. Initial: `pinned ? 'details' : 'template'`. Keep `?from=<slug>` → set template + `'details'` (current behaviour preserved).
+- New prop `templates?: AstTemplateEntry[]` passed from `/agents/new` page (server-fetch `listAstTemplates('agent')`).
+- `template` step: a card grid of templates + a prominent **"Start from scratch"** button. Selecting a template → `setTemplateSlug`, prefill `name`/`title`, → `'scope'`. "Start from scratch" → `'scope'`.
+- Back navigation: `details → scope → template`.
+- Guard: if `templates` is empty, skip the template step entirely (initial step becomes `'scope'`) so we never show an empty step.
+
+`/agents/new/page.tsx` — add `templates={await listAstTemplates('agent').catch(() => [])}` to the `<NewAgentDialog>` props (alongside the existing missions/works/ideas fetch).
+
+## F. i18n
+
+Add keys under `dashboard.agentsPage` (e.g. `promptLabel`, `orDivider`, `createManually`, `chips.viewAll`, `catalog.allTemplates`, `catalog.yourTemplates`, `catalog.yourTemplatesEmpty`) and `dashboard.agentsPage.newDialog` (`templateStepTitle`, `startFromScratch`, `pickParentHint`, `nextDisabledReason`). Relabel `newAgent` is kept (still used as the manual button text) and add `createManually` = "Create Agent Manually". Write to **all 21** `apps/web/messages/*.json` (English placeholder where untranslated — NFR-4). Script the injection with a small node merge.
+
+## G. Tests
+
+- Unit: `AgentTemplateChips` (renders View All first; chip click calls `onPick`; View All toggles panel). Co-locate `*.unit.spec.tsx` like neighbours.
+- Unit: `NewAgentDialog` — Workspace happy path still advances; Mission+empty shows hint and Next disabled with `title`; template step pre-fills + advances; `pinned` skips template step.
+- Unit/`agent-templates.spec.ts`: fallback includes the named roles; `listAstTemplates('agent')` returns them; cache hit path.
+- Backend: `AgentTemplateService` cache-hit / clone-miss / invalid-folder-skip / unreachable→[] (mock git + cache).
+- E2E (Playwright) smoke: `/agents` renders composer + chips; `+ Create Agent Manually` routes to wizard. (Match existing agents e2e if present.)
+
+## H. Sequencing / PRs
+
+1. **PR 1 (frontend, no backend dep):** §A + §B + §C(fallback+cache) + §E + §F + §G(frontend). Delivers the full visible feature off the extended fallback catalog. Self-contained, reviewable.
+2. **PR 2 (backend):** §D — `AgentTemplateService` + endpoint + server-action swap + §G(backend). Flips chips to live repo data. Depends on operator creating/seeding `ever-works/agents` (Q4) for non-fallback content, but ships safely either way.
+
+Both target `develop`. Migrations only if "Your templates" needs a column (FR-29) — default v1 derives from existing Agents, so likely none.

--- a/docs/specs/features/agent-prompt-first-creation/spec.md
+++ b/docs/specs/features/agent-prompt-first-creation/spec.md
@@ -1,0 +1,225 @@
+# Feature Specification: Agent prompt-first creation & template chips
+
+**Feature ID**: `agent-prompt-first-creation`
+**Branch**: `session/agent-prompt-first`
+**Status**: `Draft`
+**Created**: 2026-05-29
+**Last updated**: 2026-05-29
+**Owner**: Product (Ruslan)
+**Jira**: Epic [EW-705](https://evertech.atlassian.net/browse/EW-705) — stories EW-706 (prompt-first + Or block), EW-707 (chips + View All), EW-708 (wizard fix + template step), EW-709 (catalog backend)
+
+**Related code today**:
+
+- Agents catalog page: `apps/web/src/app/[locale]/(dashboard)/agents/page.tsx`, `apps/web/src/components/agents/AgentsList.tsx`
+- Manual create wizard: `apps/web/src/components/agents/NewAgentDialog.tsx` (rendered at `/agents/new`)
+- Template browser (existing): `apps/web/src/app/[locale]/(dashboard)/agents/templates/page.tsx`
+- Template client helper (fallback catalog today): `apps/web/src/lib/api/agent-templates.ts`
+- Prompt-first primitives reused verbatim: `apps/web/src/components/common/PromptComposer.tsx`, `apps/web/src/components/common/PromptChipsRow.tsx`, `apps/web/src/lib/hooks/use-start-from-prompt.tsx`, `apps/web/src/lib/hooks/use-chat-panel.tsx`
+- Reference implementations of the prompt-first list page: `apps/web/src/components/ideas/IdeasPageClient.tsx`, the unified `apps/web/src/components/new/NewPageClient.tsx`, and the Works manual/`Or` block in `apps/web/src/components/works/CreationBlockTrio.tsx`
+
+> **Scope of this document:** the _creation UX_ for Agents — what the user sees and does when they create an Agent from the `/agents` page. It layers a prompt-first ("just describe it") entry point on top of the existing manual wizard, surfaces a community **template catalog** (CEO, CTO, Lead Engineer, Copywriter, Sales, Brand Specialist, …) as quick-pick chips, and fixes a wizard dead-end. It does **not** redefine what an Agent _is_, its runtime, scope cascade, budgets, or tabs — that lives in [`features/agents/spec.md`](../agents/spec.md). Implementation detail is in [plan.md](./plan.md); the task breakdown is in [tasks.md](./tasks.md).
+>
+> **Hard rule (additive only — [Workspace AGENTS.md NN #20](file:///C:/Coding/Workspace/AGENTS.md)):** Everything that ships today stays. The manual `NewAgentDialog` wizard is _kept_ and _improved_, never removed. The only thing that moves is the placement + label of one button (`+ New Agent` → `+ Create Agent Manually`), which the operator requested explicitly. The existing `/agents/templates` browser stays. New surfaces are added; nothing is renamed away.
+
+---
+
+## 1. Overview
+
+Today the only way to create an Agent from `/agents` is the top-right **`+ New Agent`** button, which opens a two-step manual wizard (pick scope → name it). Every _other_ creatable entity in the product — Missions, Ideas, Works — opens with a **prompt-first** surface: a big `PromptComposer` where the user types what they want in plain language, the chat AI builds it, and a Canvas lets them edit in parallel. Agents are the odd one out.
+
+This feature brings Agents to parity:
+
+1. **Prompt-first on `/agents`.** A `PromptComposer` at the top of the page: the user types _"a research assistant that fetches AI-safety papers and summarises them weekly"_ and the chat AI takes it from there (Chat UI + Canvas), exactly like Missions/Ideas. (FR-1…FR-6)
+2. **`Or` block + `+ Create Agent Manually`.** Below the composer, an `Or` divider and a single **`+ Create Agent Manually`** button (the relabelled, repositioned former `+ New Agent`) routes to the existing wizard for users who'd rather fill a form. Mirrors the Works page's `Or` treatment. (FR-7…FR-9)
+3. **Template chips + `View All` catalog.** A horizontally-scrolling chip row under the prompt input shows agent-template names sourced from the community repo [`ever-works/agents`](https://github.com/ever-works/agents) (per [ADR-011](../../decisions/011-agent-templates-in-separate-repo.md)) — `CEO`, `CTO`, `Lead Engineer`, `Copywriter`, `Sales`, `Brand Specialist`, … The **first chip is `View All`**, which expands an inline catalog of _all_ repo templates **plus the user's own previously-created Agent templates**. Picking a chip seeds the prompt so the user can elaborate ("CTO who also owns our incident process…"). The catalog is globally cached so chips render instantly. (FR-10…FR-19)
+4. **Wizard fix + optional template step.** The wizard's "Next does nothing" dead-end is fixed (FR-20…FR-22), and the wizard gains an **optional first step that lists the same templates** so the manual path can also start from a template. (FR-23…FR-25)
+
+### Why now
+
+The operator's instruction (2026-05-29):
+
+> "In the Agents page, can we add our standard prompt there to create new Agent … same flow like we have on Missions / Ideas. The current button `+ New Agent` should just become `+ Create Agent Manually` and be positioned in the `Or` block, same as we did it in Works page. … do we have there a step that display existing Agents templates for user to select (optionally)? If not, we should have it because we should have a repo `github.com/ever-works/agents` … put `Chips` below input prompt … display names of agents templates … cached globally … first Chip as `View All` … expand full catalog of all Agents we have in the repo and also all agent templates user created before."
+
+This spec records that instruction end-to-end so it can be implemented without re-deriving the intent.
+
+---
+
+## 2. User Scenarios
+
+### 2.1 Primary scenarios
+
+**S1 — Create an Agent from a free-text prompt.**
+_Given_ a signed-in user on `/agents`,
+_When_ they type _"PR triage agent that labels new community PRs and suggests reviewers"_ into the prompt composer and press ⏎ (or click Send),
+_Then_ the chat side-panel opens with the message `I want to create a Agent. PR triage agent…` already sent, the user is routed to the Agent Canvas (`/agents/new`), and from there the chat AI guides creation while the Canvas form stays editable in parallel. (Mirrors `NewPageClient` agent-chip behaviour exactly.)
+
+**S2 — Fall back to the manual wizard.**
+_Given_ the same page,
+_When_ the user ignores the prompt and clicks **`+ Create Agent Manually`** in the `Or` block,
+_Then_ they land on the existing `NewAgentDialog` wizard at `/agents/new`.
+
+**S3 — Quick-pick a template via a chip.**
+_Given_ the chip row under the prompt shows `View All · CEO · CTO · Lead Engineer · Copywriter · Sales · Brand Specialist · …`,
+_When_ the user clicks the **CTO** chip,
+_Then_ the prompt input is seeded with a CTO-flavoured starter (the template's title + one-line description) and focused so the user can elaborate, and the chip row does not retain a persistent "selected" highlight.
+
+**S4 — Browse the full catalog.**
+_Given_ the chip row,
+_When_ the user clicks the first chip **`View All`**,
+_Then_ an inline panel expands below the composer showing two sections: **All templates** (every entry from `ever-works/agents`) and **Your templates** (Agents the user created before / saved as templates), each a responsive card grid. Clicking a card seeds the prompt (S3) or routes to the manual wizard pre-filled with that template (`/agents/new?from=<slug>`), and the panel collapses. Clicking `View All` again collapses the panel.
+
+**S5 — Instant chips on a cold page.**
+_Given_ a user opening `/agents` for the first time in a session,
+_When_ the page renders,
+_Then_ the template chips appear without a perceptible loading delay because the catalog is served from a globally-shared cache (server: `cache_entries`, 1h TTL per ADR-011; client: a module-level in-memory cache + revalidate).
+
+**S6 — Start the manual wizard from a template.**
+_Given_ the user clicked `+ Create Agent Manually`,
+_When_ the wizard opens,
+_Then_ its first (optional) step lists the same templates with a prominent **"Start from scratch"** escape hatch; picking a template pre-fills the name + title and advances to the scope step.
+
+**S7 — Fresh account, Mission-scope, no Missions (the bug today).**
+_Given_ a brand-new user with zero Missions/Works/Ideas in the manual wizard,
+_When_ they select the **Mission** scope and look for a way forward,
+_Then_ they see a clear inline explanation ("You don't have any Missions yet — create one first, or choose Workspace scope"), the disabled **Next** button carries a tooltip explaining why it's disabled, and choosing **Workspace** scope (always available) lets them proceed. (Today: Next is silently disabled with no path forward — see §E1.)
+
+### 2.2 Edge cases & failures
+
+**E1 — Wizard dead-end (the reported bug).** On `develop` today, selecting a non-`tenant` scope when the corresponding catalog is empty renders no parent `<select>` (it only renders when `parentOptions.length > 0`, [`NewAgentDialog.tsx:255`](../../../apps/web/src/components/agents/NewAgentDialog.tsx)), so `parentId` can never be set, `canAdvance` stays `false` ([`:173`](../../../apps/web/src/components/agents/NewAgentDialog.tsx)), and the **Next** button is permanently disabled with no feedback. The user perceives "clicking Next does nothing." **MUST be fixed** (FR-20).
+
+**E2 — Catalog unreachable.** If `ever-works/agents` can't be fetched and the cache is cold, the chip row degrades to the built-in fallback list (still includes CEO/CTO/… so the feature is never empty) and `View All` shows only "Your templates". No error toast; a subtle "Showing built-in templates" note is acceptable. (Mirrors ADR-011 §Consequences/Negative mitigation.)
+
+**E3 — User has no saved templates.** The `View All` panel's "Your templates" section renders an empty-state nudge ("Agents you create can be saved as templates and will appear here") rather than an empty grid.
+
+**E4 — Prompt too short.** The composer enforces the same min-length guard the other surfaces use (`< 10` chars → inline toast `hints.minLength`), so a stray ⏎ on an empty box doesn't dispatch a chat message.
+
+**E5 — Chip seed overwrites a typed prompt.** If the user already typed something and then clicks a chip, the seed is **appended/merged**, not destructively replaced, OR a confirm is skipped in favour of prepending the role label — see [plan.md §Chip seed semantics](./plan.md). Default: if the box is empty, seed fully; if non-empty, prepend the role label only (`CTO — <existing text>`).
+
+**E6 — Locale without translated strings.** New UI strings ship in all 21 `apps/web/messages/*.json` locale files (English placeholder values where not yet translated) so non-`en` locales don't hit missing-message fallbacks.
+
+---
+
+## 3. Functional Requirements
+
+Numbered, atomic, testable. `MUST` / `SHOULD` / `MUST NOT` per Spec Kit convention.
+
+### 3.1 Prompt-first surface on `/agents`
+
+- **FR-1** The `/agents` page MUST render a `PromptComposer` above the Agent list, using the shared component (`@/components/common/PromptComposer`) — the same primitive Missions/Ideas/`/new` use.
+- **FR-2** The composer MUST cycle Agent-specific placeholder examples (reuse the four agent placeholders already defined in `NewPageClient` `PLACEHOLDERS_BY_CHIP.agent`).
+- **FR-3** On submit the page MUST call `useStartFromPrompt()(description, { intent: 'Agent', attachments })` and then `router.push(ROUTES.DASHBOARD_AGENT_NEW)` — i.e. dispatch the prompt into the chat AI and route to the Agent Canvas. It MUST NOT re-create the Agent twice or pass `?prompt=` to the canvas.
+- **FR-4** The composer MUST enforce the shared `< 10`-char min-length guard before dispatching.
+- **FR-5** The composer MUST support attachments via the existing `+` affordance and forward them through `buildAttachmentRefs`.
+- **FR-6** The Agent list (cards grid + empty state) MUST continue to render below the new surface, unchanged in behaviour.
+
+### 3.2 `Or` block + manual button
+
+- **FR-7** The page MUST render an **`Or`** divider between the prompt-first surface and a manual-create affordance, visually consistent with the Works page treatment.
+- **FR-8** The former header button labelled `+ New Agent` MUST be relabelled **`+ Create Agent Manually`** and MUST live in the `Or` block (not the page header). It MUST route to `ROUTES.DASHBOARD_AGENT_NEW` (the existing wizard).
+- **FR-9** No other entry point to the wizard is removed — sidebar, deep links, and `/agents/new` direct navigation MUST all keep working.
+
+### 3.3 Template chips
+
+- **FR-10** Below the prompt input the page MUST render a horizontally-scrolling chip row using the shared `PromptChipsRow` look-and-feel (arrow paging, edge gradients, keyboard a11y).
+- **FR-11** The chip row's **first** chip MUST be **`View All`** (distinct icon, e.g. `LayoutGrid`).
+- **FR-12** Subsequent chips MUST be agent-template names from the catalog (`CEO`, `CTO`, `Lead Engineer`, `Copywriter`, `Sales`, `Brand Specialist`, …), in catalog order.
+- **FR-13** Clicking a template chip MUST seed the prompt (per §E5 semantics) and focus the composer input. It MUST NOT immediately create an Agent and MUST NOT leave a persistent selected-chip highlight.
+- **FR-14** Clicking `View All` MUST toggle an inline catalog panel (FR-16). While open, `View All` MAY render as the active chip.
+- **FR-15** The catalog used for chips MUST come from `listAstTemplates('agent')` (the stable client helper), which returns repo data when available and a built-in fallback otherwise (E2). Chips MUST render from cache with no perceptible delay (FR-30/NFR-1).
+
+### 3.4 `View All` catalog panel
+
+- **FR-16** Expanding `View All` MUST show two labelled sections: **All templates** (catalog entries from `ever-works/agents`) and **Your templates** (Agents the signed-in user created before / saved as templates).
+- **FR-17** Each catalog entry MUST render as a card (icon + title + one-line description + optional category tag). Clicking a card MUST either seed the prompt (default) or route to `/agents/new?from=<slug>` (the wizard pre-fill path the dialog already supports), then collapse the panel.
+- **FR-18** The "Your templates" section MUST render an empty-state nudge when the user has none (E3).
+- **FR-19** The panel MUST be keyboard-navigable and dismissible (collapse via `View All` or `Esc`).
+
+### 3.5 Wizard fix + optional template step
+
+- **FR-20** The `NewAgentDialog` MUST NOT present a dead-end: when a non-`tenant` scope is selected but has zero parent candidates, the dialog MUST (a) show an inline explanation, (b) give the disabled **Next** a `title`/tooltip stating why it's disabled, and (c) keep **Workspace** scope selectable so the user can always advance.
+- **FR-21** The dialog SHOULD surface a one-line helper near the **Next** button whenever `!canAdvance`, telling the user what to do (pick a parent, or switch to Workspace).
+- **FR-22** The fix MUST NOT change the happy path: with the default `tenant` scope, **Next** stays enabled and advances exactly as today.
+- **FR-23** The wizard MUST gain an **optional** template-selection step shown first (skipped when the dialog is `pinned` to a scope-parent). It MUST list the same `agent` templates as the chips plus a prominent **"Start from scratch"** option.
+- **FR-24** Selecting a template in the wizard MUST pre-fill `name` (template title) and `title` (template description, truncated) and advance to the scope step. "Start from scratch" MUST advance with empty fields.
+- **FR-25** The existing `?from=<slug>` deep-link behaviour (pre-fill from the `/agents/templates` browser) MUST continue to work.
+
+### 3.6 Catalog source, caching, and backend
+
+- **FR-26** Agent templates MUST be sourced from the [`ever-works/agents`](https://github.com/ever-works/agents) repo per [ADR-011](../../decisions/011-agent-templates-in-separate-repo.md) — **not** hard-coded in the platform monorepo as the long-term source ([ADR-014](../../decisions/014-no-hardcoded-catalogs.md)). The built-in list in `agent-templates.ts` is an explicitly-documented fallback bridge only (E2), not the source of truth.
+- **FR-27** The backend MUST expose `GET /agent-templates?entity=agent` (auth-optional read) returning the catalog as `AstTemplateEntry[]` (stable shape already defined in `agent-templates.ts`), backed by an `AgentTemplateService` that `git clone --depth 1`s the repo (pinned by `EVER_WORKS_AGENTS_REF`, default `main`; local override `EVER_WORKS_AGENTS_PATH`), caches the parsed list in `cache_entries` for 1h, and validates each template folder against a schema (bad folders skipped with a warning).
+- **FR-28** `listAstTemplates('agent')` MUST be swapped to call the new endpoint (via a server action so the web client bundle stays clean — see the note in `agent-templates.ts`) while keeping its return type stable so the chips, the `View All` panel, and the wizard step need no change when the swap lands.
+- **FR-29** "Your templates" MUST be sourced from the user's existing Agents (and, when the save-as-template capability lands, explicitly-saved templates). v1 MAY derive it from `agentsAPI.list()` filtered to a `isTemplate`/draft marker; the exact source is a [plan.md](./plan.md) decision, but the UI contract (a list of `AstTemplateEntry`-shaped cards) is fixed here.
+- **FR-30** The client MUST cache the catalog globally for the session (module-level cache keyed by entity type) so re-renders and route revisits don't refetch within the TTL.
+
+---
+
+## 4. Non-Functional Requirements
+
+- **NFR-1** Template chips MUST paint within the first render of `/agents` (server-fetched + passed as props, or hydrated from the global cache) — no spinner on the chip row in the common case.
+- **NFR-2** The prompt-first surface MUST NOT regress `/agents` server-render time meaningfully; the template fetch MUST be defensive (`.catch(() => fallback)`) so a flaky catalog never 500s the page (mirrors the existing `agentsAPI.list().catch(...)`).
+- **NFR-3** The `AgentTemplateService` clone/cache MUST be resilient: cold cache + unreachable repo → fallback, never a hard failure (E2). Network calls MUST have a timeout.
+- **NFR-4** All new user-facing strings MUST exist in every `apps/web/messages/*.json` locale file (E6).
+- **NFR-5** No secrets/credentials are introduced; the repo clone is public/unauthenticated read (NN #6 — credentials assumed handled; nothing logged).
+- **NFR-6** Accessibility: chips and catalog cards MUST be keyboard-operable and screen-reader labelled, consistent with `PromptChipsRow`'s existing a11y.
+
+---
+
+## 5. Key Entities & Domain Concepts
+
+| Concept                    | One-line definition                                                                                                                                                                          |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Prompt-first surface**   | The `PromptComposer` + chips block at the top of `/agents` that turns a free-text description into a chat-driven Agent build.                                                                |
+| **`Or` block**             | A divider + `+ Create Agent Manually` button offering the manual wizard as the explicit alternative to the prompt.                                                                           |
+| **Agent template**         | A reusable Agent definition (`agent.yml` + `SOUL.md`/`AGENTS.md`/`HEARTBEAT.md`/`TOOLS.md`) living in `ever-works/agents`; surfaced as a chip and a catalog card. Shape: `AstTemplateEntry`. |
+| **Template chip**          | A quick-pick pill (`CEO`, `CTO`, …) that seeds the prompt. The first chip `View All` instead expands the catalog.                                                                            |
+| **`View All` catalog**     | The inline expand showing all repo templates + the user's own templates.                                                                                                                     |
+| **`AgentTemplateService`** | The backend service that clones + caches `ever-works/agents` and serves the catalog (ADR-011).                                                                                               |
+
+---
+
+## 6. Out of Scope (this slice)
+
+- A full standalone "Hire an Agent" marketplace with search, ratings, install counts (the broader catalog vision; this slice only adds chips + an inline `View All`). Tracked separately under [`features/agents/spec.md §6`](../agents/spec.md).
+- The community-contribution / PR-review lifecycle of `ever-works/agents` (curation policy, schema CI, tagged releases) — owned by ADR-011 ops notes, not this UX slice.
+- A "save this Agent as a template" authoring flow. v1 derives "Your templates" from existing Agents; explicit save-as-template is a follow-up (FR-29 leaves the hook).
+- Changing what an Agent _is_, its runtime, scope cascade, budgets, or detail tabs.
+
+---
+
+## 7. Acceptance Criteria
+
+- [ ] `/agents` shows a prompt composer; submitting a ≥10-char prompt opens chat with `I want to create a Agent. …` and routes to `/agents/new`.
+- [ ] The header no longer shows `+ New Agent`; an `Or` block shows `+ Create Agent Manually` routing to the wizard.
+- [ ] A chip row renders under the prompt with `View All` first, then `CEO/CTO/Lead Engineer/Copywriter/Sales/Brand Specialist/…`; clicking a template chip seeds + focuses the prompt.
+- [ ] Clicking `View All` expands a catalog with "All templates" + "Your templates"; clicking a card seeds the prompt (or opens the wizard pre-filled) and collapses the panel.
+- [ ] Chips render with no spinner on a warm cache; with the catalog unreachable, built-in fallback chips still render.
+- [ ] In the wizard, selecting Mission scope with zero Missions shows a clear hint + disabled-Next tooltip, and Workspace scope still advances. The `tenant` happy path is unchanged.
+- [ ] The wizard's optional template step lists templates + "Start from scratch"; picking one pre-fills name/title and advances; `?from=<slug>` still pre-fills.
+- [ ] `GET /agent-templates?entity=agent` returns the catalog; `listAstTemplates('agent')` consumes it with the fallback intact; all existing Agent tests still pass.
+- [ ] New strings exist in all 21 locale files.
+
+---
+
+## 8. Open Questions
+
+- **[NEEDS CLARIFICATION: Q1]** Chip seed semantics when the prompt box is non-empty — prepend role label vs. append vs. replace-with-confirm. **Default for v1:** seed fully if empty, prepend `"<Role> — "` if non-empty (E5).
+- **[NEEDS CLARIFICATION: Q2]** "Your templates" source in v1 — derive from `agentsAPI.list()` (all the user's Agents as re-usable starting points) vs. only Agents explicitly marked `isTemplate`. **Default:** show the user's existing Agents as starting points; refine when save-as-template ships (FR-29).
+- **[NEEDS CLARIFICATION: Q3]** Does clicking a catalog card seed the prompt or jump straight to the wizard pre-filled? **Default:** seed the prompt (keeps the prompt-first flow primary); offer a secondary "Open in wizard" affordance on the card.
+- **[RESOLVED: Q4]** The `ever-works/agents` repo has been created + seeded (separate agent; private, with a `manifest.json` index). The backend (`AgentTemplateCatalogService` + `GET /api/agent-templates`) reads it live and falls back to the built-in list. **No new secret is required:** the service reuses the platform's existing GitHub App (the same App that creates repos in the `ever-works` org) via `GitFacadeService.getInstallationTokenForOwner('ever-works')`. `EVER_WORKS_AGENTS_TOKEN` / `GITHUB_TOKEN` remain as an optional override for self-hosted installs that don't run the App. If the App isn't installed on the `ever-works` org and no override is set, chips render the built-in fallback.
+
+## 9. Constitution Gates
+
+- [x] **I — Plugin-First**. No new plugin. Reuses AI facade + chat. `AgentTemplateService` is a core service (cold-path catalog read), consistent with ADR-011.
+- [x] **III — Source-of-Truth Repositories**. Templates live in `ever-works/agents`, not the monorepo (ADR-011/014). Fallback is a documented bridge only.
+- [x] **V — Forward-Only Migrations**. No schema change required (reuses existing `cache_entries`); if any column is added for "Your templates" it ships with an additive migration (NN #16).
+- [x] **IX — Behaviour-First Specs**. This spec is behaviour; implementation is in plan.md.
+- [x] **X — Backwards Compatibility**. Additive only; the wizard and `/agents/templates` browser stay; one button is relabelled/repositioned per explicit operator request.
+
+## 10. References
+
+- Plan: [`./plan.md`](./plan.md)
+- Tasks: [`./tasks.md`](./tasks.md)
+- Parent feature: [`../agents/spec.md`](../agents/spec.md)
+- Prompt-first precedent: [`../missions-ideas-works/spec.md`](../missions-ideas-works/spec.md)
+- ADR-011 (agent templates repo): [`../../decisions/011-agent-templates-in-separate-repo.md`](../../decisions/011-agent-templates-in-separate-repo.md)
+- ADR-014 (no hardcoded catalogs): [`../../decisions/014-no-hardcoded-catalogs.md`](../../decisions/014-no-hardcoded-catalogs.md)

--- a/docs/specs/features/agent-prompt-first-creation/tasks.md
+++ b/docs/specs/features/agent-prompt-first-creation/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: Agent prompt-first creation & template chips
+
+Tracks [spec.md](./spec.md) / [plan.md](./plan.md). Jira Epic [EW-705](https://evertech.atlassian.net/browse/EW-705) + child stories EW-706…EW-709 (see the Epic for live status). `[x]` = landed on `develop`.
+
+## Story 1 — Prompt-first `/agents` page + `Or` block (FR-1…FR-9) — [EW-706](https://evertech.atlassian.net/browse/EW-706)
+
+- [ ] T1.1 `agents/page.tsx`: fetch `listAstTemplates('agent')` (defensive) + pass to `AgentsList`.
+- [ ] T1.2 `AgentsList.tsx`: add `PromptComposer` with agent placeholders; `submit()` → `startFromPrompt(intent:'Agent')` + `router.push(DASHBOARD_AGENT_NEW)`; min-length 10; attachments via `buildAttachmentRefs`.
+- [ ] T1.3 Move `+ New Agent` out of the header → `Or` block as `+ Create Agent Manually` (→ `DASHBOARD_AGENT_NEW`).
+- [ ] T1.4 Auto-collapse chat panel on mount; keep cards grid + empty-state below.
+- [ ] T1.5 Unit + e2e smoke (composer renders, manual button routes).
+
+## Story 2 — Template chips + `View All` catalog (FR-10…FR-19) — [EW-707](https://evertech.atlassian.net/browse/EW-707)
+
+- [ ] T2.1 `AgentTemplateChips.tsx`: `PromptChipsRow` with `View All` first + template chips; chip click → `onPick`; `View All` toggles panel.
+- [ ] T2.2 `View All` panel: "All templates" + "Your templates" card grids; card click seeds prompt (+ "Open in wizard" secondary); `Esc` collapses.
+- [ ] T2.3 Wire `AgentTemplateChips` into `AgentsList.chipsBelow`; implement chip-seed semantics (empty→full, non-empty→prepend role).
+- [ ] T2.4 "Your templates" source from `agentsAPI.list()` (Q2 default) + empty-state nudge.
+- [ ] T2.5 Unit tests.
+
+## Story 3 — Wizard `Next` fix + optional template step (FR-20…FR-25) — [EW-708](https://evertech.atlassian.net/browse/EW-708)
+
+- [ ] T3.1 Fix dead-end: inline hint + disabled-Next `title` + Workspace always advances; tenant happy path unchanged.
+- [ ] T3.2 Step machine `'template' | 'scope' | 'details'`; initial `pinned ? 'details' : (templates.length ? 'template' : 'scope')`.
+- [ ] T3.3 Template step UI: card grid + "Start from scratch"; select → prefill name/title → scope step; preserve `?from=<slug>`.
+- [ ] T3.4 `/agents/new/page.tsx`: pass `templates`.
+- [ ] T3.5 Unit tests (happy path, empty-scope, template prefill, pinned skip).
+
+## Story 4 — Catalog backend: `AgentTemplateService` + endpoint (FR-26…FR-30) — [EW-709](https://evertech.atlassian.net/browse/EW-709)
+
+> **Implemented in PR [#1131](https://github.com/ever-works/ever-works/pull/1131).** The `ever-works/agents` repo now exists (private, `manifest.json` index). `AgentTemplateCatalogService` reads the manifest (not a folder walk), so the backend was simpler than the original clone-and-walk plan.
+
+- [x] T4.1 Extend `agent-templates.ts` fallback with CEO/CTO/Lead Engineer/Copywriter/Sales/Brand Specialist (+ keep existing) and add session catalog cache.
+- [x] T4.2 `AgentTemplateCatalogService`: read `manifest.json` from `ever-works/agents` via `GitFacadeService` (`EVER_WORKS_AGENTS_REF`, default `main`), map `templates[]` → `AstTemplateEntry`, cache in `cache_entries` 1h, fallback→[] on any failure.
+- [x] T4.3 `GET /api/agent-templates?entity=agent` controller (`@Public()` read) → service, wired into `AgentsModule`.
+- [x] T4.4 `server-only` `fetchAgentTemplateCatalog()` helper (used by `/agents` + `/agents/new` server pages) calling the endpoint with built-in fallback on error. `agent-templates.ts` stays isomorphic for client imports.
+- [x] T4.5 Backend Jest tests (cache-hit / no-token / repo-throw / malformed-manifest / missing-file / invalid-row-drop).
+- [x] T4.6 ~~Operator action (Q4): create + seed `ever-works/agents`~~ — **done** (seeded by a separate agent; repo is private).
+- [x] T4.7 Token resolution reuses the platform GitHub App installation on the `ever-works` org (`getInstallationTokenForOwner`) — no new secret. `EVER_WORKS_AGENTS_TOKEN`/`GITHUB_TOKEN` env is an optional self-hosted override. (Live data requires the App to be installed on the `ever-works` org, which it already is for repo creation.)
+
+## Cross-cutting
+
+- [x] X.1 i18n: new keys added to `en.json`. The loader does `deepmerge(en, locale)`, so every locale inherits them with English fallback — and the non-English files carry pre-existing duplicate keys, so a full round-trip would drop translations. Per-locale translation is a separate pass.
+- [ ] X.2 `pnpm lint && pnpm type-check` clean for touched packages.
+- [ ] X.3 Drive PR(s) through bot review + CI green (NN #14/#18/#19).
+
+## Open decisions (mirror spec §8)
+
+- Q1 chip-seed semantics (default: empty→full, non-empty→prepend role).
+- Q2 "Your templates" source (default: user's existing Agents).
+- Q3 catalog card → seed vs. wizard (default: seed; secondary "Open in wizard").
+- Q4 create/seed `ever-works/agents` now? (operator decision — shared state).

--- a/packages/agent/src/database/repositories/github-app-installation.repository.ts
+++ b/packages/agent/src/database/repositories/github-app-installation.repository.ts
@@ -31,6 +31,19 @@ export class GitHubAppInstallationRepository {
         return this.repository.findOne({ where: { installationId } });
     }
 
+    /**
+     * Find the active (not deleted, not suspended) GitHub App installation
+     * for an account login (org or user) — e.g. the `ever-works` org's
+     * installation. Used for system-level reads of org-owned repos
+     * (agent-template catalog) without a Work context. Newest first.
+     */
+    async findActiveByAccountLogin(accountLogin: string): Promise<GitHubAppInstallation | null> {
+        return this.repository.findOne({
+            where: { accountLogin, deletedAt: IsNull(), suspendedAt: IsNull() },
+            order: { createdAt: 'DESC' },
+        });
+    }
+
     async listAll(): Promise<GitHubAppInstallation[]> {
         return this.repository.find({
             order: {

--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -1030,6 +1030,25 @@ export class GitFacadeService implements IGitFacade {
         throw new GitProviderNotFoundError(providerId);
     }
 
+    /**
+     * System-level installation token for an org/user login (no Work
+     * context). Reuses the platform GitHub App: looks up the active
+     * installation for `ownerLogin` (e.g. the `ever-works` org — the
+     * same App that lets the platform create repos there) and mints an
+     * installation access token. Returns null when the App isn't
+     * installed on that account or app credentials are unset, so callers
+     * can fall back to other auth. Used for reading org-owned catalog
+     * repos like `ever-works/agents` from system endpoints.
+     */
+    async getInstallationTokenForOwner(ownerLogin: string): Promise<string | null> {
+        const installation =
+            await this.gitHubAppInstallationRepository.findActiveByAccountLogin(ownerLogin);
+        if (!installation || installation.deletedAt || installation.suspendedAt) {
+            return null;
+        }
+        return this.createGitHubAppInstallationToken(installation.installationId);
+    }
+
     private async getInstallationTokenForWork(options: GitFacadeOptions): Promise<string | null> {
         if (!options.workId || options.providerId !== 'github') {
             return null;

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -1245,10 +1245,15 @@ describe('KnowledgeBaseService', () => {
             storage.putObject.mockResolvedValue({ key: 'kb-originals/freeform/abc.bin', url: '' });
             const uploadRow = buildUpload({ mimeType: 'application/pdf' });
             uploadRepo.create.mockResolvedValue(uploadRow);
-            uploadRepo.update.mockResolvedValue({
+            const skippedRow = {
                 ...uploadRow,
                 extractionStatus: 'skipped' as KbUploadExtractionStatus,
-            });
+            };
+            uploadRepo.update.mockResolvedValue(skippedRow);
+            // The terminal-state re-read at the bottom of createUpload —
+            // ensures `result.upload` reflects the post-extract status
+            // ('skipped'), not the create-time status ('running').
+            uploadRepo.findById.mockResolvedValueOnce(skippedRow);
 
             const result = await service.createUpload({
                 ...buildUploadInput({ mimeType: 'application/pdf', originalFilename: 'spec.pdf' }),
@@ -1256,10 +1261,16 @@ describe('KnowledgeBaseService', () => {
             });
 
             expect(result.document).toBeNull();
+            // Without the terminal re-read the response would carry the
+            // 'running' row from uploadRepo.create — the e2e A16 suite
+            // (kb-extraction-retry.spec.ts:81) asserts on this field
+            // directly, no settle-poll.
+            expect(result.upload.extractionStatus).toBe('skipped');
             expect(uploadRepo.update).toHaveBeenCalledWith(
                 uploadRow.id,
                 expect.objectContaining({ extractionStatus: 'skipped' }),
             );
+            expect(uploadRepo.findById).toHaveBeenCalledWith(WORK_ID, uploadRow.id);
             const kinds = activityLog.log.mock.calls.map(
                 (c) => (c[0] as { actionType: string }).actionType,
             );

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -1363,8 +1363,10 @@ export class KnowledgeBaseService {
         // extract path updates the row but returns only the document, so
         // `current` still carries the pre-extract RUNNING status. Re-read
         // so callers (and the API response) see the terminal state.
-        const refreshed = await this.uploadRepository.findById(workId, upload.id);
-        return { upload: refreshed ?? current, document };
+        // (Named `terminalUpload` to avoid shadowing the `refreshed` const
+        // from the earlier RUNNING-write at line 1342.)
+        const terminalUpload = await this.uploadRepository.findById(workId, upload.id);
+        return { upload: terminalUpload ?? current, document };
     }
 
     /**

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -1296,7 +1296,14 @@ export class KnowledgeBaseService {
         );
 
         const document = await this.extractAndMaterialize(upload, input);
-        return { upload, document };
+        // `upload` above was returned from `uploadRepository.create` with
+        // `extractionStatus = RUNNING`. `extractAndMaterialize` mutates the
+        // row in-place to SUCCEEDED / SKIPPED / FAILED but only returns the
+        // document. Without this re-read the API response carries the stale
+        // RUNNING value, which trips the e2e A16 suite (it asserts on the
+        // create-response shape directly, no settle-poll).
+        const refreshed = await this.uploadRepository.findById(input.workId, upload.id);
+        return { upload: refreshed ?? upload, document };
     }
 
     /**
@@ -1352,7 +1359,12 @@ export class KnowledgeBaseService {
             description: null,
             title: undefined,
         });
-        return { upload: current, document };
+        // Same stale-state hazard as createUpload (see comment there): the
+        // extract path updates the row but returns only the document, so
+        // `current` still carries the pre-extract RUNNING status. Re-read
+        // so callers (and the API response) see the terminal state.
+        const refreshed = await this.uploadRepository.findById(workId, upload.id);
+        return { upload: refreshed ?? current, document };
     }
 
     /**


### PR DESCRIPTION
## Summary
Cascade `stage` -> `main` to ship #1138 (KB stale-extraction fix).

## Source
- #1138 merged to develop at `0f6368a3`
- #1139 merged develop -> stage at `13f64b43`

## CI notes
- Build/lint/test green on source PR. e2e shard 2 fails on pre-existing KB-extraction cascade (`seedKbBinaryDoc 500`, `pollForSkippedRows`); orthogonal to this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)