### PR TITLE
fix(deploy): bump api memory limit to 4Gi so new image can boot

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -289,10 +289,10 @@ spec:
 
           resources:
             requests:
-              memory: "512Mi"
+              memory: "1Gi"
               cpu: "500m"
             limits:
-              memory: "2Gi"
+              memory: "4Gi"
               cpu: "2"
 
           ports:

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -299,10 +299,10 @@ spec:
 
           resources:
             requests:
-              memory: "512Mi"
+              memory: "1Gi"
               cpu: "500m"
             limits:
-              memory: "2Gi"
+              memory: "4Gi"
               cpu: "2"
 
           ports:

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -287,10 +287,10 @@ spec:
 
           resources:
             requests:
-              memory: "512Mi"
+              memory: "1Gi"
               cpu: "500m"
             limits:
-              memory: "2Gi"
+              memory: "4Gi"
               cpu: "2"
 
           ports:


### PR DESCRIPTION
## Summary
- The new `ever-works-api` image OOMKills (exit 137) at the 2Gi container limit during NestJS boot — never passes the startup probe. k8s keeps the older replica serving traffic; that replica predates the AgentsController, so `POST /api/agents` returns 404 and "Create Agent" from `/works/[id]/agents/new` fails for users.
- Bumps `limits.memory` 2Gi → 4Gi and `requests.memory` 512Mi → 1Gi on the `ever-works-api` container in prod, stage, and dev manifests. Web and MCP containers are untouched.
- Investigating *why* startup needs > 2 GiB now is a separate follow-up — this PR is the unblock.

## Evidence
- Live `curl -X POST https://api.ever.works/api/agents` → `404 {"message":"Cannot POST /api/agents"}`; `/api/works` returns `401` (route exists, needs auth) — confirms the live API binary doesn't have the AgentsController.
- `kubectl describe pod ever-works-api-59c7469c66-mzclv`: `Reason: OOMKilled`, `Exit Code: 137`, `Restart Count: 22`.
- All three envs (`ever-works-api`, `ever-works-api-stage`, `ever-works-api-dev`) are CrashLoopBackOff on the new image.
- Web pod log: `Error [ApiResponseError]: Cannot POST /api/agents at .../works/[id]/agents/new/page.js` — confirms the user-visible failure traces back to the upstream 404.

## Test plan
- [x] Diff verified — only `ever-works-api` resources block changed in each manifest (web/mcp untouched)
- [ ] After merge → develop → stage → main, watch `ever-works-api*` pods come up `Ready 1/1`
- [ ] Probe `curl -X POST https://api.ever.works/api/agents` returns `401` (route present, needs auth), not `404`
- [ ] Repro the original UI flow: `/works/<id>/agents/new` → fill name → Create → land on `/agents/<id>` without the "Server Components render" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for API deployments across development, staging, and production environments to improve application performance and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->