### PR TITLE
chore: cascade develop → stage (page padding consistency + Templates header icon)

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/agents/templates/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/templates/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 export default async function AgentTemplatesPage() {
     const entries = await listAstTemplates('agent');
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto space-y-5">
+        <div className="w-full space-y-5">
             <Link
                 href={ROUTES.DASHBOARD_AGENTS}
                 className="text-xs text-text-muted hover:text-text"

--- a/apps/web/src/app/[locale]/(dashboard)/skills/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/skills/page.tsx
@@ -34,7 +34,7 @@ export default async function SkillsPage() {
     ]);
 
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
             <PageHeader
                 icon={Sparkles}
                 title={t('title')}

--- a/apps/web/src/app/[locale]/(dashboard)/skills/templates/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/skills/templates/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
 export default async function SkillTemplatesPage() {
     const entries = await listAstTemplates('skill');
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto space-y-5">
+        <div className="w-full space-y-5">
             <Link
                 href={ROUTES.DASHBOARD_SKILLS}
                 className="text-xs text-text-muted hover:text-text"

--- a/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
@@ -24,7 +24,7 @@ export default async function TasksPage() {
         .catch(() => ({ data: [] as Task[], meta: { total: 0, limit: 50, offset: 0 } }));
 
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
             <PageHeader
                 icon={ListChecks}
                 title={t('title')}

--- a/apps/web/src/app/[locale]/(dashboard)/tasks/templates/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/tasks/templates/page.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
 export default async function TaskTemplatesPage() {
     const entries = await listAstTemplates('task');
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto space-y-5">
+        <div className="w-full space-y-5">
             <Link href={ROUTES.DASHBOARD_TASKS} className="text-xs text-text-muted hover:text-text">
                 ← Tasks
             </Link>

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -254,7 +254,7 @@ export default function NewWorkClient({
         // Mirrors the global `/new` page but with Work-only chips
         // (no Mission/Idea) so the user can stay focused on a Work.
         return (
-            <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto space-y-6">
+            <div className="w-full space-y-6">
                 <PageHeader
                     icon={FolderKanban}
                     title={t('title')}

--- a/apps/web/src/components/agents/AgentsList.tsx
+++ b/apps/web/src/components/agents/AgentsList.tsx
@@ -96,7 +96,7 @@ export function AgentsList({ agents, templates = [], userTemplates = [] }: Agent
     };
 
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
             <PageHeader icon={Bot} title={t('title')} subtitle={t('subtitle')} tone="agent" />
 
             {/* Prompt-first surface — describe the Agent you want. Chips

--- a/apps/web/src/components/ideas/IdeasPageClient.tsx
+++ b/apps/web/src/components/ideas/IdeasPageClient.tsx
@@ -168,7 +168,7 @@ export function IdeasPageClient({ initialIdeas }: IdeasPageClientProps) {
     void dismissProposalAction;
 
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
             {/* Header — title + subtitle take the full row width and
                 the gears menu floats to the far right so the subtitle
                 isn't truncated next to it. */}

--- a/apps/web/src/components/missions/MissionsList.tsx
+++ b/apps/web/src/components/missions/MissionsList.tsx
@@ -68,7 +68,7 @@ export function MissionsList({ missions }: { missions: Mission[] }) {
     };
 
     return (
-        <div className="w-full overflow-auto p-6 max-w-screen-2xl mx-auto">
+        <div className="w-full">
             {/* Header */}
             <PageHeader icon={Target} title={t('title')} subtitle={t('subtitle')} tone="mission" />
 

--- a/apps/web/src/components/templates/TemplatesCatalog.tsx
+++ b/apps/web/src/components/templates/TemplatesCatalog.tsx
@@ -881,12 +881,26 @@ export function TemplatesCatalog({
         <div className="w-full">
             <div className="mb-8 flex flex-col gap-4 @lg/main:flex-row @lg/main:items-start @lg/main:justify-between">
                 <div className="min-w-0">
-                    <h1 className="text-3xl font-bold text-text dark:text-text-dark">
-                        {t('title')}
-                    </h1>
-                    <p className="mt-2 text-text-secondary dark:text-text-secondary-dark">
-                        {t('subtitle')}
-                    </p>
+                    {/* UI consistency (2026-05-29) — page header matches the
+                        Missions / Ideas / Works / Tasks / Agents catalog
+                        pages: 9×9 rounded icon tile in the page tone +
+                        title + subtitle. Templates aren't tied to a single
+                        concept (the KindSwitcher below flips between
+                        Mission / Work / Website), so we use the neutral
+                        `primary` tone rather than a concept color. */}
+                    <div className="flex items-start gap-3">
+                        <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                            <LayoutTemplate className="w-4 h-4 text-primary" />
+                        </div>
+                        <div className="min-w-0">
+                            <h1 className="text-2xl font-semibold text-text dark:text-text-dark truncate">
+                                {t('title')}
+                            </h1>
+                            <p className="mt-1 text-sm text-text-secondary dark:text-text-secondary-dark max-w-2xl">
+                                {t('subtitle')}
+                            </p>
+                        </div>
+                    </div>
                     {/* Phase 8 PR W — kind-switch segmented control.
                         Mission Templates default per spec §10, Work
                         Templates secondary, Website third. Navigation


### PR DESCRIPTION
Cascading #1151 (page padding consistency + Templates page header icon) from develop to stage.

Only commit included:
- c180ff39 feat(web): consistent page padding + Templates page header icon (#1151)

## Test plan

- [x] Source PR #1151 — type-check + 22 unit tests green; pure CSS className strips + one inline icon-tile addition (no logic / API / schema change)
- [ ] Visual review on stage at `/missions`, `/ideas`, `/works`, `/tasks`, `/agents`, `/skills`, `/templates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)