### PR TITLE
fix(kb): inherited tree excludes Work-overridden docs

### DIFF
--- a/apps/web/src/components/works/detail/kb/KbTreePanel.tsx
+++ b/apps/web/src/components/works/detail/kb/KbTreePanel.tsx
@@ -70,7 +70,19 @@ export async function KbTreePanel({
 }: KbTreePanelProps) {
     const t = await getTranslations('dashboard.workDetail.kb');
 
-    if (documents.length === 0 && inheritedDocuments.length === 0) {
+    // `inheritedDocuments` comes from `resolveInheritableDocuments`, which
+    // returns the MERGED effective set (org docs with Work overrides applied
+    // by path) — so once a Work overrides an inherited doc, that path comes
+    // back as a Work-OWNED row (`workId !== null`). The "Inherited from
+    // organization" section must only show docs the Work has NOT overridden
+    // (genuinely org-scoped, `workId === null`); the overridden copy already
+    // appears in the Work-owned `documents` list under its class group.
+    // Without this filter the overridden doc lingers in the inherited
+    // section (EW-641 row 38d / kb-inherited.spec.ts step 7 — "override
+    // masks the inherited row").
+    const orgInheritedDocuments = inheritedDocuments.filter((doc) => doc.workId === null);
+
+    if (documents.length === 0 && orgInheritedDocuments.length === 0) {
         return (
             <section
                 data-testid="kb-tree"
@@ -116,10 +128,10 @@ export async function KbTreePanel({
             </header>
 
             <nav aria-label={t('panes.tree.title')} className="flex flex-col gap-3">
-                {inheritedDocuments.length > 0 ? (
+                {orgInheritedDocuments.length > 0 ? (
                     <KbInheritedSection
                         workId={workId}
-                        documents={inheritedDocuments}
+                        documents={orgInheritedDocuments}
                         sectionTitle={t('panes.tree.inheritedSection.title')}
                         sectionEmptyDescription={t('panes.tree.inheritedSection.description')}
                         lockedLabel={t('panes.tree.inheritedSection.lockedLabel')}

--- a/apps/web/src/components/works/detail/kb/KbTreePanel.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbTreePanel.unit.spec.tsx
@@ -307,13 +307,18 @@ describe('KbTreePanel', () => {
                     workId: 'work-1',
                     documents: [],
                     inheritedDocuments: [
-                        // Seed order is intentionally noisy.
+                        // Seed order is intentionally noisy. Inherited docs are
+                        // org-scoped (workId === null) — the tree's inherited
+                        // section only renders genuine org docs (overrides are
+                        // Work-owned and filtered out).
                         doc({
                             id: '1',
                             title: 'zebra',
                             class: 'style',
                             slug: 'z',
                             path: 'style/z.md',
+                            workId: null,
+                            organizationId: 'org-1',
                         }),
                         doc({
                             id: '2',
@@ -321,6 +326,8 @@ describe('KbTreePanel', () => {
                             class: 'legal',
                             slug: 'a',
                             path: 'legal/a.md',
+                            workId: null,
+                            organizationId: 'org-1',
                         }),
                         doc({
                             id: '3',
@@ -328,6 +335,8 @@ describe('KbTreePanel', () => {
                             class: 'legal',
                             slug: 'b',
                             path: 'legal/b.md',
+                            workId: null,
+                            organizationId: 'org-1',
                         }),
                         doc({
                             id: '4',
@@ -335,6 +344,8 @@ describe('KbTreePanel', () => {
                             class: 'style',
                             slug: 'c',
                             path: 'style/c.md',
+                            workId: null,
+                            organizationId: 'org-1',
                         }),
                     ],
                 }),
@@ -360,6 +371,8 @@ describe('KbTreePanel', () => {
                             class: 'legal',
                             slug: 'privacy',
                             path: 'legal/privacy.md',
+                            workId: null,
+                            organizationId: 'org-1',
                         }),
                     ],
                 }),
@@ -373,6 +386,95 @@ describe('KbTreePanel', () => {
             expect(screen.getByTestId('kb-tree-inherited-description').textContent).toBe(
                 'panes.tree.inheritedSection.description',
             );
+        });
+
+        // ─── EW-641 Phase 2/e row 38d — override masks the inherited row ───
+        // `inheritedDocuments` is the MERGED effective set from
+        // `resolveInheritableDocuments` (org docs with Work overrides applied
+        // by path). Once a Work overrides an inherited doc, that path comes
+        // back Work-OWNED (`workId !== null`) and must NOT appear in the
+        // "Inherited from organization" section — the Work-owned copy lives in
+        // the per-class groups instead. (kb-inherited.spec.ts step 7.)
+        it('excludes Work-overridden docs (workId !== null) from the inherited section', async () => {
+            render(
+                await KbTreePanel({
+                    workId: 'work-1',
+                    documents: [
+                        // The override surfaces here as a normal Work-owned doc.
+                        doc({
+                            id: 'work-privacy',
+                            title: 'Privacy',
+                            class: 'legal',
+                            slug: 'privacy',
+                            path: 'legal/privacy.md',
+                            workId: 'work-1',
+                            organizationId: null,
+                        }),
+                    ],
+                    inheritedDocuments: [
+                        // Merged set: the privacy path is now Work-owned (overridden)…
+                        doc({
+                            id: 'work-privacy',
+                            title: 'Privacy',
+                            class: 'legal',
+                            slug: 'privacy',
+                            path: 'legal/privacy.md',
+                            workId: 'work-1',
+                            organizationId: null,
+                        }),
+                        // …while terms is still a genuine org-scoped inherited doc.
+                        doc({
+                            id: 'org-terms',
+                            title: 'Terms',
+                            class: 'legal',
+                            slug: 'terms',
+                            path: 'legal/terms.md',
+                            workId: null,
+                            organizationId: 'org-1',
+                        }),
+                    ],
+                }),
+            );
+
+            // The overridden privacy row must NOT show in the inherited section.
+            expect(screen.queryByTestId('kb-tree-inherited-legal-privacy')).toBeNull();
+            // The still-inherited terms row remains.
+            expect(screen.getByTestId('kb-tree-inherited-legal-terms')).toBeTruthy();
+        });
+
+        it('hides the inherited section entirely when every inherited doc is overridden', async () => {
+            render(
+                await KbTreePanel({
+                    workId: 'work-1',
+                    documents: [
+                        doc({
+                            id: 'work-privacy',
+                            title: 'Privacy',
+                            class: 'legal',
+                            slug: 'privacy',
+                            path: 'legal/privacy.md',
+                            workId: 'work-1',
+                            organizationId: null,
+                        }),
+                    ],
+                    inheritedDocuments: [
+                        doc({
+                            id: 'work-privacy',
+                            title: 'Privacy',
+                            class: 'legal',
+                            slug: 'privacy',
+                            path: 'legal/privacy.md',
+                            workId: 'work-1',
+                            organizationId: null,
+                        }),
+                    ],
+                }),
+            );
+
+            // Only an overridden (Work-owned) entry remains → no inherited section.
+            expect(screen.queryByTestId('kb-tree-inherited')).toBeNull();
+            // The Work-owned copy still renders in its class group.
+            expect(screen.getByTestId('kb-tree-group-legal')).toBeTruthy();
         });
     });
 });


### PR DESCRIPTION
## What

The KB tree's "Inherited from organization" section kept showing a doc as still-inherited **after** the user clicked "Override locally" — the last remaining e2e failure: `kb-inherited.spec.ts:54` step 7 (`expect(getByTestId('kb-tree-inherited-legal-privacy')).toHaveCount(0)` received 1).

## Root cause

`KbTreePanel` renders the inherited section from `inheritedDocuments`, which is the **merged effective set** from `resolveInheritableDocuments` (org docs with Work overrides applied by path). Once a Work overrides an inherited doc, that path returns **Work-owned** (`workId !== null`) — but the tree still rendered it as an inherited row.

## Fix

Filter the inherited section to genuinely org-scoped docs (`workId === null`). The overridden copy already shows in the Work-owned `documents` list under its class group. Web-only render change — `resolveInheritableDocuments` keeps its merged-set semantics (its unit test + the agent-context contract are untouched).

## Tests
- Added 2 `KbTreePanel` unit tests (override excluded from section; section hidden when all overridden).
- Corrected 2 pre-existing inherited-section fixtures that built org docs without `workId: null` (they only passed before because the buggy code never filtered).
- **17/17 KbTreePanel unit tests pass** locally.

This is the last known deterministic e2e failure on develop (shards 1/3/4 + e2e-prod-build + lint already green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where inherited documents customized at the work level would appear in both the work-owned and inherited sections. Customized inherited documents now display only in their correct location, and the inherited section properly hides when all inherited documents are customized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->