### PR TITLE
feat(kb): EW-724 — IVectorStorePlugin contract + facade + contract tests (Phase 2 slice 1)

### DIFF
--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -444,5 +444,28 @@ export const config = {
             const raw = parseInt(process.env.KB_RECONCILE_STALE_AFTER_MS || '', 10);
             return Number.isFinite(raw) && raw > 0 ? raw : 24 * 60 * 60 * 1000;
         },
+        /**
+         * EW-642 — operator-pinned vector-store provider plugin id.
+         * When set, `VectorStoreFacadeService` ONLY tries this provider
+         * — no silent fallback. Leave unset to let the facade resolve
+         * via per-Work pin → scope-active → first-available chain.
+         * Mirrors the `KB_TRANSCRIPTION_PROVIDER_ID` knob shape.
+         */
+        getVectorStoreProviderId(): string | undefined {
+            const v = process.env.KB_VECTOR_STORE_PROVIDER_ID;
+            return v && v.length > 0 ? v : undefined;
+        },
+        /**
+         * EW-642 — embedding routing mode. `'pgvector'` keeps the
+         * legacy `WorkKnowledgeChunkRepository` SQL path; `'external'`
+         * forces the facade-routed `IVectorStorePlugin` path; `'auto'`
+         * (default) lets the facade pick based on whether a non-pgvector
+         * vector-store plugin is registered. Free-form string so the
+         * future "hybrid" / "shadow-write" modes don't need a contract
+         * bump.
+         */
+        getEmbeddingMode(): 'pgvector' | 'external' | 'auto' | string {
+            return process.env.KB_EMBEDDING_MODE || 'auto';
+        },
     },
 };

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -119,6 +119,19 @@ export {
 // hosted `agentmemory` REST server on :3111)
 export { AgentMemoryFacadeService, AgentMemoryFacadeError } from './agent-memory.facade';
 
+// Vector Store Facade — EW-642 RFC §6 selection chain + D4 embedding
+// mode resolver. Routes KB chunk upsert / query / delete through the
+// resolved `IVectorStorePlugin` for the (work, user) tuple.
+export {
+    VectorStoreFacadeService,
+    VectorStoreNotConfiguredError,
+    EmbeddingModeResolver,
+    EmbeddingModeUnsupportedError,
+    type SelectVectorStoreOpts,
+    type EmbeddingMode,
+    type EmbeddingModeSetting,
+} from './vector-store.facade';
+
 // Re-export facade types from plugin for convenience
 export type { FacadeExtractionOptions, FacadeExtractedContent } from '@ever-works/plugin';
 export type {

--- a/packages/agent/src/facades/vector-store.facade.spec.ts
+++ b/packages/agent/src/facades/vector-store.facade.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * EW-642 — `VectorStoreFacadeService` + `EmbeddingModeResolver` unit tests.
+ *
+ * Mirrors the AiFacadeService.transcribe spec shape. The facade is
+ * exercised in isolation via mocked `PluginRegistryService` +
+ * `WorkPluginRepository`; the concrete `IVectorStorePlugin` is the
+ * in-memory fake from the contract suite.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+    VectorStoreFacadeService,
+    VectorStoreNotConfiguredError,
+    EmbeddingModeResolver,
+    EmbeddingModeUnsupportedError,
+} from './vector-store.facade';
+import {
+    PluginRegistryService,
+    type RegisteredPlugin,
+} from '../plugins/services/plugin-registry.service';
+import { WorkPluginRepository } from '../plugins/repositories/work-plugin.repository';
+import { InMemoryVectorStorePlugin } from '../../../plugin/src/contracts/__tests__/fakes/in-memory-vector-store';
+import type {
+    IVectorStorePlugin,
+    PluginManifest,
+    VectorStoreCapabilities,
+} from '@ever-works/plugin';
+
+describe('VectorStoreFacadeService', () => {
+    let service: VectorStoreFacadeService;
+    let registry: jest.Mocked<PluginRegistryService>;
+    let workPluginRepository: { findActiveByCapability: jest.Mock };
+
+    const createMockVectorPlugin = (
+        id: string,
+        opts: { embedsOnWrite?: boolean } = {},
+    ): IVectorStorePlugin => {
+        const fake = new InMemoryVectorStorePlugin();
+        // Override the readonly fields the facade actually looks at.
+        Object.defineProperty(fake, 'id', { value: id });
+        if (opts.embedsOnWrite !== undefined) {
+            const caps: VectorStoreCapabilities = {
+                ...fake.vectorCapabilities,
+                embedsOnWrite: opts.embedsOnWrite,
+            };
+            Object.defineProperty(fake, 'vectorCapabilities', { value: caps });
+        }
+        return fake;
+    };
+
+    const createRegisteredPlugin = (
+        plugin: IVectorStorePlugin,
+        manifest: Partial<PluginManifest> = {},
+        state: RegisteredPlugin['state'] = 'loaded',
+    ): RegisteredPlugin => ({
+        plugin: plugin as any,
+        manifest: {
+            id: plugin.id,
+            name: plugin.name,
+            version: plugin.version,
+            description: 'Test vector-store plugin',
+            category: 'vector-store',
+            capabilities: ['vector-store'],
+            ...manifest,
+        } as PluginManifest,
+        state,
+        builtIn: manifest.builtIn ?? false,
+        stateHistory: [],
+        registeredAt: Date.now(),
+    });
+
+    beforeEach(async () => {
+        workPluginRepository = {
+            findActiveByCapability: jest.fn().mockResolvedValue(null),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                VectorStoreFacadeService,
+                {
+                    provide: PluginRegistryService,
+                    useValue: {
+                        get: jest.fn(),
+                        getByCapability: jest.fn().mockReturnValue([]),
+                        isPluginEnabledForScope: jest.fn().mockResolvedValue(true),
+                    },
+                },
+                {
+                    provide: WorkPluginRepository,
+                    useValue: workPluginRepository,
+                },
+            ],
+        }).compile();
+
+        service = module.get<VectorStoreFacadeService>(VectorStoreFacadeService);
+        registry = module.get(PluginRegistryService);
+
+        // Ensure the env pin doesn't leak between tests.
+        delete process.env.KB_VECTOR_STORE_PROVIDER_ID;
+    });
+
+    afterEach(() => {
+        delete process.env.KB_VECTOR_STORE_PROVIDER_ID;
+    });
+
+    describe('select()', () => {
+        it('1. providerOverride routes to the matching plugin', async () => {
+            const pgvector = createMockVectorPlugin('pgvector-plugin');
+            const qdrant = createMockVectorPlugin('qdrant-plugin');
+
+            registry.get.mockImplementation((id: string) => {
+                if (id === 'qdrant-plugin') return createRegisteredPlugin(qdrant);
+                if (id === 'pgvector-plugin') return createRegisteredPlugin(pgvector);
+                return undefined;
+            });
+
+            const resolved = await service.select({
+                workId: 'w1',
+                userId: 'u1',
+                providerOverride: 'qdrant-plugin',
+            });
+
+            expect(resolved.id).toBe('qdrant-plugin');
+        });
+
+        it('2. providerOverride that does not exist throws VectorStoreNotConfiguredError', async () => {
+            registry.get.mockReturnValue(undefined);
+
+            await expect(
+                service.select({
+                    workId: 'w1',
+                    userId: 'u1',
+                    providerOverride: 'nope-plugin',
+                }),
+            ).rejects.toBeInstanceOf(VectorStoreNotConfiguredError);
+        });
+
+        it('3. operator env pin (KB_VECTOR_STORE_PROVIDER_ID) routes to that plugin', async () => {
+            const pinned = createMockVectorPlugin('pinecone-plugin');
+            process.env.KB_VECTOR_STORE_PROVIDER_ID = 'pinecone-plugin';
+            registry.get.mockReturnValue(createRegisteredPlugin(pinned));
+
+            const resolved = await service.select({ workId: 'w1', userId: 'u1' });
+
+            expect(resolved.id).toBe('pinecone-plugin');
+            expect(registry.get).toHaveBeenCalledWith('pinecone-plugin');
+        });
+
+        it('4. scope-active plugin is returned when no override is set', async () => {
+            const pgvector = createMockVectorPlugin('pgvector-plugin');
+            const qdrant = createMockVectorPlugin('qdrant-plugin');
+
+            workPluginRepository.findActiveByCapability.mockResolvedValue({
+                pluginId: 'qdrant-plugin',
+                capability: 'vector-store',
+            });
+            registry.get.mockImplementation((id: string) => {
+                if (id === 'qdrant-plugin') return createRegisteredPlugin(qdrant);
+                return undefined;
+            });
+            // Registry default would prefer pgvector; scope-active must win.
+            registry.getByCapability.mockReturnValue([createRegisteredPlugin(pgvector)]);
+
+            const resolved = await service.select({ workId: 'w1', userId: 'u1' });
+
+            expect(resolved.id).toBe('qdrant-plugin');
+        });
+
+        it('5. registry-default plugin returned when no override and no scope-active plugin', async () => {
+            const pgvector = createMockVectorPlugin('pgvector-plugin');
+
+            workPluginRepository.findActiveByCapability.mockResolvedValue(null);
+            registry.getByCapability.mockReturnValue([
+                createRegisteredPlugin(pgvector, {
+                    defaultForCapabilities: ['vector-store'],
+                }),
+            ]);
+
+            const resolved = await service.select({ workId: 'w1', userId: 'u1' });
+
+            expect(resolved.id).toBe('pgvector-plugin');
+        });
+
+        it('6. throws VectorStoreNotConfiguredError when no selectable plugin exists', async () => {
+            workPluginRepository.findActiveByCapability.mockResolvedValue(null);
+            registry.getByCapability.mockReturnValue([]);
+
+            await expect(service.select({ workId: 'w1', userId: 'u1' })).rejects.toBeInstanceOf(
+                VectorStoreNotConfiguredError,
+            );
+        });
+    });
+
+    describe('EmbeddingModeResolver', () => {
+        let resolver: EmbeddingModeResolver;
+        const originalEnv = process.env.KB_EMBEDDING_MODE;
+
+        beforeEach(() => {
+            resolver = new EmbeddingModeResolver();
+            delete process.env.KB_EMBEDDING_MODE;
+        });
+
+        afterEach(() => {
+            if (originalEnv !== undefined) {
+                process.env.KB_EMBEDDING_MODE = originalEnv;
+            } else {
+                delete process.env.KB_EMBEDDING_MODE;
+            }
+        });
+
+        it('7. explicit Work-level setting wins over org / env / auto', async () => {
+            const plugin = createMockVectorPlugin('pgvector-plugin', { embedsOnWrite: true });
+            process.env.KB_EMBEDDING_MODE = 'plugin';
+
+            const mode = resolver.resolve({
+                workId: 'w1',
+                resolvedVectorStorePlugin: plugin,
+                workEmbeddingMode: 'platform',
+                orgEmbeddingMode: 'plugin',
+            });
+
+            expect(mode).toBe('platform');
+        });
+
+        it("8. 'auto' picks 'plugin' when capabilities.embedsOnWrite=true, else 'platform'", async () => {
+            const embedsOnWrite = createMockVectorPlugin('weaviate-plugin', {
+                embedsOnWrite: true,
+            });
+            const callerEmbeds = createMockVectorPlugin('pgvector-plugin', {
+                embedsOnWrite: false,
+            });
+
+            // 'auto' against an embedsOnWrite=true backend → 'plugin'.
+            const autoMode = resolver.resolve({
+                workId: 'w1',
+                resolvedVectorStorePlugin: embedsOnWrite,
+                workEmbeddingMode: 'auto',
+                orgEmbeddingMode: 'auto',
+            });
+            expect(autoMode).toBe('plugin');
+
+            // 'auto' against an embedsOnWrite=false backend → 'platform'.
+            const platformMode = resolver.resolve({
+                workId: 'w1',
+                resolvedVectorStorePlugin: callerEmbeds,
+                workEmbeddingMode: 'auto',
+                orgEmbeddingMode: 'auto',
+            });
+            expect(platformMode).toBe('platform');
+        });
+
+        it("9. 'plugin' mode + embedsOnWrite=false throws EmbeddingModeUnsupportedError", async () => {
+            const plugin = createMockVectorPlugin('pgvector-plugin', {
+                embedsOnWrite: false,
+            });
+
+            expect(() =>
+                resolver.resolve({
+                    workId: 'w1',
+                    resolvedVectorStorePlugin: plugin,
+                    workEmbeddingMode: 'plugin',
+                }),
+            ).toThrow(EmbeddingModeUnsupportedError);
+        });
+    });
+});

--- a/packages/agent/src/facades/vector-store.facade.ts
+++ b/packages/agent/src/facades/vector-store.facade.ts
@@ -1,0 +1,376 @@
+/**
+ * EW-642 — `VectorStoreFacadeService` + `EmbeddingModeResolver`.
+ *
+ * Mirrors `AiFacadeService.transcribe`'s selection chain so the KB
+ * ingest/retrieval paths get a single entry point that picks the right
+ * `IVectorStorePlugin` for the (work, user) tuple and routes upsert /
+ * query / delete calls through it.
+ *
+ * RFC anchors:
+ *   - §6 selection chain — `providerOverride` → operator env pin
+ *     (`KB_VECTOR_STORE_PROVIDER_ID`) → per-Work scope-active plugin →
+ *     registry default (`defaultForCapabilities`) → first by id →
+ *     otherwise throw `VectorStoreNotConfiguredError`.
+ *   - D4 — embedding mode cascade (work → org → env → auto). The
+ *     `'auto'` fallback picks `'plugin'` when the resolved vector store
+ *     declares `vectorCapabilities.embedsOnWrite === true` (e.g.
+ *     Weaviate text2vec, Pinecone with vendor-managed embedding); else
+ *     `'platform'` (caller-side embedding via the AI facade).
+ *
+ * Slice-2 wires the optional `ActivityLogService` for auto-mode flips
+ * (today the @Optional() injection just keeps the constructor stable so
+ * Phase 3 doesn't have to re-touch the FacadesModule).
+ *
+ * Design rationale lives in the RFC:
+ * `docs/specs/features/knowledge-base/phase-2-vector-plugin-design.md`.
+ */
+
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import {
+    isVectorStorePlugin,
+    type IVectorStorePlugin,
+    type UpsertChunksInput,
+    type UpsertChunksResult,
+    type QueryChunksInput,
+    type QueryChunksResult,
+    type DeleteByDocumentInput,
+    type DeleteByWorkInput,
+} from '@ever-works/plugin';
+import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
+import { WorkPluginRepository } from '../plugins/repositories/work-plugin.repository';
+import { ActivityLogService } from '../activity-log/activity-log.service';
+import { config } from '../config';
+import { FacadeError } from './base.facade';
+
+const VECTOR_STORE_CAPABILITY = 'vector-store';
+const VECTOR_STORE_CATEGORY = 'vector-store' as const;
+
+/**
+ * Options accepted by every selection-aware method on
+ * `VectorStoreFacadeService`. Mirrors the per-call surface of
+ * `FacadeOptions` but keeps the field set tight so callers don't have
+ * to thread agent/task ids through paths that don't need them — KB
+ * ingest carries them via the work record, retrieval doesn't have them
+ * at all.
+ */
+export interface SelectVectorStoreOpts {
+    readonly workId: string;
+    readonly userId: string;
+    /**
+     * Caller-pinned provider id. Highest-priority leg of the RFC §6
+     * chain — when set, the facade ONLY tries this provider; no silent
+     * fallback to operator pin / scope-active / registry default.
+     */
+    readonly providerOverride?: string;
+}
+
+/**
+ * Resolved embedding-mode literal returned by
+ * `EmbeddingModeResolver.resolve()`. `'platform'` keeps the legacy
+ * caller-side embedding lane (AI facade → embedding bytes → vector
+ * store); `'plugin'` defers embedding to the vector-store plugin
+ * (vendor-managed, requires `embedsOnWrite === true`).
+ */
+export type EmbeddingMode = 'platform' | 'plugin';
+
+/**
+ * Operator-knob shape — the env var accepts the literal `'auto'`
+ * alongside the resolved-mode literals so admins can express "let the
+ * facade pick based on what's wired in".
+ */
+export type EmbeddingModeSetting = EmbeddingMode | 'auto';
+
+/**
+ * Thrown by `VectorStoreFacadeService.select()` when no vector-store
+ * plugin is selectable for the (work, user, override) tuple. KB
+ * ingest catches this and surfaces "no vector store configured" on
+ * the workbench so the operator can either install
+ * `@ever-works/pgvector-plugin` (the default) or pin one via
+ * `KB_VECTOR_STORE_PROVIDER_ID`. Same shape as
+ * `TranscriptionNotConfiguredError` from EW-643.
+ */
+export class VectorStoreNotConfiguredError extends FacadeError {
+    constructor(message: string, provider?: string) {
+        super(message, 'selectVectorStore', provider);
+        this.name = 'VectorStoreNotConfiguredError';
+    }
+}
+
+/**
+ * Thrown by `EmbeddingModeResolver.resolve()` when the resolved mode
+ * is `'plugin'` but the chosen vector store declares
+ * `capabilities.embedsOnWrite === false`. Callers may catch this and
+ * either degrade to `'platform'` (caller-side embedding) or surface
+ * the misconfiguration to the user — the facade does NOT auto-degrade
+ * because RFC D4 is explicit that the platform/plugin choice is a
+ * deliberate operator decision (cost, data-residency, vendor
+ * lock-in).
+ */
+export class EmbeddingModeUnsupportedError extends FacadeError {
+    constructor(message: string, provider?: string) {
+        super(message, 'resolveEmbeddingMode', provider);
+        this.name = 'EmbeddingModeUnsupportedError';
+    }
+}
+
+/**
+ * Helper class that owns the D4 embedding-mode cascade. Pulled out of
+ * `VectorStoreFacadeService` so it can be exercised in isolation
+ * without any plugin-registry boilerplate (the resolution only depends
+ * on the already-resolved plugin's static capabilities + three
+ * scalar settings).
+ *
+ * Cascade (RFC D4):
+ *   1. Work-level setting, if explicit (`'platform'` | `'plugin'`).
+ *   2. Org-level setting, if explicit.
+ *   3. `KB_EMBEDDING_MODE` env value, if explicit.
+ *   4. `'auto'` — pick `'plugin'` iff the resolved vector-store plugin
+ *      declares `vectorCapabilities.embedsOnWrite === true`; else
+ *      `'platform'`.
+ *
+ * After resolving the mode, the resolver validates the plugin can
+ * actually honor it: a resolved `'plugin'` mode against a plugin that
+ * does NOT embed-on-write throws `EmbeddingModeUnsupportedError`.
+ */
+export class EmbeddingModeResolver {
+    resolve(opts: {
+        workId: string;
+        resolvedVectorStorePlugin: IVectorStorePlugin;
+        workEmbeddingMode?: EmbeddingModeSetting;
+        orgEmbeddingMode?: EmbeddingModeSetting;
+    }): EmbeddingMode {
+        const cascaded = this.cascade(opts.workEmbeddingMode, opts.orgEmbeddingMode);
+
+        // `'auto'` is resolved here (not in `cascade()`) because the
+        // embedsOnWrite-aware fallback depends on the resolved plugin —
+        // which `cascade()` deliberately does not know about. RFC D4:
+        // pick `'plugin'` iff the plugin declares `embedsOnWrite === true`;
+        // else `'platform'`.
+        const mode: EmbeddingMode =
+            cascaded === 'auto'
+                ? opts.resolvedVectorStorePlugin.vectorCapabilities.embedsOnWrite
+                    ? 'plugin'
+                    : 'platform'
+                : cascaded;
+
+        if (mode === 'plugin' && !opts.resolvedVectorStorePlugin.vectorCapabilities.embedsOnWrite) {
+            throw new EmbeddingModeUnsupportedError(
+                `Vector-store plugin '${opts.resolvedVectorStorePlugin.id}' does not support ` +
+                    `embedsOnWrite; resolved embedding mode 'plugin' cannot be honored for ` +
+                    `work '${opts.workId}'. Either switch the work/org/env setting to 'platform' ` +
+                    `or pick a plugin (e.g. Weaviate text2vec) that embeds on write.`,
+                opts.resolvedVectorStorePlugin.id,
+            );
+        }
+
+        return mode;
+    }
+
+    private cascade(
+        workSetting?: EmbeddingModeSetting,
+        orgSetting?: EmbeddingModeSetting,
+    ): EmbeddingModeSetting {
+        // 1. Work-level explicit pin wins.
+        if (workSetting === 'platform' || workSetting === 'plugin') {
+            return workSetting;
+        }
+        // 2. Org-level explicit pin.
+        if (orgSetting === 'platform' || orgSetting === 'plugin') {
+            return orgSetting;
+        }
+        // 3. Env-level explicit pin (KB_EMBEDDING_MODE).
+        const envSetting = config.kb.getEmbeddingMode();
+        if (envSetting === 'platform' || envSetting === 'plugin') {
+            return envSetting;
+        }
+        // 4. Otherwise propagate `'auto'` so `resolve()` can apply the
+        // embedsOnWrite-aware fallback against the actual plugin.
+        return 'auto';
+    }
+}
+
+/**
+ * `VectorStoreFacadeService` — single entry point for upsert / query /
+ * delete against the resolved `IVectorStorePlugin`. Slice-2 wires this
+ * into the KB ingest + retrieval paths; until then the facade is just
+ * Phase-3 plumbing.
+ *
+ * Resolution chain mirrors `AiFacadeService.transcribe`:
+ *   1. `providerOverride` (highest priority — caller pinned).
+ *   2. Operator env pin via `KB_VECTOR_STORE_PROVIDER_ID`.
+ *   3. Per-Work scope-active plugin (via `WorkPluginRepository`).
+ *   4. Registry default — first plugin in the `vector-store` category
+ *      with `defaultForCapabilities.includes('vector-store')`; else
+ *      first by id.
+ *   5. Otherwise throw `VectorStoreNotConfiguredError`.
+ */
+@Injectable()
+export class VectorStoreFacadeService {
+    private readonly logger = new Logger(VectorStoreFacadeService.name);
+
+    constructor(
+        private readonly registry: PluginRegistryService,
+        @Optional() private readonly workPluginRepository?: WorkPluginRepository,
+        @Optional() private readonly activityLogService?: ActivityLogService,
+    ) {}
+
+    /**
+     * Resolve the vector-store plugin for the (workId, userId,
+     * providerOverride) tuple. Throws
+     * `VectorStoreNotConfiguredError` when nothing qualifies — KB
+     * ingest catches this and surfaces a workbench banner so the
+     * operator can install/pin a backend.
+     */
+    async select(opts: SelectVectorStoreOpts): Promise<IVectorStorePlugin> {
+        // 1. Caller pin — when set, ONLY this provider is tried.
+        if (opts.providerOverride) {
+            const pinned = this.lookupPlugin(opts.providerOverride);
+            if (!pinned) {
+                throw new VectorStoreNotConfiguredError(
+                    `Pinned vector-store provider '${opts.providerOverride}' not found or not ` +
+                        `a vector-store plugin.`,
+                    opts.providerOverride,
+                );
+            }
+            return pinned;
+        }
+
+        // 2. Operator pin via KB_VECTOR_STORE_PROVIDER_ID — same
+        // hard-fail semantics as the caller-level override; the env
+        // var is an explicit operator decision and a missing plugin is
+        // a misconfiguration, not a fallback trigger.
+        const envPin = config.kb.getVectorStoreProviderId();
+        if (envPin) {
+            const pinned = this.lookupPlugin(envPin);
+            if (!pinned) {
+                throw new VectorStoreNotConfiguredError(
+                    `Operator-pinned vector-store provider '${envPin}' ` +
+                        `(KB_VECTOR_STORE_PROVIDER_ID) not found or not a vector-store plugin.`,
+                    envPin,
+                );
+            }
+            return pinned;
+        }
+
+        // 3. Per-Work scope-active plugin — same `WorkPluginRepository`
+        // path AiFacadeService uses. Quietly fall through when no
+        // active row exists (this leg is best-effort).
+        if (this.workPluginRepository) {
+            try {
+                const active = await this.workPluginRepository.findActiveByCapability(
+                    opts.workId,
+                    VECTOR_STORE_CAPABILITY,
+                );
+                if (active) {
+                    const registered = this.registry.get(active.pluginId);
+                    const inst = registered?.plugin as unknown as IVectorStorePlugin | undefined;
+                    if (
+                        registered &&
+                        registered.state === 'loaded' &&
+                        inst &&
+                        isVectorStorePlugin(inst)
+                    ) {
+                        return inst;
+                    }
+                }
+            } catch (err) {
+                this.logger.debug(
+                    `Scope-active vector-store lookup failed for work ${opts.workId}: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            }
+        }
+
+        // 4. Registry iteration — pick category === 'vector-store' AND
+        // capability advertised. Prefer `defaultForCapabilities`; fall
+        // back to first by id (stable sort for deterministic dev/test
+        // runs).
+        const candidates = this.registry
+            .getByCapability(VECTOR_STORE_CAPABILITY)
+            .filter(
+                (p) =>
+                    p.state === 'loaded' &&
+                    p.manifest.category === VECTOR_STORE_CATEGORY &&
+                    p.manifest.capabilities.includes(VECTOR_STORE_CAPABILITY),
+            );
+
+        if (candidates.length > 0) {
+            const preferred = candidates.find((p) =>
+                p.manifest.defaultForCapabilities?.includes(VECTOR_STORE_CAPABILITY),
+            );
+            const chosen =
+                preferred ??
+                [...candidates].sort((a, b) => a.plugin.id.localeCompare(b.plugin.id))[0];
+            const inst = chosen.plugin as unknown as IVectorStorePlugin;
+            if (isVectorStorePlugin(inst)) {
+                return inst;
+            }
+        }
+
+        // 5. Nothing qualifies.
+        throw new VectorStoreNotConfiguredError(
+            `No vector-store plugin registered for work '${opts.workId}'. ` +
+                `Install '@ever-works/pgvector-plugin' (default) or pin one via ` +
+                `KB_VECTOR_STORE_PROVIDER_ID.`,
+        );
+    }
+
+    /**
+     * Pass-through wrapper for `upsertChunks` — resolves the plugin
+     * once and delegates. Keeps KB ingest from re-implementing the
+     * `select()` dance on every call.
+     */
+    async upsertChunks(
+        input: UpsertChunksInput,
+        opts: SelectVectorStoreOpts,
+    ): Promise<UpsertChunksResult> {
+        const plugin = await this.select(opts);
+        return plugin.upsertChunks(input);
+    }
+
+    /** Pass-through wrapper for `queryChunks`. */
+    async queryChunks(
+        input: QueryChunksInput,
+        opts: SelectVectorStoreOpts,
+    ): Promise<QueryChunksResult> {
+        const plugin = await this.select(opts);
+        return plugin.queryChunks(input);
+    }
+
+    /** Pass-through wrapper for `deleteByDocument`. */
+    async deleteByDocument(
+        input: DeleteByDocumentInput,
+        opts: SelectVectorStoreOpts,
+    ): Promise<void> {
+        const plugin = await this.select(opts);
+        return plugin.deleteByDocument(input);
+    }
+
+    /** Pass-through wrapper for `deleteByWork`. */
+    async deleteByWork(input: DeleteByWorkInput, opts: SelectVectorStoreOpts): Promise<void> {
+        const plugin = await this.select(opts);
+        return plugin.deleteByWork(input);
+    }
+
+    /**
+     * Registry lookup that respects the vector-store contract: must be
+     * `'loaded'`, must declare the `'vector-store'` capability token,
+     * must structurally satisfy `IVectorStorePlugin`. Used by the
+     * operator-pin + caller-pin legs of `select()`.
+     */
+    private lookupPlugin(pluginId: string): IVectorStorePlugin | null {
+        const registered = this.registry.get(pluginId);
+        if (!registered || registered.state !== 'loaded') {
+            return null;
+        }
+        if (!registered.manifest.capabilities.includes(VECTOR_STORE_CAPABILITY)) {
+            return null;
+        }
+        const inst = registered.plugin as unknown as IVectorStorePlugin;
+        if (!isVectorStorePlugin(inst)) {
+            return null;
+        }
+        return inst;
+    }
+}

--- a/packages/plugin/src/abstract/base-vector-store.ts
+++ b/packages/plugin/src/abstract/base-vector-store.ts
@@ -1,0 +1,160 @@
+/**
+ * EW-642 — abstract base class for vector-store plugins.
+ *
+ * Concrete implementations (`@ever-works/pgvector-plugin`,
+ * `@ever-works/qdrant-plugin`, …) extend `BaseVectorStore` so they
+ * inherit:
+ *
+ *   - the boilerplate `category = 'vector-store'` + manifest token
+ *     `capabilities = ['vector-store']` declaration;
+ *   - the `wrapVendorError` helper that converts a backend's native
+ *     error into the platform-shaped `VectorStoreError`;
+ *   - the default `isAvailable()` returning `true` (subclasses override
+ *     when they can run a cheap probe — pgvector pings the connection,
+ *     Qdrant hits `GET /collections`, Pinecone hits `describe_index`).
+ *
+ * Subclasses must implement `normalize(rawScore)` (RFC D6 — every
+ * plugin owns its score scale) plus the four core methods.
+ *
+ * Design rationale: `docs/specs/features/knowledge-base/phase-2-vector-plugin-design.md`.
+ */
+
+import { BasePlugin } from './base-plugin.js';
+import type { PluginCategory } from '../contracts/plugin-manifest.types.js';
+import type { PluginLogger } from '../contracts/plugin-context.interface.js';
+import type { PluginSettings } from '../settings/settings.types.js';
+import type {
+	IVectorStorePlugin,
+	VectorStoreCapabilities,
+	VectorStoreProviderType,
+	UpsertChunksInput,
+	UpsertChunksResult,
+	QueryChunksInput,
+	QueryChunksResult,
+	DeleteByDocumentInput,
+	DeleteByWorkInput
+} from '../contracts/capabilities/vector-store.interface.js';
+
+/**
+ * Stable error-code taxonomy for vector-store failures. Facades key off
+ * `code` for retry / surface decisions; new codes are appended as
+ * needed without breaking existing handlers.
+ */
+export type VectorStoreErrorCode =
+	| 'unavailable'
+	| 'unauthorized'
+	| 'invalid-input'
+	| 'not-found'
+	| 'conflict'
+	| 'rate-limited'
+	| 'timeout'
+	| 'internal';
+
+/**
+ * Error thrown out of `IVectorStorePlugin` methods after vendor errors
+ * have been normalized. Carries a stable `code` for callers to branch
+ * on plus a `retriable` flag so the facade knows whether to back off
+ * and retry vs surface the failure immediately.
+ */
+export class VectorStoreError extends Error {
+	readonly code: VectorStoreErrorCode;
+	readonly retriable: boolean;
+	readonly cause?: Error;
+
+	constructor(message: string, code: VectorStoreErrorCode, retriable: boolean, cause?: Error) {
+		super(message);
+		this.name = 'VectorStoreError';
+		this.code = code;
+		this.retriable = retriable;
+		if (cause) {
+			this.cause = cause;
+		}
+	}
+}
+
+/**
+ * Abstract base class for vector-store plugins. See file header for the
+ * contract recap.
+ */
+export abstract class BaseVectorStore extends BasePlugin implements IVectorStorePlugin {
+	readonly category: PluginCategory = 'vector-store';
+	readonly capabilities: readonly string[] = ['vector-store'];
+
+	abstract readonly providerType: VectorStoreProviderType;
+	abstract readonly providerName: string;
+	abstract readonly vectorCapabilities: VectorStoreCapabilities;
+
+	/**
+	 * Caller-supplied settings snapshot. Concrete plugins typically
+	 * read connection strings + index tuning knobs out of this. The
+	 * field is kept `protected` so subclasses can re-resolve on each
+	 * call when the facade passes per-call `settings` (mirrors the
+	 * `BaseAiProvider.resolveConfig` pattern).
+	 */
+	protected readonly settings: PluginSettings;
+
+	/**
+	 * Optional logger handed in by the facade. Concrete plugins use it
+	 * for structured connection / query telemetry. Marked optional so
+	 * the plugin loader (`new()`) path still works — the loader calls
+	 * `onLoad(context)` which provides the real `context.logger` via
+	 * `BasePlugin.logger`.
+	 */
+	protected readonly injectedLogger?: PluginLogger;
+
+	constructor(settings: PluginSettings = {}, logger?: PluginLogger) {
+		super();
+		this.settings = settings;
+		this.injectedLogger = logger;
+	}
+
+	/**
+	 * Map a vendor-native score / distance into `[0, 1]` (higher =
+	 * better). Required by RFC D6 — `QueryHit.normalizedScore` is the
+	 * fusion-friendly score consumers display in the UI and feed into
+	 * RRF / cross-encoder rerank. Implementations:
+	 *
+	 *   - pgvector returns cosine distance ∈ `[0, 2]` → `1 - rawScore / 2`.
+	 *   - Qdrant returns cosine similarity ∈ `[-1, 1]` → `(rawScore + 1) / 2`.
+	 *   - Pinecone returns dot-product similarity, range model-dependent
+	 *     → sigmoid or min-max within the result set.
+	 */
+	abstract normalize(rawScore: number): number;
+
+	abstract upsertChunks(input: UpsertChunksInput): Promise<UpsertChunksResult>;
+	abstract queryChunks(input: QueryChunksInput): Promise<QueryChunksResult>;
+	abstract deleteByDocument(input: DeleteByDocumentInput): Promise<void>;
+	abstract deleteByWork(input: DeleteByWorkInput): Promise<void>;
+
+	/**
+	 * Default availability probe — returns `true`. Concrete plugins
+	 * override with a cheap round-trip (pgvector pings the connection,
+	 * Qdrant hits `GET /collections`, Pinecone hits `describe_index`).
+	 * The default `true` is safe for the in-memory test fake; production
+	 * plugins MUST override.
+	 */
+	async isAvailable(_settings?: PluginSettings): Promise<boolean> {
+		return true;
+	}
+
+	/**
+	 * Convert any vendor-thrown error into a `VectorStoreError`. Use
+	 * this at every public method's outermost `catch` so the facade
+	 * sees a consistent shape regardless of which backend is wired in.
+	 *
+	 * @param err - The raw vendor error (may be anything, including non-Error throws).
+	 * @param code - The stable taxonomy code the facade branches on.
+	 * @param retriable - Whether the facade should back off and retry.
+	 * @param message - Optional human-readable override; defaults to the vendor message.
+	 */
+	protected wrapVendorError(
+		err: unknown,
+		code: VectorStoreErrorCode,
+		retriable: boolean,
+		message?: string
+	): VectorStoreError {
+		const cause = err instanceof Error ? err : new Error(String(err));
+		const finalMessage = message ?? `${this.providerName} ${code}${cause.message ? `: ${cause.message}` : ''}`;
+		return new VectorStoreError(finalMessage, code, retriable, cause);
+	}
+}

--- a/packages/plugin/src/abstract/index.ts
+++ b/packages/plugin/src/abstract/index.ts
@@ -2,3 +2,5 @@ export * from './base-plugin.js';
 export * from './base-git-provider.js';
 export * from './base-ai-provider.js';
 export * from './base-pipeline-step.js';
+// EW-642 — vector-store plugin base class.
+export * from './base-vector-store.js';

--- a/packages/plugin/src/contracts/__tests__/fakes/in-memory-vector-store.ts
+++ b/packages/plugin/src/contracts/__tests__/fakes/in-memory-vector-store.ts
@@ -1,0 +1,173 @@
+/**
+ * EW-642 — in-memory `IVectorStorePlugin` fake.
+ *
+ * Purpose:
+ *   - Verifies the shared contract test suite (`runVectorStoreContractSuite`)
+ *     against a known-good reference implementation so the suite itself
+ *     can never accidentally pass an empty implementation.
+ *   - Backs every facade unit test (`vector-store.facade.spec.ts`) so they
+ *     don't need a real Postgres / Qdrant / Pinecone connection.
+ *   - Slice 2's `@ever-works/pgvector-plugin` tests fall back to this fake
+ *     when `PGVECTOR_TEST_URL` is unset — keeping CI deterministic.
+ *
+ * Storage model:
+ *   - Chunks live in a `Map<chunkKey, KnowledgeChunk>` keyed by
+ *     `${workId}::${id}` to mirror the entity's composite PK
+ *     (`workId, id`) without overlapping chunk ids across Works.
+ *   - Re-upserting a `(workId, documentId)` first wipes every chunk for
+ *     that pair (RFC §4 invariant 2 — replace, never append).
+ *   - Query runs an O(N) cosine k-NN over chunks filtered by `workId`
+ *     plus the optional `documentId`. Cosine similarity ∈ [-1, 1] is
+ *     normalized into [0, 1] via `(cos + 1) / 2`, matching the
+ *     `BaseVectorStore.normalize` recipe Qdrant uses in production.
+ */
+
+import { BaseVectorStore } from '../../../abstract/base-vector-store.js';
+import type {
+	DeleteByDocumentInput,
+	DeleteByWorkInput,
+	IVectorStorePlugin,
+	KnowledgeChunk,
+	QueryChunksInput,
+	QueryChunksResult,
+	QueryHit,
+	UpsertChunksInput,
+	UpsertChunksResult,
+	VectorStoreCapabilities,
+	VectorStoreProviderType
+} from '../../capabilities/vector-store.interface.js';
+
+const STORE_KEY = (workId: string, id: string): string => `${workId}::${id}`;
+
+function cosineSimilarity(a: number[], b: number[]): number {
+	if (a.length !== b.length) {
+		throw new Error(`embedding dimension mismatch: ${a.length} vs ${b.length}`);
+	}
+	let dot = 0;
+	let normA = 0;
+	let normB = 0;
+	for (let i = 0; i < a.length; i++) {
+		dot += a[i] * b[i];
+		normA += a[i] * a[i];
+		normB += b[i] * b[i];
+	}
+	if (normA === 0 || normB === 0) return 0;
+	return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/**
+ * In-memory `IVectorStorePlugin` implementation. Not for production use —
+ * only mounted in tests + dev fixtures.
+ */
+export class InMemoryVectorStorePlugin extends BaseVectorStore {
+	readonly id = 'in-memory-vector-store';
+	readonly name = 'In-Memory Vector Store (test fake)';
+	readonly version = '0.0.0-test';
+
+	readonly providerType: VectorStoreProviderType = 'in-memory';
+	readonly providerName = 'In-Memory';
+
+	readonly vectorCapabilities: VectorStoreCapabilities = {
+		supportsMetadataFilter: true,
+		supportsHybridSearch: false,
+		supportsNamespaces: false,
+		supportsDelete: true,
+		nativeDimensions: 0,
+		embedsOnWrite: false,
+		// RFC §12 #2 / D5 — in-memory uses a single Map filtered by workId,
+		// which is structurally identical to the pgvector row-filter shape.
+		namespacePerWork: 'rowFilter'
+	};
+
+	private readonly chunks = new Map<string, KnowledgeChunk>();
+
+	/** Cosine similarity ∈ [-1, 1] → normalized ∈ [0, 1]. */
+	normalize(rawScore: number): number {
+		return (rawScore + 1) / 2;
+	}
+
+	async upsertChunks(input: UpsertChunksInput): Promise<UpsertChunksResult> {
+		// Replace, never append. Wipe every existing chunk for (workId, documentId).
+		const beforeCount = this.chunks.size;
+		for (const [key, chunk] of this.chunks) {
+			if (chunk.workId === input.workId && chunk.documentId === input.documentId) {
+				this.chunks.delete(key);
+			}
+		}
+		const removed = beforeCount - this.chunks.size;
+
+		let written = 0;
+		for (const chunk of input.chunks) {
+			if (chunk.workId !== input.workId || chunk.documentId !== input.documentId) {
+				throw new Error(`chunk ${chunk.id} has (workId, documentId) mismatch vs upsert input`);
+			}
+			if (chunk.embedding == null) {
+				throw new Error(`in-memory fake requires a non-null embedding (embedsOnWrite=false)`);
+			}
+			this.chunks.set(STORE_KEY(chunk.workId, chunk.id), chunk);
+			written++;
+		}
+		// `skipped` here means "previously-stored rows the upsert replaced",
+		// which is the closest mirror of a real backend's idempotency signal.
+		return { written, skipped: removed };
+	}
+
+	async queryChunks(input: QueryChunksInput): Promise<QueryChunksResult> {
+		if (!input.queryEmbedding) {
+			throw new Error('in-memory fake requires queryEmbedding (embedsOnWrite=false → queryText unsupported)');
+		}
+
+		const candidates: Array<{ chunk: KnowledgeChunk; rawScore: number }> = [];
+		for (const chunk of this.chunks.values()) {
+			if (chunk.workId !== input.workId) continue;
+			if (input.filter?.documentId && chunk.documentId !== input.filter.documentId) continue;
+			if (input.filter?.locale) {
+				const locale = (chunk.metadata?.locale as string | undefined) ?? null;
+				if (locale !== input.filter.locale) continue;
+			}
+			if (input.filter?.class) {
+				const klass = (chunk.metadata?.class as string | undefined) ?? null;
+				if (klass !== input.filter.class) continue;
+			}
+			if (chunk.embedding == null) continue;
+			const score = cosineSimilarity(chunk.embedding, input.queryEmbedding);
+			candidates.push({ chunk, rawScore: score });
+		}
+
+		candidates.sort((a, b) => b.rawScore - a.rawScore);
+
+		const top = candidates.slice(0, Math.max(0, input.topK));
+		const hits: QueryHit[] = top.map((c, idx) => ({
+			chunk: c.chunk,
+			rawScore: c.rawScore,
+			normalizedScore: this.normalize(c.rawScore),
+			rank: idx + 1
+		}));
+		return { hits };
+	}
+
+	async deleteByDocument(input: DeleteByDocumentInput): Promise<void> {
+		for (const [key, chunk] of this.chunks) {
+			if (chunk.workId === input.workId && chunk.documentId === input.documentId) {
+				this.chunks.delete(key);
+			}
+		}
+	}
+
+	async deleteByWork(input: DeleteByWorkInput): Promise<void> {
+		for (const [key, chunk] of this.chunks) {
+			if (chunk.workId === input.workId) {
+				this.chunks.delete(key);
+			}
+		}
+	}
+}
+
+/**
+ * Factory returning a fresh `InMemoryVectorStorePlugin`. The contract suite
+ * accepts a factory (not a singleton) so each describe-block scenario
+ * starts with an empty store and tests stay independent.
+ */
+export async function createInMemoryVectorStore(): Promise<IVectorStorePlugin> {
+	return new InMemoryVectorStorePlugin();
+}

--- a/packages/plugin/src/contracts/__tests__/vector-store.spec.ts
+++ b/packages/plugin/src/contracts/__tests__/vector-store.spec.ts
@@ -1,0 +1,324 @@
+/**
+ * EW-642 — reusable contract test suite for `IVectorStorePlugin`.
+ *
+ * Every concrete implementation (`@ever-works/pgvector-plugin`,
+ * `@ever-works/qdrant-plugin`, `@ever-works/pinecone-plugin`, …) MUST
+ * pass these tests. The suite encodes the RFC §4 invariants:
+ *
+ *   1. `workId` is the leftmost filter (cross-Work isolation).
+ *   2. Upsert is by `(workId, documentId, chunkIndex)` — replace, never
+ *      append — so a second upsert MUST return the same top-K (no
+ *      duplicates).
+ *   3. `deleteByDocument` cascades only the targeted chunks; other
+ *      documents in the same Work are untouched.
+ *   4. `queryChunks` returns at most `topK` hits, ordered best-first by
+ *      `normalizedScore` ∈ [0, 1], with `rawScore` preserved verbatim.
+ *
+ * Plus the locked design resolutions:
+ *   - D5 → `namespacePerWork` is one of `'collection' | 'namespace' | 'rowFilter'`.
+ *   - D6 → every hit exposes BOTH `rawScore` and `normalizedScore`.
+ *
+ * Usage:
+ *
+ *   ```ts
+ *   import { describe } from 'vitest';
+ *   import { runVectorStoreContractSuite } from '@ever-works/plugin/contracts/__tests__/vector-store.spec.js';
+ *   import { createPgVectorStore } from './fixtures/pgvector-factory.js';
+ *
+ *   describe('PgVector plugin — contract', () => {
+ *     runVectorStoreContractSuite(createPgVectorStore);
+ *   });
+ *   ```
+ *
+ * The suite is also self-applied at the bottom of this file against the
+ * in-memory fake so the contract itself is exercised in `pnpm test`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type {
+	IVectorStorePlugin,
+	KnowledgeChunk,
+	VectorStoreNamespaceMode
+} from '../capabilities/vector-store.interface.js';
+import { createInMemoryVectorStore } from './fakes/in-memory-vector-store.js';
+
+export interface VectorStoreContractOptions {
+	/**
+	 * Skip the deleteByDocument / deleteByWork tests. Only true for
+	 * backends that publicly advertise `supportsDelete: false` (read-only
+	 * mirrors etc.). Default `false`.
+	 */
+	readonly skipDelete?: boolean;
+}
+
+const VEC = {
+	x: [1, 0, 0],
+	y: [0, 1, 0],
+	z: [0, 0, 1]
+} as const;
+
+function makeChunk(overrides: Partial<KnowledgeChunk> & Pick<KnowledgeChunk, 'id'>): KnowledgeChunk {
+	return {
+		workId: 'w1',
+		documentId: 'd1',
+		chunkIndex: 0,
+		content: 'placeholder',
+		tokenCount: 1,
+		embedding: VEC.x as number[],
+		metadata: null,
+		tenantId: null,
+		organizationId: null,
+		...overrides
+	};
+}
+
+/**
+ * Registers the EW-642 vector-store contract describe block. Pass a
+ * factory that returns a fresh, empty plugin per call — the suite spins
+ * one up before every test for isolation.
+ */
+export function runVectorStoreContractSuite(
+	factory: () => Promise<IVectorStorePlugin>,
+	options: VectorStoreContractOptions = {}
+): void {
+	describe('IVectorStorePlugin contract (EW-642)', () => {
+		let plugin: IVectorStorePlugin;
+
+		beforeEach(async () => {
+			plugin = await factory();
+		});
+
+		afterEach(async () => {
+			// Best-effort cleanup so factories that hand back a shared
+			// backend (e.g. one Postgres schema reused by every test) don't
+			// bleed state between scenarios. Errors are swallowed because
+			// the in-memory fake doesn't need it.
+			try {
+				await plugin.deleteByWork({ workId: 'w1' });
+				await plugin.deleteByWork({ workId: 'w2' });
+			} catch {
+				/* noop */
+			}
+		});
+
+		it('1. upsert + query returns the closest hit first with normalized scores in [0,1]', async () => {
+			await plugin.upsertChunks({
+				workId: 'w1',
+				documentId: 'd1',
+				chunks: [
+					makeChunk({ id: 'c-x', chunkIndex: 0, content: 'x-chunk', embedding: VEC.x as number[] }),
+					makeChunk({ id: 'c-y', chunkIndex: 1, content: 'y-chunk', embedding: VEC.y as number[] }),
+					makeChunk({ id: 'c-z', chunkIndex: 2, content: 'z-chunk', embedding: VEC.z as number[] })
+				]
+			});
+
+			const { hits } = await plugin.queryChunks({
+				workId: 'w1',
+				queryEmbedding: VEC.x as number[],
+				topK: 2
+			});
+
+			expect(hits).toHaveLength(2);
+			expect(hits[0].chunk.content).toBe('x-chunk');
+			for (const hit of hits) {
+				expect(hit.normalizedScore).toBeGreaterThanOrEqual(0);
+				expect(hit.normalizedScore).toBeLessThanOrEqual(1);
+			}
+		});
+
+		it('2. upsert is idempotent — re-running with the same chunks returns the same top-K (no duplicates)', async () => {
+			const chunks = [
+				makeChunk({ id: 'c-x', chunkIndex: 0, content: 'x-chunk', embedding: VEC.x as number[] }),
+				makeChunk({ id: 'c-y', chunkIndex: 1, content: 'y-chunk', embedding: VEC.y as number[] }),
+				makeChunk({ id: 'c-z', chunkIndex: 2, content: 'z-chunk', embedding: VEC.z as number[] })
+			];
+
+			await plugin.upsertChunks({ workId: 'w1', documentId: 'd1', chunks });
+			const first = await plugin.queryChunks({
+				workId: 'w1',
+				queryEmbedding: VEC.x as number[],
+				topK: 3
+			});
+
+			await plugin.upsertChunks({ workId: 'w1', documentId: 'd1', chunks });
+			const second = await plugin.queryChunks({
+				workId: 'w1',
+				queryEmbedding: VEC.x as number[],
+				topK: 3
+			});
+
+			expect(second.hits).toHaveLength(first.hits.length);
+			expect(second.hits.map((h) => h.chunk.id)).toEqual(first.hits.map((h) => h.chunk.id));
+
+			// Independently verify no row leaked — topK=10 must still be ≤ 3 chunks.
+			const wide = await plugin.queryChunks({
+				workId: 'w1',
+				queryEmbedding: VEC.x as number[],
+				topK: 10
+			});
+			expect(wide.hits).toHaveLength(3);
+			const uniqueIds = new Set(wide.hits.map((h) => h.chunk.id));
+			expect(uniqueIds.size).toBe(3);
+		});
+
+		(options.skipDelete ? it.skip : it)(
+			'3. deleteByDocument removes only the targeted document chunks',
+			async () => {
+				await plugin.upsertChunks({
+					workId: 'w1',
+					documentId: 'd1',
+					chunks: [
+						makeChunk({
+							id: 'd1-c0',
+							documentId: 'd1',
+							chunkIndex: 0,
+							content: 'd1-chunk-0',
+							embedding: VEC.x as number[]
+						})
+					]
+				});
+				await plugin.upsertChunks({
+					workId: 'w1',
+					documentId: 'd2',
+					chunks: [
+						makeChunk({
+							id: 'd2-c0',
+							documentId: 'd2',
+							chunkIndex: 0,
+							content: 'd2-chunk-0',
+							embedding: VEC.y as number[]
+						})
+					]
+				});
+
+				await plugin.deleteByDocument({ workId: 'w1', documentId: 'd1' });
+
+				const { hits } = await plugin.queryChunks({
+					workId: 'w1',
+					queryEmbedding: VEC.x as number[],
+					topK: 10
+				});
+
+				expect(hits).toHaveLength(1);
+				expect(hits[0].chunk.documentId).toBe('d2');
+			}
+		);
+
+		it('4. cross-Work isolation — query for w1 NEVER returns w2 hits even with identical embeddings', async () => {
+			const identicalShape = (workId: string) =>
+				makeChunk({
+					id: `${workId}-c0`,
+					workId,
+					documentId: 'd-same',
+					chunkIndex: 0,
+					content: `${workId}-content`,
+					embedding: VEC.x as number[]
+				});
+
+			await plugin.upsertChunks({
+				workId: 'w1',
+				documentId: 'd-same',
+				chunks: [identicalShape('w1')]
+			});
+			await plugin.upsertChunks({
+				workId: 'w2',
+				documentId: 'd-same',
+				chunks: [identicalShape('w2')]
+			});
+
+			const w1Hits = await plugin.queryChunks({
+				workId: 'w1',
+				queryEmbedding: VEC.x as number[],
+				topK: 10
+			});
+
+			expect(w1Hits.hits).toHaveLength(1);
+			expect(w1Hits.hits[0].chunk.workId).toBe('w1');
+			for (const hit of w1Hits.hits) {
+				expect(hit.chunk.workId).not.toBe('w2');
+			}
+		});
+
+		it('5. namespacePerWork advertises one of the three allowed values', () => {
+			const mode = plugin.vectorCapabilities.namespacePerWork;
+			const allowed: readonly VectorStoreNamespaceMode[] = ['collection', 'namespace', 'rowFilter'];
+			expect(allowed).toContain(mode);
+		});
+
+		it('6. normalizedScore is monotonic non-increasing across the result set', async () => {
+			// Vectors with steadily decreasing similarity to `query = VEC.x`.
+			const variants: Array<readonly [string, number[]]> = [
+				['c-0', [1, 0, 0]],
+				['c-1', [0.9, 0.1, 0]],
+				['c-2', [0.7, 0.3, 0]],
+				['c-3', [0.4, 0.6, 0]],
+				['c-4', [0, 1, 0]]
+			];
+
+			await plugin.upsertChunks({
+				workId: 'w1',
+				documentId: 'd1',
+				chunks: variants.map(([id, embedding], idx) =>
+					makeChunk({
+						id,
+						chunkIndex: idx,
+						content: id,
+						embedding: embedding as number[]
+					})
+				)
+			});
+
+			const { hits } = await plugin.queryChunks({
+				workId: 'w1',
+				queryEmbedding: VEC.x as number[],
+				topK: 5
+			});
+
+			expect(hits).toHaveLength(5);
+			for (let i = 0; i < hits.length - 1; i++) {
+				expect(hits[i].normalizedScore).toBeGreaterThanOrEqual(hits[i + 1].normalizedScore);
+			}
+		});
+
+		it('7. rawScore + normalizedScore are both preserved and distinct fields', async () => {
+			await plugin.upsertChunks({
+				workId: 'w1',
+				documentId: 'd1',
+				chunks: [
+					makeChunk({ id: 'c-x', chunkIndex: 0, embedding: VEC.x as number[] }),
+					makeChunk({ id: 'c-y', chunkIndex: 1, embedding: VEC.y as number[] })
+				]
+			});
+
+			const { hits } = await plugin.queryChunks({
+				workId: 'w1',
+				// Mid-vector so neither raw nor normalized scores collapse to 0/1.
+				queryEmbedding: [0.5, 0.5, 0],
+				topK: 2
+			});
+
+			expect(hits).toHaveLength(2);
+			for (const hit of hits) {
+				expect(typeof hit.rawScore).toBe('number');
+				expect(Number.isFinite(hit.rawScore)).toBe(true);
+				expect(typeof hit.normalizedScore).toBe('number');
+				expect(hit.normalizedScore).toBeGreaterThanOrEqual(0);
+				expect(hit.normalizedScore).toBeLessThanOrEqual(1);
+				expect('rawScore' in hit).toBe(true);
+				expect('normalizedScore' in hit).toBe(true);
+			}
+
+			// rawScore MUST NOT have been silently overwritten to equal
+			// normalizedScore. For any backend whose normalize() is not the
+			// identity, at least one hit shows a measurable gap.
+			const anyDistinct = hits.some((h) => Math.abs(h.rawScore - h.normalizedScore) > 1e-9);
+			expect(anyDistinct).toBe(true);
+		});
+	});
+}
+
+// Self-application — exercises the contract against the in-memory fake
+// every time `pnpm --filter @ever-works/plugin test` runs. Acts as a
+// canary: a contract change that breaks the reference implementation
+// breaks here first, before any concrete plugin's CI run.
+runVectorStoreContractSuite(createInMemoryVectorStore);

--- a/packages/plugin/src/contracts/capabilities/index.ts
+++ b/packages/plugin/src/contracts/capabilities/index.ts
@@ -19,3 +19,5 @@ export * from './task-tracker.interface.js';
 export * from './email-provider.interface.js';
 export * from './notification-channel.interface.js';
 export * from './agent-memory.interface.js';
+// EW-642 — pluggable vector-store backends.
+export * from './vector-store.interface.js';

--- a/packages/plugin/src/contracts/capabilities/vector-store.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/vector-store.interface.ts
@@ -1,0 +1,321 @@
+/**
+ * EW-642 — pluggable vector store capability.
+ *
+ * `IVectorStorePlugin` is the contract every vector database (pgvector,
+ * Qdrant, Pinecone, Weaviate, Milvus, ...) implements so the Knowledge
+ * Base can store and retrieve chunk embeddings without hard-coding any
+ * particular backend. The platform owns only invalidation coordinates
+ * (work_id, document_id, chunk_count, last_embedded_at); the actual
+ * chunks + vectors live inside the plugin's own store.
+ *
+ * Design rationale lives in the RFC:
+ * `docs/specs/features/knowledge-base/phase-2-vector-plugin-design.md`
+ * (sections §4 contract, §6 selection chain, §7 data model).
+ */
+
+import type { IPlugin } from '../plugin.interface.js';
+import type { PluginSettings } from '../../settings/settings.types.js';
+
+/**
+ * Free-form provider identifier ('pgvector', 'qdrant', 'pinecone', ...).
+ * Mirrors the `AiProviderType` shape on `IAiProviderPlugin` so facades
+ * can log + key by provider without baking in a closed enum.
+ */
+export type VectorStoreProviderType = string;
+
+/**
+ * How the backend models per-Work tenancy. Resolution of RFC §12 open
+ * question #2 (locked in D5): every plugin MUST declare which physical
+ * strategy it uses so the platform UX can hint operators correctly
+ * (single collection + namespace per Work for Pinecone serverless,
+ * one collection per Work for self-hosted Qdrant, row-filter on a
+ * shared table for pgvector).
+ */
+export type VectorStoreNamespaceMode = 'collection' | 'namespace' | 'rowFilter';
+
+/**
+ * Static capabilities advertised by a vector-store plugin. The facade
+ * uses these to route around features the backend lacks (e.g. skip
+ * server-side hybrid search and fall back to RRF on the caller side).
+ *
+ * RFC §4 — every field is REQUIRED, including `namespacePerWork`
+ * (locked in resolution D5).
+ */
+export interface VectorStoreCapabilities {
+	/**
+	 * Server-side metadata filter pushdown. Every retrieval query MUST
+	 * filter by `workId`; backends without filter pushdown have to
+	 * implement this client-side and the facade still enforces it.
+	 */
+	readonly supportsMetadataFilter: boolean;
+	/** Hybrid (vector + keyword) scoring in a single round trip. */
+	readonly supportsHybridSearch: boolean;
+	/** Multi-tenant namespace / collection per Work without a per-Work index. */
+	readonly supportsNamespaces: boolean;
+	/** Server-side hard delete (vs soft delete + sweep). */
+	readonly supportsDelete: boolean;
+	/**
+	 * Native embedding dimensions the backend was provisioned for.
+	 * `0` = backend-managed (e.g. Weaviate text2vec modules choose
+	 * dimensions per collection).
+	 */
+	readonly nativeDimensions: number;
+	/**
+	 * Backend re-embeds on write (e.g. Weaviate text2vec). When `true`,
+	 * callers MAY pass `chunk.embedding = null` and the backend computes
+	 * the vector. When `false`, callers MUST provide a non-null
+	 * `embedding` for every chunk.
+	 */
+	readonly embedsOnWrite: boolean;
+	/**
+	 * Physical tenancy strategy this backend uses for per-Work isolation
+	 * (RFC §12 #2 → resolution D5). Required so the operator UX can hint
+	 * "Pinecone uses namespaces; one index serves all Works" vs "Qdrant
+	 * creates one collection per Work" vs "pgvector shares a table and
+	 * filters by work_id".
+	 */
+	readonly namespacePerWork: VectorStoreNamespaceMode;
+}
+
+/**
+ * Payload aligned with the `WorkKnowledgeChunk` entity (the platform-side
+ * invalidation coordinates pin the same shape). The plugin stores
+ * whatever subset its backend needs; the platform only round-trips this
+ * shape across the contract.
+ *
+ * `embedding` may be `null` when the plugin advertises
+ * `capabilities.embedsOnWrite === true` and the caller wants the backend
+ * to compute the vector. For every other plugin a non-null `embedding`
+ * is required.
+ */
+export interface KnowledgeChunk {
+	/** Stable chunk id. Composite uniqueness is `(workId, id)` to mirror the entity PK. */
+	readonly id: string;
+	/** Owning Work — leftmost filter on every retrieval, P0 invariant. */
+	readonly workId: string;
+	/** Source document the chunk was derived from. */
+	readonly documentId: string;
+	/** 0-based chunk ordinal within the document. */
+	readonly chunkIndex: number;
+	/** The chunk text. Stored as-is for retrieval display + reranker rerun. */
+	readonly content: string;
+	/** Token count produced by the chunker. Used for budgeting at query time. */
+	readonly tokenCount: number;
+	/**
+	 * Caller-side embedding. Required unless
+	 * `capabilities.embedsOnWrite === true`, in which case `null` lets
+	 * the backend compute the vector. Plugins MUST validate this
+	 * invariant at upsert time and surface `VectorStoreError` with a
+	 * non-retriable code when violated.
+	 */
+	readonly embedding?: number[] | null;
+	/** Free-form metadata (headingPath, charRange, …). Round-tripped opaquely. */
+	readonly metadata?: Record<string, unknown> | null;
+	/** Optional tenant scoping (mirrors entity). */
+	readonly tenantId?: string | null;
+	/** Optional organization scoping (mirrors entity). */
+	readonly organizationId?: string | null;
+}
+
+/**
+ * Typed metadata filter accepted by `queryChunks`. The shape is
+ * deliberately small (the platform only routes a handful of fields
+ * through today) — backends that support richer filters can still
+ * receive them via the catch-all `[key: string]: unknown` shape on the
+ * raw query, but every first-class field is pinned here so we get
+ * compile-time checks at every call site.
+ */
+export interface VectorFilter {
+	/** Restrict to a single source document. */
+	readonly documentId?: string;
+	/** Restrict to chunks tagged with at least one of these tags. */
+	readonly tags?: readonly string[];
+	/**
+	 * Restrict to a single KbDocumentClass ('research', 'reference', …).
+	 * Mirrors `KB_TRANSCRIPTION_TARGET_CLASS` on the embedding side.
+	 */
+	readonly class?: string;
+	/** Restrict to a single BCP-47 locale (e.g. 'en', 'fr-CA'). */
+	readonly locale?: string;
+}
+
+/**
+ * Input to `upsertChunks`. Upsert semantics are
+ * by-(workId, documentId, chunkIndex) — re-ingesting a document MUST
+ * replace previous chunks, never append duplicates (RFC §4 invariant 2).
+ */
+export interface UpsertChunksInput {
+	readonly workId: string;
+	readonly documentId: string;
+	readonly chunks: readonly KnowledgeChunk[];
+	readonly settings?: PluginSettings;
+}
+
+/**
+ * Result of a successful `upsertChunks`. `written` counts new + updated
+ * rows; `skipped` counts no-op duplicates the plugin detected (used by
+ * the agent to short-circuit downstream events).
+ */
+export interface UpsertChunksResult {
+	readonly written: number;
+	readonly skipped: number;
+}
+
+/**
+ * Input to `queryChunks`. Exactly one of `queryEmbedding` or
+ * `queryText` must be supplied — plugins with
+ * `capabilities.embedsOnWrite === true` accept `queryText` and embed
+ * it server-side; everyone else expects `queryEmbedding`.
+ */
+export interface QueryChunksInput {
+	readonly workId: string;
+	/** Caller-side query vector. Preferred when the plugin doesn't embed on the server. */
+	readonly queryEmbedding?: number[];
+	/** Raw query text. Only used when `capabilities.embedsOnWrite === true`. */
+	readonly queryText?: string;
+	/** Maximum number of hits to return. Plugins MUST clamp to this. */
+	readonly topK: number;
+	/**
+	 * Caller-side metadata filter, AND-combined with the mandatory
+	 * `workId` filter the plugin already applies.
+	 */
+	readonly filter?: VectorFilter;
+	readonly settings?: PluginSettings;
+}
+
+/**
+ * A single retrieval hit. RFC §12 #3 → resolution D6: every plugin MUST
+ * expose BOTH the raw vendor score (for diagnostics + telemetry) AND a
+ * `normalizedScore ∈ [0, 1]` so consumers can fuse results across
+ * plugins (e.g. RRF + cross-encoder rerank) without per-plugin
+ * calibration knowledge at the call site.
+ */
+export interface QueryHit {
+	/** The retrieved chunk. */
+	readonly chunk: KnowledgeChunk;
+	/**
+	 * Vendor-native score / distance the backend returned. Preserved
+	 * verbatim for diagnostics; consumers MUST NOT compare `rawScore`
+	 * across plugins because the scale is plugin-defined.
+	 */
+	readonly rawScore: number;
+	/**
+	 * Normalized score in `[0, 1]` (higher = better) produced by
+	 * `BaseVectorStore.normalize(rawScore)`. RFC D6 — mandatory; this is
+	 * the score consumers use for fusion and UI confidence display.
+	 */
+	readonly normalizedScore: number;
+	/** 1-based rank within the result set. Plugins MUST return ordered hits. */
+	readonly rank: number;
+}
+
+/**
+ * Result of a successful `queryChunks`. Hits are ordered best-first by
+ * `normalizedScore` (ties broken by `rawScore`).
+ */
+export interface QueryChunksResult {
+	readonly hits: readonly QueryHit[];
+}
+
+/**
+ * Input to `deleteByDocument`. Cascades all chunks for the
+ * `(workId, documentId)` pair. Called during document delete and
+ * re-ingest (RFC §4 invariant 3).
+ */
+export interface DeleteByDocumentInput {
+	readonly workId: string;
+	readonly documentId: string;
+	readonly settings?: PluginSettings;
+}
+
+/**
+ * Input to `deleteByWork`. Cascades every chunk owned by the Work.
+ * Called during Work deletion and tenant offboarding.
+ */
+export interface DeleteByWorkInput {
+	readonly workId: string;
+	readonly settings?: PluginSettings;
+}
+
+/**
+ * Input to the optional `upsertEmbedding` escape hatch. Lets the
+ * platform store non-chunk embeddings (e.g. per-document summary
+ * vectors planned for future "section-of-interest" retrieval). Plugins
+ * MAY leave this unimplemented; consumers MUST guard with `typeof
+ * plugin.upsertEmbedding === 'function'`.
+ */
+export interface UpsertEmbeddingInput {
+	readonly workId: string;
+	/** Caller-defined key — opaque to the plugin, used for retrieval. */
+	readonly key: string;
+	readonly embedding: number[];
+	readonly metadata?: Record<string, unknown>;
+	readonly settings?: PluginSettings;
+}
+
+/**
+ * Vector-store plugin contract — capability `vector-store`.
+ *
+ * Concrete implementations:
+ *   - `@ever-works/pgvector-plugin` (default, ships with the platform image)
+ *   - `@ever-works/qdrant-plugin` (next slice)
+ *   - `@ever-works/pinecone-plugin` (customer-driven slice)
+ *
+ * Selection chain lives on `VectorStoreFacadeService` (`packages/agent/src/facades/`):
+ *   1. operator env pin `KB_VECTOR_STORE_PROVIDER_ID`
+ *   2. per-Work pin via `WorkPlugin`
+ *   3. scope-active registry default
+ *   4. first available registry plugin
+ *   5. otherwise throw `VectorStoreNotConfiguredError`
+ *
+ * RFC §4 invariants every implementation MUST honor:
+ *   1. `workId` is the leftmost filter; cross-Work leakage is a P0 bug.
+ *   2. Upsert is by `(workId, documentId, chunkIndex)` — replace, never append.
+ *   3. `deleteByDocument` cascades the chunks.
+ *   4. `queryChunks` returns at most `topK` hits, ordered best-first.
+ */
+export interface IVectorStorePlugin extends IPlugin {
+	/** Provider identifier ('pgvector', 'qdrant', …). */
+	readonly providerType: VectorStoreProviderType;
+	/** Human-readable backend name for logs + facade identification. */
+	readonly providerName: string;
+	/**
+	 * Static capability flags. NOTE: this shadows `IPlugin.capabilities`
+	 * (which is a `readonly string[]` of capability tokens) with a
+	 * structured object — implementations MUST still declare the string
+	 * `'vector-store'` in their manifest's `capabilities` array; the
+	 * structured object lives at runtime for facade routing.
+	 */
+	readonly vectorCapabilities: VectorStoreCapabilities;
+
+	/** Upsert chunks for a `(workId, documentId)` pair. RFC §4 invariant 2. */
+	upsertChunks(input: UpsertChunksInput): Promise<UpsertChunksResult>;
+
+	/** Run a vector query within a single Work. RFC §4 invariant 4. */
+	queryChunks(input: QueryChunksInput): Promise<QueryChunksResult>;
+
+	/** Cascade-delete every chunk for a document. RFC §4 invariant 3. */
+	deleteByDocument(input: DeleteByDocumentInput): Promise<void>;
+
+	/** Cascade-delete every chunk owned by a Work. */
+	deleteByWork(input: DeleteByWorkInput): Promise<void>;
+
+	/**
+	 * Optional: write a non-chunk embedding (summary vectors, future
+	 * "section-of-interest" indexes). Plugins MAY leave this unset.
+	 */
+	upsertEmbedding?(input: UpsertEmbeddingInput): Promise<void>;
+
+	/** Whether the backend is healthy / configured. */
+	isAvailable(settings?: PluginSettings): Promise<boolean>;
+}
+
+/**
+ * Type guard for vector-store plugins. Checks the capability token
+ * advertised on the plugin manifest (consistent with `isStoragePlugin`
+ * + `isAiProviderPlugin`). The structured `vectorCapabilities` object
+ * is a runtime-only convenience — the manifest token is the truth.
+ */
+export function isVectorStorePlugin(plugin: IPlugin): plugin is IVectorStorePlugin {
+	return plugin.capabilities.includes('vector-store');
+}

--- a/packages/plugin/src/contracts/plugin-manifest.types.ts
+++ b/packages/plugin/src/contracts/plugin-manifest.types.ts
@@ -22,7 +22,11 @@ export const PLUGIN_CATEGORIES = [
 	// See `capabilities/email-provider.interface.ts` and
 	// `capabilities/notification-channel.interface.ts`.
 	'email-provider',
-	'notification-channel'
+	'notification-channel',
+	// EW-642 — pluggable vector-store backends (pgvector, Qdrant, Pinecone, …).
+	// See `capabilities/vector-store.interface.ts` and the RFC at
+	// `docs/specs/features/knowledge-base/phase-2-vector-plugin-design.md`.
+	'vector-store'
 ] as const;
 
 export type PluginCategory = (typeof PLUGIN_CATEGORIES)[number];


### PR DESCRIPTION
## Summary

Foundational slice for **EW-642 Phase 2** (semantic retrieval via plugin abstraction). Establishes the contract every concrete vector-store plugin implements, plus the facade `KnowledgeBaseService` will route through in slice 2. **No consumer migration yet** — `KnowledgeBaseService` still calls `WorkKnowledgeChunkRepository` directly after this PR.

Implements all design decisions from the RFC (`docs/specs/features/knowledge-base/phase-2-vector-plugin-design.md`) including resolutions D4-D7 just merged.

## What lands

### Contract layer (`@ever-works/plugin`)

- `packages/plugin/src/contracts/capabilities/vector-store.interface.ts` (321 lines) — `IVectorStorePlugin`, `VectorStoreCapabilities` (with required `namespacePerWork: 'collection' | 'namespace' | 'rowFilter'` — **D5**), `KnowledgeChunk`, `UpsertChunksInput/Result`, `QueryChunksInput/Result`, `QueryHit` (mandatory `normalizedScore`, preserved `rawScore` — **D6**), `VectorFilter`, `UpsertEmbeddingInput`.
- `packages/plugin/src/abstract/base-vector-store.ts` (160 lines) — `BaseVectorStore` abstract class with `normalize(rawScore)` abstract method (**D6**), error-wrap helper, default `isAvailable()`. `VectorStoreError` class with `code` + `retriable`.
- `plugin-manifest.types.ts` — adds `'vector-store'` to `PluginCategory`.

### Facade layer (`@ever-works/agent`)

- `packages/agent/src/facades/vector-store.facade.ts` (376 lines):
  - `VectorStoreFacadeService` with the operator-pin → scope-active → registry-default selection chain (mirrors `AiFacadeService.transcribe` 1:1).
  - `VectorStoreNotConfiguredError` + `EmbeddingModeUnsupportedError`.
  - `EmbeddingModeResolver` helper implementing the **D4** cascade `env default → org → Work → plugin capability auto-fallback`.
  - Pass-through wrappers (`upsertChunks` / `queryChunks` / `deleteByDocument` / `deleteByWork`) so slice 2 consumers don't repeat the select dance.

### Config

- `KB_VECTOR_STORE_PROVIDER_ID` + `KB_EMBEDDING_MODE` env knobs under `config.kb.*` following EW-643's `KB_TRANSCRIPTION_PROVIDER_ID` pattern.

### Tests

- `packages/plugin/src/contracts/__tests__/vector-store.spec.ts` (324 lines) — reusable `runVectorStoreContractSuite(factory)` every concrete plugin will pass. Covers upsert+query, idempotency, `deleteByDocument` scope, cross-Work isolation, `namespacePerWork` correctness, `normalizedScore` monotonicity, `rawScore` preservation.
- `packages/plugin/src/contracts/__tests__/fakes/in-memory-vector-store.ts` — in-memory `IVectorStorePlugin` fake. Used by the contract suite to self-verify + later by every facade unit test.
- `packages/agent/src/facades/vector-store.facade.spec.ts` (266 lines) — 9 cases covering the facade selection chain + `EmbeddingModeResolver` cascade.

## Verification

- **`@ever-works/plugin` Vitest: 216/216 passing** (16 suites including the new contract suite against the in-memory fake).
- **`@ever-works/agent` Jest: 9/9 new facade specs passing** (`pnpm test --testPathPattern='vector-store'`).
- `@ever-works/plugin` + `@ever-works/agent` `pnpm type-check` clean.

## What's NOT in this PR

- `@ever-works/pgvector-plugin` extraction → **EW-725 (slice 2)**.
- `work_knowledge_chunk_coordinates` table + backfill → slice 2.
- `KnowledgeBaseService` migration through the facade → slice 2.
- `kb-reembed-work` Trigger.dev task (D7) → slice 2.
- `@ever-works/qdrant-plugin` → **EW-726 (slice 3)**.

## Test plan

- [ ] CI green (`lint-and-test`, `prettier --check`, `pnpm audit --prod --audit-level=high`).
- [ ] `pnpm --filter @ever-works/plugin test` passes (216/216).
- [ ] `cd packages/agent && npx jest --testPathPattern='vector-store'` passes (9/9).
- [ ] `pnpm type-check` (root) clean on the touched packages.

Refs: EW-642, EW-724. RFC: PR #1223 + resolutions PR #1229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)