### PR TITLE
release: develop -> stage (e2e fixes #1166 + OOM #1162)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -169,6 +169,11 @@ jobs:
           pnpm exec playwright test --shard=${{ matrix.shard }}/4
           echo "::endgroup::"
         env:
+          # Give every Node process (API, web, the swc/tsc type-checker, and
+          # Playwright) generous heap headroom on the 32 GB
+          # ubicloud-standard-8 runner instead of V8's ~2 GB default old-space,
+          # so a heavy dev-mode e2e run never starves for memory.
+          NODE_OPTIONS: --max-old-space-size=8192
           # API
           DATABASE_TYPE: sqlite
           DATABASE_IN_MEMORY: 'true'
@@ -419,6 +424,9 @@ jobs:
           pnpm exec playwright test bundle-size-budget static-asset-fingerprint
           echo "::endgroup::"
         env:
+          # Heap headroom on the 32 GB runner — see the dev-mode job's
+          # NODE_OPTIONS note above.
+          NODE_OPTIONS: --max-old-space-size=8192
           # API + web env mirror the dev-mode job above; the only delta
           # is NODE_ENV=production for the web server (set inline on
           # the `start` command) so the asset-fingerprint / bundle-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -139,12 +139,12 @@ jobs:
           echo "::endgroup::"
 
           echo "Waiting for API on :3100 ..."
-          timeout 180 bash -c 'until curl -sSf http://localhost:3100/api/health > /dev/null; do sleep 3; done' \
+          timeout 180 bash -c 'until curl -sSf http://127.0.0.1:3100/api/health > /dev/null; do sleep 3; done' \
             || { echo "API never came up — last 80 lines:"; tail -n 80 /tmp/api.log || true; exit 1; }
           echo "API ready."
 
           echo "Waiting for Web on :3000 ..."
-          timeout 240 bash -c 'until curl -sSf http://localhost:3000/en/login > /dev/null; do sleep 3; done' \
+          timeout 240 bash -c 'until curl -sSf http://127.0.0.1:3000/en/login > /dev/null; do sleep 3; done' \
             || { echo "Web never came up — last 80 lines:"; tail -n 80 /tmp/web.log || true; exit 1; }
           echo "Web ready."
 
@@ -277,9 +277,16 @@ jobs:
             /5OiPgoTdSy7bcF9IGpSE8ZgGKzgYQVZeN97YE00
             -----END RSA PRIVATE KEY-----
           # Web
-          API_URL: http://localhost:3100
-          NEXT_PUBLIC_API_URL: http://localhost:3100/api
-          WEB_URL: http://localhost:3000
+          # NOTE: use 127.0.0.1 (not `localhost`) for every in-cluster HTTP
+          # URL the test harness connects to. Node 18+/undici resolve
+          # `localhost` to IPv6 `::1` first, but the dev API/web bind IPv4
+          # only — so Playwright's apiRequestContext hit `::1:3100` and
+          # failed every API-touching spec with `connect ECONNREFUSED
+          # ::1:3100` (the curl health-gate uses IPv4 and passed, masking
+          # it). Pinning IPv4 also keeps origins/cookies/callbacks aligned.
+          API_URL: http://127.0.0.1:3100
+          NEXT_PUBLIC_API_URL: http://127.0.0.1:3100/api
+          WEB_URL: http://127.0.0.1:3000
           # CORS — declare the dev server origin explicitly so:
           # 1. cors-origin-allowlist e2e contract sees a non-default
           #    allowlist (the fallback `localhost:3000` works fine but
@@ -288,11 +295,11 @@ jobs:
           #    ALLOWED_CALLBACK_HOSTS keeps the host allow-list aligned
           #    so reset/verify links built against the web origin pass
           #    the C-04 host check.
-          ALLOWED_ORIGINS: http://localhost:3000
-          ALLOWED_CALLBACK_HOSTS: localhost:3000
+          ALLOWED_ORIGINS: http://127.0.0.1:3000
+          ALLOWED_CALLBACK_HOSTS: 127.0.0.1:3000
           # Playwright
           CI: 'true'
-          PLAYWRIGHT_BASE_URL: http://localhost:3000
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000
 
       - name: Sanitize branch tag for artifact names
         # GitHub Actions expressions have no `replace()` function, and
@@ -393,11 +400,11 @@ jobs:
           echo "::endgroup::"
 
           echo "Waiting for API on :3100 ..."
-          timeout 180 bash -c 'until curl -sSf http://localhost:3100/api/health > /dev/null; do sleep 3; done' \
+          timeout 180 bash -c 'until curl -sSf http://127.0.0.1:3100/api/health > /dev/null; do sleep 3; done' \
             || { echo "API never came up — last 80 lines:"; tail -n 80 /tmp/api.log || true; exit 1; }
 
           echo "Waiting for prod Web on :3000 ..."
-          timeout 240 bash -c 'until curl -sSf http://localhost:3000/en/login > /dev/null; do sleep 3; done' \
+          timeout 240 bash -c 'until curl -sSf http://127.0.0.1:3000/en/login > /dev/null; do sleep 3; done' \
             || { echo "Prod Web never came up — last 80 lines:"; tail -n 80 /tmp/web.log || true; exit 1; }
 
           echo "::group::Running prod-only Playwright specs"
@@ -422,11 +429,12 @@ jobs:
           NODE_ENV: development # API stays in dev for in-memory DB
           DATABASE_AUTOMIGRATE: 'true'
           REQUIRE_EMAIL_VERIFICATION: 'false'
-          API_URL: http://localhost:3100
-          NEXT_PUBLIC_API_URL: http://localhost:3100/api
-          WEB_URL: http://localhost:3000
+          # 127.0.0.1 (not localhost) — force IPv4; see the e2e job's note.
+          API_URL: http://127.0.0.1:3100
+          NEXT_PUBLIC_API_URL: http://127.0.0.1:3100/api
+          WEB_URL: http://127.0.0.1:3000
           CI: 'true'
-          PLAYWRIGHT_BASE_URL: http://localhost:3000
+          PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000
           # E2E_PROD_BUILD signals the prod-only specs that the web
           # server is running under `next start` (so bundle-size +
           # static-asset-fingerprint should run their full assertions,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -300,8 +300,13 @@ jobs:
           #    ALLOWED_CALLBACK_HOSTS keeps the host allow-list aligned
           #    so reset/verify links built against the web origin pass
           #    the C-04 host check.
-          ALLOWED_ORIGINS: http://127.0.0.1:3000
-          ALLOWED_CALLBACK_HOSTS: 127.0.0.1:3000
+          # Allow BOTH the 127.0.0.1 harness origin AND localhost, so specs
+          # that hard-code an `Origin: http://localhost:3000` preflight header
+          # are still recognized as a known origin (CORS allow-list is
+          # comma-split). Without localhost here, those preflights fall through
+          # to routing and 404 instead of returning 204.
+          ALLOWED_ORIGINS: http://127.0.0.1:3000,http://localhost:3000
+          ALLOWED_CALLBACK_HOSTS: 127.0.0.1:3000,localhost:3000
           # Playwright
           CI: 'true'
           PLAYWRIGHT_BASE_URL: http://127.0.0.1:3000

--- a/apps/api/src/scope/scope.module.ts
+++ b/apps/api/src/scope/scope.module.ts
@@ -70,12 +70,20 @@ export class ScopeModule implements NestModule {
     configure(consumer: MiddlewareConsumer): void {
         consumer
             .apply(ScopeResolverMiddleware)
+            // NB: use the path-to-regexp v8 named-wildcard syntax (`{*splat}`),
+            // NOT the legacy `(.*)`. Under NestJS 11 / Express 5, path-to-regexp
+            // 8.x THROWS on `(.*)` ("Unexpected ("), so Nest falls back to an
+            // auto-conversion that compiles to a pathological regex — a crafted
+            // request path then blows the V8 RegExp compiler
+            // (`RegExpCompiler Allocation failed - process out of memory`) and
+            // crashes the whole API process. `{*splat}` compiles to a clean,
+            // linear `^(?:api\/([^]+)|api\/)(?:\/$)?$` and matches the same paths.
             .exclude(
-                { path: 'api/auth/(.*)', method: RequestMethod.ALL },
+                { path: 'api/auth/{*splat}', method: RequestMethod.ALL },
                 { path: 'api/auth', method: RequestMethod.ALL },
                 { path: 'api/users/check-username', method: RequestMethod.GET },
                 { path: 'api/organizations/check-slug', method: RequestMethod.GET },
             )
-            .forRoutes({ path: 'api/(.*)', method: RequestMethod.ALL });
+            .forRoutes({ path: 'api/{*splat}', method: RequestMethod.ALL });
     }
 }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -77,6 +77,14 @@ const securityHeaders = [
 
 const nextConfig: NextConfig = {
     output: BUILD_OUTPUT as NextConfig['output'],
+    // Dev-only (Next ignores this in production builds): let the e2e/CI
+    // harness reach the dev server over 127.0.0.1. The self-hosted CI
+    // runner resolves `localhost` to IPv6 `::1`, where the dev servers
+    // don't listen, so the harness pins IPv4 (127.0.0.1) for every URL.
+    // Next 16 otherwise treats 127.0.0.1 as a cross-origin host and blocks
+    // its own dev resources / server actions from it — which silently
+    // stalls the post-login server-action redirect (waitForURL timeout).
+    allowedDevOrigins: ['127.0.0.1', 'localhost'],
     images: {
         remotePatterns: [
             {

--- a/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
+++ b/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
@@ -198,4 +198,54 @@ describe('lazy-plugin-proxy', () => {
         // the hook is best-effort bookkeeping and must not mask the cause.
         await expect(stub.onLoad({} as never)).rejects.toThrow('original');
     });
+
+    // Regression: the stub is a plain object, NOT a thenable. Before the fix,
+    // `get` returned a materialize-and-forward wrapper for ANY unknown prop —
+    // including `then`. So `await stub` (or returning it from an async fn, or
+    // Promise.resolve(stub)) made the runtime see a thenable, call
+    // `then(resolve, reject)`, materialize, find no real `then` method, and
+    // throw `TypeError: Plugin "<id>" has no method "then"` from an async tick
+    // — an uncaught rejection that crashed the API process and ECONNREFUSED'd
+    // the rest of the e2e suite.
+    it('does not expose Promise-detection keys (then/catch/finally are undefined)', () => {
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('github', jest.fn()));
+        const stub = createLazyPluginProxy(makeManifest('github'), loader);
+        const asRecord = stub as unknown as Record<string, unknown>;
+
+        expect(asRecord.then).toBeUndefined();
+        expect(asRecord.catch).toBeUndefined();
+        expect(asRecord.finally).toBeUndefined();
+        expect(loader).not.toHaveBeenCalled();
+    });
+
+    it('`await stub` resolves to the stub without materializing or throwing', async () => {
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('github', jest.fn()));
+        const stub = createLazyPluginProxy(makeManifest('github'), loader);
+
+        // Must NOT throw `Plugin "github" has no method "then"`.
+        const awaited = await stub;
+
+        expect(awaited).toBe(stub);
+        expect(stub.__isMaterialized).toBe(false);
+        expect(loader).not.toHaveBeenCalled();
+    });
+
+    it('Promise.resolve(stub) does not trigger materialization', async () => {
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('github', jest.fn()));
+        const stub = createLazyPluginProxy(makeManifest('github'), loader);
+
+        await Promise.resolve(stub);
+
+        expect(loader).not.toHaveBeenCalled();
+    });
+
+    it('well-known symbol access returns undefined (no spurious materialization)', () => {
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('github', jest.fn()));
+        const stub = createLazyPluginProxy(makeManifest('github'), loader);
+        const asSym = stub as unknown as Record<symbol, unknown>;
+
+        expect(asSym[Symbol.iterator]).toBeUndefined();
+        expect(asSym[Symbol.asyncIterator]).toBeUndefined();
+        expect(loader).not.toHaveBeenCalled();
+    });
 });

--- a/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
@@ -1977,6 +1977,10 @@ describe('PluginOperationsService', () => {
         const createDeviceAuthPlugin = (): IPlugin & IDeviceAuthProvider =>
             ({
                 ...createMockPlugin(),
+                // Declare the capability so the operations service's capability
+                // gate (added to stop a lazy proxy from duck-typing as a
+                // device-auth provider and 500-ing) treats this as a real one.
+                capabilities: ['device-auth'],
                 getDeviceAuthStatus: jest.fn().mockResolvedValue({
                     installed: true,
                     connected: true,

--- a/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
+++ b/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
@@ -141,6 +141,25 @@ export function createLazyPluginProxy(
             if (prop in target) {
                 return Reflect.get(target, prop, receiver);
             }
+            // The stub is a plain object, NOT a Promise/thenable. When a
+            // caller `await`s this proxy (or passes it to Promise.resolve, or
+            // returns it from an async function), the runtime reads `then` to
+            // detect a thenable. If the forwarding wrapper below were returned
+            // for `then`, the proxy would look thenable: the runtime would
+            // invoke `then(resolve, reject)`, materialize, find no real `then`
+            // method, and throw `TypeError: Plugin "<id>" has no method "then"`
+            // from an async tick — an UNCAUGHT rejection that crashes the whole
+            // API process. The same hazard applies to inspection/coercion via
+            // well-known symbols. Return undefined for those so the proxy is
+            // treated as an ordinary value and is never spuriously invoked.
+            if (
+                prop === 'then' ||
+                prop === 'catch' ||
+                prop === 'finally' ||
+                typeof prop === 'symbol'
+            ) {
+                return undefined;
+            }
             // Special-case onUnload: skip materialization if never loaded —
             // a plugin that was never used has no resources to release.
             if (prop === 'onUnload') {

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -334,7 +334,19 @@ export class PluginOperationsService {
             throw new NotFoundException(`Plugin "${pluginId}" not found`);
         }
 
-        if (!isDeviceAuthProvider(plugin)) {
+        // Gate on the DECLARED capability, not just method existence. A lazy
+        // plugin proxy forwards every method name (its `get` trap returns a
+        // wrapper for any prop), so `isDeviceAuthProvider`'s
+        // `typeof fn === 'function'` duck-typing always passes for an
+        // un-materialized plugin — the subsequent call then materializes the
+        // real plugin, finds no such method, throws "has no method", and
+        // surfaces as a 500 instead of a clean 400. The manifest
+        // `capabilities` array is the source of truth (validated at
+        // registration), so check it first.
+        const supportsDeviceAuth =
+            (plugin.capabilities?.includes(PLUGIN_CAPABILITIES.DEVICE_AUTH) ?? false) &&
+            isDeviceAuthProvider(plugin);
+        if (!supportsDeviceAuth) {
             throw new BadRequestException(`Plugin "${pluginId}" does not support device auth`);
         }
 


### PR DESCRIPTION
Cascade develop to stage. Brings the #1166 develop e2e fixes (IPv4/::1 pin, allowedDevOrigins, lazy-plugin-proxy crash, scope path-to-regexp v8, device-auth capability gate, CORS origins) on top of the already-staged api V8-heap OOM fix #1162. Next hop: stage to main via #1165. Co-Authored-By: Claude Opus 4.8