### PR TITLE
feat(kb): Phase 3 slice 1 — transcribe capability + KB telemetry surface (EW-643)

### DIFF
--- a/docs/specs/features/knowledge-base/phase-3-implementation-notes.md
+++ b/docs/specs/features/knowledge-base/phase-3-implementation-notes.md
@@ -26,16 +26,16 @@ opt-in.
 
 ### What ships
 
-| Area | Path | Notes |
-|---|---|---|
-| `transcribe(file)` capability | `packages/plugin/src/contracts/capabilities/ai-provider.interface.ts` | Optional method on `IAiProviderPlugin`. New `TranscriptionOptions` + `TranscriptionResponse` + `TranscriptionSegment` types. Plugins that don't implement it leave the field `undefined` and `AiFacadeService.transcribe()` (next slice) falls through to the next available provider. |
-| OpenAI Whisper impl | `packages/plugins/openai/src/openai.plugin.ts` | Wraps `/v1/audio/transcriptions` directly with `fetch` + `FormData` to avoid the heavy `openai` SDK dependency. New `transcriptionModel` setting (default `whisper-1`, env override `OPENAI_TRANSCRIPTION_MODEL`). |
-| Activity-log lock events | `packages/agent/src/entities/activity-log.types.ts` | Adds `KB_DOCUMENT_LOCKED`, `KB_DOCUMENT_UNLOCKED`, `KB_DOCUMENT_RESTORED`, `KB_DOCUMENT_LOCK_VIOLATION`, `KB_RECONCILE_COMPLETED`, `KB_UPLOAD_TOMBSTONED`, `KB_UPLOAD_REVIVED`, `KB_CONTEXT_TRUNCATED`, `KB_UPLOAD_TRANSCRIBED`, `KB_UPLOAD_TRANSCRIPTION_FAILED`. Storage is `varchar` (no enum migration needed); API/service layer is the source of allowed strings. |
-| Typed PostHog event surface | `packages/monitoring/src/posthog/kb-events.ts` (new) | One module enumerating every KB-related telemetry event with its property type. Includes a defensive scrubber that strips body-ish properties (`body`, `content`, `markdown`, `text`, `html`, `excerpt`, `snippet`, `chunk`, `raw`, `preview`). In `NODE_ENV=test` the scrubber throws so unit tests can assert the gate; in `production` it strips silently to keep telemetry call sites zero-throw. |
-| Static CI gate | `scripts/ci/no-kb-body-in-events.sh` (new) | Greps every PostHog / activity-log / `emitKbEvent` call site within a tight scope (`apps/api`, `apps/web`, `apps/mcp`, `apps/cli`, `packages/agent`, `packages/tasks`) and looks for forbidden property keys near each emit. Whitelist comment: `// kb-events-allow: <reason>`. |
-| Vitest spec | `packages/monitoring/src/posthog/__tests__/kb-events.spec.ts` | Asserts forward path, no-op on null client, scrubber throws in test mode, and the forbidden-key list exists for the gate. |
+| Area                          | Path                                                                  | Notes                                                                                                                                                                                                                                                                                                                                                                                                 |
+| ----------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `transcribe(file)` capability | `packages/plugin/src/contracts/capabilities/ai-provider.interface.ts` | Optional method on `IAiProviderPlugin`. New `TranscriptionOptions` + `TranscriptionResponse` + `TranscriptionSegment` types. Plugins that don't implement it leave the field `undefined` and `AiFacadeService.transcribe()` (next slice) falls through to the next available provider.                                                                                                                |
+| OpenAI Whisper impl           | `packages/plugins/openai/src/openai.plugin.ts`                        | Wraps `/v1/audio/transcriptions` directly with `fetch` + `FormData` to avoid the heavy `openai` SDK dependency. New `transcriptionModel` setting (default `whisper-1`, env override `OPENAI_TRANSCRIPTION_MODEL`).                                                                                                                                                                                    |
+| Activity-log lock events      | `packages/agent/src/entities/activity-log.types.ts`                   | Adds `KB_DOCUMENT_LOCKED`, `KB_DOCUMENT_UNLOCKED`, `KB_DOCUMENT_RESTORED`, `KB_DOCUMENT_LOCK_VIOLATION`, `KB_RECONCILE_COMPLETED`, `KB_UPLOAD_TOMBSTONED`, `KB_UPLOAD_REVIVED`, `KB_CONTEXT_TRUNCATED`, `KB_UPLOAD_TRANSCRIBED`, `KB_UPLOAD_TRANSCRIPTION_FAILED`. Storage is `varchar` (no enum migration needed); API/service layer is the source of allowed strings.                               |
+| Typed PostHog event surface   | `packages/monitoring/src/posthog/kb-events.ts` (new)                  | One module enumerating every KB-related telemetry event with its property type. Includes a defensive scrubber that strips body-ish properties (`body`, `content`, `markdown`, `text`, `html`, `excerpt`, `snippet`, `chunk`, `raw`, `preview`). In `NODE_ENV=test` the scrubber throws so unit tests can assert the gate; in `production` it strips silently to keep telemetry call sites zero-throw. |
+| Static CI gate                | `scripts/ci/no-kb-body-in-events.sh` (new)                            | Greps every PostHog / activity-log / `emitKbEvent` call site within a tight scope (`apps/api`, `apps/web`, `apps/mcp`, `apps/cli`, `packages/agent`, `packages/tasks`) and looks for forbidden property keys near each emit. Whitelist comment: `// kb-events-allow: <reason>`.                                                                                                                       |
+| Vitest spec                   | `packages/monitoring/src/posthog/__tests__/kb-events.spec.ts`         | Asserts forward path, no-op on null client, scrubber throws in test mode, and the forbidden-key list exists for the gate.                                                                                                                                                                                                                                                                             |
 
-### What is *not* in this slice
+### What is _not_ in this slice
 
 The audit in the parent session named these as the heaviest remaining
 Phase 3 deliverables. They land in follow-up slices on the same
@@ -67,9 +67,9 @@ small and reviewable:
 
 ### Configuration knobs (env)
 
-| Env var | Effect | Default |
-|---|---|---|
-| `OPENAI_TRANSCRIPTION_MODEL` | Whisper model the OpenAI plugin uses. `whisper-1` is cheapest at $0.006/min; `gpt-4o-transcribe` is higher accuracy on noisy audio at higher cost. | `whisper-1` |
+| Env var                        | Effect                                                                                                                                                                                                                                                           | Default                   |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `OPENAI_TRANSCRIPTION_MODEL`   | Whisper model the OpenAI plugin uses. `whisper-1` is cheapest at $0.006/min; `gpt-4o-transcribe` is higher accuracy on noisy audio at higher cost.                                                                                                               | `whisper-1`               |
 | `KB_TRANSCRIPTION_PROVIDER_ID` | Operator-pinned transcription provider for `AiFacadeService.transcribe()`. When set, only this provider is tried; on failure the call throws (no silent fallback). Useful when audit requires sticking to a specific compliance-cleared vendor. Read in slice 2. | _unset_ → first available |
 
 ## How the slice fits the modular plugin design
@@ -94,8 +94,7 @@ slice keeps that contract:
 ## How to verify locally
 
 ```bash
-# From repo root, then in the worktree:
-cd C:/Coding/Worktrees/wt-ew639-phase3
+# From the repo root of your local clone:
 
 # 1) Type-check the touched packages
 pnpm --filter @ever-works/plugin type-check
@@ -106,6 +105,6 @@ pnpm --filter '@ever-works/plugin-openai' type-check  # or whichever plugin id
 # 2) Run the new tests
 pnpm --filter @ever-works/monitoring test -- kb-events
 
-# 3) Run the static CI gate against the worktree
+# 3) Run the static CI gate against the repo
 bash scripts/ci/no-kb-body-in-events.sh .
 ```

--- a/docs/specs/features/knowledge-base/phase-3-implementation-notes.md
+++ b/docs/specs/features/knowledge-base/phase-3-implementation-notes.md
@@ -1,0 +1,111 @@
+# Knowledge Base — Phase 3 implementation notes (EW-643)
+
+**Status**: `In progress`
+**Branch**: `session/ew639-phase3`
+**Tracks**: [EW-639](https://evertech.atlassian.net/browse/EW-639) (epic),
+[EW-643](https://evertech.atlassian.net/browse/EW-643) (Phase 3).
+**See also**: [spec.md](spec.md) · [tasks.md](tasks.md) ·
+[acceptance.md](acceptance.md).
+
+## Why this file exists
+
+`tasks.md` is the human-facing checklist, and `acceptance.md` is the
+acceptance gate. This file is the engineer-facing notebook for the
+Phase 3 PR series — what is shipping in each slice, the contracts that
+new code lands behind, and the deliberate scope cuts. It belongs in
+`docs/specs/features/knowledge-base/` because it is feature-scoped (per
+the platform's CLAUDE.md "no stray docs in root" rule), and it stays
+indexed alongside the rest of the KB spec.
+
+## Slice 1 — contracts (this PR)
+
+Lands the **contracts and emitter surface** that the remaining Phase 3
+slices will plug into. No user-visible behaviour changes; every change
+is additive and gated by capability detection or by an explicit
+opt-in.
+
+### What ships
+
+| Area | Path | Notes |
+|---|---|---|
+| `transcribe(file)` capability | `packages/plugin/src/contracts/capabilities/ai-provider.interface.ts` | Optional method on `IAiProviderPlugin`. New `TranscriptionOptions` + `TranscriptionResponse` + `TranscriptionSegment` types. Plugins that don't implement it leave the field `undefined` and `AiFacadeService.transcribe()` (next slice) falls through to the next available provider. |
+| OpenAI Whisper impl | `packages/plugins/openai/src/openai.plugin.ts` | Wraps `/v1/audio/transcriptions` directly with `fetch` + `FormData` to avoid the heavy `openai` SDK dependency. New `transcriptionModel` setting (default `whisper-1`, env override `OPENAI_TRANSCRIPTION_MODEL`). |
+| Activity-log lock events | `packages/agent/src/entities/activity-log.types.ts` | Adds `KB_DOCUMENT_LOCKED`, `KB_DOCUMENT_UNLOCKED`, `KB_DOCUMENT_RESTORED`, `KB_DOCUMENT_LOCK_VIOLATION`, `KB_RECONCILE_COMPLETED`, `KB_UPLOAD_TOMBSTONED`, `KB_UPLOAD_REVIVED`, `KB_CONTEXT_TRUNCATED`, `KB_UPLOAD_TRANSCRIBED`, `KB_UPLOAD_TRANSCRIPTION_FAILED`. Storage is `varchar` (no enum migration needed); API/service layer is the source of allowed strings. |
+| Typed PostHog event surface | `packages/monitoring/src/posthog/kb-events.ts` (new) | One module enumerating every KB-related telemetry event with its property type. Includes a defensive scrubber that strips body-ish properties (`body`, `content`, `markdown`, `text`, `html`, `excerpt`, `snippet`, `chunk`, `raw`, `preview`). In `NODE_ENV=test` the scrubber throws so unit tests can assert the gate; in `production` it strips silently to keep telemetry call sites zero-throw. |
+| Static CI gate | `scripts/ci/no-kb-body-in-events.sh` (new) | Greps every PostHog / activity-log / `emitKbEvent` call site within a tight scope (`apps/api`, `apps/web`, `apps/mcp`, `apps/cli`, `packages/agent`, `packages/tasks`) and looks for forbidden property keys near each emit. Whitelist comment: `// kb-events-allow: <reason>`. |
+| Vitest spec | `packages/monitoring/src/posthog/__tests__/kb-events.spec.ts` | Asserts forward path, no-op on null client, scrubber throws in test mode, and the forbidden-key list exists for the gate. |
+
+### What is *not* in this slice
+
+The audit in the parent session named these as the heaviest remaining
+Phase 3 deliverables. They land in follow-up slices on the same
+`session/ew639-phase3*` branch family to keep this PR's blast radius
+small and reviewable:
+
+- **ffmpeg-backed video → MP4 + audio → MP3 normalization tasks**
+  (`packages/tasks/src/tasks/trigger/kb-normalize-video.ts`,
+  `kb-normalize-audio.ts`). Blocks A28 + A29.
+- **`AiFacadeService.transcribe()`** that selects the right provider
+  per the chain documented on the interface (operator pin →
+  capability-available → fallback throw). Wires the new
+  `transcribe()` capability into the KB ingest pipeline. Blocks A28 +
+  A29.
+- **MCP `kb` namespace** (`apps/mcp/src/tools/kb/`). One tool file per
+  REST endpoint — `kb.list`, `kb.read`, `kb.search`, `kb.create`,
+  `kb.update`, `kb.upload`. Blocks A32.
+- **CLI `ever works kb` subcommand group** (`apps/cli/src/commands/kb/`).
+  Mirrors the MCP surface. Blocks A33.
+- **Embedded-app outputs viewer** — sandboxed iframe for
+  `outputs/<slug>/index.html` agent-authored bundles. Web-side. Blocks
+  A30 + A31.
+- **Daily reconciliation Trigger.dev task**
+  (`packages/tasks/src/tasks/trigger/kb-reconcile.ts`) +
+  `KbReconcileService`. Blocks A24 (lock-violation surfacing), A35
+  (drift), A36 (orphan tombstones + 7-day grace).
+- **Wikilink resolver + rename rewriter** in the document mutation
+  pipeline. Blocks A34.
+
+### Configuration knobs (env)
+
+| Env var | Effect | Default |
+|---|---|---|
+| `OPENAI_TRANSCRIPTION_MODEL` | Whisper model the OpenAI plugin uses. `whisper-1` is cheapest at $0.006/min; `gpt-4o-transcribe` is higher accuracy on noisy audio at higher cost. | `whisper-1` |
+| `KB_TRANSCRIPTION_PROVIDER_ID` | Operator-pinned transcription provider for `AiFacadeService.transcribe()`. When set, only this provider is tried; on failure the call throws (no silent fallback). Useful when audit requires sticking to a specific compliance-cleared vendor. Read in slice 2. | _unset_ → first available |
+
+## How the slice fits the modular plugin design
+
+The user's brief asked for a modular, plugin-friendly design. This
+slice keeps that contract:
+
+1. **No KB-specific code lives inside `packages/plugin`.** The
+   `transcribe` capability is generic speech-to-text — the same shape
+   any voice-note feature would need. KB consumes it via the facade.
+2. **Per-provider impl lives in the plugin package**, not in the
+   monorepo's core. Other AI-provider plugins (Anthropic, Groq,
+   Google) can ship Whisper-equivalents in their own packages without
+   any core changes.
+3. **Telemetry events live in `packages/monitoring`** so the web,
+   API, MCP, CLI, and worker layers can all import the same typed
+   surface. The scrubber guarantees no KB body content leaks
+   regardless of which layer emits.
+4. **The CI gate is a standalone script**, not coupled to any one
+   framework. It runs in CI, in pre-commit if desired, or ad-hoc.
+
+## How to verify locally
+
+```bash
+# From repo root, then in the worktree:
+cd C:/Coding/Worktrees/wt-ew639-phase3
+
+# 1) Type-check the touched packages
+pnpm --filter @ever-works/plugin type-check
+pnpm --filter @ever-works/monitoring type-check
+pnpm --filter @ever-works/agent type-check
+pnpm --filter '@ever-works/plugin-openai' type-check  # or whichever plugin id
+
+# 2) Run the new tests
+pnpm --filter @ever-works/monitoring test -- kb-events
+
+# 3) Run the static CI gate against the worktree
+bash scripts/ci/no-kb-body-in-events.sh .
+```

--- a/packages/agent/src/entities/__tests__/activity-log.types.spec.ts
+++ b/packages/agent/src/entities/__tests__/activity-log.types.spec.ts
@@ -74,14 +74,16 @@ describe('activity-log.types', () => {
         });
 
         it('has the expected total number of literal values (catch silent additions)', () => {
-            // 84 documented literals — pinned so any silent addition is a
-            // deliberate change. Last bumped by post-PR-1019 follow-up FU-2
-            // (added AGENT_RUN_TRIGGERED + AGENT_TASK_ASSIGNED for the new
-            // controller endpoints; PR #1019 itself had added 30 Agent /
-            // Skill / Task lifecycle values that weren't pinned here at
-            // the time).
+            // 94 documented literals — pinned so any silent addition is a
+            // deliberate change. Last bumped by EW-643 Phase 3 slice 1
+            // (added 10 KB lock/reconcile/transcribe lifecycle values:
+            // KB_DOCUMENT_LOCKED, KB_DOCUMENT_UNLOCKED, KB_DOCUMENT_RESTORED,
+            // KB_DOCUMENT_LOCK_VIOLATION, KB_RECONCILE_COMPLETED,
+            // KB_UPLOAD_TOMBSTONED, KB_UPLOAD_REVIVED, KB_CONTEXT_TRUNCATED,
+            // KB_UPLOAD_TRANSCRIBED, KB_UPLOAD_TRANSCRIPTION_FAILED).
+            // Previously bumped by post-PR-1019 follow-up FU-2 (84).
             const literals = Object.values(ActivityActionType).filter((v) => typeof v === 'string');
-            expect(literals).toHaveLength(84);
+            expect(literals).toHaveLength(94);
         });
 
         it('every literal value is unique (no accidental duplicate string)', () => {

--- a/packages/agent/src/entities/activity-log.types.ts
+++ b/packages/agent/src/entities/activity-log.types.ts
@@ -91,6 +91,29 @@ export enum ActivityActionType {
     KB_DOCUMENT_CREATED = 'kb_document_created',
     KB_DOCUMENT_UPDATED = 'kb_document_updated',
     KB_DOCUMENT_DELETED = 'kb_document_deleted',
+    // EW-643 Phase 3 — lock semantics + reconciliation. Spec §19.1 + §9.6.
+    // LOCKED/UNLOCKED fire on POST /lock and /unlock; RESTORED fires on
+    // restore-from-history; LOCK_VIOLATION fires from the daily Git ↔ DB
+    // reconcile job when a locked document was mutated by a direct Git
+    // push (workbench surfaces this as a banner with accept/revert).
+    KB_DOCUMENT_LOCKED = 'kb_document_locked',
+    KB_DOCUMENT_UNLOCKED = 'kb_document_unlocked',
+    KB_DOCUMENT_RESTORED = 'kb_document_restored',
+    KB_DOCUMENT_LOCK_VIOLATION = 'kb_document_lock_violation',
+    // Reconciliation sweep terminal outcomes. `details` carries `{ scanned,
+    // driftCount, violationCount, orphanCount }`. Orphan tombstoning +
+    // 7-day grace land alongside (KB_UPLOAD_TOMBSTONED on first detection,
+    // KB_UPLOAD_REVIVED when re-uploaded within the grace window).
+    KB_RECONCILE_COMPLETED = 'kb_reconcile_completed',
+    KB_UPLOAD_TOMBSTONED = 'kb_upload_tombstoned',
+    KB_UPLOAD_REVIVED = 'kb_upload_revived',
+    // Context-budget truncation in KbPromptFormatter. Emitted with
+    // `{ requestedTokens, budgetTokens, droppedClasses }` for budget tuning.
+    KB_CONTEXT_TRUNCATED = 'kb_context_truncated',
+    // Transcription pipeline (EW-643 — Whisper / Anthropic). Mirrors the
+    // upload-extraction event shape; transcription is "extraction for media".
+    KB_UPLOAD_TRANSCRIBED = 'kb_upload_transcribed',
+    KB_UPLOAD_TRANSCRIPTION_FAILED = 'kb_upload_transcription_failed',
 
     // Agents / Skills / Tasks (PR #1017 specs — architecture §10).
     // Lifecycle + heartbeat + file edits + budget + skills + tasks.

--- a/packages/monitoring/src/posthog/__tests__/kb-events.spec.ts
+++ b/packages/monitoring/src/posthog/__tests__/kb-events.spec.ts
@@ -1,70 +1,140 @@
-import { describe, expect, it, vi } from 'vitest';
 import {
-	emitKbEvent,
-	KB_EVENT_KIND,
-	KB_EVENTS_FORBIDDEN_PROPERTY_KEYS,
-	type PostHogCaptureClient
+    emitKbEvent,
+    KB_EVENT_KIND,
+    KB_EVENTS_FORBIDDEN_PROPERTY_KEYS,
+    KbForbiddenPropertyError,
+    type PostHogCaptureClient,
 } from '../kb-events';
 
 describe('emitKbEvent', () => {
-	it('forwards a well-formed payload to the PostHog client', () => {
-		const capture = vi.fn();
-		const client: PostHogCaptureClient = { capture };
-		emitKbEvent(client, 'user-1', {
-			kind: KB_EVENT_KIND.DOCUMENT_CREATED,
-			props: {
-				workId: 'w-1',
-				actorType: 'user',
-				documentClass: 'brand',
-				source: 'user',
-				tagCount: 3
-			}
-		});
-		expect(capture).toHaveBeenCalledTimes(1);
-		const arg = capture.mock.calls[0][0];
-		expect(arg.event).toBe('kb.document.created');
-		expect(arg.distinctId).toBe('user-1');
-		expect(arg.properties).toMatchObject({ workId: 'w-1', documentClass: 'brand', tagCount: 3 });
-	});
+    it('forwards a well-formed payload to the PostHog client', () => {
+        const capture = jest.fn();
+        const client: PostHogCaptureClient = { capture };
+        emitKbEvent(client, 'user-1', {
+            kind: KB_EVENT_KIND.DOCUMENT_CREATED,
+            props: {
+                workId: 'w-1',
+                actorType: 'user',
+                documentClass: 'brand',
+                source: 'user',
+                tagCount: 3,
+            },
+        });
+        expect(capture).toHaveBeenCalledTimes(1);
+        const arg = capture.mock.calls[0][0] as {
+            event: string;
+            distinctId: string;
+            properties: Record<string, unknown>;
+        };
+        expect(arg.event).toBe('kb.document.created');
+        expect(arg.distinctId).toBe('user-1');
+        expect(arg.properties).toMatchObject({
+            workId: 'w-1',
+            documentClass: 'brand',
+            tagCount: 3,
+        });
+    });
 
-	it('is a no-op when client is null', () => {
-		expect(() => emitKbEvent(null, 'user-1', {
-			kind: KB_EVENT_KIND.SEARCH_EXECUTED,
-			props: { workId: 'w-1', actorType: 'user', hitCount: 0, usedSemantic: false, durationBucketMs: 50 }
-		})).not.toThrow();
-	});
+    it('is a no-op when client is null', () => {
+        expect(() =>
+            emitKbEvent(null, 'user-1', {
+                kind: KB_EVENT_KIND.SEARCH_EXECUTED,
+                props: {
+                    workId: 'w-1',
+                    actorType: 'user',
+                    hitCount: 0,
+                    usedSemantic: false,
+                    durationBucketMs: 50,
+                },
+            }),
+        ).not.toThrow();
+    });
 
-	it('throws in NODE_ENV=test when a forbidden body-like property is included', () => {
-		const prev = process.env.NODE_ENV;
-		process.env.NODE_ENV = 'test';
-		try {
-			const capture = vi.fn();
-			expect(() =>
-				emitKbEvent({ capture }, 'user-1', {
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					kind: KB_EVENT_KIND.SEARCH_EXECUTED,
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					props: {
-						workId: 'w-1',
-						actorType: 'user',
-						hitCount: 0,
-						usedSemantic: false,
-						durationBucketMs: 50,
-						// Intentional violation — should be caught by scrubPayload's
-						// strict mode in tests.
-						body: 'leaked KB content'
-					} as any
-				})
-			).toThrow(/forbidden property/);
-			expect(capture).not.toHaveBeenCalled();
-		} finally {
-			process.env.NODE_ENV = prev;
-		}
-	});
+    it('throws KbForbiddenPropertyError in NODE_ENV=test when a body-like property is included', () => {
+        const prev = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'test';
+        try {
+            const capture = jest.fn();
+            let caught: unknown;
+            try {
+                emitKbEvent({ capture }, 'user-1', {
+                    kind: KB_EVENT_KIND.SEARCH_EXECUTED,
+                    props: {
+                        workId: 'w-1',
+                        actorType: 'user',
+                        hitCount: 0,
+                        usedSemantic: false,
+                        durationBucketMs: 50,
+                        // Intentional violation — should bubble out as a typed
+                        // KbForbiddenPropertyError, NOT be swallowed by the outer
+                        // catch (Greptile P2 on PR #1215).
+                        body: 'leaked KB content',
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    } as any,
+                });
+            } catch (e) {
+                caught = e;
+            }
+            expect(caught).toBeInstanceOf(KbForbiddenPropertyError);
+            expect((caught as KbForbiddenPropertyError).propertyKey).toBe('body');
+            expect(capture).not.toHaveBeenCalled();
+        } finally {
+            process.env.NODE_ENV = prev;
+        }
+    });
 
-	it('exposes the forbidden-key list for the CI gate', () => {
-		expect(KB_EVENTS_FORBIDDEN_PROPERTY_KEYS).toEqual(
-			expect.arrayContaining(['body', 'content', 'markdown', 'snippet', 'chunk'])
-		);
-	});
+    it('also blocks "text" (the key Greptile flagged as missing from the CI gate regex)', () => {
+        const prev = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'test';
+        try {
+            const capture = jest.fn();
+            expect(() =>
+                emitKbEvent({ capture }, 'user-1', {
+                    kind: KB_EVENT_KIND.SEARCH_EXECUTED,
+                    props: {
+                        workId: 'w-1',
+                        actorType: 'user',
+                        hitCount: 0,
+                        usedSemantic: false,
+                        durationBucketMs: 50,
+                        text: 'leaked KB content',
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    } as any,
+                }),
+            ).toThrow(KbForbiddenPropertyError);
+        } finally {
+            process.env.NODE_ENV = prev;
+        }
+    });
+
+    it('still completes when the PostHog client throws (telemetry must not take down callers)', () => {
+        const prev = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+        try {
+            const capture = jest.fn(() => {
+                throw new Error('network down');
+            });
+            expect(() =>
+                emitKbEvent({ capture }, 'user-1', {
+                    kind: KB_EVENT_KIND.SEARCH_EXECUTED,
+                    props: {
+                        workId: 'w-1',
+                        actorType: 'user',
+                        hitCount: 0,
+                        usedSemantic: false,
+                        durationBucketMs: 50,
+                    },
+                }),
+            ).not.toThrow();
+            expect(capture).toHaveBeenCalledTimes(1);
+        } finally {
+            process.env.NODE_ENV = prev;
+        }
+    });
+
+    it('exposes the forbidden-key list for the CI gate', () => {
+        expect(KB_EVENTS_FORBIDDEN_PROPERTY_KEYS).toEqual(
+            expect.arrayContaining(['body', 'content', 'markdown', 'text', 'snippet', 'chunk']),
+        );
+    });
 });

--- a/packages/monitoring/src/posthog/__tests__/kb-events.spec.ts
+++ b/packages/monitoring/src/posthog/__tests__/kb-events.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	emitKbEvent,
+	KB_EVENT_KIND,
+	KB_EVENTS_FORBIDDEN_PROPERTY_KEYS,
+	type PostHogCaptureClient
+} from '../kb-events';
+
+describe('emitKbEvent', () => {
+	it('forwards a well-formed payload to the PostHog client', () => {
+		const capture = vi.fn();
+		const client: PostHogCaptureClient = { capture };
+		emitKbEvent(client, 'user-1', {
+			kind: KB_EVENT_KIND.DOCUMENT_CREATED,
+			props: {
+				workId: 'w-1',
+				actorType: 'user',
+				documentClass: 'brand',
+				source: 'user',
+				tagCount: 3
+			}
+		});
+		expect(capture).toHaveBeenCalledTimes(1);
+		const arg = capture.mock.calls[0][0];
+		expect(arg.event).toBe('kb.document.created');
+		expect(arg.distinctId).toBe('user-1');
+		expect(arg.properties).toMatchObject({ workId: 'w-1', documentClass: 'brand', tagCount: 3 });
+	});
+
+	it('is a no-op when client is null', () => {
+		expect(() => emitKbEvent(null, 'user-1', {
+			kind: KB_EVENT_KIND.SEARCH_EXECUTED,
+			props: { workId: 'w-1', actorType: 'user', hitCount: 0, usedSemantic: false, durationBucketMs: 50 }
+		})).not.toThrow();
+	});
+
+	it('throws in NODE_ENV=test when a forbidden body-like property is included', () => {
+		const prev = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'test';
+		try {
+			const capture = vi.fn();
+			expect(() =>
+				emitKbEvent({ capture }, 'user-1', {
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					kind: KB_EVENT_KIND.SEARCH_EXECUTED,
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					props: {
+						workId: 'w-1',
+						actorType: 'user',
+						hitCount: 0,
+						usedSemantic: false,
+						durationBucketMs: 50,
+						// Intentional violation — should be caught by scrubPayload's
+						// strict mode in tests.
+						body: 'leaked KB content'
+					} as any
+				})
+			).toThrow(/forbidden property/);
+			expect(capture).not.toHaveBeenCalled();
+		} finally {
+			process.env.NODE_ENV = prev;
+		}
+	});
+
+	it('exposes the forbidden-key list for the CI gate', () => {
+		expect(KB_EVENTS_FORBIDDEN_PROPERTY_KEYS).toEqual(
+			expect.arrayContaining(['body', 'content', 'markdown', 'snippet', 'chunk'])
+		);
+	});
+});

--- a/packages/monitoring/src/posthog/index.ts
+++ b/packages/monitoring/src/posthog/index.ts
@@ -1,3 +1,4 @@
 export * from './posthog.config';
 export * from './posthog.module';
 export * from './posthog-logger.service';
+export * from './kb-events';

--- a/packages/monitoring/src/posthog/kb-events.ts
+++ b/packages/monitoring/src/posthog/kb-events.ts
@@ -24,25 +24,25 @@
  */
 
 export const KB_EVENT_KIND = {
-	WORKBENCH_OPENED: 'kb.workbench.opened',
-	DOCUMENT_CREATED: 'kb.document.created',
-	DOCUMENT_UPDATED: 'kb.document.updated',
-	DOCUMENT_DELETED: 'kb.document.deleted',
-	DOCUMENT_LOCKED: 'kb.document.locked',
-	DOCUMENT_UNLOCKED: 'kb.document.unlocked',
-	DOCUMENT_RESTORED: 'kb.document.restored',
-	DOCUMENT_LOCK_VIOLATION: 'kb.document.lock_violation',
-	UPLOAD_STARTED: 'kb.upload.started',
-	UPLOAD_EXTRACTED: 'kb.upload.extracted',
-	UPLOAD_TRANSCRIBED: 'kb.upload.transcribed',
-	UPLOAD_DEDUPED: 'kb.upload.deduped',
-	UPLOAD_TOMBSTONED: 'kb.upload.tombstoned',
-	UPLOAD_REVIVED: 'kb.upload.revived',
-	SEARCH_EXECUTED: 'kb.search.executed',
-	AI_MESSAGE_SENT: 'kb.ai.message_sent',
-	CONTEXT_INJECTED: 'kb.context.injected',
-	CONTEXT_TRUNCATED: 'kb.context.truncated',
-	RECONCILE_COMPLETED: 'kb.reconcile.completed'
+    WORKBENCH_OPENED: 'kb.workbench.opened',
+    DOCUMENT_CREATED: 'kb.document.created',
+    DOCUMENT_UPDATED: 'kb.document.updated',
+    DOCUMENT_DELETED: 'kb.document.deleted',
+    DOCUMENT_LOCKED: 'kb.document.locked',
+    DOCUMENT_UNLOCKED: 'kb.document.unlocked',
+    DOCUMENT_RESTORED: 'kb.document.restored',
+    DOCUMENT_LOCK_VIOLATION: 'kb.document.lock_violation',
+    UPLOAD_STARTED: 'kb.upload.started',
+    UPLOAD_EXTRACTED: 'kb.upload.extracted',
+    UPLOAD_TRANSCRIBED: 'kb.upload.transcribed',
+    UPLOAD_DEDUPED: 'kb.upload.deduped',
+    UPLOAD_TOMBSTONED: 'kb.upload.tombstoned',
+    UPLOAD_REVIVED: 'kb.upload.revived',
+    SEARCH_EXECUTED: 'kb.search.executed',
+    AI_MESSAGE_SENT: 'kb.ai.message_sent',
+    CONTEXT_INJECTED: 'kb.context.injected',
+    CONTEXT_TRUNCATED: 'kb.context.truncated',
+    RECONCILE_COMPLETED: 'kb.reconcile.completed',
 } as const;
 
 export type KbEventKind = (typeof KB_EVENT_KIND)[keyof typeof KB_EVENT_KIND];
@@ -53,142 +53,157 @@ export type KbEventKind = (typeof KB_EVENT_KIND)[keyof typeof KB_EVENT_KIND];
  * package must not import contracts; it's loaded by API + web + workers).
  */
 export type KbDocumentClassTelemetry =
-	| 'brand'
-	| 'legal'
-	| 'glossary'
-	| 'style'
-	| 'seo'
-	| 'personas'
-	| 'competitors'
-	| 'research'
-	| 'output'
-	| 'freeform';
+    | 'brand'
+    | 'legal'
+    | 'glossary'
+    | 'style'
+    | 'seo'
+    | 'personas'
+    | 'competitors'
+    | 'research'
+    | 'output'
+    | 'freeform';
 
 export type KbDocumentSource = 'user' | 'upload' | 'agent' | 'inherited' | 'cli' | 'mcp';
 
 /** Coarse MIME family for upload events — picked because page-by-page leakage isn't possible from a category. */
-export type KbMimeFamily = 'pdf' | 'doc' | 'sheet' | 'slide' | 'image' | 'video' | 'audio' | 'text' | 'html' | 'other';
+export type KbMimeFamily =
+    | 'pdf'
+    | 'doc'
+    | 'sheet'
+    | 'slide'
+    | 'image'
+    | 'video'
+    | 'audio'
+    | 'text'
+    | 'html'
+    | 'other';
 
 export type KbActorType = 'user' | 'agent' | 'cli' | 'mcp' | 'system';
 
 interface KbBase {
-	workId: string;
-	actorType: KbActorType;
+    workId: string;
+    actorType: KbActorType;
 }
 
 export interface KbWorkbenchOpenedProps extends KbBase {
-	hasOriginals: boolean;
-	hasDocuments: boolean;
+    hasOriginals: boolean;
+    hasDocuments: boolean;
 }
 export interface KbDocumentCreatedProps extends KbBase {
-	documentClass: KbDocumentClassTelemetry;
-	source: KbDocumentSource;
-	tagCount: number;
+    documentClass: KbDocumentClassTelemetry;
+    source: KbDocumentSource;
+    tagCount: number;
 }
 export interface KbDocumentUpdatedProps extends KbBase {
-	documentClass: KbDocumentClassTelemetry;
-	source: KbDocumentSource;
-	bytesDelta: number;
+    documentClass: KbDocumentClassTelemetry;
+    source: KbDocumentSource;
+    bytesDelta: number;
 }
 export interface KbDocumentDeletedProps extends KbBase {
-	documentClass: KbDocumentClassTelemetry;
+    documentClass: KbDocumentClassTelemetry;
 }
 export interface KbDocumentLockedProps extends KbBase {
-	documentClass: KbDocumentClassTelemetry;
-	lockMode: 'full' | 'additions-only';
+    documentClass: KbDocumentClassTelemetry;
+    lockMode: 'full' | 'additions-only';
 }
 export type KbDocumentUnlockedProps = KbBase & { documentClass: KbDocumentClassTelemetry };
 export interface KbDocumentRestoredProps extends KbBase {
-	documentClass: KbDocumentClassTelemetry;
-	fromCommitShaPrefix: string;
+    documentClass: KbDocumentClassTelemetry;
+    fromCommitShaPrefix: string;
 }
 export interface KbDocumentLockViolationProps extends KbBase {
-	documentClass: KbDocumentClassTelemetry;
-	lockMode: 'full' | 'additions-only';
-	detectedBy: 'reconcile' | 'preReceive';
+    documentClass: KbDocumentClassTelemetry;
+    lockMode: 'full' | 'additions-only';
+    detectedBy: 'reconcile' | 'preReceive';
 }
 export interface KbUploadStartedProps extends KbBase {
-	mimeFamily: KbMimeFamily;
-	byteSize: number;
+    mimeFamily: KbMimeFamily;
+    byteSize: number;
 }
 export interface KbUploadExtractedProps extends KbBase {
-	mimeFamily: KbMimeFamily;
-	extractionPluginId: string;
-	durationBucketMs: 100 | 500 | 1000 | 5000 | 30_000 | 120_000 | 600_000;
-	success: boolean;
+    mimeFamily: KbMimeFamily;
+    extractionPluginId: string;
+    durationBucketMs: 100 | 500 | 1000 | 5000 | 30_000 | 120_000 | 600_000;
+    success: boolean;
 }
 export interface KbUploadTranscribedProps extends KbBase {
-	mimeFamily: KbMimeFamily;
-	transcriptionProviderId: string;
-	durationSecondsBucket: 10 | 60 | 300 | 1800 | 7200;
-	success: boolean;
+    mimeFamily: KbMimeFamily;
+    transcriptionProviderId: string;
+    durationSecondsBucket: 10 | 60 | 300 | 1800 | 7200;
+    success: boolean;
 }
 export interface KbUploadDedupedProps extends KbBase {
-	mimeFamily: KbMimeFamily;
+    mimeFamily: KbMimeFamily;
 }
 export interface KbUploadTombstonedProps extends KbBase {
-	mimeFamily: KbMimeFamily;
-	graceDays: number;
+    mimeFamily: KbMimeFamily;
+    graceDays: number;
 }
 export interface KbUploadRevivedProps extends KbBase {
-	mimeFamily: KbMimeFamily;
+    mimeFamily: KbMimeFamily;
 }
 export interface KbSearchExecutedProps extends KbBase {
-	hitCount: number;
-	usedSemantic: boolean;
-	durationBucketMs: 50 | 100 | 250 | 500 | 1000 | 5000;
+    hitCount: number;
+    usedSemantic: boolean;
+    durationBucketMs: 50 | 100 | 250 | 500 | 1000 | 5000;
 }
 export interface KbAiMessageSentProps extends KbBase {
-	mentionCount: number;
-	pipelinePluginId: string;
+    mentionCount: number;
+    pipelinePluginId: string;
 }
 export interface KbContextInjectedProps extends KbBase {
-	chunkCount: number;
-	tokensUsed: number;
-	pipelinePluginId: string;
+    chunkCount: number;
+    tokensUsed: number;
+    pipelinePluginId: string;
 }
 export interface KbContextTruncatedProps extends KbBase {
-	requestedTokens: number;
-	budgetTokens: number;
-	droppedClasses: KbDocumentClassTelemetry[];
+    requestedTokens: number;
+    budgetTokens: number;
+    droppedClasses: KbDocumentClassTelemetry[];
 }
 export interface KbReconcileCompletedProps extends KbBase {
-	scanned: number;
-	driftCount: number;
-	violationCount: number;
-	orphanCount: number;
-	tombstonedCount: number;
-	revivedCount: number;
-	durationMs: number;
+    scanned: number;
+    driftCount: number;
+    violationCount: number;
+    orphanCount: number;
+    tombstonedCount: number;
+    revivedCount: number;
+    durationMs: number;
 }
 
 export type KbEventPayload =
-	| { kind: typeof KB_EVENT_KIND.WORKBENCH_OPENED; props: KbWorkbenchOpenedProps }
-	| { kind: typeof KB_EVENT_KIND.DOCUMENT_CREATED; props: KbDocumentCreatedProps }
-	| { kind: typeof KB_EVENT_KIND.DOCUMENT_UPDATED; props: KbDocumentUpdatedProps }
-	| { kind: typeof KB_EVENT_KIND.DOCUMENT_DELETED; props: KbDocumentDeletedProps }
-	| { kind: typeof KB_EVENT_KIND.DOCUMENT_LOCKED; props: KbDocumentLockedProps }
-	| { kind: typeof KB_EVENT_KIND.DOCUMENT_UNLOCKED; props: KbDocumentUnlockedProps }
-	| { kind: typeof KB_EVENT_KIND.DOCUMENT_RESTORED; props: KbDocumentRestoredProps }
-	| { kind: typeof KB_EVENT_KIND.DOCUMENT_LOCK_VIOLATION; props: KbDocumentLockViolationProps }
-	| { kind: typeof KB_EVENT_KIND.UPLOAD_STARTED; props: KbUploadStartedProps }
-	| { kind: typeof KB_EVENT_KIND.UPLOAD_EXTRACTED; props: KbUploadExtractedProps }
-	| { kind: typeof KB_EVENT_KIND.UPLOAD_TRANSCRIBED; props: KbUploadTranscribedProps }
-	| { kind: typeof KB_EVENT_KIND.UPLOAD_DEDUPED; props: KbUploadDedupedProps }
-	| { kind: typeof KB_EVENT_KIND.UPLOAD_TOMBSTONED; props: KbUploadTombstonedProps }
-	| { kind: typeof KB_EVENT_KIND.UPLOAD_REVIVED; props: KbUploadRevivedProps }
-	| { kind: typeof KB_EVENT_KIND.SEARCH_EXECUTED; props: KbSearchExecutedProps }
-	| { kind: typeof KB_EVENT_KIND.AI_MESSAGE_SENT; props: KbAiMessageSentProps }
-	| { kind: typeof KB_EVENT_KIND.CONTEXT_INJECTED; props: KbContextInjectedProps }
-	| { kind: typeof KB_EVENT_KIND.CONTEXT_TRUNCATED; props: KbContextTruncatedProps }
-	| { kind: typeof KB_EVENT_KIND.RECONCILE_COMPLETED; props: KbReconcileCompletedProps };
+    | { kind: typeof KB_EVENT_KIND.WORKBENCH_OPENED; props: KbWorkbenchOpenedProps }
+    | { kind: typeof KB_EVENT_KIND.DOCUMENT_CREATED; props: KbDocumentCreatedProps }
+    | { kind: typeof KB_EVENT_KIND.DOCUMENT_UPDATED; props: KbDocumentUpdatedProps }
+    | { kind: typeof KB_EVENT_KIND.DOCUMENT_DELETED; props: KbDocumentDeletedProps }
+    | { kind: typeof KB_EVENT_KIND.DOCUMENT_LOCKED; props: KbDocumentLockedProps }
+    | { kind: typeof KB_EVENT_KIND.DOCUMENT_UNLOCKED; props: KbDocumentUnlockedProps }
+    | { kind: typeof KB_EVENT_KIND.DOCUMENT_RESTORED; props: KbDocumentRestoredProps }
+    | { kind: typeof KB_EVENT_KIND.DOCUMENT_LOCK_VIOLATION; props: KbDocumentLockViolationProps }
+    | { kind: typeof KB_EVENT_KIND.UPLOAD_STARTED; props: KbUploadStartedProps }
+    | { kind: typeof KB_EVENT_KIND.UPLOAD_EXTRACTED; props: KbUploadExtractedProps }
+    | { kind: typeof KB_EVENT_KIND.UPLOAD_TRANSCRIBED; props: KbUploadTranscribedProps }
+    | { kind: typeof KB_EVENT_KIND.UPLOAD_DEDUPED; props: KbUploadDedupedProps }
+    | { kind: typeof KB_EVENT_KIND.UPLOAD_TOMBSTONED; props: KbUploadTombstonedProps }
+    | { kind: typeof KB_EVENT_KIND.UPLOAD_REVIVED; props: KbUploadRevivedProps }
+    | { kind: typeof KB_EVENT_KIND.SEARCH_EXECUTED; props: KbSearchExecutedProps }
+    | { kind: typeof KB_EVENT_KIND.AI_MESSAGE_SENT; props: KbAiMessageSentProps }
+    | { kind: typeof KB_EVENT_KIND.CONTEXT_INJECTED; props: KbContextInjectedProps }
+    | { kind: typeof KB_EVENT_KIND.CONTEXT_TRUNCATED; props: KbContextTruncatedProps }
+    | { kind: typeof KB_EVENT_KIND.RECONCILE_COMPLETED; props: KbReconcileCompletedProps };
 
 /** Minimal PostHog client surface required by the emitter — kept narrow so callers can pass mocks. */
 export interface PostHogCaptureClient {
-	capture: (input: { distinctId: string; event: string; properties?: Record<string, unknown> }) => void;
+    capture: (input: {
+        distinctId: string;
+        event: string;
+        properties?: Record<string, unknown>;
+    }) => void;
 }
 
-const FORBIDDEN_KEY_PATTERN = /^(body|content|markdown|text|html|excerpt|snippet|chunk|raw|preview)$/i;
+const FORBIDDEN_KEY_PATTERN =
+    /^(body|content|markdown|text|html|excerpt|snippet|chunk|raw|preview)$/i;
 
 /**
  * Defensive guard. PostHog will happily ingest whatever we send, so a single
@@ -199,49 +214,74 @@ const FORBIDDEN_KEY_PATTERN = /^(body|content|markdown|text|html|excerpt|snippet
  * runtime throw is too high given how many call sites this serves.
  */
 function scrubPayload(
-	props: Record<string, unknown>,
-	mode: 'dev' | 'prod' | 'test'
+    props: Record<string, unknown>,
+    mode: 'dev' | 'prod' | 'test',
 ): Record<string, unknown> {
-	const out: Record<string, unknown> = {};
-	for (const [k, v] of Object.entries(props)) {
-		if (FORBIDDEN_KEY_PATTERN.test(k)) {
-			if (mode === 'test') {
-				throw new Error(`kb-events: forbidden property "${k}" — KB body content must not be sent to telemetry`);
-			}
-			if (mode === 'dev') {
-				// eslint-disable-next-line no-console
-				console.warn(`kb-events: stripped forbidden property "${k}"`);
-			}
-			continue;
-		}
-		out[k] = v;
-	}
-	return out;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(props)) {
+        if (FORBIDDEN_KEY_PATTERN.test(k)) {
+            if (mode === 'test') {
+                throw new KbForbiddenPropertyError(k);
+            }
+            if (mode === 'dev') {
+                // eslint-disable-next-line no-console
+                console.warn(`kb-events: stripped forbidden property "${k}"`);
+            }
+            continue;
+        }
+        out[k] = v;
+    }
+    return out;
 }
 
 function resolveMode(): 'dev' | 'prod' | 'test' {
-	if (process.env.NODE_ENV === 'test') return 'test';
-	if (process.env.NODE_ENV === 'production') return 'prod';
-	return 'dev';
+    if (process.env.NODE_ENV === 'test') return 'test';
+    if (process.env.NODE_ENV === 'production') return 'prod';
+    return 'dev';
+}
+
+/**
+ * Sentinel error type used so the outer try-catch in `emitKbEvent` can let
+ * the privacy-guard throw escape in `test` mode while still swallowing
+ * unrelated runtime failures from the PostHog client. (Greptile P2 on
+ * PR #1215: a plain catch made the test-mode throw a silent no-op.)
+ */
+export class KbForbiddenPropertyError extends Error {
+    constructor(public readonly propertyKey: string) {
+        super(
+            `kb-events: forbidden property "${propertyKey}" — KB body content must not be sent to telemetry`,
+        );
+        this.name = 'KbForbiddenPropertyError';
+    }
 }
 
 /**
  * Emit a typed KB event. Returns void; failures inside the PostHog client are
- * swallowed because telemetry must NEVER take down a user-facing request.
+ * swallowed because telemetry must NEVER take down a user-facing request —
+ * EXCEPT a `KbForbiddenPropertyError` from the privacy guard, which is
+ * deliberately rethrown so `NODE_ENV=test` callers (and the
+ * `no-kb-body-in-events.sh` CI gate's accompanying spec) fail loudly.
  */
 export function emitKbEvent(
-	client: PostHogCaptureClient | null | undefined,
-	distinctId: string,
-	payload: KbEventPayload
+    client: PostHogCaptureClient | null | undefined,
+    distinctId: string,
+    payload: KbEventPayload,
 ): void {
-	if (!client) return;
-	try {
-		const scrubbed = scrubPayload(payload.props as unknown as Record<string, unknown>, resolveMode());
-		client.capture({ distinctId, event: payload.kind, properties: scrubbed });
-	} catch {
-		// Drop silently in prod/dev — emitter must not throw on call sites.
-		// The `test` mode short-circuits earlier via scrubPayload's throw.
-	}
+    if (!client) return;
+    let scrubbed: Record<string, unknown>;
+    try {
+        scrubbed = scrubPayload(payload.props as unknown as Record<string, unknown>, resolveMode());
+    } catch (err) {
+        // The privacy guard's throw must surface to tests and CI.
+        if (err instanceof KbForbiddenPropertyError) throw err;
+        return;
+    }
+    try {
+        client.capture({ distinctId, event: payload.kind, properties: scrubbed });
+    } catch {
+        // PostHog client failures (network, serialization) are intentionally
+        // swallowed — telemetry must not take down a user-facing request.
+    }
 }
 
 /**
@@ -249,14 +289,14 @@ export function emitKbEvent(
  * shell `grep -E` can sweep call sites without parsing TypeScript.
  */
 export const KB_EVENTS_FORBIDDEN_PROPERTY_KEYS = [
-	'body',
-	'content',
-	'markdown',
-	'text',
-	'html',
-	'excerpt',
-	'snippet',
-	'chunk',
-	'raw',
-	'preview'
+    'body',
+    'content',
+    'markdown',
+    'text',
+    'html',
+    'excerpt',
+    'snippet',
+    'chunk',
+    'raw',
+    'preview',
 ] as const;

--- a/packages/monitoring/src/posthog/kb-events.ts
+++ b/packages/monitoring/src/posthog/kb-events.ts
@@ -1,0 +1,262 @@
+/**
+ * Typed PostHog event surface for the Knowledge Base feature.
+ *
+ * EW-643 Phase 3 — backs spec.md §23 "Telemetry". Every KB user action that
+ * the product team needs to measure flows through this module so that:
+ *
+ *  1. The set of event names is enumerated in ONE place (so the analytics
+ *     team's funnel queries don't break the moment someone renames a string
+ *     literal in a controller).
+ *  2. Properties are statically typed (the compiler refuses payloads with
+ *     unknown / missing required fields, eliminating the "dashboard quietly
+ *     went blank because a property changed" failure mode).
+ *  3. **Body content can never leak.** See the spec's privacy / NN #22 rule:
+ *     no KB document body, snippet, or citation excerpt is allowed in any
+ *     telemetry event. Every payload here is shapes + counts + identifiers
+ *     only. The companion script `scripts/ci/no-kb-body-in-events.sh` runs
+ *     as a CI gate and greps the call sites in this file (and the rest of
+ *     the codebase) for any property whose key matches a body-ish pattern.
+ *
+ * Consumers call `emitKbEvent(client, 'kb.document.created', { ... })`.
+ * `client` is the PostHog client returned by `getPostHogClient()` (kept as
+ * a parameter so this module stays test-friendly — pass a no-op client in
+ * unit tests, the real one in production).
+ */
+
+export const KB_EVENT_KIND = {
+	WORKBENCH_OPENED: 'kb.workbench.opened',
+	DOCUMENT_CREATED: 'kb.document.created',
+	DOCUMENT_UPDATED: 'kb.document.updated',
+	DOCUMENT_DELETED: 'kb.document.deleted',
+	DOCUMENT_LOCKED: 'kb.document.locked',
+	DOCUMENT_UNLOCKED: 'kb.document.unlocked',
+	DOCUMENT_RESTORED: 'kb.document.restored',
+	DOCUMENT_LOCK_VIOLATION: 'kb.document.lock_violation',
+	UPLOAD_STARTED: 'kb.upload.started',
+	UPLOAD_EXTRACTED: 'kb.upload.extracted',
+	UPLOAD_TRANSCRIBED: 'kb.upload.transcribed',
+	UPLOAD_DEDUPED: 'kb.upload.deduped',
+	UPLOAD_TOMBSTONED: 'kb.upload.tombstoned',
+	UPLOAD_REVIVED: 'kb.upload.revived',
+	SEARCH_EXECUTED: 'kb.search.executed',
+	AI_MESSAGE_SENT: 'kb.ai.message_sent',
+	CONTEXT_INJECTED: 'kb.context.injected',
+	CONTEXT_TRUNCATED: 'kb.context.truncated',
+	RECONCILE_COMPLETED: 'kb.reconcile.completed'
+} as const;
+
+export type KbEventKind = (typeof KB_EVENT_KIND)[keyof typeof KB_EVENT_KIND];
+
+/**
+ * Document class union — mirrors `packages/contracts/src/kb/kb-document-class.ts`
+ * but redeclared here so this module stays dependency-free (the monitoring
+ * package must not import contracts; it's loaded by API + web + workers).
+ */
+export type KbDocumentClassTelemetry =
+	| 'brand'
+	| 'legal'
+	| 'glossary'
+	| 'style'
+	| 'seo'
+	| 'personas'
+	| 'competitors'
+	| 'research'
+	| 'output'
+	| 'freeform';
+
+export type KbDocumentSource = 'user' | 'upload' | 'agent' | 'inherited' | 'cli' | 'mcp';
+
+/** Coarse MIME family for upload events — picked because page-by-page leakage isn't possible from a category. */
+export type KbMimeFamily = 'pdf' | 'doc' | 'sheet' | 'slide' | 'image' | 'video' | 'audio' | 'text' | 'html' | 'other';
+
+export type KbActorType = 'user' | 'agent' | 'cli' | 'mcp' | 'system';
+
+interface KbBase {
+	workId: string;
+	actorType: KbActorType;
+}
+
+export interface KbWorkbenchOpenedProps extends KbBase {
+	hasOriginals: boolean;
+	hasDocuments: boolean;
+}
+export interface KbDocumentCreatedProps extends KbBase {
+	documentClass: KbDocumentClassTelemetry;
+	source: KbDocumentSource;
+	tagCount: number;
+}
+export interface KbDocumentUpdatedProps extends KbBase {
+	documentClass: KbDocumentClassTelemetry;
+	source: KbDocumentSource;
+	bytesDelta: number;
+}
+export interface KbDocumentDeletedProps extends KbBase {
+	documentClass: KbDocumentClassTelemetry;
+}
+export interface KbDocumentLockedProps extends KbBase {
+	documentClass: KbDocumentClassTelemetry;
+	lockMode: 'full' | 'additions-only';
+}
+export type KbDocumentUnlockedProps = KbBase & { documentClass: KbDocumentClassTelemetry };
+export interface KbDocumentRestoredProps extends KbBase {
+	documentClass: KbDocumentClassTelemetry;
+	fromCommitShaPrefix: string;
+}
+export interface KbDocumentLockViolationProps extends KbBase {
+	documentClass: KbDocumentClassTelemetry;
+	lockMode: 'full' | 'additions-only';
+	detectedBy: 'reconcile' | 'preReceive';
+}
+export interface KbUploadStartedProps extends KbBase {
+	mimeFamily: KbMimeFamily;
+	byteSize: number;
+}
+export interface KbUploadExtractedProps extends KbBase {
+	mimeFamily: KbMimeFamily;
+	extractionPluginId: string;
+	durationBucketMs: 100 | 500 | 1000 | 5000 | 30_000 | 120_000 | 600_000;
+	success: boolean;
+}
+export interface KbUploadTranscribedProps extends KbBase {
+	mimeFamily: KbMimeFamily;
+	transcriptionProviderId: string;
+	durationSecondsBucket: 10 | 60 | 300 | 1800 | 7200;
+	success: boolean;
+}
+export interface KbUploadDedupedProps extends KbBase {
+	mimeFamily: KbMimeFamily;
+}
+export interface KbUploadTombstonedProps extends KbBase {
+	mimeFamily: KbMimeFamily;
+	graceDays: number;
+}
+export interface KbUploadRevivedProps extends KbBase {
+	mimeFamily: KbMimeFamily;
+}
+export interface KbSearchExecutedProps extends KbBase {
+	hitCount: number;
+	usedSemantic: boolean;
+	durationBucketMs: 50 | 100 | 250 | 500 | 1000 | 5000;
+}
+export interface KbAiMessageSentProps extends KbBase {
+	mentionCount: number;
+	pipelinePluginId: string;
+}
+export interface KbContextInjectedProps extends KbBase {
+	chunkCount: number;
+	tokensUsed: number;
+	pipelinePluginId: string;
+}
+export interface KbContextTruncatedProps extends KbBase {
+	requestedTokens: number;
+	budgetTokens: number;
+	droppedClasses: KbDocumentClassTelemetry[];
+}
+export interface KbReconcileCompletedProps extends KbBase {
+	scanned: number;
+	driftCount: number;
+	violationCount: number;
+	orphanCount: number;
+	tombstonedCount: number;
+	revivedCount: number;
+	durationMs: number;
+}
+
+export type KbEventPayload =
+	| { kind: typeof KB_EVENT_KIND.WORKBENCH_OPENED; props: KbWorkbenchOpenedProps }
+	| { kind: typeof KB_EVENT_KIND.DOCUMENT_CREATED; props: KbDocumentCreatedProps }
+	| { kind: typeof KB_EVENT_KIND.DOCUMENT_UPDATED; props: KbDocumentUpdatedProps }
+	| { kind: typeof KB_EVENT_KIND.DOCUMENT_DELETED; props: KbDocumentDeletedProps }
+	| { kind: typeof KB_EVENT_KIND.DOCUMENT_LOCKED; props: KbDocumentLockedProps }
+	| { kind: typeof KB_EVENT_KIND.DOCUMENT_UNLOCKED; props: KbDocumentUnlockedProps }
+	| { kind: typeof KB_EVENT_KIND.DOCUMENT_RESTORED; props: KbDocumentRestoredProps }
+	| { kind: typeof KB_EVENT_KIND.DOCUMENT_LOCK_VIOLATION; props: KbDocumentLockViolationProps }
+	| { kind: typeof KB_EVENT_KIND.UPLOAD_STARTED; props: KbUploadStartedProps }
+	| { kind: typeof KB_EVENT_KIND.UPLOAD_EXTRACTED; props: KbUploadExtractedProps }
+	| { kind: typeof KB_EVENT_KIND.UPLOAD_TRANSCRIBED; props: KbUploadTranscribedProps }
+	| { kind: typeof KB_EVENT_KIND.UPLOAD_DEDUPED; props: KbUploadDedupedProps }
+	| { kind: typeof KB_EVENT_KIND.UPLOAD_TOMBSTONED; props: KbUploadTombstonedProps }
+	| { kind: typeof KB_EVENT_KIND.UPLOAD_REVIVED; props: KbUploadRevivedProps }
+	| { kind: typeof KB_EVENT_KIND.SEARCH_EXECUTED; props: KbSearchExecutedProps }
+	| { kind: typeof KB_EVENT_KIND.AI_MESSAGE_SENT; props: KbAiMessageSentProps }
+	| { kind: typeof KB_EVENT_KIND.CONTEXT_INJECTED; props: KbContextInjectedProps }
+	| { kind: typeof KB_EVENT_KIND.CONTEXT_TRUNCATED; props: KbContextTruncatedProps }
+	| { kind: typeof KB_EVENT_KIND.RECONCILE_COMPLETED; props: KbReconcileCompletedProps };
+
+/** Minimal PostHog client surface required by the emitter — kept narrow so callers can pass mocks. */
+export interface PostHogCaptureClient {
+	capture: (input: { distinctId: string; event: string; properties?: Record<string, unknown> }) => void;
+}
+
+const FORBIDDEN_KEY_PATTERN = /^(body|content|markdown|text|html|excerpt|snippet|chunk|raw|preview)$/i;
+
+/**
+ * Defensive guard. PostHog will happily ingest whatever we send, so a single
+ * sloppy caller could leak proprietary KB content into a third-party sink.
+ * This narrows the door: any property key matching FORBIDDEN_KEY_PATTERN is
+ * stripped in dev (with a console.warn) and throws in test (so CI fails
+ * loudly). In production the field is stripped silently — surface-area for a
+ * runtime throw is too high given how many call sites this serves.
+ */
+function scrubPayload(
+	props: Record<string, unknown>,
+	mode: 'dev' | 'prod' | 'test'
+): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(props)) {
+		if (FORBIDDEN_KEY_PATTERN.test(k)) {
+			if (mode === 'test') {
+				throw new Error(`kb-events: forbidden property "${k}" — KB body content must not be sent to telemetry`);
+			}
+			if (mode === 'dev') {
+				// eslint-disable-next-line no-console
+				console.warn(`kb-events: stripped forbidden property "${k}"`);
+			}
+			continue;
+		}
+		out[k] = v;
+	}
+	return out;
+}
+
+function resolveMode(): 'dev' | 'prod' | 'test' {
+	if (process.env.NODE_ENV === 'test') return 'test';
+	if (process.env.NODE_ENV === 'production') return 'prod';
+	return 'dev';
+}
+
+/**
+ * Emit a typed KB event. Returns void; failures inside the PostHog client are
+ * swallowed because telemetry must NEVER take down a user-facing request.
+ */
+export function emitKbEvent(
+	client: PostHogCaptureClient | null | undefined,
+	distinctId: string,
+	payload: KbEventPayload
+): void {
+	if (!client) return;
+	try {
+		const scrubbed = scrubPayload(payload.props as unknown as Record<string, unknown>, resolveMode());
+		client.capture({ distinctId, event: payload.kind, properties: scrubbed });
+	} catch {
+		// Drop silently in prod/dev — emitter must not throw on call sites.
+		// The `test` mode short-circuits earlier via scrubPayload's throw.
+	}
+}
+
+/**
+ * For the static CI gate — exposes the list of forbidden property keys so a
+ * shell `grep -E` can sweep call sites without parsing TypeScript.
+ */
+export const KB_EVENTS_FORBIDDEN_PROPERTY_KEYS = [
+	'body',
+	'content',
+	'markdown',
+	'text',
+	'html',
+	'excerpt',
+	'snippet',
+	'chunk',
+	'raw',
+	'preview'
+] as const;

--- a/packages/plugin/src/contracts/capabilities/ai-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/ai-provider.interface.ts
@@ -255,6 +255,54 @@ export interface EmbeddingResponse {
 }
 
 /**
+ * Transcription options — speech-to-text capability (EW-643 Phase 3).
+ *
+ * Powers KB media ingest. Uploaded audio/video lands in `WorkKnowledgeUpload`;
+ * a Trigger.dev task fans the binary out to whichever AI provider plugin the
+ * operator has configured for the `transcribe` capability, then materializes
+ * the returned text as the body of the corresponding `WorkKnowledgeDocument`
+ * (class `research` or `originals` depending on classification).
+ */
+export interface TranscriptionOptions {
+	/** Audio/video bytes to transcribe. Accepts a Web ReadableStream, Node Buffer, or Uint8Array. */
+	readonly file: ReadableStream<Uint8Array> | Uint8Array | Buffer;
+	/** Original filename — provider may use the extension to detect format. */
+	readonly filename: string;
+	/** Provider-specific model override (e.g. OpenAI's `whisper-1`, `gpt-4o-transcribe`). */
+	readonly model?: string;
+	/** BCP-47 language hint (e.g. `'en'`, `'pt-BR'`). Providers detect on omission. */
+	readonly language?: string;
+	/** Optional bias prompt — caller-provided context (glossary terms, speaker names). */
+	readonly prompt?: string;
+	/** Resolved per-call settings, threaded through by the facade. */
+	readonly settings?: PluginSettings;
+}
+
+/**
+ * Transcription response. Tracks the original audio duration so the
+ * UsageLedgerEntry billing line for `kb-transcription` is computed in
+ * provider-neutral units (minutes).
+ */
+export interface TranscriptionResponse {
+	/** Concatenated transcript text. */
+	readonly text: string;
+	/** Model used (echoed by provider). */
+	readonly model: string;
+	/** Detected language as BCP-47, when the provider returns one. */
+	readonly language?: string;
+	/** Audio duration in seconds — used for cost reconciliation. */
+	readonly durationSeconds?: number;
+	/** Per-segment timing for downstream chapter / chunk synthesis. */
+	readonly segments?: readonly TranscriptionSegment[];
+}
+
+export interface TranscriptionSegment {
+	readonly start: number;
+	readonly end: number;
+	readonly text: string;
+}
+
+/**
  * AI provider plugin interface
  * Capability: 'ai-provider'
  */
@@ -327,6 +375,33 @@ export interface IAiProviderPlugin extends IPlugin {
 	 * than reject the response.
 	 */
 	createEmbedding?(options: EmbeddingOptions): Promise<EmbeddingResponse>;
+
+	/**
+	 * Transcribe audio/video to text — optional capability (EW-643 Phase 3).
+	 *
+	 * Implementations wrap the provider's speech-to-text endpoint (OpenAI
+	 * Whisper, Anthropic Claude audio, Google Speech-to-Text, Groq Whisper,
+	 * etc.). When the upstream has no STT endpoint, leave this `undefined`
+	 * and `AiFacadeService.transcribe()` falls back to the next available
+	 * provider in the chain.
+	 *
+	 * **Selection order** (resolved by the facade):
+	 *   1. Operator-pinned transcription provider, if configured
+	 *      (`pluginSettings.transcriptionProviderId`).
+	 *   2. First AI-provider plugin in the registry with `transcribe`
+	 *      defined AND `isAvailable()` resolving true.
+	 *   3. If none qualifies, the facade throws
+	 *      `TranscriptionNotConfiguredError`. The KB media-ingest task
+	 *      catches that and marks the upload `extractionStatus='failed'`
+	 *      with `extractionError='no transcription provider'`.
+	 *
+	 * **Cost note.** Caller is expected to populate
+	 * `UsageLedgerEntry.category='kb-transcription'` with
+	 * `unit='audio_minutes'` and `units=ceil(durationSeconds/60)`. Plugins
+	 * MUST NOT bill — billing lives at the facade layer so it stays
+	 * provider-neutral.
+	 */
+	transcribe?(options: TranscriptionOptions): Promise<TranscriptionResponse>;
 
 	/**
 	 * List available models

--- a/packages/plugins/openai/src/openai.plugin.ts
+++ b/packages/plugins/openai/src/openai.plugin.ts
@@ -87,7 +87,7 @@ export class OpenAiPlugin extends BaseAiProvider {
 				type: 'string',
 				title: 'Transcription Model',
 				description:
-					"Speech-to-text model for Knowledge Base media (video/audio) ingest. whisper-1 is the broadest-supported and the cheapest at $0.006/min. gpt-4o-transcribe yields higher accuracy on noisy audio at higher cost.",
+					'Speech-to-text model for Knowledge Base media (video/audio) ingest. whisper-1 is the broadest-supported and the cheapest at $0.006/min. gpt-4o-transcribe yields higher accuracy on noisy audio at higher cost.',
 				default: 'whisper-1',
 				'x-widget': 'model-select',
 				'x-scope': 'global',
@@ -199,10 +199,7 @@ export class OpenAiPlugin extends BaseAiProvider {
 			throw new Error('OpenAI apiKey is required for transcribe()');
 		}
 		const baseUrl = (resolvedConfig.baseURL as string) || 'https://api.openai.com/v1';
-		const model =
-			options.model ||
-			(resolvedConfig.transcriptionModel as string | undefined) ||
-			'whisper-1';
+		const model = options.model || (resolvedConfig.transcriptionModel as string | undefined) || 'whisper-1';
 		const url = `${baseUrl.replace(/\/$/, '')}/audio/transcriptions`;
 
 		const bytes = await this.normaliseAudioInput(options.file);
@@ -238,25 +235,33 @@ export class OpenAiPlugin extends BaseAiProvider {
 		};
 	}
 
-	private async normaliseAudioInput(
-		input: TranscriptionOptions['file']
-	): Promise<Uint8Array> {
+	private async normaliseAudioInput(input: TranscriptionOptions['file']): Promise<Uint8Array> {
 		if (input instanceof Uint8Array) return input;
 		// Node Buffer is a Uint8Array subclass — handled above. Otherwise
 		// drain the Web ReadableStream into a single Uint8Array.
 		const reader = (input as ReadableStream<Uint8Array>).getReader();
 		const chunks: Uint8Array[] = [];
 		let total = 0;
-		// Loop until end-of-stream. We avoid `for await` so this runs
-		// unchanged on Node runtimes that don't yet expose async iteration
-		// on the global ReadableStream.
-		// eslint-disable-next-line no-constant-condition
-		while (true) {
-			const { value, done } = await reader.read();
-			if (done) break;
-			if (value) {
-				chunks.push(value);
-				total += value.byteLength;
+		try {
+			// Loop until end-of-stream. We avoid `for await` so this runs
+			// unchanged on Node runtimes that don't yet expose async
+			// iteration on the global ReadableStream.
+			// eslint-disable-next-line no-constant-condition
+			while (true) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				if (value) {
+					chunks.push(value);
+					total += value.byteLength;
+				}
+			}
+		} finally {
+			// Greptile P2: must release the lock even on read() error —
+			// otherwise the stream stays locked and any retry blocks forever.
+			try {
+				reader.releaseLock();
+			} catch {
+				// releaseLock throws if the stream is already closed; ignore.
 			}
 		}
 		const out = new Uint8Array(total);

--- a/packages/plugins/openai/src/openai.plugin.ts
+++ b/packages/plugins/openai/src/openai.plugin.ts
@@ -11,6 +11,8 @@ import type {
 	ChatCompletionChunk,
 	EmbeddingOptions,
 	EmbeddingResponse,
+	TranscriptionOptions,
+	TranscriptionResponse,
 	AiModel,
 	AiModelCapabilities
 } from '@ever-works/plugin';
@@ -80,6 +82,16 @@ export class OpenAiPlugin extends BaseAiProvider {
 				default: 'text-embedding-3-small',
 				'x-widget': 'model-select',
 				'x-scope': 'global'
+			},
+			transcriptionModel: {
+				type: 'string',
+				title: 'Transcription Model',
+				description:
+					"Speech-to-text model for Knowledge Base media (video/audio) ingest. whisper-1 is the broadest-supported and the cheapest at $0.006/min. gpt-4o-transcribe yields higher accuracy on noisy audio at higher cost.",
+				default: 'whisper-1',
+				'x-widget': 'model-select',
+				'x-scope': 'global',
+				'x-envVar': 'OPENAI_TRANSCRIPTION_MODEL'
 			},
 			temperature: {
 				type: 'number',
@@ -160,6 +172,117 @@ export class OpenAiPlugin extends BaseAiProvider {
 			resolvedConfig.embeddingModel = 'text-embedding-3-small';
 		}
 		return this.aiOps.createEmbedding(options, resolvedConfig);
+	}
+
+	/**
+	 * Whisper-backed speech-to-text. Wraps OpenAI's `/v1/audio/transcriptions`
+	 * REST endpoint directly with `fetch` + `FormData` so the plugin avoids
+	 * pulling the heavy `openai` SDK just for this code path (we already do
+	 * everything else via LangChain).
+	 *
+	 * The handler accepts any of the three binary shapes the KB ingest task
+	 * forwards — Web ReadableStream (from the upload route), Node Buffer (from
+	 * the Trigger.dev local runner), or Uint8Array (from tests). We normalize
+	 * to a Blob before constructing the multipart body so the OpenAI server's
+	 * MIME sniffer sees a real file part with the original filename.
+	 *
+	 * Disabled-by-omission: when `apiKey` is unset the call throws — the
+	 * facade catches and falls through to the next provider in the chain.
+	 */
+	async transcribe(options: TranscriptionOptions): Promise<TranscriptionResponse> {
+		if (!this.aiOps) {
+			throw new Error('OpenAI plugin not loaded');
+		}
+		const resolvedConfig = this.resolveConfig(options.settings);
+		const apiKey = resolvedConfig.apiKey;
+		if (!apiKey || typeof apiKey !== 'string') {
+			throw new Error('OpenAI apiKey is required for transcribe()');
+		}
+		const baseUrl = (resolvedConfig.baseURL as string) || 'https://api.openai.com/v1';
+		const model =
+			options.model ||
+			(resolvedConfig.transcriptionModel as string | undefined) ||
+			'whisper-1';
+		const url = `${baseUrl.replace(/\/$/, '')}/audio/transcriptions`;
+
+		const bytes = await this.normaliseAudioInput(options.file);
+		const blob = new Blob([bytes], { type: this.detectMimeFromName(options.filename) });
+		const form = new FormData();
+		form.append('file', blob, options.filename);
+		form.append('model', model);
+		form.append('response_format', 'verbose_json');
+		if (options.language) form.append('language', options.language);
+		if (options.prompt) form.append('prompt', options.prompt);
+
+		const response = await fetch(url, {
+			method: 'POST',
+			headers: { Authorization: `Bearer ${apiKey}` },
+			body: form
+		});
+		if (!response.ok) {
+			const errBody = await response.text();
+			throw new Error(`OpenAI transcribe HTTP ${response.status}: ${errBody.slice(0, 400)}`);
+		}
+		const payload = (await response.json()) as {
+			text: string;
+			language?: string;
+			duration?: number;
+			segments?: Array<{ start: number; end: number; text: string }>;
+		};
+		return {
+			text: payload.text,
+			model,
+			language: payload.language,
+			durationSeconds: payload.duration,
+			segments: payload.segments?.map((s) => ({ start: s.start, end: s.end, text: s.text }))
+		};
+	}
+
+	private async normaliseAudioInput(
+		input: TranscriptionOptions['file']
+	): Promise<Uint8Array> {
+		if (input instanceof Uint8Array) return input;
+		// Node Buffer is a Uint8Array subclass — handled above. Otherwise
+		// drain the Web ReadableStream into a single Uint8Array.
+		const reader = (input as ReadableStream<Uint8Array>).getReader();
+		const chunks: Uint8Array[] = [];
+		let total = 0;
+		// Loop until end-of-stream. We avoid `for await` so this runs
+		// unchanged on Node runtimes that don't yet expose async iteration
+		// on the global ReadableStream.
+		// eslint-disable-next-line no-constant-condition
+		while (true) {
+			const { value, done } = await reader.read();
+			if (done) break;
+			if (value) {
+				chunks.push(value);
+				total += value.byteLength;
+			}
+		}
+		const out = new Uint8Array(total);
+		let offset = 0;
+		for (const c of chunks) {
+			out.set(c, offset);
+			offset += c.byteLength;
+		}
+		return out;
+	}
+
+	private detectMimeFromName(filename: string): string {
+		const ext = filename.toLowerCase().split('.').pop() ?? '';
+		const map: Record<string, string> = {
+			mp3: 'audio/mpeg',
+			m4a: 'audio/mp4',
+			mp4: 'audio/mp4',
+			mpeg: 'audio/mpeg',
+			mpga: 'audio/mpeg',
+			wav: 'audio/wav',
+			webm: 'audio/webm',
+			oga: 'audio/ogg',
+			ogg: 'audio/ogg',
+			flac: 'audio/flac'
+		};
+		return map[ext] ?? 'application/octet-stream';
 	}
 
 	async listModels(settings?: PluginSettings): Promise<readonly AiModel[]> {

--- a/packages/plugins/openai/src/openai.plugin.ts
+++ b/packages/plugins/openai/src/openai.plugin.ts
@@ -199,11 +199,26 @@ export class OpenAiPlugin extends BaseAiProvider {
 			throw new Error('OpenAI apiKey is required for transcribe()');
 		}
 		const baseUrl = (resolvedConfig.baseURL as string) || 'https://api.openai.com/v1';
-		const model = options.model || (resolvedConfig.transcriptionModel as string | undefined) || 'whisper-1';
+		// `transcriptionModel` is a plugin-settings field, not part of
+		// `AiOperationsConfig`. Read through an index access so TS doesn't
+		// reject the optional access on the narrower facade type. The OpenAI
+		// settings schema declares the default `whisper-1` — the explicit
+		// fallback below is defensive for callers that mutated settings.
+		const settingsBag = resolvedConfig as unknown as Record<string, unknown>;
+		const transcriptionModelSetting =
+			typeof settingsBag.transcriptionModel === 'string' ? (settingsBag.transcriptionModel as string) : undefined;
+		const model = options.model || transcriptionModelSetting || 'whisper-1';
 		const url = `${baseUrl.replace(/\/$/, '')}/audio/transcriptions`;
 
 		const bytes = await this.normaliseAudioInput(options.file);
-		const blob = new Blob([bytes], { type: this.detectMimeFromName(options.filename) });
+		// TS5.9 + lib.dom.d.ts narrowed Blob's BlobPart to ArrayBuffer
+		// instead of ArrayBufferLike, so a raw `Uint8Array<ArrayBufferLike>`
+		// no longer assigns. Slicing the underlying ArrayBuffer gives a
+		// fresh `ArrayBuffer` view that satisfies BlobPart without copying
+		// twice (we still own the bytes; the caller's Buffer/stream is
+		// fully drained by `normaliseAudioInput`).
+		const arrayBuffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+		const blob = new Blob([arrayBuffer], { type: this.detectMimeFromName(options.filename) });
 		const form = new FormData();
 		form.append('file', blob, options.filename);
 		form.append('model', model);

--- a/scripts/ci/no-kb-body-in-events.sh
+++ b/scripts/ci/no-kb-body-in-events.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# EW-643 Phase 3 — static gate for KB body content in telemetry events.
+#
+# Acceptance criterion A40 (spec acceptance.md / spec.md §22):
+#
+#   > No KB body content appears in webhooks, telemetry, or activity-log
+#   > payloads (verified by a static-grep CI check on event-emitter call
+#   > sites).
+#
+# This script implements that check. It greps every call site that passes a
+# payload object to PostHog (`capture(`), the activity-log facade
+# (`activityLogService.create(`), and the typed KB event emitter
+# (`emitKbEvent(`) and looks for any object literal property keyed with one
+# of the forbidden body-ish names enumerated in
+# `packages/monitoring/src/posthog/kb-events.ts`
+# (`KB_EVENTS_FORBIDDEN_PROPERTY_KEYS`).
+#
+# Forbidden keys (must stay in sync with kb-events.ts):
+#   body, content, markdown, text, html, excerpt, snippet, chunk, raw, preview
+#
+# Exit codes:
+#   0 — no violations
+#   1 — one or more violations (CI fails)
+#   2 — environment/usage error
+#
+# The check is intentionally conservative: it scans only directories where
+# KB-related code lives, and explicitly whitelists `kb-events.ts` (the
+# defining module) plus any line marked `// kb-events-allow:<reason>`.
+
+set -euo pipefail
+
+ROOT="${1:-.}"
+
+# Directories likely to emit telemetry events. Keep tight so the grep stays
+# fast on the full monorepo (~7000 TS files).
+SCOPE=(
+    "$ROOT/apps/api/src"
+    "$ROOT/apps/web/src"
+    "$ROOT/apps/mcp/src"
+    "$ROOT/apps/cli/src"
+    "$ROOT/packages/agent/src"
+    "$ROOT/packages/tasks/src"
+)
+
+FORBIDDEN='\b(body|content|markdown|html|excerpt|snippet|chunk|raw|preview)\b\s*:'
+
+# Find emit-event-like call sites first (cheap), then check whether the next
+# ~10 lines after that call contain a forbidden property literal. This avoids
+# false positives on unrelated code that happens to use "content" as a prop
+# name far away from any analytics emit.
+EMIT_CALLERS='(emitKbEvent\(|posthog\.capture\(|posthogClient\.capture\(|activityLogService\.create\(|activityLog\.create\()'
+
+violations=0
+exists=0
+for dir in "${SCOPE[@]}"; do
+    if [ ! -d "$dir" ]; then continue; fi
+    exists=1
+    while IFS= read -r -d '' file; do
+        # Skip the defining module + its tests.
+        case "$file" in
+            */kb-events.ts|*/kb-events.spec.ts|*/no-kb-body-in-events.sh)
+                continue
+                ;;
+        esac
+        # Use awk to find emit calls and inspect the next 12 lines for forbidden keys.
+        # `kb-events-allow:<reason>` comment on the property line whitelists it.
+        if awk -v pat="$EMIT_CALLERS" -v forbidden="$FORBIDDEN" '
+            BEGIN { window=0; found=0 }
+            /kb-events-allow:/ { allow_line=NR }
+            $0 ~ pat { window=12; emit_line=NR; emit_text=$0 }
+            window > 0 {
+                if ($0 ~ forbidden && NR != allow_line) {
+                    printf("%s:%d: forbidden body-ish property near emit on line %d (%s)\n",
+                        FILENAME, NR, emit_line, $0)
+                    found=1
+                }
+                window--
+            }
+            END { exit found }
+        ' "$file"; then
+            :
+        else
+            violations=$((violations + 1))
+        fi
+    done < <(find "$dir" -type f \( -name '*.ts' -o -name '*.tsx' \) -print0)
+done
+
+if [ "$exists" -eq 0 ]; then
+    echo "no-kb-body-in-events: no scope directories found under '$ROOT' (root flag wrong?)" >&2
+    exit 2
+fi
+
+if [ "$violations" -gt 0 ]; then
+    echo "no-kb-body-in-events: FAILED — $violations call site(s) include forbidden KB body content" >&2
+    echo "  Add '// kb-events-allow: <short reason>' on the property line to whitelist intentional cases." >&2
+    exit 1
+fi
+
+echo "no-kb-body-in-events: OK — no body-ish properties near event emitters."
+exit 0

--- a/scripts/ci/no-kb-body-in-events.sh
+++ b/scripts/ci/no-kb-body-in-events.sh
@@ -42,7 +42,7 @@ SCOPE=(
     "$ROOT/packages/tasks/src"
 )
 
-FORBIDDEN='\b(body|content|markdown|html|excerpt|snippet|chunk|raw|preview)\b\s*:'
+FORBIDDEN='\b(body|content|markdown|text|html|excerpt|snippet|chunk|raw|preview)\b\s*:'
 
 # Find emit-event-like call sites first (cheap), then check whether the next
 # ~10 lines after that call contain a forbidden property literal. This avoids


### PR DESCRIPTION
## Summary

Closes the contract layer of **EW-643 Phase 3** for the Knowledge Base
epic ([EW-639](https://evertech.atlassian.net/browse/EW-639)). This is an
additive, behaviour-preserving slice that the remaining Phase 3
deliverables (ffmpeg media normalize, MCP/CLI surfaces, reconciliation
job, wikilink rewriter, embedded-app viewer) plug into.

### Why a slice and not the full phase

After auditing the worktree against the Phase 3 deliverables in
[`tasks.md`](docs/specs/features/knowledge-base/tasks.md), the heaviest
items (ffmpeg, MCP namespace, CLI subcommand group, reconciliation
Trigger.dev task, wikilink rewriter) each need their own focused PR
and review pass. Landing them in one mega-diff would make the review
unreviewable and the bisect surface unhelpful. This PR keeps the blast
radius small (8 files, no behaviour changes) and seeds the contracts +
typed telemetry surface every other slice depends on. The follow-up
slices ship on the same \`session/ew639-phase3*\` branch family with
\`EW-643\` references in the commit messages.

The deferred scope and rationale is documented inline in
[\`phase-3-implementation-notes.md\`](docs/specs/features/knowledge-base/phase-3-implementation-notes.md).

### What ships

| Area | Path |
|---|---|
| \`transcribe(file)\` capability on \`IAiProviderPlugin\` | \`packages/plugin/src/contracts/capabilities/ai-provider.interface.ts\` |
| OpenAI Whisper impl (no SDK dep — \`fetch\` + \`FormData\`) | \`packages/plugins/openai/src/openai.plugin.ts\` |
| Activity-log lock + reconcile + transcribe event kinds | \`packages/agent/src/entities/activity-log.types.ts\` |
| Typed PostHog KB event surface + defensive body-scrubber | \`packages/monitoring/src/posthog/kb-events.ts\` (new) |
| Static CI gate for KB body in telemetry | \`scripts/ci/no-kb-body-in-events.sh\` (new) |
| Vitest spec | \`packages/monitoring/src/posthog/__tests__/kb-events.spec.ts\` (new) |
| Phase 3 engineer notes | \`docs/specs/features/knowledge-base/phase-3-implementation-notes.md\` (new) |

### Configuration knobs (env)

| Env var | Effect | Default |
|---|---|---|
| \`OPENAI_TRANSCRIPTION_MODEL\` | Whisper model OpenAI plugin uses | \`whisper-1\` |
| \`KB_TRANSCRIPTION_PROVIDER_ID\` | Operator-pinned transcription provider (read by \`AiFacadeService.transcribe()\` in slice 2) | _unset → first available_ |

### Modular design

- **No KB-specific code in \`packages/plugin\`** — \`transcribe\` is a
  generic speech-to-text capability any feature could consume.
- **Per-provider impl lives in the plugin package**, not in core.
- **Telemetry events live in \`packages/monitoring\`** so web, API,
  MCP, CLI, and workers all import the same typed surface.
- **The CI gate is a standalone shell script**, framework-agnostic.

## Test plan

- [x] \`packages/monitoring\` vitest suite (\`kb-events\` spec — forward path, null-client no-op, scrubber throws in test mode, forbidden-key list export)
- [ ] Reviewer: run \`pnpm --filter @ever-works/plugin type-check\` (the new types compile)
- [ ] Reviewer: run \`pnpm --filter @ever-works/monitoring type-check && pnpm --filter @ever-works/monitoring test\`
- [ ] Reviewer: run \`bash scripts/ci/no-kb-body-in-events.sh .\` from repo root — should report OK
- [ ] Reviewer: skim the new \`transcribe\` JSDoc on \`IAiProviderPlugin\` for the facade fallback contract

## Follow-up (same branch family)

Tracked in
[\`phase-3-implementation-notes.md\`](docs/specs/features/knowledge-base/phase-3-implementation-notes.md):

- ffmpeg video → MP4 + audio → MP3 Trigger.dev tasks (A28, A29)
- \`AiFacadeService.transcribe()\` + KB ingest wiring (A28, A29)
- MCP \`kb\` namespace (A32) + CLI \`ever works kb\` subcommand group (A33)
- Embedded-app outputs viewer + "promote to KB" action (A30, A31)
- Daily reconciliation Trigger.dev task + lock-violation surfacing (A24, A35, A36)
- Wikilink resolver + rename rewriter (A34)

Refs: [EW-639](https://evertech.atlassian.net/browse/EW-639) (epic) ·
[EW-643](https://evertech.atlassian.net/browse/EW-643) (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-639]: https://evertech.atlassian.net/browse/EW-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-639]: https://evertech.atlassian.net/browse/EW-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Speech-to-text transcription support (Whisper) for uploads and provider contract for transcription; configurable transcription model and return of segments/duration.

* **Telemetry**
  * Typed KB telemetry surface with forbidden-body scrubbing, safer emit behavior, and forbidden-key export for CI gating; added tests for forbidden-key/error/no-op modes.

* **Events**
  * Expanded Knowledge Base lifecycle events for lock/unlock/restore/violations, reconcile outcomes, truncation, and upload transcription results.

* **Documentation**
  * Phase 3 Knowledge Base implementation notes: scope, exclusions, env knobs, verification steps.

* **Chores / CI**
  * New CI gate script that flags forbidden KB body keys in event emissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->