### PR TITLE
release: develop -> stage (api V8-heap OOM fix #1162 + accumulated)

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -90,6 +90,14 @@ spec:
               value: "$AUTH_SECRET"
             - name: JWT_SECRET
               value: "$JWT_SECRET"
+            # V8 heap: bootstrap (TypeORM ~150 entities + Nest DI graph +
+            # transitively-imported plugin packages) exceeds Node 22's default
+            # ~1.7 GiB old-space BEFORE #1156's lazy deferral runs in
+            # onApplicationBootstrap(), so the pod V8-OOM crashloops even under
+            # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
+            # comfortably under the limit and lets bootstrap complete.
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=3072"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -95,6 +95,14 @@ spec:
               value: "$AUTH_SECRET"
             - name: JWT_SECRET
               value: "$JWT_SECRET"
+            # V8 heap: bootstrap (TypeORM ~150 entities + Nest DI graph +
+            # transitively-imported plugin packages) exceeds Node 22's default
+            # ~1.7 GiB old-space BEFORE #1156's lazy deferral runs in
+            # onApplicationBootstrap(), so the pod V8-OOM crashloops even under
+            # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
+            # comfortably under the limit and lets bootstrap complete.
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=3072"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -90,6 +90,14 @@ spec:
               value: "$AUTH_SECRET"
             - name: JWT_SECRET
               value: "$JWT_SECRET"
+            # V8 heap: bootstrap (TypeORM ~150 entities + Nest DI graph +
+            # transitively-imported plugin packages) exceeds Node 22's default
+            # ~1.7 GiB old-space BEFORE #1156's lazy deferral runs in
+            # onApplicationBootstrap(), so the pod V8-OOM crashloops even under
+            # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
+            # comfortably under the limit and lets bootstrap complete.
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=3072"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED

--- a/apps/web/e2e/skills-list-filter.spec.ts
+++ b/apps/web/e2e/skills-list-filter.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Skills — list filtering + pagination (ownerType, search, limit/offset).
+ * Pins real filter semantics across scopes. Verified against the live API.
+ */
+
+// Seeds 2 tenant skills + 1 mission-scoped skill.
+async function seedSkills(request: import('@playwright/test').APIRequestContext) {
+    const u = await registerUserViaAPI(request);
+    const headers = authedHeaders(u.access_token);
+    const mission = await (
+        await request.post(`${API_BASE}/api/me/missions`, {
+            headers,
+            data: { title: 'M', description: 'd', type: 'one-shot' },
+        })
+    ).json();
+    const mk = (title: string, ownerType: string, ownerId: string) =>
+        request.post(`${API_BASE}/api/skills`, {
+            headers,
+            data: { ownerType, ownerId, title, description: 'd', instructionsMd: `# ${title}` },
+        });
+    await mk('Alpha Skill', 'tenant', u.user.id);
+    await mk('Beta Skill', 'tenant', u.user.id);
+    await mk('Mission Scoped Skill', 'mission', mission.id);
+    return { headers };
+}
+
+test.describe('Skills — list filtering', () => {
+    test('?ownerType filters by scope (tenant vs mission)', async ({ request }) => {
+        const { headers } = await seedSkills(request);
+
+        const all = await (await request.get(`${API_BASE}/api/skills`, { headers })).json();
+        expect(all.meta.total).toBe(3);
+
+        const tenant = await (
+            await request.get(`${API_BASE}/api/skills?ownerType=tenant`, { headers })
+        ).json();
+        expect(tenant.data.length).toBe(2);
+        expect(tenant.data.every((s: { ownerType: string }) => s.ownerType === 'tenant')).toBe(
+            true,
+        );
+
+        const mission = await (
+            await request.get(`${API_BASE}/api/skills?ownerType=mission`, { headers })
+        ).json();
+        expect(mission.data.length).toBe(1);
+        expect(mission.data[0].ownerType).toBe('mission');
+    });
+
+    test('?search matches on title', async ({ request }) => {
+        const { headers } = await seedSkills(request);
+        const res = await (
+            await request.get(`${API_BASE}/api/skills?search=Beta`, { headers })
+        ).json();
+        expect(res.data.length).toBe(1);
+        expect(res.data[0].title).toBe('Beta Skill');
+    });
+
+    test('limit/offset paginate without overlap', async ({ request }) => {
+        const { headers } = await seedSkills(request);
+        const p1 = await (
+            await request.get(`${API_BASE}/api/skills?limit=1&offset=0`, { headers })
+        ).json();
+        const p2 = await (
+            await request.get(`${API_BASE}/api/skills?limit=1&offset=1`, { headers })
+        ).json();
+        expect(p1.data.length).toBe(1);
+        expect(p2.data.length).toBe(1);
+        expect(p1.meta.total).toBe(3);
+        expect(p1.data[0].id).not.toBe(p2.data[0].id);
+    });
+});

--- a/apps/web/src/components/budgets/BudgetSummaryCard.tsx
+++ b/apps/web/src/components/budgets/BudgetSummaryCard.tsx
@@ -73,7 +73,10 @@ export function BudgetSummaryCard({ summary }: BudgetSummaryCardProps) {
                 <div className="space-y-2">
                     <div className="h-0.5 rounded-full bg-surface-secondary dark:bg-surface-secondary-dark overflow-hidden">
                         <div
-                            className={cn('h-full rounded-full transition-all duration-500', barTone)}
+                            className={cn(
+                                'h-full rounded-full transition-all duration-500',
+                                barTone,
+                            )}
                             style={{ width: `${clampedPercent}%` }}
                         />
                     </div>

--- a/apps/web/src/components/budgets/BudgetSummaryCard.unit.spec.tsx
+++ b/apps/web/src/components/budgets/BudgetSummaryCard.unit.spec.tsx
@@ -28,11 +28,11 @@ function mkSummary(overrides: Partial<OwnerBudgetSummary> = {}): OwnerBudgetSumm
 describe('BudgetSummaryCard (Phase 7 PR V)', () => {
     it('renders the period header derived from periodStart', () => {
         const { container } = render(<BudgetSummaryCard summary={mkSummary()} />);
-        // The mock surfaces the t-key with the interpolation payload
-        // inline. With jsdom's en-US locale defaults, periodStart
+        // The component renders the formatted month-year period label
+        // directly via formatPeriod() (toLocaleDateString month:long,
+        // year:numeric) — no i18n key wrapper. Under UTC, periodStart
         // 2026-05-01 formats as "May 2026".
-        expect(container.textContent).toContain('period');
-        expect(container.textContent).toContain('"period":"May 2026"');
+        expect(container.textContent).toContain('May 2026');
     });
 
     it('formats currentSpend as a USD money string', () => {

--- a/apps/web/src/components/common/PromptComposer.tsx
+++ b/apps/web/src/components/common/PromptComposer.tsx
@@ -584,7 +584,10 @@ export function PromptComposer({
                                         className="inline-flex items-center gap-1.5 rounded-lg border border-border/50 dark:border-white/10 bg-foreground/[0.04] dark:bg-white/[0.04] px-2.5 py-1 text-xs text-text dark:text-text-dark"
                                         title={a.url}
                                     >
-                                        <Github className="size-3 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />
+                                        <Github
+                                            className="size-3 text-text-muted dark:text-text-muted-dark"
+                                            aria-hidden="true"
+                                        />
                                         <span className="max-w-[12rem] truncate" title={a.url}>
                                             {a.displayName}
                                         </span>
@@ -628,7 +631,10 @@ export function PromptComposer({
                                             aria-hidden="true"
                                         />
                                     ) : a.kind === 'folder-file' ? (
-                                        <Folder className="size-3 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />
+                                        <Folder
+                                            className="size-3 text-text-muted dark:text-text-muted-dark"
+                                            aria-hidden="true"
+                                        />
                                     ) : (
                                         <FileIcon
                                             className="size-3 text-text-muted dark:text-text-muted-dark"

--- a/apps/web/src/components/dashboard/BudgetOverviewCard.tsx
+++ b/apps/web/src/components/dashboard/BudgetOverviewCard.tsx
@@ -41,13 +41,13 @@ export function BudgetOverviewCard({
     return (
         <div
             className={cn(
-                'relative rounded-md p-1 transition-shadow duration-200 overflow-hidden',
+                'relative rounded-md p-1 transition-shadow duration-200 overflow-hidden h-full flex flex-col',
                 'border border-card-border dark:border-border-dark',
             )}
         >
             <div
                 className={cn(
-                    'rounded-sm p-5 overflow-hidden',
+                    'rounded-sm p-5 overflow-hidden flex-1',
                     'bg-card dark:bg-surface-secondary-dark',
                     'border border-card-border dark:border-border-dark',
                 )}

--- a/apps/web/src/components/dashboard/SpendTrendCard.tsx
+++ b/apps/web/src/components/dashboard/SpendTrendCard.tsx
@@ -31,13 +31,13 @@ export function SpendTrendCard({ buckets, currency, periodLabel }: SpendTrendCar
     return (
         <div
             className={cn(
-                'relative rounded-md p-1 overflow-hidden',
+                'relative rounded-md p-1 overflow-hidden h-full flex flex-col',
                 'border border-card-border dark:border-border-dark',
             )}
         >
             <div
                 className={cn(
-                    'rounded-sm p-5 overflow-hidden',
+                    'rounded-sm p-5 overflow-hidden flex-1',
                     'bg-card dark:bg-surface-secondary-dark',
                     'border border-card-border dark:border-border-dark',
                 )}

--- a/apps/web/src/components/dashboard/TopPluginsCard.tsx
+++ b/apps/web/src/components/dashboard/TopPluginsCard.tsx
@@ -38,13 +38,13 @@ export function TopPluginsCard({ perPlugin, currency }: TopPluginsCardProps) {
     return (
         <div
             className={cn(
-                'relative rounded-md p-1 overflow-hidden',
+                'relative rounded-md p-1 overflow-hidden h-full flex flex-col',
                 'border border-card-border dark:border-border-dark',
             )}
         >
             <div
                 className={cn(
-                    'rounded-sm p-5 overflow-hidden',
+                    'rounded-sm p-5 overflow-hidden flex-1',
                     'bg-card dark:bg-surface-secondary-dark',
                     'border border-card-border dark:border-border-dark',
                 )}

--- a/apps/web/src/components/ideas/IdeaCard.unit.spec.tsx
+++ b/apps/web/src/components/ideas/IdeaCard.unit.spec.tsx
@@ -257,7 +257,7 @@ describe('IdeaCard (Phase 5 PR M)', () => {
               class="flex items-center gap-3 mb-2 pr-6 min-w-0"
             >
               <div
-                class="min-h-[2lh] flex items-center min-w-0"
+                class="min-h-[lh] flex items-center min-w-0"
               >
                 <h3
                   class="text-sm font-semibold text-text dark:text-text-dark leading-snug line-clamp-2"

--- a/apps/web/src/components/missions/MissionDetailClient.unit.spec.tsx
+++ b/apps/web/src/components/missions/MissionDetailClient.unit.spec.tsx
@@ -198,8 +198,10 @@ describe('MissionDetailClient (Phase 6 PR R)', () => {
     it('Ideas list renders one IdeaCard per child Idea + the per-section count', () => {
         const ideas = [mkIdea('p1'), mkIdea('p2'), mkIdea('p3')];
         render(<MissionDetailClient mission={mkMission()} ideas={ideas} />);
-        // Count in the section header.
-        expect(screen.getByText(/sections\.ideas/).textContent).toMatch(/3/);
+        // Per-section count now renders as a separate badge pill in the
+        // SectionHeader (not inline in the title text), so assert the badge.
+        const ideasSection = screen.getByText(/sections\.ideas/).closest('section') as HTMLElement;
+        expect(within(ideasSection).getByText('3')).toBeTruthy();
         expect(screen.getByText('Idea p1')).toBeTruthy();
         expect(screen.getByText('Idea p2')).toBeTruthy();
         expect(screen.getByText('Idea p3')).toBeTruthy();
@@ -222,8 +224,8 @@ describe('MissionDetailClient (Phase 6 PR R)', () => {
         expect(links).toHaveLength(2);
         const hrefs = links.map((l) => l.getAttribute('href'));
         expect(hrefs).toEqual(expect.arrayContaining(['/works/work-A', '/works/work-B']));
-        // count badge says 2.
-        expect(worksSection.textContent).toMatch(/\(2\)/);
+        // count badge says 2 (a separate pill in SectionHeader, no parens).
+        expect(within(worksSection).getByText('2')).toBeTruthy();
         void container;
     });
 
@@ -337,9 +339,11 @@ describe('MissionDetailClient (Phase 6 PR R)', () => {
                     inheritedIdeas={inheritedIdeas}
                 />,
             );
-            // Section heading + count badge.
-            const heading = screen.getByText(/sections\.inheritedWorks/);
-            expect(heading.textContent).toMatch(/2/);
+            // Section heading + count badge (a separate pill in SectionHeader).
+            const inheritedSection = screen
+                .getByText(/sections\.inheritedWorks/)
+                .closest('section') as HTMLElement;
+            expect(within(inheritedSection).getByText('2')).toBeTruthy();
             // From-source link points at the source Mission detail page.
             const sourceLink = screen.getByText('Source Mission').closest('a');
             expect(sourceLink?.getAttribute('href')).toBe('/missions/src');

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -44,7 +44,8 @@ const Checkbox = ({
                         'text-primary focus:ring-primary focus:ring-2 focus:ring-offset-0',
                         'disabled:opacity-50 disabled:cursor-not-allowed',
                         variant === 'form' && 'bg-surface dark:bg-surface-dark',
-                        variant === 'default' && 'bg-surface-secondary dark:bg-surface-secondary-dark',
+                        variant === 'default' &&
+                            'bg-surface-secondary dark:bg-surface-secondary-dark',
                         error && 'border-danger/50 focus:ring-danger/20',
                         className,
                     )}


### PR DESCRIPTION
## Release cascade: develop → stage

Promotes develop to stage as the first step of the develop → stage → main cascade. Headline payload is the **urgent prod fix**:

- **#1162** — `NODE_OPTIONS=--max-old-space-size=3072` on the `ever-works-api` container in all 3 k8s manifests. The new image (91d702d9) V8-heap-OOMs during bootstrap (TypeORM ~150 entities + Nest DI graph + transitively-imported plugin packages exceed Node 22's ~1.7 GiB default old-space) *before* #1156's lazy deferral runs in `onApplicationBootstrap()`, so pods crashloop even under the 4 GiB cgroup limit (#1145). 3 GiB old-space fits under the limit and lets bootstrap complete. Once it reaches `main`, `deploy-do-prod` rolls new pods with the env and the crashloop clears (`POST /api/agents` stops 404-ing).
- Also folds in the `format:check` fix + the markup-lock unit-test re-sync (drifted by #1126/#1146) that were red on `lint-and-test`, plus the accumulated develop work (e2e coverage, KB fixes, plugin lazy-loading).

Standard cascade, same shape as #1145 → continues to `stage → main` once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
