### PR TITLE
feat(plugins): lazy-load plugin runtimes on first use to reduce API boot RSS

### DIFF
--- a/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
+++ b/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
@@ -143,4 +143,59 @@ describe('lazy-plugin-proxy', () => {
         expect(loader).toHaveBeenCalledTimes(2);
         expect(stub.__isMaterialized).toBe(true);
     });
+
+    it('fires onMaterializeError when the loader throws', async () => {
+        const loader = jest.fn<Promise<IPlugin | null>, []>().mockRejectedValue(new Error('boom'));
+        const onMaterializeError = jest.fn().mockResolvedValue(undefined);
+
+        const stub = createLazyPluginProxy(
+            makeManifest('p7'),
+            loader,
+            undefined,
+            onMaterializeError,
+        );
+
+        await expect(stub.onLoad({} as never)).rejects.toThrow('boom');
+
+        expect(onMaterializeError).toHaveBeenCalledTimes(1);
+        expect(onMaterializeError).toHaveBeenCalledWith(
+            'p7',
+            expect.objectContaining({ message: 'boom' }),
+        );
+    });
+
+    it('fires onMaterializeError when the loader returns null', async () => {
+        const loader = jest.fn<Promise<IPlugin | null>, []>().mockResolvedValue(null);
+        const onMaterializeError = jest.fn().mockResolvedValue(undefined);
+
+        const stub = createLazyPluginProxy(
+            makeManifest('p8'),
+            loader,
+            undefined,
+            onMaterializeError,
+        );
+
+        await expect(stub.onLoad({} as never)).rejects.toThrow(/Failed to materialize plugin/);
+        expect(onMaterializeError).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not let onMaterializeError swallow the original loader error', async () => {
+        const loader = jest
+            .fn<Promise<IPlugin | null>, []>()
+            .mockRejectedValue(new Error('original'));
+        const onMaterializeError = jest
+            .fn<Promise<void>, [string, Error]>()
+            .mockRejectedValue(new Error('hook-failure'));
+
+        const stub = createLazyPluginProxy(
+            makeManifest('p9'),
+            loader,
+            undefined,
+            onMaterializeError,
+        );
+
+        // Caller should see the ORIGINAL loader error, not the hook's error —
+        // the hook is best-effort bookkeeping and must not mask the cause.
+        await expect(stub.onLoad({} as never)).rejects.toThrow('original');
+    });
 });

--- a/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
+++ b/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
@@ -90,7 +90,10 @@ describe('lazy-plugin-proxy', () => {
         await Promise.all([stub.onLoad({} as never), stub.healthCheck?.()]);
 
         expect(onFirstMaterialize).toHaveBeenCalledTimes(1);
-        expect(onFirstMaterialize).toHaveBeenCalledWith('p3', expect.objectContaining({ id: 'p3' }));
+        expect(onFirstMaterialize).toHaveBeenCalledWith(
+            'p3',
+            expect.objectContaining({ id: 'p3' }),
+        );
         expect(loader).toHaveBeenCalledTimes(1);
     });
 
@@ -100,8 +103,9 @@ describe('lazy-plugin-proxy', () => {
         const loader = jest.fn().mockResolvedValue(real);
 
         const stub = createLazyPluginProxy(makeManifest('p4'), loader);
-        const customResult = await (stub as unknown as { customMethod: () => Promise<string> })
-            .customMethod();
+        const customResult = await (
+            stub as unknown as { customMethod: () => Promise<string> }
+        ).customMethod();
 
         expect(customResult).toBe('result');
         expect((real as unknown as { customMethod: jest.Mock }).customMethod).toHaveBeenCalledTimes(

--- a/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
+++ b/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
@@ -1,0 +1,142 @@
+import { createLazyPluginProxy } from '../services/lazy-plugin-proxy';
+import type { IPlugin, PluginManifest } from '@ever-works/plugin';
+
+const makeManifest = (id: string): PluginManifest =>
+    ({
+        id,
+        name: `Plugin ${id}`,
+        version: '1.0.0',
+        description: 'Test plugin',
+        category: 'utility',
+        capabilities: ['test'],
+    }) as PluginManifest;
+
+const makeRealPlugin = (id: string, onLoad: jest.Mock): IPlugin =>
+    ({
+        id,
+        name: `Plugin ${id}`,
+        version: '1.0.0',
+        category: 'utility',
+        capabilities: ['test'],
+        settingsSchema: { type: 'object', properties: { apiKey: { type: 'string' } } },
+        onLoad,
+        onUnload: jest.fn().mockResolvedValue(undefined),
+        // Plugin-specific method only on the real instance — verifies the
+        // proxy forwards arbitrary subclass methods (e.g. generate, extract).
+        customMethod: jest.fn().mockResolvedValue('result'),
+    }) as unknown as IPlugin;
+
+describe('lazy-plugin-proxy', () => {
+    it('does not invoke the loader until the first method call', async () => {
+        const onLoad = jest.fn().mockResolvedValue(undefined);
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('p1', onLoad));
+
+        const stub = createLazyPluginProxy(makeManifest('p1'), loader);
+
+        // Sync property reads come from the manifest — no import required.
+        expect(stub.id).toBe('p1');
+        expect(stub.name).toBe('Plugin p1');
+        expect(stub.version).toBe('1.0.0');
+        expect(stub.category).toBe('utility');
+        expect(stub.capabilities).toEqual(['test']);
+        expect(stub.__isMaterialized).toBe(false);
+
+        expect(loader).not.toHaveBeenCalled();
+        expect(onLoad).not.toHaveBeenCalled();
+
+        // First method call triggers materialization.
+        await stub.onLoad({} as never);
+        expect(loader).toHaveBeenCalledTimes(1);
+        expect(stub.__isMaterialized).toBe(true);
+    });
+
+    it('shares a single import across concurrent method calls', async () => {
+        const onLoad = jest.fn().mockResolvedValue(undefined);
+        let resolveLoader!: (p: IPlugin) => void;
+        const loader = jest.fn().mockImplementation(
+            () =>
+                new Promise<IPlugin>((resolve) => {
+                    resolveLoader = resolve;
+                }),
+        );
+
+        const stub = createLazyPluginProxy(makeManifest('p2'), loader);
+
+        // Fire three concurrent method invocations while the loader is in flight.
+        const p1 = stub.onLoad({} as never);
+        const p2 = stub.onLoad({} as never);
+        const p3 = stub.healthCheck?.();
+
+        // Loader was only invoked once despite three concurrent calls.
+        expect(loader).toHaveBeenCalledTimes(1);
+
+        // Finish the import; all three calls resolve.
+        resolveLoader(makeRealPlugin('p2', onLoad));
+        await Promise.all([p1, p2, p3]);
+
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs onFirstMaterialize exactly once on first method call', async () => {
+        const onLoad = jest.fn().mockResolvedValue(undefined);
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('p3', onLoad));
+        const onFirstMaterialize = jest.fn().mockResolvedValue(undefined);
+
+        const stub = createLazyPluginProxy(makeManifest('p3'), loader, onFirstMaterialize);
+
+        // Multiple method calls, in series and parallel.
+        await stub.onLoad({} as never);
+        await stub.healthCheck?.();
+        await Promise.all([stub.onLoad({} as never), stub.healthCheck?.()]);
+
+        expect(onFirstMaterialize).toHaveBeenCalledTimes(1);
+        expect(onFirstMaterialize).toHaveBeenCalledWith('p3', expect.objectContaining({ id: 'p3' }));
+        expect(loader).toHaveBeenCalledTimes(1);
+    });
+
+    it('forwards plugin-specific subclass methods after materialization', async () => {
+        const onLoad = jest.fn().mockResolvedValue(undefined);
+        const real = makeRealPlugin('p4', onLoad);
+        const loader = jest.fn().mockResolvedValue(real);
+
+        const stub = createLazyPluginProxy(makeManifest('p4'), loader);
+        const customResult = await (stub as unknown as { customMethod: () => Promise<string> })
+            .customMethod();
+
+        expect(customResult).toBe('result');
+        expect((real as unknown as { customMethod: jest.Mock }).customMethod).toHaveBeenCalledTimes(
+            1,
+        );
+    });
+
+    it('skips materialization when onUnload is called before any other method', async () => {
+        const onLoad = jest.fn().mockResolvedValue(undefined);
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('p5', onLoad));
+
+        const stub = createLazyPluginProxy(makeManifest('p5'), loader);
+        await stub.onUnload();
+
+        // A never-used plugin has no resources to release; we must not pay
+        // the import cost just to call its onUnload.
+        expect(loader).not.toHaveBeenCalled();
+        expect(stub.__isMaterialized).toBe(false);
+    });
+
+    it('retries import after a transient loader failure', async () => {
+        const onLoad = jest.fn().mockResolvedValue(undefined);
+        const loader = jest
+            .fn<Promise<IPlugin | null>, []>()
+            .mockRejectedValueOnce(new Error('transient fs error'))
+            .mockResolvedValueOnce(makeRealPlugin('p6', onLoad));
+
+        const stub = createLazyPluginProxy(makeManifest('p6'), loader);
+
+        await expect(stub.onLoad({} as never)).rejects.toThrow('transient fs error');
+        expect(loader).toHaveBeenCalledTimes(1);
+
+        // Second call should retry (importPromise was reset on failure).
+        await expect(stub.onLoad({} as never)).resolves.toBeUndefined();
+        expect(loader).toHaveBeenCalledTimes(2);
+        expect(stub.__isMaterialized).toBe(true);
+    });
+});

--- a/packages/agent/src/plugins/__tests__/plugin-bootstrap.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-bootstrap.service.spec.ts
@@ -4,6 +4,8 @@ import { PluginBootstrapService } from '../services/plugin-bootstrap.service';
 import { PluginLoaderService } from '../services/plugin-loader.service';
 import { PluginLifecycleManagerService } from '../services/plugin-lifecycle-manager.service';
 import { PluginContextFactoryService } from '../services/plugin-context-factory.service';
+import { PluginRegistryService } from '../services/plugin-registry.service';
+import { PluginRepository } from '../repositories/plugin.repository';
 
 // Silence Logger output during tests
 jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
@@ -13,11 +15,21 @@ jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
 
 describe('PluginBootstrapService', () => {
     let service: PluginBootstrapService;
-    let loader: PluginLoaderService;
     let lifecycleManager: PluginLifecycleManagerService;
+    let registry: PluginRegistryService;
 
     beforeEach(async () => {
         PluginBootstrapService.resetForTesting();
+
+        // Three registered plugins: one built-in (eagerly loaded at boot,
+        // gets callOnLoad immediately) and two lazy (modules deferred until
+        // first method call; callOnLoad fires via onFirstMaterialize hook,
+        // not at boot).
+        const registryEntries: Record<string, { builtIn: boolean }> = {
+            'system-plugin': { builtIn: true },
+            'auto-plugin': { builtIn: false },
+            'manual-plugin': { builtIn: false },
+        };
 
         const module: TestingModule = await Test.createTestingModule({
             providers: [
@@ -35,6 +47,8 @@ describe('PluginBootstrapService', () => {
                                 { success: true, pluginId: 'manual-plugin' },
                             ],
                         }),
+                        setOnFirstMaterialize: jest.fn(),
+                        setOnMaterializeError: jest.fn(),
                     },
                 },
                 {
@@ -49,12 +63,25 @@ describe('PluginBootstrapService', () => {
                     provide: PluginContextFactoryService,
                     useValue: {},
                 },
+                {
+                    provide: PluginRegistryService,
+                    useValue: {
+                        get: jest.fn((id: string) => registryEntries[id]),
+                        updateState: jest.fn(),
+                    },
+                },
+                {
+                    provide: PluginRepository,
+                    useValue: {
+                        updateState: jest.fn().mockResolvedValue(undefined),
+                    },
+                },
             ],
         }).compile();
 
         service = module.get<PluginBootstrapService>(PluginBootstrapService);
-        loader = module.get<PluginLoaderService>(PluginLoaderService);
         lifecycleManager = module.get<PluginLifecycleManagerService>(PluginLifecycleManagerService);
+        registry = module.get<PluginRegistryService>(PluginRegistryService);
     });
 
     afterEach(() => {
@@ -62,13 +89,18 @@ describe('PluginBootstrapService', () => {
     });
 
     describe('bootstrap', () => {
-        it('should call callOnLoad for each loaded plugin', async () => {
+        it('should call callOnLoad eagerly only for built-in plugins', async () => {
             await service.bootstrap();
 
-            expect(lifecycleManager.callOnLoad).toHaveBeenCalledTimes(3);
+            // Built-in plugin's module is bundled and has nothing to defer,
+            // so its onLoad fires at boot. Lazy (filesystem) plugins skip
+            // this — their onLoad fires via the proxy's onFirstMaterialize
+            // hook on first method call.
+            expect(lifecycleManager.callOnLoad).toHaveBeenCalledTimes(1);
             expect(lifecycleManager.callOnLoad).toHaveBeenCalledWith('system-plugin');
-            expect(lifecycleManager.callOnLoad).toHaveBeenCalledWith('auto-plugin');
-            expect(lifecycleManager.callOnLoad).toHaveBeenCalledWith('manual-plugin');
+            expect(registry.get).toHaveBeenCalledWith('system-plugin');
+            expect(registry.get).toHaveBeenCalledWith('auto-plugin');
+            expect(registry.get).toHaveBeenCalledWith('manual-plugin');
         });
 
         it('should return loaded count in result', async () => {
@@ -84,7 +116,7 @@ describe('PluginBootstrapService', () => {
             const result = await service.bootstrap();
 
             expect(result.executed).toBe(false);
-            expect(lifecycleManager.callOnLoad).toHaveBeenCalledTimes(3);
+            expect(lifecycleManager.callOnLoad).toHaveBeenCalledTimes(1);
         });
 
         it('should set context factory on lifecycle manager', async () => {

--- a/packages/agent/src/plugins/__tests__/plugin-loader.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-loader.service.spec.ts
@@ -63,6 +63,8 @@ describe('PluginLoaderService', () => {
                         has: jest.fn().mockReturnValue(false),
                         get: jest.fn(),
                         register: jest.fn().mockReturnValue({}),
+                        registerLazy: jest.fn().mockReturnValue({}),
+                        updateRegisteredManifest: jest.fn().mockReturnValue(true),
                         unregister: jest.fn().mockReturnValue(true),
                         getVersionsMap: jest.fn().mockReturnValue(new Map()),
                     },

--- a/packages/agent/src/plugins/services/index.ts
+++ b/packages/agent/src/plugins/services/index.ts
@@ -1,5 +1,6 @@
 export * from './plugin-registry.service';
 export * from './plugin-loader.service';
+export * from './lazy-plugin-proxy';
 export * from './plugin-manifest-validator.service';
 export * from './plugin-version-checker.service';
 export * from './plugin-class-validator.service';

--- a/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
+++ b/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
@@ -1,0 +1,152 @@
+import type { IPlugin, PluginManifest } from '@ever-works/plugin';
+
+/**
+ * Loader closure that imports the real plugin module on demand.
+ * Returns the instantiated plugin (or null on failure — caller decides how to surface).
+ */
+export type PluginInstanceLoader = () => Promise<IPlugin | null>;
+
+/**
+ * Lazy plugin stub used by the registry while the real module has not been
+ * imported yet. Exposes manifest-derived static properties synchronously so
+ * callers that only need metadata pay no import cost. Any method call on the
+ * proxy awaits a deduped import + onLoad of the real plugin before forwarding.
+ */
+export interface LazyPluginStub extends IPlugin {
+    /** True once the underlying real plugin instance has been materialized. */
+    readonly __isMaterialized: boolean;
+    /**
+     * Force materialization (import + onLoad) and return the real plugin.
+     * Concurrent callers share a single import + onLoad invocation.
+     */
+    __materialize(): Promise<IPlugin>;
+}
+
+/**
+ * Optional hook fired the first time a plugin materializes. The lifecycle
+ * manager wires this to its callOnLoad bookkeeping so events/state updates
+ * still happen exactly once even though materialization is now triggered by
+ * the first method call rather than at boot.
+ */
+export type OnFirstMaterialize = (pluginId: string, real: IPlugin) => Promise<void>;
+
+const FORWARDED_LIFECYCLE_METHODS = new Set<keyof IPlugin>([
+    'onLoad',
+    'onUnload',
+    'healthCheck',
+    'getManifest',
+    'validateSettings',
+    'validateConnection',
+]);
+
+/**
+ * Build a lazy IPlugin proxy backed by `manifest` for sync reads and `loader`
+ * for first-use materialization. `onFirstMaterialize` runs exactly once after
+ * a successful import, before the triggering method call is forwarded — this
+ * is where the lifecycle manager hooks its onLoad event emission.
+ */
+export function createLazyPluginProxy(
+    manifest: PluginManifest,
+    loader: PluginInstanceLoader,
+    onFirstMaterialize?: OnFirstMaterialize,
+): LazyPluginStub {
+    let materialized: IPlugin | null = null;
+    let importPromise: Promise<IPlugin> | null = null;
+
+    const ensureMaterialized = async (): Promise<IPlugin> => {
+        if (materialized) return materialized;
+        if (!importPromise) {
+            importPromise = (async () => {
+                const real = await loader();
+                if (!real) {
+                    throw new Error(`Failed to materialize plugin "${manifest.id}"`);
+                }
+                materialized = real;
+                if (onFirstMaterialize) {
+                    await onFirstMaterialize(manifest.id, real);
+                }
+                return real;
+            })().catch((err) => {
+                // Reset so a later call can retry (e.g. transient FS error).
+                importPromise = null;
+                throw err;
+            });
+        }
+        return importPromise;
+    };
+
+    const stub = {
+        get id() {
+            return manifest.id;
+        },
+        get name() {
+            return manifest.name;
+        },
+        get version() {
+            return manifest.version;
+        },
+        get category() {
+            return manifest.category;
+        },
+        get capabilities() {
+            return manifest.capabilities;
+        },
+        get settingsSchema() {
+            return manifest.settingsSchema ?? {};
+        },
+        get configurationMode() {
+            return manifest.configurationMode;
+        },
+        get __isMaterialized() {
+            return materialized !== null;
+        },
+        __materialize: ensureMaterialized,
+    } as unknown as LazyPluginStub;
+
+    return new Proxy(stub, {
+        get(target, prop, receiver) {
+            if (prop in target) {
+                return Reflect.get(target, prop, receiver);
+            }
+            // Special-case onUnload: skip materialization if never loaded —
+            // a plugin that was never used has no resources to release.
+            if (prop === 'onUnload') {
+                return async () => {
+                    if (!materialized) return;
+                    const real = materialized as IPlugin;
+                    return real.onUnload();
+                };
+            }
+            // For every other method (lifecycle hooks + plugin-specific
+            // subclass methods like generate/extract/etc.), materialize then
+            // forward.
+            const propKey = prop as keyof IPlugin;
+            const isLifecycle = FORWARDED_LIFECYCLE_METHODS.has(propKey);
+
+            return (...args: unknown[]) => {
+                return ensureMaterialized().then((real) => {
+                    const target = real as unknown as Record<string | symbol, unknown>;
+                    const fn = target[prop];
+                    if (typeof fn !== 'function') {
+                        if (isLifecycle) {
+                            // Optional lifecycle method missing on real plugin —
+                            // mirror native "undefined" behavior.
+                            return undefined;
+                        }
+                        throw new TypeError(
+                            `Plugin "${manifest.id}" has no method "${String(prop)}"`,
+                        );
+                    }
+                    return (fn as (...a: unknown[]) => unknown).apply(real, args);
+                });
+            };
+        },
+        has(target, prop) {
+            if (prop in target) return true;
+            // Optimistic: assume the real plugin has it. Callers that probe
+            // via `in` typically check for optional lifecycle methods, and
+            // we'd rather over-report than force materialization for a probe.
+            return true;
+        },
+    }) as LazyPluginStub;
+}

--- a/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
+++ b/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
@@ -30,9 +30,22 @@ export interface LazyPluginStub extends IPlugin {
  */
 export type OnFirstMaterialize = (pluginId: string, real: IPlugin) => Promise<void>;
 
+/**
+ * Optional hook fired when materialization fails (loader throws or returns
+ * null). Without this, a persistently-failing plugin holds a `'loaded'` slot
+ * in the registry forever — readiness filters still return it and every
+ * subsequent call re-throws into application code. Bootstrap wires this to
+ * `registry.updateState(id, 'error')` + DB upsert so the failure surfaces.
+ */
+export type OnMaterializeError = (pluginId: string, error: Error) => Promise<void>;
+
+/**
+ * Lifecycle methods that should fall through to the materialized plugin if
+ * defined. `onUnload` is handled separately (it must NOT force materialization
+ * for a plugin that was never used), so it's intentionally omitted here.
+ */
 const FORWARDED_LIFECYCLE_METHODS = new Set<keyof IPlugin>([
     'onLoad',
-    'onUnload',
     'healthCheck',
     'getManifest',
     'validateSettings',
@@ -49,6 +62,7 @@ export function createLazyPluginProxy(
     manifest: PluginManifest,
     loader: PluginInstanceLoader,
     onFirstMaterialize?: OnFirstMaterialize,
+    onMaterializeError?: OnMaterializeError,
 ): LazyPluginStub {
     let materialized: IPlugin | null = null;
     let importPromise: Promise<IPlugin> | null = null;
@@ -66,9 +80,23 @@ export function createLazyPluginProxy(
                     await onFirstMaterialize(manifest.id, real);
                 }
                 return real;
-            })().catch((err) => {
+            })().catch(async (err) => {
                 // Reset so a later call can retry (e.g. transient FS error).
                 importPromise = null;
+                if (onMaterializeError) {
+                    // Best-effort: surface the failure to the registry / DB so
+                    // readiness filters stop returning the broken stub. We
+                    // swallow hook errors so the original loader failure is
+                    // what reaches the caller.
+                    try {
+                        await onMaterializeError(
+                            manifest.id,
+                            err instanceof Error ? err : new Error(String(err)),
+                        );
+                    } catch {
+                        // ignore
+                    }
+                }
                 throw err;
             });
         }
@@ -130,8 +158,8 @@ export function createLazyPluginProxy(
 
             return (...args: unknown[]) => {
                 return ensureMaterialized().then((real) => {
-                    const target = real as unknown as Record<string | symbol, unknown>;
-                    const fn = target[prop];
+                    const realPlugin = real as unknown as Record<string | symbol, unknown>;
+                    const fn = realPlugin[prop];
                     if (typeof fn !== 'function') {
                         if (isLifecycle) {
                             // Optional lifecycle method missing on real plugin —

--- a/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
+++ b/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
@@ -75,6 +75,11 @@ export function createLazyPluginProxy(
         return importPromise;
     };
 
+    // PluginManifest (the package.json `everworks.plugin` block) does not
+    // carry the JSON-Schema or configurationMode today — those live on the
+    // plugin class. Until a sync caller forces materialization, expose an
+    // empty schema. See PR body "Known caveat — settingsSchema sync access".
+    const manifestExt = manifest as unknown as Record<string, unknown>;
     const stub = {
         get id() {
             return manifest.id;
@@ -92,10 +97,10 @@ export function createLazyPluginProxy(
             return manifest.capabilities;
         },
         get settingsSchema() {
-            return manifest.settingsSchema ?? {};
+            return manifestExt.settingsSchema ?? {};
         },
         get configurationMode() {
-            return manifest.configurationMode;
+            return manifestExt.configurationMode;
         },
         get __isMaterialized() {
             return materialized !== null;

--- a/packages/agent/src/plugins/services/plugin-bootstrap.service.ts
+++ b/packages/agent/src/plugins/services/plugin-bootstrap.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PluginLoaderService } from './plugin-loader.service';
 import { PluginLifecycleManagerService } from './plugin-lifecycle-manager.service';
 import { PluginContextFactoryService } from './plugin-context-factory.service';
+import { PluginRegistryService } from './plugin-registry.service';
 
 /**
  * Result of the bootstrap operation
@@ -44,6 +45,7 @@ export class PluginBootstrapService {
         private readonly pluginLoader: PluginLoaderService,
         private readonly lifecycleManager: PluginLifecycleManagerService,
         private readonly contextFactory: PluginContextFactoryService,
+        private readonly registry: PluginRegistryService,
     ) {}
 
     /**
@@ -85,15 +87,29 @@ export class PluginBootstrapService {
         // Connect the context factory to the lifecycle manager
         this.lifecycleManager.setContextFactory(this.contextFactory);
 
-        // Discover and load plugins
+        // Wire lazy-materialization hook: when a filesystem-discovered plugin
+        // is touched for the first time, the proxy invokes this callback so
+        // the lifecycle manager fires onLoad bookkeeping (event emit, state
+        // history) exactly as it would have done at boot.
+        this.pluginLoader.setOnFirstMaterialize(async (pluginId) => {
+            await this.lifecycleManager.callOnLoad(pluginId);
+        });
+
+        // Discover and register plugins. Built-ins still load eagerly (their
+        // modules are bundled); discovered plugins are registered as manifest
+        // stubs and materialize on first method call.
         const result = await this.pluginLoader.discoverAndLoadAll();
         this.logger.log(
-            `Plugin discovery complete: ${result.loaded} loaded, ${result.failed} failed`,
+            `Plugin registration complete: ${result.loaded} ready, ${result.failed} failed`,
         );
 
-        // Call onLoad for all loaded plugins
+        // Call onLoad for built-in plugins immediately — they have no entry
+        // module to defer. Lazy-registered (filesystem) plugins skip this:
+        // their onLoad runs on first materialization via the hook above.
         for (const loadResult of result.results) {
-            if (loadResult.success && loadResult.pluginId) {
+            if (!loadResult.success || !loadResult.pluginId) continue;
+            const registered = this.registry.get(loadResult.pluginId);
+            if (registered?.builtIn) {
                 await this.lifecycleManager.callOnLoad(loadResult.pluginId);
             }
         }

--- a/packages/agent/src/plugins/services/plugin-bootstrap.service.ts
+++ b/packages/agent/src/plugins/services/plugin-bootstrap.service.ts
@@ -3,6 +3,7 @@ import { PluginLoaderService } from './plugin-loader.service';
 import { PluginLifecycleManagerService } from './plugin-lifecycle-manager.service';
 import { PluginContextFactoryService } from './plugin-context-factory.service';
 import { PluginRegistryService } from './plugin-registry.service';
+import { PluginRepository } from '../repositories/plugin.repository';
 
 /**
  * Result of the bootstrap operation
@@ -46,6 +47,7 @@ export class PluginBootstrapService {
         private readonly lifecycleManager: PluginLifecycleManagerService,
         private readonly contextFactory: PluginContextFactoryService,
         private readonly registry: PluginRegistryService,
+        private readonly pluginRepository: PluginRepository,
     ) {}
 
     /**
@@ -93,6 +95,22 @@ export class PluginBootstrapService {
         // history) exactly as it would have done at boot.
         this.pluginLoader.setOnFirstMaterialize(async (pluginId) => {
             await this.lifecycleManager.callOnLoad(pluginId);
+        });
+        // Wire failure hook: when a lazy plugin's loader throws, mark the
+        // registry state as 'error' + persist to DB so readiness filters stop
+        // returning the broken stub. Without this a permanently-failing
+        // plugin would hold a 'loaded' slot forever.
+        this.pluginLoader.setOnMaterializeError(async (pluginId, error) => {
+            this.registry.updateState(pluginId, 'error', error);
+            try {
+                await this.pluginRepository.updateState(pluginId, 'error', error.message);
+            } catch (dbErr) {
+                this.logger.warn(
+                    `Failed to persist error state for plugin ${pluginId}: ${
+                        dbErr instanceof Error ? dbErr.message : String(dbErr)
+                    }`,
+                );
+            }
         });
 
         // Discover and register plugins. Built-ins still load eagerly (their

--- a/packages/agent/src/plugins/services/plugin-loader.service.ts
+++ b/packages/agent/src/plugins/services/plugin-loader.service.ts
@@ -13,7 +13,7 @@ import type {
     PluginsModuleOptions,
     PluginModule,
 } from '../interfaces/plugins-module-options.interface';
-import type { OnFirstMaterialize } from './lazy-plugin-proxy';
+import type { OnFirstMaterialize, OnMaterializeError } from './lazy-plugin-proxy';
 
 /**
  * Result of plugin discovery
@@ -77,6 +77,12 @@ export class PluginLoaderService {
      * first real use rather than at boot.
      */
     private onFirstMaterialize?: OnFirstMaterialize;
+    /**
+     * Hook invoked when a lazily-registered plugin's loader throws. Wired by
+     * PluginBootstrapService to mark the plugin's state as `'error'` so
+     * readiness filters stop returning the broken stub.
+     */
+    private onMaterializeError?: OnMaterializeError;
 
     constructor(
         @Inject(PLUGINS_MODULE_OPTIONS)
@@ -92,6 +98,10 @@ export class PluginLoaderService {
 
     setOnFirstMaterialize(hook: OnFirstMaterialize): void {
         this.onFirstMaterialize = hook;
+    }
+
+    setOnMaterializeError(hook: OnMaterializeError): void {
+        this.onMaterializeError = hook;
     }
 
     /**
@@ -575,6 +585,49 @@ export class PluginLoaderService {
     }
 
     /**
+     * Merge the runtime manifest from the plugin class with the package.json
+     * manifest stored in the registry + DB. Mirrors the eager `load()` path's
+     * inline merge at lines 237–246; runs at first materialization for lazy
+     * plugins so fields like icon, homepage, readme don't go missing in the
+     * admin UI for the lifetime of the install.
+     */
+    private async enrichManifestAfterMaterialize(
+        pluginId: string,
+        real: IPlugin,
+        discovered: DiscoveredPlugin,
+    ): Promise<void> {
+        if (typeof real.getManifest !== 'function') return;
+        try {
+            const runtimeManifest = real.getManifest();
+            const definedManifest = pickBy(
+                discovered.manifest as unknown as Record<string, unknown>,
+                (v) => v !== undefined,
+            );
+            const merged = { ...runtimeManifest, ...definedManifest } as typeof discovered.manifest;
+
+            this.registry.updateRegisteredManifest(pluginId, merged);
+            await this.pluginRepository.upsert({
+                pluginId: merged.id,
+                name: merged.name,
+                version: merged.version,
+                description: merged.description,
+                category: merged.category,
+                capabilities: [...merged.capabilities],
+                manifest: merged as unknown as Record<string, unknown>,
+                builtIn: discovered.builtIn,
+                installPath: discovered.path,
+                state: 'loaded',
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Failed to enrich manifest for plugin ${pluginId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /**
      * Register a discovered plugin as a lazy stub. The plugin's entry module
      * is not imported here — that happens on first method call via the proxy.
      */
@@ -607,15 +660,30 @@ export class PluginLoaderService {
                 warnings.push(...versionResult.warnings.map((w) => w.message));
             }
 
+            // Capture hooks by value so unit tests can swap them.
+            const userOnFirstMaterialize = this.onFirstMaterialize;
+            const userOnMaterializeError = this.onMaterializeError;
+
             const loader = () => this.loadPluginModule(pluginPath, manifest);
 
-            // Capture loader hook by value so unit tests can swap it.
-            const onFirstMaterialize = this.onFirstMaterialize;
+            // Wrap onFirstMaterialize to fold the runtime manifest from the
+            // plugin class (icon, homepage, readme, runtime overrides) into
+            // both the in-memory registry entry and the DB row. The eager
+            // load() path used to do this inline before the upsert; for lazy
+            // loading we have to defer it to first materialization so we don't
+            // lose those fields for the lifetime of the install.
+            const onFirstMaterialize = async (id: string, real: IPlugin) => {
+                await this.enrichManifestAfterMaterialize(id, real, discovered);
+                if (userOnFirstMaterialize) {
+                    await userOnFirstMaterialize(id, real);
+                }
+            };
 
             this.registry.registerLazy(manifest, loader, {
                 builtIn: discovered.builtIn,
                 installPath: pluginPath,
                 onFirstMaterialize,
+                onMaterializeError: userOnMaterializeError,
             });
 
             await this.pluginRepository.upsert({

--- a/packages/agent/src/plugins/services/plugin-loader.service.ts
+++ b/packages/agent/src/plugins/services/plugin-loader.service.ts
@@ -13,6 +13,7 @@ import type {
     PluginsModuleOptions,
     PluginModule,
 } from '../interfaces/plugins-module-options.interface';
+import type { OnFirstMaterialize } from './lazy-plugin-proxy';
 
 /**
  * Result of plugin discovery
@@ -69,6 +70,13 @@ interface DependencyNode {
 export class PluginLoaderService {
     private readonly logger = new Logger(PluginLoaderService.name);
     private readonly pluginPaths: string[];
+    /**
+     * Hook invoked the first time a lazily-registered plugin materializes.
+     * Wired by PluginBootstrapService so the lifecycle manager can fire its
+     * onLoad bookkeeping (event emit, state history, error capture) on the
+     * first real use rather than at boot.
+     */
+    private onFirstMaterialize?: OnFirstMaterialize;
 
     constructor(
         @Inject(PLUGINS_MODULE_OPTIONS)
@@ -80,6 +88,10 @@ export class PluginLoaderService {
         private readonly pluginRepository: PluginRepository,
     ) {
         this.pluginPaths = options.pluginPaths || DEFAULT_PLUGIN_PATHS;
+    }
+
+    setOnFirstMaterialize(hook: OnFirstMaterialize): void {
+        this.onFirstMaterialize = hook;
     }
 
     /**
@@ -475,7 +487,14 @@ export class PluginLoaderService {
     }
 
     /**
-     * Discover and load all plugins with dependency resolution
+     * Discover and lazily register all plugins with dependency resolution.
+     *
+     * Manifest-only stubs are registered up-front (cheap fs reads only) so
+     * capability / category queries work immediately. The actual `import()`
+     * of each plugin's entry module is deferred until first use via the
+     * lazy proxy; the lifecycle `onLoad` hook fires at first materialization
+     * rather than at boot. Cuts API boot RSS for installs where most
+     * plugins (39 on develop) are never exercised in a given session.
      */
     async discoverAndLoadAll(): Promise<{
         discovered: number;
@@ -495,7 +514,9 @@ export class PluginLoaderService {
             builtIn: boolean;
         }> = [];
 
-        // Add built-in plugins
+        // Add built-in plugins — instantiating just to read the manifest id;
+        // they stay eagerly loaded because they're already bundled and have
+        // no separate entry-point import to defer.
         if (this.options.builtInPlugins) {
             for (const pluginModule of this.options.builtInPlugins) {
                 const plugin =
@@ -522,13 +543,13 @@ export class PluginLoaderService {
         // Build dependency graph and perform topological sort
         const sortedPlugins = this.topologicalSort(allPlugins);
 
-        // Load plugins in dependency order
+        // Register plugins in dependency order
         for (const pluginInfo of sortedPlugins) {
             let result: LoadResult;
             if (pluginInfo.builtIn) {
                 result = await this.loadBuiltIn(pluginInfo.plugin as PluginModule);
             } else {
-                result = await this.load(pluginInfo.plugin as DiscoveredPlugin);
+                result = await this.registerLazy(pluginInfo.plugin as DiscoveredPlugin);
             }
             results.push(result);
             if (result.success) {
@@ -536,13 +557,13 @@ export class PluginLoaderService {
             } else {
                 failed++;
                 this.logger.warn(
-                    `Failed to load plugin "${result.pluginId || 'unknown'}": ${result.error || 'unknown error'}`,
+                    `Failed to register plugin "${result.pluginId || 'unknown'}": ${result.error || 'unknown error'}`,
                 );
             }
         }
 
         this.logger.log(
-            `Plugin loading complete: ${loaded} loaded, ${failed} failed out of ${allPlugins.length} total`,
+            `Plugin registration complete: ${loaded} registered, ${failed} failed out of ${allPlugins.length} total (discovered plugins materialize on first use)`,
         );
 
         return {
@@ -551,6 +572,81 @@ export class PluginLoaderService {
             failed,
             results,
         };
+    }
+
+    /**
+     * Register a discovered plugin as a lazy stub. The plugin's entry module
+     * is not imported here — that happens on first method call via the proxy.
+     */
+    async registerLazy(discovered: DiscoveredPlugin): Promise<LoadResult> {
+        const { manifest, path: pluginPath } = discovered;
+        const warnings: string[] = [];
+
+        try {
+            if (this.registry.has(manifest.id)) {
+                return {
+                    success: false,
+                    pluginId: manifest.id,
+                    error: `Plugin "${manifest.id}" is already loaded`,
+                };
+            }
+
+            const versionResult = this.versionChecker.check(
+                manifest,
+                this.registry.getVersionsMap(),
+            );
+
+            if (!versionResult.valid) {
+                return {
+                    success: false,
+                    pluginId: manifest.id,
+                    error: `Version check failed: ${versionResult.errors?.map((e) => e.message).join(', ')}`,
+                };
+            }
+            if (versionResult.warnings) {
+                warnings.push(...versionResult.warnings.map((w) => w.message));
+            }
+
+            const loader = () => this.loadPluginModule(pluginPath, manifest);
+
+            // Capture loader hook by value so unit tests can swap it.
+            const onFirstMaterialize = this.onFirstMaterialize;
+
+            this.registry.registerLazy(manifest, loader, {
+                builtIn: discovered.builtIn,
+                installPath: pluginPath,
+                onFirstMaterialize,
+            });
+
+            await this.pluginRepository.upsert({
+                pluginId: manifest.id,
+                name: manifest.name,
+                version: manifest.version,
+                description: manifest.description,
+                category: manifest.category,
+                capabilities: [...manifest.capabilities],
+                manifest: manifest as unknown as Record<string, unknown>,
+                builtIn: discovered.builtIn,
+                installPath: pluginPath,
+                state: 'loaded',
+            });
+
+            this.logger.debug(`Registered lazy plugin: ${manifest.id} v${manifest.version}`);
+
+            return {
+                success: true,
+                pluginId: manifest.id,
+                warnings: warnings.length > 0 ? warnings : undefined,
+            };
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.logger.error(`Failed to register plugin ${manifest.id}:`, error);
+            return {
+                success: false,
+                pluginId: manifest.id,
+                error: message,
+            };
+        }
     }
 
     /**

--- a/packages/agent/src/plugins/services/plugin-registry.service.ts
+++ b/packages/agent/src/plugins/services/plugin-registry.service.ts
@@ -16,6 +16,7 @@ import {
     createLazyPluginProxy,
     LazyPluginStub,
     OnFirstMaterialize,
+    OnMaterializeError,
     PluginInstanceLoader,
 } from './lazy-plugin-proxy';
 
@@ -100,6 +101,7 @@ export class PluginRegistryService {
             builtIn?: boolean;
             installPath?: string;
             onFirstMaterialize?: OnFirstMaterialize;
+            onMaterializeError?: OnMaterializeError;
         },
     ): RegisteredPlugin {
         if (this.plugins.has(manifest.id)) {
@@ -109,12 +111,27 @@ export class PluginRegistryService {
             manifest,
             loader,
             options?.onFirstMaterialize,
+            options?.onMaterializeError,
         );
         return this.register(stub, manifest, {
             builtIn: options?.builtIn,
             installPath: options?.installPath,
             state: 'loaded',
         });
+    }
+
+    /**
+     * Replace the in-memory manifest for a registered plugin. Used after
+     * lazy materialization to fold in fields the plugin class fills in
+     * via `getManifest()` (icon, homepage, readme, etc.) that the package.json
+     * manifest didn't carry. Capability / category indexes are not touched —
+     * the runtime manifest can only enrich, not change those.
+     */
+    updateRegisteredManifest(pluginId: string, manifest: PluginManifest): boolean {
+        const registered = this.plugins.get(pluginId);
+        if (!registered) return false;
+        registered.manifest = manifest;
+        return true;
     }
 
     register(

--- a/packages/agent/src/plugins/services/plugin-registry.service.ts
+++ b/packages/agent/src/plugins/services/plugin-registry.service.ts
@@ -12,6 +12,12 @@ import { PluginEvents } from '../plugins.constants';
 import { WorkPluginRepository } from '../repositories/work-plugin.repository';
 import { UserPluginRepository } from '../repositories/user-plugin.repository';
 import { hasActiveCapability } from '../utils/active-capabilities.util';
+import {
+    createLazyPluginProxy,
+    LazyPluginStub,
+    OnFirstMaterialize,
+    PluginInstanceLoader,
+} from './lazy-plugin-proxy';
 
 export interface PluginEnableContext {
     systemPlugin?: boolean;
@@ -75,6 +81,41 @@ export class PluginRegistryService {
         @Optional() private readonly workPluginRepository?: WorkPluginRepository,
         @Optional() private readonly userPluginRepository?: UserPluginRepository,
     ) {}
+
+    /**
+     * Register a manifest-only stub backed by a lazy loader. The real plugin
+     * module is not imported until the first method call on the returned
+     * stub (or an explicit `__materialize()` call), at which point
+     * `onFirstMaterialize` runs exactly once to drive the lifecycle hooks.
+     *
+     * Category / capability indexes are populated immediately so discovery
+     * queries (`getByCapability`, `getByCategory`) work without forcing a
+     * load. The registered state is `'loaded'` so existing readiness filters
+     * keep working — lazy materialization is invisible to consumers.
+     */
+    registerLazy(
+        manifest: PluginManifest,
+        loader: PluginInstanceLoader,
+        options?: {
+            builtIn?: boolean;
+            installPath?: string;
+            onFirstMaterialize?: OnFirstMaterialize;
+        },
+    ): RegisteredPlugin {
+        if (this.plugins.has(manifest.id)) {
+            throw new Error(`Plugin "${manifest.id}" is already registered`);
+        }
+        const stub: LazyPluginStub = createLazyPluginProxy(
+            manifest,
+            loader,
+            options?.onFirstMaterialize,
+        );
+        return this.register(stub, manifest, {
+            builtIn: options?.builtIn,
+            installPath: options?.installPath,
+            state: 'loaded',
+        });
+    }
 
     register(
         plugin: IPlugin,


### PR DESCRIPTION
## Summary
- Defers each filesystem-discovered plugin's entry-module `import()` until the first method call on its `IPlugin` instance, cutting the eager-load fan-out that forced #1145's 2Gi → 4Gi `ever-works-api` memory bump.
- New `lazy-plugin-proxy.ts` exposes a Proxy-backed `IPlugin` stub from the package.json manifest. Sync property reads (`id`, `name`, `version`, `category`, `capabilities`) come straight from the manifest; any method call awaits a deduped import + `onLoad` of the real plugin, then forwards. A per-id import Promise is cached so concurrent callers share a single import. `onUnload` skips materialization if the plugin was never used.
- `PluginRegistryService.registerLazy(manifest, loader, options)` wraps the loader closure in the proxy and registers it under `state='loaded'` so capability / category indexes work without forcing a load.
- `PluginLoaderService.discoverAndLoadAll()` now calls `registerLazy()` for filesystem-discovered plugins; built-in plugins still load eagerly (their modules are bundled, nothing to defer).
- `PluginBootstrapService` skips the eager `callOnLoad` loop for lazy plugins and instead wires an `onFirstMaterialize` hook that fires `lifecycleManager.callOnLoad(id)` the first time each plugin is touched, so event emit + state-history bookkeeping happens exactly once.

## Why
- Live prod evidence at #1145 PR time: API images OOMKilled at 2Gi during NestJS module init in prod, stage, and dev → `POST /api/agents` returned 404 → \"Create Agent\" failed on `/works/[id]/agents/new`.
- Most of the 39 plugins on `develop` (AI providers, search providers, content extractors, etc.) are never touched in a given API session, so eagerly importing them all at boot was burning RSS we never recovered.
- Cascading #1145 (4Gi limit) keeps prod alive today; this PR is the structural fix so the limit can be revisited.

## Test plan
- [x] 6 new unit tests in `lazy-plugin-proxy.spec.ts` covering: plugin not loaded until first call; concurrent calls share one import; `onFirstMaterialize` runs exactly once; subclass methods forward post-materialization; `onUnload` before any use stays cost-free; failed import is retryable.
- [ ] CI green on `develop`
- [ ] After merge → eyeball `ever-works-api*` boot RSS on dev/stage to confirm headroom (follow-up: revisit the 4Gi limit if comfortable)
- [ ] `POST https://api.ever.works/api/agents` continues to return `401` (cascade probe from #1145)

## Known caveat — `settingsSchema` sync access
A handful of `plugin-operations.service` and facade callers read `registered.plugin.settingsSchema` synchronously for validation / secret masking / model summaries. While unmaterialized, the proxy returns `manifest.settingsSchema ?? {}` — and no plugin puts the schema in its package.json manifest today, so those callers see an empty schema **until any other method call on the plugin triggers materialization**.

The admin **Settings > Plugins** UI naturally drives that first method call (`validateSettings` / `validateConnection`), so the regression window is **one HTTP request per cold plugin**. A follow-up will migrate the sync `settingsSchema` readers to `await registered.plugin.__materialize()` first (or expose `getSettingsSchema(): Promise<JsonSchema>` on the contract).

## Composio caveat from change brief — verified safe
The brief flagged `composio-triggers` `onLoad`-time subscription registration per recent fix `df07d23d`. `df07d23d` actually fixed the `ComposioTriggerSubscription` entity-names inventory (EW-684 / #1109) — it didn't touch the plugin's `onLoad`. `ComposioPlugin.onLoad` (`packages/plugins/composio/src/composio.plugin.ts:146`) only stashes the context. Lazy first-use timing is safe.

## Cascade context
Builds on the 4Gi memory bump cascade: #1145 → #1149 → #1150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lazy plugin loading enhanced: discovered plugins defer actual loading until first use; on-load is now invoked eagerly only for built-in plugins.
  * Better failure handling: plugin materialization errors are now reported and persisted so failed plugins are marked accordingly.
  * Manifests are enriched after a plugin first materializes to capture runtime-provided metadata.

* **Tests**
  * Expanded tests cover additional error paths around lazy materialization and failure reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->