### PR TITLE
chore(k8s): right-size resource requests for all Ever Works deployments

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -307,10 +307,14 @@ spec:
             requests:
               # Right-sized to measured steady-state (~370 MiB boot, ~0.4-1.2
               # GiB under load) with headroom — see the NODE_OPTIONS note above.
-              # Reserves honestly without over-packing the node (the previous
-              # 6 GiB reservation needlessly held ~24 GiB across the 4 api pods).
-              memory: "2Gi"
-              cpu: "500m"
+              # 2026-06-06 dev right-sizing: live `kubectl top pod` measured
+              # ~379 MiB on this single replica (no chat load — dev sees
+              # near-zero traffic). 1 GiB request reserves honestly; 3 GiB
+              # limit untouched so it can still grow into the V8 2 GiB cap.
+              # CPU 500m → 100m: observed peak 3m, 100m is the prod-floor we
+              # use for "occasionally active" services and frees 0.4 cores.
+              memory: "1Gi"
+              cpu: "100m"
             limits:
               memory: "3Gi"
               cpu: "2"
@@ -414,8 +418,12 @@ spec:
 
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "250m"
+              # 2026-06-06 right-sizing: live `kubectl top pod` measured ~72
+              # MiB on the dev replica (idle). 128 MiB request reserves
+              # honestly with ~1.8x headroom; 512 MiB limit untouched. CPU
+              # 250m → 50m: observed peak 3m, 50m is the dev/stage floor.
+              memory: "128Mi"
+              cpu: "50m"
             limits:
               memory: "512Mi"
               cpu: "500m"

--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -306,12 +306,12 @@ spec:
           resources:
             requests:
               # 2026-06-06 dev right-sizing: live `kubectl top pod` measured
-              # ~379 MiB on this single replica. 576 MiB request reserves
-              # ~1.5x current steady-state; 3 GiB limit untouched so the
-              # container can still grow into the V8 2 GiB cap if needed.
-              # CPU 500m → 100m: observed peak 3m, plenty of headroom and
-              # frees 0.4 cores cluster-wide.
-              memory: "576Mi"
+              # ~379 MiB on this single replica. 672 MiB request matches prod
+              # for consistency (~1.8x current steady-state); 3 GiB limit
+              # untouched so the container can still grow into the V8 2 GiB
+              # cap if needed. CPU 500m → 100m: observed peak 3m, plenty of
+              # headroom and frees 0.4 cores cluster-wide.
+              memory: "672Mi"
               cpu: "100m"
             limits:
               memory: "3Gi"

--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -305,15 +305,13 @@ spec:
 
           resources:
             requests:
-              # Right-sized to measured steady-state (~370 MiB boot, ~0.4-1.2
-              # GiB under load) with headroom — see the NODE_OPTIONS note above.
               # 2026-06-06 dev right-sizing: live `kubectl top pod` measured
-              # ~379 MiB on this single replica (no chat load — dev sees
-              # near-zero traffic). 1 GiB request reserves honestly; 3 GiB
-              # limit untouched so it can still grow into the V8 2 GiB cap.
-              # CPU 500m → 100m: observed peak 3m, 100m is the prod-floor we
-              # use for "occasionally active" services and frees 0.4 cores.
-              memory: "1Gi"
+              # ~379 MiB on this single replica. 576 MiB request reserves
+              # ~1.5x current steady-state; 3 GiB limit untouched so the
+              # container can still grow into the V8 2 GiB cap if needed.
+              # CPU 500m → 100m: observed peak 3m, plenty of headroom and
+              # frees 0.4 cores cluster-wide.
+              memory: "576Mi"
               cpu: "100m"
             limits:
               memory: "3Gi"

--- a/.deploy/k8s/k8s-manifest.mcp.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.dev.yaml
@@ -70,8 +70,12 @@ spec:
 
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "100m"
+              # 2026-06-06 right-sizing: live `kubectl top pod` measured
+              # ~63 MiB on the dev MCP replica. 96 MiB request reserves
+              # honestly with ~1.5x headroom; 256 MiB limit untouched.
+              # CPU 100m → 50m: observed peak 2m on this idle env.
+              memory: "96Mi"
+              cpu: "50m"
             limits:
               memory: "256Mi"
               cpu: "250m"

--- a/.deploy/k8s/k8s-manifest.mcp.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.prod.yaml
@@ -75,8 +75,12 @@ spec:
 
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "100m"
+              # 2026-06-06 right-sizing: live `kubectl top pod` measured
+              # ~61 MiB / replica steady on the 2 prod MCP pods. 96 MiB
+              # request reserves honestly with ~1.6x headroom; 256 MiB limit
+              # untouched. CPU 100m → 50m: observed peak 3m, plenty of room.
+              memory: "96Mi"
+              cpu: "50m"
             limits:
               memory: "256Mi"
               cpu: "250m"

--- a/.deploy/k8s/k8s-manifest.mcp.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.mcp.stage.yaml
@@ -70,8 +70,12 @@ spec:
 
           resources:
             requests:
-              memory: "128Mi"
-              cpu: "100m"
+              # 2026-06-06 right-sizing: live `kubectl top pod` measured
+              # ~62 MiB on the stage MCP replica. 96 MiB request reserves
+              # honestly with ~1.5x headroom; 256 MiB limit untouched.
+              # CPU 100m → 50m: observed peak 1m on this idle env.
+              memory: "96Mi"
+              cpu: "50m"
             limits:
               memory: "256Mi"
               cpu: "250m"

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -330,11 +330,14 @@ spec:
             requests:
               # Right-sized to measured steady-state (~370 MiB boot, ~0.4-1.2
               # GiB under load) with headroom — see the NODE_OPTIONS note above.
-              # Reserves honestly without over-packing the node (the previous
-              # 6 GiB reservation needlessly held ~24 GiB across the 4 api pods:
-              # prod x2 + stage + dev).
-              memory: "2Gi"
-              cpu: "500m"
+              # 2026-06-06 follow-up: live `kubectl top pod` measured ~430 MiB
+              # /replica warm-up across the 4 prod pods. Trimmed to 1.5 GiB so
+              # the documented ~1.2 GiB chat peak still fits inside the request
+              # with margin; 3 GiB limit still catches unexpected spikes.
+              # CPU 500m → 300m: observed peak ~58m/pod, 300m leaves >5x
+              # headroom and frees 0.4 cores cluster-wide across the 2 replicas.
+              memory: "1536Mi"
+              cpu: "300m"
             limits:
               memory: "3Gi"
               cpu: "2"
@@ -501,8 +504,13 @@ spec:
 
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "250m"
+              # 2026-06-06 right-sizing: live `kubectl top pod` measured
+              # ~71 MiB / replica steady (Next.js SSR, 2 prod replicas).
+              # 192 MiB request leaves ~2.5x headroom for SSR spikes; 512 MiB
+              # limit untouched. CPU 250m → 100m frees 0.3 cores across the
+              # 2 replicas (observed peak 9m, kept enough for SSR bursts).
+              memory: "192Mi"
+              cpu: "100m"
             limits:
               memory: "512Mi"
               cpu: "500m"

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -328,15 +328,16 @@ spec:
 
           resources:
             requests:
-              # Right-sized to measured steady-state (~370 MiB boot, ~0.4-1.2
-              # GiB under load) with headroom — see the NODE_OPTIONS note above.
-              # 2026-06-06 follow-up: live `kubectl top pod` measured ~430 MiB
-              # /replica warm-up across the 4 prod pods. Trimmed to 1.5 GiB so
-              # the documented ~1.2 GiB chat peak still fits inside the request
-              # with margin; 3 GiB limit still catches unexpected spikes.
-              # CPU 500m → 300m: observed peak ~58m/pod, 300m leaves >5x
-              # headroom and frees 0.4 cores cluster-wide across the 2 replicas.
-              memory: "1536Mi"
+              # 2026-06-06 right-sizing: live `kubectl top pod` measured ~430
+              # MiB / replica steady on the 2 prod pods (post-#1190 lazy-proxy
+              # fix). The historical "~0.4-1.2 GiB under load" range from the
+              # earlier comment block reflected the pre-#1190 chat regression
+              # and is no longer representative — 672 MiB request reserves
+              # ~1.5x current steady-state with the 3 GiB limit still
+              # catching any unexpected spike.
+              # CPU 500m → 300m: observed peak ~58m / pod, 300m leaves >5x
+              # headroom and frees 0.4 cores cluster-wide across 2 replicas.
+              memory: "672Mi"
               cpu: "300m"
             limits:
               memory: "3Gi"

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -303,15 +303,13 @@ spec:
 
           resources:
             requests:
-              # Right-sized to measured steady-state (~370 MiB boot, ~0.4-1.2
-              # GiB under load) with headroom — see the NODE_OPTIONS note above.
               # 2026-06-06 stage right-sizing: live `kubectl top pod` measured
-              # ~388 MiB on this single replica (no chat load — stage sees
-              # near-zero traffic). 1 GiB request reserves honestly; 3 GiB
-              # limit untouched so it can still grow into the V8 2 GiB cap.
-              # CPU 500m → 100m: observed peak 2m, 100m is the prod-floor we
-              # use for "occasionally active" services and frees 0.4 cores.
-              memory: "1Gi"
+              # ~388 MiB on this single replica. 608 MiB request reserves
+              # ~1.5x current steady-state; 3 GiB limit untouched so the
+              # container can still grow into the V8 2 GiB cap if needed.
+              # CPU 500m → 100m: observed peak 2m, plenty of headroom and
+              # frees 0.4 cores cluster-wide.
+              memory: "608Mi"
               cpu: "100m"
             limits:
               memory: "3Gi"

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -304,12 +304,12 @@ spec:
           resources:
             requests:
               # 2026-06-06 stage right-sizing: live `kubectl top pod` measured
-              # ~388 MiB on this single replica. 608 MiB request reserves
-              # ~1.5x current steady-state; 3 GiB limit untouched so the
-              # container can still grow into the V8 2 GiB cap if needed.
-              # CPU 500m → 100m: observed peak 2m, plenty of headroom and
-              # frees 0.4 cores cluster-wide.
-              memory: "608Mi"
+              # ~388 MiB on this single replica. 672 MiB request matches prod
+              # for consistency (~1.7x current steady-state); 3 GiB limit
+              # untouched so the container can still grow into the V8 2 GiB
+              # cap if needed. CPU 500m → 100m: observed peak 2m, plenty of
+              # headroom and frees 0.4 cores cluster-wide.
+              memory: "672Mi"
               cpu: "100m"
             limits:
               memory: "3Gi"

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -305,10 +305,14 @@ spec:
             requests:
               # Right-sized to measured steady-state (~370 MiB boot, ~0.4-1.2
               # GiB under load) with headroom — see the NODE_OPTIONS note above.
-              # Reserves honestly without over-packing the node (the previous
-              # 6 GiB reservation needlessly held ~24 GiB across the 4 api pods).
-              memory: "2Gi"
-              cpu: "500m"
+              # 2026-06-06 stage right-sizing: live `kubectl top pod` measured
+              # ~388 MiB on this single replica (no chat load — stage sees
+              # near-zero traffic). 1 GiB request reserves honestly; 3 GiB
+              # limit untouched so it can still grow into the V8 2 GiB cap.
+              # CPU 500m → 100m: observed peak 2m, 100m is the prod-floor we
+              # use for "occasionally active" services and frees 0.4 cores.
+              memory: "1Gi"
+              cpu: "100m"
             limits:
               memory: "3Gi"
               cpu: "2"
@@ -435,8 +439,12 @@ spec:
 
           resources:
             requests:
-              memory: "256Mi"
-              cpu: "250m"
+              # 2026-06-06 right-sizing: live `kubectl top pod` measured ~72
+              # MiB / replica on stage (2 idle replicas). 128 MiB request
+              # reserves honestly with ~1.8x headroom; 512 MiB limit untouched.
+              # CPU 250m → 50m: observed peak 4m, 50m is the dev/stage floor.
+              memory: "128Mi"
+              cpu: "50m"
             limits:
               memory: "512Mi"
               cpu: "500m"


### PR DESCRIPTION
## Summary

Tighten CPU + MEM **requests** across all 9 Ever Works k8s workloads (api/web/mcp × prod/stage/dev) based on live `kubectl top pod` data from `k8s-gauzy` on **2026-06-06**. Limits are **unchanged everywhere** — this only adjusts what the scheduler reserves, not what containers can consume.

| Workload | Replicas | CPU req | MEM req | Δ CPU / pod | Δ MEM / pod |
|---|---:|---|---|---:|---:|
| `ever-works-api` (prod) | 2 | `500m` → **`300m`** | `2Gi` → **`672Mi`** | −200m | −1408Mi |
| `ever-works-api-stage` | 1 | `500m` → **`100m`** | `2Gi` → **`672Mi`** | −400m | −1408Mi |
| `ever-works-api-dev` | 1 | `500m` → **`100m`** | `2Gi` → **`672Mi`** | −400m | −1408Mi |
| `ever-works-web` (prod) | 2 | `250m` → **`100m`** | `256Mi` → **`192Mi`** | −150m | −64Mi |
| `ever-works-web-stage` | 2 | `250m` → **`50m`** | `256Mi` → **`128Mi`** | −200m | −128Mi |
| `ever-works-web-dev` | 1 | `250m` → **`50m`** | `256Mi` → **`128Mi`** | −200m | −128Mi |
| `ever-works-mcp` (prod) | 2 | `100m` → **`50m`** | `128Mi` → **`96Mi`** | −50m | −32Mi |
| `ever-works-mcp-stage` | 1 | `100m` → **`50m`** | `128Mi` → **`96Mi`** | −50m | −32Mi |
| `ever-works-mcp-dev` | 1 | `100m` → **`50m`** | `128Mi` → **`96Mi`** | −50m | −32Mi |

**Net saving across all replicas: ~2.3 CPU cores + ~6.0 GiB RAM** in scheduler reservations.

## How the numbers were chosen

For each container: per-pod **MEM request** ≈ `ceil(observed max × 1.5)` rounded to a clean size with a 96 MiB floor. Per-pod **CPU request** ≈ `max(observed peak × 3, role-floor)` (prod-api 300m, other prod 100m, stage/dev/MCP 50m).

### `ever-works-api` is the same 672 MiB across all 3 envs

Same code, same image, same NODE_OPTIONS — keeping the MEM request identical across prod/stage/dev makes future right-sizing decisions easier to reason about. Live measurement was 379–430 MiB / pod across the envs, so 672 MiB gives ~1.5–1.8× headroom in all three.

The earlier in-manifest comment about "~0.4–1.2 GiB under load" reflected the **pre-#1190 lazy-proxy chat regression** which has since been fixed. Per operator confirmation, the service no longer hits those peaks.

### `NODE_OPTIONS=--max-old-space-size=2048` left untouched on the API

The V8 heap ceiling is tied to the 3 GiB MEM **limit** (unchanged), not the request — the existing manifest rule ("`--max-old-space-size` ≈ 2/3 of `resources.limits.memory`") still holds (2048 / 3072 ≈ 0.67). Lowering it to match the new tighter request would just risk OOMs during legitimate spikes for no scheduling benefit. V8 grows the heap on demand, so the 2 GiB cap costs nothing when the steady-state is only ~430 MiB.

### What's NOT changed in this PR

- All **limits** (CPU and MEM). Containers can still grow to the same 3 GiB / 512 MiB / 256 MiB ceiling on traffic spikes.
- `NODE_OPTIONS=--max-old-space-size=2048` on the API.
- All other config (env vars, probes, security context, podAntiAffinity).
- Any non-Ever-Works workloads on these clusters.

## Test plan

- [ ] Review the inline comments in each manifest — they cite the observed numbers and reasoning per workload.
- [ ] Roll out to **dev first** via the normal deploy workflow; watch `kubectl top pod -n default | grep ever-works-` for ~30 min.
- [ ] Roll out to **stage**; do a couple of chat conversations through stage to sanity-check the api pod stays below ~600 MiB.
- [ ] Roll out to **prod**; monitor `ever-works-api` MEM usage for 24h — alert threshold around 600 MiB (close to the 672 MiB request).
- [ ] After 48h of green prod, on `k8s-gauzy` consider cordoning + draining the most-packed node (`ever-gauzy-pool-3uwn3v`, was 91% CPU requests pre-change) and downsizing the node pool from 3 → 2.

## Reference

Full per-pod requests-vs-live-usage tables (gauzy cluster, all workloads not just Ever Works): https://github.com/ever-works/workspace/pull/6