### PR TITLE
release: stage -> main (MCP unbreak #1176)

### DIFF
--- a/.deploy/docker/mcp/Dockerfile
+++ b/.deploy/docker/mcp/Dockerfile
@@ -26,6 +26,34 @@ COPY --from=pruner /app/out/full/ .
 RUN pnpm exec turbo build --filter=ever-works-mcp...
 RUN pnpm deploy --filter=ever-works-mcp --prod --legacy /app/deploy
 
+#-- API pruner (for OpenAPI spec generation)
+FROM base AS api-pruner
+WORKDIR /app
+COPY . .
+RUN turbo prune --scope=ever-works-api --docker
+
+#-- OpenAPI spec generation
+# The MCP loads the API's OpenAPI spec at boot to build its tools, but C-09
+# disables the live /api/openapi.json endpoint whenever NODE_ENV=production
+# (every deployed env). So we generate the spec here and bundle it into the
+# image. `generate-openapi` runs the API under Nest PREVIEW mode — routes are
+# introspected for the document, but providers are NOT instantiated and no DB
+# / external service is contacted. The dummy secrets below only satisfy
+# module-config validation (e.g. AUTH_SECRET length, #869); nothing connects.
+FROM base AS specgen
+WORKDIR /app
+COPY --from=api-pruner /app/out/json/ .
+COPY --from=api-pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+RUN echo "shamefully-hoist=true" > .npmrc
+RUN pnpm install --frozen-lockfile
+COPY --from=api-pruner /app/out/full/ .
+RUN pnpm exec turbo build --filter=ever-works-api...
+RUN NODE_ENV=development \
+    DATABASE_URL="postgres://user:pass@localhost:5432/everworks" \
+    AUTH_SECRET="00000000000000000000000000000000" \
+    JWT_SECRET="00000000000000000000000000000000" \
+    node apps/api/dist/openapi/generate-openapi.js /app/openapi.json
+
 #-- Production
 FROM node:22-alpine
 
@@ -34,10 +62,14 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3200
+# The MCP reads this bundled spec instead of fetching the API (C-09 disables
+# the live spec endpoint in deployed envs). See OpenApiLoaderService.
+ENV EVER_WORKS_OPENAPI_SPEC_PATH=/app/openapi.json
 
 COPY --from=installer --chown=node:node /app/deploy/dist ./dist
 COPY --from=installer --chown=node:node /app/deploy/node_modules ./node_modules
 COPY --from=installer --chown=node:node /app/deploy/package.json ./
+COPY --from=specgen --chown=node:node /app/openapi.json ./openapi.json
 
 EXPOSE 3200
 CMD ["node", "dist/http.js"]

--- a/.deploy/k8s/k8s-manifest.mcp.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.dev.yaml
@@ -53,6 +53,16 @@ spec:
           env:
             - name: EVER_WORKS_API_URL
               value: "http://ever-works-api-dev:3100"
+            # Auth mode for incoming MCP requests. `per-user-jwt` requires each
+            # caller to present their own Ever Works JWT (forwarded upstream to
+            # the API for verification) and needs NO shared key. The default
+            # (`hybrid`) REQUIRES EVER_WORKS_API_KEY; since the
+            # $EVER_WORKS_MCP_API_KEY deploy secret was never provisioned,
+            # McpConfigService threw at boot and the pod crashlooped in every
+            # env since #816 (2026-05-17 audit). To re-enable shared-key auth,
+            # set this to `hybrid` AND provision EVER_WORKS_MCP_API_KEY.
+            - name: EVER_WORKS_MCP_AUTH_MODE
+              value: "per-user-jwt"
             - name: EVER_WORKS_API_KEY
               value: "$EVER_WORKS_MCP_API_KEY"
             - name: EVER_WORKS_MCP_PORT

--- a/.deploy/k8s/k8s-manifest.mcp.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.prod.yaml
@@ -58,6 +58,16 @@ spec:
           env:
             - name: EVER_WORKS_API_URL
               value: "http://ever-works-api:3100"
+            # Auth mode for incoming MCP requests. `per-user-jwt` requires each
+            # caller to present their own Ever Works JWT (forwarded upstream to
+            # the API for verification) and needs NO shared key. The default
+            # (`hybrid`) REQUIRES EVER_WORKS_API_KEY to be set; since the
+            # $EVER_WORKS_MCP_API_KEY deploy secret was never provisioned,
+            # McpConfigService threw at boot and the pod crashlooped in every
+            # env since #816 (2026-05-17 audit). To re-enable shared-key auth,
+            # set this to `hybrid` AND provision EVER_WORKS_MCP_API_KEY.
+            - name: EVER_WORKS_MCP_AUTH_MODE
+              value: "per-user-jwt"
             - name: EVER_WORKS_API_KEY
               value: "$EVER_WORKS_MCP_API_KEY"
             - name: EVER_WORKS_MCP_PORT

--- a/.deploy/k8s/k8s-manifest.mcp.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.stage.yaml
@@ -53,6 +53,16 @@ spec:
           env:
             - name: EVER_WORKS_API_URL
               value: "http://ever-works-api-stage:3100"
+            # Auth mode for incoming MCP requests. `per-user-jwt` requires each
+            # caller to present their own Ever Works JWT (forwarded upstream to
+            # the API for verification) and needs NO shared key. The default
+            # (`hybrid`) REQUIRES EVER_WORKS_API_KEY; since the
+            # $EVER_WORKS_MCP_API_KEY deploy secret was never provisioned,
+            # McpConfigService threw at boot and the pod crashlooped in every
+            # env since #816 (2026-05-17 audit). To re-enable shared-key auth,
+            # set this to `hybrid` AND provision EVER_WORKS_MCP_API_KEY.
+            - name: EVER_WORKS_MCP_AUTH_MODE
+              value: "per-user-jwt"
             - name: EVER_WORKS_API_KEY
               value: "$EVER_WORKS_MCP_API_KEY"
             - name: EVER_WORKS_MCP_PORT

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
         "start:debug": "nest start -b swc --debug --watch",
         "start:prod": "node dist/main",
         "build": "nest build -b swc",
+        "generate:openapi": "node dist/openapi/generate-openapi.js",
         "type-check": "tsc -p tsconfig.build.json --noEmit",
         "format": "prettier --write \"**/*.{ts,tsx,jsx,json,css,md}\"",
         "test": "jest --maxWorkers=2",

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,9 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { configDotenv } from 'dotenv';
 import { ValidationPipe } from '@nestjs/common';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { SwaggerModule } from '@nestjs/swagger';
 import { apiReference } from '@scalar/nestjs-api-reference';
 import { ApiModule } from './api.module';
+import { buildOpenApiConfig } from './openapi/openapi-document.config';
 import helmet from 'helmet';
 import { initSentry, initPostHog, PostHogLoggerService } from '@ever-works/monitoring';
 import { IncomingMessage, ServerResponse } from 'http';
@@ -118,34 +119,9 @@ async function bootstrap() {
         }),
     );
 
-    // OpenAPI/Swagger configuration
-    const config = new DocumentBuilder()
-        .setTitle('Ever Works API')
-        .setDescription(
-            'The Ever Works Platform API - Build and manage AI-powered works with automated content generation, deployment, and integrations.',
-        )
-        .setVersion('1.0')
-        .addBearerAuth(
-            {
-                type: 'http',
-                scheme: 'bearer',
-                bearerFormat: 'JWT',
-                name: 'Authorization',
-                description: 'Enter your JWT token',
-                in: 'header',
-            },
-            'JWT-auth',
-        )
-        .addTag('Health', 'API health check endpoints')
-        .addTag('Auth', 'Authentication and authorization endpoints')
-        .addTag('Works', 'Work management endpoints')
-        .addTag('Deploy', 'Deployment endpoints')
-        .addTag('AI Conversation', 'AI-powered conversation and content generation')
-        .addTag('Screenshot', 'Screenshot capture and smart image preview')
-        .addTag('Subscriptions', 'Subscription and billing management')
-        .addTag('Notifications', 'User notifications')
-        .addTag('Members', 'Work member management')
-        .build();
+    // OpenAPI/Swagger configuration (shared with the build-time
+    // `generate-openapi` script that bundles the spec into the MCP image).
+    const config = buildOpenApiConfig();
 
     // C-09: never expose Swagger UI, the Scalar reference, or the OpenAPI JSON spec
     // in production. The OpenAPI document hands attackers a full inventory of public,

--- a/apps/api/src/openapi/generate-openapi.ts
+++ b/apps/api/src/openapi/generate-openapi.ts
@@ -1,0 +1,50 @@
+import { writeFileSync, mkdirSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { NestFactory } from '@nestjs/core';
+import { SwaggerModule } from '@nestjs/swagger';
+import { ApiModule } from '../api.module';
+import { buildOpenApiConfig } from './openapi-document.config';
+
+/**
+ * Build-time OpenAPI spec generator.
+ *
+ * Emits the dereferenced OpenAPI JSON document WITHOUT starting an HTTP
+ * listener or connecting to the database. The MCP image bundles the output
+ * so `OpenApiLoaderService` can load it locally at runtime — see C-09
+ * (`apps/api/src/main.ts`), which deliberately disables the live spec
+ * endpoint in production, and the MCP's hard dependency on the spec.
+ *
+ * Runs under Nest **preview mode** (`{ preview: true }`): controllers and
+ * routes are introspected for the document, but providers are NOT
+ * instantiated and lifecycle hooks do NOT run — so no real DATABASE_URL,
+ * Redis, or external services are needed during the build.
+ *
+ * Usage: `node dist/openapi/generate-openapi.js [outputPath]`
+ *   (defaults to `openapi.json` in the current working directory)
+ */
+async function generateOpenApi(): Promise<void> {
+    const outputPath = resolve(process.argv[2] ?? 'openapi.json');
+
+    const app = await NestFactory.create(ApiModule, {
+        preview: true,
+        abortOnError: false,
+        logger: ['error', 'warn'],
+    });
+
+    try {
+        const document = SwaggerModule.createDocument(app, buildOpenApiConfig());
+        mkdirSync(dirname(outputPath), { recursive: true });
+        writeFileSync(outputPath, JSON.stringify(document, null, 2), 'utf8');
+        const pathCount = Object.keys(document.paths ?? {}).length;
+        // eslint-disable-next-line no-console
+        console.log(`Wrote OpenAPI spec (${pathCount} paths) to ${outputPath}`);
+    } finally {
+        await app.close();
+    }
+}
+
+generateOpenApi().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('Failed to generate OpenAPI spec:', error);
+    process.exit(1);
+});

--- a/apps/api/src/openapi/openapi-document.config.ts
+++ b/apps/api/src/openapi/openapi-document.config.ts
@@ -1,0 +1,38 @@
+import { DocumentBuilder } from '@nestjs/swagger';
+
+/**
+ * Single source of truth for the Ever Works OpenAPI document metadata.
+ *
+ * Shared between the runtime Swagger setup in `main.ts` (dev/non-prod only,
+ * gated by C-09) and the build-time `generate-openapi` script that bundles
+ * the spec into the MCP image. Keeping it here prevents the two from drifting.
+ */
+export function buildOpenApiConfig() {
+    return new DocumentBuilder()
+        .setTitle('Ever Works API')
+        .setDescription(
+            'The Ever Works Platform API - Build and manage AI-powered works with automated content generation, deployment, and integrations.',
+        )
+        .setVersion('1.0')
+        .addBearerAuth(
+            {
+                type: 'http',
+                scheme: 'bearer',
+                bearerFormat: 'JWT',
+                name: 'Authorization',
+                description: 'Enter your JWT token',
+                in: 'header',
+            },
+            'JWT-auth',
+        )
+        .addTag('Health', 'API health check endpoints')
+        .addTag('Auth', 'Authentication and authorization endpoints')
+        .addTag('Works', 'Work management endpoints')
+        .addTag('Deploy', 'Deployment endpoints')
+        .addTag('AI Conversation', 'AI-powered conversation and content generation')
+        .addTag('Screenshot', 'Screenshot capture and smart image preview')
+        .addTag('Subscriptions', 'Subscription and billing management')
+        .addTag('Notifications', 'User notifications')
+        .addTag('Members', 'Work member management')
+        .build();
+}

--- a/apps/mcp/src/config/mcp-config.service.ts
+++ b/apps/mcp/src/config/mcp-config.service.ts
@@ -24,9 +24,18 @@ export class McpConfigService {
 	readonly httpPort: number;
 	readonly transport: string;
 	readonly authMode: McpAuthMode;
+	/**
+	 * Absolute path to an OpenAPI spec bundled into the image at build time.
+	 * When set and present, OpenApiLoaderService reads it instead of fetching
+	 * the live API — required in deployed envs where C-09 disables the live
+	 * /api/openapi.json endpoint (NODE_ENV=production). Null = fetch the API
+	 * (local dev). See EVER_WORKS_OPENAPI_SPEC_PATH.
+	 */
+	readonly specPath: string | null;
 
 	constructor() {
 		this.authMode = parseAuthMode(process.env.EVER_WORKS_MCP_AUTH_MODE);
+		this.specPath = process.env.EVER_WORKS_OPENAPI_SPEC_PATH?.trim() || null;
 
 		// H-21: the shared API key is OPTIONAL in `per-user-jwt` mode. In any
 		// mode that may accept it (`shared-key`, `shared-key-jwt`, `hybrid`)

--- a/apps/mcp/src/openapi-tools/openapi-loader.service.ts
+++ b/apps/mcp/src/openapi-tools/openapi-loader.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, Inject, Logger, OnModuleInit } from '@nestjs/common';
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
 import { McpConfigService } from '../config/mcp-config.service.js';
 import SwaggerParser from '@apidevtools/swagger-parser';
 import type { JsonSchema, OpenApiParam } from './schema-converter.service.js';
@@ -66,6 +68,27 @@ export class OpenApiLoaderService implements OnModuleInit {
 	}
 
 	private async loadSpec() {
+		// Prefer a spec bundled into the image at build time
+		// (EVER_WORKS_OPENAPI_SPEC_PATH). C-09 disables the live
+		// /api/openapi.json endpoint whenever NODE_ENV=production — which is
+		// every deployed env — so the bundled file is the ONLY source there.
+		// We fall back to fetching the API for local dev, where the endpoint
+		// is served (NODE_ENV !== 'production').
+		const specPath = this.config.specPath;
+		if (specPath && existsSync(specPath)) {
+			const spec = await this.readFileAndDereference(specPath);
+			this.operations = this.extractOperations(spec);
+			this.logger.log(
+				`Loaded ${this.operations.length} operations from bundled OpenAPI spec at ${specPath}`
+			);
+			return;
+		}
+		if (specPath) {
+			this.logger.warn(
+				`EVER_WORKS_OPENAPI_SPEC_PATH="${specPath}" not found on disk; falling back to fetching the API.`
+			);
+		}
+
 		const url = `${this.config.apiUrl}/openapi.json`;
 
 		let spec: OpenApiSpec;
@@ -96,6 +119,11 @@ export class OpenApiLoaderService implements OnModuleInit {
 			throw new Error(`Failed to fetch OpenAPI spec: HTTP ${response.status}`);
 		}
 		const rawSpec = (await response.json()) as Record<string, unknown>;
+		return (await SwaggerParser.dereference(rawSpec as never)) as unknown as OpenApiSpec;
+	}
+
+	private async readFileAndDereference(specPath: string): Promise<OpenApiSpec> {
+		const rawSpec = JSON.parse(await readFile(specPath, 'utf8')) as Record<string, unknown>;
 		return (await SwaggerParser.dereference(rawSpec as never)) as unknown as OpenApiSpec;
 	}
 

--- a/apps/mcp/src/openapi-tools/openapi-loader.service.ts
+++ b/apps/mcp/src/openapi-tools/openapi-loader.service.ts
@@ -78,9 +78,7 @@ export class OpenApiLoaderService implements OnModuleInit {
 		if (specPath && existsSync(specPath)) {
 			const spec = await this.readFileAndDereference(specPath);
 			this.operations = this.extractOperations(spec);
-			this.logger.log(
-				`Loaded ${this.operations.length} operations from bundled OpenAPI spec at ${specPath}`
-			);
+			this.logger.log(`Loaded ${this.operations.length} operations from bundled OpenAPI spec at ${specPath}`);
 			return;
 		}
 		if (specPath) {

--- a/apps/mcp/test/openapi-loader.spec.ts
+++ b/apps/mcp/test/openapi-loader.spec.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
 import { OpenApiLoaderService } from '../src/openapi-tools/openapi-loader.service.js';
 import { McpConfigService } from '../src/config/mcp-config.service.js';
 
@@ -8,6 +10,14 @@ vi.mock('@apidevtools/swagger-parser', () => ({
 		dereference: vi.fn((spec: unknown) => Promise.resolve(spec))
 	}
 }));
+
+// Mock fs so the bundled-spec branch is controllable per-test. Default:
+// no bundled file present, so existing tests fall through to fetch.
+vi.mock('fs', () => ({ existsSync: vi.fn(() => false) }));
+vi.mock('fs/promises', () => ({ readFile: vi.fn() }));
+
+const existsSyncMock = vi.mocked(existsSync);
+const readFileMock = vi.mocked(readFile);
 
 describe('OpenApiLoaderService', () => {
 	let service: OpenApiLoaderService;
@@ -71,6 +81,8 @@ describe('OpenApiLoaderService', () => {
 		service = new OpenApiLoaderService(config);
 		fetchSpy = vi.fn();
 		globalThis.fetch = fetchSpy;
+		existsSyncMock.mockReturnValue(false);
+		readFileMock.mockReset();
 	});
 
 	afterEach(() => {
@@ -146,5 +158,37 @@ describe('OpenApiLoaderService', () => {
 		mockFetchSpec({ openapi: '3.0.0', info: { title: 'Empty', version: '1.0' }, paths: {} });
 		await service.onModuleInit();
 		expect(service.getOperations()).toHaveLength(0);
+	});
+
+	it('loads from the bundled spec file when specPath is set and present (no fetch)', async () => {
+		const config = {
+			apiUrl: 'http://localhost:3100/api',
+			specPath: '/app/openapi.json'
+		} as McpConfigService;
+		service = new OpenApiLoaderService(config);
+		existsSyncMock.mockReturnValue(true);
+		readFileMock.mockResolvedValue(JSON.stringify(minimalSpec));
+
+		await service.onModuleInit();
+
+		expect(readFileMock).toHaveBeenCalledWith('/app/openapi.json', 'utf8');
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(service.getOperations().length).toBe(3);
+	});
+
+	it('falls back to fetching the API when the bundled spec path is missing', async () => {
+		const config = {
+			apiUrl: 'http://localhost:3100/api',
+			specPath: '/app/openapi.json'
+		} as McpConfigService;
+		service = new OpenApiLoaderService(config);
+		existsSyncMock.mockReturnValue(false);
+		mockFetchSpec();
+
+		await service.onModuleInit();
+
+		expect(readFileMock).not.toHaveBeenCalled();
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(service.getOperations().length).toBe(3);
 	});
 });


### PR DESCRIPTION
Cascade of `stage` -> `main` (production).

Headline: **#1176** — unbreak `ever-works-mcp` (per-user-jwt auth + bundled OpenAPI spec).

specgen Docker stage verified locally (349-path spec generated). On merge: the prod MCP image build runs the specgen stage, then deploy restarts `ever-works-mcp` with the bundled spec.