### PR TITLE
release: develop → stage (suppress health-probe HTTP logs #1251)

### DIFF
--- a/apps/api/src/logging.interceptor.spec.ts
+++ b/apps/api/src/logging.interceptor.spec.ts
@@ -79,13 +79,14 @@ describe('LoggingInterceptor', () => {
 
         it('logs the incoming request line synchronously before subscribing', async () => {
             const next: CallHandler = { handle: () => of('payload') };
-            const ctx = buildContext({ method: 'GET', originalUrl: '/api/health' });
+            const ctx = buildContext({ method: 'GET', originalUrl: '/api/works' });
 
             const result$ = interceptor.intercept(ctx, next);
 
             // Incoming-Request line fires synchronously inside `intercept`
-            // before any subscription happens.
-            expect(logSpy).toHaveBeenCalledWith('Incoming Request: GET /api/health');
+            // before any subscription happens. (Uses a non-health path — health
+            // probes are deliberately NOT logged; see the suppression block below.)
+            expect(logSpy).toHaveBeenCalledWith('Incoming Request: GET /api/works');
 
             await lastValueFrom(result$);
         });
@@ -217,6 +218,57 @@ describe('LoggingInterceptor', () => {
             await expect(lastValueFrom(interceptor.intercept(ctx, next))).rejects.toBe(err);
 
             expect(errorSpy).toHaveBeenCalledWith('Error Response: GET /api/x 500 - 250ms');
+        });
+    });
+
+    describe('health/probe suppression (debug-on)', () => {
+        beforeEach(() => {
+            process.env.HTTP_DEBUG = 'true';
+        });
+
+        it.each([
+            '/api/health',
+            '/api/health/live',
+            '/api/health/ready',
+            '/api/health/',
+            '/api/health?x=1',
+        ])('logs NOTHING for a successful health/probe request to %s', async (originalUrl) => {
+            const next: CallHandler = { handle: () => of('ok') };
+            const ctx = buildContext({ method: 'GET', originalUrl });
+
+            await expect(lastValueFrom(interceptor.intercept(ctx, next))).resolves.toBe('ok');
+
+            expect(logSpy).not.toHaveBeenCalled();
+            expect(errorSpy).not.toHaveBeenCalled();
+        });
+
+        it('STILL logs an error raised inside a health endpoint (failing readiness probe)', async () => {
+            const err = { response: { statusCode: 503 }, message: 'db down' };
+            const next: CallHandler = { handle: () => throwError(() => err) };
+            const ctx = buildContext({ method: 'GET', originalUrl: '/api/health/ready' });
+
+            await expect(lastValueFrom(interceptor.intercept(ctx, next))).rejects.toBe(err);
+
+            // No incoming/outgoing noise...
+            expect(logSpy).not.toHaveBeenCalled();
+            // ...but the error IS logged — that's the signal we want to keep.
+            const errorCall = errorSpy.mock.calls.find((c) =>
+                String(c[0]).startsWith('Error Response'),
+            );
+            expect(errorCall).toBeDefined();
+            expect(errorCall![0]).toMatch(/^Error Response: GET \/api\/health\/ready 503 - \d+ms$/);
+        });
+
+        it('still logs normally for a non-probe path that merely starts with "health"', async () => {
+            const next: CallHandler = { handle: () => of('ok') };
+            const ctx = buildContext({ method: 'GET', originalUrl: '/api/healthcheck-foo' });
+
+            await lastValueFrom(interceptor.intercept(ctx, next));
+
+            expect(logSpy).toHaveBeenCalledWith('Incoming Request: GET /api/healthcheck-foo');
+            expect(
+                logSpy.mock.calls.some((c) => String(c[0]).startsWith('Outgoing Response')),
+            ).toBe(true);
         });
     });
 });

--- a/apps/api/src/logging.interceptor.ts
+++ b/apps/api/src/logging.interceptor.ts
@@ -16,7 +16,18 @@ export class LoggingInterceptor implements NestInterceptor {
         const request = context.switchToHttp().getRequest();
         const { method, originalUrl } = request;
 
-        this.logger.log(`Incoming Request: ${method} ${originalUrl}`);
+        // Health-check / probe endpoints are hit every few seconds by k8s
+        // liveness/readiness probes + uptime monitors on every replica, around
+        // the clock. We do NOT want their request/response lines in the logs —
+        // they're forwarded to PostHog as `$log` events and drown out real
+        // signal (and bill per event). We STILL log errors raised inside a
+        // health endpoint though (the catchError branch below runs regardless):
+        // a failing readiness probe is exactly the signal we want to keep.
+        const isHealthProbe = this.isHealthProbePath(originalUrl);
+
+        if (!isHealthProbe) {
+            this.logger.log(`Incoming Request: ${method} ${originalUrl}`);
+        }
 
         return next.handle().pipe(
             catchError((err) => {
@@ -32,6 +43,12 @@ export class LoggingInterceptor implements NestInterceptor {
             }),
 
             tap(() => {
+                // Skip the success-response line for health/probe traffic. Errors
+                // still go through the catchError branch above and are logged.
+                if (isHealthProbe) {
+                    return;
+                }
+
                 const response = context.switchToHttp().getResponse();
                 const { statusCode } = response;
                 const delay = Date.now() - now;
@@ -41,5 +58,16 @@ export class LoggingInterceptor implements NestInterceptor {
                 );
             }),
         );
+    }
+
+    // Match `/api/health` exactly plus the `/api/health/live` + `/api/health/ready`
+    // probes under it. Query string / fragment are stripped first. Kept narrow
+    // (exact match or `/api/health/` prefix) so an unrelated route like
+    // `/api/healthcheck-foo` is still logged normally.
+    private isHealthProbePath(url: string): boolean {
+        if (!url) return false;
+        const path = url.split('?')[0].split('#')[0];
+        const normalized = path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+        return normalized === '/api/health' || normalized.startsWith('/api/health/');
     }
 }


### PR DESCRIPTION
Cascade `develop → stage`. Promotes the one commit ahead of `stage`:

- **#1251** `fix(api): stop logging health-check / probe request lines` — follow-up to #1248. `LoggingInterceptor` no longer emits "Incoming Request" / "Outgoing Response" lines for `/api/health*` (which were ~900k `$log` events forwarded to PostHog). Errors raised inside health endpoints are still logged. Non-health logging unchanged.

No schema/migration changes. `lint-and-test` green on #1251; e2e shards carry the known pre-existing flake (see #1245/#1249). Fast-tracking to production at operator request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)