### PR TITLE
chore: cascade stage → main (per-concept colors across all pages)

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
@@ -29,7 +29,7 @@ export default async function TasksPage() {
                 icon={ListChecks}
                 title={t('title')}
                 subtitle={t('subtitle')}
-                tone="info"
+                tone="task"
                 actions={
                     <Button href={ROUTES.DASHBOARD_TASK_NEW} size="sm" className="gap-1.5 shrink-0">
                         <Plus className="w-3.5 h-3.5" />

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -259,7 +259,7 @@ export default function NewWorkClient({
                     icon={FolderKanban}
                     title={t('title')}
                     subtitle={t('subtitle')}
-                    tone="accent"
+                    tone="work"
                 />
 
                 <PromptComposer

--- a/apps/web/src/app/[locale]/(dashboard)/works/works-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/works-client.tsx
@@ -234,7 +234,7 @@ export default function WorksClient({ initialWorks, totalWorks, initialStats }: 
                 icon={FolderKanban}
                 title={t('title')}
                 subtitle={t('subtitle')}
-                tone="accent"
+                tone="work"
                 actions={
                     <div className="flex flex-wrap gap-2">
                         {summaryCards.map((card) => (

--- a/apps/web/src/components/agents/AgentCard.tsx
+++ b/apps/web/src/components/agents/AgentCard.tsx
@@ -52,11 +52,13 @@ export function AgentCard({ agent }: { agent: Agent }) {
             className="group block rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 hover:border-border dark:hover:border-border-dark transition-colors"
         >
             <div className="flex items-start gap-3">
-                <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-concept-agents/10 border border-concept-agents/20 flex items-center justify-center">
                     {agent.avatarMode === 'initials' ? (
-                        <span className="text-xs font-semibold text-primary">{initials}</span>
+                        <span className="text-xs font-semibold text-concept-agents">
+                            {initials}
+                        </span>
                     ) : (
-                        <Bot className="w-4 h-4 text-primary" />
+                        <Bot className="w-4 h-4 text-concept-agents" />
                     )}
                 </div>
                 <div className="min-w-0 flex-1">

--- a/apps/web/src/components/agents/AgentsList.tsx
+++ b/apps/web/src/components/agents/AgentsList.tsx
@@ -97,7 +97,7 @@ export function AgentsList({ agents, templates = [], userTemplates = [] }: Agent
 
     return (
         <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
-            <PageHeader icon={Bot} title={t('title')} subtitle={t('subtitle')} tone="primary" />
+            <PageHeader icon={Bot} title={t('title')} subtitle={t('subtitle')} tone="agent" />
 
             {/* Prompt-first surface — describe the Agent you want. Chips
                 with quick-pick templates + `View All` render below the

--- a/apps/web/src/components/agents/NewAgentDialog.tsx
+++ b/apps/web/src/components/agents/NewAgentDialog.tsx
@@ -238,8 +238,8 @@ export function NewAgentDialog({
     return (
         <div className="max-w-xl mx-auto p-6">
             <div className="flex items-center gap-3 mb-6">
-                <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
-                    <Bot className="w-4 h-4 text-primary" />
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-concept-agents/10 border border-concept-agents/20 flex items-center justify-center">
+                    <Bot className="w-4 h-4 text-concept-agents" />
                 </div>
                 <h1 className="text-xl font-semibold text-text dark:text-text-dark">
                     {t('title')}

--- a/apps/web/src/components/common/PageHeader.tsx
+++ b/apps/web/src/components/common/PageHeader.tsx
@@ -12,7 +12,18 @@ import { cn } from '@/lib/utils/cn';
  * right side of the header row (e.g. "+ New X" CTA) and stays
  * pinned right when the title block shrinks.
  */
-export type PageHeaderTone = 'primary' | 'success' | 'info' | 'warning' | 'danger' | 'accent';
+export type PageHeaderTone =
+    | 'primary'
+    | 'success'
+    | 'info'
+    | 'warning'
+    | 'danger'
+    | 'accent'
+    | 'mission'
+    | 'idea'
+    | 'work'
+    | 'task'
+    | 'agent';
 
 interface PageHeaderProps {
     icon: LucideIcon;
@@ -53,6 +64,31 @@ const toneClasses: Record<PageHeaderTone, { bg: string; border: string; text: st
         bg: 'bg-accent-indigo/10',
         border: 'border-accent-indigo/20',
         text: 'text-accent-indigo',
+    },
+    mission: {
+        bg: 'bg-concept-missions/10',
+        border: 'border-concept-missions/20',
+        text: 'text-concept-missions',
+    },
+    idea: {
+        bg: 'bg-concept-ideas/10',
+        border: 'border-concept-ideas/20',
+        text: 'text-concept-ideas',
+    },
+    work: {
+        bg: 'bg-concept-works/10',
+        border: 'border-concept-works/20',
+        text: 'text-concept-works',
+    },
+    task: {
+        bg: 'bg-concept-tasks/10',
+        border: 'border-concept-tasks/20',
+        text: 'text-concept-tasks',
+    },
+    agent: {
+        bg: 'bg-concept-agents/10',
+        border: 'border-concept-agents/20',
+        text: 'text-concept-agents',
     },
 };
 

--- a/apps/web/src/components/dashboard/AgentsCountTile.tsx
+++ b/apps/web/src/components/dashboard/AgentsCountTile.tsx
@@ -13,11 +13,11 @@ export function AgentsCountTile({ total, active }: { total: number; active: numb
     return (
         <Link
             href={ROUTES.DASHBOARD_AGENTS}
-            className="group block rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 hover:border-primary/40 transition-colors"
+            className="group block rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 hover:border-concept-agents/40 transition-colors"
         >
             <div className="flex items-start gap-3">
-                <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
-                    <Bot className="w-4 h-4 text-primary" />
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-concept-agents/10 border border-concept-agents/20 flex items-center justify-center">
+                    <Bot className="w-4 h-4 text-concept-agents" />
                 </div>
                 <div className="min-w-0 flex-1">
                     <h3 className="text-xs text-text-secondary dark:text-text-secondary-dark uppercase tracking-wide">

--- a/apps/web/src/components/dashboard/TasksInProgressTile.tsx
+++ b/apps/web/src/components/dashboard/TasksInProgressTile.tsx
@@ -18,11 +18,11 @@ export function TasksInProgressTile({
     return (
         <Link
             href={`${ROUTES.DASHBOARD_TASKS}`}
-            className="group block rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 hover:border-info/40 transition-colors"
+            className="group block rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 hover:border-concept-tasks/40 transition-colors"
         >
             <div className="flex items-start gap-3">
-                <div className="shrink-0 w-9 h-9 rounded-lg bg-info/10 border border-info/20 flex items-center justify-center">
-                    <ListChecks className="w-4 h-4 text-info" />
+                <div className="shrink-0 w-9 h-9 rounded-lg bg-concept-tasks/10 border border-concept-tasks/20 flex items-center justify-center">
+                    <ListChecks className="w-4 h-4 text-concept-tasks" />
                 </div>
                 <div className="min-w-0 flex-1">
                     <h3 className="text-xs text-text-secondary dark:text-text-secondary-dark uppercase tracking-wide">

--- a/apps/web/src/components/ideas/IdeasPageClient.tsx
+++ b/apps/web/src/components/ideas/IdeasPageClient.tsx
@@ -176,7 +176,7 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
                 icon={Lightbulb}
                 title={t('title')}
                 subtitle={t('subtitle')}
-                tone="warning"
+                tone="idea"
                 actions={
                     <DropdownMenu>
                         <DropdownMenuTrigger asChild>
@@ -350,8 +350,8 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
             {/* Sorted list */}
             {visibleIdeas.length === 0 ? (
                 <div className="rounded-lg border border-dashed border-border/70 dark:border-border-dark/70 bg-surface/40 dark:bg-surface-dark/30 p-8 text-center">
-                    <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-warning/20 bg-warning/10">
-                        <Lightbulb className="w-4 h-4 text-warning" />
+                    <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-concept-ideas/20 bg-concept-ideas/10">
+                        <Lightbulb className="w-4 h-4 text-concept-ideas" />
                     </div>
                     <p className="text-sm font-medium text-text dark:text-text-dark">
                         {t('empty.title')}

--- a/apps/web/src/components/missions/MissionCard.tsx
+++ b/apps/web/src/components/missions/MissionCard.tsx
@@ -45,8 +45,8 @@ export function MissionCard({ mission }: { mission: Mission }) {
             )}
         >
             <div className="flex items-start gap-3 mb-3 pr-6 min-w-0">
-                <div className="shrink-0 w-8 h-8 rounded-lg flex items-center justify-center bg-warning/10 border border-warning/20">
-                    <Target strokeWidth={1.4} className="w-4 h-4 text-warning" />
+                <div className="shrink-0 w-8 h-8 rounded-lg flex items-center justify-center bg-concept-missions/10 border border-concept-missions/20">
+                    <Target strokeWidth={1.4} className="w-4 h-4 text-concept-missions" />
                 </div>
                 <div className="min-w-0 flex-1">
                     <h3 className="text-sm font-semibold text-text dark:text-text-dark leading-snug line-clamp-2">

--- a/apps/web/src/components/missions/MissionDetailClient.tsx
+++ b/apps/web/src/components/missions/MissionDetailClient.tsx
@@ -286,8 +286,8 @@ export function MissionDetailClient({
                 </Link>
                 <div className="mt-2 flex flex-wrap items-start justify-between gap-3">
                     <div className="flex items-start gap-3 min-w-0">
-                        <div className="shrink-0 w-10 h-10 rounded-lg bg-warning/10 border border-warning/20 flex items-center justify-center">
-                            <Target className="w-5 h-5 text-warning" />
+                        <div className="shrink-0 w-10 h-10 rounded-lg bg-concept-missions/10 border border-concept-missions/20 flex items-center justify-center">
+                            <Target className="w-5 h-5 text-concept-missions" />
                         </div>
                         <div className="min-w-0 flex-1">
                             <h1 className="text-2xl font-semibold text-text dark:text-text-dark leading-tight">

--- a/apps/web/src/components/missions/MissionsList.tsx
+++ b/apps/web/src/components/missions/MissionsList.tsx
@@ -70,7 +70,7 @@ export function MissionsList({ missions }: { missions: Mission[] }) {
     return (
         <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
             {/* Header */}
-            <PageHeader icon={Target} title={t('title')} subtitle={t('subtitle')} tone="warning" />
+            <PageHeader icon={Target} title={t('title')} subtitle={t('subtitle')} tone="mission" />
 
             {/* Quick-add composer — modeled on the marketing site's
                 landing prompt. Used by both empty and populated
@@ -100,8 +100,8 @@ export function MissionsList({ missions }: { missions: Mission[] }) {
             {/* List */}
             {missions.length === 0 ? (
                 <div className="rounded-lg border border-dashed border-border/70 dark:border-border-dark/70 bg-surface/40 dark:bg-surface-dark/30 p-8 text-center">
-                    <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-warning/20 bg-warning/10">
-                        <Target className="w-4 h-4 text-warning" />
+                    <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-lg border border-concept-missions/20 bg-concept-missions/10">
+                        <Target className="w-4 h-4 text-concept-missions" />
                     </div>
                     <p className="text-sm font-medium text-text dark:text-text-dark">
                         {t('empty.title')}


### PR DESCRIPTION
Cascading #1146 (per-concept colors applied across all per-concept pages) from stage to main.

Chain: #1146 (feature → develop) → #1147 (develop → stage) → this PR (stage → main).

## Test plan

- [x] #1146 type-check + 57 unit tests green; pure CSS class swaps
- [ ] Visual review on prod at `/missions`, `/ideas`, `/works`, `/tasks`, `/agents` post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)