### PR TITLE
feat(pgvector): EW-642 D7 follow-up — handleEmbeddingSettingsChange reembed hook

### DIFF
--- a/packages/plugins/pgvector/src/__tests__/pgvector.reembed-hook.spec.ts
+++ b/packages/plugins/pgvector/src/__tests__/pgvector.reembed-hook.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * EW-642 D7 follow-up — pgvector re-embed hook unit tests.
+ *
+ * Covers `PgVectorPlugin.handleEmbeddingSettingsChange`: the public
+ * method the host calls when `embeddingModel` or `embeddingDimensions`
+ * flips in the plugin's settings. The plugin walks every affected
+ * Work via the injected `PgVectorAffectedWorksPort`, fans a
+ * `kb-reembed-work` Trigger.dev dispatch out per Work via the injected
+ * `PgVectorReembedDispatcher`, and surfaces partial-sweep failures by
+ * propagating the underlying error.
+ *
+ * Receiver-side idempotency lives on the slice-2
+ * `KnowledgeBaseReembedService` + `kb-reembed-work` Trigger.dev task,
+ * which watermark every chunk-coordinate row by `embedding_model` so
+ * re-dispatching a Work that already completed is a no-op.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	PgVectorPlugin,
+	type PgVectorReembedDispatcher,
+	type PgVectorAffectedWorksPort,
+	type PgVectorReembedHook
+} from '../pgvector.plugin.js';
+
+function createDispatcher(): PgVectorReembedDispatcher {
+	return {
+		dispatchKbReembedWork: vi.fn(async (payload) => `run-${payload.workId}-${payload.newModel}`)
+	};
+}
+
+function createAffectedWorks(workIds: ReadonlyArray<string>): PgVectorAffectedWorksPort {
+	return {
+		listAffectedWorkIds: vi.fn(async () => workIds)
+	};
+}
+
+describe('PgVectorPlugin.handleEmbeddingSettingsChange (D7 reembed hook)', () => {
+	let plugin: PgVectorPlugin;
+
+	beforeEach(() => {
+		plugin = new PgVectorPlugin();
+	});
+
+	it('is a no-op when neither embeddingModel nor embeddingDimensions change', async () => {
+		const dispatcher = createDispatcher();
+		const affectedWorks = createAffectedWorks(['w-1', 'w-2']);
+		plugin.setReembedHook({ dispatcher, affectedWorks });
+
+		const result = await plugin.handleEmbeddingSettingsChange({
+			previousModel: 'text-embedding-3-small',
+			previousDims: 1536,
+			newModel: 'text-embedding-3-small',
+			newDims: 1536
+		});
+
+		expect(result).toEqual([]);
+		expect(dispatcher.dispatchKbReembedWork).not.toHaveBeenCalled();
+		// Doesn't even need to ask the port — early-return short-circuits
+		// before any I/O happens. Avoids a stray DB query on every save.
+		expect(affectedWorks.listAffectedWorkIds).not.toHaveBeenCalled();
+	});
+
+	it('fans a dispatch out per affected Work when embeddingModel changes', async () => {
+		const dispatcher = createDispatcher();
+		const affectedWorks = createAffectedWorks(['w-1', 'w-2', 'w-3']);
+		plugin.setReembedHook({ dispatcher, affectedWorks });
+
+		const result = await plugin.handleEmbeddingSettingsChange({
+			previousModel: 'text-embedding-3-small',
+			previousDims: 1536,
+			newModel: 'text-embedding-3-large',
+			newDims: 1536
+		});
+
+		expect(result).toEqual([
+			{ workId: 'w-1', runId: 'run-w-1-text-embedding-3-large' },
+			{ workId: 'w-2', runId: 'run-w-2-text-embedding-3-large' },
+			{ workId: 'w-3', runId: 'run-w-3-text-embedding-3-large' }
+		]);
+		expect(dispatcher.dispatchKbReembedWork).toHaveBeenCalledTimes(3);
+		expect(dispatcher.dispatchKbReembedWork).toHaveBeenNthCalledWith(1, {
+			workId: 'w-1',
+			previousModel: 'text-embedding-3-small',
+			newModel: 'text-embedding-3-large',
+			newDims: 1536
+		});
+	});
+
+	it('fans a dispatch out per affected Work when embeddingDimensions changes', async () => {
+		const dispatcher = createDispatcher();
+		const affectedWorks = createAffectedWorks(['w-only']);
+		plugin.setReembedHook({ dispatcher, affectedWorks });
+
+		const result = await plugin.handleEmbeddingSettingsChange({
+			previousModel: 'text-embedding-3-small',
+			previousDims: 1536,
+			newModel: 'text-embedding-3-small',
+			newDims: 3072
+		});
+
+		expect(result).toEqual([{ workId: 'w-only', runId: 'run-w-only-text-embedding-3-small' }]);
+		expect(dispatcher.dispatchKbReembedWork).toHaveBeenCalledTimes(1);
+		expect(dispatcher.dispatchKbReembedWork).toHaveBeenCalledWith({
+			workId: 'w-only',
+			previousModel: 'text-embedding-3-small',
+			newModel: 'text-embedding-3-small',
+			newDims: 3072
+		});
+	});
+
+	it('returns an empty list when there are no affected Works (settings change is a no-op against an unused plugin)', async () => {
+		const dispatcher = createDispatcher();
+		const affectedWorks = createAffectedWorks([]);
+		plugin.setReembedHook({ dispatcher, affectedWorks });
+
+		const result = await plugin.handleEmbeddingSettingsChange({
+			previousModel: 'text-embedding-3-small',
+			previousDims: 1536,
+			newModel: 'text-embedding-3-large',
+			newDims: 1536
+		});
+
+		expect(result).toEqual([]);
+		expect(dispatcher.dispatchKbReembedWork).not.toHaveBeenCalled();
+		expect(affectedWorks.listAffectedWorkIds).toHaveBeenCalledTimes(1);
+	});
+
+	it('throws when the hook has not been wired in — silent drops would leave Works on stale models', async () => {
+		await expect(
+			plugin.handleEmbeddingSettingsChange({
+				previousModel: 'text-embedding-3-small',
+				previousDims: 1536,
+				newModel: 'text-embedding-3-large',
+				newDims: 1536
+			})
+		).rejects.toThrow(/re-embed hook not wired in/i);
+	});
+
+	it('propagates a partial-sweep failure with context — names the failed Work and the count of already-dispatched runs', async () => {
+		const dispatcher: PgVectorReembedDispatcher = {
+			dispatchKbReembedWork: vi.fn(async (payload) => {
+				if (payload.workId === 'w-2') {
+					throw new Error('trigger.dev queue full');
+				}
+				return `run-${payload.workId}`;
+			})
+		};
+		const affectedWorks = createAffectedWorks(['w-1', 'w-2', 'w-3']);
+		plugin.setReembedHook({ dispatcher, affectedWorks });
+
+		await expect(
+			plugin.handleEmbeddingSettingsChange({
+				previousModel: 'text-embedding-3-small',
+				previousDims: 1536,
+				newModel: 'text-embedding-3-large',
+				newDims: 1536
+			})
+		).rejects.toThrow(/dispatch failed for work=w-2 after 1 prior successful dispatch.*trigger.dev queue full/);
+
+		// w-3 is never attempted — the throw stops the loop. That's fine
+		// because the receiver task is idempotent on `embedding_model`,
+		// so the host can safely retry the entire settings-change handler
+		// (already-dispatched runs no-op inside the task).
+		expect(dispatcher.dispatchKbReembedWork).toHaveBeenCalledTimes(2);
+	});
+
+	it('accepts the hook via the constructor option (parity with setReembedHook)', async () => {
+		const dispatcher = createDispatcher();
+		const affectedWorks = createAffectedWorks(['w-1']);
+		const hook: PgVectorReembedHook = { dispatcher, affectedWorks };
+		const constructed = new PgVectorPlugin({ reembedHook: hook });
+
+		const result = await constructed.handleEmbeddingSettingsChange({
+			previousModel: 'text-embedding-3-small',
+			previousDims: 1536,
+			newModel: 'text-embedding-3-large',
+			newDims: 1536
+		});
+
+		expect(result).toHaveLength(1);
+		expect(dispatcher.dispatchKbReembedWork).toHaveBeenCalledTimes(1);
+	});
+
+	it('setReembedHook(undefined) unbinds the hook and subsequent change calls throw', async () => {
+		plugin.setReembedHook({
+			dispatcher: createDispatcher(),
+			affectedWorks: createAffectedWorks(['w-1'])
+		});
+		plugin.setReembedHook(undefined);
+
+		await expect(
+			plugin.handleEmbeddingSettingsChange({
+				previousModel: 'text-embedding-3-small',
+				previousDims: 1536,
+				newModel: 'text-embedding-3-large',
+				newDims: 1536
+			})
+		).rejects.toThrow(/re-embed hook not wired in/i);
+	});
+});

--- a/packages/plugins/pgvector/src/pgvector.plugin.ts
+++ b/packages/plugins/pgvector/src/pgvector.plugin.ts
@@ -133,6 +133,69 @@ export interface PgVectorPluginOptions {
 	readonly chunkRepository?: PgVectorChunkRepositoryPort;
 	/** Optional cheap probe — round-trips to the Postgres instance. */
 	readonly pingDatabase?: () => Promise<boolean>;
+	/**
+	 * Optional re-embed hook. When wired in, `handleEmbeddingSettingsChange`
+	 * fans `kb-reembed-work` dispatches out over every affected Work. See
+	 * `PgVectorReembedHook` for the producer-side contract.
+	 */
+	readonly reembedHook?: PgVectorReembedHook;
+}
+
+/**
+ * Producer-side dispatcher the plugin calls when `embeddingModel` or
+ * `embeddingDimensions` flip in this plugin's settings. Symmetric with
+ * `KbReembedWorkDispatcher` in `@ever-works/agent/tasks` — the host
+ * adapts that interface to this one. We keep the surface local to the
+ * plugin package so the package doesn't take a hard dependency on
+ * `@ever-works/agent`.
+ */
+export interface PgVectorReembedDispatcher {
+	dispatchKbReembedWork(payload: {
+		readonly workId: string;
+		readonly previousModel: string;
+		readonly newModel: string;
+		readonly newDims: number;
+	}): Promise<string>;
+}
+
+/**
+ * Read-side port for "which Works currently route their KB chunk store
+ * through THIS plugin instance?". Production binds to a small DB
+ * lookup (read `work_knowledge_chunk_coordinates` filtered to
+ * `vector_store_id = 'pgvector'` and project the distinct work_id set,
+ * for example). Tests provide an in-memory fake.
+ */
+export interface PgVectorAffectedWorksPort {
+	listAffectedWorkIds(): Promise<ReadonlyArray<string>>;
+}
+
+/**
+ * Combined hook bag. Bundled so the host wires both halves in one
+ * setter call — separating them would create a partially-wired state
+ * (dispatcher set, port still missing) that's just a foot-gun.
+ */
+export interface PgVectorReembedHook {
+	readonly dispatcher: PgVectorReembedDispatcher;
+	readonly affectedWorks: PgVectorAffectedWorksPort;
+}
+
+/**
+ * Public input to `handleEmbeddingSettingsChange`. The host computes
+ * this from a settings diff and hands it to the plugin — the plugin
+ * does not subscribe to a settings-change event itself, which keeps
+ * the host firmly in control of WHEN the sweep happens.
+ */
+export interface PgVectorEmbeddingChangeArgs {
+	readonly previousModel: string;
+	readonly previousDims: number;
+	readonly newModel: string;
+	readonly newDims: number;
+}
+
+/** One dispatched re-embed run. */
+export interface PgVectorReembedRunRef {
+	readonly workId: string;
+	readonly runId: string;
 }
 
 const PGVECTOR_PROVIDER_TYPE: VectorStoreProviderType = 'pgvector';
@@ -234,11 +297,13 @@ export class PgVectorPlugin extends BaseVectorStore {
 
 	private chunkRepository?: PgVectorChunkRepositoryPort;
 	private pingDatabase?: () => Promise<boolean>;
+	private reembedHook?: PgVectorReembedHook;
 
 	constructor(options: PgVectorPluginOptions = {}) {
 		super();
 		this.chunkRepository = options.chunkRepository;
 		this.pingDatabase = options.pingDatabase;
+		this.reembedHook = options.reembedHook;
 	}
 
 	/**
@@ -258,44 +323,114 @@ export class PgVectorPlugin extends BaseVectorStore {
 
 	async onUnload(): Promise<void> {
 		this.chunkRepository = undefined;
+		this.reembedHook = undefined;
 		await super.onUnload();
 	}
 
-	// TODO(EW-642 D7 follow-up): wire the settings-change → re-embed
-	// dispatch hook here. When the operator flips `embeddingModel` (or
-	// `embeddingDimensions`) in this plugin's settings UI, the host
-	// should fan out a `kb-reembed-work` Trigger.dev run per affected
-	// Work so the existing chunks get re-embedded against the new model
-	// before retrieval drifts into a mixed vector space.
-	//
-	// Expected call shape (KB_REEMBED_WORK_DISPATCHER lives in
-	// `@ever-works/agent/tasks`):
-	//
-	//   await dispatcher.dispatchKbReembedWork({
-	//       workId,
-	//       previousModel: oldSettings.embeddingModel,
-	//       newModel:      newSettings.embeddingModel,
-	//       newDims:       newSettings.embeddingDimensions,
-	//   });
-	//
-	// Sketch (host wires the dispatcher on `onLoad` via context):
-	//
-	//   async onSettingsChange(diff: SettingsDiff, ctx: PluginContext) {
-	//       if (diff.changed('embeddingModel') || diff.changed('embeddingDimensions')) {
-	//           const affectedWorkIds = await ctx.kb.listWorksUsingThisStore('pgvector');
-	//           for (const workId of affectedWorkIds) {
-	//               await ctx.dispatchers.kbReembedWork({
-	//                   workId,
-	//                   previousModel: diff.previous.embeddingModel,
-	//                   newModel: diff.next.embeddingModel,
-	//                   newDims: diff.next.embeddingDimensions,
-	//               });
-	//           }
-	//       }
-	//   }
-	//
-	// Out of scope for this slice — see `kb-reembed-work.task.ts` and
-	// `KnowledgeBaseReembedService` for the receiver side.
+	/**
+	 * Setter mirror of `setChunkRepository` — lets the host bind the
+	 * re-embed hook after construction (matches how the NestJS DI graph
+	 * wires the chunk repository on `onLoad`). Passing `undefined`
+	 * unbinds the hook; subsequent `handleEmbeddingSettingsChange`
+	 * calls then throw a `unavailable` error rather than silently
+	 * no-op'ing — silent drops on the re-embed path leave Works pinned
+	 * to a stale model with no operator signal, which the
+	 * `KbReembedWorkDispatcher` docstring explicitly forbids.
+	 */
+	setReembedHook(hook: PgVectorReembedHook | undefined): void {
+		this.reembedHook = hook;
+	}
+
+	/**
+	 * EW-642 D7 — fan a `kb-reembed-work` Trigger.dev run out over every
+	 * Work whose KB chunk store routes through this plugin instance.
+	 *
+	 * The host calls this method when the operator flips
+	 * `embeddingModel` or `embeddingDimensions` in the plugin's settings.
+	 * If neither changed, the call is a no-op (early return) — callers
+	 * can invoke it on every settings save without filtering first.
+	 *
+	 * Error semantics: the dispatch fans out sequentially. On the FIRST
+	 * dispatch failure the method throws, surfacing both the underlying
+	 * error AND the list of run-refs that DID dispatch successfully
+	 * before the failure. This trades a small risk of partial sweep for
+	 * a strong observability guarantee — the receiver task
+	 * (`kb-reembed-work` + `KnowledgeBaseReembedService`) is idempotent
+	 * because it watermarks every coordinate by `embedding_model`, so a
+	 * retry that re-dispatches an already-completed Work just no-ops
+	 * inside the task. Per the `KbReembedWorkDispatcher` docstring, "a
+	 * silent drop would leave a Work permanently on the old embedding
+	 * model with no operator signal" — propagating the error is the
+	 * intentional choice.
+	 *
+	 * Host wiring sketch — the actual call site lives in whatever
+	 * plugin-settings UPDATE handler the platform exposes (e.g.
+	 * `apps/api/src/works/works.module.ts` adapter that watches the
+	 * pgvector settings doc):
+	 *
+	 *   const diff = computeSettingsDiff(previous, next);
+	 *   if (diff.changed('embeddingModel') || diff.changed('embeddingDimensions')) {
+	 *       const result = await pgvectorPlugin.handleEmbeddingSettingsChange({
+	 *           previousModel: previous.embeddingModel,
+	 *           previousDims: previous.embeddingDimensions,
+	 *           newModel: next.embeddingModel,
+	 *           newDims: next.embeddingDimensions,
+	 *       });
+	 *       logger.log(`pgvector re-embed sweep dispatched ${result.length} runs`);
+	 *   }
+	 *
+	 * The dispatcher + affected-works port are bound via
+	 * `setReembedHook` (or `PgVectorPluginOptions.reembedHook` at
+	 * construction time). See the in-flight slice-2 dispatcher token
+	 * `KB_REEMBED_WORK_DISPATCHER` in `@ever-works/agent/tasks` for the
+	 * platform-side producer.
+	 */
+	async handleEmbeddingSettingsChange(
+		args: PgVectorEmbeddingChangeArgs
+	): Promise<ReadonlyArray<PgVectorReembedRunRef>> {
+		// No model or dim change → nothing to do. Lets the host invoke
+		// this on every settings save without diffing first.
+		if (args.previousModel === args.newModel && args.previousDims === args.newDims) {
+			return [];
+		}
+
+		if (!this.reembedHook) {
+			throw this.wrapVendorError(
+				new Error(
+					'pgvector re-embed hook not wired in — call setReembedHook() on the plugin before changing embeddingModel / embeddingDimensions'
+				),
+				'unavailable',
+				false
+			);
+		}
+
+		const { dispatcher, affectedWorks } = this.reembedHook;
+		const workIds = await affectedWorks.listAffectedWorkIds();
+
+		const dispatched: PgVectorReembedRunRef[] = [];
+		for (const workId of workIds) {
+			try {
+				const runId = await dispatcher.dispatchKbReembedWork({
+					workId,
+					previousModel: args.previousModel,
+					newModel: args.newModel,
+					newDims: args.newDims
+				});
+				dispatched.push({ workId, runId });
+			} catch (err) {
+				const cause = err instanceof Error ? err.message : String(err);
+				throw this.wrapVendorError(
+					new Error(
+						`kb-reembed-work dispatch failed for work=${workId} after ${dispatched.length} prior successful dispatch(es); cause: ${cause}`
+					),
+					'internal',
+					true
+				);
+			}
+		}
+
+		return dispatched;
+	}
 
 	/** Cosine distance ∈ `[0, 2]` → normalized ∈ `[0, 1]`. */
 	normalize(rawScore: number): number {


### PR DESCRIPTION
## Summary

Closes the open follow-up from EW-725 (slice 2): the pgvector plugin TODO at the settings-change site is replaced with a real public method the host calls when `embeddingModel` or `embeddingDimensions` flips in the plugin's settings.

This ships the **plugin-side primitive**. The host-side observer that detects a pgvector settings update and calls this method is intentionally deferred — there is no plugin-settings event-bus surface today, and building one is a separate epic. When that infrastructure lands, the host wiring becomes a 5-line adapter.

## What lands

`PgVectorPlugin.handleEmbeddingSettingsChange(args)`:

- Early-returns when neither model nor dims changed (host can invoke on every settings save without diffing first).
- Asks the injected `PgVectorAffectedWorksPort` for the list of Works currently routing through this plugin instance.
- Fans `dispatcher.dispatchKbReembedWork({ workId, previousModel, newModel, newDims })` out per Work, sequentially.
- Throws on the **first dispatch failure**, surfacing both the underlying cause AND the count of already-dispatched runs so the operator sees the partial-sweep state. The receiver task (slice 2's `kb-reembed-work` + `KnowledgeBaseReembedService`) is **idempotent on `embedding_model`**, so retrying the full settings-change handler is safe.
- Throws `unavailable` when the hook is not wired in — silent drops would leave Works on stale models with no operator signal, which `KbReembedWorkDispatcher`'s docstring explicitly forbids.

New `setReembedHook(hook | undefined)` setter mirroring the existing `setChunkRepository` pattern. Constructor option `reembedHook` for full-init wiring; passing `undefined` unbinds.

New local types kept inside the plugin package so it doesn't take a hard dependency on `@ever-works/agent`:
- `PgVectorReembedDispatcher` (one-method interface, trivially adapted from `KbReembedWorkDispatcher` at the call site)
- `PgVectorAffectedWorksPort`
- `PgVectorReembedHook`
- `PgVectorEmbeddingChangeArgs`
- `PgVectorReembedRunRef`

The multi-line TODO comment is replaced with a JSDoc block on the new method that includes the host wiring sketch.

## Test coverage

8 new cases in `packages/plugins/pgvector/src/__tests__/pgvector.reembed-hook.spec.ts`:
1. No-op when neither model nor dims change (no port query — avoids a stray DB hit on every save).
2. Fans dispatches when `embeddingModel` changes.
3. Fans dispatches when `embeddingDimensions` changes.
4. Empty list when no Works route through the plugin.
5. Throws when hook unwired (silent-drop prevention).
6. Partial-sweep failure propagates with context (names the failed Work + count of prior successful dispatches).
7. Hook accepted via constructor option (parity with `setReembedHook`).
8. `setReembedHook(undefined)` unbinds; subsequent calls throw.

**22/22 pgvector tests passing** (14 existing contract + 8 new reembed-hook). `@ever-works/pgvector-plugin` type-check clean.

## What's NOT in this PR

- Host-side wiring (the `apps/api` settings-update endpoint that observes a pgvector settings flip and calls into this method).
- A plugin-settings event-bus surface on the platform — separate epic, deliberately out of scope.

Refs: EW-642, EW-725 (slice 2 dispatcher), EW-724 (slice 1 contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * pgvector plugin now supports automatic re-embedding of documents when embedding model or dimensions settings change. Configure the re-embed hook during plugin initialization or dynamically via the new binding method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->