### PR TITLE
release: stage → main (chat lazy-plugin fix #1190 + staged fixes)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,30 +3,24 @@ name: E2E Tests
 # Playwright e2e suite — auto-starts API (sqlite in-memory) + Next.js dev
 # server in the runner, then runs all specs from apps/web/e2e/.
 #
-# Scope:
-#   - push to `stage` / `main`            → run (release gate)
-#   - pull_request to `develop`/`stage`/`main` → run (pre-merge validation)
-#   - workflow_dispatch on any branch     → run (one-off verification)
+# Scope (intentionally BRANCH-ONLY — never runs on feature/fix branches):
+#   - push to `develop` / `stage` / `main` (+ `master`) → run (release-line gate)
+#   - workflow_dispatch on any branch                   → run (one-off verification)
 #
-# The full suite is sharded 4× across the matrix (~25 min wall-clock per
-# shard on ubicloud-standard-8). PR pre-validation was added because
-# stage/main-only triggers let test debt accumulate undetected until the
-# release cut. If PR cost proves too high, narrow the `pull_request:`
-# branches list to `[stage, main]` only.
+# There is deliberately NO `pull_request` trigger. The full suite is
+# sharded 4× across the matrix (~25 min wall-clock per shard on
+# ubicloud-standard-8), so running it on every feature/fix PR burned
+# runners without gating anything the post-merge branch push doesn't
+# already catch. e2e now runs only once code lands on a release-line
+# branch (`develop`, `stage`, `main`/`master`). The `concurrency` block
+# below cancels a superseded run when a newer commit reaches the same
+# branch, so only the latest commit per branch is ever validated.
 #
 # See Workspace/knowledge/runbooks/CI_RELEASE_GATES.md for the policy.
 
 on:
   push:
-    branches: [stage, main]
-  # Pre-validate PRs heading into the release pipeline so test debt
-  # surfaces BEFORE the merge instead of after. Sharded across 4
-  # runners (~25 min wall-clock), so the cost is bearable to catch
-  # regressions before they reach `stage`. If this proves too
-  # expensive, narrow to `[stage, main]` only and rely on push for
-  # `develop`-merged regressions.
-  pull_request:
-    branches: [develop, stage, main]
+    branches: [develop, stage, main, master]
   workflow_dispatch:
 
 # M-12: minimum default permissions. Individual jobs can elevate where needed.

--- a/packages/agent/src/facades/base.facade.ts
+++ b/packages/agent/src/facades/base.facade.ts
@@ -318,21 +318,56 @@ export abstract class BaseFacadeService {
                 registered.state === 'loaded'
             ) {
                 const isEnabled = await this.isPluginEnabled(effectiveOverride, workId, userId);
-                if (isEnabled) return registered.plugin as T;
+                if (isEnabled) return this.materializeForUse<T>(registered.plugin);
             }
             throw new ProviderNotFoundError(effectiveOverride, this.CAPABILITY);
         }
 
         if (workId) {
             const activePlugin = await this.findActivePluginForWork(workId);
-            if (activePlugin) return activePlugin.plugin as T;
+            if (activePlugin) return this.materializeForUse<T>(activePlugin.plugin);
         }
 
         const enabledPlugins = await this.getEnabledPlugins(workId, userId);
         if (enabledPlugins.length > 0) {
-            return enabledPlugins[0].plugin as T;
+            return this.materializeForUse<T>(enabledPlugins[0].plugin);
         }
 
         throw new NoProviderError(this.CAPABILITY);
+    }
+
+    /**
+     * Materialize a (possibly lazy) plugin before an operation uses it.
+     *
+     * Under lazy plugin loading (PR #1156) the registry hands out a proxy whose
+     * synchronous getters — notably `settingsSchema` — only reflect the real
+     * plugin AFTER materialization. `resolvePlugin` is the operation path: the
+     * caller is about to use this plugin (chat / search / deploy / …) and will
+     * immediately read its resolved settings, which depend on the schema's
+     * `x-envVar` bindings (e.g. `PLUGIN_OPENROUTER_API_KEY`). If we hand back a
+     * cold proxy, `settingsSchema` is `{}`, the env var is never read, and the
+     * provider call fails with `401 Missing Authentication header`. Forcing
+     * materialization here is cheap — only the single plugin actually being
+     * used is imported, not the whole registry, so lazy-load's memory win is
+     * preserved.
+     */
+    private async materializeForUse<T extends IPlugin>(plugin: IPlugin): Promise<T> {
+        const stub = plugin as unknown as {
+            __materialize?: () => Promise<IPlugin>;
+        };
+        if (typeof stub.__materialize === 'function') {
+            // Return the REAL instance, not the lazy proxy. The proxy forwards
+            // every method through `ensureMaterialized().then(...)`, so it wraps
+            // results in a Promise — which silently breaks methods that must
+            // return a value synchronously, notably the streaming generator
+            // `createStreamingChatCompletion()` (a `Promise<AsyncGenerator>` is
+            // not itself async-iterable → "is not a function or its return
+            // value is not async iterable"). Handing back the materialized
+            // instance lets the facade call real methods directly. Settings
+            // resolution is unaffected: it looks the plugin up by id in the
+            // registry (still the proxy) and reads its now-materialized schema.
+            return (await stub.__materialize()) as T;
+        }
+        return plugin as T;
     }
 }

--- a/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
+++ b/packages/agent/src/plugins/__tests__/lazy-plugin-proxy.spec.ts
@@ -50,6 +50,30 @@ describe('lazy-plugin-proxy', () => {
         expect(stub.__isMaterialized).toBe(true);
     });
 
+    it('exposes the real plugin settingsSchema only after materialization', async () => {
+        // Regression for the lazy-load PR #1156 chat outage: while cold the
+        // proxy returned `{}` for settingsSchema (the package.json manifest
+        // carries no JSON-Schema), and it kept returning `{}` even AFTER
+        // materialization. Settings resolution then found no x-envVar-bound
+        // fields (e.g. the OpenRouter apiKey), never read PLUGIN_OPENROUTER_API_KEY,
+        // and AI calls failed with "401 Missing Authentication header".
+        const onLoad = jest.fn().mockResolvedValue(undefined);
+        const loader = jest.fn().mockResolvedValue(makeRealPlugin('p-schema', onLoad));
+        const stub = createLazyPluginProxy(makeManifest('p-schema'), loader);
+
+        // Cold: no import cost, empty schema from the manifest.
+        expect(stub.settingsSchema).toEqual({});
+        expect(loader).not.toHaveBeenCalled();
+
+        // After materialization the proxy must delegate to the real plugin's
+        // class-level schema.
+        await stub.__materialize();
+        expect(stub.settingsSchema).toEqual({
+            type: 'object',
+            properties: { apiKey: { type: 'string' } },
+        });
+    });
+
     it('shares a single import across concurrent method calls', async () => {
         const onLoad = jest.fn().mockResolvedValue(undefined);
         let resolveLoader!: (p: IPlugin) => void;

--- a/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
+++ b/packages/agent/src/plugins/services/lazy-plugin-proxy.ts
@@ -125,9 +125,23 @@ export function createLazyPluginProxy(
             return manifest.capabilities;
         },
         get settingsSchema() {
+            // Once the real plugin is materialized, its class-level JSON-Schema
+            // is the source of truth (the manifest/package.json does not carry
+            // it). Falling back to the manifest while cold keeps sync metadata
+            // reads cheap; delegating after materialization is what lets
+            // settings resolution (incl. x-envVar bindings like
+            // PLUGIN_OPENROUTER_API_KEY) see the real schema instead of `{}`.
+            const real = materialized as unknown as Record<string, unknown> | null;
+            if (real && real.settingsSchema !== undefined) {
+                return real.settingsSchema;
+            }
             return manifestExt.settingsSchema ?? {};
         },
         get configurationMode() {
+            const real = materialized as unknown as Record<string, unknown> | null;
+            if (real && real.configurationMode !== undefined) {
+                return real.configurationMode;
+            }
             return manifestExt.configurationMode;
         },
         get __isMaterialized() {

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -1716,7 +1716,13 @@ export class PluginOperationsService {
 
         if (plugin?.validateSettings) {
             const pluginResult = await plugin.validateSettings(settings);
-            if (!pluginResult.valid) {
+            // Under lazy plugin loading the proxy exposes optional lifecycle
+            // methods (validateSettings is optional) as a forwarding wrapper
+            // even when the real plugin doesn't implement them; calling it then
+            // resolves to `undefined`. Treat a missing/undefined result as "no
+            // custom validation" instead of dereferencing `.valid` — that threw
+            // `Cannot read properties of undefined (reading 'valid')` → HTTP 500.
+            if (pluginResult && !pluginResult.valid) {
                 throw new BadRequestException({
                     message: 'Invalid plugin settings',
                     errors: pluginResult.errors?.map((e) => e.message) ?? [

--- a/packages/agent/src/services/__tests__/generator-form-schema.service.spec.ts
+++ b/packages/agent/src/services/__tests__/generator-form-schema.service.spec.ts
@@ -220,6 +220,33 @@ describe('GeneratorFormSchemaService', () => {
             expect(pipelineFields).toHaveLength(1);
             expect(apifyFields).toHaveLength(1);
         });
+
+        it('does not 500 when a pipeline plugin getFormFields() returns a non-array', async () => {
+            // Regression: agent-pipeline's getFormFields() returned a non-array
+            // at runtime despite its FormFieldDefinition[] type, so the
+            // `pluginFields.map(...)` in getFormSchema threw
+            // `TypeError: pluginFields.map is not a function` and 500'd the
+            // whole GET /works/:id/generator-form endpoint. getFormSchema must
+            // coerce a non-array to [] so one misbehaving plugin can't take
+            // down form-schema resolution.
+            const brokenPipeline = createFormSchemaPlugin('agent-pipeline', [], {
+                category: 'pipeline',
+                capabilities: ['pipeline', 'form-schema-provider'],
+            });
+            // getFormFields stays a function (so isFormSchemaProvider passes) but
+            // returns undefined — the exact misbehaving runtime contract.
+            (brokenPipeline as { getFormFields: () => unknown }).getFormFields = () => undefined;
+            const registered = createRegistered(brokenPipeline);
+
+            mockRegistry.get.mockImplementation((id: string) =>
+                id === 'agent-pipeline' ? registered : undefined,
+            );
+
+            const schema = await service.getFormSchema('agent-pipeline');
+
+            expect(Array.isArray(schema.pluginFields)).toBe(true);
+            expect(schema.pluginFields).toHaveLength(0);
+        });
     });
 
     describe('processFormConfig', () => {

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -348,15 +348,18 @@ export class GeneratorFormSchemaService {
                     ),
                 );
             } catch (error) {
-                // Pass the stack as the 2nd arg so the NestJS logger attaches
-                // the full call chain — without it (once the PostHog logger
-                // fix #1183 restores logging) only the bare message would
-                // surface, making the originally-throwing plugin hard to trace.
+                // Embed the stack INSIDE the message rather than passing it as
+                // the 2nd arg: NestJS `Logger.warn(message, context?)` treats
+                // the 2nd arg as the context prefix, and PostHogLoggerService
+                // hard-codes warn's trace to undefined — so a 2nd-arg stack
+                // would clobber the "GeneratorFormSchemaService" context without
+                // recording a trace. Embedding keeps the context AND surfaces
+                // the full call chain (error.stack starts with the message)
+                // once the PostHog logger fix (#1183) restores prod logging.
+                const reason =
+                    error instanceof Error ? (error.stack ?? error.message) : String(error);
                 this.logger.warn(
-                    `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${
-                        error instanceof Error ? error.message : String(error)
-                    }`,
-                    error instanceof Error ? error.stack : undefined,
+                    `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${reason}`,
                 );
             }
         }

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -348,10 +348,15 @@ export class GeneratorFormSchemaService {
                     ),
                 );
             } catch (error) {
+                // Pass the stack as the 2nd arg so the NestJS logger attaches
+                // the full call chain — without it (once the PostHog logger
+                // fix #1183 restores logging) only the bare message would
+                // surface, making the originally-throwing plugin hard to trace.
                 this.logger.warn(
                     `Skipping provider "${registered.plugin.id}" for capability "${capability}": ${
                         error instanceof Error ? error.message : String(error)
                     }`,
+                    error instanceof Error ? error.stack : undefined,
                 );
             }
         }

--- a/packages/agent/src/services/generator-form-schema.service.ts
+++ b/packages/agent/src/services/generator-form-schema.service.ts
@@ -95,7 +95,15 @@ export class GeneratorFormSchemaService {
         if (pipelinePlugin && isFormSchemaProvider(pipelinePlugin.plugin)) {
             const provider = pipelinePlugin.plugin;
 
-            pluginFields = provider.getFormFields();
+            // Defensive: getFormFields() is typed `FormFieldDefinition[]`, but a
+            // misbehaving pipeline plugin (observed: agent-pipeline) can return a
+            // non-array at runtime — which made `pluginFields.map(...)` below throw
+            // `TypeError: pluginFields.map is not a function` and 500 the whole
+            // GET /generator-form endpoint. Coerce to [] so one bad plugin can't
+            // take down form-schema resolution (same resilience stance as the
+            // per-plugin try/catch in getProvidersForCapability, #1184).
+            const resolvedFields = provider.getFormFields();
+            pluginFields = Array.isArray(resolvedFields) ? resolvedFields : [];
             pluginGroups = provider.getFormGroups?.();
             handledConfigFields = provider.handledConfigFields ?? [];
             defaultValues = provider.getDefaultValues?.();


### PR DESCRIPTION
Promotes the verified stage release to production. Headline: fixes the built-in chat outage from PR #1156 (lazy plugin proxy empty settingsSchema → OpenRouter key never applied → 401; plus streaming + settings-PATCH 500). **Verified on the deployed stage env**: same token returned 401 before deploy, real completion (HTTP 200) after. Also carries previously-staged fixes (#1189 generator-form 500 guard, e2e-branch-only CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)