### PR TITLE
feat(web): consistent page padding + Templates page header icon

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/agents/templates/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/templates/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 export default async function AgentTemplatesPage() {
     const entries = await listAstTemplates('agent');
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto space-y-5">
+        <div className="w-full space-y-5">
             <Link
                 href={ROUTES.DASHBOARD_AGENTS}
                 className="text-xs text-text-muted hover:text-text"

--- a/apps/web/src/app/[locale]/(dashboard)/skills/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/skills/page.tsx
@@ -34,7 +34,7 @@ export default async function SkillsPage() {
     ]);
 
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
             <PageHeader
                 icon={Sparkles}
                 title={t('title')}

--- a/apps/web/src/app/[locale]/(dashboard)/skills/templates/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/skills/templates/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
 export default async function SkillTemplatesPage() {
     const entries = await listAstTemplates('skill');
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto space-y-5">
+        <div className="w-full space-y-5">
             <Link
                 href={ROUTES.DASHBOARD_SKILLS}
                 className="text-xs text-text-muted hover:text-text"

--- a/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
@@ -24,7 +24,7 @@ export default async function TasksPage() {
         .catch(() => ({ data: [] as Task[], meta: { total: 0, limit: 50, offset: 0 } }));
 
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
             <PageHeader
                 icon={ListChecks}
                 title={t('title')}

--- a/apps/web/src/app/[locale]/(dashboard)/tasks/templates/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/tasks/templates/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
 export default async function TaskTemplatesPage() {
     const entries = await listAstTemplates('task');
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto space-y-5">
+        <div className="w-full space-y-5">
             <Link href={ROUTES.DASHBOARD_TASKS} className="text-xs text-text-muted hover:text-text">
                 ← Tasks
             </Link>

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -254,7 +254,7 @@ export default function NewWorkClient({
         // Mirrors the global `/new` page but with Work-only chips
         // (no Mission/Idea) so the user can stay focused on a Work.
         return (
-            <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto space-y-6">
+            <div className="w-full space-y-6">
                 <PageHeader
                     icon={FolderKanban}
                     title={t('title')}

--- a/apps/web/src/components/agents/AgentsList.tsx
+++ b/apps/web/src/components/agents/AgentsList.tsx
@@ -96,7 +96,7 @@ export function AgentsList({ agents, templates = [], userTemplates = [] }: Agent
     };
 
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
             <PageHeader icon={Bot} title={t('title')} subtitle={t('subtitle')} tone="agent" />
 
             {/* Prompt-first surface — describe the Agent you want. Chips

--- a/apps/web/src/components/ideas/IdeasPageClient.tsx
+++ b/apps/web/src/components/ideas/IdeasPageClient.tsx
@@ -168,7 +168,7 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
     void dismissProposalAction;
 
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
             {/* Header — title + subtitle take the full row width and
                 the gears menu floats to the far right so the subtitle
                 isn't truncated next to it. */}

--- a/apps/web/src/components/missions/MissionsList.tsx
+++ b/apps/web/src/components/missions/MissionsList.tsx
@@ -68,7 +68,7 @@ export function MissionsList({ missions }: { missions: Mission[] }) {
     };
 
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
             {/* Header */}
             <PageHeader icon={Target} title={t('title')} subtitle={t('subtitle')} tone="mission" />
 

--- a/apps/web/src/components/templates/TemplatesCatalog.tsx
+++ b/apps/web/src/components/templates/TemplatesCatalog.tsx
@@ -881,12 +881,26 @@ export function TemplatesCatalog({
         <div className="w-full">
             <div className="mb-8 flex flex-col gap-4 @lg/main:flex-row @lg/main:items-start @lg/main:justify-between">
                 <div className="min-w-0">
-                    <h1 className="text-3xl font-bold text-text dark:text-text-dark">
-                        {t('title')}
-                    </h1>
-                    <p className="mt-2 text-text-secondary dark:text-text-secondary-dark">
-                        {t('subtitle')}
-                    </p>
+                    {/* UI consistency (2026-05-29) — page header matches the
+                        Missions / Ideas / Works / Tasks / Agents catalog
+                        pages: 9×9 rounded icon tile in the page tone +
+                        title + subtitle. Templates aren't tied to a single
+                        concept (the KindSwitcher below flips between
+                        Mission / Work / Website), so we use the neutral
+                        `primary` tone rather than a concept color. */}
+                    <div className="flex items-start gap-3">
+                        <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                            <LayoutTemplate className="w-4 h-4 text-primary" />
+                        </div>
+                        <div className="min-w-0">
+                            <h1 className="text-2xl font-semibold text-text dark:text-text-dark truncate">
+                                {t('title')}
+                            </h1>
+                            <p className="mt-1 text-sm text-text-secondary dark:text-text-secondary-dark max-w-2xl">
+                                {t('subtitle')}
+                            </p>
+                        </div>
+                    </div>
                     {/* Phase 8 PR W — kind-switch segmented control.
                         Mission Templates default per spec §10, Work
                         Templates secondary, Website third. Navigation


### PR DESCRIPTION
## Summary

User reported the Works page content sits **wider** than every other dashboard page (Ideas, Missions, Tasks, Agents, Skills, etc.), and that the Templates page lacks the icon-tile header the other concept pages use. Both are fixed here.

## Root cause for the padding mismatch

The dashboard layout (`(dashboard)/layout-client.tsx:494`) already provides the page container:

```html
flex-1 mx-auto w-full
px-4 @sm/main:px-6 @3xl/main:px-8
py-6 @3xl/main:py-8
max-w-full @5xl/main:max-w-7xl
```

Every page is meant to render inside this. **Works** did the right thing and just used `<div className="w-full">`. But Missions / Ideas / Tasks / Agents / Skills / each `*/templates` page / `/works/new` all wrapped themselves a **second** time:

```jsx
<div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto …">
```

That inner `p-6` doubles the layout's horizontal padding (24px extra each side ≈ **48px of width lost**); `max-w-screen-2xl` (1536px) is a *larger* ceiling than the layout's `max-w-7xl` (1280px) so it never actually kicked in — only the padding stuck.

**Fix:** strip the redundant wrapper on 9 pages, leaving Works's shape (`w-full` plus whatever vertical `space-y-*` the page needs). Every catalog page now reports identical content width.

## Templates page header icon

`/templates` rendered an inline `<h1>` + `<p>` — no icon tile, so it felt unrooted next to its siblings.

The Templates page has its own complex header (KindSwitcher + active-default chip column on the right), so a drop-in `PageHeader` would have broken the layout. Instead the title block is upgraded to the same 9×9 icon-tile pattern PageHeader uses:

- Icon: `LayoutTemplate` (same icon the sidebar uses for Templates)
- Tone: neutral `primary` — Templates aren't tied to a single concept (the KindSwitcher flips between Mission / Work / Website), so a concept color would have been misleading
- Same 2xl semibold title + 2xl-max subtitle as PageHeader

## Files

| File | Change |
|---|---|
| `MissionsList.tsx`, `IdeasPageClient.tsx`, `AgentsList.tsx` | strip redundant wrapper |
| `tasks/page.tsx`, `skills/page.tsx` | strip redundant wrapper |
| `agents/templates/page.tsx`, `skills/templates/page.tsx`, `tasks/templates/page.tsx` | strip wrapper, keep `space-y-5` |
| `works/new/new-work-client.tsx` | strip wrapper, keep `space-y-6` |
| `templates/TemplatesCatalog.tsx` | add `LayoutTemplate` icon-tile to header |

## Test plan

- [x] `pnpm --filter ever-works-web type-check` — clean
- [x] `pnpm vitest run` on the affected spec files — 22/22 pass (MissionsList 5, IdeasPageClient 14, TemplatesKindSwitcher 3)
- [x] `eslint` on touched files — only pre-existing errors in `IdeasPageClient.tsx` (unchanged; unrelated `<a>` inside `DropdownMenuItem`)
- [ ] Visual: open the dashboard, then click each of Missions / Ideas / Works / Tasks / Agents / Skills / Templates / `/works/new` — confirm the content width is identical to Works
- [ ] Visual: open `/templates` — confirm the LayoutTemplate icon tile sits next to the title in the same shape as the other catalog pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified page layout styling across dashboard pages for improved spacing consistency.
  * Updated header design in the templates catalog with an icon and refined typography for better visual hierarchy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->