### PR TITLE
fix(monitoring): PostHogLoggerService recursion killed all API logging

### DIFF
--- a/packages/monitoring/src/posthog/posthog-logger.service.ts
+++ b/packages/monitoring/src/posthog/posthog-logger.service.ts
@@ -1,4 +1,4 @@
-import { Logger, LoggerService } from '@nestjs/common';
+import { ConsoleLogger, LoggerService } from '@nestjs/common';
 import { getPostHogClient } from './posthog.config';
 import { getSentryInstance } from '../sentry/sentry.config';
 
@@ -40,14 +40,21 @@ type LogLevel = 'log' | 'warn' | 'error' | 'debug' | 'verbose';
  * Wired into the API in `apps/api/src/main.ts` via `app.useLogger(...)`.
  */
 export class PostHogLoggerService implements LoggerService {
-    private readonly fallbackLogger: Logger;
+    private readonly fallbackLogger: ConsoleLogger;
     private readonly defaultContext?: string;
     private readonly distinctId: string;
 
     constructor(context?: string, distinctId: string = 'system') {
         this.defaultContext = context;
         this.distinctId = distinctId;
-        this.fallbackLogger = new Logger(context ?? 'PostHogLogger');
+        // MUST be ConsoleLogger, NOT Logger. This service is installed as the
+        // global app logger via `app.useLogger(...)`; NestJS's `Logger` facade
+        // delegates back to whatever global logger is registered — i.e. THIS
+        // service — so `new Logger().log()` here would recurse into
+        // dispatch() → stack overflow on every emit, killing ALL logging
+        // ("fallback logger threw ..." then silence). ConsoleLogger writes to
+        // stdout directly and never delegates, breaking the cycle.
+        this.fallbackLogger = new ConsoleLogger(context ?? 'PostHogLogger');
     }
 
     log(message: unknown, context?: string): void {


### PR DESCRIPTION
## Bug
`PostHogLoggerService` is installed as the **global** app logger (`app.useLogger(new PostHogLoggerService())`). Its fallback used `new Logger(...)` — but NestJS's `Logger` facade **delegates to the registered global logger, which is this service**. So every emit recursed:

`dispatch() → fallbackLogger.log() → (global logger) → PostHogLoggerService → dispatch() → …` → **stack overflow**, swallowed by the try/catch as `[PostHogLoggerService] fallback logger threw …`.

**Net effect in prod: all API logging died after boot** — confirmed live (route-mapping logs print via the catch, then total silence; the chat `/api/generator-form` 500 emits **zero** log output, which is why it's been undiagnosable).

## Fix
Use **`ConsoleLogger`** (concrete stdout writer, never delegates) for the fallback instead of `Logger`. One-line change; logging works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging infrastructure by switching the fallback logger implementation to improve consistency and prevent recursive logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->