### PR TITLE
fix(generator-form): guard non-array getFormFields() (stop /generator-form 500) + log skipped-plugin stack

### DIFF
--- a/packages/agent/src/services/__tests__/generator-form-schema.service.spec.ts
+++ b/packages/agent/src/services/__tests__/generator-form-schema.service.spec.ts
@@ -220,6 +220,33 @@ describe('GeneratorFormSchemaService', () => {
             expect(pipelineFields).toHaveLength(1);
             expect(apifyFields).toHaveLength(1);
         });
+
+        it('does not 500 when a pipeline plugin getFormFields() returns a non-array', async () => {
+            // Regression: agent-pipeline's getFormFields() returned a non-array
+            // at runtime despite its FormFieldDefinition[] type, so the
+            // `pluginFields.map(...)` in getFormSchema threw
+            // `TypeError: pluginFields.map is not a function` and 500'd the
+            // whole GET /works/:id/generator-form endpoint. getFormSchema must
+            // coerce a non-array to [] so one misbehaving plugin can't take
+            // down form-schema resolution.
+            const brokenPipeline = createFormSchemaPlugin('agent-pipeline', [], {
+                category: 'pipeline',
+                capabilities: ['pipeline', 'form-schema-provider'],
+            });
+            // getFormFields stays a function (so isFormSchemaProvider passes) but
+            // returns undefined — the exact misbehaving runtime contract.
+            (brokenPipeline as { getFormFields: () => unknown }).getFormFields = () => undefined;
+            const registered = createRegistered(brokenPipeline);
+
+            mockRegistry.get.mockImplementation((id: string) =>
+                id === 'agent-pipeline' ? registered : undefined,
+            );
+
+            const schema = await service.getFormSchema('agent-pipeline');
+
+            expect(Array.isArray(schema.pluginFields)).toBe(true);
+            expect(schema.pluginFields).toHaveLength(0);
+        });
     });
 
     describe('processFormConfig', () => {

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -348,15 +348,18 @@ export class GeneratorFormSchemaService {
                     ),
                 );
             } catch (error) {
-                // Pass the stack as the 2nd arg so the NestJS logger attaches
-                // the full call chain — without it (once the PostHog logger
-                // fix #1183 restores logging) only the bare message would
-                // surface, making the originally-throwing plugin hard to trace.
+                // Embed the stack INSIDE the message rather than passing it as
+                // the 2nd arg: NestJS `Logger.warn(message, context?)` treats
+                // the 2nd arg as the context prefix, and PostHogLoggerService
+                // hard-codes warn's trace to undefined — so a 2nd-arg stack
+                // would clobber the "GeneratorFormSchemaService" context without
+                // recording a trace. Embedding keeps the context AND surfaces
+                // the full call chain (error.stack starts with the message)
+                // once the PostHog logger fix (#1183) restores prod logging.
+                const reason =
+                    error instanceof Error ? (error.stack ?? error.message) : String(error);
                 this.logger.warn(
-                    `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${
-                        error instanceof Error ? error.message : String(error)
-                    }`,
-                    error instanceof Error ? error.stack : undefined,
+                    `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${reason}`,
                 );
             }
         }

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -348,10 +348,15 @@ export class GeneratorFormSchemaService {
                     ),
                 );
             } catch (error) {
+                // Pass the stack as the 2nd arg so the NestJS logger attaches
+                // the full call chain — without it (once the PostHog logger
+                // fix #1183 restores logging) only the bare message would
+                // surface, making the originally-throwing plugin hard to trace.
                 this.logger.warn(
                     `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${
                         error instanceof Error ? error.message : String(error)
                     }`,
+                    error instanceof Error ? error.stack : undefined,
                 );
             }
         }

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -95,7 +95,15 @@ export class GeneratorFormSchemaService {
         if (pipelinePlugin && isFormSchemaProvider(pipelinePlugin.plugin)) {
             const provider = pipelinePlugin.plugin;
 
-            pluginFields = provider.getFormFields();
+            // Defensive: getFormFields() is typed `FormFieldDefinition[]`, but a
+            // misbehaving pipeline plugin (observed: agent-pipeline) can return a
+            // non-array at runtime — which made `pluginFields.map(...)` below throw
+            // `TypeError: pluginFields.map is not a function` and 500 the whole
+            // GET /generator-form endpoint. Coerce to [] so one bad plugin can't
+            // take down form-schema resolution (same resilience stance as the
+            // per-plugin try/catch in getProvidersForCapability, #1184).
+            const resolvedFields = provider.getFormFields();
+            pluginFields = Array.isArray(resolvedFields) ? resolvedFields : [];
             pluginGroups = provider.getFormGroups?.();
             handledConfigFields = provider.handledConfigFields ?? [];
             defaultValues = provider.getDefaultValues?.();


### PR DESCRIPTION
## Summary

Two related hardening changes in `GeneratorFormSchemaService`, both in the resilience lineage of #1184:

### 1. Stop the `GET /api/works/:id/generator-form` 500 (new — surfaced by this PR's e2e)

This PR's own e2e run turned `work-generator.spec.ts:42` ("GET …/generator-form for own work returns shape") **deterministically red** (500 on all 3 retries). API log:

```
TypeError: pluginFields.map is not a function
    at GeneratorFormSchemaService.getFormSchema (...:111)
DEBUG Resolved undefined form fields from pipeline: agent-pipeline
```

`getFormSchema()` types `pluginFields` as `FormFieldDefinition[]` but reassigns it to `provider.getFormFields()`. The `agent-pipeline` plugin returns a **non-array** at runtime, so `pluginFields.map(...)` threw and 500'd the whole endpoint whenever that pipeline resolved.

**Fix:** coerce a non-array result to `[]`:
```ts
const resolvedFields = provider.getFormFields();
pluginFields = Array.isArray(resolvedFields) ? resolvedFields : [];
```
Same resilience stance as the per-plugin `try/catch` #1184 added to `getProvidersForCapability` — one misbehaving form-schema provider can't take down the whole endpoint. Adds a regression unit test (pipeline whose `getFormFields()` returns `undefined` → `pluginFields` is `[]`, no throw).

### 2. Log the skipped-plugin stack trace (original scope — greptile P2 on #1184)

In `getProvidersForCapability`'s per-plugin `catch`, embed the error **stack** in the warn message instead of just the message, so a skipped provider is diagnosable once prod logging is restored (#1183). Stack is embedded **in the message string** (single-arg `warn`) rather than passed as the 2nd arg, because `this.logger` is the NestJS `Logger` facade → our custom `PostHogLoggerService`, whose `warn(message, context?)` treats the 2nd arg strictly as a **context string** (it would clobber the `GeneratorFormSchemaService` label) and hard-codes warn's trace to `undefined`.

## Bot review notes

- **Greptile P2 (r3329873510)** suggesting `warn(msg, error)` (pass the Error object as 2nd arg) was **declined** — it assumes a Pino/Winston-style logger that serializes a trailing Error as metadata, but our global logger is `PostHogLoggerService` which treats arg2 as a context string, so that change would reintroduce the exact context-clobbering it warns about. Rationale posted on the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)