### PR TITLE
fix(e2e): bound global-setup warm-up below the setup timeout

### DIFF
--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -176,11 +176,34 @@ setup('authenticate', async ({ page, baseURL }) => {
         '/en/settings/integrations/channels',
         '/en/works/new',
     ];
+    //
+    //    Bound the whole loop so it can NEVER blow the 600s setup budget: a
+    //    degraded dev server that hangs every route at the per-route timeout
+    //    would otherwise accumulate 17 × 60s ≈ 17min and trip
+    //    `setup.setTimeout(600_000)` mid-loop — which would fail the entire
+    //    setup project (including the already-saved auth artifacts) and block
+    //    every dependent spec. So: (a) a 30s per-route cap (cold compile is
+    //    ~10-25s; a route that needs more just warms during its first spec,
+    //    which has its own 90s budget), and (b) a hard cumulative deadline well
+    //    under the setup budget, after which we stop early and log what was
+    //    skipped (never a silent truncation). Codex/Greptile P2 on PR #1196.
+    const WARMUP_BUDGET_MS = 240_000;
+    const warmupDeadline = Date.now() + WARMUP_BUDGET_MS;
+    let warmed = 0;
     for (const route of warmupRoutes) {
+        if (Date.now() > warmupDeadline) {
+            console.warn(
+                `[e2e global-setup] warm-up budget (${WARMUP_BUDGET_MS}ms) exhausted after ` +
+                    `${warmed}/${warmupRoutes.length} routes; skipping the rest. Auth artifacts ` +
+                    `are already saved (steps 5-6); remaining routes warm on first spec hit.`,
+            );
+            break;
+        }
         try {
-            await page.goto(route, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+            await page.goto(route, { waitUntil: 'domcontentloaded', timeout: 30_000 });
         } catch {
             // Best-effort warm-up — never block the suite on a slow compile.
         }
+        warmed++;
     }
 });


### PR DESCRIPTION
## What

Addresses the two P2 review comments on [#1196](https://github.com/ever-works/ever-works/pull/1196) (Codex + Greptile), both on `apps/web/e2e/global-setup.ts`.

The dashboard-route warm-up loop (added in #1195) visits 17 routes at a **60s** per-route navigation timeout. On a degraded dev server that hangs every route, the loop could accumulate ~17 × 60s ≈ 17 min and trip `setup.setTimeout(600_000)` **mid-loop** — which fails the entire `setup` project (including the already-saved auth artifacts in steps 5–6) and blocks every dependent spec.

## Fix

- **30s per-route cap** (cold compile is ~10–25s; a route that needs longer simply warms during its first spec, which has its own 90s budget).
- **Hard 240s cumulative deadline** well under the 600s setup budget; once hit, the loop stops early and **logs** which routes were skipped (no silent truncation).

Worst case is now ~270s (deadline + one in-flight 30s nav), leaving ample headroom under the 600s budget.

## Verification

- `setup` project passes in ~50s on a healthy local stack (warm-up finishes long before the deadline).
- `tsc --noEmit` + prettier clean.

This lands on `develop` and flows into #1196 (develop → stage) automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized end-to-end test performance by implementing time-bounded warm-up for dashboard route initialization, reducing individual timeout from 60s to 30s per route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->