### PR TITLE
fix(security): secret/permission hardening — D2/D3/D6/D9 (EW-715/716 + agent-export)

### DIFF
--- a/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { AgentExportService, type AgentExportEnvelope } from '../agent-export.service';
 import {
+    AGENT_PERMISSIONS_DEFAULT,
     AgentAvatarMode,
     AgentIdleBehavior,
     AgentScope,
@@ -221,6 +222,68 @@ describe('AgentExportService', () => {
             const env = baseEnvelope();
             env.files.toolsMd = 'GH=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
             await expect(svc.importOne('u1', env)).rejects.toThrow(/Secret-like/);
+        });
+
+        // Security (D9) — clamp imported permissions to least-privilege.
+        // The envelope is attacker-editable, so an import must NEVER carry
+        // its `runtime.permissions` into the created/overwritten Agent;
+        // every imported Agent starts at the all-false frozen default and
+        // the owner must explicitly re-grant.
+        describe('permission clamp (D9)', () => {
+            const elevatedEnvelope = (): AgentExportEnvelope => {
+                const env = baseEnvelope();
+                env.runtime.permissions = {
+                    canCreateAgents: true,
+                    canAssignTasks: true,
+                    canEditSkills: true,
+                    canEditAgentFiles: true,
+                    canSpend: true,
+                    canCommitToRepo: true,
+                    canOpenPullRequests: true,
+                    canCallExternalTools: true,
+                };
+                return env;
+            };
+
+            it('does NOT honour elevated envelope permissions on create — clamps to AGENT_PERMISSIONS_DEFAULT', async () => {
+                agents.findByUserIdAndSlug.mockResolvedValue(null);
+                agents.create.mockResolvedValueOnce(
+                    makeAgent({ id: 'new-a', status: AgentStatus.DRAFT }),
+                );
+                await svc.importOne('u1', elevatedEnvelope());
+
+                const createArg = agents.create.mock.calls[0][0];
+                expect(createArg.permissions).toEqual(AGENT_PERMISSIONS_DEFAULT);
+                // Every flag is false — no privilege escalation across import.
+                expect(Object.values(createArg.permissions).every((v) => v === false)).toBe(true);
+            });
+
+            it('clamps permissions on the overwrite path too', async () => {
+                const existing = makeAgent({ id: 'existing-ceo' });
+                agents.findByUserIdAndSlug.mockResolvedValueOnce(existing);
+                agents.findById.mockResolvedValueOnce(existing);
+                await svc.importOne('u1', elevatedEnvelope(), { onConflict: 'overwrite' });
+
+                expect(agents.updateById).toHaveBeenCalledWith(
+                    'existing-ceo',
+                    expect.objectContaining({ permissions: AGENT_PERMISSIONS_DEFAULT }),
+                );
+                const patch = agents.updateById.mock.calls[0][1];
+                expect(Object.values(patch.permissions).every((v) => v === false)).toBe(true);
+            });
+
+            it('legit import (default permissions) still creates a draft Agent unchanged', async () => {
+                // baseEnvelope already carries the all-false default set.
+                agents.findByUserIdAndSlug.mockResolvedValue(null);
+                agents.create.mockResolvedValueOnce(
+                    makeAgent({ id: 'new-a', status: AgentStatus.DRAFT }),
+                );
+                const res = await svc.importOne('u1', baseEnvelope());
+                expect(res.conflictResolution).toBe('none');
+                const createArg = agents.create.mock.calls[0][0];
+                expect(createArg.permissions).toEqual(AGENT_PERMISSIONS_DEFAULT);
+                expect(createArg.status).toBe(AgentStatus.DRAFT);
+            });
         });
 
         // Security (EW-711 #8) — scope-ownership IDOR. The scope columns are

--- a/packages/agent/src/agents/agent-export.service.ts
+++ b/packages/agent/src/agents/agent-export.service.ts
@@ -409,13 +409,17 @@ export class AgentExportService {
             }
         }
 
-        const permissions: AgentPermissions = {
-            ...AGENT_PERMISSIONS_DEFAULT,
-            ...envelope.runtime.permissions,
-        };
-        if (permissions.canOpenPullRequests && !permissions.canCommitToRepo) {
-            permissions.canCommitToRepo = true;
-        }
+        // Security (D9): clamp imported permissions to least-privilege.
+        // The envelope's `runtime.permissions` is attacker-controllable
+        // (it round-trips through an off-platform JSON file an importer
+        // can hand-edit), so honouring it would let an import grant an
+        // Agent ELEVATED capabilities the importer may not be entitled to
+        // (privilege escalation across import). Start every imported Agent
+        // at the all-false frozen default — the owner must explicitly
+        // re-grant capabilities via the normal permissions UI after
+        // vetting the imported Agent (which also starts in DRAFT). We
+        // deliberately do NOT spread `envelope.runtime.permissions` here.
+        const permissions: AgentPermissions = { ...AGENT_PERMISSIONS_DEFAULT };
 
         // Image uploads from a different tenant are not visible to this
         // user — fall back to initials so the import never 404s on a
@@ -604,7 +608,13 @@ export class AgentExportService {
             aiProviderId: envelope.model.aiProviderId,
             modelId: envelope.model.modelId,
             maxSkillContextTokens: envelope.model.maxSkillContextTokens,
-            permissions: envelope.runtime.permissions,
+            // Security (D9): clamp imported permissions to least-privilege
+            // on the overwrite path too — the envelope is attacker-editable,
+            // so an overwrite import must NOT silently elevate an existing
+            // Agent beyond the all-false frozen default. Mirrors the
+            // create-path clamp in `importOne`; the owner re-grants
+            // explicitly after vetting. Deliberately not the envelope value.
+            permissions: { ...AGENT_PERMISSIONS_DEFAULT },
             targets: envelope.runtime.targets,
             heartbeatCadence: envelope.runtime.heartbeatCadence,
             idleBehavior: envelope.runtime.idleBehavior,

--- a/packages/agent/src/plugins/__tests__/plugin-context-factory.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-context-factory.service.spec.ts
@@ -420,8 +420,27 @@ describe('PluginContextFactoryService', () => {
     });
 
     describe('EnvironmentVariables', () => {
+        // The plugin must DECLARE the env var it reads via the `x-envVar`
+        // JSON-Schema extension; `TEST_VAR` is declared on the mock plugin's
+        // settings schema below so the legitimate happy path keeps working.
+        const createPluginDeclaringEnvVar = (envVarName: string): RegisteredPlugin => {
+            const registered = createRegisteredPlugin();
+            (registered.plugin as any).settingsSchema = {
+                type: 'object',
+                properties: {
+                    apiKey: {
+                        type: 'string',
+                        'x-secret': true,
+                        'x-envVar': envVarName,
+                    },
+                },
+            };
+            return registered;
+        };
+
         beforeEach(() => {
             process.env.TEST_VAR = 'test-value';
+            jest.spyOn(registry, 'get').mockReturnValue(createPluginDeclaringEnvVar('TEST_VAR'));
         });
 
         afterEach(() => {
@@ -456,6 +475,101 @@ describe('PluginContextFactoryService', () => {
             expect(() => context.envVars.getRequired('NON_EXISTENT')).toThrow(
                 'Required environment variable "NON_EXISTENT" is not set',
             );
+        });
+
+        describe('allowlist (security)', () => {
+            const SECRET_ENV_KEYS = ['DATABASE_URL', 'AUTH_SECRET', 'AWS_SECRET_KEY'];
+
+            beforeEach(() => {
+                process.env.DATABASE_URL = 'postgres://secret';
+                process.env.AUTH_SECRET = 'super-secret';
+                process.env.AWS_SECRET_KEY = 'aws-secret';
+                // A different plugin's declared key, which THIS plugin must not read.
+                process.env.OTHER_PLUGIN_API_KEY = 'other-key';
+            });
+
+            afterEach(() => {
+                for (const key of [...SECRET_ENV_KEYS, 'OTHER_PLUGIN_API_KEY']) {
+                    delete process.env[key];
+                }
+            });
+
+            it('blocks reading undeclared platform secrets via every accessor', () => {
+                const context = service.createContext('test-plugin');
+
+                for (const key of SECRET_ENV_KEYS) {
+                    expect(context.envVars.get(key)).toBeUndefined();
+                    expect(context.envVars.getOrDefault(key, 'fallback')).toBe('fallback');
+                    expect(context.envVars.has(key)).toBe(false);
+                    expect(() => context.envVars.getRequired(key)).toThrow(
+                        `Required environment variable "${key}" is not set`,
+                    );
+                }
+            });
+
+            it("blocks reading another plugin's declared env var", () => {
+                // This plugin declares only TEST_VAR; OTHER_PLUGIN_API_KEY belongs
+                // to a different plugin and must not be reachable.
+                const context = service.createContext('test-plugin');
+
+                expect(context.envVars.get('OTHER_PLUGIN_API_KEY')).toBeUndefined();
+                expect(context.envVars.has('OTHER_PLUGIN_API_KEY')).toBe(false);
+            });
+
+            it('allows reading a key the plugin declared via x-envVar', () => {
+                process.env.FOO_KEY = 'foo-value';
+                jest.spyOn(registry, 'get').mockReturnValue(createPluginDeclaringEnvVar('FOO_KEY'));
+
+                const context = service.createContext('test-plugin');
+
+                expect(context.envVars.get('FOO_KEY')).toBe('foo-value');
+                expect(context.envVars.has('FOO_KEY')).toBe(true);
+                expect(context.envVars.getRequired('FOO_KEY')).toBe('foo-value');
+                // ...but still cannot reach unrelated secrets.
+                expect(context.envVars.get('DATABASE_URL')).toBeUndefined();
+
+                delete process.env.FOO_KEY;
+            });
+
+            it('collects x-envVar names declared under anyOf/allOf/oneOf branches', () => {
+                process.env.COMPOSED_KEY = 'composed-value';
+                const registered = createRegisteredPlugin();
+                (registered.plugin as any).settingsSchema = {
+                    type: 'object',
+                    anyOf: [
+                        {
+                            properties: {
+                                token: {
+                                    type: 'string',
+                                    'x-envVar': 'COMPOSED_KEY',
+                                },
+                            },
+                        },
+                    ],
+                };
+                jest.spyOn(registry, 'get').mockReturnValue(registered);
+
+                const context = service.createContext('test-plugin');
+
+                expect(context.envVars.get('COMPOSED_KEY')).toBe('composed-value');
+                expect(context.envVars.get('DATABASE_URL')).toBeUndefined();
+
+                delete process.env.COMPOSED_KEY;
+            });
+
+            it('allows the fixed non-sensitive platform env (NODE_ENV)', () => {
+                const previous = process.env.NODE_ENV;
+                process.env.NODE_ENV = 'test';
+                // A plugin declaring no env vars at all.
+                jest.spyOn(registry, 'get').mockReturnValue(createRegisteredPlugin());
+
+                const context = service.createContext('test-plugin');
+
+                expect(context.envVars.get('NODE_ENV')).toBe('test');
+                expect(context.envVars.get('DATABASE_URL')).toBeUndefined();
+
+                process.env.NODE_ENV = previous;
+            });
         });
     });
 

--- a/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
@@ -159,6 +159,9 @@ describe('PluginOperationsService', () => {
                     useValue: {
                         resolveSettings: jest.fn().mockResolvedValue({}),
                         getResolvedSettings: jest.fn().mockResolvedValue({}),
+                        // D3 / C-08 — encrypting write path that enable-time
+                        // secrets must be routed through.
+                        updateUserSettings: jest.fn().mockResolvedValue(undefined),
                     },
                 },
                 {
@@ -976,7 +979,7 @@ describe('PluginOperationsService', () => {
             );
         });
 
-        it('should save secret settings on enablePluginForUser', async () => {
+        it('should route enable-time secret settings through the encrypting write path (D3 / C-08)', async () => {
             const registered = createRegisteredPlugin();
             jest.spyOn(pluginRegistryService, 'get').mockReturnValue(registered);
             jest.spyOn(pluginRepository, 'findOne').mockResolvedValue({
@@ -984,16 +987,60 @@ describe('PluginOperationsService', () => {
                 pluginId: 'test-plugin',
             } as any);
             jest.spyOn(userPluginRepository, 'findOne').mockResolvedValue(null);
+            const updateUserSettingsSpy = jest.spyOn(settingsService, 'updateUserSettings');
+
+            // Snapshot secretSettings AT save-time (deep copy) — the entity is
+            // passed by reference, so a post-save in-memory mutation (used only
+            // to build the masked response) must not contaminate this evidence.
+            const secretSnapshotsAtSave: Array<Record<string, unknown>> = [];
+            jest.spyOn(userPluginRepository, 'save').mockImplementation((entity: any) => {
+                secretSnapshotsAtSave.push(JSON.parse(JSON.stringify(entity.secretSettings ?? {})));
+                return entity;
+            });
 
             await service.enablePluginForUser('test-plugin', 'user-1', undefined, {
                 secretField: 'my-secret',
             });
 
+            // LEGIT path: the secret is persisted, but ONLY through the
+            // PluginSettingsService.updateUserSettings encrypting path
+            // (which runs encryptSecrets() at rest).
+            expect(updateUserSettingsSpy).toHaveBeenCalledWith('test-plugin', 'user-1', {
+                secretField: 'my-secret',
+            });
+
+            // BLOCKED path: the raw plaintext secret must NEVER be written
+            // directly onto the user-plugin entity that is saved to the DB —
+            // doing so would bypass C-08 envelope encryption entirely.
+            expect(secretSnapshotsAtSave.length).toBeGreaterThan(0);
+            for (const snapshot of secretSnapshotsAtSave) {
+                expect(snapshot).not.toEqual(expect.objectContaining({ secretField: 'my-secret' }));
+            }
+        });
+
+        it('should NOT invoke the encrypting write path when no secrets are supplied on enable', async () => {
+            const registered = createRegisteredPlugin();
+            jest.spyOn(pluginRegistryService, 'get').mockReturnValue(registered);
+            jest.spyOn(pluginRepository, 'findOne').mockResolvedValue({
+                id: '1',
+                pluginId: 'test-plugin',
+            } as any);
+            jest.spyOn(userPluginRepository, 'findOne').mockResolvedValue(null);
+            const updateUserSettingsSpy = jest.spyOn(settingsService, 'updateUserSettings');
+
+            // Enable with only non-secret settings — the legit happy path
+            // must still persist normally without touching the secret path.
+            const result = await service.enablePluginForUser('test-plugin', 'user-1', {
+                normalSetting: 'plain-value',
+            });
+
+            expect(result.enabled).toBe(true);
             expect(userPluginRepository.save).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    secretSettings: { secretField: 'my-secret' },
+                    settings: { normalSetting: 'plain-value' },
                 }),
             );
+            expect(updateUserSettingsSpy).not.toHaveBeenCalled();
         });
 
         it('should save secret settings on updateWorkPluginSettings', async () => {

--- a/packages/agent/src/plugins/services/plugin-context-factory.service.ts
+++ b/packages/agent/src/plugins/services/plugin-context-factory.service.ts
@@ -22,6 +22,7 @@ import type {
     CustomCapabilityDefinition,
     PluginServices,
     HttpResponse,
+    JsonSchema,
 } from '@ever-works/plugin';
 import { PluginRegistryService } from './plugin-registry.service';
 import { PluginSettingsService } from './plugin-settings.service';
@@ -96,7 +97,7 @@ export class PluginContextFactoryService {
             cache: this.createCache(pluginId),
             http: this.createHttpClient(pluginId),
             env: this.createEnvironment(),
-            envVars: this.createEnvVars(),
+            envVars: this.createEnvVars(pluginId),
             services: this.createServices(scopeOptions),
 
             getSettings: async (
@@ -441,27 +442,112 @@ export class PluginContextFactoryService {
     }
 
     /**
-     * Create an EnvironmentVariables accessor
+     * Create an EnvironmentVariables accessor scoped to a single plugin.
+     *
+     * Security: the plugin host runs inside the API process and shares its
+     * `process.env`, which holds DATABASE_URL, AUTH_SECRET, TRIGGER_* secrets,
+     * and every OTHER plugin's API key. The old accessor proxied
+     * `process.env[anyKey]` straight through, so any plugin could read all of
+     * them. Instead we build the env from an allowlist (mirroring the
+     * from-scratch `buildSubprocessEnv` philosophy used by the CLI plugins):
+     * the only keys a plugin may read are the env-var names it DECLARES via the
+     * `x-envVar` JSON-Schema extension on its own settings schema, plus a tiny
+     * fixed set of non-sensitive platform vars. Every accessor FAILS CLOSED for
+     * any key outside that set (undefined / false / throws), so a
+     * compromised/prompt-injected plugin cannot exfiltrate co-tenant secrets.
      */
-    private createEnvVars(): EnvironmentVariables {
+    private createEnvVars(pluginId: string): EnvironmentVariables {
+        const allowedKeys = this.resolveAllowedEnvKeys(pluginId);
+
+        const read = (key: string): string | undefined => {
+            if (!allowedKeys.has(key)) {
+                this.logger.warn(
+                    `Plugin "${pluginId}" attempted to read environment variable "${key}" it did not declare via x-envVar`,
+                );
+                return undefined;
+            }
+            return process.env[key];
+        };
+
         return {
             get: (key: string): string | undefined => {
-                return process.env[key];
+                return read(key);
             },
             getOrDefault: (key: string, defaultValue: string): string => {
-                return process.env[key] ?? defaultValue;
+                return read(key) ?? defaultValue;
             },
             has: (key: string): boolean => {
+                if (!allowedKeys.has(key)) {
+                    return false;
+                }
                 return key in process.env;
             },
             getRequired: (key: string): string => {
-                const value = process.env[key];
+                const value = read(key);
                 if (value === undefined) {
                     throw new Error(`Required environment variable "${key}" is not set`);
                 }
                 return value;
             },
         };
+    }
+
+    /**
+     * Non-sensitive platform env vars every plugin may read regardless of its
+     * declared schema. Keep this list tiny and free of secrets — anything added
+     * here is exposed to ALL plugins.
+     */
+    private static readonly PLATFORM_ENV_ALLOWLIST: readonly string[] = ['NODE_ENV'];
+
+    /**
+     * Resolve the set of env-var names a plugin is allowed to read: the
+     * `x-envVar` names declared on its settings schema properties (collected
+     * recursively so `allOf`/`anyOf`/`oneOf`-composed schemas still work) plus
+     * the fixed platform allowlist. Returns a fail-closed set — unknown plugins
+     * get only the platform vars.
+     */
+    private resolveAllowedEnvKeys(pluginId: string): ReadonlySet<string> {
+        const allowed = new Set<string>(PluginContextFactoryService.PLATFORM_ENV_ALLOWLIST);
+
+        const registered = this.registry.get(pluginId);
+        const schema = registered?.plugin?.settingsSchema;
+        if (schema) {
+            this.collectEnvVarNames(schema, allowed);
+        }
+
+        return allowed;
+    }
+
+    /**
+     * Walk a settings schema and add every declared `x-envVar` name to `out`.
+     * Recurses into `properties` and the JSON-Schema composition keywords so a
+     * plugin that declares its credentials under `anyOf`/`allOf`/`oneOf` (e.g.
+     * the zapier plugin) still resolves its env-var names correctly.
+     */
+    private collectEnvVarNames(schema: JsonSchema, out: Set<string>): void {
+        if (!schema || typeof schema !== 'object') {
+            return;
+        }
+
+        const envVar = schema['x-envVar'];
+        if (typeof envVar === 'string' && envVar.length > 0) {
+            out.add(envVar);
+        }
+
+        if (schema.properties) {
+            for (const child of Object.values(schema.properties)) {
+                this.collectEnvVarNames(child, out);
+            }
+        }
+
+        for (const keyword of ['allOf', 'anyOf', 'oneOf'] as const) {
+            const branches = schema[keyword];
+            if (Array.isArray(branches)) {
+                for (const branch of branches) {
+                    this.collectEnvVarNames(branch, out);
+                }
+            }
+        }
     }
 
     /**

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -490,12 +490,6 @@ export class PluginOperationsService {
             if (settings) {
                 userPlugin.settings = { ...userPlugin.settings, ...settings };
             }
-            if (secretSettings) {
-                userPlugin.secretSettings = {
-                    ...userPlugin.secretSettings,
-                    ...secretSettings,
-                };
-            }
         } else {
             // Create new user plugin record
             userPlugin = this.userPluginRepository.create({
@@ -505,12 +499,38 @@ export class PluginOperationsService {
                 enabled: true,
                 autoEnableForWorks: autoEnableForWorks ?? false,
                 settings: settings || {},
-                secretSettings: secretSettings || {},
+                secretSettings: {},
                 metadata: {},
             });
         }
 
+        // Persist the entity-level fields (enabled / autoEnableForWorks /
+        // non-secret settings). Secrets are intentionally NOT written onto
+        // the entity here — they go through the encrypting write path below
+        // so they are never stored in plaintext at rest.
         await this.userPluginRepository.save(userPlugin);
+
+        // D3 / C-08 — route enable-time secrets through the
+        // PluginSettingsService encrypting write path so they are encrypted
+        // at rest exactly like every other secret write (updateUserSettings →
+        // encryptSecrets). Previously this method wrote `secretSettings`
+        // DIRECTLY onto the user-plugin entity, bypassing C-08 envelope
+        // encryption entirely. The base record is saved first (above) so
+        // updateUserSettings finds the existing row and merges + encrypts the
+        // secret bag onto it. The schema's `x-secret` markers route each key
+        // into the encrypted `secretSettings` column.
+        if (secretSettings && Object.keys(secretSettings).length > 0) {
+            await this.settingsService.updateUserSettings(pluginId, userId, secretSettings);
+            // Reflect the just-written secrets in the in-memory entity used to
+            // build the response. The response masks x-secret fields, so the
+            // plaintext view here is only used to produce the masked output;
+            // the persisted column holds the encrypted envelope.
+            userPlugin.secretSettings = {
+                ...userPlugin.secretSettings,
+                ...secretSettings,
+            };
+        }
+
         this.logger.log(`Plugin "${pluginId}" enabled for user "${userId}"`);
 
         return this.toUserPluginResponseWithResolvedSettings(registered, userPlugin, userId, {

--- a/packages/plugins/make/src/__tests__/make.spec.ts
+++ b/packages/plugins/make/src/__tests__/make.spec.ts
@@ -622,6 +622,87 @@ describe('MakePlugin', () => {
 		});
 	});
 
+	describe('baseUrl make.com host allowlist (SSRF / credential-leak hardening)', () => {
+		beforeEach(async () => {
+			await plugin.onLoad(createMockContext());
+		});
+
+		// ── settings-check path: validateConnection ──────────────────────
+		it('rejects a non-make.com host that still passes the SSRF check', async () => {
+			// https://evil.com is a public HTTPS host (passes isSafeWebhookUrl) but
+			// is NOT a make.com host — it must be rejected and no REST call issued.
+			const result = await plugin.validateConnection({
+				apiKey: 'valid-key',
+				baseUrl: 'https://evil.com/api/v2'
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.message).toMatch(/make\.com host/i);
+			// The authenticated whoAmI/scenario call (which carries the token) must
+			// never have been attempted.
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('accepts a regional make.com host (eu1.make.com)', async () => {
+			fetchMock.mockResolvedValueOnce(mockResponse({ body: { user: { id: 1 } } }));
+
+			const result = await plugin.validateConnection({
+				apiKey: 'valid-key',
+				baseUrl: 'https://eu1.make.com/api/v2'
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.message).toContain('Connected to Make.com');
+		});
+
+		it('accepts the default make.com base URL', async () => {
+			fetchMock.mockResolvedValueOnce(mockResponse({ body: { user: { id: 1 } } }));
+
+			const result = await plugin.validateConnection({
+				apiKey: 'valid-key',
+				baseUrl: 'https://us2.make.com/api/v2'
+			});
+
+			expect(result.success).toBe(true);
+			expect(result.message).toContain('Connected to Make.com');
+		});
+
+		// ── request-path guard: execute → resolveMakeSettings ────────────
+		// The execute() path resolves settings via context.getSettings('user'|'work'),
+		// so override that to inject a tenant-controlled baseUrl.
+		it('fails the pipeline when the configured baseUrl is not a make.com host', async () => {
+			const ctx = createMockContext();
+			(ctx.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue({
+				apiKey: 'test-api-key',
+				baseUrl: 'https://evil.com/api/v2'
+			});
+			await plugin.onLoad(ctx);
+
+			const result = await plugin.execute(createWork(), createRequest(), createExisting());
+
+			expect(result.success).toBe(false);
+			const errorMessage = result.error instanceof Error ? result.error.message : String(result.error);
+			expect(errorMessage).toMatch(/make\.com host/i);
+			// No authenticated REST call should have been made for the rejected host.
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('runs the pipeline normally for a make.com baseUrl', async () => {
+			const ctx = createMockContext();
+			(ctx.getSettings as ReturnType<typeof vi.fn>).mockResolvedValue({
+				apiKey: 'test-api-key',
+				baseUrl: 'https://eu1.make.com/api/v2'
+			});
+			await plugin.onLoad(ctx);
+			mockSuccessfulScenarioRun(fetchMock);
+
+			const result = await plugin.execute(createWork(), createRequest(), createExisting());
+
+			expect(result.success).toBe(true);
+			expect(result.outputs.items.length).toBeGreaterThan(0);
+		});
+	});
+
 	describe('getManifest', () => {
 		it('should return a valid manifest', () => {
 			const manifest = plugin.getManifest();

--- a/packages/plugins/make/src/make.plugin.ts
+++ b/packages/plugins/make/src/make.plugin.ts
@@ -179,6 +179,15 @@ export class MakePlugin implements IPlugin, IPipelinePlugin, IFormSchemaProvider
 					message: 'Make.com API base URL is not allowed (must be a public HTTPS host).'
 				};
 			}
+			// Security (credential leak / abuse): on top of the SSRF check, restrict
+			// the host to the make.com domain so a tenant cannot point the baseUrl
+			// at an arbitrary public host while carrying their Make API token.
+			if (!isMakeHost(baseUrl)) {
+				return {
+					success: false,
+					message: 'Make.com API base URL must be an HTTPS make.com host (e.g. https://us2.make.com/api/v2).'
+				};
+			}
 			const client = new MakeClient({
 				apiKey,
 				baseUrl,
@@ -580,6 +589,12 @@ export class MakePlugin implements IPlugin, IPipelinePlugin, IFormSchemaProvider
 		if (!isSafeWebhookUrl(baseUrl)) {
 			throw new Error('Make.com API base URL is not allowed (must be a public HTTPS host).');
 		}
+		// Security (credential leak / abuse): on top of the SSRF check, restrict the
+		// host to the make.com domain so a tenant cannot point the baseUrl at an
+		// arbitrary public host while carrying their Make API token. Fails closed.
+		if (!isMakeHost(baseUrl)) {
+			throw new Error('Make.com API base URL must be an HTTPS make.com host (e.g. https://us2.make.com/api/v2).');
+		}
 
 		return {
 			apiKey,
@@ -708,6 +723,26 @@ export class MakePlugin implements IPlugin, IPipelinePlugin, IFormSchemaProvider
 		}
 		return flat;
 	}
+}
+
+/**
+ * Security (host allowlist): returns true only when `url` parses as an HTTPS URL
+ * whose hostname is exactly `make.com` or a sub-domain ending in `.make.com`
+ * (Make uses regional/zone hosts like `us2.make.com`, `eu1.make.com`, and
+ * webhook hosts like `hook.us2.make.com`). Applied ON TOP of `isSafeWebhookUrl`
+ * so a tenant cannot point the baseUrl at an arbitrary public host while
+ * carrying their Make API token. Fails closed on any parse error.
+ */
+function isMakeHost(url: string): boolean {
+	let parsed: URL;
+	try {
+		parsed = new URL(url);
+	} catch {
+		return false;
+	}
+	if (parsed.protocol !== 'https:') return false;
+	const host = parsed.hostname.toLowerCase();
+	return host === 'make.com' || host.endsWith('.make.com');
 }
 
 /**


### PR DESCRIPTION
## Wave D — operator-approved build wave (decisions D2/D3/D6/D9)

Four approved hardening fixes from the EW-710 open-decisions list (plan §8.1). Produced via a fix + adversarial-verify workflow; each **mutation-tested** (guard reverted to prove the security test fails without it) and re-verified by hand.

### D2 — plugin `envVars` allowlist (highest value) · `plugin-context-factory.service.ts`
`createEnvVars()` returned `process.env[anyKey]` to **any** plugin — so a third-party plugin could read `DATABASE_URL`, `AUTH_SECRET`, every other plugin's API key. Now `createEnvVars(pluginId)` builds a **fail-closed allowlist** = the plugin's declared `x-envVar` schema keys (recursed through `allOf`/`anyOf`/`oneOf`) + a tiny platform set (`NODE_ENV`); all four accessors (`get`/`getOrDefault`/`has`/`getRequired`) block undeclared keys. Mirrors the subprocess-env allowlist. **+5 tests (54/54).**

### D3 — secret-at-rest · `plugin-operations.service.ts`
`enablePluginForUser` wrote `secretSettings` straight onto the entity, **bypassing** the C-08 `PluginSecretEncService` envelope encryption (the column is plain `simple-json`, no ORM transformer). Now routes the enable-time secret write through `PluginSettingsService.updateUserSettings` (the encrypting path); the masked response is preserved. **(88/88.)**
> **Known follow-up (same file):** `updateUserPluginSettings` + `updateWorkPluginSettings` have the **same** plaintext-write bypass. Scoped out of this PR (they overlap with the encrypting `updateUserSettings`/`updateWorkSettings` and have masked-value/merge semantics that need a careful consolidation). **No data corruption** — `decryptSecrets` passes plaintext through (gradual encrypt-on-next-write). Tracked as a follow-up.

### D6 — make.com host allowlist · `make.plugin.ts`
Tenant `baseUrl` was only SSRF-checked (`isSafeWebhookUrl` accepts any public https host), so a tenant could point `baseUrl` at an attacker host carrying their Make API token. Added `isMakeHost` (https + hostname `make.com` or `*.make.com`, anchored to defeat `make.com.evil.com`) **on top of** the SSRF check, in both the settings-check and request paths. **+5 tests (119/119).**

### D9 — clamp imported Agent permissions · `agent-export.service.ts`
`importOne` carried the envelope's `permissions` into the created/overwritten Agent (privilege escalation across import). Now plants `AGENT_PERMISSIONS_DEFAULT` (all-false) at every write site; the owner must explicitly re-grant. **+3 tests (16/16).**

## Verification
- `packages/agent` (plugin-context-factory + plugin-operations + agent-export): **158/158**
- `packages/plugins/make`: **119/119**
- `packages/agent` `tsc --noEmit`: clean
- Each fix mutation-tested (security tests fail with the guard reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security: Agent permissions no longer accept elevated privileges during import operations.
  * Enhanced security: Plugins can only access environment variables explicitly declared in their configuration schema.
  * Enhanced security: Plugin secrets are now encrypted at rest during storage.
  * Enhanced security: Make plugin connections are restricted to make.com domains only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->