### PR TITLE
fix(security): service-layer IDOR/authz gates — plugins, invitations, agent-task (EW-711 Wave B)

### DIFF
--- a/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
@@ -9,6 +9,7 @@ import { WorkPluginEntity } from '../entities/work-plugin.entity';
 import { PluginRegistryService } from '../services/plugin-registry.service';
 import { SettingsSchemaValidatorService } from '../services/settings-schema-validator.service';
 import { PluginSettingsService } from '../services/plugin-settings.service';
+import { WorkOwnershipService } from '../../services/work-ownership.service';
 import type { RegisteredPlugin } from '../services/plugin-registry.service';
 import type {
     IDeviceAuthProvider,
@@ -38,6 +39,7 @@ describe('PluginOperationsService', () => {
     let workPluginRepository: Repository<WorkPluginEntity>;
     let pluginRegistryService: PluginRegistryService;
     let settingsService: PluginSettingsService;
+    let workOwnershipService: WorkOwnershipService;
 
     const createSettingsSchema = (): JsonSchema =>
         ({
@@ -165,6 +167,17 @@ describe('PluginOperationsService', () => {
                         getAvailableModels: jest.fn().mockResolvedValue([]),
                     },
                 },
+                {
+                    provide: WorkOwnershipService,
+                    useValue: {
+                        // Default: caller is authorized. Individual tests
+                        // override these to assert the fail-closed path.
+                        ensureCanView: jest.fn().mockResolvedValue({}),
+                        ensureCanEdit: jest.fn().mockResolvedValue({}),
+                        ensureCanManageMembers: jest.fn().mockResolvedValue({}),
+                        ensureAccess: jest.fn().mockResolvedValue({}),
+                    },
+                },
             ],
         }).compile();
 
@@ -178,6 +191,7 @@ describe('PluginOperationsService', () => {
         );
         pluginRegistryService = module.get<PluginRegistryService>(PluginRegistryService);
         settingsService = module.get<PluginSettingsService>(PluginSettingsService);
+        workOwnershipService = module.get<WorkOwnershipService>(WorkOwnershipService);
     });
 
     describe('secret settings in API response', () => {
@@ -690,6 +704,84 @@ describe('PluginOperationsService', () => {
 
             expect(result.workEnabled).toBe(false);
             expect(workPluginRepository.save).toHaveBeenCalled();
+        });
+    });
+
+    describe('work-scoped ownership gate (IDOR defense-in-depth)', () => {
+        describe('listWorkPlugins', () => {
+            it('rejects a non-owner / foreign workId before touching any repository', async () => {
+                jest.spyOn(workOwnershipService, 'ensureCanView').mockRejectedValue(
+                    new NotFoundException(`Work with id 'dir-1' not found`),
+                );
+                const registryGet = jest.spyOn(pluginRegistryService, 'getAll');
+                const workFind = jest.spyOn(workPluginRepository, 'find');
+
+                await expect(service.listWorkPlugins('dir-1', 'attacker')).rejects.toThrow(
+                    NotFoundException,
+                );
+
+                expect(workOwnershipService.ensureCanView).toHaveBeenCalledWith(
+                    'dir-1',
+                    'attacker',
+                );
+                // Fail-closed BEFORE any registry/repository access.
+                expect(registryGet).not.toHaveBeenCalled();
+                expect(workFind).not.toHaveBeenCalled();
+            });
+
+            it('allows the legitimate owner (viewer access) to list work plugins', async () => {
+                const registered = createRegisteredPlugin();
+                jest.spyOn(pluginRegistryService, 'getAll').mockReturnValue([registered]);
+                jest.spyOn(userPluginRepository, 'find').mockResolvedValue([]);
+                jest.spyOn(workPluginRepository, 'find').mockResolvedValue([]);
+
+                const result = await service.listWorkPlugins('dir-1', 'owner-1');
+
+                expect(workOwnershipService.ensureCanView).toHaveBeenCalledWith('dir-1', 'owner-1');
+                expect(result.plugins.length).toBe(1);
+            });
+        });
+
+        describe('enablePluginForWork', () => {
+            it('rejects a non-owner / foreign workId before touching the registry', async () => {
+                jest.spyOn(workOwnershipService, 'ensureCanEdit').mockRejectedValue(
+                    new NotFoundException(`Work with id 'dir-1' not found`),
+                );
+                const registryGet = jest.spyOn(pluginRegistryService, 'get');
+
+                await expect(
+                    service.enablePluginForWork('dir-1', 'test-plugin', 'attacker'),
+                ).rejects.toThrow(NotFoundException);
+
+                expect(workOwnershipService.ensureCanEdit).toHaveBeenCalledWith(
+                    'dir-1',
+                    'attacker',
+                );
+                // Fail-closed BEFORE registry/repository access — no mutation possible.
+                expect(registryGet).not.toHaveBeenCalled();
+                expect(workPluginRepository.save).not.toHaveBeenCalled();
+            });
+
+            it('allows the legitimate owner (editor access) to enable a plugin for a work', async () => {
+                const autoEnablePlugin = createRegisteredPlugin();
+                autoEnablePlugin.manifest = {
+                    ...autoEnablePlugin.manifest,
+                    autoEnable: true,
+                } as PluginManifest;
+                jest.spyOn(pluginRegistryService, 'get').mockReturnValue(autoEnablePlugin);
+                jest.spyOn(userPluginRepository, 'findOne').mockResolvedValue(null);
+                jest.spyOn(pluginRepository, 'findOne').mockResolvedValue({
+                    id: '1',
+                    pluginId: 'test-plugin',
+                } as any);
+                jest.spyOn(workPluginRepository, 'findOne').mockResolvedValue(null);
+
+                const result = await service.enablePluginForWork('dir-1', 'test-plugin', 'owner-1');
+
+                expect(workOwnershipService.ensureCanEdit).toHaveBeenCalledWith('dir-1', 'owner-1');
+                expect(result.workEnabled).toBe(true);
+                expect(workPluginRepository.save).toHaveBeenCalled();
+            });
         });
     });
 
@@ -2091,6 +2183,15 @@ describe('PluginOperationsService', () => {
                     {
                         provide: AiFacadeService,
                         useValue: { getAvailableModels: jest.fn().mockResolvedValue([]) },
+                    },
+                    {
+                        provide: WorkOwnershipService,
+                        useValue: {
+                            ensureCanView: jest.fn().mockResolvedValue({}),
+                            ensureCanEdit: jest.fn().mockResolvedValue({}),
+                            ensureCanManageMembers: jest.fn().mockResolvedValue({}),
+                            ensureAccess: jest.fn().mockResolvedValue({}),
+                        },
                     },
                 ],
             }).compile();

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -59,6 +59,7 @@ import { buildProviderModelSummaries } from '../utils/plugin-model-settings.util
 // EW-693 — install-on-enable hook (T18). Optional so bundled-mode
 // deployments don't structurally depend on the installer.
 import { PluginInstallerService } from './plugin-installer.service';
+import { WorkOwnershipService } from '../../services/work-ownership.service';
 
 @Injectable()
 export class PluginOperationsService {
@@ -82,6 +83,19 @@ export class PluginOperationsService {
         // plugins before the existing registry.get() lookup.
         @Optional()
         private readonly pluginInstaller?: PluginInstallerService,
+        // Work-scoped authorization gate. NOT decorated `@Optional()`,
+        // so NestJS resolves it as a REQUIRED dependency by token (both
+        // this service and WorkOwnershipService are providers of
+        // WorkModule) and throws at startup if it can't be provided —
+        // it never silently no-ops. The TS `?` is only to satisfy the
+        // "required param cannot follow optional param" rule introduced
+        // by the two preceding `@Optional()` params; it does not relax
+        // the DI requirement. Appended at the END so positional
+        // construction in any unit spec keeps resolving the prior
+        // params. Used to fail-closed on the work-scoped read/write
+        // paths before any repository access so a foreign workId cannot
+        // be probed or mutated.
+        private readonly workOwnershipService?: WorkOwnershipService,
     ) {}
 
     /**
@@ -729,6 +743,14 @@ export class PluginOperationsService {
      * List plugins for a work with work-specific status
      */
     async listWorkPlugins(workId: string, userId: string): Promise<WorkPluginListResponse> {
+        // Defense-in-depth: gate the work-scoped READ on viewer access
+        // before touching the registry or any repository. Throws an
+        // existence-leak-safe 404/403 for a non-member, so a foreign
+        // workId cannot be probed. The `!` keeps this a hard call (never
+        // optional-chained) so a missing dependency throws rather than
+        // silently skipping the check.
+        await this.workOwnershipService!.ensureCanView(workId, userId);
+
         const allPlugins = this.pluginRegistryService.getAll();
 
         // Filter: visible + applicable to work scope
@@ -804,6 +826,14 @@ export class PluginOperationsService {
             priority?: number;
         },
     ): Promise<WorkPluginResponse> {
+        // Defense-in-depth: gate the work-scoped WRITE on editor access
+        // before touching the registry or any repository. Throws an
+        // existence-leak-safe 404/403 for a non-editor, so a foreign
+        // workId cannot be mutated. The `!` keeps this a hard call (never
+        // optional-chained) so a missing dependency throws rather than
+        // silently skipping the check.
+        await this.workOwnershipService!.ensureCanEdit(workId, userId);
+
         const registered = this.pluginRegistryService.get(pluginId);
         if (!registered) {
             throw new NotFoundException(`Plugin "${pluginId}" not found`);

--- a/packages/agent/src/services/__tests__/work-invitation.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-invitation.service.spec.ts
@@ -1,11 +1,13 @@
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { createHash } from 'crypto';
 import { WorkInvitationService } from '../work-invitation.service';
+import { WorkOwnershipService } from '../work-ownership.service';
 import { WorkInvitationRepository } from '../../database/repositories/work-invitation.repository';
 import { WorkInvitation } from '../../entities/work-invitation.entity';
 import { WorkInvitationStatus, INVITATION_ROLE_OWNER_CLAIM } from '../../entities/types';
 
 type RepoMock = jest.Mocked<WorkInvitationRepository>;
+type OwnershipMock = jest.Mocked<WorkOwnershipService>;
 
 function sha256(s: string): string {
     return createHash('sha256').update(s).digest('hex');
@@ -23,6 +25,18 @@ function buildRepoMock(): RepoMock {
         expireBefore: jest.fn(),
         findExpiredPending: jest.fn(),
     } as unknown as RepoMock;
+}
+
+function buildOwnershipMock(): OwnershipMock {
+    return {
+        ensureAccess: jest.fn(),
+        ensureCanView: jest.fn(),
+        ensureCanEdit: jest.fn(),
+        ensureCanManageMembers: jest.fn().mockResolvedValue(undefined),
+        ensureIsOwner: jest.fn(),
+        hasAccess: jest.fn(),
+        getUserRole: jest.fn(),
+    } as unknown as OwnershipMock;
 }
 
 function makeInvitation(overrides: Partial<WorkInvitation> = {}): WorkInvitation {
@@ -47,11 +61,13 @@ function makeInvitation(overrides: Partial<WorkInvitation> = {}): WorkInvitation
 
 describe('WorkInvitationService', () => {
     let repo: RepoMock;
+    let ownership: OwnershipMock;
     let service: WorkInvitationService;
 
     beforeEach(() => {
         repo = buildRepoMock();
-        service = new WorkInvitationService(repo);
+        ownership = buildOwnershipMock();
+        service = new WorkInvitationService(repo, ownership);
     });
 
     describe('issue', () => {
@@ -240,11 +256,26 @@ describe('WorkInvitationService', () => {
     });
 
     describe('revoke', () => {
-        it('marks pending as revoked', async () => {
-            repo.findById.mockResolvedValue(makeInvitation());
+        it('marks pending as revoked for a manager and gates on the work', async () => {
+            repo.findById.mockResolvedValue(makeInvitation({ workId: 'work-1' }));
             repo.markRevoked.mockResolvedValue(true);
             await expect(service.revoke('inv-1', 'user-1')).resolves.toBeUndefined();
+            expect(ownership.ensureCanManageMembers).toHaveBeenCalledWith('work-1', 'user-1');
             expect(repo.markRevoked).toHaveBeenCalledWith('inv-1');
+        });
+
+        it('rejects a non-manager actor and does not mutate state', async () => {
+            repo.findById.mockResolvedValue(makeInvitation({ workId: 'work-1' }));
+            ownership.ensureCanManageMembers.mockRejectedValue(
+                new ForbiddenException(
+                    'You do not have the required permission level for this action',
+                ),
+            );
+            await expect(service.revoke('inv-1', 'intruder')).rejects.toBeInstanceOf(
+                ForbiddenException,
+            );
+            expect(ownership.ensureCanManageMembers).toHaveBeenCalledWith('work-1', 'intruder');
+            expect(repo.markRevoked).not.toHaveBeenCalled();
         });
 
         it('throws NotFound when missing', async () => {

--- a/packages/agent/src/services/work-invitation.service.ts
+++ b/packages/agent/src/services/work-invitation.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { WorkInvitationRepository } from '../database/repositories/work-invitation.repository';
 import { WorkInvitation } from '../entities/work-invitation.entity';
+import { WorkOwnershipService } from './work-ownership.service';
 import {
     ALL_INVITATION_ROLES,
     INVITATION_ROLE_OWNER_CLAIM,
@@ -64,7 +65,10 @@ const TOKEN_BYTES = 32;
  */
 @Injectable()
 export class WorkInvitationService {
-    constructor(private readonly invitations: WorkInvitationRepository) {}
+    constructor(
+        private readonly invitations: WorkInvitationRepository,
+        private readonly ownership: WorkOwnershipService,
+    ) {}
 
     async issue(input: CreateInvitationInput): Promise<IssuedInvitation> {
         this.assertRole(input.role);
@@ -111,10 +115,12 @@ export class WorkInvitationService {
         if (invitation.status !== WorkInvitationStatus.PENDING) {
             throw new BadRequestException('invitation_not_pending');
         }
-        if (invitation.invitedById !== actorUserId) {
-            // Authorization beyond inviter (e.g., owner/manager) is enforced
-            // by the caller; this is a defensive default.
-        }
+        // Defense-in-depth: only a manager (or higher) on the underlying work
+        // may revoke a pending invitation. ensureCanManageMembers throws an
+        // existence-leak-safe error for non-managers, so a foreign actor can't
+        // probe or cancel another work's invitations even if the caller forgets
+        // its own check.
+        await this.ownership.ensureCanManageMembers(invitation.workId, actorUserId);
         const ok = await this.invitations.markRevoked(invitationId);
         if (!ok) {
             throw new BadRequestException('invitation_state_changed');

--- a/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
+++ b/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Security regression — `agent-task-execute` IDOR guard.
+ *
+ * The Trigger.dev payload is attacker-influenced. Two ownership gates must
+ * hold at the TOP of `run()`, BEFORE any AgentRun row is created/linked:
+ *
+ *   1. the Agent is resolved via `AgentRepository.findByIdAndUser`
+ *      (already covered by an earlier hardening round), and
+ *   2. the Task is resolved via `TasksService.getOne(userId, taskId)` —
+ *      which delegates to `TaskRepository.findByIdAndUser` and throws an
+ *      existence-leak-safe 404 for a foreign / non-owned `taskId`.
+ *
+ * These tests pin (b): a forged payload that pairs an owned `agentId` with
+ * another tenant's `taskId` must be skipped with `reason: 'task-not-found'`
+ * WITHOUT creating/starting any AgentRun, while the legitimate owner path
+ * still creates + starts + executes the run unchanged.
+ */
+
+const {
+    taskMock,
+    createApplicationContextMock,
+    createTriggerLoggerMock,
+    StubInternalModule,
+    AgentRepositoryToken,
+    AgentRunRepositoryToken,
+    AgentRunServiceToken,
+    TasksServiceToken,
+} = vi.hoisted(() => {
+    class StubInternalModule {}
+    class AgentRepositoryToken {}
+    class AgentRunRepositoryToken {}
+    class AgentRunServiceToken {}
+    class TasksServiceToken {}
+    return {
+        taskMock: vi.fn(),
+        createApplicationContextMock: vi.fn(),
+        createTriggerLoggerMock: vi.fn().mockReturnValue({ __kind: 'trigger-logger' }),
+        StubInternalModule,
+        AgentRepositoryToken,
+        AgentRunRepositoryToken,
+        AgentRunServiceToken,
+        TasksServiceToken,
+    };
+});
+
+vi.mock('@trigger.dev/sdk', () => ({
+    task: taskMock,
+    schedules: { task: vi.fn() },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@nestjs/core', () => ({
+    NestFactory: { createApplicationContext: createApplicationContextMock },
+}));
+
+vi.mock('@ever-works/agent/database', () => ({
+    AgentRepository: AgentRepositoryToken,
+    AgentRunRepository: AgentRunRepositoryToken,
+}));
+
+vi.mock('@ever-works/agent/agents', () => ({
+    AgentRunService: AgentRunServiceToken,
+}));
+
+vi.mock('@ever-works/agent/tasks-domain', () => ({
+    TasksService: TasksServiceToken,
+}));
+
+vi.mock('../trigger/worker/modules/trigger-internal.module', () => ({
+    TriggerInternalModule: StubInternalModule,
+}));
+
+vi.mock('../trigger/worker/trigger-logger', () => ({
+    createTriggerLogger: createTriggerLoggerMock,
+}));
+
+type TaskConfig = {
+    id: string;
+    maxDuration: number;
+    run: (payload: any) => Promise<any>;
+    onFailure: (args: { payload: any; error: unknown }) => Promise<void>;
+};
+
+const OWNER = 'user-owner';
+const AGENT_ID = 'agent-1';
+const OWNED_TASK_ID = 'task-owned';
+const FOREIGN_TASK_ID = 'task-foreign';
+
+describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
+    let appContext: {
+        useLogger: ReturnType<typeof vi.fn>;
+        get: ReturnType<typeof vi.fn>;
+        close: ReturnType<typeof vi.fn>;
+    };
+    let agents: { findByIdAndUser: ReturnType<typeof vi.fn> };
+    let runs: {
+        findById: ReturnType<typeof vi.fn>;
+        findInFlightForTaskAgent: ReturnType<typeof vi.fn>;
+        createQueued: ReturnType<typeof vi.fn>;
+        markStarted: ReturnType<typeof vi.fn>;
+        markCompleted: ReturnType<typeof vi.fn>;
+        markFailed: ReturnType<typeof vi.fn>;
+    };
+    let runner: { execute: ReturnType<typeof vi.fn> };
+    let tasks: { getOne: ReturnType<typeof vi.fn> };
+    let registeredConfig: TaskConfig;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        vi.resetModules();
+
+        agents = { findByIdAndUser: vi.fn() };
+        runs = {
+            findById: vi.fn().mockResolvedValue(null),
+            findInFlightForTaskAgent: vi.fn().mockResolvedValue(null),
+            createQueued: vi.fn().mockResolvedValue({ id: 'run-1' }),
+            markStarted: vi.fn().mockResolvedValue(undefined),
+            markCompleted: vi.fn().mockResolvedValue(undefined),
+            markFailed: vi.fn().mockResolvedValue(undefined),
+        };
+        runner = {
+            execute: vi.fn().mockResolvedValue({ status: 'assembled' }),
+        };
+        tasks = { getOne: vi.fn() };
+
+        // The owner owns AGENT_ID and OWNED_TASK_ID. A foreign taskId is
+        // rejected by TasksService.getOne exactly like the real
+        // `findByIdAndUser` lookup (throws NotFoundException).
+        agents.findByIdAndUser.mockImplementation(async (agentId: string, userId: string) =>
+            agentId === AGENT_ID && userId === OWNER ? { id: AGENT_ID, userId: OWNER } : null,
+        );
+        tasks.getOne.mockImplementation(async (userId: string, taskId: string) => {
+            if (userId === OWNER && taskId === OWNED_TASK_ID) {
+                return {
+                    id: OWNED_TASK_ID,
+                    slug: 'owned-task',
+                    title: 'Owned Task',
+                    description: null,
+                    status: 'in_progress',
+                    priority: 'medium',
+                    labels: [],
+                    missionId: null,
+                    ideaId: null,
+                    workId: null,
+                };
+            }
+            throw new Error(`Task ${taskId} not found.`);
+        });
+
+        appContext = {
+            useLogger: vi.fn(),
+            get: vi.fn().mockImplementation((token: unknown) => {
+                if (token === AgentRepositoryToken) return agents;
+                if (token === AgentRunRepositoryToken) return runs;
+                if (token === AgentRunServiceToken) return runner;
+                if (token === TasksServiceToken) return tasks;
+                throw new Error(`Unexpected DI token: ${String(token)}`);
+            }),
+            close: vi.fn().mockResolvedValue(undefined),
+        };
+        createApplicationContextMock.mockResolvedValue(appContext);
+
+        await import('../tasks/trigger/agent-task-execute.task');
+        const lastCall = taskMock.mock.calls[taskMock.mock.calls.length - 1];
+        registeredConfig = lastCall[0] as TaskConfig;
+    });
+
+    const basePayload = (taskId: string) => ({
+        agentId: AGENT_ID,
+        userId: OWNER,
+        taskId,
+        dedupKey: `${taskId}:${AGENT_ID}:1`,
+    });
+
+    it('registers the "agent-task-execute" task', () => {
+        expect(registeredConfig.id).toBe('agent-task-execute');
+    });
+
+    describe('foreign / non-owned taskId (attacker path)', () => {
+        it('skips with reason "task-not-found" and does NOT echo the taskId', async () => {
+            const result = await registeredConfig.run(basePayload(FOREIGN_TASK_ID));
+
+            expect(result).toEqual({ status: 'skipped', reason: 'task-not-found' });
+            // No-existence-leak: the forged taskId must not be reflected back.
+            expect(JSON.stringify(result)).not.toContain(FOREIGN_TASK_ID);
+        });
+
+        it('does NOT create, start, or execute any AgentRun for a foreign task', async () => {
+            await registeredConfig.run(basePayload(FOREIGN_TASK_ID));
+
+            expect(tasks.getOne).toHaveBeenCalledWith(OWNER, FOREIGN_TASK_ID);
+            expect(runs.createQueued).not.toHaveBeenCalled();
+            expect(runs.findInFlightForTaskAgent).not.toHaveBeenCalled();
+            expect(runs.markStarted).not.toHaveBeenCalled();
+            expect(runner.execute).not.toHaveBeenCalled();
+        });
+
+        it('still closes the Nest application context (no resource leak)', async () => {
+            await registeredConfig.run(basePayload(FOREIGN_TASK_ID));
+            expect(appContext.close).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('legitimate owner path (unchanged)', () => {
+        it('resolves the owned task, creates + starts + executes the run, and completes', async () => {
+            const result = await registeredConfig.run(basePayload(OWNED_TASK_ID));
+
+            expect(tasks.getOne).toHaveBeenCalledWith(OWNER, OWNED_TASK_ID);
+            expect(runs.createQueued).toHaveBeenCalledWith({
+                agentId: AGENT_ID,
+                userId: OWNER,
+                triggerKind: 'task',
+                taskId: OWNED_TASK_ID,
+            });
+            expect(runs.markStarted).toHaveBeenCalledWith('run-1', null);
+            expect(runner.execute).toHaveBeenCalledTimes(1);
+            expect(runner.execute.mock.calls[0][0]).toMatchObject({
+                runId: 'run-1',
+                agentId: AGENT_ID,
+                userId: OWNER,
+                kind: 'task',
+                taskId: OWNED_TASK_ID,
+            });
+            expect(runs.markCompleted).toHaveBeenCalledTimes(1);
+            expect(result).toMatchObject({
+                status: 'completed',
+                agentId: AGENT_ID,
+                taskId: OWNED_TASK_ID,
+                runId: 'run-1',
+            });
+        });
+
+        it('feeds the owned task fields into the agent immediateInput', async () => {
+            await registeredConfig.run(basePayload(OWNED_TASK_ID));
+            const arg = runner.execute.mock.calls[0][0];
+            expect(arg.immediateInput).toContain('Owned Task');
+            expect(arg.immediateInput).toContain('Status: in_progress');
+        });
+    });
+
+    describe('forged agentId still rejected (regression for the sibling guard)', () => {
+        it('skips with "agent-not-found" for an unowned agentId', async () => {
+            const result = await registeredConfig.run({
+                agentId: 'agent-foreign',
+                userId: OWNER,
+                taskId: OWNED_TASK_ID,
+                dedupKey: 'x',
+            });
+            expect(result).toEqual({ status: 'skipped', reason: 'agent-not-found' });
+            expect(runs.createQueued).not.toHaveBeenCalled();
+            expect(tasks.getOne).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -84,6 +84,24 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 return { status: 'skipped', reason: 'agent-not-found' };
             }
 
+            // Security: scope the Task lookup to the payload's userId before
+            // we link/create any AgentRun row (IDOR guard). `getOne` resolves
+            // via `TaskRepository.findByIdAndUser` and throws an
+            // existence-leak-safe 404 for a foreign/non-owned `taskId`, so a
+            // forged payload that pairs an owned `agentId` with another
+            // tenant's `taskId` cannot attach a run to that task. The
+            // legitimate dispatch path (`TaskTransitionService`) always derives
+            // `taskId` from a task the `userId` owns, so this never rejects a
+            // real run. We resolve `taskRow` here (instead of after
+            // markStarted) and reuse it for prompt assembly below — null only
+            // for a foreign/missing task, in which case we skip without
+            // mutating any run state. The reason is non-leaking and does not
+            // echo the caller-supplied `taskId`.
+            const taskRow = await tasks.getOne(payload.userId, payload.taskId).catch(() => null);
+            if (!taskRow) {
+                return { status: 'skipped', reason: 'task-not-found' };
+            }
+
             // Look up the dispatcher-queued in-flight run (created when
             // TaskTransitionService fanned out the dispatch). If we
             // don't find one, create on the fly so the audit trail is
@@ -120,7 +138,8 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
 
             await runs.markStarted(run.id, null);
 
-            const taskRow = await tasks.getOne(payload.userId, payload.taskId).catch(() => null);
+            // `taskRow` was resolved above (owner-scoped) before any run
+            // mutation; it is guaranteed non-null here.
             const immediateInput = taskRow
                 ? [
                       `Task ${taskRow.slug ?? taskRow.id}: ${taskRow.title}`,


### PR DESCRIPTION
## Wave B — EW-710 security-audit remediation (continues [#1231](https://github.com/ever-works/ever-works/pull/1231)/[#1228](https://github.com/ever-works/ever-works/pull/1228))

Three genuine service/task-layer authorization gaps from the deferred backlog (idor/authz, high). Each was **verified against current code first** — the `deferred-final.json` snapshot is static and overstates the open set, so several siblings (`comparison-generation`, `agent-run`, `skills`) were confirmed **already-fixed** by #1209/#1210 and left untouched. Produced via a fix + adversarial-diff-review workflow; every diff additionally re-verified by hand (DI resolution, legit-flow preservation, reachability).

### [#12] `plugin-operations.service.ts` — work-scoped IDOR
`listWorkPlugins` / `enablePluginForWork` received a `userId` but **never authorized the `workId`** — only the controller gated it. Inject `WorkOwnershipService` (required dependency) and call `ensureCanView` (read) / `ensureCanEdit` (write) at the top, before any registry/repository access.
- **DI verified safe at both registration sites:** `WorkModule` (provides both services) and `apps/api/.../plugins.module.ts` (imports `WorkModule`, which exports `WorkOwnershipService`). No boot crash.
- +4 IDOR tests → **87/87**.

### [#16] `work-invitation.service.ts` — dead authz check
`revoke()` had a **dead empty `if` block** doing zero authorization. Replaced with `ensureCanManageMembers(invitation.workId, actorUserId)`.
- **No legit flow broken:** the controller's `revoke` handler already calls `ensureCanManageMembers` before the service (line 134); issuance is gated the same way, so inviters are managers. This is pure defense-in-depth.
- `setTransferState` deliberately **unchanged** — its only caller is the token-verified owner-claim acceptance path (adding an actor param would break that caller for no security gain).
- +1 test → **32/32**.

### [#19] `agent-task-execute.task.ts` — cross-user task linkage
A forged payload pairing an owned `agentId` with a **foreign `taskId`** could attach an `AgentRun` to another user's task — the owner-scoped lookup ran *after* `markStarted` and was swallowed. Moved `getOne(userId, taskId)` to the **top, before any run mutation**; skip with non-leaking `task-not-found` on miss; reuse the row for prompt assembly.
- `taskId` is a required payload field (always set by dispatchers), so the early-skip can't break a non-task run.
- New spec → **7/7** (Vitest).

## Verification
- packages/agent at-risk suites (work.module DI wiring, plugin-operations, work-invitation, works-config-import-applier, plugin-model-settings): **228/228**
- apps/api `plugins.controller` + `device-auth`: **46/46**
- packages/tasks `agent-task-execute` (Vitest): **7/7**
- `packages/agent` `tsc --noEmit`: clean
- `comparison-generation.service.ts` (#14/#15): confirmed **already-fixed**, no change

> Note: an unrelated **pre-existing** tsc error in `packages/tasks/src/tasks/trigger/kb-reconcile.task.ts` (`KnowledgeBaseReconcileService` not exported) exists on `develop` and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced authorization checks for work plugin management
  * Improved security verification for work invitation revocation
  * Strengthened task execution ownership validation to prevent unauthorized access

* **Tests**
  * Added authorization gate testing for work operations and task execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->