### PR TITLE
fix(web): equalize bg of /works/[id] budget summary cards

### DIFF
--- a/apps/web/src/components/dashboard/BudgetOverviewCard.tsx
+++ b/apps/web/src/components/dashboard/BudgetOverviewCard.tsx
@@ -41,13 +41,13 @@ export function BudgetOverviewCard({
     return (
         <div
             className={cn(
-                'relative rounded-md p-1 transition-shadow duration-200 overflow-hidden',
+                'relative rounded-md p-1 transition-shadow duration-200 overflow-hidden h-full flex flex-col',
                 'border border-card-border dark:border-border-dark',
             )}
         >
             <div
                 className={cn(
-                    'rounded-sm p-5 overflow-hidden',
+                    'rounded-sm p-5 overflow-hidden flex-1',
                     'bg-card dark:bg-surface-secondary-dark',
                     'border border-card-border dark:border-border-dark',
                 )}

--- a/apps/web/src/components/dashboard/SpendTrendCard.tsx
+++ b/apps/web/src/components/dashboard/SpendTrendCard.tsx
@@ -31,13 +31,13 @@ export function SpendTrendCard({ buckets, currency, periodLabel }: SpendTrendCar
     return (
         <div
             className={cn(
-                'relative rounded-md p-1 overflow-hidden',
+                'relative rounded-md p-1 overflow-hidden h-full flex flex-col',
                 'border border-card-border dark:border-border-dark',
             )}
         >
             <div
                 className={cn(
-                    'rounded-sm p-5 overflow-hidden',
+                    'rounded-sm p-5 overflow-hidden flex-1',
                     'bg-card dark:bg-surface-secondary-dark',
                     'border border-card-border dark:border-border-dark',
                 )}

--- a/apps/web/src/components/dashboard/TopPluginsCard.tsx
+++ b/apps/web/src/components/dashboard/TopPluginsCard.tsx
@@ -38,13 +38,13 @@ export function TopPluginsCard({ perPlugin, currency }: TopPluginsCardProps) {
     return (
         <div
             className={cn(
-                'relative rounded-md p-1 overflow-hidden',
+                'relative rounded-md p-1 overflow-hidden h-full flex flex-col',
                 'border border-card-border dark:border-border-dark',
             )}
         >
             <div
                 className={cn(
-                    'rounded-sm p-5 overflow-hidden',
+                    'rounded-sm p-5 overflow-hidden flex-1',
                     'bg-card dark:bg-surface-secondary-dark',
                     'border border-card-border dark:border-border-dark',
                 )}


### PR DESCRIPTION
## Summary

On `/works/[id]`, the 3 top cards (Spend / Top plugins / Daily spend) share the same wrapper markup, but in their grid row the cards stretch to the tallest sibling. The inner `bg-card` panel only took its natural content height, so cards with shorter content (Top plugins, Daily spend — visible in empty states) exposed the transparent outer strip below the panel and looked visually darker than the Spend card.

Fix: outer wrapper becomes `h-full flex flex-col`, inner panel adds `flex-1` — so the `bg-card` layer always fills the row height. Identical change in all 3 cards (`BudgetOverviewCard`, `TopPluginsCard`, `SpendTrendCard`) to keep the wrappers in sync.

## Before / after

<img width="1918" height="868" alt="Screenshot 2026-05-30 132645" src="https://github.com/user-attachments/assets/d84d93eb-8cac-470c-aca5-eff1681e0427" />
<img width="1916" height="872" alt="Screenshot 2026-05-30 135834" src="https://github.com/user-attachments/assets/b3a6f408-5d4a-4405-aeb7-2cdb4009e1e8" />


Isolated visual preview at `C:/Users/evereq/AppData/Local/Temp/works-cards-fix-preview.png` (also attached in the Discord thread). Top row reproduces the original mismatch; bottom row shows the equalized look.

## Test plan

- [ ] Pull this branch, run `pnpm dev:web` (with `pnpm dev:api`), open `/works/[id]` for a Work with no usage recorded — cards 2 & 3 should now have the same lighter bg as card 1.
- [ ] Resize viewport from mobile → desktop and confirm the cards stay aligned in 1-col / 2-col / 3-col layouts.
- [ ] Light mode also visually consistent (same wrapper applies in both themes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated layout styling across dashboard cards to enhance visual consistency and optimize vertical space distribution for improved visual hierarchy and better spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->