### PR TITLE
fix(agent): materialize lazy plugins before use so chat works again

### DIFF
--- a/packages/agent/src/facades/base.facade.ts
+++ b/packages/agent/src/facades/base.facade.ts
@@ -318,21 +318,56 @@ export abstract class BaseFacadeService {
                 registered.state === 'loaded'
             ) {
                 const isEnabled = await this.isPluginEnabled(effectiveOverride, workId, userId);
-                if (isEnabled) return registered.plugin as T;
+                if (isEnabled) return this.materializeForUse<T>(registered.plugin);
             }
             throw new ProviderNotFoundError(effectiveOverride, this.CAPABILITY);
         }
 
         if (workId) {
             const activePlugin = await this.findActivePluginForWork(workId);
-            if (activePlugin) return activePlugin.plugin as T;
+            if (activePlugin) return this.materializeForUse<T>(activePlugin.plugin);
         }
 
         const enabledPlugins = await this.getEnabledPlugins(workId, userId);
         if (enabledPlugins.length > 0) {
-            return enabledPlugins[0].plugin as T;
+            return this.materializeForUse<T>(enabledPlugins[0].plugin);
         }
 
         throw new NoProviderError(this.CAPABILITY);
+    }
+
+    /**
+     * Materialize a (possibly lazy) plugin before an operation uses it.
+     *
+     * Under lazy plugin loading (PR #1156) the registry hands out a proxy whose
+     * synchronous getters — notably `settingsSchema` — only reflect the real
+     * plugin AFTER materialization. `resolvePlugin` is the operation path: the
+     * caller is about to use this plugin (chat / search / deploy / …) and will
+     * immediately read its resolved settings, which depend on the schema's
+     * `x-envVar` bindings (e.g. `PLUGIN_OPENROUTER_API_KEY`). If we hand back a
+     * cold proxy, `settingsSchema` is `{}`, the env var is never read, and the
+     * provider call fails with `401 Missing Authentication header`. Forcing
+     * materialization here is cheap — only the single plugin actually being
+     * used is imported, not the whole registry, so lazy-load's memory win is
+     * preserved.
+     */
+    private async materializeForUse<T extends IPlugin>(plugin: IPlugin): Promise<T> {
+        const stub = plugin as unknown as {
+            __materialize?: () => Promise<IPlugin>;
+        };
+        if (typeof stub.__materialize === 'function') {
+            // Return the REAL instance, not the lazy proxy. The proxy forwards
+            // every method through `ensureMaterialized().then(...)`, so it wraps
+            // results in a Promise — which silently breaks methods that must
+            // return a value synchronously, notably the streaming generator
+            // `createStreamingChatCompletion()` (a `Promise<AsyncGenerator>` is
+            // not itself async-iterable → "is not a function or its return
+            // value is not async iterable"). Handing back the materialized
+            // instance lets the facade call real methods directly. Settings
+            // resolution is unaffected: it looks the plugin up by id in the
+            // registry (still the proxy) and reads its now-materialized schema.
+            return (await stub.__materialize()) as T;
+        }
+        return plugin as T;
     }
 }

--- a/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
+++ b/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
@@ -50,6 +50,30 @@ describe('lazy-plugin-proxy', () => {
         expect(stub.__isMaterialized).toBe(true);
     });
 
+    it('exposes the real plugin settingsSchema only after materialization', async () => {
+        // Regression for the lazy-load PR #1156 chat outage: while cold the
+        // proxy returned `{}` for settingsSchema (the package.json manifest
+        // carries no JSON-Schema), and it kept returning `{}` even AFTER
+        // materialization. Settings resolution then found no x-envVar-bound
+        // fields (e.g. the OpenRouter apiKey), never read PLUGIN_OPENROUTER_API_KEY,
+        // and AI calls failed with "401 Missing Authentication header".
+        const onLoad = jest.fn().mockResolvedValue(undefined);
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('p-schema', onLoad));
+        const stub = createLazyPluginProxy(makeManifest('p-schema'), loader);
+
+        // Cold: no import cost, empty schema from the manifest.
+        expect(stub.settingsSchema).toEqual({});
+        expect(loader).not.toHaveBeenCalled();
+
+        // After materialization the proxy must delegate to the real plugin's
+        // class-level schema.
+        await stub.__materialize();
+        expect(stub.settingsSchema).toEqual({
+            type: 'object',
+            properties: { apiKey: { type: 'string' } },
+        });
+    });
+
     it('shares a single import across concurrent method calls', async () => {
         const onLoad = jest.fn().mockResolvedValue(undefined);
         let resolveLoader!: (p: IPlugin) => void;

--- a/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
+++ b/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
@@ -125,9 +125,23 @@ export function createLazyPluginProxy(
             return manifest.capabilities;
         },
         get settingsSchema() {
+            // Once the real plugin is materialized, its class-level JSON-Schema
+            // is the source of truth (the manifest/package.json does not carry
+            // it). Falling back to the manifest while cold keeps sync metadata
+            // reads cheap; delegating after materialization is what lets
+            // settings resolution (incl. x-envVar bindings like
+            // PLUGIN_OPENROUTER_API_KEY) see the real schema instead of `{}`.
+            const real = materialized as unknown as Record<string, unknown> | null;
+            if (real && real.settingsSchema !== undefined) {
+                return real.settingsSchema;
+            }
             return manifestExt.settingsSchema ?? {};
         },
         get configurationMode() {
+            const real = materialized as unknown as Record<string, unknown> | null;
+            if (real && real.configurationMode !== undefined) {
+                return real.configurationMode;
+            }
             return manifestExt.configurationMode;
         },
         get __isMaterialized() {

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -1716,7 +1716,13 @@ export class PluginOperationsService {
 
         if (plugin?.validateSettings) {
             const pluginResult = await plugin.validateSettings(settings);
-            if (!pluginResult.valid) {
+            // Under lazy plugin loading the proxy exposes optional lifecycle
+            // methods (validateSettings is optional) as a forwarding wrapper
+            // even when the real plugin doesn't implement them; calling it then
+            // resolves to `undefined`. Treat a missing/undefined result as "no
+            // custom validation" instead of dereferencing `.valid` — that threw
+            // `Cannot read properties of undefined (reading 'valid')` → HTTP 500.
+            if (pluginResult && !pluginResult.valid) {
                 throw new BadRequestException({
                     message: 'Invalid plugin settings',
                     errors: pluginResult.errors?.map((e) => e.message) ?? [


### PR DESCRIPTION
## Summary

Fixes the built-in AI chat outage on `develop` introduced by **PR #1156 (lazy-load plugin runtimes on first use)**. The lazy plugin proxy reflected the real plugin only *after* materialization, which broke two paths:

1. **Chat → `422 provider_unavailable` / `401 Missing Authentication header`.** The proxy's `settingsSchema` getter always returned the (empty) `package.json` manifest schema — even after materialization — so settings resolution found no `x-envVar`-bound fields (e.g. `PLUGIN_OPENROUTER_API_KEY`) and never applied the provider key. The model also fell back to the schema default (`openai/gpt-5-nano`).
2. **`PATCH /api/plugins/:id/settings` → `500` `Cannot read properties of undefined (reading 'valid')`.** The proxy exposed the optional `validateSettings` lifecycle method as a truthy forwarding wrapper that resolves to `undefined`; `validateSettingsOrThrow` then dereferenced `.valid`.

## Changes

- **`lazy-plugin-proxy.ts`** — `settingsSchema` / `configurationMode` getters delegate to the materialized instance once warm (manifest fallback while cold). This is the documented "Known caveat — settingsSchema sync access" from #1156, now closed.
- **`base.facade.ts` `resolvePlugin`** — materialize the resolved plugin and return the **real instance** for operations. This (a) lets settings resolution read the real schema, and (b) fixes **streaming chat** — the proxy wrapped every call in a `Promise`, so `createStreamingChatCompletion()` returned a `Promise<AsyncGenerator>` that wasn't async-iterable. Only the single plugin actually used materializes, so lazy-load's memory benefit is preserved.
- **`plugin-operations.service.ts` `validateSettingsOrThrow`** — null-safe the optional `validateSettings` result.
- **`lazy-plugin-proxy.spec.ts`** — regression test: cold proxy reports `{}`, materialized proxy reports the real schema.

## Verification (latest `develop`, local)

- ✅ Non-streaming chat (`POST /api/v1/chat/completions`) → `200`, real OpenRouter completion.
- ✅ Streaming chat (the UI path) → SSE chunks.
- ✅ `connection-status` → `connected: true`; `PATCH settings` no longer 500s.
- ✅ **289** agent unit tests green (lazy-plugin-proxy, base.facade, ai.facade, plugin-settings, plugin-operations) + new regression test.

## Memory findings (the suspected OOM)

Measured the compiled API (`node dist/main`, matches k8s):

| Scenario | API RSS |
| --- | --- |
| Lazy (default) — boot/idle | ~370 MB |
| Lazy — after 40 chat calls (then settled) | ~410 MB (flat, **no leak**) |
| Eager (`PLUGIN_LAZY_LOAD=false`, all ~60 plugins) | ~542 MB |
| Live prod/dev/stage pods | ~330–390 MB |

All far under the 8 Gi pod limit / 6 GB heap cap. The historical OOM was the **pre-#1156 eager path under the old 2 Gi limit**; lazy-loading already fixed memory but silently broke chat (this PR). No per-plugin memory leak found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed plugin settings failing to load in specific scenarios during plugin initialization.
  * Fixed validation errors occurring when plugins lack custom validation logic.

* **Tests**
  * Added regression test to verify plugin settings schema loads correctly after plugin initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->