### PR TITLE
release: promote develop → stage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -124,8 +124,27 @@ jobs:
         run: |
           set -e
 
-          echo "::group::Starting API on :3100"
-          nohup pnpm --filter ever-works-api dev > /tmp/api.log 2>&1 &
+          echo "::group::Starting API on :3100 (prebuilt dist — no watch/typecheck)"
+          # Run the API from the prebuilt `dist/` (the "Build all packages"
+          # step above already compiled apps/api) via `start:prod`
+          # (`node dist/main`), NOT `nest start -b swc --watch`.
+          #
+          # Why: `nest start --watch` runs a concurrent TSC type-checker
+          # (nest-cli.json `typeCheck: true`) plus a file watcher alongside
+          # the booting app. Under that extra memory pressure V8's RegExp
+          # compiler intermittently fails to allocate while the route table
+          # is compiled at startup —
+          #   FATAL ERROR: RegExpCompiler Allocation failed - process out of
+          #   memory   (RegExpCapture::ToNode -> RegExpDisjunction::ToNode)
+          # — which ABORTS the whole API process mid-suite. Every later spec
+          # in that shard then fails with `connect ECONNREFUSED
+          # 127.0.0.1:3100`, and because the timing is nondeterministic the
+          # casualty shard moves run-to-run (the classic "random" e2e red).
+          # The prebuilt server has no watcher and no typechecker, so it
+          # boots once and stays up. Runtime behaviour is identical — the
+          # dev-vs-prod code branches key off env vars (NODE_ENV,
+          # DATABASE_*), not the build/start mode.
+          nohup pnpm --filter ever-works-api start:prod > /tmp/api.log 2>&1 &
           API_PID=$!
           disown $API_PID
           echo "API pid=$API_PID"
@@ -396,8 +415,13 @@ jobs:
         run: |
           set -e
 
-          echo "::group::Starting API on :3100"
-          nohup pnpm --filter ever-works-api dev > /tmp/api.log 2>&1 &
+          echo "::group::Starting API on :3100 (prebuilt dist — no watch/typecheck)"
+          # Same rationale as the sharded e2e job: run the prebuilt API via
+          # `start:prod` (`node dist/main`) rather than `nest start --watch`,
+          # so the concurrent TSC type-checker + file watcher can't pressure
+          # V8 into a `RegExpCompiler Allocation failed` abort during route
+          # registration. The build step above already produced apps/api/dist.
+          nohup pnpm --filter ever-works-api start:prod > /tmp/api.log 2>&1 &
           disown $!
           echo "::endgroup::"
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -8,6 +8,30 @@ import { getAuthFromCookie } from './lib/auth';
 
 const nextIntlMiddleware = createMiddleware(routing);
 
+// Does this pathname look like a real static asset (so the proxy should
+// skip it) rather than an app route?
+//
+// Historically this was "any path containing a dot" (`pathname.includes('.')`
+// + a `.*\..*` matcher). That is correct for every asset the app serves —
+// `favicon.ico`, `*.lottie` animations, `manifest.webmanifest`, `*.json`,
+// fonts, images — but it ALSO swallowed the one family of app routes that
+// legitimately contains a dot: KB document pages use the canonical
+// `<class>/<slug>.md` shape (e.g. `/works/<id>/kb/legal/privacy.md`).
+// Skipping the proxy for those meant the next-intl locale rewrite never
+// ran (under `localePrefix: 'never'`), so client-side <Link> navigation
+// into the `/[locale]` tree stalled — the inherited-doc row click in
+// kb-inherited.spec.ts never settled on the dotted URL.
+//
+// So we keep the broad "has a dot → static asset" rule (preserving the
+// exact prior behaviour for every real asset, including `.lottie` and
+// `.webmanifest`) and carve out ONLY a trailing `.md`, which is always an
+// app doc route, never a served static file. This RE is the runtime twin
+// of the negative-lookahead in `config.matcher` at the bottom of this
+// file — keep the two in lock-step.
+function isStaticAssetPath(pathname: string): boolean {
+    return pathname.includes('.') && !pathname.endsWith('.md');
+}
+
 // next-intl persists the active locale in this cookie when `localePrefix:
 // 'never'` is set. We read/write it directly when redirecting legacy
 // `/<locale>/...` URLs so the user keeps the language they were using.
@@ -136,8 +160,17 @@ export default async function proxy(req: NextRequest) {
         return applySecurityHeaders(intlResponse);
     }
 
-    // 4) Static assets and API routes pass through.
-    if (pathname.startsWith('/_next') || pathname.startsWith('/api/') || pathname.includes('.')) {
+    // 4) Static assets and API routes pass through. `isStaticAssetPath`
+    //    keeps the original "has a dot → static asset" rule but carves out
+    //    a trailing `.md`, so dotted app routes like the KB
+    //    `<class>/<slug>.md` doc pages still flow through the auth gate
+    //    below and the next-intl rewrite above, while real assets
+    //    (`.lottie`, `.webmanifest`, images, fonts, …) keep bypassing.
+    if (
+        pathname.startsWith('/_next') ||
+        pathname.startsWith('/api/') ||
+        isStaticAssetPath(pathname)
+    ) {
         return applySecurityHeaders(intlResponse);
     }
 
@@ -160,6 +193,16 @@ export default async function proxy(req: NextRequest) {
 export const config = {
     // Match all pathnames except for
     // - … if they start with `/api`, `/trpc`, `/_next` or `/_vercel`
-    // - … the ones containing a dot (e.g. `favicon.ico`)
-    matcher: '/((?!api|trpc|_next|_vercel|.*\\..*).*)',
+    // - … any path that contains a dot (a static asset) UNLESS it ends in
+    //   `.md` (a KB document app route).
+    //
+    // The exclusion `.*\.(?!md$)[^/]*$` reads as "a dot whose trailing
+    // segment is not exactly `md`" — i.e. every real static asset
+    // (`favicon.ico`, `*.lottie`, `manifest.webmanifest`, images, fonts,
+    // `.json`, …) is still excluded and bypasses the middleware exactly as
+    // before, while the KB doc routes `/works/<id>/kb/<class>/<slug>.md`
+    // are NOT excluded so the next-intl locale rewrite runs and client-side
+    // navigation to them settles. MUST stay in lock-step with
+    // `isStaticAssetPath` at the top of this file (its runtime twin).
+    matcher: '/((?!api|trpc|_next|_vercel|.*\\.(?!md$)[^/]*$).*)',
 };

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -318,28 +318,42 @@ export class GeneratorFormSchemaService {
             // canExtract() URL matching in the facade — they are not user-selectable providers.
             if (registered.manifest.supplementary) continue;
 
-            // Check if plugin is enabled for this context
-            if (options?.workId || options?.userId) {
-                const isEnabled = await this.pluginRegistry.isPluginEnabledForScope(
-                    registered.plugin.id,
-                    options.workId,
-                    options.userId,
-                );
-                if (!isEnabled) {
-                    continue;
+            // Resilience: a single plugin whose enable-check / settings
+            // resolution / model-summary build throws must NOT 500 the whole
+            // provider list — that breaks the dashboard's "load AI providers"
+            // call entirely (the chat then shows "failed to load AI
+            // providers"). Skip the offending plugin instead, mirroring the
+            // fault-tolerance isPluginConfigured already applies internally.
+            try {
+                // Check if plugin is enabled for this context
+                if (options?.workId || options?.userId) {
+                    const isEnabled = await this.pluginRegistry.isPluginEnabledForScope(
+                        registered.plugin.id,
+                        options.workId,
+                        options.userId,
+                    );
+                    if (!isEnabled) {
+                        continue;
+                    }
                 }
-            }
 
-            const configured = await this.isPluginConfigured(registered, options);
-            result.push(
-                await this.toProviderOption(
-                    registered,
-                    activePluginId,
-                    configured,
-                    capability,
-                    options,
-                ),
-            );
+                const configured = await this.isPluginConfigured(registered, options);
+                result.push(
+                    await this.toProviderOption(
+                        registered,
+                        activePluginId,
+                        configured,
+                        capability,
+                        options,
+                    ),
+                );
+            } catch (error) {
+                this.logger.warn(
+                    `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
         }
 
         return result;

--- a/packages/monitoring/src/posthog/posthog-logger.service.ts
+++ b/packages/monitoring/src/posthog/posthog-logger.service.ts
@@ -1,4 +1,4 @@
-import { Logger, LoggerService } from '@nestjs/common';
+import { ConsoleLogger, LoggerService } from '@nestjs/common';
 import { getPostHogClient } from './posthog.config';
 import { getSentryInstance } from '../sentry/sentry.config';
 
@@ -40,14 +40,21 @@ type LogLevel = 'log' | 'warn' | 'error' | 'debug' | 'verbose';
  * Wired into the API in `apps/api/src/main.ts` via `app.useLogger(...)`.
  */
 export class PostHogLoggerService implements LoggerService {
-    private readonly fallbackLogger: Logger;
+    private readonly fallbackLogger: ConsoleLogger;
     private readonly defaultContext?: string;
     private readonly distinctId: string;
 
     constructor(context?: string, distinctId: string = 'system') {
         this.defaultContext = context;
         this.distinctId = distinctId;
-        this.fallbackLogger = new Logger(context ?? 'PostHogLogger');
+        // MUST be ConsoleLogger, NOT Logger. This service is installed as the
+        // global app logger via `app.useLogger(...)`; NestJS's `Logger` facade
+        // delegates back to whatever global logger is registered — i.e. THIS
+        // service — so `new Logger().log()` here would recurse into
+        // dispatch() → stack overflow on every emit, killing ALL logging
+        // ("fallback logger threw ..." then silence). ConsoleLogger writes to
+        // stdout directly and never delegates, breaking the cycle.
+        this.fallbackLogger = new ConsoleLogger(context ?? 'PostHogLogger');
     }
 
     log(message: unknown, context?: string): void {


### PR DESCRIPTION
Promote develop to stage (23 commits) as part of cascading the e2e-stability fixes (PR #1182: API start:prod, kb-inherited proxy routing, generator-form subscription-gate guard, KBDBG debug-log cleanup) plus all other merged develop work to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)