### PR TITLE
fix(generator-form): one throwing plugin must not 500 the whole AI-provider list

### DIFF
--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -318,28 +318,42 @@ export class GeneratorFormSchemaService {
             // canExtract() URL matching in the facade — they are not user-selectable providers.
             if (registered.manifest.supplementary) continue;
 
-            // Check if plugin is enabled for this context
-            if (options?.workId || options?.userId) {
-                const isEnabled = await this.pluginRegistry.isPluginEnabledForScope(
-                    registered.plugin.id,
-                    options.workId,
-                    options.userId,
-                );
-                if (!isEnabled) {
-                    continue;
+            // Resilience: a single plugin whose enable-check / settings
+            // resolution / model-summary build throws must NOT 500 the whole
+            // provider list — that breaks the dashboard's "load AI providers"
+            // call entirely (the chat then shows "failed to load AI
+            // providers"). Skip the offending plugin instead, mirroring the
+            // fault-tolerance isPluginConfigured already applies internally.
+            try {
+                // Check if plugin is enabled for this context
+                if (options?.workId || options?.userId) {
+                    const isEnabled = await this.pluginRegistry.isPluginEnabledForScope(
+                        registered.plugin.id,
+                        options.workId,
+                        options.userId,
+                    );
+                    if (!isEnabled) {
+                        continue;
+                    }
                 }
-            }
 
-            const configured = await this.isPluginConfigured(registered, options);
-            result.push(
-                await this.toProviderOption(
-                    registered,
-                    activePluginId,
-                    configured,
-                    capability,
-                    options,
-                ),
-            );
+                const configured = await this.isPluginConfigured(registered, options);
+                result.push(
+                    await this.toProviderOption(
+                        registered,
+                        activePluginId,
+                        configured,
+                        capability,
+                        options,
+                    ),
+                );
+            } catch (error) {
+                this.logger.warn(
+                    `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
         }
 
         return result;


### PR DESCRIPTION
## Bug
Production chat shows *"failed to get AI provider"* / *"failed to load AI providers"*. Root cause: **`GET /api/generator-form` returns 500** (reproduced for a logged-in user). In `GeneratorFormSchemaService.getProvidersForCapability`, the per-plugin body — `isPluginEnabledForScope` + `isPluginConfigured` + `toProviderOption` (which calls `buildProviderModelSummaries(schema, await getResolvedSettings(...))` for ai-provider plugins) — is **not** wrapped in try/catch. So a single AI-provider plugin whose settings/model-summary resolution throws takes down the **entire** provider list.

## Fix
Wrap the per-plugin body in try/catch and skip the offending plugin (log a warn) — same fault-tolerance `isPluginConfigured` already applies. The endpoint degrades gracefully instead of 500ing → chat loads the working providers.

## Note
The *exact* throwing plugin is masked because API logging is dead in prod (PostHogLoggerService recursion — fixed separately in #1183). With #1183 deployed, the skipped plugin's real error becomes visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of provider loading to handle individual plugin failures gracefully. The system now skips plugins with configuration issues and logs warnings instead of failing entirely, ensuring other available providers continue to function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->