### PR TITLE
fix(security): Wave G — contained SSRF + import-bound fixes (EW-715/EW-717)

### DIFF
--- a/apps/api/src/missions/dto/mission.dto.spec.ts
+++ b/apps/api/src/missions/dto/mission.dto.spec.ts
@@ -1,0 +1,125 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+// `mission.dto.ts` imports `MissionType` from the `@ever-works/agent/missions`
+// barrel, which transitively pulls in MissionsService -> ai.facade ->
+// plugin-usage.service, whose entity classes reference `@src/*` aliases that the
+// api jest scope does not map (it maps `@src` to the api package, not agent).
+// Stub the barrel to expose only the `MissionType` enum the DTO needs — the same
+// pattern used by trigger-internal.controller.spec.ts. The SSRF guard under test
+// depends on `@ever-works/agent/utils` (isSafeWebhookUrl), which loads fine and is
+// intentionally NOT mocked, so the validation is genuinely exercised.
+jest.mock('@ever-works/agent/missions', () => ({
+    MissionType: { ONE_SHOT: 'one-shot', SCHEDULED: 'scheduled' },
+}));
+
+// `mission.dto.ts` also imports `WorkAgentGuardrailsDto` from
+// `../../work-agent/dto/work-agent.dto`, which pulls in the
+// `@ever-works/agent/work-agent` barrel -> database.module -> `@src/config`
+// (again unmapped in the api jest scope). Stub the barrel with the real cadence
+// regex (the only value used at module-eval, via `@Matches`) plus placeholder
+// enums (used only in erased type positions). Same approach as above.
+jest.mock('@ever-works/agent/work-agent', () => ({
+    SUPPORTED_AUTO_GENERATE_CADENCE_PATTERN:
+        /^\*\/([1-9]|[1-9]\d|[1-9]\d{2}|1[0-3]\d{2}|14[0-3]\d|1440)\s+\*\s+\*\s+\*\s+\*$/,
+    WorkAgentGoalSource: {},
+    WorkAgentGoalStatus: {},
+    WorkAgentRunLogLevel: {},
+    WorkAgentRunStatus: {},
+}));
+
+import { CreateMissionDto, UpdateMissionDto } from './mission.dto';
+import { MissionType } from '@ever-works/agent/missions';
+
+const constraintsFor = (
+    errs: { property: string; constraints?: Record<string, string> }[],
+    property: string,
+) => errs.find((e) => e.property === property)?.constraints ?? {};
+
+// A minimal valid base body so the ONLY thing under test is `missionTemplateRepo`.
+const baseCreate = { description: 'do a thing', type: MissionType.ONE_SHOT };
+
+describe('missions CreateMissionDto.missionTemplateRepo (SSRF defense-in-depth)', () => {
+    describe('accepted shapes (behavior-preserving — must still validate clean)', () => {
+        it.each([
+            'ever-works/p2p-marketplace-mission-template', // owner/repo slug
+            'starter-business', // bare catalog id
+            'https://github.com/ever-works/some-template', // HTTPS public host
+        ])('accepts %s', async (missionTemplateRepo) => {
+            const dto = plainToInstance(CreateMissionDto, { ...baseCreate, missionTemplateRepo });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('accepts omitted missionTemplateRepo (@IsOptional)', async () => {
+            const dto = plainToInstance(CreateMissionDto, { ...baseCreate });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('accepts null missionTemplateRepo (clears the field — @ValidateIf skips)', async () => {
+            const dto = plainToInstance(CreateMissionDto, {
+                ...baseCreate,
+                missionTemplateRepo: null,
+            });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+
+        it('accepts an empty string (service treats it as "clear")', async () => {
+            const dto = plainToInstance(CreateMissionDto, {
+                ...baseCreate,
+                missionTemplateRepo: '',
+            });
+            expect(await validate(dto)).toHaveLength(0);
+        });
+    });
+
+    describe('rejected SSRF / scheme-injection payloads (these passed the old @IsString @MaxLength only)', () => {
+        // Each of these is a <=200-char string, so the pre-fix DTO (@IsString @MaxLength(200))
+        // accepted them; the IsMissionTemplateRepo guard must now reject them.
+        it.each([
+            'http://169.254.169.254/latest/meta-data/', // cloud metadata over http
+            'https://169.254.169.254/latest/meta-data/', // metadata IP even over https
+            'https://127.0.0.1/repo.git', // loopback
+            'https://user:pass@github.com/x/y', // embedded credentials
+            'file:///etc/passwd', // file scheme
+            'git://github.com/x/y.git', // git scheme
+            'ssh://git@github.com/x/y.git', // ssh scheme
+            'https://[::1]/repo.git', // IPv6 loopback
+            'owner/repo with space', // space breaks the slug shape and is not a valid URL
+        ])('rejects %s', async (missionTemplateRepo) => {
+            const dto = plainToInstance(CreateMissionDto, { ...baseCreate, missionTemplateRepo });
+            const errs = await validate(dto);
+            expect(constraintsFor(errs, 'missionTemplateRepo').isMissionTemplateRepo).toBeDefined();
+        });
+    });
+});
+
+describe('missions UpdateMissionDto.missionTemplateRepo (SSRF defense-in-depth)', () => {
+    it('accepts a valid owner/repo slug', async () => {
+        const dto = plainToInstance(UpdateMissionDto, {
+            missionTemplateRepo: 'ever-works/template',
+        });
+        expect(await validate(dto)).toHaveLength(0);
+    });
+
+    it('accepts null (clears the field)', async () => {
+        const dto = plainToInstance(UpdateMissionDto, { missionTemplateRepo: null });
+        expect(await validate(dto)).toHaveLength(0);
+    });
+
+    it('rejects a metadata-IP SSRF URL', async () => {
+        const dto = plainToInstance(UpdateMissionDto, {
+            missionTemplateRepo: 'http://169.254.169.254/latest/meta-data/',
+        });
+        const errs = await validate(dto);
+        expect(constraintsFor(errs, 'missionTemplateRepo').isMissionTemplateRepo).toBeDefined();
+    });
+
+    it('rejects embedded credentials over https', async () => {
+        const dto = plainToInstance(UpdateMissionDto, {
+            missionTemplateRepo: 'https://user:pass@github.com/x/y',
+        });
+        const errs = await validate(dto);
+        expect(constraintsFor(errs, 'missionTemplateRepo').isMissionTemplateRepo).toBeDefined();
+    });
+});

--- a/apps/api/src/missions/dto/mission.dto.ts
+++ b/apps/api/src/missions/dto/mission.dto.ts
@@ -9,13 +9,69 @@ import {
     MaxLength,
     Min,
     MinLength,
+    Validate,
     ValidateIf,
     ValidateNested,
+    ValidatorConstraint,
+    type ValidatorConstraintInterface,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { MissionType } from '@ever-works/agent/missions';
+// Security (SSRF): lexical guard reused by MissionsService.normalizeTemplateRepo to
+// vet full-URL forms of `missionTemplateRepo`. Mirror that check at the DTO boundary
+// so a hostile value is rejected before the service ever sees it (defense-in-depth).
+import { isSafeWebhookUrl } from '@ever-works/agent/utils';
 // Security: import the typed guardrails DTO so guardrailsOverride is validated against a strict allowlist
 import { WorkAgentGuardrailsDto } from '../../work-agent/dto/work-agent.dto';
+
+// Security (SSRF defense-in-depth): `missionTemplateRepo` is consumed by the Phase 8
+// scaffolder to clone/fetch a template repo. The service-layer
+// `MissionsService.normalizeTemplateRepo` (packages/agent/src/missions/missions.service.ts)
+// already vets the value, but it runs AFTER the DTO. Enforce the SAME accepted shapes
+// at the DTO boundary so SSRF/scheme-injection payloads are rejected by the global
+// ValidationPipe before they reach the service. The three accepted shapes mirror the
+// service exactly:
+//   1. GitHub-style `owner/repo` slug  (2+ segments of [A-Za-z0-9._-] joined by `/`)
+//   2. bare catalog-id selector        (single [A-Za-z0-9._-] segment, no `/`)
+//   3. a full HTTPS git URL on a public host (no embedded credentials, passes the
+//      lexical SSRF guard) — `http://`, `file://`, `git://`, `ssh://`, private/
+//      loopback/metadata hosts and `user:pass@` forms are all rejected.
+// Empty / whitespace-only strings are accepted here because the service treats them as
+// "clear the field" (returns null) — preserving the currently-accepted clear behavior.
+const TEMPLATE_REPO_SLUG_RE = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+$/;
+const TEMPLATE_REPO_BARE_SLUG_RE = /^[A-Za-z0-9._-]+$/;
+
+@ValidatorConstraint({ name: 'isMissionTemplateRepo', async: false })
+class IsMissionTemplateRepo implements ValidatorConstraintInterface {
+    validate(value: unknown): boolean {
+        if (typeof value !== 'string') return false;
+        const trimmed = value.trim();
+        // Empty/whitespace clears the field at the service layer — preserve that.
+        if (trimmed.length === 0) return true;
+        if (trimmed.length > 200) return false;
+        if (TEMPLATE_REPO_SLUG_RE.test(trimmed)) return true;
+        if (TEMPLATE_REPO_BARE_SLUG_RE.test(trimmed)) return true;
+        // Only other acceptable shape: a full HTTPS git URL on a public host with no
+        // embedded credentials, passing the shared lexical SSRF guard.
+        let parsed: URL | null = null;
+        try {
+            parsed = new URL(trimmed);
+        } catch {
+            parsed = null;
+        }
+        return Boolean(
+            parsed &&
+            parsed.protocol === 'https:' &&
+            !parsed.username &&
+            !parsed.password &&
+            isSafeWebhookUrl(trimmed),
+        );
+    }
+
+    defaultMessage(): string {
+        return 'missionTemplateRepo must be a GitHub-style "owner/repo" slug, a bare catalog id, or an HTTPS git URL on a public host';
+    }
+}
 
 /**
  * Phase 3 PR H — request body for `POST /me/missions`. Validated
@@ -97,6 +153,10 @@ export class CreateMissionDto {
     @ValidateIf((o) => o.missionTemplateRepo !== null)
     @IsString()
     @MaxLength(200)
+    // Security (SSRF defense-in-depth): enforce the accepted owner/repo-slug,
+    // bare-catalog-id, or HTTPS-public-host shape at the DTO boundary, mirroring
+    // MissionsService.normalizeTemplateRepo so SSRF payloads are rejected up front.
+    @Validate(IsMissionTemplateRepo)
     missionTemplateRepo?: string | null;
 }
 
@@ -181,6 +241,10 @@ export class UpdateMissionDto {
     @ValidateIf((o) => o.missionTemplateRepo !== null)
     @IsString()
     @MaxLength(200)
+    // Security (SSRF defense-in-depth): enforce the accepted owner/repo-slug,
+    // bare-catalog-id, or HTTPS-public-host shape at the DTO boundary, mirroring
+    // MissionsService.normalizeTemplateRepo so SSRF payloads are rejected up front.
+    @Validate(IsMissionTemplateRepo)
     missionTemplateRepo?: string | null;
 }
 

--- a/apps/api/src/onboarding/onboarding.service.spec.ts
+++ b/apps/api/src/onboarding/onboarding.service.spec.ts
@@ -386,6 +386,75 @@ spec:
         ).rejects.toMatchObject({ response: { code: 'gh_credential_invalid' } });
     });
 
+    describe('webhookUrl SSRF guard', () => {
+        const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+        afterEach(() => {
+            process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+        });
+
+        it('rejects a private/loopback webhookUrl in a non-local env (production)', async () => {
+            process.env.NODE_ENV = 'production';
+            const repo = fakeRepository();
+            const { service } = createService({ repo });
+
+            await expect(
+                service.handle({
+                    body: {
+                        ...validBody,
+                        webhookUrl: 'http://169.254.169.254/latest/meta-data',
+                    } as any,
+                    githubToken: 'token-aaaa',
+                }),
+            ).rejects.toMatchObject({ response: { code: 'validation_error' } });
+
+            // Rejected before any persistence / GitHub work.
+            expect(repo.save).not.toHaveBeenCalled();
+        });
+
+        it('allows a private webhookUrl in local dev/test env (env-gate parity with WebhooksService)', async () => {
+            process.env.NODE_ENV = 'test';
+            const repo = fakeRepository();
+            repo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+            const { service } = createService({ repo });
+
+            const result = await service.handle({
+                body: {
+                    ...validBody,
+                    webhookUrl: 'http://127.0.0.1:9000/hook',
+                    subdomain: 'my-dir',
+                } as any,
+                githubToken: 'token-aaaa',
+            });
+
+            expect(repo.save).toHaveBeenCalled();
+            const saved = repo.save.mock.calls[0][0];
+            expect(saved.webhookUrl).toBe('http://127.0.0.1:9000/hook');
+            expect(result.status).toBe('queued');
+        });
+
+        it('allows a public webhookUrl in a non-local env (production)', async () => {
+            process.env.NODE_ENV = 'production';
+            const repo = fakeRepository();
+            repo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+            const { service } = createService({ repo });
+
+            const result = await service.handle({
+                body: {
+                    ...validBody,
+                    webhookUrl: 'https://my-agent.example.com/webhooks/ever-works',
+                    subdomain: 'my-dir',
+                } as any,
+                githubToken: 'token-aaaa',
+            });
+
+            expect(repo.save).toHaveBeenCalled();
+            const saved = repo.save.mock.calls[0][0];
+            expect(saved.webhookUrl).toBe('https://my-agent.example.com/webhooks/ever-works');
+            expect(result.status).toBe('queued');
+        });
+    });
+
     it('getStatus rejects when token does not match the row owner', async () => {
         const repo = fakeRepository();
         repo.findOne.mockResolvedValueOnce({

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -20,6 +20,7 @@ import {
     ONBOARDING_WORK_CREATOR,
     OnboardingRequestRepository,
     WorksManifestService,
+    isSafeWebhookUrl,
     type OnboardingAccountUpsert,
     type OnboardingGitProvider,
     type OnboardingWorkCreator,
@@ -88,6 +89,25 @@ export class OnboardingService {
      *   - Webhook + state-marker fan-out on terminal status (T10, T11, T21).
      */
     async handle(ctx: OnboardingContext): Promise<RegisterWorkResponse> {
+        // Security (SSRF): the DTO only enforces an http(s) shape on
+        // webhookUrl. The persisted URL is later fetched server-side on
+        // terminal status, so a private / loopback / link-local / metadata
+        // target must be refused before it is stored. Mirror
+        // WebhooksService.assertValidUrl()'s env-gate: allow local targets in
+        // dev/test so a developer can point at a local tunnel, but enforce in
+        // every other (staging/prod) env that shares internal network access.
+        if (ctx.body.webhookUrl) {
+            const env = process.env.NODE_ENV;
+            const isLocalEnv =
+                env === 'development' || env === 'test' || env === undefined || env === '';
+            if (!isLocalEnv && !isSafeWebhookUrl(ctx.body.webhookUrl)) {
+                this.fail({
+                    code: 'validation_error',
+                    message: 'webhookUrl resolves to a private/loopback/link-local address',
+                });
+            }
+        }
+
         const coords = parseRepoCoords(ctx.body.repo);
         if (!coords) {
             this.fail({ code: 'validation_error', message: 'invalid repo URL' });

--- a/apps/web/src/app/actions/account-transfer-schemas.ts
+++ b/apps/web/src/app/actions/account-transfer-schemas.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+/**
+ * M-08 / EW-717 (deserialization): defense-in-depth shape validation for the
+ * account-import Server Action args. The API tier has its own DTO check, but a
+ * malformed/hostile shape at this boundary (oversized payload, wrong type)
+ * should fail fast in the web tier rather than be proxied verbatim and force
+ * unbounded memory + RPC body size before the upstream call.
+ *
+ * The schema is deliberately permissive on the deep element shape (the export
+ * payload is large and varied) but enforces hard COUNT caps on the nested
+ * import arrays. `works`/`userPlugins` are the confirmed v1 arrays; the rest
+ * are the v2 export tail (optional → a no-op when absent). `.catchall` keeps
+ * any future field forward-compatible. The same `.max()` pattern already
+ * guards the `resolutions` array in `applyImport`.
+ *
+ * Extracted into this pure (non-`'use server'`) module so the caps can be
+ * unit-tested directly.
+ */
+export const accountExportPayloadSchema = z
+    .object({
+        // Top-level fields the API tier requires
+        version: z.union([z.string().max(64), z.number()]).optional(),
+        user: z.unknown().optional(),
+        data: z
+            .object({
+                works: z.array(z.unknown()).max(50_000).optional(),
+                userPlugins: z.array(z.unknown()).max(5_000).optional(),
+                agents: z.array(z.unknown()).max(5_000).optional(),
+                skills: z.array(z.unknown()).max(50_000).optional(),
+                tasks: z.array(z.unknown()).max(100_000).optional(),
+                taskChat: z.array(z.unknown()).max(500_000).optional(),
+            })
+            .catchall(z.unknown())
+            .optional(),
+    })
+    .catchall(z.unknown());

--- a/apps/web/src/app/actions/account-transfer-schemas.unit.spec.ts
+++ b/apps/web/src/app/actions/account-transfer-schemas.unit.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { accountExportPayloadSchema } from './account-transfer-schemas';
+
+/**
+ * EW-717 (deserialization): the import payload's nested arrays must be
+ * count-capped so a hostile/corrupted export cannot force unbounded memory +
+ * RPC body size in the web tier before the upstream API DTO check.
+ */
+describe('accountExportPayloadSchema (EW-717 import array caps)', () => {
+    const baseData = { profile: { username: 'u', email: 'u@x.io' } };
+
+    it('accepts a well-formed v1 payload (small arrays)', () => {
+        const payload = {
+            version: 1,
+            exportedAt: '2026-06-08T00:00:00.000Z',
+            includesSecrets: false,
+            data: { ...baseData, works: [{ slug: 'a' }], userPlugins: [{ pluginId: 'p' }] },
+        };
+        expect(accountExportPayloadSchema.safeParse(payload).success).toBe(true);
+    });
+
+    it('accepts a minimal payload (optional fields absent)', () => {
+        expect(accountExportPayloadSchema.safeParse({}).success).toBe(true);
+        expect(accountExportPayloadSchema.safeParse({ version: 2, data: baseData }).success).toBe(
+            true,
+        );
+    });
+
+    it('keeps unknown top-level and unknown data fields forward-compatible (catchall)', () => {
+        const payload = {
+            version: 2,
+            somethingNew: { nested: true },
+            data: { ...baseData, works: [], userPlugins: [], futureV3Field: [1, 2, 3] },
+        };
+        expect(accountExportPayloadSchema.safeParse(payload).success).toBe(true);
+    });
+
+    it('REJECTS an oversized data.works array (> 50_000)', () => {
+        const payload = {
+            version: 1,
+            data: { ...baseData, works: new Array(50_001).fill({}), userPlugins: [] },
+        };
+        const res = accountExportPayloadSchema.safeParse(payload);
+        expect(res.success).toBe(false);
+    });
+
+    it('REJECTS an oversized data.userPlugins array (> 5_000)', () => {
+        const payload = {
+            version: 1,
+            data: { ...baseData, works: [], userPlugins: new Array(5_001).fill({}) },
+        };
+        expect(accountExportPayloadSchema.safeParse(payload).success).toBe(false);
+    });
+
+    it('REJECTS an oversized v2-tail array (e.g. taskChat > 500_000)', () => {
+        const payload = {
+            version: 2,
+            data: {
+                ...baseData,
+                works: [],
+                userPlugins: [],
+                taskChat: new Array(500_001).fill({}),
+            },
+        };
+        expect(accountExportPayloadSchema.safeParse(payload).success).toBe(false);
+    });
+
+    it('accepts arrays exactly at the cap boundary', () => {
+        const payload = {
+            version: 1,
+            data: {
+                ...baseData,
+                works: new Array(50_000).fill({}),
+                userPlugins: new Array(5_000).fill({}),
+            },
+        };
+        expect(accountExportPayloadSchema.safeParse(payload).success).toBe(true);
+    });
+});

--- a/apps/web/src/app/actions/account-transfer.ts
+++ b/apps/web/src/app/actions/account-transfer.ts
@@ -7,24 +7,9 @@ import { getAuthFromCookie } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { ROUTES } from '@/lib/constants';
 import { serverFetch } from '@/lib/api/server-api';
-
-/**
- * M-08: defense-in-depth shape validation for Server Action args. The API
- * tier has its own DTO check, but a malformed shape at this boundary
- * (oversized payload, wrong type) should fail fast in the web tier rather
- * than be proxied verbatim and trigger an opaque 400/500 from the API.
- *
- * The schemas are deliberately permissive on the deep shape (the export
- * payload is large and varied) but enforce length / count caps that bound
- * memory + RPC body size before the upstream call.
- */
-const accountExportPayloadSchema = z
-    .object({
-        // Top-level fields the API tier requires
-        version: z.union([z.string().max(64), z.number()]).optional(),
-        user: z.unknown().optional(),
-    })
-    .catchall(z.unknown());
+// M-08 / EW-717: nested-array count caps for the import payload live in a pure
+// module so they can be unit-tested without importing this `'use server'` file.
+import { accountExportPayloadSchema } from './account-transfer-schemas';
 
 const conflictResolutionSchema = z.unknown(); // ConflictResolution shape is server-owned; cap by array length below.
 

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -26,4 +26,18 @@ export async function register() {
                 'key, and the OAuth callback handler now fails closed if the secret is too short.',
         );
     }
+
+    // ALLOWED_REDIRECT_URLS: in production this env var has no safe default.
+    // `lib/constants.ts` falls back to `localhost,127.0.0.1` when it is unset,
+    // which means `addSessionTokenToUrl` silently refuses to attach session
+    // tokens to any real (non-loopback) production redirect target. Warn (not
+    // throw) at boot so the misconfiguration is loud in the logs without
+    // breaking deploys that intentionally rely on loopback-only redirects.
+    if (process.env.NODE_ENV === 'production' && !process.env.ALLOWED_REDIRECT_URLS) {
+        console.warn(
+            '[security] ALLOWED_REDIRECT_URLS is not set — defaulting to localhost,127.0.0.1. ' +
+                'Set this to your production domain(s) or session tokens will not be appended to ' +
+                'any absolute redirect URL.',
+        );
+    }
 }

--- a/apps/web/src/instrumentation.unit.spec.ts
+++ b/apps/web/src/instrumentation.unit.spec.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `register()` reads its config straight from `process.env`, so we reset the
+// module registry and re-import per test to get a clean evaluation each time.
+// We also pin the env we care about (NEXT_RUNTIME so the body actually runs,
+// a valid 32+ char secret so it reaches the ALLOWED_REDIRECT_URLS guard, and
+// NODE_ENV / ALLOWED_REDIRECT_URLS which are the inputs under test).
+const ORIGINAL_ENV = { ...process.env };
+
+async function loadRegister(): Promise<typeof import('./instrumentation').register> {
+    vi.resetModules();
+    const mod = await import('./instrumentation');
+    return mod.register;
+}
+
+const VALID_SECRET = 'a'.repeat(32);
+
+describe('instrumentation register() — ALLOWED_REDIRECT_URLS prod guard', () => {
+    beforeEach(() => {
+        process.env = { ...ORIGINAL_ENV };
+        // Run the Node-runtime branch and pass the AUTH_SECRET checks so the
+        // new ALLOWED_REDIRECT_URLS guard is reached.
+        process.env.NEXT_RUNTIME = 'nodejs';
+        process.env.COOKIE_SECRET = VALID_SECRET;
+        delete process.env.AUTH_SECRET;
+    });
+
+    afterEach(() => {
+        process.env = { ...ORIGINAL_ENV };
+        vi.restoreAllMocks();
+    });
+
+    it('warns when NODE_ENV=production and ALLOWED_REDIRECT_URLS is unset', async () => {
+        (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+        delete process.env.ALLOWED_REDIRECT_URLS;
+
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const register = await loadRegister();
+        await register();
+
+        const warned = warnSpy.mock.calls
+            .flat()
+            .map((arg) => String(arg))
+            .join(' ');
+        expect(warned).toMatch(/ALLOWED_REDIRECT_URLS is not set/i);
+        expect(warned).toMatch(/\[security\]/i);
+    });
+
+    it('does NOT warn when ALLOWED_REDIRECT_URLS is set in production', async () => {
+        (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+        process.env.ALLOWED_REDIRECT_URLS = 'app.ever.works,ever.works';
+
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const register = await loadRegister();
+        await register();
+
+        const warned = warnSpy.mock.calls
+            .flat()
+            .map((arg) => String(arg))
+            .join(' ');
+        expect(warned).not.toMatch(/ALLOWED_REDIRECT_URLS is not set/i);
+    });
+
+    it('does NOT warn outside production even when ALLOWED_REDIRECT_URLS is unset', async () => {
+        (process.env as Record<string, string | undefined>).NODE_ENV = 'development';
+        delete process.env.ALLOWED_REDIRECT_URLS;
+
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const register = await loadRegister();
+        await register();
+
+        const warned = warnSpy.mock.calls
+            .flat()
+            .map((arg) => String(arg))
+            .join(' ');
+        expect(warned).not.toMatch(/ALLOWED_REDIRECT_URLS is not set/i);
+    });
+});

--- a/packages/agent/src/plugins/__tests__/plugin-context-factory.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-context-factory.service.spec.ts
@@ -9,6 +9,21 @@ import { CustomCapabilityRegistryService } from '../services/custom-capability-r
 import { PLUGINS_MODULE_OPTIONS } from '../plugins.constants';
 import type { IPlugin, PluginManifest, CustomCapabilityDefinition } from '@ever-works/plugin';
 
+// Security: the plugin HTTP client routes every request through the DNS-pinned
+// SSRF guard `safeFetchWithDnsPin`. We mock that module so the HTTP-client tests
+// don't perform real DNS lookups, while keeping the real `SsrfBlockedError`
+// class so the guard-block / error-remap path can be exercised faithfully.
+jest.mock('../../utils/ssrf-guard', () => {
+    const actual = jest.requireActual('../../utils/ssrf-guard');
+    return {
+        ...actual,
+        safeFetchWithDnsPin: jest.fn(),
+    };
+});
+import { safeFetchWithDnsPin, SsrfBlockedError } from '../../utils/ssrf-guard';
+
+const safeFetchWithDnsPinMock = safeFetchWithDnsPin as unknown as jest.Mock;
+
 // Silence Logger output during tests
 jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
 jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
@@ -269,8 +284,11 @@ describe('PluginContextFactoryService', () => {
 
     describe('PluginHttpClient', () => {
         beforeEach(() => {
-            // Mock global fetch
-            global.fetch = jest.fn().mockResolvedValue({
+            // The plugin HTTP client routes every request through the DNS-pinned
+            // SSRF guard `safeFetchWithDnsPin` (mocked at module scope above), so
+            // assertions are made against that call rather than `global.fetch`.
+            safeFetchWithDnsPinMock.mockReset();
+            safeFetchWithDnsPinMock.mockResolvedValue({
                 json: jest.fn().mockResolvedValue({ data: 'test' }),
                 status: 200,
                 statusText: 'OK',
@@ -278,16 +296,12 @@ describe('PluginContextFactoryService', () => {
             });
         });
 
-        afterEach(() => {
-            (global.fetch as jest.Mock).mockRestore();
-        });
-
         it('should provide get method', async () => {
             const context = service.createContext('test-plugin');
 
             const result = await context.http.get('https://api.example.com/data');
 
-            expect(global.fetch).toHaveBeenCalledWith(
+            expect(safeFetchWithDnsPinMock).toHaveBeenCalledWith(
                 'https://api.example.com/data',
                 expect.objectContaining({
                     method: 'GET',
@@ -301,7 +315,7 @@ describe('PluginContextFactoryService', () => {
 
             await context.http.post('https://api.example.com/data', { key: 'value' });
 
-            expect(global.fetch).toHaveBeenCalledWith(
+            expect(safeFetchWithDnsPinMock).toHaveBeenCalledWith(
                 'https://api.example.com/data',
                 expect.objectContaining({
                     method: 'POST',
@@ -315,7 +329,7 @@ describe('PluginContextFactoryService', () => {
 
             await context.http.put('https://api.example.com/data', { key: 'value' });
 
-            expect(global.fetch).toHaveBeenCalledWith(
+            expect(safeFetchWithDnsPinMock).toHaveBeenCalledWith(
                 'https://api.example.com/data',
                 expect.objectContaining({
                     method: 'PUT',
@@ -328,7 +342,7 @@ describe('PluginContextFactoryService', () => {
 
             await context.http.patch('https://api.example.com/data', { key: 'value' });
 
-            expect(global.fetch).toHaveBeenCalledWith(
+            expect(safeFetchWithDnsPinMock).toHaveBeenCalledWith(
                 'https://api.example.com/data',
                 expect.objectContaining({
                     method: 'PATCH',
@@ -341,7 +355,7 @@ describe('PluginContextFactoryService', () => {
 
             await context.http.delete('https://api.example.com/data');
 
-            expect(global.fetch).toHaveBeenCalledWith(
+            expect(safeFetchWithDnsPinMock).toHaveBeenCalledWith(
                 'https://api.example.com/data',
                 expect.objectContaining({
                     method: 'DELETE',
@@ -356,7 +370,7 @@ describe('PluginContextFactoryService', () => {
                 headers: { Authorization: 'Bearer token' },
             });
 
-            expect(global.fetch).toHaveBeenCalledWith(
+            expect(safeFetchWithDnsPinMock).toHaveBeenCalledWith(
                 'https://api.example.com/data',
                 expect.objectContaining({
                     headers: expect.objectContaining({ Authorization: 'Bearer token' }),
@@ -371,6 +385,55 @@ describe('PluginContextFactoryService', () => {
 
             expect(result.status).toBe(200);
             expect(result.statusText).toBe('OK');
+        });
+
+        describe('SSRF guard (DNS-pinned)', () => {
+            it('routes requests through safeFetchWithDnsPin, not raw fetch', async () => {
+                const context = service.createContext('test-plugin');
+
+                await context.http.get('https://api.example.com/data');
+
+                // The DNS-pinned guard re-runs the lexical check AND resolves the
+                // hostname to refuse private/rebinding targets before connecting.
+                expect(safeFetchWithDnsPinMock).toHaveBeenCalledTimes(1);
+            });
+
+            it('re-maps a lexically blocked URL (SsrfBlockedError) to the generic plugin error', async () => {
+                safeFetchWithDnsPinMock.mockRejectedValueOnce(
+                    new SsrfBlockedError('lexical_blocked', 'URL rejected by lexical SSRF guard'),
+                );
+                const context = service.createContext('test-plugin');
+
+                await expect(
+                    context.http.get('http://169.254.169.254/latest/meta-data'),
+                ).rejects.toThrow('Request blocked: target URL is not permitted');
+            });
+
+            it('re-maps a DNS-rebinding block (private-IP resolution) to the generic plugin error', async () => {
+                // safeFetchWithDnsPin resolves the hostname and throws when it
+                // points at a private IP — the case the old lexical-only guard
+                // missed entirely.
+                safeFetchWithDnsPinMock.mockRejectedValueOnce(
+                    new SsrfBlockedError(
+                        'dns_private_ip',
+                        'rebind.evil.test resolved to private IPv4 127.0.0.1',
+                    ),
+                );
+                const context = service.createContext('test-plugin');
+
+                await expect(
+                    context.http.post('https://rebind.evil.test/x', { a: 1 }),
+                ).rejects.toThrow('Request blocked: target URL is not permitted');
+            });
+
+            it('does not swallow non-SSRF errors (e.g. network failures)', async () => {
+                safeFetchWithDnsPinMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+                const context = service.createContext('test-plugin');
+
+                await expect(context.http.get('https://api.example.com/data')).rejects.toThrow(
+                    'ECONNREFUSED',
+                );
+            });
         });
     });
 

--- a/packages/agent/src/plugins/services/plugin-context-factory.service.ts
+++ b/packages/agent/src/plugins/services/plugin-context-factory.service.ts
@@ -2,9 +2,12 @@ import { randomUUID } from 'node:crypto';
 import { Injectable, Inject, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
-// Security: lexical SSRF guard for the plugin HTTP client (blocks literal
-// private/loopback/link-local IPs and cloud-metadata hostnames before fetch).
-import { isSafeWebhookUrl } from '../../utils/ssrf-guard';
+// Security: DNS-pinned SSRF guard for the plugin HTTP client. safeFetchWithDnsPin
+// runs the lexical check (blocks literal private/loopback/link-local IPs and
+// cloud-metadata hostnames) AND resolves the hostname to refuse any private IP
+// before the socket connect, mitigating DNS-rebinding. Mirrors the guard used by
+// WebhookDeliveryService. Throws SsrfBlockedError on any refusal.
+import { safeFetchWithDnsPin, SsrfBlockedError } from '../../utils/ssrf-guard';
 import type {
     PluginContext,
     PluginLogger,
@@ -339,27 +342,35 @@ export class PluginContextFactoryService {
             // request. The plugin HTTP client runs inside the API process and
             // shares its network namespace, so a malicious/compromised plugin
             // could otherwise reach cloud-metadata endpoints (169.254.169.254),
-            // loopback, or RFC1918 internal hosts. isSafeWebhookUrl is the same
-            // lexical guard used by WebhookDeliveryService; it blocks literal
-            // private/loopback/link-local IPs, metadata hostnames, and
-            // non-HTTP(S) schemes without a DNS lookup (so legitimate external
-            // calls to public hosts are unaffected).
-            if (!isSafeWebhookUrl(url)) {
-                this.logger.warn(
-                    `Plugin "${pluginId}" attempted a blocked ${method} request to a disallowed URL`,
-                );
-                throw new Error('Request blocked: target URL is not permitted');
+            // loopback, or RFC1918 internal hosts. safeFetchWithDnsPin is the
+            // same DNS-pinned guard used by WebhookDeliveryService: it runs the
+            // lexical check internally (blocking literal private/loopback/
+            // link-local IPs, metadata hostnames, and non-HTTP(S) schemes) AND
+            // resolves the hostname to refuse any private IP before connecting,
+            // mitigating DNS-rebinding. Legitimate external calls to public
+            // hosts are unaffected. On any refusal it throws SsrfBlockedError,
+            // which we re-map to the existing generic plugin-facing error so the
+            // error surface seen by plugins is unchanged.
+            let response: Response;
+            try {
+                response = await safeFetchWithDnsPin(url, {
+                    method,
+                    headers: {
+                        ...(body ? { 'Content-Type': 'application/json' } : {}),
+                        ...options?.headers,
+                    },
+                    body: body ? JSON.stringify(body) : undefined,
+                    signal: options?.timeout ? AbortSignal.timeout(options.timeout) : undefined,
+                });
+            } catch (err) {
+                if (err instanceof SsrfBlockedError) {
+                    this.logger.warn(
+                        `Plugin "${pluginId}" attempted a blocked ${method} request to a disallowed URL (${err.code})`,
+                    );
+                    throw new Error('Request blocked: target URL is not permitted');
+                }
+                throw err;
             }
-
-            const response = await fetch(url, {
-                method,
-                headers: {
-                    ...(body ? { 'Content-Type': 'application/json' } : {}),
-                    ...options?.headers,
-                },
-                body: body ? JSON.stringify(body) : undefined,
-                signal: options?.timeout ? AbortSignal.timeout(options.timeout) : undefined,
-            });
 
             let data: T;
             try {

--- a/packages/cli-shared/src/prompts/__tests__/base-prompt.service.spec.ts
+++ b/packages/cli-shared/src/prompts/__tests__/base-prompt.service.spec.ts
@@ -73,6 +73,21 @@ describe('BasePromptService — validateUrl', () => {
 	it('rejects empty string', () => {
 		expect(svc.exposeValidateUrl('')).not.toBe(true);
 	});
+
+	it('rejects non-http(s) schemes (file:, javascript:, data:, ftp:)', () => {
+		// Security (SSRF/LFI): these are syntactically valid URLs that the old
+		// guard accepted because it only checked `new URL(...)` did not throw.
+		for (const dangerous of [
+			'file:///etc/passwd',
+			'javascript:alert(1)',
+			'data:text/html,<script>alert(1)</script>',
+			'ftp://example.com/resource'
+		]) {
+			const r = svc.exposeValidateUrl(dangerous);
+			expect(typeof r).toBe('string');
+			expect(r as string).toMatch(/http and https/);
+		}
+	});
 });
 
 describe('BasePromptService — validateEmail', () => {

--- a/packages/cli-shared/src/prompts/base-prompt.service.ts
+++ b/packages/cli-shared/src/prompts/base-prompt.service.ts
@@ -229,7 +229,13 @@ export abstract class BasePromptService {
 	 */
 	protected validateUrl(url: string): string | boolean {
 		try {
-			new URL(url);
+			const parsed = new URL(url);
+			// Security: restrict to http(s) so non-fetchable/dangerous schemes
+			// (file:, javascript:, data:, ftp:, etc.) cannot pass validation and
+			// be stored as work config or handed to downstream fetch/agent code (SSRF/LFI).
+			if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+				return 'Only http and https URLs are allowed (e.g., https://example.com)';
+			}
 			return true;
 		} catch {
 			return 'Please enter a valid URL (e.g., https://example.com)';

--- a/packages/plugins/activepieces/src/__tests__/form-schema.spec.ts
+++ b/packages/plugins/activepieces/src/__tests__/form-schema.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { validateFormInput } from '../form-schema.js';
+
+describe('validateFormInput', () => {
+	it('is valid when repository access is disabled', () => {
+		expect(validateFormInput({ pass_repo_access: false })).toEqual({ valid: true });
+	});
+
+	it('requires a repo_url when repository access is enabled', () => {
+		const result = validateFormInput({ pass_repo_access: true });
+		expect(result.valid).toBe(false);
+		expect(result.errors?.[0]?.path).toBe('repo_url');
+		expect(result.errors?.[0]?.message).toMatch(/required/i);
+	});
+
+	it('accepts a valid https://github.com repo URL (with token)', () => {
+		const result = validateFormInput({
+			pass_repo_access: true,
+			repo_url: 'https://github.com/org/repo',
+			repo_access_token: 'ghp_xxx'
+		});
+		expect(result).toEqual({ valid: true });
+	});
+
+	// SSRF guard: these all pass the non-empty check but must be rejected as repo_url.
+	it.each([
+		['internal host', 'http://internal-secrets-service/'],
+		['non-https github', 'http://github.com/org/repo'],
+		['file scheme', 'file:///etc/passwd'],
+		['github.com subdomain lookalike', 'https://github.com.evil.com/org/repo'],
+		['credential-host lookalike', 'https://github.com@evil.com/org/repo'],
+		['arbitrary external host', 'https://evil.com/org/repo'],
+		['not a URL at all', 'not-a-url']
+	])('rejects %s as repo_url (%s)', (_label, repoUrl) => {
+		const result = validateFormInput({
+			pass_repo_access: true,
+			repo_url: repoUrl,
+			repo_access_token: 'ghp_xxx'
+		});
+		expect(result.valid).toBe(false);
+		expect(result.errors?.[0]?.path).toBe('repo_url');
+		expect(result.errors?.[0]?.message).toMatch(/https:\/\/github\.com/i);
+	});
+
+	it('still requires repo_access_token after a valid repo_url', () => {
+		const result = validateFormInput({
+			pass_repo_access: true,
+			repo_url: 'https://github.com/org/repo'
+		});
+		expect(result.valid).toBe(false);
+		expect(result.errors?.[0]?.path).toBe('repo_access_token');
+	});
+});

--- a/packages/plugins/activepieces/src/form-schema.ts
+++ b/packages/plugins/activepieces/src/form-schema.ts
@@ -158,6 +158,25 @@ export function validateFormInput(values: Record<string, unknown>): ValidationRe
 				errors: [{ path: 'repo_url', message: 'Repository URL is required when repository access is enabled' }]
 			};
 		}
+		// Security (SSRF / supply-chain): the repo URL is forwarded (with the access token) to the
+		// Activepieces flow, so reject anything that is not an https://github.com/... URL at validation
+		// time. Mirrors assertSafeGithubRepoUrl in utils/payload-builder.ts (the runtime guard).
+		let parsedRepoUrl: URL | null = null;
+		try {
+			parsedRepoUrl = new URL(values.repo_url.trim());
+		} catch {
+			parsedRepoUrl = null;
+		}
+		if (
+			!parsedRepoUrl ||
+			parsedRepoUrl.protocol !== 'https:' ||
+			parsedRepoUrl.hostname.toLowerCase() !== 'github.com'
+		) {
+			return {
+				valid: false,
+				errors: [{ path: 'repo_url', message: 'Repository URL must be an https://github.com/... URL' }]
+			};
+		}
 		if (
 			!values.repo_access_token ||
 			typeof values.repo_access_token !== 'string' ||


### PR DESCRIPTION
## Wave G — contained SSRF + import-bound fixes (EW-715 / EW-717)

Part of the **EW-710** security-audit remediation epic. Two clusters were
verify-live triaged against current code; most findings were already mitigated
by earlier waves. This lands the genuinely-open, contained, mechanically-
verifiable subset.

### Triage outcome (verify-live, not the stale snapshot)

| Cluster | Candidates | Already-fixed | Defer-decision | Behavioral-risk | **Open → fixed here** |
|---|--:|--:|--:|--:|--:|
| EW-717 path-traversal / upload / deser | 14 | 9 | 3 | 0 | **1** |
| EW-715 SSRF | 34 | 18 | 7 | 3 | **6** |

The defer/behavioral items are recorded on their tickets (KB-upload MIME policy → new **D12**; `allowedPaths` → D7/D10 sandbox; DNS-rebinding full IP-pinning → needs `undici` dispatcher).

### Fixes (one file + a co-located test each; fail-without/pass-with verified)

| # | Ticket | File | Fix |
|---|---|---|---|
| 1 | EW-717 | `apps/web/.../account-transfer-schemas.ts` | cap nested import arrays (`works`/`userPlugins` + v2 tail) so a hostile/corrupted export can't force unbounded memory/RPC body; schema extracted to a pure module for unit testing |
| 2 | EW-715 | `cli-shared/.../base-prompt.service.ts` | `validateUrl` restricted to http(s) (reject `file:`/`javascript:`/`data:`/`ftp:`) |
| 3 | EW-715 | `agent/.../plugin-context-factory.service.ts` | plugin HTTP client lexical guard → DNS-pinned `safeFetchWithDnsPin` (refuses DNS-rebinding to private/loopback/metadata); `SsrfBlockedError` re-mapped to the existing plugin error |
| 4 | EW-715 | `api/.../onboarding.service.ts` | env-gated `isSafeWebhookUrl` on the persisted register-work `webhookUrl` (fetched server-side on terminal status) |
| 5 | EW-715 | `apps/web/.../instrumentation.ts` | warn (not throw) at boot when `ALLOWED_REDIRECT_URLS` is unset in production |
| 6 | EW-715 | `api/.../missions/dto/mission.dto.ts` | `IsMissionTemplateRepo` DTO constraint mirrors `MissionsService.normalizeTemplateRepo`, rejecting SSRF payloads at the boundary |
| 7 | EW-715 | `activepieces/.../form-schema.ts` | `validateFormInput` requires an `https://github.com/...` repo_url (token is forwarded to the flow) |

### Verification

- **Affected packages build clean:** apps/api **TSC 0 issues**, packages/agent **TSC 0 issues**, cli-shared + activepieces built.
- **All affected suites pass (independently re-run):** apps/api Jest 46, agent Jest 58, cli-shared Vitest 46, activepieces Vitest 11, web instrumentation 3, web account-transfer-schemas 7.
- apps/web touched files type-check clean (the pre-existing `KbMetadataPanel.tsx` baseline error is unrelated and unchanged from `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added account export payload validation with array size limits to prevent oversized imports.

* **Security Improvements**
  * Enhanced SSRF defenses for mission templates and webhook URLs.
  * Strengthened plugin HTTP request security with DNS-pinned validation.
  * URL scheme validation now enforces HTTPS for CLI and form inputs.
  * Repository URL validation restricted to GitHub with HTTPS requirement.
  * Added production warning when redirect URL allowlist is unconfigured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->