### PR TITLE
test(e2e): update 4 specs to the post-hardening security contracts (Wave J sanitization, D9 permission clamp)

### DIFF
--- a/apps/web/e2e/flow-agent-permissions-matrix.spec.ts
+++ b/apps/web/e2e/flow-agent-permissions-matrix.spec.ts
@@ -34,7 +34,9 @@ import { createTaskViaAPI, listAgentRuns } from './helpers/agents-tasks';
  *       `runtime.permissions` block faithfully mirrors the live matrix.
  *   POST  /api/agents/import?onConflict=rename { …envelope } → 201
  *       { created:{ …, permissions }, finalSlug, conflictResolution }. The
- *       imported clone preserves the exported permission matrix byte-for-byte.
+ *       imported clone is CLAMPED to the least-privilege all-false matrix —
+ *       D9 (#1258): envelope runtime.permissions is attacker-controllable,
+ *       so import deliberately ignores it; owners re-grant via the UI.
  *
  *   RUNTIME ENFORCEMENT NOTE: the flags gate the Agent's *tool catalog*
  *   (packages/agent/src/agents/agent-tool.service.ts — editAgentFile /
@@ -314,13 +316,13 @@ test.describe('Agent permissions matrix', () => {
         expect(fresh.permissions.canSpend).toBe(true);
     });
 
-    test('export/import faithfully round-trips a bespoke permission matrix onto the cloned Agent', async ({
+    test('export carries the bespoke permission matrix; import CLAMPS the clone to least-privilege (D9)', async ({
         request,
     }) => {
         const u = await registerUserViaAPI(request);
 
         // Build a non-trivial matrix: a couple of orthogonal grants PLUS the
-        // PR pair (so the round-trip has to carry the coerced commit too).
+        // PR pair (so the export has to carry the coerced commit too).
         const source = await createAgent(request, u.access_token, `Perm Export Src ${stamp()}`, {
             canCallExternalTools: true,
             canEditSkills: true,
@@ -353,11 +355,14 @@ test.describe('Agent permissions matrix', () => {
         expect(imported.created?.id).toMatch(UUID_RE);
         expect(imported.created.id).not.toBe(source.id);
 
-        // The clone preserves the matrix byte-for-byte (incl. the coerced
-        // commit), and a follow-up GET on the new id confirms persistence.
-        expect(imported.created.permissions).toEqual(sourceMatrix);
+        // Security (D9, #1258 agent-export hardening): the envelope's
+        // runtime.permissions is attacker-controllable (an envelope can come
+        // from an untrusted export), so import deliberately does NOT honor it
+        // — the clone is clamped to the least-privilege default matrix and
+        // the owner re-grants capabilities through the permissions UI.
+        expect(imported.created.permissions).toEqual(ALL_FALSE);
         const freshClone = await getAgent(request, u.access_token, imported.created.id);
-        expect(freshClone.permissions).toEqual(sourceMatrix);
+        expect(freshClone.permissions).toEqual(ALL_FALSE);
 
         // The original is untouched by the export/import cycle.
         const freshSource = await getAgent(request, u.access_token, source.id);

--- a/apps/web/e2e/flow-agent-templates-clone.spec.ts
+++ b/apps/web/e2e/flow-agent-templates-clone.spec.ts
@@ -38,8 +38,10 @@ import { createAgentViaAPI } from './helpers/agents-tasks';
  *       row in place (resolution:"overwritten", finalSlug==originalSlug).
  *   - The clone ALWAYS lands in status DRAFT regardless of the source's status
  *       (export carries no status; import forces `AgentStatus.DRAFT`).
- *   - Clone copies files (soulMd etc.) + permissions + avatar(icon) + runtime
- *       knobs. `canOpenPullRequests` implies `canCommitToRepo` on import.
+ *   - Clone copies files (soulMd etc.) + avatar(icon) + runtime knobs. The
+ *       envelope's permissions are EXPORTED but NOT honored on import — D9
+ *       (#1258) clamps the clone to the least-privilege all-false matrix
+ *       because envelopes are attacker-controllable.
  *   - Cross-tenant IMAGE avatar with imageUploadId:null degrades to INITIALS on
  *       import (no dangling upload reference). Verified live.
  *   - Envelope guards: version!==1 → 400 "Unsupported envelope version"; missing
@@ -221,15 +223,16 @@ test.describe('Agent template catalog — public, environment-adaptive', () => {
     });
 });
 
-test.describe('Clone an Agent — export → import copies files/permissions/avatar', () => {
+test.describe('Clone an Agent — export → import copies files/avatar; permissions clamp to least-privilege', () => {
     /**
      * The canonical "clone" path. Build a richly-configured source Agent (icon
      * avatar, granted permissions, custom runtime knobs, two inline definition
      * files), export the envelope, import it back, and assert the resulting clone
-     * is a faithful DRAFT copy with a uniquely-renamed slug — proving files +
-     * permissions + avatar + runtime knobs all round-trip.
+     * is a DRAFT copy with a uniquely-renamed slug — files + avatar + runtime
+     * knobs round-trip, while permissions are deliberately CLAMPED to the
+     * all-false default (D9, #1258: envelopes are attacker-controllable).
      */
-    test('full clone faithfully copies files, permissions, avatar and runtime knobs into a DRAFT', async ({
+    test('full clone copies files, avatar and runtime knobs into a DRAFT; permissions clamp to least-privilege', async ({
         request,
     }) => {
         const { token } = await freshToken(request);
@@ -305,9 +308,15 @@ test.describe('Clone an Agent — export → import copies files/permissions/ava
         expect(clone.pauseAfterFailures).toBe(7);
         expect(clone.avatarMode).toBe('icon');
         expect(clone.avatarIcon).toBe('bot');
-        expect(clone.permissions.canSpend).toBe(true);
-        expect(clone.permissions.canCommitToRepo).toBe(true);
-        expect(clone.permissions.canEditSkills).toBe(true);
+        // Security (D9, #1258 agent-export hardening): the envelope's
+        // runtime.permissions is attacker-controllable, so import deliberately
+        // does NOT honor it — the clone is clamped to the least-privilege
+        // default (all-false) matrix even though the export envelope carries
+        // the source's grants (asserted above). The owner re-grants via the
+        // permissions UI.
+        expect(clone.permissions.canSpend).toBe(false);
+        expect(clone.permissions.canCommitToRepo).toBe(false);
+        expect(clone.permissions.canEditSkills).toBe(false);
         expect(clone.hasInlineFiles).toBe(true);
 
         // The clone's files endpoint serves the copied bodies.

--- a/apps/web/e2e/flow-git-provider-connection.spec.ts
+++ b/apps/web/e2e/flow-git-provider-connection.spec.ts
@@ -27,9 +27,10 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *
  * THIS file deliberately covers what those do NOT:
  *   1. TWO real fresh users each holding an INDEPENDENT connection record whose
- *      disconnected sub-resource error envelopes are scoped to their OWN userId
- *      (no cross-leak), and one user's DELETE-disconnect never perturbs the
- *      other's connection state (lifecycle ∩ isolation).
+ *      disconnected sub-resource error envelopes are SANITIZED (EW-721 Wave J:
+ *      generic message, no userId echo — own or cross-user), and one user's
+ *      DELETE-disconnect never perturbs the other's connection state
+ *      (lifecycle ∩ isolation).
  *   2. The "connected-as" display contract is verifiably ABSENT for a
  *      disconnected user (no @username / avatar / email / Organizations card; the
  *      summary reads "No providers connected") — proving no fabricated identity.
@@ -66,7 +67,9 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *            { id:p, name:'Unknown', enabled:false, connected:false }. (anon 401)
  *   GET    /api/git-providers/:p/{organizations|repositories|user}
  *            (disconnected) → 200 { success:false, <collection>:[]/null,
- *              error:'No connected account found for user <THIS-userId> with provider <p>' }
+ *              error:<generic sanitized message, e.g. 'Failed to fetch organizations'> }
+ *            (EW-721 Wave J #1264: the old 'No connected account found for user
+ *             <userId> with provider <p>' detail was a userId/provider leak)
  *   GET    /api/oauth/providers               (authed) → { configured:true,
  *            providers:[{ id:'github', name:'GitHub', enabled:true }] }
  *   GET    /api/oauth/:p/connection           (authed) → { id, name:'GitHub',
@@ -172,7 +175,7 @@ async function gotoAuthed(page: Page, url: string): Promise<number> {
 }
 
 test.describe('flow: per-user connection isolation — two fresh users hold independent, leak-free connection records', () => {
-    test("each user sees their OWN disconnected connection, every sub-resource error names THAT user's id (no cross-leak), and user A disconnecting never perturbs user B", async ({
+    test('each user sees their OWN disconnected connection, every sub-resource error is sanitized (leaks NO userId, neither own nor cross-user), and user A disconnecting never perturbs user B', async ({
         request,
     }) => {
         // Two completely independent fresh accounts.
@@ -211,10 +214,11 @@ test.describe('flow: per-user connection isolation — two fresh users hold inde
             );
         }
 
-        // STEP 2 — The disconnected sub-resource error envelope is SCOPED to each
-        // caller's own userId. User A's "no connected account" error must name
-        // A's id and NOT B's id, and vice-versa — proving the error is derived
-        // from the authenticated principal, not a shared/global lookup.
+        // STEP 2 — The disconnected sub-resource error envelope is SANITIZED.
+        // EW-721 Wave J (#1264) replaced the old detailed "no connected account
+        // found for user <id>" errors with generic non-leaking messages: the
+        // envelope must not echo ANY internal identifier — not even the
+        // caller's own userId — and certainly not the other user's.
         const aOrgs = await request.get(`${API_BASE}/api/git-providers/${PROVIDER}/organizations`, {
             headers: hA,
         });
@@ -225,7 +229,10 @@ test.describe('flow: per-user connection isolation — two fresh users hold inde
             true,
         );
         const aErr = String(aOrgsBody.error ?? '');
-        expect(aErr, "A's error names A's userId").toContain(userA.user.id);
+        expect(aErr.length, "A's error is a non-empty generic message").toBeGreaterThan(0);
+        expect(aErr, "A's error does NOT leak A's own userId (sanitized)").not.toContain(
+            userA.user.id,
+        );
         expect(aErr, "A's error does NOT name B's userId (no cross-user leak)").not.toContain(
             userB.user.id,
         );
@@ -238,7 +245,10 @@ test.describe('flow: per-user connection isolation — two fresh users hold inde
         const bReposBody = await bRepos.json();
         expect(bReposBody.success, 'B repositories success:false (disconnected)').toBe(false);
         const bErr = String(bReposBody.error ?? '');
-        expect(bErr, "B's error names B's userId").toContain(userB.user.id);
+        expect(bErr.length, "B's error is a non-empty generic message").toBeGreaterThan(0);
+        expect(bErr, "B's error does NOT leak B's own userId (sanitized)").not.toContain(
+            userB.user.id,
+        );
         expect(bErr, "B's error does NOT name A's userId").not.toContain(userA.user.id);
         expectNoTokenLeak(bErr, 'B repositories error');
 

--- a/apps/web/e2e/flow-plugin-git-provider.spec.ts
+++ b/apps/web/e2e/flow-plugin-git-provider.spec.ts
@@ -229,11 +229,14 @@ test.describe('flow: git-provider full connection lifecycle (status → connect 
                         expect(Array.isArray(body[key]), `disconnected ${path} → array`).toBe(true);
                         expect(body[key].length, `disconnected ${path} → empty`).toBe(0);
                     }
-                    // The error names the provider but must NOT leak a token.
+                    // EW-721 Wave J (#1264): the error is a SANITIZED generic
+                    // message (the old detail named the provider AND the
+                    // caller's userId — an identifier leak). It must be
+                    // non-empty and must NOT leak a token.
                     expect(
-                        String(body.error),
-                        `disconnected ${path} error names the provider`,
-                    ).toMatch(new RegExp(`provider ${PROVIDER}`, 'i'));
+                        String(body.error).length,
+                        `disconnected ${path} error is a non-empty generic message`,
+                    ).toBeGreaterThan(0);
                     expect(
                         String(body.error),
                         `disconnected ${path} error leaks no token`,


### PR DESCRIPTION
@-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated E2E tests to reflect hardened security behavior for agent cloning and export/import operations.

* **Bug Fixes**
  * Agent permissions are now clamped to least-privilege defaults when imported or cloned.
  * Error messages are now sanitized and no longer leak user identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->