### PR TITLE
release: develop → stage (chat fixes: generator-form 500, provider-list resilience, logging) + e2e branch-only

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,30 +3,24 @@ name: E2E Tests
 # Playwright e2e suite — auto-starts API (sqlite in-memory) + Next.js dev
 # server in the runner, then runs all specs from apps/web/e2e/.
 #
-# Scope:
-#   - push to `stage` / `main`            → run (release gate)
-#   - pull_request to `develop`/`stage`/`main` → run (pre-merge validation)
-#   - workflow_dispatch on any branch     → run (one-off verification)
+# Scope (intentionally BRANCH-ONLY — never runs on feature/fix branches):
+#   - push to `develop` / `stage` / `main` (+ `master`) → run (release-line gate)
+#   - workflow_dispatch on any branch                   → run (one-off verification)
 #
-# The full suite is sharded 4× across the matrix (~25 min wall-clock per
-# shard on ubicloud-standard-8). PR pre-validation was added because
-# stage/main-only triggers let test debt accumulate undetected until the
-# release cut. If PR cost proves too high, narrow the `pull_request:`
-# branches list to `[stage, main]` only.
+# There is deliberately NO `pull_request` trigger. The full suite is
+# sharded 4× across the matrix (~25 min wall-clock per shard on
+# ubicloud-standard-8), so running it on every feature/fix PR burned
+# runners without gating anything the post-merge branch push doesn't
+# already catch. e2e now runs only once code lands on a release-line
+# branch (`develop`, `stage`, `main`/`master`). The `concurrency` block
+# below cancels a superseded run when a newer commit reaches the same
+# branch, so only the latest commit per branch is ever validated.
 #
 # See Workspace/knowledge/runbooks/CI_RELEASE_GATES.md for the policy.
 
 on:
   push:
-    branches: [stage, main]
-  # Pre-validate PRs heading into the release pipeline so test debt
-  # surfaces BEFORE the merge instead of after. Sharded across 4
-  # runners (~25 min wall-clock), so the cost is bearable to catch
-  # regressions before they reach `stage`. If this proves too
-  # expensive, narrow to `[stage, main]` only and rely on push for
-  # `develop`-merged regressions.
-  pull_request:
-    branches: [develop, stage, main]
+    branches: [develop, stage, main, master]
   workflow_dispatch:
 
 # M-12: minimum default permissions. Individual jobs can elevate where needed.

--- a/packages/agent/src/services/__tests__/generator-form-schema.service.spec.ts
+++ b/packages/agent/src/services/__tests__/generator-form-schema.service.spec.ts
@@ -220,6 +220,33 @@ describe('GeneratorFormSchemaService', () => {
             expect(pipelineFields).toHaveLength(1);
             expect(apifyFields).toHaveLength(1);
         });
+
+        it('does not 500 when a pipeline plugin getFormFields() returns a non-array', async () => {
+            // Regression: agent-pipeline's getFormFields() returned a non-array
+            // at runtime despite its FormFieldDefinition[] type, so the
+            // `pluginFields.map(...)` in getFormSchema threw
+            // `TypeError: pluginFields.map is not a function` and 500'd the
+            // whole GET /works/:id/generator-form endpoint. getFormSchema must
+            // coerce a non-array to [] so one misbehaving plugin can't take
+            // down form-schema resolution.
+            const brokenPipeline = createFormSchemaPlugin('agent-pipeline', [], {
+                category: 'pipeline',
+                capabilities: ['pipeline', 'form-schema-provider'],
+            });
+            // getFormFields stays a function (so isFormSchemaProvider passes) but
+            // returns undefined — the exact misbehaving runtime contract.
+            (brokenPipeline as { getFormFields: () => unknown }).getFormFields = () => undefined;
+            const registered = createRegistered(brokenPipeline);
+
+            mockRegistry.get.mockImplementation((id: string) =>
+                id === 'agent-pipeline' ? registered : undefined,
+            );
+
+            const schema = await service.getFormSchema('agent-pipeline');
+
+            expect(Array.isArray(schema.pluginFields)).toBe(true);
+            expect(schema.pluginFields).toHaveLength(0);
+        });
     });
 
     describe('processFormConfig', () => {

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -348,15 +348,18 @@ export class GeneratorFormSchemaService {
                     ),
                 );
             } catch (error) {
-                // Pass the stack as the 2nd arg so the NestJS logger attaches
-                // the full call chain — without it (once the PostHog logger
-                // fix #1183 restores logging) only the bare message would
-                // surface, making the originally-throwing plugin hard to trace.
+                // Embed the stack INSIDE the message rather than passing it as
+                // the 2nd arg: NestJS `Logger.warn(message, context?)` treats
+                // the 2nd arg as the context prefix, and PostHogLoggerService
+                // hard-codes warn's trace to undefined — so a 2nd-arg stack
+                // would clobber the "GeneratorFormSchemaService" context without
+                // recording a trace. Embedding keeps the context AND surfaces
+                // the full call chain (error.stack starts with the message)
+                // once the PostHog logger fix (#1183) restores prod logging.
+                const reason =
+                    error instanceof Error ? (error.stack ?? error.message) : String(error);
                 this.logger.warn(
-                    `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${
-                        error instanceof Error ? error.message : String(error)
-                    }`,
-                    error instanceof Error ? error.stack : undefined,
+                    `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${reason}`,
                 );
             }
         }

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -348,10 +348,15 @@ export class GeneratorFormSchemaService {
                     ),
                 );
             } catch (error) {
+                // Pass the stack as the 2nd arg so the NestJS logger attaches
+                // the full call chain — without it (once the PostHog logger
+                // fix #1183 restores logging) only the bare message would
+                // surface, making the originally-throwing plugin hard to trace.
                 this.logger.warn(
                     `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${
                         error instanceof Error ? error.message : String(error)
                     }`,
+                    error instanceof Error ? error.stack : undefined,
                 );
             }
         }

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -95,7 +95,15 @@ export class GeneratorFormSchemaService {
         if (pipelinePlugin && isFormSchemaProvider(pipelinePlugin.plugin)) {
             const provider = pipelinePlugin.plugin;
 
-            pluginFields = provider.getFormFields();
+            // Defensive: getFormFields() is typed `FormFieldDefinition[]`, but a
+            // misbehaving pipeline plugin (observed: agent-pipeline) can return a
+            // non-array at runtime — which made `pluginFields.map(...)` below throw
+            // `TypeError: pluginFields.map is not a function` and 500 the whole
+            // GET /generator-form endpoint. Coerce to [] so one bad plugin can't
+            // take down form-schema resolution (same resilience stance as the
+            // per-plugin try/catch in getProvidersForCapability, #1184).
+            const resolvedFields = provider.getFormFields();
+            pluginFields = Array.isArray(resolvedFields) ? resolvedFields : [];
             pluginGroups = provider.getFormGroups?.();
             handledConfigFields = provider.handledConfigFields ?? [];
             defaultValues = provider.getDefaultValues?.();


### PR DESCRIPTION
## Release cascade: develop → stage

Promotes 6 commits from `develop` to `stage`. All already merged + CI-green on `develop`.

### Chat / AI-provider fixes (the prod "failed to get AI provider" line)
- **#1185** — `fix(generator-form)`: guard non-array `getFormFields()` so a misbehaving pipeline plugin can't 500 `GET /api/works/:id/generator-form` (`TypeError: pluginFields.map is not a function`); + embed skipped-plugin stack in the warn message (greptile P2 on #1184). Regression unit test included.
- (already on stage as ancestors, shipping in the resulting image) **#1183** dead-logging recursion fix, **#1184** provider-list per-plugin try/catch resilience.

### CI
- **#1187** — `ci(e2e)`: make E2E branch-only — runs on push to `develop`/`stage`/`main`/`master`, drops the `pull_request` trigger (no e2e on feature/fix PRs); existing `concurrency` cancels superseded runs per branch.

### Why now
Prod API is healthy again (boot-OOM resolved by the cluster resize — pods stable, 0 restarts), but it's running the pre-fix image. This cascade builds + deploys an image carrying all the above so prod chat actually gets the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)