### PR TITLE
feat(plugins): opt-in lazy plugin loading (PLUGIN_LAZY_LOAD=true)

### DIFF
--- a/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.spec.ts
@@ -28,6 +28,8 @@ describe('ScreenshotController', () => {
     let pluginRegistry: {
         getEnabledPluginsScoped: jest.Mock;
         getDefaultForCapabilityScoped: jest.Mock;
+        isLazy: jest.Mock;
+        ensureLoaded: jest.Mock;
     };
     let pluginSettings: { getSettings: jest.Mock };
     let controller: ScreenshotController;
@@ -38,6 +40,26 @@ describe('ScreenshotController', () => {
         pluginRegistry = {
             getEnabledPluginsScoped: jest.fn(),
             getDefaultForCapabilityScoped: jest.fn(),
+            // Lazy-mode shim — tests pass `state: 'loaded'`
+            // RegisteredPlugin shapes via getEnabledPluginsScoped, so
+            // ensureLoaded looks the eager instance up by id from the
+            // most recent return value.
+            isLazy: jest.fn(() => false),
+            ensureLoaded: jest.fn(async (id: string) => {
+                const calls = pluginRegistry.getEnabledPluginsScoped.mock.results;
+                for (const r of calls) {
+                    const arr = (await r.value) as Array<{
+                        plugin?: { id?: string };
+                        manifest?: { id?: string };
+                    }>;
+                    if (!arr) continue;
+                    const found = arr.find(
+                        (p) => p.manifest?.id === id || p.plugin?.id === id,
+                    );
+                    if (found && (found as any).plugin) return (found as any).plugin;
+                }
+                return undefined;
+            }),
         };
         pluginSettings = { getSettings: jest.fn() };
         controller = new ScreenshotController(
@@ -75,6 +97,8 @@ describe('ScreenshotController', () => {
                 : undefined,
         },
         manifest: {
+            id,
+            name: opts.name ?? id,
             description: opts.description,
             icon: opts.icon,
             defaultForCapabilities: opts.isDefault ? ['screenshot'] : undefined,

--- a/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.ts
+++ b/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.ts
@@ -46,13 +46,17 @@ export class ScreenshotController {
         activePluginId: string | null,
         configured: boolean,
     ): ProviderOption {
+        // id/name come from the manifest (class-validated to equal
+        // the runtime plugin's id/name) so we don't have to
+        // materialise the plugin instance just to render the picker.
+        const pluginId = registered.manifest.id;
         return {
-            id: registered.plugin.id,
-            name: registered.plugin.name,
+            id: pluginId,
+            name: registered.manifest.name ?? pluginId,
             description: registered.manifest.description,
             configured,
             isDefault: activePluginId
-                ? registered.plugin.id === activePluginId
+                ? pluginId === activePluginId
                 : registered.manifest.defaultForCapabilities?.includes(
                       PLUGIN_CAPABILITIES.SCREENSHOT,
                   ) || registered.manifest.systemPlugin,
@@ -71,21 +75,24 @@ export class ScreenshotController {
             workId,
             userId,
         );
-        const activePluginId = activeProvider?.plugin.id ?? null;
+        const activePluginId = activeProvider?.manifest.id ?? null;
 
         const providers: ProviderOption[] = [];
 
         for (const registered of enabledPlugins) {
-            const settings = await this.pluginSettings.getSettings(registered.plugin.id, {
+            const pluginId = registered.manifest.id;
+            const settings = await this.pluginSettings.getSettings(pluginId, {
                 userId,
                 workId,
                 includeSecrets: true,
             });
 
-            const configured = this.hasAllRequiredSettings(
-                registered.plugin.settingsSchema,
-                settings,
-            );
+            // `settingsSchema` is an instance-only property — it
+            // doesn't live on the manifest, so we materialise here.
+            // Eager mode returns the cached instance instantly; lazy
+            // mode fires the deferred import + onLoad once per id.
+            const plugin = await this.pluginRegistry.ensureLoaded(pluginId);
+            const configured = this.hasAllRequiredSettings(plugin.settingsSchema, settings);
             providers.push(this.toProviderOption(registered, activePluginId, configured));
         }
 

--- a/packages/agent/src/facades/__tests__/data-source.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/data-source.facade.spec.ts
@@ -68,6 +68,29 @@ describe('DataSourceFacadeService', () => {
                         getByCapability: jest.fn().mockReturnValue([]),
                         isPluginEnabledForScope: jest.fn().mockResolvedValue(true),
                         getDefaultForCapabilityScoped: jest.fn().mockResolvedValue(undefined),
+                        // Lazy-mode shim — eager-only tests register
+                        // plugins with `state: 'loaded'` and the
+                        // eager `plugin` instance. The shim scans the
+                        // by-capability and by-id mocks for a match.
+                        isLazy: jest.fn(() => false),
+                        ensureLoaded: jest.fn(async (id: string) => {
+                            // Try the by-id mock first; fall back to
+                            // a scan of the most recent
+                            // getByCapability return values so tests
+                            // that only set up getByCapability still
+                            // pass.
+                            const direct = registry.get(id);
+                            if (direct?.plugin) return direct.plugin as any;
+                            const calls = (registry.getByCapability as jest.Mock).mock.results;
+                            for (const r of calls) {
+                                const arr = (r.value as RegisteredPlugin[]) || [];
+                                const found = arr.find(
+                                    (p: RegisteredPlugin) => p.manifest.id === id,
+                                );
+                                if (found?.plugin) return found.plugin as any;
+                            }
+                            return undefined as any;
+                        }),
                     },
                 },
                 {

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -29,6 +29,12 @@ describe('DeployFacadeService', () => {
         const registry = {
             get: jest.fn((id: string) => (id === pluginId ? registered : undefined)),
             getByCapability: jest.fn(() => [registered]),
+            // Lazy-mode shim — eager plugins go through ensureLoaded
+            // too in resolvePluginAndTokenWithWork.
+            isLazy: jest.fn(() => false),
+            ensureLoaded: jest.fn(async (id: string) =>
+                id === pluginId ? plugin : undefined,
+            ),
         };
         const settingsService = {
             getResolvedSettings: jest.fn().mockResolvedValue(args.settings ?? {}),

--- a/packages/agent/src/facades/__tests__/email.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/email.facade.spec.ts
@@ -20,6 +20,19 @@ describe('EmailFacadeService', () => {
     beforeEach(async () => {
         registry = {
             getByCapability: jest.fn().mockReturnValue([]),
+            // Lazy-mode shim — tests register plugins via getByCapability
+            // with eager `state: 'loaded'`, so ensureLoaded just looks
+            // up by id in the most recent getByCapability return value.
+            isLazy: jest.fn(() => false),
+            ensureLoaded: jest.fn(async (id: string) => {
+                const calls = (registry.getByCapability as jest.Mock).mock.results;
+                for (const r of calls) {
+                    const arr = (r.value as Array<{ plugin: { id: string } }>) || [];
+                    const found = arr.find((p) => p.plugin?.id === id);
+                    if (found) return (found as any).plugin;
+                }
+                return undefined as never;
+            }),
         } as unknown as jest.Mocked<PluginRegistryService>;
         settings = {
             getResolvedSettings: jest.fn().mockResolvedValue({}),
@@ -100,7 +113,7 @@ describe('EmailFacadeService', () => {
         it('resolves the recipient owner and verifies with the owner-scoped secret', async () => {
             const plugin = makeInboundPlugin();
             registry.getByCapability.mockImplementation(((cap: string) =>
-                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded', manifest: { id: plugin.id, name: plugin.id, capabilities: ['email-inbound'] } }] : []) as never);
             (settings.getSettings as jest.Mock).mockResolvedValue({
                 inboundWebhookSecret: 'owner-secret',
             });
@@ -132,7 +145,7 @@ describe('EmailFacadeService', () => {
         it('falls back to default scope when no owner matches the recipient', async () => {
             const plugin = makeInboundPlugin();
             registry.getByCapability.mockImplementation(((cap: string) =>
-                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded', manifest: { id: plugin.id, name: plugin.id, capabilities: ['email-inbound'] } }] : []) as never);
             emailAddresses.findByAddress.mockResolvedValue(null);
 
             await facade.parseInbound('postmark', Buffer.from('{}'), {});
@@ -149,7 +162,7 @@ describe('EmailFacadeService', () => {
         it('falls back to default scope when the matched address belongs to a different plugin', async () => {
             const plugin = makeInboundPlugin();
             registry.getByCapability.mockImplementation(((cap: string) =>
-                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded', manifest: { id: plugin.id, name: plugin.id, capabilities: ['email-inbound'] } }] : []) as never);
             // Address is registered to mailgun, not the postmark webhook in flight.
             emailAddresses.findByAddress.mockResolvedValue({
                 userId: 'owner-9',
@@ -167,7 +180,7 @@ describe('EmailFacadeService', () => {
         it('skips recipient resolution when the caller already supplies a userId', async () => {
             const plugin = makeInboundPlugin();
             registry.getByCapability.mockImplementation(((cap: string) =>
-                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded', manifest: { id: plugin.id, name: plugin.id, capabilities: ['email-inbound'] } }] : []) as never);
 
             await facade.parseInbound('postmark', Buffer.from('{}'), {}, { userId: 'caller-1' });
 
@@ -203,7 +216,7 @@ describe('EmailFacadeService', () => {
                 },
             ]);
             registry.getByCapability.mockImplementation(((cap: string) =>
-                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded', manifest: { id: plugin.id, name: plugin.id, capabilities: ['email-inbound'] } }] : []) as never);
 
             const events = await facade.parseEventWebhook('postmark', Buffer.from('{}'), {});
             expect(plugin.verifyWebhookSignature).toHaveBeenCalled();
@@ -213,7 +226,7 @@ describe('EmailFacadeService', () => {
         it('returns [] when the plugin does not publish delivery events', async () => {
             const plugin = makeInboundPlugin({ parseEventWebhook: undefined });
             registry.getByCapability.mockImplementation(((cap: string) =>
-                cap === 'email-inbound' ? [{ plugin, state: 'loaded' }] : []) as never);
+                cap === 'email-inbound' ? [{ plugin, state: 'loaded', manifest: { id: plugin.id, name: plugin.id, capabilities: ['email-inbound'] } }] : []) as never);
             await expect(
                 facade.parseEventWebhook('postmark', Buffer.from('{}'), {}),
             ).resolves.toEqual([]);

--- a/packages/agent/src/facades/__tests__/git.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/git.facade.spec.ts
@@ -274,6 +274,30 @@ describe('GitFacadeService', () => {
                         get: jest.fn(),
                         getByCapability: jest.fn().mockReturnValue([]),
                         isPluginEnabledForScope: jest.fn().mockResolvedValue(true),
+                        // Lazy-mode shim — eager plugins from get(id)
+                        // also pass through resolvePlugin's ensureLoaded
+                        // call. Fall back to a getByCapability scan so
+                        // older test fixtures that only set the
+                        // by-capability mock still resolve.
+                        isLazy: jest.fn(() => false),
+                        ensureLoaded: jest.fn(async (id: string) => {
+                            const direct = registry.get(id);
+                            if (direct?.plugin) return direct.plugin as any;
+                            const calls = (registry.getByCapability as jest.Mock).mock
+                                .results;
+                            for (const r of calls) {
+                                const arr = (r.value as Array<{
+                                    plugin?: { id: string };
+                                    manifest?: { id: string };
+                                }>) || [];
+                                const found = arr.find(
+                                    (p) => p.manifest?.id === id || p.plugin?.id === id,
+                                );
+                                if (found && (found as any).plugin)
+                                    return (found as any).plugin;
+                            }
+                            return undefined as never;
+                        }),
                     },
                 },
                 {

--- a/packages/agent/src/facades/base.facade.ts
+++ b/packages/agent/src/facades/base.facade.ts
@@ -73,8 +73,17 @@ export abstract class BaseFacadeService {
     }
 
     isConfigured(): boolean {
+        // Lazy-safe: `unloaded` plugins with a parked loader ARE
+        // configured — they'll materialise on first use. Eager-mode
+        // plugins in `unloaded` state (no parked loader) are still
+        // treated as not-configured to preserve existing semantics.
         const plugins = this.registry.getByCapability(this.CAPABILITY);
-        return plugins.length > 0 && plugins.some((p) => p.state === 'loaded');
+        return (
+            plugins.length > 0 &&
+            plugins.some(
+                (p) => p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
+            )
+        );
     }
 
     getAvailableProviders(): Array<{
@@ -84,9 +93,17 @@ export abstract class BaseFacadeService {
     }> {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
         return plugins.map((p) => ({
-            id: p.plugin.id,
-            name: this.getProviderName(p.plugin),
-            enabled: p.state === 'loaded',
+            id: p.manifest.id,
+            // Plugin instance may not be loaded yet under lazy mode —
+            // fall back to manifest.name (which is the same value in
+            // practice; runtime `providerName` overrides aren't
+            // available until the plugin is materialised).
+            name: p.plugin ? this.getProviderName(p.plugin) : p.manifest.name,
+            // Lazy-registered plugins report as enabled even before
+            // first load (they're available; `ensureLoaded` will
+            // materialise on demand). Eager `unloaded` plugins remain
+            // not-enabled to preserve existing semantics.
+            enabled: p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
         }));
     }
 
@@ -102,11 +119,14 @@ export abstract class BaseFacadeService {
         return enabled
             .filter((p) => !p.manifest.supplementary)
             .map((p) => ({
-                id: p.plugin.id,
-                name: p.manifest.name ?? p.plugin.id,
+                id: p.manifest.id,
+                name: p.manifest.name ?? p.manifest.id,
                 description: p.manifest.description,
                 icon: p.manifest.icon,
-                providerName: this.getProviderName(p.plugin),
+                // Plugin instance may not be loaded yet under lazy
+                // mode — fall back to manifest.name when the runtime
+                // `providerName` override isn't available yet.
+                providerName: p.plugin ? this.getProviderName(p.plugin) : p.manifest.name,
                 enabled: true,
                 isDefault: p.manifest.defaultForCapabilities?.includes(this.CAPABILITY) ?? false,
                 selectableProviderCategories: p.manifest.selectableProviderCategories ?? [],
@@ -126,7 +146,15 @@ export abstract class BaseFacadeService {
 
                 if (activePlugin) {
                     const registered = this.registry.get(activePlugin.pluginId);
-                    if (registered && registered.state === 'loaded') {
+                    // Lazy-aware: `unloaded` plugins with a parked
+                    // loader ARE valid defaults; the caller
+                    // materialises them on demand. Eager `unloaded`
+                    // entries remain ineligible.
+                    if (
+                        registered &&
+                        (registered.state === 'loaded' ||
+                            (this.registry.isLazy?.(registered.manifest.id) ?? false))
+                    ) {
                         // Verify plugin is enabled for this scope (work + user)
                         const isEnabled = await this.isPluginEnabled(
                             activePlugin.pluginId,
@@ -135,8 +163,10 @@ export abstract class BaseFacadeService {
                         );
                         if (isEnabled) {
                             return {
-                                id: registered.plugin.id,
-                                name: this.getProviderName(registered.plugin),
+                                id: registered.manifest.id,
+                                name: registered.plugin
+                                    ? this.getProviderName(registered.plugin)
+                                    : registered.manifest.name,
                             };
                         }
                     }
@@ -149,9 +179,12 @@ export abstract class BaseFacadeService {
         const enabledPlugins = await this.getEnabledPlugins(workId, userId);
 
         if (enabledPlugins.length > 0) {
+            const first = enabledPlugins[0];
             return {
-                id: enabledPlugins[0].plugin.id,
-                name: this.getProviderName(enabledPlugins[0].plugin),
+                id: first.manifest.id,
+                name: first.plugin
+                    ? this.getProviderName(first.plugin)
+                    : first.manifest.name,
             };
         }
 
@@ -257,7 +290,15 @@ export abstract class BaseFacadeService {
 
             if (activePlugin) {
                 const registered = this.registry.get(activePlugin.pluginId);
-                if (registered && registered.state === 'loaded') {
+                // Lazy-aware: `unloaded` plugins with a parked loader
+                // ARE valid candidates; the caller (`resolvePlugin`)
+                // materialises them on demand. Eager `unloaded`
+                // entries remain ineligible.
+                if (
+                    registered &&
+                    (registered.state === 'loaded' ||
+                        (this.registry.isLazy?.(registered.manifest.id) ?? false))
+                ) {
                     return registered;
                 }
             }
@@ -273,9 +314,16 @@ export abstract class BaseFacadeService {
         const result: RegisteredPlugin[] = [];
 
         for (const p of plugins) {
-            if (p.state !== 'loaded') continue;
+            // Lazy-aware: plugins with a parked loader (registered
+            // lazily, state==='unloaded') ARE eligible — the caller
+            // will materialise on demand. Eager `unloaded` plugins
+            // (no loader) stay ineligible, matching pre-lazy
+            // behaviour exactly.
+            if (p.state !== 'loaded' && !(this.registry.isLazy?.(p.manifest.id) ?? false)) {
+                continue;
+            }
 
-            const isEnabled = await this.isPluginEnabled(p.plugin.id, workId, userId);
+            const isEnabled = await this.isPluginEnabled(p.manifest.id, workId, userId);
             if (isEnabled) {
                 result.push(p);
             }
@@ -315,24 +363,37 @@ export abstract class BaseFacadeService {
             if (
                 registered &&
                 registered.manifest.capabilities.includes(this.CAPABILITY) &&
-                registered.state === 'loaded'
+                (registered.state === 'loaded' || (this.registry.isLazy?.(effectiveOverride) ?? false))
             ) {
                 const isEnabled = await this.isPluginEnabled(effectiveOverride, workId, userId);
-                if (isEnabled) return registered.plugin as T;
+                if (isEnabled) return (await this.materialize(registered)) as T;
             }
             throw new ProviderNotFoundError(effectiveOverride, this.CAPABILITY);
         }
 
         if (workId) {
             const activePlugin = await this.findActivePluginForWork(workId);
-            if (activePlugin) return activePlugin.plugin as T;
+            if (activePlugin) return (await this.materialize(activePlugin)) as T;
         }
 
         const enabledPlugins = await this.getEnabledPlugins(workId, userId);
         if (enabledPlugins.length > 0) {
-            return enabledPlugins[0].plugin as T;
+            return (await this.materialize(enabledPlugins[0])) as T;
         }
 
         throw new NoProviderError(this.CAPABILITY);
+    }
+
+    /**
+     * Backward-compatible plugin instance resolver. In eager mode the
+     * registered entry already carries the IPlugin instance (no
+     * `ensureLoaded` round-trip needed; existing test mocks keep
+     * working). In lazy mode the instance is undefined until first
+     * use, so we delegate to `registry.ensureLoaded()` which fires
+     * the deferred `import()` + `onLoad` exactly once per plugin id.
+     */
+    private async materialize(registered: RegisteredPlugin): Promise<IPlugin> {
+        if (registered.plugin) return registered.plugin;
+        return this.registry.ensureLoaded(registered.manifest.id);
     }
 }

--- a/packages/agent/src/facades/base.facade.ts
+++ b/packages/agent/src/facades/base.facade.ts
@@ -391,8 +391,12 @@ export abstract class BaseFacadeService {
      * working). In lazy mode the instance is undefined until first
      * use, so we delegate to `registry.ensureLoaded()` which fires
      * the deferred `import()` + `onLoad` exactly once per plugin id.
+     *
+     * `protected` so subclass facades (Search/Deploy/Email/etc.) can
+     * use the same materialise-on-demand pattern without each
+     * re-implementing the eager-vs-lazy branching.
      */
-    private async materialize(registered: RegisteredPlugin): Promise<IPlugin> {
+    protected async materialize(registered: RegisteredPlugin): Promise<IPlugin> {
         if (registered.plugin) return registered.plugin;
         return this.registry.ensureLoaded(registered.manifest.id);
     }

--- a/packages/agent/src/facades/code-edit.facade.ts
+++ b/packages/agent/src/facades/code-edit.facade.ts
@@ -63,20 +63,32 @@ export class CodeEditFacadeService extends BaseFacadeService {
         const registered = this.registry.get(providerId);
         if (
             !registered ||
-            registered.state !== 'loaded' ||
             !registered.manifest.capabilities.includes(this.CAPABILITY) ||
             registered.manifest.supplementary
         ) {
             return null;
         }
+        // Lazy-aware eligibility: `unloaded` plugins with a parked
+        // loader ARE valid (they materialise on demand). Eager
+        // `unloaded` entries remain ineligible — matches base.facade.
+        if (
+            registered.state !== 'loaded' &&
+            !(this.registry.isLazy?.(providerId) ?? false)
+        ) {
+            return null;
+        }
         const enabled = await this.registry.isPluginEnabledForScope(providerId, workId, userId);
         if (!enabled) return null;
+        // For runtime `providerName` we need the instance; everything
+        // else comes from the manifest so we don't force a load when
+        // the plugin is still parked.
+        const plugin = registered.plugin ?? null;
         return {
-            id: registered.plugin.id,
-            name: registered.manifest.name ?? registered.plugin.id,
+            id: registered.manifest.id,
+            name: registered.manifest.name ?? registered.manifest.id,
             description: registered.manifest.description,
             icon: registered.manifest.icon,
-            providerName: this.getProviderName(registered.plugin),
+            providerName: plugin ? this.getProviderName(plugin) : registered.manifest.name,
             enabled: true,
             isDefault:
                 registered.manifest.defaultForCapabilities?.includes(this.CAPABILITY) ?? false,

--- a/packages/agent/src/facades/content-extractor.facade.ts
+++ b/packages/agent/src/facades/content-extractor.facade.ts
@@ -231,11 +231,19 @@ export class ContentExtractorFacadeService
 
     override getAvailableProviders(): Array<{ id: string; name: string; enabled: boolean }> {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
-        return plugins.map((p) => ({
-            id: p.plugin.id,
-            name: (p.plugin as IContentExtractorPlugin).providerName,
-            enabled: p.state === 'loaded',
-        }));
+        return plugins.map((p) => {
+            // Sync method — fall back to the manifest name when the
+            // plugin instance isn't materialised yet (lazy mode).
+            // Runtime `providerName` overrides are only available
+            // after first load.
+            const plugin = p.plugin as IContentExtractorPlugin | undefined;
+            return {
+                id: p.manifest.id,
+                name: plugin?.providerName ?? p.manifest.name ?? p.manifest.id,
+                enabled:
+                    p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
+            };
+        });
     }
 
     /**
@@ -254,19 +262,29 @@ export class ContentExtractorFacadeService
         userId?: string,
         workId?: string,
     ): Promise<ExtractorCandidate[]> {
+        // Lazy-aware: include parked-but-unloaded plugins. Their
+        // instance is materialised on demand below; eager `unloaded`
+        // entries stay excluded (no parked loader = nothing to load).
         const loadedPlugins = this.registry
             .getByCapability(this.CAPABILITY)
-            .filter((p) => p.state === 'loaded');
+            .filter(
+                (p) =>
+                    p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
+            );
         const candidates: ExtractorCandidate[] = [];
         const seen = new Set<string>();
 
-        const addCandidate = (registered: RegisteredPlugin): void => {
-            if (seen.has(registered.plugin.id)) return;
-            seen.add(registered.plugin.id);
+        const addCandidate = (
+            registered: RegisteredPlugin,
+            plugin: IContentExtractorPlugin,
+        ): void => {
+            const pluginId = registered.manifest.id;
+            if (seen.has(pluginId)) return;
+            seen.add(pluginId);
             candidates.push({
-                plugin: registered.plugin as IContentExtractorPlugin,
-                id: registered.plugin.id,
-                name: this.getProviderName(registered.plugin),
+                plugin,
+                id: pluginId,
+                name: this.getProviderName(plugin),
             });
         };
 
@@ -276,9 +294,9 @@ export class ContentExtractorFacadeService
             if (!registered.manifest.supplementary) continue;
             if (!(await this.isPluginUsableForScope(registered, userId, workId))) continue;
 
-            const plugin = registered.plugin as IContentExtractorPlugin;
-            if (await this.canExtractSafe(plugin, url, registered.plugin.id)) {
-                addCandidate(registered);
+            const plugin = (await this.materialize(registered)) as IContentExtractorPlugin;
+            if (await this.canExtractSafe(plugin, url, registered.manifest.id)) {
+                addCandidate(registered, plugin);
             }
         }
 
@@ -288,7 +306,8 @@ export class ContentExtractorFacadeService
             if (
                 !registered ||
                 !registered.manifest.capabilities.includes(this.CAPABILITY) ||
-                registered.state !== 'loaded'
+                (registered.state !== 'loaded' &&
+                    !(this.registry.isLazy?.(providerOverride) ?? false))
             ) {
                 throw new ContentExtractorProviderNotFoundError(providerOverride);
             }
@@ -297,18 +316,18 @@ export class ContentExtractorFacadeService
                 throw new ContentExtractorProviderNotFoundError(providerOverride);
             }
 
-            const plugin = registered.plugin as IContentExtractorPlugin;
+            const plugin = (await this.materialize(registered)) as IContentExtractorPlugin;
             await this.assertCanExtractForOverride(plugin, url, providerOverride);
-            addCandidate(registered);
+            addCandidate(registered, plugin);
         }
 
         // 2. Work's configured default
         if (workId) {
             const active = await this.findActivePluginForWork(workId);
             if (active && (await this.isPluginUsableForScope(active, userId, workId))) {
-                const plugin = active.plugin as IContentExtractorPlugin;
-                if (await this.canExtractSafe(plugin, url, active.plugin.id)) {
-                    addCandidate(active);
+                const plugin = (await this.materialize(active)) as IContentExtractorPlugin;
+                if (await this.canExtractSafe(plugin, url, active.manifest.id)) {
+                    addCandidate(active, plugin);
                 }
             }
         }
@@ -323,9 +342,9 @@ export class ContentExtractorFacadeService
         for (const registered of general) {
             if (!(await this.isPluginUsableForScope(registered, userId, workId))) continue;
 
-            const plugin = registered.plugin as IContentExtractorPlugin;
-            if (await this.canExtractSafe(plugin, url, registered.plugin.id)) {
-                addCandidate(registered);
+            const plugin = (await this.materialize(registered)) as IContentExtractorPlugin;
+            if (await this.canExtractSafe(plugin, url, registered.manifest.id)) {
+                addCandidate(registered, plugin);
             }
         }
 
@@ -334,9 +353,9 @@ export class ContentExtractorFacadeService
             if (!registered.manifest.defaultForCapabilities?.includes(this.CAPABILITY)) continue;
             if (!(await this.isPluginUsableForScope(registered, userId, workId))) continue;
 
-            const plugin = registered.plugin as IContentExtractorPlugin;
-            if (await this.canExtractSafe(plugin, url, registered.plugin.id)) {
-                addCandidate(registered);
+            const plugin = (await this.materialize(registered)) as IContentExtractorPlugin;
+            if (await this.canExtractSafe(plugin, url, registered.manifest.id)) {
+                addCandidate(registered, plugin);
             }
         }
 
@@ -344,9 +363,9 @@ export class ContentExtractorFacadeService
         for (const registered of loadedPlugins) {
             if (!(await this.isPluginUsableForScope(registered, userId, workId))) continue;
 
-            const plugin = registered.plugin as IContentExtractorPlugin;
-            if (await this.canExtractSafe(plugin, url, registered.plugin.id)) {
-                addCandidate(registered);
+            const plugin = (await this.materialize(registered)) as IContentExtractorPlugin;
+            if (await this.canExtractSafe(plugin, url, registered.manifest.id)) {
+                addCandidate(registered, plugin);
             }
         }
 
@@ -377,13 +396,17 @@ export class ContentExtractorFacadeService
         userId?: string,
         workId?: string,
     ): Promise<boolean> {
-        if (!(await this.isPluginEnabled(registered.plugin.id, workId, userId))) return false;
+        const pluginId = registered.manifest.id;
+        if (!(await this.isPluginEnabled(pluginId, workId, userId))) return false;
 
-        const settings = await this.getResolvedSettings(registered.plugin.id, {
+        const settings = await this.getResolvedSettings(pluginId, {
             userId,
             workId,
         });
-        return this.hasAllRequiredSettings(registered.plugin.settingsSchema, settings);
+        // `settingsSchema` is an instance-only property — materialise
+        // to read it. Eager mode returns the cached instance instantly.
+        const plugin = await this.materialize(registered);
+        return this.hasAllRequiredSettings(plugin.settingsSchema, settings);
     }
 
     /**

--- a/packages/agent/src/facades/data-source.facade.ts
+++ b/packages/agent/src/facades/data-source.facade.ts
@@ -34,7 +34,13 @@ export class DataSourceFacadeService implements IDataSourceFacade {
 
     async queryAll(options: DataSourceFacadeOptions): Promise<DataSourceFacadeResult> {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
-        const enabledPlugins = plugins.filter((p) => p.state === 'loaded');
+        // Lazy-aware: include parked-but-unloaded plugins (they
+        // materialise on demand below). Eager `unloaded` entries
+        // (no parked loader) stay excluded.
+        const enabledPlugins = plugins.filter(
+            (p) =>
+                p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
+        );
 
         const allItems: MutableItemData[] = [];
         const sourceMap = new Map<string, string>();
@@ -44,7 +50,7 @@ export class DataSourceFacadeService implements IDataSourceFacade {
         const allBrands: Brand[] = [];
 
         for (const registered of enabledPlugins) {
-            const pluginId = registered.plugin.id;
+            const pluginId = registered.manifest.id;
 
             const isEnabled = await this.isPluginEnabledForWork(
                 pluginId,
@@ -63,7 +69,12 @@ export class DataSourceFacadeService implements IDataSourceFacade {
                 | undefined;
 
             try {
-                const plugin = registered.plugin as IDataSourcePlugin;
+                // Materialise via the registry — eager mode returns
+                // the cached instance instantly; lazy mode fires the
+                // deferred import + onLoad exactly once.
+                const plugin = (await this.registry.ensureLoaded(
+                    pluginId,
+                )) as IDataSourcePlugin;
 
                 const isAvailable = await plugin.isAvailable();
                 if (!isAvailable) {
@@ -121,16 +132,27 @@ export class DataSourceFacadeService implements IDataSourceFacade {
         if (!workId) return [];
 
         const plugins = this.registry.getByCapability(this.CAPABILITY);
-        const enabledPlugins = plugins.filter((p) => p.state === 'loaded');
+        // Lazy-aware filter — see queryAll().
+        const enabledPlugins = plugins.filter(
+            (p) =>
+                p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
+        );
         const result: EnabledDataSource[] = [];
 
         for (const registered of enabledPlugins) {
-            const plugin = registered.plugin as IDataSourcePlugin;
-            const isEnabled = await this.isPluginEnabledForWork(plugin.id, workId, userId);
+            const pluginId = registered.manifest.id;
+            const isEnabled = await this.isPluginEnabledForWork(pluginId, workId, userId);
 
             if (isEnabled) {
+                // `sourceName` is an instance-only override (set on
+                // the plugin class, not the manifest), so we need to
+                // materialise here. `id` and `name` would otherwise
+                // be manifest-only reads.
+                const plugin = (await this.registry.ensureLoaded(
+                    pluginId,
+                )) as IDataSourcePlugin;
                 result.push({
-                    id: plugin.id,
+                    id: pluginId,
                     name: plugin.name,
                     sourceName: plugin.sourceName,
                 });
@@ -142,7 +164,14 @@ export class DataSourceFacadeService implements IDataSourceFacade {
 
     isConfigured(): boolean {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
-        return plugins.length > 0 && plugins.some((p) => p.state === 'loaded');
+        // Lazy-aware: parked-but-unloaded plugins ARE configured.
+        return (
+            plugins.length > 0 &&
+            plugins.some(
+                (p) =>
+                    p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
+            )
+        );
     }
 
     getAvailableProviders(): Array<{
@@ -153,12 +182,18 @@ export class DataSourceFacadeService implements IDataSourceFacade {
     }> {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
         return plugins.map((p) => {
-            const plugin = p.plugin as IDataSourcePlugin;
+            // Fall back to manifest fields when the plugin instance
+            // hasn't been materialised yet (lazy mode). `sourceName`
+            // is an instance-only override — there's no manifest
+            // equivalent, so we return the manifest id as a stable
+            // placeholder until first use.
+            const plugin = p.plugin as IDataSourcePlugin | undefined;
             return {
-                id: plugin.id,
-                name: plugin.name,
-                sourceName: plugin.sourceName,
-                enabled: p.state === 'loaded',
+                id: p.manifest.id,
+                name: plugin?.name ?? p.manifest.name ?? p.manifest.id,
+                sourceName: plugin?.sourceName ?? p.manifest.name ?? p.manifest.id,
+                enabled:
+                    p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
             };
         });
     }
@@ -187,7 +222,13 @@ export class DataSourceFacadeService implements IDataSourceFacade {
             userId,
         );
         if (registered) {
-            return { id: registered.plugin.id, name: registered.plugin.name };
+            // id/name are manifest-equivalent (class-validated on
+            // load) — no need to materialise the plugin instance
+            // just to read them.
+            return {
+                id: registered.manifest.id,
+                name: registered.plugin?.name ?? registered.manifest.name ?? registered.manifest.id,
+            };
         }
         return null;
     }

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -103,9 +103,13 @@ export class DeployFacadeService implements IDeployFacade {
 
         const resolvedProviderId = resolvePluginProviderId(providerId);
         const registered = this.registry.get(resolvedProviderId);
-        const plugin = registered?.plugin as IDeploymentPlugin | undefined;
-
-        return plugin?.name || plugin?.providerName || providerId;
+        if (!registered) return providerId;
+        // Sync method — return manifest.name when the plugin instance
+        // isn't materialised yet (lazy mode). Manifest.name is the
+        // class-validated equivalent of plugin.name; runtime
+        // `providerName` overrides are only available after load.
+        const plugin = registered.plugin as IDeploymentPlugin | undefined;
+        return plugin?.name || plugin?.providerName || registered.manifest.name || providerId;
     }
 
     /**
@@ -120,7 +124,14 @@ export class DeployFacadeService implements IDeployFacade {
 
             const pluginProviderId = resolvePluginProviderId(work.deployProvider);
             const registered = this.registry.get(pluginProviderId);
-            if (!registered || registered.state !== 'loaded') {
+            // Lazy-aware eligibility: parked-but-unloaded plugins ARE
+            // configured (the work just needs a valid token below);
+            // they'll materialise on first use.
+            if (
+                !registered ||
+                (registered.state !== 'loaded' &&
+                    !(this.registry.isLazy?.(pluginProviderId) ?? false))
+            ) {
                 return false;
             }
 
@@ -148,7 +159,12 @@ export class DeployFacadeService implements IDeployFacade {
     ): Promise<boolean> {
         const resolvedProviderId = resolvePluginProviderId(providerId);
         const registered = this.registry.get(resolvedProviderId);
-        if (!registered || registered.state !== 'loaded') {
+        if (!registered) return false;
+        // Lazy-aware: parked-but-unloaded plugins ARE valid.
+        if (
+            registered.state !== 'loaded' &&
+            !(this.registry.isLazy?.(resolvedProviderId) ?? false)
+        ) {
             return false;
         }
         if (!registered.manifest.capabilities.includes(this.CAPABILITY)) {
@@ -162,14 +178,25 @@ export class DeployFacadeService implements IDeployFacade {
      */
     getAvailableProviders(): DeployProviderInfo[] {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
-        return plugins.map((p) => ({
-            id: p.plugin.id,
-            name: p.plugin.name || (p.plugin as IDeploymentPlugin).providerName || p.plugin.id,
-            enabled: p.state === 'loaded',
-            icon: p.manifest.icon,
-            description: p.manifest.description,
-            homepage: p.manifest.homepage,
-        }));
+        return plugins.map((p) => {
+            // Sync method — fall back to manifest fields when the
+            // plugin instance hasn't been materialised yet. Runtime
+            // `providerName` overrides only apply post-load.
+            const plugin = p.plugin as IDeploymentPlugin | undefined;
+            return {
+                id: p.manifest.id,
+                name:
+                    plugin?.name ||
+                    plugin?.providerName ||
+                    p.manifest.name ||
+                    p.manifest.id,
+                enabled:
+                    p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
+                icon: p.manifest.icon,
+                description: p.manifest.description,
+                homepage: p.manifest.homepage,
+            };
+        });
     }
 
     /**
@@ -751,7 +778,12 @@ export class DeployFacadeService implements IDeployFacade {
             throw new DeployProviderNotFoundError(providerId);
         }
 
-        if (registered.state !== 'loaded') {
+        // Lazy-aware: parked-but-unloaded plugins are valid; the
+        // ensureLoaded call below will materialise on demand.
+        if (
+            registered.state !== 'loaded' &&
+            !(this.registry.isLazy?.(pluginProviderId) ?? false)
+        ) {
             throw new DeployProviderNotFoundError(providerId);
         }
 
@@ -762,14 +794,19 @@ export class DeployFacadeService implements IDeployFacade {
             options.workId,
         );
 
+        // Materialise the plugin instance now — both the error path
+        // (providerName for the credentials error) and the success
+        // return need the IPlugin runtime. Eager mode returns the
+        // cached instance instantly.
+        const plugin = (await this.registry.ensureLoaded(pluginProviderId)) as IDeploymentPlugin;
+
         if (!token) {
-            const providerName =
-                (registered.plugin as IDeploymentPlugin).providerName || registered.plugin.name;
+            const providerName = plugin.providerName || plugin.name;
             throw new NoDeployCredentialsError(providerId, options.userId, providerName);
         }
 
         return {
-            plugin: registered.plugin as IDeploymentPlugin,
+            plugin,
             token,
             work,
         };

--- a/packages/agent/src/facades/email.facade.ts
+++ b/packages/agent/src/facades/email.facade.ts
@@ -162,7 +162,7 @@ export class EmailFacadeService extends BaseFacadeService {
         headers: Readonly<Record<string, string>>,
         options?: FacadeOptions,
     ): Promise<EmailInboundMessage> {
-        const plugin = this.getInboundPluginById(pluginId);
+        const plugin = await this.getInboundPluginById(pluginId);
 
         // EW-670 follow-up — resolve the recipient address's OWNER before
         // verifying the signature. The inbound webhook controller can't
@@ -203,7 +203,7 @@ export class EmailFacadeService extends BaseFacadeService {
         headers: Readonly<Record<string, string>>,
         options?: FacadeOptions,
     ): Promise<readonly EmailDeliveryEvent[]> {
-        const plugin = this.getInboundPluginById(pluginId);
+        const plugin = await this.getInboundPluginById(pluginId);
         if (!plugin.parseEventWebhook) return [];
         const settings = await this.resolveSettings(pluginId, options);
         const emailOpts: EmailOptions = {
@@ -310,7 +310,7 @@ export class EmailFacadeService extends BaseFacadeService {
         if (options.addressId && this.emailAddresses) {
             const address = await this.emailAddresses.findById(options.addressId);
             if (address?.pluginId) {
-                const plugin = this.getOutboundPluginByIdSafe(address.pluginId);
+                const plugin = await this.getOutboundPluginByIdSafe(address.pluginId);
                 if (plugin) return plugin;
             }
         }
@@ -324,40 +324,71 @@ export class EmailFacadeService extends BaseFacadeService {
             for (const assignment of assignments) {
                 const address = await this.emailAddresses.findById(assignment.emailAddressId);
                 if (address?.pluginId) {
-                    const plugin = this.getOutboundPluginByIdSafe(address.pluginId);
+                    const plugin = await this.getOutboundPluginByIdSafe(address.pluginId);
                     if (plugin) return plugin;
                 }
             }
         }
+        // Lazy-aware: include parked-but-unloaded entries (they
+        // materialise via this.materialize below).
         const fallback = this.registry
             .getByCapability(this.CAPABILITY)
-            .find((p) => p.state === 'loaded');
-        if (!fallback || !isEmailOutboundPlugin(fallback.plugin)) {
+            .find(
+                (p) =>
+                    p.state === 'loaded' ||
+                    (this.registry.isLazy?.(p.manifest.id) ?? false),
+            );
+        if (!fallback) {
             throw new NoProviderError(this.CAPABILITY);
         }
-        return fallback.plugin;
+        const plugin = await this.materialize(fallback);
+        if (!isEmailOutboundPlugin(plugin)) {
+            throw new NoProviderError(this.CAPABILITY);
+        }
+        return plugin;
     }
 
-    private getOutboundPluginByIdSafe(pluginId: string): IEmailOutboundPlugin | undefined {
+    private async getOutboundPluginByIdSafe(
+        pluginId: string,
+    ): Promise<IEmailOutboundPlugin | undefined> {
         const registered = this.registry
             .getByCapability(this.CAPABILITY)
-            .find((p) => p.plugin.id === pluginId && p.state === 'loaded');
+            .find(
+                (p) =>
+                    p.manifest.id === pluginId &&
+                    (p.state === 'loaded' ||
+                        (this.registry.isLazy?.(p.manifest.id) ?? false)),
+            );
         if (!registered) return undefined;
-        return isEmailOutboundPlugin(registered.plugin) ? registered.plugin : undefined;
+        const plugin = await this.materialize(registered);
+        return isEmailOutboundPlugin(plugin) ? plugin : undefined;
     }
 
-    private getInboundPluginById(pluginId: string): IEmailInboundPlugin {
+    private async getInboundPluginById(pluginId: string): Promise<IEmailInboundPlugin> {
         const registered = this.registry
             .getByCapability(PLUGIN_CAPABILITIES.EMAIL_INBOUND)
-            .find((p) => p.plugin.id === pluginId && p.state === 'loaded');
-        if (!registered || !isEmailInboundPlugin(registered.plugin)) {
+            .find(
+                (p) =>
+                    p.manifest.id === pluginId &&
+                    (p.state === 'loaded' ||
+                        (this.registry.isLazy?.(p.manifest.id) ?? false)),
+            );
+        if (!registered) {
             throw new EmailFacadeError(
                 `Inbound email plugin not found or disabled: ${pluginId}`,
                 'parseInbound',
                 pluginId,
             );
         }
-        return registered.plugin;
+        const plugin = await this.materialize(registered);
+        if (!isEmailInboundPlugin(plugin)) {
+            throw new EmailFacadeError(
+                `Inbound email plugin not found or disabled: ${pluginId}`,
+                'parseInbound',
+                pluginId,
+            );
+        }
+        return plugin;
     }
 
     private async resolveSettings(

--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -139,7 +139,14 @@ export class GitFacadeService implements IGitFacade {
 
     isConfigured(): boolean {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
-        return plugins.length > 0 && plugins.some((p) => p.state === 'loaded');
+        // Lazy-aware: parked-but-unloaded plugins ARE configured.
+        return (
+            plugins.length > 0 &&
+            plugins.some(
+                (p) =>
+                    p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
+            )
+        );
     }
 
     /**
@@ -171,14 +178,21 @@ export class GitFacadeService implements IGitFacade {
 
     getAvailableProviders(): GitProviderInfo[] {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
-        return plugins.map((p) => ({
-            id: p.plugin.id,
-            name: (p.plugin as IGitProviderPlugin).providerName,
-            enabled: p.state === 'loaded',
-            icon: p.manifest.icon,
-            description: p.manifest.description,
-            homepage: p.manifest.homepage,
-        }));
+        return plugins.map((p) => {
+            // Sync method — fall back to the manifest when the
+            // plugin instance hasn't been materialised yet. Runtime
+            // `providerName` overrides are only available post-load.
+            const plugin = p.plugin as IGitProviderPlugin | undefined;
+            return {
+                id: p.manifest.id,
+                name: plugin?.providerName ?? p.manifest.name ?? p.manifest.id,
+                enabled:
+                    p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
+                icon: p.manifest.icon,
+                description: p.manifest.description,
+                homepage: p.manifest.homepage,
+            };
+        });
     }
 
     async hasValidCredentials(options: GitFacadeOptions): Promise<boolean> {
@@ -862,15 +876,21 @@ export class GitFacadeService implements IGitFacade {
     private getPluginSync(providerId: string): IGitProviderPlugin {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
 
+        // Sync method — only returns plugins whose instance is
+        // already loaded. The git-provider capability is fulfilled
+        // by the built-in `github` plugin which is always eager, so
+        // this stays a hot path that never has to await a lazy load.
+        // If lazy git providers are introduced later, the caller
+        // must go through `resolvePlugin` (async) instead.
         if (providerId) {
-            const registered = plugins.find((p) => p.plugin.id === providerId);
-            if (registered?.state === 'loaded') {
+            const registered = plugins.find((p) => p.manifest.id === providerId);
+            if (registered?.state === 'loaded' && registered.plugin) {
                 return registered.plugin as IGitProviderPlugin;
             }
         }
 
-        const enabled = plugins.find((p) => p.state === 'loaded');
-        if (!enabled) {
+        const enabled = plugins.find((p) => p.state === 'loaded' && p.plugin);
+        if (!enabled || !enabled.plugin) {
             throw new NoGitProviderError();
         }
         return enabled.plugin as IGitProviderPlugin;
@@ -1013,10 +1033,14 @@ export class GitFacadeService implements IGitFacade {
         }
 
         const registered = this.registry.get(providerId);
+        // Lazy-aware: parked-but-unloaded plugins are valid here —
+        // `ensureLoaded` materialises on demand below. Eager
+        // `unloaded` entries (no parked loader) remain ineligible.
         if (
             registered &&
             registered.manifest.capabilities.includes(this.CAPABILITY) &&
-            registered.state === 'loaded'
+            (registered.state === 'loaded' ||
+                (this.registry.isLazy?.(providerId) ?? false))
         ) {
             const isEnabled = await this.registry.isPluginEnabledForScope(
                 providerId,
@@ -1024,7 +1048,7 @@ export class GitFacadeService implements IGitFacade {
                 userId,
             );
             if (isEnabled) {
-                return registered.plugin as IGitProviderPlugin;
+                return (await this.registry.ensureLoaded(providerId)) as IGitProviderPlugin;
             }
         }
         throw new GitProviderNotFoundError(providerId);

--- a/packages/agent/src/facades/notification-channel.facade.ts
+++ b/packages/agent/src/facades/notification-channel.facade.ts
@@ -240,7 +240,7 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
         config: ChannelTargetConfig,
         options: FacadeOptions,
     ): Promise<ChannelVerification> {
-        const plugin = this.getChannelPluginById(pluginId);
+        const plugin = await this.getChannelPluginById(pluginId);
         const settings = await this.resolveSettings(pluginId, options);
         return plugin.verifyTarget(config, {
             userId: options.userId,
@@ -322,7 +322,7 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
         }
 
         try {
-            const plugin = this.getChannelPluginById(channel.pluginId);
+            const plugin = await this.getChannelPluginById(channel.pluginId);
             const settings = await this.resolveSettings(channel.pluginId, options);
             const channelOpts: ChannelOptions = {
                 userId: options.userId,
@@ -376,18 +376,34 @@ export class NotificationChannelFacadeService extends BaseFacadeService {
         }
     }
 
-    private getChannelPluginById(pluginId: string): INotificationChannelPlugin {
+    private async getChannelPluginById(pluginId: string): Promise<INotificationChannelPlugin> {
+        // Lazy-aware: a parked-but-unloaded plugin is a valid match.
+        // We compare by manifest.id (the id is class-validated to
+        // equal plugin.id), then materialise via the registry.
         const registered = this.registry
             .getByCapability(this.CAPABILITY)
-            .find((p) => p.plugin.id === pluginId && p.state === 'loaded');
-        if (!registered || !isNotificationChannelPlugin(registered.plugin)) {
+            .find(
+                (p) =>
+                    p.manifest.id === pluginId &&
+                    (p.state === 'loaded' ||
+                        (this.registry.isLazy?.(p.manifest.id) ?? false)),
+            );
+        if (!registered) {
             throw new NotificationChannelFacadeError(
                 `Notification channel plugin not found or disabled: ${pluginId}`,
                 'send',
                 pluginId,
             );
         }
-        return registered.plugin;
+        const plugin = await this.materialize(registered);
+        if (!isNotificationChannelPlugin(plugin)) {
+            throw new NotificationChannelFacadeError(
+                `Notification channel plugin not found or disabled: ${pluginId}`,
+                'send',
+                pluginId,
+            );
+        }
+        return plugin;
     }
 
     private async resolveSettings(

--- a/packages/agent/src/facades/oauth.facade.ts
+++ b/packages/agent/src/facades/oauth.facade.ts
@@ -81,15 +81,22 @@ export class OAuthFacadeService implements IOAuthFacade {
 
     isConfigured(): boolean {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
-        return plugins.length > 0 && plugins.some((p) => p.state === 'loaded');
+        // Lazy-aware: parked-but-unloaded plugins ARE configured.
+        return (
+            plugins.length > 0 &&
+            plugins.some(
+                (p) =>
+                    p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
+            )
+        );
     }
 
     getAvailableProviders(): OAuthProviderInfo[] {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
         return plugins.map((p) => ({
-            id: p.plugin.id,
+            id: p.manifest.id,
             name: p.manifest.name,
-            enabled: p.state === 'loaded',
+            enabled: p.state === 'loaded' || (this.registry.isLazy?.(p.manifest.id) ?? false),
         }));
     }
 
@@ -181,9 +188,15 @@ export class OAuthFacadeService implements IOAuthFacade {
     private getPluginSync(providerId: string): IOAuthPlugin {
         const plugins = this.registry.getByCapability(this.CAPABILITY);
 
+        // Sync method — the OAuth capability is fulfilled by
+        // built-in (eager) providers in the current monorepo, so we
+        // only return already-loaded plugin instances. If lazy OAuth
+        // providers are introduced later, this needs a sibling async
+        // path; for now matching the existing IOAuthFacade interface
+        // (sync `getAuthorizationUrl`) is the priority.
         if (providerId) {
-            const registered = plugins.find((p) => p.plugin.id === providerId);
-            if (registered?.state === 'loaded') {
+            const registered = plugins.find((p) => p.manifest.id === providerId);
+            if (registered?.state === 'loaded' && registered.plugin) {
                 if (!isOAuthPlugin(registered.plugin)) {
                     throw new OAuthNotSupportedError(providerId, 'getPlugin');
                 }
@@ -192,12 +205,12 @@ export class OAuthFacadeService implements IOAuthFacade {
         }
 
         // If no specific provider requested, try to find any enabled OAuth provider
-        const enabled = plugins.find((p) => p.state === 'loaded');
-        if (!enabled) {
+        const enabled = plugins.find((p) => p.state === 'loaded' && p.plugin);
+        if (!enabled || !enabled.plugin) {
             throw new NoOAuthProviderError();
         }
         if (!isOAuthPlugin(enabled.plugin)) {
-            throw new OAuthNotSupportedError(enabled.plugin.id, 'getPlugin');
+            throw new OAuthNotSupportedError(enabled.manifest.id, 'getPlugin');
         }
         return enabled.plugin as IOAuthPlugin;
     }

--- a/packages/agent/src/pipeline/pipeline-builder.service.ts
+++ b/packages/agent/src/pipeline/pipeline-builder.service.ts
@@ -134,7 +134,7 @@ export class PipelineBuilderService {
 
         // 4. Process each modifier's step contributions
         for (const { registered, modifierPlugin } of modifiers) {
-            this.processModifierSteps(modifierPlugin, registered.plugin.id, buildContext);
+            this.processModifierSteps(modifierPlugin, registered.manifest.id, buildContext);
         }
 
         // 5. Apply modifications in order
@@ -228,20 +228,33 @@ export class PipelineBuilderService {
         );
 
         for (const registered of pluginsWithCapability) {
-            if (registered.state !== 'loaded') continue;
+            const pluginId = registered.manifest.id;
+            // Lazy-aware: parked-but-unloaded plugins ARE eligible
+            // — `ensureLoaded` materialises them below before any
+            // instance method is touched. Eager `unloaded` entries
+            // (no parked loader) stay ineligible.
+            if (
+                registered.state !== 'loaded' &&
+                !(this.registry.isLazy?.(pluginId) ?? false)
+            ) {
+                continue;
+            }
 
             const isEnabled = await this.registry.isPluginEnabledForScope(
-                registered.plugin.id,
+                pluginId,
                 workId,
                 userId,
             );
             if (!isEnabled) continue;
 
-            if (!isPipelineModifierPlugin(registered.plugin)) continue;
+            // Materialise via the registry — eager mode returns the
+            // cached instance instantly; lazy mode fires the
+            // deferred import + onLoad exactly once per id.
+            const modifierPlugin = await this.registry.ensureLoaded(pluginId);
+            if (!isPipelineModifierPlugin(modifierPlugin)) continue;
 
             // Check targetPipelines
-            const targets =
-                registered.plugin.targetPipelines ?? registered.manifest.targetPipelines;
+            const targets = modifierPlugin.targetPipelines ?? registered.manifest.targetPipelines;
             if (!targets?.includes(pipelineId) && !targets?.includes('*')) continue;
 
             // PR #1087 — KB option B. If the modifier implements
@@ -251,17 +264,17 @@ export class PipelineBuilderService {
             // `execute()` after their steps were already injected.
             // Fail-open: a thrown error is treated as "don't skip" so
             // a buggy modifier doesn't silently disappear.
-            if (typeof registered.plugin.canSkipAtBuildTime === 'function') {
+            if (typeof modifierPlugin.canSkipAtBuildTime === 'function') {
                 let skip = false;
                 try {
                     const settings = this.settingsService
-                        ? await this.settingsService.getSettings(registered.plugin.id, {
+                        ? await this.settingsService.getSettings(pluginId, {
                               userId,
                               workId,
                               includeSecrets: true,
                           })
                         : {};
-                    skip = await registered.plugin.canSkipAtBuildTime({
+                    skip = await modifierPlugin.canSkipAtBuildTime({
                         settings,
                         ...(workId ? { workId } : {}),
                         ...(userId ? { userId } : {}),
@@ -269,12 +282,12 @@ export class PipelineBuilderService {
                     });
                 } catch (err) {
                     this.logger.warn(
-                        `Modifier "${registered.plugin.id}".canSkipAtBuildTime threw — treating as don't-skip: ${(err as Error).message}`,
+                        `Modifier "${pluginId}".canSkipAtBuildTime threw — treating as don't-skip: ${(err as Error).message}`,
                     );
                 }
                 if (skip) {
                     this.logger.debug(
-                        `Modifier "${registered.plugin.id}" requested skip for pipeline=${pipelineId} work=${workId ?? '-'} user=${userId ?? '-'}`,
+                        `Modifier "${pluginId}" requested skip for pipeline=${pipelineId} work=${workId ?? '-'} user=${userId ?? '-'}`,
                     );
                     continue;
                 }
@@ -282,7 +295,7 @@ export class PipelineBuilderService {
 
             result.push({
                 registered,
-                modifierPlugin: registered.plugin,
+                modifierPlugin,
             });
         }
 

--- a/packages/agent/src/plugins/__tests__/plugin-bootstrap.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-bootstrap.service.spec.ts
@@ -4,6 +4,7 @@ import { PluginBootstrapService } from '../services/plugin-bootstrap.service';
 import { PluginLoaderService } from '../services/plugin-loader.service';
 import { PluginLifecycleManagerService } from '../services/plugin-lifecycle-manager.service';
 import { PluginContextFactoryService } from '../services/plugin-context-factory.service';
+import { PluginRegistryService } from '../services/plugin-registry.service';
 
 // Silence Logger output during tests
 jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
@@ -48,6 +49,18 @@ describe('PluginBootstrapService', () => {
                 {
                     provide: PluginContextFactoryService,
                     useValue: {},
+                },
+                {
+                    provide: PluginRegistryService,
+                    useValue: {
+                        // Lazy-mode plumbing: bootstrap consults the
+                        // registry to wire `setPostLoadHook` and to
+                        // ask `isLazy(id)` per result. Defaults here
+                        // (no-op hook setter, all eager) preserve the
+                        // pre-lazy assertions in this suite.
+                        setPostLoadHook: jest.fn(),
+                        isLazy: jest.fn().mockReturnValue(false),
+                    },
                 },
             ],
         }).compile();

--- a/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
@@ -144,6 +144,48 @@ describe('PluginOperationsService', () => {
                         getAll: jest.fn().mockReturnValue([createRegisteredPlugin()]),
                         getAvailableCategories: jest.fn().mockReturnValue(['utility']),
                         getAvailableCapabilities: jest.fn().mockReturnValue(['test']),
+                        // Lazy-mode shim — tests register plugins
+                        // with `state: 'loaded'` and the eager
+                        // `plugin` instance. We try the by-id `get`
+                        // mock first (the most-specific override
+                        // tests use) and fall back to a scan of
+                        // getAll(). Per-test
+                        // `jest.spyOn(...).mockReturnValue(...)`
+                        // continues to drive ensureLoaded.
+                        isLazy: jest.fn(() => false),
+                        ensureLoaded: jest.fn(async function (
+                            this: PluginRegistryService,
+                            id: string,
+                        ) {
+                            // Prefer the by-id `get` mock when its
+                            // returned plugin matches the requested
+                            // id (most tests use that as the direct
+                            // override). Otherwise fall back to a
+                            // scan of getAll() (handles list-shaped
+                            // tests that drive everything via getAll).
+                            // Final fallback is whatever `get(id)`
+                            // returned — many beforeEach mocks
+                            // ignore the id argument and always
+                            // return the default registered plugin.
+                            const reg = this.get(id);
+                            if (
+                                reg?.plugin &&
+                                ((reg as any).manifest?.id === id ||
+                                    (reg as any).plugin?.id === id)
+                            ) {
+                                return reg.plugin as any;
+                            }
+                            const all =
+                                (this.getAll() as Array<{
+                                    plugin?: { id?: string };
+                                    manifest?: { id?: string };
+                                }>) || [];
+                            const fromAll = all.find(
+                                (p) => p.manifest?.id === id || p.plugin?.id === id,
+                            );
+                            if (fromAll?.plugin) return fromAll.plugin as any;
+                            return reg?.plugin as any;
+                        }),
                     },
                 },
                 {
@@ -2075,6 +2117,15 @@ describe('PluginOperationsService', () => {
                         useValue: {
                             get: jest.fn(),
                             getAll: jest.fn().mockReturnValue([]),
+                            // Lazy-mode shim — see beforeEach above.
+                            isLazy: jest.fn(() => false),
+                            ensureLoaded: jest.fn(async function (
+                                this: PluginRegistryService,
+                                id: string,
+                            ) {
+                                const reg = this.get(id);
+                                return reg?.plugin as any;
+                            }),
                         },
                     },
                     {

--- a/packages/agent/src/plugins/__tests__/plugin-registry.lazy-load.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-registry.lazy-load.spec.ts
@@ -1,0 +1,160 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Logger } from '@nestjs/common';
+import type { IPlugin, PluginManifest } from '@ever-works/plugin';
+import { PluginRegistryService } from '../services/plugin-registry.service';
+
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+
+const makeManifest = (id: string): PluginManifest =>
+    ({
+        id,
+        name: `Test Plugin ${id}`,
+        version: '1.0.0',
+        category: 'utility',
+        capabilities: ['utility'],
+        description: '',
+    }) as PluginManifest;
+
+const makePlugin = (id: string): IPlugin =>
+    ({
+        id,
+        name: `Test Plugin ${id}`,
+        version: '1.0.0',
+        category: 'utility',
+        capabilities: ['utility'],
+        onLoad: jest.fn().mockResolvedValue(undefined),
+        onUnload: jest.fn().mockResolvedValue(undefined),
+    }) as unknown as IPlugin;
+
+describe('PluginRegistryService — lazy loading', () => {
+    let registry: PluginRegistryService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [PluginRegistryService, EventEmitter2],
+        }).compile();
+        registry = module.get(PluginRegistryService);
+    });
+
+    afterEach(() => {
+        registry.clear();
+    });
+
+    it('registerLazy parks a loader without invoking it', () => {
+        const manifest = makeManifest('lazy-1');
+        const loader = jest.fn().mockResolvedValue(makePlugin('lazy-1'));
+
+        const registered = registry.registerLazy(manifest, loader);
+
+        expect(registered.state).toBe('unloaded');
+        expect(registered.plugin).toBeUndefined();
+        expect(loader).not.toHaveBeenCalled();
+        expect(registry.isLazy('lazy-1')).toBe(true);
+        // Manifest indices must be populated so capability/category
+        // lookups still find the plugin pre-load.
+        expect(registry.getByCapability('utility')).toHaveLength(1);
+        expect(registry.getByCategory('utility')).toHaveLength(1);
+    });
+
+    it('ensureLoaded invokes the loader on first call and caches thereafter', async () => {
+        const manifest = makeManifest('lazy-2');
+        const plugin = makePlugin('lazy-2');
+        const loader = jest.fn().mockResolvedValue(plugin);
+        registry.registerLazy(manifest, loader);
+
+        const first = await registry.ensureLoaded('lazy-2');
+        expect(first).toBe(plugin);
+        expect(loader).toHaveBeenCalledTimes(1);
+
+        const second = await registry.ensureLoaded('lazy-2');
+        expect(second).toBe(plugin);
+        // Second call MUST be a cache hit — same loader is not
+        // re-invoked, no second `import()` cost.
+        expect(loader).toHaveBeenCalledTimes(1);
+
+        // After load, registry has the plugin instance attached and
+        // state transitioned to 'loaded'.
+        expect(registry.get('lazy-2')?.plugin).toBe(plugin);
+        expect(registry.get('lazy-2')?.state).toBe('loaded');
+    });
+
+    it('ensureLoaded dedupes concurrent calls to a single import', async () => {
+        const manifest = makeManifest('lazy-3');
+        const plugin = makePlugin('lazy-3');
+        let resolveLoader: ((p: IPlugin) => void) | null = null;
+        const loaderPromise = new Promise<IPlugin>((resolve) => {
+            resolveLoader = resolve;
+        });
+        const loader = jest.fn().mockReturnValue(loaderPromise);
+        registry.registerLazy(manifest, loader);
+
+        const a = registry.ensureLoaded('lazy-3');
+        const b = registry.ensureLoaded('lazy-3');
+        const c = registry.ensureLoaded('lazy-3');
+
+        // All three callers share the same in-flight promise — only
+        // one `import()` ever runs.
+        expect(loader).toHaveBeenCalledTimes(1);
+
+        resolveLoader!(plugin);
+        const [ra, rb, rc] = await Promise.all([a, b, c]);
+        expect(ra).toBe(plugin);
+        expect(rb).toBe(plugin);
+        expect(rc).toBe(plugin);
+    });
+
+    it('ensureLoaded fires the post-load hook exactly once after the plugin is attached', async () => {
+        const manifest = makeManifest('lazy-4');
+        const plugin = makePlugin('lazy-4');
+        const loader = jest.fn().mockResolvedValue(plugin);
+        const hook = jest.fn().mockResolvedValue(undefined);
+
+        registry.setPostLoadHook(hook);
+        registry.registerLazy(manifest, loader);
+
+        await registry.ensureLoaded('lazy-4');
+        await registry.ensureLoaded('lazy-4'); // re-call
+
+        expect(hook).toHaveBeenCalledTimes(1);
+        expect(hook).toHaveBeenCalledWith('lazy-4');
+    });
+
+    it('ensureLoaded surfaces loader failures and transitions state to error', async () => {
+        const manifest = makeManifest('lazy-5');
+        const err = new Error('boom');
+        const loader = jest.fn().mockRejectedValue(err);
+        registry.registerLazy(manifest, loader);
+
+        await expect(registry.ensureLoaded('lazy-5')).rejects.toThrow('boom');
+        expect(registry.get('lazy-5')?.state).toBe('error');
+    });
+
+    it('ensureLoaded returns the already-attached instance for eager-registered plugins', async () => {
+        const manifest = makeManifest('eager-1');
+        const plugin = makePlugin('eager-1');
+        registry.register(plugin, manifest, { state: 'loaded' });
+
+        const resolved = await registry.ensureLoaded('eager-1');
+        expect(resolved).toBe(plugin);
+        expect(registry.isLazy('eager-1')).toBe(false);
+    });
+
+    it('ensureLoaded throws when the plugin id is unknown', async () => {
+        await expect(registry.ensureLoaded('nope')).rejects.toThrow(/not registered/);
+    });
+
+    it('unregister clears the parked loader so re-registration is allowed', async () => {
+        const manifest = makeManifest('lazy-6');
+        registry.registerLazy(manifest, jest.fn());
+        registry.unregister('lazy-6');
+
+        expect(registry.has('lazy-6')).toBe(false);
+        expect(registry.isLazy('lazy-6')).toBe(false);
+        // Re-registration must not collide with leftover state.
+        expect(() => registry.registerLazy(manifest, jest.fn())).not.toThrow();
+    });
+});

--- a/packages/agent/src/plugins/services/plugin-bootstrap.service.ts
+++ b/packages/agent/src/plugins/services/plugin-bootstrap.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PluginLoaderService } from './plugin-loader.service';
 import { PluginLifecycleManagerService } from './plugin-lifecycle-manager.service';
 import { PluginContextFactoryService } from './plugin-context-factory.service';
+import { PluginRegistryService } from './plugin-registry.service';
 
 /**
  * Result of the bootstrap operation
@@ -44,6 +45,7 @@ export class PluginBootstrapService {
         private readonly pluginLoader: PluginLoaderService,
         private readonly lifecycleManager: PluginLifecycleManagerService,
         private readonly contextFactory: PluginContextFactoryService,
+        private readonly registry: PluginRegistryService,
     ) {}
 
     /**
@@ -80,12 +82,75 @@ export class PluginBootstrapService {
             };
         }
 
-        this.logger.log('Bootstrapping plugin system...');
+        // Lazy-load mode (opt-in via `PLUGIN_LAZY_LOAD=true`): only
+        // discover manifests at boot, defer each plugin's `await
+        // import()` + `onLoad` until the first `registry.ensureLoaded`
+        // call (typically from a facade's `resolvePlugin`). Reduces
+        // API process RSS by the sum of every plugin's SDK weight —
+        // material when many notification-channel + email-provider +
+        // pipeline plugins ship but the API process only ever invokes
+        // a handful of them at runtime (most channel/email delivery
+        // happens inside the Trigger.dev hosted sandbox, not the API).
+        //
+        // Default stays eager so existing behaviour is unchanged for
+        // any environment that doesn't flip the flag.
+        const lazyLoad = process.env.PLUGIN_LAZY_LOAD === 'true';
+
+        this.logger.log(
+            `Bootstrapping plugin system... (${lazyLoad ? 'lazy' : 'eager'} mode)`,
+        );
 
         // Connect the context factory to the lifecycle manager
         this.lifecycleManager.setContextFactory(this.contextFactory);
 
-        // Discover and load plugins
+        if (lazyLoad) {
+            // Wire the post-load hook so the registry fires `onLoad`
+            // after `ensureLoaded` constructs each plugin. Without
+            // this, lazy-loaded plugins would never get their lifecycle
+            // hook called.
+            this.registry.setPostLoadHook(async (pluginId: string) => {
+                const result = await this.lifecycleManager.callOnLoad(pluginId);
+                if (!result.success) {
+                    // Don't throw — the plugin instance is already
+                    // attached and `state=loaded`. Surface as a log;
+                    // the caller still gets the plugin.
+                    this.logger.error(
+                        `Post-load onLoad failed for "${pluginId}": ${result.error}`,
+                    );
+                }
+            });
+
+            const result = await this.pluginLoader.discoverAndRegisterAll();
+            this.logger.log(
+                `Plugin lazy-discovery complete: ${result.loaded} registered (${result.discovered} lazy), ${result.failed} failed. ` +
+                    `Heavy import() deferred until first use.`,
+            );
+
+            // Built-in plugins (small, pre-constructed instances) ARE
+            // already loaded by discoverAndRegisterAll(). Fire their
+            // onLoad now to preserve existing eager semantics for the
+            // built-in subset — only the lazy-registered filesystem
+            // plugins defer.
+            for (const loadResult of result.results) {
+                if (
+                    loadResult.success &&
+                    loadResult.pluginId &&
+                    !this.registry.isLazy(loadResult.pluginId)
+                ) {
+                    await this.lifecycleManager.callOnLoad(loadResult.pluginId);
+                }
+            }
+
+            PluginBootstrapService.initialized = true;
+            this.logger.log('Plugin system bootstrapped successfully (lazy mode)');
+            return {
+                executed: true,
+                loaded: result.loaded,
+                failed: result.failed,
+            };
+        }
+
+        // Eager (default) path — unchanged.
         const result = await this.pluginLoader.discoverAndLoadAll();
         this.logger.log(
             `Plugin discovery complete: ${result.loaded} loaded, ${result.failed} failed`,

--- a/packages/agent/src/plugins/services/plugin-loader.service.ts
+++ b/packages/agent/src/plugins/services/plugin-loader.service.ts
@@ -475,6 +475,201 @@ export class PluginLoaderService {
     }
 
     /**
+     * Lazy-load variant of `discoverAndLoadAll`. Built-in plugins
+     * (passed via `PluginsModuleOptions.builtInPlugins`) are still
+     * eagerly loaded — they're already pre-constructed in memory, so
+     * registering them lazily would save nothing. Filesystem-discovered
+     * plugins are registered via `registry.registerLazy` so their
+     * heavy `await import()` is deferred until the first
+     * `registry.ensureLoaded(id)` call.
+     *
+     * Used by the lazy bootstrap path when `PLUGIN_LAZY_LOAD=true`.
+     * Returns the same shape as the eager variant so callers can swap
+     * paths without rewriting telemetry.
+     */
+    async discoverAndRegisterAll(): Promise<{
+        discovered: number;
+        loaded: number;
+        failed: number;
+        results: LoadResult[];
+    }> {
+        const discovered = await this.discover();
+        const results: LoadResult[] = [];
+        let loaded = 0;
+        let failed = 0;
+
+        // Built-in plugins remain eager: they're already constructed
+        // instances, so there's no `import()` cost to defer.
+        if (this.options.builtInPlugins) {
+            for (const pluginModule of this.options.builtInPlugins) {
+                const result = await this.loadBuiltIn(pluginModule);
+                results.push(result);
+                if (result.success) loaded++;
+                else {
+                    failed++;
+                    this.logger.warn(
+                        `Failed to load built-in plugin "${result.pluginId || 'unknown'}": ${result.error || 'unknown error'}`,
+                    );
+                }
+            }
+        }
+
+        // Filesystem-discovered plugins register lazily.
+        for (const discoveredPlugin of discovered) {
+            const result = await this.registerLazy(discoveredPlugin);
+            results.push(result);
+            if (result.success) loaded++;
+            else {
+                failed++;
+                this.logger.warn(
+                    `Failed to lazy-register plugin "${result.pluginId || 'unknown'}": ${result.error || 'unknown error'}`,
+                );
+            }
+        }
+
+        this.logger.log(
+            `Plugin registration complete: ${loaded} registered (${discovered.length} lazy), ${failed} failed`,
+        );
+
+        return {
+            discovered: discovered.length,
+            loaded,
+            failed,
+            results,
+        };
+    }
+
+    /**
+     * Lazy-register a discovered plugin. Runs only the cheap pre-flight
+     * checks (duplicate-id, version-compat from manifest) and parks a
+     * loader closure with the registry. The plugin's main module is
+     * NOT imported here — that happens on the first
+     * `registry.ensureLoaded(id)` call, typically from a facade's
+     * `resolvePlugin` path.
+     */
+    async registerLazy(discovered: DiscoveredPlugin): Promise<LoadResult> {
+        const { manifest, path: pluginPath } = discovered;
+
+        try {
+            if (this.registry.has(manifest.id)) {
+                return {
+                    success: false,
+                    pluginId: manifest.id,
+                    error: `Plugin "${manifest.id}" is already registered`,
+                };
+            }
+
+            const versionResult = this.versionChecker.check(
+                manifest,
+                this.registry.getVersionsMap(),
+            );
+            if (!versionResult.valid) {
+                return {
+                    success: false,
+                    pluginId: manifest.id,
+                    error: `Version check failed: ${versionResult.errors?.map((e) => e.message).join(', ')}`,
+                };
+            }
+
+            const warnings: string[] = [];
+            if (versionResult.warnings) {
+                warnings.push(...versionResult.warnings.map((w) => w.message));
+            }
+
+            // Loader closure: invoked at most once per plugin id by
+            // PluginRegistryService.ensureLoaded(). Owns the deferred
+            // import + class validation + DB state transition; the
+            // registry handles attach-plugin + state=loaded + the
+            // post-load onLoad hook.
+            const loader = async (): Promise<IPlugin> => {
+                const plugin = await this.loadPluginModule(pluginPath, manifest);
+                if (!plugin) {
+                    throw new Error(
+                        `Failed to load plugin module for "${manifest.id}" from ${pluginPath}`,
+                    );
+                }
+
+                // Merge runtime manifest (icon, readme, etc.) — same
+                // logic as the eager `load()` path.
+                let resolvedManifest = manifest;
+                if (typeof plugin.getManifest === 'function') {
+                    const runtimeManifest = plugin.getManifest();
+                    const definedManifest = pickBy(
+                        manifest as unknown as Record<string, unknown>,
+                        (v) => v !== undefined,
+                    );
+                    resolvedManifest = {
+                        ...runtimeManifest,
+                        ...definedManifest,
+                    } as typeof manifest;
+                }
+
+                const classValidation = this.classValidator.validate(plugin, resolvedManifest);
+                if (!classValidation.valid) {
+                    throw new Error(
+                        `Plugin validation failed: ${classValidation.errors?.map((e) => e.message).join(', ')}`,
+                    );
+                }
+
+                // Persist DB state — the row was upserted as 'unloaded'
+                // at lazy-register time; update to 'loaded' now.
+                await this.pluginRepository.upsert({
+                    pluginId: resolvedManifest.id,
+                    name: resolvedManifest.name,
+                    version: resolvedManifest.version,
+                    description: resolvedManifest.description,
+                    category: resolvedManifest.category,
+                    capabilities: [...resolvedManifest.capabilities],
+                    manifest: resolvedManifest as unknown as Record<string, unknown>,
+                    builtIn: discovered.builtIn,
+                    installPath: pluginPath,
+                    state: 'loaded',
+                });
+
+                this.logger.log(
+                    `Lazy-loaded plugin: ${resolvedManifest.id} v${resolvedManifest.version}`,
+                );
+                return plugin;
+            };
+
+            this.registry.registerLazy(manifest, loader, {
+                builtIn: discovered.builtIn,
+                installPath: pluginPath,
+            });
+
+            // Persist a manifest-only row so the DB reflects "known but
+            // not loaded yet" — admin tooling reading `plugins` table
+            // sees every discovered plugin even before first use.
+            await this.pluginRepository.upsert({
+                pluginId: manifest.id,
+                name: manifest.name,
+                version: manifest.version,
+                description: manifest.description,
+                category: manifest.category,
+                capabilities: [...manifest.capabilities],
+                manifest: manifest as unknown as Record<string, unknown>,
+                builtIn: discovered.builtIn,
+                installPath: pluginPath,
+                state: 'unloaded',
+            });
+
+            return {
+                success: true,
+                pluginId: manifest.id,
+                warnings: warnings.length > 0 ? warnings : undefined,
+            };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.error(`Failed to lazy-register plugin ${manifest.id}:`, error);
+            return {
+                success: false,
+                pluginId: manifest.id,
+                error: message,
+            };
+        }
+    }
+
+    /**
      * Discover and load all plugins with dependency resolution
      */
     async discoverAndLoadAll(): Promise<{

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -104,7 +104,7 @@ export class PluginOperationsService {
         // When filtering by category (settings page), only show enabled plugins
         if (category) {
             filteredPlugins = filteredPlugins.filter((registered) => {
-                const userPlugin = userPluginMap.get(registered.plugin.id) ?? null;
+                const userPlugin = userPluginMap.get(registered.manifest.id) ?? null;
                 return resolvePluginEnabled({
                     systemPlugin: registered.manifest?.systemPlugin,
                     autoEnable: registered.manifest?.autoEnable,
@@ -118,7 +118,7 @@ export class PluginOperationsService {
         // Map to response
         const plugins = await Promise.all(
             filteredPlugins.map((registered) => {
-                const userPlugin = userPluginMap.get(registered.plugin.id);
+                const userPlugin = userPluginMap.get(registered.manifest.id);
                 return this.toUserPluginResponseWithResolvedSettings(
                     registered,
                     userPlugin,
@@ -157,16 +157,19 @@ export class PluginOperationsService {
         // 2. Are installed and enabled by the user
         // 3. Have user-configurable settings (configurationMode !== 'admin-only')
         // 4. Have settings schema with properties
-        const configurablePlugins = allPlugins.filter((registered) => {
+        //
+        // Lazy-safe note: `capabilities` come off the manifest;
+        // `configurationMode` + `settingsSchema` are instance-only.
+        // We materialise once per plugin via ensureLoaded — eager
+        // mode is a hot path (cached instance, no I/O), lazy mode
+        // fires the deferred import + onLoad exactly once per id.
+        const configurablePluginsAsync = allPlugins.map(async (registered) => {
             const visibility = registered.manifest?.visibility ?? 'public';
-            if (visibility === 'hidden') return false;
+            if (visibility === 'hidden') return null;
 
-            const hasOAuth = registered.plugin.capabilities?.includes('oauth') ?? false;
+            const hasOAuth = registered.manifest.capabilities?.includes('oauth') ?? false;
 
-            const configMode = registered.plugin.configurationMode || 'hybrid';
-            if (configMode === 'admin-only' && !hasOAuth) return false;
-
-            const userPlugin = userPluginMap.get(registered.plugin.id) ?? null;
+            const userPlugin = userPluginMap.get(registered.manifest.id) ?? null;
             const isEnabled = resolvePluginEnabled({
                 systemPlugin: registered.manifest?.systemPlugin,
                 autoEnable: registered.manifest?.autoEnable,
@@ -174,11 +177,15 @@ export class PluginOperationsService {
                 workPlugin: null,
                 hasWorkContext: false,
             });
-            if (!isEnabled) return false;
+            if (!isEnabled) return null;
+
+            const plugin = await this.pluginRegistryService.ensureLoaded(registered.manifest.id);
+            const configMode = plugin.configurationMode || 'hybrid';
+            if (configMode === 'admin-only' && !hasOAuth) return null;
 
             // Check if plugin has user-configurable settings
-            const schema = registered.plugin.settingsSchema;
-            if (!schema?.properties && !hasOAuth) return false;
+            const schema = plugin.settingsSchema;
+            if (!schema?.properties && !hasOAuth) return null;
 
             // Check if there are any non-admin-only settings visible to users
             const hasUserSettings = Object.values(schema?.properties || {}).some((prop) => {
@@ -188,24 +195,29 @@ export class PluginOperationsService {
                 return scope === 'global' || scope === 'user';
             });
 
-            return hasUserSettings || hasOAuth;
+            if (!hasUserSettings && !hasOAuth) return null;
+            return { registered, schema };
         });
+        const configurablePlugins = (await Promise.all(configurablePluginsAsync)).filter(
+            (entry): entry is { registered: RegisteredPlugin; schema: JsonSchema | undefined } =>
+                entry !== null,
+        );
 
         // Group by category
         const categoryMap = new Map<string, SettingsMenuPlugin[]>();
 
-        for (const registered of configurablePlugins) {
+        for (const { registered, schema } of configurablePlugins) {
             const category = registered.manifest.category;
-            const userPlugin = userPluginMap.get(registered.plugin.id);
+            const userPlugin = userPluginMap.get(registered.manifest.id);
 
             const hasRequiredSettings = await this.hasUnconfiguredRequiredSettings(
-                registered.plugin.id,
-                registered.plugin.settingsSchema,
+                registered.manifest.id,
+                schema,
                 userId,
             );
 
             const pluginItem: SettingsMenuPlugin = {
-                pluginId: registered.plugin.id,
+                pluginId: registered.manifest.id,
                 name: registered.manifest.name,
                 icon: this.extractIcon(registered.manifest),
                 enabled: resolvePluginEnabled({
@@ -388,12 +400,19 @@ export class PluginOperationsService {
             throw new NotFoundException(`Plugin "${pluginId}" not found`);
         }
 
+        // `settingsSchema` + `configurationMode` are instance-only —
+        // materialise once and reuse. Eager mode returns the cached
+        // instance instantly.
+        const pluginInstance = settings || secretSettings
+            ? await this.pluginRegistryService.ensureLoaded(pluginId)
+            : undefined;
+
         // Enforce configurationMode — admin-only plugins cannot have user settings
-        if (settings || secretSettings) {
-            this.enforceConfigurationMode(registered, 'user');
+        if ((settings || secretSettings) && pluginInstance) {
+            this.enforceConfigurationModeFromInstance(pluginInstance, 'user');
         }
 
-        const schema = registered.plugin.settingsSchema;
+        const schema = pluginInstance?.settingsSchema;
 
         // Validate combined settings+secretSettings together against schema
         if (settings || secretSettings) {
@@ -401,7 +420,7 @@ export class PluginOperationsService {
                 ...(settings || {}),
                 ...(secretSettings || {}),
             };
-            await this.validateSettingsOrThrow(allSettings, schema, 'user', registered.plugin);
+            await this.validateSettingsOrThrow(allSettings, schema, 'user', pluginInstance);
         }
 
         // Get the plugin entity from database
@@ -529,7 +548,7 @@ export class PluginOperationsService {
 
         // Enforce configurationMode — admin-only plugins cannot have user settings
         if (settings || secretSettings) {
-            this.enforceConfigurationMode(registered, 'user');
+            await this.enforceConfigurationMode(registered, 'user');
         }
 
         let userPlugin = await this.userPluginRepository.findOne({
@@ -561,7 +580,11 @@ export class PluginOperationsService {
             });
         }
 
-        const schema = registered.plugin.settingsSchema;
+        // `settingsSchema` is instance-only — materialise to read it.
+        // Eager mode returns the cached instance instantly; the same
+        // instance feeds `validateSettings` below.
+        const plugin = await this.pluginRegistryService.ensureLoaded(pluginId);
+        const schema = plugin.settingsSchema;
 
         // Validate combined settings+secretSettings together against schema
         if (settings || secretSettings) {
@@ -573,7 +596,7 @@ export class PluginOperationsService {
             };
             // Strip null values before validation — null means "cleared"
             const cleanedSettings = this.stripNullValues(allSettings);
-            await this.validateSettingsOrThrow(cleanedSettings, schema, 'user', registered.plugin);
+            await this.validateSettingsOrThrow(cleanedSettings, schema, 'user', plugin);
         }
 
         // Strip masked placeholders then merge settings, clearing null keys
@@ -635,7 +658,10 @@ export class PluginOperationsService {
         if (!target) {
             throw new NotFoundException(`Plugin "${pluginId}" not found`);
         }
-        if (!target.plugin.capabilities.includes(PLUGIN_CAPABILITIES.PIPELINE)) {
+        // Capabilities live on the manifest (class-validated against
+        // the plugin instance at load) so we can answer this without
+        // forcing the lazy import.
+        if (!target.manifest.capabilities.includes(PLUGIN_CAPABILITIES.PIPELINE)) {
             throw new BadRequestException(`Plugin "${pluginId}" is not a pipeline plugin`);
         }
 
@@ -700,7 +726,7 @@ export class PluginOperationsService {
         const workPluginMap = new Map(workPlugins.map((dp) => [dp.pluginId, dp]));
 
         // Build registry map for quick supplementary lookups
-        const registryMap = new Map(allPlugins.map((p) => [p.plugin.id, p]));
+        const registryMap = new Map(allPlugins.map((p) => [p.manifest.id, p]));
 
         // Build capability providers mapping (exclude supplementary plugins)
         const capabilityProviders: Record<string, string> = {};
@@ -725,8 +751,8 @@ export class PluginOperationsService {
         // Map to response
         const plugins: WorkPluginResponse[] = await Promise.all(
             visiblePlugins.map((registered) => {
-                const userPlugin = userPluginMap.get(registered.plugin.id);
-                const workPlugin = workPluginMap.get(registered.plugin.id);
+                const userPlugin = userPluginMap.get(registered.manifest.id);
+                const workPlugin = workPluginMap.get(registered.manifest.id);
                 return this.toWorkPluginResponse(registered, userPlugin, workPlugin, {
                     userId,
                     workId,
@@ -761,10 +787,14 @@ export class PluginOperationsService {
 
         // Enforce configurationMode — admin-only plugins cannot have work settings
         if (options?.settings) {
-            this.enforceConfigurationMode(registered, 'work');
+            await this.enforceConfigurationMode(registered, 'work');
         }
 
-        const schema = registered.plugin.settingsSchema;
+        // Materialise once — both validateUserLevelRequiredFields
+        // and validateSettingsOrThrow need the instance + schema.
+        // Eager mode returns the cached instance instantly.
+        const pluginInstance = await this.pluginRegistryService.ensureLoaded(pluginId);
+        const schema = pluginInstance.settingsSchema;
 
         // Check if user has the plugin enabled (or plugin is autoEnabled)
         const userPlugin = await this.userPluginRepository.findOne({
@@ -778,7 +808,7 @@ export class PluginOperationsService {
             );
         }
 
-        this.validateUserLevelRequiredFields(userPlugin, registered.plugin.settingsSchema);
+        this.validateUserLevelRequiredFields(userPlugin, schema);
 
         // Validate settings against schema if provided, using merged (user + new) settings
         if (options?.settings) {
@@ -787,7 +817,7 @@ export class PluginOperationsService {
                 ...(userPlugin?.secretSettings || {}),
                 ...options.settings,
             };
-            await this.validateSettingsOrThrow(allSettings, schema, 'work', registered.plugin);
+            await this.validateSettingsOrThrow(allSettings, schema, 'work', pluginInstance);
         }
 
         // Get the plugin entity
@@ -935,7 +965,7 @@ export class PluginOperationsService {
 
         // Enforce configurationMode — admin-only plugins cannot have work settings
         if (settings || secretSettings) {
-            this.enforceConfigurationMode(registered, 'work');
+            await this.enforceConfigurationMode(registered, 'work');
         }
 
         const userPlugin = await this.userPluginRepository.findOne({
@@ -949,7 +979,10 @@ export class PluginOperationsService {
             registered.manifest,
         );
 
-        const schema = registered.plugin.settingsSchema;
+        // Materialise once — `settingsSchema` is instance-only and
+        // we also pass the instance into validateSettingsOrThrow.
+        const pluginInstance = await this.pluginRegistryService.ensureLoaded(pluginId);
+        const schema = pluginInstance.settingsSchema;
 
         this.validateUserLevelRequiredFields(userPlugin, schema);
 
@@ -978,7 +1011,7 @@ export class PluginOperationsService {
                 allSettingsForValidation,
                 schema,
                 'work',
-                registered.plugin,
+                pluginInstance,
             );
         }
 
@@ -1122,17 +1155,20 @@ export class PluginOperationsService {
             throw new NotFoundException(`Plugin "${pluginId}" not found`);
         }
 
-        const plugin = registered.plugin as any;
-        if (typeof plugin.listModels !== 'function') {
-            return [];
-        }
-
+        // Capabilities live on the manifest — answer the AI-provider
+        // short-circuit without materialising. The fallback branch
+        // needs `listModels`, which is instance-only.
         try {
-            if (registered.plugin.capabilities.includes('ai-provider')) {
+            if (registered.manifest.capabilities.includes('ai-provider')) {
                 return await this.aiFacade.getAvailableModels({
                     providerOverride: pluginId,
                     userId,
                 });
+            }
+
+            const plugin = (await this.pluginRegistryService.ensureLoaded(pluginId)) as any;
+            if (typeof plugin.listModels !== 'function') {
+                return [];
             }
 
             const settings = await this.settingsService.getResolvedSettings(pluginId, {
@@ -1227,18 +1263,26 @@ export class PluginOperationsService {
      */
     private toPluginResponse(registered: RegisteredPlugin): PluginResponse {
         const manifest = registered.manifest;
+        // Sync method — fall back to safe defaults when the plugin
+        // instance hasn't been materialised yet (lazy mode). The
+        // dynamic shapes here (`configurationMode`, `settingsSchema`)
+        // are filled in by the lazy-aware callers below
+        // (`toUserPluginResponseWithResolvedSettings`,
+        // `toWorkPluginResponse`) before this response is returned to
+        // the API.
+        const plugin = registered.plugin;
         return {
             ...manifest,
-            id: registered.plugin.id,
-            pluginId: registered.plugin.id,
+            id: manifest.id,
+            pluginId: manifest.id,
             capabilities: [...manifest.capabilities],
-            configurationMode: registered.plugin.configurationMode || 'hybrid',
+            configurationMode: plugin?.configurationMode || 'hybrid',
             builtIn: registered.builtIn,
             systemPlugin: manifest.systemPlugin ?? false,
             visibility: manifest.visibility ?? 'public',
             state: registered.state,
             icon: this.extractIcon(manifest),
-            settingsSchema: this.extractSettingsSchema(registered.plugin.settingsSchema),
+            settingsSchema: this.extractSettingsSchema(plugin?.settingsSchema),
             autoEnable: manifest.autoEnable ?? false,
             supplementary: manifest.supplementary ?? false,
         };
@@ -1250,10 +1294,10 @@ export class PluginOperationsService {
      * For plugins with autoEnable=true, they are considered installed and enabled
      * even without a UserPluginEntity record (unless explicitly disabled).
      */
-    private toUserPluginResponse(
+    private async toUserPluginResponse(
         registered: RegisteredPlugin,
         userPlugin?: UserPluginEntity | null,
-    ): UserPluginResponse {
+    ): Promise<UserPluginResponse> {
         const baseResponse = this.toPluginResponse(registered);
         const enabled = resolvePluginEnabled({
             systemPlugin: registered.manifest?.systemPlugin,
@@ -1267,11 +1311,22 @@ export class PluginOperationsService {
             ? { ...userPlugin.settings, ...userPlugin.secretSettings }
             : undefined;
 
+        // Need the instance for `settingsSchema` (instance-only) so
+        // secret masking is correct. Eager mode returns the cached
+        // instance instantly; lazy mode fires the deferred import
+        // exactly once per id.
+        const plugin = await this.pluginRegistryService.ensureLoaded(registered.manifest.id);
+
         return {
             ...baseResponse,
+            // Re-emit the dynamic fields with the now-materialised
+            // instance — toPluginResponse fell back to defaults when
+            // the instance was still parked.
+            configurationMode: plugin.configurationMode || 'hybrid',
+            settingsSchema: this.extractSettingsSchema(plugin.settingsSchema),
             installed: !!userPlugin || enabled,
             enabled,
-            settings: this.maskSecretSettings(mergedSettings, registered.plugin.settingsSchema),
+            settings: this.maskSecretSettings(mergedSettings, plugin.settingsSchema),
             metadata: userPlugin?.metadata ?? {},
             userPluginId: userPlugin?.id,
             autoEnableForWorks: userPlugin?.autoEnableForWorks ?? false,
@@ -1284,7 +1339,7 @@ export class PluginOperationsService {
         userId: string,
         options: { includeConnectionStatus?: boolean } = {},
     ): Promise<UserPluginResponse> {
-        const response = this.toUserPluginResponse(registered, userPlugin);
+        const response = await this.toUserPluginResponse(registered, userPlugin);
 
         // Fan out the two independent reads in parallel:
         //   (1) resolve the user-scope settings (used for the display
@@ -1302,10 +1357,17 @@ export class PluginOperationsService {
         // original concurrency on the opt-in path while preserving
         // the list-path savings (the probe is `Promise.resolve(undefined)`
         // when `includeConnectionStatus` is false, so no extra work).
-        const schema = registered.plugin.settingsSchema;
+        //
+        // `toUserPluginResponse` above already materialised the
+        // instance (eager mode is a cache hit), so reading
+        // `registered.plugin.settingsSchema` here is safe — it's
+        // populated by the time we get here in both eager and lazy
+        // modes.
+        const schema = registered.plugin?.settingsSchema;
+        const pluginId = registered.manifest.id;
         const needsResolved = !!schema?.properties || this.hasAiProviderCapability(registered);
         const resolvedP = needsResolved
-            ? this.settingsService.getResolvedSettings(registered.plugin.id, { userId })
+            ? this.settingsService.getResolvedSettings(pluginId, { userId })
             : Promise.resolve(undefined);
         const connectionStatusP = options.includeConnectionStatus
             ? this.getConnectionStatus(registered, userId)
@@ -1333,7 +1395,10 @@ export class PluginOperationsService {
     }
 
     private hasAiProviderCapability(registered: RegisteredPlugin): boolean {
-        return registered.plugin.capabilities.includes(PLUGIN_CAPABILITIES.AI_PROVIDER);
+        // Capabilities live on the manifest (class-validated to
+        // equal the runtime instance's capabilities at load), so no
+        // need to materialise the plugin instance for this check.
+        return registered.manifest.capabilities.includes(PLUGIN_CAPABILITIES.AI_PROVIDER);
     }
 
     /**
@@ -1362,16 +1427,24 @@ export class PluginOperationsService {
             return undefined;
         }
 
-        if (registered.plugin.capabilities.includes('oauth')) {
+        // Capabilities live on the manifest — answer the OAuth
+        // short-circuit without materialising.
+        if (registered.manifest.capabilities.includes('oauth')) {
             return undefined;
         }
 
-        const settings = await this.settingsService.getSettings(registered.plugin.id, {
+        const pluginId = registered.manifest.id;
+        // Materialise the plugin instance — eager mode returns the
+        // cached instance instantly. The rest of this function reads
+        // instance-only methods (`getDeviceAuthStatus`,
+        // `validateConnection`, `isAvailable`).
+        const pluginInstance = await this.pluginRegistryService.ensureLoaded(pluginId);
+        const settings = await this.settingsService.getSettings(pluginId, {
             userId,
             includeSecrets: true,
         });
 
-        if (isDeviceAuthProvider(registered.plugin)) {
+        if (isDeviceAuthProvider(pluginInstance)) {
             const authModeField =
                 registered.manifest.uiHints?.deviceAuth?.authModeField ?? 'authMode';
             const authMode =
@@ -1380,7 +1453,7 @@ export class PluginOperationsService {
 
             if (prefersDeviceAuth) {
                 try {
-                    const deviceAuthStatus = await registered.plugin.getDeviceAuthStatus(userId);
+                    const deviceAuthStatus = await pluginInstance.getDeviceAuthStatus(userId);
 
                     if (
                         deviceAuthStatus.connected ||
@@ -1396,20 +1469,20 @@ export class PluginOperationsService {
                     }
                 } catch (error) {
                     this.logger.warn(
-                        `Failed to read device auth status for plugin "${registered.plugin.id}": ${error}`,
+                        `Failed to read device auth status for plugin "${pluginId}": ${error}`,
                     );
                 }
             }
         }
 
-        const plugin = registered.plugin as unknown as Record<string, unknown>;
-        const validateConnection = plugin.validateConnection as
+        const pluginAsAny = pluginInstance as unknown as Record<string, unknown>;
+        const validateConnection = pluginAsAny.validateConnection as
             | ((s: Record<string, unknown>) => Promise<{ success: boolean; message: string }>)
             | undefined;
 
         if (typeof validateConnection === 'function') {
             try {
-                const result = await validateConnection.call(registered.plugin, settings);
+                const result = await validateConnection.call(pluginInstance, settings);
                 return {
                     connected: result.success,
                     scope: 'user',
@@ -1417,33 +1490,33 @@ export class PluginOperationsService {
                 };
             } catch (error) {
                 this.logger.warn(
-                    `Failed to validate onboarding connection for plugin "${registered.plugin.id}": ${error}`,
+                    `Failed to validate onboarding connection for plugin "${pluginId}": ${error}`,
                 );
                 return {
                     connected: false,
                     scope: 'user',
-                    message: `${registered.plugin.name} is not configured yet.`,
+                    message: `${pluginInstance.name} is not configured yet.`,
                 };
             }
         }
 
-        const isAvailable = plugin.isAvailable as
+        const isAvailable = pluginAsAny.isAvailable as
             | ((s?: Record<string, unknown>) => Promise<boolean>)
             | undefined;
 
         if (typeof isAvailable === 'function') {
             try {
-                const available = await isAvailable.call(registered.plugin, settings);
+                const available = await isAvailable.call(pluginInstance, settings);
                 return {
                     connected: available,
                     scope: 'user',
                     message: available
-                        ? `${registered.plugin.name} is configured.`
-                        : `${registered.plugin.name} is not configured yet.`,
+                        ? `${pluginInstance.name} is configured.`
+                        : `${pluginInstance.name} is not configured yet.`,
                 };
             } catch (error) {
                 this.logger.warn(
-                    `Failed to resolve availability for plugin "${registered.plugin.id}": ${error}`,
+                    `Failed to resolve availability for plugin "${pluginId}": ${error}`,
                 );
             }
         }
@@ -1455,12 +1528,15 @@ export class PluginOperationsService {
         registered: RegisteredPlugin,
         userId: string,
     ): Promise<Record<string, unknown> | undefined> {
-        const schema = registered.plugin.settingsSchema;
+        // `settingsSchema` is instance-only — materialise to read it.
+        // Eager mode returns the cached instance instantly.
+        const plugin = await this.pluginRegistryService.ensureLoaded(registered.manifest.id);
+        const schema = plugin.settingsSchema;
         if (!schema?.properties) {
             return undefined;
         }
 
-        const resolved = await this.settingsService.getResolvedSettings(registered.plugin.id, {
+        const resolved = await this.settingsService.getResolvedSettings(registered.manifest.id, {
             userId,
         });
 
@@ -1479,7 +1555,11 @@ export class PluginOperationsService {
         registered: RegisteredPlugin,
         resolved: ResolvedSettings,
     ): Record<string, unknown> | undefined {
-        const schema = registered.plugin.settingsSchema;
+        // Sync projection — both callers ensure the instance is
+        // materialised before reaching us (toUserPluginResponseWithResolvedSettings
+        // and getResolvedDisplaySettings both call ensureLoaded
+        // earlier in their pipelines).
+        const schema = registered.plugin?.settingsSchema;
         if (!schema?.properties) {
             return undefined;
         }
@@ -1518,10 +1598,16 @@ export class PluginOperationsService {
         workPlugin?: WorkPluginEntity | null,
         options?: { userId: string; workId: string },
     ): Promise<WorkPluginResponse> {
-        const userResponse = this.toUserPluginResponse(registered, userPlugin);
+        const userResponse = await this.toUserPluginResponse(registered, userPlugin);
+        // Materialise via the registry — eager mode returns the
+        // cached instance; needed to read `settingsSchema` for the
+        // secret-mask projection below.
+        const pluginInstance = await this.pluginRegistryService.ensureLoaded(
+            registered.manifest.id,
+        );
         const rawWorkSettings = this.maskSecretSettings(
             workPlugin ? { ...workPlugin.settings, ...workPlugin.secretSettings } : undefined,
-            registered.plugin.settingsSchema,
+            pluginInstance.settingsSchema,
         );
         const [resolvedSettings, models, workSettings] = options
             ? await Promise.all([
@@ -1557,12 +1643,15 @@ export class PluginOperationsService {
             return undefined;
         }
 
-        const resolved = await this.settingsService.getResolvedSettings(registered.plugin.id, {
+        const pluginId = registered.manifest.id;
+        // `settingsSchema` is instance-only — materialise to read it.
+        const plugin = await this.pluginRegistryService.ensureLoaded(pluginId);
+        const resolved = await this.settingsService.getResolvedSettings(pluginId, {
             userId: options.userId,
             workId: options.workId,
         });
 
-        return buildProviderModelSummaries(registered.plugin.settingsSchema, resolved);
+        return buildProviderModelSummaries(plugin.settingsSchema, resolved);
     }
 
     /**
@@ -1578,19 +1667,24 @@ export class PluginOperationsService {
         if (!this.hasAiProviderCapability(registered)) {
             return undefined;
         }
-        return buildProviderModelSummaries(registered.plugin.settingsSchema, resolved);
+        // Caller already materialised the instance — see
+        // toUserPluginResponseWithResolvedSettings.
+        return buildProviderModelSummaries(registered.plugin?.settingsSchema, resolved);
     }
 
     private async getWorkOverrideDisplaySettings(
         registered: RegisteredPlugin,
         options: { userId: string; workId: string },
     ): Promise<Record<string, unknown> | undefined> {
-        const schema = registered.plugin.settingsSchema;
+        const pluginId = registered.manifest.id;
+        // `settingsSchema` is instance-only — materialise to read it.
+        const plugin = await this.pluginRegistryService.ensureLoaded(pluginId);
+        const schema = plugin.settingsSchema;
         if (!schema?.properties) {
             return undefined;
         }
 
-        const resolved = await this.settingsService.getResolvedSettings(registered.plugin.id, {
+        const resolved = await this.settingsService.getResolvedSettings(pluginId, {
             userId: options.userId,
             workId: options.workId,
             includeSecrets: true,
@@ -1787,16 +1881,32 @@ export class PluginOperationsService {
     }
 
     /**
-     * Enforce configurationMode restrictions.
-     * Throws ForbiddenException if the plugin is admin-only and the caller is trying
-     * to modify settings at user or work scope.
+     * Enforce configurationMode restrictions from an already-loaded
+     * plugin instance. Pair with `ensureLoaded` at the call site.
      */
-    private enforceConfigurationMode(registered: RegisteredPlugin, scope: 'user' | 'work'): void {
-        const configMode = registered.plugin.configurationMode || 'hybrid';
+    private enforceConfigurationModeFromInstance(
+        plugin: IPlugin,
+        scope: 'user' | 'work',
+    ): void {
+        const configMode = plugin.configurationMode || 'hybrid';
         if (configMode === 'admin-only') {
             throw new ForbiddenException(
-                `Plugin "${registered.plugin.id}" is admin-only and cannot be configured at ${scope} level`,
+                `Plugin "${plugin.id}" is admin-only and cannot be configured at ${scope} level`,
             );
         }
+    }
+
+    /**
+     * Lazy-aware wrapper around enforceConfigurationModeFromInstance.
+     * Materialises the plugin via the registry — eager mode returns
+     * the cached instance instantly. Use when the call site already
+     * has a `registered` ref and doesn't otherwise need the instance.
+     */
+    private async enforceConfigurationMode(
+        registered: RegisteredPlugin,
+        scope: 'user' | 'work',
+    ): Promise<void> {
+        const plugin = await this.pluginRegistryService.ensureLoaded(registered.manifest.id);
+        this.enforceConfigurationModeFromInstance(plugin, scope);
     }
 }

--- a/packages/agent/src/plugins/services/plugin-registry.service.ts
+++ b/packages/agent/src/plugins/services/plugin-registry.service.ts
@@ -48,8 +48,31 @@ export function resolvePluginEnabled(ctx: PluginEnableContext): boolean {
     return ctx.autoEnable ?? false;
 }
 
+/**
+ * Loader callback used by lazy-registered plugins. Returns the
+ * fully-constructed IPlugin instance — invoked at most once per
+ * plugin id (memoized by `ensureLoaded`), the first time something
+ * actually needs the runtime.
+ */
+export type LazyPluginLoader = (pluginId: string) => Promise<IPlugin>;
+
+/**
+ * Optional hook the bootstrap layer wires onto the registry so the
+ * lazy-load path can fire `onLoad` lifecycle after `ensureLoaded`
+ * constructs the plugin. Kept as an injected callback (not a direct
+ * dep on PluginLifecycleManagerService) so the registry stays a
+ * leaf-level service with no upward NestJS dependency.
+ */
+export type PluginPostLoadHook = (pluginId: string) => Promise<void>;
+
 export interface RegisteredPlugin {
-    plugin: IPlugin;
+    /**
+     * The plugin runtime instance. Eager-registered plugins always
+     * have this set; lazy-registered plugins leave it `undefined`
+     * until `ensureLoaded` fires the deferred `import()` and stores
+     * the constructed instance here.
+     */
+    plugin?: IPlugin;
     manifest: PluginManifest;
     state: PluginState;
     builtIn: boolean;
@@ -70,11 +93,174 @@ export class PluginRegistryService {
     private readonly byCategory = new Map<PluginCategory, Set<string>>();
     private readonly byCapability = new Map<string, Set<string>>();
 
+    /**
+     * Lazy-load support: deferred constructor + memoised resolution
+     * promise per plugin id. Populated by `registerLazy`; drained by
+     * `ensureLoaded`. Eager-registered plugins (system plugins, tests,
+     * pre-constructed built-ins) never touch these maps.
+     */
+    private readonly lazyLoaders = new Map<string, LazyPluginLoader>();
+    private readonly loadPromises = new Map<string, Promise<IPlugin>>();
+    private postLoadHook: PluginPostLoadHook | null = null;
+
     constructor(
         private readonly eventEmitter: EventEmitter2,
         @Optional() private readonly workPluginRepository?: WorkPluginRepository,
         @Optional() private readonly userPluginRepository?: UserPluginRepository,
     ) {}
+
+    /**
+     * Wire the post-load hook (typically `lifecycleManager.callOnLoad`)
+     * so lazy-loaded plugins fire `onLoad` after construction. Eager
+     * mode doesn't use this — the bootstrap iterates `callOnLoad` itself.
+     */
+    setPostLoadHook(hook: PluginPostLoadHook | null): void {
+        this.postLoadHook = hook;
+    }
+
+    /**
+     * Register a plugin manifest with a deferred loader. The plugin
+     * code is NOT imported here — the entry is added to the indices
+     * (by-id / by-category / by-capability) using manifest fields only,
+     * and the `loader` is parked for the first `ensureLoaded(id)` call.
+     *
+     * Use this in place of `register()` for any plugin you don't need
+     * fully constructed at boot. The first runtime consumer (typically
+     * a facade calling `ensureLoaded` from `resolvePlugin`) triggers
+     * the deferred `import()`.
+     */
+    registerLazy(
+        manifest: PluginManifest,
+        loader: LazyPluginLoader,
+        options?: {
+            builtIn?: boolean;
+            installPath?: string;
+        },
+    ): RegisteredPlugin {
+        const pluginId = manifest.id;
+
+        if (this.plugins.has(pluginId)) {
+            throw new Error(`Plugin "${pluginId}" is already registered`);
+        }
+
+        const registered: RegisteredPlugin = {
+            plugin: undefined,
+            manifest,
+            state: 'unloaded',
+            builtIn: options?.builtIn || false,
+            installPath: options?.installPath,
+            registeredAt: Date.now(),
+            stateHistory: [
+                {
+                    from: 'unloaded',
+                    to: 'unloaded',
+                    timestamp: Date.now(),
+                },
+            ],
+        };
+
+        this.plugins.set(pluginId, registered);
+        this.lazyLoaders.set(pluginId, loader);
+
+        if (!this.byCategory.has(manifest.category)) {
+            this.byCategory.set(manifest.category, new Set());
+        }
+        this.byCategory.get(manifest.category)!.add(pluginId);
+
+        for (const capability of manifest.capabilities) {
+            if (!this.byCapability.has(capability)) {
+                this.byCapability.set(capability, new Set());
+            }
+            this.byCapability.get(capability)!.add(pluginId);
+        }
+
+        this.logger.debug(`Registered lazy plugin: ${pluginId} v${manifest.version}`);
+
+        this.eventEmitter.emit(PluginEvents.REGISTERED, {
+            pluginId,
+            version: manifest.version,
+            category: manifest.category,
+            capabilities: manifest.capabilities,
+            timestamp: Date.now(),
+            lazy: true,
+        });
+
+        return registered;
+    }
+
+    /**
+     * Materialise a lazy-registered plugin: invoke the deferred loader,
+     * attach the resulting IPlugin to the registry entry, transition
+     * state to `loaded`, and fire the post-load hook (typically
+     * `onLoad`). Subsequent calls return the cached instance instantly.
+     *
+     * Throws if the plugin id is unknown, or rejects with the loader's
+     * error if the deferred import fails (state transitions to `error`).
+     * Failed loads are NOT retried — the rejected promise is kept so
+     * repeat callers see the same failure deterministically.
+     *
+     * For eager-registered plugins this is a no-op fast path: the
+     * cached `plugin` is returned without any extra work.
+     */
+    async ensureLoaded(pluginId: string): Promise<IPlugin> {
+        const registered = this.plugins.get(pluginId);
+        if (!registered) {
+            throw new Error(`Plugin "${pluginId}" is not registered`);
+        }
+
+        if (registered.state === 'loaded' && registered.plugin) {
+            return registered.plugin;
+        }
+
+        if (registered.state === 'error') {
+            throw new Error(
+                `Plugin "${pluginId}" previously failed to load: ${
+                    registered.error instanceof Error
+                        ? registered.error.message
+                        : registered.error ?? 'unknown error'
+                }`,
+            );
+        }
+
+        const cached = this.loadPromises.get(pluginId);
+        if (cached) return cached;
+
+        const loader = this.lazyLoaders.get(pluginId);
+        if (!loader) {
+            throw new Error(
+                `Plugin "${pluginId}" has no lazy loader registered ` +
+                    `(state=${registered.state}, plugin=${registered.plugin ? 'present' : 'missing'})`,
+            );
+        }
+
+        this.updateState(pluginId, 'loading');
+
+        const promise = (async () => {
+            const plugin = await loader(pluginId);
+            registered.plugin = plugin;
+            this.updateState(pluginId, 'loaded');
+            if (this.postLoadHook) {
+                await this.postLoadHook(pluginId);
+            }
+            return plugin;
+        })().catch((error) => {
+            this.loadPromises.delete(pluginId);
+            this.updateState(pluginId, 'error', error as Error);
+            throw error;
+        });
+
+        this.loadPromises.set(pluginId, promise);
+        return promise;
+    }
+
+    /**
+     * `true` when the plugin id was registered lazily (has a parked
+     * loader). Caller-side gate for "should I call ensureLoaded
+     * before reading `.plugin`?". Eager registrations return `false`.
+     */
+    isLazy(pluginId: string): boolean {
+        return this.lazyLoaders.has(pluginId);
+    }
 
     register(
         plugin: IPlugin,
@@ -159,6 +345,8 @@ export class PluginRegistryService {
         }
 
         this.plugins.delete(pluginId);
+        this.lazyLoaders.delete(pluginId);
+        this.loadPromises.delete(pluginId);
 
         this.logger.log(`Unregistered plugin: ${pluginId}`);
 
@@ -334,6 +522,8 @@ export class PluginRegistryService {
         this.plugins.clear();
         this.byCategory.clear();
         this.byCapability.clear();
+        this.lazyLoaders.clear();
+        this.loadPromises.clear();
         this.logger.warn('Registry cleared');
     }
 

--- a/packages/agent/src/services/__tests__/generator-form-schema.service.spec.ts
+++ b/packages/agent/src/services/__tests__/generator-form-schema.service.spec.ts
@@ -80,6 +80,26 @@ describe('GeneratorFormSchemaService', () => {
             get: jest.fn(),
             getByCapability: jest.fn().mockReturnValue([]),
             isPluginEnabledForScope: jest.fn().mockResolvedValue(true),
+            // Lazy-mode shim — eager-only tests register plugins
+            // with `state: 'loaded'` and the eager `plugin` instance.
+            // Scan recent by-id / by-capability calls for the match.
+            isLazy: jest.fn(() => false),
+            ensureLoaded: jest.fn(async (id: string) => {
+                const direct = mockRegistry.get(id);
+                if (direct?.plugin) return direct.plugin as any;
+                const calls = (mockRegistry.getByCapability as jest.Mock).mock.results;
+                for (const r of calls) {
+                    const arr = (r.value as Array<{
+                        plugin?: { id: string };
+                        manifest?: { id: string };
+                    }>) || [];
+                    const found = arr.find(
+                        (p) => p.manifest?.id === id || p.plugin?.id === id,
+                    );
+                    if (found && (found as any).plugin) return (found as any).plugin;
+                }
+                return undefined as never;
+            }),
         } as unknown as jest.Mocked<PluginRegistryService>;
 
         service = new GeneratorFormSchemaService(mockRegistry);

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -92,8 +92,14 @@ export class GeneratorFormSchemaService {
         let handledConfigFields: readonly string[] = [];
         let defaultValues: Record<string, unknown> | undefined;
 
-        if (pipelinePlugin && isFormSchemaProvider(pipelinePlugin.plugin)) {
-            const provider = pipelinePlugin.plugin;
+        // Materialise the pipeline plugin once — eager mode returns
+        // the cached instance instantly. We need the runtime instance
+        // for `isFormSchemaProvider` + the form schema methods.
+        const pipelinePluginInstance = pipelinePlugin
+            ? await this.pluginRegistry.ensureLoaded(pipelinePlugin.manifest.id)
+            : undefined;
+        if (pipelinePluginInstance && isFormSchemaProvider(pipelinePluginInstance)) {
+            const provider = pipelinePluginInstance;
 
             pluginFields = provider.getFormFields();
             pluginGroups = provider.getFormGroups?.();
@@ -101,7 +107,7 @@ export class GeneratorFormSchemaService {
             defaultValues = provider.getDefaultValues?.();
 
             this.logger.debug(
-                `Resolved ${pluginFields.length} form fields from pipeline: ${pipelinePlugin.plugin.id}`,
+                `Resolved ${pluginFields.length} form fields from pipeline: ${pipelinePlugin?.manifest.id}`,
             );
         }
 
@@ -124,13 +130,19 @@ export class GeneratorFormSchemaService {
         let enforcedPipelineId: string | undefined;
         if (userGlobalDefault?.enforce) {
             const enforced = this.pluginRegistry.get(userGlobalDefault.pluginId);
-            if (enforced && enforced.state === 'loaded') {
+            // Lazy-aware: parked-but-unloaded plugins ARE valid here
+            // — the form schema just needs the id, not the instance.
+            if (
+                enforced &&
+                (enforced.state === 'loaded' ||
+                    (this.pluginRegistry.isLazy?.(userGlobalDefault.pluginId) ?? false))
+            ) {
                 enforcedPipelineId = userGlobalDefault.pluginId;
             }
         }
 
         return {
-            resolvedPipelineId: pipelinePlugin?.plugin.id,
+            resolvedPipelineId: pipelinePlugin?.manifest.id,
             enforcedPipelineId,
             providers,
             pluginFields,
@@ -150,17 +162,26 @@ export class GeneratorFormSchemaService {
     ): Promise<ValidationResult> {
         const pipelinePlugin = await this.resolvePipelinePlugin(pipelineId, options);
 
-        if (pipelinePlugin && isFormSchemaProvider(pipelinePlugin.plugin)) {
-            const result = await pipelinePlugin.plugin.validateFormInput(values);
-            if (!result.valid) return result;
+        if (pipelinePlugin) {
+            // Materialise — eager mode returns the cached instance
+            // instantly; lazy mode fires the deferred import + onLoad.
+            const pipelineInstance = await this.pluginRegistry.ensureLoaded(
+                pipelinePlugin.manifest.id,
+            );
+            if (isFormSchemaProvider(pipelineInstance)) {
+                const result = await pipelineInstance.validateFormInput(values);
+                if (!result.valid) return result;
+            }
         }
 
         // Validate form-schema-provider plugin form values
         const dsPlugins = await this.getEnabledFormSchemaPlugins(options);
         for (const registered of dsPlugins) {
-            if (!isFormSchemaProvider(registered.plugin)) continue;
-            const pluginValues = (values[registered.plugin.id] as Record<string, unknown>) ?? {};
-            const result = await registered.plugin.validateFormInput(pluginValues);
+            const pluginId = registered.manifest.id;
+            const pluginInstance = await this.pluginRegistry.ensureLoaded(pluginId);
+            if (!isFormSchemaProvider(pluginInstance)) continue;
+            const pluginValues = (values[pluginId] as Record<string, unknown>) ?? {};
+            const result = await pluginInstance.validateFormInput(pluginValues);
             if (!result.valid) return result;
         }
 
@@ -184,23 +205,28 @@ export class GeneratorFormSchemaService {
 
         // Let the pipeline plugin transform first
         const pipelinePlugin = await this.resolvePipelinePlugin(pipelineId, options);
-        if (pipelinePlugin && isFormSchemaProvider(pipelinePlugin.plugin)) {
-            const transform = pipelinePlugin.plugin.transformFormValues;
-            if (transform) {
-                config = transform.call(pipelinePlugin.plugin, config);
+        if (pipelinePlugin) {
+            const pipelineInstance = await this.pluginRegistry.ensureLoaded(
+                pipelinePlugin.manifest.id,
+            );
+            if (isFormSchemaProvider(pipelineInstance)) {
+                const transform = pipelineInstance.transformFormValues;
+                if (transform) {
+                    config = transform.call(pipelineInstance, config);
+                }
             }
         }
 
         // Let each form-schema-provider plugin transform the full config, then extract its nested key
         const dsPlugins = await this.getEnabledFormSchemaPlugins(options);
         for (const registered of dsPlugins) {
-            if (!isFormSchemaProvider(registered.plugin)) continue;
-
-            const pluginId = registered.plugin.id;
+            const pluginId = registered.manifest.id;
+            const pluginInstance = await this.pluginRegistry.ensureLoaded(pluginId);
+            if (!isFormSchemaProvider(pluginInstance)) continue;
 
             // Call transformFormValues on full config — this produces the nested key
-            if (registered.plugin.transformFormValues) {
-                const transformed = registered.plugin.transformFormValues(config);
+            if (pluginInstance.transformFormValues) {
+                const transformed = pluginInstance.transformFormValues(config);
                 const nested = transformed[pluginId];
 
                 if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
@@ -232,16 +258,24 @@ export class GeneratorFormSchemaService {
         const pipelineIds = new Set(
             this.pluginRegistry
                 .getByCapability(PLUGIN_CAPABILITIES.PIPELINE)
-                .map((p) => p.plugin.id),
+                .map((p) => p.manifest.id),
         );
         const errors: string[] = [];
 
         for (const registered of plugins) {
-            if (registered.state !== 'loaded') continue;
-            if (pipelineIds.has(registered.plugin.id)) continue;
+            const pluginId = registered.manifest.id;
+            // Lazy-aware: parked-but-unloaded plugins ARE eligible —
+            // `isPluginConfigured` below materialises on demand.
+            if (
+                registered.state !== 'loaded' &&
+                !(this.pluginRegistry.isLazy?.(pluginId) ?? false)
+            ) {
+                continue;
+            }
+            if (pipelineIds.has(pluginId)) continue;
 
             const isEnabled = await this.pluginRegistry.isPluginEnabledForScope(
-                registered.plugin.id,
+                pluginId,
                 options.workId,
                 options.userId,
             );
@@ -294,7 +328,12 @@ export class GeneratorFormSchemaService {
         options?: FormSchemaOptions,
     ): Promise<ProviderOption[]> {
         const plugins = this.pluginRegistry.getByCapability(capability);
-        const enabledPlugins = plugins.filter((p) => p.state === 'loaded');
+        // Lazy-aware filter — see resolveExtractorCandidates() in
+        // content-extractor.facade.ts for the same pattern.
+        const enabledPlugins = plugins.filter(
+            (p) =>
+                p.state === 'loaded' || (this.pluginRegistry.isLazy?.(p.manifest.id) ?? false),
+        );
         const result: ProviderOption[] = [];
 
         // Get the active (default) plugin for this capability in the work
@@ -321,7 +360,7 @@ export class GeneratorFormSchemaService {
             // Check if plugin is enabled for this context
             if (options?.workId || options?.userId) {
                 const isEnabled = await this.pluginRegistry.isPluginEnabledForScope(
-                    registered.plugin.id,
+                    registered.manifest.id,
                     options.workId,
                     options.userId,
                 );
@@ -355,23 +394,27 @@ export class GeneratorFormSchemaService {
         capability?: string,
         options?: FormSchemaOptions,
     ): Promise<ProviderOption> {
-        const { plugin, manifest } = registered;
+        const { manifest } = registered;
+        const pluginId = manifest.id;
 
         // Mark as default if:
         // 1. It's the active plugin for the work.
         // 2. OR it declares this capability in defaultForCapabilities
         // 3. OR it's a system plugin (fallback if no capability provided)
         const isDefault = activePluginId
-            ? plugin.id === activePluginId
+            ? pluginId === activePluginId
             : capability
               ? manifest.defaultForCapabilities?.includes(capability) || false
               : manifest.systemPlugin || false;
 
+        // AI provider model summaries need the instance's
+        // settingsSchema (instance-only property). Materialise on
+        // demand — eager mode returns the cached instance instantly.
         const models =
             capability === PLUGIN_CAPABILITIES.AI_PROVIDER && this.pluginSettingsService
                 ? buildProviderModelSummaries(
-                      plugin.settingsSchema,
-                      await this.pluginSettingsService.getResolvedSettings(plugin.id, {
+                      (await this.pluginRegistry.ensureLoaded(pluginId)).settingsSchema,
+                      await this.pluginSettingsService.getResolvedSettings(pluginId, {
                           userId: options?.userId,
                           workId: options?.workId,
                       }),
@@ -379,7 +422,7 @@ export class GeneratorFormSchemaService {
                 : undefined;
 
         return {
-            id: plugin.id,
+            id: pluginId,
             name: manifest.name,
             description: manifest.description,
             configured,
@@ -401,7 +444,11 @@ export class GeneratorFormSchemaService {
             return true;
         }
 
-        const schema = registered.plugin.settingsSchema;
+        const pluginId = registered.manifest.id;
+        // `settingsSchema` is an instance-only property — materialise
+        // to read it. Eager mode returns the cached instance instantly.
+        const plugin = await this.pluginRegistry.ensureLoaded(pluginId);
+        const schema = plugin.settingsSchema;
         if (
             !schema?.properties ||
             (!schema.required?.length && !schema['x-requiredGroups']?.length)
@@ -410,14 +457,11 @@ export class GeneratorFormSchemaService {
         }
 
         try {
-            const resolved = await this.pluginSettingsService.getResolvedSettings(
-                registered.plugin.id,
-                {
-                    userId: options?.userId,
-                    workId: options?.workId,
-                    includeSecrets: true,
-                },
-            );
+            const resolved = await this.pluginSettingsService.getResolvedSettings(pluginId, {
+                userId: options?.userId,
+                workId: options?.workId,
+                includeSecrets: true,
+            });
 
             if (!this.checkRequiredFields(schema, resolved)) return false;
             if (!this.checkRequiredGroups(schema, resolved)) return false;
@@ -425,7 +469,7 @@ export class GeneratorFormSchemaService {
             return true;
         } catch (error) {
             this.logger.warn(
-                `Failed to check configured status for plugin ${registered.plugin.id}: ${error}`,
+                `Failed to check configured status for plugin ${pluginId}: ${error}`,
             );
             return true;
         }
@@ -523,7 +567,7 @@ export class GeneratorFormSchemaService {
     ): Promise<void> {
         const providerErrors: Record<string, string> = {};
         const pipelinePlugin = await this.resolvePipelinePlugin(pipelineId, options);
-        const resolvedPipelineId = pipelinePlugin?.plugin.id ?? pipelineId;
+        const resolvedPipelineId = pipelinePlugin?.manifest.id ?? pipelineId;
 
         if (resolvedPipelineId) {
             const error = await this.validateSingleProvider(resolvedPipelineId, options);
@@ -603,7 +647,12 @@ export class GeneratorFormSchemaService {
         if (!registered) {
             return `Provider "${pluginId}" is not registered.`;
         }
-        if (registered.state !== 'loaded') {
+        // Lazy-aware: parked-but-unloaded plugins ARE valid here —
+        // `isPluginConfigured` will materialise on demand.
+        if (
+            registered.state !== 'loaded' &&
+            !(this.pluginRegistry.isLazy?.(pluginId) ?? false)
+        ) {
             return `Provider "${pluginId}" is not loaded (state: ${registered.state}).`;
         }
 
@@ -638,8 +687,9 @@ export class GeneratorFormSchemaService {
         const plugins = await this.getEnabledFormSchemaPlugins(options);
 
         for (const registered of plugins) {
-            if (!isFormSchemaProvider(registered.plugin)) continue;
-            const provider = registered.plugin;
+            const pluginId = registered.manifest.id;
+            const provider = await this.pluginRegistry.ensureLoaded(pluginId);
+            if (!isFormSchemaProvider(provider)) continue;
 
             fields.push(...provider.getFormFields());
 
@@ -651,7 +701,7 @@ export class GeneratorFormSchemaService {
                 defaultValues = { ...defaultValues, ...providerDefaults };
             }
 
-            this.logger.debug(`Collected form fields from plugin: ${provider.id}`);
+            this.logger.debug(`Collected form fields from plugin: ${pluginId}`);
         }
 
         return { fields, groups, defaultValues };
@@ -667,17 +717,26 @@ export class GeneratorFormSchemaService {
         const pipelineIds = new Set(
             this.pluginRegistry
                 .getByCapability(PLUGIN_CAPABILITIES.PIPELINE)
-                .map((p) => p.plugin.id),
+                .map((p) => p.manifest.id),
         );
         const result: RegisteredPlugin[] = [];
 
         for (const registered of plugins) {
-            if (registered.state !== 'loaded') continue;
-            if (pipelineIds.has(registered.plugin.id)) continue;
+            const pluginId = registered.manifest.id;
+            // Lazy-aware: parked-but-unloaded plugins ARE eligible
+            // — the caller materialises via ensureLoaded before
+            // touching the instance.
+            if (
+                registered.state !== 'loaded' &&
+                !(this.pluginRegistry.isLazy?.(pluginId) ?? false)
+            ) {
+                continue;
+            }
+            if (pipelineIds.has(pluginId)) continue;
 
             if (options?.workId || options?.userId) {
                 const isEnabled = await this.pluginRegistry.isPluginEnabledForScope(
-                    registered.plugin.id,
+                    pluginId,
                     options.workId,
                     options.userId,
                 );
@@ -697,10 +756,13 @@ export class GeneratorFormSchemaService {
         // 1. Explicit pipelineId — from .works/works.yml or user click in the form
         if (pipelineId) {
             const registered = this.pluginRegistry.get(pipelineId);
+            // Lazy-aware: parked-but-unloaded plugins are valid here.
+            // The caller materialises via ensureLoaded when needed.
             if (
                 registered &&
-                registered.state === 'loaded' &&
-                (await this.isEnabledForScope(registered.plugin.id, options))
+                (registered.state === 'loaded' ||
+                    (this.pluginRegistry.isLazy?.(pipelineId) ?? false)) &&
+                (await this.isEnabledForScope(registered.manifest.id, options))
             ) {
                 return registered;
             }
@@ -718,8 +780,9 @@ export class GeneratorFormSchemaService {
                     const registered = this.pluginRegistry.get(activePlugin.pluginId);
                     if (
                         registered &&
-                        registered.state === 'loaded' &&
-                        (await this.isEnabledForScope(registered.plugin.id, options))
+                        (registered.state === 'loaded' ||
+                            (this.pluginRegistry.isLazy?.(activePlugin.pluginId) ?? false)) &&
+                        (await this.isEnabledForScope(registered.manifest.id, options))
                     ) {
                         return registered;
                     }
@@ -733,9 +796,15 @@ export class GeneratorFormSchemaService {
         const pipelines = this.pluginRegistry.getByCapability(PLUGIN_CAPABILITIES.PIPELINE);
 
         for (const registered of pipelines) {
-            if (registered.state !== 'loaded') continue;
+            const pluginId = registered.manifest.id;
+            if (
+                registered.state !== 'loaded' &&
+                !(this.pluginRegistry.isLazy?.(pluginId) ?? false)
+            ) {
+                continue;
+            }
             if (registered.manifest.defaultForCapabilities?.includes('pipeline')) {
-                if (await this.isEnabledForScope(registered.plugin.id, options)) {
+                if (await this.isEnabledForScope(pluginId, options)) {
                     return registered;
                 }
             }
@@ -743,9 +812,11 @@ export class GeneratorFormSchemaService {
 
         // 4. Fallback: first loaded pipeline
         for (const registered of pipelines) {
+            const pluginId = registered.manifest.id;
             if (
-                registered.state === 'loaded' &&
-                (await this.isEnabledForScope(registered.plugin.id, options))
+                (registered.state === 'loaded' ||
+                    (this.pluginRegistry.isLazy?.(pluginId) ?? false)) &&
+                (await this.isEnabledForScope(pluginId, options))
             ) {
                 return registered;
             }

--- a/packages/agent/src/user-research/__tests__/provider-resolver.spec.ts
+++ b/packages/agent/src/user-research/__tests__/provider-resolver.spec.ts
@@ -24,6 +24,7 @@ function makeRegistered(p: FakePlugin): RegisteredPlugin {
     return {
         plugin: { id: p.id, settingsSchema: p.settingsSchema } as RegisteredPlugin['plugin'],
         manifest: {
+            id: p.id,
             defaultForCapabilities: p.defaultForCapabilities,
             capabilities: p.capabilities ?? ['ai-provider', 'search'],
         } as unknown as RegisteredPlugin['manifest'],
@@ -32,8 +33,21 @@ function makeRegistered(p: FakePlugin): RegisteredPlugin {
 }
 
 function makeRegistry(plugins: FakePlugin[]): PluginRegistryService {
+    const registered = plugins.map(makeRegistered);
     return {
-        getEnabledPluginsScoped: jest.fn().mockResolvedValue(plugins.map(makeRegistered)),
+        getEnabledPluginsScoped: jest.fn().mockResolvedValue(registered),
+        // Lazy-mode shim — tests register plugins with eager
+        // `state: 'loaded'` and the eager `plugin` instance, so
+        // ensureLoaded just returns the cached instance.
+        isLazy: jest.fn(() => false),
+        ensureLoaded: jest.fn(async (id: string) => {
+            const found = registered.find(
+                (p) =>
+                    (p.plugin as { id?: string })?.id === id ||
+                    (p.manifest as { id?: string })?.id === id,
+            );
+            return found?.plugin as any;
+        }),
     } as unknown as PluginRegistryService;
 }
 

--- a/packages/agent/src/user-research/provider-resolver.ts
+++ b/packages/agent/src/user-research/provider-resolver.ts
@@ -68,16 +68,21 @@ export async function resolveSearchProviderIds(
 
     for (const candidate of chain) {
         if (settingsService) {
-            const settings = await settingsService.getSettings(candidate.plugin.id, {
+            const pluginId = candidate.manifest.id;
+            const settings = await settingsService.getSettings(pluginId, {
                 userId,
                 includeSecrets: true,
             });
-            if (!hasAllRequiredSettings(candidate.plugin.settingsSchema, settings)) continue;
+            // `settingsSchema` is an instance-only property — it
+            // doesn't live on the manifest, so we have to materialise.
+            // Eager mode returns the cached instance instantly.
+            const plugin = await registry.ensureLoaded(pluginId);
+            if (!hasAllRequiredSettings(plugin.settingsSchema, settings)) continue;
         }
         configured.push(candidate);
     }
 
-    return capChain(configured, DEFAULT_PROVIDER_FALLBACK_MAX).map((p) => p.plugin.id);
+    return capChain(configured, DEFAULT_PROVIDER_FALLBACK_MAX).map((p) => p.manifest.id);
 }
 
 /**
@@ -150,7 +155,7 @@ async function resolveAiProvidersFromChain(
         try {
             const cfg = await aiFacade.getProviderConfig({
                 userId,
-                providerOverride: candidate.plugin.id,
+                providerOverride: candidate.manifest.id,
             });
             if (!cfg.baseUrl || !cfg.apiKey) continue;
             const modelName =
@@ -170,7 +175,9 @@ async function resolveAiProvidersFromChain(
             });
         } catch (err) {
             if (isAuthOrConfigError(err)) throw err;
-            logger?.warn(`ai-provider ${candidate.plugin.id} unusable: ${(err as Error).message}`);
+            logger?.warn(
+                `ai-provider ${candidate.manifest.id} unusable: ${(err as Error).message}`,
+            );
         }
     }
     return resolved;


### PR DESCRIPTION
## Summary
- Adds a deferred-`import()` path for the plugin subsystem so the API process can register manifests at boot without paying the SDK-import cost for every plugin upfront. Eager loading remains the default — nothing changes unless `PLUGIN_LAZY_LOAD=true` is set on the container env.
- Sized at the underlying problem behind PR #1145: 17 plugins added in the last 4 days (channel/mail/AI providers — see PR #1145 description) blew the ever-works-api pod past its 2 GiB boot RSS. The bump unblocked the deploy; this PR removes the structural reason most of those plugins ever need to be in-memory inside the API HTTP process (most channel/email delivery actually runs inside the Trigger.dev hosted sandbox, which already loads plugins from its own bundle).

## Mechanism
- `PluginRegistryService.registerLazy(manifest, loader)` parks the constructor as a closure, populates by-id / by-category / by-capability indices from manifest fields only, reports `state='unloaded'`.
- `PluginRegistryService.ensureLoaded(id)` is the gated entry point for callers that need the IPlugin instance: cache-hit fast path for already-loaded plugins (eager mode), one-shot deferred import for lazy ones. Concurrent first-use callers share a single in-flight promise; the post-load hook fires `onLoad` exactly once after the instance is attached.
- `PluginLoaderService.discoverAndRegisterAll()` is the lazy variant of `discoverAndLoadAll`. Built-in plugins (pre-constructed `IPlugin` instances) stay eager — registering them lazily saves nothing. Filesystem-discovered plugins register through `registerLazy`.
- `PluginBootstrapService.bootstrap()` reads `PLUGIN_LAZY_LOAD`. Lazy mode wires `setPostLoadHook` to the lifecycle manager and skips per-plugin `callOnLoad` iteration (the hook fires it on demand).
- `BaseFacadeService.resolvePlugin` materialises the chosen plugin via `ensureLoaded` only when `registered.plugin` isn't already attached — eager-mode test mocks keep working unchanged. `isConfigured` / `getAvailableProviders` / `getDefaultProvider` / `getEnabledPlugins` / `findActivePluginForWork` accept `unloaded` plugins as eligible when `registry.isLazy(id)` is true (preserves eager semantics — a plugin with no parked loader stays ineligible).

## Failure semantics
- Failed loads transition `state='error'` and are **not retried** — the rejected promise is kept so repeat callers see the same failure deterministically (no silent retry-amplification).
- Lazy mode adds **per-plugin first-call latency** equal to the deferred `await import()`. Subsequent calls are cache hits. Net win for plugins that are rarely or never invoked from inside the API process (channel/email-provider/most pipeline categories under our current ops shape).

## Coverage
- New: `plugin-registry.lazy-load.spec.ts` — 8 tests (parks loader without invoking, single-call invocation + cache, concurrent dedup, post-load hook fires once, loader failure → error state, eager fast path, unknown-id error, unregister clears parked state).
- Existing: 65 `base.facade` tests + 1006 other plugin/facade tests still green; full agent suite (**5661 tests across 288 suites, 0 failures**) green; full `pnpm type-check` clean.

## Rollout
- **Default behaviour unchanged** — eager loading still runs on every existing environment until ops sets `PLUGIN_LAZY_LOAD=true`.
- Recommended: enable in dev → stage → prod with one observability cycle between each, watching for first-call latency spikes on cold paths and any `Post-load onLoad failed` log lines (the registry surfaces these but does not throw — the plugin instance is still attached).
- A small set of consumers outside `BaseFacadeService` still read `.plugin.X` directly (the 9 files surfaced by `grep -rn 'registered\.plugin\.\|p\.plugin\.id'` excluding tests — `content-extractor.facade.ts`, `code-edit.facade.ts`, `data-source.facade.ts`, `deploy.facade.ts`, `email.facade.ts`, `notification-channel.facade.ts`, `git.facade.ts`, `oauth.facade.ts`, `pipeline-builder.service.ts`, `plugin-operations.service.ts`, `generator-form-schema.service.ts`, `user-research/provider-resolver.ts`, `apps/api/src/plugins-capabilities/screenshot/screenshot.controller.ts`). These either need an `ensureLoaded` call or a `.manifest.X` fallback before prod can flip the flag. Tracked as the next-step in this PR's review thread; the registry infrastructure ships here so consumer fixes can land incrementally without redoing the foundation.

## Test plan
- [x] Lazy unit tests pass (8/8)
- [x] Existing plugin + facade tests pass (1071/1071)
- [x] Full agent suite passes (5661/5661, 2 skipped)
- [x] `pnpm type-check` clean
- [ ] Stage env smoke: set `PLUGIN_LAZY_LOAD=true` on `ever-works-api-stage`, watch boot logs for `Plugin lazy-discovery complete: N registered (M lazy)` and the new `(lazy mode)` banner; confirm RSS at boot before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins now support lazy loading: many providers appear immediately (using manifest info) and initialize on demand, reducing startup cost.
  * Provider lists, defaults, and configuration checks across features (email, deploy, git, OAuth, extractors, pipelines, etc.) now recognize lazy/parked plugins.
  * Improved plugin discovery, registration, and lifecycle handling with post-load hooks.

* **Bug Fixes**
  * Provider display names and default selection prefer loaded instance data when available, falling back to manifest values when not.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->