### PR TITLE
fix(security): gate paid-plan grants behind billing — free-only self-service (EW-711 #23)

### DIFF
--- a/apps/api/src/subscriptions/subscriptions.controller.spec.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.spec.ts
@@ -24,7 +24,7 @@ import type { AuthenticatedUser } from '../auth/types/auth.types';
 
 describe('SubscriptionsController', () => {
     let subscriptionService: jest.Mocked<
-        Pick<SubscriptionService, 'summarizePlan' | 'isEnabled' | 'assignPlanToUser'>
+        Pick<SubscriptionService, 'summarizePlan' | 'isEnabled' | 'changePlanSelfService'>
     >;
     let authService: jest.Mocked<Pick<AuthService, 'getUser'>>;
     let controller: SubscriptionsController;
@@ -48,7 +48,7 @@ describe('SubscriptionsController', () => {
         subscriptionService = {
             summarizePlan: jest.fn(),
             isEnabled: jest.fn(),
-            assignPlanToUser: jest.fn(),
+            changePlanSelfService: jest.fn(),
         } as any;
         authService = {
             getUser: jest.fn().mockResolvedValue(user),
@@ -116,7 +116,7 @@ describe('SubscriptionsController', () => {
     });
 
     describe('updatePlan', () => {
-        it('throws BadRequestException when subscriptions are disabled (and never calls getUser/assignPlanToUser)', async () => {
+        it('throws BadRequestException when subscriptions are disabled (and never calls getUser/changePlanSelfService)', async () => {
             subscriptionService.isEnabled.mockReturnValue(false);
 
             await expect(
@@ -126,12 +126,12 @@ describe('SubscriptionsController', () => {
                 'Subscriptions are disabled',
             );
             expect(authService.getUser).not.toHaveBeenCalled();
-            expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+            expect(subscriptionService.changePlanSelfService).not.toHaveBeenCalled();
         });
 
         it('assigns plan and returns mapped envelope when enabled', async () => {
             subscriptionService.isEnabled.mockReturnValue(true);
-            subscriptionService.assignPlanToUser.mockResolvedValue({
+            subscriptionService.changePlanSelfService.mockResolvedValue({
                 code: 'starter',
                 displayName: 'Starter',
             } as any);
@@ -144,7 +144,7 @@ describe('SubscriptionsController', () => {
             const result = await controller.updatePlan(auth, { planCode: 'starter' as any });
 
             expect(authService.getUser).toHaveBeenCalledWith('user-1');
-            expect(subscriptionService.assignPlanToUser).toHaveBeenCalledWith(user, 'starter');
+            expect(subscriptionService.changePlanSelfService).toHaveBeenCalledWith(user, 'starter');
             expect(subscriptionService.summarizePlan).toHaveBeenCalledWith(user);
             expect(result).toEqual({
                 status: 'success',
@@ -157,15 +157,15 @@ describe('SubscriptionsController', () => {
             });
         });
 
-        it('uses the assignPlanToUser response (not summarizePlan) for code/name', async () => {
+        it('uses the changePlanSelfService response (not summarizePlan) for code/name', async () => {
             subscriptionService.isEnabled.mockReturnValue(true);
-            subscriptionService.assignPlanToUser.mockResolvedValue({
+            subscriptionService.changePlanSelfService.mockResolvedValue({
                 code: 'pro',
                 displayName: 'Pro Plan',
             } as any);
             subscriptionService.summarizePlan.mockResolvedValue({
                 enabled: true,
-                // a different plan in the summary — controller must trust assignPlanToUser
+                // a different plan in the summary — controller must trust changePlanSelfService
                 plan: { code: 'free', displayName: 'Free' },
                 allowances: ['weekly'],
             } as any);
@@ -179,9 +179,11 @@ describe('SubscriptionsController', () => {
             });
         });
 
-        it('propagates assignPlanToUser errors', async () => {
+        it('propagates changePlanSelfService errors', async () => {
             subscriptionService.isEnabled.mockReturnValue(true);
-            subscriptionService.assignPlanToUser.mockRejectedValue(new Error('plan not found'));
+            subscriptionService.changePlanSelfService.mockRejectedValue(
+                new Error('plan not found'),
+            );
 
             await expect(
                 controller.updatePlan(auth, { planCode: 'unknown' as any }),
@@ -196,7 +198,7 @@ describe('SubscriptionsController', () => {
             await expect(controller.updatePlan(auth, { planCode: 'pro' as any })).rejects.toThrow(
                 'User not found',
             );
-            expect(subscriptionService.assignPlanToUser).not.toHaveBeenCalled();
+            expect(subscriptionService.changePlanSelfService).not.toHaveBeenCalled();
         });
     });
 });

--- a/apps/api/src/subscriptions/subscriptions.controller.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.ts
@@ -66,11 +66,13 @@ export class SubscriptionsController {
     @Post('plan')
     @HttpCode(HttpStatus.OK)
     @ApiOperation({
-        summary: 'Update subscription plan',
-        description: 'Update the subscription plan for the user',
+        summary: 'Update subscription plan (self-service)',
+        description:
+            'Self-service plan change for the authenticated user. Only FREE plans may be set this way (sign-up default / downgrade / cancel); a paid plan must be activated through billing and is rejected with 403. (EW-711 #23.)',
     })
     @ApiResponse({ status: 200, description: 'Subscription plan updated' })
     @ApiResponse({ status: 400, description: 'Subscriptions are disabled' })
+    @ApiResponse({ status: 403, description: 'Paid plans cannot be self-assigned' })
     async updatePlan(
         @CurrentUser() auth: AuthenticatedUser,
         @Body() dto: UpdateSubscriptionPlanDto,
@@ -80,7 +82,10 @@ export class SubscriptionsController {
         }
 
         const user = await this.authService.getUser(auth.userId);
-        const plan = await this.subscriptionService.assignPlanToUser(user, dto.planCode);
+        // Security (EW-711 #23): self-service may only set a FREE plan; a paid
+        // plan requires a billing-verified grant. `changePlanSelfService`
+        // enforces this (403 on a paid plan), closing the free->paid escalation.
+        const plan = await this.subscriptionService.changePlanSelfService(user, dto.planCode);
         const summary = await this.subscriptionService.summarizePlan(user);
 
         return {

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { SubscriptionService } from './subscription.service';
 import { SubscriptionPlanCode } from '@src/entities/types';
 import { WorkScheduleBillingMode, WorkScheduleCadence } from '@ever-works/contracts/api';
@@ -620,6 +620,68 @@ describe('SubscriptionService', () => {
             });
             await service.assignPlanToUser({ id: 'u1' } as any, undefined as any);
             expect(planRepository.findByCode).toHaveBeenCalledWith(SubscriptionPlanCode.FREE);
+        });
+    });
+
+    describe('changePlanSelfService (EW-711 #23 — self-service may only set FREE)', () => {
+        it('throws BadRequestException when subscriptions are disabled', async () => {
+            process.env.SUBSCRIPTIONS_ENABLED = 'false';
+            const { service } = makeService();
+            await expect(
+                service.changePlanSelfService({ id: 'u1' } as any, SubscriptionPlanCode.FREE),
+            ).rejects.toThrow(BadRequestException);
+        });
+
+        it('throws NotFoundException when the requested plan code is not in the DB', async () => {
+            const { service } = makeService({ findByCode: jest.fn().mockResolvedValue(null) });
+            await expect(
+                service.changePlanSelfService({ id: 'u1' } as any, SubscriptionPlanCode.FREE),
+            ).rejects.toThrow(NotFoundException);
+        });
+
+        it('assigns a FREE plan (monthlyPrice 0) and persists it', async () => {
+            const user = { id: 'u1' } as any;
+            const { service, userRepository } = makeService({
+                findByCode: jest.fn().mockResolvedValue(FREE_PLAN),
+            });
+            const plan = await service.changePlanSelfService(user, SubscriptionPlanCode.FREE);
+            expect(plan).toBe(FREE_PLAN);
+            expect(userRepository.update).toHaveBeenCalledWith('u1', {
+                defaultPlanId: FREE_PLAN.id,
+            });
+            expect(user.defaultPlanId).toBe(FREE_PLAN.id);
+        });
+
+        // The escalation the fix closes: a user must NOT be able to self-assign
+        // a paid tier (monthlyPrice > 0) — that requires a billing-verified
+        // grant via the privileged `assignPlanToUser`.
+        it.each([
+            ['STANDARD', SubscriptionPlanCode.STANDARD, STANDARD_PLAN],
+            ['PREMIUM', SubscriptionPlanCode.PREMIUM, PREMIUM_PLAN],
+        ] as const)(
+            'rejects self-assigning the paid %s plan with ForbiddenException and does NOT persist',
+            async (_label, code, planFixture) => {
+                const { service, userRepository } = makeService({
+                    findByCode: jest.fn().mockResolvedValue(planFixture),
+                });
+                await expect(
+                    service.changePlanSelfService({ id: 'u1' } as any, code),
+                ).rejects.toThrow(ForbiddenException);
+                // No grant happened — the user stays on their current plan.
+                expect(userRepository.update).not.toHaveBeenCalled();
+            },
+        );
+
+        it('still lets the PRIVILEGED assignPlanToUser grant a paid plan (billing/admin seam unchanged)', async () => {
+            const user = { id: 'u1' } as any;
+            const { service, userRepository } = makeService({
+                findByCode: jest.fn().mockResolvedValue(PREMIUM_PLAN),
+            });
+            const plan = await service.assignPlanToUser(user, SubscriptionPlanCode.PREMIUM);
+            expect(plan).toBe(PREMIUM_PLAN);
+            expect(userRepository.update).toHaveBeenCalledWith('u1', {
+                defaultPlanId: PREMIUM_PLAN.id,
+            });
         });
     });
 

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -672,6 +672,19 @@ describe('SubscriptionService', () => {
             },
         );
 
+        // Fail-closed: a malformed plan row (missing / NaN monthlyPrice) must be
+        // treated as PAID and rejected, never silently self-grantable.
+        it('rejects a plan whose monthlyPrice is missing/NaN (fail-closed) and does NOT persist', async () => {
+            const malformed = { ...FREE_PLAN, monthlyPrice: undefined as any };
+            const { service, userRepository } = makeService({
+                findByCode: jest.fn().mockResolvedValue(malformed),
+            });
+            await expect(
+                service.changePlanSelfService({ id: 'u1' } as any, SubscriptionPlanCode.FREE),
+            ).rejects.toThrow(ForbiddenException);
+            expect(userRepository.update).not.toHaveBeenCalled();
+        });
+
         it('still lets the PRIVILEGED assignPlanToUser grant a paid plan (billing/admin seam unchanged)', async () => {
             const user = { id: 'u1' } as any;
             const { service, userRepository } = makeService({

--- a/packages/agent/src/subscriptions/subscription.service.spec.ts
+++ b/packages/agent/src/subscriptions/subscription.service.spec.ts
@@ -672,18 +672,24 @@ describe('SubscriptionService', () => {
             },
         );
 
-        // Fail-closed: a malformed plan row (missing / NaN monthlyPrice) must be
-        // treated as PAID and rejected, never silently self-grantable.
-        it('rejects a plan whose monthlyPrice is missing/NaN (fail-closed) and does NOT persist', async () => {
-            const malformed = { ...FREE_PLAN, monthlyPrice: undefined as any };
-            const { service, userRepository } = makeService({
-                findByCode: jest.fn().mockResolvedValue(malformed),
-            });
-            await expect(
-                service.changePlanSelfService({ id: 'u1' } as any, SubscriptionPlanCode.FREE),
-            ).rejects.toThrow(ForbiddenException);
-            expect(userRepository.update).not.toHaveBeenCalled();
-        });
+        // Fail-closed: a malformed plan row (missing/null/NaN monthlyPrice) must
+        // be treated as PAID and rejected, never silently self-grantable.
+        it.each([
+            ['undefined', undefined],
+            ['null', null],
+        ] as const)(
+            'rejects a plan whose monthlyPrice is %s (fail-closed) and does NOT persist',
+            async (_label, badPrice) => {
+                const malformed = { ...FREE_PLAN, monthlyPrice: badPrice as any };
+                const { service, userRepository } = makeService({
+                    findByCode: jest.fn().mockResolvedValue(malformed),
+                });
+                await expect(
+                    service.changePlanSelfService({ id: 'u1' } as any, SubscriptionPlanCode.FREE),
+                ).rejects.toThrow(ForbiddenException);
+                expect(userRepository.update).not.toHaveBeenCalled();
+            },
+        );
 
         it('still lets the PRIVILEGED assignPlanToUser grant a paid plan (billing/admin seam unchanged)', async () => {
             const user = { id: 'u1' } as any;

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -1,5 +1,6 @@
 import {
     BadRequestException,
+    ForbiddenException,
     Injectable,
     Logger,
     NotFoundException,
@@ -195,23 +196,75 @@ export class SubscriptionService implements OnModuleInit {
         return SubscriptionPlanCode.FREE;
     }
 
+    /**
+     * A plan that carries a recurring subscription price must be paid for
+     * through a billing-verified path; only free plans (`monthlyPrice` 0) are
+     * self-serviceable. (Per-run overage is metered separately and does not
+     * make a plan "paid" to switch onto.)
+     */
+    private isPaidPlan(plan: SubscriptionPlan): boolean {
+        return Number(plan.monthlyPrice) > 0;
+    }
+
+    private async resolvePlanOrThrow(planCode: SubscriptionPlanCode): Promise<SubscriptionPlan> {
+        const plan = await this.planRepository.findByCode(this.normalizePlanCode(planCode));
+        if (!plan) {
+            throw new NotFoundException('Plan not found');
+        }
+        return plan;
+    }
+
+    private async persistDefaultPlan(
+        user: User,
+        plan: SubscriptionPlan,
+    ): Promise<SubscriptionPlan> {
+        await this.userRepository.update(user.id, { defaultPlanId: plan.id });
+        user.defaultPlan = plan;
+        user.defaultPlanId = plan.id;
+        return plan;
+    }
+
+    /**
+     * PRIVILEGED grant — assigns ANY plan (including paid tiers) with NO
+     * self-service gate. Call this ONLY from a billing-verified path (a
+     * payment-provider webhook, once wired) or an admin/platform context.
+     *
+     * Security (EW-711 #23): user-initiated plan changes MUST go through
+     * {@link changePlanSelfService}, which refuses paid plans — otherwise any
+     * authenticated user could escalate to a paid tier without paying.
+     */
     async assignPlanToUser(user: User, planCode: SubscriptionPlanCode): Promise<SubscriptionPlan> {
         if (!this.isEnabled()) {
             throw new BadRequestException('Subscriptions are disabled');
         }
+        const plan = await this.resolvePlanOrThrow(planCode);
+        return this.persistDefaultPlan(user, plan);
+    }
 
-        const normalized = this.normalizePlanCode(planCode);
-        const plan = await this.planRepository.findByCode(normalized);
-
-        if (!plan) {
-            throw new NotFoundException('Plan not found');
+    /**
+     * User-initiated (self-service) plan change. May only move the caller to a
+     * FREE plan — the sign-up default, a self-downgrade, or a cancel. A paid
+     * plan requires a billing-verified grant ({@link assignPlanToUser}), so a
+     * self-assignment of one is rejected with 403.
+     *
+     * EW-711 #23 — closes the free→paid privilege escalation on
+     * `POST /api/subscriptions/plan` (any authenticated user could previously
+     * self-grant PREMIUM/STANDARD with no payment).
+     */
+    async changePlanSelfService(
+        user: User,
+        planCode: SubscriptionPlanCode,
+    ): Promise<SubscriptionPlan> {
+        if (!this.isEnabled()) {
+            throw new BadRequestException('Subscriptions are disabled');
         }
-
-        await this.userRepository.update(user.id, { defaultPlanId: plan.id });
-        user.defaultPlan = plan;
-        user.defaultPlanId = plan.id;
-
-        return plan;
+        const plan = await this.resolvePlanOrThrow(planCode);
+        if (this.isPaidPlan(plan)) {
+            throw new ForbiddenException(
+                'Paid plans must be activated through billing and cannot be self-assigned.',
+            );
+        }
+        return this.persistDefaultPlan(user, plan);
     }
 
     async summarizePlan(user: User) {

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -203,7 +203,11 @@ export class SubscriptionService implements OnModuleInit {
      * make a plan "paid" to switch onto.)
      */
     private isPaidPlan(plan: SubscriptionPlan): boolean {
-        return Number(plan.monthlyPrice) > 0;
+        const price = Number(plan.monthlyPrice);
+        // Fail closed: only a finite, non-positive price is a free (and thus
+        // self-serviceable) plan. A missing / NaN / positive `monthlyPrice` is
+        // treated as PAID, so a malformed plan row can never be self-granted.
+        return !(Number.isFinite(price) && price <= 0);
     }
 
     private async resolvePlanOrThrow(planCode: SubscriptionPlanCode): Promise<SubscriptionPlan> {

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -203,10 +203,17 @@ export class SubscriptionService implements OnModuleInit {
      * make a plan "paid" to switch onto.)
      */
     private isPaidPlan(plan: SubscriptionPlan): boolean {
-        const price = Number(plan.monthlyPrice);
-        // Fail closed: only a finite, non-positive price is a free (and thus
-        // self-serviceable) plan. A missing / NaN / positive `monthlyPrice` is
-        // treated as PAID, so a malformed plan row can never be self-granted.
+        const raw = plan.monthlyPrice;
+        // Fail closed: a plan is free (self-serviceable) ONLY when its
+        // `monthlyPrice` is explicitly present and parses to a finite,
+        // non-positive number. A missing / null / NaN / positive value is
+        // treated as PAID so a malformed plan row can never be self-granted.
+        // (`Number(null)` is 0 and `Number(undefined)` is NaN — neither should
+        // read as "free", hence the explicit null/undefined guard.)
+        if (raw === null || raw === undefined) {
+            return true;
+        }
+        const price = Number(raw);
         return !(Number.isFinite(price) && price <= 0);
     }
 


### PR DESCRIPTION
**Jira:** [EW-711](https://evertech.atlassian.net/browse/EW-711) #23 (epic [EW-710](https://evertech.atlassian.net/browse/EW-710)) — the highest-impact live exploit from the highs verification.

## Problem (privilege escalation)
`POST /api/subscriptions/plan` (and the `update_subscription_plan` chat tool, which calls the same endpoint) was guarded only by `AuthSessionGuard` and called `assignPlanToUser` directly. Any authenticated user could `POST {planCode:'premium'}` and **self-grant STANDARD/PREMIUM (monthlyPrice > 0) with no payment**, bypassing the billing providers.

## Fix — billing gate (your call: "wire the real billing gate")
- `SubscriptionService.assignPlanToUser` is now documented as the **PRIVILEGED** grant (any plan) — for a billing-verified path (payment webhook, once wired) or admin/platform context only. Behavior unchanged.
- New **`changePlanSelfService(user, planCode)`** is the user-facing seam: it may only set a **FREE** plan (sign-up default / self-downgrade / cancel); a paid plan (`monthlyPrice > 0`) is rejected **403** ("Paid plans must be activated through billing"). The controller now calls this.
- **Tests:** self-service rejects paid STANDARD + PREMIUM with 403 and does NOT persist; allows FREE; the privileged `assignPlanToUser` still grants paid (billing/admin seam intact). Subscription specs **76/76 green**; prettier + tsc clean.

## Note
There's no payment-verification flow yet (no Stripe checkout/webhook; `billing.provider.ts` is usage-charging only). This PR establishes the **security seam** — paid grants are now reachable only from the privileged path, so the future billing webhook plugs into `assignPlanToUser`. Building the full Stripe checkout/webhook is a separate feature tracked on EW-711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-711]: https://evertech.atlassian.net/browse/EW-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-710]: https://evertech.atlassian.net/browse/EW-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-service plan switching: users may only self-switch to the FREE plan; attempts to self-assign paid tiers are rejected with 403 Forbidden. Disabled-subscriptions now block self-service requests with a 400.

* **Bug Fixes**
  * Malformed or missing plan pricing is treated as paid (fail-closed) to prevent unintended self-assignment.

* **Documentation**
  * Subscription endpoint docs updated to document the 403 response.

* **Tests**
  * Unit tests expanded to cover self-service restrictions, disabled-subscriptions, error cases, persistence, and privileged paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->