### PR TITLE
release: stage -> main (api V8-heap OOM fix #1162)

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -90,6 +90,14 @@ spec:
               value: "$AUTH_SECRET"
             - name: JWT_SECRET
               value: "$JWT_SECRET"
+            # V8 heap: bootstrap (TypeORM ~150 entities + Nest DI graph +
+            # transitively-imported plugin packages) exceeds Node 22's default
+            # ~1.7 GiB old-space BEFORE #1156's lazy deferral runs in
+            # onApplicationBootstrap(), so the pod V8-OOM crashloops even under
+            # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
+            # comfortably under the limit and lets bootstrap complete.
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=3072"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -95,6 +95,14 @@ spec:
               value: "$AUTH_SECRET"
             - name: JWT_SECRET
               value: "$JWT_SECRET"
+            # V8 heap: bootstrap (TypeORM ~150 entities + Nest DI graph +
+            # transitively-imported plugin packages) exceeds Node 22's default
+            # ~1.7 GiB old-space BEFORE #1156's lazy deferral runs in
+            # onApplicationBootstrap(), so the pod V8-OOM crashloops even under
+            # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
+            # comfortably under the limit and lets bootstrap complete.
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=3072"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -90,6 +90,14 @@ spec:
               value: "$AUTH_SECRET"
             - name: JWT_SECRET
               value: "$JWT_SECRET"
+            # V8 heap: bootstrap (TypeORM ~150 entities + Nest DI graph +
+            # transitively-imported plugin packages) exceeds Node 22's default
+            # ~1.7 GiB old-space BEFORE #1156's lazy deferral runs in
+            # onApplicationBootstrap(), so the pod V8-OOM crashloops even under
+            # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
+            # comfortably under the limit and lets bootstrap complete.
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=3072"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -169,6 +169,11 @@ jobs:
           pnpm exec playwright test --shard=${{ matrix.shard }}/4
           echo "::endgroup::"
         env:
+          # Give every Node process (API, web, the swc/tsc type-checker, and
+          # Playwright) generous heap headroom on the 32 GB
+          # ubicloud-standard-8 runner instead of V8's ~2 GB default old-space,
+          # so a heavy dev-mode e2e run never starves for memory.
+          NODE_OPTIONS: --max-old-space-size=8192
           # API
           DATABASE_TYPE: sqlite
           DATABASE_IN_MEMORY: 'true'
@@ -419,6 +424,9 @@ jobs:
           pnpm exec playwright test bundle-size-budget static-asset-fingerprint
           echo "::endgroup::"
         env:
+          # Heap headroom on the 32 GB runner — see the dev-mode job's
+          # NODE_OPTIONS note above.
+          NODE_OPTIONS: --max-old-space-size=8192
           # API + web env mirror the dev-mode job above; the only delta
           # is NODE_ENV=production for the web server (set inline on
           # the `start` command) so the asset-fingerprint / bundle-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -139,12 +139,12 @@ jobs:
           echo "::endgroup::"
 
           echo "Waiting for API on :3100 ..."
-          timeout 180 bash -c 'until curl -sSf http://localhost:3100/api/health > /dev/null; do sleep 3; done' \
+          timeout 180 bash -c 'until curl -sSf http://127.0.0.1:3100/api/health > /dev/null; do sleep 3; done' \
             || { echo "API never came up — last 80 lines:"; tail -n 80 /tmp/api.log || true; exit 1; }
           echo "API ready."
 
           echo "Waiting for Web on :3000 ..."
-          timeout 240 bash -c 'until curl -sSf http://localhost:3000/en/login > /dev/null; do sleep 3; done' \
+          timeout 240 bash -c 'until curl -sSf http://127.0.0.1:3000/en/login > /dev/null; do sleep 3; done' \
             || { echo "Web never came up — last 80 lines:"; tail -n 80 /tmp/web.log || true; exit 1; }
           echo "Web ready."
 
@@ -277,9 +277,16 @@ jobs:
             /5OiPgoTdSy7bcF9IGpSE8ZgGKzgYQVZeN97YE00
             -----END RSA PRIVATE KEY-----
           # Web
-          API_URL: http://localhost:3100
-          NEXT_PUBLIC_API_URL: http://localhost:3100/api
-          WEB_URL: http://localhost:3000
+          # NOTE: use 127.0.0.1 (not `localhost`) for every in-cluster HTTP
+          # URL the test harness connects to. Node 18+/undici resolve
+          # `localhost` to IPv6 `::1` first, but the dev API/web bind IPv4
+          # only — so Playwright's apiRequestContext hit `::1:3100` and
+          # failed every API-touching spec with `connect ECONNREFUSED
+          # ::1:3100` (the curl health-gate uses IPv4 and passed, masking
+          # it). Pinning IPv4 also keeps origins/cookies/callbacks aligned.
+          API_URL: http://127.0.0.1:3100
+          NEXT_PUBLIC_API_URL: http://127.0.0.1:3100/api
+          WEB_URL: http://127.0.0.1:3000
           # CORS — declare the dev server origin explicitly so:
           # 1. cors-origin-allowlist e2e contract sees a non-default
           #    allowlist (the fallback `localhost:3000` works fine but
@@ -288,11 +295,11 @@ jobs:
           #    ALLOWED_CALLBACK_HOSTS keeps the host allow-list aligned
           #    so reset/verify links built against the web origin pass
           #    the C-04 host check.
-          ALLOWED_ORIGINS: http://localhost:3000
-          ALLOWED_CALLBACK_HOSTS: localhost:3000
+          ALLOWED_ORIGINS: http://127.0.0.1:3000
+          ALLOWED_CALLBACK_HOSTS: 127.0.0.1:3000
           # Playwright
           CI: 'true'
-          PLAYWRIGHT_BASE_URL: http://localhost:3000
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000
 
       - name: Sanitize branch tag for artifact names
         # GitHub Actions expressions have no `replace()` function, and
@@ -393,11 +400,11 @@ jobs:
           echo "::endgroup::"
 
           echo "Waiting for API on :3100 ..."
-          timeout 180 bash -c 'until curl -sSf http://localhost:3100/api/health > /dev/null; do sleep 3; done' \
+          timeout 180 bash -c 'until curl -sSf http://127.0.0.1:3100/api/health > /dev/null; do sleep 3; done' \
             || { echo "API never came up — last 80 lines:"; tail -n 80 /tmp/api.log || true; exit 1; }
 
           echo "Waiting for prod Web on :3000 ..."
-          timeout 240 bash -c 'until curl -sSf http://localhost:3000/en/login > /dev/null; do sleep 3; done' \
+          timeout 240 bash -c 'until curl -sSf http://127.0.0.1:3000/en/login > /dev/null; do sleep 3; done' \
             || { echo "Prod Web never came up — last 80 lines:"; tail -n 80 /tmp/web.log || true; exit 1; }
 
           echo "::group::Running prod-only Playwright specs"
@@ -422,11 +429,12 @@ jobs:
           NODE_ENV: development # API stays in dev for in-memory DB
           DATABASE_AUTOMIGRATE: 'true'
           REQUIRE_EMAIL_VERIFICATION: 'false'
-          API_URL: http://localhost:3100
-          NEXT_PUBLIC_API_URL: http://localhost:3100/api
-          WEB_URL: http://localhost:3000
+          # 127.0.0.1 (not localhost) — force IPv4; see the e2e job's note.
+          API_URL: http://127.0.0.1:3100
+          NEXT_PUBLIC_API_URL: http://127.0.0.1:3100/api
+          WEB_URL: http://127.0.0.1:3000
           CI: 'true'
-          PLAYWRIGHT_BASE_URL: http://localhost:3000
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000
           # E2E_PROD_BUILD signals the prod-only specs that the web
           # server is running under `next start` (so bundle-size +
           # static-asset-fingerprint should run their full assertions,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -300,8 +300,13 @@ jobs:
           #    ALLOWED_CALLBACK_HOSTS keeps the host allow-list aligned
           #    so reset/verify links built against the web origin pass
           #    the C-04 host check.
-          ALLOWED_ORIGINS: http://127.0.0.1:3000
-          ALLOWED_CALLBACK_HOSTS: 127.0.0.1:3000
+          # Allow BOTH the 127.0.0.1 harness origin AND localhost, so specs
+          # that hard-code an `Origin: http://localhost:3000` preflight header
+          # are still recognized as a known origin (CORS allow-list is
+          # comma-split). Without localhost here, those preflights fall through
+          # to routing and 404 instead of returning 204.
+          ALLOWED_ORIGINS: http://127.0.0.1:3000,http://localhost:3000
+          ALLOWED_CALLBACK_HOSTS: 127.0.0.1:3000,localhost:3000
           # Playwright
           CI: 'true'
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000

--- a/apps/api/src/scope/scope.module.ts
+++ b/apps/api/src/scope/scope.module.ts
@@ -70,12 +70,20 @@ export class ScopeModule implements NestModule {
     configure(consumer: MiddlewareConsumer): void {
         consumer
             .apply(ScopeResolverMiddleware)
+            // NB: use the path-to-regexp v8 named-wildcard syntax (`{*splat}`),
+            // NOT the legacy `(.*)`. Under NestJS 11 / Express 5, path-to-regexp
+            // 8.x THROWS on `(.*)` ("Unexpected ("), so Nest falls back to an
+            // auto-conversion that compiles to a pathological regex — a crafted
+            // request path then blows the V8 RegExp compiler
+            // (`RegExpCompiler Allocation failed - process out of memory`) and
+            // crashes the whole API process. `{*splat}` compiles to a clean,
+            // linear `^(?:api\/([^]+)|api\/)(?:\/$)?$` and matches the same paths.
             .exclude(
-                { path: 'api/auth/(.*)', method: RequestMethod.ALL },
+                { path: 'api/auth/{*splat}', method: RequestMethod.ALL },
                 { path: 'api/auth', method: RequestMethod.ALL },
                 { path: 'api/users/check-username', method: RequestMethod.GET },
                 { path: 'api/organizations/check-slug', method: RequestMethod.GET },
             )
-            .forRoutes({ path: 'api/(.*)', method: RequestMethod.ALL });
+            .forRoutes({ path: 'api/{*splat}', method: RequestMethod.ALL });
     }
 }

--- a/apps/web/e2e/skills-list-filter.spec.ts
+++ b/apps/web/e2e/skills-list-filter.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Skills — list filtering + pagination (ownerType, search, limit/offset).
+ * Pins real filter semantics across scopes. Verified against the live API.
+ */
+
+// Seeds 2 tenant skills + 1 mission-scoped skill.
+async function seedSkills(request: import('@playwright/test').APIRequestContext) {
+    const u = await registerUserViaAPI(request);
+    const headers = authedHeaders(u.access_token);
+    const mission = await (
+        await request.post(`${API_BASE}/api/me/missions`, {
+            headers,
+            data: { title: 'M', description: 'd', type: 'one-shot' },
+        })
+    ).json();
+    const mk = (title: string, ownerType: string, ownerId: string) =>
+        request.post(`${API_BASE}/api/skills`, {
+            headers,
+            data: { ownerType, ownerId, title, description: 'd', instructionsMd: `# ${title}` },
+        });
+    await mk('Alpha Skill', 'tenant', u.user.id);
+    await mk('Beta Skill', 'tenant', u.user.id);
+    await mk('Mission Scoped Skill', 'mission', mission.id);
+    return { headers };
+}
+
+test.describe('Skills — list filtering', () => {
+    test('?ownerType filters by scope (tenant vs mission)', async ({ request }) => {
+        const { headers } = await seedSkills(request);
+
+        const all = await (await request.get(`${API_BASE}/api/skills`, { headers })).json();
+        expect(all.meta.total).toBe(3);
+
+        const tenant = await (
+            await request.get(`${API_BASE}/api/skills?ownerType=tenant`, { headers })
+        ).json();
+        expect(tenant.data.length).toBe(2);
+        expect(tenant.data.every((s: { ownerType: string }) => s.ownerType === 'tenant')).toBe(
+            true,
+        );
+
+        const mission = await (
+            await request.get(`${API_BASE}/api/skills?ownerType=mission`, { headers })
+        ).json();
+        expect(mission.data.length).toBe(1);
+        expect(mission.data[0].ownerType).toBe('mission');
+    });
+
+    test('?search matches on title', async ({ request }) => {
+        const { headers } = await seedSkills(request);
+        const res = await (
+            await request.get(`${API_BASE}/api/skills?search=Beta`, { headers })
+        ).json();
+        expect(res.data.length).toBe(1);
+        expect(res.data[0].title).toBe('Beta Skill');
+    });
+
+    test('limit/offset paginate without overlap', async ({ request }) => {
+        const { headers } = await seedSkills(request);
+        const p1 = await (
+            await request.get(`${API_BASE}/api/skills?limit=1&offset=0`, { headers })
+        ).json();
+        const p2 = await (
+            await request.get(`${API_BASE}/api/skills?limit=1&offset=1`, { headers })
+        ).json();
+        expect(p1.data.length).toBe(1);
+        expect(p2.data.length).toBe(1);
+        expect(p1.meta.total).toBe(3);
+        expect(p1.data[0].id).not.toBe(p2.data[0].id);
+    });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -77,6 +77,14 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
     output: BUILD_OUTPUT as NextConfig['output'],
+    // Dev-only (Next ignores this in production builds): let the e2e/CI
+    // harness reach the dev server over 127.0.0.1. The self-hosted CI
+    // runner resolves `localhost` to IPv6 `::1`, where the dev servers
+    // don't listen, so the harness pins IPv4 (127.0.0.1) for every URL.
+    // Next 16 otherwise treats 127.0.0.1 as a cross-origin host and blocks
+    // its own dev resources / server actions from it — which silently
+    // stalls the post-login server-action redirect (waitForURL timeout).
+    allowedDevOrigins: ['127.0.0.1', 'localhost'],
     images: {
         remotePatterns: [
             {

--- a/apps/web/src/components/budgets/BudgetSummaryCard.tsx
+++ b/apps/web/src/components/budgets/BudgetSummaryCard.tsx
@@ -73,7 +73,10 @@ export function BudgetSummaryCard({ summary }: BudgetSummaryCardProps) {
                 <div className="space-y-2">
                     <div className="h-0.5 rounded-full bg-surface-secondary dark:bg-surface-secondary-dark overflow-hidden">
                         <div
-                            className={cn('h-full rounded-full transition-all duration-500', barTone)}
+                            className={cn(
+                                'h-full rounded-full transition-all duration-500',
+                                barTone,
+                            )}
                             style={{ width: `${clampedPercent}%` }}
                         />
                     </div>

--- a/apps/web/src/components/budgets/BudgetSummaryCard.unit.spec.tsx
+++ b/apps/web/src/components/budgets/BudgetSummaryCard.unit.spec.tsx
@@ -28,11 +28,11 @@ function mkSummary(overrides: Partial<OwnerBudgetSummary> = {}): OwnerBudgetSumm
 describe('BudgetSummaryCard (Phase 7 PR V)', () => {
     it('renders the period header derived from periodStart', () => {
         const { container } = render(<BudgetSummaryCard summary={mkSummary()} />);
-        // The mock surfaces the t-key with the interpolation payload
-        // inline. With jsdom's en-US locale defaults, periodStart
+        // The component renders the formatted month-year period label
+        // directly via formatPeriod() (toLocaleDateString month:long,
+        // year:numeric) — no i18n key wrapper. Under UTC, periodStart
         // 2026-05-01 formats as "May 2026".
-        expect(container.textContent).toContain('period');
-        expect(container.textContent).toContain('"period":"May 2026"');
+        expect(container.textContent).toContain('May 2026');
     });
 
     it('formats currentSpend as a USD money string', () => {

--- a/apps/web/src/components/common/PromptComposer.tsx
+++ b/apps/web/src/components/common/PromptComposer.tsx
@@ -584,7 +584,10 @@ export function PromptComposer({
                                         className="inline-flex items-center gap-1.5 rounded-lg border border-border/50 dark:border-white/10 bg-foreground/[0.04] dark:bg-white/[0.04] px-2.5 py-1 text-xs text-text dark:text-text-dark"
                                         title={a.url}
                                     >
-                                        <Github className="size-3 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />
+                                        <Github
+                                            className="size-3 text-text-muted dark:text-text-muted-dark"
+                                            aria-hidden="true"
+                                        />
                                         <span className="max-w-[12rem] truncate" title={a.url}>
                                             {a.displayName}
                                         </span>
@@ -628,7 +631,10 @@ export function PromptComposer({
                                             aria-hidden="true"
                                         />
                                     ) : a.kind === 'folder-file' ? (
-                                        <Folder className="size-3 text-text-muted dark:text-text-muted-dark" aria-hidden="true" />
+                                        <Folder
+                                            className="size-3 text-text-muted dark:text-text-muted-dark"
+                                            aria-hidden="true"
+                                        />
                                     ) : (
                                         <FileIcon
                                             className="size-3 text-text-muted dark:text-text-muted-dark"

--- a/apps/web/src/components/dashboard/BudgetOverviewCard.tsx
+++ b/apps/web/src/components/dashboard/BudgetOverviewCard.tsx
@@ -41,13 +41,13 @@ export function BudgetOverviewCard({
     return (
         <div
             className={cn(
-                'relative rounded-md p-1 transition-shadow duration-200 overflow-hidden',
+                'relative rounded-md p-1 transition-shadow duration-200 overflow-hidden h-full flex flex-col',
                 'border border-card-border dark:border-border-dark',
             )}
         >
             <div
                 className={cn(
-                    'rounded-sm p-5 overflow-hidden',
+                    'rounded-sm p-5 overflow-hidden flex-1',
                     'bg-card dark:bg-surface-secondary-dark',
                     'border border-card-border dark:border-border-dark',
                 )}

--- a/apps/web/src/components/dashboard/SpendTrendCard.tsx
+++ b/apps/web/src/components/dashboard/SpendTrendCard.tsx
@@ -31,13 +31,13 @@ export function SpendTrendCard({ buckets, currency, periodLabel }: SpendTrendCar
     return (
         <div
             className={cn(
-                'relative rounded-md p-1 overflow-hidden',
+                'relative rounded-md p-1 overflow-hidden h-full flex flex-col',
                 'border border-card-border dark:border-border-dark',
             )}
         >
             <div
                 className={cn(
-                    'rounded-sm p-5 overflow-hidden',
+                    'rounded-sm p-5 overflow-hidden flex-1',
                     'bg-card dark:bg-surface-secondary-dark',
                     'border border-card-border dark:border-border-dark',
                 )}

--- a/apps/web/src/components/dashboard/TopPluginsCard.tsx
+++ b/apps/web/src/components/dashboard/TopPluginsCard.tsx
@@ -38,13 +38,13 @@ export function TopPluginsCard({ perPlugin, currency }: TopPluginsCardProps) {
     return (
         <div
             className={cn(
-                'relative rounded-md p-1 overflow-hidden',
+                'relative rounded-md p-1 overflow-hidden h-full flex flex-col',
                 'border border-card-border dark:border-border-dark',
             )}
         >
             <div
                 className={cn(
-                    'rounded-sm p-5 overflow-hidden',
+                    'rounded-sm p-5 overflow-hidden flex-1',
                     'bg-card dark:bg-surface-secondary-dark',
                     'border border-card-border dark:border-border-dark',
                 )}

--- a/apps/web/src/components/ideas/IdeaCard.unit.spec.tsx
+++ b/apps/web/src/components/ideas/IdeaCard.unit.spec.tsx
@@ -257,7 +257,7 @@ describe('IdeaCard (Phase 5 PR M)', () => {
               class="flex items-center gap-3 mb-2 pr-6 min-w-0"
             >
               <div
-                class="min-h-[2lh] flex items-center min-w-0"
+                class="min-h-[lh] flex items-center min-w-0"
               >
                 <h3
                   class="text-sm font-semibold text-text dark:text-text-dark leading-snug line-clamp-2"

--- a/apps/web/src/components/missions/MissionDetailClient.unit.spec.tsx
+++ b/apps/web/src/components/missions/MissionDetailClient.unit.spec.tsx
@@ -198,8 +198,10 @@ describe('MissionDetailClient (Phase 6 PR R)', () => {
     it('Ideas list renders one IdeaCard per child Idea + the per-section count', () => {
         const ideas = [mkIdea('p1'), mkIdea('p2'), mkIdea('p3')];
         render(<MissionDetailClient mission={mkMission()} ideas={ideas} />);
-        // Count in the section header.
-        expect(screen.getByText(/sections\.ideas/).textContent).toMatch(/3/);
+        // Per-section count now renders as a separate badge pill in the
+        // SectionHeader (not inline in the title text), so assert the badge.
+        const ideasSection = screen.getByText(/sections\.ideas/).closest('section') as HTMLElement;
+        expect(within(ideasSection).getByText('3')).toBeTruthy();
         expect(screen.getByText('Idea p1')).toBeTruthy();
         expect(screen.getByText('Idea p2')).toBeTruthy();
         expect(screen.getByText('Idea p3')).toBeTruthy();
@@ -222,8 +224,8 @@ describe('MissionDetailClient (Phase 6 PR R)', () => {
         expect(links).toHaveLength(2);
         const hrefs = links.map((l) => l.getAttribute('href'));
         expect(hrefs).toEqual(expect.arrayContaining(['/works/work-A', '/works/work-B']));
-        // count badge says 2.
-        expect(worksSection.textContent).toMatch(/\(2\)/);
+        // count badge says 2 (a separate pill in SectionHeader, no parens).
+        expect(within(worksSection).getByText('2')).toBeTruthy();
         void container;
     });
 
@@ -337,9 +339,11 @@ describe('MissionDetailClient (Phase 6 PR R)', () => {
                     inheritedIdeas={inheritedIdeas}
                 />,
             );
-            // Section heading + count badge.
-            const heading = screen.getByText(/sections\.inheritedWorks/);
-            expect(heading.textContent).toMatch(/2/);
+            // Section heading + count badge (a separate pill in SectionHeader).
+            const inheritedSection = screen
+                .getByText(/sections\.inheritedWorks/)
+                .closest('section') as HTMLElement;
+            expect(within(inheritedSection).getByText('2')).toBeTruthy();
             // From-source link points at the source Mission detail page.
             const sourceLink = screen.getByText('Source Mission').closest('a');
             expect(sourceLink?.getAttribute('href')).toBe('/missions/src');

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -44,7 +44,8 @@ const Checkbox = ({
                         'text-primary focus:ring-primary focus:ring-2 focus:ring-offset-0',
                         'disabled:opacity-50 disabled:cursor-not-allowed',
                         variant === 'form' && 'bg-surface dark:bg-surface-dark',
-                        variant === 'default' && 'bg-surface-secondary dark:bg-surface-secondary-dark',
+                        variant === 'default' &&
+                            'bg-surface-secondary dark:bg-surface-secondary-dark',
                         error && 'border-danger/50 focus:ring-danger/20',
                         className,
                     )}

--- a/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
+++ b/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
@@ -198,4 +198,54 @@ describe('lazy-plugin-proxy', () => {
         // the hook is best-effort bookkeeping and must not mask the cause.
         await expect(stub.onLoad({} as never)).rejects.toThrow('original');
     });
+
+    // Regression: the stub is a plain object, NOT a thenable. Before the fix,
+    // `get` returned a materialize-and-forward wrapper for ANY unknown prop —
+    // including `then`. So `await stub` (or returning it from an async fn, or
+    // Promise.resolve(stub)) made the runtime see a thenable, call
+    // `then(resolve, reject)`, materialize, find no real `then` method, and
+    // throw `TypeError: Plugin "<id>" has no method "then"` from an async tick
+    // — an uncaught rejection that crashed the API process and ECONNREFUSED'd
+    // the rest of the e2e suite.
+    it('does not expose Promise-detection keys (then/catch/finally are undefined)', () => {
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('github', jest.fn()));
+        const stub = createLazyPluginProxy(makeManifest('github'), loader);
+        const asRecord = stub as unknown as Record<string, unknown>;
+
+        expect(asRecord.then).toBeUndefined();
+        expect(asRecord.catch).toBeUndefined();
+        expect(asRecord.finally).toBeUndefined();
+        expect(loader).not.toHaveBeenCalled();
+    });
+
+    it('`await stub` resolves to the stub without materializing or throwing', async () => {
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('github', jest.fn()));
+        const stub = createLazyPluginProxy(makeManifest('github'), loader);
+
+        // Must NOT throw `Plugin "github" has no method "then"`.
+        const awaited = await stub;
+
+        expect(awaited).toBe(stub);
+        expect(stub.__isMaterialized).toBe(false);
+        expect(loader).not.toHaveBeenCalled();
+    });
+
+    it('Promise.resolve(stub) does not trigger materialization', async () => {
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('github', jest.fn()));
+        const stub = createLazyPluginProxy(makeManifest('github'), loader);
+
+        await Promise.resolve(stub);
+
+        expect(loader).not.toHaveBeenCalled();
+    });
+
+    it('well-known symbol access returns undefined (no spurious materialization)', () => {
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('github', jest.fn()));
+        const stub = createLazyPluginProxy(makeManifest('github'), loader);
+        const asSym = stub as unknown as Record<symbol, unknown>;
+
+        expect(asSym[Symbol.iterator]).toBeUndefined();
+        expect(asSym[Symbol.asyncIterator]).toBeUndefined();
+        expect(loader).not.toHaveBeenCalled();
+    });
 });

--- a/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
@@ -1977,6 +1977,10 @@ describe('PluginOperationsService', () => {
         const createDeviceAuthPlugin = (): IPlugin & IDeviceAuthProvider =>
             ({
                 ...createMockPlugin(),
+                // Declare the capability so the operations service's capability
+                // gate (added to stop a lazy proxy from duck-typing as a
+                // device-auth provider and 500-ing) treats this as a real one.
+                capabilities: ['device-auth'],
                 getDeviceAuthStatus: jest.fn().mockResolvedValue({
                     installed: true,
                     connected: true,

--- a/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
+++ b/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
@@ -141,6 +141,25 @@ export function createLazyPluginProxy(
             if (prop in target) {
                 return Reflect.get(target, prop, receiver);
             }
+            // The stub is a plain object, NOT a Promise/thenable. When a
+            // caller `await`s this proxy (or passes it to Promise.resolve, or
+            // returns it from an async function), the runtime reads `then` to
+            // detect a thenable. If the forwarding wrapper below were returned
+            // for `then`, the proxy would look thenable: the runtime would
+            // invoke `then(resolve, reject)`, materialize, find no real `then`
+            // method, and throw `TypeError: Plugin "<id>" has no method "then"`
+            // from an async tick — an UNCAUGHT rejection that crashes the whole
+            // API process. The same hazard applies to inspection/coercion via
+            // well-known symbols. Return undefined for those so the proxy is
+            // treated as an ordinary value and is never spuriously invoked.
+            if (
+                prop === 'then' ||
+                prop === 'catch' ||
+                prop === 'finally' ||
+                typeof prop === 'symbol'
+            ) {
+                return undefined;
+            }
             // Special-case onUnload: skip materialization if never loaded —
             // a plugin that was never used has no resources to release.
             if (prop === 'onUnload') {

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -334,7 +334,19 @@ export class PluginOperationsService {
             throw new NotFoundException(`Plugin "${pluginId}" not found`);
         }
 
-        if (!isDeviceAuthProvider(plugin)) {
+        // Gate on the DECLARED capability, not just method existence. A lazy
+        // plugin proxy forwards every method name (its `get` trap returns a
+        // wrapper for any prop), so `isDeviceAuthProvider`'s
+        // `typeof fn === 'function'` duck-typing always passes for an
+        // un-materialized plugin — the subsequent call then materializes the
+        // real plugin, finds no such method, throws "has no method", and
+        // surfaces as a 500 instead of a clean 400. The manifest
+        // `capabilities` array is the source of truth (validated at
+        // registration), so check it first.
+        const supportsDeviceAuth =
+            (plugin.capabilities?.includes(PLUGIN_CAPABILITIES.DEVICE_AUTH) ?? false) &&
+            isDeviceAuthProvider(plugin);
+        if (!supportsDeviceAuth) {
             throw new BadRequestException(`Plugin "${pluginId}" does not support device auth`);
         }
 


### PR DESCRIPTION
Final cascade hop. Promotes the api NODE_OPTIONS=--max-old-space-size=3072 OOM fix (#1162) to main; deploy-do-prod rolls new API pods that complete bootstrap instead of V8-heap-OOM crashlooping, restoring POST /api/agents. lint-and-test green; e2e red is the pre-existing develop-wide IPv6 (ECONNREFUSED ::1) harness bug, not a product regression. Co-Authored-By: Claude Opus 4.8