### PR TITLE
fix(e2e): unblock MailHog mail + remaining auth throttles

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -258,6 +258,14 @@ jobs:
           # spec is tolerant — it annotates when no 429 surfaces rather than
           # failing.
           LOGIN_THROTTLE_LIMIT: '100000'
+          # Belt-and-braces for ALL the other audit-added auth throttles
+          # (anonymous 5/h, claim 10/h, forgot/reset-password 5/min, magic-link,
+          # validate-*): rather than tune each per-IP cap, skip throttling for
+          # `/api/auth/*` ONLY (UserAwareThrottlerGuard, hard-gated off in prod).
+          # NON-auth throttling (ingest / notification / global) stays active so
+          # those rate-limit specs keep coverage; the auth-throttle specs already
+          # `test.skip` when no 429 surfaces.
+          E2E_DISABLE_AUTH_THROTTLE: 'true'
           # Subscriptions — flip the kill-switch so the plan / tier /
           # billing-grace specs run their real branches. The default
           # disabled state returns `plan: { code: 'free' }` (post-fix

--- a/apps/api/src/config/user-aware-throttler.guard.ts
+++ b/apps/api/src/config/user-aware-throttler.guard.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
 
 type ThrottledRequest = Record<string, unknown> & {
@@ -7,6 +7,8 @@ type ThrottledRequest = Record<string, unknown> & {
         id?: unknown;
         sub?: unknown;
     };
+    url?: unknown;
+    originalUrl?: unknown;
     ip?: unknown;
     ips?: unknown;
     socket?: {
@@ -16,6 +18,33 @@ type ThrottledRequest = Record<string, unknown> & {
 
 @Injectable()
 export class UserAwareThrottlerGuard extends ThrottlerGuard {
+    /**
+     * Test/CI escape hatch for the AUTH endpoints only. The e2e suite drives
+     * every spec from a single CI IP and must register / log in / mint many
+     * accounts, so the per-IP auth throttles (register 5/min, login 10/min,
+     * anonymous 5/h, …) would 429 its bulk setup. When `E2E_DISABLE_AUTH_THROTTLE`
+     * is set AND we are not in production, skip throttling for `/api/auth/*`
+     * routes. NON-auth throttling (ingest / notification / global tiers) stays
+     * fully active so those rate-limit specs keep their coverage, and this is
+     * HARD-gated off in production so it can never weaken a real deployment.
+     */
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        if (
+            process.env.E2E_DISABLE_AUTH_THROTTLE === 'true' &&
+            process.env.NODE_ENV !== 'production'
+        ) {
+            const req = context.switchToHttp().getRequest<ThrottledRequest>();
+            const rawUrl =
+                (typeof req.originalUrl === 'string' && req.originalUrl) ||
+                (typeof req.url === 'string' && req.url) ||
+                '';
+            if (rawUrl.split('?')[0].startsWith('/api/auth/')) {
+                return true;
+            }
+        }
+        return super.canActivate(context);
+    }
+
     protected getTracker(req: ThrottledRequest): Promise<string> {
         const userId = firstString(req.user?.userId, req.user?.id, req.user?.sub);
         if (userId) {

--- a/apps/api/src/mail/mail.module.ts
+++ b/apps/api/src/mail/mail.module.ts
@@ -19,10 +19,23 @@ import { MailerService } from './providers/mailer.service';
                     port: config.mail.smtpPort(),
                     secure: config.mail.smtpSecure(),
                     ignoreTLS: config.mail.smtpIgnoreTLS(),
-                    auth: {
-                        user: config.mail.smtpUser(),
-                        pass: config.mail.smtpPassword(),
-                    },
+                    // Only send SMTP AUTH when credentials are actually
+                    // configured. A local relay (MailHog/Mailpit, used by e2e)
+                    // accepts unauthenticated mail; passing
+                    // `auth: { user: undefined, pass: undefined }` makes
+                    // nodemailer attempt PLAIN auth with no credentials and
+                    // abort the connection with `Missing credentials for
+                    // "PLAIN"`, so every outbound message silently fails and the
+                    // email-flow e2e specs can't read the sent mail. Ternary
+                    // (not `&&`) keeps the spread typed as an object.
+                    ...(config.mail.smtpUser() && config.mail.smtpPassword()
+                        ? {
+                              auth: {
+                                  user: config.mail.smtpUser(),
+                                  pass: config.mail.smtpPassword(),
+                              },
+                          }
+                        : {}),
                     // Security: verify the SMTP relay's TLS certificate by
                     // default so outbound mail (password-reset, magic-link and
                     // account-deletion tokens) can't be intercepted via a


### PR DESCRIPTION
Follow-up to #1212. After the API booted and register/login were un-throttled, develop's e2e ([run 26876669364](https://github.com/ever-works/ever-works/actions/runs/26876669364)) surfaced two more blockers:

## 1 · SMTP `Missing credentials for "PLAIN"` (dominant — 33 failing assertions)
`mail.module.ts` always set `transport.auth = { user, pass }`. Against MailHog (e2e) those are empty, so nodemailer attempts PLAIN auth with no credentials and **aborts the connection** — every outbound email silently fails and the email-flow specs can't read the sent mail (verification, reset, magic-link).

**Fix:** send `auth` only when credentials are actually configured (ternary spread, not `&&`, to keep it typed). Prod has creds → unchanged; MailHog doesn't need them.

## 2 · Remaining audit-added auth throttles
`anonymous` (5/h), `claim` (10/h), `forgot/reset-password` (5/min), `magic-link`, `validate-*` also 429 the single-CI-IP suite. Rather than tune each per-IP cap, add a **gated skip for `/api/auth/*` only** in `UserAwareThrottlerGuard`, enabled by `E2E_DISABLE_AUTH_THROTTLE` and **hard-gated off in production**.

Non-auth throttling (ingest / notification / global tiers) stays fully active, so those rate-limit specs keep coverage; the auth-throttle specs already `test.skip` when no 429 surfaces.

## Verification
- API type-check green.
- `throttler.config`, `user-aware-throttler.guard`, `mail.service` specs pass (42 tests).
- E2E re-triggered on this branch (`workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end testing reliability for authentication flow validation.

* **Bug Fixes**
  * Improved SMTP email configuration to gracefully handle optional authentication credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->