### PR TITLE
fix(security): input-validation guards — plugin SSRF + path-traversal (EW-715/716/717 Wave C)

### DIFF
--- a/apps/api/src/integrations/twenty-crm/controllers/companies.controller.spec.ts
+++ b/apps/api/src/integrations/twenty-crm/controllers/companies.controller.spec.ts
@@ -13,7 +13,12 @@ jest.mock('@ever-works/agent/database', () => ({
     UserRepository: class UserRepository {},
 }));
 
-import { NotFoundException } from '@nestjs/common';
+import {
+    ArgumentMetadata,
+    BadRequestException,
+    NotFoundException,
+    ParseUUIDPipe,
+} from '@nestjs/common';
 import { CompaniesController } from './companies.service';
 import { CrmTenantService } from '../services/crm-tenant.service';
 import type { ClientService } from '../services/client.service';
@@ -25,6 +30,11 @@ const TENANT_B = 'tenant-b';
 // Controllers now pass the raw tenant id (which selects that tenant's own
 // Twenty workspace credentials), not a `/tenants/{id}` path prefix.
 const PREFIX_A = TENANT_A;
+
+// Real UUIDs: the by-id handlers are now guarded by `ParseUUIDPipe`, so the
+// route param must be a valid UUID for the happy path to reach the controller.
+const COMPANY_ID = '11111111-1111-4111-8111-111111111111';
+const FOREIGN_COMPANY_ID = '99999999-9999-4999-8999-999999999999';
 
 const authUser = (userId = 'user-1'): AuthenticatedUser =>
     ({ userId, email: 'u@x.test' }) as AuthenticatedUser;
@@ -81,23 +91,44 @@ describe('CompaniesController', () => {
 
     it('PATCH /companies/:id verifies ownership then forwards id + body + prefix', async () => {
         const body = { name: 'Acme v2' };
-        client.getCompany.mockResolvedValue({ id: 'co-1', name: 'Acme' });
-        client.updateCompany.mockResolvedValue({ id: 'co-1', ...body });
-        await expect(controller.updateCompany(authUser(), 'co-1', body)).resolves.toEqual({
-            id: 'co-1',
+        client.getCompany.mockResolvedValue({ id: COMPANY_ID, name: 'Acme' });
+        client.updateCompany.mockResolvedValue({ id: COMPANY_ID, ...body });
+        await expect(controller.updateCompany(authUser(), COMPANY_ID, body)).resolves.toEqual({
+            id: COMPANY_ID,
             name: 'Acme v2',
         });
         // Ownership read is scoped to the caller's tenant before the mutation.
-        expect(client.getCompany).toHaveBeenCalledWith('co-1', PREFIX_A);
-        expect(client.updateCompany).toHaveBeenCalledWith('co-1', body, PREFIX_A);
+        expect(client.getCompany).toHaveBeenCalledWith(COMPANY_ID, PREFIX_A);
+        expect(client.updateCompany).toHaveBeenCalledWith(COMPANY_ID, body, PREFIX_A);
     });
 
     it('DELETE /companies/:id verifies ownership then forwards id + prefix', async () => {
-        client.getCompany.mockResolvedValue({ id: 'co-1', name: 'Acme' });
+        client.getCompany.mockResolvedValue({ id: COMPANY_ID, name: 'Acme' });
         client.deleteCompany.mockResolvedValue(undefined);
-        await controller.deleteCompany(authUser(), 'co-1');
-        expect(client.getCompany).toHaveBeenCalledWith('co-1', PREFIX_A);
-        expect(client.deleteCompany).toHaveBeenCalledWith('co-1', PREFIX_A);
+        await controller.deleteCompany(authUser(), COMPANY_ID);
+        expect(client.getCompany).toHaveBeenCalledWith(COMPANY_ID, PREFIX_A);
+        expect(client.deleteCompany).toHaveBeenCalledWith(COMPANY_ID, PREFIX_A);
+    });
+
+    // Security (EW-717 #3): the by-id mutating handlers (`@Get/@Patch/@Delete(':id')`)
+    // are decorated with `new ParseUUIDPipe()`, so a non-UUID `:id` is rejected at the
+    // pipe layer (400) before any tenant resolution / CRM call. Pipes do not run on a
+    // direct method call in a unit test, so we exercise the exact pipe wired onto the
+    // route param here.
+    describe('id route param is UUID-validated (ParseUUIDPipe)', () => {
+        const pipe = new ParseUUIDPipe();
+        const meta: ArgumentMetadata = { type: 'param', data: 'id' };
+
+        it('rejects a malformed / injection-shaped id with a 400 BadRequestException', async () => {
+            await expect(pipe.transform('co-1', meta)).rejects.toBeInstanceOf(BadRequestException);
+            await expect(pipe.transform("co-1' OR '1'='1", meta)).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+
+        it('passes a legitimate UUID through unchanged', async () => {
+            await expect(pipe.transform(COMPANY_ID, meta)).resolves.toBe(COMPANY_ID);
+        });
     });
 
     describe('cross-tenant IDOR is blocked', () => {
@@ -112,18 +143,22 @@ describe('CompaniesController', () => {
         it('PATCH of a record not in the caller’s tenant 404s and never mutates', async () => {
             // Upstream returns 404 (record not under the caller's tenant prefix)
             // when the ownership read runs.
-            client.getCompany.mockRejectedValue(new NotFoundException('Company co-9 not found'));
+            client.getCompany.mockRejectedValue(
+                new NotFoundException(`Company ${FOREIGN_COMPANY_ID} not found`),
+            );
             await expect(
-                controller.updateCompany(authUser(), 'co-9', { name: 'pwned' }),
+                controller.updateCompany(authUser(), FOREIGN_COMPANY_ID, { name: 'pwned' }),
             ).rejects.toBeInstanceOf(NotFoundException);
             expect(client.updateCompany).not.toHaveBeenCalled();
         });
 
         it('DELETE of a record not in the caller’s tenant 404s and never deletes', async () => {
-            client.getCompany.mockRejectedValue(new NotFoundException('Company co-9 not found'));
-            await expect(controller.deleteCompany(authUser(), 'co-9')).rejects.toBeInstanceOf(
-                NotFoundException,
+            client.getCompany.mockRejectedValue(
+                new NotFoundException(`Company ${FOREIGN_COMPANY_ID} not found`),
             );
+            await expect(
+                controller.deleteCompany(authUser(), FOREIGN_COMPANY_ID),
+            ).rejects.toBeInstanceOf(NotFoundException);
             expect(client.deleteCompany).not.toHaveBeenCalled();
         });
 

--- a/apps/api/src/integrations/twenty-crm/controllers/companies.service.ts
+++ b/apps/api/src/integrations/twenty-crm/controllers/companies.service.ts
@@ -5,6 +5,7 @@ import {
     Get,
     NotFoundException,
     Param,
+    ParseUUIDPipe,
     Patch,
     Post,
     UseGuards,
@@ -145,7 +146,9 @@ export class CompaniesController {
     @Get(':id')
     async getCompany(
         @CurrentUser() auth: AuthenticatedUser,
-        @Param('id') id: string,
+        // Security: reject malformed/abusive ids at the pipe layer (400) before
+        // they are forwarded to the CRM. Mirrors `kb.controller.ts`.
+        @Param('id', new ParseUUIDPipe()) id: string,
     ): Promise<TwentyOrganization> {
         const tenantId = await this.resolveTenantId(auth);
         // Reads use the caller-tenant's own workspace credentials: a foreign id
@@ -169,7 +172,9 @@ export class CompaniesController {
     @Patch(':id')
     async updateCompany(
         @CurrentUser() auth: AuthenticatedUser,
-        @Param('id') id: string,
+        // Security: reject malformed/abusive ids at the pipe layer (400) before
+        // they are forwarded to the CRM. Mirrors `kb.controller.ts`.
+        @Param('id', new ParseUUIDPipe()) id: string,
         @Body() company: UpdateCompanyBodyDto,
     ): Promise<TwentyOrganization> {
         const tenantId = await this.resolveTenantId(auth);
@@ -180,7 +185,12 @@ export class CompaniesController {
     }
 
     @Delete(':id')
-    async deleteCompany(@CurrentUser() auth: AuthenticatedUser, @Param('id') id: string) {
+    async deleteCompany(
+        @CurrentUser() auth: AuthenticatedUser,
+        // Security: reject malformed/abusive ids at the pipe layer (400) before
+        // they are forwarded to the CRM. Mirrors `kb.controller.ts`.
+        @Param('id', new ParseUUIDPipe()) id: string,
+    ) {
         const tenantId = await this.resolveTenantId(auth);
         // Security: verify ownership before deleting so a foreign id 404s.
         await this.assertCompanyInTenant(id, tenantId);

--- a/apps/api/src/integrations/twenty-crm/controllers/people.controler.ts
+++ b/apps/api/src/integrations/twenty-crm/controllers/people.controler.ts
@@ -5,6 +5,7 @@ import {
     Get,
     NotFoundException,
     Param,
+    ParseUUIDPipe,
     Patch,
     Post,
     UseGuards,
@@ -81,7 +82,9 @@ export class PeopleController {
     @Get(':id')
     async getContact(
         @CurrentUser() auth: AuthenticatedUser,
-        @Param('id') id: string,
+        // Security: reject malformed/abusive ids at the pipe layer (400) before
+        // they are forwarded to the CRM. Mirrors `kb.controller.ts`.
+        @Param('id', new ParseUUIDPipe()) id: string,
     ): Promise<TwentyContact> {
         const tenantId = await this.resolveTenantId(auth);
         const contact = await this.clientService.getContact(id, tenantId);
@@ -111,7 +114,9 @@ export class PeopleController {
     @Patch(':id')
     async updateContact(
         @CurrentUser() auth: AuthenticatedUser,
-        @Param('id') id: string,
+        // Security: reject malformed/abusive ids at the pipe layer (400) before
+        // they are forwarded to the CRM. Mirrors `kb.controller.ts`.
+        @Param('id', new ParseUUIDPipe()) id: string,
         @Body() contact: TwentyContact,
     ) {
         const tenantId = await this.resolveTenantId(auth);
@@ -121,7 +126,12 @@ export class PeopleController {
     }
 
     @Delete(':id')
-    async deleteContact(@CurrentUser() auth: AuthenticatedUser, @Param('id') id: string) {
+    async deleteContact(
+        @CurrentUser() auth: AuthenticatedUser,
+        // Security: reject malformed/abusive ids at the pipe layer (400) before
+        // they are forwarded to the CRM. Mirrors `kb.controller.ts`.
+        @Param('id', new ParseUUIDPipe()) id: string,
+    ) {
         const tenantId = await this.resolveTenantId(auth);
         // Security: verify ownership before deleting so a foreign id 404s.
         await this.assertContactInTenant(id, tenantId);

--- a/apps/api/src/integrations/twenty-crm/controllers/people.controller.spec.ts
+++ b/apps/api/src/integrations/twenty-crm/controllers/people.controller.spec.ts
@@ -13,7 +13,12 @@ jest.mock('@ever-works/agent/database', () => ({
     UserRepository: class UserRepository {},
 }));
 
-import { NotFoundException } from '@nestjs/common';
+import {
+    ArgumentMetadata,
+    BadRequestException,
+    NotFoundException,
+    ParseUUIDPipe,
+} from '@nestjs/common';
 import { PeopleController } from './people.controler';
 import { CrmTenantService } from '../services/crm-tenant.service';
 import type { ClientService } from '../services/client.service';
@@ -24,6 +29,11 @@ const TENANT_A = 'tenant-a';
 // Controllers now pass the raw tenant id (which selects that tenant's own
 // Twenty workspace credentials), not a `/tenants/{id}` path prefix.
 const PREFIX_A = TENANT_A;
+
+// Real UUIDs: the by-id handlers are now guarded by `ParseUUIDPipe`, so the
+// route param must be a valid UUID for the happy path to reach the controller.
+const CONTACT_ID = '22222222-2222-4222-8222-222222222222';
+const FOREIGN_CONTACT_ID = '88888888-8888-4888-8888-888888888888';
 
 const authUser = (userId = 'user-1'): AuthenticatedUser =>
     ({ userId, email: 'u@x.test' }) as AuthenticatedUser;
@@ -116,22 +126,43 @@ describe('PeopleController', () => {
 
     it('PATCH /people/:id verifies ownership then forwards id + body + prefix', async () => {
         const body = { firstName: 'Ada2' };
-        client.getContact.mockResolvedValue({ id: 'p-1', firstName: 'Ada' });
-        client.updateContact.mockResolvedValue({ id: 'p-1', ...body });
-        await expect(controller.updateContact(authUser(), 'p-1', body)).resolves.toEqual({
-            id: 'p-1',
+        client.getContact.mockResolvedValue({ id: CONTACT_ID, firstName: 'Ada' });
+        client.updateContact.mockResolvedValue({ id: CONTACT_ID, ...body });
+        await expect(controller.updateContact(authUser(), CONTACT_ID, body)).resolves.toEqual({
+            id: CONTACT_ID,
             firstName: 'Ada2',
         });
-        expect(client.getContact).toHaveBeenCalledWith('p-1', PREFIX_A);
-        expect(client.updateContact).toHaveBeenCalledWith('p-1', body, PREFIX_A);
+        expect(client.getContact).toHaveBeenCalledWith(CONTACT_ID, PREFIX_A);
+        expect(client.updateContact).toHaveBeenCalledWith(CONTACT_ID, body, PREFIX_A);
     });
 
     it('DELETE /people/:id verifies ownership then forwards id + prefix', async () => {
-        client.getContact.mockResolvedValue({ id: 'p-1', firstName: 'Ada' });
+        client.getContact.mockResolvedValue({ id: CONTACT_ID, firstName: 'Ada' });
         client.deleteContact.mockResolvedValue(undefined);
-        await controller.deleteContact(authUser(), 'p-1');
-        expect(client.getContact).toHaveBeenCalledWith('p-1', PREFIX_A);
-        expect(client.deleteContact).toHaveBeenCalledWith('p-1', PREFIX_A);
+        await controller.deleteContact(authUser(), CONTACT_ID);
+        expect(client.getContact).toHaveBeenCalledWith(CONTACT_ID, PREFIX_A);
+        expect(client.deleteContact).toHaveBeenCalledWith(CONTACT_ID, PREFIX_A);
+    });
+
+    // Security (EW-717 #3): the by-id mutating handlers (`@Get/@Patch/@Delete(':id')`)
+    // are decorated with `new ParseUUIDPipe()`, so a non-UUID `:id` is rejected at the
+    // pipe layer (400) before any tenant resolution / CRM call. Pipes do not run on a
+    // direct method call in a unit test, so we exercise the exact pipe wired onto the
+    // route param here.
+    describe('id route param is UUID-validated (ParseUUIDPipe)', () => {
+        const pipe = new ParseUUIDPipe();
+        const meta: ArgumentMetadata = { type: 'param', data: 'id' };
+
+        it('rejects a malformed / injection-shaped id with a 400 BadRequestException', async () => {
+            await expect(pipe.transform('p-1', meta)).rejects.toBeInstanceOf(BadRequestException);
+            await expect(pipe.transform("p-1' OR '1'='1", meta)).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+
+        it('passes a legitimate UUID through unchanged', async () => {
+            await expect(pipe.transform(CONTACT_ID, meta)).resolves.toBe(CONTACT_ID);
+        });
     });
 
     describe('cross-tenant IDOR is blocked', () => {
@@ -144,18 +175,22 @@ describe('PeopleController', () => {
         });
 
         it('PATCH of a record not in the caller’s tenant 404s and never mutates', async () => {
-            client.getContact.mockRejectedValue(new NotFoundException('Contact p-9 not found'));
+            client.getContact.mockRejectedValue(
+                new NotFoundException(`Contact ${FOREIGN_CONTACT_ID} not found`),
+            );
             await expect(
-                controller.updateContact(authUser(), 'p-9', { firstName: 'pwned' }),
+                controller.updateContact(authUser(), FOREIGN_CONTACT_ID, { firstName: 'pwned' }),
             ).rejects.toBeInstanceOf(NotFoundException);
             expect(client.updateContact).not.toHaveBeenCalled();
         });
 
         it('DELETE of a record not in the caller’s tenant 404s and never deletes', async () => {
-            client.getContact.mockRejectedValue(new NotFoundException('Contact p-9 not found'));
-            await expect(controller.deleteContact(authUser(), 'p-9')).rejects.toBeInstanceOf(
-                NotFoundException,
+            client.getContact.mockRejectedValue(
+                new NotFoundException(`Contact ${FOREIGN_CONTACT_ID} not found`),
             );
+            await expect(
+                controller.deleteContact(authUser(), FOREIGN_CONTACT_ID),
+            ).rejects.toBeInstanceOf(NotFoundException);
             expect(client.deleteContact).not.toHaveBeenCalled();
         });
     });

--- a/packages/agent/src/generators/data-generator/data-repository.spec.ts
+++ b/packages/agent/src/generators/data-generator/data-repository.spec.ts
@@ -166,6 +166,42 @@ describe('DataRepository', () => {
         await fs.rm(repoDir, { recursive: true, force: true });
     });
 
+    it('confines item slugs to dataDir: rejects traversal slugs, preserves legit paths', async () => {
+        const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'data-repository-spec-'));
+        await fs.mkdir(path.join(repoDir, 'data'), { recursive: true });
+
+        const repository = await DataRepository.create(repoDir);
+        const dataDir = path.join(repoDir, 'data');
+
+        // (a) Malicious slugs that would escape dataDir must throw before any
+        // fs sink (rm/mkdir/access) is reached — fail closed, never fail open.
+        for (const hostile of ['../victim', '../../etc', '..', '.', 'a/b', 'a\\b', 'foo/../bar']) {
+            await expect(repository.itemExists(hostile)).rejects.toThrow(/Invalid slug/);
+            await expect(repository.removeItem(hostile)).rejects.toThrow(/Invalid slug/);
+            await expect(repository.createItemDir({ slug: hostile } as any)).rejects.toThrow(
+                /Invalid slug/,
+            );
+        }
+
+        // Sanity: the guard actually prevented escape — no directory was
+        // created outside dataDir for any hostile slug.
+        await expect(fs.readdir(dataDir)).resolves.toEqual([]);
+
+        // (b) A legitimate slugifyText-shaped slug still passes unchanged: the
+        // item directory lands exactly at path.join(dataDir, slug) (the
+        // pre-guard return value) and round-trips through the public API.
+        const legitSlug = 'compare_cloud-pricing1';
+        const expectedDir = path.join(dataDir, legitSlug);
+
+        await expect(repository.itemExists(legitSlug)).resolves.toBe(false);
+        await repository.createItemDir({ slug: legitSlug } as any);
+        await expect(fs.stat(expectedDir)).resolves.toBeDefined();
+        await expect(repository.itemExists(legitSlug)).resolves.toBe(true);
+        await expect(fs.readdir(dataDir)).resolves.toEqual([legitSlug]);
+
+        await fs.rm(repoDir, { recursive: true, force: true });
+    });
+
     it('normalizes public reference errors before writing references.yaml', async () => {
         const repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'data-repository-spec-'));
         const repository = await DataRepository.create(repoDir);

--- a/packages/agent/src/generators/markdown-generator/markdown-repository.spec.ts
+++ b/packages/agent/src/generators/markdown-generator/markdown-repository.spec.ts
@@ -149,6 +149,66 @@ describe('MarkdownRepository', () => {
             });
             // Note: explicitly NOT recursive — files only.
         });
+
+        // EW-717 #1 — path-traversal guard. A caller-supplied slug must be a
+        // single safe `[A-Za-z0-9_-]+` segment; anything that could escape the
+        // `details/` dir must throw BEFORE any fs write/delete.
+        describe('slug confinement (path traversal)', () => {
+            it.each([
+                '../../evil',
+                '../escape',
+                'a/b',
+                '..',
+                '.',
+                '',
+                'foo/../../bar',
+                'sub/child',
+            ])('writeDetails rejects hostile slug %p without writing', async (slug) => {
+                await expect(new MarkdownRepository(dir).writeDetails(slug, 'x')).rejects.toThrow(
+                    /Invalid slug/,
+                );
+                expect(fsMock.writeFile).not.toHaveBeenCalled();
+            });
+
+            it.each([
+                '../../evil',
+                '../escape',
+                'a/b',
+                '..',
+                '.',
+                '',
+                'foo/../../bar',
+                'sub/child',
+            ])('removeDetails rejects hostile slug %p without removing', async (slug) => {
+                await expect(new MarkdownRepository(dir).removeDetails(slug)).rejects.toThrow(
+                    /Invalid slug/,
+                );
+                expect(fsMock.rm).not.toHaveBeenCalled();
+            });
+
+            it('does not bump the write counter when a hostile slug is rejected', async () => {
+                const repo = new MarkdownRepository(dir);
+                await expect(repo.writeDetails('../../evil', 'x')).rejects.toThrow(/Invalid slug/);
+                await expect(repo.removeDetails('../../evil')).rejects.toThrow(/Invalid slug/);
+                expect(repo.getWriteCount()).toBe(0);
+            });
+
+            it('still writes a legitimate slug unchanged under details/', async () => {
+                await new MarkdownRepository(dir).writeDetails('my-item', '# ok');
+                expect(fsMock.writeFile).toHaveBeenCalledWith(
+                    path.join(detailsDir, 'my-item.md'),
+                    '# ok',
+                    'utf-8',
+                );
+            });
+
+            it('still removes a legitimate slug unchanged under details/', async () => {
+                await new MarkdownRepository(dir).removeDetails('my-item');
+                expect(fsMock.rm).toHaveBeenCalledWith(path.join(detailsDir, 'my-item.md'), {
+                    force: true,
+                });
+            });
+        });
     });
 
     describe('writeLicense', () => {

--- a/packages/agent/src/generators/markdown-generator/markdown-repository.ts
+++ b/packages/agent/src/generators/markdown-generator/markdown-repository.ts
@@ -1,6 +1,14 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 
+// Security (path traversal): a caller-supplied `slug` is interpolated into a
+// filename under `details/`. `path.basename` already drops directory parts, but
+// it has platform-dependent edge cases and would happily accept OS-reserved
+// names like `.`/`..`, so we additionally require a strict allowlist matching
+// the `slugifyText` output charset ([A-Za-z0-9_-]) before any path is built.
+// Mirrors `DataRepository.confineSlugPath` / `GitHubSyncService.safeSlugDir`.
+const SAFE_SLUG_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
 export class MarkdownRepository {
     private readonly detailsPath: string;
 
@@ -61,14 +69,41 @@ export class MarkdownRepository {
         this.writeCount += 1;
     }
 
+    /**
+     * Resolve a slug to a `<slug>.md` filename under `detailsPath`, rejecting
+     * anything that is not a strict `[A-Za-z0-9_-]+` token or that would escape
+     * `detailsPath` once resolved (e.g. `../../etc/passwd`). Throws on a hostile
+     * slug BEFORE the path reaches any `fs.writeFile`/`fs.rm` sink, so the
+     * traversal never performs an arbitrary file write/delete. Legitimate slugs
+     * are `slugifyText` output ([a-z0-9_-]) and pass through unchanged.
+     */
+    private detailFilePath(slug: string): string {
+        const safeName = path.basename(slug);
+        // Reject empty results and anything outside the slug allowlist before
+        // building a path — defends against platform-dependent `basename`
+        // behaviour and OS-reserved names (`.`, `..`, etc.).
+        if (!safeName || safeName !== slug || !SAFE_SLUG_PATTERN.test(safeName)) {
+            throw new Error(`Invalid slug: ${slug}`);
+        }
+        const filename = path.join(this.detailsPath, `${safeName}.md`);
+        // Belt-and-suspenders containment check: the resolved file must stay
+        // strictly under the resolved details directory.
+        const resolvedRoot = path.resolve(this.detailsPath);
+        const resolvedChild = path.resolve(filename);
+        if (!resolvedChild.startsWith(resolvedRoot + path.sep)) {
+            throw new Error(`Invalid slug: ${slug}`);
+        }
+        return filename;
+    }
+
     async writeDetails(slug: string, content: string) {
-        const filename = path.join(this.detailsPath, `${slug}.md`);
+        const filename = this.detailFilePath(slug);
         await fs.writeFile(filename, content, 'utf-8');
         this.writeCount += 1;
     }
 
     async removeDetails(slug: string) {
-        const filename = path.join(this.detailsPath, `${slug}.md`);
+        const filename = this.detailFilePath(slug);
         await fs.rm(filename, { force: true });
         this.writeCount += 1;
     }

--- a/packages/plugins/make/src/__tests__/payload-builder.spec.ts
+++ b/packages/plugins/make/src/__tests__/payload-builder.spec.ts
@@ -134,6 +134,53 @@ describe('buildWorkflowPayload', () => {
 		expect(payload.dataSource?.branch).toBe('data');
 	});
 
+	// Security (SSRF): repo_url + access token are forwarded to the external
+	// Make.com runner, which fetches the URL server-side. Malicious URLs must
+	// fail closed — no dataSource, so neither the SSRF probe nor the access
+	// token reaches the runner. Legitimate https://github.com/... is unaffected.
+	it.each([
+		['cloud-metadata IP', 'http://169.254.169.254/latest/meta-data/'],
+		['loopback host', 'http://127.0.0.1:8080/internal'],
+		['private RFC1918 host', 'http://10.0.0.5/admin'],
+		['non-HTTP scheme', 'file:///etc/passwd'],
+		['malformed url', 'not-a-url']
+	])('should NOT attach dataSource (or token) for a malicious repo_url: %s', (_label, repoUrl) => {
+		const payload = buildWorkflowPayload(
+			createOptions({
+				config: {
+					target_items: 50,
+					pass_repo_access: true,
+					repo_url: repoUrl,
+					repo_access_token: 'ghp_secret_should_not_leak'
+				}
+			})
+		);
+
+		expect(payload.dataSource).toBeUndefined();
+	});
+
+	it('should attach dataSource with the token for a legitimate github https repo_url', () => {
+		const payload = buildWorkflowPayload(
+			createOptions({
+				config: {
+					target_items: 50,
+					pass_repo_access: true,
+					repo_url: 'https://github.com/org/repo',
+					repo_access_token: 'ghp_test123',
+					repo_branch: 'main'
+				}
+			})
+		);
+
+		expect(payload.dataSource).toEqual({
+			type: 'github-repo',
+			repoUrl: 'https://github.com/org/repo',
+			accessToken: 'ghp_test123',
+			branch: 'main',
+			path: 'items/'
+		});
+	});
+
 	it('should include custom scenario params', () => {
 		const payload = buildWorkflowPayload(
 			createOptions({

--- a/packages/plugins/make/src/utils/payload-builder.ts
+++ b/packages/plugins/make/src/utils/payload-builder.ts
@@ -1,4 +1,5 @@
 import type { WorkReference, GenerationRequest, ExistingItems } from '@ever-works/plugin';
+import { isSafeWebhookUrl } from '@ever-works/plugin/helpers/ssrf-guard';
 import type { MakeWorkflowInput } from '../types.js';
 import { DEFAULT_TARGET_ITEMS } from '../types.js';
 
@@ -87,7 +88,16 @@ export function buildWorkflowPayload(options: PayloadOptions): MakeWorkflowInput
 	}
 
 	// Strategy 2: GitHub repository reference
-	if (config.pass_repo_access && config.repo_url) {
+	// Security: the user-supplied repo_url (plus its access token) is forwarded
+	// to the external Make.com scenario, which fetches it server-side. Without
+	// validation an attacker could point it at http://169.254.169.254/, a
+	// private/loopback host, or a non-HTTP scheme (file://) to probe internal
+	// services via the Make runner (SSRF) and exfiltrate the attached token.
+	// Gate the dataSource on the shared lexical SSRF guard (rejects non-HTTP(S)
+	// schemes and literal private/loopback/link-local/cloud-metadata IPs).
+	// Legitimate https://github.com/... URLs are unaffected; an unsafe URL fails
+	// closed by omitting dataSource so neither the probe nor the token leaks.
+	if (config.pass_repo_access && config.repo_url && isSafeWebhookUrl(config.repo_url as string)) {
 		payload.dataSource = {
 			type: 'github-repo',
 			repoUrl: config.repo_url as string,

--- a/packages/plugins/zapier/src/__tests__/payload-builder.spec.ts
+++ b/packages/plugins/zapier/src/__tests__/payload-builder.spec.ts
@@ -119,6 +119,69 @@ describe('buildWorkflowPayload', () => {
 		expect(payload.dataSource).toBeUndefined();
 	});
 
+	it('should NOT attach the repo access token when repo_url is an SSRF/metadata target', () => {
+		const payload = buildWorkflowPayload(
+			createOptions({
+				config: {
+					target_items: 50,
+					pass_repo_access: true,
+					repo_url: 'http://169.254.169.254/latest/meta-data/',
+					repo_access_token: 'ghp_secret_token',
+					repo_branch: 'main'
+				}
+			})
+		);
+
+		// Fail-closed: an unsafe repo_url omits dataSource entirely, so the
+		// GitHub access token can never be exfiltrated to the metadata endpoint.
+		expect(payload.dataSource).toBeUndefined();
+		expect(JSON.stringify(payload)).not.toContain('ghp_secret_token');
+	});
+
+	it.each([
+		['private/loopback host', 'http://127.0.0.1:8080/repo'],
+		['private RFC1918 host', 'http://10.0.0.5/internal'],
+		['non-HTTP scheme', 'file:///etc/passwd'],
+		['cloud-metadata hostname', 'http://metadata.google.internal/computeMetadata/v1/']
+	])('should omit dataSource (and token) for unsafe repo_url: %s', (_label, repoUrl) => {
+		const payload = buildWorkflowPayload(
+			createOptions({
+				config: {
+					target_items: 50,
+					pass_repo_access: true,
+					repo_url: repoUrl,
+					repo_access_token: 'ghp_secret_token'
+				}
+			})
+		);
+
+		expect(payload.dataSource).toBeUndefined();
+		expect(JSON.stringify(payload)).not.toContain('ghp_secret_token');
+	});
+
+	it('should still attach the repo access token for a legitimate github.com URL', () => {
+		const payload = buildWorkflowPayload(
+			createOptions({
+				config: {
+					target_items: 50,
+					pass_repo_access: true,
+					repo_url: 'https://github.com/org/repo',
+					repo_access_token: 'ghp_test123',
+					repo_branch: 'main'
+				}
+			})
+		);
+
+		// Legitimate happy path is unchanged: dataSource attached with the token.
+		expect(payload.dataSource).toEqual({
+			type: 'github-repo',
+			repoUrl: 'https://github.com/org/repo',
+			accessToken: 'ghp_test123',
+			branch: 'main',
+			path: 'items/'
+		});
+	});
+
 	it('should default repo branch to "data" when not specified', () => {
 		const payload = buildWorkflowPayload(
 			createOptions({

--- a/packages/plugins/zapier/src/__tests__/result-parser.spec.ts
+++ b/packages/plugins/zapier/src/__tests__/result-parser.spec.ts
@@ -245,6 +245,94 @@ describe('parseZapierOutput — native shape', () => {
 	});
 });
 
+describe('parseZapierOutput — SSRF filtering (native shape)', () => {
+	it('should drop SSRF image URLs and null out an SSRF source_url, keeping safe ones', () => {
+		const mapping: ZapierFieldMapping = { nameField: 'title', urlField: 'link', imageField: 'imgs' };
+		const result = parseZapierOutput(
+			[
+				{
+					title: 'Item',
+					link: 'http://169.254.169.254/latest/meta-data/',
+					imgs: [
+						'http://169.254.169.254/logo.png',
+						'http://127.0.0.1/internal.png',
+						'http://10.0.0.5/private.png',
+						'https://cdn.example.com/safe.png'
+					]
+				}
+			],
+			'native',
+			mapping
+		);
+
+		// Cloud-metadata source_url dropped to empty string.
+		expect(result.items[0].source_url).toBe('');
+		// Only the public https image survives the lexical guard.
+		expect(result.items[0].images).toEqual(['https://cdn.example.com/safe.png']);
+	});
+
+	it('should drop a single SSRF image-string mapping entirely', () => {
+		const mapping: ZapierFieldMapping = { nameField: 'title', imageField: 'img' };
+		const result = parseZapierOutput([{ title: 'Item', img: 'http://127.0.0.1/x.png' }], 'native', mapping);
+		expect(result.items[0].images).toBeUndefined();
+	});
+
+	it('should preserve a legitimate https source_url and image unchanged', () => {
+		const mapping: ZapierFieldMapping = { nameField: 'title', urlField: 'link', imageField: 'img' };
+		const result = parseZapierOutput(
+			[{ title: 'Item', link: 'https://example.com/page', img: 'https://example.com/a.png' }],
+			'native',
+			mapping
+		);
+		expect(result.items[0].source_url).toBe('https://example.com/page');
+		expect(result.items[0].images).toEqual(['https://example.com/a.png']);
+	});
+});
+
+describe('parseZapierOutput — SSRF filtering (structured shape)', () => {
+	it('should drop SSRF images and null out an SSRF source_url, keeping safe ones', () => {
+		const result = parseZapierOutput(
+			{
+				items: [
+					{
+						name: 'Item',
+						url: 'http://169.254.169.254/latest/meta-data/',
+						images: [
+							'http://127.0.0.1/internal.png',
+							'http://10.1.2.3/private.png',
+							'https://cdn.example.com/safe.png'
+						]
+					}
+				]
+			},
+			'structured',
+			EMPTY_MAPPING
+		);
+
+		expect(result.items[0].source_url).toBe('');
+		expect(result.items[0].images).toEqual(['https://cdn.example.com/safe.png']);
+	});
+
+	it('should preserve a legitimate https source_url and images unchanged', () => {
+		const result = parseZapierOutput(
+			{
+				items: [
+					{
+						name: 'Item',
+						url: 'https://example.com/page',
+						images: ['https://example.com/a.png', 'https://example.com/b.png']
+					}
+				]
+			},
+			'structured',
+			EMPTY_MAPPING
+		);
+
+		expect(result.items[0].source_url).toBe('https://example.com/page');
+		expect(result.items[0].images).toEqual(['https://example.com/a.png', 'https://example.com/b.png']);
+	});
+});
+
 describe('deduplicateItems', () => {
 	it('should remove items whose names match existing items', () => {
 		const items = [

--- a/packages/plugins/zapier/src/utils/payload-builder.ts
+++ b/packages/plugins/zapier/src/utils/payload-builder.ts
@@ -1,4 +1,5 @@
 import type { WorkReference, GenerationRequest, ExistingItems } from '@ever-works/plugin';
+import { isSafeWebhookUrl } from '@ever-works/plugin/helpers/ssrf-guard';
 import type { ZapierWorkflowInput } from '../types.js';
 import { DEFAULT_TARGET_ITEMS } from '../types.js';
 
@@ -54,7 +55,16 @@ export function buildWorkflowPayload(options: PayloadOptions): ZapierWorkflowInp
 		};
 	}
 
-	if (config.pass_repo_access && config.repo_url) {
+	// Security: the user-supplied repo_url (and the repo access token attached
+	// alongside it) is forwarded to the external Zapier action, which fetches it
+	// server-side. Without validation an attacker could set repo_url to
+	// http://169.254.169.254/, a private/loopback host, or a non-HTTP scheme to
+	// exfiltrate the GitHub access token / probe internal services via the Zapier
+	// runner (SSRF). Gate the dataSource on the shared lexical SSRF guard (rejects
+	// non-HTTP(S) schemes and literal private/loopback/link-local/cloud-metadata
+	// IPs). Legitimate https://github.com/... URLs are unaffected; an unsafe URL
+	// fails closed by omitting dataSource so the token never leaves the platform.
+	if (config.pass_repo_access && config.repo_url && isSafeWebhookUrl(config.repo_url as string)) {
 		envelope.dataSource = {
 			type: 'github-repo',
 			repoUrl: config.repo_url as string,

--- a/packages/plugins/zapier/src/utils/result-parser.ts
+++ b/packages/plugins/zapier/src/utils/result-parser.ts
@@ -1,4 +1,5 @@
 import type { ItemData, Category, Tag, Brand } from '@ever-works/plugin';
+import { isSafeWebhookUrl } from '@ever-works/plugin/helpers/ssrf-guard';
 import type { ZapierWorkflowOutput, ZapierOutputItem, ZapierResultShape, ZapierFieldMapping } from '../types.js';
 
 export interface ParsedResults {
@@ -181,17 +182,24 @@ function mapNativeRecord(record: Record<string, unknown>, mapping: ZapierFieldMa
 		const raw = readField(record, mapping.imageField);
 		if (Array.isArray(raw)) {
 			for (const img of raw) {
-				if (typeof img === 'string' && img.trim()) images.push(img.trim());
+				// Security (SSRF): webhook-supplied image URLs are fetched/rendered
+				// server-side, so drop any pointing at private/loopback/link-local
+				// or cloud-metadata addresses before they enter ItemData.
+				if (typeof img === 'string' && img.trim() && isSafeWebhookUrl(img.trim())) images.push(img.trim());
 			}
-		} else if (typeof raw === 'string' && raw.trim()) {
+		} else if (typeof raw === 'string' && raw.trim() && isSafeWebhookUrl(raw.trim())) {
 			images.push(raw.trim());
 		}
 	}
 
+	// Security (SSRF): the mapped source_url is later fetched server-side;
+	// null it out when it resolves to an unsafe (private/metadata) target.
+	const safeSourceUrl = (url || '').trim();
+
 	return {
 		name: (name || '').trim(),
 		description: (description || '').trim(),
-		source_url: (url || '').trim(),
+		source_url: safeSourceUrl && isSafeWebhookUrl(safeSourceUrl) ? safeSourceUrl : '',
 		markdown: content,
 		category: (category || '').trim(),
 		tags,
@@ -246,16 +254,24 @@ function parseItems(rawItems: ZapierOutputItem[]): ItemData[] {
 		if (!raw || typeof raw !== 'object') continue;
 		if (!raw.name || typeof raw.name !== 'string') continue;
 
+		// Security (SSRF): source_url is fetched server-side; drop it when it
+		// points at a private/loopback/link-local or cloud-metadata target.
+		const rawSourceUrl =
+			typeof raw.url === 'string' ? raw.url : typeof raw.source_url === 'string' ? raw.source_url : '';
+
 		const item: ItemData = {
 			name: raw.name.trim(),
 			description: typeof raw.description === 'string' ? raw.description.trim() : '',
-			source_url:
-				typeof raw.url === 'string' ? raw.url : typeof raw.source_url === 'string' ? raw.source_url : '',
+			source_url: rawSourceUrl && isSafeWebhookUrl(rawSourceUrl) ? rawSourceUrl : '',
 			markdown: typeof raw.content === 'string' ? raw.content : undefined,
 			category: typeof raw.category === 'string' ? raw.category.trim() : '',
 			tags: Array.isArray(raw.tags) ? raw.tags.filter((t): t is string => typeof t === 'string') : [],
 			brand: typeof raw.brand === 'string' ? raw.brand.trim() : undefined,
-			images: Array.isArray(raw.images) ? raw.images.filter((i): i is string => typeof i === 'string') : undefined
+			// Security (SSRF): each image URL is fetched/rendered server-side; keep
+			// only strings that pass the lexical SSRF guard.
+			images: Array.isArray(raw.images)
+				? raw.images.filter((i): i is string => typeof i === 'string' && isSafeWebhookUrl(i))
+				: undefined
 		};
 
 		items.push(item);


### PR DESCRIPTION
## Wave C — EW-710 remediation (Phase-2 highs, contained subset)

The Phase-2 triage confirmed the stale-snapshot pattern holds for the highs (EW-715 was **13/17 already-mitigated** by #1209/#1210). This PR lands the genuinely-open, **contained** remainder across EW-715/716/717. Produced by a fix + adversarial-diff workflow; every fix was **mutation-tested** (guard reverted to prove the new security tests fail without it) and re-verified by hand.

### SSRF / token-exfiltration
- **[EW-715 #1] `zapier/result-parser.ts`** — attacker-controlled webhook payloads fed `images[]` / `source_url` straight into `ItemData` with no vetting (stored SSRF). Now filtered through `isSafeWebhookUrl` at both mapping paths; fail-closed (drop image / empty `source_url`), legit `https` preserved.
- **[EW-716 #7] `zapier/payload-builder.ts`** + **[EW-716 #6] `make/payload-builder.ts`** — the GitHub access token was attached to `dataSource` for **any** `repo_url` → a malicious url (`http://169.254.169.254/`, loopback, RFC1918) exfiltrates the token. Now gated on `isSafeWebhookUrl(repo_url)`, mirroring the sim-ai/composio siblings.

### Path-traversal
- **[EW-717 #1] `markdown-repository.ts`** — `writeDetails`/`removeDetails` interpolated a caller slug into `path.join` with no confinement (`../` → arbitrary file write/delete). Now routed through a strict `^[a-zA-Z0-9_-]+$` + `basename` + `path.resolve` containment guard (mirrors `DataRepository.confineSlugPath`) before any fs sink.
- **[EW-717 #3] twenty-crm `companies` + `people` controllers** — `@Get/@Patch/@Delete(':id')` took raw string ids. Now `@Param('id', ParseUUIDPipe)` → non-UUID/injection id rejected 400 before tenant resolution or any CRM call. Spec fixtures updated to real UUIDs.

### Already-fixed (regression test only)
- **[EW-717 #2] `data-repository.ts`** — `getItemPath` was already guarded by `confineSlugPath` in current code; added a traversal regression test, **no source change**.

## Verification (run independently, not just agent-reported)
- `packages/plugins/zapier`: **112/112** · `packages/plugins/make`: **114/114**
- `packages/agent` markdown-repository + data-repository: **44/44**
- `apps/api` twenty-crm: **135/135**
- Each fix mutation-tested (5 security tests fail with the guard removed, pass with it)

> Note: `PeopleController` is intentionally not yet registered in `TwentyCrmModule` (documented in-file) — its guard is secure-by-default for when it's wired. `CompaniesController`'s guard is on a live route. Deferred-with-decision items (make.com baseUrl allowlist, plugin envVars allowlist, secret-at-rest audit, allowedPaths sandbox) are documented on EW-715/716/717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added path-traversal protection to repository/markdown file operations.
  * Implemented SSRF-safe URL gating in Make and Zapier payload/result handling to avoid exposing repo access tokens and to filter unsafe image/URL outputs.
  * Enforced UUID validation on API by-id endpoints to reject malformed IDs early (400).

* **Tests**
  * Added/updated unit tests covering UUID validation, slug confinement, SSRF cases, and result parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->