### PR TITLE
ci(e2e): make E2E branch-only — develop/stage/main/master push, drop PR trigger

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,30 +3,24 @@ name: E2E Tests
 # Playwright e2e suite — auto-starts API (sqlite in-memory) + Next.js dev
 # server in the runner, then runs all specs from apps/web/e2e/.
 #
-# Scope:
-#   - push to `stage` / `main`            → run (release gate)
-#   - pull_request to `develop`/`stage`/`main` → run (pre-merge validation)
-#   - workflow_dispatch on any branch     → run (one-off verification)
+# Scope (intentionally BRANCH-ONLY — never runs on feature/fix branches):
+#   - push to `develop` / `stage` / `main` (+ `master`) → run (release-line gate)
+#   - workflow_dispatch on any branch                   → run (one-off verification)
 #
-# The full suite is sharded 4× across the matrix (~25 min wall-clock per
-# shard on ubicloud-standard-8). PR pre-validation was added because
-# stage/main-only triggers let test debt accumulate undetected until the
-# release cut. If PR cost proves too high, narrow the `pull_request:`
-# branches list to `[stage, main]` only.
+# There is deliberately NO `pull_request` trigger. The full suite is
+# sharded 4× across the matrix (~25 min wall-clock per shard on
+# ubicloud-standard-8), so running it on every feature/fix PR burned
+# runners without gating anything the post-merge branch push doesn't
+# already catch. e2e now runs only once code lands on a release-line
+# branch (`develop`, `stage`, `main`/`master`). The `concurrency` block
+# below cancels a superseded run when a newer commit reaches the same
+# branch, so only the latest commit per branch is ever validated.
 #
 # See Workspace/knowledge/runbooks/CI_RELEASE_GATES.md for the policy.
 
 on:
   push:
-    branches: [stage, main]
-  # Pre-validate PRs heading into the release pipeline so test debt
-  # surfaces BEFORE the merge instead of after. Sharded across 4
-  # runners (~25 min wall-clock), so the cost is bearable to catch
-  # regressions before they reach `stage`. If this proves too
-  # expensive, narrow to `[stage, main]` only and rely on push for
-  # `develop`-merged regressions.
-  pull_request:
-    branches: [develop, stage, main]
+    branches: [develop, stage, main, master]
   workflow_dispatch:
 
 # M-12: minimum default permissions. Individual jobs can elevate where needed.


### PR DESCRIPTION
## What

Makes the Playwright **E2E Tests** workflow (`.github/workflows/e2e.yml`) **branch-only**:

- **Removes the `pull_request:` trigger entirely** — e2e no longer runs on feature/fix PRs.
- **Adds `develop` and `master` to `push:`** so every merge to a release-line branch (`develop` / `stage` / `main` / `master`) runs the full suite.

```diff
 on:
   push:
-    branches: [stage, main]
-  pull_request:
-    branches: [develop, stage, main]
+    branches: [develop, stage, main, master]
   workflow_dispatch:
```

## Why

Operator request: *"I want e2e tests ONLY to run for develop, stage and main/master branches, never for feature/fix branches"* and *"make sure past executions stop if there is a new execution of such Actions in same env."*

- The sharded suite is ~25 min wall-clock × 4 shards on `ubicloud-standard-8`. Running it on every feature/fix PR burned runners without gating anything the post-merge branch push doesn't already catch.
- e2e now fires only once code lands on a release-line branch.

## Past-execution cancellation — already satisfied (no change)

The existing `concurrency` block already does exactly what's asked:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

A newer commit on the same branch cancels the in-flight run, so only the **latest commit per branch** is ever validated. Left unchanged.

## Notes

- `workflow_dispatch:` retained — targeted one-off runs on any branch still work (`gh workflow run e2e.yml --ref <branch>`).
- The artifact-name sanitize steps already fall back from `github.head_ref` (PR-only) to `github.ref_name`, so they work correctly with the PR trigger gone.
- Policy runbook `Workspace/knowledge/runbooks/CI_RELEASE_GATES.md` updated with a dated 2026-05-31 amendment (separate Workspace repo) — re-adds `develop` to Platform's heavy-CI gate and removes the PR trigger; Template / Minimal Template unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated E2E test workflow to run on pushes to develop, stage, main, and master branches, and manual triggers. Tests no longer run automatically on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->