### PR TITLE
fix(monitoring): stop recording health-check / probe traffic in PostHog

### DIFF
--- a/apps/api/src/api.controller.spec.ts
+++ b/apps/api/src/api.controller.spec.ts
@@ -176,27 +176,28 @@ describe('APIController', () => {
     });
 
     describe('healthCheck', () => {
-        it('delegates to home() and returns the same envelope', () => {
-            const homeSpy = jest.spyOn(controller, 'home');
-
+        it('returns the same success envelope as home()', () => {
             const result = controller.healthCheck();
 
-            expect(homeSpy).toHaveBeenCalledTimes(1);
             expect(result).toEqual({ status: 'success', message: 'API is up and running' });
         });
 
-        it('emits an analytics track event (delegates through home())', () => {
+        it('does NOT emit any analytics event — probe traffic must not reach PostHog', () => {
+            // Health/probe endpoints (k8s liveness/readiness + uptime monitors) hit
+            // this every few seconds; tracking them floods PostHog with machine noise
+            // and bills per event. healthCheck() therefore returns the status payload
+            // directly instead of delegating to home() (which fires api_home_visit).
             controller.healthCheck();
 
-            // Health check still goes through the same code path, so analytics
-            // fires. Sentry/PostHog noise filtering happens at the
-            // monitoring-package level, not in this controller.
-            expect(analytics.track).toHaveBeenCalledTimes(1);
-            expect(analytics.track).toHaveBeenCalledWith(
-                'anonymous',
-                'api_home_visit',
-                expect.objectContaining({ endpoint: '/' }),
-            );
+            expect(analytics.track).not.toHaveBeenCalled();
+        });
+
+        it('does not delegate to home() (which would emit api_home_visit)', () => {
+            const homeSpy = jest.spyOn(controller, 'home');
+
+            controller.healthCheck();
+
+            expect(homeSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/apps/api/src/api.controller.ts
+++ b/apps/api/src/api.controller.ts
@@ -34,7 +34,7 @@ export class APIController {
             timestamp: new Date().toISOString(),
         });
 
-        return { status: 'success', message: 'API is up and running' };
+        return this.status();
     }
 
     @Public()
@@ -43,9 +43,20 @@ export class APIController {
     @ApiOperation({ summary: 'Health check', description: 'Check API health status' })
     @ApiResponse({ status: 200, description: 'API is healthy' })
     healthCheck() {
-        // Health check endpoints are filtered from Sentry and PostHog
-        // to avoid noise in monitoring
-        return this.home();
+        // Health-check / probe endpoints are deliberately NOT tracked in PostHog —
+        // k8s liveness/readiness probes + uptime monitors hit this every few seconds,
+        // which would flood analytics with machine noise (and bill per event). Note we
+        // return the status payload DIRECTLY rather than delegating to home(): home()
+        // fires the `api_home_visit` event, so calling it here previously made every
+        // probe masquerade as a home visit. The PostHogInterceptor also skips this path.
+        return this.status();
+    }
+
+    // Shared, side-effect-free status payload. Kept separate from home() so the health
+    // probe can reuse the response shape without emitting the `api_home_visit` analytics
+    // event that home() fires for genuine `/` visits.
+    private status() {
+        return { status: 'success', message: 'API is up and running' };
     }
 
     /**

--- a/packages/monitoring/src/interceptors/__tests__/posthog.interceptor.spec.ts
+++ b/packages/monitoring/src/interceptors/__tests__/posthog.interceptor.spec.ts
@@ -99,6 +99,43 @@ describe('PostHogInterceptor', () => {
         expect(apiRequestCall![0].properties.ip).toBe('10.0.0.1');
     });
 
+    it.each(['/api/health', '/api/health/live', '/api/health/ready', '/api/health/'])(
+        'does NOT capture any event for health/probe path %s',
+        async (originalUrl) => {
+            initPostHog({ apiKey: 'k' });
+            const req = {
+                method: 'GET',
+                originalUrl,
+                headers: { 'user-agent': 'kube-probe' },
+                body: undefined,
+            };
+            const next: CallHandler = { handle: () => of({ ok: true }) };
+
+            // The request still flows through untouched...
+            await expect(
+                lastValueFrom(interceptor.intercept(buildExecCtx(req), next)),
+            ).resolves.toEqual({ ok: true });
+            // ...but nothing is sent to PostHog.
+            expect(captureMock).not.toHaveBeenCalled();
+        },
+    );
+
+    it('still captures for non-probe paths that merely start with "health"', async () => {
+        initPostHog({ apiKey: 'k' });
+        const req = {
+            method: 'GET',
+            originalUrl: '/api/healthcheck-foo',
+            headers: {},
+            body: undefined,
+        };
+        const next: CallHandler = { handle: () => of({}) };
+        await lastValueFrom(interceptor.intercept(buildExecCtx(req), next));
+
+        // Exemption is narrow (exact `/api/health` or `/api/health/` prefix), so this
+        // unrelated route is still tracked.
+        expect(captureMock).toHaveBeenCalled();
+    });
+
     it('replaces numeric IDs with :id and lowercases the named-event slug', async () => {
         initPostHog({ apiKey: 'k' });
         const req = {

--- a/packages/monitoring/src/interceptors/posthog.interceptor.ts
+++ b/packages/monitoring/src/interceptors/posthog.interceptor.ts
@@ -15,6 +15,17 @@ export class PostHogInterceptor implements NestInterceptor {
         // ?api_key=) that must not be persisted in third-party analytics.
         const endpointPath = this.getEndpointPath(originalUrl);
 
+        // Do NOT record analytics for health-check / probe endpoints. k8s liveness +
+        // readiness probes (plus uptime monitors / load balancers) hit these every few
+        // seconds on every replica, around the clock. Each probe would otherwise emit an
+        // `api_request` event plus a per-endpoint `api_get_api_health` event — pure
+        // machine noise that bills per event and tells us nothing about real product
+        // usage. Covers `/api/health`, `/api/health/live`, `/api/health/ready`
+        // (see APIController + HealthController).
+        if (this.isHealthProbePath(endpointPath)) {
+            return next.handle();
+        }
+
         const startTime = Date.now();
 
         return next.handle().pipe(
@@ -60,6 +71,16 @@ export class PostHogInterceptor implements NestInterceptor {
     private getEndpointPath(url: string): string {
         if (!url) return url;
         return url.split('?')[0].split('#')[0];
+    }
+
+    // Health-check / probe endpoints we never want in analytics. Matches the base
+    // `/api/health` liveness route plus the `/api/health/live` + `/api/health/ready`
+    // probes underneath it. Kept narrow (exact match or `/api/health/` prefix) so an
+    // unrelated future route like `/api/healthcheck-foo` would NOT be silently dropped.
+    private isHealthProbePath(path: string): boolean {
+        if (!path) return false;
+        const normalized = path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+        return normalized === '/api/health' || normalized.startsWith('/api/health/');
     }
 
     private getEndpointName(url: string): string {


### PR DESCRIPTION
## Why

PostHog event volume spiked from **~350 events/day to ~450k/day starting May 31** — and ~98% of it is machine noise, not real usage. Root cause: the backend monitoring layer captures an event on every request + every log line, with **no exemption for health-check / probe traffic**.

Live PostHog data (project 144390, last 10 days) — top events:

| Event | Count | Source |
|---|---|---|
| `$log` | 1,013,436 | NestJS log forwarding (kept for now) |
| `api_request` | 839,340 | Interceptor, every request |
| `api_home_visit` | 773,300 | `home()` — fired on every `/api/health` via delegation |
| `api_get_api_health` | 773,291 | Interceptor, `/api/health` probe |

`api_home_visit` ≈ `api_get_api_health` because **every `GET /api/health` probe fired all three** — `healthCheck()` delegated to `home()`, and the interceptor had no path filter. k8s liveness/readiness + uptime monitors hit `/api/health` ~1.2×/sec per replica, around the clock.

## What

**Scope: exclude ONLY health/probe traffic. Everything else is kept as-is** (per request: `$log` forwarding, real-endpoint `api_request`, etc. all unchanged).

- **`PostHogInterceptor`** — skip both `trackEvent` calls for `/api/health`, `/api/health/live`, `/api/health/ready`. Narrow exact/prefix match, so an unrelated route like `/api/healthcheck-foo` is still tracked. The request flows through untouched; only the analytics capture is skipped.
- **`APIController.healthCheck()`** — return the status payload directly instead of delegating to `home()`, so probes no longer masquerade as `api_home_visit`. `home()` still fires `api_home_visit` for genuine `/` visits. Makes the existing *"filtered from Sentry and PostHog"* comment finally true.

Expected effect: removes `api_get_api_health` (~773k), the `api_request` duplicates for probes (~773k of 839k), and the probe-driven `api_home_visit` (~773k) — i.e. the bulk of the volume — while preserving all real-usage analytics.

## Tests
- `PostHogInterceptor`: 4 new cases — `/api/health[/live|/ready|/]` capture nothing; near-miss `/api/healthcheck-foo` still captured. (10/10 pass)
- `APIController.healthCheck`: updated to assert no `api_home_visit` and no `home()` delegation. (16/16 pass)
- `monitoring` package `tsc --noEmit`: clean.

## Follow-ups (deferred, not in this PR)
Two further reductions discussed but intentionally left for later: (2) gate `$log` forwarding to warn/error only (the `$log` event is ~1M/mo, 99% info-level), (3) drop the HTTP request/response logging from the PostHog sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)