### PR TITLE
fix(k8s): stop emptyDir shadowing baked plugins at /app/plugins (prod chat outage)

### DIFF
--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -386,33 +386,29 @@ spec:
           volumeMounts:
             - name: git-repos
               mountPath: /tmp/ever-works-repos
-            # EW-693 / T30 — Writable runtime plugin store. Default
-            # PLUGIN_INSTALL_DIR is `/app/plugins`, set in
-            # apps/api/src/config/constants.ts. emptyDir is per-pod
-            # ephemeral, which is exactly what FR-13 expects: each
-            # replica's installer lazily installs distributable plugins
-            # on first use, and boot warmup pre-installs the DB-recorded
-            # set. NO shared RWX volume is required.
+            # NOTE (incident 2026-06-07): do NOT mount any volume at
+            # `/app/plugins` while running in `PLUGIN_DISTRIBUTION_MODE=bundled`.
+            # The bundled image BAKES all ~66 plugins into `/app/plugins`
+            # (Dockerfile `.deploy/docker/api/Dockerfile` →
+            # `COPY --from=installer /app/deploy/plugins ./plugins`). An
+            # `emptyDir` here shadows them, so `PluginLoaderService`
+            # discovers 0 plugins, the registry stays empty, and every
+            # AI / search / deploy capability (incl. the chat assistant)
+            # fails with `<capability> provider not found`. That is exactly
+            # the outage this volume previously caused.
             #
-            # For deployments that want to avoid cold-start install
-            # cost, swap `emptyDir` for a `persistentVolumeClaim` with
-            # `ReadWriteOnce` (the API's StatefulSet semantics tolerate
-            # per-pod PVCs). A shared `ReadWriteMany` PVC is supported
-            # but NOT required.
-            - name: plugin-install-dir
-              mountPath: /app/plugins
+            # The EW-693 dynamic installer's writable store
+            # (`PLUGIN_INSTALL_DIR`, default `/app/plugins`) is only needed
+            # when `PLUGIN_DISTRIBUTION_MODE=dynamic`. When dynamic mode is
+            # adopted here, point `PLUGIN_INSTALL_DIR` at a SEPARATE path
+            # (e.g. `/app/plugins-runtime`) and mount the writable volume
+            # THERE so it never shadows the baked core plugins — do not
+            # re-add a mount at `/app/plugins`.
 
       volumes:
         - name: git-repos
           emptyDir:
             sizeLimit: 5Gi
-        # EW-693 / T30 — see volumeMounts above. 2Gi covers ~40
-        # distributable plugins at typical sizes (notion-extractor ≈
-        # 18 MB, screenshot plugins ≈ 5 MB, AI providers ≈ 1-5 MB);
-        # tighten or bump after observability confirms real usage.
-        - name: plugin-install-dir
-          emptyDir:
-            sizeLimit: 2Gi
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
@
## Incident: production chat (and all AI/search/deploy) down

**Symptom.** `POST /api/v1/chat/completions` returned `422 {"error":{"message":"ai-provider provider not found: openrouter","type":"provider_unavailable"}}`. The web chat assistant silently failed. No Sentry errors (the controller maps provider errors to a handled 422, so nothing was thrown/logged).

**Root cause.** The prod API Deployment mounts an **empty `plugin-install-dir` `emptyDir` at `/app/plugins`**. The bundled Docker image **bakes all ~66 plugins into `/app/plugins`** (`.deploy/docker/api/Dockerfile`: `COPY --from=installer /app/deploy/plugins ./plugins`). The empty volume **shadows** them, so on boot:

```
[PluginLoaderService] Discovered 0 plugins
[PluginBootstrapService] Plugin registration complete: 0 ready, 0 failed
```

→ empty registry → every `resolvePlugin()` throws `<capability> provider not found` → chat, generation, search, deploy all broken.

`dev` and `stage` manifests never had this mount, which is why **only prod** broke. Regression from #1216 (EW-693 dynamic plugin distribution): it both started baking plugins into `/app/plugins` *and* added the writable-store mount at the same path. In `bundled` mode (current prod) the warmup/installer is a no-op, so the mount is pure downside.

**Verification (live prod, before fix).** Image confirmed to contain `/app/plugins/{openrouter,anthropic,openai,...}` (66 dirs) underneath the mount; with the mount, `GET /api/plugins` returned `{"total":0}`.

## Fix

Remove the `/app/plugins` `volumeMount` + `volume` from `k8s-manifest.prod.yaml` (now matches dev/stage). Bundled plugins are read-only from the image; no writable store is needed in `bundled` mode. Added a prominent comment so it is not re-introduced.

When `PLUGIN_DISTRIBUTION_MODE=dynamic` is eventually adopted in prod, the writable install dir must use a **separate** path (e.g. `PLUGIN_INSTALL_DIR=/app/plugins-runtime`) so it never shadows the baked core plugins — see follow-up note in the comment.

## Status

- **Immediate prod relief already applied** out-of-band via `kubectl patch` (removed the mount + volume; rollout healthy). Registry recovered **0 → 66 plugins**; chat verified **HTTP 200** (non-streaming + streaming).
- This PR makes that change durable through the normal `develop → stage → main` cascade (the live patch would otherwise be reverted on the next prod deploy).

## Follow-up (separate)

EW-693 dynamic mode needs the install-dir-vs-baked-plugins path separation before it can be enabled in any env. Filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where plugins would not load correctly in bundled mode. Updated deployment configuration to ensure proper plugin distribution when using the bundled image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->