### PR TITLE
fix(kb): viewable stub for non-text binary uploads + KB e2e investigation (EW-641)

### DIFF
--- a/apps/web/src/components/works/detail/kb/viewers/pick-viewer.ts
+++ b/apps/web/src/components/works/detail/kb/viewers/pick-viewer.ts
@@ -15,6 +15,13 @@
  * `KbVideoViewer`, `KbAudioViewer`) take over only when the MIME is
  * unambiguously theirs.
  *
+ * Server mirror: the API decides whether to create a viewable "stub" KB
+ * document for a non-text-extractable upload using the SAME binary-viewer
+ * MIME set — see `KnowledgeBaseService.hasBinaryViewer`
+ * (`packages/agent/src/services/knowledge-base.service.ts`). Keep the two
+ * in lock-step: a stub is only useful if `pickKbViewer` mounts a viewer
+ * for that MIME here.
+ *
  * Caller note: dispatch on a non-`'text'` result ONLY when the doc has a
  * non-null `sourceUploadId` (otherwise there's no URL to point the viewer
  * at). Markdown / plain MIMEs always fall through to `'text'` because the

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -1346,7 +1346,9 @@ describe('KnowledgeBaseService', () => {
             const throwingExtractor = {
                 extract: jest
                     .fn()
-                    .mockRejectedValue(new Error('KB PDF extraction failed: Invalid PDF structure')),
+                    .mockRejectedValue(
+                        new Error('KB PDF extraction failed: Invalid PDF structure'),
+                    ),
                 supports: jest.fn().mockReturnValue(true),
             };
             const module3: TestingModule = await Test.createTestingModule({

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -1241,9 +1241,12 @@ describe('KnowledgeBaseService', () => {
             expect(extractedCall?.[0].details?.extractedVia).toBe('html-turndown');
         });
 
-        it('unsupported MIME: marks upload skipped + emits kb_upload_extraction_skipped', async () => {
+        it('non-viewable MIME (octet-stream): marks upload skipped, no stub doc', async () => {
             storage.putObject.mockResolvedValue({ key: 'kb-originals/freeform/abc.bin', url: '' });
-            const uploadRow = buildUpload({ mimeType: 'application/pdf' });
+            const uploadRow = buildUpload({
+                mimeType: 'application/octet-stream',
+                originalFilename: 'spec.bin',
+            });
             uploadRepo.create.mockResolvedValue(uploadRow);
             const skippedRow = {
                 ...uploadRow,
@@ -1256,7 +1259,10 @@ describe('KnowledgeBaseService', () => {
             uploadRepo.findById.mockResolvedValueOnce(skippedRow);
 
             const result = await service.createUpload({
-                ...buildUploadInput({ mimeType: 'application/pdf', originalFilename: 'spec.pdf' }),
+                ...buildUploadInput({
+                    mimeType: 'application/octet-stream',
+                    originalFilename: 'spec.bin',
+                }),
                 targetClass: undefined,
             });
 
@@ -1271,11 +1277,191 @@ describe('KnowledgeBaseService', () => {
                 expect.objectContaining({ extractionStatus: 'skipped' }),
             );
             expect(uploadRepo.findById).toHaveBeenCalledWith(WORK_ID, uploadRow.id);
+            // octet-stream has no row-21b viewer → no stub document created.
+            expect(docRepo.create).not.toHaveBeenCalled();
             const kinds = activityLog.log.mock.calls.map(
                 (c) => (c[0] as { actionType: string }).actionType,
             );
             expect(kinds).toContain(ActivityActionType.KB_UPLOAD_EXTRACTION_SKIPPED);
             expect(kinds).not.toContain(ActivityActionType.KB_DOCUMENT_CREATED);
+        });
+
+        it('viewable binary with no extractor route (image): SKIPPED branch creates a viewable stub doc', async () => {
+            storage.putObject.mockResolvedValue({ key: 'kb-originals/freeform/abc.png', url: '' });
+            const uploadRow = buildUpload({
+                mimeType: 'image/png',
+                originalFilename: 'diagram.png',
+                storagePath: 'kb-originals/freeform/abc.png',
+            });
+            uploadRepo.create.mockResolvedValue(uploadRow);
+            const skippedRow = {
+                ...uploadRow,
+                extractionStatus: 'skipped' as KbUploadExtractionStatus,
+                extractedDocumentId: '00000000-0000-0000-0000-000000000050',
+            };
+            uploadRepo.update.mockResolvedValue(skippedRow);
+            uploadRepo.findById.mockResolvedValue(skippedRow);
+            const stubDoc = buildDocument({
+                id: '00000000-0000-0000-0000-000000000050',
+                path: 'freeform/diagram.md',
+                kbDocumentClass: 'freeform' as KbDocumentClass,
+                source: 'imported' as KbDocumentSource,
+                sourceUploadId: uploadRow.id,
+            });
+            docRepo.create.mockResolvedValue(stubDoc);
+            docRepo.findById.mockResolvedValue(stubDoc);
+
+            const result = await service.createUpload({
+                ...buildUploadInput({ mimeType: 'image/png', originalFilename: 'diagram.png' }),
+                targetClass: undefined,
+            });
+
+            // The image MIME has no text extractor → upload stays skipped,
+            // but the row-21b viewer can render it, so a body-less stub doc
+            // is created + linked so the viewer surfaces in the tree.
+            expect(result.upload.extractionStatus).toBe('skipped');
+            expect(result.document?.id).toBe(stubDoc.id);
+            expect(docRepo.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    path: 'freeform/diagram.md',
+                    source: 'imported',
+                    sourceUploadId: uploadRow.id,
+                    // createDocument nests the body under `metadata.body`,
+                    // not a top-level field.
+                    metadata: expect.objectContaining({ body: '' }),
+                }),
+            );
+            expect(uploadRepo.update).toHaveBeenCalledWith(
+                uploadRow.id,
+                expect.objectContaining({ extractedDocumentId: stubDoc.id }),
+            );
+            const kinds = activityLog.log.mock.calls.map(
+                (c) => (c[0] as { actionType: string }).actionType,
+            );
+            expect(kinds).toContain(ActivityActionType.KB_UPLOAD_EXTRACTION_SKIPPED);
+            expect(kinds).toContain(ActivityActionType.KB_DOCUMENT_CREATED);
+        });
+
+        it('viewable binary whose extraction FAILS (pdf): FAILED branch creates a viewable stub doc', async () => {
+            const throwingExtractor = {
+                extract: jest
+                    .fn()
+                    .mockRejectedValue(new Error('KB PDF extraction failed: Invalid PDF structure')),
+                supports: jest.fn().mockReturnValue(true),
+            };
+            const module3: TestingModule = await Test.createTestingModule({
+                providers: [
+                    KnowledgeBaseService,
+                    { provide: WorkKnowledgeDocumentRepository, useValue: docRepo },
+                    { provide: WorkKnowledgeUploadRepository, useValue: uploadRepo },
+                    { provide: WorkKnowledgeTagRepository, useValue: tagRepo },
+                    {
+                        provide: WorkKnowledgeCitationRepository,
+                        useValue: { listForDocument: jest.fn().mockResolvedValue([]) },
+                    },
+                    { provide: WorkOwnershipService, useValue: ownership },
+                    { provide: KB_STORAGE_PLUGIN, useValue: storage },
+                    { provide: ActivityLogService, useValue: activityLog },
+                    { provide: KnowledgeBaseBufferExtractorService, useValue: throwingExtractor },
+                ],
+            }).compile();
+            const wired = module3.get(KnowledgeBaseService);
+
+            storage.putObject.mockResolvedValue({ key: 'kb-originals/freeform/abc.pdf', url: '' });
+            const uploadRow = buildUpload({
+                mimeType: 'application/pdf',
+                originalFilename: 'broken.pdf',
+            });
+            uploadRepo.create.mockResolvedValue(uploadRow);
+            const failedRow = {
+                ...uploadRow,
+                extractionStatus: 'failed' as KbUploadExtractionStatus,
+                extractedDocumentId: '00000000-0000-0000-0000-000000000060',
+            };
+            uploadRepo.update.mockResolvedValue(failedRow);
+            uploadRepo.findById.mockResolvedValue(failedRow);
+            const stubDoc = buildDocument({
+                id: '00000000-0000-0000-0000-000000000060',
+                path: 'freeform/broken.md',
+                kbDocumentClass: 'freeform' as KbDocumentClass,
+                source: 'imported' as KbDocumentSource,
+                sourceUploadId: uploadRow.id,
+            });
+            docRepo.create.mockResolvedValue(stubDoc);
+            docRepo.findById.mockResolvedValue(stubDoc);
+
+            const result = await wired.createUpload({
+                workId: WORK_ID,
+                userId: USER_ID,
+                file: {
+                    buffer: Buffer.from('%PDF-broken', 'utf-8'),
+                    originalFilename: 'broken.pdf',
+                    mimeType: 'application/pdf',
+                    size: 11,
+                },
+                targetClass: undefined,
+            });
+
+            // Extraction threw → upload marked FAILED, but the PDF viewer
+            // can still render the bytes, so a stub doc is created + linked.
+            expect(result.upload.extractionStatus).toBe('failed');
+            expect(result.document?.id).toBe(stubDoc.id);
+            expect(docRepo.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    source: 'imported',
+                    sourceUploadId: uploadRow.id,
+                    metadata: expect.objectContaining({ body: '' }),
+                }),
+            );
+            const kinds = activityLog.log.mock.calls.map(
+                (c) => (c[0] as { actionType: string }).actionType,
+            );
+            expect(kinds).toContain(ActivityActionType.KB_UPLOAD_EXTRACTION_FAILED);
+            expect(kinds).toContain(ActivityActionType.KB_DOCUMENT_CREATED);
+        });
+
+        it('viewable binary on retry: reuses the existing stub instead of duplicating', async () => {
+            // `extractAndMaterialize` is also the retry-extraction workhorse.
+            // When the upload already links a stub (extractedDocumentId set),
+            // a second pass must reuse it — never create a duplicate doc.
+            const existingStub = buildDocument({
+                id: '00000000-0000-0000-0000-000000000070',
+                path: 'freeform/diagram.md',
+                source: 'imported' as KbDocumentSource,
+            });
+            docRepo.findById.mockResolvedValue(existingStub);
+            const upload = {
+                ...buildUpload(),
+                mimeType: 'image/png',
+                originalFilename: 'diagram.png',
+                extractionStatus: 'skipped' as KbUploadExtractionStatus,
+                extractedDocumentId: existingStub.id,
+            } as WorkKnowledgeUpload;
+
+            const result = await (
+                service as unknown as {
+                    extractAndMaterialize: (
+                        u: WorkKnowledgeUpload,
+                        input: {
+                            workId: string;
+                            userId: string;
+                            file: { buffer: Buffer; mimeType: string; originalFilename: string };
+                        },
+                    ) => Promise<WorkKnowledgeDocument | null>;
+                }
+            ).extractAndMaterialize(upload, {
+                workId: WORK_ID,
+                userId: USER_ID,
+                file: {
+                    buffer: Buffer.from('PNGDATA', 'utf-8'),
+                    mimeType: 'image/png',
+                    originalFilename: 'diagram.png',
+                },
+            });
+
+            expect(result).toBe(existingStub);
+            expect(docRepo.create).not.toHaveBeenCalled();
+            expect(docRepo.findById).toHaveBeenCalledWith(WORK_ID, existingStub.id);
         });
 
         it('rejects when storage plugin is not configured', async () => {

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -1457,11 +1457,14 @@ export class KnowledgeBaseService {
                     },
                     ActivityStatus.FAILED,
                 );
-                // Body stays null → SKIPPED branch below short-circuits
-                // to `return null`. Returning early here would also work
-                // but bypasses the SKIPPED activity-log row; the test
-                // suite checks the FAILED activity row, not SKIPPED.
-                return null;
+                // The extractor selected a route but failed mid-parse.
+                // The bytes still live in storage and the upload row stays
+                // FAILED (set above) so retry-extraction keeps applying.
+                // For a MIME the row-21b viewer can render (PDF / XLSX /
+                // DOCX / image / video / audio) surface a viewable stub
+                // document so the binary is still reachable in the tree +
+                // viewer; opaque types (octet-stream, unknown) get none.
+                return this.maybeCreateViewableUploadStub(upload, input);
             }
         }
 
@@ -1487,7 +1490,12 @@ export class KnowledgeBaseService {
                 `Extraction skipped for ${input.file.originalFilename}`,
                 { uploadId: upload.id, mimeType: input.file.mimeType },
             );
-            return null;
+            // Non-text-extractable MIME (image / video / audio, or a
+            // binary with no extractor route yet). For a MIME the row-21b
+            // viewer can render, surface a viewable stub document so the
+            // bytes render via the viewer dispatcher; opaque types
+            // (octet-stream, unknown) stay document-less.
+            return this.maybeCreateViewableUploadStub(upload, input);
         }
 
         const klass = (input.targetClass ?? ('freeform' as KbDocumentClass)) as KbDocumentClass;
@@ -1562,6 +1570,157 @@ export class KnowledgeBaseService {
                 ActivityStatus.FAILED,
             );
             throw error;
+        }
+    }
+
+    /**
+     * EW-641 row 21b — MIME types the web KB viewer dispatcher
+     * (`pickKbViewer`, apps/web/src/components/works/detail/kb/viewers/pick-viewer.ts)
+     * mounts a dedicated binary viewer for. Keep this set in lock-step
+     * with `pickKbViewer`: a stub created here is only useful if the web
+     * side renders a `Kb{Pdf,Xlsx,Docx,Image,Video,Audio}Viewer` for the
+     * same MIME. Anything not here falls through to `'text'` on the web
+     * (the markdown editor), where a body-less stub would render as an
+     * empty doc with no download affordance — so opaque types
+     * (application/octet-stream, application/zip, unknown) are NOT stubbed.
+     *
+     * Legacy binary office formats (.xls / .doc / .ppt) are excluded on
+     * purpose, mirroring both `pickKbViewer` and the buffer extractor:
+     * exceljs / mammoth / jszip can't read them, so there's no viewer to
+     * mount.
+     */
+    private static readonly VIEWABLE_STUB_MIME_TYPES: ReadonlySet<string> = new Set([
+        'application/pdf',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ]);
+
+    private static readonly VIEWABLE_STUB_MIME_PREFIXES: readonly string[] = [
+        'image/',
+        'video/',
+        'audio/',
+    ];
+
+    /**
+     * True iff `pickKbViewer` would mount a dedicated binary viewer for
+     * this MIME (i.e. returns a non-`'text'` kind). Normalises the same
+     * way `pickKbViewer` does — strip `; charset=…` params, trim, lower.
+     */
+    private hasBinaryViewer(mimeType: string): boolean {
+        const bare = mimeType.split(';')[0].trim().toLowerCase();
+        if (bare.length === 0) {
+            return false;
+        }
+        if (KnowledgeBaseService.VIEWABLE_STUB_MIME_TYPES.has(bare)) {
+            return true;
+        }
+        return KnowledgeBaseService.VIEWABLE_STUB_MIME_PREFIXES.some((prefix) =>
+            bare.startsWith(prefix),
+        );
+    }
+
+    /**
+     * EW-641 row 21b — gate + idempotency wrapper around
+     * {@link createViewableUploadStub}. Called from the SKIPPED and
+     * FAILED branches of {@link extractAndMaterialize}.
+     *
+     *  - Non-viewable MIME (octet-stream, zip, unknown) → return null so
+     *    the upload stays document-less. This preserves the A16
+     *    retry-extraction spec invariant that an `application/octet-stream`
+     *    upload has a null `extractedDocumentId`.
+     *  - Retry-idempotent: if a prior attempt already linked a document to
+     *    this upload (`extractedDocumentId` set) reuse it instead of
+     *    creating a duplicate — `extractAndMaterialize` is also reachable
+     *    from `retryUploadExtraction`.
+     */
+    private async maybeCreateViewableUploadStub(
+        upload: WorkKnowledgeUpload,
+        input: {
+            workId: string;
+            userId: string;
+            file: { buffer: Buffer; mimeType: string; originalFilename: string };
+            targetClass?: KbDocumentClass;
+            tags?: string[];
+            description?: string | null;
+            title?: string;
+        },
+    ): Promise<WorkKnowledgeDocument | null> {
+        if (!this.hasBinaryViewer(input.file.mimeType)) {
+            return null;
+        }
+        if (upload.extractedDocumentId) {
+            // Already materialised (stub or real doc) on a prior pass —
+            // reuse it rather than creating a duplicate row.
+            return this.documentRepository.findById(input.workId, upload.extractedDocumentId);
+        }
+        return this.createViewableUploadStub(upload, input);
+    }
+
+    /**
+     * EW-641 row 21b — create a viewable "stub" KB document for an upload
+     * whose bytes carry no extractable text: a non-text MIME the extractor
+     * skips (image / video / audio), or an extractable MIME whose parse
+     * FAILED (e.g. a malformed PDF). The binary already lives in storage;
+     * the web viewer dispatcher (`pickKbViewer`) renders it from the
+     * upload's MIME / size via `sourceUploadId`, so the upload needs a
+     * `WorkKnowledgeDocument` row to surface in the tree and mount a
+     * `Kb{Pdf,Xlsx,Docx,Image,Video,Audio}Viewer`.
+     *
+     * Body is empty — no text was extracted. The upload's terminal
+     * `extractionStatus` (SKIPPED / FAILED) is left exactly as the caller
+     * set it; only `extractedDocumentId` is linked to the stub, so
+     * retry-extraction still applies. Returns null (and logs) if the stub
+     * itself can't be created so a viewer gap never fails the POST.
+     */
+    private async createViewableUploadStub(
+        upload: WorkKnowledgeUpload,
+        input: {
+            workId: string;
+            userId: string;
+            file: { buffer: Buffer; mimeType: string; originalFilename: string };
+            targetClass?: KbDocumentClass;
+            tags?: string[];
+            description?: string | null;
+            title?: string;
+        },
+    ): Promise<WorkKnowledgeDocument | null> {
+        const klass = (input.targetClass ?? ('freeform' as KbDocumentClass)) as KbDocumentClass;
+        const slug = this.slugFromFilename(input.file.originalFilename) || 'document';
+        const path = `${klass}/${slug}.md`;
+        const title = input.title?.trim() || this.humanizeFilename(input.file.originalFilename);
+        try {
+            const doc = await this.createDocument({
+                workId: input.workId,
+                userId: input.userId,
+                path,
+                title,
+                class: klass,
+                body: '',
+                description: input.description ?? null,
+                tags: input.tags,
+                source: 'imported' as KbDocumentSource,
+                sourceUploadId: upload.id,
+            });
+            const docRow = await this.documentRepository.findById(input.workId, doc.id);
+            if (!docRow) {
+                return null;
+            }
+            await this.uploadRepository.update(upload.id, {
+                extractedDocumentId: docRow.id,
+            });
+            await this.recordUploadActivity(
+                input.workId,
+                input.userId,
+                ActivityActionType.KB_DOCUMENT_CREATED,
+                `Created KB document ${path}`,
+                { documentId: docRow.id, path, class: klass, source: 'imported' },
+            );
+            return docRow;
+        } catch (error) {
+            this.logger.warn(
+                `KB viewable-stub creation failed for upload=${upload.id} mime=${input.file.mimeType}: ${(error as Error).message}`,
+            );
+            return null;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes **Item 1** of the KB e2e remediation: KB uploads of non-text-extractable binaries (image/video/audio, or an extractable MIME whose parse FAILS — e.g. a malformed PDF) now get a viewable **stub document**, so the row-21b viewer dispatcher (`pickKbViewer` → `Kb{Pdf,Xlsx,Docx,Image,Video,Audio}Viewer`) can mount and the binary is no longer silently unviewable.

`extractAndMaterialize` previously returned `null` in the SKIPPED/FAILED branches → no `WorkKnowledgeDocument` row → nothing for the viewer to mount (and `seedKbBinaryDoc` threw "missing ids").

### What changed
- **`packages/agent/src/services/knowledge-base.service.ts`**
  - `hasBinaryViewer(mime)` predicate mirroring the web `pickKbViewer` set (pdf / `…spreadsheetml.sheet` / `…wordprocessingml.document` / `image/*` / `video/*` / `audio/*`).
  - `createViewableUploadStub` + `maybeCreateViewableUploadStub`, called from BOTH the SKIPPED (`body === null`) and FAILED (extractor `catch`) branches. Creates an empty-body doc linked to the upload (`sourceUploadId` + `extractedDocumentId`), leaving the terminal `extractionStatus` (SKIPPED/FAILED) intact so retry-extraction still applies.
  - **Opaque types** (`application/octet-stream`, zip, unknown) get **no** stub → preserves the A16 `kb-extraction-retry` invariant (`extractedDocumentId` stays null).
  - **Retry-idempotent**: if `extractedDocumentId` is already set, reuse the doc instead of duplicating (`extractAndMaterialize` is also the retry-extraction workhorse).
- **`apps/web/.../viewers/pick-viewer.ts`**: cross-reference comment pointing at the server-side predicate (kept in lock-step).
- **Unit tests**: viewable-SKIPPED stub, viewable-FAILED stub, octet-stream no-stub, retry-reuse. **KB service suite: 59/59 green** (`cd packages/agent && npx jest knowledge-base.service`).

## Investigation findings on Items 2 & 3 (no code change here)

From the failing develop E2E run **26688508182** (artifacts + logs):

- **kb-upload (Item 2) and kb-viewer-size-cap are currently PASSING** on develop — not in the run's failed-spec set; shard-2 web log shows `GET …/kb/freeform/kb-a14-{pdf,xlsx}-….md 200`. So in this run PDF/XLSX extraction succeeded and produced real docs; the stub above is the defensive design change the task described and also covers the SKIPPED/FAILED path.
- **kb-inherited (Item 3) is FLAKY, not deterministically broken**: the inherited detail GET returns `200` for some attempts (works `53f1da97`, `ca25a6c4`) and `404` (→ `notFound()`) for another (`1ccd611f`). The `*idOrPath` route is correct (path-to-regexp@8.4.2 matches `legal/privacy.md`), `getInheritedDocument`→`findOrgByPath` is correct, and the shard-2 API log is clean. The "Override locally" server action is also abnormally slow (8–13s `createDocument`). The run additionally has unrelated non-KB failures (settings + work-generator, `500 "global form schema"` on shard 3) indicating broader instability.

Net: only **kb-inherited** is red on develop and it presents as a race/timing/instability issue rather than a clean feature bug. It needs reproduction on a stable environment (intermittent inherited 404 + slow override) before a safe fix — deliberately not changing it blindly to avoid regressing a path that only 404s intermittently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Viewable binary uploads (PDFs, images, video, audio, Office) now materialize as visible Knowledge Base documents even when text extraction is skipped or fails, so files appear in the KB tree and can be opened in the viewer.

* **Bug Fixes**
  * Prevents missing document entries for supported binary uploads, avoiding duplicate creation on retries and improving upload/activity log consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->