### PR TITLE
test(web): deep e2e coverage for Agents, Skills, Tasks (Pass 22)

### DIFF
--- a/apps/web/e2e/COVERAGE.md
+++ b/apps/web/e2e/COVERAGE.md
@@ -530,6 +530,33 @@ New feature areas (previously uncovered):
   400, both listed); catalog `{entries,total}`; cross-user 404;
   delete→`{deleted:true}`; UI hub + detail-page render.
 
+Additional clusters landed on this branch (all verified green against the
+live stack):
+
+- `agents.spec.ts` — draft→active⇄paused state machine, SOUL.md file
+  hash round-trip, budget/runs defaults, mission-scope validation.
+- `agents-advanced.spec.ts` — PATCH metadata, JSON export envelope
+  (`version:1` + identity + runtime.permissions), attachments, the
+  archive→hard-delete lifecycle, run-endpoint auth gates.
+- `settings-integrations.spec.ts` — notification-channel CRUD+test,
+  Work-Agent preferences PUT round-trip + guardrails, event-types
+  catalog, email-address registry.
+- `notifications-preferences.spec.ts` — Notifications v2: per-event
+  channel subscription round-trip, channel disable (`disabledAt`),
+  category mute/unmute, quiet-hours persistence.
+- `missions-ideas-hierarchy.spec.ts` — mission clone (full fork), Idea
+  (work-proposal) lifecycle + idea-scoped budget, Agent/Task scoping
+  across Mission/Idea.
+- `tasks-collaboration.spec.ts` — assignees (human + agent), reviewers
+    - approvers pending states, RFC-5545 RRULE recurrence (set/clear +
+      parse-error rejection).
+
+Real product issues surfaced while pinning live behavior (candidates for
+follow-up, not codified as "correct" here): `POST /api/notification-channels`
+missing `pluginId` → 500 (not 400); `GET /api/tasks?ideaId=<garbage>` → 500;
+`/api/agents/:id/run-now` + `/assign-task` → 500 (not 503) when Trigger.dev
+is unbound.
+
 Method note: each spec is written after probing the **live** API for
 exact shapes (recon surfaced several stale assumptions — e.g. Task
 default is `backlog` not `todo`; Skills require an explicit `ownerId`

--- a/apps/web/e2e/COVERAGE.md
+++ b/apps/web/e2e/COVERAGE.md
@@ -510,14 +510,14 @@ Redis + API + Web), pinning real response shapes and real UX flows.
 
 New feature areas (previously uncovered):
 
-| Feature                                                             | Status | Spec(s)                                      |
-| ------------------------------------------------------------------- | ------ | -------------------------------------------- |
-| Tasks (CRUD, state machine, chat, scoping)                          | [x]    | tasks.spec.ts                                |
-| Skills (custom create, bindings, catalog, detail UI)                | [x]    | skills.spec.ts                               |
-| Agents (CRUD, state-machine, instructions, budget/runs, scoping)    | [x]    | agents.spec.ts                               |
-| Missions/Ideas UI flows + unified `/new` (cross-entity)             | [ ]    | _next_ (deepens existing API-contract specs) |
-| settings/integrations (channels, emails, notifications, work-agent) | [x]    | settings-integrations.spec.ts                |
-| magic-link auth (issuance no-enumeration, redeem)                   | [x]    | magic-link.spec.ts (pre-existing)            |
+| Feature                                                                   | Status | Spec(s)                           |
+| ------------------------------------------------------------------------- | ------ | --------------------------------- |
+| Tasks (CRUD, state machine, chat, scoping)                                | [x]    | tasks.spec.ts                     |
+| Skills (custom create, bindings, catalog, detail UI)                      | [x]    | skills.spec.ts                    |
+| Agents (CRUD, state-machine, instructions, budget/runs, scoping)          | [x]    | agents.spec.ts                    |
+| Missions/Ideas hierarchy: clone, idea lifecycle, Agent/Task cross-scoping | [x]    | missions-ideas-hierarchy.spec.ts  |
+| settings/integrations (channels, emails, notifications, work-agent)       | [x]    | settings-integrations.spec.ts     |
+| magic-link auth (issuance no-enumeration, redeem)                         | [x]    | magic-link.spec.ts (pre-existing) |
 
 - `tasks.spec.ts` — auth gating; create (`T-<n>` slug, `backlog` default,
   echoed fields); list `{data, meta}` + status filter/pagination; status

--- a/apps/web/e2e/COVERAGE.md
+++ b/apps/web/e2e/COVERAGE.md
@@ -510,13 +510,14 @@ Redis + API + Web), pinning real response shapes and real UX flows.
 
 New feature areas (previously uncovered):
 
-| Feature                                                                          | Status | Spec(s)                                      |
-| -------------------------------------------------------------------------------- | ------ | -------------------------------------------- |
-| Tasks (CRUD, state machine, chat, scoping)                                       | [x]    | tasks.spec.ts                                |
-| Skills (custom create, bindings, catalog, detail UI)                             | [x]    | skills.spec.ts                               |
-| Agents (CRUD, state-machine, instructions, budget/runs, scoping)                 | [x]    | agents.spec.ts                               |
-| Missions/Ideas UI flows + unified `/new` (cross-entity)                          | [ ]    | _next_ (deepens existing API-contract specs) |
-| settings/integrations (channels, emails, notifications, work-agent) + magic-link | [ ]    | _next_                                       |
+| Feature                                                             | Status | Spec(s)                                      |
+| ------------------------------------------------------------------- | ------ | -------------------------------------------- |
+| Tasks (CRUD, state machine, chat, scoping)                          | [x]    | tasks.spec.ts                                |
+| Skills (custom create, bindings, catalog, detail UI)                | [x]    | skills.spec.ts                               |
+| Agents (CRUD, state-machine, instructions, budget/runs, scoping)    | [x]    | agents.spec.ts                               |
+| Missions/Ideas UI flows + unified `/new` (cross-entity)             | [ ]    | _next_ (deepens existing API-contract specs) |
+| settings/integrations (channels, emails, notifications, work-agent) | [x]    | settings-integrations.spec.ts                |
+| magic-link auth (issuance no-enumeration, redeem)                   | [x]    | magic-link.spec.ts (pre-existing)            |
 
 - `tasks.spec.ts` — auth gating; create (`T-<n>` slug, `backlog` default,
   echoed fields); list `{data, meta}` + status filter/pagination; status

--- a/apps/web/e2e/COVERAGE.md
+++ b/apps/web/e2e/COVERAGE.md
@@ -499,6 +499,43 @@ Concurrency + OAuth provider isolation + markdown sanitization + UX/i18n hygiene
 - [ ] `viewport-meta-shape.spec.ts` — `<meta name="viewport">` declares width=device-width AND initial-scale=1 (no fixed-zoom locks)
 - [ ] `cron-cancellation-flow.spec.ts` — cancelling a queued cron run returns 4xx if not running, 2xx if cancelled; idempotent
 
+## Pass 22 — `session/e2e-coverage-loop` — new-feature DEEP coverage (in progress)
+
+Closes the biggest real gap: the Agents/Skills/Tasks build and the
+Mission→Idea hierarchy shipped UI + API but had **zero or only shallow**
+e2e coverage, while most recent passes piled up permissive
+`status < 500` smoke probes that don't catch broken features. This pass
+adds **deep, assertive** specs verified against a live stack (Postgres +
+Redis + API + Web), pinning real response shapes and real UX flows.
+
+New feature areas (previously uncovered):
+
+| Feature | Status | Spec(s) |
+| ------- | ------ | ------- |
+| Tasks (CRUD, state machine, chat, scoping) | [x] | tasks.spec.ts |
+| Skills (custom create, bindings, catalog, detail UI) | [x] | skills.spec.ts |
+| Agents (CRUD, pause/resume, instructions, inbox) | [ ] | _next_ |
+| Missions/Ideas UI flows + unified `/new` (cross-entity) | [ ] | _next_ (deepens existing API-contract specs) |
+| settings/integrations (channels, emails, notifications, work-agent) + magic-link | [ ] | _next_ |
+
+- `tasks.spec.ts` — auth gating; create (`T-<n>` slug, `backlog` default,
+  echoed fields); list `{data, meta}` + status filter/pagination; status
+  **state-machine** (valid chain backlog→todo→in_progress→in_review→done,
+  illegal `todo→done` rejected 400); chat round-trip; `?missionId`
+  scoping; cross-user 403/404; delete→404; UI create→detail + API→UI list.
+- `skills.spec.ts` — custom create (ownerType+ownerId, slug lowercased,
+  v1.0.0, frontmatter); ownerType/ownerId validation; PATCH recomputes
+  contentHash; bindings (tenant + mission create, agent-needs-targetId
+  400, both listed); catalog `{entries,total}`; cross-user 404;
+  delete→`{deleted:true}`; UI hub + detail-page render.
+
+Method note: each spec is written after probing the **live** API for
+exact shapes (recon surfaced several stale assumptions — e.g. Task
+default is `backlog` not `todo`; Skills require an explicit `ownerId`
+even for tenant scope). Specs run green against the local stack before
+commit. Local bring-up mirrors `.github/workflows/e2e.yml`
+(`REQUIRE_EMAIL_VERIFICATION=false`, etc.).
+
 ## Pass 15+ — long-tail / hardening
 
 Then iteratively tighten any `[x]` that still has thin assertions

--- a/apps/web/e2e/COVERAGE.md
+++ b/apps/web/e2e/COVERAGE.md
@@ -510,13 +510,13 @@ Redis + API + Web), pinning real response shapes and real UX flows.
 
 New feature areas (previously uncovered):
 
-| Feature | Status | Spec(s) |
-| ------- | ------ | ------- |
-| Tasks (CRUD, state machine, chat, scoping) | [x] | tasks.spec.ts |
-| Skills (custom create, bindings, catalog, detail UI) | [x] | skills.spec.ts |
-| Agents (CRUD, state-machine, instructions, budget/runs, scoping) | [x] | agents.spec.ts |
-| Missions/Ideas UI flows + unified `/new` (cross-entity) | [ ] | _next_ (deepens existing API-contract specs) |
-| settings/integrations (channels, emails, notifications, work-agent) + magic-link | [ ] | _next_ |
+| Feature                                                                          | Status | Spec(s)                                      |
+| -------------------------------------------------------------------------------- | ------ | -------------------------------------------- |
+| Tasks (CRUD, state machine, chat, scoping)                                       | [x]    | tasks.spec.ts                                |
+| Skills (custom create, bindings, catalog, detail UI)                             | [x]    | skills.spec.ts                               |
+| Agents (CRUD, state-machine, instructions, budget/runs, scoping)                 | [x]    | agents.spec.ts                               |
+| Missions/Ideas UI flows + unified `/new` (cross-entity)                          | [ ]    | _next_ (deepens existing API-contract specs) |
+| settings/integrations (channels, emails, notifications, work-agent) + magic-link | [ ]    | _next_                                       |
 
 - `tasks.spec.ts` — auth gating; create (`T-<n>` slug, `backlog` default,
   echoed fields); list `{data, meta}` + status filter/pagination; status

--- a/apps/web/e2e/COVERAGE.md
+++ b/apps/web/e2e/COVERAGE.md
@@ -514,7 +514,7 @@ New feature areas (previously uncovered):
 | ------- | ------ | ------- |
 | Tasks (CRUD, state machine, chat, scoping) | [x] | tasks.spec.ts |
 | Skills (custom create, bindings, catalog, detail UI) | [x] | skills.spec.ts |
-| Agents (CRUD, pause/resume, instructions, inbox) | [ ] | _next_ |
+| Agents (CRUD, state-machine, instructions, budget/runs, scoping) | [x] | agents.spec.ts |
 | Missions/Ideas UI flows + unified `/new` (cross-entity) | [ ] | _next_ (deepens existing API-contract specs) |
 | settings/integrations (channels, emails, notifications, work-agent) + magic-link | [ ] | _next_ |
 

--- a/apps/web/e2e/activity-log-audit.spec.ts
+++ b/apps/web/e2e/activity-log-audit.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Activity log — audit/observability surface. Pins the real shapes:
+ * the signup audit entry every account gets, the status-bucket summary,
+ * and the running-count. (Note: mission/agent creation does NOT emit
+ * activity entries — only work/generation + auth events do — so this
+ * asserts what's actually recorded, not an aspirational audit trail.)
+ *
+ * API: GET /api/activity-log, /summary, /running-count.
+ */
+
+test.describe('Activity log — audit surface', () => {
+    test('GET /api/activity-log without auth → 401', async ({ request }) => {
+        expect((await request.get(`${API_BASE}/api/activity-log`)).status()).toBe(401);
+    });
+
+    test('a new account has a completed "user_signup" audit entry', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/activity-log`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(Array.isArray(body.activities)).toBe(true);
+        expect(typeof body.total).toBe('number');
+
+        const signup = body.activities.find(
+            (a: { actionType: string }) => a.actionType === 'user_signup',
+        );
+        expect(signup, 'signup audit entry').toBeTruthy();
+        expect(signup.action).toBe('user.signup');
+        expect(signup.status).toBe('completed');
+        expect(signup.userId).toBe(u.user.id);
+        expect(typeof signup.createdAt).toBe('string');
+    });
+
+    test('GET /summary returns a status-bucket count map', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/activity-log/summary`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        const { counts } = await res.json();
+        // All lifecycle buckets are present; the signup already counts as completed.
+        for (const k of ['pending', 'in_progress', 'completed', 'failed', 'cancelled']) {
+            expect(typeof counts[k]).toBe('number');
+        }
+        expect(counts.completed).toBeGreaterThanOrEqual(1);
+    });
+
+    test('GET /running-count is a non-negative integer (0 for an idle account)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/activity-log/running-count`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        const { count } = await res.json();
+        expect(Number.isInteger(count)).toBe(true);
+        expect(count).toBe(0);
+    });
+
+    test('?limit caps the returned activities', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/activity-log?limit=1`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        expect((await res.json()).activities.length).toBeLessThanOrEqual(1);
+    });
+});

--- a/apps/web/e2e/agents-advanced.spec.ts
+++ b/apps/web/e2e/agents-advanced.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Agents — sub-resources beyond core CRUD: metadata update, the JSON
+ * export envelope, attachments, the archive → hard-delete lifecycle, and
+ * auth-gating of the Trigger.dev-backed run endpoints. Pinned to live shapes.
+ *
+ * Note: POST /assign-task and /run-now require a bound Trigger.dev adapter
+ * (TRIGGER_ENABLED is off locally and in CI), so only their auth gate is
+ * asserted here — the happy path isn't reachable without Trigger.
+ */
+
+const UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
+
+async function makeAgent(
+    request: import('@playwright/test').APIRequestContext,
+    token: string,
+    name = 'Sub Agent',
+) {
+    const res = await request.post(`${API_BASE}/api/agents`, {
+        headers: authedHeaders(token),
+        data: { scope: 'tenant', name },
+    });
+    return res.json();
+}
+
+test.describe('Agents — metadata, export, attachments', () => {
+    test('PATCH updates metadata and a follow-up GET reflects it', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const agent = await makeAgent(request, u.access_token);
+
+        const patch = await request.patch(`${API_BASE}/api/agents/${agent.id}`, {
+            headers,
+            data: { title: 'Updated Title' },
+        });
+        expect(patch.status(), `patch body=${await patch.text()}`).toBe(200);
+        expect((await patch.json()).title).toBe('Updated Title');
+
+        const reread = await (
+            await request.get(`${API_BASE}/api/agents/${agent.id}`, { headers })
+        ).json();
+        expect(reread.title).toBe('Updated Title');
+    });
+
+    test('GET /export returns a versioned envelope with identity + runtime', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const agent = await makeAgent(request, u.access_token, 'Exportable Agent');
+
+        const res = await request.get(`${API_BASE}/api/agents/${agent.id}/export`, { headers });
+        expect(res.status()).toBe(200);
+        const env = await res.json();
+        expect(env.version).toBe(1);
+        expect(env.meta.sourceAgentId).toBe(agent.id);
+        expect(typeof env.meta.exportedAt).toBe('string');
+        expect(env.identity.name).toBe('Exportable Agent');
+        expect(env.identity.scope).toBe('tenant');
+        // The export carries the permission matrix so an import is faithful.
+        expect(env.runtime.permissions).toMatchObject({ canSpend: false, canCommitToRepo: false });
+    });
+
+    test('GET /attachments is an (initially empty) array', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const agent = await makeAgent(request, u.access_token);
+        const res = await request.get(`${API_BASE}/api/agents/${agent.id}/attachments`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        expect(await res.json()).toEqual([]);
+    });
+});
+
+test.describe('Agents — archive → hard-delete lifecycle', () => {
+    test('soft delete archives (kept for audit, hidden from list); hard delete removes', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const agent = await makeAgent(request, u.access_token, 'Disposable Agent');
+
+        const soft = await request.delete(`${API_BASE}/api/agents/${agent.id}`, { headers });
+        expect(soft.status()).toBe(200);
+        expect(await soft.json()).toMatchObject({ archived: true });
+
+        // Archived agent is excluded from the default list but still queryable for audit.
+        const list = await (await request.get(`${API_BASE}/api/agents`, { headers })).json();
+        expect(list.data.find((a: { id: string }) => a.id === agent.id)).toBeUndefined();
+        const stillThere = await (
+            await request.get(`${API_BASE}/api/agents/${agent.id}`, { headers })
+        ).json();
+        expect(stillThere.status).toBe('archived');
+
+        const hard = await request.delete(`${API_BASE}/api/agents/${agent.id}?hard=true`, {
+            headers,
+        });
+        expect(hard.status()).toBe(200);
+        expect(await hard.json()).toMatchObject({ deleted: true });
+
+        const gone = await request.get(`${API_BASE}/api/agents/${agent.id}`, { headers });
+        expect([403, 404]).toContain(gone.status());
+    });
+});
+
+test.describe('Agents — auth gating + isolation', () => {
+    test('run endpoints require auth (assign-task, run-now)', async ({ request }) => {
+        expect(
+            (
+                await request.post(`${API_BASE}/api/agents/${UNKNOWN_UUID}/assign-task`, {
+                    data: { taskId: UNKNOWN_UUID },
+                })
+            ).status(),
+        ).toBe(401);
+        expect(
+            (await request.post(`${API_BASE}/api/agents/${UNKNOWN_UUID}/run-now`)).status(),
+        ).toBe(401);
+    });
+
+    test('a stranger cannot export or patch my agent', async ({ request }) => {
+        const alice = await registerUserViaAPI(request);
+        const bob = await registerUserViaAPI(request);
+        const agent = await makeAgent(request, alice.access_token, 'Private Agent');
+
+        const exp = await request.get(`${API_BASE}/api/agents/${agent.id}/export`, {
+            headers: authedHeaders(bob.access_token),
+        });
+        expect([403, 404]).toContain(exp.status());
+        const patch = await request.patch(`${API_BASE}/api/agents/${agent.id}`, {
+            headers: authedHeaders(bob.access_token),
+            data: { title: 'hacked' },
+        });
+        expect([403, 404]).toContain(patch.status());
+    });
+});

--- a/apps/web/e2e/agents-list-filter.spec.ts
+++ b/apps/web/e2e/agents-list-filter.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Agents — list filtering + pagination semantics (status, search, limit/offset).
+ * Pins real behaviour, including that archived agents are excluded from list
+ * queries entirely. Verified against the live API.
+ */
+
+// Seeds: Alpha (draft), Beta (active), Gamma (archived).
+async function seedAgents(request: import('@playwright/test').APIRequestContext) {
+    const u = await registerUserViaAPI(request);
+    const headers = authedHeaders(u.access_token);
+    const mk = async (name: string) =>
+        (
+            await request.post(`${API_BASE}/api/agents`, {
+                headers,
+                data: { scope: 'tenant', name },
+            })
+        ).json();
+    const alpha = await mk('Alpha Researcher');
+    const beta = await mk('Beta Builder');
+    const gamma = await mk('Gamma Archived');
+    await request.post(`${API_BASE}/api/agents/${beta.id}/resume`, { headers }); // draft -> active
+    await request.delete(`${API_BASE}/api/agents/${gamma.id}`, { headers }); // -> archived
+    return { headers, alpha, beta, gamma };
+}
+
+test.describe('Agents — list filtering', () => {
+    test('default list excludes archived agents', async ({ request }) => {
+        const { headers, gamma } = await seedAgents(request);
+        const list = await (await request.get(`${API_BASE}/api/agents`, { headers })).json();
+        expect(list.meta.total).toBe(2);
+        expect(list.data.map((a: { id: string }) => a.id)).not.toContain(gamma.id);
+    });
+
+    test('?status filters to a single lifecycle state', async ({ request }) => {
+        const { headers } = await seedAgents(request);
+
+        const draft = await (
+            await request.get(`${API_BASE}/api/agents?status=draft`, { headers })
+        ).json();
+        expect(draft.data.length).toBe(1);
+        expect(draft.data[0].status).toBe('draft');
+        expect(draft.data[0].name).toBe('Alpha Researcher');
+
+        const active = await (
+            await request.get(`${API_BASE}/api/agents?status=active`, { headers })
+        ).json();
+        expect(active.data.length).toBe(1);
+        expect(active.data[0].status).toBe('active');
+
+        // Archived agents stay out of list queries even when explicitly requested.
+        const archived = await (
+            await request.get(`${API_BASE}/api/agents?status=archived`, { headers })
+        ).json();
+        expect(archived.data.length).toBe(0);
+    });
+
+    test('?search matches on agent name', async ({ request }) => {
+        const { headers } = await seedAgents(request);
+        const res = await (
+            await request.get(`${API_BASE}/api/agents?search=Beta`, { headers })
+        ).json();
+        expect(res.data.length).toBe(1);
+        expect(res.data[0].name).toBe('Beta Builder');
+    });
+
+    test('limit/offset paginate without overlap', async ({ request }) => {
+        const { headers } = await seedAgents(request);
+        const p1 = await (
+            await request.get(`${API_BASE}/api/agents?limit=1&offset=0`, { headers })
+        ).json();
+        const p2 = await (
+            await request.get(`${API_BASE}/api/agents?limit=1&offset=1`, { headers })
+        ).json();
+        expect(p1.data.length).toBe(1);
+        expect(p2.data.length).toBe(1);
+        expect(p1.meta.total).toBe(2);
+        expect(p1.data[0].id).not.toBe(p2.data[0].id);
+    });
+});

--- a/apps/web/e2e/agents.spec.ts
+++ b/apps/web/e2e/agents.spec.ts
@@ -23,150 +23,220 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  */
 
 test.describe('Agents — API contract', () => {
-	test('GET /api/agents without auth → 401', async ({ request }) => {
-		expect((await request.get(`${API_BASE}/api/agents`)).status()).toBe(401);
-	});
+    test('GET /api/agents without auth → 401', async ({ request }) => {
+        expect((await request.get(`${API_BASE}/api/agents`)).status()).toBe(401);
+    });
 
-	test('GET /api/agents for a fresh user → empty {data, meta}', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const res = await request.get(`${API_BASE}/api/agents`, { headers: authedHeaders(u.access_token) });
-		expect(res.status()).toBe(200);
-		const body = await res.json();
-		expect(Array.isArray(body.data)).toBe(true);
-		expect(body.data.length).toBe(0);
-		expect(body.meta).toMatchObject({ total: 0 });
-	});
+    test('GET /api/agents for a fresh user → empty {data, meta}', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/agents`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(Array.isArray(body.data)).toBe(true);
+        expect(body.data.length).toBe(0);
+        expect(body.meta).toMatchObject({ total: 0 });
+    });
 
-	test('POST /api/agents creates a draft tenant agent with locked-down permissions', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const res = await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'tenant', name: 'Research Agent' } });
-		expect(res.status(), `create body=${await res.text()}`).toBe(201);
-		const agent = await res.json();
-		expect(agent.id).toMatch(/^[0-9a-f-]{36}$/);
-		expect(agent.slug).toBe('research-agent');
-		expect(agent.scope).toBe('tenant');
-		// New agents start as drafts; every capability defaults to OFF.
-		expect(agent.status).toBe('draft');
-		expect(agent.permissions).toMatchObject({
-			canCreateAgents: false,
-			canAssignTasks: false,
-			canEditAgentFiles: false,
-			canSpend: false,
-			canCommitToRepo: false,
-			canCallExternalTools: false
-		});
+    test('POST /api/agents creates a draft tenant agent with locked-down permissions', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const res = await request.post(`${API_BASE}/api/agents`, {
+            headers,
+            data: { scope: 'tenant', name: 'Research Agent' },
+        });
+        expect(res.status(), `create body=${await res.text()}`).toBe(201);
+        const agent = await res.json();
+        expect(agent.id).toMatch(/^[0-9a-f-]{36}$/);
+        expect(agent.slug).toBe('research-agent');
+        expect(agent.scope).toBe('tenant');
+        // New agents start as drafts; every capability defaults to OFF.
+        expect(agent.status).toBe('draft');
+        expect(agent.permissions).toMatchObject({
+            canCreateAgents: false,
+            canAssignTasks: false,
+            canEditAgentFiles: false,
+            canSpend: false,
+            canCommitToRepo: false,
+            canCallExternalTools: false,
+        });
 
-		const list = await (await request.get(`${API_BASE}/api/agents`, { headers })).json();
-		expect(list.data.find((a: { id: string }) => a.id === agent.id)).toBeTruthy();
-	});
+        const list = await (await request.get(`${API_BASE}/api/agents`, { headers })).json();
+        expect(list.data.find((a: { id: string }) => a.id === agent.id)).toBeTruthy();
+    });
 
-	test('status state-machine: draft cannot pause; resume activates; active⇄paused', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const agent = await (await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'tenant', name: 'Lifecycle Agent' } })).json();
-		expect(agent.status).toBe('draft');
+    test('status state-machine: draft cannot pause; resume activates; active⇄paused', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const agent = await (
+            await request.post(`${API_BASE}/api/agents`, {
+                headers,
+                data: { scope: 'tenant', name: 'Lifecycle Agent' },
+            })
+        ).json();
+        expect(agent.status).toBe('draft');
 
-		// A draft has never been activated — pausing it is an illegal hop.
-		const badPause = await request.post(`${API_BASE}/api/agents/${agent.id}/pause`, { headers });
-		expect(badPause.status()).toBe(400);
-		expect((await badPause.json()).message).toMatch(/cannot transition/i);
+        // A draft has never been activated — pausing it is an illegal hop.
+        const badPause = await request.post(`${API_BASE}/api/agents/${agent.id}/pause`, {
+            headers,
+        });
+        expect(badPause.status()).toBe(400);
+        expect((await badPause.json()).message).toMatch(/cannot transition/i);
 
-		const resume = await request.post(`${API_BASE}/api/agents/${agent.id}/resume`, { headers });
-		expect(resume.status()).toBe(200);
-		expect((await resume.json()).status).toBe('active');
+        const resume = await request.post(`${API_BASE}/api/agents/${agent.id}/resume`, { headers });
+        expect(resume.status()).toBe(200);
+        expect((await resume.json()).status).toBe('active');
 
-		const pause = await request.post(`${API_BASE}/api/agents/${agent.id}/pause`, { headers });
-		expect(pause.status()).toBe(200);
-		expect((await pause.json()).status).toBe('paused');
+        const pause = await request.post(`${API_BASE}/api/agents/${agent.id}/pause`, { headers });
+        expect(pause.status()).toBe(200);
+        expect((await pause.json()).status).toBe('paused');
 
-		const resume2 = await request.post(`${API_BASE}/api/agents/${agent.id}/resume`, { headers });
-		expect(resume2.status()).toBe(200);
-		expect((await resume2.json()).status).toBe('active');
-	});
+        const resume2 = await request.post(`${API_BASE}/api/agents/${agent.id}/resume`, {
+            headers,
+        });
+        expect(resume2.status()).toBe(200);
+        expect((await resume2.json()).status).toBe('active');
+    });
 
-	test('instruction files: SOUL.md starts empty, PUT persists body + returns matching hash', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const agent = await (await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'tenant', name: 'Documented Agent' } })).json();
+    test('instruction files: SOUL.md starts empty, PUT persists body + returns matching hash', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const agent = await (
+            await request.post(`${API_BASE}/api/agents`, {
+                headers,
+                data: { scope: 'tenant', name: 'Documented Agent' },
+            })
+        ).json();
 
-		const empty = await request.get(`${API_BASE}/api/agents/${agent.id}/files/SOUL.md`, { headers });
-		expect(empty.status()).toBe(200);
-		const before = await empty.json();
-		expect(before).toMatchObject({ name: 'SOUL.md', body: '', storage: 'db' });
+        const empty = await request.get(`${API_BASE}/api/agents/${agent.id}/files/SOUL.md`, {
+            headers,
+        });
+        expect(empty.status()).toBe(200);
+        const before = await empty.json();
+        expect(before).toMatchObject({ name: 'SOUL.md', body: '', storage: 'db' });
 
-		const body = '# Soul\n\nI research developer tools and write crisp summaries.';
-		const put = await request.put(`${API_BASE}/api/agents/${agent.id}/files/SOUL.md`, { headers, data: { body } });
-		expect(put.status()).toBe(200);
-		const { newHash } = await put.json();
-		expect(newHash).toMatch(/^[0-9a-f]{64}$/);
+        const body = '# Soul\n\nI research developer tools and write crisp summaries.';
+        const put = await request.put(`${API_BASE}/api/agents/${agent.id}/files/SOUL.md`, {
+            headers,
+            data: { body },
+        });
+        expect(put.status()).toBe(200);
+        const { newHash } = await put.json();
+        expect(newHash).toMatch(/^[0-9a-f]{64}$/);
 
-		const after = await (await request.get(`${API_BASE}/api/agents/${agent.id}/files/SOUL.md`, { headers })).json();
-		expect(after.body).toBe(body);
-		expect(after.hash).toBe(newHash);
-	});
+        const after = await (
+            await request.get(`${API_BASE}/api/agents/${agent.id}/files/SOUL.md`, { headers })
+        ).json();
+        expect(after.body).toBe(body);
+        expect(after.hash).toBe(newHash);
+    });
 
-	test('budget + runs surfaces: zero-spend defaults and empty run history', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const agent = await (await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'tenant', name: 'Budgeted Agent' } })).json();
+    test('budget + runs surfaces: zero-spend defaults and empty run history', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const agent = await (
+            await request.post(`${API_BASE}/api/agents`, {
+                headers,
+                data: { scope: 'tenant', name: 'Budgeted Agent' },
+            })
+        ).json();
 
-		const budget = await (await request.get(`${API_BASE}/api/agents/${agent.id}/budget`, { headers })).json();
-		expect(budget.currentSpendCents).toBe(0);
-		expect(budget.currency).toBe('USD');
-		expect(typeof budget.periodStart).toBe('string');
+        const budget = await (
+            await request.get(`${API_BASE}/api/agents/${agent.id}/budget`, { headers })
+        ).json();
+        expect(budget.currentSpendCents).toBe(0);
+        expect(budget.currency).toBe('USD');
+        expect(typeof budget.periodStart).toBe('string');
 
-		const runs = await request.get(`${API_BASE}/api/agents/${agent.id}/runs`, { headers });
-		expect(runs.status()).toBe(200);
-		const runsBody = await runs.json();
-		expect(Array.isArray(runsBody.data)).toBe(true);
-		expect(runsBody.data.length).toBe(0);
-	});
+        const runs = await request.get(`${API_BASE}/api/agents/${agent.id}/runs`, { headers });
+        expect(runs.status()).toBe(200);
+        const runsBody = await runs.json();
+        expect(Array.isArray(runsBody.data)).toBe(true);
+        expect(runsBody.data.length).toBe(0);
+    });
 
-	test('scoping: mission-scoped agent requires missionId; filter returns only that scope', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
+    test('scoping: mission-scoped agent requires missionId; filter returns only that scope', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
 
-		const noParent = await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'mission', name: 'Orphan' } });
-		expect(noParent.status()).toBe(400);
-		expect((await noParent.json()).message).toMatch(/missionId/i);
+        const noParent = await request.post(`${API_BASE}/api/agents`, {
+            headers,
+            data: { scope: 'mission', name: 'Orphan' },
+        });
+        expect(noParent.status()).toBe(400);
+        expect((await noParent.json()).message).toMatch(/missionId/i);
 
-		const mission = await (await request.post(`${API_BASE}/api/me/missions`, { headers, data: { title: 'AgentMission', description: 'd', type: 'one-shot' } })).json();
-		const agent = await (await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'mission', missionId: mission.id, name: 'Mission Worker' } })).json();
-		expect(agent.missionId).toBe(mission.id);
+        const mission = await (
+            await request.post(`${API_BASE}/api/me/missions`, {
+                headers,
+                data: { title: 'AgentMission', description: 'd', type: 'one-shot' },
+            })
+        ).json();
+        const agent = await (
+            await request.post(`${API_BASE}/api/agents`, {
+                headers,
+                data: { scope: 'mission', missionId: mission.id, name: 'Mission Worker' },
+            })
+        ).json();
+        expect(agent.missionId).toBe(mission.id);
 
-		const filtered = await (await request.get(`${API_BASE}/api/agents?scope=mission&missionId=${mission.id}`, { headers })).json();
-		const ids = filtered.data.map((a: { id: string }) => a.id);
-		expect(ids).toContain(agent.id);
-		expect(ids.length).toBe(1);
-	});
+        const filtered = await (
+            await request.get(`${API_BASE}/api/agents?scope=mission&missionId=${mission.id}`, {
+                headers,
+            })
+        ).json();
+        const ids = filtered.data.map((a: { id: string }) => a.id);
+        expect(ids).toContain(agent.id);
+        expect(ids.length).toBe(1);
+    });
 
-	test('cross-user isolation: another user gets 403/404 on my agent', async ({ request }) => {
-		const alice = await registerUserViaAPI(request);
-		const bob = await registerUserViaAPI(request);
-		const agent = await (await request.post(`${API_BASE}/api/agents`, {
-			headers: authedHeaders(alice.access_token), data: { scope: 'tenant', name: 'Private Agent' }
-		})).json();
-		const res = await request.get(`${API_BASE}/api/agents/${agent.id}`, { headers: authedHeaders(bob.access_token) });
-		expect([403, 404]).toContain(res.status());
-	});
+    test('cross-user isolation: another user gets 403/404 on my agent', async ({ request }) => {
+        const alice = await registerUserViaAPI(request);
+        const bob = await registerUserViaAPI(request);
+        const agent = await (
+            await request.post(`${API_BASE}/api/agents`, {
+                headers: authedHeaders(alice.access_token),
+                data: { scope: 'tenant', name: 'Private Agent' },
+            })
+        ).json();
+        const res = await request.get(`${API_BASE}/api/agents/${agent.id}`, {
+            headers: authedHeaders(bob.access_token),
+        });
+        expect([403, 404]).toContain(res.status());
+    });
 });
 
 test.describe('Agents — UI (authenticated as the seeded user)', () => {
-	test('/agents index renders and lists an agent created via API', async ({ page, request }) => {
-		const seeded = loadSeededTestUser();
-		const login = await request.post(`${API_BASE}/api/auth/login`, { data: { email: seeded.email, password: seeded.password } });
-		const { access_token } = await login.json();
-		const name = `E2E Agent ${Date.now().toString(36)}`;
-		const create = await request.post(`${API_BASE}/api/agents`, { headers: authedHeaders(access_token), data: { scope: 'tenant', name } });
-		expect(create.status()).toBe(201);
-		const agent = await create.json();
+    test('/agents index renders and lists an agent created via API', async ({ page, request }) => {
+        const seeded = loadSeededTestUser();
+        const login = await request.post(`${API_BASE}/api/auth/login`, {
+            data: { email: seeded.email, password: seeded.password },
+        });
+        const { access_token } = await login.json();
+        const name = `E2E Agent ${Date.now().toString(36)}`;
+        const create = await request.post(`${API_BASE}/api/agents`, {
+            headers: authedHeaders(access_token),
+            data: { scope: 'tenant', name },
+        });
+        expect(create.status()).toBe(201);
+        const agent = await create.json();
 
-		await page.goto('/agents', { waitUntil: 'domcontentloaded' });
-		await expect(page.getByText(name).first()).toBeVisible({ timeout: 30_000 });
+        await page.goto('/agents', { waitUntil: 'domcontentloaded' });
+        await expect(page.getByText(name).first()).toBeVisible({ timeout: 30_000 });
 
-		// Detail page renders the agent's name too.
-		await page.goto(`/agents/${agent.id}`, { waitUntil: 'domcontentloaded' });
-		await expect(page.getByText(name).first()).toBeVisible({ timeout: 30_000 });
-	});
+        // Detail page renders the agent's name too.
+        await page.goto(`/agents/${agent.id}`, { waitUntil: 'domcontentloaded' });
+        await expect(page.getByText(name).first()).toBeVisible({ timeout: 30_000 });
+    });
 });

--- a/apps/web/e2e/agents.spec.ts
+++ b/apps/web/e2e/agents.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
+
+/**
+ * Agents — deep coverage of the Agents feature (Agents/Skills/Tasks build).
+ * Zero dedicated e2e specs existed before this file. Assertions are pinned
+ * against live API shapes (verified on a running stack).
+ *
+ * An Agent is a scoped (tenant/mission/idea/work) AI worker with a status
+ * lifecycle (draft → active ⇄ paused → archived), 8 default-false
+ * permissions, canonical instruction files (SOUL.md/AGENTS.md/…), a budget,
+ * and a run history.
+ *
+ * API surface (`apps/api/src/agents/*`):
+ *   - GET  /api/agents                 list `{data, meta}` (+ scope/status/parent filters)
+ *   - POST /api/agents                 create (scope required; status defaults to `draft`)
+ *   - GET  /api/agents/:id             get one (cross-user 404)
+ *   - POST /api/agents/:id/{pause,resume}  status state-machine
+ *   - GET/PUT /api/agents/:id/files/:name  canonical instruction files
+ *   - GET  /api/agents/:id/budget      `{currentSpendCents, capCents, period…, currency}`
+ *   - GET  /api/agents/:id/runs        `{data, meta}`
+ */
+
+test.describe('Agents — API contract', () => {
+	test('GET /api/agents without auth → 401', async ({ request }) => {
+		expect((await request.get(`${API_BASE}/api/agents`)).status()).toBe(401);
+	});
+
+	test('GET /api/agents for a fresh user → empty {data, meta}', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const res = await request.get(`${API_BASE}/api/agents`, { headers: authedHeaders(u.access_token) });
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body.data)).toBe(true);
+		expect(body.data.length).toBe(0);
+		expect(body.meta).toMatchObject({ total: 0 });
+	});
+
+	test('POST /api/agents creates a draft tenant agent with locked-down permissions', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const res = await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'tenant', name: 'Research Agent' } });
+		expect(res.status(), `create body=${await res.text()}`).toBe(201);
+		const agent = await res.json();
+		expect(agent.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(agent.slug).toBe('research-agent');
+		expect(agent.scope).toBe('tenant');
+		// New agents start as drafts; every capability defaults to OFF.
+		expect(agent.status).toBe('draft');
+		expect(agent.permissions).toMatchObject({
+			canCreateAgents: false,
+			canAssignTasks: false,
+			canEditAgentFiles: false,
+			canSpend: false,
+			canCommitToRepo: false,
+			canCallExternalTools: false
+		});
+
+		const list = await (await request.get(`${API_BASE}/api/agents`, { headers })).json();
+		expect(list.data.find((a: { id: string }) => a.id === agent.id)).toBeTruthy();
+	});
+
+	test('status state-machine: draft cannot pause; resume activates; active⇄paused', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const agent = await (await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'tenant', name: 'Lifecycle Agent' } })).json();
+		expect(agent.status).toBe('draft');
+
+		// A draft has never been activated — pausing it is an illegal hop.
+		const badPause = await request.post(`${API_BASE}/api/agents/${agent.id}/pause`, { headers });
+		expect(badPause.status()).toBe(400);
+		expect((await badPause.json()).message).toMatch(/cannot transition/i);
+
+		const resume = await request.post(`${API_BASE}/api/agents/${agent.id}/resume`, { headers });
+		expect(resume.status()).toBe(200);
+		expect((await resume.json()).status).toBe('active');
+
+		const pause = await request.post(`${API_BASE}/api/agents/${agent.id}/pause`, { headers });
+		expect(pause.status()).toBe(200);
+		expect((await pause.json()).status).toBe('paused');
+
+		const resume2 = await request.post(`${API_BASE}/api/agents/${agent.id}/resume`, { headers });
+		expect(resume2.status()).toBe(200);
+		expect((await resume2.json()).status).toBe('active');
+	});
+
+	test('instruction files: SOUL.md starts empty, PUT persists body + returns matching hash', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const agent = await (await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'tenant', name: 'Documented Agent' } })).json();
+
+		const empty = await request.get(`${API_BASE}/api/agents/${agent.id}/files/SOUL.md`, { headers });
+		expect(empty.status()).toBe(200);
+		const before = await empty.json();
+		expect(before).toMatchObject({ name: 'SOUL.md', body: '', storage: 'db' });
+
+		const body = '# Soul\n\nI research developer tools and write crisp summaries.';
+		const put = await request.put(`${API_BASE}/api/agents/${agent.id}/files/SOUL.md`, { headers, data: { body } });
+		expect(put.status()).toBe(200);
+		const { newHash } = await put.json();
+		expect(newHash).toMatch(/^[0-9a-f]{64}$/);
+
+		const after = await (await request.get(`${API_BASE}/api/agents/${agent.id}/files/SOUL.md`, { headers })).json();
+		expect(after.body).toBe(body);
+		expect(after.hash).toBe(newHash);
+	});
+
+	test('budget + runs surfaces: zero-spend defaults and empty run history', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const agent = await (await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'tenant', name: 'Budgeted Agent' } })).json();
+
+		const budget = await (await request.get(`${API_BASE}/api/agents/${agent.id}/budget`, { headers })).json();
+		expect(budget.currentSpendCents).toBe(0);
+		expect(budget.currency).toBe('USD');
+		expect(typeof budget.periodStart).toBe('string');
+
+		const runs = await request.get(`${API_BASE}/api/agents/${agent.id}/runs`, { headers });
+		expect(runs.status()).toBe(200);
+		const runsBody = await runs.json();
+		expect(Array.isArray(runsBody.data)).toBe(true);
+		expect(runsBody.data.length).toBe(0);
+	});
+
+	test('scoping: mission-scoped agent requires missionId; filter returns only that scope', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+
+		const noParent = await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'mission', name: 'Orphan' } });
+		expect(noParent.status()).toBe(400);
+		expect((await noParent.json()).message).toMatch(/missionId/i);
+
+		const mission = await (await request.post(`${API_BASE}/api/me/missions`, { headers, data: { title: 'AgentMission', description: 'd', type: 'one-shot' } })).json();
+		const agent = await (await request.post(`${API_BASE}/api/agents`, { headers, data: { scope: 'mission', missionId: mission.id, name: 'Mission Worker' } })).json();
+		expect(agent.missionId).toBe(mission.id);
+
+		const filtered = await (await request.get(`${API_BASE}/api/agents?scope=mission&missionId=${mission.id}`, { headers })).json();
+		const ids = filtered.data.map((a: { id: string }) => a.id);
+		expect(ids).toContain(agent.id);
+		expect(ids.length).toBe(1);
+	});
+
+	test('cross-user isolation: another user gets 403/404 on my agent', async ({ request }) => {
+		const alice = await registerUserViaAPI(request);
+		const bob = await registerUserViaAPI(request);
+		const agent = await (await request.post(`${API_BASE}/api/agents`, {
+			headers: authedHeaders(alice.access_token), data: { scope: 'tenant', name: 'Private Agent' }
+		})).json();
+		const res = await request.get(`${API_BASE}/api/agents/${agent.id}`, { headers: authedHeaders(bob.access_token) });
+		expect([403, 404]).toContain(res.status());
+	});
+});
+
+test.describe('Agents — UI (authenticated as the seeded user)', () => {
+	test('/agents index renders and lists an agent created via API', async ({ page, request }) => {
+		const seeded = loadSeededTestUser();
+		const login = await request.post(`${API_BASE}/api/auth/login`, { data: { email: seeded.email, password: seeded.password } });
+		const { access_token } = await login.json();
+		const name = `E2E Agent ${Date.now().toString(36)}`;
+		const create = await request.post(`${API_BASE}/api/agents`, { headers: authedHeaders(access_token), data: { scope: 'tenant', name } });
+		expect(create.status()).toBe(201);
+		const agent = await create.json();
+
+		await page.goto('/agents', { waitUntil: 'domcontentloaded' });
+		await expect(page.getByText(name).first()).toBeVisible({ timeout: 30_000 });
+
+		// Detail page renders the agent's name too.
+		await page.goto(`/agents/${agent.id}`, { waitUntil: 'domcontentloaded' });
+		await expect(page.getByText(name).first()).toBeVisible({ timeout: 30_000 });
+	});
+});

--- a/apps/web/e2e/missions-ideas-hierarchy.spec.ts
+++ b/apps/web/e2e/missions-ideas-hierarchy.spec.ts
@@ -1,0 +1,218 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
+
+/**
+ * Missions / Ideas hierarchy — deepens the existing API-contract specs
+ * (missions.spec.ts, ideas-extension.spec.ts) with the cross-entity wiring
+ * that had no coverage: full-fork mission clone, the user-manual Idea
+ * (work-proposal) lifecycle + budget, and the Mission/Idea scoping of
+ * Agents and Tasks. AI-driven build/research paths are intentionally out
+ * of scope (no provider locally) — this pins the deterministic wiring.
+ *
+ * Taxonomy: Mission = ongoing goal; Idea = atomic one-shot (a
+ * work-proposal). Agents and Tasks can be scoped to either, plus Work.
+ */
+
+const UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
+
+test.describe('Mission clone (full fork)', () => {
+    test('clone copies the mission, sets sourceMissionId, and titles it "Copy of …"', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const origin = await (
+            await request.post(`${API_BASE}/api/me/missions`, {
+                headers,
+                data: { title: 'Curate AI dev tools', description: 'weekly', type: 'one-shot' },
+            })
+        ).json();
+
+        const cloneRes = await request.post(`${API_BASE}/api/me/missions/${origin.id}/clone`, {
+            headers,
+            data: {},
+        });
+        expect(cloneRes.status(), `clone body=${await cloneRes.text()}`).toBe(201);
+        const cloned = (await cloneRes.json()).mission;
+        expect(cloned.id).not.toBe(origin.id);
+        expect(cloned.sourceMissionId).toBe(origin.id);
+        expect(cloned.title).toBe('Copy of Curate AI dev tools');
+        expect(cloned.status).toBe('active');
+
+        // Both now exist independently for the owner.
+        const list = await (await request.get(`${API_BASE}/api/me/missions`, { headers })).json();
+        const ids = list.map((m: { id: string }) => m.id);
+        expect(ids).toContain(origin.id);
+        expect(ids).toContain(cloned.id);
+    });
+});
+
+test.describe('Idea (work-proposal) lifecycle — user-manual', () => {
+    test('manual create → pending/user-manual; budget is idea-scoped; cross-user 404', async ({
+        request,
+    }) => {
+        const alice = await registerUserViaAPI(request);
+        const bob = await registerUserViaAPI(request);
+        const headers = authedHeaders(alice.access_token);
+
+        const idea = await (
+            await request.post(`${API_BASE}/api/me/work-proposals`, {
+                headers,
+                data: { description: 'A directory of AI dev tools' },
+            })
+        ).json();
+        expect(idea.id).toMatch(/^[0-9a-f-]{36}$/);
+        expect(idea.source).toBe('user-manual');
+        expect(idea.status).toBe('pending');
+        expect(idea.slugSuggestion).toBe('a-directory-of-ai-dev-tools');
+
+        const got = await request.get(`${API_BASE}/api/me/work-proposals/${idea.id}`, { headers });
+        expect(got.status()).toBe(200);
+
+        const budget = await (
+            await request.get(`${API_BASE}/api/me/work-proposals/${idea.id}/budget`, { headers })
+        ).json();
+        expect(budget.ownerType).toBe('idea');
+        expect(budget.ownerId).toBe(idea.id);
+        expect(budget.currentSpendCents).toBe(0);
+        expect(budget.blocked).toBe(false);
+
+        // Cross-user isolation.
+        const bobGet = await request.get(`${API_BASE}/api/me/work-proposals/${idea.id}`, {
+            headers: authedHeaders(bob.access_token),
+        });
+        expect([403, 404]).toContain(bobGet.status());
+    });
+});
+
+test.describe('Cross-entity scoping — Agents & Tasks across Mission/Idea', () => {
+    test('Tasks: ?missionId and ?ideaId each return only their own scope', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+
+        const mission = await (
+            await request.post(`${API_BASE}/api/me/missions`, {
+                headers,
+                data: { title: 'M', description: 'd', type: 'one-shot' },
+            })
+        ).json();
+        const ideaRes = await request.post(`${API_BASE}/api/me/work-proposals`, {
+            headers,
+            data: { description: 'A curated directory of AI developer tools' },
+        });
+        expect(ideaRes.status()).toBe(201);
+        const idea = await ideaRes.json();
+        expect(idea.id).toBeTruthy();
+
+        const missionTask = await (
+            await request.post(`${API_BASE}/api/tasks`, {
+                headers,
+                data: { title: 'Mission task', missionId: mission.id },
+            })
+        ).json();
+        const ideaTask = await (
+            await request.post(`${API_BASE}/api/tasks`, {
+                headers,
+                data: { title: 'Idea task', ideaId: idea.id },
+            })
+        ).json();
+        await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Unscoped task' } });
+
+        const byMission = await (
+            await request.get(`${API_BASE}/api/tasks?missionId=${mission.id}`, { headers })
+        ).json();
+        expect(byMission.data.map((t: { id: string }) => t.id)).toEqual([missionTask.id]);
+
+        const byIdea = await (
+            await request.get(`${API_BASE}/api/tasks?ideaId=${idea.id}`, { headers })
+        ).json();
+        expect(byIdea.data.map((t: { id: string }) => t.id)).toEqual([ideaTask.id]);
+
+        const byUnknown = await (
+            await request.get(`${API_BASE}/api/tasks?ideaId=${UNKNOWN_UUID}`, { headers })
+        ).json();
+        expect(byUnknown.data.length).toBe(0);
+    });
+
+    test('Agents: idea-scoped agent requires ideaId and is isolated by the scope filter', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+
+        const orphan = await request.post(`${API_BASE}/api/agents`, {
+            headers,
+            data: { scope: 'idea', name: 'No parent' },
+        });
+        expect(orphan.status()).toBe(400);
+        expect((await orphan.json()).message).toMatch(/ideaId/i);
+
+        const ideaRes = await request.post(`${API_BASE}/api/me/work-proposals`, {
+            headers,
+            data: { description: 'An agent-driven research directory idea' },
+        });
+        expect(ideaRes.status()).toBe(201);
+        const idea = await ideaRes.json();
+        const mission = await (
+            await request.post(`${API_BASE}/api/me/missions`, {
+                headers,
+                data: { title: 'M2', description: 'd', type: 'one-shot' },
+            })
+        ).json();
+
+        const ideaAgent = await (
+            await request.post(`${API_BASE}/api/agents`, {
+                headers,
+                data: { scope: 'idea', ideaId: idea.id, name: 'Idea Worker' },
+            })
+        ).json();
+        expect(ideaAgent.scope).toBe('idea');
+        expect(ideaAgent.ideaId).toBe(idea.id);
+        await request.post(`${API_BASE}/api/agents`, {
+            headers,
+            data: { scope: 'mission', missionId: mission.id, name: 'Mission Worker' },
+        });
+
+        const byIdea = await (
+            await request.get(`${API_BASE}/api/agents?scope=idea&ideaId=${idea.id}`, { headers })
+        ).json();
+        expect(byIdea.data.map((a: { id: string }) => a.id)).toEqual([ideaAgent.id]);
+    });
+});
+
+test.describe('Missions / Ideas — UI (authenticated as the seeded user)', () => {
+    async function seededToken(
+        request: import('@playwright/test').APIRequestContext,
+    ): Promise<string> {
+        const seeded = loadSeededTestUser();
+        const login = await request.post(`${API_BASE}/api/auth/login`, {
+            data: { email: seeded.email, password: seeded.password },
+        });
+        return (await login.json()).access_token;
+    }
+
+    test('a mission created via API appears on /missions', async ({ page, request }) => {
+        const token = await seededToken(request);
+        const title = `E2E Mission ${Date.now().toString(36)}`;
+        const res = await request.post(`${API_BASE}/api/me/missions`, {
+            headers: authedHeaders(token),
+            data: { title, description: 'd', type: 'one-shot' },
+        });
+        expect(res.status()).toBe(201);
+        await page.goto('/missions', { waitUntil: 'domcontentloaded' });
+        await expect(page.getByText(title).first()).toBeVisible({ timeout: 30_000 });
+    });
+
+    test('an idea created via API appears on /ideas', async ({ page, request }) => {
+        const token = await seededToken(request);
+        const desc = `E2E Idea ${Date.now().toString(36)}`;
+        const res = await request.post(`${API_BASE}/api/me/work-proposals`, {
+            headers: authedHeaders(token),
+            data: { description: desc },
+        });
+        expect(res.status()).toBe(201);
+        await page.goto('/ideas', { waitUntil: 'domcontentloaded' });
+        await expect(page.getByText(desc).first()).toBeVisible({ timeout: 30_000 });
+    });
+});

--- a/apps/web/e2e/notifications-preferences.spec.ts
+++ b/apps/web/e2e/notifications-preferences.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Notifications v2 — preference engine: per-event channel subscriptions,
+ * channel disable, category mutes, and quiet hours. These persistence
+ * round-trips had no dedicated coverage. Pinned to live API shapes.
+ *
+ * API surface:
+ *   - PUT  /api/notifications/preferences/event/:eventKey  { channelIds }
+ *   - GET  /api/notifications/preferences                  { subscriptions, preference, mutes }
+ *   - PATCH /api/notification-channels/:id                 { disabled }
+ *   - POST/DELETE /api/notifications/preferences/mute      { category }
+ *   - PUT  /api/notifications/preferences/quiet-hours      { start, end, timezone }
+ */
+
+async function setup(request: import('@playwright/test').APIRequestContext) {
+    const u = await registerUserViaAPI(request);
+    const headers = authedHeaders(u.access_token);
+    const channel = (
+        await (
+            await request.post(`${API_BASE}/api/notification-channels`, {
+                headers,
+                data: {
+                    pluginId: 'discord-channel',
+                    name: 'D',
+                    targetConfig: { webhookUrl: 'https://discord.com/api/webhooks/1/a' },
+                },
+            })
+        ).json()
+    ).channel;
+    const eventTypes = (
+        await (await request.get(`${API_BASE}/api/notifications/event-types`, { headers })).json()
+    ).eventTypes;
+    return { headers, channel, eventTypes };
+}
+
+test.describe('Notifications v2 — preferences', () => {
+    test('GET /api/notifications/preferences without auth → 401', async ({ request }) => {
+        expect((await request.get(`${API_BASE}/api/notifications/preferences`)).status()).toBe(401);
+    });
+
+    test('subscribe an event to a channel round-trips into the preferences view', async ({
+        request,
+    }) => {
+        const { headers, channel, eventTypes } = await setup(request);
+        const eventKey = eventTypes[0].key;
+
+        const put = await request.put(
+            `${API_BASE}/api/notifications/preferences/event/${eventKey}`,
+            {
+                headers,
+                data: { channelIds: [channel.id] },
+            },
+        );
+        expect(put.status(), `subscribe body=${await put.text()}`).toBe(200);
+        const sub = (await put.json()).subscription;
+        expect(sub.eventTypeKey).toBe(eventKey);
+        expect(sub.channelIds).toContain(channel.id);
+
+        const view = await (
+            await request.get(`${API_BASE}/api/notifications/preferences`, { headers })
+        ).json();
+        const found = view.subscriptions.find(
+            (s: { eventTypeKey: string }) => s.eventTypeKey === eventKey,
+        );
+        expect(found).toBeTruthy();
+        expect(found.channelIds).toContain(channel.id);
+    });
+
+    test('disabling a channel stamps disabledAt', async ({ request }) => {
+        const { headers, channel } = await setup(request);
+        const res = await request.patch(`${API_BASE}/api/notification-channels/${channel.id}`, {
+            headers,
+            data: { disabled: true },
+        });
+        expect(res.status()).toBe(200);
+        const updated = (await res.json()).channel;
+        expect(updated.id).toBe(channel.id);
+        expect(updated.disabledAt).not.toBeNull();
+    });
+
+    test('muting a category appears in the preferences view, and unmuting clears it', async ({
+        request,
+    }) => {
+        const { headers, eventTypes } = await setup(request);
+        const category = eventTypes[0].category;
+
+        const muted = await request.post(`${API_BASE}/api/notifications/preferences/mute`, {
+            headers,
+            data: { category },
+        });
+        expect(muted.status()).toBe(201);
+        expect((await muted.json()).mute.category).toBe(category);
+
+        const afterMute = await (
+            await request.get(`${API_BASE}/api/notifications/preferences`, { headers })
+        ).json();
+        expect(afterMute.mutes.some((m: { category: string }) => m.category === category)).toBe(
+            true,
+        );
+
+        const unmute = await request.delete(
+            `${API_BASE}/api/notifications/preferences/mute/${category}`,
+            { headers },
+        );
+        expect([200, 204]).toContain(unmute.status());
+
+        const afterUnmute = await (
+            await request.get(`${API_BASE}/api/notifications/preferences`, { headers })
+        ).json();
+        expect(afterUnmute.mutes.some((m: { category: string }) => m.category === category)).toBe(
+            false,
+        );
+    });
+
+    test('quiet hours persist into the preference record', async ({ request }) => {
+        const { headers } = await setup(request);
+        const put = await request.put(`${API_BASE}/api/notifications/preferences/quiet-hours`, {
+            headers,
+            data: { quietHoursStart: '22:00', quietHoursEnd: '07:00', timezone: 'UTC' },
+        });
+        expect(put.status()).toBe(200);
+        expect((await put.json()).preference).toMatchObject({
+            quietHoursStart: '22:00',
+            quietHoursEnd: '07:00',
+            timezone: 'UTC',
+        });
+
+        const view = await (
+            await request.get(`${API_BASE}/api/notifications/preferences`, { headers })
+        ).json();
+        expect(view.preference).toMatchObject({ quietHoursStart: '22:00', quietHoursEnd: '07:00' });
+    });
+});

--- a/apps/web/e2e/settings-integrations.spec.ts
+++ b/apps/web/e2e/settings-integrations.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Settings / Integrations — notification channels, the Work Agent
+ * preferences engine, notification preferences, and the email-address
+ * registry. These settings surfaces shipped without dedicated e2e specs.
+ * Assertions are pinned against live API shapes.
+ *
+ * API surface:
+ *   - GET/POST/DELETE /api/notification-channels(+/:id/test)
+ *   - GET/PUT /api/me/work-agent/preferences ; GET /api/me/work-agent/runs/active
+ *   - GET /api/notifications/event-types ; GET /api/notifications/preferences
+ *   - GET /api/email/addresses
+ */
+
+test.describe('Notification channels — API contract', () => {
+    test('GET /api/notification-channels without auth → 401', async ({ request }) => {
+        expect((await request.get(`${API_BASE}/api/notification-channels`)).status()).toBe(401);
+    });
+
+    test('CRUD + test: create discord channel → list → test → delete', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+
+        const fresh = await request.get(`${API_BASE}/api/notification-channels`, { headers });
+        expect(fresh.status()).toBe(200);
+        expect((await fresh.json()).channels).toEqual([]);
+
+        const created = await request.post(`${API_BASE}/api/notification-channels`, {
+            headers,
+            data: {
+                pluginId: 'discord-channel',
+                name: 'My Discord',
+                targetConfig: { webhookUrl: 'https://discord.com/api/webhooks/123/abc' },
+            },
+        });
+        expect(created.status(), `create body=${await created.text()}`).toBe(201);
+        const channel = (await created.json()).channel;
+        expect(channel.id).toMatch(/^[0-9a-f-]{36}$/);
+        expect(channel.pluginId).toBe('discord-channel');
+        expect(channel.name).toBe('My Discord');
+        // A freshly added channel is unverified until a test send confirms it.
+        expect(channel.verified).toBe(false);
+
+        const list = await (
+            await request.get(`${API_BASE}/api/notification-channels`, { headers })
+        ).json();
+        expect(list.channels.map((c: { id: string }) => c.id)).toContain(channel.id);
+
+        // Test send responds with a structured result (status may be "failed"
+        // locally when the channel plugin isn't enabled — pin the shape, not
+        // the outcome, so the assertion is environment-independent).
+        const tested = await request.post(
+            `${API_BASE}/api/notification-channels/${channel.id}/test`,
+            { headers },
+        );
+        expect([200, 201]).toContain(tested.status());
+        expect(typeof (await tested.json()).status).toBe('string');
+
+        const del = await request.delete(`${API_BASE}/api/notification-channels/${channel.id}`, {
+            headers,
+        });
+        expect([200, 204]).toContain(del.status());
+
+        const after = await (
+            await request.get(`${API_BASE}/api/notification-channels`, { headers })
+        ).json();
+        expect(after.channels.map((c: { id: string }) => c.id)).not.toContain(channel.id);
+    });
+});
+
+test.describe('Work Agent preferences — API contract', () => {
+    test('GET /api/me/work-agent/preferences without auth → 401', async ({ request }) => {
+        expect((await request.get(`${API_BASE}/api/me/work-agent/preferences`)).status()).toBe(401);
+    });
+
+    test('preferences expose guardrails and a PUT round-trips a changed field', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+
+        const prefsRes = await request.get(`${API_BASE}/api/me/work-agent/preferences`, {
+            headers,
+        });
+        expect(prefsRes.status()).toBe(200);
+        const prefs = await prefsRes.json();
+        expect(typeof prefs.enabled).toBe('boolean');
+        // Guardrails are the safety envelope around autonomous generation.
+        expect(prefs.guardrails).toMatchObject({
+            requireApprovalBeforeCreate: expect.any(Boolean),
+            dryRunByDefault: expect.any(Boolean),
+        });
+
+        // PATCH-semantics PUT: an omitted key is a no-op, a set key persists.
+        const put = await request.put(`${API_BASE}/api/me/work-agent/preferences`, {
+            headers,
+            data: { autoGenerateBatchSize: 7 },
+        });
+        expect(put.status()).toBe(200);
+        expect((await put.json()).autoGenerateBatchSize).toBe(7);
+
+        const reread = await (
+            await request.get(`${API_BASE}/api/me/work-agent/preferences`, { headers })
+        ).json();
+        expect(reread.autoGenerateBatchSize).toBe(7);
+        // The untouched guardrails must survive the partial update.
+        expect(reread.guardrails.requireApprovalBeforeCreate).toBe(
+            prefs.guardrails.requireApprovalBeforeCreate,
+        );
+    });
+
+    test('GET /api/me/work-agent/runs/active → 200 (no active run for a fresh user)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/me/work-agent/runs/active`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+    });
+});
+
+test.describe('Notification preferences + email registry — API contract', () => {
+    test('event-types catalog is non-empty and well-shaped', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/notifications/event-types`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        const { eventTypes } = await res.json();
+        expect(Array.isArray(eventTypes)).toBe(true);
+        expect(eventTypes.length).toBeGreaterThan(0);
+        for (const et of eventTypes) {
+            expect(typeof et.key).toBe('string');
+            expect(typeof et.category).toBe('string');
+            expect(typeof et.title).toBe('string');
+            expect(Array.isArray(et.defaultChannels)).toBe(true);
+        }
+    });
+
+    test('preferences view for a fresh user is empty + the in-app channel is always present in defaults', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const res = await request.get(`${API_BASE}/api/notifications/preferences`, { headers });
+        expect(res.status()).toBe(200);
+        const view = await res.json();
+        expect(Array.isArray(view.subscriptions)).toBe(true);
+        expect(Array.isArray(view.mutes)).toBe(true);
+
+        // Every core event type defaults to the built-in in-app channel.
+        const { eventTypes } = await (
+            await request.get(`${API_BASE}/api/notifications/event-types`, { headers })
+        ).json();
+        expect(
+            eventTypes.some((et: { defaultChannels: string[] }) =>
+                et.defaultChannels.includes('in-app'),
+            ),
+        ).toBe(true);
+    });
+
+    test('email address registry requires auth and starts empty', async ({ request }) => {
+        expect((await request.get(`${API_BASE}/api/email/addresses`)).status()).toBe(401);
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/email/addresses`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        expect((await res.json()).addresses).toEqual([]);
+    });
+});

--- a/apps/web/e2e/skills.spec.ts
+++ b/apps/web/e2e/skills.spec.ts
@@ -24,177 +24,270 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
 
 const UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
 
-async function ownerIdFor(request: import('@playwright/test').APIRequestContext, token: string): Promise<string> {
-	const res = await request.get(`${API_BASE}/api/auth/profile`, { headers: authedHeaders(token) });
-	const me = await res.json();
-	return me.id ?? me.user?.id;
+async function ownerIdFor(
+    request: import('@playwright/test').APIRequestContext,
+    token: string,
+): Promise<string> {
+    const res = await request.get(`${API_BASE}/api/auth/profile`, {
+        headers: authedHeaders(token),
+    });
+    const me = await res.json();
+    return me.id ?? me.user?.id;
 }
 
 test.describe('Skills — API contract', () => {
-	test('GET /api/skills without auth → 401', async ({ request }) => {
-		expect((await request.get(`${API_BASE}/api/skills`)).status()).toBe(401);
-	});
+    test('GET /api/skills without auth → 401', async ({ request }) => {
+        expect((await request.get(`${API_BASE}/api/skills`)).status()).toBe(401);
+    });
 
-	test('POST /api/skills without auth → 401', async ({ request }) => {
-		const res = await request.post(`${API_BASE}/api/skills`, { data: { title: 'x' } });
-		expect(res.status()).toBe(401);
-	});
+    test('POST /api/skills without auth → 401', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/skills`, { data: { title: 'x' } });
+        expect(res.status()).toBe(401);
+    });
 
-	test('GET /api/skills for a fresh user → empty {data, meta}', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const res = await request.get(`${API_BASE}/api/skills`, { headers: authedHeaders(u.access_token) });
-		expect(res.status()).toBe(200);
-		const body = await res.json();
-		expect(Array.isArray(body.data)).toBe(true);
-		expect(body.data.length).toBe(0);
-		expect(body.meta).toMatchObject({ total: 0 });
-	});
+    test('GET /api/skills for a fresh user → empty {data, meta}', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/skills`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(Array.isArray(body.data)).toBe(true);
+        expect(body.data.length).toBe(0);
+        expect(body.meta).toMatchObject({ total: 0 });
+    });
 
-	test('POST /api/skills creates a custom skill (slug lowercased, frontmatter, v1.0.0)', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const res = await request.post(`${API_BASE}/api/skills`, {
-			headers,
-			data: { ownerType: 'tenant', ownerId: u.user.id, title: 'Code Review Checklist', description: 'how to review', instructionsMd: '# Code Review\n\nsteps' }
-		});
-		expect(res.status(), `create body=${await res.text()}`).toBe(201);
-		const skill = await res.json();
-		expect(skill.id).toMatch(/^[0-9a-f-]{36}$/);
-		expect(skill.slug).toBe('code-review-checklist');
-		expect(skill.ownerType).toBe('tenant');
-		expect(skill.version).toBe('1.0.0');
-		// Hand-authored custom skill — not sourced from a catalog entry.
-		expect(skill.sourceCatalogSlug).toBeNull();
-		expect(skill.frontmatter).toMatchObject({ name: 'code-review-checklist' });
+    test('POST /api/skills creates a custom skill (slug lowercased, frontmatter, v1.0.0)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const res = await request.post(`${API_BASE}/api/skills`, {
+            headers,
+            data: {
+                ownerType: 'tenant',
+                ownerId: u.user.id,
+                title: 'Code Review Checklist',
+                description: 'how to review',
+                instructionsMd: '# Code Review\n\nsteps',
+            },
+        });
+        expect(res.status(), `create body=${await res.text()}`).toBe(201);
+        const skill = await res.json();
+        expect(skill.id).toMatch(/^[0-9a-f-]{36}$/);
+        expect(skill.slug).toBe('code-review-checklist');
+        expect(skill.ownerType).toBe('tenant');
+        expect(skill.version).toBe('1.0.0');
+        // Hand-authored custom skill — not sourced from a catalog entry.
+        expect(skill.sourceCatalogSlug).toBeNull();
+        expect(skill.frontmatter).toMatchObject({ name: 'code-review-checklist' });
 
-		const list = await (await request.get(`${API_BASE}/api/skills`, { headers })).json();
-		expect(list.data.find((s: { id: string }) => s.id === skill.id)).toBeTruthy();
-	});
+        const list = await (await request.get(`${API_BASE}/api/skills`, { headers })).json();
+        expect(list.data.find((s: { id: string }) => s.id === skill.id)).toBeTruthy();
+    });
 
-	test('POST /api/skills validates ownerType/ownerId', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
+    test('POST /api/skills validates ownerType/ownerId', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
 
-		const noOwnerId = await request.post(`${API_BASE}/api/skills`, {
-			headers,
-			data: { ownerType: 'tenant', title: 'S', description: 'd', instructionsMd: '# S' }
-		});
-		expect(noOwnerId.status()).toBe(400);
-		expect((await noOwnerId.json()).message).toMatch(/ownerId is required/i);
+        const noOwnerId = await request.post(`${API_BASE}/api/skills`, {
+            headers,
+            data: { ownerType: 'tenant', title: 'S', description: 'd', instructionsMd: '# S' },
+        });
+        expect(noOwnerId.status()).toBe(400);
+        expect((await noOwnerId.json()).message).toMatch(/ownerId is required/i);
 
-		const badType = await request.post(`${API_BASE}/api/skills`, {
-			headers,
-			data: { ownerType: 'user', ownerId: u.user.id, title: 'S', description: 'd', instructionsMd: '# S' }
-		});
-		expect(badType.status()).toBe(400);
-		expect((await badType.json()).message).toMatch(/invalid ownerType/i);
-	});
+        const badType = await request.post(`${API_BASE}/api/skills`, {
+            headers,
+            data: {
+                ownerType: 'user',
+                ownerId: u.user.id,
+                title: 'S',
+                description: 'd',
+                instructionsMd: '# S',
+            },
+        });
+        expect(badType.status()).toBe(400);
+        expect((await badType.json()).message).toMatch(/invalid ownerType/i);
+    });
 
-	test('PATCH /api/skills/:id updates body and recomputes contentHash', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const skill = await (await request.post(`${API_BASE}/api/skills`, {
-			headers, data: { ownerType: 'tenant', ownerId: u.user.id, title: 'Editable Skill', description: 'd', instructionsMd: '# v1' }
-		})).json();
+    test('PATCH /api/skills/:id updates body and recomputes contentHash', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const skill = await (
+            await request.post(`${API_BASE}/api/skills`, {
+                headers,
+                data: {
+                    ownerType: 'tenant',
+                    ownerId: u.user.id,
+                    title: 'Editable Skill',
+                    description: 'd',
+                    instructionsMd: '# v1',
+                },
+            })
+        ).json();
 
-		const patch = await request.patch(`${API_BASE}/api/skills/${skill.id}`, { headers, data: { instructionsMd: '# v2\n\nmore' } });
-		expect(patch.status()).toBe(200);
-		const updated = await patch.json();
-		expect(updated.instructionsMd).toBe('# v2\n\nmore');
-		expect(updated.contentHash).not.toBe(skill.contentHash);
-	});
+        const patch = await request.patch(`${API_BASE}/api/skills/${skill.id}`, {
+            headers,
+            data: { instructionsMd: '# v2\n\nmore' },
+        });
+        expect(patch.status()).toBe(200);
+        const updated = await patch.json();
+        expect(updated.instructionsMd).toBe('# v2\n\nmore');
+        expect(updated.contentHash).not.toBe(skill.contentHash);
+    });
 
-	test('bindings: empty array → create tenant + mission bindings → both listed; agent target requires targetId', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const skill = await (await request.post(`${API_BASE}/api/skills`, {
-			headers, data: { ownerType: 'tenant', ownerId: u.user.id, title: 'Bindable', description: 'd', instructionsMd: '# B' }
-		})).json();
+    test('bindings: empty array → create tenant + mission bindings → both listed; agent target requires targetId', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const skill = await (
+            await request.post(`${API_BASE}/api/skills`, {
+                headers,
+                data: {
+                    ownerType: 'tenant',
+                    ownerId: u.user.id,
+                    title: 'Bindable',
+                    description: 'd',
+                    instructionsMd: '# B',
+                },
+            })
+        ).json();
 
-		const empty = await request.get(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers });
-		expect(empty.status()).toBe(200);
-		expect(await empty.json()).toEqual([]);
+        const empty = await request.get(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers });
+        expect(empty.status()).toBe(200);
+        expect(await empty.json()).toEqual([]);
 
-		const tenantBinding = await request.post(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers, data: { targetType: 'tenant', priority: 100 } });
-		expect(tenantBinding.status()).toBe(201);
-		const tb = await tenantBinding.json();
-		expect(tb.targetType).toBe('tenant');
-		expect(tb.injectIntoAgent).toBe(true);
-		expect(tb.priority).toBe(100);
+        const tenantBinding = await request.post(`${API_BASE}/api/skills/${skill.id}/bindings`, {
+            headers,
+            data: { targetType: 'tenant', priority: 100 },
+        });
+        expect(tenantBinding.status()).toBe(201);
+        const tb = await tenantBinding.json();
+        expect(tb.targetType).toBe('tenant');
+        expect(tb.injectIntoAgent).toBe(true);
+        expect(tb.priority).toBe(100);
 
-		// agent target without an id is rejected (server-side validation).
-		const badAgent = await request.post(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers, data: { targetType: 'agent' } });
-		expect(badAgent.status()).toBe(400);
-		expect((await badAgent.json()).message).toMatch(/targetId is required/i);
+        // agent target without an id is rejected (server-side validation).
+        const badAgent = await request.post(`${API_BASE}/api/skills/${skill.id}/bindings`, {
+            headers,
+            data: { targetType: 'agent' },
+        });
+        expect(badAgent.status()).toBe(400);
+        expect((await badAgent.json()).message).toMatch(/targetId is required/i);
 
-		// bind to a real mission.
-		const mission = await (await request.post(`${API_BASE}/api/me/missions`, { headers, data: { title: 'BindMission', description: 'd', type: 'one-shot' } })).json();
-		const missionBinding = await request.post(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers, data: { targetType: 'mission', targetId: mission.id } });
-		expect(missionBinding.status()).toBe(201);
+        // bind to a real mission.
+        const mission = await (
+            await request.post(`${API_BASE}/api/me/missions`, {
+                headers,
+                data: { title: 'BindMission', description: 'd', type: 'one-shot' },
+            })
+        ).json();
+        const missionBinding = await request.post(`${API_BASE}/api/skills/${skill.id}/bindings`, {
+            headers,
+            data: { targetType: 'mission', targetId: mission.id },
+        });
+        expect(missionBinding.status()).toBe(201);
 
-		const all = await (await request.get(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers })).json();
-		expect(all.length).toBe(2);
-		expect(all.map((b: { targetType: string }) => b.targetType).sort()).toEqual(['mission', 'tenant']);
-	});
+        const all = await (
+            await request.get(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers })
+        ).json();
+        expect(all.length).toBe(2);
+        expect(all.map((b: { targetType: string }) => b.targetType).sort()).toEqual([
+            'mission',
+            'tenant',
+        ]);
+    });
 
-	test('GET /api/skills/catalog returns {entries, total} shape', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const res = await request.get(`${API_BASE}/api/skills/catalog?limit=3`, { headers: authedHeaders(u.access_token) });
-		expect(res.status()).toBe(200);
-		const body = await res.json();
-		expect(Array.isArray(body.entries)).toBe(true);
-		expect(typeof body.total).toBe('number');
-	});
+    test('GET /api/skills/catalog returns {entries, total} shape', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/skills/catalog?limit=3`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(Array.isArray(body.entries)).toBe(true);
+        expect(typeof body.total).toBe('number');
+    });
 
-	test('cross-user isolation: another user gets 403/404 on my skill', async ({ request }) => {
-		const alice = await registerUserViaAPI(request);
-		const bob = await registerUserViaAPI(request);
-		const skill = await (await request.post(`${API_BASE}/api/skills`, {
-			headers: authedHeaders(alice.access_token), data: { ownerType: 'tenant', ownerId: alice.user.id, title: 'Private', description: 'd', instructionsMd: '# P' }
-		})).json();
-		const res = await request.get(`${API_BASE}/api/skills/${skill.id}`, { headers: authedHeaders(bob.access_token) });
-		expect([403, 404]).toContain(res.status());
-	});
+    test('cross-user isolation: another user gets 403/404 on my skill', async ({ request }) => {
+        const alice = await registerUserViaAPI(request);
+        const bob = await registerUserViaAPI(request);
+        const skill = await (
+            await request.post(`${API_BASE}/api/skills`, {
+                headers: authedHeaders(alice.access_token),
+                data: {
+                    ownerType: 'tenant',
+                    ownerId: alice.user.id,
+                    title: 'Private',
+                    description: 'd',
+                    instructionsMd: '# P',
+                },
+            })
+        ).json();
+        const res = await request.get(`${API_BASE}/api/skills/${skill.id}`, {
+            headers: authedHeaders(bob.access_token),
+        });
+        expect([403, 404]).toContain(res.status());
+    });
 
-	test('DELETE /api/skills/:id → {deleted:true}; subsequent GET → 404', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const skill = await (await request.post(`${API_BASE}/api/skills`, {
-			headers, data: { ownerType: 'tenant', ownerId: u.user.id, title: 'Delete Me Skill', description: 'd', instructionsMd: '# D' }
-		})).json();
+    test('DELETE /api/skills/:id → {deleted:true}; subsequent GET → 404', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const skill = await (
+            await request.post(`${API_BASE}/api/skills`, {
+                headers,
+                data: {
+                    ownerType: 'tenant',
+                    ownerId: u.user.id,
+                    title: 'Delete Me Skill',
+                    description: 'd',
+                    instructionsMd: '# D',
+                },
+            })
+        ).json();
 
-		const del = await request.delete(`${API_BASE}/api/skills/${skill.id}`, { headers });
-		expect(del.status()).toBe(200);
-		expect(await del.json()).toMatchObject({ deleted: true });
+        const del = await request.delete(`${API_BASE}/api/skills/${skill.id}`, { headers });
+        expect(del.status()).toBe(200);
+        expect(await del.json()).toMatchObject({ deleted: true });
 
-		const after = await request.get(`${API_BASE}/api/skills/${skill.id}`, { headers });
-		expect([403, 404]).toContain(after.status());
-	});
+        const after = await request.get(`${API_BASE}/api/skills/${skill.id}`, { headers });
+        expect([403, 404]).toContain(after.status());
+    });
 });
 
 test.describe('Skills — UI (authenticated as the seeded user)', () => {
-	test('/skills index renders the hub', async ({ page }) => {
-		await page.goto('/skills', { waitUntil: 'domcontentloaded' });
-		await page.waitForLoadState('networkidle');
-		// The hub exposes section toggles (installed / available / custom).
-		await expect(page.getByText(/installed/i).first()).toBeVisible({ timeout: 30_000 });
-	});
+    test('/skills index renders the hub', async ({ page }) => {
+        await page.goto('/skills', { waitUntil: 'domcontentloaded' });
+        await page.waitForLoadState('networkidle');
+        // The hub exposes section toggles (installed / available / custom).
+        await expect(page.getByText(/installed/i).first()).toBeVisible({ timeout: 30_000 });
+    });
 
-	test('a custom skill created via API renders on its detail page', async ({ page, request }) => {
-		const seeded = loadSeededTestUser();
-		const login = await request.post(`${API_BASE}/api/auth/login`, { data: { email: seeded.email, password: seeded.password } });
-		const { access_token, user } = await login.json();
-		const ownerId = user?.id ?? (await ownerIdFor(request, access_token));
+    test('a custom skill created via API renders on its detail page', async ({ page, request }) => {
+        const seeded = loadSeededTestUser();
+        const login = await request.post(`${API_BASE}/api/auth/login`, {
+            data: { email: seeded.email, password: seeded.password },
+        });
+        const { access_token, user } = await login.json();
+        const ownerId = user?.id ?? (await ownerIdFor(request, access_token));
 
-		const title = `E2E Skill ${Date.now().toString(36)}`;
-		const createRes = await request.post(`${API_BASE}/api/skills`, {
-			headers: authedHeaders(access_token),
-			data: { ownerType: 'tenant', ownerId, title, description: 'created by e2e', instructionsMd: '# E2E\n\nbody' }
-		});
-		expect(createRes.status()).toBe(201);
-		const skill = await createRes.json();
+        const title = `E2E Skill ${Date.now().toString(36)}`;
+        const createRes = await request.post(`${API_BASE}/api/skills`, {
+            headers: authedHeaders(access_token),
+            data: {
+                ownerType: 'tenant',
+                ownerId,
+                title,
+                description: 'created by e2e',
+                instructionsMd: '# E2E\n\nbody',
+            },
+        });
+        expect(createRes.status()).toBe(201);
+        const skill = await createRes.json();
 
-		await page.goto(`/skills/${skill.id}`, { waitUntil: 'domcontentloaded' });
-		await expect(page.getByRole('heading', { name: title })).toBeVisible({ timeout: 30_000 });
-	});
+        await page.goto(`/skills/${skill.id}`, { waitUntil: 'domcontentloaded' });
+        await expect(page.getByRole('heading', { name: title })).toBeVisible({ timeout: 30_000 });
+    });
 });

--- a/apps/web/e2e/skills.spec.ts
+++ b/apps/web/e2e/skills.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
+
+/**
+ * Skills — deep coverage of the Skills feature (Agents/Skills/Tasks build).
+ * Zero dedicated e2e specs existed before this file. Assertions are pinned
+ * against live API shapes (verified on a running stack).
+ *
+ * A "Skill" is a reusable markdown capability (frontmatter + instructionsMd)
+ * owned at a scope (tenant/mission/idea/work/agent). Bindings attach a skill
+ * to a target. The local catalog is empty without a catalog provider, so the
+ * catalog test asserts shape only; custom-create is the exercised path.
+ *
+ * API surface (`apps/api/src/skills/*`):
+ *   - GET  /api/skills                 list `{data, meta}` (+ ownerType/search/pagination)
+ *   - POST /api/skills                 create (ownerType + ownerId required; slug auto-lowercased)
+ *   - GET  /api/skills/:id             get one (cross-user 404)
+ *   - PATCH /api/skills/:id            update body (contentHash recomputed)
+ *   - DELETE /api/skills/:id           delete -> {deleted:true}
+ *   - GET/POST /api/skills/:id/bindings  bindings (array; agent target needs targetId)
+ *   - GET  /api/skills/catalog         platform catalog `{entries, total}`
+ */
+
+const UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
+
+async function ownerIdFor(request: import('@playwright/test').APIRequestContext, token: string): Promise<string> {
+	const res = await request.get(`${API_BASE}/api/auth/profile`, { headers: authedHeaders(token) });
+	const me = await res.json();
+	return me.id ?? me.user?.id;
+}
+
+test.describe('Skills — API contract', () => {
+	test('GET /api/skills without auth → 401', async ({ request }) => {
+		expect((await request.get(`${API_BASE}/api/skills`)).status()).toBe(401);
+	});
+
+	test('POST /api/skills without auth → 401', async ({ request }) => {
+		const res = await request.post(`${API_BASE}/api/skills`, { data: { title: 'x' } });
+		expect(res.status()).toBe(401);
+	});
+
+	test('GET /api/skills for a fresh user → empty {data, meta}', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const res = await request.get(`${API_BASE}/api/skills`, { headers: authedHeaders(u.access_token) });
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body.data)).toBe(true);
+		expect(body.data.length).toBe(0);
+		expect(body.meta).toMatchObject({ total: 0 });
+	});
+
+	test('POST /api/skills creates a custom skill (slug lowercased, frontmatter, v1.0.0)', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const res = await request.post(`${API_BASE}/api/skills`, {
+			headers,
+			data: { ownerType: 'tenant', ownerId: u.user.id, title: 'Code Review Checklist', description: 'how to review', instructionsMd: '# Code Review\n\nsteps' }
+		});
+		expect(res.status(), `create body=${await res.text()}`).toBe(201);
+		const skill = await res.json();
+		expect(skill.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(skill.slug).toBe('code-review-checklist');
+		expect(skill.ownerType).toBe('tenant');
+		expect(skill.version).toBe('1.0.0');
+		// Hand-authored custom skill — not sourced from a catalog entry.
+		expect(skill.sourceCatalogSlug).toBeNull();
+		expect(skill.frontmatter).toMatchObject({ name: 'code-review-checklist' });
+
+		const list = await (await request.get(`${API_BASE}/api/skills`, { headers })).json();
+		expect(list.data.find((s: { id: string }) => s.id === skill.id)).toBeTruthy();
+	});
+
+	test('POST /api/skills validates ownerType/ownerId', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+
+		const noOwnerId = await request.post(`${API_BASE}/api/skills`, {
+			headers,
+			data: { ownerType: 'tenant', title: 'S', description: 'd', instructionsMd: '# S' }
+		});
+		expect(noOwnerId.status()).toBe(400);
+		expect((await noOwnerId.json()).message).toMatch(/ownerId is required/i);
+
+		const badType = await request.post(`${API_BASE}/api/skills`, {
+			headers,
+			data: { ownerType: 'user', ownerId: u.user.id, title: 'S', description: 'd', instructionsMd: '# S' }
+		});
+		expect(badType.status()).toBe(400);
+		expect((await badType.json()).message).toMatch(/invalid ownerType/i);
+	});
+
+	test('PATCH /api/skills/:id updates body and recomputes contentHash', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const skill = await (await request.post(`${API_BASE}/api/skills`, {
+			headers, data: { ownerType: 'tenant', ownerId: u.user.id, title: 'Editable Skill', description: 'd', instructionsMd: '# v1' }
+		})).json();
+
+		const patch = await request.patch(`${API_BASE}/api/skills/${skill.id}`, { headers, data: { instructionsMd: '# v2\n\nmore' } });
+		expect(patch.status()).toBe(200);
+		const updated = await patch.json();
+		expect(updated.instructionsMd).toBe('# v2\n\nmore');
+		expect(updated.contentHash).not.toBe(skill.contentHash);
+	});
+
+	test('bindings: empty array → create tenant + mission bindings → both listed; agent target requires targetId', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const skill = await (await request.post(`${API_BASE}/api/skills`, {
+			headers, data: { ownerType: 'tenant', ownerId: u.user.id, title: 'Bindable', description: 'd', instructionsMd: '# B' }
+		})).json();
+
+		const empty = await request.get(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers });
+		expect(empty.status()).toBe(200);
+		expect(await empty.json()).toEqual([]);
+
+		const tenantBinding = await request.post(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers, data: { targetType: 'tenant', priority: 100 } });
+		expect(tenantBinding.status()).toBe(201);
+		const tb = await tenantBinding.json();
+		expect(tb.targetType).toBe('tenant');
+		expect(tb.injectIntoAgent).toBe(true);
+		expect(tb.priority).toBe(100);
+
+		// agent target without an id is rejected (server-side validation).
+		const badAgent = await request.post(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers, data: { targetType: 'agent' } });
+		expect(badAgent.status()).toBe(400);
+		expect((await badAgent.json()).message).toMatch(/targetId is required/i);
+
+		// bind to a real mission.
+		const mission = await (await request.post(`${API_BASE}/api/me/missions`, { headers, data: { title: 'BindMission', description: 'd', type: 'one-shot' } })).json();
+		const missionBinding = await request.post(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers, data: { targetType: 'mission', targetId: mission.id } });
+		expect(missionBinding.status()).toBe(201);
+
+		const all = await (await request.get(`${API_BASE}/api/skills/${skill.id}/bindings`, { headers })).json();
+		expect(all.length).toBe(2);
+		expect(all.map((b: { targetType: string }) => b.targetType).sort()).toEqual(['mission', 'tenant']);
+	});
+
+	test('GET /api/skills/catalog returns {entries, total} shape', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const res = await request.get(`${API_BASE}/api/skills/catalog?limit=3`, { headers: authedHeaders(u.access_token) });
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body.entries)).toBe(true);
+		expect(typeof body.total).toBe('number');
+	});
+
+	test('cross-user isolation: another user gets 403/404 on my skill', async ({ request }) => {
+		const alice = await registerUserViaAPI(request);
+		const bob = await registerUserViaAPI(request);
+		const skill = await (await request.post(`${API_BASE}/api/skills`, {
+			headers: authedHeaders(alice.access_token), data: { ownerType: 'tenant', ownerId: alice.user.id, title: 'Private', description: 'd', instructionsMd: '# P' }
+		})).json();
+		const res = await request.get(`${API_BASE}/api/skills/${skill.id}`, { headers: authedHeaders(bob.access_token) });
+		expect([403, 404]).toContain(res.status());
+	});
+
+	test('DELETE /api/skills/:id → {deleted:true}; subsequent GET → 404', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const skill = await (await request.post(`${API_BASE}/api/skills`, {
+			headers, data: { ownerType: 'tenant', ownerId: u.user.id, title: 'Delete Me Skill', description: 'd', instructionsMd: '# D' }
+		})).json();
+
+		const del = await request.delete(`${API_BASE}/api/skills/${skill.id}`, { headers });
+		expect(del.status()).toBe(200);
+		expect(await del.json()).toMatchObject({ deleted: true });
+
+		const after = await request.get(`${API_BASE}/api/skills/${skill.id}`, { headers });
+		expect([403, 404]).toContain(after.status());
+	});
+});
+
+test.describe('Skills — UI (authenticated as the seeded user)', () => {
+	test('/skills index renders the hub', async ({ page }) => {
+		await page.goto('/skills', { waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('networkidle');
+		// The hub exposes section toggles (installed / available / custom).
+		await expect(page.getByText(/installed/i).first()).toBeVisible({ timeout: 30_000 });
+	});
+
+	test('a custom skill created via API renders on its detail page', async ({ page, request }) => {
+		const seeded = loadSeededTestUser();
+		const login = await request.post(`${API_BASE}/api/auth/login`, { data: { email: seeded.email, password: seeded.password } });
+		const { access_token, user } = await login.json();
+		const ownerId = user?.id ?? (await ownerIdFor(request, access_token));
+
+		const title = `E2E Skill ${Date.now().toString(36)}`;
+		const createRes = await request.post(`${API_BASE}/api/skills`, {
+			headers: authedHeaders(access_token),
+			data: { ownerType: 'tenant', ownerId, title, description: 'created by e2e', instructionsMd: '# E2E\n\nbody' }
+		});
+		expect(createRes.status()).toBe(201);
+		const skill = await createRes.json();
+
+		await page.goto(`/skills/${skill.id}`, { waitUntil: 'domcontentloaded' });
+		await expect(page.getByRole('heading', { name: title })).toBeVisible({ timeout: 30_000 });
+	});
+});

--- a/apps/web/e2e/tasks-collaboration.spec.ts
+++ b/apps/web/e2e/tasks-collaboration.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Tasks — collaboration sub-resources (assignees / reviewers / approvers)
+ * and recurrence (RFC 5545 RRULE). These endpoints had no e2e coverage.
+ * Assertions pinned against live API shapes.
+ *
+ * API surface (`apps/api/src/tasks/*`):
+ *   - POST /api/tasks/:id/assignees   { assigneeType: user|agent, assigneeId }
+ *   - POST /api/tasks/:id/reviewers   { reviewerType, reviewerId } -> reviewState
+ *   - POST /api/tasks/:id/approvers   { approverType, approverId } -> approvalState
+ *   - POST/DELETE /api/tasks/:id/recurring   { recurrenceRule }
+ */
+
+const UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
+
+async function makeTask(
+    request: import('@playwright/test').APIRequestContext,
+    token: string,
+    title = 'Collab task',
+) {
+    const res = await request.post(`${API_BASE}/api/tasks`, {
+        headers: authedHeaders(token),
+        data: { title },
+    });
+    return res.json();
+}
+
+test.describe('Tasks — assignees / reviewers / approvers', () => {
+    test('POST /api/tasks/:id/assignees without auth → 401', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/tasks/${UNKNOWN_UUID}/assignees`, {
+            data: { assigneeType: 'user', assigneeId: UNKNOWN_UUID },
+        });
+        expect(res.status()).toBe(401);
+    });
+
+    test('assign a human and an agent to a task', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const task = await makeTask(request, u.access_token);
+
+        const human = await request.post(`${API_BASE}/api/tasks/${task.id}/assignees`, {
+            headers,
+            data: { assigneeType: 'user', assigneeId: u.user.id },
+        });
+        expect(human.status(), `assignee body=${await human.text()}`).toBe(201);
+        const ha = await human.json();
+        expect(ha.taskId).toBe(task.id);
+        expect(ha.assigneeType).toBe('user');
+        expect(ha.assigneeId).toBe(u.user.id);
+
+        // Agents are first-class assignees (polymorphic assigneeType).
+        const agent = await (
+            await request.post(`${API_BASE}/api/agents`, {
+                headers,
+                data: { scope: 'tenant', name: 'Collab Agent' },
+            })
+        ).json();
+        const agentAssign = await request.post(`${API_BASE}/api/tasks/${task.id}/assignees`, {
+            headers,
+            data: { assigneeType: 'agent', assigneeId: agent.id },
+        });
+        expect(agentAssign.status()).toBe(201);
+        expect((await agentAssign.json()).assigneeType).toBe('agent');
+    });
+
+    test('reviewers and approvers start in a pending state', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const task = await makeTask(request, u.access_token);
+
+        const reviewer = await request.post(`${API_BASE}/api/tasks/${task.id}/reviewers`, {
+            headers,
+            data: { reviewerType: 'user', reviewerId: u.user.id },
+        });
+        expect(reviewer.status()).toBe(201);
+        const rv = await reviewer.json();
+        expect(rv.reviewState).toBe('pending');
+        expect(rv.reviewedAt).toBeNull();
+
+        const approver = await request.post(`${API_BASE}/api/tasks/${task.id}/approvers`, {
+            headers,
+            data: { approverType: 'user', approverId: u.user.id },
+        });
+        expect(approver.status()).toBe(201);
+        const ap = await approver.json();
+        expect(ap.approvalState).toBe('pending');
+        expect(ap.approvedAt).toBeNull();
+    });
+
+    test('cross-user isolation: a stranger cannot assign on my task', async ({ request }) => {
+        const alice = await registerUserViaAPI(request);
+        const bob = await registerUserViaAPI(request);
+        const task = await makeTask(request, alice.access_token);
+
+        const res = await request.post(`${API_BASE}/api/tasks/${task.id}/assignees`, {
+            headers: authedHeaders(bob.access_token),
+            data: { assigneeType: 'user', assigneeId: bob.user.id },
+        });
+        expect([403, 404]).toContain(res.status());
+    });
+});
+
+test.describe('Tasks — recurrence (RFC 5545 RRULE)', () => {
+    test('set a valid RRULE → task becomes recurring; clear it → not recurring', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const task = await makeTask(request, u.access_token, 'Weekly standup');
+
+        const set = await request.post(`${API_BASE}/api/tasks/${task.id}/recurring`, {
+            headers,
+            data: { recurrenceRule: 'FREQ=WEEKLY;INTERVAL=1;BYDAY=MO' },
+        });
+        expect(set.status(), `recurring body=${await set.text()}`).toBe(200);
+
+        const afterSet = await (
+            await request.get(`${API_BASE}/api/tasks/${task.id}`, { headers })
+        ).json();
+        expect(afterSet.isRecurring).toBe(true);
+
+        const cleared = await request.delete(`${API_BASE}/api/tasks/${task.id}/recurring`, {
+            headers,
+        });
+        expect(cleared.status()).toBe(200);
+        const afterClear = await (
+            await request.get(`${API_BASE}/api/tasks/${task.id}`, { headers })
+        ).json();
+        expect(afterClear.isRecurring).toBe(false);
+    });
+
+    test('a malformed RRULE is rejected with a 400 parse error (not a 500)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const task = await makeTask(request, u.access_token);
+
+        const res = await request.post(`${API_BASE}/api/tasks/${task.id}/recurring`, {
+            headers,
+            data: { recurrenceRule: 'not-a-rule' },
+        });
+        expect(res.status()).toBe(400);
+        expect((await res.json()).message).toMatch(/rrule/i);
+    });
+});

--- a/apps/web/e2e/tasks-pagination-filter.spec.ts
+++ b/apps/web/e2e/tasks-pagination-filter.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Tasks — real pagination + filter semantics. Existing pagination/sort-filter
+ * specs only assert "no 5xx"; this pins actual behaviour: limit/offset
+ * windows (no overlap), priority/label/search filters, and garbage-param
+ * tolerance. Verified against live shapes.
+ */
+
+// Seeds a fresh user with 5 tasks:
+//   index 0..4, priority p3/p1 alternating (2 are p1), label `alpha` on #0 else `beta`.
+async function seedTasks(request: import('@playwright/test').APIRequestContext) {
+    const u = await registerUserViaAPI(request);
+    const headers = authedHeaders(u.access_token);
+    for (let i = 0; i < 5; i++) {
+        await request.post(`${API_BASE}/api/tasks`, {
+            headers,
+            data: {
+                title: `Task ${i}`,
+                priority: i % 2 ? 'p1' : 'p3',
+                labels: i === 0 ? ['alpha'] : ['beta'],
+            },
+        });
+    }
+    return headers;
+}
+
+test.describe('Tasks — pagination', () => {
+    test('limit/offset return non-overlapping windows with correct meta', async ({ request }) => {
+        const headers = await seedTasks(request);
+
+        const page1 = await (
+            await request.get(`${API_BASE}/api/tasks?limit=2&offset=0`, { headers })
+        ).json();
+        expect(page1.data.length).toBe(2);
+        expect(page1.meta).toMatchObject({ total: 5, limit: 2, offset: 0 });
+
+        const page2 = await (
+            await request.get(`${API_BASE}/api/tasks?limit=2&offset=2`, { headers })
+        ).json();
+        expect(page2.data.length).toBe(2);
+        expect(page2.meta).toMatchObject({ total: 5, limit: 2, offset: 2 });
+
+        // The two pages must be disjoint — offset genuinely shifts the window.
+        const p1 = page1.data.map((t: { id: string }) => t.id);
+        const p2 = page2.data.map((t: { id: string }) => t.id);
+        expect(p1.some((id: string) => p2.includes(id))).toBe(false);
+    });
+
+    test('a garbage limit is tolerated (200, not 5xx)', async ({ request }) => {
+        const headers = await seedTasks(request);
+        const res = await request.get(`${API_BASE}/api/tasks?limit=abc`, { headers });
+        expect(res.status()).toBe(200);
+        expect(Array.isArray((await res.json()).data)).toBe(true);
+    });
+});
+
+test.describe('Tasks — filters', () => {
+    test('?priority returns only matching tasks', async ({ request }) => {
+        const headers = await seedTasks(request);
+        const res = await (
+            await request.get(`${API_BASE}/api/tasks?priority=p1`, { headers })
+        ).json();
+        expect(res.data.length).toBe(2);
+        expect(res.data.every((t: { priority: string }) => t.priority === 'p1')).toBe(true);
+    });
+
+    test('?label filters by tag', async ({ request }) => {
+        const headers = await seedTasks(request);
+        const res = await (
+            await request.get(`${API_BASE}/api/tasks?label=alpha`, { headers })
+        ).json();
+        expect(res.data.length).toBe(1);
+        expect(res.data[0].labels).toContain('alpha');
+    });
+
+    test('?search matches on title', async ({ request }) => {
+        const headers = await seedTasks(request);
+        const res = await (
+            await request.get(`${API_BASE}/api/tasks?search=${encodeURIComponent('Task 3')}`, {
+                headers,
+            })
+        ).json();
+        expect(res.data.length).toBeGreaterThanOrEqual(1);
+        expect(res.data.some((t: { title: string }) => t.title === 'Task 3')).toBe(true);
+    });
+});

--- a/apps/web/e2e/tasks.spec.ts
+++ b/apps/web/e2e/tasks.spec.ts
@@ -1,0 +1,240 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
+import { loginViaAPI } from './helpers/auth';
+
+/**
+ * Tasks — deep coverage of the Task-tracking feature (Agents/Skills/Tasks
+ * build). The feature had ZERO dedicated e2e specs before this file; the
+ * assertions here are pinned against the live API shapes (verified on a
+ * running stack), not the permissive `status < 500` smoke pattern.
+ *
+ * API surface (`apps/api/src/tasks/*`):
+ *   - GET    /api/tasks                 list (+ status/priority/scope/label/search filters, pagination)
+ *   - POST   /api/tasks                 create (auto slug `T-<n>`, status defaults to `backlog`)
+ *   - GET    /api/tasks/:id             get one (cross-user 404)
+ *   - PATCH  /api/tasks/:id             partial update
+ *   - DELETE /api/tasks/:id             delete
+ *   - POST   /api/tasks/:id/transition  status state-machine (rejects illegal hops with 400)
+ *   - GET/POST /api/tasks/:id/chat      flat chat thread
+ *
+ * UI (`apps/web/.../tasks/*` + components/tasks/*):
+ *   - /tasks            list (cards/table/kanban + status filter)
+ *   - /tasks/new        create form (title/description/priority/labels)
+ *   - /tasks/:id        detail (status transitions + chat)
+ *
+ * The UI tests run authenticated via the storageState from global-setup
+ * (the default `chromium` project). The API-contract tests register their
+ * own isolated users so they don't depend on the seeded session.
+ */
+
+const UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
+
+test.describe('Tasks — API contract', () => {
+	test('GET /api/tasks without auth → 401', async ({ request }) => {
+		const res = await request.get(`${API_BASE}/api/tasks`);
+		expect(res.status()).toBe(401);
+	});
+
+	test('POST /api/tasks without auth → 401', async ({ request }) => {
+		const res = await request.post(`${API_BASE}/api/tasks`, { data: { title: 'x' } });
+		expect(res.status()).toBe(401);
+	});
+
+	test('GET /api/tasks for a fresh user → empty {data, meta}', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const res = await request.get(`${API_BASE}/api/tasks`, { headers: authedHeaders(u.access_token) });
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body.data)).toBe(true);
+		expect(body.data.length).toBe(0);
+	});
+
+	test('POST /api/tasks creates with slug + backlog default + echoed fields', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+
+		const createRes = await request.post(`${API_BASE}/api/tasks`, {
+			headers,
+			data: { title: 'Ship the launch checklist', description: 'all the things', priority: 'p1', labels: ['launch', 'urgent'] }
+		});
+		expect(createRes.status(), `create body=${await createRes.text()}`).toBe(201);
+		const task = await createRes.json();
+
+		expect(task.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(task.slug).toMatch(/^T-\d+$/);
+		expect(task.title).toBe('Ship the launch checklist');
+		expect(task.description).toBe('all the things');
+		expect(task.priority).toBe('p1');
+		expect(task.labels).toEqual(['launch', 'urgent']);
+		// New tasks always start in `backlog`, created by a human (not an agent).
+		expect(task.status).toBe('backlog');
+		expect(task.createdByType).toBe('user');
+
+		// It shows up in the owner's list.
+		const listRes = await request.get(`${API_BASE}/api/tasks`, { headers });
+		const list = await listRes.json();
+		expect(list.data.find((t: { id: string }) => t.id === task.id)).toBeTruthy();
+	});
+
+	test('GET /api/tasks honours status filter + pagination meta', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'A backlog task' } });
+
+		// A fresh user has no `todo` tasks yet → empty page, meta echoes the query.
+		const res = await request.get(`${API_BASE}/api/tasks?status=todo&limit=5`, { headers });
+		expect(res.status()).toBe(200);
+		const body = await res.json();
+		expect(Array.isArray(body.data)).toBe(true);
+		expect(body.data.length).toBe(0);
+		expect(body.meta).toMatchObject({ total: 0, limit: 5, offset: 0 });
+	});
+
+	test('transition: valid chain backlog → todo → in_progress → in_review → done', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const task = await (await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Walk the state machine' } })).json();
+		expect(task.status).toBe('backlog');
+
+		for (const to of ['todo', 'in_progress', 'in_review', 'done'] as const) {
+			const res = await request.post(`${API_BASE}/api/tasks/${task.id}/transition`, { headers, data: { to } });
+			expect(res.status(), `transition to ${to} body=${await res.text()}`).toBe(200);
+			expect((await res.json()).status).toBe(to);
+		}
+	});
+
+	test('transition: illegal hop todo → done is rejected 400 (state machine enforced server-side)', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const task = await (await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Cannot skip review' } })).json();
+
+		await request.post(`${API_BASE}/api/tasks/${task.id}/transition`, { headers, data: { to: 'todo' } });
+		const res = await request.post(`${API_BASE}/api/tasks/${task.id}/transition`, { headers, data: { to: 'done' } });
+		expect(res.status()).toBe(400);
+		expect((await res.json()).message).toMatch(/cannot transition/i);
+	});
+
+	test('chat: empty thread → post → message visible with author + body', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const task = await (await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Discuss the plan' } })).json();
+
+		const before = await request.get(`${API_BASE}/api/tasks/${task.id}/chat`, { headers });
+		expect(before.status()).toBe(200);
+		expect((await before.json()).data).toEqual([]);
+
+		const postRes = await request.post(`${API_BASE}/api/tasks/${task.id}/chat`, { headers, data: { body: 'Kicking this off — who can own it?' } });
+		expect(postRes.status()).toBe(201);
+		const msg = await postRes.json();
+		expect(msg.id).toMatch(/^[0-9a-f-]{36}$/);
+		expect(msg.authorType).toBe('user');
+		expect(msg.body).toBe('Kicking this off — who can own it?');
+
+		const after = await request.get(`${API_BASE}/api/tasks/${task.id}/chat`, { headers });
+		const afterData = (await after.json()).data;
+		expect(afterData.length).toBe(1);
+		expect(afterData[0].body).toBe('Kicking this off — who can own it?');
+	});
+
+	test('scoping: ?missionId filters to the owning mission', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+
+		const mission = await (await request.post(`${API_BASE}/api/me/missions`, {
+			headers,
+			data: { title: 'Scope mission', description: 'owns a task', type: 'one-shot' }
+		})).json();
+
+		const scoped = await (await request.post(`${API_BASE}/api/tasks`, {
+			headers,
+			data: { title: 'Mission-scoped task', missionId: mission.id }
+		})).json();
+		expect(scoped.missionId).toBe(mission.id);
+
+		// Also create an unscoped task to prove the filter actually filters.
+		await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Unscoped task' } });
+
+		const filtered = await request.get(`${API_BASE}/api/tasks?missionId=${mission.id}`, { headers });
+		expect(filtered.status()).toBe(200);
+		const ids = (await filtered.json()).data.map((t: { id: string }) => t.id);
+		expect(ids).toContain(scoped.id);
+		expect(ids.length).toBe(1);
+
+		// Unknown mission → empty.
+		const none = await request.get(`${API_BASE}/api/tasks?missionId=${UNKNOWN_UUID}`, { headers });
+		expect((await none.json()).data.length).toBe(0);
+	});
+
+	test('cross-user isolation: another user gets 403/404 on my task', async ({ request }) => {
+		const alice = await registerUserViaAPI(request);
+		const bob = await registerUserViaAPI(request);
+		const task = await (await request.post(`${API_BASE}/api/tasks`, {
+			headers: authedHeaders(alice.access_token),
+			data: { title: "Alice's private task" }
+		})).json();
+
+		const res = await request.get(`${API_BASE}/api/tasks/${task.id}`, { headers: authedHeaders(bob.access_token) });
+		expect([403, 404]).toContain(res.status());
+	});
+
+	test('DELETE removes the task (subsequent GET → 404)', async ({ request }) => {
+		const u = await registerUserViaAPI(request);
+		const headers = authedHeaders(u.access_token);
+		const task = await (await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Delete me' } })).json();
+
+		const del = await request.delete(`${API_BASE}/api/tasks/${task.id}`, { headers });
+		expect([200, 204]).toContain(del.status());
+
+		const after = await request.get(`${API_BASE}/api/tasks/${task.id}`, { headers });
+		expect([403, 404]).toContain(after.status());
+	});
+});
+
+test.describe('Tasks — UI (authenticated as the seeded user)', () => {
+	test('/tasks/new renders the form, creates a task, and lands on its detail page', async ({ page }) => {
+		await page.goto('/tasks/new', { waitUntil: 'domcontentloaded' });
+		// Let dev-mode hydration finish before typing — otherwise an early
+		// fill() lands in the DOM before React attaches its onChange and the
+		// controlled `title` state stays empty (Create button stuck disabled).
+		await page.waitForLoadState('networkidle');
+
+		// Accessible name comes from the placeholder ("Add a task title").
+		const titleInput = page.getByRole('textbox', { name: 'Add a task title' });
+		await expect(titleInput).toBeVisible();
+
+		const unique = `E2E UI task ${Date.now().toString(36)}`;
+		await titleInput.click();
+		await titleInput.pressSequentially(unique, { delay: 15 });
+		await expect(titleInput).toHaveValue(unique);
+
+		// Scope to the form's Create button by name — the dashboard chrome
+		// also renders a global chat composer with its own submit button.
+		const submit = page.getByRole('button', { name: 'Create', exact: true });
+		await expect(submit).toBeEnabled();
+		await submit.click();
+
+		// Routes to ROUTES.DASHBOARD_TASK(id) — /tasks/<uuid> (locale prefix optional).
+		await page.waitForURL(/\/(en\/)?tasks\/[0-9a-f-]{36}/, { timeout: 60_000 });
+		await expect(page.getByText(unique).first()).toBeVisible();
+	});
+
+	test('a task created via API for the seeded user appears on /tasks', async ({ page, request }) => {
+		// Create the task as the SAME user the browser is authenticated as,
+		// so it shows up in this session's list (cross-layer: API write → UI read).
+		const seeded = loadSeededTestUser();
+		const { access_token } = await loginViaAPI(page.url() || 'http://localhost:3000', {
+			email: seeded.email,
+			password: seeded.password
+		});
+		const unique = `E2E list task ${Date.now().toString(36)}`;
+		const createRes = await request.post(`${API_BASE}/api/tasks`, {
+			headers: authedHeaders(access_token),
+			data: { title: unique }
+		});
+		expect(createRes.status()).toBe(201);
+
+		await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
+		await expect(page.getByText(unique).first()).toBeVisible({ timeout: 30_000 });
+	});
+});

--- a/apps/web/e2e/tasks.spec.ts
+++ b/apps/web/e2e/tasks.spec.ts
@@ -31,210 +31,269 @@ import { loginViaAPI } from './helpers/auth';
 const UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
 
 test.describe('Tasks — API contract', () => {
-	test('GET /api/tasks without auth → 401', async ({ request }) => {
-		const res = await request.get(`${API_BASE}/api/tasks`);
-		expect(res.status()).toBe(401);
-	});
+    test('GET /api/tasks without auth → 401', async ({ request }) => {
+        const res = await request.get(`${API_BASE}/api/tasks`);
+        expect(res.status()).toBe(401);
+    });
 
-	test('POST /api/tasks without auth → 401', async ({ request }) => {
-		const res = await request.post(`${API_BASE}/api/tasks`, { data: { title: 'x' } });
-		expect(res.status()).toBe(401);
-	});
+    test('POST /api/tasks without auth → 401', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/tasks`, { data: { title: 'x' } });
+        expect(res.status()).toBe(401);
+    });
 
-	test('GET /api/tasks for a fresh user → empty {data, meta}', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const res = await request.get(`${API_BASE}/api/tasks`, { headers: authedHeaders(u.access_token) });
-		expect(res.status()).toBe(200);
-		const body = await res.json();
-		expect(Array.isArray(body.data)).toBe(true);
-		expect(body.data.length).toBe(0);
-	});
+    test('GET /api/tasks for a fresh user → empty {data, meta}', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/tasks`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(Array.isArray(body.data)).toBe(true);
+        expect(body.data.length).toBe(0);
+    });
 
-	test('POST /api/tasks creates with slug + backlog default + echoed fields', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
+    test('POST /api/tasks creates with slug + backlog default + echoed fields', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
 
-		const createRes = await request.post(`${API_BASE}/api/tasks`, {
-			headers,
-			data: { title: 'Ship the launch checklist', description: 'all the things', priority: 'p1', labels: ['launch', 'urgent'] }
-		});
-		expect(createRes.status(), `create body=${await createRes.text()}`).toBe(201);
-		const task = await createRes.json();
+        const createRes = await request.post(`${API_BASE}/api/tasks`, {
+            headers,
+            data: {
+                title: 'Ship the launch checklist',
+                description: 'all the things',
+                priority: 'p1',
+                labels: ['launch', 'urgent'],
+            },
+        });
+        expect(createRes.status(), `create body=${await createRes.text()}`).toBe(201);
+        const task = await createRes.json();
 
-		expect(task.id).toMatch(/^[0-9a-f-]{36}$/);
-		expect(task.slug).toMatch(/^T-\d+$/);
-		expect(task.title).toBe('Ship the launch checklist');
-		expect(task.description).toBe('all the things');
-		expect(task.priority).toBe('p1');
-		expect(task.labels).toEqual(['launch', 'urgent']);
-		// New tasks always start in `backlog`, created by a human (not an agent).
-		expect(task.status).toBe('backlog');
-		expect(task.createdByType).toBe('user');
+        expect(task.id).toMatch(/^[0-9a-f-]{36}$/);
+        expect(task.slug).toMatch(/^T-\d+$/);
+        expect(task.title).toBe('Ship the launch checklist');
+        expect(task.description).toBe('all the things');
+        expect(task.priority).toBe('p1');
+        expect(task.labels).toEqual(['launch', 'urgent']);
+        // New tasks always start in `backlog`, created by a human (not an agent).
+        expect(task.status).toBe('backlog');
+        expect(task.createdByType).toBe('user');
 
-		// It shows up in the owner's list.
-		const listRes = await request.get(`${API_BASE}/api/tasks`, { headers });
-		const list = await listRes.json();
-		expect(list.data.find((t: { id: string }) => t.id === task.id)).toBeTruthy();
-	});
+        // It shows up in the owner's list.
+        const listRes = await request.get(`${API_BASE}/api/tasks`, { headers });
+        const list = await listRes.json();
+        expect(list.data.find((t: { id: string }) => t.id === task.id)).toBeTruthy();
+    });
 
-	test('GET /api/tasks honours status filter + pagination meta', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'A backlog task' } });
+    test('GET /api/tasks honours status filter + pagination meta', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'A backlog task' } });
 
-		// A fresh user has no `todo` tasks yet → empty page, meta echoes the query.
-		const res = await request.get(`${API_BASE}/api/tasks?status=todo&limit=5`, { headers });
-		expect(res.status()).toBe(200);
-		const body = await res.json();
-		expect(Array.isArray(body.data)).toBe(true);
-		expect(body.data.length).toBe(0);
-		expect(body.meta).toMatchObject({ total: 0, limit: 5, offset: 0 });
-	});
+        // A fresh user has no `todo` tasks yet → empty page, meta echoes the query.
+        const res = await request.get(`${API_BASE}/api/tasks?status=todo&limit=5`, { headers });
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(Array.isArray(body.data)).toBe(true);
+        expect(body.data.length).toBe(0);
+        expect(body.meta).toMatchObject({ total: 0, limit: 5, offset: 0 });
+    });
 
-	test('transition: valid chain backlog → todo → in_progress → in_review → done', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const task = await (await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Walk the state machine' } })).json();
-		expect(task.status).toBe('backlog');
+    test('transition: valid chain backlog → todo → in_progress → in_review → done', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const task = await (
+            await request.post(`${API_BASE}/api/tasks`, {
+                headers,
+                data: { title: 'Walk the state machine' },
+            })
+        ).json();
+        expect(task.status).toBe('backlog');
 
-		for (const to of ['todo', 'in_progress', 'in_review', 'done'] as const) {
-			const res = await request.post(`${API_BASE}/api/tasks/${task.id}/transition`, { headers, data: { to } });
-			expect(res.status(), `transition to ${to} body=${await res.text()}`).toBe(200);
-			expect((await res.json()).status).toBe(to);
-		}
-	});
+        for (const to of ['todo', 'in_progress', 'in_review', 'done'] as const) {
+            const res = await request.post(`${API_BASE}/api/tasks/${task.id}/transition`, {
+                headers,
+                data: { to },
+            });
+            expect(res.status(), `transition to ${to} body=${await res.text()}`).toBe(200);
+            expect((await res.json()).status).toBe(to);
+        }
+    });
 
-	test('transition: illegal hop todo → done is rejected 400 (state machine enforced server-side)', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const task = await (await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Cannot skip review' } })).json();
+    test('transition: illegal hop todo → done is rejected 400 (state machine enforced server-side)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const task = await (
+            await request.post(`${API_BASE}/api/tasks`, {
+                headers,
+                data: { title: 'Cannot skip review' },
+            })
+        ).json();
 
-		await request.post(`${API_BASE}/api/tasks/${task.id}/transition`, { headers, data: { to: 'todo' } });
-		const res = await request.post(`${API_BASE}/api/tasks/${task.id}/transition`, { headers, data: { to: 'done' } });
-		expect(res.status()).toBe(400);
-		expect((await res.json()).message).toMatch(/cannot transition/i);
-	});
+        await request.post(`${API_BASE}/api/tasks/${task.id}/transition`, {
+            headers,
+            data: { to: 'todo' },
+        });
+        const res = await request.post(`${API_BASE}/api/tasks/${task.id}/transition`, {
+            headers,
+            data: { to: 'done' },
+        });
+        expect(res.status()).toBe(400);
+        expect((await res.json()).message).toMatch(/cannot transition/i);
+    });
 
-	test('chat: empty thread → post → message visible with author + body', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const task = await (await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Discuss the plan' } })).json();
+    test('chat: empty thread → post → message visible with author + body', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const task = await (
+            await request.post(`${API_BASE}/api/tasks`, {
+                headers,
+                data: { title: 'Discuss the plan' },
+            })
+        ).json();
 
-		const before = await request.get(`${API_BASE}/api/tasks/${task.id}/chat`, { headers });
-		expect(before.status()).toBe(200);
-		expect((await before.json()).data).toEqual([]);
+        const before = await request.get(`${API_BASE}/api/tasks/${task.id}/chat`, { headers });
+        expect(before.status()).toBe(200);
+        expect((await before.json()).data).toEqual([]);
 
-		const postRes = await request.post(`${API_BASE}/api/tasks/${task.id}/chat`, { headers, data: { body: 'Kicking this off — who can own it?' } });
-		expect(postRes.status()).toBe(201);
-		const msg = await postRes.json();
-		expect(msg.id).toMatch(/^[0-9a-f-]{36}$/);
-		expect(msg.authorType).toBe('user');
-		expect(msg.body).toBe('Kicking this off — who can own it?');
+        const postRes = await request.post(`${API_BASE}/api/tasks/${task.id}/chat`, {
+            headers,
+            data: { body: 'Kicking this off — who can own it?' },
+        });
+        expect(postRes.status()).toBe(201);
+        const msg = await postRes.json();
+        expect(msg.id).toMatch(/^[0-9a-f-]{36}$/);
+        expect(msg.authorType).toBe('user');
+        expect(msg.body).toBe('Kicking this off — who can own it?');
 
-		const after = await request.get(`${API_BASE}/api/tasks/${task.id}/chat`, { headers });
-		const afterData = (await after.json()).data;
-		expect(afterData.length).toBe(1);
-		expect(afterData[0].body).toBe('Kicking this off — who can own it?');
-	});
+        const after = await request.get(`${API_BASE}/api/tasks/${task.id}/chat`, { headers });
+        const afterData = (await after.json()).data;
+        expect(afterData.length).toBe(1);
+        expect(afterData[0].body).toBe('Kicking this off — who can own it?');
+    });
 
-	test('scoping: ?missionId filters to the owning mission', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
+    test('scoping: ?missionId filters to the owning mission', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
 
-		const mission = await (await request.post(`${API_BASE}/api/me/missions`, {
-			headers,
-			data: { title: 'Scope mission', description: 'owns a task', type: 'one-shot' }
-		})).json();
+        const mission = await (
+            await request.post(`${API_BASE}/api/me/missions`, {
+                headers,
+                data: { title: 'Scope mission', description: 'owns a task', type: 'one-shot' },
+            })
+        ).json();
 
-		const scoped = await (await request.post(`${API_BASE}/api/tasks`, {
-			headers,
-			data: { title: 'Mission-scoped task', missionId: mission.id }
-		})).json();
-		expect(scoped.missionId).toBe(mission.id);
+        const scoped = await (
+            await request.post(`${API_BASE}/api/tasks`, {
+                headers,
+                data: { title: 'Mission-scoped task', missionId: mission.id },
+            })
+        ).json();
+        expect(scoped.missionId).toBe(mission.id);
 
-		// Also create an unscoped task to prove the filter actually filters.
-		await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Unscoped task' } });
+        // Also create an unscoped task to prove the filter actually filters.
+        await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Unscoped task' } });
 
-		const filtered = await request.get(`${API_BASE}/api/tasks?missionId=${mission.id}`, { headers });
-		expect(filtered.status()).toBe(200);
-		const ids = (await filtered.json()).data.map((t: { id: string }) => t.id);
-		expect(ids).toContain(scoped.id);
-		expect(ids.length).toBe(1);
+        const filtered = await request.get(`${API_BASE}/api/tasks?missionId=${mission.id}`, {
+            headers,
+        });
+        expect(filtered.status()).toBe(200);
+        const ids = (await filtered.json()).data.map((t: { id: string }) => t.id);
+        expect(ids).toContain(scoped.id);
+        expect(ids.length).toBe(1);
 
-		// Unknown mission → empty.
-		const none = await request.get(`${API_BASE}/api/tasks?missionId=${UNKNOWN_UUID}`, { headers });
-		expect((await none.json()).data.length).toBe(0);
-	});
+        // Unknown mission → empty.
+        const none = await request.get(`${API_BASE}/api/tasks?missionId=${UNKNOWN_UUID}`, {
+            headers,
+        });
+        expect((await none.json()).data.length).toBe(0);
+    });
 
-	test('cross-user isolation: another user gets 403/404 on my task', async ({ request }) => {
-		const alice = await registerUserViaAPI(request);
-		const bob = await registerUserViaAPI(request);
-		const task = await (await request.post(`${API_BASE}/api/tasks`, {
-			headers: authedHeaders(alice.access_token),
-			data: { title: "Alice's private task" }
-		})).json();
+    test('cross-user isolation: another user gets 403/404 on my task', async ({ request }) => {
+        const alice = await registerUserViaAPI(request);
+        const bob = await registerUserViaAPI(request);
+        const task = await (
+            await request.post(`${API_BASE}/api/tasks`, {
+                headers: authedHeaders(alice.access_token),
+                data: { title: "Alice's private task" },
+            })
+        ).json();
 
-		const res = await request.get(`${API_BASE}/api/tasks/${task.id}`, { headers: authedHeaders(bob.access_token) });
-		expect([403, 404]).toContain(res.status());
-	});
+        const res = await request.get(`${API_BASE}/api/tasks/${task.id}`, {
+            headers: authedHeaders(bob.access_token),
+        });
+        expect([403, 404]).toContain(res.status());
+    });
 
-	test('DELETE removes the task (subsequent GET → 404)', async ({ request }) => {
-		const u = await registerUserViaAPI(request);
-		const headers = authedHeaders(u.access_token);
-		const task = await (await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Delete me' } })).json();
+    test('DELETE removes the task (subsequent GET → 404)', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+        const task = await (
+            await request.post(`${API_BASE}/api/tasks`, { headers, data: { title: 'Delete me' } })
+        ).json();
 
-		const del = await request.delete(`${API_BASE}/api/tasks/${task.id}`, { headers });
-		expect([200, 204]).toContain(del.status());
+        const del = await request.delete(`${API_BASE}/api/tasks/${task.id}`, { headers });
+        expect([200, 204]).toContain(del.status());
 
-		const after = await request.get(`${API_BASE}/api/tasks/${task.id}`, { headers });
-		expect([403, 404]).toContain(after.status());
-	});
+        const after = await request.get(`${API_BASE}/api/tasks/${task.id}`, { headers });
+        expect([403, 404]).toContain(after.status());
+    });
 });
 
 test.describe('Tasks — UI (authenticated as the seeded user)', () => {
-	test('/tasks/new renders the form, creates a task, and lands on its detail page', async ({ page }) => {
-		await page.goto('/tasks/new', { waitUntil: 'domcontentloaded' });
-		// Let dev-mode hydration finish before typing — otherwise an early
-		// fill() lands in the DOM before React attaches its onChange and the
-		// controlled `title` state stays empty (Create button stuck disabled).
-		await page.waitForLoadState('networkidle');
+    test('/tasks/new renders the form, creates a task, and lands on its detail page', async ({
+        page,
+    }) => {
+        await page.goto('/tasks/new', { waitUntil: 'domcontentloaded' });
+        // Let dev-mode hydration finish before typing — otherwise an early
+        // fill() lands in the DOM before React attaches its onChange and the
+        // controlled `title` state stays empty (Create button stuck disabled).
+        await page.waitForLoadState('networkidle');
 
-		// Accessible name comes from the placeholder ("Add a task title").
-		const titleInput = page.getByRole('textbox', { name: 'Add a task title' });
-		await expect(titleInput).toBeVisible();
+        // Accessible name comes from the placeholder ("Add a task title").
+        const titleInput = page.getByRole('textbox', { name: 'Add a task title' });
+        await expect(titleInput).toBeVisible();
 
-		const unique = `E2E UI task ${Date.now().toString(36)}`;
-		await titleInput.click();
-		await titleInput.pressSequentially(unique, { delay: 15 });
-		await expect(titleInput).toHaveValue(unique);
+        const unique = `E2E UI task ${Date.now().toString(36)}`;
+        await titleInput.click();
+        await titleInput.pressSequentially(unique, { delay: 15 });
+        await expect(titleInput).toHaveValue(unique);
 
-		// Scope to the form's Create button by name — the dashboard chrome
-		// also renders a global chat composer with its own submit button.
-		const submit = page.getByRole('button', { name: 'Create', exact: true });
-		await expect(submit).toBeEnabled();
-		await submit.click();
+        // Scope to the form's Create button by name — the dashboard chrome
+        // also renders a global chat composer with its own submit button.
+        const submit = page.getByRole('button', { name: 'Create', exact: true });
+        await expect(submit).toBeEnabled();
+        await submit.click();
 
-		// Routes to ROUTES.DASHBOARD_TASK(id) — /tasks/<uuid> (locale prefix optional).
-		await page.waitForURL(/\/(en\/)?tasks\/[0-9a-f-]{36}/, { timeout: 60_000 });
-		await expect(page.getByText(unique).first()).toBeVisible();
-	});
+        // Routes to ROUTES.DASHBOARD_TASK(id) — /tasks/<uuid> (locale prefix optional).
+        await page.waitForURL(/\/(en\/)?tasks\/[0-9a-f-]{36}/, { timeout: 60_000 });
+        await expect(page.getByText(unique).first()).toBeVisible();
+    });
 
-	test('a task created via API for the seeded user appears on /tasks', async ({ page, request }) => {
-		// Create the task as the SAME user the browser is authenticated as,
-		// so it shows up in this session's list (cross-layer: API write → UI read).
-		const seeded = loadSeededTestUser();
-		const { access_token } = await loginViaAPI(page.url() || 'http://localhost:3000', {
-			email: seeded.email,
-			password: seeded.password
-		});
-		const unique = `E2E list task ${Date.now().toString(36)}`;
-		const createRes = await request.post(`${API_BASE}/api/tasks`, {
-			headers: authedHeaders(access_token),
-			data: { title: unique }
-		});
-		expect(createRes.status()).toBe(201);
+    test('a task created via API for the seeded user appears on /tasks', async ({
+        page,
+        request,
+    }) => {
+        // Create the task as the SAME user the browser is authenticated as,
+        // so it shows up in this session's list (cross-layer: API write → UI read).
+        const seeded = loadSeededTestUser();
+        const { access_token } = await loginViaAPI(page.url() || 'http://localhost:3000', {
+            email: seeded.email,
+            password: seeded.password,
+        });
+        const unique = `E2E list task ${Date.now().toString(36)}`;
+        const createRes = await request.post(`${API_BASE}/api/tasks`, {
+            headers: authedHeaders(access_token),
+            data: { title: unique },
+        });
+        expect(createRes.status()).toBe(201);
 
-		await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
-		await expect(page.getByText(unique).first()).toBeVisible({ timeout: 30_000 });
-	});
+        await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
+        await expect(page.getByText(unique).first()).toBeVisible({ timeout: 30_000 });
+    });
 });


### PR DESCRIPTION
## What

Adds **deep, assertive Playwright e2e coverage** for three feature areas that shipped UI + API but had **zero dedicated specs**: **Tasks**, **Skills**, **Agents** (the Agents/Skills/Tasks build). +37 tests across 3 spec files, all verified green against a live local stack (Postgres + Redis + API + Web).

## Why

The suite already had ~280 specs, but the recent passes are mostly permissive smoke probes (`expect(status).toBeLessThan(500)`, "skip if not exposed") — green tests that don't catch broken features. Meanwhile the newest, most complex features had no real coverage, which is exactly where production regressions slip through. This PR starts a coverage loop (tracked as "Pass 22" in `apps/web/e2e/COVERAGE.md`) that prioritizes real-behavior assertions on the uncovered surfaces.

## What's covered

- **`tasks.spec.ts`** (14) — auth gating; create (`T-<n>` slug, `backlog` default); list `{data, meta}` + status filter/pagination; status **state-machine** (valid chain `backlog→todo→in_progress→in_review→done`, illegal `todo→done` rejected 400); chat round-trip; `?missionId` scoping; cross-user 403/404; delete→404; UI create→detail + API→UI list.
- **`skills.spec.ts`** (13) — custom create (ownerType+ownerId, slug lowercased, v1.0.0, frontmatter); ownerType/ownerId validation; PATCH recomputes `contentHash`; bindings (tenant + mission, `agent` needs `targetId` → 400, both listed); catalog `{entries,total}`; cross-user 404; delete→`{deleted:true}`; UI hub + detail render.
- **`agents.spec.ts`** (10) — create draft tenant agent (8 permissions default OFF); status state-machine (draft can't pause; resume activates; active⇄paused); instruction files (SOUL.md empty→PUT persists body + sha256 hash echoed by GET); budget/runs defaults; mission-scope requires `missionId`; cross-user 403/404; UI index + detail.

## Method

Each spec was written after probing the **live** API for exact shapes — recon surfaced several stale assumptions (Task default is `backlog` not `todo`; Skills require an explicit `ownerId` even for tenant scope; Agents reject `draft→paused`). Local bring-up mirrors `.github/workflows/e2e.yml` (`REQUIRE_EMAIL_VERIFICATION=false`, etc.). All specs are **additive** — no existing tests touched.

## Next in this loop

Missions/Ideas UI flows + unified `/new` (deepening the existing API-contract specs), settings/integrations (channels, emails, notifications, work-agent) + magic-link, then hardening shallow `< 500` smoke specs into real assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded E2E coverage across Agents, Skills, Tasks (including collaboration/recurrence), Missions/Ideas, settings/integrations, notification channels/preferences, work-agent prefs, and magic-link auth — API contract checks plus authenticated UI smoke flows (creation, status transitions, scoping/isolation, bindings, canonical content, chat, validation, and deletion).

* **Documentation**
  * Updated E2E coverage tracker with a new pass summarizing covered areas, detailed coverage scopes, and methodology notes for the next-phase validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->