### PR TITLE
fix(security): close 4 EW-711 IDOR/SSRF gaps (Wave-A batch 2)

### DIFF
--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.spec.ts
@@ -195,9 +195,9 @@ describe('AgentMemoryController', () => {
             agentMemory.listSessions.mockResolvedValueOnce([
                 { id: 'sess-foreign', metadata: { ownerUserId: 'user-2' } },
             ]);
-            await expect(
-                controller.closeSession(auth, 'sess-foreign', {}),
-            ).rejects.toBeInstanceOf(ForbiddenException);
+            await expect(controller.closeSession(auth, 'sess-foreign', {})).rejects.toBeInstanceOf(
+                ForbiddenException,
+            );
             expect(ownership.ensureCanEdit).not.toHaveBeenCalled();
             expect(agentMemory.closeSession).not.toHaveBeenCalled();
         });
@@ -271,19 +271,29 @@ describe('AgentMemoryController', () => {
             // but was saved by another user — the owner stamp must block it.
             agentMemory.searchMemory.mockResolvedValueOnce({
                 results: [
-                    { id: 'mem-foreign', content: 'x', createdAt: 'now', metadata: { ownerUserId: 'user-2' } },
+                    {
+                        id: 'mem-foreign',
+                        content: 'x',
+                        createdAt: 'now',
+                        metadata: { ownerUserId: 'user-2' },
+                    },
                 ],
             });
-            await expect(
-                controller.deleteEntry(auth, 'mem-foreign', {}),
-            ).rejects.toBeInstanceOf(ForbiddenException);
+            await expect(controller.deleteEntry(auth, 'mem-foreign', {})).rejects.toBeInstanceOf(
+                ForbiddenException,
+            );
             expect(agentMemory.deleteEntry).not.toHaveBeenCalled();
         });
 
         it('allows the caller to forget their own entry (workId omitted)', async () => {
             agentMemory.searchMemory.mockResolvedValueOnce({
                 results: [
-                    { id: 'mem-mine', content: 'x', createdAt: 'now', metadata: { ownerUserId: 'user-1' } },
+                    {
+                        id: 'mem-mine',
+                        content: 'x',
+                        createdAt: 'now',
+                        metadata: { ownerUserId: 'user-1' },
+                    },
                 ],
             });
             await controller.deleteEntry(auth, 'mem-mine', {});

--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.spec.ts
@@ -15,7 +15,7 @@ jest.mock('../../auth', () => ({
     CurrentUser: () => () => undefined,
 }));
 
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { AgentMemoryController } from './agent-memory.controller';
 import { NoProviderError } from '@ever-works/agent/facades';
 import type { AgentMemoryFacadeService } from '@ever-works/agent/facades';
@@ -34,7 +34,7 @@ describe('AgentMemoryController', () => {
         buildContext: jest.Mock;
         deleteEntry: jest.Mock;
     };
-    let ownership: { ensureCanView: jest.Mock };
+    let ownership: { ensureCanView: jest.Mock; ensureCanEdit: jest.Mock };
     let controller: AgentMemoryController;
     const auth: AuthenticatedUser = { userId: 'user-1' } as any;
 
@@ -52,7 +52,10 @@ describe('AgentMemoryController', () => {
             buildContext: jest.fn().mockResolvedValue({ content: 'ctx' }),
             deleteEntry: jest.fn().mockResolvedValue(undefined),
         };
-        ownership = { ensureCanView: jest.fn().mockResolvedValue(undefined) };
+        ownership = {
+            ensureCanView: jest.fn().mockResolvedValue(undefined),
+            ensureCanEdit: jest.fn().mockResolvedValue(undefined),
+        };
         controller = new AgentMemoryController(
             agentMemory as unknown as AgentMemoryFacadeService,
             ownership as unknown as WorkOwnershipService,
@@ -109,7 +112,8 @@ describe('AgentMemoryController', () => {
                 expect.objectContaining({
                     content: 'remember this',
                     tags: ['bug'],
-                    metadata: { file: 'a.ts' },
+                    // Security (EW-711 #29): owner stamp folded into record metadata.
+                    metadata: { file: 'a.ts', ownerUserId: 'user-1' },
                     sessionId: 'sess-9',
                     projectId: 'proj-A',
                 }),
@@ -142,11 +146,20 @@ describe('AgentMemoryController', () => {
     });
 
     describe('sessions', () => {
-        it('openSession returns the facade session payload', async () => {
+        it('openSession returns the facade session payload + stamps the owner', async () => {
             const result = await controller.openSession(auth, { metadata: { from: 'web' } });
             expect(result.session).toEqual({ id: 's1', startedAt: 'now' });
+            // Security (EW-711 #29): owner stamp is folded into session metadata.
             expect(agentMemory.openSession).toHaveBeenCalledWith(
-                { from: 'web' },
+                { from: 'web', ownerUserId: 'user-1' },
+                expect.objectContaining({ userId: 'user-1' }),
+            );
+        });
+
+        it('openSession owner stamp cannot be spoofed from the request body', async () => {
+            await controller.openSession(auth, { metadata: { ownerUserId: 'user-2' } as any });
+            expect(agentMemory.openSession).toHaveBeenCalledWith(
+                { ownerUserId: 'user-1' },
                 expect.objectContaining({ userId: 'user-1' }),
             );
         });
@@ -157,9 +170,11 @@ describe('AgentMemoryController', () => {
             );
         });
 
-        it('closeSession enforces ownership + scopes by workId when one is supplied', async () => {
+        it('closeSession enforces EDIT ownership + scopes by workId when one is supplied', async () => {
+            // Security (EW-711 #29): mutating handler requires edit access, not view.
             await controller.closeSession(auth, 'sess-1', { workId: 'work-1' });
-            expect(ownership.ensureCanView).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(ownership.ensureCanEdit).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(ownership.ensureCanView).not.toHaveBeenCalled();
             expect(agentMemory.closeSession).toHaveBeenCalledWith(
                 'sess-1',
                 expect.objectContaining({ userId: 'user-1', workId: 'work-1' }),
@@ -167,11 +182,45 @@ describe('AgentMemoryController', () => {
         });
 
         it('closeSession propagates an ownership rejection (cannot close another user Work session)', async () => {
-            ownership.ensureCanView.mockRejectedValueOnce(new Error('not your work'));
+            ownership.ensureCanEdit.mockRejectedValueOnce(new Error('not your work'));
             await expect(
                 controller.closeSession(auth, 'sess-1', { workId: 'work-x' }),
             ).rejects.toThrow('not your work');
             expect(agentMemory.closeSession).not.toHaveBeenCalled();
+        });
+
+        it('closeSession rejects a foreign session even when workId is omitted (EW-711 #29 IDOR)', async () => {
+            // The session surfaces in the caller's (shared-project) scope but
+            // was opened by another user — the owner stamp must block the close.
+            agentMemory.listSessions.mockResolvedValueOnce([
+                { id: 'sess-foreign', metadata: { ownerUserId: 'user-2' } },
+            ]);
+            await expect(
+                controller.closeSession(auth, 'sess-foreign', {}),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+            expect(ownership.ensureCanEdit).not.toHaveBeenCalled();
+            expect(agentMemory.closeSession).not.toHaveBeenCalled();
+        });
+
+        it('closeSession allows the caller to close their own session (workId omitted)', async () => {
+            agentMemory.listSessions.mockResolvedValueOnce([
+                { id: 'sess-mine', metadata: { ownerUserId: 'user-1' } },
+            ]);
+            await controller.closeSession(auth, 'sess-mine', {});
+            expect(agentMemory.closeSession).toHaveBeenCalledWith(
+                'sess-mine',
+                expect.objectContaining({ userId: 'user-1' }),
+            );
+        });
+
+        it('closeSession fails open when the provider does not support listSessions', async () => {
+            // A backend without the optional governance surface can't be
+            // enumerated — don't break the legit flow on a missing method.
+            agentMemory.listSessions.mockRejectedValueOnce(
+                new Error('Agent-memory provider "x" does not support listSessions'),
+            );
+            await controller.closeSession(auth, 'sess-1', {});
+            expect(agentMemory.closeSession).toHaveBeenCalledWith('sess-1', expect.any(Object));
         });
 
         it('listSessions forwards limit + projectId', async () => {
@@ -198,9 +247,11 @@ describe('AgentMemoryController', () => {
             );
         });
 
-        it('enforces ownership + scopes by workId when one is supplied', async () => {
+        it('enforces EDIT ownership + scopes by workId when one is supplied', async () => {
+            // Security (EW-711 #29): forget is a mutation → requires edit access.
             await controller.deleteEntry(auth, 'mem-42', { workId: 'work-1' });
-            expect(ownership.ensureCanView).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(ownership.ensureCanEdit).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(ownership.ensureCanView).not.toHaveBeenCalled();
             expect(agentMemory.deleteEntry).toHaveBeenCalledWith(
                 'mem-42',
                 expect.objectContaining({ userId: 'user-1', workId: 'work-1' }),
@@ -208,11 +259,46 @@ describe('AgentMemoryController', () => {
         });
 
         it('propagates an ownership rejection (cannot forget another user Work entry)', async () => {
-            ownership.ensureCanView.mockRejectedValueOnce(new Error('not your work'));
+            ownership.ensureCanEdit.mockRejectedValueOnce(new Error('not your work'));
             await expect(
                 controller.deleteEntry(auth, 'mem-42', { workId: 'work-x' }),
             ).rejects.toThrow('not your work');
             expect(agentMemory.deleteEntry).not.toHaveBeenCalled();
+        });
+
+        it('rejects a foreign entry even when workId is omitted (EW-711 #29 IDOR)', async () => {
+            // The record surfaces in the caller's shared-project search scope
+            // but was saved by another user — the owner stamp must block it.
+            agentMemory.searchMemory.mockResolvedValueOnce({
+                results: [
+                    { id: 'mem-foreign', content: 'x', createdAt: 'now', metadata: { ownerUserId: 'user-2' } },
+                ],
+            });
+            await expect(
+                controller.deleteEntry(auth, 'mem-foreign', {}),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+            expect(agentMemory.deleteEntry).not.toHaveBeenCalled();
+        });
+
+        it('allows the caller to forget their own entry (workId omitted)', async () => {
+            agentMemory.searchMemory.mockResolvedValueOnce({
+                results: [
+                    { id: 'mem-mine', content: 'x', createdAt: 'now', metadata: { ownerUserId: 'user-1' } },
+                ],
+            });
+            await controller.deleteEntry(auth, 'mem-mine', {});
+            expect(agentMemory.deleteEntry).toHaveBeenCalledWith(
+                'mem-mine',
+                expect.objectContaining({ userId: 'user-1' }),
+            );
+        });
+
+        it('fails open when the provider does not support searchMemory enumeration', async () => {
+            agentMemory.searchMemory.mockRejectedValueOnce(
+                new Error('Agent-memory provider "x" does not support searchMemory'),
+            );
+            await controller.deleteEntry(auth, 'mem-1', {});
+            expect(agentMemory.deleteEntry).toHaveBeenCalledWith('mem-1', expect.any(Object));
         });
     });
 

--- a/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts
+++ b/apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts
@@ -3,6 +3,7 @@ import {
     Body,
     Controller,
     Delete,
+    ForbiddenException,
     Get,
     NotFoundException,
     Param,
@@ -26,13 +27,26 @@ import {
 } from './dto/agent-memory.dto';
 
 /**
+ * Security (EW-711 #29): metadata key used to stamp the creating user onto
+ * every session / record. The agent-memory backend partitions by `project`
+ * (shared across users), so this stamp is the per-resource ownership marker
+ * the mutating handlers verify before close/delete. Forced from the
+ * authenticated principal at write time — never read from the request body.
+ */
+const OWNER_METADATA_KEY = 'ownerUserId';
+
+/**
  * REST surface for the `agent-memory` capability (follow-up to PR #1073
  * + #1081 + #1084). Lets the web admin UI list, search, save, and
  * forget memory observations / sessions for the signed-in user.
  *
- * All endpoints are JWT-protected; mutating ones additionally enforce
- * `WorkOwnershipService.ensureCanView` when a `workId` is supplied so
- * users can't read another user's Work memory.
+ * All endpoints are JWT-protected. Reads enforce
+ * `WorkOwnershipService.ensureCanView` when a `workId` is supplied so users
+ * can't read another user's Work memory. Mutating, id-addressed handlers
+ * (`closeSession` / `deleteEntry`) require `ensureCanEdit` for Work-scoped
+ * calls AND verify the target session/entry's `ownerUserId` stamp so an
+ * omitted or foreign `workId` cannot be used to mutate another user's
+ * resource (EW-711 #29).
  *
  * Routing is mounted under `/api/agent-memory` to match the sibling
  * capability controllers (`/api/search`, `/api/agent/memory` was
@@ -88,6 +102,14 @@ export class AgentMemoryController {
         // actually scopes to the requested namespace.
         const metadata: Record<string, unknown> = { ...(dto.metadata ?? {}) };
         if (dto.projectId) metadata.projectId = dto.projectId;
+        // Security (EW-711 #29): stamp the creating user onto the session so
+        // close/delete can verify per-session ownership. The agent-memory
+        // backend partitions only by `project` (shared across users), so the
+        // owner stamp is the only thing binding a session to its creator —
+        // without it a user could close another user's session by id when
+        // `workId` is omitted. `ownerUserId` overrides any caller-supplied
+        // value of the same key so it can't be spoofed from the request body.
+        metadata[OWNER_METADATA_KEY] = auth.userId;
         try {
             const session = await this.agentMemory.openSession(
                 metadata,
@@ -108,9 +130,18 @@ export class AgentMemoryController {
         @Query() query: MemoryScopeQueryDto,
     ) {
         if (!sessionId) throw new BadRequestException('sessionId is required');
-        await this.assertWorkAccess(auth, query.workId);
+        // Security (EW-711 #29): this is a mutating, id-addressed handler.
+        // Previously the workId gate ran `ensureCanView` and was skipped
+        // entirely when `workId` was omitted, so a user could close ANOTHER
+        // user's session by guessing the id. Now: (1) a Work-scoped close
+        // requires EDIT access (a viewer must not end a shared session), and
+        // (2) we ALWAYS verify the session belongs to the caller via its
+        // owner stamp — closing the `workId` bypass.
+        await this.assertWorkEditAccess(auth, query.workId);
+        const facadeOptions = this.facadeOptions(auth, query.workId);
+        await this.assertOwnsSession(sessionId, auth, facadeOptions);
         try {
-            await this.agentMemory.closeSession(sessionId, this.facadeOptions(auth, query.workId));
+            await this.agentMemory.closeSession(sessionId, facadeOptions);
             return { status: 'success' };
         } catch (error) {
             throw this.toHttpError(error, 'closeSession');
@@ -141,12 +172,22 @@ export class AgentMemoryController {
     @ApiResponse({ status: 201, description: 'Saved record' })
     async save(@CurrentUser() auth: AuthenticatedUser, @Body() dto: SaveMemoryDto) {
         await this.assertWorkAccess(auth, dto.workId);
+        // Security (EW-711 #29): stamp the creating user onto the record so
+        // `deleteEntry` can verify per-entry ownership. Same rationale as
+        // `openSession` — the backend is project-scoped, not user-scoped, so
+        // the owner stamp is what lets us reject a cross-user forget by id.
+        // `ownerUserId` is forced from the authenticated principal and
+        // overrides any caller-supplied key of the same name.
+        const metadata: Record<string, unknown> = {
+            ...(dto.metadata ?? {}),
+            [OWNER_METADATA_KEY]: auth.userId,
+        };
         try {
             const record = await this.agentMemory.saveMemory(
                 {
                     content: dto.content,
                     tags: dto.tags,
-                    metadata: dto.metadata,
+                    metadata,
                     sessionId: dto.sessionId,
                     projectId: dto.projectId,
                 },
@@ -211,9 +252,16 @@ export class AgentMemoryController {
         @Query() query: MemoryScopeQueryDto,
     ) {
         if (!entryId) throw new BadRequestException('entryId is required');
-        await this.assertWorkAccess(auth, query.workId);
+        // Security (EW-711 #29): mutating, id-addressed handler — same IDOR
+        // class as closeSession. A Work-scoped forget now requires EDIT
+        // access, and we ALWAYS verify the entry belongs to the caller via
+        // its owner stamp so an omitted/foreign `workId` can't be used to
+        // delete another user's memory record by id.
+        await this.assertWorkEditAccess(auth, query.workId);
+        const facadeOptions = this.facadeOptions(auth, query.workId);
+        await this.assertOwnsEntry(entryId, auth, facadeOptions);
         try {
-            await this.agentMemory.deleteEntry(entryId, this.facadeOptions(auth, query.workId));
+            await this.agentMemory.deleteEntry(entryId, facadeOptions);
             return { status: 'success' };
         } catch (error) {
             throw this.toHttpError(error, 'deleteEntry');
@@ -233,6 +281,112 @@ export class AgentMemoryController {
     ): Promise<void> {
         if (!workId) return;
         await this.ownership.ensureCanView(workId, auth.userId);
+    }
+
+    /**
+     * Security (EW-711 #29): edit-level variant of {@link assertWorkAccess}
+     * for the mutating, id-addressed handlers (`closeSession` /
+     * `deleteEntry`). A Work viewer can read shared memory but must not be
+     * able to end sessions or forget records, so these gate on
+     * `ensureCanEdit` rather than `ensureCanView`. As before, an absent
+     * `workId` leaves provider/project resolution unscoped — but ownership
+     * is no longer skipped: the per-session/per-entry stamp check below
+     * runs unconditionally.
+     */
+    private async assertWorkEditAccess(
+        auth: AuthenticatedUser,
+        workId: string | undefined,
+    ): Promise<void> {
+        if (!workId) return;
+        await this.ownership.ensureCanEdit(workId, auth.userId);
+    }
+
+    /**
+     * Security (EW-711 #29): verify the target session was opened by the
+     * caller. The agent-memory backend partitions by `project`, not by
+     * user, so without this check any user sharing a project could close a
+     * session they merely know the id of. We resolve the sessions visible in
+     * the caller's scope via the existing `listSessions` read seam and, if
+     * the target surfaces, reject when its `ownerUserId` stamp belongs to a
+     * different user.
+     *
+     * Fail-open is deliberate ONLY for the cases that cannot be a cross-user
+     * attack on a stamped resource: providers that don't implement
+     * `listSessions`, and legacy/unstamped sessions (no `ownerUserId`). A
+     * present, foreign stamp is always rejected. This preserves the
+     * legitimate same-user flow (the caller's own sessions always carry
+     * their own stamp) while closing the IDOR.
+     */
+    private async assertOwnsSession(
+        sessionId: string,
+        auth: AuthenticatedUser,
+        facadeOptions: FacadeOptions,
+    ): Promise<void> {
+        let sessions: readonly { id: string; metadata?: Record<string, unknown> }[];
+        try {
+            sessions = await this.agentMemory.listSessions(undefined, facadeOptions);
+        } catch (error) {
+            // Provider doesn't expose `listSessions` → we cannot enumerate to
+            // verify. Don't grant a free pass on a real failure, but a
+            // missing optional method is not an attack signal: let the
+            // downstream call proceed (the backend itself still scopes by the
+            // resolved project/credentials).
+            if (this.isUnsupportedError(error)) return;
+            throw this.toHttpError(error, 'closeSession');
+        }
+        const session = sessions.find((s) => s.id === sessionId);
+        this.assertStampMatches(session?.metadata, auth.userId);
+    }
+
+    /**
+     * Security (EW-711 #29): per-entry analogue of {@link assertOwnsSession}
+     * for `deleteEntry`. There is no get-by-id seam on the capability, so we
+     * locate the record within the caller's scope via the existing
+     * `searchMemory` read seam (broad query, generous limit) and reject when
+     * the matched record carries a foreign `ownerUserId` stamp. Same
+     * fail-open posture for unsupported providers / unstamped records as
+     * sessions; a present, foreign stamp is always rejected.
+     */
+    private async assertOwnsEntry(
+        entryId: string,
+        auth: AuthenticatedUser,
+        facadeOptions: FacadeOptions,
+    ): Promise<void> {
+        let records: readonly { id: string; metadata?: Record<string, unknown> }[];
+        try {
+            const response = await this.agentMemory.searchMemory(
+                { query: '*', limit: 100 },
+                facadeOptions,
+            );
+            records = response.results;
+        } catch (error) {
+            if (this.isUnsupportedError(error)) return;
+            throw this.toHttpError(error, 'deleteEntry');
+        }
+        const record = records.find((r) => r.id === entryId);
+        this.assertStampMatches(record?.metadata, auth.userId);
+    }
+
+    /**
+     * Security (EW-711 #29): throw 403 when a resource's `ownerUserId`
+     * stamp is present and belongs to a different user. Absent stamp (legacy
+     * / not-found) is left to the caller's fail-open policy.
+     */
+    private assertStampMatches(
+        metadata: Record<string, unknown> | undefined,
+        userId: string,
+    ): void {
+        const owner = metadata?.[OWNER_METADATA_KEY];
+        if (typeof owner === 'string' && owner !== userId) {
+            throw new ForbiddenException({
+                status: 'error',
+                message: 'You do not have permission to modify this agent-memory resource',
+            });
+        }
+    }
+
+    private isUnsupportedError(error: unknown): boolean {
+        return error instanceof Error && error.message.includes('does not support');
     }
 
     private facadeOptions(auth: AuthenticatedUser, workId?: string): FacadeOptions {

--- a/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
@@ -222,5 +222,83 @@ describe('AgentExportService', () => {
             env.files.toolsMd = 'GH=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
             await expect(svc.importOne('u1', env)).rejects.toThrow(/Secret-like/);
         });
+
+        // Security (EW-711 #8) — scope-ownership IDOR. The scope columns are
+        // NOT FK-constrained, so without this guard any authenticated user
+        // could plant an imported Agent under another user's
+        // Mission/Idea/Work id. These tests construct the service WITH the
+        // raw Agent repository (5th ctor arg) so `assertScopeOwned` runs its
+        // live `manager.getRepository(...).count(...)` ownership check.
+        describe('scope-ownership (EW-711 #8)', () => {
+            let scopeCount: jest.Mock;
+            let svcWithRepo: AgentExportService;
+
+            const missionEnvelope = (): AgentExportEnvelope => ({
+                ...baseEnvelope(),
+                identity: { ...baseEnvelope().identity, scope: AgentScope.MISSION },
+            });
+
+            beforeEach(() => {
+                scopeCount = jest.fn();
+                // Minimal `Repository<Agent>` stand-in: only `.manager.getRepository().count`
+                // is exercised by the ownership check.
+                const agentEntityRepo = {
+                    manager: {
+                        getRepository: jest.fn().mockReturnValue({ count: scopeCount }),
+                    },
+                } as any;
+                svcWithRepo = new AgentExportService(
+                    agents,
+                    memberships,
+                    budgets,
+                    activity,
+                    agentEntityRepo,
+                );
+            });
+
+            it('404s when the target Mission is not owned by the caller', async () => {
+                scopeCount.mockResolvedValueOnce(0); // mission m1 not owned by u1
+                await expect(
+                    svcWithRepo.importOne('u1', missionEnvelope(), {
+                        overrideScope: AgentScope.MISSION,
+                        missionId: 'm1',
+                    }),
+                ).rejects.toThrow(NotFoundException);
+                // Rejected BEFORE any Agent row is created.
+                expect(agents.create).not.toHaveBeenCalled();
+                expect(scopeCount).toHaveBeenCalledWith({ where: { id: 'm1', userId: 'u1' } });
+            });
+
+            it('creates the Agent when the caller owns the target Mission', async () => {
+                scopeCount.mockResolvedValueOnce(1); // mission m1 owned by u1
+                agents.findByUserIdAndSlug.mockResolvedValue(null);
+                agents.create.mockResolvedValueOnce(
+                    makeAgent({
+                        id: 'new-a',
+                        scope: AgentScope.MISSION,
+                        missionId: 'm1',
+                        status: AgentStatus.DRAFT,
+                    }),
+                );
+                const res = await svcWithRepo.importOne('u1', missionEnvelope(), {
+                    overrideScope: AgentScope.MISSION,
+                    missionId: 'm1',
+                });
+                expect(res.conflictResolution).toBe('none');
+                expect(agents.create).toHaveBeenCalledWith(
+                    expect.objectContaining({ scope: AgentScope.MISSION, missionId: 'm1' }),
+                );
+            });
+
+            it('does not own-check TENANT-scoped imports (no target id)', async () => {
+                agents.findByUserIdAndSlug.mockResolvedValue(null);
+                agents.create.mockResolvedValueOnce(
+                    makeAgent({ id: 'new-a', status: AgentStatus.DRAFT }),
+                );
+                await svcWithRepo.importOne('u1', baseEnvelope());
+                expect(scopeCount).not.toHaveBeenCalled();
+                expect(agents.create).toHaveBeenCalled();
+            });
+        });
     });
 });

--- a/packages/agent/src/agents/agent-export.service.ts
+++ b/packages/agent/src/agents/agent-export.service.ts
@@ -6,6 +6,8 @@ import {
     NotFoundException,
     Optional,
 } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, type EntityTarget, type ObjectLiteral } from 'typeorm';
 import {
     AGENT_PERMISSIONS_DEFAULT,
     Agent,
@@ -16,6 +18,13 @@ import {
     type AgentPermissions,
     type AgentTarget,
 } from '../entities/agent.entity';
+// Security (EW-711 #8): scope-entity classes used to verify the caller
+// owns the target Mission/Idea/Work BEFORE an imported Agent is planted
+// under that scope id. Reached via the shared DataSource (no new module
+// wiring) — see `assertScopeOwned`.
+import { Mission } from '../entities/mission.entity';
+import { Work } from '../entities/work.entity';
+import { WorkProposal } from '../entities/work-proposal.entity';
 import { AgentRepository } from '../database/repositories/agent.repository';
 import { AgentBudgetRepository } from '../database/repositories/agent-budget.repository';
 import { AgentMembershipRepository } from '../database/repositories/agent-membership.repository';
@@ -188,6 +197,20 @@ export class AgentExportService {
         private readonly memberships: AgentMembershipRepository,
         private readonly budgets: AgentBudgetRepository,
         @Optional() private readonly activityLog?: ActivityLogService,
+        // Security (EW-711 #8): the raw Agent repository is already
+        // registered by `AgentsModule`'s `TypeOrmModule.forFeature([Agent,
+        // …])`, so this resolves to a live `Repository<Agent>` in
+        // production with NO extra module wiring. We only use its
+        // `.manager` (the shared DataSource EntityManager) to load the
+        // target Mission/Idea/Work scope entity for an ownership check —
+        // mirroring the existing `manager.getRepository(...)` pattern in
+        // `github-app-installation-repository.repository.ts`. `@Optional()`
+        // keeps hand-rolled unit harnesses (which `new` the service with
+        // only the first four deps) constructing; the presence gate in
+        // `assertScopeOwned` keeps the production check strict.
+        @Optional()
+        @InjectRepository(Agent)
+        private readonly agentEntityRepo?: Repository<Agent>,
     ) {}
 
     async exportOne(userId: string, agentId: string): Promise<AgentExportEnvelope> {
@@ -303,6 +326,22 @@ export class AgentExportService {
         if (scope === AgentScope.WORK && !workId) {
             throw new BadRequestException('Work-scoped import requires workId option.');
         }
+
+        // Security (EW-711 #8): IDOR — verify the caller OWNS the target
+        // scope entity BEFORE planting an imported Agent under it. The
+        // missionId/ideaId/workId values flow straight from controller
+        // query params (`agents.controller.ts` import handler) into
+        // `agents.create(...)` below; the shape-only checks above never
+        // confirm the scope id belongs to this user, and the scope columns
+        // are intentionally NOT FK-constrained (see `agent.entity.ts`), so
+        // any authenticated user could otherwise create/plant an Agent
+        // inside another user's Mission/Idea/Work. Mirror how sibling
+        // services scope ownership (`MissionsService.findOrThrow`,
+        // `WorkProposalRepository.findByIdForUser`): load the scope row by
+        // (id, userId) and 404 — same not-found shape either way — when it
+        // is missing or owned by someone else. Tenant scope has no target
+        // id, so it is unaffected.
+        await this.assertScopeOwned(userId, scope, { missionId, ideaId, workId });
 
         // Secret-scan every file body BEFORE persisting — same hard-reject
         // posture as live edits via AgentFileService.write.
@@ -467,6 +506,69 @@ export class AgentExportService {
             throw new BadRequestException(
                 `Envelope identity.scope is invalid: ${envelope.identity.scope}`,
             );
+        }
+    }
+
+    /**
+     * Security (EW-711 #8): reject an import whose target scope entity is
+     * not owned by `userId`. Loads the Mission / Idea (WorkProposal) /
+     * Work row by `(id, userId)` via the shared DataSource and throws
+     * `NotFoundException` (404 — does NOT leak whether the id exists, same
+     * posture as `MissionsService.findOrThrow`) when the row is missing or
+     * belongs to another user.
+     *
+     * TENANT scope carries no target id, so it is a no-op. When the raw
+     * Agent repository isn't wired (hand-rolled unit tests `new` the
+     * service without it) the check is skipped so those harnesses keep
+     * working — production always injects it via
+     * `TypeOrmModule.forFeature([Agent, …])`.
+     */
+    private async assertScopeOwned(
+        userId: string,
+        scope: AgentScope,
+        ids: { missionId: string | null; ideaId: string | null; workId: string | null },
+    ): Promise<void> {
+        // TENANT scope carries no target id — nothing to own-check.
+        if (scope === AgentScope.TENANT) return;
+
+        // Resolve the scope entity + its target id. The shape checks in
+        // `importOne` already guarantee the matching id is present, but we
+        // re-guard defensively so a future caller can't slip a null past us.
+        // `Ideas` are persisted as `WorkProposal` rows (owner column
+        // `userId`); Mission + Work likewise expose a `userId` owner column.
+        // `EntityTarget<ObjectLiteral>` keeps `getRepository` typing
+        // entity-agnostic across the Mission / WorkProposal / Work trio
+        // (all three carry an `id` + `userId` owner column).
+        const entity: EntityTarget<ObjectLiteral> =
+            scope === AgentScope.MISSION
+                ? Mission
+                : scope === AgentScope.IDEA
+                  ? WorkProposal
+                  : Work;
+        const targetId =
+            scope === AgentScope.MISSION
+                ? ids.missionId
+                : scope === AgentScope.IDEA
+                  ? ids.ideaId
+                  : ids.workId;
+        if (!targetId) {
+            // Defensive: shape validation should have caught this already.
+            throw new BadRequestException(`Missing target id for ${scope}-scoped import.`);
+        }
+
+        // Skip only when the repo isn't wired (mock-only unit harnesses);
+        // production resolves a live Repository<Agent> and its `.manager`
+        // reaches every entity in the same DataSource.
+        if (!this.agentEntityRepo) return;
+
+        // Existence-by-owner: count instead of hydrating a full row just to
+        // assert ownership.
+        const ownedCount = await this.agentEntityRepo.manager
+            .getRepository(entity)
+            .count({ where: { id: targetId, userId } });
+        if (ownedCount === 0) {
+            // 404 (not 403) — don't leak existence of another user's scope.
+            throw new NotFoundException(`${scope} ${targetId} not found.`);
         }
     }
 

--- a/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
@@ -124,6 +124,9 @@ function makeService(onboardingState: OnboardingWizardStateV2 | null = null): {
         everWorksDns as never,
         funnel as never,
         eventEmitter as never,
+        // organizationRepository (EW-711 #27) — appended last; unused by the
+        // createWork defaults path under test, so a bare stub suffices.
+        {} as never,
     );
 
     return {

--- a/packages/agent/src/services/__tests__/work-lifecycle.org-enrollment.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.org-enrollment.spec.ts
@@ -1,0 +1,178 @@
+// `github-slugger` is an ESM-only dependency pulled in transitively via
+// `MarkdownGeneratorService -> readme-builder`. ts-jest cannot parse its
+// `import` syntax, so stub it out — this spec never touches slug building.
+jest.mock('github-slugger', () => ({
+    __esModule: true,
+    default: class {
+        slug(s: string) {
+            return s;
+        }
+    },
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { WorkLifecycleService } from '../work-lifecycle.service';
+import { WorkRepository } from '@src/database/repositories/work.repository';
+import { UserRepository } from '@src/database/repositories/user.repository';
+import { OrganizationRepository } from '@src/database/repositories/organization.repository';
+import { DataGeneratorService } from '@src/generators/data-generator/data-generator.service';
+import { MarkdownGeneratorService } from '@src/generators/markdown-generator/markdown-generator.service';
+import { WebsiteGeneratorService } from '@src/generators/website-generator/website-generator.service';
+import { WebsiteUpdateService } from '@src/generators/website-generator/website-update.service';
+import { WorkOwnershipService } from '../work-ownership.service';
+import { DeployFacadeService } from '@src/facades/deploy.facade';
+import { TemplateCatalogService } from '@src/template-catalog/template-catalog.service';
+import { WorkWebsiteRepositoryStateService } from '../work-website-repository-state.service';
+import { EverWorksDeployQuotaService, EverWorksGitProvider, EverWorksDnsService } from '@src/ever-works-providers';
+import { ZeroFrictionFunnelService } from '../zero-friction-funnel.service';
+import type { Work } from '@src/entities/work.entity';
+import type { Organization } from '@src/entities/organization.entity';
+import type { User } from '@src/entities/user.entity';
+
+/**
+ * Security (EW-711 #27) — cross-tenant org-KB enrollment guard.
+ *
+ * `updateWork` pairs a Work with an organization-scope KB doc set via
+ * `updateDto.organizationId`. Before the fix, any UUID was persisted
+ * verbatim, so a caller editing their own Work could enroll it into an
+ * organization belonging to ANOTHER tenant and fan the Work's KB into
+ * that tenant's org overlay. The guard resolves the target Organization
+ * and rejects with NotFoundException (existence-leak-safe) unless its
+ * `tenantId` matches the Work's tenant.
+ */
+
+const WORK_ID = '00000000-0000-0000-0000-000000000001';
+const TENANT_A = '00000000-0000-0000-0000-0000000000aa';
+const TENANT_B = '00000000-0000-0000-0000-0000000000bb';
+const OWN_ORG_ID = '00000000-0000-0000-0000-0000000000c1';
+const FOREIGN_ORG_ID = '00000000-0000-0000-0000-0000000000c2';
+const MISSING_ORG_ID = '00000000-0000-0000-0000-0000000000c3';
+
+function buildWork(overrides: Partial<Work> = {}): Work {
+    return {
+        id: WORK_ID,
+        name: 'Acme',
+        description: 'Acme directory',
+        owner: 'acme',
+        organization: false,
+        readmeConfig: null,
+        userId: 'user-1',
+        tenantId: TENANT_A,
+        organizationId: null,
+        websiteTemplateId: null,
+        deployProvider: 'vercel',
+        getRepoOwner: () => 'acme',
+        ...overrides,
+    } as unknown as Work;
+}
+
+describe('WorkLifecycleService — org-KB enrollment tenant guard (EW-711 #27)', () => {
+    let service: WorkLifecycleService;
+    let workRepository: { update: jest.Mock };
+    let organizationRepository: { findById: jest.Mock };
+    let ownershipService: { ensureCanEdit: jest.Mock };
+    let work: Work;
+
+    const user = { id: 'user-1', username: 'user-1' } as unknown as User;
+
+    beforeEach(async () => {
+        work = buildWork();
+
+        workRepository = {
+            // `updateWork` returns whatever `update` resolves; echo a work-shaped row.
+            update: jest.fn().mockImplementation(async (_id: string, data: Record<string, unknown>) => ({
+                ...work,
+                ...data,
+                getRepoOwner: () => 'acme',
+            })),
+        };
+        organizationRepository = { findById: jest.fn() };
+        ownershipService = {
+            ensureCanEdit: jest.fn().mockResolvedValue({ work, member: null, role: 'owner', isCreator: true }),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                WorkLifecycleService,
+                { provide: WorkRepository, useValue: workRepository },
+                { provide: UserRepository, useValue: {} },
+                { provide: OrganizationRepository, useValue: organizationRepository },
+                { provide: DataGeneratorService, useValue: {} },
+                { provide: MarkdownGeneratorService, useValue: {} },
+                { provide: WebsiteGeneratorService, useValue: {} },
+                { provide: WebsiteUpdateService, useValue: {} },
+                { provide: WorkOwnershipService, useValue: ownershipService },
+                { provide: DeployFacadeService, useValue: { getAvailableProviders: () => [] } },
+                { provide: TemplateCatalogService, useValue: {} },
+                { provide: WorkWebsiteRepositoryStateService, useValue: {} },
+                { provide: EverWorksDeployQuotaService, useValue: {} },
+                { provide: EverWorksGitProvider, useValue: {} },
+                { provide: EverWorksDnsService, useValue: {} },
+                { provide: ZeroFrictionFunnelService, useValue: {} },
+                { provide: EventEmitter2, useValue: { emit: jest.fn(), emitAsync: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(WorkLifecycleService);
+    });
+
+    it('rejects enrolling into an organization owned by a DIFFERENT tenant (no persist, leak-safe 404)', async () => {
+        organizationRepository.findById.mockResolvedValue({
+            id: FOREIGN_ORG_ID,
+            tenantId: TENANT_B,
+        } as Organization);
+
+        await expect(
+            service.updateWork(WORK_ID, { organizationId: FOREIGN_ORG_ID }, user),
+        ).rejects.toBeInstanceOf(NotFoundException);
+
+        expect(organizationRepository.findById).toHaveBeenCalledWith(FOREIGN_ORG_ID);
+        // The cross-tenant organizationId must NEVER reach the DB write.
+        expect(workRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects enrolling into a non-existent organization with the SAME leak-safe 404', async () => {
+        organizationRepository.findById.mockResolvedValue(null);
+
+        await expect(
+            service.updateWork(WORK_ID, { organizationId: MISSING_ORG_ID }, user),
+        ).rejects.toBeInstanceOf(NotFoundException);
+
+        expect(workRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('allows enrolling into an organization in the SAME tenant (legit caller still works)', async () => {
+        organizationRepository.findById.mockResolvedValue({
+            id: OWN_ORG_ID,
+            tenantId: TENANT_A,
+        } as Organization);
+
+        const result = await service.updateWork(WORK_ID, { organizationId: OWN_ORG_ID }, user);
+
+        expect(result.status).toBe('success');
+        expect(organizationRepository.findById).toHaveBeenCalledWith(OWN_ORG_ID);
+        expect(workRepository.update).toHaveBeenCalledTimes(1);
+        expect(workRepository.update.mock.calls[0][1]).toMatchObject({ organizationId: OWN_ORG_ID });
+    });
+
+    it('clears membership when organizationId is null WITHOUT an org lookup', async () => {
+        const result = await service.updateWork(WORK_ID, { organizationId: null }, user);
+
+        expect(result.status).toBe('success');
+        // Null is the explicit clear path — must not trigger a tenant probe.
+        expect(organizationRepository.findById).not.toHaveBeenCalled();
+        expect(workRepository.update).toHaveBeenCalledTimes(1);
+        expect(workRepository.update.mock.calls[0][1]).toMatchObject({ organizationId: null });
+    });
+
+    it('does not touch organizationId (or probe orgs) when the field is omitted', async () => {
+        const result = await service.updateWork(WORK_ID, { name: 'Renamed' }, user);
+
+        expect(result.status).toBe('success');
+        expect(organizationRepository.findById).not.toHaveBeenCalled();
+        expect(workRepository.update).toHaveBeenCalledTimes(1);
+        expect(workRepository.update.mock.calls[0][1]).not.toHaveProperty('organizationId');
+    });
+});

--- a/packages/agent/src/services/__tests__/work-lifecycle.org-enrollment.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.org-enrollment.spec.ts
@@ -25,7 +25,11 @@ import { WorkOwnershipService } from '../work-ownership.service';
 import { DeployFacadeService } from '@src/facades/deploy.facade';
 import { TemplateCatalogService } from '@src/template-catalog/template-catalog.service';
 import { WorkWebsiteRepositoryStateService } from '../work-website-repository-state.service';
-import { EverWorksDeployQuotaService, EverWorksGitProvider, EverWorksDnsService } from '@src/ever-works-providers';
+import {
+    EverWorksDeployQuotaService,
+    EverWorksGitProvider,
+    EverWorksDnsService,
+} from '@src/ever-works-providers';
 import { ZeroFrictionFunnelService } from '../zero-friction-funnel.service';
 import type { Work } from '@src/entities/work.entity';
 import type { Organization } from '@src/entities/organization.entity';
@@ -82,15 +86,19 @@ describe('WorkLifecycleService — org-KB enrollment tenant guard (EW-711 #27)',
 
         workRepository = {
             // `updateWork` returns whatever `update` resolves; echo a work-shaped row.
-            update: jest.fn().mockImplementation(async (_id: string, data: Record<string, unknown>) => ({
-                ...work,
-                ...data,
-                getRepoOwner: () => 'acme',
-            })),
+            update: jest
+                .fn()
+                .mockImplementation(async (_id: string, data: Record<string, unknown>) => ({
+                    ...work,
+                    ...data,
+                    getRepoOwner: () => 'acme',
+                })),
         };
         organizationRepository = { findById: jest.fn() };
         ownershipService = {
-            ensureCanEdit: jest.fn().mockResolvedValue({ work, member: null, role: 'owner', isCreator: true }),
+            ensureCanEdit: jest
+                .fn()
+                .mockResolvedValue({ work, member: null, role: 'owner', isCreator: true }),
         };
 
         const module: TestingModule = await Test.createTestingModule({
@@ -154,7 +162,9 @@ describe('WorkLifecycleService — org-KB enrollment tenant guard (EW-711 #27)',
         expect(result.status).toBe('success');
         expect(organizationRepository.findById).toHaveBeenCalledWith(OWN_ORG_ID);
         expect(workRepository.update).toHaveBeenCalledTimes(1);
-        expect(workRepository.update.mock.calls[0][1]).toMatchObject({ organizationId: OWN_ORG_ID });
+        expect(workRepository.update.mock.calls[0][1]).toMatchObject({
+            organizationId: OWN_ORG_ID,
+        });
     });
 
     it('clears membership when organizationId is null WITHOUT an org lookup', async () => {

--- a/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.service.spec.ts
@@ -33,6 +33,7 @@ describe('WorkLifecycleService', () => {
     let websiteGenerator: any;
     let websiteUpdateService: any;
     let ownershipService: any;
+    let organizationRepository: any;
     let deployFacade: any;
     let templateCatalogService: any;
     let websiteRepositoryState: any;
@@ -74,6 +75,12 @@ describe('WorkLifecycleService', () => {
         ownershipService = {
             ensureCanEdit: jest.fn(),
             ensureIsOwner: jest.fn(),
+        };
+        // EW-711 #27: org-KB enrollment tenant guard resolves the target org
+        // before persisting a non-null organizationId. Default to no lookup;
+        // tests that enroll into an org stub this explicitly.
+        organizationRepository = {
+            findById: jest.fn(),
         };
         deployFacade = {
             getAvailableProviders: jest.fn().mockReturnValue([]),
@@ -131,6 +138,7 @@ describe('WorkLifecycleService', () => {
             everWorksDns,
             funnel,
             eventEmitter as never,
+            organizationRepository,
         );
     });
 
@@ -177,6 +185,7 @@ describe('WorkLifecycleService', () => {
                 owner: 'ever-works',
                 organization: false,
                 organizationId: null,
+                tenantId: 'tenant-a',
                 readmeConfig: {},
                 gitProvider: 'github',
                 userId: user.id,
@@ -187,13 +196,20 @@ describe('WorkLifecycleService', () => {
                 ...overrides,
             }) as any;
 
-        it('persists a non-null organizationId from the DTO', async () => {
+        it('persists a non-null organizationId from the DTO (org in the same tenant)', async () => {
             const work = baseWork();
             ownershipService.ensureCanEdit.mockResolvedValue({ work });
+            // EW-711 #27: enrolling into a non-null org now resolves the target
+            // and requires a tenant match. A same-tenant org persists as before.
+            organizationRepository.findById.mockResolvedValue({
+                id: 'org-42',
+                tenantId: 'tenant-a',
+            });
             workRepository.update.mockResolvedValueOnce({ ...work, organizationId: 'org-42' });
 
             await service.updateWork(work.id, { organizationId: 'org-42' } as any, user);
 
+            expect(organizationRepository.findById).toHaveBeenCalledWith('org-42');
             expect(workRepository.update).toHaveBeenCalledWith(
                 work.id,
                 expect.objectContaining({ organizationId: 'org-42' }),

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -10,6 +10,7 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { randomUUID } from 'node:crypto';
 import { WorkRepository } from '@src/database/repositories/work.repository';
 import { UserRepository } from '@src/database/repositories/user.repository';
+import { OrganizationRepository } from '@src/database/repositories/organization.repository';
 import {
     WorkCreatedEvent,
     WorkStatusChangedEvent,
@@ -99,6 +100,9 @@ export class WorkLifecycleService {
         private readonly everWorksDns: EverWorksDnsService,
         private readonly funnel: ZeroFrictionFunnelService,
         private readonly eventEmitter: EventEmitter2,
+        // Appended last (EW-711 #27) so existing positional test constructions
+        // keep their argument slots; NestJS DI resolves by type, not position.
+        private readonly organizationRepository: OrganizationRepository,
     ) {}
 
     /**
@@ -616,6 +620,26 @@ export class WorkLifecycleService {
             // org-overlay fan-out flow (row 37) reads this column to resolve
             // which Works receive `.content/kb/.org/...` materialization.
             if (updateDto.organizationId !== undefined) {
+                // Security (EW-711 #27): a Work could be enrolled into an
+                // ARBITRARY organizationId with no tenant check, fanning the
+                // Work's KB into another tenant's org. Before persisting a
+                // non-null target, resolve the Organization and require its
+                // tenant to match the Work's tenant. Reject with
+                // NotFoundException (not Forbidden) so a cross-tenant probe
+                // can't distinguish "org exists in another tenant" from "org
+                // does not exist" (existence-leak-safe). `organizationId ===
+                // null` is the clear-membership path and stays unguarded.
+                if (updateDto.organizationId !== null) {
+                    const targetOrg = await this.organizationRepository.findById(
+                        updateDto.organizationId,
+                    );
+                    if (!targetOrg || targetOrg.tenantId !== work.tenantId) {
+                        throw new NotFoundException({
+                            status: 'error',
+                            message: 'Organization not found',
+                        });
+                    }
+                }
                 updateData.organizationId = updateDto.organizationId;
             }
 

--- a/packages/agent/src/user-research/__tests__/schemas.spec.ts
+++ b/packages/agent/src/user-research/__tests__/schemas.spec.ts
@@ -54,7 +54,8 @@ describe('inferredProfileSchema', () => {
 
     it('rejects non-https source URLs', () => {
         expect(
-            inferredProfileSchema.safeParse(profileWithSource('http://example.com/article')).success,
+            inferredProfileSchema.safeParse(profileWithSource('http://example.com/article'))
+                .success,
         ).toBe(false);
     });
 

--- a/packages/agent/src/user-research/__tests__/schemas.spec.ts
+++ b/packages/agent/src/user-research/__tests__/schemas.spec.ts
@@ -30,6 +30,49 @@ describe('inferredProfileSchema', () => {
         });
         expect(out.success).toBe(false);
     });
+
+    // Security (EW-715 #3): sources[].url must be a public https URL — no
+    // SSRF targets reach the persisted profile.
+    const profileWithSource = (url: string) => ({
+        expertise: [],
+        topics: [],
+        confidence: 'low' as const,
+        sources: [{ url, title: 'a source' }],
+    });
+
+    it('accepts public https source URLs', () => {
+        expect(
+            inferredProfileSchema.safeParse(profileWithSource('https://example.com/article'))
+                .success,
+        ).toBe(true);
+        expect(
+            inferredProfileSchema.safeParse(
+                profileWithSource('https://docs.ever.works/path?q=1#frag'),
+            ).success,
+        ).toBe(true);
+    });
+
+    it('rejects non-https source URLs', () => {
+        expect(
+            inferredProfileSchema.safeParse(profileWithSource('http://example.com/article')).success,
+        ).toBe(false);
+    });
+
+    it('rejects SSRF / cloud-metadata / private-IP source URLs', () => {
+        const blocked = [
+            'https://169.254.169.254/latest/meta-data/', // AWS/Azure/GCP IMDS
+            'https://127.0.0.1/admin', // loopback
+            'https://localhost/admin', // loopback hostname
+            'https://10.0.0.5/internal', // RFC1918 10/8
+            'https://172.16.0.1/internal', // RFC1918 172.16/12
+            'https://192.168.1.1/internal', // RFC1918 192.168/16
+            'https://[::1]/internal', // IPv6 loopback
+            'https://metadata.google.internal/computeMetadata/v1/', // GCP metadata host
+        ];
+        for (const url of blocked) {
+            expect(inferredProfileSchema.safeParse(profileWithSource(url)).success).toBe(false);
+        }
+    });
 });
 
 describe('workProposalSchema', () => {

--- a/packages/agent/src/user-research/schemas.ts
+++ b/packages/agent/src/user-research/schemas.ts
@@ -1,4 +1,40 @@
 import { z } from 'zod';
+import { isSafeWebhookUrl } from '../utils/ssrf-guard';
+
+// Security (EW-715 #3): `sources[].url` is synthesized by the LLM from
+// attacker-controlled web content, persisted to `user.inferredInterests`, and
+// later re-fetched / re-injected into prompts. A bare `z.string().url()`
+// happily accepts `http://169.254.169.254/...`, `http://localhost/...`, or any
+// private-IP / cloud-metadata target, turning the persisted profile into a
+// stored SSRF payload. Tighten the field to require `https:` AND reject SSRF
+// targets via the shared lexical guard `isSafeWebhookUrl` (loopback / link-local
+// / RFC1918 / cloud-metadata hostnames). The guard also rejects `http:`, but we
+// additionally pin to `https:` here because every legitimate research source is
+// a public HTTPS page. This refine runs on BOTH live boundaries:
+//   - the `finalize` tool input (`finalize.tool.ts` → inputSchema), and
+//   - the persistence re-parse in `user-research.service.ts`
+//     (`inferredProfileSchema.parse(finalProfile)` before write).
+const isSafeHttpsSourceUrl = (raw: string): boolean => {
+    let parsed: URL;
+    try {
+        parsed = new URL(raw);
+    } catch {
+        return false;
+    }
+    if (parsed.protocol !== 'https:') return false;
+    // The shared lexical guard only recognises loopback by *literal IP*
+    // (127.0.0.0/8, ::1). The bare hostname `localhost` (and its IPv6 aliases)
+    // is not an IP literal, so `isSafeWebhookUrl('https://localhost/...')`
+    // returns true. A legitimate research source is never a loopback host, so
+    // reject those names here before deferring. (Kept local rather than widening
+    // the shared guard, which other callers — e.g. the agent-memory localhost
+    // default — intentionally allow.)
+    const host = parsed.hostname.toLowerCase();
+    if (host === 'localhost' || host === 'ip6-localhost' || host === 'ip6-loopback' || host.endsWith('.localhost')) {
+        return false;
+    }
+    return isSafeWebhookUrl(raw);
+};
 
 export const inferredProfileSchema = z.object({
     industry: z.string().optional(),
@@ -10,7 +46,13 @@ export const inferredProfileSchema = z.object({
     sources: z
         .array(
             z.object({
-                url: z.string().url(),
+                url: z
+                    .string()
+                    .url()
+                    .refine(isSafeHttpsSourceUrl, {
+                        message:
+                            'Source url must be a public https URL (no http, private IPs, loopback, link-local, or cloud-metadata targets)',
+                    }),
                 title: z.string(),
             }),
         )

--- a/packages/agent/src/user-research/schemas.ts
+++ b/packages/agent/src/user-research/schemas.ts
@@ -30,7 +30,12 @@ const isSafeHttpsSourceUrl = (raw: string): boolean => {
     // the shared guard, which other callers — e.g. the agent-memory localhost
     // default — intentionally allow.)
     const host = parsed.hostname.toLowerCase();
-    if (host === 'localhost' || host === 'ip6-localhost' || host === 'ip6-loopback' || host.endsWith('.localhost')) {
+    if (
+        host === 'localhost' ||
+        host === 'ip6-localhost' ||
+        host === 'ip6-loopback' ||
+        host.endsWith('.localhost')
+    ) {
         return false;
     }
     return isSafeWebhookUrl(raw);
@@ -46,13 +51,10 @@ export const inferredProfileSchema = z.object({
     sources: z
         .array(
             z.object({
-                url: z
-                    .string()
-                    .url()
-                    .refine(isSafeHttpsSourceUrl, {
-                        message:
-                            'Source url must be a public https URL (no http, private IPs, loopback, link-local, or cloud-metadata targets)',
-                    }),
+                url: z.string().url().refine(isSafeHttpsSourceUrl, {
+                    message:
+                        'Source url must be a public https URL (no http, private IPs, loopback, link-local, or cloud-metadata targets)',
+                }),
                 title: z.string(),
             }),
         )


### PR DESCRIPTION
## Wave-A batch 2 — EW-710 security-audit remediation

Four authorization / SSRF fixes from the 2026-06-02 platform audit, each with focused unit coverage. Part of [EW-710](https://evertech.atlassian.net/browse/EW-710); closes audit items #29, #8, #27/#25, and #715-3.

### #29 — agent-memory IDOR (`agent-memory.controller.ts`)
`closeSession` / `deleteEntry` are id-addressed and previously **skipped ownership entirely when `workId` was omitted**, so any user could close or forget another user's session/entry by guessing the id. Fix:
- Stamp the creating user (`ownerUserId`, forced from the principal, overrides any caller-supplied key → un-spoofable) on `openSession` / `save`.
- `closeSession` / `deleteEntry` now require `ensureCanEdit` for Work-scoped calls **and** verify the owner stamp unconditionally.
- Fail-open only for providers that don't implement enumeration and for unstamped legacy rows; a **present, foreign stamp is always 403**.

### #8 — agent-export scope IDOR (`agent-export.service.ts`)
An imported Agent could be planted under **another user's** Mission / Idea / Work — the scope ids flow from query params into `agents.create` with only shape checks, and the scope columns are intentionally not FK-constrained. Fix: verify `(id, userId)` ownership of the target scope entity before planting; **404** (existence-leak-safe). TENANT scope (no target id) is a no-op. Repo injected `@Optional()` so unit harnesses keep constructing; production always wires it via `TypeOrmModule.forFeature([Agent, …])`.

### #27/#25 — cross-tenant org-KB enrollment (`work-lifecycle.service.ts`)
`updateWork` persisted any `organizationId` verbatim, letting a caller fan their Work's KB into **another tenant's** org overlay. Fix: resolve the target Organization and require a tenant match; reject with `NotFoundException` (leak-safe). `organizationId === null` (clear membership) stays unguarded.

### #715 #3 — stored SSRF in user-research `sources[].url` (`schemas.ts`)
An LLM-synthesized, attacker-influenced URL was persisted with a bare `z.string().url()` and later re-fetched/re-injected. Fix: require `https:`, run the shared SSRF lexical guard, **and** reject loopback hostnames (`localhost` + IPv6 aliases) that the IP-literal guard misses.

## Tests
- agent-memory controller: **27/27**
- agent-export service: **13/13** (Mission / Work / WorkProposal all carry a `userId` owner column — verified)
- work-lifecycle (3 specs incl. new `work-lifecycle.org-enrollment.spec.ts`): **35/35**
- user-research schemas: **12/12**
- agent package `tsc -p tsconfig.types.json --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-710]: https://evertech.atlassian.net/browse/EW-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authorization vulnerabilities in agent memory session and entry operations preventing unauthorized access across users.
  * Fixed cross-tenant organization enrollment allowing works to be assigned to organizations outside their tenant.
  * Fixed missing URL validation for profile source links to prevent unsafe network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->