### PR TITLE
fix(security): Wave L — 12 contained high/medium fixes (EW-711/712/722 remainder)

### DIFF
--- a/apps/api/src/email/email.module.ts
+++ b/apps/api/src/email/email.module.ts
@@ -2,6 +2,9 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from '@ever-works/agent/database';
 import { FacadesModule } from '@ever-works/agent/facades';
 import { NotificationsModule as AgentNotificationsModule } from '@ever-works/agent/notifications';
+// EW-711 #16: AgentsModule re-exports AgentRepository so EmailService can
+// verify the caller owns the agentId named in a send (IDOR guard).
+import { AgentsModule } from '@ever-works/agent/agents';
 import { AuthModule } from '@src/auth';
 import { EmailController } from './email.controller';
 import { EmailService } from './email.service';
@@ -19,7 +22,7 @@ import { EmailService } from './email.service';
  * keep working unchanged — see notifications-v2 hard rule (additive).
  */
 @Module({
-    imports: [DatabaseModule, FacadesModule, AgentNotificationsModule, AuthModule],
+    imports: [DatabaseModule, FacadesModule, AgentNotificationsModule, AgentsModule, AuthModule],
     controllers: [EmailController],
     providers: [EmailService],
     exports: [EmailService],

--- a/apps/api/src/email/email.service.spec.ts
+++ b/apps/api/src/email/email.service.spec.ts
@@ -4,6 +4,7 @@ jest.mock('@ever-works/agent/database', () => ({
     TenantEmailAddressRepository: class TenantEmailAddressRepository {},
     AgentEmailAssignmentRepository: class AgentEmailAssignmentRepository {},
     EmailMessageRepository: class EmailMessageRepository {},
+    AgentRepository: class AgentRepository {},
 }));
 jest.mock('@ever-works/agent/facades', () => ({
     EmailFacadeService: class EmailFacadeService {},
@@ -23,6 +24,10 @@ import { EmailService } from './email.service';
  * the resolved primary-outbound address MUST belong to the calling user.
  * Otherwise an authenticated caller who knows another user's `agentId` could
  * send mail from that user's outbound address.
+ *
+ * EW-711 #16 (IDOR): `sendMessage` additionally verifies the caller OWNS the
+ * agent named by `input.agentId` before any address resolution — the agentId
+ * is persisted on the email_messages audit row and recorded against usage.
  */
 describe('EmailService.sendMessage authorization', () => {
     let addresses: {
@@ -32,6 +37,7 @@ describe('EmailService.sendMessage authorization', () => {
     let assignments: { findPrimaryOutboundForAgent: jest.Mock };
     let messages: Record<string, jest.Mock>;
     let emailFacade: { send: jest.Mock };
+    let agents: { findByIdAndUser: jest.Mock };
     let service: EmailService;
 
     beforeEach(() => {
@@ -42,11 +48,17 @@ describe('EmailService.sendMessage authorization', () => {
         assignments = { findPrimaryOutboundForAgent: jest.fn() };
         messages = {};
         emailFacade = { send: jest.fn().mockResolvedValue({ providerMessageId: 'pm-1' }) };
+        // EW-711 #16: passing cases run as the agent's owner — the ownership
+        // probe resolves a stub agent; the IDOR test below overrides to null.
+        agents = {
+            findByIdAndUser: jest.fn().mockResolvedValue({ id: 'agent-1', userId: 'user-1' }),
+        };
         service = new EmailService(
             addresses as never,
             assignments as never,
             messages as never,
             emailFacade as never,
+            agents as never,
         );
     });
 
@@ -61,7 +73,7 @@ describe('EmailService.sendMessage authorization', () => {
         });
 
         await service.sendMessage('user-1', {
-            agentId: 'agent-foreign',
+            agentId: 'agent-1',
             to: ['to@x.com'],
             subject: 's',
             bodyText: 'b',
@@ -81,7 +93,7 @@ describe('EmailService.sendMessage authorization', () => {
 
         await expect(
             service.sendMessage('user-1', {
-                agentId: 'agent-foreign',
+                agentId: 'agent-1',
                 to: ['to@x.com'],
                 subject: 's',
                 bodyText: 'b',
@@ -108,5 +120,123 @@ describe('EmailService.sendMessage authorization', () => {
 
         expect(addresses.findByIdForUser).toHaveBeenCalledWith('addr-1', 'user-1');
         expect(assignments.findPrimaryOutboundForAgent).not.toHaveBeenCalled();
+    });
+
+    it('EW-711 #16: a foreign agentId throws NotFound before any address resolution or send', async () => {
+        // findByIdAndUser returns null when (agentId, userId) does not match —
+        // i.e. the agent belongs to another user (or does not exist).
+        agents.findByIdAndUser.mockResolvedValue(null);
+
+        await expect(
+            service.sendMessage('user-1', {
+                agentId: 'agent-foreign',
+                to: ['to@x.com'],
+                subject: 's',
+                bodyText: 'b',
+                fromAddressId: 'addr-1',
+            }),
+        ).rejects.toBeInstanceOf(NotFoundException);
+
+        expect(agents.findByIdAndUser).toHaveBeenCalledWith('agent-foreign', 'user-1');
+        // The guard fires FIRST — nothing downstream may run for a foreign agent.
+        expect(addresses.findByIdForUser).not.toHaveBeenCalled();
+        expect(assignments.findPrimaryOutboundForAgent).not.toHaveBeenCalled();
+        expect(emailFacade.send).not.toHaveBeenCalled();
+    });
+});
+
+/**
+ * EW-711 #44 — address-verification tokens are time-boxed (24h TTL).
+ *
+ * `createAddress` stamps `verificationTokenExpiresAt` alongside the token;
+ * `confirmVerification` rejects expired tokens and clears both fields on
+ * success. Legacy rows (NULL expiry, issued before the column existed) stay
+ * confirmable.
+ */
+describe('EmailService verification-token expiry', () => {
+    let addresses: {
+        save: jest.Mock;
+        findByVerificationToken: jest.Mock;
+        update: jest.Mock;
+    };
+    let service: EmailService;
+
+    beforeEach(() => {
+        addresses = {
+            save: jest.fn().mockImplementation(async (row) => row),
+            findByVerificationToken: jest.fn(),
+            update: jest.fn().mockResolvedValue(undefined),
+        };
+        service = new EmailService(
+            addresses as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+        );
+    });
+
+    it('createAddress stamps a ~24h verificationTokenExpiresAt alongside the token', async () => {
+        const before = Date.now();
+        const row = await service.createAddress('user-1', {
+            address: 'me@x.com',
+            direction: 'outbound',
+            pluginId: 'postmark',
+            providerSettings: {},
+        });
+        const after = Date.now();
+
+        expect(row.verificationToken).toBeTruthy();
+        expect(row.verificationTokenExpiresAt).toBeInstanceOf(Date);
+        const expiry = (row.verificationTokenExpiresAt as Date).getTime();
+        const dayMs = 24 * 60 * 60 * 1000;
+        expect(expiry).toBeGreaterThanOrEqual(before + dayMs);
+        expect(expiry).toBeLessThanOrEqual(after + dayMs);
+    });
+
+    it('confirmVerification rejects an expired token without mutating the row', async () => {
+        addresses.findByVerificationToken.mockResolvedValue({
+            id: 'addr-1',
+            verificationToken: 'tok-1',
+            verificationTokenExpiresAt: new Date(Date.now() - 1000),
+        });
+
+        await expect(service.confirmVerification('tok-1')).resolves.toEqual({ verified: false });
+        expect(addresses.update).not.toHaveBeenCalled();
+    });
+
+    it('confirmVerification accepts an unexpired token and clears token + expiry', async () => {
+        addresses.findByVerificationToken.mockResolvedValue({
+            id: 'addr-1',
+            verificationToken: 'tok-1',
+            verificationTokenExpiresAt: new Date(Date.now() + 60_000),
+        });
+
+        await expect(service.confirmVerification('tok-1')).resolves.toEqual({ verified: true });
+        expect(addresses.update).toHaveBeenCalledWith('addr-1', {
+            verified: true,
+            verificationToken: null,
+            verificationTokenExpiresAt: null,
+        });
+    });
+
+    it('confirmVerification keeps legacy rows (NULL expiry) confirmable', async () => {
+        addresses.findByVerificationToken.mockResolvedValue({
+            id: 'addr-legacy',
+            verificationToken: 'tok-legacy',
+            verificationTokenExpiresAt: null,
+        });
+
+        await expect(service.confirmVerification('tok-legacy')).resolves.toEqual({
+            verified: true,
+        });
+        expect(addresses.update).toHaveBeenCalled();
+    });
+
+    it('confirmVerification still rejects an unknown token', async () => {
+        addresses.findByVerificationToken.mockResolvedValue(null);
+
+        await expect(service.confirmVerification('nope')).resolves.toEqual({ verified: false });
+        expect(addresses.update).not.toHaveBeenCalled();
     });
 });

--- a/apps/api/src/email/email.service.ts
+++ b/apps/api/src/email/email.service.ts
@@ -18,9 +18,16 @@ import {
     TenantEmailAddressRepository,
     AgentEmailAssignmentRepository,
     EmailMessageRepository,
+    AgentRepository,
 } from '@ever-works/agent/database';
 import type { TenantEmailAddress, EmailAddressDirection } from '@ever-works/agent/entities';
 import { EmailFacadeService } from '@ever-works/agent/facades';
+
+/**
+ * EW-711 #44 — how long an address-verification token stays valid after
+ * issuance. A leaked confirmation link must not verify an address forever.
+ */
+const VERIFICATION_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
 
 // Security: these request bodies are bound directly via `@Body()` in
 // email.controller.ts. The global ValidationPipe (main.ts) runs with
@@ -134,6 +141,7 @@ export class EmailService {
         private readonly assignments: AgentEmailAssignmentRepository,
         private readonly messages: EmailMessageRepository,
         private readonly emailFacade: EmailFacadeService,
+        private readonly agents: AgentRepository,
     ) {}
 
     async listAddresses(
@@ -157,6 +165,9 @@ export class EmailService {
             defaultForReplies: input.defaultForReplies ?? false,
             verified: false,
             verificationToken,
+            // EW-711 #44: time-box the verification token so a leaked
+            // confirmation link cannot verify the address indefinitely.
+            verificationTokenExpiresAt: new Date(Date.now() + VERIFICATION_TOKEN_TTL_MS),
         } as TenantEmailAddress);
     }
 
@@ -195,7 +206,16 @@ export class EmailService {
     async confirmVerification(token: string): Promise<{ verified: boolean }> {
         const row = await this.addresses.findByVerificationToken(token);
         if (!row) return { verified: false };
-        await this.addresses.update(row.id, { verified: true, verificationToken: null });
+        // EW-711 #44: reject expired tokens (24h TTL stamped at issuance).
+        // Rows pre-dating the expiry column have NULL and stay confirmable.
+        if (row.verificationTokenExpiresAt && row.verificationTokenExpiresAt < new Date()) {
+            return { verified: false };
+        }
+        await this.addresses.update(row.id, {
+            verified: true,
+            verificationToken: null,
+            verificationTokenExpiresAt: null,
+        });
         return { verified: true };
     }
 
@@ -221,6 +241,13 @@ export class EmailService {
      * messageRef.
      */
     async sendMessage(userId: string, input: SendMessageInput) {
+        // EW-711 #16 (IDOR): the caller-supplied agentId is persisted on the
+        // email_messages audit row and recorded against usage, so it MUST
+        // belong to the calling user. Verify ownership before any address
+        // resolution or provider send.
+        const agent = await this.agents.findByIdAndUser(input.agentId, userId);
+        if (!agent) throw new NotFoundException('Agent not found');
+
         let address: TenantEmailAddress | null = null;
         if (input.fromAddressId) {
             address = await this.addresses.findByIdForUser(input.fromAddressId, userId);

--- a/apps/api/src/integrations/twenty-crm/controllers/companies.controller.spec.ts
+++ b/apps/api/src/integrations/twenty-crm/controllers/companies.controller.spec.ts
@@ -20,6 +20,8 @@ import {
     ParseUUIDPipe,
 } from '@nestjs/common';
 import { CompaniesController } from './companies.service';
+import { AuthSessionGuard } from '@src/auth/guards/auth-session.guard';
+import { CrmSyncGuard } from '../guards/crm-sync.guard';
 import { CrmTenantService } from '../services/crm-tenant.service';
 import type { ClientService } from '../services/client.service';
 import type { UserRepository } from '@ever-works/agent/database';
@@ -177,5 +179,15 @@ describe('CompaniesController', () => {
     it('propagates ClientService errors back to the caller', async () => {
         client.getCompanies.mockRejectedValue(new Error('upstream failure'));
         await expect(controller.getCompanies(authUser())).rejects.toThrow('upstream failure');
+    });
+
+    // Security (audit #61): CrmSyncGuard existed but was never applied, leaving
+    // every /api/twenty-crm/companies route reachable even with the CRM
+    // integration disabled or misconfigured. Guards do not run on direct method
+    // calls in a unit test, so assert the class-level `@UseGuards` wiring via
+    // Nest's `__guards__` metadata: auth first, then the fail-closed CRM gate.
+    it('class-level guards are AuthSessionGuard then CrmSyncGuard (fail-closed when CRM sync is off)', () => {
+        const guards = Reflect.getMetadata('__guards__', CompaniesController) as unknown[];
+        expect(guards).toEqual([AuthSessionGuard, CrmSyncGuard]);
     });
 });

--- a/apps/api/src/integrations/twenty-crm/controllers/companies.service.ts
+++ b/apps/api/src/integrations/twenty-crm/controllers/companies.service.ts
@@ -25,6 +25,7 @@ import { UserRepository } from '@ever-works/agent/database';
 import { ClientService } from '../services/client.service';
 import { CrmTenantService } from '../services/crm-tenant.service';
 import { AuthSessionGuard } from '@src/auth/guards/auth-session.guard';
+import { CrmSyncGuard } from '../guards/crm-sync.guard';
 import { CurrentUser } from '@src/auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '@src/auth/types/auth.types';
 import { TwentyOrganization } from '../types/twenty-crm.types';
@@ -87,7 +88,11 @@ class CompanyBodyDto {
 class UpdateCompanyBodyDto extends PartialType(CompanyBodyDto) {}
 
 @Controller('api/twenty-crm/companies')
-@UseGuards(AuthSessionGuard)
+// Security (audit #61): CrmSyncGuard was defined but never applied, so these
+// routes stayed reachable even when the CRM integration was disabled or
+// misconfigured (`CRM_SYNC_ENABLED` off / invalid config). Fail closed: auth
+// first, then the integration-enabled gate (403 when CRM sync is off).
+@UseGuards(AuthSessionGuard, CrmSyncGuard)
 export class CompaniesController {
     constructor(
         private readonly clientService: ClientService,

--- a/apps/api/src/migrations/1780500000000-AddVerificationTokenExpiresAtToTenantEmailAddresses.ts
+++ b/apps/api/src/migrations/1780500000000-AddVerificationTokenExpiresAtToTenantEmailAddresses.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * EW-711 #44 — Email address verification tokens had no expiry: a leaked
+ * confirmation link could verify a `tenant_email_addresses` row forever.
+ *
+ * Adds the nullable `verificationTokenExpiresAt` timestamp that
+ * `EmailService.createAddress` now stamps (24h TTL) alongside the token and
+ * `EmailService.confirmVerification` checks before flipping `verified`.
+ *
+ * NULL semantics: no pending token, or a legacy token issued before this
+ * column existed — legacy tokens stay confirmable (no backfill) so in-flight
+ * verification emails are not invalidated by the deploy.
+ *
+ * Additive + idempotent (column-existence guard, mirroring the
+ * AddAgentScopeTargetIdForDurableSlugCas pattern) so a re-run at pod boot
+ * (`migrationsRun: true`) cannot CrashLoopBackOff the API. Cross-dialect:
+ * `timestamp` matches the entity's `@PortableDateColumn` (`type: Date`) on
+ * Postgres and resolves via type affinity on the better-sqlite3 test driver,
+ * same as the existing `disabledAt` column on this table.
+ */
+export class AddVerificationTokenExpiresAtToTenantEmailAddresses1780500000000 implements MigrationInterface {
+    name = 'AddVerificationTokenExpiresAtToTenantEmailAddresses1780500000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('tenant_email_addresses');
+        const hasColumn = table?.columns.some((c) => c.name === 'verificationTokenExpiresAt');
+        if (!hasColumn) {
+            await queryRunner.addColumn(
+                'tenant_email_addresses',
+                new TableColumn({
+                    name: 'verificationTokenExpiresAt',
+                    type: 'timestamp',
+                    isNullable: true,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('tenant_email_addresses');
+        const hasColumn = table?.columns.some((c) => c.name === 'verificationTokenExpiresAt');
+        if (hasColumn) {
+            await queryRunner.dropColumn('tenant_email_addresses', 'verificationTokenExpiresAt');
+        }
+    }
+}

--- a/apps/api/src/plugins-capabilities/oauth/oauth.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/oauth/oauth.controller.spec.ts
@@ -10,6 +10,7 @@ jest.mock('../../auth/guards/auth-session.guard', () => ({ AuthSessionGuard: cla
 import { BadRequestException } from '@nestjs/common';
 import { OAuthController } from './oauth.controller';
 import type { OAuthService } from './oauth.service';
+import type { OAuthStateService } from '../../auth/services/oauth-state.service';
 
 describe('OAuthController', () => {
     let oauthService: {
@@ -18,11 +19,21 @@ describe('OAuthController', () => {
         checkConnection: jest.Mock;
         getOAuthUrl: jest.Mock;
         handleOAuthCallback: jest.Mock;
+        getReadPackagesOAuthUrl: jest.Mock;
+        handleReadPackagesOAuthCallback: jest.Mock;
         getUser: jest.Mock;
         disconnectProvider: jest.Mock;
     };
+    // EW-722 #20: the controller now mints/verifies the OAuth CSRF state
+    // via OAuthStateService — mocked here, contract covered by
+    // auth/services/oauth-state.service.spec.ts.
+    let oauthState: {
+        mint: jest.Mock;
+        verify: jest.Mock;
+    };
+    let res: { getHeader: jest.Mock; setHeader: jest.Mock };
     let controller: OAuthController;
-    const req = { user: { userId: 'user-1' } } as any;
+    const req = { user: { userId: 'user-1' }, headers: {} } as any;
 
     beforeEach(() => {
         oauthService = {
@@ -31,10 +42,22 @@ describe('OAuthController', () => {
             checkConnection: jest.fn(),
             getOAuthUrl: jest.fn(),
             handleOAuthCallback: jest.fn(),
+            getReadPackagesOAuthUrl: jest.fn(),
+            handleReadPackagesOAuthCallback: jest.fn(),
             getUser: jest.fn(),
             disconnectProvider: jest.fn(),
         };
-        controller = new OAuthController(oauthService as unknown as OAuthService);
+        oauthState = {
+            mint: jest
+                .fn()
+                .mockReturnValue({ state: 'minted-state', setCookie: 'ew_oauth_state=minted' }),
+            verify: jest.fn().mockReturnValue({ valid: true, clearCookie: 'ew_oauth_state=' }),
+        };
+        res = { getHeader: jest.fn().mockReturnValue(undefined), setHeader: jest.fn() };
+        controller = new OAuthController(
+            oauthService as unknown as OAuthService,
+            oauthState as unknown as OAuthStateService,
+        );
     });
 
     afterEach(() => {
@@ -74,35 +97,59 @@ describe('OAuthController', () => {
     });
 
     describe('getConnectUrl', () => {
-        it('forwards all params and returns service result on success', async () => {
-            const payload = { url: 'https://provider/auth', state: 'abc' };
+        it('forwards params with the SERVER-MINTED state and returns service result on success', async () => {
+            const payload = { url: 'https://provider/auth', state: 'minted-state' };
             oauthService.getOAuthUrl.mockResolvedValue(payload);
 
             const result = await controller.getConnectUrl(
                 req,
                 'github',
+                res as any,
                 'https://app/cb',
-                'abc',
                 'true',
             );
 
+            // EW-722 #20: state is minted by OAuthStateService, never taken
+            // from the client — a client-chosen state would defeat the
+            // cookie↔query CSRF binding verified at the callback.
+            expect(oauthState.mint).toHaveBeenCalledTimes(1);
             expect(oauthService.getOAuthUrl).toHaveBeenCalledWith({
                 userId: 'user-1',
                 redirectUri: 'https://app/cb',
                 forceConsent: true,
                 providerId: 'github',
-                state: 'abc',
+                state: 'minted-state',
             });
             expect(result).toBe(payload);
+        });
+
+        it('sets the minted state cookie on the response', async () => {
+            oauthService.getOAuthUrl.mockResolvedValue({ url: 'u', state: 'minted-state' });
+
+            await controller.getConnectUrl(req, 'github', res as any, 'cb');
+
+            expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', 'ew_oauth_state=minted');
+        });
+
+        it('appends to existing Set-Cookie headers instead of clobbering them', async () => {
+            res.getHeader.mockReturnValue('other=1');
+            oauthService.getOAuthUrl.mockResolvedValue({ url: 'u', state: 'minted-state' });
+
+            await controller.getConnectUrl(req, 'github', res as any, 'cb');
+
+            expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', [
+                'other=1',
+                'ew_oauth_state=minted',
+            ]);
         });
 
         it('coerces forceConsent to false when not literally "true"', async () => {
             oauthService.getOAuthUrl.mockResolvedValue({ url: 'u', state: 's' });
 
-            await controller.getConnectUrl(req, 'github', 'cb', 's', 'false');
-            await controller.getConnectUrl(req, 'github', 'cb', 's', undefined);
-            await controller.getConnectUrl(req, 'github', 'cb', 's', '');
-            await controller.getConnectUrl(req, 'github', 'cb', 's', 'TRUE'); // case-sensitive
+            await controller.getConnectUrl(req, 'github', res as any, 'cb', 'false');
+            await controller.getConnectUrl(req, 'github', res as any, 'cb', undefined);
+            await controller.getConnectUrl(req, 'github', res as any, 'cb', '');
+            await controller.getConnectUrl(req, 'github', res as any, 'cb', 'TRUE'); // case-sensitive
 
             for (const call of oauthService.getOAuthUrl.mock.calls) {
                 expect(call[0].forceConsent).toBe(false);
@@ -112,30 +159,20 @@ describe('OAuthController', () => {
         it('coerces missing callbackUrl to empty string', async () => {
             oauthService.getOAuthUrl.mockResolvedValue({ url: 'u', state: 's' });
 
-            await controller.getConnectUrl(req, 'github', undefined, 's');
+            await controller.getConnectUrl(req, 'github', res as any, undefined);
 
             expect(oauthService.getOAuthUrl).toHaveBeenCalledWith(
                 expect.objectContaining({ redirectUri: '' }),
             );
         });
 
-        it('passes state=undefined through when omitted', async () => {
-            oauthService.getOAuthUrl.mockResolvedValue({ url: 'u', state: 'auto' });
-
-            await controller.getConnectUrl(req, 'github', 'cb');
-
-            expect(oauthService.getOAuthUrl).toHaveBeenCalledWith(
-                expect.objectContaining({ state: undefined }),
-            );
-        });
-
         it('wraps Error rejection in BadRequestException with the original message', async () => {
             oauthService.getOAuthUrl.mockRejectedValue(new Error('credentials missing'));
 
-            await expect(controller.getConnectUrl(req, 'github', 'cb')).rejects.toBeInstanceOf(
-                BadRequestException,
-            );
-            await expect(controller.getConnectUrl(req, 'github', 'cb')).rejects.toThrow(
+            await expect(
+                controller.getConnectUrl(req, 'github', res as any, 'cb'),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(controller.getConnectUrl(req, 'github', res as any, 'cb')).rejects.toThrow(
                 'credentials missing',
             );
         });
@@ -143,68 +180,173 @@ describe('OAuthController', () => {
         it('wraps non-Error rejection in BadRequestException with generic message', async () => {
             oauthService.getOAuthUrl.mockRejectedValue('something');
 
-            await expect(controller.getConnectUrl(req, 'github', 'cb')).rejects.toThrow(
+            await expect(controller.getConnectUrl(req, 'github', res as any, 'cb')).rejects.toThrow(
                 'Failed to get OAuth URL',
             );
         });
     });
 
     describe('handleOAuthCallback', () => {
-        it('throws BadRequestException when code is missing', async () => {
+        it('throws BadRequestException when code is missing (BEFORE the state check)', async () => {
             await expect(
-                controller.handleOAuthCallback(req, 'github', '', 'state'),
+                controller.handleOAuthCallback(req, 'github', res as any, '', 'state'),
             ).rejects.toBeInstanceOf(BadRequestException);
             await expect(
-                controller.handleOAuthCallback(req, 'github', '', 'state'),
+                controller.handleOAuthCallback(req, 'github', res as any, '', 'state'),
             ).rejects.toThrow('Authorization code is required');
 
             expect(oauthService.handleOAuthCallback).not.toHaveBeenCalled();
+            // e2e pins 'Authorization code is required' as the FIRST gate —
+            // state verification must not run when the code is absent.
+            expect(oauthState.verify).not.toHaveBeenCalled();
         });
 
         it('throws BadRequestException when code is undefined', async () => {
             await expect(
-                controller.handleOAuthCallback(req, 'github', undefined as any, 'state'),
+                controller.handleOAuthCallback(req, 'github', res as any, undefined as any, 's'),
             ).rejects.toThrow('Authorization code is required');
         });
 
-        it('forwards (userId, providerId, code, state) to service.handleOAuthCallback', async () => {
+        it('verifies state against the cookie, clears the cookie, and forwards (userId, providerId, code)', async () => {
             const info = { id: 'github', connected: true };
             oauthService.handleOAuthCallback.mockResolvedValue(info);
+            const cookieReq = {
+                user: { userId: 'user-1' },
+                headers: { cookie: 'ew_oauth_state=state-xyz' },
+            } as any;
 
             const result = await controller.handleOAuthCallback(
-                req,
+                cookieReq,
                 'github',
+                res as any,
                 'code-abc',
                 'state-xyz',
             );
 
+            expect(oauthState.verify).toHaveBeenCalledWith({
+                cookieHeader: 'ew_oauth_state=state-xyz',
+                stateQuery: 'state-xyz',
+                secure: false,
+            });
+            // The state cookie is single-use: cleared even on success.
+            expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', 'ew_oauth_state=');
             expect(oauthService.handleOAuthCallback).toHaveBeenCalledWith(
                 'user-1',
                 'github',
                 'code-abc',
-                'state-xyz',
             );
             expect(result).toBe(info);
         });
 
-        it('passes state=undefined when omitted', async () => {
-            oauthService.handleOAuthCallback.mockResolvedValue({});
+        it('rejects with BadRequestException when state verification fails (EW-722 #20 CSRF gate)', async () => {
+            oauthState.verify.mockReturnValue({
+                valid: false,
+                clearCookie: 'ew_oauth_state=',
+                reason: 'state value mismatch',
+            });
 
-            await controller.handleOAuthCallback(req, 'github', 'code-abc');
+            await expect(
+                controller.handleOAuthCallback(req, 'github', res as any, 'code-abc', 'attacker'),
+            ).rejects.toThrow('OAuth state verification failed: state value mismatch');
 
-            expect(oauthService.handleOAuthCallback).toHaveBeenCalledWith(
-                'user-1',
-                'github',
-                'code-abc',
-                undefined,
+            // The code is NEVER exchanged on a failed state check — that is
+            // the whole point: no attacker code-to-account linkage.
+            expect(oauthService.handleOAuthCallback).not.toHaveBeenCalled();
+            // Cookie still cleared (single-use) on the failure path.
+            expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', 'ew_oauth_state=');
+        });
+
+        it('rejects when state query param is omitted', async () => {
+            oauthState.verify.mockReturnValue({
+                valid: false,
+                clearCookie: 'ew_oauth_state=',
+                reason: 'missing state query',
+            });
+
+            await expect(
+                controller.handleOAuthCallback(req, 'github', res as any, 'code-abc'),
+            ).rejects.toBeInstanceOf(BadRequestException);
+
+            expect(oauthState.verify).toHaveBeenCalledWith(
+                expect.objectContaining({ stateQuery: undefined }),
             );
+            expect(oauthService.handleOAuthCallback).not.toHaveBeenCalled();
         });
 
         it('propagates errors from service.handleOAuthCallback (no try/catch wrap)', async () => {
             const err = new Error('upstream');
             oauthService.handleOAuthCallback.mockRejectedValue(err);
 
-            await expect(controller.handleOAuthCallback(req, 'github', 'code')).rejects.toBe(err);
+            await expect(
+                controller.handleOAuthCallback(req, 'github', res as any, 'code', 's'),
+            ).rejects.toBe(err);
+        });
+    });
+
+    describe('read-packages variant (connect/url + callback)', () => {
+        it('getReadPackagesConnectUrl uses the server-minted state and sets the cookie', async () => {
+            const payload = { url: 'https://provider/auth', state: 'minted-state' };
+            oauthService.getReadPackagesOAuthUrl.mockResolvedValue(payload);
+
+            const result = await controller.getReadPackagesConnectUrl(
+                req,
+                'github',
+                res as any,
+                'cb',
+            );
+
+            expect(oauthState.mint).toHaveBeenCalledTimes(1);
+            expect(res.setHeader).toHaveBeenCalledWith('Set-Cookie', 'ew_oauth_state=minted');
+            expect(oauthService.getReadPackagesOAuthUrl).toHaveBeenCalledWith(
+                expect.objectContaining({ state: 'minted-state' }),
+            );
+            expect(result).toBe(payload);
+        });
+
+        it('handleReadPackagesOAuthCallback gates on code first, then state, then forwards', async () => {
+            await expect(
+                controller.handleReadPackagesOAuthCallback(req, 'github', res as any, '', 's'),
+            ).rejects.toThrow('Authorization code is required');
+            expect(oauthState.verify).not.toHaveBeenCalled();
+
+            oauthService.handleReadPackagesOAuthCallback.mockResolvedValue({
+                providerId: 'github',
+                connected: true,
+            });
+            const result = await controller.handleReadPackagesOAuthCallback(
+                req,
+                'github',
+                res as any,
+                'code-abc',
+                'state-xyz',
+            );
+            expect(oauthState.verify).toHaveBeenCalledTimes(1);
+            expect(oauthService.handleReadPackagesOAuthCallback).toHaveBeenCalledWith(
+                'user-1',
+                'github',
+                'code-abc',
+            );
+            expect(result).toEqual({ providerId: 'github', connected: true });
+        });
+
+        it('handleReadPackagesOAuthCallback rejects on invalid state without exchanging the code', async () => {
+            oauthState.verify.mockReturnValue({
+                valid: false,
+                clearCookie: 'ew_oauth_state=',
+                reason: 'missing state cookie',
+            });
+
+            await expect(
+                controller.handleReadPackagesOAuthCallback(
+                    req,
+                    'github',
+                    res as any,
+                    'code-abc',
+                    'forged',
+                ),
+            ).rejects.toThrow('OAuth state verification failed: missing state cookie');
+
+            expect(oauthService.handleReadPackagesOAuthCallback).not.toHaveBeenCalled();
         });
     });
 

--- a/apps/api/src/plugins-capabilities/oauth/oauth.controller.ts
+++ b/apps/api/src/plugins-capabilities/oauth/oauth.controller.ts
@@ -6,6 +6,7 @@ import {
     Query,
     UseGuards,
     Request,
+    Res,
     BadRequestException,
     HttpCode,
     HttpStatus,
@@ -19,14 +20,71 @@ import {
     ApiQuery,
 } from '@nestjs/swagger';
 import { AuthSessionGuard } from '../../auth/guards/auth-session.guard';
+import { OAuthStateService } from '../../auth/services/oauth-state.service';
 import { OAuthService } from './oauth.service';
+
+// Minimal duck-typed shapes — the platform deliberately doesn't depend on
+// `@types/express` (same pattern as auth/controllers/oauth.controller.ts).
+type OAuthCallbackRequest = {
+    user: { userId: string };
+    headers: Record<string, string | string[] | undefined>;
+};
+type OAuthResponseLike = {
+    getHeader(name: string): string | string[] | number | undefined;
+    setHeader(name: string, value: string | string[]): void;
+};
 
 @ApiTags('OAuth')
 @ApiBearerAuth('JWT-auth')
 @Controller('api/oauth')
 @UseGuards(AuthSessionGuard)
 export class OAuthController {
-    constructor(private readonly oauthService: OAuthService) {}
+    constructor(
+        private readonly oauthService: OAuthService,
+        // EW-722 #20: same server-minted `state` + HttpOnly-cookie CSRF
+        // binding the auth login flow uses (C-03). AuthModule exports it.
+        private readonly oauthState: OAuthStateService,
+    ) {}
+
+    /** Append a Set-Cookie value without clobbering ones already queued. */
+    private appendSetCookie(res: OAuthResponseLike, cookie: string): void {
+        const existing = res.getHeader('Set-Cookie');
+        if (Array.isArray(existing)) {
+            res.setHeader('Set-Cookie', [...existing.map(String), cookie]);
+        } else if (typeof existing === 'string') {
+            res.setHeader('Set-Cookie', [existing, cookie]);
+        } else {
+            res.setHeader('Set-Cookie', cookie);
+        }
+    }
+
+    /**
+     * EW-722 #20: verify the callback's `state` query param against the
+     * `ew_oauth_state` cookie BEFORE any credential lookup or code
+     * exchange. Without this an attacker could complete a victim's plugin
+     * OAuth flow and link an attacker-controlled provider account
+     * (arbitrary code-to-account linkage). The cookie is cleared
+     * regardless of outcome (single-use). Server-to-server callers (the
+     * web callback routes) synthesize the cookie from the same value they
+     * already validated against their own host-scoped cookie.
+     */
+    private verifyOAuthStateOrThrow(
+        req: OAuthCallbackRequest,
+        res: OAuthResponseLike,
+        state?: string,
+    ): void {
+        const rawCookieHeader = req.headers.cookie;
+        const cookieHeader = Array.isArray(rawCookieHeader) ? rawCookieHeader[0] : rawCookieHeader;
+        const result = this.oauthState.verify({
+            cookieHeader,
+            stateQuery: typeof state === 'string' ? state : undefined,
+            secure: process.env.NODE_ENV === 'production',
+        });
+        this.appendSetCookie(res, result.clearCookie);
+        if (!result.valid) {
+            throw new BadRequestException(`OAuth state verification failed: ${result.reason}`);
+        }
+    }
 
     @Get('providers')
     @ApiOperation({ summary: 'List available OAuth providers' })
@@ -49,16 +107,27 @@ export class OAuthController {
     @ApiOperation({ summary: 'Get OAuth authorization URL' })
     @ApiParam({ name: 'providerId', description: 'OAuth provider ID' })
     @ApiQuery({ name: 'callbackUrl', required: false })
-    @ApiQuery({ name: 'state', required: false })
     @ApiQuery({ name: 'forceConsent', required: false })
     @ApiResponse({ status: 200, description: 'OAuth authorization URL' })
     async getConnectUrl(
         @Request() req,
         @Param('providerId') providerId: string,
+        @Res({ passthrough: true }) res: OAuthResponseLike,
         @Query('callbackUrl') callbackUrl?: string,
-        @Query('state') state?: string,
         @Query('forceConsent') forceConsent?: string,
     ) {
+        // EW-722 #20: server-mint the OAuth `state` and bind it to the
+        // browser via an HttpOnly cookie. The minted value (never a
+        // client-supplied `?state=`, which is now ignored) is embedded in
+        // the authorize URL AND returned in the body so the web tier can
+        // mirror it into its own host-scoped cookie — the same
+        // dual-channel contract the auth login flow uses (C-03). Minting
+        // before the credential lookup is harmless: the unconfigured-
+        // provider 400 contract below is unchanged.
+        const { state, setCookie } = this.oauthState.mint({
+            secure: process.env.NODE_ENV === 'production',
+        });
+        this.appendSetCookie(res, setCookie);
         try {
             return await this.oauthService.getOAuthUrl({
                 userId: req.user.userId,
@@ -78,18 +147,23 @@ export class OAuthController {
     @ApiOperation({ summary: 'OAuth callback handler' })
     @ApiParam({ name: 'providerId', description: 'OAuth provider ID' })
     @ApiQuery({ name: 'code', required: true })
-    @ApiQuery({ name: 'state', required: false })
+    @ApiQuery({ name: 'state', required: true })
     @ApiResponse({ status: 200, description: 'Provider connected successfully' })
     async handleOAuthCallback(
         @Request() req,
         @Param('providerId') providerId: string,
+        @Res({ passthrough: true }) res: OAuthResponseLike,
         @Query('code') code: string,
         @Query('state') state?: string,
     ) {
         if (!code) {
             throw new BadRequestException('Authorization code is required');
         }
-        return this.oauthService.handleOAuthCallback(req.user.userId, providerId, code, state);
+        // EW-722 #20: state verification runs AFTER the code-presence
+        // check (the e2e suite pins 'Authorization code is required' as
+        // the first gate) and BEFORE any credential lookup/code exchange.
+        this.verifyOAuthStateOrThrow(req, res, state);
+        return this.oauthService.handleOAuthCallback(req.user.userId, providerId, code);
     }
 
     @Get(':providerId/user')
@@ -126,16 +200,21 @@ export class OAuthController {
     })
     @ApiParam({ name: 'providerId', description: 'OAuth provider ID' })
     @ApiQuery({ name: 'callbackUrl', required: false })
-    @ApiQuery({ name: 'state', required: false })
     @ApiQuery({ name: 'forceConsent', required: false })
     @ApiResponse({ status: 200, description: 'OAuth authorization URL' })
     async getReadPackagesConnectUrl(
         @Request() req,
         @Param('providerId') providerId: string,
+        @Res({ passthrough: true }) res: OAuthResponseLike,
         @Query('callbackUrl') callbackUrl?: string,
-        @Query('state') state?: string,
         @Query('forceConsent') forceConsent?: string,
     ) {
+        // EW-722 #20: same server-minted state + cookie binding as
+        // `getConnectUrl` — see the comment there.
+        const { state, setCookie } = this.oauthState.mint({
+            secure: process.env.NODE_ENV === 'production',
+        });
+        this.appendSetCookie(res, setCookie);
         try {
             return await this.oauthService.getReadPackagesOAuthUrl({
                 userId: req.user.userId,
@@ -159,22 +238,20 @@ export class OAuthController {
     })
     @ApiParam({ name: 'providerId', description: 'OAuth provider ID' })
     @ApiQuery({ name: 'code', required: true })
-    @ApiQuery({ name: 'state', required: false })
+    @ApiQuery({ name: 'state', required: true })
     @ApiResponse({ status: 200, description: 'Read-packages PAT saved' })
     async handleReadPackagesOAuthCallback(
         @Request() req,
         @Param('providerId') providerId: string,
+        @Res({ passthrough: true }) res: OAuthResponseLike,
         @Query('code') code: string,
         @Query('state') state?: string,
     ) {
         if (!code) {
             throw new BadRequestException('Authorization code is required');
         }
-        return this.oauthService.handleReadPackagesOAuthCallback(
-            req.user.userId,
-            providerId,
-            code,
-            state,
-        );
+        // EW-722 #20: code-presence gate first (e2e-pinned), then state.
+        this.verifyOAuthStateOrThrow(req, res, state);
+        return this.oauthService.handleReadPackagesOAuthCallback(req.user.userId, providerId, code);
     }
 }

--- a/apps/api/src/plugins-capabilities/oauth/oauth.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/oauth/oauth.service.spec.ts
@@ -395,12 +395,9 @@ describe('OAuthService', () => {
 
         it('exchanges code, fetches user, upserts account with plugin: prefix and connectionSource=plugin', async () => {
             const before = Date.now();
-            const result = await service.handleOAuthCallback(
-                'user-1',
-                'github',
-                'code-abc',
-                'state-xyz',
-            );
+            // EW-722 #20: no `state` arg — CSRF state verification moved to
+            // the controller (OAuthStateService) before this method runs.
+            const result = await service.handleOAuthCallback('user-1', 'github', 'code-abc');
             const after = Date.now();
 
             expect(oauthFacade.exchangeCodeForToken).toHaveBeenCalledWith(
@@ -463,7 +460,7 @@ describe('OAuthService', () => {
                 scope: undefined,
             });
 
-            await service.handleOAuthCallback('user-1', 'github', 'code', undefined);
+            await service.handleOAuthCallback('user-1', 'github', 'code');
 
             const arg = authAccountRepository.upsertProviderAccount.mock.calls[0][0];
             expect(arg.accessTokenExpiresAt).toBeUndefined();
@@ -547,11 +544,11 @@ describe('OAuthService', () => {
         });
 
         it('stores the read-packages token and its GitHub owner login in plugin settings', async () => {
+            // EW-722 #20: no `state` arg — verified at the controller.
             const result = await service.handleReadPackagesOAuthCallback(
                 'user-1',
                 'github',
                 'code-abc',
-                'state-xyz',
             );
 
             expect(oauthFacade.exchangeCodeForToken).toHaveBeenCalledWith(
@@ -579,7 +576,6 @@ describe('OAuthService', () => {
                 'user-1',
                 'github',
                 'code-abc',
-                'state-xyz',
             );
 
             expect(pluginSettingsService.updateUserSettings).toHaveBeenCalledWith(

--- a/apps/api/src/plugins-capabilities/oauth/oauth.service.ts
+++ b/apps/api/src/plugins-capabilities/oauth/oauth.service.ts
@@ -117,15 +117,18 @@ export class OAuthService {
         return { url, state: finalState };
     }
 
+    /**
+     * EW-722 #20: the OAuth `state` CSRF check happens in the controller
+     * (`OAuthStateService.verify` against the `ew_oauth_state` cookie)
+     * BEFORE this method runs — it deliberately takes no `state` param so
+     * a future caller can't bypass verification by invoking it directly
+     * with an attacker-supplied state.
+     */
     async handleOAuthCallback(
         userId: string,
         providerId: string,
         code: string,
-        state?: string,
     ): Promise<OAuthConnectionInfo> {
-        void userId;
-        void state;
-
         const config = await this.getOAuthConfig(providerId);
         const token = await this.oauthFacade.exchangeCodeForToken(providerId, code, config);
         const user = await this.oauthFacade.getAuthenticatedUser(providerId, token.accessToken);
@@ -221,15 +224,15 @@ export class OAuthService {
      * Critically, this does NOT touch `authAccountRepository`. The main
      * GitHub OAuth connection (used for git operations, repo OAuth scopes)
      * is left untouched; the two tokens live independently.
+     *
+     * EW-722 #20: like {@link handleOAuthCallback}, the `state` CSRF check
+     * happens in the controller before this method runs.
      */
     async handleReadPackagesOAuthCallback(
         userId: string,
         providerId: string,
         code: string,
-        state?: string,
     ): Promise<{ providerId: string; connected: true }> {
-        void state;
-
         const config = await this.getOAuthConfig(providerId);
         const token = await this.oauthFacade.exchangeCodeForToken(providerId, code, config);
         let readPackagesPatOwner = '';

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -1,8 +1,12 @@
 import { Module, OnModuleInit } from '@nestjs/common';
 import { DatabaseModule } from '@ever-works/agent/database';
+// Security (EW-711 #14): WorkModule provides/exports WorkOwnershipService so
+// WebhooksService can authorize a supplied workId before binding a
+// subscription to that Work's event stream.
 import {
     WebhookDeliveryService,
     WebhookSubscriptionDeliveryService,
+    WorkModule,
 } from '@ever-works/agent/services';
 import { TriggerModule as TasksTriggerModule } from '@ever-works/trigger-tasks';
 import { AuthModule } from '../auth/auth.module';
@@ -29,7 +33,7 @@ import { WebhooksDeliveriesService } from './webhooks-deliveries.service';
  *    delivery when Trigger.dev is unconfigured.
  */
 @Module({
-    imports: [DatabaseModule, AuthModule, TasksTriggerModule],
+    imports: [DatabaseModule, AuthModule, TasksTriggerModule, WorkModule],
     controllers: [WebhooksController],
     providers: [
         WebhooksService,

--- a/apps/api/src/webhooks/webhooks.service.spec.ts
+++ b/apps/api/src/webhooks/webhooks.service.spec.ts
@@ -2,6 +2,12 @@ jest.mock('@ever-works/agent/database', () => ({
     WebhookSubscriptionRepository: class {},
 }));
 jest.mock('@ever-works/agent/entities', () => ({}));
+// Security (EW-711 #14): the service now injects WorkOwnershipService to
+// authorize work-scoped subscriptions; a class shell keeps the spec from
+// pulling the real services barrel (TypeORM repos/entities).
+jest.mock('@ever-works/agent/services', () => ({
+    WorkOwnershipService: class {},
+}));
 
 import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { WebhooksService } from './webhooks.service';
@@ -17,6 +23,7 @@ describe('WebhooksService', () => {
         delete: jest.Mock;
     };
     let secrets: WebhookSecretService;
+    let workOwnership: { ensureCanView: jest.Mock };
     let service: WebhooksService;
     const ACCOUNT = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
     const SAVED_NODE_ENV = process.env.NODE_ENV;
@@ -45,7 +52,10 @@ describe('WebhooksService', () => {
         // the raw secret shape without an encryption key.
         delete process.env.PLATFORM_ENCRYPTION_KEY;
         secrets = new WebhookSecretService();
-        service = new WebhooksService(repo as any, secrets);
+        // Security (EW-711 #14): ownership gate passes by default so the
+        // existing (no-workId / own-workId) flows stay green.
+        workOwnership = { ensureCanView: jest.fn().mockResolvedValue({}) };
+        service = new WebhooksService(repo as any, secrets, workOwnership as any);
     });
 
     afterEach(() => {
@@ -129,7 +139,11 @@ describe('WebhooksService', () => {
             // minted; supply a valid 32-byte (hex) key so the https path
             // reaches a successful create instead of the secret-service guard.
             process.env.PLATFORM_ENCRYPTION_KEY = 'a'.repeat(64);
-            service = new WebhooksService(repo as any, new WebhookSecretService());
+            service = new WebhooksService(
+                repo as any,
+                new WebhookSecretService(),
+                workOwnership as any,
+            );
             await expect(
                 service.create(ACCOUNT, { url: 'https://hooks.example.com/ingest' }),
             ).resolves.toBeDefined();
@@ -148,6 +162,53 @@ describe('WebhooksService', () => {
             await expect(
                 service.create(ACCOUNT, { url: 'https://hooks.example/ingest' }),
             ).rejects.toThrow(/per-account limit of 25/);
+        });
+    });
+
+    // Security (EW-711 #14): create() must authorize a supplied workId via
+    // WorkOwnershipService.ensureCanView so a caller can't bind a
+    // subscription to a foreign Work and exfiltrate its event stream.
+    describe('create — workId ownership (EW-711 #14)', () => {
+        const WORK = '11111111-2222-3333-4444-555555555555';
+
+        it('skips the ownership gate when no workId is supplied', async () => {
+            await service.create(ACCOUNT, { url: 'https://hooks.example/ingest' });
+            expect(workOwnership.ensureCanView).not.toHaveBeenCalled();
+        });
+
+        it('authorizes the supplied workId for the caller before persisting', async () => {
+            const r = await service.create(ACCOUNT, {
+                url: 'https://hooks.example/ingest',
+                workId: WORK,
+            });
+            expect(workOwnership.ensureCanView).toHaveBeenCalledWith(WORK, ACCOUNT);
+            expect(r.subscription.workId).toBe(WORK);
+        });
+
+        it('masks a foreign workId (Forbidden) as NotFound — no enumeration', async () => {
+            workOwnership.ensureCanView.mockRejectedValueOnce(
+                new ForbiddenException('You do not have permission to access this work'),
+            );
+            await expect(
+                service.create(ACCOUNT, {
+                    url: 'https://hooks.example/ingest',
+                    workId: WORK,
+                }),
+            ).rejects.toThrow(NotFoundException);
+            expect(repo.createForAccount).not.toHaveBeenCalled();
+        });
+
+        it('propagates NotFound for a nonexistent workId (404-safe)', async () => {
+            workOwnership.ensureCanView.mockRejectedValueOnce(
+                new NotFoundException(`Work with id '${WORK}' not found`),
+            );
+            await expect(
+                service.create(ACCOUNT, {
+                    url: 'https://hooks.example/ingest',
+                    workId: WORK,
+                }),
+            ).rejects.toThrow(NotFoundException);
+            expect(repo.createForAccount).not.toHaveBeenCalled();
         });
     });
 

--- a/apps/api/src/webhooks/webhooks.service.ts
+++ b/apps/api/src/webhooks/webhooks.service.ts
@@ -13,6 +13,9 @@ import type { WebhookSubscription } from '@ever-works/agent/entities';
 // ULA (fc00::/7), link-local, CGNAT (100.64/10), 0.0.0.0/8 and cloud-metadata
 // hosts — closing the [::1] / ::ffff:127.0.0.1 / IPv6-range bypasses.
 import { isSafeWebhookUrl } from '@ever-works/agent/utils';
+// Security (EW-711 #14): work-scoped subscriptions must be authorized against
+// the caller's access to that Work — see the ownership gate in `create()`.
+import { WorkOwnershipService } from '@ever-works/agent/services';
 import { WebhookSecretService } from './webhook-secret.service';
 
 export interface WebhookSubscriptionView {
@@ -36,6 +39,7 @@ export class WebhooksService {
     constructor(
         private readonly repo: WebhookSubscriptionRepository,
         private readonly secrets: WebhookSecretService,
+        private readonly workOwnership: WorkOwnershipService,
     ) {}
 
     async listForAccount(accountId: string): Promise<WebhookSubscriptionView[]> {
@@ -60,6 +64,27 @@ export class WebhooksService {
         input: { url: string; workId?: string | null },
     ): Promise<{ subscription: WebhookSubscriptionView; signingSecret: string }> {
         this.assertValidUrl(input.url);
+
+        // Security (EW-711 #14): a subscription bound to a Work receives that
+        // Work's lifecycle events (names, deployment URLs, error details), so
+        // the caller must be allowed to view the Work they bind to. Nothing
+        // validated `input.workId` before — any authenticated user could
+        // subscribe to a foreign workId and exfiltrate its event stream.
+        // `ensureCanView` passes for the creator and any work member, so
+        // legitimate callers keep working. A Forbidden (work exists, not
+        // yours) is masked as 404 to match this service's enumeration
+        // defense (see `findOwn`) — callers must not learn that a foreign
+        // workId exists.
+        if (input.workId) {
+            try {
+                await this.workOwnership.ensureCanView(input.workId, accountId);
+            } catch (error) {
+                if (error instanceof ForbiddenException) {
+                    throw new NotFoundException(`Work with id '${input.workId}' not found`);
+                }
+                throw error;
+            }
+        }
 
         const existing = await this.repo.listActiveForAccount(accountId);
         if (existing.length >= MAX_PER_ACCOUNT) {

--- a/apps/web/e2e/flow-agent-inbox-messaging.spec.ts
+++ b/apps/web/e2e/flow-agent-inbox-messaging.spec.ts
@@ -125,6 +125,9 @@ interface EmailAddress {
 
 const NO_ADDRESS = 'Agent has no outbound email address assigned';
 const NO_FROM = 'From address not found';
+// EW-711 #16 (IDOR guard): compose verifies the caller OWNS input.agentId
+// BEFORE from-address resolution, so a foreign agentId 404s with this message.
+const NO_AGENT = 'Agent not found';
 const NO_BODY = 'Email requires bodyText, bodyHtml, or a template';
 const NOT_FOUND_MSG = 'Message not found';
 const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
@@ -328,8 +331,9 @@ test.describe('Agent inbox + messaging', () => {
         expect(bGet.status()).toBe(404);
         expect((await bGet.json()).message).toContain(NOT_FOUND_MSG);
 
-        // B cannot compose FROM A's reply-from address (fromAddressId is
-        // caller-scoped) → 404 "From address not found", NOT a leak.
+        // B cannot compose naming A's agent: EW-711 #16 rejects the foreign
+        // agentId BEFORE from-address resolution → 404 "Agent not found"
+        // (previously the from-address check fired first with NO_FROM).
         const bBorrow = await request.post(`${API_BASE}/api/email/messages`, {
             headers: authedHeaders(tokenB),
             data: {
@@ -341,7 +345,29 @@ test.describe('Agent inbox + messaging', () => {
             },
         });
         expect(bBorrow.status(), `borrow body=${await bBorrow.text().catch(() => '')}`).toBe(404);
-        expect((await bBorrow.json()).message).toContain(NO_FROM);
+        expect((await bBorrow.json()).message).toContain(NO_AGENT);
+
+        // And even with B's OWN agent, A's fromAddressId stays caller-scoped
+        // → 404 "From address not found", NOT a leak (Codex P1, PR #1085).
+        const agentB = await createAgentViaAPI(request, tokenB, {
+            name: uniq('B owns'),
+            scope: 'tenant',
+        });
+        const bBorrowFrom = await request.post(`${API_BASE}/api/email/messages`, {
+            headers: authedHeaders(tokenB),
+            data: {
+                agentId: agentB.id,
+                fromAddressId: addrA.id,
+                to: ['x@example.com'],
+                subject: uniq('s'),
+                bodyText: 'b body',
+            },
+        });
+        expect(
+            bBorrowFrom.status(),
+            `borrow-from body=${await bBorrowFrom.text().catch(() => '')}`,
+        ).toBe(404);
+        expect((await bBorrowFrom.json()).message).toContain(NO_FROM);
 
         // B cannot mutate (disable) or delete A's reply-from address → 404.
         const bPatch = await request.patch(`${API_BASE}/api/email/addresses/${addrA.id}`, {

--- a/apps/web/src/app/api/uploads/file/route.ts
+++ b/apps/web/src/app/api/uploads/file/route.ts
@@ -22,6 +22,12 @@ import { getAuthAccessCookie } from '@/lib/auth/cookies';
  */
 export async function POST(request: NextRequest) {
     const token = await getAuthAccessCookie();
+    // Security: reject unauthenticated requests at the BFF layer instead of
+    // proxying them upstream without credentials. Mirrors the explicit 401
+    // guard in the sibling image-upload proxy at `../route.ts`.
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
     const headers = new Headers();
     const contentType = request.headers.get('content-type');

--- a/apps/web/src/lib/api/plugins-capabilities/oauth.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/oauth.ts
@@ -49,11 +49,22 @@ export const oauthAPI = {
         }>(`/oauth/${providerId}/connect/url${query}`);
     },
 
+    /**
+     * Complete the plugin OAuth connect flow.
+     *
+     * EW-722 #20: the API now verifies `?state=` against its
+     * `ew_oauth_state` cookie (C-03 parity with the auth login flow).
+     * This call is server-to-server — the browser's cookies never reach
+     * the API origin — so synthesize the cookie from the same `state` the
+     * web callback route already validated against its own host-scoped
+     * `oauth_state` cookie. Mirrors `authAPI.connectOAuthCallback`.
+     */
     connectCallback: async (providerId: string, code: string, state?: string) => {
         const params = new URLSearchParams({ code });
         if (state) params.append('state', state);
         return serverFetch<OAuthConnectionInfo>(
             `/oauth/${providerId}/callback/plugins?${params.toString()}`,
+            state ? { headers: { cookie: `ew_oauth_state=${state}` } } : undefined,
         );
     },
 
@@ -78,12 +89,17 @@ export const oauthAPI = {
         }>(`/oauth/${providerId}/read-packages/connect/url${query}`);
     },
 
-    /** Callback for the read-packages OAuth flow (server-side, no UI). */
+    /**
+     * Callback for the read-packages OAuth flow (server-side, no UI).
+     * EW-722 #20: same synthesized `ew_oauth_state` cookie contract as
+     * {@link connectCallback} — see the comment there.
+     */
     readPackagesCallback: async (providerId: string, code: string, state?: string) => {
         const params = new URLSearchParams({ code });
         if (state) params.append('state', state);
         return serverFetch<{ providerId: string; connected: true }>(
             `/oauth/${providerId}/callback/plugins/read-packages?${params.toString()}`,
+            state ? { headers: { cookie: `ew_oauth_state=${state}` } } : undefined,
         );
     },
 

--- a/apps/web/src/lib/api/templates.ts
+++ b/apps/web/src/lib/api/templates.ts
@@ -196,7 +196,7 @@ export const templatesAPI = {
     }) => {
         return serverMutation<AddCustomTemplateResponse>({
             endpoint: '/templates/custom',
-            data: {},
+            data,
             method: 'POST',
             wrapInData: false,
         });

--- a/docs/api/oauth-capability.md
+++ b/docs/api/oauth-capability.md
@@ -108,19 +108,21 @@ Checks if the current user has a valid OAuth connection.
 ### Get Authorization URL
 
 ```
-GET /api/oauth/:providerId/connect/url?callbackUrl=...&state=...&forceConsent=true
+GET /api/oauth/:providerId/connect/url?callbackUrl=...&forceConsent=true
 Authorization: Bearer <jwt-token>
 ```
 
-Generates the OAuth authorization URL for the specified provider.
+Generates the OAuth authorization URL for the specified provider. The CSRF
+`state` is always server-minted (never client-supplied) and bound to the
+caller via an HttpOnly `ew_oauth_state` cookie; it is also returned in the
+response body so a proxying web tier can mirror it into its own cookie.
 
 **Query Parameters:**
 
-| Parameter      | Type     | Required | Description                                        |
-| -------------- | -------- | -------- | -------------------------------------------------- |
-| `callbackUrl`  | `string` | No       | Custom redirect URI after authorization            |
-| `state`        | `string` | No       | Custom state parameter (auto-generated if omitted) |
-| `forceConsent` | `string` | No       | Set to `"true"` to force re-authorization          |
+| Parameter      | Type     | Required | Description                               |
+| -------------- | -------- | -------- | ----------------------------------------- |
+| `callbackUrl`  | `string` | No       | Custom redirect URI after authorization   |
+| `forceConsent` | `string` | No       | Set to `"true"` to force re-authorization |
 
 **Response:**
 
@@ -142,10 +144,10 @@ Processes the OAuth callback after user authorization.
 
 **Query Parameters:**
 
-| Parameter | Type     | Required | Description                           |
-| --------- | -------- | -------- | ------------------------------------- |
-| `code`    | `string` | Yes      | Authorization code from provider      |
-| `state`   | `string` | No       | State parameter for CSRF verification |
+| Parameter | Type     | Required | Description                                                                              |
+| --------- | -------- | -------- | ---------------------------------------------------------------------------------------- |
+| `code`    | `string` | Yes      | Authorization code from provider                                                         |
+| `state`   | `string` | Yes      | CSRF state — must match the `ew_oauth_state` cookie minted by `connect/url` (single-use) |
 
 **Response:**
 

--- a/packages/agent/src/agents/__tests__/agent-tool-git.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool-git.spec.ts
@@ -76,11 +76,15 @@ function makeAgent(over: Partial<Agent> = {}): Agent {
 
 describe('AgentToolService git tools (Phase 16.6 + 16.7)', () => {
     let agentsRepo: any;
+    let agentsService: any;
     let git: jest.Mocked<AgentGitFacade>;
     let svc: AgentToolService;
 
     beforeEach(() => {
         agentsRepo = { create: jest.fn() };
+        // EW-721 #10: AgentsService became a required ctor dep (the
+        // optional raw-repo fallback for createSubAgent was removed).
+        agentsService = { create: jest.fn() };
         git = {
             commitToRepo: jest
                 .fn()
@@ -91,7 +95,7 @@ describe('AgentToolService git tools (Phase 16.6 + 16.7)', () => {
                 state: 'open',
             }),
         };
-        svc = new AgentToolService(agentsRepo, undefined, undefined, undefined, git);
+        svc = new AgentToolService(agentsRepo, agentsService, undefined, undefined, undefined, git);
     });
 
     it('does NOT register commitToRepo when canCommitToRepo is false', () => {
@@ -100,7 +104,7 @@ describe('AgentToolService git tools (Phase 16.6 + 16.7)', () => {
     });
 
     it('does NOT register commitToRepo when git facade is unbound (even with permission)', () => {
-        const bareSvc = new AgentToolService(agentsRepo);
+        const bareSvc = new AgentToolService(agentsRepo, agentsService);
         const tools = bareSvc.resolveAllowedTools(
             makeAgent({ permissions: makePerms({ canCommitToRepo: true }) }),
         );

--- a/packages/agent/src/agents/__tests__/agent-tool-plugins.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool-plugins.spec.ts
@@ -79,11 +79,15 @@ function makeAgent(over: Partial<Agent> = {}): Agent {
 
 describe('AgentToolService plugin pass-through tools (Phase 16.10)', () => {
     let agentsRepo: any;
+    let agentsService: any;
     let pluginTools: jest.Mocked<AgentPluginToolsFacade>;
     let svc: AgentToolService;
 
     beforeEach(() => {
         agentsRepo = { create: jest.fn() };
+        // EW-721 #10: AgentsService became a required ctor dep (the
+        // optional raw-repo fallback for createSubAgent was removed).
+        agentsService = { create: jest.fn() };
         pluginTools = {
             searchWeb: jest.fn().mockResolvedValue({
                 results: [{ title: 'r1', url: 'https://a.example/1', snippet: 's', score: 0.9 }],
@@ -102,6 +106,7 @@ describe('AgentToolService plugin pass-through tools (Phase 16.10)', () => {
         };
         svc = new AgentToolService(
             agentsRepo,
+            agentsService,
             undefined,
             undefined,
             undefined,
@@ -118,7 +123,7 @@ describe('AgentToolService plugin pass-through tools (Phase 16.10)', () => {
     });
 
     it('registers none of the 3 tools when token is unbound (even with permission)', () => {
-        const bareSvc = new AgentToolService(agentsRepo);
+        const bareSvc = new AgentToolService(agentsRepo, agentsService);
         const tools = bareSvc.resolveAllowedTools(
             makeAgent({ permissions: makePerms({ canCallExternalTools: true }) }),
         );

--- a/packages/agent/src/agents/__tests__/agent-tool.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool.service.spec.ts
@@ -52,6 +52,7 @@ function makeAgent(over: Partial<Agent> = {}): Agent {
 
 describe('AgentToolService.resolveAllowedTools', () => {
     let agents: any;
+    let agentsService: any;
     let skills: any;
     let bindings: any;
     let files: any;
@@ -59,10 +60,15 @@ describe('AgentToolService.resolveAllowedTools', () => {
 
     beforeEach(() => {
         agents = { create: jest.fn() };
+        // EW-721 #10: AgentsService is now a REQUIRED dependency — the
+        // optional injection + raw-repository fallback bypassed scope-
+        // ownership, slug-uniqueness and avatar validation when DI
+        // omitted the service.
+        agentsService = { create: jest.fn() };
         skills = { findByIdAndUser: jest.fn() };
         bindings = { resolveActive: jest.fn().mockResolvedValue([]) };
         files = { write: jest.fn() };
-        svc = new AgentToolService(agents, skills, bindings, files);
+        svc = new AgentToolService(agents, agentsService, skills, bindings, files);
     });
 
     it('always exposes the placeholder tools (getActivity + getKbDocument)', () => {
@@ -148,18 +154,24 @@ describe('AgentToolService.resolveAllowedTools', () => {
     });
 
     describe('createSubAgent tool', () => {
-        it('always creates the sub-Agent in DRAFT with all permissions FALSE', async () => {
-            agents.create.mockResolvedValueOnce({ id: 'sub-1', slug: 'helper' });
+        // EW-721 #10: createSubAgent assertions now target AgentsService.create
+        // (userId, input) — the raw AgentRepository fallback was removed because
+        // it bypassed scope-ownership, slug-uniqueness and avatar validation.
+        it('always creates the sub-Agent with all permissions FALSE via AgentsService', async () => {
+            agentsService.create.mockResolvedValueOnce({ id: 'sub-1', slug: 'helper' });
             const tools = svc.resolveAllowedTools(
                 makeAgent({
                     permissions: { ...makeAgent().permissions, canCreateAgents: true },
                 }),
             );
             const tool = tools.find((t) => t.name === 'createSubAgent')!;
-            await tool.invoke({ name: 'Helper' });
-            const arg = agents.create.mock.calls[0][0];
-            expect(arg.status).toBe('draft');
-            expect(arg.permissions).toEqual({
+            const out = await tool.invoke({ name: 'Helper' });
+            expect(out).toEqual({ id: 'sub-1', slug: 'helper' });
+            const [userId, input] = agentsService.create.mock.calls[0];
+            expect(userId).toBe('u1');
+            // DRAFT status is enforced INSIDE AgentsService.create (it is not
+            // a CreateAgentInput field), so the tool cannot escalate it.
+            expect(input.permissions).toEqual({
                 canCreateAgents: false,
                 canAssignTasks: false,
                 canEditSkills: false,
@@ -169,10 +181,13 @@ describe('AgentToolService.resolveAllowedTools', () => {
                 canOpenPullRequests: false,
                 canCallExternalTools: false,
             });
+            // Security: the validating service is the ONLY path — the raw
+            // repository must never be written directly.
+            expect(agents.create).not.toHaveBeenCalled();
         });
 
         it('inherits the actor scope into the sub-Agent', async () => {
-            agents.create.mockResolvedValueOnce({ id: 'sub-1', slug: 'helper' });
+            agentsService.create.mockResolvedValueOnce({ id: 'sub-1', slug: 'helper' });
             const tools = svc.resolveAllowedTools(
                 makeAgent({
                     scope: AgentScope.MISSION,
@@ -182,9 +197,9 @@ describe('AgentToolService.resolveAllowedTools', () => {
             );
             const tool = tools.find((t) => t.name === 'createSubAgent')!;
             await tool.invoke({ name: 'Helper' });
-            const arg = agents.create.mock.calls[0][0];
-            expect(arg.scope).toBe(AgentScope.MISSION);
-            expect(arg.missionId).toBe('m1');
+            const [, input] = agentsService.create.mock.calls[0];
+            expect(input.scope).toBe(AgentScope.MISSION);
+            expect(input.missionId).toBe('m1');
         });
 
         it('requires a name', async () => {
@@ -196,6 +211,26 @@ describe('AgentToolService.resolveAllowedTools', () => {
             const tool = tools.find((t) => t.name === 'createSubAgent')!;
             const out = (await tool.invoke({} as any)) as Record<string, unknown>;
             expect('error' in out).toBe(true);
+            expect(agentsService.create).not.toHaveBeenCalled();
+        });
+
+        it('surfaces AgentsService validation failures as tool errors', async () => {
+            // e.g. slug-uniqueness ConflictException or scope-ownership
+            // BadRequestException — must reach the model as { error }, not throw.
+            agentsService.create.mockRejectedValueOnce(
+                new Error('An Agent named "Helper" already exists in this scope.'),
+            );
+            const tools = svc.resolveAllowedTools(
+                makeAgent({
+                    permissions: { ...makeAgent().permissions, canCreateAgents: true },
+                }),
+            );
+            const tool = tools.find((t) => t.name === 'createSubAgent')!;
+            const out = (await tool.invoke({ name: 'Helper' })) as Record<string, unknown>;
+            expect(out).toEqual({
+                error: 'An Agent named "Helper" already exists in this scope.',
+            });
+            expect(agents.create).not.toHaveBeenCalled();
         });
     });
 
@@ -215,6 +250,7 @@ describe('AgentToolService.resolveAllowedTools', () => {
             const facade = makeEmailFacade();
             const withFacade = new AgentToolService(
                 agents,
+                agentsService,
                 skills,
                 bindings,
                 files,
@@ -230,6 +266,7 @@ describe('AgentToolService.resolveAllowedTools', () => {
             const facade = makeEmailFacade();
             const withFacade = new AgentToolService(
                 agents,
+                agentsService,
                 skills,
                 bindings,
                 files,
@@ -254,6 +291,7 @@ describe('AgentToolService.resolveAllowedTools', () => {
             });
             const withFacade = new AgentToolService(
                 agents,
+                agentsService,
                 skills,
                 bindings,
                 files,
@@ -294,6 +332,7 @@ describe('AgentToolService.resolveAllowedTools', () => {
             });
             const withFacade = new AgentToolService(
                 agents,
+                agentsService,
                 skills,
                 bindings,
                 files,
@@ -336,6 +375,7 @@ describe('AgentToolService.resolveAllowedTools', () => {
         const wire = (facade: unknown) =>
             new AgentToolService(
                 agents,
+                agentsService,
                 skills,
                 bindings,
                 files,
@@ -400,6 +440,7 @@ describe('AgentToolService.resolveAllowedTools', () => {
         const wire = (facade: unknown) =>
             new AgentToolService(
                 agents,
+                agentsService,
                 skills,
                 bindings,
                 files,

--- a/packages/agent/src/agents/agent-tool.service.ts
+++ b/packages/agent/src/agents/agent-tool.service.ts
@@ -1,11 +1,6 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
-import type { Agent, AgentPermissions } from '../entities/agent.entity';
-import {
-    AgentAvatarMode,
-    AgentScope,
-    AgentStatus,
-    AGENT_PERMISSIONS_DEFAULT,
-} from '../entities/agent.entity';
+import type { Agent } from '../entities/agent.entity';
+import { AgentScope, AGENT_PERMISSIONS_DEFAULT } from '../entities/agent.entity';
 import { AgentRepository } from '../database/repositories/agent.repository';
 import { AgentFileService } from './agent-file.service';
 import { AgentsService } from './agents.service';
@@ -108,6 +103,14 @@ export class AgentToolService {
 
     constructor(
         private readonly agents: AgentRepository,
+        // Review-fix I6 + EW-721 #10: createSubAgent MUST route through
+        // AgentsService so scope-ownership validation + slug-uniqueness +
+        // avatar-field validation + permission refinement all run.
+        // REQUIRED (no @Optional()) — the old optional injection left a
+        // raw-repository fallback path that silently bypassed all of
+        // those checks whenever DI omitted the service. A misconfigured
+        // module now fails at boot instead of degrading security.
+        private readonly agentsService: AgentsService,
         @Optional() private readonly skills?: SkillRepository,
         @Optional() private readonly bindings?: SkillBindingRepository,
         @Optional() private readonly files?: AgentFileService,
@@ -129,12 +132,6 @@ export class AgentToolService {
         @Optional()
         @Inject(AGENT_NOTIFY_CHANNEL_FACADE)
         private readonly notifyChannelFacade?: AgentNotifyChannelFacade,
-        // Review-fix I6: route createSubAgent through AgentsService so
-        // scope-ownership validation + slug-uniqueness + avatar-field
-        // validation + permission refinement all run, instead of the
-        // raw repository.create that bypassed everything. Optional()
-        // keeps unit tests that mock only AgentRepository working.
-        @Optional() private readonly agentsService?: AgentsService,
     ) {}
 
     /**
@@ -345,70 +342,35 @@ export class AgentToolService {
             invoke: async (args) => {
                 if (!args?.name) return { error: 'name is required' };
                 try {
-                    // Review-fix I6: route through AgentsService.create()
-                    // when available so the model gets a structured
-                    // ConflictException instead of a raw DB unique-
-                    // constraint violation. Falls back to repo.create
-                    // only when the service isn't bound (unit-test mode).
-                    if (this.agentsService) {
-                        const dto = await this.agentsService.create(actor.userId, {
-                            scope: actor.scope,
-                            missionId:
-                                actor.scope === AgentScope.MISSION
-                                    ? (actor.missionId ?? undefined)
-                                    : null,
-                            ideaId:
-                                actor.scope === AgentScope.IDEA
-                                    ? (actor.ideaId ?? undefined)
-                                    : null,
-                            workId:
-                                actor.scope === AgentScope.WORK
-                                    ? (actor.workId ?? undefined)
-                                    : null,
-                            name: args.name,
-                            title: args.title ?? null,
-                            capabilities: args.capabilities ?? null,
-                            aiProviderId: actor.aiProviderId ?? null,
-                            modelId: actor.modelId ?? null,
-                            maxSkillContextTokens: 4000,
-                            // Spec security §6 — sub-Agent always DRAFT,
-                            // permissions all-false (use the shared default
-                            // constant so future flag additions stay in sync).
-                            permissions: { ...AGENT_PERMISSIONS_DEFAULT },
-                        });
-                        return { id: dto.id, slug: dto.slug };
-                    }
-                    // Fallback repository path (unit-test mode only).
-                    // Sub-Agent inherits actor's scope verbatim — Mission-
-                    // scoped Agent creates Mission-scoped sub-Agent on the
-                    // same Mission. Permissions stay all-false per spec.
-                    const created = await this.agents.create({
-                        userId: actor.userId,
+                    // Review-fix I6 + EW-721 #10: ALWAYS route through
+                    // AgentsService.create() — scope-ownership validation,
+                    // slug-uniqueness (structured ConflictException instead
+                    // of a raw DB unique-constraint violation), avatar-field
+                    // validation and permission refinement all run there.
+                    // The old raw-repository fallback bypassed every one of
+                    // those checks and was removed.
+                    const dto = await this.agentsService.create(actor.userId, {
                         scope: actor.scope,
-                        missionId: actor.scope === AgentScope.MISSION ? actor.missionId : null,
-                        ideaId: actor.scope === AgentScope.IDEA ? actor.ideaId : null,
-                        workId: actor.scope === AgentScope.WORK ? actor.workId : null,
+                        missionId:
+                            actor.scope === AgentScope.MISSION
+                                ? (actor.missionId ?? undefined)
+                                : null,
+                        ideaId:
+                            actor.scope === AgentScope.IDEA ? (actor.ideaId ?? undefined) : null,
+                        workId:
+                            actor.scope === AgentScope.WORK ? (actor.workId ?? undefined) : null,
                         name: args.name,
-                        slug: slugify(args.name),
                         title: args.title ?? null,
                         capabilities: args.capabilities ?? null,
                         aiProviderId: actor.aiProviderId ?? null,
                         modelId: actor.modelId ?? null,
                         maxSkillContextTokens: 4000,
-                        // Second-pass fix: drop the redundant `as any` casts —
-                        // the enum values are well-typed.
-                        status: AgentStatus.DRAFT,
-                        permissions: { ...AGENT_PERMISSIONS_DEFAULT } as AgentPermissions,
-                        targets: null,
-                        heartbeatCadence: null,
-                        idleBehavior: actor.idleBehavior,
-                        pauseAfterFailures: 3,
-                        errorCount: 0,
-                        avatarMode: AgentAvatarMode.INITIALS,
-                        avatarIcon: null,
-                        avatarImageUploadId: null,
+                        // Spec security §6 — sub-Agent always DRAFT,
+                        // permissions all-false (use the shared default
+                        // constant so future flag additions stay in sync).
+                        permissions: { ...AGENT_PERMISSIONS_DEFAULT },
                     });
-                    return { id: created.id, slug: created.slug };
+                    return { id: dto.id, slug: dto.slug };
                 } catch (err) {
                     return { error: err instanceof Error ? err.message : String(err) };
                 }
@@ -988,12 +950,4 @@ export class AgentToolService {
             },
         };
     }
-}
-
-function slugify(text: string): string {
-    return text
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '')
-        .slice(0, 80);
 }

--- a/packages/agent/src/entities/tenant-email-address.entity.ts
+++ b/packages/agent/src/entities/tenant-email-address.entity.ts
@@ -69,6 +69,14 @@ export class TenantEmailAddress {
     @Column({ type: 'varchar', length: 64, nullable: true })
     verificationToken?: string | null;
 
+    /**
+     * EW-711 #44 — verification tokens are time-boxed (24h, stamped by
+     * `EmailService.createAddress`). NULL = no pending token, or a legacy
+     * token issued before this column existed (treated as non-expiring).
+     */
+    @PortableDateColumn({ nullable: true })
+    verificationTokenExpiresAt?: Date | null;
+
     @Column({ type: 'boolean', default: false })
     defaultForReplies: boolean;
 

--- a/packages/agent/src/skills/__tests__/skills.service.spec.ts
+++ b/packages/agent/src/skills/__tests__/skills.service.spec.ts
@@ -52,6 +52,7 @@ describe('SkillsService', () => {
             findByIdAndUser: jest.fn(),
             create: jest.fn(),
             deleteById: jest.fn(),
+            deleteByIdAndUser: jest.fn(),
             resolveActive: jest.fn().mockResolvedValue([]),
         };
         activity = { log: jest.fn().mockResolvedValue(undefined) };
@@ -271,10 +272,28 @@ describe('SkillsService', () => {
         });
     });
 
+    describe('listBindings', () => {
+        it('forwards userId so the repository scopes the lookup (IDOR defense)', async () => {
+            skills.findByIdAndUser.mockResolvedValueOnce(makeSkill());
+            await svc.listBindings('u1', 'sk1');
+            expect(bindings.findBySkillId).toHaveBeenCalledWith('sk1', 'u1');
+        });
+    });
+
     describe('removeBinding', () => {
         it('404s for cross-user', async () => {
             bindings.findByIdAndUser.mockResolvedValueOnce(null);
             await expect(svc.removeBinding('u1', 'b1')).rejects.toThrow(NotFoundException);
+            expect(bindings.deleteByIdAndUser).not.toHaveBeenCalled();
+            expect(bindings.deleteById).not.toHaveBeenCalled();
+        });
+
+        it('uses ownership-scoped delete (IDOR defense)', async () => {
+            bindings.findByIdAndUser.mockResolvedValueOnce({ id: 'b1', userId: 'u1' });
+            const out = await svc.removeBinding('u1', 'b1');
+            expect(out).toEqual({ deleted: true });
+            expect(bindings.deleteByIdAndUser).toHaveBeenCalledWith('b1', 'u1');
+            expect(bindings.deleteById).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/agent/src/skills/skills.service.ts
+++ b/packages/agent/src/skills/skills.service.ts
@@ -213,7 +213,9 @@ export class SkillsService {
 
     async listBindings(userId: string, skillId: string): Promise<SkillBinding[]> {
         await this.getOne(userId, skillId);
-        return this.bindings.findBySkillId(skillId);
+        // Security: forward userId so the repository scopes the lookup to the
+        // owner in the WHERE clause (defense-in-depth vs. cross-user IDOR).
+        return this.bindings.findBySkillId(skillId, userId);
     }
 
     async createBinding(userId: string, input: CreateBindingInput): Promise<SkillBinding> {
@@ -245,7 +247,10 @@ export class SkillsService {
     async removeBinding(userId: string, bindingId: string): Promise<{ deleted: true }> {
         const binding = await this.bindings.findByIdAndUser(bindingId, userId);
         if (!binding) throw new NotFoundException(`Skill binding ${bindingId} not found.`);
-        await this.bindings.deleteById(bindingId);
+        // Security: ownership-scoped delete — userId is enforced in the WHERE
+        // clause so a TOCTOU gap after the guard above cannot delete another
+        // user's binding (cross-user IDOR).
+        await this.bindings.deleteByIdAndUser(bindingId, userId);
         return { deleted: true };
     }
 

--- a/packages/plugins/novu-channel/src/novu-channel-plugin.spec.ts
+++ b/packages/plugins/novu-channel/src/novu-channel-plugin.spec.ts
@@ -131,5 +131,21 @@ describe('NovuChannelPlugin', () => {
 			expect(fetchMock).toHaveBeenCalledTimes(1);
 			fetchMock.mockRestore();
 		});
+
+		it('does NOT serve a cached result across different channelIds (tenant isolation)', async () => {
+			// Security: the idempotency cache key is scoped by options.channelId —
+			// the same messageRef sent through two different channel bindings must
+			// trigger two real sends, never leak channel A's cached result to B.
+			const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
+				ok: true,
+				status: 201,
+				json: async () => ({ data: { transactionId: 'txn-scoped' } })
+			} as Response);
+			const input = { text: 'x', messageRef: 'ref-shared', attribution: { userId: 'u1' }, target };
+			await plugin.send(input, { channelId: 'channel-a' });
+			await plugin.send(input, { channelId: 'channel-b' });
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+			fetchMock.mockRestore();
+		});
 	});
 });

--- a/packages/plugins/novu-channel/src/novu-channel-plugin.ts
+++ b/packages/plugins/novu-channel/src/novu-channel-plugin.ts
@@ -171,7 +171,12 @@ export class NovuChannelPlugin implements INotificationChannelPlugin {
 		// Security (header injection): reject control chars in the idempotency key
 		// before it is used as a header value or cache key.
 		const messageRef = assertSafeMessageRef(payload.messageRef);
-		const cached = this.idempotencyCache.get(messageRef);
+		// Security (tenant isolation): scope the idempotency cache key by the
+		// channel binding — a bare messageRef would let one tenant's send
+		// short-circuit (and return the cached ChannelSendResult of) another
+		// tenant's send that happened to reuse the same ref.
+		const cacheKey = `${options.channelId ?? ''}:${messageRef}`;
+		const cached = this.idempotencyCache.get(cacheKey);
 		if (cached) return cached;
 
 		const { apiKey, workflowId, subscriberId } = getTarget(payload.target ?? {});
@@ -206,7 +211,7 @@ export class NovuChannelPlugin implements INotificationChannelPlugin {
 			providerMessageId: data.data.transactionId,
 			deliveredAt: new Date()
 		};
-		this.idempotencyCache.set(messageRef, result);
+		this.idempotencyCache.set(cacheKey, result);
 		if (this.idempotencyCache.size > 500) {
 			const firstKey = this.idempotencyCache.keys().next().value;
 			if (firstKey) this.idempotencyCache.delete(firstKey);

--- a/packages/plugins/postmark/src/postmark-plugin.spec.ts
+++ b/packages/plugins/postmark/src/postmark-plugin.spec.ts
@@ -78,6 +78,25 @@ describe('PostmarkPlugin', () => {
 			expect(r1).toEqual(r2);
 			expect(sendEmailMock).toHaveBeenCalledTimes(1);
 		});
+
+		it('does NOT serve a cached result across different userIds (tenant isolation)', async () => {
+			// Security: the local idempotency cache key is scoped by
+			// options.userId/workId — the same messageRef from two different
+			// users must trigger two real sends, never leak user A's cached
+			// result to B.
+			sendEmailMock.mockResolvedValue({ MessageID: 'pm-scoped', ErrorCode: 0 });
+
+			const input = {
+				from: 'a@example.com',
+				to: ['b@example.com'],
+				subject: 'hi',
+				bodyText: 'hi',
+				messageRef: 'ref-shared'
+			};
+			await plugin.sendEmail(input, { userId: 'user-a' });
+			await plugin.sendEmail(input, { userId: 'user-b' });
+			expect(sendEmailMock).toHaveBeenCalledTimes(2);
+		});
 	});
 
 	describe('parseInboundWebhook', () => {

--- a/packages/plugins/postmark/src/postmark-plugin.ts
+++ b/packages/plugins/postmark/src/postmark-plugin.ts
@@ -97,7 +97,12 @@ export class PostmarkPlugin implements IEmailOutboundPlugin, IEmailInboundPlugin
 	private readonly idempotencyCache = new Map<string, EmailSendResult>();
 
 	async sendEmail(input: EmailSendInput, options: EmailOptions): Promise<EmailSendResult> {
-		const cached = this.idempotencyCache.get(input.messageRef);
+		// Security (tenant isolation): scope the local idempotency cache key by
+		// the calling user/work — a bare messageRef would let one tenant's send
+		// short-circuit (and return the cached EmailSendResult of) another
+		// tenant's send that happened to reuse the same ref.
+		const cacheKey = `${options.userId ?? options.workId ?? ''}:${input.messageRef}`;
+		const cached = this.idempotencyCache.get(cacheKey);
 		if (cached) return cached;
 
 		const client = new ServerClient(resolveApiKey(options));
@@ -136,7 +141,7 @@ export class PostmarkPlugin implements IEmailOutboundPlugin, IEmailInboundPlugin
 			accepted: [...input.to],
 			rejected: []
 		};
-		this.idempotencyCache.set(input.messageRef, result);
+		this.idempotencyCache.set(cacheKey, result);
 		// Bounded cache — drop oldest if > 500 entries.
 		if (this.idempotencyCache.size > 500) {
 			const firstKey = this.idempotencyCache.keys().next().value;

--- a/packages/plugins/resend/src/resend-plugin.spec.ts
+++ b/packages/plugins/resend/src/resend-plugin.spec.ts
@@ -67,4 +67,22 @@ describe('ResendPlugin', () => {
 		await plugin.sendEmail(input, { userId: 'u' });
 		expect(sendMock).toHaveBeenCalledTimes(1);
 	});
+
+	it('does NOT serve a cached result across different userIds (tenant isolation)', async () => {
+		// Security: the local idempotency cache key is scoped by
+		// options.userId/workId — the same messageRef from two different users
+		// must trigger two real sends, never leak user A's cached result to B.
+		sendMock.mockResolvedValue({ data: { id: 'rs-scoped' }, error: null });
+
+		const input = {
+			from: 'a@example.com',
+			to: ['b@example.com'],
+			subject: 'hi',
+			bodyText: 'hi',
+			messageRef: 'ref-shared'
+		};
+		await plugin.sendEmail(input, { userId: 'user-a' });
+		await plugin.sendEmail(input, { userId: 'user-b' });
+		expect(sendMock).toHaveBeenCalledTimes(2);
+	});
 });

--- a/packages/plugins/resend/src/resend-plugin.ts
+++ b/packages/plugins/resend/src/resend-plugin.ts
@@ -51,7 +51,14 @@ export class ResendPlugin implements IEmailOutboundPlugin {
 	private readonly idempotencyCache = new Map<string, EmailSendResult>();
 
 	async sendEmail(input: EmailSendInput, options: EmailOptions): Promise<EmailSendResult> {
-		const cached = this.idempotencyCache.get(input.messageRef);
+		// Security (tenant isolation): scope the local idempotency cache key by
+		// the calling user/work — a bare messageRef would let one tenant's send
+		// short-circuit (and return the cached EmailSendResult of) another
+		// tenant's send that happened to reuse the same ref. The provider-level
+		// `idempotencyKey` below stays the bare ref: it is already scoped by
+		// each tenant's own Resend API key.
+		const cacheKey = `${options.userId ?? options.workId ?? ''}:${input.messageRef}`;
+		const cached = this.idempotencyCache.get(cacheKey);
 		if (cached) return cached;
 
 		const resend = new Resend(resolveApiKey(options));
@@ -90,7 +97,7 @@ export class ResendPlugin implements IEmailOutboundPlugin {
 			accepted: [...input.to],
 			rejected: []
 		};
-		this.idempotencyCache.set(input.messageRef, result);
+		this.idempotencyCache.set(cacheKey, result);
 		if (this.idempotencyCache.size > 500) {
 			const firstKey = this.idempotencyCache.keys().next().value;
 			if (firstKey) this.idempotencyCache.delete(firstKey);


### PR DESCRIPTION
@-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Security & Authorization**
* Email verification tokens now expire after 24 hours
* OAuth CSRF protection enhanced with server-side state validation (no longer client-supplied)
* Stricter ownership verification for email, webhooks, and agent operations to prevent unauthorized access
* CRM integration access now requires enabled sync configuration

**Bug Fixes**
* Cache isolation ensures multi-tenant data separation across email integrations
* File upload endpoint now enforces authentication at BFF layer
* Template API now correctly transmits custom template payload data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->