### PR TITLE
fix(security): Wave H — contained secret-at-rest + hygiene fixes (EW-716)

### DIFF
--- a/apps/api/src/config/constants.spec.ts
+++ b/apps/api/src/config/constants.spec.ts
@@ -123,6 +123,59 @@ describe('config/constants', () => {
         });
     });
 
+    // #21: PLATFORM_ENCRYPTION_KEY must be present in non-local environments.
+    // The validator is exempt for local runs (NODE_ENV development/test/unset)
+    // so contributors don't need to provision a key just to boot. NODE_ENV is
+    // restored after each case because the suite-level beforeEach does not.
+    describe('config.platformEncryptionKey (#21)', () => {
+        const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+        afterEach(() => {
+            if (ORIGINAL_NODE_ENV === undefined) {
+                delete process.env.NODE_ENV;
+            } else {
+                process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+            }
+        });
+
+        it('throws in a non-local environment (e.g. production) when the key is missing', () => {
+            process.env.NODE_ENV = 'production';
+            delete process.env.PLATFORM_ENCRYPTION_KEY;
+            expect(() => config.platformEncryptionKey()).toThrow(
+                /PLATFORM_ENCRYPTION_KEY .* required in non-local environments/,
+            );
+        });
+
+        it('throws in staging (any non-local NODE_ENV) when the key is missing', () => {
+            process.env.NODE_ENV = 'staging';
+            delete process.env.PLATFORM_ENCRYPTION_KEY;
+            expect(() => config.platformEncryptionKey()).toThrow(/PLATFORM_ENCRYPTION_KEY/);
+        });
+
+        it('returns the key when set in a non-local environment', () => {
+            process.env.NODE_ENV = 'production';
+            process.env.PLATFORM_ENCRYPTION_KEY = 'k'.repeat(48);
+            expect(config.platformEncryptionKey()).toBe('k'.repeat(48));
+        });
+
+        it.each(['development', 'test', ''])(
+            'does NOT throw when NODE_ENV is local (%j) even with no key',
+            (env) => {
+                process.env.NODE_ENV = env;
+                delete process.env.PLATFORM_ENCRYPTION_KEY;
+                expect(() => config.platformEncryptionKey()).not.toThrow();
+                expect(config.platformEncryptionKey()).toBeUndefined();
+            },
+        );
+
+        it('does NOT throw when NODE_ENV is unset (undefined) even with no key', () => {
+            delete process.env.NODE_ENV;
+            delete process.env.PLATFORM_ENCRYPTION_KEY;
+            expect(() => config.platformEncryptionKey()).not.toThrow();
+            expect(config.platformEncryptionKey()).toBeUndefined();
+        });
+    });
+
     describe('config.branding', () => {
         it('falls back to defaults', () => {
             expect(config.branding.appName()).toBe('Ever Works');
@@ -245,6 +298,27 @@ describe('config/constants', () => {
             expect(config.mail.smtpHost()).toBe('mail.example.com');
             expect(config.mail.smtpUser()).toBe('user');
             expect(config.mail.smtpPassword()).toBe('pass');
+        });
+
+        // #31: TLS cert verification for outbound mail must default to ON
+        // (secure). mail.module.ts reads this accessor so the only opt-out is
+        // the explicit `SMTP_REJECT_UNAUTHORIZED=false` escape hatch.
+        describe('smtpRejectUnauthorized', () => {
+            it('defaults to true (verification ON) when SMTP_REJECT_UNAUTHORIZED is unset', () => {
+                expect(config.mail.smtpRejectUnauthorized()).toBe(true);
+            });
+
+            it('is false ONLY for the exact string "false"', () => {
+                process.env.SMTP_REJECT_UNAUTHORIZED = 'false';
+                expect(config.mail.smtpRejectUnauthorized()).toBe(false);
+            });
+
+            it('stays true for any other value (case/typo do not disable verification)', () => {
+                for (const v of ['true', 'FALSE', 'False', '0', 'no', '', 'yes']) {
+                    process.env.SMTP_REJECT_UNAUTHORIZED = v;
+                    expect(config.mail.smtpRejectUnauthorized()).toBe(true);
+                }
+            });
         });
     });
 

--- a/apps/api/src/config/constants.ts
+++ b/apps/api/src/config/constants.ts
@@ -56,6 +56,34 @@ export const config = {
         },
     },
 
+    // #21: PLATFORM_ENCRYPTION_KEY is the master key used to encrypt
+    // operator-supplied secrets at rest (plugin/integration credentials).
+    // A missing key in a real deployment means either secrets are stored
+    // in plaintext or every encrypt/decrypt call fails deep inside a
+    // request — both surface late and opaquely. Fail fast at boot
+    // (main.ts calls this right after auth.secret()) so the
+    // misconfiguration is visible immediately. Local development/test
+    // runs (where NODE_ENV is 'development', 'test', or simply unset)
+    // are exempt so contributors don't need to provision a key to boot,
+    // mirroring the local-friendly fallbacks elsewhere in this config.
+    platformEncryptionKey: () => {
+        const key = process.env.PLATFORM_ENCRYPTION_KEY;
+        const nodeEnv = process.env.NODE_ENV;
+        const isLocal =
+            nodeEnv === 'development' ||
+            nodeEnv === 'test' ||
+            nodeEnv === undefined ||
+            nodeEnv === '';
+        if (!key && !isLocal) {
+            throw new Error(
+                'PLATFORM_ENCRYPTION_KEY environment variable is required in non-local environments. ' +
+                    'It is the master key used to encrypt operator-supplied secrets at rest; ' +
+                    'set it (e.g. `openssl rand -base64 48`) and re-deploy.',
+            );
+        }
+        return key;
+    },
+
     branding: {
         appName: () => process.env.APP_NAME || process.env.NEXT_PUBLIC_APP_NAME || 'Ever Works',
         companyOwner: () =>
@@ -93,6 +121,14 @@ export const config = {
         smtpPassword: () => process.env.SMTP_PASSWORD,
         smtpSecure: () => process.env.SMTP_SECURE === 'true',
         smtpIgnoreTLS: () => process.env.SMTP_IGNORE_TLS === 'true',
+        // #31: verify the SMTP relay's TLS certificate by default so outbound
+        // mail (password-reset, magic-link, account-deletion tokens) can't be
+        // intercepted via a MITM presenting an invalid cert. Verification stays
+        // ON unless an operator explicitly opts out with
+        // `SMTP_REJECT_UNAUTHORIZED=false` (e.g. a local MailHog/Mailpit relay
+        // with a self-signed cert). Centralised here so mail.module.ts reads it
+        // through the config surface instead of touching process.env inline.
+        smtpRejectUnauthorized: () => process.env.SMTP_REJECT_UNAUTHORIZED !== 'false',
         resend: {
             apiKey: () => process.env.RESEND_APIKEY,
             emailFrom: () => {

--- a/apps/api/src/mail/mail.module.ts
+++ b/apps/api/src/mail/mail.module.ts
@@ -46,7 +46,7 @@ import { MailerService } from './providers/mailer.service';
                     // stack short-circuits TLS via `SMTP_IGNORE_TLS=true`, so
                     // this default does not affect it.
                     tls: {
-                        rejectUnauthorized: process.env.SMTP_REJECT_UNAUTHORIZED !== 'false',
+                        rejectUnauthorized: config.mail.smtpRejectUnauthorized(),
                     },
                 },
                 defaults: {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -28,6 +28,14 @@ async function bootstrap() {
     // `const config` for Swagger.
     appConfig.auth.secret();
 
+    // #21: fail fast on a missing PLATFORM_ENCRYPTION_KEY in non-local
+    // environments. It is the master key used to encrypt operator-supplied
+    // secrets at rest; without this check a misconfigured prod/staging deploy
+    // boots clean and the gap only surfaces deep inside a request (plaintext
+    // secrets or an opaque encrypt/decrypt failure). Local dev/test runs are
+    // exempt (see the validator in config/constants.ts).
+    appConfig.platformEncryptionKey();
+
     // Initialize Sentry and PostHog
     initSentry();
     initPostHog();

--- a/apps/api/src/onboarding/onboarding.service.spec.ts
+++ b/apps/api/src/onboarding/onboarding.service.spec.ts
@@ -433,6 +433,33 @@ spec:
             expect(result.status).toBe('queued');
         });
 
+        it('rejects a plaintext http:// webhookUrl in a non-local env even when the host is public (HMAC exposure)', async () => {
+            // The host is public, so isSafeWebhookUrl() returns true and the
+            // SSRF guard above lets it through. Only the https-only crypto
+            // guard rejects it — this test fails without that guard.
+            process.env.NODE_ENV = 'production';
+            const repo = fakeRepository();
+            const { service } = createService({ repo });
+
+            await expect(
+                service.handle({
+                    body: {
+                        ...validBody,
+                        webhookUrl: 'http://my-agent.example.com/webhooks/ever-works',
+                    } as any,
+                    githubToken: 'token-aaaa',
+                }),
+            ).rejects.toMatchObject({
+                response: {
+                    code: 'validation_error',
+                    message: 'webhookUrl must use https in non-local environments',
+                },
+            });
+
+            // Rejected before any persistence / GitHub work.
+            expect(repo.save).not.toHaveBeenCalled();
+        });
+
         it('allows a public webhookUrl in a non-local env (production)', async () => {
             process.env.NODE_ENV = 'production';
             const repo = fakeRepository();

--- a/apps/api/src/onboarding/onboarding.service.ts
+++ b/apps/api/src/onboarding/onboarding.service.ts
@@ -106,6 +106,18 @@ export class OnboardingService {
                     message: 'webhookUrl resolves to a private/loopback/link-local address',
                 });
             }
+            // Security (crypto/HMAC exposure): the register-work DTO accepts an
+            // http(s) shape, so a plaintext http:// webhook would be fetched
+            // server-side and the request-signing HMAC sent in the clear. The
+            // DTO regex intentionally still allows http:// so a developer can
+            // point at a local tunnel in dev/test — enforce https only in
+            // non-local (staging/prod) envs, mirroring the isLocalEnv gate above.
+            if (!isLocalEnv && !ctx.body.webhookUrl.startsWith('https://')) {
+                this.fail({
+                    code: 'validation_error',
+                    message: 'webhookUrl must use https in non-local environments',
+                });
+            }
         }
 
         const coords = parseRepoCoords(ctx.body.repo);

--- a/apps/api/src/webhooks/webhooks.service.spec.ts
+++ b/apps/api/src/webhooks/webhooks.service.spec.ts
@@ -111,6 +111,37 @@ describe('WebhooksService', () => {
             ).resolves.toBeDefined();
         });
 
+        it('rejects plaintext http in non-local envs (HMAC exposure)', async () => {
+            // A public, non-private https host so the SSRF guard passes and we
+            // isolate the https-only protocol check.
+            process.env.NODE_ENV = 'production';
+            await expect(
+                service.create(ACCOUNT, { url: 'http://hooks.example.com/ingest' }),
+            ).rejects.toThrow(BadRequestException);
+            await expect(
+                service.create(ACCOUNT, { url: 'http://hooks.example.com/ingest' }),
+            ).rejects.toThrow(/https/);
+        });
+
+        it('accepts https in non-local envs', async () => {
+            process.env.NODE_ENV = 'production';
+            // Encryption-at-rest is mandatory in prod before a secret can be
+            // minted; supply a valid 32-byte (hex) key so the https path
+            // reaches a successful create instead of the secret-service guard.
+            process.env.PLATFORM_ENCRYPTION_KEY = 'a'.repeat(64);
+            service = new WebhooksService(repo as any, new WebhookSecretService());
+            await expect(
+                service.create(ACCOUNT, { url: 'https://hooks.example.com/ingest' }),
+            ).resolves.toBeDefined();
+        });
+
+        it('still accepts http in local dev (tunnels)', async () => {
+            process.env.NODE_ENV = 'development';
+            await expect(
+                service.create(ACCOUNT, { url: 'http://hooks.example.com/ingest' }),
+            ).resolves.toBeDefined();
+        });
+
         it('enforces per-account cap (25)', async () => {
             const rows = Array.from({ length: 25 }, (_, i) => ({ id: `wh-${i}` }));
             repo.listActiveForAccount.mockResolvedValueOnce(rows as any);

--- a/apps/api/src/webhooks/webhooks.service.ts
+++ b/apps/api/src/webhooks/webhooks.service.ts
@@ -181,6 +181,16 @@ export class WebhooksService {
                     `url ${parsed.hostname} resolves to a private / loopback / link-local address`,
                 );
             }
+            // HMAC-signed webhook payloads must not traverse plaintext http
+            // in non-local envs (the signature/secret would be exposed on the
+            // wire). Local dev/test still allows http above so tunnels work.
+            // Checked after the SSRF guard so private/loopback hosts keep their
+            // existing 403 surface regardless of scheme.
+            if (parsed.protocol !== 'https:') {
+                throw new BadRequestException(
+                    'webhook url must use https in non-local environments',
+                );
+            }
         }
     }
 }

--- a/apps/cli/src/commands/auth/__tests__/credentials.service.spec.ts
+++ b/apps/cli/src/commands/auth/__tests__/credentials.service.spec.ts
@@ -4,13 +4,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 vi.mock('fs-extra', () => {
     const ensureDir = vi.fn().mockResolvedValue(undefined);
     const writeJson = vi.fn().mockResolvedValue(undefined);
+    const chmod = vi.fn().mockResolvedValue(undefined);
     const readJson = vi.fn();
     const pathExists = vi.fn();
     const remove = vi.fn().mockResolvedValue(undefined);
     return {
-        default: { ensureDir, writeJson, readJson, pathExists, remove },
+        default: { ensureDir, writeJson, chmod, readJson, pathExists, remove },
         ensureDir,
         writeJson,
+        chmod,
         readJson,
         pathExists,
         remove,
@@ -67,7 +69,7 @@ describe('CredentialsService', () => {
     });
 
     describe('save', () => {
-        it('ensures the credentials dir exists then writes JSON with 2-space indent', async () => {
+        it('ensures the credentials dir exists then writes JSON with 2-space indent then hardens file mode', async () => {
             const order: string[] = [];
             (fs.ensureDir as ReturnType<typeof vi.fn>).mockImplementation(async () => {
                 order.push('ensureDir');
@@ -75,14 +77,31 @@ describe('CredentialsService', () => {
             (fs.writeJson as ReturnType<typeof vi.fn>).mockImplementation(async () => {
                 order.push('writeJson');
             });
+            (fs.chmod as unknown as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+                order.push('chmod');
+            });
 
             const creds: Credentials = { token: validToken(), apiUrl: 'http://x' };
             await CredentialsService.save(creds);
 
-            expect(order).toEqual(['ensureDir', 'writeJson']);
+            // chmod must run AFTER the file is written, otherwise the token is
+            // briefly world-readable (or chmod targets a non-existent file).
+            expect(order).toEqual(['ensureDir', 'writeJson', 'chmod']);
             const writeCall = (fs.writeJson as ReturnType<typeof vi.fn>).mock.calls[0];
             expect(writeCall[1]).toBe(creds);
             expect(writeCall[2]).toEqual({ spaces: 2 });
+        });
+
+        it('restricts the credentials file to owner-only (0o600) so the JWT is not world-readable', async () => {
+            const creds: Credentials = { token: validToken(), apiUrl: 'http://x' };
+            await CredentialsService.save(creds);
+
+            expect(fs.chmod).toHaveBeenCalledTimes(1);
+            const chmodCall = (fs.chmod as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+            // mode must be exactly 0o600 (owner read/write, no group/other access)
+            expect(chmodCall[1]).toBe(0o600);
+            // and it must target the same credentials file that was written
+            expect(chmodCall[0]).toBe(CredentialsService.credentialsPath);
         });
     });
 

--- a/apps/cli/src/commands/auth/credentials.service.ts
+++ b/apps/cli/src/commands/auth/credentials.service.ts
@@ -35,6 +35,10 @@ export class CredentialsService {
     static async save(credentials: Credentials): Promise<void> {
         await this.ensureCredentialsDir();
         await fs.writeJson(CREDENTIALS_FILE, credentials, { spaces: 2 });
+        // Security: restrict the credentials file to owner read/write (0o600) so
+        // the stored bearer token is not world-readable. POSIX mode is a no-op on
+        // Windows. The containing dir is hardened to 0o700 separately.
+        await fs.chmod(CREDENTIALS_FILE, 0o600);
     }
 
     static async get(): Promise<Credentials | null> {

--- a/apps/internal-cli/src/config/__tests__/config.service.spec.ts
+++ b/apps/internal-cli/src/config/__tests__/config.service.spec.ts
@@ -3,12 +3,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 vi.mock('fs-extra', () => {
     const ensureDir = vi.fn().mockResolvedValue(undefined);
     const writeJson = vi.fn().mockResolvedValue(undefined);
+    const chmod = vi.fn().mockResolvedValue(undefined);
     const readJson = vi.fn();
     const pathExists = vi.fn();
     return {
-        default: { ensureDir, writeJson, readJson, pathExists },
+        default: { ensureDir, writeJson, chmod, readJson, pathExists },
         ensureDir,
         writeJson,
+        chmod,
         readJson,
         pathExists,
     };
@@ -30,6 +32,7 @@ describe('ConfigService', () => {
         // next. Re-seed the fs-extra mocks' default implementations each test.
         m(fs.ensureDir).mockResolvedValue(undefined as never);
         m(fs.writeJson).mockResolvedValue(undefined as never);
+        m(fs.chmod).mockResolvedValue(undefined as never);
         m(fs.readJson).mockReset();
         m(fs.pathExists).mockReset();
         service = new ConfigService();
@@ -101,6 +104,22 @@ describe('ConfigService', () => {
             expect(writeCall[0]).toBe(service.getConfigPath());
             expect(writeCall[1]).toEqual({ GIT_TOKEN: 'tok' });
             expect(writeCall[2]).toEqual({ spaces: 2 });
+        });
+
+        it('restricts the config file to owner read/write (chmod 0o600) after writing', async () => {
+            const order: string[] = [];
+            m(fs.writeJson).mockImplementation(async () => {
+                order.push('writeJson');
+            });
+            m(fs.chmod).mockImplementation(async () => {
+                order.push('chmod');
+            });
+
+            await service.saveConfig({ GIT_TOKEN: 'tok' });
+
+            expect(fs.chmod).toHaveBeenCalledWith(service.getConfigPath(), 0o600);
+            // chmod must run AFTER the file is written, never before.
+            expect(order).toEqual(['writeJson', 'chmod']);
         });
 
         it('strips undefined / null / empty-string values before writing', async () => {

--- a/apps/internal-cli/src/config/config.service.ts
+++ b/apps/internal-cli/src/config/config.service.ts
@@ -89,6 +89,11 @@ export class ConfigService {
             const cleanConfig = this.removeUndefinedValues(config);
 
             await fs.writeJson(this.configPath, cleanConfig, { spaces: 2 });
+
+            // Security: the config file may hold secrets (GIT_TOKEN, PLUGIN_*_API_KEY,
+            // DEPLOY_TOKEN). Restrict it to owner read/write so it is not
+            // world-readable. POSIX-only; a no-op on Windows.
+            await fs.chmod(this.configPath, 0o600);
         } catch (error) {
             throw new Error(`Failed to save configuration: ${error.message}`);
         }

--- a/apps/mcp/src/api-client/sanitize.ts
+++ b/apps/mcp/src/api-client/sanitize.ts
@@ -1,25 +1,29 @@
-// Field names matched against the response body by exact-string equality
-// (case-sensitive, no regex / prefix matching). Both camelCase and snake_case
-// variants are listed for fields that travel through both REST DTOs (camel)
-// and OAuth-style responses (snake). Add either spelling when introducing a
-// new sensitive field — there is no automatic case-normalisation.
+// Field names matched against the response body. Matching is
+// case-insensitive: every entry below is stored lowercase and lookups
+// lowercase the candidate key first, so `PASSWORD`, `AccessToken`, and
+// `apiKey` all match regardless of casing. Matching is still exact-string
+// (no regex / prefix matching). Both camelCase and snake_case variants are
+// listed for fields that travel through both REST DTOs (camel) and
+// OAuth-style responses (snake), because lowercasing alone does not bridge
+// the `_` separator (e.g. `apikey` vs `api_key`). Add new sensitive fields
+// in lowercase; casing of the incoming key no longer matters.
 const SENSITIVE_FIELDS = new Set([
 	'password',
-	'passwordResetToken',
-	'passwordResetExpires',
-	'emailVerificationToken',
-	'emailVerificationExpires',
-	'lastLoginIp',
-	'apiKey',
+	'passwordresettoken',
+	'passwordresetexpires',
+	'emailverificationtoken',
+	'emailverificationexpires',
+	'lastloginip',
+	'apikey',
 	'api_key',
 	'secret',
-	'clientSecret',
+	'clientsecret',
 	'client_secret',
-	'accessToken',
+	'accesstoken',
 	'access_token',
-	'refreshToken',
+	'refreshtoken',
 	'refresh_token',
-	'privateKey',
+	'privatekey',
 	'private_key',
 	'token',
 	// Security: additional unambiguous credential/secret field names that can
@@ -27,37 +31,37 @@ const SENSITIVE_FIELDS = new Set([
 	// Only exact, non-ambiguous names are added here — a bare `hash` is left
 	// out on purpose because in this repo it commonly denotes a git commit /
 	// content hash (a legitimate, non-sensitive value).
-	'passwordHash',
+	'passwordhash',
 	'password_hash',
-	'hashedPassword',
+	'hashedpassword',
 	'hashed_password',
 	'salt',
-	'authToken',
+	'authtoken',
 	'auth_token',
-	'apiToken',
+	'apitoken',
 	'api_token',
-	'bearerToken',
+	'bearertoken',
 	'bearer_token',
-	'oauthToken',
+	'oauthtoken',
 	'oauth_token',
-	'sessionToken',
+	'sessiontoken',
 	'session_token',
-	'verificationToken',
+	'verificationtoken',
 	'verification_token',
 	'jwt',
-	'jwtToken',
-	'idToken',
+	'jwttoken',
+	'idtoken',
 	'id_token',
-	'twoFactorSecret',
+	'twofactorsecret',
 	'two_factor_secret',
-	'totpSecret',
+	'totpsecret',
 	'totp_secret',
-	'twoFactorBackupCodes',
-	'backupCodes',
+	'twofactorbackupcodes',
+	'backupcodes',
 	'backup_codes',
-	'encryptedKey',
+	'encryptedkey',
 	'encrypted_key',
-	'encryptedSecret',
+	'encryptedsecret',
 	'encrypted_secret',
 	'otp'
 ]);
@@ -73,7 +77,7 @@ function sanitizeValue(data: unknown): unknown {
 
 	const result: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
-		if (SENSITIVE_FIELDS.has(key)) {
+		if (SENSITIVE_FIELDS.has(key.toLowerCase())) {
 			continue;
 		}
 		result[key] = sanitizeValue(value);
@@ -92,8 +96,10 @@ function sanitizeValue(data: unknown): unknown {
  *   sentinel because tool results are surfaced verbatim to the model,
  *   and a sentinel could mislead the model into thinking the data
  *   exists in some retrievable form.
- * - Match is **case-sensitive exact-string** against the `SENSITIVE_FIELDS`
- *   set; `Token` would not match `token`. Add casing variants explicitly.
+ * - Match is **case-insensitive exact-string** against the `SENSITIVE_FIELDS`
+ *   set; the candidate key is lowercased before lookup, so `Token`,
+ *   `TOKEN`, and `token` all match. Matching is still whole-key exact
+ *   (no prefix / regex), so add snake_case spellings explicitly.
  * - Recurses into objects and arrays; leaves primitives, `null`, and
  *   `undefined` untouched. Cycles are not handled — pass DAG-shaped
  *   data only.

--- a/apps/mcp/test/sanitize.spec.ts
+++ b/apps/mcp/test/sanitize.spec.ts
@@ -91,6 +91,23 @@ describe('sanitizeResponse', () => {
 		});
 	});
 
+	it('strips sensitive fields regardless of key casing', () => {
+		const input = {
+			id: 'u1',
+			email: 'test@example.com',
+			// Uppercased / PascalCased variants that case-sensitive matching
+			// would have leaked through unredacted.
+			PASSWORD: 'hunter2',
+			AccessToken: 'ghp_xxxx',
+			ApiKey: 'sk-abc123',
+			Refresh_Token: 'rt_xxxx',
+			JWT: 'eyJhbGci',
+			Salt: 'random-salt'
+		};
+		const result = sanitizeResponse(input);
+		expect(result).toEqual({ id: 'u1', email: 'test@example.com' });
+	});
+
 	it('preserves non-sensitive fields', () => {
 		const input = {
 			id: '123',

--- a/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
+++ b/packages/agent/src/plugins/__tests__/plugin-operations.service.spec.ts
@@ -160,8 +160,9 @@ describe('PluginOperationsService', () => {
                         resolveSettings: jest.fn().mockResolvedValue({}),
                         getResolvedSettings: jest.fn().mockResolvedValue({}),
                         // D3 / C-08 — encrypting write path that enable-time
-                        // secrets must be routed through.
+                        // and update-time secrets must be routed through.
                         updateUserSettings: jest.fn().mockResolvedValue(undefined),
+                        updateWorkSettings: jest.fn().mockResolvedValue(undefined),
                     },
                 },
                 {
@@ -955,7 +956,7 @@ describe('PluginOperationsService', () => {
     });
 
     describe('secretSettings persistence', () => {
-        it('should save new secret value when user updates secret field', async () => {
+        it('should route updated user secret settings through the encrypting write path (D3 / C-08)', async () => {
             const registered = createRegisteredPlugin();
             jest.spyOn(pluginRegistryService, 'get').mockReturnValue(registered);
             jest.spyOn(userPluginRepository, 'findOne').mockResolvedValue({
@@ -967,16 +968,65 @@ describe('PluginOperationsService', () => {
                 secretSettings: { secretField: 'old-secret' },
                 metadata: {},
             } as any);
+            const updateUserSettingsSpy = jest.spyOn(settingsService, 'updateUserSettings');
+
+            // Snapshot secretSettings AT save-time (deep copy) — the entity is
+            // passed by reference, so a post-save in-memory mutation (used only
+            // to build the masked response) must not contaminate this evidence.
+            const secretSnapshotsAtSave: Array<Record<string, unknown>> = [];
+            jest.spyOn(userPluginRepository, 'save').mockImplementation((entity: any) => {
+                secretSnapshotsAtSave.push(JSON.parse(JSON.stringify(entity.secretSettings ?? {})));
+                return entity;
+            });
 
             await service.updateUserPluginSettings('test-plugin', 'user-1', undefined, {
                 secretField: 'new-actual-secret',
             });
 
+            // LEGIT path: the secret is persisted, but ONLY through the
+            // PluginSettingsService.updateUserSettings encrypting path
+            // (which runs encryptSecrets() at rest).
+            expect(updateUserSettingsSpy).toHaveBeenCalledWith('test-plugin', 'user-1', {
+                secretField: 'new-actual-secret',
+            });
+
+            // BLOCKED path: the raw plaintext secret must NEVER be written
+            // directly onto the user-plugin entity that is saved to the DB —
+            // doing so would bypass C-08 envelope encryption entirely.
+            expect(secretSnapshotsAtSave.length).toBeGreaterThan(0);
+            for (const snapshot of secretSnapshotsAtSave) {
+                expect(snapshot).not.toEqual(
+                    expect.objectContaining({ secretField: 'new-actual-secret' }),
+                );
+            }
+        });
+
+        it('should NOT invoke the encrypting write path when no user secrets are supplied on update', async () => {
+            const registered = createRegisteredPlugin();
+            jest.spyOn(pluginRegistryService, 'get').mockReturnValue(registered);
+            jest.spyOn(userPluginRepository, 'findOne').mockResolvedValue({
+                id: '1',
+                userId: 'user-1',
+                pluginId: 'test-plugin',
+                enabled: true,
+                settings: {},
+                secretSettings: {},
+                metadata: {},
+            } as any);
+            const updateUserSettingsSpy = jest.spyOn(settingsService, 'updateUserSettings');
+
+            // Update only non-secret settings — the legit happy path must still
+            // persist normally without touching the secret path.
+            await service.updateUserPluginSettings('test-plugin', 'user-1', {
+                normalSetting: 'plain-value',
+            });
+
             expect(userPluginRepository.save).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    secretSettings: { secretField: 'new-actual-secret' },
+                    settings: { normalSetting: 'plain-value' },
                 }),
             );
+            expect(updateUserSettingsSpy).not.toHaveBeenCalled();
         });
 
         it('should route enable-time secret settings through the encrypting write path (D3 / C-08)', async () => {
@@ -1043,7 +1093,7 @@ describe('PluginOperationsService', () => {
             expect(updateUserSettingsSpy).not.toHaveBeenCalled();
         });
 
-        it('should save secret settings on updateWorkPluginSettings', async () => {
+        it('should route updated work secret settings through the encrypting write path (D3 / C-08)', async () => {
             const registered = createRegisteredPlugin();
             jest.spyOn(pluginRegistryService, 'get').mockReturnValue(registered);
             jest.spyOn(userPluginRepository, 'findOne').mockResolvedValue({
@@ -1064,16 +1114,69 @@ describe('PluginOperationsService', () => {
                 secretSettings: { secretField: 'original-secret' },
                 metadata: {},
             } as any);
+            const updateWorkSettingsSpy = jest.spyOn(settingsService, 'updateWorkSettings');
+
+            // Snapshot secretSettings AT save-time (deep copy) — the entity is
+            // passed by reference, so a post-save in-memory mutation (used only
+            // to build the masked response) must not contaminate this evidence.
+            const secretSnapshotsAtSave: Array<Record<string, unknown>> = [];
+            jest.spyOn(workPluginRepository, 'save').mockImplementation((entity: any) => {
+                secretSnapshotsAtSave.push(JSON.parse(JSON.stringify(entity.secretSettings ?? {})));
+                return entity;
+            });
 
             await service.updateWorkPluginSettings('dir-1', 'test-plugin', 'user-1', undefined, {
                 secretField: 'new-secret',
             });
 
-            expect(workPluginRepository.save).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    secretSettings: { secretField: 'new-secret' },
-                }),
-            );
+            // LEGIT path: the secret is persisted, but ONLY through the
+            // PluginSettingsService.updateWorkSettings encrypting path
+            // (which runs encryptSecrets() at rest). Note the (pluginId, workId)
+            // argument order matches the real method signature.
+            expect(updateWorkSettingsSpy).toHaveBeenCalledWith('test-plugin', 'dir-1', {
+                secretField: 'new-secret',
+            });
+
+            // BLOCKED path: the raw plaintext secret must NEVER be written
+            // directly onto the work-plugin entity that is saved to the DB —
+            // doing so would bypass C-08 envelope encryption entirely.
+            expect(secretSnapshotsAtSave.length).toBeGreaterThan(0);
+            for (const snapshot of secretSnapshotsAtSave) {
+                expect(snapshot).not.toEqual(
+                    expect.objectContaining({ secretField: 'new-secret' }),
+                );
+            }
+        });
+
+        it('should NOT invoke the encrypting write path when no work secrets are supplied on update', async () => {
+            const registered = createRegisteredPlugin();
+            jest.spyOn(pluginRegistryService, 'get').mockReturnValue(registered);
+            jest.spyOn(userPluginRepository, 'findOne').mockResolvedValue({
+                id: '1',
+                userId: 'user-1',
+                pluginId: 'test-plugin',
+                enabled: true,
+                settings: {},
+                secretSettings: {},
+                metadata: {},
+            } as any);
+            jest.spyOn(workPluginRepository, 'findOne').mockResolvedValue({
+                id: '1',
+                workId: 'dir-1',
+                pluginId: 'test-plugin',
+                enabled: true,
+                settings: {},
+                secretSettings: {},
+                metadata: {},
+            } as any);
+            const updateWorkSettingsSpy = jest.spyOn(settingsService, 'updateWorkSettings');
+
+            await service.updateWorkPluginSettings('dir-1', 'test-plugin', 'user-1', {
+                normalSetting: 'plain-value',
+            });
+
+            expect(workPluginRepository.save).toHaveBeenCalled();
+            expect(updateWorkSettingsSpy).not.toHaveBeenCalled();
         });
     });
 
@@ -2225,6 +2328,10 @@ describe('PluginOperationsService', () => {
                         useValue: {
                             resolveSettings: jest.fn().mockResolvedValue({}),
                             getResolvedSettings: jest.fn().mockResolvedValue({}),
+                            // D3 / C-08 — encrypting write path that update-time
+                            // secrets must be routed through.
+                            updateUserSettings: jest.fn().mockResolvedValue(undefined),
+                            updateWorkSettings: jest.fn().mockResolvedValue(undefined),
                         },
                     },
                     {

--- a/packages/agent/src/plugins/services/plugin-operations.service.ts
+++ b/packages/agent/src/plugins/services/plugin-operations.service.ts
@@ -660,23 +660,44 @@ export class PluginOperationsService {
             await this.validateSettingsOrThrow(cleanedSettings, schema, 'user', registered.plugin);
         }
 
-        // Strip masked placeholders then merge settings, clearing null keys
+        // Strip masked placeholders then merge settings, clearing null keys.
+        // Non-secret settings are written directly onto the entity. Secrets are
+        // intentionally NOT written onto the entity here — they are routed
+        // through the PluginSettingsService encrypting write path below so they
+        // are never persisted in plaintext at rest.
         if (settings) {
             const clean = this.stripMaskedValues(settings);
             userPlugin.settings = this.stripNullValues({ ...userPlugin.settings, ...clean });
         }
+        let cleanSecretSettings: Record<string, unknown> | undefined;
         if (secretSettings) {
-            const clean = this.stripMaskedValues(secretSettings);
-            userPlugin.secretSettings = this.stripNullValues({
-                ...userPlugin.secretSettings,
-                ...clean,
-            });
+            cleanSecretSettings = this.stripMaskedValues(secretSettings);
         }
         if (metadata) {
             userPlugin.metadata = { ...userPlugin.metadata, ...metadata };
         }
 
+        // Persist the entity-level fields (non-secret settings / metadata).
+        // The base record is saved first so the encrypting write path below
+        // finds the existing row and merges + encrypts the secret bag onto it.
         await this.userPluginRepository.save(userPlugin);
+
+        // D3 / C-08 — route secret settings through the PluginSettingsService
+        // encrypting write path (updateUserSettings → encryptSecrets) so they
+        // are encrypted at rest exactly like every other secret write.
+        // Previously this method wrote `secretSettings` DIRECTLY onto the
+        // user-plugin entity, bypassing C-08 envelope encryption entirely.
+        if (cleanSecretSettings && Object.keys(cleanSecretSettings).length > 0) {
+            await this.settingsService.updateUserSettings(pluginId, userId, cleanSecretSettings);
+            // Reflect the just-written secrets in the in-memory entity used to
+            // build the response. The response masks x-secret fields, so the
+            // plaintext view here is only used to produce the masked output;
+            // the persisted column holds the encrypted envelope.
+            userPlugin.secretSettings = this.stripNullValues({
+                ...userPlugin.secretSettings,
+                ...cleanSecretSettings,
+            });
+        }
         this.logger.log(`Plugin "${pluginId}" settings updated for user "${userId}"`);
 
         return this.toUserPluginResponseWithResolvedSettings(registered, userPlugin, userId, {
@@ -1091,13 +1112,13 @@ export class PluginOperationsService {
             });
         }
 
+        // Secrets are intentionally NOT written onto the entity here — they are
+        // routed through the PluginSettingsService encrypting write path below
+        // so they are never persisted in plaintext at rest.
+        let cleanSecretSettings: Record<string, unknown> | undefined;
         if (secretSettings) {
             const clean = this.stripMaskedValues(secretSettings);
-            // Update secretSettings
-            workPlugin.secretSettings = this.stripNullValues({
-                ...workPlugin.secretSettings,
-                ...clean,
-            });
+            cleanSecretSettings = clean;
 
             // Cleanup: also remove secret fields from settings if they exist there
             // (handles migration case where secret fields were stored in wrong field)
@@ -1112,7 +1133,27 @@ export class PluginOperationsService {
             workPlugin.metadata = { ...workPlugin.metadata, ...metadata };
         }
 
+        // Persist the entity-level fields (non-secret settings / metadata).
+        // The base record is saved first so the encrypting write path below
+        // finds the existing row and merges + encrypts the secret bag onto it.
         await this.workPluginRepository.save(workPlugin);
+
+        // D3 / C-08 — route secret settings through the PluginSettingsService
+        // encrypting write path (updateWorkSettings → encryptSecrets) so they
+        // are encrypted at rest exactly like every other secret write.
+        // Previously this method wrote `secretSettings` DIRECTLY onto the
+        // work-plugin entity, bypassing C-08 envelope encryption entirely.
+        if (cleanSecretSettings && Object.keys(cleanSecretSettings).length > 0) {
+            await this.settingsService.updateWorkSettings(pluginId, workId, cleanSecretSettings);
+            // Reflect the just-written secrets in the in-memory entity used to
+            // build the response. The response masks x-secret fields, so the
+            // plaintext view here is only used to produce the masked output;
+            // the persisted column holds the encrypted envelope.
+            workPlugin.secretSettings = this.stripNullValues({
+                ...workPlugin.secretSettings,
+                ...cleanSecretSettings,
+            });
+        }
         this.logger.log(`Plugin "${pluginId}" settings updated for work "${workId}"`);
 
         if (hasActiveCapability(workPlugin, 'pipeline') && settings?.model !== undefined) {

--- a/packages/agent/src/services/webhook-subscription-secret.service.spec.ts
+++ b/packages/agent/src/services/webhook-subscription-secret.service.spec.ts
@@ -1,0 +1,75 @@
+import { WebhookSubscriptionSecretService } from './webhook-subscription-secret.service';
+
+/**
+ * Security regression test for the PLATFORM_ENCRYPTION_KEY-absent path.
+ *
+ * encrypt() (and therefore generateSecret(), which calls it) must HARD-FAIL
+ * in production when no key is configured, instead of silently persisting the
+ * webhook subscription signing secret in plaintext. In non-production it keeps
+ * the documented warn+passthrough behavior so dev/test fixtures still work.
+ */
+describe('WebhookSubscriptionSecretService — PLATFORM_ENCRYPTION_KEY-absent guard', () => {
+    const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+    const ORIGINAL_KEY = process.env.PLATFORM_ENCRYPTION_KEY;
+
+    afterEach(() => {
+        if (ORIGINAL_NODE_ENV === undefined) {
+            delete process.env.NODE_ENV;
+        } else {
+            process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+        }
+        if (ORIGINAL_KEY === undefined) {
+            delete process.env.PLATFORM_ENCRYPTION_KEY;
+        } else {
+            process.env.PLATFORM_ENCRYPTION_KEY = ORIGINAL_KEY;
+        }
+        jest.restoreAllMocks();
+    });
+
+    it('encrypt() throws in production when the key is absent (no plaintext passthrough)', () => {
+        process.env.NODE_ENV = 'production';
+        delete process.env.PLATFORM_ENCRYPTION_KEY;
+        const service = new WebhookSubscriptionSecretService();
+
+        expect(() => service.encrypt('super-secret')).toThrow(
+            /PLATFORM_ENCRYPTION_KEY must be set in production/,
+        );
+    });
+
+    it('generateSecret() throws in production when the key is absent (issuance covered)', () => {
+        process.env.NODE_ENV = 'production';
+        delete process.env.PLATFORM_ENCRYPTION_KEY;
+        const service = new WebhookSubscriptionSecretService();
+
+        expect(() => service.generateSecret()).toThrow(
+            /PLATFORM_ENCRYPTION_KEY must be set in production/,
+        );
+    });
+
+    it('encrypt() warns and passes the value through in non-production when the key is absent', () => {
+        process.env.NODE_ENV = 'test';
+        delete process.env.PLATFORM_ENCRYPTION_KEY;
+        const service = new WebhookSubscriptionSecretService();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const warnSpy = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+
+        const out = service.encrypt('plain-value');
+
+        expect(out).toBe('plain-value'); // passthrough, not enveloped
+        expect(out.startsWith('enc::v1::')).toBe(false);
+        expect(warnSpy).toHaveBeenCalledTimes(1); // one-time latch
+    });
+
+    it('encrypt() warn fires once across multiple calls in non-production (latch preserved)', () => {
+        process.env.NODE_ENV = 'development';
+        delete process.env.PLATFORM_ENCRYPTION_KEY;
+        const service = new WebhookSubscriptionSecretService();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const warnSpy = jest.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+
+        expect(service.encrypt('a')).toBe('a');
+        expect(service.encrypt('b')).toBe('b');
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/agent/src/services/webhook-subscription-secret.service.ts
+++ b/packages/agent/src/services/webhook-subscription-secret.service.ts
@@ -65,6 +65,11 @@ export class WebhookSubscriptionSecretService {
             // read access (backup, replica, SQLi) can forge signed webhook bodies.
             // Tolerated only for the documented dev/test path; loudly flagged so a
             // misconfigured production deploy is caught instead of silently leaking.
+            if (process.env.NODE_ENV === 'production') {
+                throw new Error(
+                    'PLATFORM_ENCRYPTION_KEY must be set in production — refusing to store webhook subscription signing secret in plaintext',
+                );
+            }
             if (!this.warnedPlaintextPassthrough) {
                 this.warnedPlaintextPassthrough = true;
                 this.logger.warn(

--- a/packages/agent/src/utils/__tests__/secret-scan.spec.ts
+++ b/packages/agent/src/utils/__tests__/secret-scan.spec.ts
@@ -99,4 +99,56 @@ describe('secret-scan', () => {
             expect(cleaned).toBe('clean prose');
         });
     });
+
+    // EW-716 #17: defeat encoding / zero-width / homoglyph evasion via NFKC
+    // normalization on the DETECTION copy, while keeping redaction output
+    // content-preserving for legitimate (non-evasive) Unicode.
+    describe('encoding/zero-width/homoglyph evasion (NFKC normalization)', () => {
+        const ZWSP = '​';
+        const evasiveToken = `sk-${ZWSP}abcdefghij1234567890`;
+
+        it('detects a zero-width-split token that evaded the raw-regex scan', () => {
+            // The raw body (with the zero-width char) does NOT match directly —
+            // proving the normalize guard is load-bearing.
+            const rawMatch = /\b(sk-|key-|token-|Bearer\s+)[A-Za-z0-9_-]{10,}\b/.test(evasiveToken);
+            expect(rawMatch).toBe(false);
+
+            const hits = scanForSecrets(evasiveToken);
+            expect(hits.length).toBeGreaterThan(0);
+            expect(containsSecret(evasiveToken)).toBe(true);
+        });
+
+        it('detects a soft-hyphen-split token (U+00AD)', () => {
+            const SHY = '­';
+            const body = `please use ghp_${SHY}ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab now`;
+            expect(containsSecret(body)).toBe(true);
+        });
+
+        it('redacts a zero-width-split token but preserves surrounding content', () => {
+            const { cleaned, redactions } = redactSecrets(`prefix ${evasiveToken} suffix`);
+            expect(redactions).toBeGreaterThan(0);
+            expect(cleaned).toContain('[redacted secret]');
+            expect(cleaned).not.toContain('abcdefghij1234567890');
+            expect(cleaned).not.toContain(ZWSP);
+            expect(cleaned).toContain('prefix ');
+            expect(cleaned).toContain(' suffix');
+        });
+
+        it('leaves legitimate prose byte-for-byte unchanged (no false positive)', () => {
+            const prose = 'Write tokens to disk. See the key-takeaways doc and sketch-board notes.';
+            expect(scanForSecrets(prose)).toHaveLength(0);
+            const { cleaned, redactions } = redactSecrets(prose);
+            expect(redactions).toBe(0);
+            expect(cleaned).toBe(prose);
+        });
+
+        it('does NOT corrupt legitimate Unicode content (emoji ZWJ, full-width) when there is no secret', () => {
+            // redactSecrets runs on generated CONTENT — it must round-trip valid
+            // ZWJ emoji sequences and full-width CJK unchanged, never NFKC-fold them.
+            const family = 'Team \u{1F468}‍\u{1F469}‍\u{1F467} shipped ＡＢＣ today.';
+            const { cleaned, redactions } = redactSecrets(family);
+            expect(redactions).toBe(0);
+            expect(cleaned).toBe(family);
+        });
+    });
 });

--- a/packages/agent/src/utils/secret-scan.ts
+++ b/packages/agent/src/utils/secret-scan.ts
@@ -91,16 +91,30 @@ const PATTERNS: ReadonlyArray<{ name: string; re: RegExp }> = [
 ];
 
 /**
+ * Security: defeat encoding / zero-width / homoglyph evasion. A token
+ * split by a zero-width space (e.g. `sk-abcdef…`) or built from
+ * compatibility/full-width homoglyphs slips past the word-boundary
+ * anchored patterns above. NFKC folds compatibility homoglyphs to their
+ * canonical form and the strip removes the invisible joiners scanners
+ * are blind to. Applied to the WORKING COPY used for pattern matching
+ * only; the patterns themselves are unchanged.
+ */
+function normalizeForScan(s: string): string {
+    return s.normalize('NFKC').replace(/[\u200B\u200C\u200D\u00AD\uFEFF\u2060]/g, '');
+}
+
+/**
  * Scan `body` for secret patterns. Returns all matches across all
  * patterns; empty array means "clean".
  */
 export function scanForSecrets(body: string): SecretMatch[] {
     if (!body) return [];
+    const scanBody = normalizeForScan(body);
     const out: SecretMatch[] = [];
     for (const { name, re } of PATTERNS) {
         const r = new RegExp(re.source, re.flags); // fresh state per call
         let m: RegExpExecArray | null;
-        while ((m = r.exec(body)) !== null) {
+        while ((m = r.exec(scanBody)) !== null) {
             out.push({
                 pattern: name,
                 matched: truncateForDisplay(m[0]),
@@ -139,6 +153,25 @@ export function assertNoSecrets(body: string, fieldHint = 'body'): void {
  */
 export function redactSecrets(body: string): { cleaned: string; redactions: number } {
     if (!body) return { cleaned: body, redactions: 0 };
+    // redactSecrets runs on generated/synced CONTENT (data-generator,
+    // markdown-generator, github-sync), not just logs, so it MUST NOT mutate
+    // legitimate non-secret text — NFKC folding / zero-width stripping would
+    // corrupt valid emoji ZWJ sequences, full-width CJK, and ligatures.
+    // So: redact the RAW body first (byte-for-byte preserving). Only when the
+    // normalized copy catches STRICTLY MORE secrets — i.e. a genuine
+    // zero-width / homoglyph EVASION is present — fall back to the normalized
+    // redaction (acceptable for that already-suspicious input, and never
+    // reached for evasion-free content).
+    const raw = redactWith(body);
+    const normalized = normalizeForScan(body);
+    if (normalized !== body) {
+        const norm = redactWith(normalized);
+        if (norm.redactions > raw.redactions) return norm;
+    }
+    return raw;
+}
+
+function redactWith(body: string): { cleaned: string; redactions: number } {
     let cleaned = body;
     let count = 0;
     for (const { re } of PATTERNS) {

--- a/packages/cli-shared/src/utils/__tests__/config-check.spec.ts
+++ b/packages/cli-shared/src/utils/__tests__/config-check.spec.ts
@@ -17,18 +17,28 @@ describe('maskSecret', () => {
 		expect(masked.length).toBe(secret.length);
 	});
 
-	it('handles the boundary value (exactly 8 chars) by returning input unchanged', () => {
-		// length === MIN_SECRET_LENGTH: not short, but length-MIN=0 → no middle stars
-		// so first4 + '' + last4 reconstructs the original.
-		expect(maskSecret('12345678')).toBe('12345678');
+	it('never returns an 8-char secret verbatim (no >50% leak)', () => {
+		const secret = '12345678';
+		const masked = maskSecret(secret);
+		expect(masked).not.toBe(secret);
+		expect(masked).toContain('*');
+		expect(masked).toBe('****');
 	});
 
-	it('handles a 9-character secret with one masked middle char', () => {
-		const masked = maskSecret('123456789');
-		expect(masked.length).toBe(9);
-		expect(masked.startsWith('1234')).toBe(true);
-		expect(masked.endsWith('6789')).toBe(true);
-		expect(masked.charAt(4)).toBe('*');
+	it('never returns a 9-char secret verbatim (no >50% leak)', () => {
+		const secret = '123456789';
+		const masked = maskSecret(secret);
+		expect(masked).not.toBe(secret);
+		expect(masked).toContain('*');
+		expect(masked).toBe('****');
+	});
+
+	it('fully masks any secret shorter than 16 chars so the middle is never narrower than the edges', () => {
+		// 15 chars: revealing first4+last4 would expose 8/15 (>50%) → fully masked.
+		const secret = '123456789012345';
+		const masked = maskSecret(secret);
+		expect(masked).not.toBe(secret);
+		expect(masked).toBe('****');
 	});
 });
 

--- a/packages/cli-shared/src/utils/config-check.ts
+++ b/packages/cli-shared/src/utils/config-check.ts
@@ -45,10 +45,18 @@ export function displayConfigurationWarnings(warnings: string[]): void {
  * Masks sensitive values for display
  */
 export function maskSecret(secret: string): string {
-	const MIN_SECRET_LENGTH = 8;
-	if (!secret || secret.length < MIN_SECRET_LENGTH) {
+	const VISIBLE_PREFIX = 4;
+	const VISIBLE_SUFFIX = 4;
+	const VISIBLE_TOTAL = VISIBLE_PREFIX + VISIBLE_SUFFIX;
+	// Only reveal the first/last 4 chars when doing so leaks at most half of the
+	// secret (i.e. the masked middle is at least as long as the revealed edges).
+	// Shorter secrets — including the previously-leaky 8 and 9 char cases — are
+	// fully masked so we never return them verbatim or expose >50% of their value.
+	const MIN_REVEAL_LENGTH = VISIBLE_TOTAL * 2;
+	if (!secret || secret.length < MIN_REVEAL_LENGTH) {
 		return '****';
 	}
 
-	return secret.substring(0, 4) + '*'.repeat(secret.length - MIN_SECRET_LENGTH) + secret.substring(secret.length - 4);
+	const stars = secret.length - VISIBLE_TOTAL;
+	return secret.substring(0, VISIBLE_PREFIX) + '*'.repeat(stars) + secret.substring(secret.length - VISIBLE_SUFFIX);
 }

--- a/packages/plugins/claude-code/src/__tests__/subprocess-env.spec.ts
+++ b/packages/plugins/claude-code/src/__tests__/subprocess-env.spec.ts
@@ -44,9 +44,10 @@ describe('buildSubprocessEnv (C-10)', () => {
 		expect(env.PATH).toBe('/usr/local/bin:/usr/bin');
 	});
 
-	it('forwards Anthropic / Claude Code-prefixed vars (allow-list by prefix)', () => {
+	it('forwards the explicitly named Anthropic / Claude Code vars (exact-name allow-list)', () => {
 		process.env.ANTHROPIC_BASE_URL = 'https://proxy.local';
 		process.env.ANTHROPIC_API_KEY = 'sk-from-env';
+		process.env.ANTHROPIC_AUTH_TOKEN = 'anthropic-auth-token';
 		process.env.CLAUDE_CODE_CONFIG_DIR = '/tmp/cfg';
 		process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-token';
 		// Negative case: a var that just contains "ANTHROPIC" but doesn't START with the prefix
@@ -57,9 +58,32 @@ describe('buildSubprocessEnv (C-10)', () => {
 
 		expect(env.ANTHROPIC_BASE_URL).toBe('https://proxy.local');
 		expect(env.ANTHROPIC_API_KEY).toBe('sk-from-env');
+		expect(env.ANTHROPIC_AUTH_TOKEN).toBe('anthropic-auth-token');
 		expect(env.CLAUDE_CODE_CONFIG_DIR).toBe('/tmp/cfg');
 		expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token');
 		expect(env.MY_ANTHROPIC_HELPER).toBeUndefined();
+	});
+
+	it('drops arbitrary ANTHROPIC_*/CLAUDE_CODE_*-prefixed vars not on the allow-list', () => {
+		// Regression guard: the env was previously built by matching any key that
+		// merely STARTED WITH `ANTHROPIC_` or `CLAUDE_CODE_`, which silently
+		// forwarded any future/custom var with those prefixes into the model's
+		// subprocess. Only the exact-name allow-list may pass through.
+		process.env.ANTHROPIC_API_KEY = 'sk-from-env';
+		process.env.ANTHROPIC_CUSTOM_VAR = 'should-be-dropped';
+		process.env.ANTHROPIC_SECRET_PROXY_TOKEN = 'leak-me';
+		process.env.CLAUDE_CODE_INTERNAL_DEBUG = 'leak-me-too';
+
+		const env = buildSubprocessEnv();
+
+		// Allow-listed var still forwarded.
+		expect(env.ANTHROPIC_API_KEY).toBe('sk-from-env');
+		// Arbitrary prefixed vars are NOT forwarded.
+		expect(env.ANTHROPIC_CUSTOM_VAR).toBeUndefined();
+		expect(env.ANTHROPIC_SECRET_PROXY_TOKEN).toBeUndefined();
+		expect(env.CLAUDE_CODE_INTERNAL_DEBUG).toBeUndefined();
+		expect(Object.values(env)).not.toContain('leak-me');
+		expect(Object.values(env)).not.toContain('leak-me-too');
 	});
 
 	it('forwards proxy / TLS / CA cert vars from host (corporate network plumbing)', () => {

--- a/packages/plugins/claude-code/src/utils/subprocess-env.ts
+++ b/packages/plugins/claude-code/src/utils/subprocess-env.ts
@@ -30,7 +30,18 @@ const PASSTHROUGH_ENV_KEYS = [
 	'CURL_CA_BUNDLE'
 ] as const;
 
-const CLAUDE_CODE_ENV_PREFIXES = ['ANTHROPIC_', 'CLAUDE_CODE_'] as const;
+// Explicit allow-list of Anthropic-/Claude-Code-specific vars the CLI actually
+// consumes. We list each var by exact name rather than matching by prefix so a
+// future/custom var that merely starts with ANTHROPIC_ or CLAUDE_CODE_ is NOT
+// silently forwarded into the subprocess (audit: prefix forwarding leaks any
+// such var to the model).
+const PASSTHROUGH_ANTHROPIC_KEYS = [
+	'ANTHROPIC_API_KEY',
+	'ANTHROPIC_BASE_URL',
+	'ANTHROPIC_AUTH_TOKEN',
+	'CLAUDE_CODE_OAUTH_TOKEN',
+	'CLAUDE_CODE_CONFIG_DIR'
+] as const;
 
 export function buildSubprocessEnv(overrides: Record<string, string> = {}): Record<string, string> {
 	const env: Record<string, string> = {
@@ -59,14 +70,14 @@ export function buildSubprocessEnv(overrides: Record<string, string> = {}): Reco
 		}
 	}
 
-	// Allow through Anthropic-/Claude-Code-prefixed vars only. The caller is
-	// expected to set the actual auth token via `overrides` (CLAUDE_CODE_OAUTH_TOKEN
-	// or ANTHROPIC_API_KEY) — passing them through here too is harmless and
-	// preserves manual overrides in dev (e.g. ANTHROPIC_BASE_URL pointed at a
-	// local proxy).
-	for (const [key, value] of Object.entries(process.env)) {
-		if (typeof value !== 'string') continue;
-		if (CLAUDE_CODE_ENV_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+	// Allow through the explicitly named Anthropic-/Claude-Code vars only. The
+	// caller is expected to set the actual auth token via `overrides`
+	// (CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY) — passing them through here
+	// too is harmless and preserves manual overrides in dev (e.g.
+	// ANTHROPIC_BASE_URL pointed at a local proxy).
+	for (const key of PASSTHROUGH_ANTHROPIC_KEYS) {
+		const value = process.env[key];
+		if (value) {
 			env[key] = value;
 		}
 	}

--- a/packages/plugins/sim-ai/src/__tests__/sim-ai.spec.ts
+++ b/packages/plugins/sim-ai/src/__tests__/sim-ai.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SimStudioClient } from 'simstudio-ts-sdk';
 import { SimAiPlugin } from '../sim-ai.plugin.js';
 import type { WorkReference, GenerationRequest, ExistingItems, PluginContext } from '@ever-works/plugin';
 
@@ -323,6 +324,43 @@ describe('SimAiPlugin', () => {
 			const state = plugin.getState();
 			expect(state).toBeDefined();
 			expect(state!.completedSteps.length).toBeGreaterThan(0);
+		});
+
+		it('should redact GitHub tokens from the raw SIM output debug log', async () => {
+			// A misbehaving/echoing workflow could reflect the forwarded
+			// repo_access_token back inside its output. Ensure the token shape is
+			// scrubbed from the "Raw SIM output" debug log line.
+			const leakedToken = 'ghp_AbCdEf0123456789AbCdEf0123456789AbCd';
+			vi.mocked(SimStudioClient).mockImplementationOnce(function () {
+				return {
+					validateWorkflow: vi.fn().mockResolvedValue(true),
+					getWorkflowStatus: vi.fn().mockResolvedValue({ isDeployed: true, needsRedeployment: false }),
+					executeWorkflow: vi.fn().mockResolvedValue({
+						success: true,
+						output: {
+							items: [{ name: 'Echoed', description: `token=${leakedToken}` }],
+							categories: [],
+							tags: []
+						}
+					}),
+					getRateLimitInfo: vi.fn().mockReturnValue(null)
+				};
+			} as never);
+
+			const ctx = createMockContext();
+			await plugin.onLoad(ctx);
+
+			await plugin.execute(createWork(), createRequest(), createExisting());
+
+			const logSpy = ctx.logger.log as ReturnType<typeof vi.fn>;
+			const rawOutputLog = logSpy.mock.calls
+				.map((c) => String(c[0]))
+				.find((m) => m.startsWith('Raw SIM output type:'));
+
+			expect(rawOutputLog).toBeDefined();
+			expect(rawOutputLog).not.toContain(leakedToken);
+			expect(rawOutputLog).not.toContain('ghp_');
+			expect(rawOutputLog).toContain('[REDACTED]');
 		});
 	});
 

--- a/packages/plugins/sim-ai/src/sim-ai.plugin.ts
+++ b/packages/plugins/sim-ai/src/sim-ai.plugin.ts
@@ -57,6 +57,13 @@ import {
 } from './form-schema.js';
 import { README } from './readme.js';
 
+// Security (secret-leak): SIM workflow output is echoed into debug logs below.
+// When `pass_repo_access` is enabled the caller forwards a GitHub token to the
+// workflow, and a misbehaving/echoing workflow could reflect that token back in
+// its output. Scrub any GitHub token shapes before they reach the logger so the
+// `repo_access_token` is never persisted in plaintext log lines.
+const scrubTokens = (s: string): string => s.replace(/\b(ghp_|github_pat_|gho_|ghs_|ghr_)[A-Za-z0-9_]+/g, '[REDACTED]');
+
 /**
  * SIM AI Workflows Plugin
  *
@@ -358,7 +365,9 @@ export class SimAiPlugin implements IPlugin, IPipelinePlugin, IFormSchemaProvide
 			reportProgress(onProgress, 3, 75, 'Collect & Validate Results');
 
 			logger.log(
-				`Raw SIM output type: ${typeof execResult.output}, value: ${JSON.stringify(execResult.output).substring(0, 500)}`
+				`Raw SIM output type: ${typeof execResult.output}, value: ${scrubTokens(
+					JSON.stringify(execResult.output).substring(0, 500)
+				)}`
 			);
 
 			const parsed = parseSimOutput(execResult.output);

--- a/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
+++ b/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
@@ -96,6 +96,40 @@ describe('TriggerInternalApiClient', () => {
         });
     });
 
+    describe('constructor — HTTPS enforcement', () => {
+        const originalNodeEnv = process.env.NODE_ENV;
+
+        afterEach(() => {
+            process.env.NODE_ENV = originalNodeEnv;
+        });
+
+        it('throws in production when the base URL is plaintext http://', () => {
+            process.env.NODE_ENV = 'production';
+            triggerConfig.getInternalBaseUrl.mockReturnValue('http://api:3100');
+            triggerConfig.getInternalSecret.mockReturnValue('s');
+
+            expect(() => new TriggerInternalApiClient()).toThrow(
+                'TRIGGER_INTERNAL_API_URL must use HTTPS',
+            );
+        });
+
+        it('allows https:// in production', () => {
+            process.env.NODE_ENV = 'production';
+            triggerConfig.getInternalBaseUrl.mockReturnValue('https://api.internal:3100');
+            triggerConfig.getInternalSecret.mockReturnValue('s');
+
+            expect(() => new TriggerInternalApiClient()).not.toThrow();
+        });
+
+        it('still allows plaintext http:// outside production (local dev / in-cluster)', () => {
+            process.env.NODE_ENV = 'development';
+            triggerConfig.getInternalBaseUrl.mockReturnValue('http://api:3100');
+            triggerConfig.getInternalSecret.mockReturnValue('s');
+
+            expect(() => new TriggerInternalApiClient()).not.toThrow();
+        });
+    });
+
     describe('URL composition', () => {
         it('strips a trailing slash on the base URL and a leading slash on the path', async () => {
             triggerConfig.getInternalBaseUrl.mockReturnValue('https://api.example.com/');

--- a/packages/tasks/src/trigger/worker/services/trigger-internal-api.client.ts
+++ b/packages/tasks/src/trigger/worker/services/trigger-internal-api.client.ts
@@ -16,6 +16,13 @@ export class TriggerInternalApiClient {
             throw new Error('TRIGGER_INTERNAL_API_URL is not configured');
         }
 
+        // The x-trigger-secret header and decrypted plugin-secret payloads transit this
+        // connection. In production, refuse plaintext HTTP so they can't leak on the wire.
+        // Non-production (local dev / in-cluster http://api) keeps working unchanged.
+        if (process.env.NODE_ENV === 'production' && !this.baseUrl.startsWith('https://')) {
+            throw new Error('TRIGGER_INTERNAL_API_URL must use HTTPS');
+        }
+
         if (!this.secret) {
             throw new Error('TRIGGER_INTERNAL_SECRET is not configured');
         }


### PR DESCRIPTION
## Wave H — contained secret-at-rest + hygiene fixes (EW-716)

Part of the **EW-710** security-audit remediation epic. The 40 EW-716
(secrets/crypto) deferred candidates were verify-live triaged; most were
already mitigated by earlier waves. This lands the genuinely-open, contained
subset.

### Triage outcome (verify-live, 40 candidates)

| Status | Count | Examples |
|--------|------:|----------|
| Already-fixed | 15 | Hermes/codex/opencode env allowlists, D2 plugin `envVars`, D5 token-forward consent+SSRF gates, `PLUGIN_SECRET_ENCRYPTION_KEY` prod guard |
| Not applicable | 5 | ollama LAN baseUrl (intentional), AuthVerification.value (Better-Auth owns), AiProviderConfig (no leak sink) |
| Defer-decision | 3 | opencode env-injection, JWT-in-URL nonce, deploy `GH_TOKEN` least-priv |
| Behavioral-risk | 1 | `AuthAccount { select:false }` (90 consumers) |
| **Open → fixed here** | **13** | below |

### Fixes (one file + a co-located test each; fail-without/pass-with verified)

| # | Ticket | File | Fix |
|---|--------|------|-----|
| 1 | crypto | `agent/.../plugin-operations.service.ts` | route `updateUser/WorkPluginSettings` secrets through `PluginSettingsService` envelope encryption (D3 sibling bypass that still wrote plaintext) |
| 2 | crypto | `agent/.../webhook-subscription-secret.service.ts` | prod fail-fast when `PLATFORM_ENCRYPTION_KEY` absent |
| 3 | secrets | `api/.../config/constants.ts` + `main.ts` + `mail.module.ts` | boot-time `PLATFORM_ENCRYPTION_KEY` fail-fast (non-local); `SMTP_REJECT_UNAUTHORIZED` config accessor |
| 4 | crypto | `api/.../onboarding.service.ts` | env-gated https-only on register-work `webhookUrl` |
| 5 | crypto | `api/.../webhooks.service.ts` | env-gated https-only in `assertValidUrl` |
| 6 | secrets | `tasks/.../trigger-internal-api.client.ts` | assert https for internal RPC URL in prod |
| 7 | secrets | `agent/.../utils/secret-scan.ts` | NFKC + zero-width normalization on the **detection** copy (defeat homoglyph/zero-width evasion); redaction stays **content-preserving** (falls back to normalized only when it catches strictly more secrets, so emoji-ZWJ / full-width CJK round-trips unchanged) |
| 8 | secrets | `claude-code/.../subprocess-env.ts` | explicit `ANTHROPIC_*`/`CLAUDE_CODE_*` name allowlist (was prefix forwarding) |
| 9 | secrets | `mcp/.../sanitize.ts` | case-insensitive sensitive-field redaction |
| 10 | secrets | `sim-ai/.../sim-ai.plugin.ts` | scrub `ghp_`/`github_pat_`/`gho_` tokens from logged workflow output |
| 11 | secrets | `internal-cli/.../config.service.ts` | `chmod 0o600` on the secret-bearing config file |
| 12 | secrets | `cli/.../credentials.service.ts` | `chmod 0o600` on the credentials file |
| 13 | secrets | `cli-shared/.../config-check.ts` | `maskSecret` never returns short secrets verbatim |

### Verification

- **Builds clean:** apps/api + agent **TSC 0 issues**; the 7 other changed packages build green (turbo).
- **Suites pass (independently re-run):** agent jest 94 (plugin-operations, webhook-secret), 25 (secret-scan), apps/api jest 125 (onboarding, webhooks, constants), + vitest sim-ai 33 / claude-code 7 / internal-cli 33 / cli 30 / cli-shared 11 / mcp 8.
- The secret-scan redaction was hardened beyond the original agent patch to guarantee content fidelity (added an emoji-ZWJ / full-width CJK round-trip test).

### Deferred to their own follow-ups
- **notification-channel `targetConfig` encryption-at-rest** (Telegram `botToken` etc. plaintext) — real value but a read-path fan-out (decrypt at every consumer) that warrants its own PR + notification-channel test pass.
- JWT-in-URL → single-use opaque nonce; deploy `GH_TOKEN` → least-priv installation token; `AuthAccount { select:false }` (90 consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added encryption key validation for production environments with early startup checks.
  * Introduced HTTPS enforcement for webhooks and external URLs in non-local environments.

* **Bug Fixes**
  * Centralized SMTP TLS certificate verification configuration.
  * Enhanced webhook and onboarding URL validation with clearer error messaging.
  * Improved secret field handling to use encrypted persistence paths.

* **Security**
  * Hardened credentials and configuration file permissions to owner-only access.
  * Enhanced secret scanning to detect Unicode evasion techniques.
  * Tightened environment variable allow-lists.
  * Added token redaction in debug logs.

* **Tests**
  * Expanded test coverage for encryption validation and HTTPS enforcement across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->