### PR TITLE
fix(k8s): raise api pod memory to 8Gi + V8 old-space to 6 GiB (api OOM crashloop)

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -97,7 +97,7 @@ spec:
             # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
             # comfortably under the limit and lets bootstrap complete.
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=3072"
+              value: "--max-old-space-size=6144"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED
@@ -297,10 +297,10 @@ spec:
 
           resources:
             requests:
-              memory: "1Gi"
+              memory: "2Gi"
               cpu: "500m"
             limits:
-              memory: "4Gi"
+              memory: "8Gi"
               cpu: "2"
 
           ports:

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -102,7 +102,7 @@ spec:
             # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
             # comfortably under the limit and lets bootstrap complete.
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=3072"
+              value: "--max-old-space-size=6144"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED
@@ -307,10 +307,10 @@ spec:
 
           resources:
             requests:
-              memory: "1Gi"
+              memory: "2Gi"
               cpu: "500m"
             limits:
-              memory: "4Gi"
+              memory: "8Gi"
               cpu: "2"
 
           ports:

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -97,7 +97,7 @@ spec:
             # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
             # comfortably under the limit and lets bootstrap complete.
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=3072"
+              value: "--max-old-space-size=6144"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED
@@ -295,10 +295,10 @@ spec:
 
           resources:
             requests:
-              memory: "1Gi"
+              memory: "2Gi"
               cpu: "500m"
             limits:
-              memory: "4Gi"
+              memory: "8Gi"
               cpu: "2"
 
           ports:


### PR DESCRIPTION
api pods crashloop with a V8 heap OOM at ~3 GiB (Reached heap limit, exit 139) because the bootstrap holds ~3 GiB live; NODE_OPTIONS=3072 + 4Gi cgroup is too small. Raise old-space 3072->6144 and api memory limit 4Gi->8Gi (requests 1Gi->2Gi) across dev/stage/prod. Already applied live to prod via kubectl; this persists it so deploys keep it (4th node added for capacity). Deeper fix = EW-693. Co-Authored-By: Claude Opus 4.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased memory allocation for the API service across development, staging, and production environments. Container memory requests were raised from 1GB to 2GB, and memory limits were increased from 4GB to 8GB. The Node.js runtime memory configuration was updated to align with the new resource allocations across all environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->