### PR TITLE
feat(security): fail-closed OrganizationOwnershipGuard for :orgId routes (EW-711 C2a)

### DIFF
--- a/apps/api/src/organizations/__tests__/organization-ownership.guard.spec.ts
+++ b/apps/api/src/organizations/__tests__/organization-ownership.guard.spec.ts
@@ -1,0 +1,107 @@
+// Mock the agent database + entities barrels so importing the guard (which
+// pulls in OrganizationMembershipService) doesn't drag in the full TypeORM
+// DataSource graph. Same pattern as organization-membership.service.spec.ts.
+jest.mock('@ever-works/agent/database', () => ({}));
+jest.mock('@ever-works/agent/entities', () => ({}));
+
+import { NotFoundException, type ExecutionContext } from '@nestjs/common';
+import type { Reflector } from '@nestjs/core';
+import { OrganizationOwnershipGuard } from '../guards/organization-ownership.guard';
+
+/**
+ * Unit tests for the fail-closed object-level guard (EW-711 / audit C2).
+ * Contract under test:
+ *   - delegates to OrganizationMembershipService.ensureMember / ensureAdmin
+ *     (so it inherits the 404-not-403 existence-leak contract);
+ *   - `@OrgAdmin()` metadata routes to the write-side `ensureAdmin` seam;
+ *   - resolves `orgId` from the path param or the `?orgId` query param;
+ *   - fails CLOSED (404, no service call) on a missing orgId or user;
+ *   - skips non-HTTP contexts.
+ */
+describe('OrganizationOwnershipGuard', () => {
+    type Req = {
+        params?: Record<string, string>;
+        query?: Record<string, unknown>;
+        user?: { userId?: string };
+    };
+
+    function makeCtx(req: Req, type: 'http' | 'rpc' = 'http'): ExecutionContext {
+        return {
+            getType: () => type,
+            switchToHttp: () => ({ getRequest: () => req }),
+            getHandler: () => function handler() {},
+            getClass: () => class Ctrl {},
+        } as unknown as ExecutionContext;
+    }
+
+    function makeGuard(opts: {
+        admin?: boolean;
+        ensureMember?: jest.Mock;
+        ensureAdmin?: jest.Mock;
+    }) {
+        const ensureMember = opts.ensureMember ?? jest.fn().mockResolvedValue({ id: 'o-1' });
+        const ensureAdmin = opts.ensureAdmin ?? jest.fn().mockResolvedValue({ id: 'o-1' });
+        const membership = { ensureMember, ensureAdmin };
+        const reflector = {
+            getAllAndOverride: jest.fn().mockReturnValue(opts.admin),
+        } as unknown as Reflector;
+        const guard = new OrganizationOwnershipGuard(membership as never, reflector);
+        return { guard, ensureMember, ensureAdmin };
+    }
+
+    it('authorizes a member route via ensureMember(orgId, userId)', async () => {
+        const { guard, ensureMember, ensureAdmin } = makeGuard({ admin: false });
+        const ctx = makeCtx({ params: { orgId: 'o-1' }, user: { userId: 'u-1' } });
+        await expect(guard.canActivate(ctx)).resolves.toBe(true);
+        expect(ensureMember).toHaveBeenCalledWith('o-1', 'u-1');
+        expect(ensureAdmin).not.toHaveBeenCalled();
+    });
+
+    it('routes @OrgAdmin writes to ensureAdmin(orgId, userId)', async () => {
+        const { guard, ensureMember, ensureAdmin } = makeGuard({ admin: true });
+        const ctx = makeCtx({ params: { orgId: 'o-1' }, user: { userId: 'u-1' } });
+        await expect(guard.canActivate(ctx)).resolves.toBe(true);
+        expect(ensureAdmin).toHaveBeenCalledWith('o-1', 'u-1');
+        expect(ensureMember).not.toHaveBeenCalled();
+    });
+
+    it('resolves orgId from the ?orgId query param when no path param is present', async () => {
+        const { guard, ensureMember } = makeGuard({});
+        const ctx = makeCtx({ query: { orgId: 'o-q' }, user: { userId: 'u-1' } });
+        await expect(guard.canActivate(ctx)).resolves.toBe(true);
+        expect(ensureMember).toHaveBeenCalledWith('o-q', 'u-1');
+    });
+
+    it('fails closed (404) when orgId is missing — without calling the service', async () => {
+        const { guard, ensureMember, ensureAdmin } = makeGuard({});
+        const ctx = makeCtx({ user: { userId: 'u-1' } });
+        await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(NotFoundException);
+        expect(ensureMember).not.toHaveBeenCalled();
+        expect(ensureAdmin).not.toHaveBeenCalled();
+    });
+
+    it('fails closed (404) when there is no authenticated user', async () => {
+        const { guard, ensureMember } = makeGuard({});
+        const ctx = makeCtx({ params: { orgId: 'o-1' } });
+        await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(NotFoundException);
+        expect(ensureMember).not.toHaveBeenCalled();
+    });
+
+    it('propagates the service 404 on cross-tenant access (no existence leak)', async () => {
+        const ensureMember = jest
+            .fn()
+            .mockRejectedValue(new NotFoundException('Organization victim not found'));
+        const { guard } = makeGuard({ admin: false, ensureMember });
+        const ctx = makeCtx({ params: { orgId: 'victim' }, user: { userId: 'attacker' } });
+        await expect(guard.canActivate(ctx)).rejects.toMatchObject({
+            message: 'Organization victim not found',
+        });
+    });
+
+    it('skips non-HTTP execution contexts', async () => {
+        const { guard, ensureMember } = makeGuard({});
+        const ctx = makeCtx({}, 'rpc');
+        await expect(guard.canActivate(ctx)).resolves.toBe(true);
+        expect(ensureMember).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/organizations/guards/organization-ownership.guard.ts
+++ b/apps/api/src/organizations/guards/organization-ownership.guard.ts
@@ -1,0 +1,99 @@
+import {
+    CanActivate,
+    ExecutionContext,
+    Injectable,
+    NotFoundException,
+    SetMetadata,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { OrganizationMembershipService } from '../organization-membership.service';
+
+/**
+ * Metadata key + decorator marking a route as requiring org **admin**
+ * (write-side) ownership rather than plain membership. Default (no
+ * decorator) = member-level.
+ *
+ * Today member and admin resolve to the SAME tenant-ownership check — a
+ * true per-Organization admin role is a re-deferred schema + product
+ * decision (see `OrganizationMembershipService`). The distinction is
+ * carried here so that, once the role lands, the write path tightens in
+ * ONE place (the guard's `ensureAdmin` branch) without touching every
+ * route.
+ */
+export const ORG_OWNERSHIP_ADMIN = 'org_ownership_admin';
+export const OrgAdmin = () => SetMetadata(ORG_OWNERSHIP_ADMIN, true);
+
+/**
+ * Fail-closed object-level authorization for raw
+ * `/api/organizations/:orgId/...` (and `?orgId=`) routes.
+ *
+ * **Why a guard, not only the inline service call.** The platform-wide
+ * scope guards do NOT authorize an attacker-supplied `:orgId`: the
+ * un-prefixed `/api/organizations/:orgId/...` shape yields
+ * `EMPTY_SCOPE`, so `ScopeOwnershipGuard` passes trivially (see
+ * `scope-ownership.guard.ts`). Before this guard, every such route had
+ * to remember to call `OrganizationMembershipService` inline — and a new
+ * `:orgId` route that forgot the call shipped UNPROTECTED by default
+ * (the exact gap flagged by the 2026-06-02 security audit, EW-711). This
+ * guard makes the tenant-ownership check **declarative and default-on**:
+ * decorate a route with `@UseGuards(OrganizationOwnershipGuard)` (plus
+ * `@OrgAdmin()` for writes) and it is authorized before the handler runs.
+ *
+ * It delegates to the same `OrganizationMembershipService.ensureMember /
+ * ensureAdmin`, so it inherits the **404-not-403 existence-leak
+ * contract** — a foreign or missing `:orgId` is indistinguishable from
+ * "not found". Runs after `AuthSessionGuard` (which populates
+ * `req.user`); guards execute in registration order, controller-level
+ * (`AuthSessionGuard`) before route-level (this guard).
+ *
+ * Fail-closed: a missing `orgId` or an unauthenticated request resolves
+ * to `NotFoundException` — never a silent allow.
+ */
+@Injectable()
+export class OrganizationOwnershipGuard implements CanActivate {
+    constructor(
+        private readonly membership: OrganizationMembershipService,
+        private readonly reflector: Reflector,
+    ) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        // Only HTTP — skip RPC / WS / etc.
+        if (context.getType() !== 'http') {
+            return true;
+        }
+
+        const req = context.switchToHttp().getRequest<{
+            params?: Record<string, string>;
+            query?: Record<string, unknown>;
+            user?: { userId?: string };
+        }>();
+
+        const orgId =
+            req.params?.orgId ??
+            (typeof req.query?.orgId === 'string' ? req.query.orgId : undefined);
+        const userId = req.user?.userId;
+
+        // Fail closed: no org id or no authenticated user → reject with the
+        // same existence-leak-safe 404 the membership service throws.
+        // (AuthSessionGuard normally rejects unauthenticated requests before
+        // this runs; the user check is defensive.)
+        if (!orgId || !userId) {
+            throw new NotFoundException(`Organization ${orgId ?? ''} not found`.trimEnd());
+        }
+
+        const requiresAdmin = this.reflector.getAllAndOverride<boolean>(ORG_OWNERSHIP_ADMIN, [
+            context.getHandler(),
+            context.getClass(),
+        ]);
+
+        // `ensure*` throws NotFoundException (404) on any failure — no
+        // user/tenant, missing org, or cross-tenant org — preserving the
+        // existence-leak contract. A clean resolve authorizes the request.
+        if (requiresAdmin) {
+            await this.membership.ensureAdmin(orgId, userId);
+        } else {
+            await this.membership.ensureMember(orgId, userId);
+        }
+        return true;
+    }
+}

--- a/apps/api/src/organizations/organizations.module.ts
+++ b/apps/api/src/organizations/organizations.module.ts
@@ -11,6 +11,7 @@ import { TenantBootstrapService } from '../scope/tenant-bootstrap.service';
 import { UsersModule } from '../users/users.module';
 import { OrganizationService } from './organization.service';
 import { OrganizationMembershipService } from './organization-membership.service';
+import { OrganizationOwnershipGuard } from './guards/organization-ownership.guard';
 import { OrganizationsController } from './organizations.controller';
 import { WorkRegisteredListener } from './work-registered.listener';
 
@@ -50,11 +51,22 @@ import { WorkRegisteredListener } from './work-registered.listener';
         // feature modules with `:orgId` routes (e.g. WorksModule's
         // OrgKbController) share one audited implementation.
         OrganizationMembershipService,
+        // EW-711 (security-audit C2) — fail-closed `CanActivate` wrapper over
+        // OrganizationMembershipService so raw `:orgId` routes are authorized
+        // declaratively/by-default (closes the "a future route forgets the
+        // inline call" gap). Exported for feature modules with `:orgId` routes
+        // (e.g. WorksModule's OrgKbController).
+        OrganizationOwnershipGuard,
         // EW-665 (Phase 13) — turns a Company Work's `→ registered`
         // transition (the `work.status.changed` event) into an Org.
         WorkRegisteredListener,
     ],
     controllers: [OrganizationsController],
-    exports: [OrganizationService, OrganizationMembershipService, TenantBootstrapService],
+    exports: [
+        OrganizationService,
+        OrganizationMembershipService,
+        OrganizationOwnershipGuard,
+        TenantBootstrapService,
+    ],
 })
 export class OrganizationsModule {}

--- a/apps/api/src/works/org-kb.controller.ts
+++ b/apps/api/src/works/org-kb.controller.ts
@@ -15,6 +15,10 @@ import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@ne
 import { KnowledgeBaseService, WorkOwnershipService } from '@ever-works/agent/services';
 import { CreateKbDocumentDto, KbDocumentQueryDto } from '@ever-works/agent/dto';
 import { OrganizationMembershipService } from '../organizations/organization-membership.service';
+import {
+    OrganizationOwnershipGuard,
+    OrgAdmin,
+} from '../organizations/guards/organization-ownership.guard';
 import type { KbDocumentClass, KbDocumentStatus } from '@ever-works/agent/entities';
 import { AuthSessionGuard, CurrentUser } from '../auth';
 import { AuthenticatedUser } from '@src/auth/types/auth.types';
@@ -79,6 +83,7 @@ export class OrgKbController {
     }
 
     @Get('organizations/:orgId/kb/documents')
+    @UseGuards(OrganizationOwnershipGuard)
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: 'List organization-level KB documents' })
     @ApiQuery({ name: 'class', required: false, description: 'Filter by class (legal|style|seo)' })
@@ -89,6 +94,8 @@ export class OrgKbController {
         @Query() query: KbDocumentQueryDto,
     ) {
         // Security: reject cross-tenant reads of another org's KB docs.
+        // `OrganizationOwnershipGuard` (above) already enforces this
+        // default-on; the inline call is retained as defense-in-depth.
         await this.membership.ensureMember(orgId, auth.userId);
         return this.kb.listOrgDocuments(orgId, {
             class: query.class as KbDocumentClass | undefined,
@@ -96,6 +103,8 @@ export class OrgKbController {
     }
 
     @Post('organizations/:orgId/kb/documents')
+    @UseGuards(OrganizationOwnershipGuard)
+    @OrgAdmin()
     @HttpCode(HttpStatus.CREATED)
     @ApiOperation({
         summary: 'Create an organization-level KB document',
@@ -111,8 +120,10 @@ export class OrgKbController {
     ) {
         // Security: reject cross-tenant writes (stored prompt-injection /
         // repo poisoning of another tenant's org via attacker-supplied orgId).
-        // `ensureAdmin` is the write-side seam; today it's the same
+        // `@OrgAdmin()` + `OrganizationOwnershipGuard` (above) enforce this
+        // default-on via the write-side `ensureAdmin` seam — today the same
         // tenant-ownership check as `ensureMember` (org-admin role re-deferred).
+        // The inline call is retained as defense-in-depth.
         await this.membership.ensureAdmin(orgId, auth.userId);
         return this.kb.createOrgDocument(orgId, auth.userId, {
             path: body.path,


### PR DESCRIPTION
**Jira:** [EW-711](https://evertech.atlassian.net/browse/EW-711) (security-audit remediation, epic [EW-710](https://evertech.atlassian.net/browse/EW-710)) — the **C2(a)** half.

## Problem
Raw `/api/organizations/:orgId/...` routes are not authorized by the platform scope guards — the un-prefixed shape yields `EMPTY_SCOPE`, so `ScopeOwnershipGuard` passes trivially. Authorization lived only in an **easily-omittable inline** `OrganizationMembershipService.ensure*()` call; a future `:orgId` route that forgot it would ship **unprotected by default**. (Deferred-critical C2 from the 2026-06-02 audit; an adversarial verification confirmed the cross-tenant IDOR itself is already closed, but the *default-on* protection was missing.)

## Change
- **`OrganizationOwnershipGuard`** (`CanActivate`) — makes the tenant-ownership check declarative/default-on. Resolves `orgId` (path param or `?orgId`) + `req.user.userId`, delegates to `ensureMember`/`ensureAdmin`, **inheriting the 404-not-403 existence-leak contract**. **Fail-closed** on missing orgId/user. `@OrgAdmin()` metadata routes writes through the `ensureAdmin` seam.
- Applied to both `OrgKbController` `:orgId` routes (`@UseGuards` + `@OrgAdmin()` on the write). Inline `ensure*` calls **kept as defense-in-depth**.
- Provided + exported from `OrganizationsModule` (WorksModule already imports it).
- **Unit spec** (7 cases): member/admin routing, `?orgId` resolution, fail-closed on missing orgId/user, service-404 propagation, non-HTTP skip.

## Deferred (tracked on EW-711, NOT in this PR)
The **C2(b) true org-admin role** — `ensureAdmin` is still `== ensureMember`. That needs a schema + product decision (new `organization_members` entity + migration + creator-seed + **backfill** + owner-identity modeling) and is intentionally deferred. This guard gives that future role a single seam to tighten.

## Verification
`organization*` api specs **58/58 green** (incl. the new guard spec 7/7); prettier clean; type-clean. No behavior change for legitimate same-tenant callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-711]: https://evertech.atlassian.net/browse/EW-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-710]: https://evertech.atlassian.net/browse/EW-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented tenant-scoped authorization for organization endpoints that restricts KB document access based on user membership and admin status, with fail-closed security behavior.

* **Tests**
  * Added unit tests covering authorization logic, including membership verification, admin checks, and cross-tenant access prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->