### PR TITLE
fix(agent): durable slug-CAS for null-scoped agents (concurrent same-name creates)

### DIFF
--- a/apps/api/src/migrations/1780300000000-AddAgentScopeTargetIdForDurableSlugCas.ts
+++ b/apps/api/src/migrations/1780300000000-AddAgentScopeTargetIdForDurableSlugCas.ts
@@ -1,0 +1,128 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Make the Agent per-scope slug uniqueness DURABLE under concurrency.
+ *
+ * `uq_agents_user_scope_slug` previously spanned the nullable scope FKs
+ * `(userId, scope, missionId, ideaId, workId, slug)`. Because SQL treats NULLs
+ * as DISTINCT inside a unique index, that index could NOT dedup same-name
+ * agents in any null-containing scope — `tenant` has all three FKs null,
+ * `mission` has idea/work null, etc. — so a concurrent same-name create burst
+ * could ALL succeed instead of exactly one. (The app-level pre-check in
+ * `agents.service.create` races, and the `isUniqueConstraintError` → 409 path
+ * never fired because the index never threw.)
+ *
+ * Fix: a NON-NULL `scopeTargetId` column = COALESCE(missionId, ideaId, workId,
+ * '') and move the unique index to `(userId, scope, scopeTargetId, slug)`,
+ * which has no nullable members and is therefore enforced on both Postgres and
+ * SQLite. The entity keeps the column in lock-step on every persist via
+ * `@BeforeInsert/@BeforeUpdate` (`agent.entity.ts` `syncScopeTargetId`).
+ *
+ * Duplicate handling: `migrationsRun: true` applies migrations at pod boot, so
+ * a hard unique-index failure on a pre-existing duplicate would
+ * CrashLoopBackOff the API (cf. the AddUniqueIndexToUsername prod incident).
+ * Before creating the new index we auto-dedupe each
+ * `(userId, scope, scopeTargetId, slug)` bucket: the OLDEST row (createdAt ASC,
+ * id ASC) keeps its slug; every other row's slug is suffixed with a UUID prefix
+ * (`<slug>-<id6>`) — deterministic and collision-resistant. An out-of-band
+ * human decision can later merge/relabel the renamed agents.
+ *
+ * Forward-only, additive. CI e2e (sqlite + `DATABASE_AUTOMIGRATE`) builds the
+ * schema from entity metadata, so this migration is the Postgres-deploy path;
+ * it is nonetheless written cross-dialect so the migration test suite passes on
+ * better-sqlite3 too.
+ */
+export class AddAgentScopeTargetIdForDurableSlugCas1780300000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const isPostgres = queryRunner.connection.options.type === 'postgres';
+
+        // 1) Add the non-null normalized column (idempotent).
+        const table = await queryRunner.getTable('agents');
+        const hasColumn = table?.columns.some((c) => c.name === 'scopeTargetId');
+        if (!hasColumn) {
+            await queryRunner.query(
+                `ALTER TABLE "agents" ADD COLUMN "scopeTargetId" varchar(36) NOT NULL DEFAULT ''`,
+            );
+        }
+
+        // 2) Backfill from the existing scope FKs. Postgres `uuid` columns need
+        //    an explicit ::text cast for COALESCE into a varchar target.
+        const coalesce = isPostgres
+            ? `COALESCE("missionId"::text, "ideaId"::text, "workId"::text, '')`
+            : `COALESCE("missionId", "ideaId", "workId", '')`;
+        await queryRunner.query(`UPDATE "agents" SET "scopeTargetId" = ${coalesce}`);
+
+        // 3) Auto-dedupe each (userId, scope, scopeTargetId, slug) bucket BEFORE
+        //    the unique index is created, so a pre-existing duplicate cannot
+        //    CrashLoopBackOff the API on boot.
+        await this.dedupeSlugBuckets(queryRunner, isPostgres);
+
+        // 4) Replace the old NULL-distinct index with the durable one. Same name
+        //    so downstream references and the entity decorator stay in sync.
+        await queryRunner.query(`DROP INDEX IF EXISTS "uq_agents_user_scope_slug"`);
+        const refreshed = await queryRunner.getTable('agents');
+        const hasNew = refreshed?.indices.some((idx) => idx.name === 'uq_agents_user_scope_slug');
+        if (!hasNew) {
+            await queryRunner.query(
+                `CREATE UNIQUE INDEX "uq_agents_user_scope_slug" ON "agents" ("userId", "scope", "scopeTargetId", "slug")`,
+            );
+        }
+    }
+
+    private async dedupeSlugBuckets(queryRunner: QueryRunner, isPostgres: boolean): Promise<void> {
+        const buckets = (await queryRunner.query(
+            `SELECT "userId", "scope", "scopeTargetId", "slug", COUNT(*) AS cnt
+             FROM "agents"
+             GROUP BY "userId", "scope", "scopeTargetId", "slug"
+             HAVING COUNT(*) > 1`,
+        )) as Array<{ userId: string; scope: string; scopeTargetId: string; slug: string }>;
+        if (buckets.length === 0) {
+            return;
+        }
+
+        const ph = (n: number) => (isPostgres ? `$${n}` : '?');
+        const updateSql = `UPDATE "agents" SET "slug" = ${ph(1)} WHERE "id" = ${ph(2)}`;
+        const renamedIds: string[] = [];
+
+        for (const b of buckets) {
+            const rows = (await queryRunner.query(
+                `SELECT "id", "slug" FROM "agents"
+                 WHERE "userId" = ${ph(1)} AND "scope" = ${ph(2)}
+                   AND "scopeTargetId" = ${ph(3)} AND "slug" = ${ph(4)}
+                 ORDER BY "createdAt" ASC, "id" ASC`,
+                [b.userId, b.scope, b.scopeTargetId, b.slug],
+            )) as Array<{ id: string; slug: string }>;
+
+            // rows[0] (oldest) keeps the canonical slug; rename the rest.
+            for (let i = 1; i < rows.length; i++) {
+                const row = rows[i];
+                const hex = String(row.id).replace(/-/g, '');
+                const suffix = `-${hex.slice(0, 6)}`;
+                // `slug` is varchar(80); truncate the base so the suffix fits.
+                const base =
+                    row.slug.length + suffix.length > 80
+                        ? row.slug.slice(0, 80 - suffix.length)
+                        : row.slug;
+                await queryRunner.query(updateSql, [`${base}${suffix}`, row.id]);
+                renamedIds.push(row.id);
+            }
+        }
+
+        if (renamedIds.length > 0) {
+            // Log only count + ids (no slugs/PII) for ops traceability.
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[migration] AddAgentScopeTargetIdForDurableSlugCas renamed ${renamedIds.length} duplicate agent slug(s): IDs=${renamedIds.join(',')}`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Restore the prior (NULL-distinct) index form, then drop the column.
+        await queryRunner.query(`DROP INDEX IF EXISTS "uq_agents_user_scope_slug"`);
+        await queryRunner.query(
+            `CREATE UNIQUE INDEX "uq_agents_user_scope_slug" ON "agents" ("userId", "scope", "missionId", "ideaId", "workId", "slug")`,
+        );
+        await queryRunner.query(`ALTER TABLE "agents" DROP COLUMN "scopeTargetId"`);
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddAgentScopeTargetIdForDurableSlugCas.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddAgentScopeTargetIdForDurableSlugCas.spec.ts
@@ -81,7 +81,9 @@ describe('AddAgentScopeTargetIdForDurableSlugCas1780300000000', () => {
     async function rowsById(): Promise<Record<string, { slug: string; scopeTargetId: string }>> {
         const rows: Array<{ id: string; slug: string; scopeTargetId: string }> =
             await dataSource.query(`SELECT "id", "slug", "scopeTargetId" FROM "agents"`);
-        return Object.fromEntries(rows.map((r) => [r.id, { slug: r.slug, scopeTargetId: r.scopeTargetId }]));
+        return Object.fromEntries(
+            rows.map((r) => [r.id, { slug: r.slug, scopeTargetId: r.scopeTargetId }]),
+        );
     }
 
     async function indexSql(): Promise<string | null> {

--- a/apps/api/src/migrations/__tests__/AddAgentScopeTargetIdForDurableSlugCas.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddAgentScopeTargetIdForDurableSlugCas.spec.ts
@@ -1,0 +1,171 @@
+import { DataSource } from 'typeorm';
+import { AddAgentScopeTargetIdForDurableSlugCas1780300000000 } from '../1780300000000-AddAgentScopeTargetIdForDurableSlugCas';
+
+/**
+ * Migration test for the durable Agent slug-CAS fix.
+ *
+ * Uses the same in-memory better-sqlite3 harness as
+ * `AddUniqueIndexToUsername.spec.ts`. Sets up the OLD agents schema (the
+ * `(userId, scope, missionId, ideaId, workId, slug)` NULL-distinct unique
+ * index) — which, because SQL treats NULLs as DISTINCT, permits the very
+ * duplicate rows the fix must dedup — then asserts up():
+ *   - adds the non-null `scopeTargetId` column and backfills it from the FKs;
+ *   - auto-renames duplicate (userId, scope, scopeTargetId, slug) buckets
+ *     (oldest keeps the slug; later rows get a `-<id6>` suffix);
+ *   - swaps the unique index to the durable `(…, scopeTargetId, slug)` form;
+ *   - is idempotent; and down() restores the prior shape.
+ */
+describe('AddAgentScopeTargetIdForDurableSlugCas1780300000000', () => {
+    let dataSource: DataSource;
+    const migration = new AddAgentScopeTargetIdForDurableSlugCas1780300000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+
+        // OLD schema: scope FKs nullable, NULL-distinct composite unique index.
+        await dataSource.query(
+            `CREATE TABLE "agents" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "userId" varchar NOT NULL,
+                "scope" varchar NOT NULL,
+                "missionId" varchar,
+                "ideaId" varchar,
+                "workId" varchar,
+                "slug" varchar NOT NULL,
+                "createdAt" varchar NOT NULL
+            )`,
+        );
+        await dataSource.query(
+            `CREATE UNIQUE INDEX "uq_agents_user_scope_slug" ON "agents" ("userId", "scope", "missionId", "ideaId", "workId", "slug")`,
+        );
+    });
+
+    afterEach(async () => {
+        await dataSource.destroy();
+    });
+
+    function uuid(prefix: string): string {
+        return `${prefix}aa-bbbb-cccc-dddd-eeeeeeeeeeee`.slice(0, 36);
+    }
+
+    async function insert(
+        id: string,
+        userId: string,
+        scope: string,
+        fks: { missionId?: string | null; ideaId?: string | null; workId?: string | null },
+        slug: string,
+        createdAt: string,
+    ): Promise<void> {
+        await dataSource.query(
+            `INSERT INTO "agents" ("id", "userId", "scope", "missionId", "ideaId", "workId", "slug", "createdAt")
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+                id,
+                userId,
+                scope,
+                fks.missionId ?? null,
+                fks.ideaId ?? null,
+                fks.workId ?? null,
+                slug,
+                createdAt,
+            ],
+        );
+    }
+
+    async function rowsById(): Promise<Record<string, { slug: string; scopeTargetId: string }>> {
+        const rows: Array<{ id: string; slug: string; scopeTargetId: string }> =
+            await dataSource.query(`SELECT "id", "slug", "scopeTargetId" FROM "agents"`);
+        return Object.fromEntries(rows.map((r) => [r.id, { slug: r.slug, scopeTargetId: r.scopeTargetId }]));
+    }
+
+    async function indexSql(): Promise<string | null> {
+        const rows: Array<{ sql: string | null }> = await dataSource.query(
+            `SELECT sql FROM sqlite_master WHERE type='index' AND name='uq_agents_user_scope_slug'`,
+        );
+        return rows.length ? rows[0].sql : null;
+    }
+
+    async function runUp(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    it('adds + backfills scopeTargetId and installs the durable index on a clean DB', async () => {
+        await insert(uuid('111111'), 'u1', 'tenant', {}, 'alpha', '2026-01-01');
+        await insert(uuid('222222'), 'u1', 'work', { workId: 'w-9' }, 'beta', '2026-01-02');
+        await insert(uuid('333333'), 'u1', 'mission', { missionId: 'm-7' }, 'gamma', '2026-01-03');
+
+        await runUp();
+
+        const rows = await rowsById();
+        expect(rows[uuid('111111')].scopeTargetId).toBe(''); // tenant → empty, never NULL
+        expect(rows[uuid('222222')].scopeTargetId).toBe('w-9');
+        expect(rows[uuid('333333')].scopeTargetId).toBe('m-7');
+
+        const sql = await indexSql();
+        expect(sql).toContain('scopeTargetId');
+        expect(sql).not.toContain('missionId'); // old nullable members gone
+    });
+
+    it('auto-renames duplicate tenant-scoped agents the old index could not catch', async () => {
+        // Same (userId, tenant, slug); all FKs NULL → old index allowed both.
+        const oldId = uuid('aaaaaa');
+        const newId = uuid('bbbbbb');
+        await insert(oldId, 'u1', 'tenant', {}, 'dup', '2026-01-01T00:00:00Z');
+        await insert(newId, 'u1', 'tenant', {}, 'dup', '2026-02-01T00:00:00Z');
+
+        await runUp();
+
+        const rows = await rowsById();
+        expect(rows[oldId].slug).toBe('dup'); // oldest keeps the canonical slug
+        expect(rows[newId].slug).toBe('dup-bbbbbb'); // later row suffixed by id prefix
+        expect(rows[oldId].scopeTargetId).toBe('');
+        expect(rows[newId].scopeTargetId).toBe('');
+        // The durable index now exists and the rows no longer collide on it.
+        expect(await indexSql()).toContain('scopeTargetId');
+    });
+
+    it('does NOT rename rows that only collide on a nullable FK (distinct scope targets)', async () => {
+        // Same slug but different workId → genuinely distinct, must both survive.
+        await insert(uuid('aaaaaa'), 'u1', 'work', { workId: 'w-1' }, 'same', '2026-01-01');
+        await insert(uuid('bbbbbb'), 'u1', 'work', { workId: 'w-2' }, 'same', '2026-01-02');
+
+        await runUp();
+
+        const rows = await rowsById();
+        expect(rows[uuid('aaaaaa')].slug).toBe('same');
+        expect(rows[uuid('bbbbbb')].slug).toBe('same');
+        expect(rows[uuid('aaaaaa')].scopeTargetId).toBe('w-1');
+        expect(rows[uuid('bbbbbb')].scopeTargetId).toBe('w-2');
+    });
+
+    it('is idempotent — running up() twice does not throw', async () => {
+        await insert(uuid('111111'), 'u1', 'tenant', {}, 'x', '2026-01-01');
+        await runUp();
+        await expect(runUp()).resolves.toBeUndefined();
+        expect(await indexSql()).toContain('scopeTargetId');
+    });
+
+    it('down() restores the prior NULL-distinct index and drops the column', async () => {
+        await insert(uuid('111111'), 'u1', 'tenant', {}, 'x', '2026-01-01');
+        await runUp();
+        expect(await indexSql()).toContain('scopeTargetId');
+
+        const down = dataSource.createQueryRunner();
+        await migration.down(down);
+        await down.release();
+
+        const sql = await indexSql();
+        expect(sql).toContain('missionId'); // old form back
+        expect(sql).not.toContain('scopeTargetId');
+        const cols: Array<{ name: string }> = await dataSource.query(`PRAGMA table_info("agents")`);
+        expect(cols.some((c) => c.name === 'scopeTargetId')).toBe(false);
+    });
+});

--- a/packages/agent/src/entities/__tests__/agent.entity.spec.ts
+++ b/packages/agent/src/entities/__tests__/agent.entity.spec.ts
@@ -82,11 +82,40 @@ describe('Agent entity', () => {
         expect(pauseAfter?.options.default).toBe(3);
     });
 
-    it('declares the composite uniqueness on (userId, scope, missionId, ideaId, workId, slug)', () => {
+    it('declares the durable composite uniqueness on (userId, scope, scopeTargetId, slug)', () => {
         const uq = indices.find((i) => i.name === 'uq_agents_user_scope_slug');
         expect(uq).toBeDefined();
         expect(uq?.unique).toBe(true);
-        expect(uq?.columns).toEqual(['userId', 'scope', 'missionId', 'ideaId', 'workId', 'slug']);
+        // `scopeTargetId` (non-null, = missionId ?? ideaId ?? workId ?? '')
+        // replaces the three nullable scope FKs so the unique index has no
+        // nullable members. SQL treats NULLs as DISTINCT inside a unique index,
+        // so the old (…, missionId, ideaId, workId, slug) form could NOT dedup
+        // same-name agents in a null-containing scope (tenant/mission/etc.) and
+        // a concurrent create burst all succeeded instead of exactly one.
+        expect(uq?.columns).toEqual(['userId', 'scope', 'scopeTargetId', 'slug']);
+    });
+
+    it('keeps scopeTargetId (non-null) in lock-step with the scope FKs', () => {
+        const col = columns.find((c) => c.propertyName === 'scopeTargetId');
+        expect(col).toBeDefined();
+        expect(col?.options.nullable).toBeFalsy();
+        expect(col?.options.default).toBe('');
+
+        // The @BeforeInsert/@BeforeUpdate hook derives it from the scope FKs.
+        const agent = new Agent();
+        agent.missionId = null;
+        agent.ideaId = null;
+        agent.workId = null;
+        agent.syncScopeTargetId();
+        expect(agent.scopeTargetId).toBe(''); // tenant scope → empty, never NULL
+
+        agent.workId = 'work-123';
+        agent.syncScopeTargetId();
+        expect(agent.scopeTargetId).toBe('work-123');
+
+        agent.missionId = 'mission-9';
+        agent.syncScopeTargetId();
+        expect(agent.scopeTargetId).toBe('mission-9'); // missionId wins the coalesce
     });
 
     it('declares the dispatcher-hot-path index on (status, nextHeartbeatAt)', () => {

--- a/packages/agent/src/entities/agent.entity.ts
+++ b/packages/agent/src/entities/agent.entity.ts
@@ -1,4 +1,6 @@
 import {
+    BeforeInsert,
+    BeforeUpdate,
     Column,
     CreateDateColumn,
     Entity,
@@ -147,7 +149,16 @@ export enum AgentIdleBehavior {
  * avoid forward-import cycles; FK constraints are added by the migration.
  */
 @Entity({ name: 'agents' })
-@Index('uq_agents_user_scope_slug', ['userId', 'scope', 'missionId', 'ideaId', 'workId', 'slug'], {
+// Durable per-scope slug uniqueness. The scope's target is normalized into the
+// NON-NULL `scopeTargetId` column (see below) so this index has no nullable
+// members — SQL treats NULLs as DISTINCT inside a unique index, so the previous
+// `(userId, scope, missionId, ideaId, workId, slug)` form could NOT dedup
+// same-name agents in any null-containing scope (tenant has all three FKs null;
+// mission has idea/work null; etc.), letting a concurrent same-name create
+// burst ALL succeed instead of exactly one. With `scopeTargetId` non-null the
+// DB enforces the slug CAS on both Postgres and sqlite, and the lost racers get
+// the named 409 via `isUniqueConstraintError` in agents.service.create.
+@Index('uq_agents_user_scope_slug', ['userId', 'scope', 'scopeTargetId', 'slug'], {
     unique: true,
 })
 @Index('idx_agents_user_status', ['userId', 'status'])
@@ -180,6 +191,18 @@ export class Agent {
     /** FK to `works.id` when `scope = 'work'`. */
     @Column('uuid', { nullable: true })
     workId?: string | null;
+
+    /**
+     * NON-NULL normalization of the scope's target id, used solely by the
+     * `uq_agents_user_scope_slug` unique index so it carries no nullable
+     * members (NULLs are DISTINCT in a unique index and would defeat the
+     * dedup). Holds `missionId ?? ideaId ?? workId` for scoped agents, or the
+     * empty string for tenant-scope. Kept in lock-step with the FKs by
+     * `syncScopeTargetId()` (@BeforeInsert/@BeforeUpdate) — never set it by
+     * hand.
+     */
+    @Column({ type: 'varchar', length: 36, default: '' })
+    scopeTargetId: string;
 
     @Column({ type: 'varchar', length: 120 })
     name: string;
@@ -326,4 +349,16 @@ export class Agent {
 
     @UpdateDateColumn()
     updatedAt: Date;
+
+    /**
+     * Keep `scopeTargetId` in lock-step with the scope FKs on every persist so
+     * the durable `uq_agents_user_scope_slug` unique index has a non-null key.
+     * Runs on `repository.save()` (the only persistence path AgentRepository
+     * uses) for every create site — service, export, and tool-driven creates.
+     */
+    @BeforeInsert()
+    @BeforeUpdate()
+    syncScopeTargetId(): void {
+        this.scopeTargetId = this.missionId ?? this.ideaId ?? this.workId ?? '';
+    }
 }


### PR DESCRIPTION
## Problem
`uq_agents_user_scope_slug` spanned the nullable scope FKs `(userId, scope, missionId, ideaId, workId, slug)`. SQL treats **NULLs as DISTINCT inside a unique index**, so for any null-containing scope (tenant has all three FKs null; mission has idea/work null; …) the index could **not** dedup same-name agents. A concurrent same-name create burst passed the racy app-level pre-check in `agents.service.create` for every racer and **every INSERT won** — the `isUniqueConstraintError` → 409 path never fired because the index never threw.

Surfaced as the flaky `flow-optimistic-concurrency.spec.ts:393` ("a concurrent same-name Agent create burst yields exactly one 201 + the rest 409") on sqlite CI — sometimes all 6 returned 201.

## Fix
A **non-null** `scopeTargetId` column (`= missionId ?? ideaId ?? workId ?? ''`), kept in lock-step with the FKs by an `@BeforeInsert/@BeforeUpdate` hook, and the unique index moved to `(userId, scope, scopeTargetId, slug)` — no nullable members, so the DB enforces the slug CAS on **both Postgres and sqlite**. The existing 409 catch then correctly converts the lost racers.

- **Entity** (`agent.entity.ts`): column + `syncScopeTargetId()` hook + index swap. The hook runs on `repository.save()` (the only persistence path), so all three create sites — service, export, tool — populate it. CI builds schema from entity metadata via `DATABASE_AUTOMIGRATE`, so no migration is needed there.
- **Migration** (`1780300000000-…`): Postgres deploy path (`synchronize` and `migrationsRun` are mutually exclusive). Adds + backfills the column, **auto-dedupes** existing `(userId, scope, scopeTargetId, slug)` buckets (keep-oldest, suffix the rest — avoids a `migrationsRun` CrashLoopBackOff on a pre-existing duplicate, per the AddUniqueIndexToUsername incident), then swaps the index. Cross-dialect.
- **Tests**: `agent.entity.spec` (index shape + hook coalescing) and a migration spec (backfill, tenant-dup rename, distinct-FK preservation, idempotent, down).

## Verification (live sqlite-in-memory API, CI's DB)
- 6-way same-name burst → **1×201 + 5×409, deterministic across 5/5 rounds** (was all-201 before the fix)
- sequential dup → 201 then the named **409** ("An Agent named … already exists in this scope")
- distinct names → 201
- `agent.entity.spec` 13/13 · migration spec 5/5 · agent suite green

## Operator note
The migration auto-renames pre-existing duplicate agent slugs (keep-oldest). On prod that's the safe non-crashing path, but please eyeball whether any real duplicate agents exist before merge — renamed ids are logged (no PII).

Split out of the e2e-greening PR #1218 to keep the schema migration reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved reliability of agent name uniqueness constraints under concurrent operations to prevent duplicate slug creation in the same scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->