### PR TITLE
release: stage -> main (api memory 8Gi/6144 #1169)

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -97,7 +97,7 @@ spec:
             # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
             # comfortably under the limit and lets bootstrap complete.
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=3072"
+              value: "--max-old-space-size=6144"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED
@@ -297,10 +297,10 @@ spec:
 
           resources:
             requests:
-              memory: "1Gi"
+              memory: "2Gi"
               cpu: "500m"
             limits:
-              memory: "4Gi"
+              memory: "8Gi"
               cpu: "2"
 
           ports:

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -102,7 +102,7 @@ spec:
             # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
             # comfortably under the limit and lets bootstrap complete.
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=3072"
+              value: "--max-old-space-size=6144"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED
@@ -307,10 +307,10 @@ spec:
 
           resources:
             requests:
-              memory: "1Gi"
+              memory: "2Gi"
               cpu: "500m"
             limits:
-              memory: "4Gi"
+              memory: "8Gi"
               cpu: "2"
 
           ports:

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -97,7 +97,7 @@ spec:
             # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
             # comfortably under the limit and lets bootstrap complete.
             - name: NODE_OPTIONS
-              value: "--max-old-space-size=3072"
+              value: "--max-old-space-size=6144"
 
             # Trigger.dev
             - name: TRIGGER_ENABLED
@@ -295,10 +295,10 @@ spec:
 
           resources:
             requests:
-              memory: "1Gi"
+              memory: "2Gi"
               cpu: "500m"
             limits:
-              memory: "4Gi"
+              memory: "8Gi"
               cpu: "2"
 
           ports:


### PR DESCRIPTION
Final hop. Persists api pod memory 8Gi + V8 old-space 6144 to main so the prod deploy keeps the values (already applied live to prod via kubectl; this makes git the source of truth). Manifest-only. Co-Authored-By: Claude Opus 4.8