### PR TITLE
release: develop → stage (chat lazy-plugin materialize fix #1190)

### DIFF
--- a/packages/agent/src/facades/base.facade.ts
+++ b/packages/agent/src/facades/base.facade.ts
@@ -318,21 +318,56 @@ export abstract class BaseFacadeService {
                 registered.state === 'loaded'
             ) {
                 const isEnabled = await this.isPluginEnabled(effectiveOverride, workId, userId);
-                if (isEnabled) return registered.plugin as T;
+                if (isEnabled) return this.materializeForUse<T>(registered.plugin);
             }
             throw new ProviderNotFoundError(effectiveOverride, this.CAPABILITY);
         }
 
         if (workId) {
             const activePlugin = await this.findActivePluginForWork(workId);
-            if (activePlugin) return activePlugin.plugin as T;
+            if (activePlugin) return this.materializeForUse<T>(activePlugin.plugin);
         }
 
         const enabledPlugins = await this.getEnabledPlugins(workId, userId);
         if (enabledPlugins.length > 0) {
-            return enabledPlugins[0].plugin as T;
+            return this.materializeForUse<T>(enabledPlugins[0].plugin);
         }
 
         throw new NoProviderError(this.CAPABILITY);
+    }
+
+    /**
+     * Materialize a (possibly lazy) plugin before an operation uses it.
+     *
+     * Under lazy plugin loading (PR #1156) the registry hands out a proxy whose
+     * synchronous getters — notably `settingsSchema` — only reflect the real
+     * plugin AFTER materialization. `resolvePlugin` is the operation path: the
+     * caller is about to use this plugin (chat / search / deploy / …) and will
+     * immediately read its resolved settings, which depend on the schema's
+     * `x-envVar` bindings (e.g. `PLUGIN_OPENROUTER_API_KEY`). If we hand back a
+     * cold proxy, `settingsSchema` is `{}`, the env var is never read, and the
+     * provider call fails with `401 Missing Authentication header`. Forcing
+     * materialization here is cheap — only the single plugin actually being
+     * used is imported, not the whole registry, so lazy-load's memory win is
+     * preserved.
+     */
+    private async materializeForUse<T extends IPlugin>(plugin: IPlugin): Promise<T> {
+        const stub = plugin as unknown as {
+            __materialize?: () => Promise<IPlugin>;
+        };
+        if (typeof stub.__materialize === 'function') {
+            // Return the REAL instance, not the lazy proxy. The proxy forwards
+            // every method through `ensureMaterialized().then(...)`, so it wraps
+            // results in a Promise — which silently breaks methods that must
+            // return a value synchronously, notably the streaming generator
+            // `createStreamingChatCompletion()` (a `Promise<AsyncGenerator>` is
+            // not itself async-iterable → "is not a function or its return
+            // value is not async iterable"). Handing back the materialized
+            // instance lets the facade call real methods directly. Settings
+            // resolution is unaffected: it looks the plugin up by id in the
+            // registry (still the proxy) and reads its now-materialized schema.
+            return (await stub.__materialize()) as T;
+        }
+        return plugin as T;
     }
 }

--- a/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
+++ b/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
@@ -50,6 +50,30 @@ describe('lazy-plugin-proxy', () => {
         expect(stub.__isMaterialized).toBe(true);
     });
 
+    it('exposes the real plugin settingsSchema only after materialization', async () => {
+        // Regression for the lazy-load PR #1156 chat outage: while cold the
+        // proxy returned `{}` for settingsSchema (the package.json manifest
+        // carries no JSON-Schema), and it kept returning `{}` even AFTER
+        // materialization. Settings resolution then found no x-envVar-bound
+        // fields (e.g. the OpenRouter apiKey), never read PLUGIN_OPENROUTER_API_KEY,
+        // and AI calls failed with "401 Missing Authentication header".
+        const onLoad = jest.fn().mockResolvedValue(undefined);
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('p-schema', onLoad));
+        const stub = createLazyPluginProxy(makeManifest('p-schema'), loader);
+
+        // Cold: no import cost, empty schema from the manifest.
+        expect(stub.settingsSchema).toEqual({});
+        expect(loader).not.toHaveBeenCalled();
+
+        // After materialization the proxy must delegate to the real plugin's
+        // class-level schema.
+        await stub.__materialize();
+        expect(stub.settingsSchema).toEqual({
+            type: 'object',
+            properties: { apiKey: { type: 'string' } },
+        });
+    });
+
     it('shares a single import across concurrent method calls', async () => {
         const onLoad = jest.fn().mockResolvedValue(undefined);
         let resolveLoader!: (p: IPlugin) => void;

--- a/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
+++ b/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
@@ -125,9 +125,23 @@ export function createLazyPluginProxy(
             return manifest.capabilities;
         },
         get settingsSchema() {
+            // Once the real plugin is materialized, its class-level JSON-Schema
+            // is the source of truth (the manifest/package.json does not carry
+            // it). Falling back to the manifest while cold keeps sync metadata
+            // reads cheap; delegating after materialization is what lets
+            // settings resolution (incl. x-envVar bindings like
+            // PLUGIN_OPENROUTER_API_KEY) see the real schema instead of `{}`.
+            const real = materialized as unknown as Record<string, unknown> | null;
+            if (real && real.settingsSchema !== undefined) {
+                return real.settingsSchema;
+            }
             return manifestExt.settingsSchema ?? {};
         },
         get configurationMode() {
+            const real = materialized as unknown as Record<string, unknown> | null;
+            if (real && real.configurationMode !== undefined) {
+                return real.configurationMode;
+            }
             return manifestExt.configurationMode;
         },
         get __isMaterialized() {

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -1716,7 +1716,13 @@ export class PluginOperationsService {
 
         if (plugin?.validateSettings) {
             const pluginResult = await plugin.validateSettings(settings);
-            if (!pluginResult.valid) {
+            // Under lazy plugin loading the proxy exposes optional lifecycle
+            // methods (validateSettings is optional) as a forwarding wrapper
+            // even when the real plugin doesn't implement them; calling it then
+            // resolves to `undefined`. Treat a missing/undefined result as "no
+            // custom validation" instead of dereferencing `.valid` — that threw
+            // `Cannot read properties of undefined (reading 'valid')` → HTTP 500.
+            if (pluginResult && !pluginResult.valid) {
                 throw new BadRequestException({
                     message: 'Invalid plugin settings',
                     errors: pluginResult.errors?.map((e) => e.message) ?? [


### PR DESCRIPTION
Cascades [#1190](https://github.com/ever-works/ever-works/pull/1190) to stage: fixes the built-in chat outage from PR #1156 (lazy plugin proxy returned an empty settingsSchema → OpenRouter API key never applied → 401; also fixes streaming + the settings-PATCH 500). Verified locally on develop (streaming + non-streaming chat return real completions; 289 agent tests + regression test green; API RSS ~370–540MB, no leak). Single-commit delta from stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)