### PR TITLE
fix(ci): unblock develop type-check (apps/docs Link/JSX + apps/web Vitest mocks)

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -3,6 +3,22 @@
 	"extends": "@docusaurus/tsconfig",
 	"compilerOptions": {
 		"baseUrl": ".",
-		"types": ["@docusaurus/module-type-aliases"]
+		"types": ["@docusaurus/module-type-aliases"],
+		// Force @types/react / @types/react-dom resolution to the 18.x copy pinned
+		// in this app's devDependencies. Several Docusaurus 3 packages (e.g.
+		// @docusaurus/module-type-aliases, @docusaurus/react-loadable,
+		// @docusaurus/theme-common) transitively pull @types/react@19, which leaks
+		// the React-19 ReactNode (includes `bigint`) into types for `Link` etc.
+		// At the JSX call site tsc resolves to the 18.x ReactNode, producing
+		// TS2786 "'Link' cannot be used as a JSX component" (Footer/FooterLinks,
+		// Navbar/DesktopMenu). Pinning paths keeps every consumer in this app on
+		// 18.x without affecting apps/web (React 19).
+		"paths": {
+			"@site/*": ["./*"],
+			"react": ["./node_modules/@types/react"],
+			"react/*": ["./node_modules/@types/react/*"],
+			"react-dom": ["./node_modules/@types/react-dom"],
+			"react-dom/*": ["./node_modules/@types/react-dom/*"]
+		}
 	}
 }

--- a/apps/web/src/components/plugins/form/GithubRepoWidgets.unit.spec.tsx
+++ b/apps/web/src/components/plugins/form/GithubRepoWidgets.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { act, render, waitFor } from '@testing-library/react';
 
 // Mock next-intl translations — t(key) just returns the key so we can
@@ -45,11 +45,14 @@ vi.mock('@/components/ui/select', () => ({
 import { GithubOwnerWidget, GithubRepoWidget } from './GithubRepoWidgets';
 
 describe('GithubOwnerWidget (EW-644)', () => {
-    let onChange: ReturnType<typeof vi.fn>;
+    // Vitest 4 narrowed `Mock` to `Mock<Procedure | Constructable>`, so a bare
+    // `vi.fn()` no longer satisfies a concrete `(next: string) => void` slot.
+    // Pin the signature explicitly via the `Mock<…>` generic.
+    let onChange: Mock<(next: string) => void>;
 
     beforeEach(() => {
         getGitProviderOrganizations.mockReset();
-        onChange = vi.fn();
+        onChange = vi.fn<(next: string) => void>();
     });
 
     afterEach(() => {
@@ -114,16 +117,22 @@ describe('GithubOwnerWidget (EW-644)', () => {
 });
 
 describe('GithubRepoWidget (EW-644)', () => {
-    let onChange: ReturnType<typeof vi.fn>;
+    // Same Vitest-4 `Mock<…>` pinning as the owner-widget suite. The widget's
+    // `siblings` prop has concrete `get(name): unknown` / `set(name, value): void`
+    // signatures, which a bare `vi.fn()` can no longer satisfy.
+    let onChange: Mock<(next: string) => void>;
     let siblings: {
-        get: ReturnType<typeof vi.fn>;
-        set: ReturnType<typeof vi.fn>;
+        get: Mock<(name: string) => unknown>;
+        set: Mock<(name: string, value: unknown) => void>;
     };
 
     beforeEach(() => {
         getUserRepositories.mockReset();
-        onChange = vi.fn();
-        siblings = { get: vi.fn(), set: vi.fn() };
+        onChange = vi.fn<(next: string) => void>();
+        siblings = {
+            get: vi.fn<(name: string) => unknown>(),
+            set: vi.fn<(name: string, value: unknown) => void>(),
+        };
     });
 
     afterEach(() => {
@@ -179,7 +188,10 @@ describe('GithubRepoWidget (EW-644)', () => {
 
         // Now flip the sibling 'owner' under the same component instance.
         // We swap the siblings ref's `get` to return a different owner.
-        const siblings2 = { get: vi.fn().mockReturnValue('umbrella'), set: vi.fn() };
+        const siblings2 = {
+            get: vi.fn<(name: string) => unknown>().mockReturnValue('umbrella'),
+            set: vi.fn<(name: string, value: unknown) => void>(),
+        };
         await act(async () => {
             rerender(<GithubRepoWidget value="storage" onChange={onChange} siblings={siblings2} />);
         });


### PR DESCRIPTION
## Why

`pnpm type-check` on `origin/develop` is currently red because of two pre-existing failures that block every open PR (including EW-639 PR #1219, where the regression first surfaced after stashing the local work and re-running the sweep against pristine `develop`):

1. **apps/docs** — TS2786 "'Link' cannot be used as a JSX component" in `src/theme/Footer/FooterLinks.tsx:39` and `src/theme/Navbar/DesktopMenu.tsx:57`.
2. **apps/web** — ~12 TS2322 errors in `src/components/plugins/form/GithubRepoWidgets.unit.spec.tsx` (lines 130-200) around Vitest 4's narrowed `Mock` generic.

This PR fixes both so develop's type-check sweep returns to green and other PRs can merge cleanly.

## Root causes & fixes

### 1. apps/docs — Docusaurus pulls @types/react@19 transitively

Docusaurus 3 has dependencies (`@docusaurus/module-type-aliases`, `@docusaurus/react-loadable`, `@docusaurus/theme-common`) that hoist `@types/react@19.x` into apps/docs's resolution graph alongside the 18.3.12 the app pins directly. The 19.x `ReactNode` includes `bigint`, which 18.x's doesn't accept. The `Link` component's `Props` resolve through the 19.x copy, so it returns the wider `ReactNode`, while the JSX namespace at the call site resolves to the 18.x copy. Result: assignment fails.

**Fix:** `apps/docs/tsconfig.json` adds `paths` mappings forcing `react` and `react-dom` type resolution to the 18.x copy under `apps/docs/node_modules/@types/`. Scoped to docs — apps/web's React-19 graph is untouched. (Workspace-level `pnpm.overrides` was rejected because apps/web depends on React 19; a nested override would also work but the tsconfig pin is local and minimal.)

### 2. apps/web — Vitest 4 `Mock<…>` generic narrowed

Vitest 4 (already on develop) tightened `Mock` from `Mock<TArgs, TReturn>` to `Mock<Procedure | Constructable>`. Bare `vi.fn()` instances no longer satisfy concrete prop slots — the widget's `siblings.get/set` and `onChange` props in `GithubRepoWidgets.tsx` are typed against concrete signatures `(name: string) => unknown`, `(name: string, value: unknown) => void`, and `(next: string) => void`.

**Fix:** Pin each mock with the canonical generic form, e.g. `vi.fn<(name: string) => unknown>()` typed as `Mock<(name: string) => unknown>`. The test mocks now match the production widget prop signatures exactly. No `as any` / no broad escape hatches.

## Files changed

- `apps/docs/tsconfig.json` — add `paths` for `react` / `react-dom` (with rationale comment).
- `apps/web/src/components/plugins/form/GithubRepoWidgets.unit.spec.tsx` — type the mocks with `Mock<…>` generics matching the widget prop signatures.

## Verification

- `pnpm --filter ever-works-docs type-check` → clean
- `pnpm --filter ever-works-web type-check` → clean
- `pnpm type-check` (root, all 77 workspace targets) → clean

## Notes

- Conventional commit, single focused commit.
- Pre-existing PR for EW-639 (#1219) was the prompting cause — its type-check failures on develop turned out to be these two, not anything the EW-639 branch introduced. Once this merges, that PR's CI is expected to go green on rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration for improved type compatibility across applications.
  * Enhanced test suite typing for better validation during testing framework updates.

*Note: These are internal improvements with no changes to end-user functionality.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->