### PR TITLE
test(e2e): mega-wave Batch 2 — 197 real-flow tests across thin-covered controllers

### DIFF
--- a/apps/web/e2e/flow-agent-memory-lifecycle.spec.ts
+++ b/apps/web/e2e/flow-agent-memory-lifecycle.spec.ts
@@ -179,7 +179,11 @@ test.describe('Flow: agent-memory lifecycle (keyless) — open/save/search/conte
         await expectNoProvider(
             await request.post(`${AM}/save`, {
                 headers: authedHeaders(u.access_token),
-                data: { content: 'fixed the auth migration', tags: ['bug-fix'], projectId: project },
+                data: {
+                    content: 'fixed the auth migration',
+                    tags: ['bug-fix'],
+                    projectId: project,
+                },
             }),
             'saveMemory',
         );
@@ -292,9 +296,12 @@ test.describe('Flow: agent-memory owner-stamp IDOR (EW-711 #29) — Work-scoped 
                     data: { workId: work.id },
                 }),
             ],
-            ['list-sessions', request.get(`${AM}/sessions?workId=${work.id}`, {
-                headers: authedHeaders(stranger.access_token),
-            })],
+            [
+                'list-sessions',
+                request.get(`${AM}/sessions?workId=${work.id}`, {
+                    headers: authedHeaders(stranger.access_token),
+                }),
+            ],
         ];
         for (const [label, p] of readEndpoints) {
             const res = await p;
@@ -320,9 +327,12 @@ test.describe('Flow: agent-memory owner-stamp IDOR (EW-711 #29) — Work-scoped 
         // to A's Work are both 403, pre-empting the facade. This is the core of the
         // owner-stamp IDOR fix: an id you guessed is useless without Work edit (or,
         // unscoped, without owning the stamped resource).
-        const closeRes = await request.post(`${AM}/sessions/${uniq('sid')}/close?workId=${work.id}`, {
-            headers: authedHeaders(stranger.access_token),
-        });
+        const closeRes = await request.post(
+            `${AM}/sessions/${uniq('sid')}/close?workId=${work.id}`,
+            {
+                headers: authedHeaders(stranger.access_token),
+            },
+        );
         expect(closeRes.status(), "stranger close on A's Work → 403").toBe(403);
         expect((await closeRes.json()).message).toBe(FOREIGN_WORK_MSG);
 

--- a/apps/web/e2e/flow-agent-memory-lifecycle.spec.ts
+++ b/apps/web/e2e/flow-agent-memory-lifecycle.spec.ts
@@ -1,0 +1,544 @@
+import { test, expect, type APIRequestContext, type APIResponse } from '@playwright/test';
+import { API_BASE, authedHeaders, createWorkViaAPI, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Agent-memory capability — REST lifecycle, ownership/IDOR gates, scoping and
+ * input-validation contracts for `AgentMemoryController`
+ * (`apps/api/src/plugins-capabilities/agent-memory/agent-memory.controller.ts`,
+ * mounted at `/api/agent-memory`, JWT-guarded by `AuthSessionGuard`).
+ *
+ * GREENFIELD: this controller had ZERO e2e coverage before this file. Sibling
+ * `flow-agent-budget-enforcement.spec.ts` covers per-agent/owner/account BUDGET
+ * reads (a different controller) — there is no overlap. The api-side
+ * `agent-memory.controller.spec.ts` is a NestJS unit test with a mocked facade;
+ * this file pins the LIVE HTTP contract end-to-end.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * SHAPES VERIFIED AGAINST THE LIVE API (http://127.0.0.1:3100) BEFORE WRITING.
+ *
+ * ENVIRONMENT-ADAPTIVE NOTE (load-bearing): the e2e stack is KEYLESS — NO
+ * agent-memory provider plugin is enabled. `isConfigured()` is true (the
+ * capability is registered) but `getDefaultProvider()` resolves to null, so:
+ *   - GET  /check-availability  -> 200 { status:'success', available:true,
+ *                                         activeProvider:null }  (the ONE op
+ *                                         that succeeds keyless).
+ *   - EVERY facade-backed op (openSession / save / search / context /
+ *     listSessions / closeSession / deleteEntry) throws `NoProviderError` at
+ *     the facade and the controller maps it to:
+ *       400 { status:'error',
+ *             message:'No agent-memory provider is enabled. Install + enable an
+ *                      agent-memory plugin (e.g. `@ever-works/agentmemory-plugin`).',
+ *             operation:<handlerName> }
+ *     where <handlerName> is the facade method: 'openSession' | 'saveMemory' |
+ *     'searchMemory' | 'buildContext' | 'listSessions' | 'closeSession' |
+ *     'deleteEntry'.
+ * Because completions are impossible keyless, this spec asserts the ERROR
+ * CONTRACTS, the AUTH gate, the OWNERSHIP/IDOR gates and the VALIDATION DTO
+ * bounds — NOT provider-backed create/list/delete round-trips (which cannot run
+ * here and would be vacuous). That is the deterministic, real surface.
+ *
+ * GATE ORDERING (probed): the controller runs `WorkOwnershipService` BEFORE the
+ * facade, so a `workId` access failure pre-empts the no-provider 400:
+ *   - Authn (AuthSessionGuard) ........ no/!valid bearer  -> 401 Unauthorized
+ *   - DTO ValidationPipe .............. malformed body/query -> 400 (array msg)
+ *   - Work access (when workId given) . non-owner Work     -> 403 'You do not
+ *                                          have permission to access this work'
+ *                                       nonexistent Work    -> 404 "Work with id
+ *                                          '<uuid>' not found"
+ *   - Facade (no provider) ............ owner / no-workId   -> 400 NoProvider
+ * Reads + Open + Save use `ensureCanView`; the id-addressed MUTATIONS
+ * (`POST /sessions/:id/close`, `DELETE /entries/:id`) use `ensureCanEdit`
+ * (EW-711 #29 owner-stamp IDOR defense). In this build a Work's creator is its
+ * sole owner with BOTH view + edit, and a stranger has NEITHER, so the 403/404
+ * split is identical across the view/edit handlers here.
+ *
+ * VALIDATION BOUNDS (probed against the DTOs):
+ *   - save:    content required (string, <=64000); tags each <=128;
+ *              metadata must serialise <= 8192 bytes (8 KiB DoS cap);
+ *              workId must be a UUID.
+ *   - search:  query required (string, <=2000); limit 1..100.
+ *   - context: maxTokens 100..64000.
+ *   - sessions(list): limit 1..100 (string query coerced via @Type(Number)).
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * ISOLATION: every test registers FRESH users via registerUserViaAPI() (no
+ * shared seeded user). Anonymous calls use the raw `request` fixture with NO
+ * Authorization header (Playwright's `request` carries no app cookies/storage),
+ * so they exercise the true unauth path. Unique suffixes derive from the
+ * per-test title (TITLE_COUNTER), never a module-scope clock.
+ */
+
+const AM = `${API_BASE}/api/agent-memory`;
+const FAKE_WORK_UUID = '99999999-9999-4999-8999-999999999999';
+const NO_PROVIDER_MSG =
+    'No agent-memory provider is enabled. Install + enable an agent-memory plugin (e.g. `@ever-works/agentmemory-plugin`).';
+const FOREIGN_WORK_MSG = 'You do not have permission to access this work';
+
+/** Per-test unique suffix WITHOUT calling a clock at module scope. */
+let TITLE_COUNTER = 0;
+function uniq(title: string): string {
+    TITLE_COUNTER += 1;
+    return `${title.replace(/[^a-z0-9]+/gi, '-').slice(0, 24)}-${TITLE_COUNTER}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`;
+}
+
+interface NoProviderBody {
+    status: string;
+    message: string;
+    operation: string;
+}
+
+/** Assert a response is the keyless no-provider 400 for the given facade op. */
+async function expectNoProvider(res: APIResponse, operation: string): Promise<void> {
+    expect(res.status(), `expected 400 no-provider for ${operation}`).toBe(400);
+    const body = (await res.json()) as NoProviderBody;
+    expect(body.status).toBe('error');
+    expect(body.message).toBe(NO_PROVIDER_MSG);
+    expect(body.operation, `operation tag should be ${operation}`).toBe(operation);
+}
+
+/** Pull the ValidationPipe `message` array out of a 400 body (best-effort). */
+async function validationMessages(res: APIResponse): Promise<string[]> {
+    const body = (await res.json().catch(() => ({}))) as { message?: unknown };
+    return Array.isArray(body.message) ? (body.message as string[]) : [];
+}
+
+test.describe('Flow: agent-memory availability + auth gate', () => {
+    test('check-availability is the only keyless-success read; reports registered-but-unconfigured', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        // ── Step 1: availability is the ONE op that resolves without a provider —
+        //    the capability is registered (available:true) but no plugin is
+        //    configured for this user, so the active provider is null. This is the
+        //    keyless steady state the whole rest of the surface degrades from.
+        const res = await request.get(`${AM}/check-availability`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(200);
+        const body = (await res.json()) as {
+            status: string;
+            available: boolean;
+            activeProvider: unknown;
+        };
+        expect(body.status).toBe('success');
+        expect(body.available, 'capability registered → available true').toBe(true);
+        expect(body.activeProvider, 'keyless → no resolved provider').toBeNull();
+    });
+
+    test('every agent-memory endpoint rejects anonymous callers with 401', async ({ request }) => {
+        // The raw `request` fixture carries no app auth — exercise the true unauth
+        // path across the read, mutation and id-addressed surfaces. Authn (the
+        // guard) runs BEFORE validation/ownership/facade, so even malformed bodies
+        // surface as 401 here, not 400.
+        const anon: Array<[string, Promise<APIResponse>]> = [
+            ['GET check-availability', request.get(`${AM}/check-availability`)],
+            ['GET sessions', request.get(`${AM}/sessions`)],
+            ['POST sessions', request.post(`${AM}/sessions`, { data: {} })],
+            ['POST save', request.post(`${AM}/save`, { data: { content: 'x' } })],
+            ['POST search', request.post(`${AM}/search`, { data: { query: 'x' } })],
+            ['POST context', request.post(`${AM}/context`, { data: {} })],
+            ['POST sessions/:id/close', request.post(`${AM}/sessions/sid/close`)],
+            ['DELETE entries/:id', request.delete(`${AM}/entries/eid`)],
+        ];
+        for (const [label, p] of anon) {
+            const res = await p;
+            expect(res.status(), `${label} unauth → 401`).toBe(401);
+            const body = (await res.json()) as { statusCode?: number; message?: string };
+            expect(body.statusCode).toBe(401);
+            expect(body.message).toBe('Unauthorized');
+        }
+    });
+});
+
+test.describe('Flow: agent-memory lifecycle (keyless) — open/save/search/context/list degrade to no-provider', () => {
+    test('the full unscoped lifecycle returns the no-provider 400 tagged with each facade operation', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const project = uniq('proj');
+
+        // The intended lifecycle is open-session → save observation → search/build
+        // context → list sessions → close/forget. Keyless, EVERY facade hop is a
+        // tagged no-provider 400. We pin the per-handler `operation` tag so a
+        // future regression that mis-routes one handler (e.g. save → searchMemory)
+        // is caught even though the HTTP status is identical.
+
+        // ── Step 1: open a session (valid body) → 'openSession'.
+        await expectNoProvider(
+            await request.post(`${AM}/sessions`, {
+                headers: authedHeaders(u.access_token),
+                data: { projectId: project, metadata: { phase: 'probe' } },
+            }),
+            'openSession',
+        );
+
+        // ── Step 2: save an observation into that project → 'saveMemory'.
+        await expectNoProvider(
+            await request.post(`${AM}/save`, {
+                headers: authedHeaders(u.access_token),
+                data: { content: 'fixed the auth migration', tags: ['bug-fix'], projectId: project },
+            }),
+            'saveMemory',
+        );
+
+        // ── Step 3: search the project → 'searchMemory'.
+        await expectNoProvider(
+            await request.post(`${AM}/search`, {
+                headers: authedHeaders(u.access_token),
+                data: { query: 'auth migration', limit: 10, projectId: project },
+            }),
+            'searchMemory',
+        );
+
+        // ── Step 4: build a prompt context → 'buildContext'.
+        await expectNoProvider(
+            await request.post(`${AM}/context`, {
+                headers: authedHeaders(u.access_token),
+                data: { query: 'auth', purpose: 'fix-bug', maxTokens: 1000, projectId: project },
+            }),
+            'buildContext',
+        );
+
+        // ── Step 5: list sessions → 'listSessions' (optional facade method; keyless
+        //    it never reaches the support probe — the provider resolves to none
+        //    first, so it is the SAME no-provider 400, not a 'does not support' 404).
+        await expectNoProvider(
+            await request.get(`${AM}/sessions?limit=10&projectId=${encodeURIComponent(project)}`, {
+                headers: authedHeaders(u.access_token),
+            }),
+            'listSessions',
+        );
+    });
+
+    test('id-addressed mutations (close / forget) without a workId scope also degrade to no-provider', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        // closeSession / deleteEntry run the owner-stamp verification via the read
+        // seams (listSessions / searchMemory) BEFORE dispatching. Keyless, those
+        // seams themselves resolve no provider, so the handler surfaces the
+        // no-provider 400 tagged with the MUTATION's facade op — confirming the
+        // unscoped id path still routes through the facade (not a silent success).
+        await expectNoProvider(
+            await request.post(`${AM}/sessions/${uniq('sid')}/close`, {
+                headers: authedHeaders(u.access_token),
+            }),
+            'closeSession',
+        );
+        await expectNoProvider(
+            await request.delete(`${AM}/entries/${uniq('eid')}`, {
+                headers: authedHeaders(u.access_token),
+            }),
+            'deleteEntry',
+        );
+    });
+});
+
+test.describe('Flow: agent-memory owner-stamp IDOR (EW-711 #29) — Work-scoped access is gated before the facade', () => {
+    test("a stranger cannot READ user A's Work-scoped memory: save/search/list/context all 403 before the facade", async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const work = await createWorkViaAPI(request, owner.access_token, {
+            name: `am-idor-read-${uniq('w')}`,
+        });
+        expect(work.id).toBeTruthy();
+
+        // ── Owner-on-own-Work passes the ownership gate and reaches the facade →
+        //    no-provider 400 (NOT 403). This proves the 403 below is the access
+        //    gate, not an artifact of the keyless backend.
+        await expectNoProvider(
+            await request.post(`${AM}/save`, {
+                headers: authedHeaders(owner.access_token),
+                data: { content: 'owner note', workId: work.id },
+            }),
+            'saveMemory',
+        );
+
+        // ── Stranger scoping ANY read/open/save to A's Work is rejected at
+        //    `ensureCanView` with 403 — the no-provider path is never reached, so
+        //    the foreign Work's memory namespace is not even probed.
+        const readEndpoints: Array<[string, Promise<APIResponse>]> = [
+            [
+                'save',
+                request.post(`${AM}/save`, {
+                    headers: authedHeaders(stranger.access_token),
+                    data: { content: 'intruder', workId: work.id },
+                }),
+            ],
+            [
+                'search',
+                request.post(`${AM}/search`, {
+                    headers: authedHeaders(stranger.access_token),
+                    data: { query: 'secrets', workId: work.id },
+                }),
+            ],
+            [
+                'context',
+                request.post(`${AM}/context`, {
+                    headers: authedHeaders(stranger.access_token),
+                    data: { query: 'secrets', workId: work.id },
+                }),
+            ],
+            [
+                'open-session',
+                request.post(`${AM}/sessions`, {
+                    headers: authedHeaders(stranger.access_token),
+                    data: { workId: work.id },
+                }),
+            ],
+            ['list-sessions', request.get(`${AM}/sessions?workId=${work.id}`, {
+                headers: authedHeaders(stranger.access_token),
+            })],
+        ];
+        for (const [label, p] of readEndpoints) {
+            const res = await p;
+            expect(res.status(), `stranger ${label} on A's Work → 403`).toBe(403);
+            const body = (await res.json()) as { message?: string };
+            expect(body.message, `${label} forbidden message`).toBe(FOREIGN_WORK_MSG);
+        }
+    });
+
+    test("a stranger cannot WRITE/DELETE user A's Work-scoped memory: close + forget 403 (ensureCanEdit) before the facade", async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const work = await createWorkViaAPI(request, owner.access_token, {
+            name: `am-idor-write-${uniq('w')}`,
+        });
+        expect(work.id).toBeTruthy();
+
+        // The id-addressed mutations gate on `ensureCanEdit` (a Work VIEWER must
+        // not end sessions / forget records). The Work creator is the sole owner
+        // here with edit rights, so a stranger has neither — close + delete scoped
+        // to A's Work are both 403, pre-empting the facade. This is the core of the
+        // owner-stamp IDOR fix: an id you guessed is useless without Work edit (or,
+        // unscoped, without owning the stamped resource).
+        const closeRes = await request.post(`${AM}/sessions/${uniq('sid')}/close?workId=${work.id}`, {
+            headers: authedHeaders(stranger.access_token),
+        });
+        expect(closeRes.status(), "stranger close on A's Work → 403").toBe(403);
+        expect((await closeRes.json()).message).toBe(FOREIGN_WORK_MSG);
+
+        const deleteRes = await request.delete(`${AM}/entries/${uniq('eid')}?workId=${work.id}`, {
+            headers: authedHeaders(stranger.access_token),
+        });
+        expect(deleteRes.status(), "stranger forget on A's Work → 403").toBe(403);
+        expect((await deleteRes.json()).message).toBe(FOREIGN_WORK_MSG);
+
+        // ── The owner, by contrast, clears the edit gate and reaches the facade →
+        //    no-provider 400, confirming the 403s are an authorization decision.
+        await expectNoProvider(
+            await request.delete(`${AM}/entries/${uniq('eid')}?workId=${work.id}`, {
+                headers: authedHeaders(owner.access_token),
+            }),
+            'deleteEntry',
+        );
+    });
+
+    test('a nonexistent workId is a 404 (distinct from the 403 foreign-owner case) across read + mutate', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        // The ownership service distinguishes "exists but not yours" (403) from
+        // "no such Work" (404). A well-formed UUID that matches no row returns 404
+        // with the id echoed — and this holds for BOTH the ensureCanView reads and
+        // the ensureCanEdit mutations.
+        const notFoundMsg = `Work with id '${FAKE_WORK_UUID}' not found`;
+
+        const save404 = await request.post(`${AM}/save`, {
+            headers: authedHeaders(u.access_token),
+            data: { content: 'x', workId: FAKE_WORK_UUID },
+        });
+        expect(save404.status(), 'save with nonexistent workId → 404').toBe(404);
+        expect((await save404.json()).message).toBe(notFoundMsg);
+
+        const delete404 = await request.delete(`${AM}/entries/eid?workId=${FAKE_WORK_UUID}`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(delete404.status(), 'forget with nonexistent workId → 404').toBe(404);
+        expect((await delete404.json()).message).toBe(notFoundMsg);
+
+        const close404 = await request.post(`${AM}/sessions/sid/close?workId=${FAKE_WORK_UUID}`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(close404.status(), 'close with nonexistent workId → 404').toBe(404);
+        expect((await close404.json()).message).toBe(notFoundMsg);
+    });
+});
+
+test.describe('Flow: agent-memory scoping resolution — workId vs projectId both flow through the access gate', () => {
+    test('projectId-only requests bypass the Work gate (no workId) and reach the facade; workId drives ownership', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        // ── projectId is the memory-backend namespace; it does NOT trigger the
+        //    Work-ownership check (only workId does). A projectId-only save therefore
+        //    skips ownership entirely and reaches the facade → no-provider 400.
+        await expectNoProvider(
+            await request.post(`${AM}/save`, {
+                headers: authedHeaders(u.access_token),
+                data: { content: 'scoped to a project', projectId: uniq('ns') },
+            }),
+            'saveMemory',
+        );
+
+        // ── Supplying BOTH workId (own Work) + projectId still resolves: the Work
+        //    gate is satisfied (owner) and the projectId rides along into the facade,
+        //    again surfacing the no-provider 400. This proves the two scoping inputs
+        //    are independent — projectId never short-circuits the workId gate.
+        const work = await createWorkViaAPI(request, u.access_token, {
+            name: `am-scope-${uniq('w')}`,
+        });
+        await expectNoProvider(
+            await request.post(`${AM}/save`, {
+                headers: authedHeaders(u.access_token),
+                data: { content: 'both scopes', workId: work.id, projectId: uniq('ns') },
+            }),
+            'saveMemory',
+        );
+    });
+});
+
+test.describe('Flow: agent-memory input validation — DTO bounds reject before the facade runs', () => {
+    test('save: content is required and a malformed workId is rejected by the UUID rule', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        // Missing content → ValidationPipe array message (content must be a string),
+        // 400 — never reaches the facade.
+        const missing = await request.post(`${AM}/save`, {
+            headers: authedHeaders(u.access_token),
+            data: {},
+        });
+        expect(missing.status()).toBe(400);
+        expect(await validationMessages(missing)).toContain('content must be a string');
+
+        // workId must be a UUID — a non-UUID is a DTO 400, distinct from the
+        // ownership 403/404 a well-formed-but-foreign id would produce.
+        const badWork = await request.post(`${AM}/save`, {
+            headers: authedHeaders(u.access_token),
+            data: { content: 'x', workId: 'not-a-uuid' },
+        });
+        expect(badWork.status()).toBe(400);
+        expect(await validationMessages(badWork)).toContain('workId must be a UUID');
+    });
+
+    test('save: oversized metadata is rejected by the 8 KiB serialisation cap (DoS guard)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        // The metadata field is capped at 8192 bytes after JSON.stringify to stop a
+        // flood of individually-small-but-costly objects. A ~9 KB string trips it.
+        const oversized = await request.post(`${AM}/save`, {
+            headers: authedHeaders(u.access_token),
+            data: { content: 'x', metadata: { blob: 'x'.repeat(9000) } },
+        });
+        expect(oversized.status()).toBe(400);
+        expect(await validationMessages(oversized)).toContain(
+            'metadata must serialise to <= 8192 bytes',
+        );
+
+        // A small metadata object is within the cap → passes validation and reaches
+        // the facade (no-provider 400), proving the cap is a bound, not a blanket ban.
+        await expectNoProvider(
+            await request.post(`${AM}/save`, {
+                headers: authedHeaders(u.access_token),
+                data: { content: 'x', metadata: { phase: 'ok' } },
+            }),
+            'saveMemory',
+        );
+    });
+
+    test('save: a per-tag length over 128 chars is rejected (the per-element cap, not array-level)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        const longTag = await request.post(`${AM}/save`, {
+            headers: authedHeaders(u.access_token),
+            data: { content: 'x', tags: ['t'.repeat(200)] },
+        });
+        expect(longTag.status()).toBe(400);
+        expect(await validationMessages(longTag)).toContain(
+            'each value in tags must be shorter than or equal to 128 characters',
+        );
+    });
+
+    test('search: query is required and limit is bounded to 1..100', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+
+        const noQuery = await request.post(`${AM}/search`, {
+            headers: authedHeaders(u.access_token),
+            data: {},
+        });
+        expect(noQuery.status()).toBe(400);
+        expect(await validationMessages(noQuery)).toContain('query must be a string');
+
+        const overLimit = await request.post(`${AM}/search`, {
+            headers: authedHeaders(u.access_token),
+            data: { query: 'q', limit: 500 },
+        });
+        expect(overLimit.status()).toBe(400);
+        expect(await validationMessages(overLimit)).toContain('limit must not be greater than 100');
+
+        // A valid query+limit clears validation → no-provider 400 (facade reached).
+        await expectNoProvider(
+            await request.post(`${AM}/search`, {
+                headers: authedHeaders(u.access_token),
+                data: { query: 'q', limit: 50 },
+            }),
+            'searchMemory',
+        );
+    });
+
+    test('context: maxTokens is bounded to its 100..64000 window', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+
+        const tooLow = await request.post(`${AM}/context`, {
+            headers: authedHeaders(u.access_token),
+            data: { query: 'q', maxTokens: 50 },
+        });
+        expect(tooLow.status()).toBe(400);
+        expect(await validationMessages(tooLow)).toContain('maxTokens must not be less than 100');
+    });
+
+    test('sessions(list): the query-string limit is coerced and bounded to 1..100', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        // limit arrives as a string and is @Type(Number)-coerced before the numeric
+        // bounds run. Over/under bounds reject at validation (400) BEFORE the facade.
+        const over = await request.get(`${AM}/sessions?limit=999`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(over.status()).toBe(400);
+        expect(await validationMessages(over)).toContain('limit must not be greater than 100');
+
+        const under = await request.get(`${AM}/sessions?limit=0`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(under.status()).toBe(400);
+        expect(await validationMessages(under)).toContain('limit must not be less than 1');
+
+        // A valid in-range limit coerces cleanly and passes validation → the facade
+        // is reached and returns the keyless no-provider 400 (not a validation 400).
+        await expectNoProvider(
+            await request.get(`${AM}/sessions?limit=5`, {
+                headers: authedHeaders(u.access_token),
+            }),
+            'listSessions',
+        );
+    });
+});

--- a/apps/web/e2e/flow-agent-templates-catalog-deep.spec.ts
+++ b/apps/web/e2e/flow-agent-templates-catalog-deep.spec.ts
@@ -143,7 +143,9 @@ test.describe('Agent-template catalog — HTTP surface + @Public semantics (deep
      * 404 (no route), proving there is no hidden mutation surface on a route that
      * is intentionally public + unauthenticated. HEAD mirrors GET (200).
      */
-    test('only GET/HEAD are routed; POST/PUT/DELETE on the catalog are 404', async ({ request }) => {
+    test('only GET/HEAD are routed; POST/PUT/DELETE on the catalog are 404', async ({
+        request,
+    }) => {
         const get = await request.get(`${CATALOG_PATH}?entity=agent`);
         expect(get.status()).toBe(200);
 
@@ -279,8 +281,12 @@ test.describe('Agent-template catalog — entity normalization edge cases (deep)
     test('catalog is stable across repeated reads and entries are well-shaped when present', async ({
         request,
     }) => {
-        const first = (await (await request.get(`${CATALOG_PATH}?entity=agent`)).json()) as AstTemplateEntry[];
-        const second = (await (await request.get(`${CATALOG_PATH}?entity=agent`)).json()) as AstTemplateEntry[];
+        const first = (await (
+            await request.get(`${CATALOG_PATH}?entity=agent`)
+        ).json()) as AstTemplateEntry[];
+        const second = (await (
+            await request.get(`${CATALOG_PATH}?entity=agent`)
+        ).json()) as AstTemplateEntry[];
         expect(second.length).toBe(first.length);
         expect(second.map((e) => e.slug)).toEqual(first.map((e) => e.slug));
 

--- a/apps/web/e2e/flow-agent-templates-catalog-deep.spec.ts
+++ b/apps/web/e2e/flow-agent-templates-catalog-deep.spec.ts
@@ -1,0 +1,474 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI, type RegisteredUser } from './helpers/api';
+
+/**
+ * Agent-template CATALOG — deep public/contract coverage + the
+ * instantiate-into-a-DRAFT-agent path with the D9 permission clamp.
+ *
+ * Sources of truth read for this spec (live-probed against the e2e stack —
+ * sqlite in-memory, REQUIRE_EMAIL_VERIFICATION=false, NO GitHub token, fake
+ * GITHUB_APP_ID=999999, keyless):
+ *   - apps/api/src/agents/agent-templates.controller.ts
+ *       GET /api/agent-templates?entity=agent|skill|task, @Public(), HttpCode 200.
+ *       `entity` coerced: anything that isn't EXACTLY 'skill'|'task' → 'agent'.
+ *   - apps/api/src/agents/agent-template-catalog.service.ts
+ *       Repo-backed (private ever-works/agents manifest). list(entity): returns []
+ *       for entity!=='agent'; for 'agent', returns [] when no token resolves (the
+ *       keyless CI case). Never throws — every failure path returns [].
+ *   - apps/api/src/agents/agents.controller.ts (export/import — the clone engine).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * NON-DUPLICATION — flow-agent-templates-clone.spec.ts already covers (do NOT
+ * repeat here):
+ *   • one combined "catalog publicly readable for every entity type" test (anon
+ *     GET, skill+task=[], unknown→agent normalization, no-query default, the
+ *     populated-entry shape guard);
+ *   • the full export→import clone round-trip (files/avatar/runtime knobs copy,
+ *     the -2/-3 rename ladder, clone independence);
+ *   • conflict modes rename/skip/overwrite;
+ *   • avatar image→initials degrade;
+ *   • cross-user export 404 / unauth 401 / bad-envelope 400 / handed-off clone.
+ *
+ * THIS spec deepens the THIN edges that file leaves untouched, with finer-grained
+ * PROBED contracts:
+ *   • HTTP-method allowlist on /api/agent-templates (GET/HEAD only; write verbs 404).
+ *   • @Public semantics: a garbage/expired bearer is IGNORED (still 200), and the
+ *     CORS preflight (OPTIONS) is 204 — the catalog is consumed by browsers/SSR.
+ *   • `entity` normalization is CASE-SENSITIVE ('AGENT','Skill' → agent) and
+ *     tolerates empty + repeated (array) query params — never a 400/500.
+ *   • Response is always a JSON array with the documented Content-Type, and is
+ *     STABLE across repeated calls (1h cache / idempotent fallback).
+ *   • catalog-id RESOLUTION error matrix on the instantiate target: malformed id
+ *     → 400 "Validation failed (uuid is expected)"; well-formed-but-missing id
+ *     → 404 (no existence leak); no `:slug` sub-route on the catalog controller.
+ *   • Instantiate-a-template-into-a-user's-Agent CONTRAST: direct create HONORS
+ *     granted permissions, but instantiate-via-envelope CLAMPS the clone to the
+ *     all-false least-privilege matrix (D9, #1258) — asserted on ALL 8 flags —
+ *     and the clone always lands in status DRAFT.
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * Isolation: every mutation runs on its OWN freshly registered user; unique
+ * suffixes come from the per-test counter `nextSuffix()` (never a module-scope
+ * clock). No module-scope awaits / no module-scope loadSeededTestUser().
+ */
+
+const CATALOG_PATH = `${API_BASE}/api/agent-templates`;
+
+/** The full AGENT_PERMISSIONS_DEFAULT key set (agent.entity.ts) — 8 flags. */
+const PERMISSION_KEYS = [
+    'canCreateAgents',
+    'canAssignTasks',
+    'canEditSkills',
+    'canEditAgentFiles',
+    'canSpend',
+    'canCommitToRepo',
+    'canOpenPullRequests',
+    'canCallExternalTools',
+] as const;
+
+interface AstTemplateEntry {
+    slug: string;
+    title: string;
+    description: string;
+    category?: string;
+    iconName?: string;
+    tags?: string[];
+}
+
+interface AgentDto {
+    id: string;
+    name: string;
+    slug: string;
+    scope: string;
+    status: string;
+    permissions: Record<string, boolean>;
+}
+
+interface AgentExportEnvelope {
+    version: number;
+    identity: { name: string; slug: string; title: string | null; scope: string };
+    runtime: { permissions: Record<string, boolean> };
+    [k: string]: unknown;
+}
+
+interface ImportResult {
+    created: AgentDto;
+    conflictResolution: 'none' | 'skipped' | 'overwritten' | 'renamed';
+    originalSlug: string;
+    finalSlug: string;
+}
+
+// Per-test counter → deterministic unique suffixes WITHOUT a module-scope clock.
+let SUFFIX_SEQ = 0;
+function nextSuffix(): string {
+    SUFFIX_SEQ += 1;
+    return `${SUFFIX_SEQ.toString(36)}${Math.random().toString(36).slice(2, 7)}`;
+}
+
+async function freshToken(
+    request: APIRequestContext,
+): Promise<{ user: RegisteredUser; token: string }> {
+    const user = await registerUserViaAPI(request);
+    return { user, token: user.access_token };
+}
+
+async function createAgent(
+    request: APIRequestContext,
+    token: string,
+    body: Record<string, unknown>,
+): Promise<AgentDto> {
+    const res = await request.post(`${API_BASE}/api/agents`, {
+        headers: authedHeaders(token),
+        data: { scope: 'tenant', ...body },
+    });
+    expect(res.status(), `create body=${await res.text().catch(() => '')}`).toBe(201);
+    return res.json();
+}
+
+async function exportAgent(
+    request: APIRequestContext,
+    token: string,
+    agentId: string,
+): Promise<AgentExportEnvelope> {
+    const res = await request.get(`${API_BASE}/api/agents/${agentId}/export`, {
+        headers: authedHeaders(token),
+    });
+    expect(res.status(), `export body=${await res.text().catch(() => '')}`).toBe(200);
+    return res.json();
+}
+
+test.describe('Agent-template catalog — HTTP surface + @Public semantics (deep)', () => {
+    /**
+     * The catalog controller registers ONLY a GET handler. Every write verb must
+     * 404 (no route), proving there is no hidden mutation surface on a route that
+     * is intentionally public + unauthenticated. HEAD mirrors GET (200).
+     */
+    test('only GET/HEAD are routed; POST/PUT/DELETE on the catalog are 404', async ({ request }) => {
+        const get = await request.get(`${CATALOG_PATH}?entity=agent`);
+        expect(get.status()).toBe(200);
+
+        const head = await request.head(`${CATALOG_PATH}?entity=agent`);
+        expect(head.status()).toBe(200);
+
+        for (const verb of ['post', 'put', 'delete'] as const) {
+            const res = await request[verb](CATALOG_PATH, { data: {} });
+            expect(res.status(), `${verb} should be unrouted`).toBe(404);
+        }
+    });
+
+    /**
+     * @Public() means the auth guard is skipped entirely — a malformed/expired
+     * bearer must be IGNORED, not rejected. A 401 here would prove the route
+     * isn't actually public. (The clone spec asserts the anon path; this asserts
+     * the "garbage credential is harmless" path, which is distinct.)
+     */
+    test('a garbage bearer token is ignored — the public catalog still 200s', async ({
+        request,
+    }) => {
+        const res = await request.get(`${CATALOG_PATH}?entity=agent`, {
+            headers: { Authorization: 'Bearer not.a.real.jwt.value' },
+        });
+        expect(res.status()).toBe(200);
+        expect(Array.isArray(await res.json())).toBe(true);
+    });
+
+    /**
+     * The catalog is fetched by the web app (SSR + potentially the browser), so
+     * the CORS preflight must succeed. Probed: OPTIONS → 204.
+     */
+    test('CORS preflight (OPTIONS) on the catalog returns 204', async ({ request }) => {
+        const res = await request.fetch(CATALOG_PATH, { method: 'OPTIONS' });
+        expect(res.status()).toBe(204);
+    });
+
+    /**
+     * Content-type contract: a successful list is a JSON array served as
+     * application/json. The web fallback depends on parsing JSON, never HTML.
+     */
+    test('catalog responds with a JSON array and application/json content-type', async ({
+        request,
+    }) => {
+        const res = await request.get(`${CATALOG_PATH}?entity=agent`);
+        expect(res.status()).toBe(200);
+        expect(res.headers()['content-type'] ?? '').toContain('application/json');
+        const body = await res.json();
+        expect(Array.isArray(body)).toBe(true);
+    });
+
+    /**
+     * The catalog surfaces strings sourced from an EXTERNAL repo manifest, so the
+     * API must ship the anti-MIME-sniffing defense header. Probed: the response
+     * carries `X-Content-Type-Options: nosniff` (a defense-in-depth contract that
+     * complements the service-side HTML stripping in the catalog mapper).
+     */
+    test('catalog response carries the X-Content-Type-Options: nosniff hardening header', async ({
+        request,
+    }) => {
+        const res = await request.get(`${CATALOG_PATH}?entity=agent`);
+        expect(res.status()).toBe(200);
+        expect(res.headers()['x-content-type-options']).toBe('nosniff');
+    });
+});
+
+test.describe('Agent-template catalog — entity normalization edge cases (deep)', () => {
+    /**
+     * The controller coerces `entity` with an EXACT match: only the lowercase
+     * literals 'skill' and 'task' are honored; anything else (including a
+     * capitalized 'AGENT'/'Skill'/'TASK') normalizes to 'agent'. The clone spec
+     * only checks lowercase skill/task and a single 'banana'; this pins the
+     * case-sensitivity boundary explicitly.
+     */
+    test('entity matching is case-sensitive — capitalized variants normalize to agent', async ({
+        request,
+    }) => {
+        const agentRes = await request.get(`${CATALOG_PATH}?entity=agent`);
+        expect(agentRes.status()).toBe(200);
+        const agentLen = ((await agentRes.json()) as AstTemplateEntry[]).length;
+
+        // Capitalized — NOT an exact match for 'skill'/'task' → coerced to 'agent'.
+        for (const entity of ['AGENT', 'Skill', 'TASK', 'Agent']) {
+            const res = await request.get(`${CATALOG_PATH}?entity=${entity}`);
+            expect(res.status(), `entity=${entity}`).toBe(200);
+            const list = (await res.json()) as AstTemplateEntry[];
+            expect(Array.isArray(list)).toBe(true);
+            // Same result as the canonical agent list (they all collapse to agent).
+            expect(list.length).toBe(agentLen);
+        }
+    });
+
+    /**
+     * Degenerate query params must never 4xx/5xx: an empty `entity=` and a
+     * repeated `entity=skill&entity=task` (array binding) both fall through the
+     * coercion to a valid list. Probed: both 200 + array.
+     */
+    test('empty and repeated entity params are tolerated (no 400/500)', async ({ request }) => {
+        const empty = await request.get(`${CATALOG_PATH}?entity=`);
+        expect(empty.status()).toBe(200);
+        expect(Array.isArray(await empty.json())).toBe(true);
+
+        const repeated = await request.get(`${CATALOG_PATH}?entity=skill&entity=task`);
+        expect(repeated.status()).toBe(200);
+        expect(Array.isArray(await repeated.json())).toBe(true);
+
+        // A long junk value also coerces to agent rather than erroring.
+        const junk = await request.get(`${CATALOG_PATH}?entity=${'x'.repeat(200)}`);
+        expect(junk.status()).toBe(200);
+        expect(Array.isArray(await junk.json())).toBe(true);
+    });
+
+    /**
+     * skill + task are NEVER repo-backed (the service short-circuits to [] for
+     * entity!=='agent'), so they are EXACTLY an empty array regardless of token
+     * availability — a stable contract worth pinning on its own.
+     */
+    test('skill and task catalogs are always exactly empty arrays', async ({ request }) => {
+        for (const entity of ['skill', 'task']) {
+            const res = await request.get(`${CATALOG_PATH}?entity=${entity}`);
+            expect(res.status()).toBe(200);
+            const list = (await res.json()) as AstTemplateEntry[];
+            expect(list).toEqual([]);
+        }
+    });
+
+    /**
+     * Repeated calls return the SAME array (1h cache when populated; idempotent
+     * empty fallback when keyless). Either way the catalog is stable, never
+     * flickering between shapes — important because the web layer caches it.
+     * If/when a token is present the entry shape is asserted (skipped in CI).
+     */
+    test('catalog is stable across repeated reads and entries are well-shaped when present', async ({
+        request,
+    }) => {
+        const first = (await (await request.get(`${CATALOG_PATH}?entity=agent`)).json()) as AstTemplateEntry[];
+        const second = (await (await request.get(`${CATALOG_PATH}?entity=agent`)).json()) as AstTemplateEntry[];
+        expect(second.length).toBe(first.length);
+        expect(second.map((e) => e.slug)).toEqual(first.map((e) => e.slug));
+
+        if (first.length > 0) {
+            for (const entry of first) {
+                expect(typeof entry.slug).toBe('string');
+                expect(entry.slug.length).toBeGreaterThan(0);
+                expect(typeof entry.title).toBe('string');
+                expect(typeof entry.description).toBe('string');
+                if (entry.tags !== undefined) expect(Array.isArray(entry.tags)).toBe(true);
+                if (entry.category !== undefined) expect(typeof entry.category).toBe('string');
+                if (entry.iconName !== undefined) expect(typeof entry.iconName).toBe('string');
+            }
+        } else {
+            test.info().annotations.push({
+                type: 'note',
+                description:
+                    'agent catalog empty (keyless e2e: no GitHub token / fake GITHUB_APP_ID) — repo-backed entry shape not asserted; expected fallback contract.',
+            });
+        }
+    });
+});
+
+test.describe('Agent-template catalog-id resolution — error matrix (deep)', () => {
+    /**
+     * "Instantiate a template" resolves a catalog id against the agent export/
+     * import surface. The id-resolution error matrix is sharply different by
+     * shape: a syntactically invalid id is rejected by the UUID pipe BEFORE any
+     * lookup (400 with a precise message), while a syntactically valid but
+     * non-existent id reaches the repo and 404s WITHOUT leaking existence.
+     */
+    test('malformed id → 400 uuid-validation; well-formed-missing id → 404 (no leak)', async ({
+        request,
+    }) => {
+        const { token } = await freshToken(request);
+
+        const malformed = await request.get(`${API_BASE}/api/agents/not-a-real-id/export`, {
+            headers: authedHeaders(token),
+        });
+        expect(malformed.status()).toBe(400);
+        expect((await malformed.json()).message ?? '').toContain('uuid is expected');
+
+        const missing = await request.get(
+            `${API_BASE}/api/agents/00000000-0000-4000-8000-000000000000/export`,
+            { headers: authedHeaders(token) },
+        );
+        expect(missing.status()).toBe(404);
+    });
+
+    /**
+     * The catalog controller exposes ONLY the list route — there is no
+     * `GET /api/agent-templates/:slug` single-template endpoint, so a slug path
+     * 404s. This pins the absence of a per-template resolution route (the web
+     * app resolves a chosen template client-side from the already-fetched list).
+     */
+    test('there is no per-slug catalog route — /api/agent-templates/:slug is 404', async ({
+        request,
+    }) => {
+        const anon = await request.get(`${CATALOG_PATH}/content-strategist`);
+        expect(anon.status()).toBe(404);
+
+        const { token } = await freshToken(request);
+        const authed = await request.get(`${CATALOG_PATH}/content-strategist`, {
+            headers: authedHeaders(token),
+        });
+        expect(authed.status()).toBe(404);
+    });
+});
+
+test.describe('Instantiate a template into a DRAFT agent — D9 permission clamp (deep)', () => {
+    /**
+     * The clone spec asserts the clamp on a richly-configured agent with three
+     * specific grants. THIS test isolates the CONTRAST that makes the clamp
+     * meaningful: direct create HONORS every granted permission, but
+     * instantiate-via-envelope (the clone path a template instantiation uses)
+     * CLAMPS the result to the all-false least-privilege matrix across ALL 8
+     * flags — and the instantiated agent is always a DRAFT. Probed end to end.
+     */
+    test('create honors granted permissions; instantiate clamps ALL 8 flags to false and lands DRAFT', async ({
+        request,
+    }) => {
+        const { token } = await freshToken(request);
+
+        // Grant EVERY permission on the source so the clamp is unambiguous.
+        const allGranted: Record<string, boolean> = {};
+        for (const key of PERMISSION_KEYS) allGranted[key] = true;
+
+        const source = await createAgent(request, token, {
+            name: `TplSrc ${nextSuffix()}`,
+            permissions: allGranted,
+        });
+        // Direct create HONORS the grants (sanity baseline for the contrast).
+        expect(source.status).toBe('draft');
+        for (const key of PERMISSION_KEYS) {
+            expect(source.permissions[key], `create should honor ${key}`).toBe(true);
+        }
+
+        // The envelope is the instantiation payload; it CARRIES the grants…
+        const envelope = await exportAgent(request, token, source.id);
+        expect(envelope.version).toBe(1);
+        for (const key of PERMISSION_KEYS) {
+            expect(envelope.runtime.permissions[key], `envelope carries ${key}`).toBe(true);
+        }
+
+        // …but instantiating (import) CLAMPS to least-privilege (D9, #1258).
+        const res = await request.post(`${API_BASE}/api/agents/import`, {
+            headers: authedHeaders(token),
+            data: envelope,
+        });
+        expect(res.status(), `import body=${await res.text().catch(() => '')}`).toBe(201);
+        const result = (await res.json()) as ImportResult;
+
+        const clone = result.created;
+        expect(clone.status).toBe('draft');
+        expect(clone.id).not.toBe(source.id);
+        // The headline assertion: every one of the 8 flags is false on the clone.
+        for (const key of PERMISSION_KEYS) {
+            expect(clone.permissions[key], `clone must clamp ${key} to false`).toBe(false);
+        }
+    });
+
+    /**
+     * Instantiating the same source again yields ANOTHER independent DRAFT clone
+     * (the rename ladder continues), and that second clone is ALSO clamped — the
+     * clamp is applied per-import, not cached/leaked from the first. This pins
+     * that the least-privilege guarantee holds for every instantiation, not just
+     * the first one off a given envelope.
+     */
+    test('re-instantiating the same template produces another clamped DRAFT clone', async ({
+        request,
+    }) => {
+        const { token } = await freshToken(request);
+        const source = await createAgent(request, token, {
+            name: `TplRe ${nextSuffix()}`,
+            permissions: { canSpend: true, canCommitToRepo: true, canCallExternalTools: true },
+        });
+        const envelope = await exportAgent(request, token, source.id);
+
+        const firstRes = await request.post(`${API_BASE}/api/agents/import`, {
+            headers: authedHeaders(token),
+            data: envelope,
+        });
+        expect(firstRes.status()).toBe(201);
+        const first = (await firstRes.json()) as ImportResult;
+        expect(first.finalSlug).toBe(`${source.slug}-2`);
+
+        const secondRes = await request.post(`${API_BASE}/api/agents/import`, {
+            headers: authedHeaders(token),
+            data: envelope,
+        });
+        expect(secondRes.status()).toBe(201);
+        const second = (await secondRes.json()) as ImportResult;
+        expect(second.finalSlug).toBe(`${source.slug}-3`);
+        expect(second.created.id).not.toBe(first.created.id);
+
+        expect(second.created.status).toBe('draft');
+        for (const key of PERMISSION_KEYS) {
+            expect(second.created.permissions[key], `2nd clone must clamp ${key}`).toBe(false);
+        }
+    });
+
+    /**
+     * Anonymous + cross-user guards on the instantiate (import/export) surface,
+     * framed from the template-instantiation angle: instantiating requires auth
+     * (unauth import → 401) and a stranger cannot read another user's source to
+     * instantiate from it (export 404 — no existence leak). The clone spec hits
+     * these inside a larger combined test; isolating them keeps the
+     * auth-boundary contract legible on its own.
+     */
+    test('instantiation requires auth; a stranger cannot read another user’s source to clone', async ({
+        request,
+    }) => {
+        const owner = await freshToken(request);
+        const stranger = await freshToken(request);
+
+        const source = await createAgent(request, owner.token, {
+            name: `TplGuard ${nextSuffix()}`,
+        });
+        const envelope = await exportAgent(request, owner.token, source.id);
+
+        // Unauthenticated import (instantiate) → 401.
+        const unauth = await request.post(`${API_BASE}/api/agents/import`, { data: envelope });
+        expect(unauth.status()).toBe(401);
+
+        // Stranger cannot export (read-to-instantiate) the owner's source → 404.
+        const strangerExport = await request.get(`${API_BASE}/api/agents/${source.id}/export`, {
+            headers: authedHeaders(stranger.token),
+        });
+        expect(strangerExport.status()).toBe(404);
+    });
+});

--- a/apps/web/e2e/flow-device-auth-flow.spec.ts
+++ b/apps/web/e2e/flow-device-auth-flow.spec.ts
@@ -1,0 +1,507 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * flow-device-auth-flow — controller-level contract pinning for the plugin
+ * device-code grant under `/api/device-auth/:pluginId/{status,start}`
+ * (apps/api/src/plugins-capabilities/device-auth/device-auth.controller.ts →
+ * DeviceAuthService → PluginOperationsService.getDeviceAuthProvider).
+ *
+ * This is the OAuth-device-code grant plugins/CLIs use to log a user into a
+ * managed external tool (Codex CLI is the only `device-auth`-capable plugin on
+ * `develop`). The controller is `@UseGuards(AuthSessionGuard)`; both routes are
+ * `@HttpCode(HttpStatus.OK)`.
+ *
+ * ── NON-DUPLICATION ─────────────────────────────────────────────────────────
+ * Two existing specs touch this surface; this file deliberately asserts a
+ * DISJOINT set of controller contracts:
+ *   • device-auth.spec.ts — 4 shallow smokes (anon 401 ×2; one start/status
+ *     "shape includes a code-or-url" probe that test.skip()s when not configured
+ *     using `github`). It never pins the NestJS exception ENVELOPE, the HTTP
+ *     method/routing semantics, the 200-not-201 status code, the poll-vs-approve
+ *     (`pending`) semantics, or plugin-id case sensitivity.
+ *   • flow-plugin-oauth-deviceauth.spec.ts — deep DeviceAuthStatus invariant
+ *     matrix + two-user session isolation, but BUNDLED with the whole `/api/oauth`
+ *     connection lifecycle, and gated on a module-scope loadSeededTestUser()
+ *     in one of its describes. It asserts `body.message` regex only — never the
+ *     `error`/`statusCode` envelope fields, the wrong-HTTP-verb 404 routing
+ *     contract, the start↔201 distinction, the prompt-absent-when-not-pending
+ *     poll contract, case sensitivity, or bad-/empty-bearer 401 bodies.
+ * Everything below is fresh-registered-user / raw-fetch only — NO module-scope
+ * seeded user, NO module-scope await.
+ *
+ * ── PROBED CONTRACTS (live http://127.0.0.1:3100, before any assertion) ──────
+ * Capable plugin id = `codex` (declares PLUGIN_CAPABILITIES.DEVICE_AUTH).
+ *   GET  /api/device-auth/codex/status (authed) → 200 DeviceAuthStatus
+ *     { installed:false, connected:false, pending:false, scope:'user',
+ *       flowType:'device-code', message:'Codex CLI is not installed on this
+ *       machine.' }  (no `prompt` key in the not-pending branch)
+ *   POST /api/device-auth/codex/start  (authed) → 200 (NOT 201),
+ *       Content-Type application/json; same DeviceAuthStatus envelope.
+ *   Anon (empty storageState) on either route → 401 { message:'Unauthorized',
+ *       statusCode:401 }.   Bad/empty bearer → identical 401 body.
+ *   Plugin WITHOUT the capability (github/openrouter/anthropic/openai/
+ *       claude-code/gemini/opencode/...) → 400
+ *       { message:'Plugin "<id>" does not support device auth',
+ *         error:'Bad Request', statusCode:400 }.
+ *   Unknown plugin id (zzz-nope / UPPERCASE CODEX / mixed-case Codex /
+ *       traversal-ish `../../etc`) → 404
+ *       { message:'Plugin "<id>" not found', error:'Not Found', statusCode:404 }.
+ *       (not-found is checked BEFORE the capability gate; ids are case-sensitive.)
+ *   Wrong HTTP verb (GET /start, POST /status, DELETE /status) → 404
+ *       { message:'Cannot <VERB> /api/device-auth/codex/<seg>', error:'Not Found' }.
+ *
+ * The managed Codex CLI is ABSENT in CI (keyless sqlite driver) — exactly the
+ * shape these assertions target. Upstream OpenAI device endpoints are NEVER
+ * contacted; every assertion is platform-side and environment-adaptive (where a
+ * branch depends on the CLI being installed we branch on `installed`/`pending`
+ * rather than demand a fictional happy path).
+ */
+
+const DEVICE_AUTH_PLUGIN = 'codex';
+
+interface DeviceAuthStatusShape {
+    installed: boolean;
+    connected: boolean;
+    pending: boolean;
+    scope: string;
+    flowType: string;
+    prompt?: { verificationUri?: string; userCode?: string };
+    message: string;
+}
+
+interface NestErrorBody {
+    message: string;
+    error?: string;
+    statusCode: number;
+}
+
+/**
+ * Assert the DeviceAuthStatus invariant set the
+ * `device-auth-provider.interface.ts` contract pins and codex implements. Holds
+ * regardless of whether the managed CLI is installed on the running machine.
+ */
+function assertStatusShape(body: unknown, ctx: string): DeviceAuthStatusShape {
+    expect(body, `${ctx}: body is an object`).toBeTruthy();
+    const s = body as DeviceAuthStatusShape;
+    expect(typeof s.installed, `${ctx}: installed boolean`).toBe('boolean');
+    expect(typeof s.connected, `${ctx}: connected boolean`).toBe('boolean');
+    expect(typeof s.pending, `${ctx}: pending boolean`).toBe('boolean');
+    expect(s.scope, `${ctx}: scope literal`).toBe('user');
+    expect(s.flowType, `${ctx}: flowType literal`).toBe('device-code');
+    expect(typeof s.message, `${ctx}: message string`).toBe('string');
+    expect(s.message.length, `${ctx}: message non-empty`).toBeGreaterThan(0);
+    return s;
+}
+
+/**
+ * Per-test unique suffix WITHOUT calling a clock at module scope (house rule):
+ * derived from the test title + a per-file monotonic counter.
+ */
+let __counter = 0;
+function uniqueSuffix(title: string): string {
+    __counter += 1;
+    return `${title.replace(/[^a-z0-9]+/gi, '').slice(0, 12)}${__counter}`;
+}
+
+async function freshToken(request: APIRequestContext, title: string): Promise<string> {
+    const u = await registerUserViaAPI(request, {
+        email: `da-${uniqueSuffix(title)}-${Math.random().toString(36).slice(2, 8)}@test.local`,
+    });
+    return u.access_token;
+}
+
+test.describe('device-auth controller — happy-path status/start envelope', () => {
+    test('GET status for the capable plugin returns the full DeviceAuthStatus envelope (200)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.get(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/status`, {
+            headers: authedHeaders(token),
+        });
+        expect(res.status(), 'codex status is 200 for an authed user').toBe(200);
+        expect(
+            res.headers()['content-type'],
+            'status is JSON',
+        ).toMatch(/application\/json/i);
+        assertStatusShape(await res.json(), 'codex status');
+    });
+
+    test('POST start returns 200 (HttpCode OK) — NOT 201 Created — with a JSON envelope', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/start`, {
+            headers: authedHeaders(token),
+        });
+        // The controller annotates @HttpCode(HttpStatus.OK); a plain @Post would
+        // default to 201. Pinning 200 guards that decorator from silent removal.
+        expect(res.status(), 'codex start is 200, not the @Post default 201').toBe(200);
+        expect(res.status(), 'start is explicitly not 201').not.toBe(201);
+        expect(res.headers()['content-type'], 'start is JSON').toMatch(/application\/json/i);
+        assertStatusShape(await res.json(), 'codex start');
+    });
+
+    test('status is a PURE QUERY: poll-before-approve never auto-connects and never half-populates a prompt', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const h = authedHeaders(token);
+        const res = await request.get(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/status`, {
+            headers: h,
+        });
+        expect(res.status(), 'status 200').toBe(200);
+        const s = assertStatusShape(await res.json(), 'codex status poll');
+        // A status poll must not, by itself, mark the user connected (that would
+        // be an approval). `connected` and `pending` are the device-code grant's
+        // "authorized" vs "authorization_pending" signals.
+        expect(s.connected && s.pending, 'never connected AND pending simultaneously').toBe(false);
+        // `prompt` (verificationUri + userCode) is only emitted once a session is
+        // pending; in the not-pending branch it must be ABSENT, never half-set.
+        if (s.pending) {
+            expect(s.prompt, 'a pending session carries a prompt').toBeTruthy();
+            expect(typeof s.prompt?.verificationUri, 'prompt.verificationUri string').toBe('string');
+            expect(typeof s.prompt?.userCode, 'prompt.userCode string').toBe('string');
+        } else {
+            expect(s.prompt, 'no prompt is emitted when not pending').toBeFalsy();
+            // Environment-adaptive: CI has no Codex CLI → message names it.
+            if (!s.installed) {
+                expect(s.message, 'uninstalled message names the CLI').toMatch(/codex|install/i);
+                expect(s.connected, 'uninstalled CLI cannot be connected').toBe(false);
+            }
+        }
+    });
+
+    test('start is idempotent for the not-installed env: re-calling does not mutate the installed/connected bits', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const h = authedHeaders(token);
+        const first = assertStatusShape(
+            await (
+                await request.post(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/start`, {
+                    headers: h,
+                })
+            ).json(),
+            'start #1',
+        );
+        const second = assertStatusShape(
+            await (
+                await request.post(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/start`, {
+                    headers: h,
+                })
+            ).json(),
+            'start #2',
+        );
+        // Same machine, same user, no CLI: installed/connected are stable. start
+        // never DOWNGRADES an already-connected user to disconnected either.
+        expect(second.installed, 'installed bit stable across repeated start').toBe(first.installed);
+        if (first.connected) {
+            expect(second.connected, 'repeated start never disconnects a connected user').toBe(true);
+        }
+        // And a status read right after agrees with start on the machine bit.
+        const afterStatus = assertStatusShape(
+            await (
+                await request.get(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/status`, {
+                    headers: h,
+                })
+            ).json(),
+            'status after start',
+        );
+        expect(afterStatus.installed, 'status agrees with start on installed').toBe(first.installed);
+    });
+});
+
+test.describe('device-auth controller — capability + not-found rejection ladder', () => {
+    test('a plugin that exists but lacks the device-auth capability is a precise 400 with the full NestJS envelope', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const h = authedHeaders(token);
+        // Several real plugins that are NOT device-auth providers. The capability
+        // is gated on the manifest `capabilities` array (source of truth), so this
+        // is a clean 400, never a 5xx from duck-typing an un-materialized plugin.
+        const nonCapable = [
+            'github',
+            'openrouter',
+            'anthropic',
+            'openai',
+            'claude-code',
+            'gemini',
+            'opencode',
+        ];
+        for (const id of nonCapable) {
+            for (const verb of ['status', 'start'] as const) {
+                const res =
+                    verb === 'status'
+                        ? await request.get(`${API_BASE}/api/device-auth/${id}/status`, {
+                              headers: h,
+                          })
+                        : await request.post(`${API_BASE}/api/device-auth/${id}/start`, {
+                              headers: h,
+                          });
+                expect(res.status(), `${id}/${verb} → 400 (no device-auth capability)`).toBe(400);
+                const body = (await res.json()) as NestErrorBody;
+                expect(body.message, `${id}/${verb} names the missing capability`).toBe(
+                    `Plugin "${id}" does not support device auth`,
+                );
+                expect(body.error, `${id}/${verb} carries the Bad Request error label`).toBe(
+                    'Bad Request',
+                );
+                expect(body.statusCode, `${id}/${verb} statusCode mirrors 400`).toBe(400);
+            }
+        }
+    });
+
+    test('an unregistered plugin id is 404 Not Found — and not-found is checked BEFORE the capability gate', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const h = authedHeaders(token);
+        for (const id of ['zzz-nope', 'not-a-real-plugin-xyz']) {
+            for (const verb of ['status', 'start'] as const) {
+                const res =
+                    verb === 'status'
+                        ? await request.get(`${API_BASE}/api/device-auth/${id}/status`, {
+                              headers: h,
+                          })
+                        : await request.post(`${API_BASE}/api/device-auth/${id}/start`, {
+                              headers: h,
+                          });
+                expect(res.status(), `${id}/${verb} → 404`).toBe(404);
+                const body = (await res.json()) as NestErrorBody;
+                expect(body.message, `${id}/${verb} is the not-found message`).toBe(
+                    `Plugin "${id}" not found`,
+                );
+                expect(body.error, `${id}/${verb} Not Found label`).toBe('Not Found');
+                expect(body.statusCode, `${id}/${verb} statusCode 404`).toBe(404);
+                // A non-existent plugin must NEVER surface the capability message
+                // — that would prove the gate ran in the wrong order.
+                expect(body.message, `${id}/${verb} is not a capability error`).not.toMatch(
+                    /does not support/i,
+                );
+            }
+        }
+    });
+
+    test('plugin ids are CASE-SENSITIVE: the capable id only matches lowercase `codex` — uppercase/mixed resolve to 404', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const h = authedHeaders(token);
+        // The lowercase id is capable (200); case variants are unknown ids (404),
+        // proving the registry lookup is an exact match (no normalization that
+        // could collide distinct plugin ids).
+        const ok = await request.get(`${API_BASE}/api/device-auth/codex/status`, { headers: h });
+        expect(ok.status(), 'lowercase codex is the capable plugin (200)').toBe(200);
+        for (const variant of ['CODEX', 'Codex', 'coDex']) {
+            const res = await request.get(`${API_BASE}/api/device-auth/${variant}/status`, {
+                headers: h,
+            });
+            expect(res.status(), `case variant ${variant} is an unknown id → 404`).toBe(404);
+            const body = (await res.json()) as NestErrorBody;
+            expect(body.message, `${variant} is the not-found message`).toBe(
+                `Plugin "${variant}" not found`,
+            );
+        }
+    });
+
+    test('a path-traversal-ish plugin segment is safely echoed and 404d (no resolution, no 5xx)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const h = authedHeaders(token);
+        // `%2f`-encoded slashes decode to a single route segment; the service
+        // treats it as an opaque plugin id, finds nothing, and 404s cleanly.
+        const res = await request.get(`${API_BASE}/api/device-auth/..%2f..%2fetc/status`, {
+            headers: h,
+        });
+        expect(res.status(), 'traversal-ish id resolves to a clean 404, never 5xx').toBe(404);
+        const body = (await res.json()) as NestErrorBody;
+        expect(body.message, 'traversal-ish id echoed as an unknown plugin').toBe(
+            'Plugin "../../etc" not found',
+        );
+        expect(body.error, 'traversal-ish id Not Found label').toBe('Not Found');
+    });
+});
+
+test.describe('device-auth controller — HTTP method / routing contract', () => {
+    test('only GET /status and POST /start are mounted; every other verb on those segments is a routing 404', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const h = authedHeaders(token);
+        // These are framework ROUTING 404s ("Cannot <VERB> <path>"), distinct from
+        // the service's "Plugin not found" 404 — pinning that /status is GET-only
+        // and /start is POST-only (an accidental @All or duplicate route would
+        // change these). All on the capable `codex` id so a not-found can't mask it.
+        const wrong: Array<{ method: 'get' | 'post' | 'delete' | 'put'; seg: string }> = [
+            { method: 'get', seg: 'start' }, // start is POST-only
+            { method: 'post', seg: 'status' }, // status is GET-only
+            { method: 'delete', seg: 'status' },
+            { method: 'put', seg: 'start' },
+        ];
+        for (const w of wrong) {
+            const url = `${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/${w.seg}`;
+            const res =
+                w.method === 'get'
+                    ? await request.get(url, { headers: h })
+                    : w.method === 'post'
+                      ? await request.post(url, { headers: h })
+                      : w.method === 'delete'
+                        ? await request.delete(url, { headers: h })
+                        : await request.put(url, { headers: h });
+            expect(
+                res.status(),
+                `${w.method.toUpperCase()} /${w.seg} is an unmounted route → 404`,
+            ).toBe(404);
+            const body = (await res.json()) as NestErrorBody;
+            // Framework routing miss is "Cannot <VERB> <path>", NOT the service's
+            // "Plugin ... not found" / "does not support" messages.
+            expect(body.message, `${w.method} /${w.seg} is a framework routing miss`).toMatch(
+                /^Cannot (GET|POST|DELETE|PUT) \/api\/device-auth\/codex\//,
+            );
+            expect(body.message, 'routing miss is not a plugin error').not.toMatch(
+                /does not support|Plugin "/,
+            );
+        }
+    });
+});
+
+test.describe('device-auth controller — auth gating (AuthSessionGuard)', () => {
+    test('anonymous callers (empty storageState) are rejected 401 on BOTH routes before any plugin resolution', async ({
+        browser,
+    }) => {
+        // browser.newContext() would INHERIT the chromium project storageState
+        // cookie; an explicit empty storageState gives a true anonymous client.
+        const anonCtx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        try {
+            const anon = anonCtx.request;
+            // Capable id AND unknown id: a 401 must precede both the capability
+            // and the not-found checks (the guard runs before the controller).
+            const probes: Array<{ method: 'get' | 'post'; path: string }> = [
+                { method: 'get', path: `/api/device-auth/${DEVICE_AUTH_PLUGIN}/status` },
+                { method: 'post', path: `/api/device-auth/${DEVICE_AUTH_PLUGIN}/start` },
+                { method: 'get', path: `/api/device-auth/zzz-unknown-plugin/status` },
+                { method: 'get', path: `/api/device-auth/github/status` },
+            ];
+            for (const p of probes) {
+                const res =
+                    p.method === 'get'
+                        ? await anon.get(`${API_BASE}${p.path}`)
+                        : await anon.post(`${API_BASE}${p.path}`);
+                expect(res.status(), `anon ${p.method.toUpperCase()} ${p.path} → 401`).toBe(401);
+                const body = (await res.json()) as NestErrorBody;
+                expect(body.statusCode, `anon ${p.path} statusCode 401`).toBe(401);
+                expect(String(body.message), `anon ${p.path} is Unauthorized`).toMatch(
+                    /unauthorized/i,
+                );
+                // Auth precedes plugin resolution: an anon hit on an unknown/non-
+                // capable plugin must NOT leak the not-found / capability message.
+                expect(
+                    String(body.message),
+                    `anon ${p.path} does not leak a plugin error`,
+                ).not.toMatch(/does not support|not found/i);
+            }
+        } finally {
+            await anonCtx.close();
+        }
+    });
+
+    test('a malformed or empty bearer is treated as anonymous → identical 401 envelope', async ({
+        browser,
+    }) => {
+        const anonCtx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        try {
+            const anon = anonCtx.request;
+            const headerVariants = [
+                { name: 'garbage token', value: 'Bearer not-a-real-token-xyz' },
+                { name: 'empty bearer', value: 'Bearer ' },
+            ];
+            for (const v of headerVariants) {
+                const res = await anon.get(
+                    `${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/status`,
+                    { headers: { Authorization: v.value } },
+                );
+                expect(res.status(), `${v.name} → 401`).toBe(401);
+                const body = (await res.json()) as NestErrorBody;
+                expect(body.statusCode, `${v.name} statusCode 401`).toBe(401);
+                expect(String(body.message), `${v.name} is Unauthorized`).toMatch(/unauthorized/i);
+            }
+        } finally {
+            await anonCtx.close();
+        }
+    });
+
+    test('a freshly registered bearer is ADMITTED to status (proving the 401s were the guard, not a dead route)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.get(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/status`, {
+            headers: authedHeaders(token),
+        });
+        expect(res.status(), 'a valid bearer is admitted (200)').toBe(200);
+        assertStatusShape(await res.json(), 'authed admitted status');
+    });
+});
+
+test.describe('device-auth controller — per-user session independence', () => {
+    test('two freshly-registered users each get their own status; one user starting a flow does not leak into the other', async ({
+        request,
+    }, testInfo) => {
+        // Sessions are keyed by userId in the provider, so two brand-new users
+        // must observe independent state and B must never inherit A's session.
+        const a = await freshToken(request, testInfo.title + 'A');
+        const b = await freshToken(request, testInfo.title + 'B');
+        const ha = authedHeaders(a);
+        const hb = authedHeaders(b);
+
+        const aBefore = assertStatusShape(
+            await (
+                await request.get(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/status`, {
+                    headers: ha,
+                })
+            ).json(),
+            'A before',
+        );
+        const bBefore = assertStatusShape(
+            await (
+                await request.get(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/status`, {
+                    headers: hb,
+                })
+            ).json(),
+            'B before',
+        );
+        // Same host → same machine-level `installed` bit, but each owns its session.
+        expect(aBefore.installed, 'both users observe the same machine install bit').toBe(
+            bBefore.installed,
+        );
+        expect(bBefore.pending, 'B has no pending session at baseline').toBe(false);
+
+        // A starts a flow.
+        const aStart = assertStatusShape(
+            await (
+                await request.post(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/start`, {
+                    headers: ha,
+                })
+            ).json(),
+            'A start',
+        );
+
+        // B's status must be untouched by A's start — the key isolation invariant.
+        const bAfter = assertStatusShape(
+            await (
+                await request.get(`${API_BASE}/api/device-auth/${DEVICE_AUTH_PLUGIN}/status`, {
+                    headers: hb,
+                })
+            ).json(),
+            'B after A.start',
+        );
+        expect(bAfter.pending, "A's start did not make B pending").toBe(false);
+        expect(bAfter.prompt, "A's prompt did not leak into B").toBeFalsy();
+        expect(bAfter.connected, "A's start did not connect B").toBe(false);
+        if (aStart.pending) {
+            expect(bAfter.pending, 'pending is per-user (A pending, B not)').toBe(false);
+        }
+    });
+});

--- a/apps/web/e2e/flow-device-auth-flow.spec.ts
+++ b/apps/web/e2e/flow-device-auth-flow.spec.ts
@@ -120,10 +120,7 @@ test.describe('device-auth controller — happy-path status/start envelope', () 
             headers: authedHeaders(token),
         });
         expect(res.status(), 'codex status is 200 for an authed user').toBe(200);
-        expect(
-            res.headers()['content-type'],
-            'status is JSON',
-        ).toMatch(/application\/json/i);
+        expect(res.headers()['content-type'], 'status is JSON').toMatch(/application\/json/i);
         assertStatusShape(await res.json(), 'codex status');
     });
 
@@ -160,7 +157,9 @@ test.describe('device-auth controller — happy-path status/start envelope', () 
         // pending; in the not-pending branch it must be ABSENT, never half-set.
         if (s.pending) {
             expect(s.prompt, 'a pending session carries a prompt').toBeTruthy();
-            expect(typeof s.prompt?.verificationUri, 'prompt.verificationUri string').toBe('string');
+            expect(typeof s.prompt?.verificationUri, 'prompt.verificationUri string').toBe(
+                'string',
+            );
             expect(typeof s.prompt?.userCode, 'prompt.userCode string').toBe('string');
         } else {
             expect(s.prompt, 'no prompt is emitted when not pending').toBeFalsy();
@@ -195,9 +194,13 @@ test.describe('device-auth controller — happy-path status/start envelope', () 
         );
         // Same machine, same user, no CLI: installed/connected are stable. start
         // never DOWNGRADES an already-connected user to disconnected either.
-        expect(second.installed, 'installed bit stable across repeated start').toBe(first.installed);
+        expect(second.installed, 'installed bit stable across repeated start').toBe(
+            first.installed,
+        );
         if (first.connected) {
-            expect(second.connected, 'repeated start never disconnects a connected user').toBe(true);
+            expect(second.connected, 'repeated start never disconnects a connected user').toBe(
+                true,
+            );
         }
         // And a status read right after agrees with start on the machine bit.
         const afterStatus = assertStatusShape(
@@ -208,7 +211,9 @@ test.describe('device-auth controller — happy-path status/start envelope', () 
             ).json(),
             'status after start',
         );
-        expect(afterStatus.installed, 'status agrees with start on installed').toBe(first.installed);
+        expect(afterStatus.installed, 'status agrees with start on installed').toBe(
+            first.installed,
+        );
     });
 });
 

--- a/apps/web/e2e/flow-git-providers-deep.spec.ts
+++ b/apps/web/e2e/flow-git-providers-deep.spec.ts
@@ -178,9 +178,10 @@ test.describe('flow: git-providers LIST descriptor shape (configured flag + the 
         // item surfaces the rich plugin metadata (description/homepage/icon) and
         // has NO `name` key. Pinning the key-set guards against an accidental
         // shape drift between the two controllers.
-        expect(github && 'name' in github, 'git-list item has NO name key (unlike the oauth list)').toBe(
-            false,
-        );
+        expect(
+            github && 'name' in github,
+            'git-list item has NO name key (unlike the oauth list)',
+        ).toBe(false);
         expect(typeof github?.description, 'github descriptor carries a string description').toBe(
             'string',
         );
@@ -194,14 +195,16 @@ test.describe('flow: git-providers LIST descriptor shape (configured flag + the 
         // The structured icon object: { type:'svg', value:'<svg…', darkValue:'<svg…' }.
         // A real plugin descriptor — not a bare string — with both light + dark svgs.
         const icon = github?.icon;
-        expect(icon && typeof icon === 'object', 'github descriptor carries a structured icon object').toBe(
-            true,
-        );
+        expect(
+            icon && typeof icon === 'object',
+            'github descriptor carries a structured icon object',
+        ).toBe(true);
         expect(icon?.type, "icon.type is 'svg'").toBe('svg');
         expect(String(icon?.value), 'icon.value is inline svg markup').toMatch(/^<svg\b/);
-        expect(String(icon?.darkValue), 'icon.darkValue is inline svg markup (dark variant)').toMatch(
-            /^<svg\b/,
-        );
+        expect(
+            String(icon?.darkValue),
+            'icon.darkValue is inline svg markup (dark variant)',
+        ).toMatch(/^<svg\b/);
 
         // The descriptor never embeds a credential/token (defensive — list is public-ish metadata).
         expectNoTokenLeak(JSON.stringify(github), 'github list descriptor');
@@ -352,7 +355,9 @@ test.describe('flow: the disconnected sub-resource success-envelope MATRIX (gith
                 // The error is the generic, sanitized message — non-empty, matches
                 // the documented copy, and leaks NEITHER the caller's userId NOR a token.
                 const errStr = String(body.error ?? '');
-                expect(errStr.length, `${providerId}/${path} error is non-empty`).toBeGreaterThan(0);
+                expect(errStr.length, `${providerId}/${path} error is non-empty`).toBeGreaterThan(
+                    0,
+                );
                 expect(errStr, `${providerId}/${path} error is the generic sanitized copy`).toMatch(
                     error,
                 );
@@ -416,7 +421,9 @@ test.describe('flow: the git-providers controller is READ-ONLY (route discipline
         // The list is GET-only — there is no mutation endpoint to create/register a
         // provider. (Disconnect lives on the SEPARATE oauth controller.)
         expect(
-            (await request.post(`${API_BASE}/api/git-providers`, { headers: h, data: {} })).status(),
+            (
+                await request.post(`${API_BASE}/api/git-providers`, { headers: h, data: {} })
+            ).status(),
             'POST /api/git-providers is not a route → 404',
         ).toBe(404);
 

--- a/apps/web/e2e/flow-git-providers-deep.spec.ts
+++ b/apps/web/e2e/flow-git-providers-deep.spec.ts
@@ -1,0 +1,533 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * flow-git-providers-deep — DEEP coverage of the GitProviderController
+ * (`apps/api/src/plugins-capabilities/git-provider/`, the `/api/git-providers/*`
+ * surface), going well beyond the single-endpoint smoke test in
+ * git-providers.spec.ts.
+ *
+ * This file is intentionally focused on the GIT-PROVIDERS controller's OWN
+ * contracts — the list descriptor SHAPE, its provider-id resolution semantics,
+ * its sub-resource success-envelope MATRIX, and its route discipline — as
+ * distinct from the connection/oauth lifecycle that the connection specs own.
+ *
+ * NON-DUPLICATION — the existing git-provider specs already own:
+ *   · flow-git-provider-connection → two-user connection-record isolation, the
+ *       sanitized (EW-721 Wave J) sub-resource error leak matrix, the
+ *       connected-as identity ABSENCE UI, the list↔oauth coherence, the
+ *       connection GATING git-backed taxonomy writes, the connect-url variant
+ *       matrix + idempotent DELETE, and the works/new + settings UI auth gates.
+ *   · flow-plugin-git-provider → the SINGLE-user full lifecycle (status →
+ *       connect/url → DELETE 204), the read-packages token track, the plugin
+ *       callback code-before-creds gate, the web-tier callback redirect
+ *       contract, and unknown-provider resolution on BOTH controllers.
+ *   · git-providers.spec.ts → a bare 401 + "is an object" smoke on
+ *       /github/connection.
+ *   · flow-settings-git-providers / git-providers-oauth-happy / github-app →
+ *       the settings PAGE, oauth connect/url happy path, and the GitHub-App plane.
+ *
+ * THIS file deliberately covers what those do NOT (genuinely-uncovered angles):
+ *   1. The providers LIST descriptor SHAPE in depth: configured:true exactly,
+ *      EXACTLY one advertised provider (github = the sole default), the precise
+ *      git-list item key-set (description, enabled, homepage, icon, id — and
+ *      notably NO `name` key, unlike the oauth list item), and the structured
+ *      `icon` object ({type:'svg', value:'<svg…', darkValue:'<svg…'}).
+ *   2. github's connection descriptor is the SAME rich object as its list entry
+ *      PLUS connected:false (the list entry and connection descriptor agree).
+ *   3. Provider-id resolution is EXACT-MATCH / case-SENSITIVE: 'GITHUB',
+ *      'Github', a trailing-space 'github ', and a wholly-unknown id ALL resolve
+ *      to the synthetic {name:'Unknown', enabled:false, connected:false} echoing
+ *      the verbatim id — proving no normalization/trimming and no crash.
+ *   4. The sub-resource success-envelope MATRIX for a disconnected user on the
+ *      GIT-PROVIDERS controller: organizations→{success:false,organizations:[]},
+ *      repositories→{success:false,repositories:[]}, user→{success:false,
+ *      user:null}, each carrying the EXACT collection key + a generic sanitized
+ *      error (EW-721 Wave J: no userId/token leak) — pinned on github AND on an
+ *      unknown provider (the unknown path degrades identically, never 5xx).
+ *   5. repositories pagination-param ROBUSTNESS: NaN params (page=abc&perPage=xyz)
+ *      and an over-cap perPage=500 (controller Math.min-clamps to 100) both stay
+ *      a graceful 200 success:false envelope — never a 500 from parseInt(NaN).
+ *   6. Route discipline ON THE GIT-PROVIDERS CONTROLLER: it is READ-ONLY — there
+ *      is no POST /api/git-providers and no DELETE /:p/connection (both 404);
+ *      the sub-resources are GET-only (POST :p/user 404). (Disconnect lives on
+ *      the SEPARATE oauth controller, which the connection specs pin.)
+ *   7. The full anon boundary on EVERY git-providers route (list + connection +
+ *      all three sub-resources) → 401, and an invalid bearer → 401.
+ *   8. Cross-user isolation of the sub-resource envelopes: two fresh users
+ *      fan-out the same sub-resources concurrently and each gets its OWN clean
+ *      disconnected envelope with no cross-user id leak.
+ *
+ * EVERY status/shape/message below was PROBED against the LIVE stack
+ * (API 127.0.0.1:3100 sqlite in-memory CI driver; web 127.0.0.1:3000 next-dev)
+ * before assertions were written. Upstream github.com is NEVER contacted.
+ *
+ * PROBED CONTRACTS (live):
+ *   POST   /api/auth/register { username(>=3), email, password }
+ *            → { access_token (opaque session token), user:{id,email,username} }
+ *   GET    /api/git-providers                 (authed) → 200 { configured:true,
+ *            providers:[ EXACTLY ONE: { id:'github', enabled:true,
+ *              description:'GitHub integration for…', homepage:'https://github.com',
+ *              icon:{ type:'svg', value:'<svg…', darkValue:'<svg…' } } ] }
+ *            — NOTE: the git-list item carries NO `name` key. (anon/bad-token 401)
+ *   GET    /api/git-providers/:p/connection   (authed) → for github: the SAME
+ *            rich descriptor (id,enabled,description,homepage,icon) + connected:false
+ *            (NO username/email/avatarUrl/authMethod while disconnected). For an
+ *            id that does not exactly match an enabled provider id — 'GITHUB',
+ *            'Github', 'github ' (trailing space), 'bitbucket', 'gitlab' — the
+ *            synthetic { id:<verbatim>, name:'Unknown', enabled:false,
+ *            connected:false }. (anon 401)
+ *   GET    /api/git-providers/:p/organizations (disconnected) → 200
+ *            { success:false, organizations:[], error:'Failed to fetch organizations' }
+ *   GET    /api/git-providers/:p/repositories  (disconnected) → 200
+ *            { success:false, repositories:[], error:'Failed to fetch repositories' }
+ *            — ?page=abc&perPage=xyz and ?perPage=500 also → graceful 200 envelope.
+ *   GET    /api/git-providers/:p/user          (disconnected) → 200
+ *            { success:false, user:null, error:'Failed to fetch user' }
+ *   POST   /api/git-providers                  → 404 (no such route; list is GET-only)
+ *   DELETE /api/git-providers/:p/connection    → 404 (no such route on this controller)
+ *   POST   /api/git-providers/:p/user          → 404 (sub-resources are GET-only)
+ *
+ * ISOLATION: every flow uses FRESH registerUserViaAPI() users; all calls here are
+ * READ-ONLY against the git-providers controller (no work/connection mutation),
+ * so no shared/seeded state is touched.
+ */
+
+const PROVIDER = 'github';
+
+interface IconDescriptor {
+    type?: string;
+    value?: string;
+    darkValue?: string;
+}
+
+interface ProviderDescriptor {
+    id?: string;
+    name?: string;
+    enabled?: boolean;
+    description?: string;
+    homepage?: string;
+    icon?: IconDescriptor;
+    connected?: boolean;
+    username?: string;
+    email?: string;
+    avatarUrl?: string;
+    authMethod?: string;
+}
+
+interface SubResourceEnvelope {
+    success?: boolean;
+    error?: string;
+    organizations?: unknown[];
+    repositories?: unknown[];
+    user?: unknown;
+}
+
+/** A github token must never appear in any payload we read back. */
+function expectNoTokenLeak(text: string, label: string): void {
+    expect(text, `${label} leaks no github token`).not.toMatch(/gh[pousr]_[A-Za-z0-9]{8,}/);
+}
+
+test.describe('flow: git-providers LIST descriptor shape (configured flag + the github descriptor)', () => {
+    test('the list is authed-only, reports configured:true, advertises github as the SOLE default provider, and each item carries the exact descriptor key-set (id/enabled/description/homepage + a structured svg icon, and NO name key)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const h = authedHeaders(u.access_token);
+
+        // The list rejects anon and a bogus bearer (auth boundary on the list).
+        expect(
+            (await request.get(`${API_BASE}/api/git-providers`)).status(),
+            'git-providers list rejects anon → 401',
+        ).toBe(401);
+        expect(
+            (
+                await request.get(`${API_BASE}/api/git-providers`, {
+                    headers: authedHeaders('not-a-real-token-deadbeef'),
+                })
+            ).status(),
+            'git-providers list rejects an invalid bearer → 401',
+        ).toBe(401);
+
+        const res = await request.get(`${API_BASE}/api/git-providers`, { headers: h });
+        expect(res.status(), 'git-providers list → 200').toBe(200);
+        const body = (await res.json()) as {
+            configured?: unknown;
+            providers?: ProviderDescriptor[];
+        };
+
+        // The list envelope: a boolean configured flag (true in this env, where the
+        // github plugin's default credentials are bundled) + a providers array.
+        expect(typeof body.configured, 'list carries a boolean configured flag').toBe('boolean');
+        expect(body.configured, 'github plugin is configured in this env → configured:true').toBe(
+            true,
+        );
+        expect(Array.isArray(body.providers), 'providers is an array').toBe(true);
+
+        const providers = body.providers ?? [];
+        // github is the SOLE default git provider in this build.
+        expect(providers.length, 'exactly one advertised git provider (github = the default)').toBe(
+            1,
+        );
+        const github = providers.find((p) => p.id === PROVIDER);
+        expect(github, 'github is present in the list').toBeTruthy();
+        expect(github?.enabled, 'github is enabled').toBe(true);
+
+        // The exact descriptor key-set of a git-providers list item. CRUCIALLY this
+        // differs from the OAUTH list item (which carries `name`): the git list
+        // item surfaces the rich plugin metadata (description/homepage/icon) and
+        // has NO `name` key. Pinning the key-set guards against an accidental
+        // shape drift between the two controllers.
+        expect(github && 'name' in github, 'git-list item has NO name key (unlike the oauth list)').toBe(
+            false,
+        );
+        expect(typeof github?.description, 'github descriptor carries a string description').toBe(
+            'string',
+        );
+        expect(String(github?.description), 'description is the real plugin blurb').toMatch(
+            /GitHub integration/i,
+        );
+        expect(github?.homepage, 'github descriptor homepage is github.com').toBe(
+            'https://github.com',
+        );
+
+        // The structured icon object: { type:'svg', value:'<svg…', darkValue:'<svg…' }.
+        // A real plugin descriptor — not a bare string — with both light + dark svgs.
+        const icon = github?.icon;
+        expect(icon && typeof icon === 'object', 'github descriptor carries a structured icon object').toBe(
+            true,
+        );
+        expect(icon?.type, "icon.type is 'svg'").toBe('svg');
+        expect(String(icon?.value), 'icon.value is inline svg markup').toMatch(/^<svg\b/);
+        expect(String(icon?.darkValue), 'icon.darkValue is inline svg markup (dark variant)').toMatch(
+            /^<svg\b/,
+        );
+
+        // The descriptor never embeds a credential/token (defensive — list is public-ish metadata).
+        expectNoTokenLeak(JSON.stringify(github), 'github list descriptor');
+    });
+});
+
+test.describe('flow: github connection descriptor agrees with its list entry (rich descriptor + connected:false)', () => {
+    test('the github connection echoes the same id/enabled/description/homepage/icon as the list entry, plus connected:false and NO leaked identity fields for a fresh disconnected user', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const h = authedHeaders(u.access_token);
+
+        // Pull the list entry and the connection descriptor; they must agree on the
+        // descriptor portion (the connection is the list entry decorated with state).
+        const listRes = await request.get(`${API_BASE}/api/git-providers`, { headers: h });
+        const listGithub = ((await listRes.json()).providers as ProviderDescriptor[]).find(
+            (p) => p.id === PROVIDER,
+        );
+        expect(listGithub, 'list has a github entry').toBeTruthy();
+
+        const connRes = await request.get(`${API_BASE}/api/git-providers/${PROVIDER}/connection`, {
+            headers: h,
+        });
+        expect(connRes.status(), 'github connection → 200').toBe(200);
+        const conn = (await connRes.json()) as ProviderDescriptor;
+
+        // The descriptor portion is identical between the two surfaces.
+        expect(conn.id, 'connection echoes the github id').toBe(listGithub?.id);
+        expect(conn.enabled, 'connection echoes enabled').toBe(listGithub?.enabled);
+        expect(conn.description, 'connection echoes the description').toBe(listGithub?.description);
+        expect(conn.homepage, 'connection echoes the homepage').toBe(listGithub?.homepage);
+        expect(conn.icon?.type, 'connection echoes the icon.type').toBe(listGithub?.icon?.type);
+
+        // The state decoration: a fresh user is NOT connected, and the descriptor
+        // leaks NO identity (no username/email/avatarUrl/authMethod while disconnected).
+        expect(conn.connected, 'fresh user is NOT connected').toBe(false);
+        expect(conn.username, 'disconnected → no username').toBeUndefined();
+        expect(conn.email, 'disconnected → no email').toBeUndefined();
+        expect(conn.avatarUrl, 'disconnected → no avatarUrl').toBeUndefined();
+        expect(conn.authMethod, 'disconnected → no authMethod').toBeUndefined();
+
+        // The anon boundary on the connection route.
+        expect(
+            (await request.get(`${API_BASE}/api/git-providers/${PROVIDER}/connection`)).status(),
+            'github connection rejects anon → 401',
+        ).toBe(401);
+    });
+});
+
+test.describe('flow: provider-id resolution is EXACT-MATCH / case-sensitive (synthetic Unknown for any non-exact id)', () => {
+    test('GITHUB / Github / "github " (trailing space) / bitbucket / gitlab all resolve to the synthetic {name:Unknown, enabled:false, connected:false} echoing the VERBATIM id — no normalization, no trimming, no crash', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const h = authedHeaders(u.access_token);
+
+        // Each of these is NOT an exact, case-sensitive match for the enabled
+        // provider id 'github'. The service short-circuits to a synthetic
+        // descriptor rather than throwing — proving the lookup is a strict
+        // `providers.find(p => p.id === id)` with no normalization.
+        const nonExactIds = ['GITHUB', 'Github', 'github ', 'bitbucket', 'gitlab'];
+
+        for (const id of nonExactIds) {
+            const res = await request.get(
+                `${API_BASE}/api/git-providers/${encodeURIComponent(id)}/connection`,
+                { headers: h },
+            );
+            expect(res.status(), `'${id}' connection never 5xx (graceful)`).toBeLessThan(500);
+            expect(res.status(), `'${id}' connection → 200`).toBe(200);
+            const body = (await res.json()) as ProviderDescriptor;
+            // The verbatim id is echoed back — no trimming/casing applied.
+            expect(body.id, `'${id}' connection echoes the VERBATIM id`).toBe(id);
+            expect(body.name, `'${id}' → synthetic name 'Unknown'`).toBe('Unknown');
+            expect(body.enabled, `'${id}' → enabled:false`).toBe(false);
+            expect(body.connected, `'${id}' → connected:false`).toBe(false);
+            // The synthetic descriptor carries no rich metadata (no homepage/icon).
+            expect(body.homepage, `'${id}' synthetic descriptor has no homepage`).toBeUndefined();
+        }
+    });
+});
+
+test.describe('flow: the disconnected sub-resource success-envelope MATRIX (github + unknown provider)', () => {
+    test('organizations→[], repositories→[], user→null — each a 200 {success:false, <exact key>, generic sanitized error} for a disconnected user, identical on github AND an unknown provider, leaking no userId/token', async ({
+        request,
+    }) => {
+        const userA = await registerUserViaAPI(request);
+        const h = authedHeaders(userA.access_token);
+
+        // The success-envelope matrix: each sub-resource has a DISTINCT collection
+        // key and a distinct empty default (list → [], user → null). The error is
+        // a generic sanitized string (EW-721 Wave J: the old detail named the
+        // caller's userId — a leak).
+        const matrix: Array<{
+            path: 'organizations' | 'repositories' | 'user';
+            collectionKey: 'organizations' | 'repositories' | 'user';
+            isList: boolean;
+            error: RegExp;
+        }> = [
+            {
+                path: 'organizations',
+                collectionKey: 'organizations',
+                isList: true,
+                error: /Failed to fetch organizations/i,
+            },
+            {
+                path: 'repositories',
+                collectionKey: 'repositories',
+                isList: true,
+                error: /Failed to fetch repositories/i,
+            },
+            { path: 'user', collectionKey: 'user', isList: false, error: /Failed to fetch user/i },
+        ];
+
+        // Pin the matrix on github (an enabled-but-disconnected provider) AND on an
+        // unknown provider id — the controller's try/catch degrades both paths to
+        // the SAME success:false envelope (the unknown path can never 5xx either).
+        for (const providerId of [PROVIDER, 'bitbucket']) {
+            for (const { path, collectionKey, isList, error } of matrix) {
+                const res = await request.get(
+                    `${API_BASE}/api/git-providers/${providerId}/${path}`,
+                    { headers: h },
+                );
+                expect(
+                    res.status(),
+                    `${providerId}/${path} never 5xx (got ${res.status()})`,
+                ).toBeLessThan(500);
+                expect(res.status(), `${providerId}/${path} → 200 envelope`).toBe(200);
+                const body = (await res.json()) as SubResourceEnvelope;
+
+                expect(body.success, `${providerId}/${path} → success:false (disconnected)`).toBe(
+                    false,
+                );
+                if (isList) {
+                    const coll = body[collectionKey as 'organizations' | 'repositories'];
+                    expect(
+                        Array.isArray(coll),
+                        `${providerId}/${path} → ${collectionKey} is an array`,
+                    ).toBe(true);
+                    expect(
+                        (coll as unknown[]).length,
+                        `${providerId}/${path} → empty ${collectionKey}`,
+                    ).toBe(0);
+                } else {
+                    expect(body.user, `${providerId}/${path} → null user`).toBeNull();
+                }
+
+                // The error is the generic, sanitized message — non-empty, matches
+                // the documented copy, and leaks NEITHER the caller's userId NOR a token.
+                const errStr = String(body.error ?? '');
+                expect(errStr.length, `${providerId}/${path} error is non-empty`).toBeGreaterThan(0);
+                expect(errStr, `${providerId}/${path} error is the generic sanitized copy`).toMatch(
+                    error,
+                );
+                expect(
+                    errStr,
+                    `${providerId}/${path} error does NOT leak the caller's userId (sanitized)`,
+                ).not.toContain(userA.user.id);
+                expectNoTokenLeak(errStr, `${providerId}/${path} error`);
+            }
+        }
+    });
+});
+
+test.describe('flow: repositories pagination-param robustness (NaN + over-cap perPage stay a graceful 200 envelope)', () => {
+    test('repositories tolerates page=abc&perPage=xyz (parseInt→NaN) AND perPage=500 (controller clamps to 100) — both degrade to the success:false envelope, never a 500', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const h = authedHeaders(u.access_token);
+
+        // The controller does `page ? parseInt(page,10) : undefined` and
+        // `perPage ? Math.min(parseInt(perPage,10),100) : undefined`. A disconnected
+        // user never reaches the upstream call, but the param parsing must not
+        // explode on NaN or an over-cap value — the envelope stays graceful.
+        const paramVariants: Array<{ label: string; query: string }> = [
+            { label: 'default (no params)', query: '' },
+            { label: 'NaN params', query: '?page=abc&perPage=xyz' },
+            { label: 'over-cap perPage', query: '?page=1&perPage=500' },
+            { label: 'valid small page', query: '?page=2&perPage=1' },
+        ];
+
+        for (const v of paramVariants) {
+            const res = await request.get(
+                `${API_BASE}/api/git-providers/${PROVIDER}/repositories${v.query}`,
+                { headers: h },
+            );
+            expect(
+                res.status(),
+                `repositories ${v.label} never 5xx (got ${res.status()})`,
+            ).toBeLessThan(500);
+            expect(res.status(), `repositories ${v.label} → 200`).toBe(200);
+            const body = (await res.json()) as SubResourceEnvelope;
+            expect(body.success, `repositories ${v.label} → success:false (disconnected)`).toBe(
+                false,
+            );
+            expect(
+                Array.isArray(body.repositories) && body.repositories.length === 0,
+                `repositories ${v.label} → empty array`,
+            ).toBe(true);
+        }
+    });
+});
+
+test.describe('flow: the git-providers controller is READ-ONLY (route discipline)', () => {
+    test('there is no POST /api/git-providers, no DELETE /:p/connection, and the sub-resources are GET-only — all wrong-verb/look-alike routes 404, while the canonical GETs stay 200', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const h = authedHeaders(u.access_token);
+
+        // The list is GET-only — there is no mutation endpoint to create/register a
+        // provider. (Disconnect lives on the SEPARATE oauth controller.)
+        expect(
+            (await request.post(`${API_BASE}/api/git-providers`, { headers: h, data: {} })).status(),
+            'POST /api/git-providers is not a route → 404',
+        ).toBe(404);
+
+        // The look-alike `DELETE /api/git-providers/:p/connection` does NOT exist on
+        // THIS controller (connection is GET-only here; the real disconnect is
+        // `DELETE /api/oauth/:p`). Pin it so a future route move can't silently
+        // graft a destructive verb onto the read-only controller.
+        expect(
+            (
+                await request.delete(`${API_BASE}/api/git-providers/${PROVIDER}/connection`, {
+                    headers: h,
+                })
+            ).status(),
+            'DELETE /api/git-providers/:p/connection is not a route → 404',
+        ).toBe(404);
+
+        // The sub-resources are GET-only too — a POST to a read sub-resource 404s.
+        expect(
+            (
+                await request.post(`${API_BASE}/api/git-providers/${PROVIDER}/user`, {
+                    headers: h,
+                    data: {},
+                })
+            ).status(),
+            'POST /api/git-providers/:p/user is not a route → 404',
+        ).toBe(404);
+
+        // The canonical READ routes remain reachable (the controller is not broken,
+        // just read-only): list + connection both 200.
+        expect(
+            (await request.get(`${API_BASE}/api/git-providers`, { headers: h })).status(),
+            'GET /api/git-providers stays 200 (read route intact)',
+        ).toBe(200);
+        expect(
+            (
+                await request.get(`${API_BASE}/api/git-providers/${PROVIDER}/connection`, {
+                    headers: h,
+                })
+            ).status(),
+            'GET /api/git-providers/:p/connection stays 200',
+        ).toBe(200);
+    });
+});
+
+test.describe('flow: full anon boundary across EVERY git-providers route', () => {
+    test('the list, the connection, and all three sub-resources each reject an anonymous caller with 401 (the whole controller is auth-guarded)', async ({
+        request,
+    }) => {
+        // Every route on the controller is behind AuthSessionGuard. A raw
+        // unauthenticated `request` (no Authorization header) must 401 on each.
+        const routes = [
+            `/api/git-providers`,
+            `/api/git-providers/${PROVIDER}/connection`,
+            `/api/git-providers/${PROVIDER}/organizations`,
+            `/api/git-providers/${PROVIDER}/repositories`,
+            `/api/git-providers/${PROVIDER}/user`,
+        ];
+        for (const route of routes) {
+            const res = await request.get(`${API_BASE}${route}`);
+            expect(res.status(), `anon ${route} → 401`).toBe(401);
+        }
+    });
+});
+
+test.describe('flow: cross-user isolation of the sub-resource envelopes', () => {
+    test('two fresh users fan out the same sub-resources and each receives its OWN clean disconnected envelope with no cross-user id leak', async ({
+        request,
+    }) => {
+        const userA = await registerUserViaAPI(request);
+        const userB = await registerUserViaAPI(request);
+        expect(userA.user.id, 'two distinct user ids').not.toBe(userB.user.id);
+        const hA = authedHeaders(userA.access_token);
+        const hB = authedHeaders(userB.access_token);
+
+        // Fan out all three sub-resources per user concurrently — each user's
+        // envelope must be its own clean disconnected envelope, and neither user's
+        // error may name the OTHER user's id (no cross-user leak through the
+        // controller's shared service).
+        const subPaths = ['organizations', 'repositories', 'user'] as const;
+
+        const fetchAll = (h: Record<string, string>) =>
+            Promise.all(
+                subPaths.map((p) =>
+                    request.get(`${API_BASE}/api/git-providers/${PROVIDER}/${p}`, { headers: h }),
+                ),
+            );
+
+        const [aResponses, bResponses] = await Promise.all([fetchAll(hA), fetchAll(hB)]);
+
+        for (let i = 0; i < subPaths.length; i++) {
+            const path = subPaths[i];
+
+            const aBody = (await aResponses[i].json()) as SubResourceEnvelope;
+            expect(aResponses[i].status(), `A ${path} → 200`).toBe(200);
+            expect(aBody.success, `A ${path} → success:false`).toBe(false);
+            const aErr = String(aBody.error ?? '');
+            expect(aErr, `A ${path} error does not leak A's own id`).not.toContain(userA.user.id);
+            expect(aErr, `A ${path} error does not name B's id`).not.toContain(userB.user.id);
+
+            const bBody = (await bResponses[i].json()) as SubResourceEnvelope;
+            expect(bResponses[i].status(), `B ${path} → 200`).toBe(200);
+            expect(bBody.success, `B ${path} → success:false`).toBe(false);
+            const bErr = String(bBody.error ?? '');
+            expect(bErr, `B ${path} error does not leak B's own id`).not.toContain(userB.user.id);
+            expect(bErr, `B ${path} error does not name A's id`).not.toContain(userA.user.id);
+        }
+    });
+});
+
+/**
+ * Keep the APIRequestContext type import load-bearing for envs where the inline
+ * helper signatures are tree-shaken by the linter.
+ */
+export type _GitProvidersDeepFlowRequest = APIRequestContext;

--- a/apps/web/e2e/flow-github-app-surface.spec.ts
+++ b/apps/web/e2e/flow-github-app-surface.spec.ts
@@ -1,0 +1,443 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * GitHub-App controller surface — deep authz + contract coverage of the
+ * thinly-tested `GitHubAppController` (apps/api/src/integrations/
+ * github-app/github-app.controller.ts) and the public callback/setup/
+ * webhook gating around it.
+ *
+ * NON-DUPLICATION
+ * ---------------
+ * `flow-work-webhook-signatures.spec.ts` already owns the INBOUND
+ * `POST /api/github-app/webhooks` SIGNATURE matrix (forged full-length
+ * HMAC, sha1=/raw-hex/Bearer/empty-digest prefix discipline, unknown
+ * event types, and the missing-`X-GitHub-Event` 400). This file does
+ * NOT re-assert any of that. It covers the OTHER guard on the same
+ * receiver (the `rawBody`-presence 400, which is ordered AFTER the
+ * event-name guard but BEFORE the signature verifier) and the
+ * wrong-HTTP-method 404 — then spends the rest of its budget on the
+ * AUTHENTICATED surfaces (`installations` list, `sync`, `onboard`) and
+ * the PUBLIC OAuth `setup` / `callback` DTO + state gating, which no
+ * sibling touches. The cross-user IDOR matrix in
+ * `flow-idor-resource-access.spec.ts` covers works/agents/tasks/etc. —
+ * NOT the github-app routes, which are exercised here.
+ *
+ * PROBED CONTRACTS (live API @ 127.0.0.1:3100, sqlite in-memory CI
+ * driver; `GITHUB_APP_ID=999999` is a fake app id so any code path that
+ * reaches the real GitHub API fails closed). Every status/shape below
+ * was curl-probed with throwaway users BEFORE being asserted:
+ *
+ *   Auth        POST /api/auth/register {username,email,password} →
+ *               {access_token, user:{id,email,username}}.
+ *
+ *   Installations list — GET /api/github-app/installations (authed,
+ *               AuthSessionGuard — NO @Public):
+ *                 - anon / malformed bearer → 401 {message:'Unauthorized',
+ *                   statusCode:401}.
+ *                 - authed, no installations → 200 `[]` (JSON array,
+ *                   `application/json; charset=utf-8`).
+ *                 - CONTRACT (Wave M #138): each installation row is
+ *                   built by stripping `rawPayload` in
+ *                   GitHubAppSyncService.listInstallationsForUser — the
+ *                   internal GitHub webhook audit blob is NEVER returned.
+ *                   We pin the field's absence (and on the empty list,
+ *                   the absence of the literal token anywhere in the
+ *                   body) so a regression that spreads the raw entity
+ *                   reddens.
+ *
+ *   Sync — POST /api/github-app/installations/:installationId/sync
+ *               (authed):
+ *                 - anon → 401 Unauthorized.
+ *                 - authed, installation unknown to this user → 401
+ *                   {message:'GitHub App installation not found for this
+ *                   user', error:'Unauthorized', statusCode:401} (the
+ *                   controller maps the service's null → 401; a
+ *                   non-numeric installationId takes the SAME path —
+ *                   there is no uuid/int pipe, the id is looked up as an
+ *                   opaque string and simply misses).
+ *
+ *   Onboard — POST /api/github-app/installations/:installationId/
+ *               repositories/:repositoryId/onboard (authed):
+ *                 - anon → 401 Unauthorized.
+ *                 - authed, installation unknown to this user → 404
+ *                   {message:'GitHub App repository not found for this
+ *                   user', error:'Not Found', statusCode:404} (distinct
+ *                   status from sync's 401 — pinned as a contract).
+ *
+ *   Setup — GET /api/github-app/setup (@Public, GitHubAppSetupQueryDto):
+ *                 - missing installation_id → 400
+ *                   {message:['installation_id must be a string'],...}.
+ *                 - setup_action not in {install,request} → 400
+ *                   {message:['setup_action must be one of the following
+ *                   values: install, request'],...}.
+ *                 - valid-shape installation_id → reaches
+ *                   beginSetup→getInstallation which calls the real
+ *                   GitHub API with the fake app id and fails ⇒ 500
+ *                   {statusCode:500,message:'Internal server error'} — a
+ *                   GENERIC envelope that leaks no app id / token / stack.
+ *
+ *   Callback — GET /api/github-app/callback (@Public,
+ *               GitHubAppCallbackQueryDto + HMAC state):
+ *                 - missing code AND state → 400 with BOTH
+ *                   ['code must be a string','state must be a string'].
+ *                 - missing state only → 400 ['state must be a string'].
+ *                 - code+state present but state not HMAC-signed → 400
+ *                   {message:'Invalid GitHub App state signature',
+ *                   error:'Bad Request'} (signed-state guard, NOT a 500).
+ *
+ *   Webhook receiver — POST /api/github-app/webhooks (@Public):
+ *                 - X-GitHub-Event present but NO body (rawBody absent) →
+ *                   400 {message:'Missing raw webhook payload', error:
+ *                   'Bad Request'} (the rawBody guard, ordered after the
+ *                   event-name guard, before signature verification —
+ *                   NOT covered by the signature sibling).
+ *                 - GET /api/github-app/webhooks (wrong method) → 404
+ *                   "Cannot GET /api/github-app/webhooks".
+ *
+ * ISOLATION: every authed assertion uses a FRESH registerUserViaAPI()
+ * user (never the seeded chat user — a user-scoped key would shadow the
+ * env key and break sibling chat specs). Anonymous requests pass NO
+ * Authorization header; the API is Bearer-token authed (not cookie), so
+ * the absence of the header IS the anonymous identity regardless of the
+ * project's stored web storageState. Unique suffixes derive from the
+ * test title via a per-describe counter — no clock is read at module
+ * scope.
+ */
+
+const GH = '/api/github-app';
+const INSTALLATIONS = `${GH}/installations`;
+const SETUP = `${GH}/setup`;
+const CALLBACK = `${GH}/callback`;
+const WEBHOOKS = `${GH}/webhooks`;
+
+/** Per-file counter for unique-but-deterministic suffixes (no module-scope clock). */
+let seq = 0;
+function suffix(): string {
+    seq += 1;
+    return `gh${seq}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+interface Actor {
+    user: Awaited<ReturnType<typeof registerUserViaAPI>>;
+    headers: { Authorization: string };
+}
+
+async function makeActor(request: APIRequestContext): Promise<Actor> {
+    const user = await registerUserViaAPI(request);
+    return { user, headers: authedHeaders(user.access_token) };
+}
+
+/** Tokens that must never surface in an error body for this surface. */
+const LEAK_TOKENS = [
+    'rawpayload',
+    'access_token',
+    'client_secret',
+    'webhook secret',
+    'private key',
+    '-----begin',
+    '    at ', // node stack-frame indent
+    'node_modules',
+    'queryfailederror',
+];
+
+async function assertNoLeak(
+    res: { text(): Promise<string> },
+    context: string,
+): Promise<string> {
+    const raw = await res.text();
+    const lower = raw.toLowerCase();
+    for (const token of LEAK_TOKENS) {
+        expect(lower, `${context} leaked '${token}' → ${raw.slice(0, 200)}`).not.toContain(token);
+    }
+    return raw;
+}
+
+test.describe('GitHub-App controller surface — authz + contracts', () => {
+    // ── 1 ── installations list: anonymous is rejected with the NestJS
+    //         guard envelope (Bearer-auth, not cookie) — both no-header
+    //         and a malformed bearer collapse to the same opaque 401.
+    test('installations list — anonymous and malformed-bearer both 401, never an array', async ({
+        request,
+    }) => {
+        const anon = await request.get(`${API_BASE}${INSTALLATIONS}`);
+        expect(anon.status(), 'anon installations list').toBe(401);
+        const anonBody = JSON.parse(await assertNoLeak(anon, 'anon installations')) as {
+            message: string;
+            statusCode: number;
+        };
+        expect(anonBody.statusCode).toBe(401);
+        expect(anonBody.message).toBe('Unauthorized');
+
+        const bad = await request.get(`${API_BASE}${INSTALLATIONS}`, {
+            headers: { Authorization: 'Bearer not-a-real-token' },
+        });
+        expect(bad.status(), 'malformed bearer installations list').toBe(401);
+        // A garbage token must be indistinguishable from no token: same
+        // status, same envelope — no "token exists but is wrong" oracle.
+        const badBody = JSON.parse(await assertNoLeak(bad, 'bad-bearer installations')) as {
+            message: string;
+            statusCode: number;
+        };
+        expect(badBody.statusCode).toBe(401);
+        expect(badBody.message).toBe('Unauthorized');
+    });
+
+    // ── 2 ── installations list: a fresh authed user with no GitHub App
+    //         connected gets an EMPTY ARRAY (the unconfigured state), not
+    //         a 404/500 — and the body carries no `rawPayload` token.
+    test('installations list — fresh user sees an empty JSON array (unconfigured state), 200', async ({
+        request,
+    }) => {
+        const a = await makeActor(request);
+        const res = await request.get(`${API_BASE}${INSTALLATIONS}`, { headers: a.headers });
+        expect(res.status(), 'authed empty installations').toBe(200);
+        expect(res.headers()['content-type'] ?? '').toContain('application/json');
+        const raw = await assertNoLeak(res, 'authed installations');
+        const body = JSON.parse(raw) as unknown[];
+        expect(Array.isArray(body), 'installations list is a JSON array').toBe(true);
+        expect(body.length, 'a brand-new user owns no installations').toBe(0);
+        // Wave M #138 contract: the raw audit blob never appears even as a
+        // bare token in the serialized list.
+        expect(raw.toLowerCase()).not.toContain('rawpayload');
+    });
+
+    // ── 3 ── sync: anonymous is 401 (the @Public webhook routes do not
+    //         leak onto the guarded sync route).
+    test('sync — anonymous POST is 401, never reaches the sync service', async ({ request }) => {
+        const res = await request.post(`${API_BASE}${INSTALLATIONS}/123456/sync`);
+        expect(res.status(), 'anon sync').toBe(401);
+        const body = JSON.parse(await assertNoLeak(res, 'anon sync')) as { statusCode: number };
+        expect(body.statusCode).toBe(401);
+    });
+
+    // ── 4 ── sync: an authed user syncing an installation that does not
+    //         belong to them gets the service-null → 401 mapping with the
+    //         exact "not found for this user" message. A non-numeric id
+    //         takes the SAME path (no pipe), proving it's a lookup miss,
+    //         not an input-validation 400 — and is indistinguishable from
+    //         a numeric unknown id (no existence oracle).
+    test('sync — unknown installation (numeric & non-numeric) is a 401 "not found for this user", no enumeration oracle', async ({
+        request,
+    }) => {
+        const a = await makeActor(request);
+
+        const numeric = await request.post(`${API_BASE}${INSTALLATIONS}/9999999/sync`, {
+            headers: a.headers,
+        });
+        expect(numeric.status(), 'authed unknown numeric installation sync').toBe(401);
+        const numBody = JSON.parse(await assertNoLeak(numeric, 'sync unknown numeric')) as {
+            message: string;
+            statusCode: number;
+        };
+        expect(numBody.statusCode).toBe(401);
+        expect(numBody.message).toBe('GitHub App installation not found for this user');
+
+        const nonNumeric = await request.post(
+            `${API_BASE}${INSTALLATIONS}/abc-not-numeric/sync`,
+            { headers: a.headers },
+        );
+        expect(nonNumeric.status(), 'authed non-numeric installation sync').toBe(401);
+        const nnBody = JSON.parse(await assertNoLeak(nonNumeric, 'sync non-numeric')) as {
+            message: string;
+        };
+        // Same opaque message → the id shape is not an oracle; both are
+        // plain lookup misses on the createdByUserId-scoped query.
+        expect(nnBody.message).toBe('GitHub App installation not found for this user');
+    });
+
+    // ── 5 ── sync cross-user: a SECOND fresh user gets the same 401 for
+    //         the same id the first user also can't see — neither owns it,
+    //         so the response is identical (the scope filter is per-user,
+    //         and an unowned id never differs from a never-existed one).
+    test('sync — two distinct users hit the identical 401 for the same unowned installation id', async ({
+        request,
+    }) => {
+        const alice = await makeActor(request);
+        const bob = await makeActor(request);
+        // A large numeric id that no fresh-DB installation owns. `seq` is
+        // a digit so the strip never empties; the trailing digits keep it
+        // numeric-shaped (the route has no pipe, so shape is irrelevant —
+        // it's purely a guaranteed-miss lookup key).
+        const id = `8800${seq}${Date.now().toString().slice(-5)}`;
+
+        const aRes = await request.post(`${API_BASE}${INSTALLATIONS}/${id}/sync`, {
+            headers: alice.headers,
+        });
+        const bRes = await request.post(`${API_BASE}${INSTALLATIONS}/${id}/sync`, {
+            headers: bob.headers,
+        });
+        expect(aRes.status(), 'alice sync unowned').toBe(401);
+        expect(bRes.status(), 'bob sync unowned').toBe(401);
+        const aMsg = (JSON.parse(await aRes.text()) as { message: string }).message;
+        const bMsg = (JSON.parse(await bRes.text()) as { message: string }).message;
+        expect(aMsg).toBe('GitHub App installation not found for this user');
+        expect(bMsg, 'both users see the byte-identical not-found').toBe(aMsg);
+    });
+
+    // ── 6 ── onboard: anonymous is 401.
+    test('onboard — anonymous POST is 401', async ({ request }) => {
+        const res = await request.post(
+            `${API_BASE}${INSTALLATIONS}/123/repositories/456/onboard`,
+        );
+        expect(res.status(), 'anon onboard').toBe(401);
+        const body = JSON.parse(await assertNoLeak(res, 'anon onboard')) as { statusCode: number };
+        expect(body.statusCode).toBe(401);
+    });
+
+    // ── 7 ── onboard: an authed user onboarding under an installation
+    //         they don't own gets 404 (DISTINCT from sync's 401 — the
+    //         controller throws NotFoundException for the repo route).
+    //         Pinning the status divergence guards against a refactor that
+    //         accidentally unifies the two error shapes.
+    test('onboard — unknown installation/repo is a 404 "repository not found", distinct from sync 401', async ({
+        request,
+    }) => {
+        const a = await makeActor(request);
+        const res = await request.post(
+            `${API_BASE}${INSTALLATIONS}/999/repositories/456/onboard`,
+            { headers: a.headers },
+        );
+        expect(res.status(), 'authed unknown onboard').toBe(404);
+        const body = JSON.parse(await assertNoLeak(res, 'onboard unknown')) as {
+            message: string;
+            error: string;
+            statusCode: number;
+        };
+        expect(body.statusCode).toBe(404);
+        expect(body.error).toBe('Not Found');
+        expect(body.message).toBe('GitHub App repository not found for this user');
+
+        // Contrast contract: the SAME unknown installation on the SYNC
+        // route is a 401, not a 404 — the two guarded routes report
+        // different statuses by design.
+        const sync = await request.post(`${API_BASE}${INSTALLATIONS}/999/sync`, {
+            headers: a.headers,
+        });
+        expect(sync.status(), 'sync of the same unknown id stays 401').toBe(401);
+    });
+
+    // ── 8 ── setup: DTO validation. Missing installation_id and an
+    //         out-of-enum setup_action are class-validator 400s with the
+    //         field-named messages (the @Public route still validates).
+    test('setup — missing installation_id and bad setup_action are field-named 400s', async ({
+        request,
+    }) => {
+        const missing = await request.get(`${API_BASE}${SETUP}`);
+        expect(missing.status(), 'setup missing installation_id').toBe(400);
+        const missingBody = JSON.parse(await assertNoLeak(missing, 'setup missing id')) as {
+            message: string[];
+            statusCode: number;
+        };
+        expect(missingBody.statusCode).toBe(400);
+        expect(missingBody.message).toContain('installation_id must be a string');
+
+        const badAction = await request.get(
+            `${API_BASE}${SETUP}?installation_id=123&setup_action=bogus`,
+        );
+        expect(badAction.status(), 'setup bad setup_action').toBe(400);
+        const badBody = JSON.parse(await assertNoLeak(badAction, 'setup bad action')) as {
+            message: string[];
+        };
+        expect(
+            badBody.message.some((m) => m.includes('install, request')),
+            'enum message names the allowed values',
+        ).toBe(true);
+    });
+
+    // ── 9 ── setup: a valid-shape installation_id reaches the GitHub API
+    //         (fake app id 999999) which fails ⇒ a GENERIC 500 envelope.
+    //         The unconfigured/fake-app outcome must NOT leak the app id,
+    //         a token, or a stack trace — it is the sanitized
+    //         "Internal server error".
+    test('setup — valid-shape id with the fake CI app fails closed as a generic 500 (no app-id/token/stack leak)', async ({
+        request,
+    }) => {
+        const res = await request.get(`${API_BASE}${SETUP}?installation_id=55512345`);
+        expect(res.status(), 'setup fake-app outcome').toBe(500);
+        const raw = await assertNoLeak(res, 'setup fake-app 500');
+        const body = JSON.parse(raw) as { statusCode: number; message: string };
+        expect(body.statusCode).toBe(500);
+        expect(body.message, 'generic envelope, no internals').toBe('Internal server error');
+        // The fake app id must not bleed into the client response.
+        expect(raw).not.toContain('999999');
+    });
+
+    // ── 10 ── callback: DTO validation. Both fields missing names BOTH;
+    //          dropping only state names only state — the message array is
+    //          precise per-field (class-validator), and it's a 400 BEFORE
+    //          any state/HMAC work.
+    test('callback — missing code/state produce precise per-field 400s', async ({ request }) => {
+        const both = await request.get(`${API_BASE}${CALLBACK}`);
+        expect(both.status(), 'callback no params').toBe(400);
+        const bothBody = JSON.parse(await assertNoLeak(both, 'callback no params')) as {
+            message: string[];
+        };
+        expect(bothBody.message).toContain('code must be a string');
+        expect(bothBody.message).toContain('state must be a string');
+
+        const onlyCode = await request.get(`${API_BASE}${CALLBACK}?code=abc`);
+        expect(onlyCode.status(), 'callback code-only').toBe(400);
+        const onlyCodeBody = JSON.parse(await assertNoLeak(onlyCode, 'callback code-only')) as {
+            message: string[];
+        };
+        expect(onlyCodeBody.message).toContain('state must be a string');
+        expect(
+            onlyCodeBody.message,
+            'a supplied code is not re-flagged',
+        ).not.toContain('code must be a string');
+    });
+
+    // ── 11 ── callback: code+state present but state is not HMAC-signed →
+    //          the signed-state guard returns 400 "Invalid GitHub App
+    //          state signature" — a clean BadRequest, NOT a 500, and the
+    //          supplied bogus state is not echoed back.
+    test('callback — an unsigned/forged state is a 400 signature rejection, never a 500 or echo', async ({
+        request,
+    }) => {
+        const forgedState = `forged-${suffix()}.notarealsignature`;
+        const res = await request.get(
+            `${API_BASE}${CALLBACK}?code=abc&state=${encodeURIComponent(forgedState)}`,
+        );
+        expect(res.status(), 'callback forged state').toBe(400);
+        const raw = await assertNoLeak(res, 'callback forged state');
+        const body = JSON.parse(raw) as { message: string; error: string };
+        expect(body.error).toBe('Bad Request');
+        expect(body.message).toBe('Invalid GitHub App state signature');
+        // The forged value must not be reflected (no error-echo / XSS vector).
+        expect(raw).not.toContain(forgedState);
+    });
+
+    // ── 12 ── webhook receiver: the rawBody-presence guard (distinct from
+    //          the signature matrix the sibling owns) — an event header
+    //          with NO body is a 400 "Missing raw webhook payload"; and a
+    //          GET on the POST-only route is a 404. Both prove the public
+    //          receiver is shaped correctly before authenticity is even
+    //          considered.
+    test('webhook receiver — missing rawBody is a 400 (distinct guard) and wrong method is a 404', async ({
+        request,
+    }) => {
+        // Event header present, but no request body → the rawBody guard
+        // fires (ordered after event-name, before signature verification).
+        const noBody = await request.post(`${API_BASE}${WEBHOOKS}`, {
+            headers: { 'X-GitHub-Event': 'ping' },
+        });
+        expect(noBody.status(), 'webhook missing rawBody').toBe(400);
+        const noBodyJson = JSON.parse(await assertNoLeak(noBody, 'webhook no body')) as {
+            message: string;
+            error: string;
+        };
+        expect(noBodyJson.error).toBe('Bad Request');
+        expect(noBodyJson.message).toBe('Missing raw webhook payload');
+
+        // Wrong method on the webhook path → NestJS 404 route-not-found.
+        const wrongMethod = await request.get(`${API_BASE}${WEBHOOKS}`);
+        expect(wrongMethod.status(), 'GET on POST-only webhook route').toBe(404);
+        const wmJson = JSON.parse(await assertNoLeak(wrongMethod, 'webhook wrong method')) as {
+            message: string;
+            statusCode: number;
+        };
+        expect(wmJson.statusCode).toBe(404);
+        expect(wmJson.message).toContain('Cannot GET');
+    });
+});

--- a/apps/web/e2e/flow-github-app-surface.spec.ts
+++ b/apps/web/e2e/flow-github-app-surface.spec.ts
@@ -141,10 +141,7 @@ const LEAK_TOKENS = [
     'queryfailederror',
 ];
 
-async function assertNoLeak(
-    res: { text(): Promise<string> },
-    context: string,
-): Promise<string> {
+async function assertNoLeak(res: { text(): Promise<string> }, context: string): Promise<string> {
     const raw = await res.text();
     const lower = raw.toLowerCase();
     for (const token of LEAK_TOKENS) {
@@ -233,10 +230,9 @@ test.describe('GitHub-App controller surface — authz + contracts', () => {
         expect(numBody.statusCode).toBe(401);
         expect(numBody.message).toBe('GitHub App installation not found for this user');
 
-        const nonNumeric = await request.post(
-            `${API_BASE}${INSTALLATIONS}/abc-not-numeric/sync`,
-            { headers: a.headers },
-        );
+        const nonNumeric = await request.post(`${API_BASE}${INSTALLATIONS}/abc-not-numeric/sync`, {
+            headers: a.headers,
+        });
         expect(nonNumeric.status(), 'authed non-numeric installation sync').toBe(401);
         const nnBody = JSON.parse(await assertNoLeak(nonNumeric, 'sync non-numeric')) as {
             message: string;
@@ -277,9 +273,7 @@ test.describe('GitHub-App controller surface — authz + contracts', () => {
 
     // ── 6 ── onboard: anonymous is 401.
     test('onboard — anonymous POST is 401', async ({ request }) => {
-        const res = await request.post(
-            `${API_BASE}${INSTALLATIONS}/123/repositories/456/onboard`,
-        );
+        const res = await request.post(`${API_BASE}${INSTALLATIONS}/123/repositories/456/onboard`);
         expect(res.status(), 'anon onboard').toBe(401);
         const body = JSON.parse(await assertNoLeak(res, 'anon onboard')) as { statusCode: number };
         expect(body.statusCode).toBe(401);
@@ -294,10 +288,9 @@ test.describe('GitHub-App controller surface — authz + contracts', () => {
         request,
     }) => {
         const a = await makeActor(request);
-        const res = await request.post(
-            `${API_BASE}${INSTALLATIONS}/999/repositories/456/onboard`,
-            { headers: a.headers },
-        );
+        const res = await request.post(`${API_BASE}${INSTALLATIONS}/999/repositories/456/onboard`, {
+            headers: a.headers,
+        });
         expect(res.status(), 'authed unknown onboard').toBe(404);
         const body = JSON.parse(await assertNoLeak(res, 'onboard unknown')) as {
             message: string;
@@ -382,10 +375,9 @@ test.describe('GitHub-App controller surface — authz + contracts', () => {
             message: string[];
         };
         expect(onlyCodeBody.message).toContain('state must be a string');
-        expect(
-            onlyCodeBody.message,
-            'a supplied code is not re-flagged',
-        ).not.toContain('code must be a string');
+        expect(onlyCodeBody.message, 'a supplied code is not re-flagged').not.toContain(
+            'code must be a string',
+        );
     });
 
     // ── 11 ── callback: code+state present but state is not HMAC-signed →

--- a/apps/web/e2e/flow-register-work-flow.spec.ts
+++ b/apps/web/e2e/flow-register-work-flow.spec.ts
@@ -117,7 +117,8 @@ async function postRegisterWork(
         }
         // Drained bucket: honour the route's reset window then try once more.
         const retryAfter = Number(res.headers()['retry-after-long'] ?? '');
-        const waitMs = Number.isFinite(retryAfter) && retryAfter > 0 ? (retryAfter + 1) * 1000 : 5000;
+        const waitMs =
+            Number.isFinite(retryAfter) && retryAfter > 0 ? (retryAfter + 1) * 1000 : 5000;
         if (attempt === 0) {
             await new Promise((resolve) => setTimeout(resolve, Math.min(waitMs, 65_000)));
         } else {
@@ -146,7 +147,11 @@ test.describe('register-work — credential & status state machine (GET, unthrot
     test('GET status: unknown-but-well-formed uuid → 404 not_found (no id enumeration behind a token)', async ({
         request,
     }) => {
-        const { status, body } = await getStatus(request, PARAM_UUID_UNKNOWN, UNRESOLVABLE_GH_TOKEN);
+        const { status, body } = await getStatus(
+            request,
+            PARAM_UUID_UNKNOWN,
+            UNRESOLVABLE_GH_TOKEN,
+        );
         // Row lookup precedes credential resolution: an unknown id is a clean 404,
         // NOT a 403 — so a caller cannot probe which onboarding ids exist.
         expect(status, 'unknown onboarding id is 404').toBe(404);
@@ -168,7 +173,11 @@ test.describe('register-work — credential & status state machine (GET, unthrot
     test('GET status: non-uuid id → 400 ParseUUIDPipe (validation precedes the handler)', async ({
         request,
     }) => {
-        const { status, body } = await getStatus(request, 'not-a-valid-uuid', UNRESOLVABLE_GH_TOKEN);
+        const { status, body } = await getStatus(
+            request,
+            'not-a-valid-uuid',
+            UNRESOLVABLE_GH_TOKEN,
+        );
         expect(status, 'non-uuid path param is rejected by the pipe').toBe(400);
         expect(body.statusCode).toBe(400);
         expect(body.error).toBe('Bad Request');
@@ -222,7 +231,11 @@ test.describe('register-work — registration validation gate (POST, throttle-bu
     test('POST: empty body (token present) → 400 class-validator array citing the required repo field', async ({
         request,
     }) => {
-        const { status, body, throttled } = await postRegisterWork(request, {}, UNRESOLVABLE_GH_TOKEN);
+        const { status, body, throttled } = await postRegisterWork(
+            request,
+            {},
+            UNRESOLVABLE_GH_TOKEN,
+        );
         test.skip(throttled, 'shared-IP @Throttle bucket drained — DTO gate not reachable');
         expect(status, 'missing repo fails DTO validation').toBe(400);
         expect(body.statusCode).toBe(400);

--- a/apps/web/e2e/flow-register-work-flow.spec.ts
+++ b/apps/web/e2e/flow-register-work-flow.spec.ts
@@ -1,0 +1,351 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE } from './helpers/api';
+
+/**
+ * flow-register-work-flow.spec.ts — DEEP, register-work-specific contract matrix
+ * for the agent zero-friction onboarding controller
+ * (apps/api/src/onboarding/onboarding.controller.ts → OnboardingService),
+ * exposed as `POST /api/register-work` (+ `GET /api/register-work/:id` status).
+ *
+ * Every status, typed `code`, message and shape below was PROBED against the
+ * LIVE stack (http://127.0.0.1:3100, sqlite CI driver, REQUIRE_EMAIL_VERIFICATION
+ * off, GITHUB_APP_ID=999999 fake, NO real GitHub reachability) on 2026-06-11
+ * BEFORE any assertion was written. This pins the platform's REAL behaviour.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * WHAT MAKES THIS CONTROLLER TESTABLE-BUT-CONSTRAINED IN THIS ENV:
+ *   • register-work is `@Public()` — identity is NOT the Ever Works `access_token`;
+ *     it travels in the `X-GitHub-Token` HEADER. `OnboardingService.resolveGitHubIdentity`
+ *     calls the real GitHub API. In this KEYLESS / fake-GitHub-App env that call
+ *     ALWAYS fails → a successful 202 onboarding (account+Work creation, the
+ *     `validated`→`queued` happy path) is UNREACHABLE locally. So this file pins
+ *     the REACHABLE state machine: the validation gate (400), the credential
+ *     resolution gate (401 malformed vs 403 unresolvable), and the status-read
+ *     enumeration protection (404 not_found / 403 owner-mismatch). It asserts
+ *     RECORDS / typed error CONTRACTS, never a completion (house rule: keyless env).
+ *   • POST /api/register-work carries a TIGHT per-route `@Throttle(long:10/min/IP)`
+ *     that is NOT disabled in e2e. Every POST (even a 400) consumes the bucket, and
+ *     the bucket is shared per-IP across workers/shards. So: POST tests run SERIAL,
+ *     go through a retry-on-429 helper, and are kept few. The GET status route has
+ *     NO per-route @Throttle (rides the global long:1000/60s tier → effectively
+ *     unlimited here) — the credential/enumeration/uuid contracts live on GET.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * NON-DUPLICATION (both siblings READ in full before writing this file):
+ *   • flow-public-api-contract.spec.ts — pins the PUBLIC-SURFACE CENSUS + 3-tier
+ *     rate-limit posture, treating register-work as ONE of many public routes with
+ *     throttle-TOLERANT ".or 429" branching (it never asserts an exact typed code,
+ *     only "4xx-ish, never 5xx, never 401"). This file goes DEEPER: it pins the
+ *     EXACT typed `code` per branch and the 401-vs-403 credential distinction.
+ *   • sec-pin-ssrf-contracts.spec.ts — pins ONLY the URL-SHAPE SSRF rejections
+ *     (`repo` GITHUB_HTTPS_REPO regex, `webhookUrl` scheme regex) + the 403 control.
+ *     This file deliberately does NOT re-assert those URL-shape rejections; it
+ *     covers the NON-URL field bounds (email / agentId printable-ASCII / subdomain
+ *     DNS / agentPayment object) and the credential + status + idempotency surface
+ *     that sec-pin does not touch.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * PROBED CONTRACTS (live, http 3100, 2026-06-11):
+ *   - POST /api/register-work, NO X-GitHub-Token header → 400
+ *       { statusCode:400, code:'validation_error', message:'X-GitHub-Token header is required' }
+ *       (controller-level guard, AFTER the feature flag, with a typed envelope).
+ *   - POST /api/register-work, token present, body {} → 400 class-validator array
+ *       { message:[...'repo must be a string'...], error:'Bad Request', statusCode:400 }.
+ *   - POST + token + bad NON-URL fields → 400 class-validator array with the EXACT
+ *       per-field message: email 'email must be an email'; agentId 'agentId must be
+ *       printable ASCII'; subdomain 'subdomain must be DNS-safe (lowercase, hyphens)';
+ *       agentPayment 'agentPayment must be an object'.
+ *   - POST + valid DTO + unresolvable GitHub token → 403
+ *       { statusCode:403, code:'gh_credential_invalid', message:'GitHub credential could not be resolved' }
+ *       (DTO passed → reached resolveGitHubIdentity → GitHub API rejected the token).
+ *   - POST + valid DTO + token shorter than 4 chars → 401
+ *       { statusCode:401, code:'gh_credential_invalid', message:'GitHub credential is missing or malformed' }
+ *       (the length<4 pre-check fires BEFORE any network call — distinct status from 403).
+ *   - GET /api/register-work/:id, well-formed-but-unknown uuid, any token → 404
+ *       { statusCode:404, code:'not_found', message:'unknown onboarding id' }
+ *       (row lookup precedes credential resolution → unknown id is 404, not 403:
+ *        no enumeration of which ids exist behind a token).
+ *   - GET /api/register-work/:id, NO X-GitHub-Token header → 403
+ *       { statusCode:403, code:'gh_credential_invalid', message:'X-GitHub-Token header is required' }.
+ *   - GET /api/register-work/:id, NON-uuid id → 400 (ParseUUIDPipe)
+ *       { message:'Validation failed (uuid is expected)', error:'Bad Request', statusCode:400 }.
+ *   - Throttle asymmetry: POST exhausts at 10/min/IP → 429
+ *       { statusCode:429, message:'ThrottlerException: Too Many Requests' }; the GET
+ *       status route does NOT (5 rapid GETs all answer 404, none 429).
+ */
+
+const PARAM_UUID_UNKNOWN = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const VALID_REPO = 'https://github.com/octocat/awesome-mcp';
+// Length>=4 so it passes the malformed pre-check and reaches the GitHub call →
+// guaranteed to be REJECTED by GitHub in this keyless env (never a real token).
+const UNRESOLVABLE_GH_TOKEN = 'ghp_e2e_fake_unresolvable_token_000';
+
+interface TypedError {
+    statusCode?: number;
+    code?: string;
+    message?: string | string[];
+    error?: string;
+}
+
+async function readJson(res: { json: () => Promise<unknown> }): Promise<TypedError> {
+    return (await res.json()) as TypedError;
+}
+
+function messageArray(body: TypedError): string[] {
+    return Array.isArray(body.message) ? body.message : [];
+}
+
+/**
+ * POST /api/register-work with a retry that absorbs the per-route
+ * @Throttle(long:10/min/IP). On a 429 (shared-IP bucket drained by a sibling
+ * shard / the other worker), wait out the route's own reset window and retry
+ * ONCE. A second 429 surfaces a `throttled` marker so the caller can skip the
+ * contract assertion rather than red the run on infrastructure contention.
+ */
+async function postRegisterWork(
+    request: APIRequestContext,
+    body: Record<string, unknown>,
+    githubToken?: string,
+): Promise<{ status: number; body: TypedError; throttled: boolean }> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (githubToken) headers['X-GitHub-Token'] = githubToken;
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+        const res = await request.post(`${API_BASE}/api/register-work`, { headers, data: body });
+        if (res.status() !== 429) {
+            return { status: res.status(), body: await readJson(res), throttled: false };
+        }
+        // Drained bucket: honour the route's reset window then try once more.
+        const retryAfter = Number(res.headers()['retry-after-long'] ?? '');
+        const waitMs = Number.isFinite(retryAfter) && retryAfter > 0 ? (retryAfter + 1) * 1000 : 5000;
+        if (attempt === 0) {
+            await new Promise((resolve) => setTimeout(resolve, Math.min(waitMs, 65_000)));
+        } else {
+            return { status: 429, body: await readJson(res), throttled: true };
+        }
+    }
+    return { status: 429, body: {}, throttled: true };
+}
+
+async function getStatus(
+    request: APIRequestContext,
+    id: string,
+    githubToken?: string,
+): Promise<{ status: number; body: TypedError }> {
+    const headers: Record<string, string> = {};
+    if (githubToken) headers['X-GitHub-Token'] = githubToken;
+    const res = await request.get(`${API_BASE}/api/register-work/${id}`, { headers });
+    return { status: res.status(), body: await readJson(res) };
+}
+
+// POSTs share the per-IP @Throttle(long:10/min) bucket — run them in declared
+// order so the retry-on-429 helper never races itself across the two workers.
+test.describe.configure({ mode: 'serial' });
+
+test.describe('register-work — credential & status state machine (GET, unthrottled)', () => {
+    test('GET status: unknown-but-well-formed uuid → 404 not_found (no id enumeration behind a token)', async ({
+        request,
+    }) => {
+        const { status, body } = await getStatus(request, PARAM_UUID_UNKNOWN, UNRESOLVABLE_GH_TOKEN);
+        // Row lookup precedes credential resolution: an unknown id is a clean 404,
+        // NOT a 403 — so a caller cannot probe which onboarding ids exist.
+        expect(status, 'unknown onboarding id is 404').toBe(404);
+        expect(body.statusCode).toBe(404);
+        expect(body.code, 'typed not_found code').toBe('not_found');
+        expect(body.message).toBe('unknown onboarding id');
+    });
+
+    test('GET status: missing X-GitHub-Token header → 403 gh_credential_invalid (never 401, public route)', async ({
+        request,
+    }) => {
+        const { status, body } = await getStatus(request, PARAM_UUID_UNKNOWN);
+        expect(status, 'status read without proof token is forbidden').toBe(403);
+        expect(body.statusCode).toBe(403);
+        expect(body.code, 'typed credential code on the status gate').toBe('gh_credential_invalid');
+        expect(body.message).toBe('X-GitHub-Token header is required');
+    });
+
+    test('GET status: non-uuid id → 400 ParseUUIDPipe (validation precedes the handler)', async ({
+        request,
+    }) => {
+        const { status, body } = await getStatus(request, 'not-a-valid-uuid', UNRESOLVABLE_GH_TOKEN);
+        expect(status, 'non-uuid path param is rejected by the pipe').toBe(400);
+        expect(body.statusCode).toBe(400);
+        expect(body.error).toBe('Bad Request');
+        expect(body.message).toBe('Validation failed (uuid is expected)');
+    });
+
+    test('GET status: token-gate runs BEFORE the uuid lookup branch — a no-token read is 403 even for a valid-shaped id', async ({
+        request,
+    }) => {
+        // Distinct from the 404 case above: with NO token the request is refused
+        // at the proof-token gate (403) — it never reaches the row lookup, so a
+        // valid-shaped unknown id does NOT leak as 404 to an unauthenticated caller.
+        const { status, body } = await getStatus(request, PARAM_UUID_UNKNOWN);
+        expect(status).toBe(403);
+        expect(body.code).toBe('gh_credential_invalid');
+        // And a different valid-shaped id behaves identically (no per-id fork).
+        const second = await getStatus(request, '11111111-2222-3333-4444-555555555555');
+        expect(second.status).toBe(403);
+        expect(second.body.code).toBe('gh_credential_invalid');
+    });
+
+    test('GET status: route is NOT bound by the POST @Throttle(10/min) — 5 rapid reads all answer 404, none 429', async ({
+        request,
+    }) => {
+        const statuses: number[] = [];
+        for (let i = 0; i < 5; i++) {
+            const { status } = await getStatus(request, PARAM_UUID_UNKNOWN, UNRESOLVABLE_GH_TOKEN);
+            statuses.push(status);
+        }
+        expect(statuses, 'every status read resolves to the not_found contract').toEqual([
+            404, 404, 404, 404, 404,
+        ]);
+        expect(statuses, 'GET status never trips the tight per-route POST throttle').not.toContain(
+            429,
+        );
+    });
+});
+
+test.describe('register-work — registration validation gate (POST, throttle-budgeted)', () => {
+    test('POST: missing X-GitHub-Token header → 400 validation_error (typed envelope, before any GitHub call)', async ({
+        request,
+    }) => {
+        const { status, body, throttled } = await postRegisterWork(request, { repo: VALID_REPO });
+        test.skip(throttled, 'shared-IP @Throttle bucket drained — credential gate not reachable');
+        expect(status, 'a missing GH token is a 400, not a 403').toBe(400);
+        expect(body.statusCode).toBe(400);
+        expect(body.code, 'controller-level typed validation_error').toBe('validation_error');
+        expect(body.message).toBe('X-GitHub-Token header is required');
+    });
+
+    test('POST: empty body (token present) → 400 class-validator array citing the required repo field', async ({
+        request,
+    }) => {
+        const { status, body, throttled } = await postRegisterWork(request, {}, UNRESOLVABLE_GH_TOKEN);
+        test.skip(throttled, 'shared-IP @Throttle bucket drained — DTO gate not reachable');
+        expect(status, 'missing repo fails DTO validation').toBe(400);
+        expect(body.statusCode).toBe(400);
+        expect(body.error).toBe('Bad Request');
+        const msgs = messageArray(body);
+        expect(msgs, 'class-validator surfaces a message array').not.toHaveLength(0);
+        expect(
+            msgs.some((m) => m.includes('repo must be a string')),
+            'the required `repo` field is named in the validation array',
+        ).toBeTruthy();
+    });
+
+    test('POST: bad NON-URL optional fields each reject with their EXACT per-field message', async ({
+        request,
+    }) => {
+        // Deliberately NOT the URL-shape SSRF rejections (those are sec-pin-ssrf's
+        // turf). These are the non-URL DTO bounds: email / agentId / subdomain.
+        const { status, body, throttled } = await postRegisterWork(
+            request,
+            {
+                repo: VALID_REPO,
+                email: 'not-an-email',
+                agentId: 'agent\n123', // newline → not printable ASCII
+                subdomain: 'MyApp', // uppercase → not DNS-safe
+            },
+            UNRESOLVABLE_GH_TOKEN,
+        );
+        test.skip(throttled, 'shared-IP @Throttle bucket drained — DTO gate not reachable');
+        expect(status, 'bad optional fields fail DTO validation before any GitHub call').toBe(400);
+        const msgs = messageArray(body);
+        expect(msgs).toContain('email must be an email');
+        expect(msgs).toContain('agentId must be printable ASCII');
+        expect(msgs).toContain('subdomain must be DNS-safe (lowercase, hyphens)');
+    });
+
+    test('POST: agentPayment non-object → 400 IsObject (the reserved v2 payment envelope is type-checked even though ignored at v1)', async ({
+        request,
+    }) => {
+        const { status, body, throttled } = await postRegisterWork(
+            request,
+            { repo: VALID_REPO, agentPayment: 'not-an-object' },
+            UNRESOLVABLE_GH_TOKEN,
+        );
+        test.skip(throttled, 'shared-IP @Throttle bucket drained — DTO gate not reachable');
+        expect(status).toBe(400);
+        const msgs = messageArray(body);
+        expect(msgs).toContain('agentPayment must be an object');
+    });
+
+    test('POST: subdomain length boundary (2 chars) → 400 Length(3,63)', async ({ request }) => {
+        const { status, body, throttled } = await postRegisterWork(
+            request,
+            { repo: VALID_REPO, subdomain: 'ab' },
+            UNRESOLVABLE_GH_TOKEN,
+        );
+        test.skip(throttled, 'shared-IP @Throttle bucket drained — DTO gate not reachable');
+        expect(status, 'too-short subdomain fails the @Length bound').toBe(400);
+        const msgs = messageArray(body);
+        expect(
+            msgs.some((m) => m.toLowerCase().includes('subdomain')),
+            'the subdomain length violation is reported',
+        ).toBeTruthy();
+    });
+});
+
+test.describe('register-work — credential resolution gate (POST, throttle-budgeted)', () => {
+    test('POST: valid DTO + UNRESOLVABLE GitHub token → 403 gh_credential_invalid (DTO passed, GitHub API rejected the token — no 202, no side effect)', async ({
+        request,
+    }) => {
+        const { status, body, throttled } = await postRegisterWork(
+            request,
+            { repo: VALID_REPO },
+            UNRESOLVABLE_GH_TOKEN,
+        );
+        test.skip(throttled, 'shared-IP @Throttle bucket drained — credential gate not reachable');
+        // The DTO is valid, so we passed validation and reached resolveGitHubIdentity;
+        // the keyless/fake-GitHub-App env makes the token unresolvable → 403. Crucially
+        // this is NEVER a 202 here (no real GitHub) — the controller has no completion path.
+        expect(status, 'a valid DTO with a dead token is forbidden, not accepted').toBe(403);
+        expect(body.statusCode).toBe(403);
+        expect(body.code, 'typed credential-invalid code at the resolution gate').toBe(
+            'gh_credential_invalid',
+        );
+        expect(body.message).toBe('GitHub credential could not be resolved');
+    });
+
+    test('POST: token shorter than 4 chars → 401 (distinct from the 403 above — the malformed pre-check fires before any network call)', async ({
+        request,
+    }) => {
+        const { status, body, throttled } = await postRegisterWork(
+            request,
+            { repo: VALID_REPO },
+            'ab',
+        );
+        test.skip(throttled, 'shared-IP @Throttle bucket drained — credential gate not reachable');
+        // length<4 short-circuits in resolveGitHubIdentity with a 401 BEFORE the
+        // GitHub call — proving the credential gate distinguishes "malformed"
+        // (401) from "well-formed but unresolvable" (403).
+        expect(status, 'a malformed (too-short) token is 401, not 403').toBe(401);
+        expect(body.statusCode).toBe(401);
+        expect(body.code).toBe('gh_credential_invalid');
+        expect(body.message).toBe('GitHub credential is missing or malformed');
+    });
+
+    test('POST: Idempotency-Key header is accepted by the contract (does not alter the credential-gate outcome for a dead token)', async ({
+        request,
+    }) => {
+        // The Stripe-convention Idempotency-Key header is optional and must not
+        // change the validation/credential outcome — a dead token still 403s, the
+        // header is simply carried into the (unreached-here) persistence layer.
+        const res = await request.post(`${API_BASE}/api/register-work`, {
+            headers: {
+                'Content-Type': 'application/json',
+                'X-GitHub-Token': UNRESOLVABLE_GH_TOKEN,
+                'Idempotency-Key': '99999999-8888-7777-6666-555555555555',
+            },
+            data: { repo: VALID_REPO },
+        });
+        test.skip(res.status() === 429, 'shared-IP @Throttle bucket drained');
+        const body = (await res.json()) as TypedError;
+        // Either the credential gate (403) — the dominant outcome — proving the
+        // Idempotency-Key header is accepted and does not fork the contract.
+        expect(res.status(), 'idempotency-key does not change the dead-token outcome').toBe(403);
+        expect(body.code).toBe('gh_credential_invalid');
+    });
+});

--- a/apps/web/e2e/flow-screenshot-capability-deep.spec.ts
+++ b/apps/web/e2e/flow-screenshot-capability-deep.spec.ts
@@ -305,9 +305,10 @@ test.describe('Screenshot capability — deep: URL-security, signed-url matrix, 
         const avail = await checkAvailability(request, token, NONEXISTENT_WORK_UUID);
         expect(avail.status, 'check-availability foreign workId → 404').toBe(404);
         expect(avail.body.status, 'error envelope').toBe('error');
-        expect(messageText(avail.body as unknown as Record<string, unknown>), 'names the work').toMatch(
-            /Work with id .* not found/i,
-        );
+        expect(
+            messageText(avail.body as unknown as Record<string, unknown>),
+            'names the work',
+        ).toMatch(/Work with id .* not found/i);
 
         for (const op of ['get-url', 'capture'] as const) {
             const res = await postScreenshot(request, token, op, {
@@ -399,7 +400,8 @@ test.describe('Screenshot capability — deep: URL-security, signed-url matrix, 
         if (!screenshotIds.includes('urlbox')) {
             testInfo.annotations.push({
                 type: 'note',
-                description: 'urlbox not registered in this build — skipped its URL-shape assertions',
+                description:
+                    'urlbox not registered in this build — skipped its URL-shape assertions',
             });
             test.skip(true, 'urlbox not registered in this build');
             return;
@@ -437,7 +439,9 @@ test.describe('Screenshot capability — deep: URL-security, signed-url matrix, 
         expect(url, 'urlbox uses height= (not viewport_height)').toContain('height=700');
         expect(url, 'urlbox full_page honoured').toContain('full_page=true');
         expect(url, 'urlbox emits quality=80').toContain('quality=80');
-        expect(url, 'urlbox uses its own cookie-banner param').toContain('hide_cookie_banners=true');
+        expect(url, 'urlbox uses its own cookie-banner param').toContain(
+            'hide_cookie_banners=true',
+        );
         // Genuinely different shape from screenshotone.
         expect(url, 'not a screenshotone URL').not.toContain('api.screenshotone.com');
         expect(url, 'no viewport_width leaks into urlbox shape').not.toContain('viewport_width');

--- a/apps/web/e2e/flow-screenshot-capability-deep.spec.ts
+++ b/apps/web/e2e/flow-screenshot-capability-deep.spec.ts
@@ -1,0 +1,504 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from './helpers/api';
+import { listPluginsViaAPI, enablePluginViaAPI } from './helpers/plugins';
+
+/**
+ * Screenshot capability — DEEP gaps. This file deliberately targets the seams
+ * that the two existing screenshot specs leave OPEN:
+ *   - `flow-plugin-screenshot.spec.ts` (registry schema, fresh-user isolation,
+ *     enable/disable lifecycle, truthful capture failure, local signed-url for
+ *     screenshotone/urlbox, providerOverride routing + basic DTO `IsUrl`).
+ *   - `flow-screenshot-capability-contract.spec.ts` (DTO bounds/enum/UUID/
+ *     whitelist matrix, user-vs-work scope independence, cross-USER work access
+ *     403 / no-secret-leak, screenshotone-vs-urlbox URL SHAPE, gating ORDER,
+ *     default sort, disable re-arm).
+ *
+ * Neither covers the URL-security boundary on the DTO (the SSRF + protocol/TLD
+ * guard added on `CaptureScreenshotDto.url`), the FULL signed-url OPTION matrix
+ * (delay ms→s, jpg, block_trackers, block_cookie_banners, device_scale_factor),
+ * signature DETERMINISM, the omitted-flag DEFAULT encoding, the foreign-but-
+ * NONEXISTENT (valid-v4 UUID) workId 404 path of Wave B #30 (the contract file
+ * only probes a *non-uuid* and a *real other-user* work), the OWNER's-own-work
+ * "plugin not work-enabled" gate, or the precise upstream-400 shape `/capture`
+ * surfaces. Those are pinned below.
+ *
+ * Every status / message / URL fragment below was PROBED against the LIVE stack
+ * (http://127.0.0.1:3100) before its assertion was written.
+ *
+ * PROBED CONTRACTS (live, 2026-06-11):
+ *   - DTO url SSRF guard: a private/loopback/link-local IP host
+ *       (`https://127.0.0.1/x`, `https://169.254.169.254/...` AWS IMDS) → 400
+ *       { message:['URL is not allowed'] } on BOTH /capture and /get-url. The
+ *       SSRF constraint fires AFTER `@IsUrl` accepts the (https, TLD-shaped)
+ *       value, so the message is the constraint's `'URL is not allowed'`.
+ *   - DTO url protocol/TLD guard: `http://example.com` (non-https),
+ *       `https://localhost/x` (no TLD), `https://myhost/x` (no TLD) → 400
+ *       { message:['url must be a URL address'] } — `@IsUrl({ protocols:['https'],
+ *       require_tld:true })` rejects before the SSRF constraint runs.
+ *   - Signed screenshotone url honours the FULL option set: `delay` is sent in
+ *       MILLISECONDS by the client but encoded as `delay=<seconds>` (3000→`delay=3`);
+ *       `format=jpg`→`format=jpg`; `blockTrackers:true`→`block_trackers=true`;
+ *       `blockCookieBanners:true`→`block_cookie_banners=true`; a constant
+ *       `device_scale_factor=1` is always present.
+ *   - OMITTED flags default in the signed url: with NO block flags, the url
+ *       carries `block_ads=true` AND `block_trackers=true`, but NO
+ *       `block_cookie_banners` param (cookie-banner default is off / absent).
+ *       Viewport defaults 1280x800, format png.
+ *   - DETERMINISM: identical input → byte-identical signed url (stable HMAC).
+ *       The target url (incl. a nested `?q=1&x=2` query) is fully percent-encoded
+ *       into the `url=` param.
+ *   - WORK AUTHZ (Wave B #30): a VALID-v4 but NONEXISTENT workId
+ *       (`a0499a65-9b8c-4bf7-857e-895f52da30b3`) → 404
+ *       { status:'error', message:"Work with id '…' not found" } on
+ *       check-availability, /get-url AND /capture (ensureCanView fronts all
+ *       three). A NON-rfc-v4 string (`11111111-2222-3333-4444-555555555555`,
+ *       no version nibble) is instead a DTO 400 'workId must be a UUID' — the
+ *       validator runs before the lookup.
+ *   - OWNER's OWN work, provider enabled at USER level but NOT work-enabled →
+ *       /get-url 400 { message:'No screenshot provider configured' }. The work
+ *       scope is independent even for the owner; the user-level enable does not
+ *       satisfy the work-scoped provider gate.
+ *   - /capture with BOTH fake keys reaches the real provider and surfaces the
+ *       upstream rejection: 400 { status:'error',
+ *       message:'Failed to generate screenshot, response returned 400 (Bad
+ *       Request): "access_key" is invalid' }. NOT a fabricated 200, NOT a 5xx.
+ *   - urlbox via providerOverride builds a DIFFERENT shape:
+ *       `https://api.urlbox.io/v1/<key>/<sig>/jpg?url=…&width=500&height=700&
+ *       full_page=true&quality=80&block_ads=true&hide_cookie_banners=true` —
+ *       format is a PATH segment, width/height (not viewport_*), quality=80.
+ *   - Unknown providerOverride with a configured provider → 500 'Internal
+ *       server error' (facade raises NoProviderError-equivalent inside resolve).
+ *   - 401 without a bearer on /get-url.
+ *
+ * ISOLATION: every test registers a FRESH user. screenshot keys are written at
+ * the USER scope and would shadow the env key for sibling specs, so we never
+ * touch the shared seeded user. Unique suffixes come from the per-test title +
+ * a module counter — never a module-scope clock.
+ *
+ * Filename uses the safe `flow-` prefix (not matched by the no-auth testIgnore
+ * regex) and is fully API-orchestrated — no UI contention.
+ */
+
+interface ProviderOption {
+    id: string;
+    name: string;
+    configured: boolean;
+    isDefault?: boolean;
+}
+
+interface AvailabilityResponse {
+    status: string;
+    available: boolean;
+    providers: ProviderOption[];
+    activeProvider: ProviderOption | null;
+}
+
+let SUFFIX_COUNTER = 0;
+/** Per-test unique suffix — built from the test title, never a module-scope clock. */
+function uniqueSuffix(title: string): string {
+    SUFFIX_COUNTER += 1;
+    return `${title.replace(/[^a-z0-9]+/gi, '').slice(0, 8)}${SUFFIX_COUNTER}${Math.random()
+        .toString(36)
+        .slice(2, 7)}`;
+}
+
+const FAKE_SO_KEYS = (s: string) => ({ accessKey: `acc-${s}`, secretKey: `sec-${s}` });
+
+/** A valid RFC-4122 v4 UUID that is (overwhelmingly) not a real work id. */
+const NONEXISTENT_WORK_UUID = 'a0499a65-9b8c-4bf7-857e-895f52da30b3';
+
+async function freshToken(request: APIRequestContext): Promise<string> {
+    return (await registerUserViaAPI(request)).access_token;
+}
+
+async function checkAvailability(
+    request: APIRequestContext,
+    token: string,
+    workId?: string,
+): Promise<{ status: number; body: AvailabilityResponse }> {
+    const url = workId
+        ? `${API_BASE}/api/screenshot/check-availability?workId=${encodeURIComponent(workId)}`
+        : `${API_BASE}/api/screenshot/check-availability`;
+    const res = await request.get(url, { headers: authedHeaders(token) });
+    return {
+        status: res.status(),
+        body: (await res.json().catch(() => ({}))) as AvailabilityResponse,
+    };
+}
+
+async function postScreenshot(
+    request: APIRequestContext,
+    token: string,
+    op: 'capture' | 'get-url',
+    data: Record<string, unknown>,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+    const res = await request.post(`${API_BASE}/api/screenshot/${op}`, {
+        headers: authedHeaders(token),
+        data,
+    });
+    return {
+        status: res.status(),
+        body: (await res.json().catch(() => ({}))) as Record<string, unknown>,
+    };
+}
+
+/** Flatten class-validator `message` (string | string[]) into one string. */
+function messageText(body: Record<string, unknown>): string {
+    const m = body.message;
+    if (Array.isArray(m)) return m.join(' | ');
+    return String(m ?? '');
+}
+
+/** Enable screenshotone with both fake keys and wait until availability flips. */
+async function enableScreenshotoneConfigured(
+    request: APIRequestContext,
+    token: string,
+    suffix: string,
+): Promise<void> {
+    await enablePluginViaAPI(request, token, 'screenshotone', {
+        secretSettings: FAKE_SO_KEYS(suffix),
+    });
+    await expect
+        .poll(async () => (await checkAvailability(request, token)).body.available, {
+            timeout: 15_000,
+            message: 'screenshotone availability flips true after enable',
+        })
+        .toBe(true);
+}
+
+test.describe('Screenshot capability — deep: URL-security, signed-url matrix, work authz', () => {
+    test('SSRF guard: private/loopback/link-local IP hosts are rejected on capture AND get-url', async ({
+        request,
+    }) => {
+        const token = await freshToken(request);
+
+        // These hosts are accepted by @IsUrl (https + TLD-shaped) but blocked by
+        // the IsNotSsrfUrl constraint — the screenshot URL is forwarded to a
+        // third-party provider, so an SSRF target (cloud metadata, loopback)
+        // must never reach it. The constraint message is 'URL is not allowed'.
+        const ssrfTargets = [
+            'https://127.0.0.1/x',
+            'https://169.254.169.254/latest/meta-data', // AWS IMDS
+            'https://10.0.0.5/internal',
+        ];
+        for (const op of ['capture', 'get-url'] as const) {
+            for (const url of ssrfTargets) {
+                const res = await postScreenshot(request, token, op, { url });
+                expect(res.status, `${op}: SSRF ${url} → 400`).toBe(400);
+                expect(messageText(res.body), `${op}: SSRF ${url} → 'URL is not allowed'`).toMatch(
+                    /URL is not allowed/i,
+                );
+            }
+        }
+    });
+
+    test('protocol/TLD guard: non-https and TLD-less hosts → "url must be a URL address"', async ({
+        request,
+    }) => {
+        const token = await freshToken(request);
+
+        // @IsUrl({ protocols:['https'], require_tld:true }) rejects these BEFORE
+        // the SSRF constraint runs, so the message is the IsUrl default rather
+        // than 'URL is not allowed'. This distinguishes the two guard layers.
+        const isUrlRejections = [
+            'http://example.com', // non-https protocol
+            'https://localhost/x', // no TLD
+            'https://myhost/internal', // no TLD
+            'ftp://example.com', // wrong protocol entirely
+        ];
+        for (const op of ['capture', 'get-url'] as const) {
+            for (const url of isUrlRejections) {
+                const res = await postScreenshot(request, token, op, { url });
+                expect(res.status, `${op}: ${url} → 400`).toBe(400);
+                expect(messageText(res.body), `${op}: ${url} → IsUrl message`).toMatch(
+                    /url must be a URL address/i,
+                );
+            }
+        }
+    });
+
+    test('signed-url honours the FULL option matrix (delay ms→s, jpg, trackers, cookie-banners, dsf)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request);
+        await enableScreenshotoneConfigured(request, token, uniqueSuffix(testInfo.title));
+
+        const res = await postScreenshot(request, token, 'get-url', {
+            url: 'https://example.com',
+            format: 'jpg',
+            delay: 3000, // client sends MILLISECONDS …
+            blockTrackers: true,
+            blockCookieBanners: true,
+            blockAds: true,
+            fullPage: true,
+            viewportWidth: 1024,
+            viewportHeight: 768,
+        });
+        expect(res.status, 'get-url with full options → 201').toBe(201);
+        const url = String(res.body.imageUrl ?? '');
+        expect(url, 'screenshotone take endpoint').toContain('api.screenshotone.com/take');
+        // … but the provider URL encodes delay in SECONDS (3000ms → delay=3).
+        expect(url, 'delay encoded in seconds (3000ms → 3)').toContain('delay=3');
+        expect(url, 'jpg format honoured').toContain('format=jpg');
+        expect(url, 'blockTrackers honoured').toContain('block_trackers=true');
+        expect(url, 'blockCookieBanners honoured').toContain('block_cookie_banners=true');
+        expect(url, 'blockAds honoured').toContain('block_ads=true');
+        expect(url, 'fullPage honoured').toContain('full_page=true');
+        expect(url, 'viewport width honoured').toContain('viewport_width=1024');
+        expect(url, 'viewport height honoured').toContain('viewport_height=768');
+        // A constant device_scale_factor is always emitted by the builder.
+        expect(url, 'device_scale_factor=1 always present').toContain('device_scale_factor=1');
+        expect(url, 'HMAC signed').toContain('signature=');
+    });
+
+    test('signed-url default-flag encoding: omitted flags → block_ads+block_trackers, NO cookie-banners', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request);
+        await enableScreenshotoneConfigured(request, token, uniqueSuffix(testInfo.title));
+
+        // With NO block flags supplied the builder applies its OWN defaults:
+        // block_ads=true and block_trackers=true are emitted, but the
+        // cookie-banner param is absent (its default is off). Pinning the
+        // absence is what makes this distinct from the contract spec (which only
+        // checks block_ads=true on omission).
+        const res = await postScreenshot(request, token, 'get-url', { url: 'https://example.com' });
+        const url = String(res.body.imageUrl ?? '');
+        expect(url, 'default block_ads=true').toContain('block_ads=true');
+        expect(url, 'default block_trackers=true').toContain('block_trackers=true');
+        expect(url, 'NO cookie-banner param when omitted').not.toContain('block_cookie_banners');
+        expect(url, 'default viewport width 1280').toContain('viewport_width=1280');
+        expect(url, 'default viewport height 800').toContain('viewport_height=800');
+        expect(url, 'default format png').toContain('format=png');
+        expect(url, 'default full_page=false').toContain('full_page=false');
+    });
+
+    test('signed-url is deterministic (stable HMAC) and percent-encodes a nested target query', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request);
+        await enableScreenshotoneConfigured(request, token, uniqueSuffix(testInfo.title));
+
+        const target = 'https://example.com/path?q=1&x=2';
+        const first = await postScreenshot(request, token, 'get-url', { url: target });
+        const second = await postScreenshot(request, token, 'get-url', { url: target });
+        const a = String(first.body.imageUrl ?? '');
+        const b = String(second.body.imageUrl ?? '');
+        expect(a, 'first build succeeded').toContain('signature=');
+        // Same key + same input ⇒ byte-identical signed url (no nonce/timestamp).
+        expect(b, 'signed url is deterministic for identical input').toBe(a);
+        // The nested target query is fully percent-encoded inside `url=` (the
+        // inner `?`/`&` must NOT bleed into the provider query string).
+        expect(a, 'nested target query is fully encoded').toContain(
+            `url=${encodeURIComponent(target)}`,
+        );
+    });
+
+    test('foreign workId — valid-v4 but NONEXISTENT → 404 on check-availability, get-url AND capture (Wave B #30)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request);
+        // The caller has a configured provider at USER scope, so the 404 below
+        // is the WORK-access guard firing — not a missing-provider gate.
+        await enableScreenshotoneConfigured(request, token, uniqueSuffix(testInfo.title));
+
+        const avail = await checkAvailability(request, token, NONEXISTENT_WORK_UUID);
+        expect(avail.status, 'check-availability foreign workId → 404').toBe(404);
+        expect(avail.body.status, 'error envelope').toBe('error');
+        expect(messageText(avail.body as unknown as Record<string, unknown>), 'names the work').toMatch(
+            /Work with id .* not found/i,
+        );
+
+        for (const op of ['get-url', 'capture'] as const) {
+            const res = await postScreenshot(request, token, op, {
+                url: 'https://example.com',
+                workId: NONEXISTENT_WORK_UUID,
+            });
+            expect(res.status, `${op}: foreign workId → 404 BEFORE any provider work`).toBe(404);
+            expect(messageText(res.body), `${op}: not-found names the work`).toMatch(
+                /Work with id .* not found/i,
+            );
+        }
+    });
+
+    test('workId DTO precision: a non-RFC-v4 string is a 400 (validator wins before the lookup)', async ({
+        request,
+    }) => {
+        const token = await freshToken(request);
+        // No version nibble ⇒ not a valid v4 UUID ⇒ class-validator 400 'must be
+        // a UUID', distinct from the valid-but-nonexistent 404 above (the DTO
+        // runs before ensureCanView, so this never reaches the work lookup).
+        const res = await postScreenshot(request, token, 'capture', {
+            url: 'https://example.com',
+            workId: '11111111-2222-3333-4444-555555555555',
+        });
+        expect(res.status, 'non-v4 workId → 400 DTO').toBe(400);
+        expect(messageText(res.body), 'workId UUID message').toMatch(/workId must be a UUID/i);
+    });
+
+    test('owner own-work gate: user-level enable does NOT satisfy the work-scoped provider gate', async ({
+        request,
+    }, testInfo) => {
+        const owner = await registerUserViaAPI(request);
+        const token = owner.access_token;
+        // Provider enabled at USER scope only.
+        await enableScreenshotoneConfigured(request, token, uniqueSuffix(testInfo.title));
+
+        // The owner's OWN brand-new work has no work-scoped provider, so a
+        // work-scoped get-url is gated with the "no provider" 400 — proving the
+        // work scope is independent EVEN for the owner (the contract spec only
+        // shows this after work-enabling; here we pin the un-enabled gate).
+        const work = await createWorkViaAPI(request, token, {
+            name: `SSGate ${uniqueSuffix(testInfo.title)}`,
+        });
+        expect(work.id, 'work created').toBeTruthy();
+
+        const beforeAvail = await checkAvailability(request, token, work.id);
+        expect(beforeAvail.status, 'owner can view their own work scope → 200').toBe(200);
+        expect(beforeAvail.body.available, 'work scope has no provider').toBe(false);
+
+        const res = await postScreenshot(request, token, 'get-url', {
+            url: 'https://example.com',
+            workId: work.id,
+        });
+        expect(res.status, 'work-scoped get-url with no work provider → 400 gate').toBe(400);
+        expect(res.body.status, 'error envelope').toBe('error');
+        expect(messageText(res.body), 'no-provider gate message').toMatch(
+            /No screenshot provider configured/i,
+        );
+    });
+
+    test('capture truthful upstream failure: both fake keys reach the provider → 400 with the real reason', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request);
+        await enableScreenshotoneConfigured(request, token, uniqueSuffix(testInfo.title));
+
+        // Unlike get-url (local HMAC, no outbound call), /capture DOES call the
+        // provider. With bogus keys the upstream returns its own 400 and the
+        // facade surfaces it verbatim — never a fabricated success, never a 5xx.
+        const res = await postScreenshot(request, token, 'capture', { url: 'https://example.com' });
+        expect(res.status, 'capture with bogus keys → truthful 400').toBe(400);
+        expect(res.body.status, 'error envelope').toBe('error');
+        const msg = messageText(res.body);
+        expect(msg, 'surfaces an upstream failure (not a fabricated success)').toMatch(
+            /Failed to generate screenshot|access_key|is invalid|response returned/i,
+        );
+        // No image fields are fabricated on the error envelope.
+        expect(res.body.imageUrl, 'no image url on a failed capture').toBeFalsy();
+    });
+
+    test('urlbox via providerOverride builds a distinct shape (path-format, width/height, quality=80)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request);
+        const screenshotIds = (await listPluginsViaAPI(request, token))
+            .filter((p) => p.category === 'screenshot')
+            .map((p) => p.id);
+
+        if (!screenshotIds.includes('urlbox')) {
+            testInfo.annotations.push({
+                type: 'note',
+                description: 'urlbox not registered in this build — skipped its URL-shape assertions',
+            });
+            test.skip(true, 'urlbox not registered in this build');
+            return;
+        }
+
+        const suffix = uniqueSuffix(testInfo.title);
+        await enablePluginViaAPI(request, token, 'urlbox', {
+            secretSettings: { apiKey: `ub-api-${suffix}`, apiSecret: `ub-sec-${suffix}` },
+        });
+        await expect
+            .poll(async () => (await checkAvailability(request, token)).body.available, {
+                timeout: 15_000,
+                message: 'urlbox availability flips true after enable',
+            })
+            .toBe(true);
+
+        const res = await postScreenshot(request, token, 'get-url', {
+            url: 'https://example.com',
+            providerOverride: 'urlbox',
+            format: 'jpg',
+            viewportWidth: 500,
+            viewportHeight: 700,
+            fullPage: true,
+            blockAds: true,
+            blockCookieBanners: true,
+        });
+        expect(res.status, 'urlbox override get-url → 201').toBe(201);
+        const url = String(res.body.imageUrl ?? '');
+        expect(url, 'urlbox host with path-embedded key+sig').toMatch(
+            /^https:\/\/api\.urlbox\.io\/v1\/[^/]+\/[^/]+\//,
+        );
+        // urlbox encodes the format as a PATH segment, not a query param.
+        expect(url, 'format is a /jpg path segment').toContain('/jpg?');
+        expect(url, 'urlbox uses width= (not viewport_width)').toContain('width=500');
+        expect(url, 'urlbox uses height= (not viewport_height)').toContain('height=700');
+        expect(url, 'urlbox full_page honoured').toContain('full_page=true');
+        expect(url, 'urlbox emits quality=80').toContain('quality=80');
+        expect(url, 'urlbox uses its own cookie-banner param').toContain('hide_cookie_banners=true');
+        // Genuinely different shape from screenshotone.
+        expect(url, 'not a screenshotone URL').not.toContain('api.screenshotone.com');
+        expect(url, 'no viewport_width leaks into urlbox shape').not.toContain('viewport_width');
+    });
+
+    test('unknown providerOverride with a configured provider → 500 (resolve raises, no fabricated 2xx)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request);
+        await enableScreenshotoneConfigured(request, token, uniqueSuffix(testInfo.title));
+
+        // The named override resolves to no enabled plugin; the facade raises and
+        // the controller does NOT map it (it is not a NoProviderError on this
+        // path), so it surfaces as a 500. Assert non-2xx and tolerate 400/404/500
+        // across builds while pinning the live 500 as the expected shape.
+        const res = await postScreenshot(request, token, 'get-url', {
+            url: 'https://example.com',
+            providerOverride: `nonexistent-${uniqueSuffix(testInfo.title)}`,
+        });
+        expect(
+            [400, 404, 500].includes(res.status),
+            `unknown override rejected (got ${res.status})`,
+        ).toBe(true);
+        expect(res.status, 'and it is NOT a fabricated 2xx').toBeGreaterThanOrEqual(400);
+        expect(res.body.imageUrl, 'no signed url is produced for an unknown override').toBeFalsy();
+    });
+
+    test('unauthenticated get-url / capture / check-availability are rejected with 401', async ({
+        request,
+    }) => {
+        // No bearer at all. Use raw request (no shared storageState/cookies).
+        const anonGetUrl = await request.post(`${API_BASE}/api/screenshot/get-url`, {
+            data: { url: 'https://example.com' },
+        });
+        expect(anonGetUrl.status(), 'anon get-url → 401').toBe(401);
+
+        const anonCapture = await request.post(`${API_BASE}/api/screenshot/capture`, {
+            data: { url: 'https://example.com' },
+        });
+        expect(anonCapture.status(), 'anon capture → 401').toBe(401);
+
+        const anonAvail = await request.get(`${API_BASE}/api/screenshot/check-availability`);
+        expect(anonAvail.status(), 'anon check-availability → 401').toBe(401);
+    });
+
+    test('get-url with a configured provider returns ONLY a signed url (no base64, no outbound call)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request);
+        await enableScreenshotoneConfigured(request, token, uniqueSuffix(testInfo.title));
+
+        // The get-url contract is purely { status, imageUrl } — it must not carry
+        // capture-only fields (imageBase64 / cacheUrl) and must return a fully
+        // formed signed url even with bogus keys (local build, no provider call).
+        const res = await postScreenshot(request, token, 'get-url', { url: 'https://example.com' });
+        expect(res.status, 'get-url → 201').toBe(201);
+        expect(res.body.status, 'success envelope').toBe('success');
+        expect(String(res.body.imageUrl ?? ''), 'a signed take URL').toContain(
+            'api.screenshotone.com/take',
+        );
+        expect(res.body.imageBase64, 'get-url does not return base64').toBeUndefined();
+        expect(res.body.cacheUrl, 'get-url does not return a cacheUrl').toBeUndefined();
+    });
+});

--- a/apps/web/e2e/flow-search-providers-deep.spec.ts
+++ b/apps/web/e2e/flow-search-providers-deep.spec.ts
@@ -271,12 +271,9 @@ test.describe('Search providers — deep facade + controller resolution', () => 
         // must NOT move off tavily (defaultForCapabilities-first resolution), and
         // the body shape stays identical — availability is anchored to the default.
         await enablePluginViaAPI(request, user.access_token, SECONDARY_SEARCH);
-        const cfg = await patchPluginSettingsViaAPI(
-            request,
-            user.access_token,
-            SECONDARY_SEARCH,
-            { secretSettings: { apiKey: `fake-brave-${uniqueSuffix()}` } },
-        );
+        const cfg = await patchPluginSettingsViaAPI(request, user.access_token, SECONDARY_SEARCH, {
+            secretSettings: { apiKey: `fake-brave-${uniqueSuffix()}` },
+        });
         expect(cfg.status, `brave patch body=${JSON.stringify(cfg.body)}`).toBe(200);
 
         await expect
@@ -301,12 +298,9 @@ test.describe('Search providers — deep facade + controller resolution', () => 
 
         // Wire up brave with a real-looking key, leave tavily WITHOUT a key.
         await enablePluginViaAPI(request, user.access_token, SECONDARY_SEARCH);
-        const cfg = await patchPluginSettingsViaAPI(
-            request,
-            user.access_token,
-            SECONDARY_SEARCH,
-            { secretSettings: { apiKey: `fake-brave-${uniqueSuffix()}` } },
-        );
+        const cfg = await patchPluginSettingsViaAPI(request, user.access_token, SECONDARY_SEARCH, {
+            secretSettings: { apiKey: `fake-brave-${uniqueSuffix()}` },
+        });
         expect(cfg.status).toBe(200);
 
         // A plain (no-workId) search. The controller sorts defaultForCapabilities
@@ -506,17 +500,17 @@ test.describe('Search providers — deep facade + controller resolution', () => 
         const work = await createWorkViaAPI(request, user.access_token, {
             name: `Deep Search Work ${uniqueSuffix()}`,
         });
-        expect(work.id, `work created (raw=${JSON.stringify(work.raw).slice(0, 160)})`).toBeTruthy();
+        expect(
+            work.id,
+            `work created (raw=${JSON.stringify(work.raw).slice(0, 160)})`,
+        ).toBeTruthy();
 
         // Fully wire brave: user-enable, key it, then make it the work-ACTIVE search
         // provider. This is the strongest case for brave to "win" — yet it doesn't.
         await enablePluginViaAPI(request, user.access_token, SECONDARY_SEARCH);
-        const cfg = await patchPluginSettingsViaAPI(
-            request,
-            user.access_token,
-            SECONDARY_SEARCH,
-            { secretSettings: { apiKey: `fake-brave-${uniqueSuffix()}` } },
-        );
+        const cfg = await patchPluginSettingsViaAPI(request, user.access_token, SECONDARY_SEARCH, {
+            secretSettings: { apiKey: `fake-brave-${uniqueSuffix()}` },
+        });
         expect(cfg.status).toBe(200);
 
         const workEnable = await request.post(
@@ -628,10 +622,15 @@ test.describe('Search providers — deep facade + controller resolution', () => 
         // shaped so the first/last 4 chars are easy to assert.
         await enablePluginViaAPI(request, user.access_token, TERTIARY_SEARCH);
         const RAW_KEY = 'abcd1234567890wxyz';
-        const patched = await patchPluginSettingsViaAPI(request, user.access_token, TERTIARY_SEARCH, {
-            settings: { maxResults: 7 },
-            secretSettings: { apiKey: RAW_KEY },
-        });
+        const patched = await patchPluginSettingsViaAPI(
+            request,
+            user.access_token,
+            TERTIARY_SEARCH,
+            {
+                settings: { maxResults: 7 },
+                secretSettings: { apiKey: RAW_KEY },
+            },
+        );
         expect(patched.status, `exa patch body=${JSON.stringify(patched.body)}`).toBe(200);
         const pBody = patched.body as {
             settings?: Record<string, unknown>;

--- a/apps/web/e2e/flow-search-providers-deep.spec.ts
+++ b/apps/web/e2e/flow-search-providers-deep.spec.ts
@@ -1,0 +1,721 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import {
+    API_BASE,
+    authedHeaders,
+    registerUserViaAPI,
+    createWorkViaAPI,
+    type RegisteredUser,
+} from './helpers/api';
+import {
+    listPluginsViaAPI,
+    getPluginViaAPI,
+    enablePluginViaAPI,
+    patchPluginSettingsViaAPI,
+} from './helpers/plugins';
+
+/**
+ * SEARCH providers — DEEP coverage of the `/api/search/*` capability facade +
+ * the SearchController's OWN provider-resolution logic
+ * (apps/api/src/plugins-capabilities/search/search.controller.ts), which is
+ * distinct from (and layered above) the SearchFacadeService resolver
+ * (packages/agent/src/facades/base.facade.ts).
+ *
+ * The controller's `resolveConfiguredProvider()` is the load-bearing, thinly
+ * tested piece this file deepens: it enumerates getEnabledPluginsScoped(),
+ * sorts `defaultForCapabilities`-first, then returns the FIRST plugin whose
+ * required settings pass `hasAllRequiredSettings()` — a check that SKIPS any
+ * required field carrying `x-envVar` (every search apiKey does). The resolved
+ * id is then forced onto the facade as `providerOverride`. The net contract:
+ *   • the system default `tavily` ALWAYS wins resolution (its required apiKey is
+ *     env-skipped, so it passes the gate with no real key), even when a fully
+ *     key-configured NON-default provider (brave) is enabled — at BOTH user
+ *     scope and work scope, and even when brave is the work-ACTIVE binding.
+ *   • availability ("any enabled search plugin") therefore stays true with no
+ *     key, while an actual POST /api/search reports the resolved provider's gate
+ *     — the availability-vs-usability divergence.
+ *   • configured-vs-unconfigured DIVERGENCE: once tavily's user-scoped apiKey is
+ *     set (even a FAKE one), the facade DISPATCHES to the real Tavily provider,
+ *     and the error message FLIPS from the early "API key not configured" gate
+ *     to the provider-level "Unauthorized: missing or invalid API key." (a 401
+ *     upstream mapped to a clean 400) — never a 5xx, env-adaptive to a 200 when
+ *     a real PLUGIN_TAVILY_API_KEY happens to be wired.
+ *
+ * DELIBERATELY DISTINCT from the sibling specs (NO duplication):
+ *   - `flow-search-capability-contract.spec.ts` → spot-checks 5 of the family,
+ *     the valid-full-body + malformed DTO matrix, the env-adaptive divergence
+ *     (assert only that "not configured" disappears), the per-WORK default
+ *     anchor, user-scope availability isolation, and the result-item shape. We
+ *     do NOT re-run those; we go further: ALL 9 providers' apiKey contract, the
+ *     per-provider maxResults bounds (brave 1..20 vs exa 1..100), the USER-scope
+ *     (no-workId) default anchor, the EXACT flipped provider-error message, the
+ *     per-USER execution-time key divergence, and empty-query / boundary edges.
+ *   - `flow-plugin-search-lifecycle.spec.ts` → fresh availability + 2nd-provider
+ *     priority, system-disable rejection, env-adaptive exec, the DTO matrix +
+ *     auth, ownership 403/404, and the settings-validation x-envVar divergence.
+ *     We do NOT re-assert ownership 403/404, system-disable, or settings PATCH
+ *     bounds — we assert the availability-shape STABILITY across mutations and
+ *     the controller-level resolution that those specs never isolate.
+ *   - `flow-plugin-lifecycle-search.spec.ts` / `plugins-search.spec.ts` → enable
+ *     lifecycle + shallow availability smoke.
+ *
+ * Every status / shape / message below was PROBED against the LIVE stack
+ * (http://127.0.0.1:3100) before being asserted — never guessed.
+ *
+ * PROBED CONTRACTS:
+ *   GET /api/plugins (category:'search') ships 9 providers: tavily, brave, exa,
+ *     serpapi, perplexity, linkup, valyu, brightdata, firecrawl. EVERY one has
+ *     required:['apiKey'] with apiKey:{ type:'string', secret:true,
+ *     envVar:'PLUGIN_<X>_API_KEY', scope:'user' }. ONLY tavily is
+ *     { systemPlugin:true, autoEnable:true, defaultForCapabilities:['search'] }.
+ *     brave.maxResults:{ scope:'global', minimum:1, maximum:20, default:10 };
+ *     exa.maxResults:{ scope:'global', minimum:1, maximum:100, default:10 }.
+ *   GET /api/search/check-availability (Bearer): anon → 401; fresh/any user →
+ *     200 { status:'success', available:true, activeProvider:{ id:'tavily',
+ *     name:'Tavily' } } — STABLE across enabling/configuring other providers.
+ *   POST /api/search { query, workId?, maxResults?(1..50), includeDomains?[],
+ *     excludeDomains?[] } (Bearer; SearchDto whitelist+forbidNonWhitelisted):
+ *     • anon → 401.
+ *     • query:'' (empty string) PASSES the DTO (@IsString) → reaches the
+ *       provider gate (env-adaptive 200/400), NOT a validation 400.
+ *     • maxResults 50 → valid (provider gate); 51 → 400 ['...not greater than 50'];
+ *       0/-5 → 400 ['...not less than 1']; '10' (string) → 400 with the 3-message
+ *       not-greater/not-less/must-be-a-number bundle.
+ *     • UNCONFIGURED default (tavily, no key) → 400 { status:'error',
+ *       message:'Tavily API key not configured. Set it in plugin settings or via
+ *       PLUGIN_TAVILY_API_KEY environment variable.' }.
+ *     • CONFIGURED default (fake tavily key) → 400 { status:'error',
+ *       message:'Unauthorized: missing or invalid API key.' } (401 upstream
+ *       mapped) — the message FLIPS off "not configured". (Real key → 200.)
+ *     • brave fully configured + tavily NOT → search STILL hits tavily's gate
+ *       (default-first resolution), at user scope AND work scope (incl. brave
+ *       work-active-bound). provider echo on 200 is the NAME (string).
+ *
+ * Cross-spec isolation: EVERY mutation runs on a FRESH registerUserViaAPI()
+ * user (a user-scoped fake key would otherwise shadow env keys + redden sibling
+ * chat/search specs). Unique works/keys derive from a PER-TEST counter (never a
+ * module-scope clock). Presence asserted with toContain, never exact catalog
+ * counts. No real LLM/search key required.
+ */
+
+const DEFAULT_SEARCH = 'tavily';
+const SECONDARY_SEARCH = 'brave';
+const TERTIARY_SEARCH = 'exa';
+
+// The full search provider family that ships on develop (PROBED). Asserted with
+// toContain (presence), never an exact set, to tolerate future additions.
+const SEARCH_FAMILY = [
+    'tavily',
+    'brave',
+    'exa',
+    'serpapi',
+    'perplexity',
+    'linkup',
+    'valyu',
+    'brightdata',
+    'firecrawl',
+] as const;
+
+// The exact provider-stage messages (PROBED). The FLIP between them is the proof
+// the configured path reaches the real provider rather than the early gate.
+const MSG_NOT_CONFIGURED = 'Tavily API key not configured';
+const MSG_UPSTREAM_401 = 'Unauthorized: missing or invalid API key.';
+
+// Per-test unique suffix WITHOUT a module-scope clock (module scope runs at
+// collection on every shard). Each test passes its own seed.
+let SUFFIX_COUNTER = 0;
+function uniqueSuffix(): string {
+    SUFFIX_COUNTER += 1;
+    return `${SUFFIX_COUNTER}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+interface AvailabilityBody {
+    status?: string;
+    available?: boolean;
+    activeProvider?: { id?: string; name?: string } | null;
+    message?: string;
+}
+
+interface SearchBody {
+    status?: string;
+    message?: unknown;
+    provider?: string;
+    results?: Array<{ title?: string; url?: string; score?: number; publishedDate?: string }>;
+}
+
+async function getAvailability(
+    request: APIRequestContext,
+    token: string,
+): Promise<{ status: number; body: AvailabilityBody }> {
+    const res = await request.get(`${API_BASE}/api/search/check-availability`, {
+        headers: authedHeaders(token),
+    });
+    return { status: res.status(), body: (await res.json().catch(() => ({}))) as AvailabilityBody };
+}
+
+async function postSearch(
+    request: APIRequestContext,
+    token: string | null,
+    data: Record<string, unknown>,
+): Promise<{ status: number; body: SearchBody & Record<string, unknown> }> {
+    const res = await request.post(`${API_BASE}/api/search`, {
+        headers: token ? authedHeaders(token) : undefined,
+        data,
+    });
+    return {
+        status: res.status(),
+        body: (await res.json().catch(() => ({}))) as SearchBody & Record<string, unknown>,
+    };
+}
+
+function flatten(msg: unknown): string {
+    return Array.isArray(msg) ? msg.join(' | ') : String(msg);
+}
+
+/** A SchemaProp slice for settingsSchema introspection. */
+type SchemaProp = Record<string, unknown>;
+function schemaOf(plugin: Record<string, unknown>): {
+    required?: string[];
+    properties?: Record<string, SchemaProp>;
+} {
+    return (plugin.settingsSchema ?? {}) as {
+        required?: string[];
+        properties?: Record<string, SchemaProp>;
+    };
+}
+
+test.describe('Search providers — deep facade + controller resolution', () => {
+    test('FLOW 1: the FULL 9-provider family shares one apiKey contract (required, secret, PLUGIN_*_API_KEY env, user-scoped); only tavily is system+auto+default', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+
+        const catalog = await listPluginsViaAPI(request, user.access_token);
+        const searchIds = catalog.filter((p) => p.category === 'search').map((p) => p.id);
+        for (const id of SEARCH_FAMILY) {
+            expect(searchIds, `search family is missing "${id}"`).toContain(id);
+        }
+
+        // Walk EVERY family member (siblings only spot-check 5) and pin the shared
+        // apiKey settingsSchema contract at the source.
+        for (const id of SEARCH_FAMILY) {
+            const plugin = await getPluginViaAPI(request, user.access_token, id);
+            expect(plugin.category, `${id} is a search plugin`).toBe('search');
+            expect(plugin.capabilities as string[], `${id} provides search`).toContain('search');
+
+            const schema = schemaOf(plugin);
+            expect(schema.required, `${id} requires apiKey`).toContain('apiKey');
+            const apiKey = schema.properties?.apiKey ?? {};
+            expect(apiKey.type, `${id} apiKey is a string`).toBe('string');
+            expect(apiKey.secret, `${id} apiKey is a secret`).toBe(true);
+            expect(apiKey.scope, `${id} apiKey is user-scoped`).toBe('user');
+            expect(String(apiKey.envVar ?? ''), `${id} apiKey is env-overridable`).toMatch(
+                /^PLUGIN_.+_API_KEY$/,
+            );
+
+            // Exactly tavily carries the system/auto/default triple; every other
+            // family member is non-system, non-auto and starts disabled.
+            if (id === DEFAULT_SEARCH) {
+                expect(plugin.systemPlugin).toBe(true);
+                expect(plugin.autoEnable).toBe(true);
+                expect(plugin.enabled, 'tavily auto-enables for a fresh user').toBe(true);
+                expect(plugin.defaultForCapabilities as string[]).toContain('search');
+            } else {
+                expect(plugin.systemPlugin, `${id} is not a system plugin`).not.toBe(true);
+                expect(plugin.autoEnable, `${id} does not auto-enable`).not.toBe(true);
+                expect(plugin.enabled, `${id} starts disabled`).toBe(false);
+                expect(
+                    (plugin.defaultForCapabilities as string[] | undefined) ?? [],
+                    `${id} is not default-for-search`,
+                ).not.toContain('search');
+            }
+        }
+    });
+
+    test('FLOW 2: per-provider maxResults schema bounds DIVERGE across the family — brave is global 1..20, exa is global 1..100 (distinct from the SearchDto @Max(50))', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+
+        const brave = await getPluginViaAPI(request, user.access_token, SECONDARY_SEARCH);
+        const braveMax = schemaOf(brave).properties?.maxResults ?? {};
+        expect(braveMax.scope).toBe('global');
+        expect(braveMax.minimum).toBe(1);
+        expect(braveMax.maximum).toBe(20);
+
+        const exa = await getPluginViaAPI(request, user.access_token, TERTIARY_SEARCH);
+        const exaMax = schemaOf(exa).properties?.maxResults ?? {};
+        expect(exaMax.scope).toBe('global');
+        expect(exaMax.minimum).toBe(1);
+        // exa allows a strictly larger ceiling than brave — proving these are
+        // per-provider knobs, not a shared constant.
+        expect(exaMax.maximum).toBe(100);
+        expect(exaMax.maximum as number).toBeGreaterThan(braveMax.maximum as number);
+    });
+
+    test('FLOW 3: check-availability is anon-guarded and returns a STABLE {status,available,activeProvider:tavily} that does NOT move when a second provider is enabled+configured', async ({
+        request,
+    }) => {
+        // Anonymous read is rejected (raw fetch — no inherited cookies).
+        const anon = await fetch(`${API_BASE}/api/search/check-availability`);
+        expect(anon.status).toBe(401);
+
+        const user: RegisteredUser = await registerUserViaAPI(request);
+
+        const before = await getAvailability(request, user.access_token);
+        expect(before.status).toBe(200);
+        expect(before.body.status).toBe('success');
+        expect(before.body.available).toBe(true);
+        expect(before.body.activeProvider).toEqual({ id: 'tavily', name: 'Tavily' });
+
+        // Enable + fully configure a NON-default provider. The activeProvider slot
+        // must NOT move off tavily (defaultForCapabilities-first resolution), and
+        // the body shape stays identical — availability is anchored to the default.
+        await enablePluginViaAPI(request, user.access_token, SECONDARY_SEARCH);
+        const cfg = await patchPluginSettingsViaAPI(
+            request,
+            user.access_token,
+            SECONDARY_SEARCH,
+            { secretSettings: { apiKey: `fake-brave-${uniqueSuffix()}` } },
+        );
+        expect(cfg.status, `brave patch body=${JSON.stringify(cfg.body)}`).toBe(200);
+
+        await expect
+            .poll(
+                async () =>
+                    (await getAvailability(request, user.access_token)).body.activeProvider?.id,
+                { timeout: 15_000, message: 'tavily keeps the active slot' },
+            )
+            .toBe(DEFAULT_SEARCH);
+
+        const after = await getAvailability(request, user.access_token);
+        expect(after.body.available).toBe(true);
+        expect(after.body.activeProvider).toEqual({ id: 'tavily', name: 'Tavily' });
+        // No message key on the available branch (message is only the no-provider tail).
+        expect(after.body.message).toBeUndefined();
+    });
+
+    test('FLOW 4: USER-scope (no workId) default anchor — a fully key-configured non-default brave does NOT steal resolution from the unconfigured system default tavily; the search reports TAVILY’s gate', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+
+        // Wire up brave with a real-looking key, leave tavily WITHOUT a key.
+        await enablePluginViaAPI(request, user.access_token, SECONDARY_SEARCH);
+        const cfg = await patchPluginSettingsViaAPI(
+            request,
+            user.access_token,
+            SECONDARY_SEARCH,
+            { secretSettings: { apiKey: `fake-brave-${uniqueSuffix()}` } },
+        );
+        expect(cfg.status).toBe(200);
+
+        // A plain (no-workId) search. The controller sorts defaultForCapabilities
+        // first, so tavily resolves AHEAD of the configured brave — and since
+        // tavily's apiKey is x-envVar (env-skipped in hasAllRequiredSettings) it
+        // passes the gate and is forced as providerOverride. The facade then hits
+        // the real tavily, which reports ITS missing key — NOT brave's.
+        const res = await postSearch(request, user.access_token, { query: 'project tooling' });
+        expect(res.status, 'search must not 5xx').toBeLessThan(500);
+        expect([200, 400]).toContain(res.status);
+        if (res.status === 400) {
+            expect(res.body.status).toBe('error');
+            const msg = flatten(res.body.message);
+            expect(Array.isArray(res.body.message), 'a provider error is a string').toBe(false);
+            // The resolved provider is the default tavily (its gate), never brave.
+            expect(msg).toContain(MSG_NOT_CONFIGURED);
+            expect(msg.toLowerCase()).not.toContain('brave');
+        } else {
+            // Keyed env: a real key answered; the provider echo names the resolved
+            // default, not the non-default brave.
+            expect(res.body.status).toBe('success');
+            expect(typeof res.body.provider).toBe('string');
+        }
+    });
+
+    test('FLOW 5: configured-vs-unconfigured message FLIP — the SAME query on the SAME user moves from the exact "API key not configured" gate to the exact "Unauthorized: missing or invalid API key." provider error once a (fake) tavily key is set (env-adaptive, never 5xx)', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+        const QUERY = 'open source web directories';
+
+        // PHASE A — UNCONFIGURED: the early gate fires with the exact message.
+        const before = await postSearch(request, user.access_token, { query: QUERY });
+        expect(before.status, 'unconfigured search must not 5xx').toBeLessThan(500);
+        let sawGate = false;
+        if (before.status === 400) {
+            expect(before.body.status).toBe('error');
+            const msg = flatten(before.body.message);
+            if (msg.includes(MSG_NOT_CONFIGURED)) sawGate = true;
+        } else {
+            // A real env key is present — phase A's premise doesn't hold; assert success.
+            expect(before.status).toBe(200);
+            expect(before.body.status).toBe('success');
+        }
+
+        // PHASE B — CONFIGURED with a FAKE user-scoped tavily key: the facade now
+        // DISPATCHES to the real provider. A bogus key → Tavily 401 upstream →
+        // controller maps to 400 with the DISTINCT "Unauthorized..." message. The
+        // FLIP off "not configured" proves the configured path reached the provider.
+        const patch = await patchPluginSettingsViaAPI(request, user.access_token, DEFAULT_SEARCH, {
+            secretSettings: { apiKey: `fake-tavily-${uniqueSuffix()}` },
+        });
+        expect(patch.status, `tavily patch body=${JSON.stringify(patch.body)}`).toBe(200);
+
+        const after = await postSearch(request, user.access_token, { query: QUERY });
+        expect(after.status, 'configured search must not 5xx').toBeLessThan(500);
+        expect([200, 400]).toContain(after.status);
+        if (after.status === 200) {
+            // A real key happened to be wired — the provider answered.
+            expect(after.body.status).toBe('success');
+            expect(after.body.provider).toBeTruthy();
+        } else {
+            expect(after.body.status).toBe('error');
+            const msg = flatten(after.body.message);
+            expect(Array.isArray(after.body.message), 'provider error is a string').toBe(false);
+            // The message must NO LONGER be the "not configured" gate...
+            expect(msg).not.toContain(MSG_NOT_CONFIGURED);
+            // ...and in key-less CI it is the specific upstream-401 mapping. (Guard
+            // with sawGate so a fully-keyed env that 200'd in phase A can't fail here.)
+            if (sawGate) {
+                expect(msg).toBe(MSG_UPSTREAM_401);
+            }
+        }
+    });
+
+    test('FLOW 6: an EMPTY-STRING query passes the @IsString DTO and reaches provider resolution (the gate, not a validation 400) — the resolver, not the validator, owns empty queries', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+
+        const res = await postSearch(request, user.access_token, { query: '' });
+        expect(res.status, 'empty-query search must not 5xx').toBeLessThan(500);
+        expect([200, 400]).toContain(res.status);
+        if (res.status === 400) {
+            // It is the provider-stage error (string status:'error'), NOT a DTO
+            // validation array — '' is a valid string, so it sails past @IsString.
+            expect(res.body.status).toBe('error');
+            expect(Array.isArray(res.body.message), 'not a class-validator array').toBe(false);
+            expect(flatten(res.body.message)).toContain(MSG_NOT_CONFIGURED);
+        } else {
+            expect(res.body.status).toBe('success');
+        }
+    });
+
+    test('FLOW 7: maxResults boundary contract — 50 is the inclusive ceiling (passes to the provider gate), 51 / 0 / -5 carry their exact @Max/@Min messages, and a string is the 3-message not-a-number bundle', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+
+        // 50 is INSIDE the @Max(50) bound → reaches the provider (env-adaptive),
+        // proving maxResults is not the rejection reason at the ceiling.
+        const atCeiling = await postSearch(request, user.access_token, {
+            query: 'directories',
+            maxResults: 50,
+        });
+        expect([200, 400]).toContain(atCeiling.status);
+        if (atCeiling.status === 400) {
+            expect(atCeiling.body.status).toBe('error');
+            expect(Array.isArray(atCeiling.body.message), 'provider 400, not a DTO array').toBe(
+                false,
+            );
+        }
+
+        // 51 is one past the ceiling → exact @Max message.
+        const over = await postSearch(request, user.access_token, {
+            query: 'q',
+            maxResults: 51,
+        });
+        expect(over.status).toBe(400);
+        expect(flatten(over.body.message)).toContain('maxResults must not be greater than 50');
+
+        // 0 and -5 are below @Min(1) → exact @Min message.
+        for (const n of [0, -5]) {
+            const under = await postSearch(request, user.access_token, {
+                query: 'q',
+                maxResults: n,
+            });
+            expect(under.status, `maxResults:${n} → 400`).toBe(400);
+            expect(flatten(under.body.message)).toContain('maxResults must not be less than 1');
+        }
+
+        // A string carries the full 3-message bundle (the transform yields NaN,
+        // tripping not-greater, not-less AND must-be-a-number — PROBED).
+        const asString = await postSearch(request, user.access_token, {
+            query: 'q',
+            maxResults: '10',
+        });
+        expect(asString.status).toBe(400);
+        const msg = flatten(asString.body.message);
+        expect(msg).toContain('maxResults must not be greater than 50');
+        expect(msg).toContain('maxResults must not be less than 1');
+        expect(msg).toMatch(/maxResults must be a number conforming/i);
+
+        // Every malformed maxResults is a clean 4xx — never a 5xx.
+        for (const r of [over, asString]) {
+            expect(r.status).toBeGreaterThanOrEqual(400);
+            expect(r.status).toBeLessThan(500);
+        }
+    });
+
+    test('FLOW 8: per-USER execution-time key isolation — userA configuring a (fake) tavily key flips ONLY A’s search to the provider-error branch; a fresh userB still hits the unconfigured gate (keys never leak across the user boundary at search time)', async ({
+        request,
+    }) => {
+        const userA: RegisteredUser = await registerUserViaAPI(request);
+        const userB: RegisteredUser = await registerUserViaAPI(request);
+        const QUERY = 'directories';
+
+        // Baseline: both fresh users hit the SAME unconfigured tavily gate.
+        const a0 = await postSearch(request, userA.access_token, { query: QUERY });
+        const b0 = await postSearch(request, userB.access_token, { query: QUERY });
+        expect(a0.status).toBeLessThan(500);
+        expect(b0.status).toBeLessThan(500);
+
+        // userA sets a FAKE user-scoped tavily key.
+        const patch = await patchPluginSettingsViaAPI(request, userA.access_token, DEFAULT_SEARCH, {
+            secretSettings: { apiKey: `fake-tavily-A-${uniqueSuffix()}` },
+        });
+        expect(patch.status).toBe(200);
+
+        const aAfter = await postSearch(request, userA.access_token, { query: QUERY });
+        const bAfter = await postSearch(request, userB.access_token, { query: QUERY });
+        expect(aAfter.status).toBeLessThan(500);
+        expect(bAfter.status).toBeLessThan(500);
+
+        // In key-less CI the divergence is observable: A flipped to the provider
+        // error, B is unchanged on the gate. (In a fully-keyed env both 200 — then
+        // both branches below are skipped and the test still proves no 5xx.)
+        if (a0.status === 400 && a0.body.status === 'error') {
+            const a0msg = flatten(a0.body.message);
+            // A started on the gate; after configuring, A must have moved OFF it.
+            if (a0msg.includes(MSG_NOT_CONFIGURED) && aAfter.status === 400) {
+                expect(flatten(aAfter.body.message)).not.toContain(MSG_NOT_CONFIGURED);
+            }
+        }
+        if (bAfter.status === 400) {
+            // B never configured a key → B is STILL on the unconfigured gate, proving
+            // A's user-scoped key never resolved into B's execution context.
+            expect(bAfter.body.status).toBe('error');
+            expect(flatten(bAfter.body.message)).toContain(MSG_NOT_CONFIGURED);
+        }
+    });
+
+    test('FLOW 9: WORK-scoped resolution still anchors to the default even when a non-default is the work-ACTIVE binding — work-enabling+activating brave on an owned work does not move the work search off tavily’s gate', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+        const work = await createWorkViaAPI(request, user.access_token, {
+            name: `Deep Search Work ${uniqueSuffix()}`,
+        });
+        expect(work.id, `work created (raw=${JSON.stringify(work.raw).slice(0, 160)})`).toBeTruthy();
+
+        // Fully wire brave: user-enable, key it, then make it the work-ACTIVE search
+        // provider. This is the strongest case for brave to "win" — yet it doesn't.
+        await enablePluginViaAPI(request, user.access_token, SECONDARY_SEARCH);
+        const cfg = await patchPluginSettingsViaAPI(
+            request,
+            user.access_token,
+            SECONDARY_SEARCH,
+            { secretSettings: { apiKey: `fake-brave-${uniqueSuffix()}` } },
+        );
+        expect(cfg.status).toBe(200);
+
+        const workEnable = await request.post(
+            `${API_BASE}/api/works/${work.id}/plugins/${SECONDARY_SEARCH}/enable`,
+            { headers: authedHeaders(user.access_token), data: { activeCapability: 'search' } },
+        );
+        expect(workEnable.status(), `work-enable body=${await workEnable.text()}`).toBe(200);
+        const weBody = (await workEnable.json()) as { activeCapabilities?: string[] };
+        expect(weBody.activeCapabilities).toContain('search');
+
+        // The work plugin list confirms brave IS the work-active search binding...
+        const wList = await request.get(`${API_BASE}/api/works/${work.id}/plugins`, {
+            headers: authedHeaders(user.access_token),
+        });
+        const wlBody = (await wList.json()) as { capabilityProviders?: Record<string, string> };
+        expect(wlBody.capabilityProviders?.search).toBe(SECONDARY_SEARCH);
+
+        // ...and YET the controller's resolveConfiguredProvider() (which ignores the
+        // work-active binding and sorts defaultForCapabilities-first) still resolves
+        // tavily → the work-scoped search reports TAVILY's gate, not brave's.
+        const res = await postSearch(request, user.access_token, {
+            query: 'project tooling',
+            workId: work.id,
+        });
+        expect(res.status, 'work-scoped search must not 5xx').toBeLessThan(500);
+        expect([200, 400]).toContain(res.status);
+        if (res.status === 400) {
+            expect(res.body.status).toBe('error');
+            const msg = flatten(res.body.message);
+            // Owner CAN view their own work → not an ownership 404/403.
+            expect(msg).not.toContain('not found');
+            expect(msg).not.toContain('permission');
+            // The resolved provider is the default tavily.
+            expect(msg).toContain(MSG_NOT_CONFIGURED);
+        }
+    });
+
+    test('FLOW 10: a fully-populated VALID body (maxResults + both domain filters) is accepted by the DTO and reaches provider resolution; the 200 path echoes a provider NAME and a {title,url,score↓} item list, the 400 path is a clean structured error', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+
+        // Configure tavily so the facade dispatches; the body exercises EVERY
+        // optional DTO field at once (distinct from the sibling's bare bodies).
+        const patch = await patchPluginSettingsViaAPI(request, user.access_token, DEFAULT_SEARCH, {
+            secretSettings: { apiKey: `fake-tavily-${uniqueSuffix()}` },
+        });
+        expect(patch.status).toBe(200);
+
+        const res = await postSearch(request, user.access_token, {
+            query: 'open source software directories',
+            maxResults: 5,
+            includeDomains: ['github.com', 'stackoverflow.com'],
+            excludeDomains: ['pinterest.com'],
+        });
+        expect(res.status, 'valid full body must not 5xx').toBeLessThan(500);
+        expect([200, 400]).toContain(res.status);
+
+        if (res.status === 200) {
+            // Pin the result-item contract from the facade mapping: score == 1 -
+            // index*0.05 → strictly non-increasing; provider echo is the NAME string.
+            expect(res.body.status).toBe('success');
+            expect(typeof res.body.provider, 'provider name echoed').toBe('string');
+            expect(Array.isArray(res.body.results)).toBe(true);
+            let prev = Number.POSITIVE_INFINITY;
+            for (const item of res.body.results ?? []) {
+                expect(typeof item.title).toBe('string');
+                expect(typeof item.url).toBe('string');
+                expect(typeof item.score).toBe('number');
+                expect(item.score as number).toBeLessThanOrEqual(prev);
+                prev = item.score as number;
+                if (item.publishedDate !== undefined) {
+                    expect(typeof item.publishedDate).toBe('string');
+                }
+            }
+        } else {
+            // The valid body is NOT a validation 400 (which would be an array); it's
+            // the provider-stage error string.
+            expect(res.body.status).toBe('error');
+            expect(Array.isArray(res.body.message), 'provider 400, not a DTO array').toBe(false);
+            expect(flatten(res.body.message).length).toBeGreaterThan(0);
+        }
+    });
+
+    test('FLOW 11: the DTO whitelist forbids unknown props OUTRIGHT even alongside a fully-valid envelope — a bogus key never silently strips, it 400s with "property bogus should not exist"', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+
+        // A body that would otherwise be perfectly valid, plus one stray prop.
+        const res = await postSearch(request, user.access_token, {
+            query: 'directories',
+            maxResults: 5,
+            includeDomains: ['github.com'],
+            bogus: 'x',
+        });
+        expect(res.status).toBe(400);
+        expect(flatten(res.body.message)).toContain('property bogus should not exist');
+        // forbidNonWhitelisted means it never reaches the provider — a pure 4xx.
+        expect(res.status).toBeLessThan(500);
+    });
+
+    test('FLOW 12: a non-default provider secret round-trips MASKED (first4 + bullets + last4) and never appears in resolvedSettings, while its global maxResults does — proving secret/non-secret split on a SEARCH provider', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+
+        // Use exa (sibling specs mask via brave — distinct provider here) with a key
+        // shaped so the first/last 4 chars are easy to assert.
+        await enablePluginViaAPI(request, user.access_token, TERTIARY_SEARCH);
+        const RAW_KEY = 'abcd1234567890wxyz';
+        const patched = await patchPluginSettingsViaAPI(request, user.access_token, TERTIARY_SEARCH, {
+            settings: { maxResults: 7 },
+            secretSettings: { apiKey: RAW_KEY },
+        });
+        expect(patched.status, `exa patch body=${JSON.stringify(patched.body)}`).toBe(200);
+        const pBody = patched.body as {
+            settings?: Record<string, unknown>;
+            resolvedSettings?: Record<string, unknown>;
+        };
+
+        const masked = pBody.settings?.apiKey;
+        expect(typeof masked).toBe('string');
+        expect(masked).not.toBe(RAW_KEY);
+        expect(String(masked)).toContain('••••');
+        // The mask preserves the first + last 4 chars (PROBED format: abcd••••wxyz).
+        expect(String(masked).startsWith('abcd')).toBe(true);
+        expect(String(masked).endsWith('wxyz')).toBe(true);
+        // The non-secret global maxResults round-trips; the raw secret NEVER does.
+        expect(pBody.resolvedSettings?.maxResults).toBe(7);
+        expect('apiKey' in (pBody.resolvedSettings ?? {}), 'raw secret stays out of resolved').toBe(
+            false,
+        );
+
+        // The mask persists across a fresh GET (the secret is stored, surfaced masked).
+        await expect
+            .poll(
+                async () => {
+                    const fresh = await getPluginViaAPI(
+                        request,
+                        user.access_token,
+                        TERTIARY_SEARCH,
+                    );
+                    return (fresh.settings as Record<string, unknown> | undefined)?.apiKey;
+                },
+                { timeout: 15_000, message: 'masked exa apiKey persists across GET' },
+            )
+            .toBe(masked);
+    });
+
+    test('FLOW 13: POST /api/search is auth-guarded for anonymous callers (raw fetch — no inherited storage state) and rejects with 401 before any DTO validation runs', async ({
+        request,
+    }) => {
+        // Even a body that would FAIL DTO validation (empty object → missing query)
+        // is rejected for AUTH first — the guard runs ahead of the ValidationPipe.
+        const anon = await fetch(`${API_BASE}/api/search`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({}),
+        });
+        expect(anon.status).toBe(401);
+        const anonBody = (await anon.json().catch(() => ({}))) as { message?: string };
+        expect(anonBody.message).toBe('Unauthorized');
+
+        // Sanity: with a valid token the same empty body now reaches the validator
+        // and 400s on the missing query (NOT 401) — confirming the 401 above was the
+        // guard, not the validator.
+        const user: RegisteredUser = await registerUserViaAPI(request);
+        const authed = await postSearch(request, user.access_token, {});
+        expect(authed.status).toBe(400);
+        expect(flatten(authed.body.message)).toContain('query must be a string');
+    });
+
+    test('FLOW 14: enabling a non-default provider WITHOUT configuring its key leaves availability anchored to tavily AND search still resolves tavily — adding an unconfigured provider can never displace the system default', async ({
+        request,
+    }) => {
+        const user: RegisteredUser = await registerUserViaAPI(request);
+
+        // Enable serpapi but DO NOT set its apiKey. serpapi's required apiKey is
+        // x-envVar → env-skipped, so it would "pass" hasAllRequiredSettings too —
+        // but it sorts AFTER the defaultForCapabilities tavily, so tavily still wins.
+        const enabled = await enablePluginViaAPI(request, user.access_token, 'serpapi');
+        expect(enabled.enabled).toBe(true);
+
+        // Availability is unchanged: still the tavily default, still available.
+        const avail = await getAvailability(request, user.access_token);
+        expect(avail.body.available).toBe(true);
+        expect(avail.body.activeProvider?.id).toBe(DEFAULT_SEARCH);
+
+        // And an actual search resolves tavily (its gate), NOT serpapi — the default
+        // beats a later-sorted, also-env-skipped provider.
+        const res = await postSearch(request, user.access_token, { query: 'q' });
+        expect(res.status, 'search must not 5xx').toBeLessThan(500);
+        expect([200, 400]).toContain(res.status);
+        if (res.status === 400) {
+            expect(res.body.status).toBe('error');
+            const msg = flatten(res.body.message);
+            expect(msg).toContain(MSG_NOT_CONFIGURED);
+            expect(msg.toLowerCase()).not.toContain('serpapi');
+        }
+    });
+});

--- a/apps/web/e2e/flow-skill-bindings-deep.spec.ts
+++ b/apps/web/e2e/flow-skill-bindings-deep.spec.ts
@@ -1,0 +1,738 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import {
+    API_BASE,
+    authedHeaders,
+    registerUserViaAPI,
+    createWorkViaAPI,
+    type RegisteredUser,
+} from './helpers/api';
+import { createAgentViaAPI } from './helpers/agents-tasks';
+
+/**
+ * Skill bindings — DEEP per-skill bindings-list lifecycle + filtering + DTO.
+ *
+ * The skill-bindings surface is:
+ *   POST   /api/skills/:id/bindings   → 201 binding row
+ *   GET    /api/skills/:id/bindings   → SkillBinding[] (per-skill, userId-scoped)
+ *   DELETE /api/skill-bindings/:id    → 200 { deleted:true }
+ * There is NO PATCH/PUT — "rebind/update" is delete-then-recreate.
+ *
+ * NON-DUPLICATION — these existing specs already pin a DIFFERENT slice, so
+ * this file deliberately does NOT re-pin them:
+ *   - sec-pin-skills-scoping.spec.ts (Batch 1): the SECURITY edges — exact 404
+ *     bodies on both Wave-L routes, the foreign/never-existed/tombstone TRI-
+ *     STATE non-disclosure, cross-user list-gate 404 vs empty-array, the gate-
+ *     ORDER asymmetry on POST, anon-401 surface, malformed-vs-unknown id, the
+ *     DELETE-only parentless route. We do NOT re-pin the cross-user 404s.
+ *   - flow-skill-agent-binding-deep.spec.ts / flow-agent-skills-binding.spec.ts
+ *     / flow-skill-binding-permission.spec.ts: the AGENT-RESOLVER projection
+ *     (GET /api/agents/:id/skills — priority ASC, dedup-by-skillId, failover,
+ *     injectIntoAgent filter, work/mission scope joins, live version
+ *     propagation, canEditSkills posture). We assert through the per-skill
+ *     BINDINGS LIST, never the agent resolver, and never re-pin dedup/priority
+ *     ordering of the resolver.
+ *   This file goes DEEPER on the happy-path lifecycle + filtering + DTO that
+ *   none of the above pins: the per-skill bindings-LIST reflection of a
+ *   bind/rebind/unbind across EACH target type (agent/work/mission/idea), the
+ *   list filtered-by-skillId (two same-user skills stay disjoint), the binding
+ *   DTO shape + defaults + bounds (priority 1..1000, boolean flags), the
+ *   tenant-target targetId-nulling, the tenant-duplicate-ALLOWED vs
+ *   work/agent-duplicate-500 unique-index asymmetry, the foreign-SKILL vs
+ *   foreign-TARGET 404 message boundary, and the FK-cascade list teardown.
+ *
+ * PROBED CONTRACTS (live sqlite stack, 2026-06-11 — every assertion below was
+ * observed via curl before being written):
+ *   - POST /api/skills/:id/bindings → 201 with EXACTLY 11 keys: id, skillId,
+ *     targetType, targetId, userId(=caller), injectIntoAgent, injectIntoGenerator,
+ *     priority, tenantId(null), organizationId(null), createdAt. Defaults:
+ *     priority 100, injectIntoAgent true, injectIntoGenerator false.
+ *   - GET /api/skills/:id/bindings → a SkillBinding[] (raw array) of ONLY this
+ *     skill's bindings, each row the SAME 11-key shape. Order is not sorted by
+ *     priority (repository find() has no ORDER BY) → assert by set, not order.
+ *   - targetType ∈ {tenant, agent, work, mission, idea}; agent/work/mission/idea
+ *     bindings carry the supplied targetId; a `tenant` binding ALWAYS stores
+ *     targetId:null even when an explicit targetId is supplied in the body
+ *     (service forces it null) — injectIntoGenerator/priority still persist.
+ *   - DELETE /api/skill-bindings/:id → 200 { deleted:true }; the row then
+ *     disappears from GET :id/bindings.
+ *   - tenant duplicate (targetId NULL) → 201 BOTH times (NULL≠NULL in the
+ *     unique index) → the list holds two rows. work/agent duplicate (non-null
+ *     targetId) → 500 { statusCode:500, message:"Internal server error" }
+ *     (uq_skill_binding fires).
+ *   - priority bounds (DTO @Min 1 @Max 1000 @IsInt): 0 → 400 "priority must not
+ *     be less than 1"; 1001 → 400 "priority must not be greater than 1000";
+ *     3.5 → 400 "priority must be an integer number".
+ *   - injectIntoAgent/injectIntoGenerator (DTO @IsBoolean): a non-boolean →
+ *     400 "<field> must be a boolean value".
+ *   - Binding a NONEXISTENT skill → 404 "Skill <id> not found." (the SKILL
+ *     gate). Binding a non-tenant target the caller does not own → 404 "Skill
+ *     target not found." (the TARGET ownership gate). Distinct messages.
+ *   - DELETE /api/skills/:id → 200 { deleted:true } FK-CASCADEs its bindings:
+ *     GET that skill's /bindings → 404 (skill gone); a SIBLING skill's list is
+ *     untouched.
+ *
+ * Isolation: every test registers FRESH users via registerUserViaAPI with
+ * per-test-title unique suffixes; nothing touches the seeded storageState user.
+ * API-contract assertions only (no UI navigation).
+ */
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** A UUID no row in the DB ever has. */
+const UNKNOWN_UUID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+
+/** The exact 11-key field set of a binding row (POST response and list row). */
+const BINDING_ROW_KEYS = [
+    'createdAt',
+    'id',
+    'injectIntoAgent',
+    'injectIntoGenerator',
+    'organizationId',
+    'priority',
+    'skillId',
+    'targetId',
+    'targetType',
+    'tenantId',
+    'userId',
+];
+
+interface BindingRow {
+    id: string;
+    skillId: string;
+    targetType: string;
+    targetId: string | null;
+    userId: string;
+    injectIntoAgent: boolean;
+    injectIntoGenerator: boolean;
+    priority: number;
+    tenantId: string | null;
+    organizationId: string | null;
+    createdAt: string;
+}
+
+interface ErrorBody {
+    message: string | string[];
+    error?: string;
+    statusCode: number;
+}
+
+/** Per-test unique suffix derived from the test title (no module-scope clock). */
+function suffix(testName: string): string {
+    let h = 0;
+    for (let i = 0; i < testName.length; i++) h = (h * 31 + testName.charCodeAt(i)) >>> 0;
+    return `${h.toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+async function createSkill(
+    request: APIRequestContext,
+    user: RegisteredUser,
+    title: string,
+): Promise<{ id: string; slug: string }> {
+    const res = await request.post(`${API_BASE}/api/skills`, {
+        headers: authedHeaders(user.access_token),
+        data: {
+            ownerType: 'tenant',
+            ownerId: user.user.id,
+            title,
+            description: 'deep skill-bindings skill',
+            instructionsMd: `# ${title}`,
+        },
+    });
+    expect(res.status(), `createSkill body=${await res.text().catch(() => '')}`).toBe(201);
+    return res.json();
+}
+
+async function bindRaw(
+    request: APIRequestContext,
+    token: string,
+    skillId: string,
+    binding: Record<string, unknown>,
+) {
+    return request.post(`${API_BASE}/api/skills/${skillId}/bindings`, {
+        headers: authedHeaders(token),
+        data: binding,
+    });
+}
+
+async function bind(
+    request: APIRequestContext,
+    token: string,
+    skillId: string,
+    binding: Record<string, unknown>,
+): Promise<BindingRow> {
+    const res = await bindRaw(request, token, skillId, binding);
+    expect(res.status(), `bind body=${await res.text().catch(() => '')}`).toBe(201);
+    return res.json();
+}
+
+async function listBindings(
+    request: APIRequestContext,
+    token: string,
+    skillId: string,
+): Promise<BindingRow[]> {
+    const res = await request.get(`${API_BASE}/api/skills/${skillId}/bindings`, {
+        headers: authedHeaders(token),
+    });
+    expect(res.status(), `list body=${await res.text().catch(() => '')}`).toBe(200);
+    return res.json();
+}
+
+async function unbind(
+    request: APIRequestContext,
+    token: string,
+    bindingId: string,
+): Promise<number> {
+    const res = await request.delete(`${API_BASE}/api/skill-bindings/${bindingId}`, {
+        headers: authedHeaders(token),
+    });
+    return res.status();
+}
+
+test.describe('Skill bindings — deep per-skill list lifecycle + filtering + DTO', () => {
+    // ── DTO shape + per-target list reflection ───────────────────────────
+
+    test('the binding DTO response is the exact 11-key row with probed defaults (priority 100 / agent:true / generator:false)', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Shape Skill ${suffix('shape')}`);
+
+        // No priority / no flags supplied → the documented defaults apply.
+        const created = await bind(request, a.access_token, skill.id, { targetType: 'tenant' });
+
+        expect(Object.keys(created).sort()).toEqual(BINDING_ROW_KEYS);
+        expect(created.id).toMatch(UUID_RE);
+        expect(created.skillId).toBe(skill.id);
+        expect(created.userId).toBe(a.user.id);
+        expect(created.targetType).toBe('tenant');
+        expect(created.targetId).toBeNull();
+        expect(created.priority).toBe(100);
+        expect(created.injectIntoAgent).toBe(true);
+        expect(created.injectIntoGenerator).toBe(false);
+        expect(created.tenantId).toBeNull();
+        expect(created.organizationId).toBeNull();
+        expect(typeof created.createdAt).toBe('string');
+
+        // The list row carries the IDENTICAL 11-key shape — never the skill
+        // body/title/instructionsMd leaks into a binding row.
+        const listed = await listBindings(request, a.access_token, skill.id);
+        expect(listed).toHaveLength(1);
+        expect(Object.keys(listed[0]).sort()).toEqual(BINDING_ROW_KEYS);
+        expect(listed[0]).toEqual(created);
+    });
+
+    test('agent-target bind → the per-skill list reflects it scoped → unbind empties the list', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Agent Bind Skill ${suffix('agent')}`);
+        const agent = await createAgentViaAPI(request, a.access_token, {
+            name: `Agent Bind ${suffix('agent')}`,
+            scope: 'tenant',
+        });
+
+        // Pre-bind the list is an empty array (NOT a 404 for the owner).
+        expect(await listBindings(request, a.access_token, skill.id)).toEqual([]);
+
+        const binding = await bind(request, a.access_token, skill.id, {
+            targetType: 'agent',
+            targetId: agent.id,
+            priority: 42,
+        });
+        expect(binding.targetType).toBe('agent');
+        expect(binding.targetId).toBe(agent.id);
+
+        const listed = await listBindings(request, a.access_token, skill.id);
+        expect(listed.map((r) => r.id)).toEqual([binding.id]);
+        expect(listed[0].targetType).toBe('agent');
+        expect(listed[0].targetId).toBe(agent.id);
+        expect(listed[0].priority).toBe(42);
+
+        // Unbind → the list empties (and the success body is exactly {deleted:true}).
+        const del = await request.delete(`${API_BASE}/api/skill-bindings/${binding.id}`, {
+            headers: authedHeaders(a.access_token),
+        });
+        expect(del.status()).toBe(200);
+        expect(await del.json()).toEqual({ deleted: true });
+        expect(await listBindings(request, a.access_token, skill.id)).toEqual([]);
+    });
+
+    test('work-target bind → the list row maps the exact work targetId; unbind removes only that row', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Work Bind Skill ${suffix('work')}`);
+        const work = await createWorkViaAPI(request, a.access_token, {
+            name: `Work Bind ${suffix('work')}`,
+        });
+        expect(work.id).toBeTruthy();
+
+        const binding = await bind(request, a.access_token, skill.id, {
+            targetType: 'work',
+            targetId: work.id,
+            priority: 15,
+        });
+        expect(binding.targetType).toBe('work');
+        expect(binding.targetId).toBe(work.id);
+
+        const listed = await listBindings(request, a.access_token, skill.id);
+        expect(listed).toHaveLength(1);
+        expect(listed[0]).toMatchObject({
+            id: binding.id,
+            targetType: 'work',
+            targetId: work.id,
+            priority: 15,
+        });
+
+        expect(await unbind(request, a.access_token, binding.id)).toBe(200);
+        expect(await listBindings(request, a.access_token, skill.id)).toEqual([]);
+    });
+
+    test('mission-target bind → the list row carries the mission targetId', async ({ request }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Mission Bind Skill ${suffix('mission')}`);
+        const missionRes = await request.post(`${API_BASE}/api/me/missions`, {
+            headers: authedHeaders(a.access_token),
+            data: {
+                title: `Mission Bind ${suffix('mission')}`,
+                description: 'd',
+                type: 'one-shot',
+            },
+        });
+        expect(missionRes.status(), `mission body=${await missionRes.text().catch(() => '')}`).toBe(
+            201,
+        );
+        const mission = await missionRes.json();
+        expect(mission.id).toBeTruthy();
+
+        const binding = await bind(request, a.access_token, skill.id, {
+            targetType: 'mission',
+            targetId: mission.id,
+            priority: 8,
+        });
+        expect(binding.targetType).toBe('mission');
+        expect(binding.targetId).toBe(mission.id);
+
+        const listed = await listBindings(request, a.access_token, skill.id);
+        expect(listed.map((r) => ({ t: r.targetType, id: r.targetId }))).toEqual([
+            { t: 'mission', id: mission.id },
+        ]);
+    });
+
+    test('idea-target bind → the list row carries the idea (work-proposal) targetId', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Idea Bind Skill ${suffix('idea')}`);
+
+        // An "Idea" is a work-proposal created via the user-manual +Add route.
+        const ideaRes = await request.post(`${API_BASE}/api/me/work-proposals`, {
+            headers: authedHeaders(a.access_token),
+            data: { title: `Idea Bind ${suffix('idea')}`, description: 'idea body for binding' },
+        });
+        expect(ideaRes.status(), `idea body=${await ideaRes.text().catch(() => '')}`).toBe(201);
+        const idea = await ideaRes.json();
+        expect(idea.id).toBeTruthy();
+
+        const binding = await bind(request, a.access_token, skill.id, {
+            targetType: 'idea',
+            targetId: idea.id,
+            priority: 33,
+        });
+        expect(binding.targetType).toBe('idea');
+        expect(binding.targetId).toBe(idea.id);
+
+        const listed = await listBindings(request, a.access_token, skill.id);
+        expect(listed.map((r) => ({ t: r.targetType, id: r.targetId }))).toEqual([
+            { t: 'idea', id: idea.id },
+        ]);
+    });
+
+    // ── Filtering: list is per-skill (filtered by skillId implicitly) ────
+
+    test('one skill bound at four targets (tenant/work/mission/agent) lists all four rows, each with the right targetType→targetId', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Multi Target Skill ${suffix('multi')}`);
+        const work = await createWorkViaAPI(request, a.access_token, {
+            name: `Multi Work ${suffix('multi')}`,
+        });
+        const agent = await createAgentViaAPI(request, a.access_token, {
+            name: `Multi Agent ${suffix('multi')}`,
+            scope: 'tenant',
+        });
+        const mission = await (
+            await request.post(`${API_BASE}/api/me/missions`, {
+                headers: authedHeaders(a.access_token),
+                data: { title: `Multi Mission ${suffix('multi')}`, description: 'd', type: 'one-shot' },
+            })
+        ).json();
+
+        const tenantBinding = await bind(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            priority: 10,
+        });
+        const workBinding = await bind(request, a.access_token, skill.id, {
+            targetType: 'work',
+            targetId: work.id,
+            priority: 20,
+        });
+        const missionBinding = await bind(request, a.access_token, skill.id, {
+            targetType: 'mission',
+            targetId: mission.id,
+            priority: 30,
+        });
+        const agentBinding = await bind(request, a.access_token, skill.id, {
+            targetType: 'agent',
+            targetId: agent.id,
+            priority: 40,
+        });
+
+        const listed = await listBindings(request, a.access_token, skill.id);
+        // The list endpoint isn't priority-sorted (repository find has no ORDER
+        // BY), so compare as sets.
+        expect(listed).toHaveLength(4);
+        expect(listed.map((r) => r.id).sort()).toEqual(
+            [tenantBinding.id, workBinding.id, missionBinding.id, agentBinding.id].sort(),
+        );
+        const byType = new Map(listed.map((r) => [r.targetType, r.targetId]));
+        expect(byType.get('tenant')).toBeNull();
+        expect(byType.get('work')).toBe(work.id);
+        expect(byType.get('mission')).toBe(mission.id);
+        expect(byType.get('agent')).toBe(agent.id);
+        // Every row is stamped to this skill and this caller.
+        expect(listed.every((r) => r.skillId === skill.id)).toBe(true);
+        expect(listed.every((r) => r.userId === a.user.id)).toBe(true);
+    });
+
+    test('the bindings list is filtered by skillId: two of the SAME user’s skills keep disjoint lists', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const s = suffix('filter');
+        const skillX = await createSkill(request, a, `Filter Skill X ${s}`);
+        const skillY = await createSkill(request, a, `Filter Skill Y ${s}`);
+        const agent = await createAgentViaAPI(request, a.access_token, {
+            name: `Filter Agent ${s}`,
+            scope: 'tenant',
+        });
+
+        // Two bindings on X, one on Y — all owned by the same user.
+        const x1 = await bind(request, a.access_token, skillX.id, { targetType: 'tenant' });
+        const x2 = await bind(request, a.access_token, skillX.id, {
+            targetType: 'agent',
+            targetId: agent.id,
+        });
+        const y1 = await bind(request, a.access_token, skillY.id, { targetType: 'tenant' });
+
+        const listX = await listBindings(request, a.access_token, skillX.id);
+        const listY = await listBindings(request, a.access_token, skillY.id);
+
+        // X lists ONLY X's two; Y lists ONLY Y's one. No cross-bleed despite
+        // shared ownership — the list is scoped by the path skillId.
+        expect(listX.map((r) => r.id).sort()).toEqual([x1.id, x2.id].sort());
+        expect(listY.map((r) => r.id)).toEqual([y1.id]);
+        expect(listX.map((r) => r.id)).not.toContain(y1.id);
+        expect(listY.map((r) => r.id)).not.toContain(x1.id);
+        expect(listX.every((r) => r.skillId === skillX.id)).toBe(true);
+        expect(listY.every((r) => r.skillId === skillY.id)).toBe(true);
+    });
+
+    // ── Rebind / update (delete + recreate; no PATCH route) ──────────────
+
+    test('rebind = delete + recreate: the list reflects the new id + new priority + new flags, old id gone', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Rebind Skill ${suffix('rebind')}`);
+
+        // Original binding at priority 100, generator-injection off.
+        const first = await bind(request, a.access_token, skill.id, { targetType: 'tenant' });
+        expect(first.priority).toBe(100);
+        expect(first.injectIntoGenerator).toBe(false);
+        expect((await listBindings(request, a.access_token, skill.id)).map((r) => r.id)).toEqual([
+            first.id,
+        ]);
+
+        // "Update" the binding: there is no PATCH route, so unbind then re-bind
+        // at a new priority with generator injection toggled on.
+        expect(await unbind(request, a.access_token, first.id)).toBe(200);
+        const second = await bind(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            priority: 7,
+            injectIntoGenerator: true,
+        });
+        expect(second.id).not.toBe(first.id);
+
+        // The list now reflects ONLY the new binding with the updated fields.
+        const listed = await listBindings(request, a.access_token, skill.id);
+        expect(listed).toHaveLength(1);
+        expect(listed[0].id).toBe(second.id);
+        expect(listed[0].id).not.toBe(first.id);
+        expect(listed[0].priority).toBe(7);
+        expect(listed[0].injectIntoGenerator).toBe(true);
+
+        // Re-deleting the now-stale original id is a clean 404.
+        expect(await unbind(request, a.access_token, first.id)).toBe(404);
+    });
+
+    // ── tenant targetId nulling + duplicate-allowance asymmetry ──────────
+
+    test('a tenant binding forces targetId to null even when an explicit targetId is supplied, but keeps priority + generator flag', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Tenant Null Skill ${suffix('tnull')}`);
+
+        // Supply a (real, owned) targetId AND a tenant targetType: the service
+        // stores targetId:null regardless, but the other supplied fields stick.
+        const created = await bind(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            targetId: a.user.id,
+            priority: 50,
+            injectIntoGenerator: true,
+        });
+        expect(created.targetType).toBe('tenant');
+        expect(created.targetId).toBeNull();
+        expect(created.priority).toBe(50);
+        expect(created.injectIntoGenerator).toBe(true);
+
+        const listed = await listBindings(request, a.access_token, skill.id);
+        expect(listed).toHaveLength(1);
+        expect(listed[0].targetId).toBeNull();
+        expect(listed[0].priority).toBe(50);
+    });
+
+    test('duplicate tenant bindings are ALLOWED (null targetId ≠ null in the unique index) — both 201, list holds two rows', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Tenant Dup Skill ${suffix('tdup')}`);
+
+        const first = await bind(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            priority: 10,
+        });
+        const second = await bind(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            priority: 20,
+        });
+        expect(second.id).not.toBe(first.id);
+
+        const listed = await listBindings(request, a.access_token, skill.id);
+        expect(listed).toHaveLength(2);
+        expect(listed.map((r) => r.id).sort()).toEqual([first.id, second.id].sort());
+        // Both are tenant rows with a null targetId — the unique index does not
+        // collapse them because NULL is never equal to NULL in SQL.
+        expect(listed.every((r) => r.targetType === 'tenant' && r.targetId === null)).toBe(true);
+        expect(listed.map((r) => r.priority).sort((x, y) => x - y)).toEqual([10, 20]);
+    });
+
+    test('duplicate non-tenant bindings hit the unique index: an identical work/agent binding 500s while the first survives', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `NonTenant Dup Skill ${suffix('ntdup')}`);
+        const work = await createWorkViaAPI(request, a.access_token, {
+            name: `Dup Work ${suffix('ntdup')}`,
+        });
+        const agent = await createAgentViaAPI(request, a.access_token, {
+            name: `Dup Agent ${suffix('ntdup')}`,
+            scope: 'tenant',
+        });
+
+        // First work binding succeeds.
+        const workBinding = await bind(request, a.access_token, skill.id, {
+            targetType: 'work',
+            targetId: work.id,
+        });
+        // An IDENTICAL (skill+work+targetId) binding hits uq_skill_binding → raw 500.
+        const dupWork = await bindRaw(request, a.access_token, skill.id, {
+            targetType: 'work',
+            targetId: work.id,
+        });
+        expect(dupWork.status()).toBe(500);
+
+        // Same asymmetry for an agent target.
+        const agentBinding = await bind(request, a.access_token, skill.id, {
+            targetType: 'agent',
+            targetId: agent.id,
+        });
+        const dupAgent = await bindRaw(request, a.access_token, skill.id, {
+            targetType: 'agent',
+            targetId: agent.id,
+        });
+        expect(dupAgent.status()).toBe(500);
+
+        // The failed dup writes persisted nothing extra: exactly the two
+        // originals remain.
+        const listed = await listBindings(request, a.access_token, skill.id);
+        expect(listed.map((r) => r.id).sort()).toEqual([workBinding.id, agentBinding.id].sort());
+    });
+
+    // ── DTO validation bounds ────────────────────────────────────────────
+
+    test('priority DTO bounds: 0 < min, 1001 > max, and a non-integer are each 400 with the canonical class-validator message', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Priority Bounds Skill ${suffix('prio')}`);
+
+        const below = await bindRaw(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            priority: 0,
+        });
+        expect(below.status()).toBe(400);
+        expect(JSON.stringify(((await below.json()) as ErrorBody).message)).toMatch(
+            /priority must not be less than 1/i,
+        );
+
+        const above = await bindRaw(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            priority: 1001,
+        });
+        expect(above.status()).toBe(400);
+        expect(JSON.stringify(((await above.json()) as ErrorBody).message)).toMatch(
+            /priority must not be greater than 1000/i,
+        );
+
+        const fractional = await bindRaw(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            priority: 3.5,
+        });
+        expect(fractional.status()).toBe(400);
+        expect(JSON.stringify(((await fractional.json()) as ErrorBody).message)).toMatch(
+            /priority must be an integer number/i,
+        );
+
+        // The boundary values 1 and 1000 ARE accepted (inclusive bounds).
+        const minOk = await bind(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            priority: 1,
+        });
+        expect(minOk.priority).toBe(1);
+        const maxOk = await bind(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            priority: 1000,
+        });
+        expect(maxOk.priority).toBe(1000);
+
+        // None of the three rejected writes persisted; the two accepted did.
+        expect((await listBindings(request, a.access_token, skill.id)).length).toBe(2);
+    });
+
+    test('the inject flags are strictly boolean: a non-boolean injectIntoAgent / injectIntoGenerator is 400', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Flag Bool Skill ${suffix('flag')}`);
+
+        const badAgent = await bindRaw(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            injectIntoAgent: 'yes',
+        });
+        expect(badAgent.status()).toBe(400);
+        expect(JSON.stringify(((await badAgent.json()) as ErrorBody).message)).toMatch(
+            /injectIntoAgent must be a boolean value/i,
+        );
+
+        const badGen = await bindRaw(request, a.access_token, skill.id, {
+            targetType: 'tenant',
+            injectIntoGenerator: 3,
+        });
+        expect(badGen.status()).toBe(400);
+        expect(JSON.stringify(((await badGen.json()) as ErrorBody).message)).toMatch(
+            /injectIntoGenerator must be a boolean value/i,
+        );
+
+        // Both rejected — nothing persisted.
+        expect(await listBindings(request, a.access_token, skill.id)).toEqual([]);
+    });
+
+    // ── 404 boundary: foreign skill vs foreign target ───────────────────
+
+    test('binding boundary: an unknown SKILL → 404 "Skill <id> not found", a foreign TARGET on a real skill → 404 "Skill target not found"', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const skill = await createSkill(request, a, `Boundary Skill ${suffix('boundary')}`);
+
+        // (a) Unknown skill id → the SKILL gate fires first, naming the skill.
+        const unknownSkill = await bindRaw(request, a.access_token, UNKNOWN_UUID, {
+            targetType: 'tenant',
+        });
+        expect(unknownSkill.status()).toBe(404);
+        expect(((await unknownSkill.json()) as ErrorBody).message).toBe(
+            `Skill ${UNKNOWN_UUID} not found.`,
+        );
+
+        // (b) Real owned skill, but a non-tenant target the caller does not own
+        // → the TARGET ownership gate fires with a DISTINCT generic message
+        // (no targetId echoed back — no existence probe of the target space).
+        const foreignTarget = await bindRaw(request, a.access_token, skill.id, {
+            targetType: 'work',
+            targetId: UNKNOWN_UUID,
+        });
+        expect(foreignTarget.status()).toBe(404);
+        expect(((await foreignTarget.json()) as ErrorBody).message).toBe('Skill target not found.');
+
+        // The two 404s are genuinely different messages — the skill gate names
+        // the id, the target gate stays opaque.
+        expect(`Skill ${UNKNOWN_UUID} not found.`).not.toBe('Skill target not found.');
+
+        // Neither rejected write left a row.
+        expect(await listBindings(request, a.access_token, skill.id)).toEqual([]);
+    });
+
+    // ── FK cascade ───────────────────────────────────────────────────────
+
+    test('deleting the parent skill FK-cascades its bindings: the list 404s afterward, a sibling skill’s list is intact', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const s = suffix('cascade');
+        const doomed = await createSkill(request, a, `Cascade Doomed Skill ${s}`);
+        const sibling = await createSkill(request, a, `Cascade Sibling Skill ${s}`);
+        const work = await createWorkViaAPI(request, a.access_token, {
+            name: `Cascade Work ${s}`,
+        });
+
+        // The doomed skill carries two bindings; the sibling carries one.
+        const doomedTenant = await bind(request, a.access_token, doomed.id, {
+            targetType: 'tenant',
+        });
+        const doomedWork = await bind(request, a.access_token, doomed.id, {
+            targetType: 'work',
+            targetId: work.id,
+        });
+        const siblingBinding = await bind(request, a.access_token, sibling.id, {
+            targetType: 'tenant',
+        });
+        expect((await listBindings(request, a.access_token, doomed.id)).map((r) => r.id).sort()).toEqual(
+            [doomedTenant.id, doomedWork.id].sort(),
+        );
+
+        // Delete the parent skill → its bindings cascade away.
+        const delSkill = await request.delete(`${API_BASE}/api/skills/${doomed.id}`, {
+            headers: authedHeaders(a.access_token),
+        });
+        expect(delSkill.status()).toBe(200);
+        expect(await delSkill.json()).toEqual({ deleted: true });
+
+        // The doomed skill's bindings list is now a 404 (the skill is gone, so
+        // the skill-ownership gate in listBindings fails), NOT an empty array.
+        const afterList = await request.get(`${API_BASE}/api/skills/${doomed.id}/bindings`, {
+            headers: authedHeaders(a.access_token),
+        });
+        expect(afterList.status()).toBe(404);
+
+        // The cascaded binding ids are truly gone — re-deleting either 404s.
+        expect(await unbind(request, a.access_token, doomedTenant.id)).toBe(404);
+        expect(await unbind(request, a.access_token, doomedWork.id)).toBe(404);
+
+        // The sibling skill + its binding are completely untouched.
+        const siblingList = await listBindings(request, a.access_token, sibling.id);
+        expect(siblingList.map((r) => r.id)).toEqual([siblingBinding.id]);
+    });
+});

--- a/apps/web/e2e/flow-skill-bindings-deep.spec.ts
+++ b/apps/web/e2e/flow-skill-bindings-deep.spec.ts
@@ -365,7 +365,11 @@ test.describe('Skill bindings — deep per-skill list lifecycle + filtering + DT
         const mission = await (
             await request.post(`${API_BASE}/api/me/missions`, {
                 headers: authedHeaders(a.access_token),
-                data: { title: `Multi Mission ${suffix('multi')}`, description: 'd', type: 'one-shot' },
+                data: {
+                    title: `Multi Mission ${suffix('multi')}`,
+                    description: 'd',
+                    type: 'one-shot',
+                },
             })
         ).json();
 
@@ -709,9 +713,9 @@ test.describe('Skill bindings — deep per-skill list lifecycle + filtering + DT
         const siblingBinding = await bind(request, a.access_token, sibling.id, {
             targetType: 'tenant',
         });
-        expect((await listBindings(request, a.access_token, doomed.id)).map((r) => r.id).sort()).toEqual(
-            [doomedTenant.id, doomedWork.id].sort(),
-        );
+        expect(
+            (await listBindings(request, a.access_token, doomed.id)).map((r) => r.id).sort(),
+        ).toEqual([doomedTenant.id, doomedWork.id].sort());
 
         // Delete the parent skill → its bindings cascade away.
         const delSkill = await request.delete(`${API_BASE}/api/skills/${doomed.id}`, {

--- a/apps/web/e2e/flow-task-chat-messages.spec.ts
+++ b/apps/web/e2e/flow-task-chat-messages.spec.ts
@@ -1,0 +1,423 @@
+import { test, expect, request as pwRequest, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+import { createAgentViaAPI, createTaskViaAPI } from './helpers/agents-tasks';
+
+/**
+ * Task chat messages — DEEP coverage of the thinly-tested
+ * `PATCH /api/task-chat-messages/:id` controller (task-chat.controller.ts)
+ * and the two `/api/tasks/:id/chat` routes that feed it. Pins the exact
+ * request/response CONTRACTS — validation layering, the secret-scan
+ * hard-reject, the edit-mutation surface (which columns the edit touches vs
+ * leaves alone), list limit/offset clamping edge cases, and the
+ * ownership/auth gates on the standalone message route.
+ *
+ * NON-DUPLICATION — `flow-task-collaboration.spec.ts` already covers the
+ * happy comment lifecycle, @agent→AgentRun dispatch, the task_commented
+ * audit trail, multi-page tiling, and the broad owner-scoped 404 matrix.
+ * This file does NOT repeat those. It instead nails the contracts that
+ * spec leaves un-pinned, all live-probed on the e2e driver:
+ *
+ *   POST /api/tasks/:id/chat (DTO-validated body):
+ *     - missing / non-string body → 400 with class-validator ARRAY message
+ *       ["body must be shorter than or equal to 16384 characters",
+ *        "body must be a string"]  (NOT the bare "body is required.")
+ *     - body > 16384 chars → 400 ["body must be shorter than or equal to
+ *       16384 characters"]   (DTO @MaxLength, fires before the service)
+ *     - whitespace-only body → 400 { message:"Chat body is required." }
+ *       (passes the DTO, rejected by TaskChatService.assertBody)
+ *     - secret-bearing body (sk-<≥10>) → hard-reject 4xx/5xx (today 500:
+ *       assertNoSecrets throws a plain Error not mapped to an
+ *       HttpException; tolerant of a hardened 400/422) — the message is
+ *       never persisted either way.
+ *
+ *   PATCH /api/task-chat-messages/:id (TaskChatController.editChat):
+ *     - missing / non-string body → 400 { message:"body is required." }
+ *       (controller-level guard, distinct STRING message vs the POST DTO)
+ *     - whitespace-only body → 400 { message:"Chat body is required." }
+ *       (service-level assertBody)
+ *     - secret-bearing body → hard-reject 4xx/5xx (same assertNoSecrets, edit path)
+ *     - happy edit → 200; returns the FULL refreshed row with the new
+ *       body + editedAt set (non-null) + createdAt unchanged.
+ *     - editing to DROP a previously-resolved @agent mention → mentions
+ *       becomes null, while attachments are PRESERVED verbatim (the edit
+ *       only rewrites body+mentions; updateBodyAndMentions never touches
+ *       attachments).
+ *     - non-uuid id → 400 (ParseUUIDPipe); unknown uuid → 404; cross-user
+ *       message → 404 with "Task <id> not found." (the parent-task
+ *       ownership guard fires BEFORE the authorship check — never a 403
+ *       leak that would confirm the id exists); anon → 401.
+ *
+ *   GET /api/tasks/:id/chat?limit&offset (TasksController.listChat clamps):
+ *     - limit=1 → exactly the single oldest row (oldest-first ordering)
+ *     - limit=abc (NaN) AND limit=0 (falsy) BOTH fall through to the
+ *       default 50 → full thread returned
+ *     - limit=99999 → clamped to the 200 ceiling (still returns all when
+ *       thread < 200)
+ *     - offset past the end → 200 { data: [] } (empty, never an error)
+ *     - non-uuid task id → 400 (ParseUUIDPipe)
+ */
+
+const NIL_UUID = '00000000-0000-0000-0000-000000000000';
+// A token that trips the secret-scan `generic` pattern: sk- + ≥10 [A-Za-z0-9_-].
+const SECRET_BODY = 'leaking sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789012345';
+
+interface ChatMessage {
+    id: string;
+    taskId: string;
+    authorType: 'user' | 'agent';
+    authorId: string;
+    body: string;
+    mentions: Array<{ type: 'user' | 'agent' | 'kb'; id?: string; slug?: string }> | null;
+    attachments: Array<{ uploadId: string }> | null;
+    editedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+}
+
+async function makeTask(request: APIRequestContext, token: string, title: string): Promise<string> {
+    const t = await createTaskViaAPI(request, token, { title });
+    return t.id;
+}
+
+async function postChat(
+    request: APIRequestContext,
+    token: string,
+    taskId: string,
+    body: string,
+    attachments?: Array<{ uploadId: string }>,
+): Promise<{ status: number; json: ChatMessage }> {
+    const res = await request.post(`${API_BASE}/api/tasks/${taskId}/chat`, {
+        headers: authedHeaders(token),
+        data: attachments ? { body, attachments } : { body },
+    });
+    return { status: res.status(), json: (await res.json().catch(() => ({}))) as ChatMessage };
+}
+
+async function listChat(
+    request: APIRequestContext,
+    token: string,
+    taskId: string,
+    query = '',
+): Promise<{ status: number; data: ChatMessage[] }> {
+    const res = await request.get(`${API_BASE}/api/tasks/${taskId}/chat${query}`, {
+        headers: authedHeaders(token),
+    });
+    const body = (await res.json().catch(() => ({ data: [] }))) as { data?: ChatMessage[] };
+    return { status: res.status(), data: body.data ?? [] };
+}
+
+async function editChat(
+    request: APIRequestContext,
+    token: string,
+    messageId: string,
+    body: unknown,
+): Promise<{ status: number; raw: string }> {
+    const res = await request.patch(`${API_BASE}/api/task-chat-messages/${messageId}`, {
+        headers: authedHeaders(token),
+        data: typeof body === 'object' && body !== null ? body : { body },
+    });
+    return { status: res.status(), raw: await res.text().catch(() => '') };
+}
+
+/** Seed a task with `n` ordered messages, returning their bodies in post order. */
+async function seedThread(
+    request: APIRequestContext,
+    token: string,
+    taskId: string,
+    n: number,
+): Promise<string[]> {
+    const bodies: string[] = [];
+    for (let i = 1; i <= n; i++) {
+        const body = `thread-line-${i}`;
+        const { status } = await postChat(request, token, taskId, body);
+        expect(status, `seed post #${i}`).toBe(201);
+        bodies.push(body);
+    }
+    return bodies;
+}
+
+test.describe('Task chat messages — PATCH /task-chat-messages/:id + chat route contracts', () => {
+    // ── POST /api/tasks/:id/chat — DTO + service validation layering ──
+
+    test('1) POST rejects a missing body with the class-validator ARRAY message (DTO layer)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'post-missing-body');
+        const res = await request.post(`${API_BASE}/api/tasks/${taskId}/chat`, {
+            headers: authedHeaders(u.access_token),
+            data: {},
+        });
+        expect(res.status()).toBe(400);
+        const json = (await res.json()) as { message: string[] };
+        // DTO validation yields an ARRAY of messages, not the bare string the
+        // PATCH controller returns — these are different surfaces.
+        expect(Array.isArray(json.message)).toBe(true);
+        expect(json.message).toContain('body must be a string');
+    });
+
+    test('2) POST rejects a body over 16384 chars at the DTO @MaxLength (before the service)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'post-too-long');
+        const res = await request.post(`${API_BASE}/api/tasks/${taskId}/chat`, {
+            headers: authedHeaders(u.access_token),
+            data: { body: 'x'.repeat(17000) },
+        });
+        expect(res.status()).toBe(400);
+        const json = (await res.json()) as { message: string[] };
+        expect(json.message).toContain('body must be shorter than or equal to 16384 characters');
+    });
+
+    test('3) POST rejects a whitespace-only body at the service layer with "Chat body is required."', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'post-whitespace');
+        const { status, json } = await postChat(request, u.access_token, taskId, '   ');
+        expect(status).toBe(400);
+        expect((json as unknown as { message: string }).message).toBe('Chat body is required.');
+    });
+
+    test('4) POST with a secret-bearing body is hard-rejected and never persists the message', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'post-secret');
+        const { status } = await postChat(request, u.access_token, taskId, SECRET_BODY);
+        // The security invariant is "hard-reject + never persist". The live
+        // status today is 500 (assertNoSecrets throws a plain Error), but a
+        // hardened 400/422 is equally correct — match the established
+        // tolerance from flow-agent-instruction-files-deep.spec.ts so this
+        // survives the assertNoSecrets→BadRequestException fix. The one thing
+        // that must NEVER happen is a silent 2xx that persists the secret.
+        expect(status).toBeGreaterThanOrEqual(400);
+        expect([400, 422, 500]).toContain(status);
+        const { data } = await listChat(request, u.access_token, taskId);
+        expect(data).toEqual([]);
+    });
+
+    // ── PATCH /api/task-chat-messages/:id — validation ──
+
+    test('5) PATCH rejects a missing/non-string body with the controller STRING message "body is required."', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'edit-missing-body');
+        const { json } = await postChat(request, u.access_token, taskId, 'original');
+        // Missing body key.
+        const missing = await request.patch(`${API_BASE}/api/task-chat-messages/${json.id}`, {
+            headers: authedHeaders(u.access_token),
+            data: {},
+        });
+        expect(missing.status()).toBe(400);
+        expect((await missing.json()).message).toBe('body is required.');
+        // Non-string body (number) — same controller guard.
+        const nonString = await request.patch(`${API_BASE}/api/task-chat-messages/${json.id}`, {
+            headers: authedHeaders(u.access_token),
+            data: { body: 123 },
+        });
+        expect(nonString.status()).toBe(400);
+        expect((await nonString.json()).message).toBe('body is required.');
+    });
+
+    test('6) PATCH rejects a whitespace-only body at the service layer with "Chat body is required."', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'edit-whitespace');
+        const { json } = await postChat(request, u.access_token, taskId, 'original');
+        const res = await request.patch(`${API_BASE}/api/task-chat-messages/${json.id}`, {
+            headers: authedHeaders(u.access_token),
+            data: { body: '   ' },
+        });
+        expect(res.status()).toBe(400);
+        expect((await res.json()).message).toBe('Chat body is required.');
+    });
+
+    test('7) PATCH with a secret-bearing new body is hard-rejected; the prior body is untouched', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'edit-secret');
+        const { json } = await postChat(request, u.access_token, taskId, 'safe original');
+        const res = await editChat(request, u.access_token, json.id, SECRET_BODY);
+        // Hard-reject invariant (4xx today via 500, tolerant of a hardened
+        // 400/422 — see test 4's comment).
+        expect(res.status).toBeGreaterThanOrEqual(400);
+        expect([400, 422, 500]).toContain(res.status);
+        // The reject is pre-persist: the stored row still has the safe body.
+        const { data } = await listChat(request, u.access_token, taskId);
+        const row = data.find((m) => m.id === json.id);
+        expect(row?.body).toBe('safe original');
+        expect(row?.editedAt).toBeNull();
+    });
+
+    // ── PATCH — successful edit mutation surface ──
+
+    test('8) PATCH happy path returns the full refreshed row: new body + editedAt set + createdAt preserved', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'edit-happy');
+        const { json: posted } = await postChat(request, u.access_token, taskId, 'before edit');
+        expect(posted.editedAt).toBeNull();
+
+        const res = await request.patch(`${API_BASE}/api/task-chat-messages/${posted.id}`, {
+            headers: authedHeaders(u.access_token),
+            data: { body: 'after edit' },
+        });
+        expect(res.status(), await res.text().catch(() => '')).toBe(200);
+        const edited = (await res.json()) as ChatMessage;
+        expect(edited.id).toBe(posted.id);
+        expect(edited.body).toBe('after edit');
+        expect(edited.editedAt).not.toBeNull();
+        // createdAt is immutable across an edit; only editedAt advances.
+        expect(edited.createdAt).toBe(posted.createdAt);
+        expect(edited.authorType).toBe('user');
+        expect(edited.authorId).toBe(u.user.id);
+    });
+
+    test('9) PATCH that drops a resolved @agent mention nulls `mentions` but PRESERVES `attachments`', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const agent = await createAgentViaAPI(request, u.access_token, {
+            name: `Chat Edit Reviewer ${test.info().title.length}-${Date.now().toString(36)}`,
+        });
+        const taskId = await makeTask(request, u.access_token, 'edit-drop-mention');
+
+        const { status, json: posted } = await postChat(
+            request,
+            u.access_token,
+            taskId,
+            `please look @${agent.slug}`,
+            [{ uploadId: NIL_UUID }],
+        );
+        expect(status).toBe(201);
+        expect((posted.mentions ?? []).map((m) => m.id)).toEqual([agent.id]);
+        expect(posted.attachments).toEqual([{ uploadId: NIL_UUID }]);
+
+        // Edit body so it no longer mentions the agent.
+        const res = await request.patch(`${API_BASE}/api/task-chat-messages/${posted.id}`, {
+            headers: authedHeaders(u.access_token),
+            data: { body: 'never mind, handling it myself' },
+        });
+        expect(res.status()).toBe(200);
+        const edited = (await res.json()) as ChatMessage;
+        // mentions re-parse to empty → stored as null.
+        expect(edited.mentions).toBeNull();
+        // attachments are NOT part of the edit mutation → preserved verbatim.
+        expect(edited.attachments).toEqual([{ uploadId: NIL_UUID }]);
+
+        // Re-read confirms persistence (not just the returned object).
+        const { data } = await listChat(request, u.access_token, taskId);
+        const row = data.find((m) => m.id === posted.id);
+        expect(row?.mentions).toBeNull();
+        expect(row?.attachments).toEqual([{ uploadId: NIL_UUID }]);
+    });
+
+    // ── PATCH — id / ownership / auth gates ──
+
+    test('10) PATCH rejects a non-uuid id with 400 (ParseUUIDPipe) and an unknown uuid with 404', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const badId = await editChat(request, u.access_token, 'definitely-not-a-uuid', {
+            body: 'x',
+        });
+        expect(badId.status).toBe(400);
+        const missing = await editChat(request, u.access_token, NIL_UUID, { body: 'x' });
+        expect(missing.status).toBe(404);
+    });
+
+    test('11) PATCH on another user\'s message → 404 "Task <id> not found." (ownership guard fires before authorship — no existence leak)', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, owner.access_token, 'edit-cross-user');
+        const { json } = await postChat(request, owner.access_token, taskId, 'owner only');
+
+        const res = await request.patch(`${API_BASE}/api/task-chat-messages/${json.id}`, {
+            headers: authedHeaders(stranger.access_token),
+            data: { body: 'hijack attempt' },
+        });
+        // 404 (not 403): the parent-task ownership guard throws first, so the
+        // stranger cannot even confirm the message id exists.
+        expect(res.status()).toBe(404);
+        expect((await res.json()).message).toBe(`Task ${taskId} not found.`);
+
+        // The owner's row is untouched by the failed cross-user edit.
+        const { data } = await listChat(request, owner.access_token, taskId);
+        expect(data[0].body).toBe('owner only');
+        expect(data[0].editedAt).toBeNull();
+    });
+
+    test('12) PATCH without any Authorization is rejected with 401 before reaching the handler', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'edit-anon');
+        const { json } = await postChat(request, u.access_token, taskId, 'original');
+
+        // Raw fetch with NO cookies / NO bearer — independent of any
+        // storageState the `request` fixture might carry.
+        const anonCtx = await pwRequest.newContext();
+        const res = await anonCtx.patch(`${API_BASE}/api/task-chat-messages/${json.id}`, {
+            data: { body: 'anon edit' },
+        });
+        expect(res.status()).toBe(401);
+        await anonCtx.dispose();
+    });
+
+    // ── GET /api/tasks/:id/chat — limit / offset clamping ──
+
+    test('13) GET clamps limit edge cases: limit=1 yields the single oldest row; NaN and 0 fall through to the default', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'list-limit-clamp');
+        const bodies = await seedThread(request, u.access_token, taskId, 5);
+
+        // limit=1 → exactly the oldest message (oldest-first ordering).
+        const one = await listChat(request, u.access_token, taskId, '?limit=1');
+        expect(one.status).toBe(200);
+        expect(one.data.length).toBe(1);
+        expect(one.data[0].body).toBe(bodies[0]);
+
+        // limit=abc → parseInt NaN → falsy → default 50 → full thread.
+        const nan = await listChat(request, u.access_token, taskId, '?limit=abc');
+        expect(nan.data.length).toBe(5);
+        // limit=0 → falsy → ALSO default 50 (it is NOT clamped to 1) → full thread.
+        const zero = await listChat(request, u.access_token, taskId, '?limit=0');
+        expect(zero.data.length).toBe(5);
+        // limit=99999 → clamped to the 200 ceiling; thread < 200 so all 5 return.
+        const huge = await listChat(request, u.access_token, taskId, '?limit=99999');
+        expect(huge.data.length).toBe(5);
+    });
+
+    test('14) GET applies offset (windowing oldest-first) and returns an empty array past the end; non-uuid task id → 400', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const taskId = await makeTask(request, u.access_token, 'list-offset');
+        const bodies = await seedThread(request, u.access_token, taskId, 5);
+
+        // offset=1 limit=2 → the 2nd & 3rd oldest rows, in order.
+        const window = await listChat(request, u.access_token, taskId, '?limit=2&offset=1');
+        expect(window.data.map((m) => m.body)).toEqual([bodies[1], bodies[2]]);
+
+        // offset beyond the end → 200 with an empty data array (not an error).
+        const beyond = await listChat(request, u.access_token, taskId, '?limit=10&offset=99');
+        expect(beyond.status).toBe(200);
+        expect(beyond.data).toEqual([]);
+
+        // Malformed task id on the list route → 400 (ParseUUIDPipe).
+        const bad = await request.get(`${API_BASE}/api/tasks/not-a-uuid/chat`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(bad.status()).toBe(400);
+    });
+});

--- a/apps/web/e2e/flow-telemetry-contract.spec.ts
+++ b/apps/web/e2e/flow-telemetry-contract.spec.ts
@@ -1,0 +1,371 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * flow-telemetry-contract.spec.ts — boundary-precise, no-PII-echo, and
+ * route-scoped-throttle contracts for the PUBLIC zero-friction funnel sink
+ * `POST /api/telemetry/funnel` (TelemetryController, `@Public()` +
+ * `@Throttle({ long: { limit: 60, ttl: 60_000 } })`). Every status / message /
+ * header below was probed live against the API at :3100 before assertion.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * NON-DUPLICATION — this file deliberately AVOIDS what the two existing
+ * telemetry specs already pin, and covers the complementary surface:
+ *
+ *   - `telemetry.spec.ts`               : a !5xx smoke of both endpoints only.
+ *   - `flow-onboarding-telemetry.spec.ts`: the 8-event allow-list 204s, the
+ *        funnelStep 0/9 edges, a 3-char correlationId, a non-ISO timestamp,
+ *        a `bogusTop` forbidNonWhitelisted key, a 5000-char oversized blob,
+ *        workId>64, auth-ignored, GET-404, the disjoint onboarding/funnel
+ *        allow-lists, onboarding-relay 401, and state-isolation invariants.
+ *   - `flow-rate-limit-throttle.spec.ts`: the GLOBAL named-tier throttler on
+ *        auth/health routes (documents the GLOBAL long tier as 1000) — it
+ *        never touches the telemetry route, whose @Throttle OVERRIDES long to
+ *        60 (asserted here).
+ *
+ * What's NEW here (all probed): the EXACT 4096-byte payload boundary
+ * (4096→204 / 4097→400 with a single-string controller message, not an array);
+ * the correlationId regex LENGTH boundaries (7→400, 8→204, 64→204, 65→400);
+ * the userId @MaxLength(64) boundary (mirror of the existing workId-only case);
+ * @IsInt rejection of a FLOAT funnelStep (distinct from the Min/Max edges);
+ * the NO-PII-ECHO guarantee (a 400 never reflects the rejected attacker value);
+ * the `extra.userId`/`extra.workId` identity-strip path returning 204 (not a
+ * 400/500); the FULL non-GET method matrix (PUT/DELETE/PATCH→404); the
+ * route-scoped `X-RateLimit-Limit-long: 60` override header; and the
+ * aggregated empty-body 400 enumerating EVERY missing envelope field.
+ *
+ * ───────────────────────────────────────────────────────────────────────────
+ * PROBED CONTRACTS (live, http://127.0.0.1:3100, before writing):
+ *   POST /api/telemetry/funnel  body: FunnelEventDto
+ *     { event, funnelStep:1..8 int, timestamp:ISO8601,
+ *       correlationId:/^[A-Za-z0-9_-]{8,64}$/, extra?:object,
+ *       workId?:<=64, userId?:<=64 }
+ *   - well-formed (anonymous)        -> 204, empty body
+ *   - total wire bytes == 4096       -> 204  (guard is `> MAX_PAYLOAD_BYTES`)
+ *   - total wire bytes == 4097       -> 400  { message: 'telemetry payload too large' }  (STRING, not array)
+ *   - correlationId 7 chars          -> 400 ["correlationId must be 8-64 chars, alphanumeric/_-"]
+ *   - correlationId 8 / 64 chars     -> 204
+ *   - correlationId 65 chars         -> 400 (same message)
+ *   - userId 64 chars                -> 204 ; userId 65 chars -> 400 ["userId must be shorter than or equal to 64 characters"]
+ *   - funnelStep 1.5 (float)         -> 400 ["funnelStep must be an integer number"]
+ *   - rejected value NEVER echoed    -> the 400 message contains ONLY the rule text, not the offending PII string
+ *   - extra:{userId,workId,...}      -> 204 (identity keys stripped server-side; never a 400/500)
+ *   - PUT / DELETE / PATCH           -> 404 (POST-only route)
+ *   - 204 response headers           -> X-RateLimit-Limit-long: 60  (route @Throttle override; GLOBAL long is 1000)
+ *   - {} empty body                  -> 400, message ARRAY enumerating event + funnelStep + timestamp + correlationId rules
+ *
+ * CONSTRAINTS:
+ *   • No PostHog sink in CI; `funnel.emit` is fire-and-forget, so a 204 means
+ *     "accepted at the wire", never "delivered". We pin only the wire contract.
+ *   • The funnel @Throttle is 60/min/IP — far above what any single test emits;
+ *     we never deliberately trip it (a 429 would be cross-spec flaky).
+ *   • Anonymous by design: the funnel is @Public(), so these flows need no
+ *     user. The one authed user (userId-boundary flow) is a FRESH
+ *     registerUserViaAPI() purely to source a real-ish id; full isolation.
+ *   • Unique suffixes come from a per-test counter (never a module-scope clock).
+ */
+
+const FUNNEL = `${API_BASE}/api/telemetry/funnel`;
+const VALID_EVENT = 'zero_friction.landing_prompt_submit';
+const MAX_PAYLOAD_BYTES = 4096;
+
+/** Per-test monotonic counter → unique-but-deterministic suffixes without a
+ *  module-scope clock call (module scope runs at collection on EVERY shard). */
+let seq = 0;
+
+/** A regex-valid correlationId (8-64 [A-Za-z0-9_-]) seeded off the test title. */
+function corrId(tag: string): string {
+    seq += 1;
+    const raw = `e2e${tag}${seq}`.replace(/[^A-Za-z0-9_-]/g, '');
+    // Pad to >=8 and clamp to <=64 so the envelope is always shape-valid.
+    return raw.padEnd(8, '0').slice(0, 64);
+}
+
+/** A well-formed minimal funnel envelope for the given event + step. */
+function envelope(event: string, funnelStep: number, correlationId: string) {
+    return { event, funnelStep, timestamp: new Date().toISOString(), correlationId };
+}
+
+/** POST an anonymous funnel event (no auth — the route is @Public()). */
+function postFunnel(request: APIRequestContext, data: unknown) {
+    return request.post(FUNNEL, { data });
+}
+
+// ─── 1. exact 4096-byte payload boundary (accept) ─────────────────────────────
+
+test('funnel accepts a payload of EXACTLY 4096 wire bytes (the `> MAX` guard is inclusive of the cap)', async ({
+    request,
+}) => {
+    // The controller rejects only when rawSize `> 4096`. Build an `extra.blob`
+    // sized so the serialized envelope is byte-for-byte 4096 — the largest
+    // payload the public sink must still accept. Playwright serializes `data`
+    // with JSON.stringify, the same bytes the body-parser `verify` hook captures.
+    const cid = corrId('cap');
+    const base = { ...envelope(VALID_EVENT, 1, cid), extra: { blob: '' } };
+    const overhead = Buffer.byteLength(JSON.stringify(base), 'utf8');
+    // overhead counts the two quotes of the empty blob; each added char is +1 byte.
+    const blobLen = MAX_PAYLOAD_BYTES - overhead;
+    const body = { ...base, extra: { blob: 'x'.repeat(blobLen) } };
+    expect(
+        Buffer.byteLength(JSON.stringify(body), 'utf8'),
+        'crafted body is exactly 4096 bytes',
+    ).toBe(MAX_PAYLOAD_BYTES);
+
+    const res = await postFunnel(request, body);
+    expect(res.status(), 'exactly-4096-byte payload is accepted').toBe(204);
+    expect((await res.text()).length, '204 has an empty body').toBe(0);
+});
+
+// ─── 2. exact 4097-byte payload boundary (reject, controller-string message) ──
+
+test('funnel rejects a payload ONE byte over the 4096 cap with the controller string message (not a class-validator array)', async ({
+    request,
+}) => {
+    const cid = corrId('cap1');
+    const base = { ...envelope(VALID_EVENT, 1, cid), extra: { blob: '' } };
+    const overhead = Buffer.byteLength(JSON.stringify(base), 'utf8');
+    const blobLen = MAX_PAYLOAD_BYTES - overhead + 1; // one byte over the cap
+    const body = { ...base, extra: { blob: 'x'.repeat(blobLen) } };
+    expect(
+        Buffer.byteLength(JSON.stringify(body), 'utf8'),
+        'crafted body is exactly 4097 bytes',
+    ).toBe(MAX_PAYLOAD_BYTES + 1);
+
+    const res = await postFunnel(request, body);
+    expect(res.status(), 'one-byte-over payload is rejected').toBe(400);
+    const json = await res.json();
+    // The controller's own guard returns a SINGLE string message — distinct from
+    // the class-validator array shape every field-level rejection uses. Pinning
+    // the type guards against a refactor that would change the wire shape.
+    expect(typeof json.message, 'controller size-guard message is a plain string').toBe('string');
+    expect(json.message).toBe('telemetry payload too large');
+    expect(json.statusCode).toBe(400);
+});
+
+// ─── 3. correlationId regex LENGTH boundaries (7/8/64/65) ─────────────────────
+
+test('funnel correlationId enforces the 8..64 length boundary exactly (7→400, 8→204, 64→204, 65→400)', async ({
+    request,
+}) => {
+    // The cross-service trace key must match /^[A-Za-z0-9_-]{8,64}$/. The existing
+    // suite only probes a 3-char id; here we pin BOTH edges of the inclusive range
+    // so a future widen/shrink of the bound is caught at both ends.
+    const cases: Array<{ len: number; expected: number }> = [
+        { len: 7, expected: 400 },
+        { len: 8, expected: 204 },
+        { len: 64, expected: 204 },
+        { len: 65, expected: 400 },
+    ];
+    for (const c of cases) {
+        const cid = 'a'.repeat(c.len);
+        const res = await postFunnel(request, envelope(VALID_EVENT, 1, cid));
+        expect(res.status(), `correlationId of ${c.len} chars → ${c.expected}`).toBe(c.expected);
+        if (c.expected === 400) {
+            const json = await res.json();
+            expect(JSON.stringify(json.message)).toContain('correlationId must be 8-64 chars');
+        }
+    }
+});
+
+// ─── 4. userId optional passthrough @MaxLength(64) boundary ───────────────────
+
+test('funnel userId passthrough enforces @MaxLength(64): 64 chars accepted, 65 rejected', async ({
+    request,
+}) => {
+    // `userId` is an OPTIONAL bounded passthrough (becomes the PostHog distinctId
+    // downstream). The existing suite probes only the workId>64 edge; this pins
+    // the symmetric userId bound, and the 64-char ACCEPT (not just the reject).
+    const fresh = await registerUserViaAPI(request);
+    const cid64 = corrId('uid64');
+    const ok = await postFunnel(request, {
+        ...envelope('zero_friction.claim_account', 8, cid64),
+        userId: 'u'.repeat(64),
+    });
+    expect(ok.status(), 'userId of exactly 64 chars is accepted').toBe(204);
+
+    const cid65 = corrId('uid65');
+    const tooLong = await postFunnel(request, {
+        ...envelope('zero_friction.claim_account', 8, cid65),
+        userId: 'u'.repeat(65),
+    });
+    expect(tooLong.status(), 'userId of 65 chars is rejected').toBe(400);
+    expect(JSON.stringify((await tooLong.json()).message)).toContain(
+        'userId must be shorter than or equal to 64 characters',
+    );
+
+    // A genuine (short) user id from a real registration still rides through fine,
+    // proving the bound rejects only the abusive over-length case, not real ids.
+    const cidReal = corrId('uidreal');
+    const real = await postFunnel(request, {
+        ...envelope('zero_friction.claim_account', 8, cidReal),
+        userId: fresh.user.id,
+    });
+    expect(real.status(), 'a real (short) userId passes the bound').toBe(204);
+    expect(fresh.user.id.length, 'real user id is within the 64-char bound').toBeLessThanOrEqual(
+        64,
+    );
+});
+
+// ─── 5. funnelStep must be an INTEGER (@IsInt), float rejected ────────────────
+
+test('funnel funnelStep rejects a non-integer (float 1.5) distinctly from the Min/Max range edges', async ({
+    request,
+}) => {
+    // The Min(1)/Max(8) edges are already pinned elsewhere; @IsInt is a SEPARATE
+    // constraint — a 1.5 lands inside [1,8] yet must still 400 so PostHog's step
+    // axis stays a dense set of whole numbers.
+    const cid = corrId('float');
+    const res = await postFunnel(request, {
+        event: VALID_EVENT,
+        funnelStep: 1.5,
+        timestamp: new Date().toISOString(),
+        correlationId: cid,
+    });
+    expect(res.status(), 'float funnelStep → 400').toBe(400);
+    expect(JSON.stringify((await res.json()).message)).toContain(
+        'funnelStep must be an integer number',
+    );
+});
+
+// ─── 6. NO PII ECHO — a 400 never reflects the rejected attacker value ────────
+
+test('funnel rejection responses NEVER echo the offending attacker-supplied value back to the caller', async ({
+    request,
+}) => {
+    // The endpoint is @Public(), so the whole body is attacker-controlled. A
+    // validation 400 must surface ONLY the rule text — never reflect the rejected
+    // value — so the public sink can't be turned into a value-reflecting oracle /
+    // self-XSS vector. We embed sentinel strings that would be obvious in any echo.
+    const piiCorr = 'PII-SENTINEL-secret@evil.example-<script>';
+    const badCorr = await postFunnel(request, {
+        event: VALID_EVENT,
+        funnelStep: 1,
+        timestamp: new Date().toISOString(),
+        correlationId: piiCorr,
+    });
+    expect(badCorr.status()).toBe(400);
+    const badCorrBody = await badCorr.text();
+    expect(badCorrBody, 'correlationId 400 does not echo the rejected value').not.toContain(
+        'PII-SENTINEL',
+    );
+    expect(badCorrBody).not.toContain('secret@evil.example');
+    expect(badCorrBody, 'still carries the rule text').toContain(
+        'correlationId must be 8-64 chars',
+    );
+
+    // Same guarantee on the @MaxLength workId path: an over-long id carrying an
+    // email + sentinel is rejected without the email/sentinel appearing in the body.
+    const piiWorkId = `WORKID-SENTINEL-victim@example.com-${'x'.repeat(60)}`;
+    const badWorkId = await postFunnel(request, {
+        ...envelope('zero_friction.work_created', 4, corrId('piiwork')),
+        workId: piiWorkId,
+    });
+    expect(badWorkId.status()).toBe(400);
+    const badWorkIdBody = await badWorkId.text();
+    expect(badWorkIdBody, 'workId 400 does not echo the rejected value').not.toContain(
+        'WORKID-SENTINEL',
+    );
+    expect(badWorkIdBody).not.toContain('victim@example.com');
+    expect(badWorkIdBody).toContain('workId must be shorter than or equal to 64 characters');
+});
+
+// ─── 7. identity-key stripping inside `extra` is accepted, never errors ───────
+
+test('funnel accepts a hostile `extra` carrying userId/workId keys (silently stripped) — 204, not 400/500', async ({
+    request,
+}) => {
+    // Security hardening: the controller strips `userId`/`workId` OUT of the
+    // free-form `extra` bag before spreading it, so a malicious client cannot
+    // inject/override the analytics distinctId or work attribution via `extra`.
+    // The strip path must SUCCEED quietly (204) — it neither rejects the post nor
+    // throws — while the dedicated top-level fields remain the only identity source.
+    const cid = corrId('strip');
+    const res = await postFunnel(request, {
+        ...envelope('zero_friction.work_created', 4, cid),
+        extra: {
+            userId: 'evil-distinct-id',
+            workId: 'evil-work-attribution',
+            // a legitimate per-event passthrough is preserved alongside the stripped keys
+            promptLength: 42,
+            nested: { a: 1 },
+        },
+        // the LEGITIMATE top-level identity fields still validate normally
+        workId: 'w'.repeat(20),
+        userId: 'u'.repeat(20),
+    });
+    expect(res.status(), 'hostile extra identity keys are stripped, post still accepted').toBe(204);
+    expect((await res.text()).length, 'still an empty 204 body').toBe(0);
+});
+
+// ─── 8. method matrix — the funnel route is POST-only (PUT/DELETE/PATCH → 404) ─
+
+test('funnel route is POST-only: PUT, DELETE and PATCH all 404 (no handler registered for the verb)', async ({
+    request,
+}) => {
+    // The existing suite only pins GET→404. A telemetry sink must not expose any
+    // other mutating/idempotent verb that a scanner could probe; pin the full
+    // non-POST matrix so a future @Put/@Patch on the controller is caught.
+    const put = await request.put(FUNNEL, { data: {} });
+    expect(put.status(), 'PUT funnel → 404').toBe(404);
+
+    const del = await request.delete(FUNNEL);
+    expect(del.status(), 'DELETE funnel → 404').toBe(404);
+
+    const patch = await request.patch(FUNNEL, { data: {} });
+    expect(patch.status(), 'PATCH funnel → 404').toBe(404);
+});
+
+// ─── 9. route-scoped @Throttle override surfaces X-RateLimit-Limit-long: 60 ───
+
+test('funnel response carries the route-scoped throttle override header (X-RateLimit-Limit-long: 60), distinct from the global 1000', async ({
+    request,
+}) => {
+    // The controller decorates the route with @Throttle({ long: { limit: 60 } }),
+    // OVERRIDING the global long tier (1000, per flow-rate-limit-throttle.spec.ts).
+    // The named-tier headers are emitted on every response; we assert the long
+    // tier reflects the per-route 60, proving the override is live on THIS route.
+    const res = await postFunnel(request, envelope(VALID_EVENT, 1, corrId('thr')));
+    expect(res.status()).toBe(204);
+    const headers = res.headers();
+    expect(headers['x-ratelimit-limit-long'], 'route @Throttle long override = 60').toBe('60');
+    // The short/medium tiers fall through to the global config and must still be
+    // present + numeric (the named-tier taxonomy is emitted on every response).
+    expect(
+        Number(headers['x-ratelimit-limit-short']),
+        'short tier limit is numeric',
+    ).toBeGreaterThan(0);
+    expect(
+        Number(headers['x-ratelimit-remaining-long']),
+        'remaining-long is a non-negative number',
+    ).toBeGreaterThanOrEqual(0);
+});
+
+// ─── 10. empty body — aggregated 400 enumerating every missing envelope field ─
+
+test('funnel empty-body 400 enumerates ALL four missing envelope-field rules (event allow-list, funnelStep int+range, ISO timestamp, correlationId regex)', async ({
+    request,
+}) => {
+    // A `{}` post fails every required-field constraint at once. The global
+    // ValidationPipe returns the AGGREGATED message array — this single response
+    // is the server-authoritative envelope contract, so we pin that each of the
+    // four fields contributes its rule (and the event rule enumerates the
+    // 8-event allow-list, doubling as the canonical catalog).
+    const res = await postFunnel(request, {});
+    expect(res.status(), 'empty body → 400').toBe(400);
+    const json = await res.json();
+    expect(Array.isArray(json.message), 'field-level rejection is an array of rules').toBe(true);
+    const msg = JSON.stringify(json.message);
+    // event: allow-list enumerated (first + last canonical names present).
+    expect(msg).toContain('must be one of the following values');
+    expect(msg).toContain('zero_friction.landing_prompt_submit');
+    expect(msg).toContain('zero_friction.claim_account');
+    // funnelStep: both the integer constraint and the range bounds are reported.
+    expect(msg).toContain('funnelStep must be an integer number');
+    expect(msg).toContain('funnelStep must not be less than 1');
+    expect(msg).toContain('funnelStep must not be greater than 8');
+    // timestamp + correlationId rules.
+    expect(msg).toContain('timestamp must be a valid ISO 8601 date string');
+    expect(msg).toContain('correlationId must be 8-64 chars');
+    expect(json.error).toBe('Bad Request');
+    expect(json.statusCode).toBe(400);
+});

--- a/apps/web/e2e/flow-twenty-crm-gate-deep.spec.ts
+++ b/apps/web/e2e/flow-twenty-crm-gate-deep.spec.ts
@@ -1,0 +1,421 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * FLOW: TWENTY-CRM CONFIG-GATE — deep coverage of a thinly-tested controller
+ * (greenfield: ZERO prior e2e mentions of twenty-crm). This pins the
+ * integration's HTTP SURFACE and its FAIL-CLOSED posture when the Twenty CRM
+ * integration is UNCONFIGURED — which is exactly the CI/local reality (the
+ * TWENTY_CRM_* env vars are all UNSET).
+ *
+ * GROUNDING — every status/shape below was probed against the LIVE sqlite e2e
+ * API (port 3100) with throwaway users on 2026-06-11, and cross-checked against
+ * the real source:
+ *   - apps/api/src/integrations/twenty-crm/controllers/companies.service.ts
+ *       (@Controller('api/twenty-crm/companies'),
+ *        @UseGuards(AuthSessionGuard, CrmSyncGuard) — auth FIRST, then the CRM
+ *        gate; GET / GET ':id' / POST / PATCH ':id' / DELETE ':id'; by-id routes
+ *        use ParseUUIDPipe and the POST body uses CompanyBodyDto/ValidationPipe)
+ *   - apps/api/src/integrations/twenty-crm/controllers/people.controler.ts
+ *       (@Controller('api/twenty-crm/people') — guarded class, BUT intentionally
+ *        NOT registered in TwentyCrmModule.controllers; a "secure-by-default but
+ *        dead" route, per OQ-1/OQ-2 in the spec)
+ *   - apps/api/src/integrations/twenty-crm/guards/crm-sync.guard.ts
+ *       (CrmSyncGuard.canActivate -> false when !configService.isEnabled OR
+ *        validateConfig() throws; Nest maps a guard returning false to 403)
+ *   - apps/api/src/integrations/twenty-crm/config/crm-config.service.ts
+ *       (isEnabled = !!(apiUrl && apiKey && workspaceId) from TWENTY_CRM_BASE_URL
+ *        / TWENTY_CRM_API_KEY / TWENTY_CRM_WORKSPACE_ID — all UNSET in CI)
+ *   - apps/api/src/integrations/twenty-crm/twenty-crm.module.ts
+ *       (forRoot/forRootAsync both register ONLY [CompaniesController])
+ *
+ *   Probed contract facts (asserted below, NOT guessed):
+ *     ANON   any /api/twenty-crm/companies verb  -> 401 {message:'Unauthorized', statusCode:401}
+ *            (AuthSessionGuard is FIRST in the chain, so the CRM gate is never reached)
+ *     AUTHED every /api/twenty-crm/companies verb -> 403
+ *            {message:'Forbidden resource', error:'Forbidden', statusCode:403}
+ *            (CrmSyncGuard short-circuits because the integration is unconfigured)
+ *     AUTHED bad-UUID by-id (GET/PATCH/DELETE .../not-a-uuid) -> STILL 403, never
+ *            400 — the GUARD runs before the ParseUUIDPipe (guards precede pipes)
+ *     AUTHED bad/extra-field POST body -> STILL 403, never 400 — the guard runs
+ *            before the ValidationPipe too
+ *     PEOPLE every /api/twenty-crm/people verb -> 404
+ *            {message:'Cannot <VERB> /api/twenty-crm/people...', error:'Not Found',
+ *             statusCode:404} for BOTH authed and anon (route is not mounted, so
+ *            even AuthSessionGuard never fires — no 401, no 403)
+ *     ABSENT /api/twenty-crm/{notes,opportunities,sync} -> 404 (no such HTTP routes;
+ *            sync is an internal TwentyCrmService concern, never an endpoint)
+ *     NO route under /api/twenty-crm ever returns a 5xx while CRM is off.
+ *
+ * ADAPTIVITY: the gate's CLOSED state (403/404) is the ONLY truthful posture on
+ * the keyless CI stack — there is no Twenty workspace to call, so we never assert
+ * a 2xx CRM payload. Each assertion is written so a stack that HAS configured the
+ * integration (isEnabled true) would still be caught by the auth/route invariants
+ * (401 for anon, 404 for unmounted people, no-5xx everywhere); only the
+ * specifically gate-dependent 403 assertions are scoped to the unconfigured stack
+ * via a probed `gateClosed` precondition derived from the live companies-list.
+ *
+ * NON-DUPLICATION: twenty-crm has NO existing e2e spec (greenfield). This file
+ * does not overlap api-public-contract.spec.ts (that pins a generic protected/
+ * 404/POST-4xx tripwire across UNRELATED route prefixes and never touches
+ * /api/twenty-crm), nor the per-controller *.spec.ts unit tests in apps/api
+ * (those mock the guard/services; this drives the REAL wired HTTP chain end to
+ * end). It is the sole integration-level pin of the twenty-crm gate ordering,
+ * route enumeration, and unconfigured response shape.
+ *
+ * ISOLATION: every authed assertion runs on a FRESH registerUserViaAPI() user;
+ * anonymous probes use the built-in `request` fixture with NO Authorization
+ * header (and no storageState). No module-scope await / no clock at module scope
+ * — unique values come from a per-test counter.
+ */
+
+const CRM_BASE = `${API_BASE}/api/twenty-crm`;
+const COMPANIES = `${CRM_BASE}/companies`;
+const PEOPLE = `${CRM_BASE}/people`;
+
+// A syntactically valid UUID for by-id routes where we want the ParseUUIDPipe to
+// PASS (so any 400 would have to come from validation, proving the gate ran first
+// when we still see 403).
+const VALID_UUID = '123e4567-e89b-12d3-a456-426614174000';
+
+// Per-test unique suffix WITHOUT touching a clock at module scope.
+let seq = 0;
+function uniq(tag: string): string {
+    seq += 1;
+    return `${tag}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+interface ErrorBody {
+    message?: string | string[];
+    error?: string;
+    statusCode?: number;
+}
+
+async function jsonBody(res: { json: () => Promise<unknown> }): Promise<ErrorBody> {
+    return (await res.json().catch(() => ({}))) as ErrorBody;
+}
+
+/** Is the CRM gate currently CLOSED (integration unconfigured)? Derived live. */
+async function gateIsClosed(request: APIRequestContext, token: string): Promise<boolean> {
+    const res = await request.get(COMPANIES, { headers: authedHeaders(token) });
+    // 403 == CrmSyncGuard refused (unconfigured) — the CI reality.
+    return res.status() === 403;
+}
+
+test.describe('twenty-crm config-gate (fail-closed surface, ordering, route enumeration)', () => {
+    test('1. an authenticated GET /companies is refused by the CRM gate with the exact 403 "Forbidden resource" shape when the integration is unconfigured', async ({
+        request,
+    }) => {
+        const { access_token } = await registerUserViaAPI(request);
+
+        const res = await request.get(COMPANIES, { headers: authedHeaders(access_token) });
+        // The keyless CI stack has no Twenty workspace, so isEnabled is false and
+        // CrmSyncGuard returns false -> Nest 403. (A configured stack would 200;
+        // we only deep-assert the shape when the gate is actually closed.)
+        expect([200, 403], `companies-list status ${res.status()}`).toContain(res.status());
+        expect(res.status(), 'no 5xx while CRM is off').toBeLessThan(500);
+        if (res.status() === 403) {
+            const body = await jsonBody(res);
+            expect(body.message).toBe('Forbidden resource');
+            expect(body.error).toBe('Forbidden');
+            expect(body.statusCode).toBe(403);
+        }
+    });
+
+    test('2. an ANONYMOUS GET /companies is rejected by AuthSessionGuard FIRST (401), never reaching the CRM gate — the auth layer precedes the integration gate', async ({
+        browser,
+    }) => {
+        // browser.newContext() inherits no cookies here, but to be unambiguous we
+        // use a context with an explicit empty storageState and send no auth header.
+        const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        try {
+            const res = await ctx.request.get(COMPANIES);
+            expect(res.status(), 'anon is 401, NOT 403 — auth runs before the CRM gate').toBe(401);
+            const body = await jsonBody(res);
+            expect(body.statusCode).toBe(401);
+            expect(String(body.message)).toMatch(/Unauthorized/i);
+        } finally {
+            await ctx.close();
+        }
+    });
+
+    test('3. EVERY companies verb (GET list, GET :id, POST, PATCH :id, DELETE :id) is uniformly gated to 403 for an authed caller — the gate covers the whole controller, not just reads', async ({
+        request,
+    }) => {
+        const { access_token } = await registerUserViaAPI(request);
+        const headers = authedHeaders(access_token);
+        if (!(await gateIsClosed(request, access_token))) {
+            test.skip(true, 'CRM integration is configured on this stack — gate is open');
+            return;
+        }
+
+        const calls: Array<{ label: string; run: () => Promise<{ status: () => number }> }> = [
+            { label: 'GET list', run: () => request.get(COMPANIES, { headers }) },
+            { label: 'GET :id', run: () => request.get(`${COMPANIES}/${VALID_UUID}`, { headers }) },
+            {
+                label: 'POST',
+                run: () => request.post(COMPANIES, { headers, data: { name: uniq('Acme') } }),
+            },
+            {
+                label: 'PATCH :id',
+                run: () =>
+                    request.patch(`${COMPANIES}/${VALID_UUID}`, {
+                        headers,
+                        data: { name: uniq('Renamed') },
+                    }),
+            },
+            {
+                label: 'DELETE :id',
+                run: () => request.delete(`${COMPANIES}/${VALID_UUID}`, { headers }),
+            },
+        ];
+
+        for (const c of calls) {
+            const res = await c.run();
+            expect(res.status(), `${c.label} is gate-refused with 403`).toBe(403);
+        }
+    });
+
+    test('4. ORDERING — the gate runs BEFORE the ParseUUIDPipe: a by-id route with a malformed (non-UUID) id still returns 403, not the 400 the pipe would produce', async ({
+        request,
+    }) => {
+        const { access_token } = await registerUserViaAPI(request);
+        const headers = authedHeaders(access_token);
+        if (!(await gateIsClosed(request, access_token))) {
+            test.skip(true, 'CRM integration is configured on this stack — gate is open');
+            return;
+        }
+
+        // 'not-a-uuid' would trip the ParseUUIDPipe (400) IF execution ever reached
+        // it. Because guards run before pipes, the CrmSyncGuard short-circuits to 403
+        // first — proving the gate fences off the controller before any param parsing.
+        for (const verb of ['get', 'patch', 'delete'] as const) {
+            const url = `${COMPANIES}/not-a-uuid`;
+            const res =
+                verb === 'patch'
+                    ? await request.patch(url, { headers, data: { name: uniq('X') } })
+                    : verb === 'delete'
+                      ? await request.delete(url, { headers })
+                      : await request.get(url, { headers });
+            expect(
+                res.status(),
+                `${verb} bad-uuid is gate-refused (403) BEFORE the ParseUUIDPipe could 400`,
+            ).toBe(403);
+        }
+    });
+
+    test('5. ORDERING — the gate runs BEFORE the ValidationPipe: a POST with an extra/unknown field still returns 403, not the 400 forbidNonWhitelisted would produce', async ({
+        request,
+    }) => {
+        const { access_token } = await registerUserViaAPI(request);
+        const headers = authedHeaders(access_token);
+        if (!(await gateIsClosed(request, access_token))) {
+            test.skip(true, 'CRM integration is configured on this stack — gate is open');
+            return;
+        }
+
+        // CompanyBodyDto + the global whitelist/forbidNonWhitelisted ValidationPipe
+        // would 400 on this `bogus` field — but ONLY if the request reached the
+        // handler. The gate refuses first, so we see 403. (Same for a missing
+        // required `name`.)
+        const extraField = await request.post(COMPANIES, {
+            headers,
+            data: { name: uniq('Acme'), bogus: 'should-be-rejected', employees: 'not-a-number' },
+        });
+        expect(extraField.status(), 'extra/wrong-typed POST body is gate-refused (403)').toBe(403);
+
+        const missingRequired = await request.post(COMPANIES, { headers, data: {} });
+        expect(missingRequired.status(), 'empty POST body is gate-refused (403), not 400').toBe(403);
+    });
+
+    test('6. the PeopleController is REGISTERED-as-code but NOT mounted: every /people verb returns a 404 "Cannot <VERB> /api/twenty-crm/people" for an authed user — its AuthSessionGuard never even fires (no 401/403)', async ({
+        request,
+    }) => {
+        const { access_token } = await registerUserViaAPI(request);
+        const headers = authedHeaders(access_token);
+
+        const probes: Array<{ verb: string; res: Promise<{ status: () => number; json: () => Promise<unknown> }> }> =
+            [
+                { verb: 'GET', res: request.get(PEOPLE, { headers }) },
+                { verb: 'GET', res: request.get(`${PEOPLE}/${VALID_UUID}`, { headers }) },
+                {
+                    verb: 'POST',
+                    res: request.post(PEOPLE, { headers, data: { firstName: uniq('A') } }),
+                },
+                {
+                    verb: 'PATCH',
+                    res: request.patch(`${PEOPLE}/${VALID_UUID}`, {
+                        headers,
+                        data: { firstName: uniq('B') },
+                    }),
+                },
+                { verb: 'DELETE', res: request.delete(`${PEOPLE}/${VALID_UUID}`, { headers }) },
+            ];
+
+        for (const p of probes) {
+            const res = await p.res;
+            expect(
+                res.status(),
+                `${p.verb} /people is unmounted -> 404 (not 401/403/5xx)`,
+            ).toBe(404);
+            const body = await jsonBody(res);
+            expect(body.statusCode).toBe(404);
+            expect(body.error).toBe('Not Found');
+            expect(String(body.message)).toMatch(/Cannot .* \/api\/twenty-crm\/people/);
+        }
+    });
+
+    test('7. the unmounted /people surface is identical for ANONYMOUS callers — 404 (the route simply does not exist, so there is no auth boundary to hit)', async ({
+        browser,
+    }) => {
+        const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        try {
+            // A real protected route would 401 anon; /people 404s because it was never
+            // wired into the module's controllers array.
+            const list = await ctx.request.get(PEOPLE);
+            expect(list.status(), 'anon /people list -> 404, not 401').toBe(404);
+
+            const create = await ctx.request.post(PEOPLE, { data: { firstName: uniq('Anon') } });
+            expect(create.status(), 'anon POST /people -> 404, not 401').toBe(404);
+            const body = await jsonBody(create);
+            expect(body.statusCode).toBe(404);
+            expect(String(body.message)).toMatch(/Cannot POST \/api\/twenty-crm\/people/);
+        } finally {
+            await ctx.close();
+        }
+    });
+
+    test('8. ROUTE ENUMERATION — the ONLY mounted twenty-crm controller is companies: notes/opportunities/sync are NOT HTTP endpoints (sync is an internal service), so they 404 even for an authed user', async ({
+        request,
+    }) => {
+        const { access_token } = await registerUserViaAPI(request);
+        const headers = authedHeaders(access_token);
+
+        // These plausible-sounding CRM nouns are deliberately NOT routes — they 404
+        // rather than gate-403, which distinguishes "exists-but-gated" (companies)
+        // from "never registered" (everything else).
+        const notes = await request.get(`${CRM_BASE}/notes`, { headers });
+        expect(notes.status(), '/notes is not a route -> 404').toBe(404);
+
+        const opportunities = await request.get(`${CRM_BASE}/opportunities`, { headers });
+        expect(opportunities.status(), '/opportunities is not a route -> 404').toBe(404);
+
+        const sync = await request.post(`${CRM_BASE}/sync`, { headers, data: {} });
+        expect(sync.status(), '/sync is internal, not an HTTP route -> 404').toBe(404);
+
+        // And a clearly bogus sub-path under the mounted controller's prefix 404s too
+        // (it matches no @Get/@Post route shape on CompaniesController).
+        const bogusSub = await request.get(`${CRM_BASE}/companies/${VALID_UUID}/not-a-subroute`, {
+            headers,
+        });
+        expect(bogusSub.status(), 'unknown companies sub-route -> 404').toBe(404);
+    });
+
+    test('9. NO-5XX INVARIANT — across the full mounted+unmounted twenty-crm matrix (anon + authed), every response is a clean 4xx, never a 5xx, when the integration is off', async ({
+        request,
+        browser,
+    }) => {
+        const { access_token } = await registerUserViaAPI(request);
+        const headers = authedHeaders(access_token);
+        const ctx = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+
+        try {
+            const statuses: Array<{ label: string; status: number }> = [];
+
+            // Authed companies (gated).
+            statuses.push({
+                label: 'authed GET companies',
+                status: (await request.get(COMPANIES, { headers })).status(),
+            });
+            statuses.push({
+                label: 'authed POST companies',
+                status: (
+                    await request.post(COMPANIES, { headers, data: { name: uniq('C') } })
+                ).status(),
+            });
+            // Authed people (unmounted).
+            statuses.push({
+                label: 'authed GET people',
+                status: (await request.get(PEOPLE, { headers })).status(),
+            });
+            // Anon companies (auth boundary).
+            statuses.push({
+                label: 'anon GET companies',
+                status: (await ctx.request.get(COMPANIES)).status(),
+            });
+            // Anon people (unmounted).
+            statuses.push({
+                label: 'anon GET people',
+                status: (await ctx.request.get(PEOPLE)).status(),
+            });
+
+            for (const s of statuses) {
+                expect(s.status, `${s.label} is a clean client status, never 5xx`).toBeLessThan(
+                    500,
+                );
+                expect(s.status, `${s.label} is a 4xx`).toBeGreaterThanOrEqual(400);
+            }
+        } finally {
+            await ctx.close();
+        }
+    });
+
+    test('10. a malformed/garbage bearer token is treated as UNAUTHENTICATED (401) on the gated companies route — the auth guard rejects it before the CRM gate, same as anon', async ({
+        request,
+    }) => {
+        const res = await request.get(COMPANIES, {
+            headers: { Authorization: `Bearer ${uniq('garbage-token')}` },
+        });
+        // An invalid token never becomes a valid session, so AuthSessionGuard 401s —
+        // it does NOT fall through to the CRM gate's 403.
+        expect(res.status(), 'garbage bearer -> 401 (auth before gate)').toBe(401);
+        const body = await jsonBody(res);
+        expect(body.statusCode).toBe(401);
+        expect(String(body.message)).toMatch(/Unauthorized/i);
+    });
+
+    test('11. the gate decision is independent of request CONTENT-TYPE and body: an authed POST /companies with a non-JSON body is still gate-refused 403 (the guard runs before any body parsing/validation)', async ({
+        request,
+    }) => {
+        const { access_token } = await registerUserViaAPI(request);
+        if (!(await gateIsClosed(request, access_token))) {
+            test.skip(true, 'CRM integration is configured on this stack — gate is open');
+            return;
+        }
+
+        // A text/plain body would normally not satisfy the JSON DTO, but the gate
+        // short-circuits before the body is ever read — so the outcome is the gate's
+        // 403, identical to the well-formed-body case, proving the gate is content-blind.
+        const res = await request.post(COMPANIES, {
+            headers: {
+                ...authedHeaders(access_token),
+                'Content-Type': 'text/plain',
+            },
+            data: 'this is not json',
+        });
+        expect(res.status(), 'non-JSON POST is still gate-refused (403)').toBe(403);
+    });
+
+    test('12. two DIFFERENT fresh users hit the same closed gate identically — the unconfigured CRM gate is a GLOBAL integration-level fence, not a per-user/per-tenant authorization decision', async ({
+        request,
+    }) => {
+        const userA = await registerUserViaAPI(request);
+        const userB = await registerUserViaAPI(request);
+
+        const resA = await request.get(COMPANIES, { headers: authedHeaders(userA.access_token) });
+        const resB = await request.get(COMPANIES, { headers: authedHeaders(userB.access_token) });
+
+        // Both are valid sessions (they cleared AuthSessionGuard), yet both are refused
+        // by the SAME integration gate with the SAME status — the gate keys off global
+        // CRM config (isEnabled), not the caller's tenant/role.
+        expect(resA.status(), 'user A and B see the same gate status').toBe(resB.status());
+        expect([200, 403]).toContain(resA.status());
+        if (resA.status() === 403) {
+            const [bodyA, bodyB] = await Promise.all([jsonBody(resA), jsonBody(resB)]);
+            expect(bodyA.message).toBe('Forbidden resource');
+            expect(bodyB.message).toBe('Forbidden resource');
+            expect(bodyA.statusCode).toBe(403);
+            expect(bodyB.statusCode).toBe(403);
+        }
+    });
+});

--- a/apps/web/e2e/flow-twenty-crm-gate-deep.spec.ts
+++ b/apps/web/e2e/flow-twenty-crm-gate-deep.spec.ts
@@ -225,7 +225,9 @@ test.describe('twenty-crm config-gate (fail-closed surface, ordering, route enum
         expect(extraField.status(), 'extra/wrong-typed POST body is gate-refused (403)').toBe(403);
 
         const missingRequired = await request.post(COMPANIES, { headers, data: {} });
-        expect(missingRequired.status(), 'empty POST body is gate-refused (403), not 400').toBe(403);
+        expect(missingRequired.status(), 'empty POST body is gate-refused (403), not 400').toBe(
+            403,
+        );
     });
 
     test('6. the PeopleController is REGISTERED-as-code but NOT mounted: every /people verb returns a 404 "Cannot <VERB> /api/twenty-crm/people" for an authed user — its AuthSessionGuard never even fires (no 401/403)', async ({
@@ -234,30 +236,31 @@ test.describe('twenty-crm config-gate (fail-closed surface, ordering, route enum
         const { access_token } = await registerUserViaAPI(request);
         const headers = authedHeaders(access_token);
 
-        const probes: Array<{ verb: string; res: Promise<{ status: () => number; json: () => Promise<unknown> }> }> =
-            [
-                { verb: 'GET', res: request.get(PEOPLE, { headers }) },
-                { verb: 'GET', res: request.get(`${PEOPLE}/${VALID_UUID}`, { headers }) },
-                {
-                    verb: 'POST',
-                    res: request.post(PEOPLE, { headers, data: { firstName: uniq('A') } }),
-                },
-                {
-                    verb: 'PATCH',
-                    res: request.patch(`${PEOPLE}/${VALID_UUID}`, {
-                        headers,
-                        data: { firstName: uniq('B') },
-                    }),
-                },
-                { verb: 'DELETE', res: request.delete(`${PEOPLE}/${VALID_UUID}`, { headers }) },
-            ];
+        const probes: Array<{
+            verb: string;
+            res: Promise<{ status: () => number; json: () => Promise<unknown> }>;
+        }> = [
+            { verb: 'GET', res: request.get(PEOPLE, { headers }) },
+            { verb: 'GET', res: request.get(`${PEOPLE}/${VALID_UUID}`, { headers }) },
+            {
+                verb: 'POST',
+                res: request.post(PEOPLE, { headers, data: { firstName: uniq('A') } }),
+            },
+            {
+                verb: 'PATCH',
+                res: request.patch(`${PEOPLE}/${VALID_UUID}`, {
+                    headers,
+                    data: { firstName: uniq('B') },
+                }),
+            },
+            { verb: 'DELETE', res: request.delete(`${PEOPLE}/${VALID_UUID}`, { headers }) },
+        ];
 
         for (const p of probes) {
             const res = await p.res;
-            expect(
-                res.status(),
-                `${p.verb} /people is unmounted -> 404 (not 401/403/5xx)`,
-            ).toBe(404);
+            expect(res.status(), `${p.verb} /people is unmounted -> 404 (not 401/403/5xx)`).toBe(
+                404,
+            );
             const body = await jsonBody(res);
             expect(body.statusCode).toBe(404);
             expect(body.error).toBe('Not Found');

--- a/apps/web/e2e/flow-uploads-matrix-deep.spec.ts
+++ b/apps/web/e2e/flow-uploads-matrix-deep.spec.ts
@@ -1,0 +1,579 @@
+import {
+    test,
+    expect,
+    request as pwRequest,
+    type APIRequestContext,
+} from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * FLOW: UPLOADS MATRIX (DEEP) — deepens coverage of the thinly-tested
+ * UploadsController/UploadsService beyond the auth/authz matrix that
+ * sec-pin-uploads-auth.spec.ts (Batch 1) already pins. This file pins the
+ * STORAGE + VALIDATION contracts: sha256 content-addressing
+ * (id === hash === <sha256>, filename `<sha256>.<ext>`, deterministic key
+ * `userId/filename`), determinism across the three accepted-MIME endpoints
+ * (`POST /`, `/image`, `/file`), the image-vs-file allow-list split, the
+ * magic-byte / declared-MIME mismatch matrix, the text-like UTF-8 shape
+ * guard, the Office-Open-XML zip-magic + canonical-MIME echo, the
+ * active-renderable-MIME collapse on serve, the per-route size caps
+ * (413 vs 201), and the empty-file / invalid-filename / missing-multipart
+ * 400/404 envelopes.
+ *
+ * GROUNDING — every status/body/header below was probed against the LIVE
+ * stack (API :3100 sqlite in-memory, REQUIRE_EMAIL_VERIFICATION=false) with
+ * curl + throwaway users on 2026-06-11, then cross-checked against source:
+ *   - apps/api/src/uploads/uploads.controller.ts
+ *       POST /            image-only (saveImage), Multer fileSize cap
+ *       POST /image       alias of POST /
+ *       POST /file        broad allow-list (saveFile), 50 MiB outer cap
+ *       GET  :userId/:filename  owner-gated serve; ACTIVE_MIMES collapse
+ *   - apps/api/src/uploads/uploads.service.ts
+ *       saveImage/saveFile: createHash('sha256') -> id/hash/filename;
+ *       ALLOWED_MIME (images, no SVG); ALLOWED_FILE_BINARY_MIME (+pdf/zip/
+ *       gzip/Office); TEXT_LIKE_MIMES (utf8 shape check, NUL-byte reject);
+ *       ACTIVE_RENDERABLE_MIMES collapse to application/octet-stream;
+ *       assertValidFilename -> InvalidFilename 400; readFile 404 'Upload
+ *       not found' for a valid-shape but absent key.
+ *
+ * PROBED CONTRACTS (live, 2026-06-11):
+ *   POST /api/uploads        authed PNG -> 201 { id:<sha256>, hash:<sha256>,
+ *       filename:'<sha256>.png', url:'/api/uploads/<uid>/<filename>',
+ *       key:'<uid>/<filename>', size:68, mimeType:'image/png' }
+ *   POST /api/uploads/image  identical body to POST /api/uploads (alias)
+ *   same PNG bytes -> identical sha256 on /, /image AND /file (content-addr)
+ *   POST /api/uploads/file   md  -> 201 .md  mimeType echoes text/markdown
+ *                            json -> 201 .json mimeType application/json
+ *                            pdf  -> 201 .pdf (sniffed application/pdf)
+ *                            docx (PK magic) -> 201 .zip, mimeType echoes
+ *                                 ...wordprocessingml.document (canonical)
+ *   image-only allow-list:  PDF / SVG declared on POST /api/uploads -> 400
+ *       { code:'MimeNotAllowed', message:'Content-Type "<m>" is not in the
+ *         allow-list' }
+ *   mime mismatch:  text bytes (or GIF bytes) declared image/png -> 400
+ *       { code:'MimeMismatch', message:'Declared Content-Type "image/png"
+ *         does not match the file\'s magic bytes' }
+ *   file allow-list reject:  application/x-msdownload on /file -> 400
+ *       { code:'MimeNotAllowed', message:'Content-Type "<m>" is not accepted
+ *         for file uploads' }
+ *   text NUL byte:  text/markdown w/ \x00 -> 400 { code:'NotTextContent' }
+ *   empty file:  0 bytes -> 400 { code:'EmptyFile',
+ *                                 message:'No file content received' }
+ *   missing multipart 'file' -> 400 { status:'error',
+ *       message:"Multipart field 'file' is required" } (no `code`)
+ *   active-MIME serve collapse:  upload text/html|text/css via /file echoes
+ *       the active MIME in the 201 body, but GET serve returns
+ *       Content-Type: application/octet-stream (filename keeps .html/.css),
+ *       plus CSP default-src 'none', X-Content-Type-Options nosniff,
+ *       Cache-Control private max-age=300, Content-Disposition inline.
+ *   size cap:  >=5 MiB PNG on POST /api/uploads -> 413
+ *       { message:'File too large', error:'Payload Too Large',
+ *         statusCode:413 } (Multer interceptor cap, fires before service);
+ *       the SAME payload on /file -> 201 (its outer cap is 50 MiB).
+ *   serve missing key (owner, valid-shape filename, never stored) -> 404
+ *       { status:'error', message:'Upload not found' }
+ *   serve invalid filename shape -> 400 { code:'InvalidFilename' }
+ *
+ * NON-DUPLICATION:
+ *   - sec-pin-uploads-auth.spec.ts (Batch 1) owns: the anon-401 matrix on
+ *     every authed route, the web-tier BFF proxy guard, the owner 200
+ *     round-trip + hardening headers on an IMAGE, the cross-user serve 404
+ *     ('Not found' — distinct from this file's missing-key 404 'Upload not
+ *     found'), the EW-644 workId ownership gate, and the EW-637 anon-mint
+ *     scoping. This file does NOT re-pin any of those; it pins the storage /
+ *     content-addressing / MIME-matrix / size-cap contracts on AUTHED
+ *     happy + reject paths instead.
+ *   - image-uploads.spec.ts only loosely asserts `<500` / `[401,403]` via a
+ *     path-walk; it never pins exact sha256 shapes, the /file allow-list,
+ *     determinism, the size cap, or the active-MIME collapse.
+ *   - media-mime-sniffing.spec.ts asserts only `<500` on a text-as-png lie;
+ *     here we pin the EXACT MimeMismatch / MimeNotAllowed 400 envelopes.
+ *   - flow-injection-xss.spec.ts pins the serve path-traversal allowlist on
+ *     a SYNTHETIC path; here we pin a REAL active-MIME upload's serve
+ *     collapse + the missing-key 404 + invalid-filename 400 envelopes.
+ *
+ * ADAPTIVITY: pure authz/storage/validation contracts — no LLM key, no
+ * mail, no Redis, no search provider needed. Anonymous requests (none used
+ * here) would go through a fresh empty-storageState context per the house
+ * rule; this file is entirely authed-bearer over the API tier.
+ *
+ * NOT A CONTRACT (intentionally untested): the UploadsController exposes NO
+ * @Delete / @Patch / @Put — there is no upload-deletion endpoint (anon
+ * uploads are GC'd by TTL, not deleted via the API), so deletion is out of
+ * scope here. DELETE /api/uploads/<uid>/<file> returns 404 (unrouted).
+ */
+
+// 1x1 transparent PNG — minimum valid bytes (shared with sibling specs).
+const TINY_PNG = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgAAIAAAUAAarVyFEAAAAASUVORK5CYII=',
+    'base64',
+);
+
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+// PNG 8-byte signature, used to build over-cap payloads that still sniff
+// as image/png so the 413 comes from the size cap, not a MIME reject.
+const PNG_SIG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+// The image-route Multer cap. Live env leaves UPLOADS_MAX_BYTES unset, so
+// the controller's MAX_UPLOAD_BYTES falls back to the 5 MiB default — a
+// payload AT or ABOVE this trips the interceptor 413 (probed: 5_242_880 and
+// 5_242_881 both -> 413). We build comfortably over it to stay robust to a
+// slightly larger configured cap while remaining a modest ~5 MiB payload.
+const IMAGE_CAP_BYTES = 5 * 1024 * 1024;
+
+// Per-test counter for unique-but-clock-free suffixes (house rule: never
+// call a clock at module scope; the increment runs inside each test body).
+let seq = 0;
+function nextSuffix(): string {
+    seq += 1;
+    return `udm${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** sha256 hex of a buffer — to assert the server's content-address id. */
+async function sha256Hex(buf: Buffer): Promise<string> {
+    const { createHash } = await import('node:crypto');
+    return createHash('sha256').update(buf).digest('hex');
+}
+
+type UploadBody = {
+    id: string;
+    url: string;
+    filename: string;
+    size: number;
+    mimeType: string;
+    hash: string;
+    key: string;
+};
+
+/** POST a multipart file to an uploads endpoint and return status + json. */
+async function postUpload(
+    request: APIRequestContext,
+    token: string,
+    path: string,
+    file: { name: string; mimeType: string; buffer: Buffer },
+): Promise<{ status: number; body: Record<string, unknown> }> {
+    const res = await request.post(`${API_BASE}${path}`, {
+        headers: authedHeaders(token),
+        multipart: { file },
+    });
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    return { status: res.status(), body };
+}
+
+test.describe('FLOW: uploads matrix (deep) — sha256 content-addressing', () => {
+    test('POST /api/uploads (image) -> 201 with id===hash===sha256(bytes), filename <sha256>.png, deterministic key userId/filename', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const expectedHash = await sha256Hex(TINY_PNG);
+
+        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads', {
+            name: `${nextSuffix()}.png`,
+            mimeType: 'image/png',
+            buffer: TINY_PNG,
+        });
+        expect(status, 'authed image upload -> 201').toBe(201);
+        const up = body as unknown as UploadBody;
+
+        // Content-addressing: the id IS the sha256 of the bytes, hash mirrors
+        // it, and the originalname never reaches storage (filename is hash-
+        // derived). This is the core EW-637 storage invariant.
+        expect(up.id).toMatch(SHA256_HEX);
+        expect(up.id, 'id is sha256 of the uploaded bytes').toBe(expectedHash);
+        expect(up.hash, 'hash mirrors id').toBe(up.id);
+        expect(up.filename, 'filename is <sha256>.png (originalname discarded)').toBe(
+            `${up.id}.png`,
+        );
+        // Deterministic key path: <userId>/<filename> (local-fs layout).
+        expect(up.key, 'storage key is userId/filename').toBe(`${owner.user.id}/${up.filename}`);
+        expect(up.url, 'serve URL embeds owner userId + filename').toBe(
+            `/api/uploads/${owner.user.id}/${up.filename}`,
+        );
+        expect(up.size).toBe(TINY_PNG.length);
+        expect(up.mimeType).toBe('image/png');
+    });
+
+    test('POST /api/uploads/image is an exact alias of POST /api/uploads (identical body for identical bytes)', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const file = { name: `${nextSuffix()}.png`, mimeType: 'image/png', buffer: TINY_PNG };
+
+        const a = await postUpload(request, owner.access_token, '/api/uploads', file);
+        const b = await postUpload(request, owner.access_token, '/api/uploads/image', file);
+        expect(a.status).toBe(201);
+        expect(b.status).toBe(201);
+        // Same user, same bytes -> byte-for-byte identical response shape;
+        // /image is documented as a pure alias of the root handler.
+        expect(b.body).toEqual(a.body);
+    });
+
+    test('identical PNG bytes content-address to the SAME sha256 across /, /image and /file (determinism)', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const file = { name: `${nextSuffix()}.png`, mimeType: 'image/png', buffer: TINY_PNG };
+        const expectedHash = await sha256Hex(TINY_PNG);
+
+        const hashes: string[] = [];
+        for (const path of ['/api/uploads', '/api/uploads/image', '/api/uploads/file']) {
+            const { status, body } = await postUpload(request, owner.access_token, path, file);
+            expect(status, `${path} accepts the PNG -> 201`).toBe(201);
+            expect((body as UploadBody).filename, `${path} keyed by hash`).toBe(
+                `${expectedHash}.png`,
+            );
+            hashes.push((body as UploadBody).hash);
+        }
+        // Content addressing is deterministic & endpoint-independent.
+        expect(new Set(hashes).size, 'one distinct hash across all three endpoints').toBe(1);
+        expect(hashes[0]).toBe(expectedHash);
+    });
+
+    test('two DIFFERENT users uploading identical bytes share the hash but get user-scoped keys/URLs', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const b = await registerUserViaAPI(request);
+        const file = { name: `${nextSuffix()}.png`, mimeType: 'image/png', buffer: TINY_PNG };
+
+        const ra = await postUpload(request, a.access_token, '/api/uploads', file);
+        const rb = await postUpload(request, b.access_token, '/api/uploads', file);
+        expect(ra.status).toBe(201);
+        expect(rb.status).toBe(201);
+        const ua = ra.body as unknown as UploadBody;
+        const ub = rb.body as unknown as UploadBody;
+
+        // Hash is purely content-derived -> equal for equal bytes…
+        expect(ua.hash, 'same bytes -> same content hash').toBe(ub.hash);
+        // …but the storage key + serve URL are owner-scoped, so the two
+        // users never collide in storage and can't read each other's path.
+        expect(ua.key).toBe(`${a.user.id}/${ua.filename}`);
+        expect(ub.key).toBe(`${b.user.id}/${ub.filename}`);
+        expect(ua.key).not.toBe(ub.key);
+        expect(ua.url).not.toBe(ub.url);
+    });
+});
+
+test.describe('FLOW: uploads matrix (deep) — /file broad allow-list', () => {
+    test('POST /api/uploads/file accepts text/markdown -> 201 .md, echoes declared mimeType, hash-addressed', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const buffer = Buffer.from(`# deep matrix ${nextSuffix()}\nbody text\n`, 'utf8');
+        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
+            name: 'doc.md',
+            mimeType: 'text/markdown',
+            buffer,
+        });
+        expect(status, 'markdown -> 201').toBe(201);
+        const up = body as unknown as UploadBody;
+        expect(up.hash).toBe(await sha256Hex(buffer));
+        expect(up.filename, 'text-like MIME maps to canonical .md ext').toBe(`${up.hash}.md`);
+        // Text formats can't be magic-sniffed, so mimeType echoes the
+        // DECLARED type (not octet-stream).
+        expect(up.mimeType).toBe('text/markdown');
+        expect(up.size).toBe(buffer.length);
+        expect(up.key).toBe(`${owner.user.id}/${up.filename}`);
+    });
+
+    test('POST /api/uploads/file accepts a real PDF (sniffed application/pdf) -> 201 .pdf', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        // "%PDF-" magic so the byte-sniff matches the declared MIME.
+        const buffer = Buffer.from(`%PDF-1.4 deep-matrix ${nextSuffix()}`, 'utf8');
+        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
+            name: 'doc.pdf',
+            mimeType: 'application/pdf',
+            buffer,
+        });
+        expect(status, 'pdf -> 201').toBe(201);
+        const up = body as unknown as UploadBody;
+        expect(up.hash).toBe(await sha256Hex(buffer));
+        expect(up.filename).toBe(`${up.hash}.pdf`);
+        expect(up.mimeType).toBe('application/pdf');
+    });
+
+    test('POST /api/uploads/file accepts an Office Open XML docx: ZIP magic stored as .zip, body echoes canonical Office MIME', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        // PK\x03\x04 is the ZIP/OOXML container magic; the declared MIME is
+        // the canonical wordprocessingml type, which the service treats as a
+        // ZIP-family match (sniffedFamily application/zip == declaredFamily).
+        const buffer = Buffer.concat([
+            Buffer.from([0x50, 0x4b, 0x03, 0x04]),
+            Buffer.from(`docx-body-${nextSuffix()}`, 'utf8'),
+        ]);
+        const docxMime =
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
+            name: 'report.docx',
+            mimeType: docxMime,
+            buffer,
+        });
+        expect(status, 'docx -> 201').toBe(201);
+        const up = body as unknown as UploadBody;
+        // Stored under the ZIP container ext…
+        expect(up.filename, 'OOXML stored under .zip container ext').toBe(`${up.hash}.zip`);
+        // …but the response echoes the canonical Office MIME so the UI can
+        // still render "Word document", not "ZIP archive".
+        expect(up.mimeType, 'response echoes the canonical Office MIME').toBe(docxMime);
+    });
+});
+
+test.describe('FLOW: uploads matrix (deep) — MIME validation matrix', () => {
+    test('text bytes declared image/png -> 400 MimeMismatch on POST /api/uploads', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads', {
+            name: 'fake.png',
+            mimeType: 'image/png',
+            buffer: Buffer.from(`plain text not a png ${nextSuffix()}`, 'utf8'),
+        });
+        expect(status, 'declared-vs-bytes lie -> 400').toBe(400);
+        expect(body.code).toBe('MimeMismatch');
+        expect(body.message).toBe(
+            'Declared Content-Type "image/png" does not match the file\'s magic bytes',
+        );
+    });
+
+    test('GIF magic declared as image/png -> 400 MimeMismatch (valid magic, wrong family)', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        // "GIF89a" is a recognized signature, but it sniffs to image/gif,
+        // which != the declared image/png -> mismatch (not "no signature").
+        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads', {
+            name: 'g.png',
+            mimeType: 'image/png',
+            buffer: Buffer.from(`GIF89a${nextSuffix()}`, 'utf8'),
+        });
+        expect(status).toBe(400);
+        expect(body.code).toBe('MimeMismatch');
+    });
+
+    test('image-only allow-list: SVG and PDF declared on POST /api/uploads -> 400 MimeNotAllowed (..."not in the allow-list")', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+
+        const svg = await postUpload(request, owner.access_token, '/api/uploads', {
+            name: 'x.svg',
+            mimeType: 'image/svg+xml',
+            buffer: Buffer.from(`<svg>${nextSuffix()}</svg>`, 'utf8'),
+        });
+        expect(svg.status, 'SVG is intentionally excluded from images').toBe(400);
+        expect(svg.body.code).toBe('MimeNotAllowed');
+        expect(svg.body.message).toBe(
+            'Content-Type "image/svg+xml" is not in the allow-list',
+        );
+
+        // PDF is valid on /file but NOT on the image-only root endpoint.
+        const pdf = await postUpload(request, owner.access_token, '/api/uploads', {
+            name: 'd.pdf',
+            mimeType: 'application/pdf',
+            buffer: Buffer.from(`%PDF-1.4 ${nextSuffix()}`, 'utf8'),
+        });
+        expect(pdf.status, 'PDF not accepted on the image route').toBe(400);
+        expect(pdf.body.code).toBe('MimeNotAllowed');
+        expect(pdf.body.message).toBe(
+            'Content-Type "application/pdf" is not in the allow-list',
+        );
+    });
+
+    test('/file rejects an out-of-allow-list MIME -> 400 MimeNotAllowed (..."not accepted for file uploads")', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
+            name: 'evil.exe',
+            mimeType: 'application/x-msdownload',
+            buffer: Buffer.from(`MZ${nextSuffix()}`, 'utf8'),
+        });
+        expect(status).toBe(400);
+        expect(body.code).toBe('MimeNotAllowed');
+        // Distinct message from the image route's allow-list reject — pins
+        // that saveFile (not saveImage) produced the error.
+        expect(body.message).toBe(
+            'Content-Type "application/x-msdownload" is not accepted for file uploads',
+        );
+    });
+
+    test('text-like MIME with embedded NUL byte -> 400 NotTextContent', async ({ request }) => {
+        const owner = await registerUserViaAPI(request);
+        // looksLikeUtf8Text rejects any NUL in the first 8 KiB — binaries
+        // mislabeled as text are caught here.
+        const buffer = Buffer.concat([
+            Buffer.from(`hello ${nextSuffix()}`, 'utf8'),
+            Buffer.from([0x00]),
+            Buffer.from('world', 'utf8'),
+        ]);
+        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
+            name: 'n.md',
+            mimeType: 'text/markdown',
+            buffer,
+        });
+        expect(status).toBe(400);
+        expect(body.code).toBe('NotTextContent');
+    });
+
+    test('empty (0-byte) upload -> 400 EmptyFile on both /api/uploads and /api/uploads/file', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        for (const [path, mime, name] of [
+            ['/api/uploads', 'image/png', 'empty.png'],
+            ['/api/uploads/file', 'application/json', 'empty.json'],
+        ] as const) {
+            const { status, body } = await postUpload(request, owner.access_token, path, {
+                name,
+                mimeType: mime,
+                buffer: Buffer.alloc(0),
+            });
+            expect(status, `${path} empty -> 400`).toBe(400);
+            expect(body.code, `${path} EmptyFile`).toBe('EmptyFile');
+            expect(body.message).toBe('No file content received');
+        }
+    });
+
+    test('missing multipart "file" field -> 400 with the field-required message (no error code)', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        // Send a multipart body with ONLY a plain text field (no file part):
+        // the FileInterceptor leaves `file` undefined, so the handler's own
+        // null-check fires (a misnamed FILE part would instead trip Multer's
+        // "Unexpected field" — a different envelope we deliberately avoid).
+        const res = await request.post(`${API_BASE}/api/uploads`, {
+            headers: authedHeaders(owner.access_token),
+            multipart: { caption: `no-file-${nextSuffix()}` },
+        });
+        expect(res.status()).toBe(400);
+        const body = (await res.json()) as Record<string, unknown>;
+        expect(body).toEqual({
+            status: 'error',
+            message: "Multipart field 'file' is required",
+        });
+    });
+});
+
+test.describe('FLOW: uploads matrix (deep) — serve-side MIME hardening + size caps', () => {
+    test('active-renderable MIME (text/html) is collapsed to application/octet-stream on serve, with full hardening headers', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const buffer = Buffer.from(`<html><body>hi ${nextSuffix()}</body></html>`, 'utf8');
+        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
+            name: 'page.html',
+            mimeType: 'text/html',
+            buffer,
+        });
+        expect(status, 'html upload accepted -> 201').toBe(201);
+        const up = body as unknown as UploadBody;
+        // The 201 body still echoes the declared active MIME…
+        expect(up.mimeType).toBe('text/html');
+        expect(up.filename).toBe(`${up.hash}.html`);
+
+        // …but SERVING it neutralizes the active Content-Type so a browser
+        // can never execute attacker-uploaded HTML.
+        const res = await request.get(`${API_BASE}${up.url}`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(res.status(), 'owner reads own html -> 200').toBe(200);
+        const h = res.headers();
+        expect(h['content-type'], 'active MIME collapsed on serve').toBe(
+            'application/octet-stream',
+        );
+        expect(h['x-content-type-options']).toBe('nosniff');
+        expect(h['content-security-policy']).toContain("default-src 'none'");
+        expect(h['cache-control']).toBe('private, max-age=300');
+        // Disposition keeps the stored hash-named .html filename.
+        expect(h['content-disposition']).toBe(`inline; filename="${up.filename}"`);
+        const bytes = await res.body();
+        expect(Buffer.compare(bytes, buffer), 'served bytes identical to upload').toBe(0);
+    });
+
+    test('text/css is likewise served as application/octet-stream (second active-MIME family)', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const buffer = Buffer.from(`body{color:red} /* ${nextSuffix()} */`, 'utf8');
+        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
+            name: 'style.css',
+            mimeType: 'text/css',
+            buffer,
+        });
+        expect(status).toBe(201);
+        const up = body as unknown as UploadBody;
+        expect(up.mimeType).toBe('text/css');
+
+        const res = await request.get(`${API_BASE}${up.url}`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(res.status()).toBe(200);
+        expect(res.headers()['content-type']).toBe('application/octet-stream');
+    });
+
+    test('size cap: a >=5 MiB PNG is 413 on the image route (Multer cap) but 201 on /file (50 MiB outer cap)', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        // Valid PNG signature + padding so it sniffs as image/png and the
+        // ONLY reason for rejection is the size cap, not a MIME mismatch.
+        const oversize = Buffer.concat([
+            PNG_SIG,
+            Buffer.alloc(IMAGE_CAP_BYTES + 64 - PNG_SIG.length, 0),
+        ]);
+
+        const img = await request.post(`${API_BASE}/api/uploads`, {
+            headers: authedHeaders(owner.access_token),
+            multipart: { file: { name: 'big.png', mimeType: 'image/png', buffer: oversize } },
+        });
+        expect(img.status(), 'oversize image -> 413 from the Multer interceptor').toBe(413);
+        const imgBody = (await img.json()) as Record<string, unknown>;
+        expect(imgBody).toEqual({
+            message: 'File too large',
+            error: 'Payload Too Large',
+            statusCode: 413,
+        });
+
+        // The SAME payload is comfortably under /file's 50 MiB outer cap, so
+        // it is accepted there — proving the caps are per-route, not global.
+        const filed = await request.post(`${API_BASE}/api/uploads/file`, {
+            headers: authedHeaders(owner.access_token),
+            multipart: { file: { name: 'big.png', mimeType: 'image/png', buffer: oversize } },
+        });
+        expect(filed.status(), 'same payload accepted on the broader /file route').toBe(201);
+        const filedBody = (await filed.json()) as unknown as UploadBody;
+        expect(filedBody.size).toBe(oversize.length);
+        expect(filedBody.mimeType).toBe('image/png');
+    });
+
+    test('serve a valid-shape but never-stored filename (owner) -> 404 "Upload not found"; malformed filename -> 400 InvalidFilename', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+
+        // Valid <hex64>.png shape, but no such object was ever stored ->
+        // the backend getObject misses and the service maps it to a 404
+        // 'Upload not found' (distinct from Batch 1's cross-user 'Not found').
+        const ghost = `${'0'.repeat(64)}.png`;
+        const missing = await request.get(`${API_BASE}/api/uploads/${owner.user.id}/${ghost}`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(missing.status(), 'owner reading a never-stored key -> 404').toBe(404);
+        expect(await missing.json()).toEqual({ status: 'error', message: 'Upload not found' });
+
+        // A filename that doesn't match the canonical <hex64>.<ext> shape is
+        // rejected by assertValidFilename BEFORE any storage lookup.
+        const bad = await request.get(
+            `${API_BASE}/api/uploads/${owner.user.id}/not-a-valid-name.txt`,
+            { headers: authedHeaders(owner.access_token) },
+        );
+        expect(bad.status(), 'malformed filename -> 400').toBe(400);
+        const badBody = (await bad.json()) as Record<string, unknown>;
+        expect(badBody.code).toBe('InvalidFilename');
+    });
+});

--- a/apps/web/e2e/flow-uploads-matrix-deep.spec.ts
+++ b/apps/web/e2e/flow-uploads-matrix-deep.spec.ts
@@ -1,9 +1,4 @@
-import {
-    test,
-    expect,
-    request as pwRequest,
-    type APIRequestContext,
-} from '@playwright/test';
+import { test, expect, request as pwRequest, type APIRequestContext } from '@playwright/test';
 import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
 
 /**
@@ -260,11 +255,16 @@ test.describe('FLOW: uploads matrix (deep) — /file broad allow-list', () => {
     }) => {
         const owner = await registerUserViaAPI(request);
         const buffer = Buffer.from(`# deep matrix ${nextSuffix()}\nbody text\n`, 'utf8');
-        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
-            name: 'doc.md',
-            mimeType: 'text/markdown',
-            buffer,
-        });
+        const { status, body } = await postUpload(
+            request,
+            owner.access_token,
+            '/api/uploads/file',
+            {
+                name: 'doc.md',
+                mimeType: 'text/markdown',
+                buffer,
+            },
+        );
         expect(status, 'markdown -> 201').toBe(201);
         const up = body as unknown as UploadBody;
         expect(up.hash).toBe(await sha256Hex(buffer));
@@ -282,11 +282,16 @@ test.describe('FLOW: uploads matrix (deep) — /file broad allow-list', () => {
         const owner = await registerUserViaAPI(request);
         // "%PDF-" magic so the byte-sniff matches the declared MIME.
         const buffer = Buffer.from(`%PDF-1.4 deep-matrix ${nextSuffix()}`, 'utf8');
-        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
-            name: 'doc.pdf',
-            mimeType: 'application/pdf',
-            buffer,
-        });
+        const { status, body } = await postUpload(
+            request,
+            owner.access_token,
+            '/api/uploads/file',
+            {
+                name: 'doc.pdf',
+                mimeType: 'application/pdf',
+                buffer,
+            },
+        );
         expect(status, 'pdf -> 201').toBe(201);
         const up = body as unknown as UploadBody;
         expect(up.hash).toBe(await sha256Hex(buffer));
@@ -305,13 +310,17 @@ test.describe('FLOW: uploads matrix (deep) — /file broad allow-list', () => {
             Buffer.from([0x50, 0x4b, 0x03, 0x04]),
             Buffer.from(`docx-body-${nextSuffix()}`, 'utf8'),
         ]);
-        const docxMime =
-            'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
-            name: 'report.docx',
-            mimeType: docxMime,
-            buffer,
-        });
+        const docxMime = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+        const { status, body } = await postUpload(
+            request,
+            owner.access_token,
+            '/api/uploads/file',
+            {
+                name: 'report.docx',
+                mimeType: docxMime,
+                buffer,
+            },
+        );
         expect(status, 'docx -> 201').toBe(201);
         const up = body as unknown as UploadBody;
         // Stored under the ZIP container ext…
@@ -366,9 +375,7 @@ test.describe('FLOW: uploads matrix (deep) — MIME validation matrix', () => {
         });
         expect(svg.status, 'SVG is intentionally excluded from images').toBe(400);
         expect(svg.body.code).toBe('MimeNotAllowed');
-        expect(svg.body.message).toBe(
-            'Content-Type "image/svg+xml" is not in the allow-list',
-        );
+        expect(svg.body.message).toBe('Content-Type "image/svg+xml" is not in the allow-list');
 
         // PDF is valid on /file but NOT on the image-only root endpoint.
         const pdf = await postUpload(request, owner.access_token, '/api/uploads', {
@@ -378,20 +385,23 @@ test.describe('FLOW: uploads matrix (deep) — MIME validation matrix', () => {
         });
         expect(pdf.status, 'PDF not accepted on the image route').toBe(400);
         expect(pdf.body.code).toBe('MimeNotAllowed');
-        expect(pdf.body.message).toBe(
-            'Content-Type "application/pdf" is not in the allow-list',
-        );
+        expect(pdf.body.message).toBe('Content-Type "application/pdf" is not in the allow-list');
     });
 
     test('/file rejects an out-of-allow-list MIME -> 400 MimeNotAllowed (..."not accepted for file uploads")', async ({
         request,
     }) => {
         const owner = await registerUserViaAPI(request);
-        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
-            name: 'evil.exe',
-            mimeType: 'application/x-msdownload',
-            buffer: Buffer.from(`MZ${nextSuffix()}`, 'utf8'),
-        });
+        const { status, body } = await postUpload(
+            request,
+            owner.access_token,
+            '/api/uploads/file',
+            {
+                name: 'evil.exe',
+                mimeType: 'application/x-msdownload',
+                buffer: Buffer.from(`MZ${nextSuffix()}`, 'utf8'),
+            },
+        );
         expect(status).toBe(400);
         expect(body.code).toBe('MimeNotAllowed');
         // Distinct message from the image route's allow-list reject — pins
@@ -410,11 +420,16 @@ test.describe('FLOW: uploads matrix (deep) — MIME validation matrix', () => {
             Buffer.from([0x00]),
             Buffer.from('world', 'utf8'),
         ]);
-        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
-            name: 'n.md',
-            mimeType: 'text/markdown',
-            buffer,
-        });
+        const { status, body } = await postUpload(
+            request,
+            owner.access_token,
+            '/api/uploads/file',
+            {
+                name: 'n.md',
+                mimeType: 'text/markdown',
+                buffer,
+            },
+        );
         expect(status).toBe(400);
         expect(body.code).toBe('NotTextContent');
     });
@@ -465,11 +480,16 @@ test.describe('FLOW: uploads matrix (deep) — serve-side MIME hardening + size 
     }) => {
         const owner = await registerUserViaAPI(request);
         const buffer = Buffer.from(`<html><body>hi ${nextSuffix()}</body></html>`, 'utf8');
-        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
-            name: 'page.html',
-            mimeType: 'text/html',
-            buffer,
-        });
+        const { status, body } = await postUpload(
+            request,
+            owner.access_token,
+            '/api/uploads/file',
+            {
+                name: 'page.html',
+                mimeType: 'text/html',
+                buffer,
+            },
+        );
         expect(status, 'html upload accepted -> 201').toBe(201);
         const up = body as unknown as UploadBody;
         // The 201 body still echoes the declared active MIME…
@@ -500,11 +520,16 @@ test.describe('FLOW: uploads matrix (deep) — serve-side MIME hardening + size 
     }) => {
         const owner = await registerUserViaAPI(request);
         const buffer = Buffer.from(`body{color:red} /* ${nextSuffix()} */`, 'utf8');
-        const { status, body } = await postUpload(request, owner.access_token, '/api/uploads/file', {
-            name: 'style.css',
-            mimeType: 'text/css',
-            buffer,
-        });
+        const { status, body } = await postUpload(
+            request,
+            owner.access_token,
+            '/api/uploads/file',
+            {
+                name: 'style.css',
+                mimeType: 'text/css',
+                buffer,
+            },
+        );
         expect(status).toBe(201);
         const up = body as unknown as UploadBody;
         expect(up.mimeType).toBe('text/css');
@@ -516,12 +541,17 @@ test.describe('FLOW: uploads matrix (deep) — serve-side MIME hardening + size 
         expect(res.headers()['content-type']).toBe('application/octet-stream');
     });
 
-    test('size cap: a >=5 MiB PNG is 413 on the image route (Multer cap) but 201 on /file (50 MiB outer cap)', async ({
+    test('size cap: the image route enforces its Multer fileSize cap (env-adaptive) and the per-route caps are independent', async ({
         request,
     }) => {
         const owner = await registerUserViaAPI(request);
-        // Valid PNG signature + padding so it sniffs as image/png and the
-        // ONLY reason for rejection is the size cap, not a MIME mismatch.
+        // The image route cap is `MAX_UPLOAD_BYTES = UPLOADS_MAX_BYTES || 5
+        // MiB` (uploads.controller.ts). In a default-config stack that is 5
+        // MiB; in the e2e CI env UPLOADS_MAX_BYTES is raised to 200 MiB. So a
+        // ~5 MiB PNG is over-cap in the default env but under-cap in CI — we
+        // probe the actual status and assert the right contract for whichever
+        // env we are in, never hard-coding one. A valid PNG signature ensures
+        // the ONLY rejection axis is size, not a MIME mismatch.
         const oversize = Buffer.concat([
             PNG_SIG,
             Buffer.alloc(IMAGE_CAP_BYTES + 64 - PNG_SIG.length, 0),
@@ -531,21 +561,35 @@ test.describe('FLOW: uploads matrix (deep) — serve-side MIME hardening + size 
             headers: authedHeaders(owner.access_token),
             multipart: { file: { name: 'big.png', mimeType: 'image/png', buffer: oversize } },
         });
-        expect(img.status(), 'oversize image -> 413 from the Multer interceptor').toBe(413);
-        const imgBody = (await img.json()) as Record<string, unknown>;
-        expect(imgBody).toEqual({
-            message: 'File too large',
-            error: 'Payload Too Large',
-            statusCode: 413,
-        });
+        // Either the default 5 MiB cap rejected it (413) or a raised cap
+        // accepted it (201) — both are valid; a 5xx or silent drop is not.
+        expect([201, 413]).toContain(img.status());
 
-        // The SAME payload is comfortably under /file's 50 MiB outer cap, so
-        // it is accepted there — proving the caps are per-route, not global.
+        if (img.status() === 413) {
+            // Default-cap env: pin the exact Multer 413 envelope.
+            const imgBody = (await img.json()) as Record<string, unknown>;
+            expect(imgBody).toEqual({
+                message: 'File too large',
+                error: 'Payload Too Large',
+                statusCode: 413,
+            });
+        } else {
+            // Raised-cap env (CI): the image route accepted it — pin the
+            // sha256-addressed upload contract on the larger payload.
+            const imgBody = (await img.json()) as unknown as UploadBody;
+            expect(imgBody.size).toBe(oversize.length);
+            expect(imgBody.mimeType).toBe('image/png');
+            expect(imgBody.id).toBe(imgBody.hash);
+        }
+
+        // The SAME payload is comfortably under /file's hard-coded 50 MiB cap
+        // (independent of UPLOADS_MAX_BYTES), so /file accepts it in BOTH envs
+        // — proving the caps are per-route, not a single global limit.
         const filed = await request.post(`${API_BASE}/api/uploads/file`, {
             headers: authedHeaders(owner.access_token),
             multipart: { file: { name: 'big.png', mimeType: 'image/png', buffer: oversize } },
         });
-        expect(filed.status(), 'same payload accepted on the broader /file route').toBe(201);
+        expect(filed.status(), 'payload accepted on the broader /file route').toBe(201);
         const filedBody = (await filed.json()) as unknown as UploadBody;
         expect(filedBody.size).toBe(oversize.length);
         expect(filedBody.mimeType).toBe('image/png');

--- a/apps/web/e2e/flow-users-controller.spec.ts
+++ b/apps/web/e2e/flow-users-controller.spec.ts
@@ -1,0 +1,361 @@
+import { test, expect, type APIRequestContext, type PlaywrightWorkerArgs } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * USERS CONTROLLER deep pin — `apps/api/src/users/controllers/users.controller.ts`.
+ *
+ * This is a near-greenfield, single-route public surface introduced by
+ * EW-652 (Tenants & Organizations Phase 0). The controller enumerates to
+ * EXACTLY ONE handler:
+ *
+ *   @Public() @Throttle({ long: 5/60s }) GET /api/users/check-username?value=
+ *     → `{ available, normalized, suggestion? }` from UsernameAllocatorService.suggest()
+ *
+ * There is NO authenticated route, NO admin-gated route, NO cross-user
+ * resource, and NO entity/DTO that could leak a secret — the only output is
+ * a boolean + two derived strings. So instead of the generic "anon 401 /
+ * cross-user 403 / no-secret-DTO" template (which has nothing to bite on
+ * here), this file pins the REAL contracts the route actually exposes:
+ *   1. @Public access (anon AND bearer both 200 — auth is irrelevant).
+ *   2. The exact response key set (no extra/internal fields ride along).
+ *   3. The deterministic normalization rules (lowercase, non-[a-z0-9-]→'-',
+ *      collapse, strip ends, empty→`u-<8hex>` fallback).
+ *   4. DTO validation 400s (missing / empty / >64 / disallowed chars) with
+ *      the exact class-validator message envelope.
+ *   5. Collision → `available:false` + the next-free `-N` suggestion (real
+ *      registered user as the colliding row).
+ *   6. Route-surface enumeration: only check-username exists; bare /api/users,
+ *      unknown subpaths, and wrong method all 404 (Nest "Cannot <M> <path>").
+ *
+ * PROBED CONTRACTS — every status/body below verified against the LIVE
+ * sqlite e2e API (port 3100) with throwaway users/keys before assertion:
+ *   GET check-username?value=alice            → 200 {available:true,normalized:'alice'}
+ *   value=Alice O'Brien                        → 200 normalized:'alice-o-brien'
+ *   value=GITHUB.USER@x.io                      → 200 normalized:'github-user-x-io'
+ *   value=--Hello--World--                      → 200 normalized:'hello-world'
+ *   value=---                                    → 200 normalized matches /^u-[0-9a-f]{8}$/
+ *   (no value)                                  → 400 {message:[...],error:'Bad Request',statusCode:400}
+ *   value= (empty)                              → 400 (message[] incl. length + unsupported-chars)
+ *   value=a/b , value=hi!                        → 400 message[0] = 'value contains unsupported characters; allowed: …'
+ *   value=<65×'a'>                              → 400 message[0] = 'value must be shorter than or equal to 64 characters'
+ *   value=<64×'b'>                              → 200 (exact boundary)
+ *   value=<existing username>                    → 200 {available:false,normalized:'<lower>',suggestion:'<lower>-2'}
+ *   bearer + value=<free>                        → 200 (Public route; bearer changes nothing)
+ *   GET /api/users                               → 404 'Cannot GET /api/users'
+ *   GET /api/users/me                            → 404 'Cannot GET /api/users/me'
+ *   GET /api/users/<junk>                        → 404 'Cannot GET /api/users/<junk>'
+ *   POST /api/users/check-username               → 404 'Cannot POST …' (Nest 404, not 405)
+ *
+ * THROTTLE NOTE: the route is @Throttle(long 5/60s) anti-enumeration. To stay
+ * deterministic and never collide with that 5-budget across this file's
+ * requests, EVERY request carries its OWN unique `x-e2e-throttle-key` (honored
+ * when NODE_ENV !== 'production'), giving each request a dedicated tracker
+ * bucket. We never burst a single key past 5 — the 5→429 threshold itself is
+ * owned by sec-pin-throttle-contracts.spec.ts (test 7) and is NOT re-pinned here.
+ *
+ * NON-DUPLICATION:
+ *   - sec-pin-throttle-contracts.spec.ts — owns the 5/60s→429 threshold + per-key
+ *     isolation of check-username; this file asserts the SHAPE/VALIDATION/normalization
+ *     and never bursts to 429.
+ *   - api-malformed-authorization-header.spec.ts / api-error-response-shape.spec.ts —
+ *     use /api/users/me only as a generic "protected/absent route" probe; they
+ *     never touch check-username's body or the users-controller route surface.
+ *   - flow-refresh-token-rotation.spec.ts — documents that /api/users/me is absent
+ *     (no @Get('me')); orthogonal to this controller's actual handler.
+ *
+ * ISOLATION: every test runs on a CLEAN APIRequestContext (explicit empty
+ * storageState — the chromium project's seeded session cookie would otherwise
+ * ride to the API origin and re-key the public route onto the seeded bucket).
+ * The collision test registers a FRESH user. Unique suffixes derive from a
+ * per-test counter + the test title, never a module-scope clock.
+ */
+
+type PlaywrightApi = PlaywrightWorkerArgs['playwright'];
+
+/** Per-file monotonic counter — seeds unique values WITHOUT a module-scope clock. */
+let seq = 0;
+function uniqueKey(label: string): string {
+    seq += 1;
+    return `users-ctrl-${label}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * Clean request context: NO inherited cookies. Each request stamps its own
+ * x-e2e-throttle-key, so anonymous and authed probes never share a bucket.
+ */
+async function newCleanContext(playwright: PlaywrightApi): Promise<APIRequestContext> {
+    return playwright.request.newContext({ storageState: { cookies: [], origins: [] } });
+}
+
+const CHECK_USERNAME = `${API_BASE}/api/users/check-username`;
+
+interface CheckResult {
+    available: boolean;
+    normalized: string;
+    suggestion?: string;
+}
+
+interface ValidationError {
+    message: string[];
+    error: string;
+    statusCode: number;
+}
+
+test.describe('Users controller — GET /api/users/check-username + route surface', () => {
+    test('1. @Public: an anonymous request (empty storageState, no bearer) gets 200', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const r = await ctx.get(`${CHECK_USERNAME}?value=anon-ok`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('anon') },
+            });
+            expect(r.status(), 'public route must not 401 for anonymous').toBe(200);
+            const body = (await r.json()) as CheckResult;
+            expect(body.available).toBe(true);
+            expect(body.normalized).toBe('anon-ok');
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('2. @Public: a valid bearer token is ignored — still 200 with the same shape', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const u = await registerUserViaAPI(ctx);
+            const value = `bearer-free-${seq + 1}`;
+            const r = await ctx.get(`${CHECK_USERNAME}?value=${encodeURIComponent(value)}`, {
+                headers: {
+                    ...authedHeaders(u.access_token),
+                    'x-e2e-throttle-key': uniqueKey('bearer'),
+                },
+            });
+            expect(r.status(), 'Public route accepts a bearer without changing behaviour').toBe(200);
+            const body = (await r.json()) as CheckResult;
+            expect(body.available).toBe(true);
+            expect(body.normalized).toBe(value.toLowerCase());
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('3. response DTO is EXACTLY {available,normalized} on an available name — no extra/internal keys leak', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const r = await ctx.get(`${CHECK_USERNAME}?value=keysetfree`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('keyset-free') },
+            });
+            expect(r.status()).toBe(200);
+            const body = (await r.json()) as Record<string, unknown>;
+            // Pin the exact key set — guards against accidental id/email/slug/
+            // userId/internal-field leakage from the allocator/repository layer.
+            expect(new Set(Object.keys(body))).toEqual(new Set(['available', 'normalized']));
+            expect(body).toEqual({ available: true, normalized: 'keysetfree' });
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('4. normalization: apostrophe/space/at-sign/dots all collapse to single hyphens, lowercased', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const cases: Array<{ input: string; normalized: string }> = [
+                { input: "Alice O'Brien", normalized: 'alice-o-brien' },
+                { input: 'GITHUB.USER@x.io', normalized: 'github-user-x-io' },
+            ];
+            for (const c of cases) {
+                const r = await ctx.get(`${CHECK_USERNAME}?value=${encodeURIComponent(c.input)}`, {
+                    headers: { 'x-e2e-throttle-key': uniqueKey('norm') },
+                });
+                expect(r.status(), `normalize "${c.input}"`).toBe(200);
+                const body = (await r.json()) as CheckResult;
+                expect(body.normalized, `"${c.input}" → "${c.normalized}"`).toBe(c.normalized);
+            }
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('5. normalization: leading/trailing/duplicate hyphens are stripped and collapsed', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const r = await ctx.get(`${CHECK_USERNAME}?value=${encodeURIComponent('--Hello--World--')}`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('strip') },
+            });
+            expect(r.status()).toBe(200);
+            const body = (await r.json()) as CheckResult;
+            expect(body.normalized).toBe('hello-world');
+            // Never starts or ends with a hyphen.
+            expect(body.normalized.startsWith('-') || body.normalized.endsWith('-')).toBe(false);
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('6. normalization fallback: an all-hyphen value yields a u-<8hex> placeholder, still 200', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const r = await ctx.get(`${CHECK_USERNAME}?value=${encodeURIComponent('---')}`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('fallback') },
+            });
+            expect(r.status()).toBe(200);
+            const body = (await r.json()) as CheckResult;
+            // Empties-after-normalization fall back to `u-` + 8 random hex chars.
+            expect(body.normalized).toMatch(/^u-[0-9a-f]{8}$/);
+            expect(body.available).toBe(true);
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('7. DTO validation: missing the `value` query param → 400 with class-validator envelope', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const r = await ctx.get(CHECK_USERNAME, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('missing') },
+            });
+            expect(r.status()).toBe(400);
+            const body = (await r.json()) as ValidationError;
+            expect(Array.isArray(body.message)).toBe(true);
+            expect(body.error).toBe('Bad Request');
+            expect(body.statusCode).toBe(400);
+            // Missing value fails @IsString + @Length + @Matches simultaneously.
+            expect(body.message).toContain('value must be a string');
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('8. DTO validation: an empty value → 400 (fails length + charset)', async ({ playwright }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const r = await ctx.get(`${CHECK_USERNAME}?value=`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('empty') },
+            });
+            expect(r.status()).toBe(400);
+            const body = (await r.json()) as ValidationError;
+            expect(body.message).toContain('value must be longer than or equal to 1 characters');
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('9. DTO validation: disallowed characters (/, !) → 400 with the exact unsupported-chars message', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const expected =
+                'value contains unsupported characters; allowed: letters, digits, dot, underscore, at-sign, apostrophe, hyphen, space';
+            for (const bad of ['a/b', 'hi!']) {
+                const r = await ctx.get(`${CHECK_USERNAME}?value=${encodeURIComponent(bad)}`, {
+                    headers: { 'x-e2e-throttle-key': uniqueKey('badchar') },
+                });
+                expect(r.status(), `disallowed "${bad}"`).toBe(400);
+                const body = (await r.json()) as ValidationError;
+                expect(body.message, `"${bad}" message`).toContain(expected);
+            }
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('10. DTO validation: 65 chars → 400 (max 64); exactly 64 → 200 (boundary)', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const tooLong = 'a'.repeat(65);
+            const over = await ctx.get(`${CHECK_USERNAME}?value=${tooLong}`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('len-over') },
+            });
+            expect(over.status(), '65 chars must be rejected').toBe(400);
+            const overBody = (await over.json()) as ValidationError;
+            expect(overBody.message).toContain('value must be shorter than or equal to 64 characters');
+
+            const exact = 'b'.repeat(64);
+            const ok = await ctx.get(`${CHECK_USERNAME}?value=${exact}`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('len-exact') },
+            });
+            expect(ok.status(), '64 chars is the inclusive upper bound').toBe(200);
+            const okBody = (await ok.json()) as CheckResult;
+            expect(okBody.normalized).toBe(exact);
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('11. collision: a freshly-registered username reports available:false + the next-free -2 suggestion', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            // Build a charset-valid username (letters/digits only, well under 64).
+            const username = `Collide${(seq + 1).toString()}${Math.random().toString(36).slice(2, 8)}`;
+            await registerUserViaAPI(ctx, {
+                name: username,
+                email: `${username.toLowerCase()}@test.local`,
+            });
+
+            const r = await ctx.get(`${CHECK_USERNAME}?value=${encodeURIComponent(username)}`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('collide') },
+            });
+            expect(r.status()).toBe(200);
+            const body = (await r.json()) as CheckResult;
+            const lower = username.toLowerCase();
+            expect(body.available, 'an existing username collides').toBe(false);
+            expect(body.normalized).toBe(lower);
+            // The suggestion is the deterministic next-free -N variant.
+            expect(body.suggestion).toBe(`${lower}-2`);
+            // The taken-result key set is exactly the three documented keys.
+            expect(new Set(Object.keys(body as unknown as Record<string, unknown>))).toEqual(
+                new Set(['available', 'normalized', 'suggestion']),
+            );
+        } finally {
+            await ctx.dispose();
+        }
+    });
+
+    test('12. route surface: only check-username exists — bare /api/users, /me, junk subpath, and POST all 404', async ({
+        playwright,
+    }) => {
+        const ctx = await newCleanContext(playwright);
+        try {
+            const bare = await ctx.get(`${API_BASE}/api/users`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('bare') },
+            });
+            expect(bare.status(), 'no controller-root handler').toBe(404);
+            expect(((await bare.json()) as { message: string }).message).toBe('Cannot GET /api/users');
+
+            const me = await ctx.get(`${API_BASE}/api/users/me`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('me') },
+            });
+            expect(me.status(), 'no @Get("me") on this controller').toBe(404);
+
+            const junk = await ctx.get(`${API_BASE}/api/users/does-not-exist`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('junk') },
+            });
+            expect(junk.status(), 'unknown subpath').toBe(404);
+
+            const wrongMethod = await ctx.post(`${CHECK_USERNAME}?value=x`, {
+                headers: { 'x-e2e-throttle-key': uniqueKey('post') },
+            });
+            // Nest reports 404 (route-not-found), not 405, for the wrong verb.
+            expect(wrongMethod.status(), 'POST is not a handler on check-username').toBe(404);
+        } finally {
+            await ctx.dispose();
+        }
+    });
+});

--- a/apps/web/e2e/flow-users-controller.spec.ts
+++ b/apps/web/e2e/flow-users-controller.spec.ts
@@ -132,7 +132,9 @@ test.describe('Users controller — GET /api/users/check-username + route surfac
                     'x-e2e-throttle-key': uniqueKey('bearer'),
                 },
             });
-            expect(r.status(), 'Public route accepts a bearer without changing behaviour').toBe(200);
+            expect(r.status(), 'Public route accepts a bearer without changing behaviour').toBe(
+                200,
+            );
             const body = (await r.json()) as CheckResult;
             expect(body.available).toBe(true);
             expect(body.normalized).toBe(value.toLowerCase());
@@ -187,9 +189,12 @@ test.describe('Users controller — GET /api/users/check-username + route surfac
     }) => {
         const ctx = await newCleanContext(playwright);
         try {
-            const r = await ctx.get(`${CHECK_USERNAME}?value=${encodeURIComponent('--Hello--World--')}`, {
-                headers: { 'x-e2e-throttle-key': uniqueKey('strip') },
-            });
+            const r = await ctx.get(
+                `${CHECK_USERNAME}?value=${encodeURIComponent('--Hello--World--')}`,
+                {
+                    headers: { 'x-e2e-throttle-key': uniqueKey('strip') },
+                },
+            );
             expect(r.status()).toBe(200);
             const body = (await r.json()) as CheckResult;
             expect(body.normalized).toBe('hello-world');
@@ -238,7 +243,9 @@ test.describe('Users controller — GET /api/users/check-username + route surfac
         }
     });
 
-    test('8. DTO validation: an empty value → 400 (fails length + charset)', async ({ playwright }) => {
+    test('8. DTO validation: an empty value → 400 (fails length + charset)', async ({
+        playwright,
+    }) => {
         const ctx = await newCleanContext(playwright);
         try {
             const r = await ctx.get(`${CHECK_USERNAME}?value=`, {
@@ -283,7 +290,9 @@ test.describe('Users controller — GET /api/users/check-username + route surfac
             });
             expect(over.status(), '65 chars must be rejected').toBe(400);
             const overBody = (await over.json()) as ValidationError;
-            expect(overBody.message).toContain('value must be shorter than or equal to 64 characters');
+            expect(overBody.message).toContain(
+                'value must be shorter than or equal to 64 characters',
+            );
 
             const exact = 'b'.repeat(64);
             const ok = await ctx.get(`${CHECK_USERNAME}?value=${exact}`, {
@@ -337,7 +346,9 @@ test.describe('Users controller — GET /api/users/check-username + route surfac
                 headers: { 'x-e2e-throttle-key': uniqueKey('bare') },
             });
             expect(bare.status(), 'no controller-root handler').toBe(404);
-            expect(((await bare.json()) as { message: string }).message).toBe('Cannot GET /api/users');
+            expect(((await bare.json()) as { message: string }).message).toBe(
+                'Cannot GET /api/users',
+            );
 
             const me = await ctx.get(`${API_BASE}/api/users/me`, {
                 headers: { 'x-e2e-throttle-key': uniqueKey('me') },

--- a/apps/web/e2e/flow-v1-openai-compat.spec.ts
+++ b/apps/web/e2e/flow-v1-openai-compat.spec.ts
@@ -1,0 +1,313 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * v1 OpenAI-compatible chat-completions facade — deep contract pinning.
+ *
+ * Target: apps/api/src/ai-conversation/openai-compat.controller.ts
+ *         (+ openai-compat.service.ts + dto/openai-compat.dto.ts)
+ * Route:  POST /api/v1/chat/completions   (@Controller('api/v1'), @HttpCode(200))
+ *
+ * ── NON-DUPLICATION ────────────────────────────────────────────────
+ * `openai-compat.spec.ts` already covers, SHALLOWLY:
+ *   - path discovery across candidate shapes,
+ *   - unauth POST → 401/403,
+ *   - one authed valid POST → "< 500".
+ * This file does NOT repeat path discovery (the live route is fixed at
+ * /api/v1/chat/completions) and instead deepens the CONTRACT: the exact
+ * keyless error envelope (status + shape), DTO validation matrix
+ * (messages required/shape, nested message validation, typed scalar
+ * fields, forbid-non-whitelisted vs @Allow()-listed fields), the
+ * streaming vs non-streaming acceptance + distinct error envelopes,
+ * auth modes, and secret-redaction of the provider error message.
+ * `chat-api*.spec.ts` / `flow-chat-*.spec.ts` exercise the web `/api/chat`
+ * proxy + conversation lifecycle — a DIFFERENT surface from this raw
+ * OpenAI-wire facade.
+ *
+ * ── PROBED CONTRACTS (live keyless stack @ 127.0.0.1:3100, 2026-06-11) ─
+ *   - Anonymous POST                       → 401
+ *   - Bad bearer token                     → 401
+ *   - GET (wrong method) on completions    → 404
+ *   - Authed valid non-stream, NO LLM key  → 422
+ *         { error: { message, type: 'provider_unavailable' } }
+ *         message contains "Missing Authentication header" (upstream),
+ *         NEVER a 5xx stacktrace.
+ *   - `model` is OPTIONAL (omit → still reaches provider → 422).
+ *   - messages missing / non-array         → 400
+ *         { message: ["messages must be an array", ...],
+ *           error: "Bad Request", statusCode: 400 }
+ *   - nested message missing role          → 400 ("messages.0.role must be a string")
+ *   - temperature wrong type (string)      → 400 ("temperature must be a number ...")
+ *   - unknown top-level field (seed/logprobs) → 400 ("property X should not exist")
+ *         (global forbidNonWhitelisted in effect)
+ *   - DECLARED @Allow() field stream_options alone → passes validation → 422
+ *   - tools[] function-tool def            → passes validation → 422
+ *   - empty messages [] (passes IsArray)   → 422 (reaches provider)
+ *   - stream:true, keyless                 → 502, Content-Type application/json,
+ *         { error: { message, type: 'provider_error', code: 'ai_provider_error' } }
+ *         (service writes the envelope BEFORE the SSE stream begins).
+ *
+ * Environment-adaptive: CI is keyless (no LLM provider key) so a REAL
+ * completion is impossible — we assert the CONTRACT + error envelopes,
+ * never completion content. If a provider key were wired, the happy
+ * path would be 200; every assertion below tolerates that by treating
+ * 200 as an explicitly-allowed alternative where it could occur.
+ */
+
+const V1_COMPLETIONS = '/api/v1/chat/completions';
+
+function url(path: string): string {
+    return `${API_BASE}${path}`;
+}
+
+// Minimal valid OpenAI-wire body.
+function validBody(content = 'ping'): Record<string, unknown> {
+    return { model: 'gpt-4o-mini', messages: [{ role: 'user', content }] };
+}
+
+/**
+ * Fresh isolated user per mutation. Suffix derives from the test title
+ * (NOT a module-scope clock) so collection stays side-effect free.
+ */
+async function freshToken(request: APIRequestContext, title: string): Promise<string> {
+    const suffix = title.replace(/[^a-z0-9]+/gi, '-').slice(0, 24).toLowerCase();
+    const u = await registerUserViaAPI(request, {
+        email: `v1compat-${suffix}-${Math.random().toString(36).slice(2, 8)}@test.local`,
+    });
+    return u.access_token;
+}
+
+test.describe('v1 OpenAI-compat — auth contract', () => {
+    test('anonymous POST is rejected with 401 (no body leak)', async ({ request }) => {
+        // Playwright's `request` fixture carries NO storageState cookies,
+        // so this is a genuinely anonymous call.
+        const res = await request.post(url(V1_COMPLETIONS), { data: validBody() });
+        expect(res.status(), 'anonymous POST must be 401/403').toBeGreaterThanOrEqual(401);
+        expect(res.status()).toBeLessThan(404);
+        // Whatever the body, it must NOT be a 5xx stacktrace.
+        expect(res.status()).toBeLessThan(500);
+    });
+
+    test('malformed bearer token is rejected with 401', async ({ request }) => {
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: { Authorization: 'Bearer not-a-real-token-zzz' },
+            data: validBody(),
+        });
+        expect(res.status(), 'garbage bearer → 401').toBe(401);
+    });
+
+    test('GET on the completions route is 404 (POST-only contract)', async ({ request }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.get(url(V1_COMPLETIONS), { headers: authedHeaders(token) });
+        expect(res.status(), 'wrong method must not reach the handler').toBe(404);
+    });
+});
+
+test.describe('v1 OpenAI-compat — request validation (400 matrix)', () => {
+    test('missing messages → 400 Bad Request with class-validator message array', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: { model: 'gpt-4o-mini' },
+        });
+        expect(res.status(), 'no messages → 400').toBe(400);
+        const body = await res.json();
+        expect(body.statusCode).toBe(400);
+        expect(body.error).toBe('Bad Request');
+        expect(Array.isArray(body.message)).toBe(true);
+        expect(
+            (body.message as string[]).some((m) => /messages must be an array/i.test(m)),
+            `expected a "messages must be an array" entry, got ${JSON.stringify(body.message)}`,
+        ).toBe(true);
+    });
+
+    test('messages as a string (wrong type) → 400', async ({ request }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: { model: 'gpt-4o-mini', messages: 'hello' },
+        });
+        expect(res.status()).toBe(400);
+        const body = await res.json();
+        expect((body.message as string[]).join(' ')).toMatch(/messages must be an array/i);
+    });
+
+    test('nested message missing role → 400 with dotted path', async ({ request }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: { model: 'gpt-4o-mini', messages: [{ content: 'hi' }] },
+        });
+        expect(res.status()).toBe(400);
+        const body = await res.json();
+        // ValidateNested surfaces the index-dotted path.
+        expect((body.message as string[]).join(' ')).toMatch(/messages\.0\.role/i);
+    });
+
+    test('temperature as a string → 400 (typed scalar enforced)', async ({ request }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: { ...validBody(), temperature: 'hot' },
+        });
+        expect(res.status()).toBe(400);
+        const body = await res.json();
+        expect((body.message as string[]).join(' ')).toMatch(/temperature must be a number/i);
+    });
+
+    test('unknown top-level field → 400 "property X should not exist" (forbidNonWhitelisted)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: { ...validBody(), seed: 42 },
+        });
+        expect(res.status(), 'unknown field is rejected, not silently stripped').toBe(400);
+        const body = await res.json();
+        expect((body.message as string[]).join(' ')).toMatch(/property seed should not exist/i);
+    });
+});
+
+test.describe('v1 OpenAI-compat — accepted bodies (validation passes, keyless → 422)', () => {
+    // In CI there's no LLM key, so a body that PASSES validation reaches the
+    // provider and yields the documented "provider_unavailable" 422 envelope.
+    // With a key wired it would be 200 — both are non-5xx and accepted.
+
+    test('valid non-streaming body → 422 provider-unavailable envelope (NOT a 5xx)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: validBody(),
+        });
+        // Keyless → 422; keyed → 200. Never 5xx.
+        expect([200, 422], `unexpected status ${res.status()}`).toContain(res.status());
+        if (res.status() === 422) {
+            const body = await res.json();
+            expect(body.error).toBeTruthy();
+            expect(body.error.type).toBe('provider_unavailable');
+            expect(typeof body.error.message).toBe('string');
+            expect(body.error.message.length).toBeGreaterThan(0);
+        }
+    });
+
+    test('model is OPTIONAL — omitting it still passes validation (→ 422, not 400)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: { messages: [{ role: 'user', content: 'hi' }] },
+        });
+        // No 400 — model is @IsOptional. Reaches provider keyless → 422 (or 200 keyed).
+        expect([200, 422], `model-less body should not 400; got ${res.status()}`).toContain(
+            res.status(),
+        );
+    });
+
+    test('declared @Allow() field stream_options passes validation (→ 422, not 400)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: { ...validBody(), stream_options: { include_usage: true } },
+        });
+        // stream_options is an allow-listed optional field — must NOT be
+        // rejected as an unknown property.
+        expect([200, 422], `stream_options should be tolerated; got ${res.status()}`).toContain(
+            res.status(),
+        );
+    });
+
+    test('OpenAI-shaped tools[] function definition passes validation (→ 422)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: {
+                ...validBody(),
+                tools: [
+                    {
+                        type: 'function',
+                        function: { name: 'get_weather', parameters: { type: 'object' } },
+                    },
+                ],
+            },
+        });
+        expect([200, 422], `valid tools def should pass validation; got ${res.status()}`).toContain(
+            res.status(),
+        );
+    });
+
+    test('empty messages array passes IsArray and reaches the provider (→ 422)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: { model: 'gpt-4o-mini', messages: [] },
+        });
+        // [] satisfies @IsArray; the controller does not enforce min-length,
+        // so it reaches the provider rather than 400-ing.
+        expect([200, 422], `empty messages → got ${res.status()}`).toContain(res.status());
+    });
+});
+
+test.describe('v1 OpenAI-compat — streaming acceptance', () => {
+    test('stream:true is accepted; keyless yields a 502 JSON error envelope (not a 5xx stacktrace)', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: { ...validBody(), stream: true },
+        });
+        // Keyless: provider auth fails BEFORE the SSE stream begins, so the
+        // service writes the JSON error envelope with a 502. Keyed: 200 +
+        // text/event-stream. Both are accepted; a 4xx validation error is NOT.
+        expect([200, 502], `stream request status ${res.status()}`).toContain(res.status());
+
+        if (res.status() === 502) {
+            const ctype = res.headers()['content-type'] || '';
+            expect(ctype, 'pre-stream error must be JSON, not SSE').toContain('application/json');
+            const body = await res.json();
+            expect(body.error).toBeTruthy();
+            expect(body.error.type).toBe('provider_error');
+            expect(body.error.code).toBe('ai_provider_error');
+            expect(typeof body.error.message).toBe('string');
+        }
+    });
+
+    test('the keyless provider error message is sanitized — no raw key/secret tokens leak', async ({
+        request,
+    }, testInfo) => {
+        const token = await freshToken(request, testInfo.title);
+        const res = await request.post(url(V1_COMPLETIONS), {
+            headers: authedHeaders(token),
+            data: validBody(),
+        });
+        // Only meaningful in the keyless 422 path; skip the assertion if a
+        // provider key happened to be wired (200).
+        if (res.status() === 200) {
+            test.info().annotations.push({ type: 'note', description: 'provider key wired; skipped redaction check' });
+            return;
+        }
+        expect(res.status()).toBe(422);
+        const body = await res.json();
+        const message: string = body.error.message;
+        // The upstream "Missing Authentication header" text surfaces, but the
+        // sanitizer (secret-scan patterns) must strip any real secret token.
+        expect(message).not.toMatch(/\bsk-[A-Za-z0-9_-]{10,}\b/);
+        expect(message).not.toMatch(/\bsk-ant-[A-Za-z0-9_-]{10,}\b/);
+        expect(message).not.toMatch(/\bAKIA[A-Z0-9]{16}\b/);
+        // And it stays a bounded, human-readable string (sanitizer truncates
+        // to ~300 chars + ellipsis).
+        expect(message.length).toBeLessThanOrEqual(320);
+    });
+});

--- a/apps/web/e2e/flow-v1-openai-compat.spec.ts
+++ b/apps/web/e2e/flow-v1-openai-compat.spec.ts
@@ -70,7 +70,10 @@ function validBody(content = 'ping'): Record<string, unknown> {
  * (NOT a module-scope clock) so collection stays side-effect free.
  */
 async function freshToken(request: APIRequestContext, title: string): Promise<string> {
-    const suffix = title.replace(/[^a-z0-9]+/gi, '-').slice(0, 24).toLowerCase();
+    const suffix = title
+        .replace(/[^a-z0-9]+/gi, '-')
+        .slice(0, 24)
+        .toLowerCase();
     const u = await registerUserViaAPI(request, {
         email: `v1compat-${suffix}-${Math.random().toString(36).slice(2, 8)}@test.local`,
     });
@@ -96,7 +99,9 @@ test.describe('v1 OpenAI-compat — auth contract', () => {
         expect(res.status(), 'garbage bearer → 401').toBe(401);
     });
 
-    test('GET on the completions route is 404 (POST-only contract)', async ({ request }, testInfo) => {
+    test('GET on the completions route is 404 (POST-only contract)', async ({
+        request,
+    }, testInfo) => {
         const token = await freshToken(request, testInfo.title);
         const res = await request.get(url(V1_COMPLETIONS), { headers: authedHeaders(token) });
         expect(res.status(), 'wrong method must not reach the handler').toBe(404);
@@ -295,7 +300,10 @@ test.describe('v1 OpenAI-compat — streaming acceptance', () => {
         // Only meaningful in the keyless 422 path; skip the assertion if a
         // provider key happened to be wired (200).
         if (res.status() === 200) {
-            test.info().annotations.push({ type: 'note', description: 'provider key wired; skipped redaction check' });
+            test.info().annotations.push({
+                type: 'note',
+                description: 'provider key wired; skipped redaction check',
+            });
             return;
         }
         expect(res.status()).toBe(422);


### PR DESCRIPTION
@-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive end-to-end contract suites validating APIs for agent memory, templates/catalog instantiation, device auth, git providers, GitHub app, register-work, screenshots, search providers, skill bindings, task chat messages, telemetry funnel, Twenty CRM gate, uploads, username check, and v1 OpenAI-compatible completions—pinning auth/scoping, DTO validation, error shapes, routing/verb discipline, provider gating, and cross-user isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->