### PR TITLE
fix(security): Wave I — encrypt notification-channel targetConfig at rest (EW-716 #22)

### DIFF
--- a/packages/agent/src/entities/_secret-json-column.integration.spec.ts
+++ b/packages/agent/src/entities/_secret-json-column.integration.spec.ts
@@ -1,0 +1,126 @@
+import { Column, DataSource, Entity, PrimaryGeneratedColumn, Repository } from 'typeorm';
+import { EncryptedJsonColumn } from './_secret-json-column';
+
+@Entity({ name: 'encrypted_json_test_records' })
+class EncryptedJsonTestRecord {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    label: string;
+
+    @EncryptedJsonColumn()
+    config: Record<string, unknown>;
+}
+
+// 32-byte key as hex (PluginSecretEncService requires a 64-hex-char key).
+const TEST_KEY = '0'.repeat(64);
+
+describe('EncryptedJsonColumn (EW-716 #22 — targetConfig encryption at rest)', () => {
+    let dataSource: DataSource;
+    let repository: Repository<EncryptedJsonTestRecord>;
+    const prevKey = process.env.PLUGIN_SECRET_ENCRYPTION_KEY;
+
+    beforeAll(async () => {
+        // Set before the first save so the module-level enc instance caches it.
+        process.env.PLUGIN_SECRET_ENCRYPTION_KEY = TEST_KEY;
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [EncryptedJsonTestRecord],
+            synchronize: true,
+        });
+        await dataSource.initialize();
+        repository = dataSource.getRepository(EncryptedJsonTestRecord);
+    });
+
+    afterAll(async () => {
+        await dataSource.destroy();
+        if (prevKey === undefined) delete process.env.PLUGIN_SECRET_ENCRYPTION_KEY;
+        else process.env.PLUGIN_SECRET_ENCRYPTION_KEY = prevKey;
+    });
+
+    beforeEach(async () => {
+        await repository.clear();
+    });
+
+    it('stores every value as ciphertext at rest but hydrates the plaintext object', async () => {
+        const config = { botToken: '123456:SECRET-bot-token', chatId: '@ops' };
+        const saved = await repository.save(repository.create({ label: 'telegram', config }));
+
+        // Raw column: each value is an `enc::v1::` envelope; no plaintext leaks.
+        const raw = await dataSource.query(
+            'SELECT config FROM encrypted_json_test_records WHERE id = ?',
+            [saved.id],
+        );
+        const stored = JSON.parse(raw[0].config) as Record<string, string>;
+        expect(stored.botToken.startsWith('enc::v1::')).toBe(true);
+        expect(stored.chatId.startsWith('enc::v1::')).toBe(true);
+        expect(JSON.stringify(stored)).not.toContain('SECRET-bot-token');
+        expect(JSON.stringify(stored)).not.toContain('@ops');
+
+        // Read path: transparent decrypt back to the original plaintext.
+        const hydrated = await repository.findOneByOrFail({ id: saved.id });
+        expect(hydrated.config).toEqual(config);
+    });
+
+    it('decrypts values returned via find operators', async () => {
+        const config = { webhookUrl: 'https://hooks.slack.com/services/T/B/x' };
+        await repository.save(repository.create({ label: 'slack', config }));
+        const found = await repository.findOneByOrFail({ label: 'slack' });
+        expect(found.config).toEqual(config);
+    });
+
+    it('encrypts targetConfig written via repository.update() (partial-update path)', async () => {
+        // The service rotates credentials via `repository.update({ id }, patch)`
+        // (QueryBuilder partial update), NOT save() — verify the transformer
+        // still runs on this path, otherwise an edited botToken leaks plaintext.
+        const saved = await repository.save(
+            repository.create({ label: 'tg', config: { botToken: 'orig-token' } }),
+        );
+        await repository.update({ id: saved.id }, { config: { botToken: 'rotated-SECRET-token' } });
+
+        const raw = await dataSource.query(
+            'SELECT config FROM encrypted_json_test_records WHERE id = ?',
+            [saved.id],
+        );
+        const stored = JSON.parse(raw[0].config) as Record<string, string>;
+        expect(stored.botToken.startsWith('enc::v1::')).toBe(true);
+        expect(JSON.stringify(stored)).not.toContain('rotated-SECRET-token');
+
+        const hydrated = await repository.findOneByOrFail({ id: saved.id });
+        expect(hydrated.config).toEqual({ botToken: 'rotated-SECRET-token' });
+    });
+
+    it('passes through legacy plaintext rows (no enc:: prefix) on read', async () => {
+        // A row written before encryption landed: raw plaintext JSON in the column.
+        const id = '11111111-1111-1111-1111-111111111111';
+        const legacy = { webhookUrl: 'https://discord.com/api/webhooks/1/legacy' };
+        await dataSource.query(
+            'INSERT INTO encrypted_json_test_records (id, label, config) VALUES (?, ?, ?)',
+            [id, 'legacy', JSON.stringify(legacy)],
+        );
+        const hydrated = await repository.findOneByOrFail({ id });
+        expect(hydrated.config).toEqual(legacy);
+    });
+
+    it('re-encrypts a legacy plaintext row on its next write', async () => {
+        const id = '22222222-2222-2222-2222-222222222222';
+        await dataSource.query(
+            'INSERT INTO encrypted_json_test_records (id, label, config) VALUES (?, ?, ?)',
+            [id, 'legacy2', JSON.stringify({ apiKey: 'nv-legacy-key' })],
+        );
+        // Load (decrypts/pass-through), mutate a sibling field, save (re-encrypts).
+        const row = await repository.findOneByOrFail({ id });
+        row.label = 'rotated';
+        await repository.save(row);
+
+        const raw = await dataSource.query(
+            'SELECT config FROM encrypted_json_test_records WHERE id = ?',
+            [id],
+        );
+        const stored = JSON.parse(raw[0].config) as Record<string, string>;
+        expect(stored.apiKey.startsWith('enc::v1::')).toBe(true);
+        expect(JSON.stringify(stored)).not.toContain('nv-legacy-key');
+    });
+});

--- a/packages/agent/src/entities/_secret-json-column.ts
+++ b/packages/agent/src/entities/_secret-json-column.ts
@@ -1,0 +1,51 @@
+import { Column, type ColumnOptions } from 'typeorm';
+import { PluginSecretEncService } from '../plugins/services/plugin-secret-enc.service';
+
+/**
+ * EW-716 #22 — a `simple-json` column whose values are envelope-encrypted at
+ * rest. Every value in the stored JSON object is AES-256-GCM encrypted with the
+ * `enc::v1::` envelope (the same `PluginSecretEncService` used for plugin
+ * `secretSettings`), so credentials carried in the column (e.g. a
+ * `notification_channels.targetConfig` Telegram `botToken`, Slack/Discord
+ * `webhookUrl`, WhatsApp `accessToken`, Novu `apiKey`) are never persisted in
+ * plaintext.
+ *
+ * The encryption is a TypeORM column transformer, so it is fully transparent:
+ * EVERY reader (service responses, the channel-send facade, future call sites)
+ * receives the decrypted plaintext object, and EVERY writer stores ciphertext —
+ * there is no read path to forget. Behaviour notes:
+ *   - **No key configured** (dev/preview): values pass through as plaintext
+ *     (PluginSecretEncService dev-convenience) — no boot break for contributors.
+ *   - **Legacy plaintext rows** (written before this column was encrypted):
+ *     decrypt passes them through unchanged (no `enc::v1::` prefix) and they are
+ *     re-encrypted on the next write.
+ *   - **Value types**: non-string values are JSON-stringified on encrypt and
+ *     return as strings on decrypt (the documented `PluginSecretEncService`
+ *     contract). Every known `targetConfig` field is already a string, so this
+ *     is lossless in practice.
+ *   - **No DDL change**: the column stays `simple-json` (portable Postgres
+ *     `jsonb` / SQLite text); the transformer is application-layer only, so no
+ *     migration is required.
+ */
+
+// Stateless except a lazily-cached key read from PLUGIN_SECRET_ENCRYPTION_KEY;
+// safe to instantiate once at module load (no DI dependencies, no env read
+// until the first encrypt/decrypt).
+const enc = new PluginSecretEncService();
+
+export const EncryptedJsonColumn = ({ nullable = false }: { nullable?: boolean } = {}) => {
+    // DTS-emit gotcha (CLAUDE.md): build options imperatively rather than with
+    // conditional spreads, which produce `string | false` and break declaration
+    // generation.
+    const opts: ColumnOptions = {
+        type: 'simple-json',
+        nullable,
+        transformer: {
+            to: (value: Record<string, unknown> | null | undefined) =>
+                value == null ? value : enc.encryptRecord(value),
+            from: (value: Record<string, unknown> | null | undefined) =>
+                value == null ? value : enc.decryptRecord(value),
+        },
+    };
+    return Column(opts);
+};

--- a/packages/agent/src/entities/notification-channel.entity.ts
+++ b/packages/agent/src/entities/notification-channel.entity.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm';
 import { User } from './user.entity';
 import { PortableDateColumn } from './_types';
+import { EncryptedJsonColumn } from './_secret-json-column';
 
 /**
  * Notifications v2 — Notification Channels.
@@ -21,7 +22,11 @@ import { PortableDateColumn } from './_types';
  *
  * `targetConfig` carries the per-plugin shape (webhook URL,
  * channel id, bot token reference, novu workflow id, …) and is
- * handed back to the plugin on every send.
+ * handed back to the plugin on every send. It carries live
+ * credentials (Telegram `botToken`, WhatsApp `accessToken`, Novu
+ * `apiKey`, Slack/Discord `webhookUrl`), so it is envelope-encrypted
+ * at rest via `@EncryptedJsonColumn` (EW-716 #22) — transparent to
+ * every reader; the DB never holds plaintext.
  *
  * See `docs/specs/features/notification-channels/spec.md` §4.1.
  */
@@ -45,7 +50,9 @@ export class NotificationChannel {
     @Column({ type: 'varchar', length: 120 })
     name: string;
 
-    @Column({ type: 'simple-json' })
+    // EW-716 #22: envelope-encrypted at rest (AES-256-GCM, `enc::v1::`).
+    // Transparent transformer — readers get plaintext, the DB holds ciphertext.
+    @EncryptedJsonColumn()
     targetConfig: Record<string, unknown>;
 
     @Column({ type: 'boolean', default: false })


### PR DESCRIPTION
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification channel configuration is now encrypted at rest in the database, with transparent decryption during normal application access
  * Legacy configuration data is automatically re-encrypted upon next update

* **Tests**
  * Added integration test suite validating encrypted storage, decryption, and legacy data handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->