### PR TITLE
chore(release): cascade develop → stage (health endpoint review fixes #1177)

### DIFF
--- a/apps/api/src/health/indicators/redis.indicator.ts
+++ b/apps/api/src/health/indicators/redis.indicator.ts
@@ -31,6 +31,10 @@ export class RedisHealthIndicator {
             client = new Redis(url, {
                 lazyConnect: true,
                 connectTimeout: 2000,
+                // Cap the PING itself, not just the TCP handshake — a Redis
+                // that accepts the socket but stops processing commands (hung
+                // replica / bad proxy) would otherwise hang /health/ready.
+                commandTimeout: 2000,
                 maxRetriesPerRequest: 1,
                 enableOfflineQueue: false,
                 retryStrategy: () => null,

--- a/apps/web/src/lib/api/version.ts
+++ b/apps/web/src/lib/api/version.ts
@@ -27,7 +27,6 @@ export const versionAPI = {
     get: cache(async (): Promise<ApiVersion | null> => {
         try {
             const res = await fetch(`${API_URL}/version`, {
-                headers: { 'Content-Type': 'application/json' },
                 next: { revalidate: 300 },
             });
             if (!res.ok) return null;


### PR DESCRIPTION
Cascade `develop → stage` per the release flow (`develop → stage → main`).

Promotes the health-endpoint review fixes merged via #1177:
- Redis health-check `commandTimeout` (P1 — prevents `/api/health/ready` hanging on a stalled Redis)
- drop misleading `Content-Type` on the GET `/version` fetch

The health feature itself (#1173) is already on `stage`/`main` via #1174/#1175; this only carries the follow-up fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)