### PR TITLE
release: cascade api 4Gi memory bump (#1145) develop → stage

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -289,10 +289,10 @@ spec:
 
           resources:
             requests:
-              memory: "512Mi"
+              memory: "1Gi"
               cpu: "500m"
             limits:
-              memory: "2Gi"
+              memory: "4Gi"
               cpu: "2"
 
           ports:

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -299,10 +299,10 @@ spec:
 
           resources:
             requests:
-              memory: "512Mi"
+              memory: "1Gi"
               cpu: "500m"
             limits:
-              memory: "2Gi"
+              memory: "4Gi"
               cpu: "2"
 
           ports:

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -287,10 +287,10 @@ spec:
 
           resources:
             requests:
-              memory: "512Mi"
+              memory: "1Gi"
               cpu: "500m"
             limits:
-              memory: "2Gi"
+              memory: "4Gi"
               cpu: "2"
 
           ports:


### PR DESCRIPTION
## Summary
- Cascades #1145 from develop → stage. Bumps `ever-works-api` `limits.memory` 2Gi → 4Gi and `requests.memory` 512Mi → 1Gi in `.deploy/k8s/k8s-manifest.{prod,stage,dev}.yaml`.
- Live prod evidence at PR time: old API pod (4d 9h) predates the AgentsController; new API images OOMKilled at 2Gi during NestJS module init in prod, stage, and dev → `POST /api/agents` returned 404 → "Create Agent" failed on `/works/[id]/agents/new`.

See #1145 for the full diagnosis and evidence.

## Test plan
- [x] Diff verified — only `ever-works-api` resources block changed in each manifest
- [ ] After merge → stage → main cascade, watch `ever-works-api*` pods come up `Ready 1/1`
- [ ] Probe `curl -X POST https://api.ever.works/api/agents` returns `401` (route present, needs auth) instead of `404`

🤖 Generated with [Claude Code](https://claude.com/claude-code)