### PR TITLE
fix(k8s): size api requests.memory to the 6 GiB heap + prod anti-affinity (stop node-pressure eviction)

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -93,9 +93,17 @@ spec:
             # V8 heap: bootstrap (TypeORM ~150 entities + Nest DI graph +
             # transitively-imported plugin packages) exceeds Node 22's default
             # ~1.7 GiB old-space BEFORE #1156's lazy deferral runs in
-            # onApplicationBootstrap(), so the pod V8-OOM crashloops even under
-            # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
-            # comfortably under the limit and lets bootstrap complete.
+            # onApplicationBootstrap(), so the pod V8-OOM crashloops under a
+            # too-small heap (#1145). Old-space is kept at 6 GiB (#1169) to
+            # clear the bootstrap peak.
+            #
+            # IMPORTANT: a 6 GiB heap means the pod RSS can climb to ~6 GiB, so
+            # `resources.requests.memory` below MUST match (6Gi). Otherwise the
+            # scheduler reserves only the nominal request (was 2Gi) and
+            # over-packs nodes; the pod then balloons past what the node can
+            # back and the kubelet evicts it under memory pressure — the
+            # 2026-05-30 chat outage (api crashloop, a node at 102% mem).
+            # Lasting footprint fix: EW-693 (plugins imported eagerly at boot).
             - name: NODE_OPTIONS
               value: "--max-old-space-size=6144"
 
@@ -297,7 +305,11 @@ spec:
 
           resources:
             requests:
-              memory: "2Gi"
+              # Sized to the 6 GiB V8 heap (NODE_OPTIONS above): the pod RSS can
+              # reach ~6 GiB, so reserve it honestly — otherwise the scheduler
+              # over-packs the node and the kubelet evicts the pod under memory
+              # pressure (the 2026-05-30 chat outage).
+              memory: "6Gi"
               cpu: "500m"
             limits:
               memory: "8Gi"

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -74,6 +74,19 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       automountServiceAccountToken: false
+      # Spread the 2 prod replicas across nodes: each api pod can use ~6 GiB,
+      # so stacking both on one node risks a single node's memory pressure
+      # evicting both at once. Soft (preferred) so a single-node hiccup never
+      # blocks scheduling entirely.
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: ever-works-api
+                topologyKey: kubernetes.io/hostname
       containers:
         - name: ever-works-api
           image: registry.digitalocean.com/ever/ever-works-api:latest
@@ -98,9 +111,17 @@ spec:
             # V8 heap: bootstrap (TypeORM ~150 entities + Nest DI graph +
             # transitively-imported plugin packages) exceeds Node 22's default
             # ~1.7 GiB old-space BEFORE #1156's lazy deferral runs in
-            # onApplicationBootstrap(), so the pod V8-OOM crashloops even under
-            # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
-            # comfortably under the limit and lets bootstrap complete.
+            # onApplicationBootstrap(), so the pod V8-OOM crashloops under a
+            # too-small heap (#1145). Old-space is kept at 6 GiB (#1169) to
+            # clear the bootstrap peak.
+            #
+            # IMPORTANT: a 6 GiB heap means the pod RSS can climb to ~6 GiB, so
+            # `resources.requests.memory` below MUST match (6Gi). Otherwise the
+            # scheduler reserves only the nominal request (was 2Gi) and
+            # over-packs nodes; the pod then balloons past what the node can
+            # back and the kubelet evicts it under memory pressure — the
+            # 2026-05-30 chat outage (api crashloop, a node at 102% mem).
+            # Lasting footprint fix: EW-693 (plugins imported eagerly at boot).
             - name: NODE_OPTIONS
               value: "--max-old-space-size=6144"
 
@@ -307,7 +328,12 @@ spec:
 
           resources:
             requests:
-              memory: "2Gi"
+              # Sized to the 6 GiB V8 heap (NODE_OPTIONS above): the pod RSS can
+              # reach ~6 GiB, so reserve it honestly — otherwise the scheduler
+              # over-packs the node and the kubelet evicts the pod under memory
+              # pressure (the 2026-05-30 chat outage). Needs node capacity to
+              # back 4 api pods (prod x2 + stage + dev) at this reservation.
+              memory: "6Gi"
               cpu: "500m"
             limits:
               memory: "8Gi"

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -93,9 +93,17 @@ spec:
             # V8 heap: bootstrap (TypeORM ~150 entities + Nest DI graph +
             # transitively-imported plugin packages) exceeds Node 22's default
             # ~1.7 GiB old-space BEFORE #1156's lazy deferral runs in
-            # onApplicationBootstrap(), so the pod V8-OOM crashloops even under
-            # the 4 GiB cgroup limit (#1145). Raise old-space to 3 GiB — fits
-            # comfortably under the limit and lets bootstrap complete.
+            # onApplicationBootstrap(), so the pod V8-OOM crashloops under a
+            # too-small heap (#1145). Old-space is kept at 6 GiB (#1169) to
+            # clear the bootstrap peak.
+            #
+            # IMPORTANT: a 6 GiB heap means the pod RSS can climb to ~6 GiB, so
+            # `resources.requests.memory` below MUST match (6Gi). Otherwise the
+            # scheduler reserves only the nominal request (was 2Gi) and
+            # over-packs nodes; the pod then balloons past what the node can
+            # back and the kubelet evicts it under memory pressure — the
+            # 2026-05-30 chat outage (api crashloop, a node at 102% mem).
+            # Lasting footprint fix: EW-693 (plugins imported eagerly at boot).
             - name: NODE_OPTIONS
               value: "--max-old-space-size=6144"
 
@@ -295,7 +303,11 @@ spec:
 
           resources:
             requests:
-              memory: "2Gi"
+              # Sized to the 6 GiB V8 heap (NODE_OPTIONS above): the pod RSS can
+              # reach ~6 GiB, so reserve it honestly — otherwise the scheduler
+              # over-packs the node and the kubelet evicts the pod under memory
+              # pressure (the 2026-05-30 chat outage).
+              memory: "6Gi"
               cpu: "500m"
             limits:
               memory: "8Gi"


### PR DESCRIPTION
## Problem (2026-05-30 chat outage)

`app.ever.works` chat intermittently failed with *"failed to get AI provider"* / *"failed to load AI providers"*. Root cause: the prod **API was in an OOM/eviction crashloop**, so the web app couldn't reach a healthy API to resolve the AI provider.

**Why it crashlooped:** #1169 kept `NODE_OPTIONS=--max-old-space-size=6144` and raised the api container `limits.memory` to `8Gi`, but left `requests.memory` at `2Gi`. With a 6 GiB V8 heap the pod RSS climbs to ~6 GiB, so a 2Gi request lets the scheduler **over-pack nodes**; the pod then balloons past what the ~13 GiB node can back and the kubelet **evicts** it.

Observed live: `ever-works-api` pods `OOMKilled`/`Evicted` with 18+ restarts, one node at **102% memory**, rollout stuck — only a single pre-#1169 pod (`2Gi` limit, no heap cap, idling at ~0.8 GiB) stayed `Ready`.

## Fix (keeps the 6 GiB heap — operator decision)

Make the reservation **honest** instead of shrinking the heap:
- `requests.memory` `2Gi → 6Gi` on api **dev/stage/prod** so the scheduler reserves the real footprint and stops over-packing.
- **prod**: soft pod anti-affinity (`topologyKey: kubernetes.io/hostname`) so the 2 replicas don't stack on one node and get evicted together.
- Updated the stale heap comment (said "3 GiB", value is 6 GiB) and documented the requests↔heap coupling.

## ⚠️ Prerequisite — node capacity (do NOT deploy before this)

4 api pods (prod×2 + stage + dev) at a `6Gi` reservation need **~24 GiB**. The current 4-node `do-sfo2-k8s-gauzy` pool has **no node with 6 GiB free** (~17 GiB free total). **Add ~2 nodes (or resize the pool) before this cascades to prod**, otherwise the api pods go `Pending` and chat goes fully down.

## Follow-up
- Lasting footprint fix: **EW-693** (plugins imported eagerly at bootstrap → ~6 GiB heap need).
- Separate pre-existing issue: `ever-works-mcp` pods are also crashlooping (not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized infrastructure configurations across development, staging, and production environments to improve memory allocation and reduce scheduling conflicts. Production deployments now include enhanced pod distribution strategies to maximize resource utilization and improve system reliability and stability during peak usage periods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->