### PR TITLE
fix(security): authorize workId before screenshot provider/secret access (EW-711 #30)

### DIFF
--- a/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.spec.ts
@@ -11,6 +11,9 @@ jest.mock('@ever-works/agent/plugins', () => ({
     PluginRegistryService: class {},
     PluginSettingsService: class {},
 }));
+jest.mock('@ever-works/agent/services', () => ({
+    WorkOwnershipService: class {},
+}));
 jest.mock('../../auth', () => ({
     AuthSessionGuard: class {},
     CurrentUser: () => () => undefined,
@@ -18,9 +21,11 @@ jest.mock('../../auth', () => ({
 
 import { BadRequestException } from '@nestjs/common';
 import { ScreenshotController } from './screenshot.controller';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { NoProviderError } from '@ever-works/agent/facades';
 import type { ScreenshotFacadeService } from '@ever-works/agent/facades';
 import type { PluginRegistryService, PluginSettingsService } from '@ever-works/agent/plugins';
+import type { WorkOwnershipService } from '@ever-works/agent/services';
 import type { AuthenticatedUser } from '../../auth/types/auth.types';
 
 describe('ScreenshotController', () => {
@@ -30,6 +35,7 @@ describe('ScreenshotController', () => {
         getDefaultForCapabilityScoped: jest.Mock;
     };
     let pluginSettings: { getSettings: jest.Mock };
+    let ownershipService: { ensureCanView: jest.Mock };
     let controller: ScreenshotController;
     const auth: AuthenticatedUser = { userId: 'user-1' } as any;
 
@@ -40,10 +46,14 @@ describe('ScreenshotController', () => {
             getDefaultForCapabilityScoped: jest.fn(),
         };
         pluginSettings = { getSettings: jest.fn() };
+        // Security (EW-711 #30): default to "access granted" so the existing
+        // same-owner behavioural specs below stay unchanged.
+        ownershipService = { ensureCanView: jest.fn().mockResolvedValue({}) };
         controller = new ScreenshotController(
             screenshotFacade as unknown as ScreenshotFacadeService,
             pluginRegistry as unknown as PluginRegistryService,
             pluginSettings as unknown as PluginSettingsService,
+            ownershipService as unknown as WorkOwnershipService,
         );
     });
 
@@ -562,6 +572,93 @@ describe('ScreenshotController', () => {
                     });
                 }
             }
+        });
+    });
+
+    // Security (EW-711 #30): cross-work IDOR. Every work-scoped entry point
+    // must authorize the supplied workId via WorkOwnershipService.ensureCanView
+    // BEFORE reading that work's enabled providers/settings (secrets) or
+    // spending its credits. No workId ⇒ personal scope ⇒ no work to authorize.
+    describe('cross-work access control (EW-711 #30)', () => {
+        const dtoWithWork = {
+            url: 'https://example.com',
+            workId: 'other-users-work',
+        } as any;
+
+        it('checkAvailability authorizes the supplied workId before reading providers', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+
+            await controller.checkAvailability(auth, 'work-42');
+
+            expect(ownershipService.ensureCanView).toHaveBeenCalledWith('work-42', 'user-1');
+        });
+
+        it('does NOT authorize when no workId is supplied (personal scope)', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+
+            await controller.checkAvailability(auth);
+
+            expect(ownershipService.ensureCanView).not.toHaveBeenCalled();
+        });
+
+        it('checkAvailability propagates ForbiddenException and never reads another work providers', async () => {
+            ownershipService.ensureCanView.mockRejectedValue(new ForbiddenException());
+
+            await expect(
+                controller.checkAvailability(auth, 'other-users-work'),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+
+            expect(ownershipService.ensureCanView).toHaveBeenCalledWith(
+                'other-users-work',
+                'user-1',
+            );
+            expect(pluginRegistry.getEnabledPluginsScoped).not.toHaveBeenCalled();
+            // The includeSecrets:true settings read must not happen for a foreign work.
+            expect(pluginSettings.getSettings).not.toHaveBeenCalled();
+        });
+
+        it('capture rejects a foreign workId before resolving providers or spending credits', async () => {
+            ownershipService.ensureCanView.mockRejectedValue(new ForbiddenException());
+
+            await expect(controller.capture(auth, dtoWithWork)).rejects.toBeInstanceOf(
+                ForbiddenException,
+            );
+
+            expect(ownershipService.ensureCanView).toHaveBeenCalledWith(
+                'other-users-work',
+                'user-1',
+            );
+            expect(pluginRegistry.getEnabledPluginsScoped).not.toHaveBeenCalled();
+            expect(pluginSettings.getSettings).not.toHaveBeenCalled();
+            expect(screenshotFacade.capture).not.toHaveBeenCalled();
+        });
+
+        it('getScreenshotUrl rejects a foreign workId before resolving providers', async () => {
+            ownershipService.ensureCanView.mockRejectedValue(new NotFoundException());
+
+            await expect(controller.getScreenshotUrl(auth, dtoWithWork)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+
+            expect(pluginRegistry.getEnabledPluginsScoped).not.toHaveBeenCalled();
+            expect(screenshotFacade.getScreenshotUrl).not.toHaveBeenCalled();
+        });
+
+        it('capture authorizes the workId for the legitimate same-owner caller and proceeds', async () => {
+            pluginRegistry.getEnabledPluginsScoped.mockResolvedValue([registered('p')]);
+            pluginRegistry.getDefaultForCapabilityScoped.mockResolvedValue(null);
+            pluginSettings.getSettings.mockResolvedValue({});
+            screenshotFacade.capture.mockResolvedValue({
+                success: true,
+                imageUrl: 'https://x/i.png',
+            });
+
+            await controller.capture(auth, { url: 'https://example.com', workId: 'work-1' } as any);
+
+            expect(ownershipService.ensureCanView).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(screenshotFacade.capture).toHaveBeenCalled();
         });
     });
 });

--- a/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.spec.ts
@@ -19,9 +19,8 @@ jest.mock('../../auth', () => ({
     CurrentUser: () => () => undefined,
 }));
 
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { ScreenshotController } from './screenshot.controller';
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { NoProviderError } from '@ever-works/agent/facades';
 import type { ScreenshotFacadeService } from '@ever-works/agent/facades';
 import type { PluginRegistryService, PluginSettingsService } from '@ever-works/agent/plugins';
@@ -642,6 +641,10 @@ describe('ScreenshotController', () => {
                 NotFoundException,
             );
 
+            expect(ownershipService.ensureCanView).toHaveBeenCalledWith(
+                'other-users-work',
+                'user-1',
+            );
             expect(pluginRegistry.getEnabledPluginsScoped).not.toHaveBeenCalled();
             expect(screenshotFacade.getScreenshotUrl).not.toHaveBeenCalled();
         });

--- a/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.ts
+++ b/apps/api/src/plugins-capabilities/screenshot/screenshot.controller.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { NoProviderError, ScreenshotFacadeService } from '@ever-works/agent/facades';
+import { WorkOwnershipService } from '@ever-works/agent/services';
 import { PluginRegistryService, PluginSettingsService } from '@ever-works/agent/plugins';
 import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
 import type { RegisteredPlugin } from '@ever-works/agent/plugins';
@@ -18,7 +19,26 @@ export class ScreenshotController {
         private readonly screenshotFacade: ScreenshotFacadeService,
         private readonly pluginRegistry: PluginRegistryService,
         private readonly pluginSettings: PluginSettingsService,
+        private readonly ownershipService: WorkOwnershipService,
     ) {}
+
+    /**
+     * Security (EW-711 #30): cross-work IDOR. When the caller supplies a
+     * `workId`, the work-scoped provider resolution below reads that work's
+     * enabled providers + settings (including secrets via
+     * `includeSecrets: true`) and spends its credits on capture. Nothing
+     * here verified the caller may access the target work, so any
+     * authenticated user could read another work's providers/secrets and
+     * burn its credits by passing a foreign `workId`. Gate on view-access
+     * to the work first (same `WorkOwnershipService.ensureCanView` seam
+     * OrgKbController uses). `ensureCanView` passes for the creator and any
+     * work member, so legitimate same-owner / same-tenant callers keep
+     * working. No `workId` ⇒ purely personal scope, no work to authorize.
+     */
+    private async ensureWorkAccess(userId: string, workId?: string): Promise<void> {
+        if (!workId) return;
+        await this.ownershipService.ensureCanView(workId, userId);
+    }
 
     private hasAllRequiredSettings(
         schema: JsonSchema | undefined,
@@ -61,6 +81,9 @@ export class ScreenshotController {
     }
 
     private async listProviders(userId: string, workId?: string) {
+        // Security (EW-711 #30): authorize the target work before reading
+        // its scoped providers/settings (incl. secrets) below.
+        await this.ensureWorkAccess(userId, workId);
         const enabledPlugins = await this.pluginRegistry.getEnabledPluginsScoped(
             PLUGIN_CAPABILITIES.SCREENSHOT,
             workId,

--- a/apps/api/src/plugins-capabilities/screenshot/screenshot.module.ts
+++ b/apps/api/src/plugins-capabilities/screenshot/screenshot.module.ts
@@ -1,10 +1,14 @@
 import { Module } from '@nestjs/common';
 import { ScreenshotController } from './screenshot.controller';
 import { FacadesModule } from '@ever-works/agent/facades';
+// Security (EW-711 #30): WorkModule provides/exports WorkOwnershipService so
+// the controller can authorize a supplied workId before reading its scoped
+// providers/secrets or spending its credits.
+import { WorkModule } from '@ever-works/agent/services';
 import { AuthModule } from '../../auth/auth.module';
 
 @Module({
-    imports: [FacadesModule, AuthModule],
+    imports: [FacadesModule, WorkModule, AuthModule],
     controllers: [ScreenshotController],
 })
 export class ScreenshotModule {}


### PR DESCRIPTION
**Jira:** [EW-711](https://evertech.atlassian.net/browse/EW-711) #30 (epic [EW-710](https://evertech.atlassian.net/browse/EW-710)) — a Wave-A deferred-high IDOR.

## Problem
The screenshot controller's `listProviders` (reached by `getScreenshotUrl`, `capture`, and the provider-list handlers) resolved a supplied `workId`'s enabled providers + settings — **including secrets** (`includeSecrets: true`) — and **spent that work's credits**, with no check that the caller may access the work. Any authenticated user could read another work's providers/secrets and burn its credits via a foreign `workId`.

## Fix
- `ensureWorkAccess(userId, workId)` → `WorkOwnershipService.ensureCanView` (the seam `OrgKbController` already uses), called at the top of `listProviders` → gates all 3 public handlers.
- No `workId` ⇒ personal scope (nothing to authorize). `ensureCanView` passes for the work creator + members, so **legit same-owner/same-tenant callers are unaffected**.
- `WorkModule` wired into `ScreenshotModule` for the DI.
- **6 new IDOR specs** (foreign workId rejected on each handler; same-owner allowed). 30/30 green; tsc + prettier clean.

Implemented via a multi-agent workflow with an adversarial diff reviewer (verified the gate reaches every handler before the secret/credit paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-711]: https://evertech.atlassian.net/browse/EW-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-710]: https://evertech.atlassian.net/browse/EW-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added access control to screenshot operations to ensure users can only access screenshots for works they own, preventing unauthorized access to shared instances.
  * Screenshot requests now validate ownership before proceeding with provider checks or credit calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->