### PR TITLE
test(e2e): warm up dashboard routes to kill dev-compile flakiness

### DIFF
--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -14,8 +14,10 @@ const credentialsFile = 'e2e/.auth/test-user.json';
  */
 setup('authenticate', async ({ page, baseURL }) => {
     // Dev-mode compilation of the dashboard route on first hit can take a
-    // long time, so the whole setup needs a generous budget.
-    setup.setTimeout(300_000);
+    // long time, and step 7 below additionally pre-compiles the heavy
+    // dashboard routes (10-25s EACH on a cold runner), so the whole setup
+    // needs a very generous budget.
+    setup.setTimeout(600_000);
 
     // 1. Register the user via API (fast)
     try {
@@ -140,4 +142,45 @@ setup('authenticate', async ({ page, baseURL }) => {
         JSON.stringify({ ...TEST_USER, generatedAt: new Date().toISOString() }, null, 2),
         'utf8',
     );
+
+    // 7. Warm up the heavy dashboard routes. The sharded e2e job runs the
+    //    web tier under `next dev`, which compiles each route LAZILY on its
+    //    first visit — a 10-25s cold compile. The first spec to hit an
+    //    un-warmed route can blow past its own navigation timeout, which is
+    //    the intermittent "random" flakiness seen on /tasks/new,
+    //    /settings/*, /missions and /ideas. Pre-visiting them here — while
+    //    the browser is still authenticated (storageState saved in step 5)
+    //    so the auth-gated routes actually COMPILE instead of redirecting
+    //    to /login — moves that one-time compile into setup, before any
+    //    assertions run, so every spec hits an already-warm route.
+    //
+    //    Best-effort: every artifact above is already written, so a slow or
+    //    failing warm-up must NEVER fail setup or block the suite. Each
+    //    visit is individually guarded.
+    const warmupRoutes = [
+        '/en/works',
+        '/en/tasks',
+        '/en/tasks/new',
+        '/en/missions',
+        '/en/ideas',
+        '/en/skills',
+        '/en/agents',
+        '/en/activity',
+        '/en/plugins',
+        '/en/settings',
+        '/en/settings/api-keys',
+        '/en/settings/security',
+        '/en/settings/data',
+        '/en/settings/danger',
+        '/en/settings/notifications',
+        '/en/settings/integrations/channels',
+        '/en/works/new',
+    ];
+    for (const route of warmupRoutes) {
+        try {
+            await page.goto(route, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+        } catch {
+            // Best-effort warm-up — never block the suite on a slow compile.
+        }
+    }
 });


### PR DESCRIPTION
## Why
After the deterministic e2e bugs were fixed (kb-inherited #1192, generator-form #1184/#1185, posthog #1183, RegExp-OOM start:prod, Lottie proxy), the remaining develop e2e redness is **dev-server cold-compile flakiness**: the sharded job runs the web tier under `next dev`, which compiles each route **lazily on first visit** (10-25s). The first spec to hit an un-warmed dashboard route (`/tasks/new`, `/settings/*`, `/missions`, `/ideas`) blows past its navigation timeout — 1 hard-fail + several retry-"flaky" per run, while the API stays healthy. The failing shard rotates run-to-run.

## Fix (the "warm it up until ready" idea)
The Playwright setup project already logs in and saves the authenticated `storageState`. Extend it to **pre-visit the heavy dashboard routes while authenticated** so the auth-gated routes actually *compile* (instead of redirecting to `/login`). This moves the one-time per-route compile into setup, before any assertions run.

- Best-effort + individually `try/catch`-guarded; all artifacts written first → a slow/failing warm-up never blocks the suite.
- Setup timeout 300s→600s.
- Pure timing change — no assertions, no app code, dev/prod split untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved E2E test setup with extended timeout budget and comprehensive warm-up phase for authenticated dashboard routes to enhance test stability and prevent flaky behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->