### PR TITLE
fix(health): cap Redis PING with commandTimeout; drop GET Content-Type

### DIFF
--- a/apps/api/src/health/indicators/redis.indicator.ts
+++ b/apps/api/src/health/indicators/redis.indicator.ts
@@ -31,6 +31,10 @@ export class RedisHealthIndicator {
             client = new Redis(url, {
                 lazyConnect: true,
                 connectTimeout: 2000,
+                // Cap the PING itself, not just the TCP handshake — a Redis
+                // that accepts the socket but stops processing commands (hung
+                // replica / bad proxy) would otherwise hang /health/ready.
+                commandTimeout: 2000,
                 maxRetriesPerRequest: 1,
                 enableOfflineQueue: false,
                 retryStrategy: () => null,

--- a/apps/web/src/lib/api/version.ts
+++ b/apps/web/src/lib/api/version.ts
@@ -27,7 +27,6 @@ export const versionAPI = {
     get: cache(async (): Promise<ApiVersion | null> => {
         try {
             const res = await fetch(`${API_URL}/version`, {
-                headers: { 'Content-Type': 'application/json' },
                 next: { revalidate: 300 },
             });
             if (!res.ok) return null;


### PR DESCRIPTION
Follow-up to #1173, which was merged at the base feature commit before the review loop completed — so these two Greptile findings didn't make it into `develop`.

### Fixes
- **P1 (`apps/api/src/health/indicators/redis.indicator.ts`)** — `connectTimeout` only bounds the TCP handshake. If Redis accepts the socket but stops processing commands (hung replica / bad proxy), `client.ping()` — and therefore `GET /api/health/ready` — would wait indefinitely. Add `commandTimeout: 2000` so the PING itself is capped.
- **P2 (`apps/web/src/lib/api/version.ts`)** — drop the meaningless `Content-Type: application/json` header on the GET `/version` fetch (request-body descriptor, no meaning on a GET).

No new dependencies, no schema changes. Verified locally: `apps/api` + `apps/web` type-check, the health controller spec (7 tests), and prettier all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced health monitoring with optimized timeout configuration to prevent command execution delays.

* **Chores**
  * Simplified API request headers for improved efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ever-works/ever-works/pull/1177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->