### PR TITLE
ci(e2e): stabilize the suite — 16 shards + prebuilt next start (kill the compile-OOM flake)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,10 +52,17 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [22.x]
-        # 8 shards (was 4): the suite grew to ~1500 tests with the 1000-flow
-        # build, so 4 shards pushed each shard's wall-clock toward the 90min
-        # cap under dev-mode cold-compile + retries. 8 keeps each shard ~half.
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        # 16 shards (was 8, was 4): the suite kept growing (now ~3200 tests
+        # with the +1000 mega-wave). The binding constraint is NOT wall-clock
+        # but MEMORY: `next dev` accumulates compiled-route memory over a long
+        # shard, and on a long run the web (or the API's RegExp route-table
+        # compiler) eventually OOM-aborts mid-shard — every later spec on that
+        # shard then fails ERR_CONNECTION_REFUSED, and the casualty shard moves
+        # run-to-run (the classic "random" e2e red). Halving each shard's spec
+        # count (and therefore its peak resident memory + duration) is a pure-
+        # parallelism, zero-behaviour-change mitigation: each runner is its own
+        # 32 GB box, so 16 shards = ~half the per-shard memory accumulation.
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 
     # Service containers — let the e2e suite exercise features that would
     # otherwise skip themselves because the dependency isn't reachable.
@@ -181,8 +188,8 @@ jobs:
           # --shard=N/M splits the test suite across M machines, deterministic.
           # Each shard runs its own subset; combined across the matrix they
           # cover every test exactly once. Keep --shard total in sync with
-          # the `shard:` matrix length above.
-          pnpm exec playwright test --shard=${{ matrix.shard }}/8
+          # the `shard:` matrix length above (16).
+          pnpm exec playwright test --shard=${{ matrix.shard }}/16
           echo "::endgroup::"
         env:
           # Give every Node process (API, web, the swc/tsc type-checker, and

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -154,8 +154,22 @@ jobs:
           echo "API pid=$API_PID"
           echo "::endgroup::"
 
-          echo "::group::Starting Web on :3000"
-          nohup pnpm --filter ever-works-web dev > /tmp/web.log 2>&1 &
+          echo "::group::Starting Web on :3000 (prebuilt next start — no dev compiler)"
+          # Run the PREBUILT web (`next start` from the .next the "Build all
+          # packages" step already produced) instead of `next dev`. Why:
+          # `next dev` keeps the whole compiler + HMR resident and LAZILY
+          # compiles every route on first hit, so a shard that navigates many
+          # distinct UI routes accumulates route-compile memory until the web
+          # process (and sometimes the API alongside it) OOM-aborts mid-shard —
+          # after which every later spec on that shard fails
+          # ERR_CONNECTION_REFUSED and the casualty shard moves run-to-run.
+          # The prebuilt server has no per-route compile and a fraction of the
+          # resident memory, which removes the OOM mechanism AND the cold-
+          # compile timing flake. The separate e2e-prod-build job already runs
+          # the web exactly this way in CI, so the prod boot path is proven.
+          # NODE_ENV=production must precede `start` so Next serves the prod
+          # build; the API stays in its dev-mode config (env block below).
+          NODE_ENV=production nohup pnpm --filter ever-works-web start > /tmp/web.log 2>&1 &
           WEB_PID=$!
           disown $WEB_PID
           echo "Web pid=$WEB_PID"

--- a/apps/web/e2e/flow-activity-sequences-concurrency.spec.ts
+++ b/apps/web/e2e/flow-activity-sequences-concurrency.spec.ts
@@ -158,11 +158,22 @@ async function ingest(
  * Ingest one event, RETRYING only on a 429. The ingest endpoint inherits the
  * global per-IP throttlers (short 50/1s, medium 300/10s, long 1000/60s — see
  * apps/api/src/config/throttler.config.ts) plus a 60/min cap on the route. Under
- * a workers=4 run all four workers share one IP, so a dense burst can momentarily
+ * a parallel run all workers share one IP, so a dense burst can momentarily
  * exhaust the per-second budget and bounce a 202 to 429. That is a transient
  * rate-limit, NOT a contract failure: we re-send the SAME event (idempotent by
  * (workId, eventId)) until it is accepted, so every event still lands exactly
  * once and the 202 contract is asserted, never weakened.
+ *
+ * Retry budget rationale (prebuilt-web/prod `next start` CI, e2e run
+ * 27374977059): the old 12-attempt back-off summed to ~18s, but the route's
+ * 60/min cap is a SLIDING window — once this file's own bursts (~65 ingests
+ * across its tests under workers>1) drain it, the next token can be up to
+ * ~60s away, so the bounded loop expired and surfaced the throttler's 429 as
+ * a failure at the 202 assertion. The prebuilt web server removed the dev
+ * cold-compile stalls that used to space the bursts out, making the drain
+ * reproducible. Fix: retry until a ~70s deadline (outlives a fully drained
+ * 60s window, fits the 90s test timeout) and honor the server's own
+ * Retry-After back-pressure header when present instead of guessing.
  */
 async function ingestAccepted(
     request: APIRequestContext,
@@ -175,11 +186,18 @@ async function ingestAccepted(
         metadata?: Record<string, unknown>;
     },
 ) {
+    const deadline = Date.now() + 70_000;
     let res = await ingest(request, workId, fields);
-    // Bounded back-off; the per-second window refills in ~1s, so a few tries
-    // across a couple of seconds comfortably clears even a sustained 429 streak.
-    for (let attempt = 0; res.status() === 429 && attempt < 12; attempt += 1) {
-        await new Promise((r) => setTimeout(r, 400 + attempt * 200));
+    while (res.status() === 429 && Date.now() < deadline) {
+        // NestJS ThrottlerGuard advertises the wait in Retry-After (seconds).
+        // Use it as the event signal for when the window refills; fall back to
+        // ~1s — the steady-state refill rate of the 60/min route cap.
+        const retryAfterSec = Number(res.headers()['retry-after']);
+        const waitMs =
+            Number.isFinite(retryAfterSec) && retryAfterSec > 0
+                ? Math.min(retryAfterSec * 1000 + 250, 10_000)
+                : 1_000;
+        await new Promise((r) => setTimeout(r, waitMs));
         res = await ingest(request, workId, fields);
     }
     expect(res.status(), `ingest body=${await res.text().catch(() => '')}`).toBe(202);
@@ -518,6 +536,16 @@ test.describe('Activity sequence — ordering & integrity under concurrent / hig
 
         // Page through with limit=3. Walk until nextCursor is null. Collect the
         // ordered id stream and the per-page timestamps.
+        //
+        // The walk is fully QUIESCED by construction (prebuilt-web/prod
+        // `next start` CI, run 27374977059 audit): every mutation above is
+        // awaited (202 + row id returned only after the synchronous insert)
+        // before the first page is fetched, and the only deferred writers
+        // (the controller's fire-and-forget work.created/work.updated rows)
+        // stamp createdAt "now" — ABOVE this 2021 ladder — so they can never
+        // enter the inclusive `createdAt <= cursor` window of pages ≥ 2 and
+        // shift it mid-walk. No settle sleep is needed; the flake on this test
+        // was the ingest throttle budget, fixed in `ingestAccepted` above.
         const limit = 3;
         const pages: FeedEntry[][] = [];
         let cursor: string | undefined;

--- a/apps/web/e2e/flow-agent-instruction-files-deep.spec.ts
+++ b/apps/web/e2e/flow-agent-instruction-files-deep.spec.ts
@@ -591,6 +591,12 @@ test.describe('Agent instruction files (deep) — caps, secret-scan, export/impo
         // the shared content hash advances, invalidating the editor's stored
         // agent.yml hash). The editor only re-sends on a fresh keystroke, so its
         // expectedHash is now stale → the next autosave conflicts.
+        //
+        // Capture the hash the editor is holding RIGHT NOW (== the live hash
+        // after its last successful save) so we can prove the conflict window is
+        // genuinely armed below, independent of UI copy.
+        const editorHeldHash = (await readFile(request, token, agent.id, 'agent.yml')).hash;
+        expect(editorHeldHash).toMatch(HEX64);
         const apiSoul = await readFile(request, token, agent.id, 'SOUL.md');
         await writeFile(
             request,
@@ -600,6 +606,22 @@ test.describe('Agent instruction files (deep) — caps, secret-scan, export/impo
             `# out of band ${stamp}`,
             apiSoul.hash,
         );
+
+        // Deterministic conflict-RESPONSE contract (prebuilt-web/prod next start
+        // safe — asserted at the API layer where nothing masks the message):
+        // replaying the editor's now-stale held hash surfaces the exact 400
+        // etag-mismatch the autosave below is about to hit. This is the same
+        // rejected write the UI will perform — proven here byte-for-byte.
+        const staleReplay = await putFileRaw(
+            request,
+            token,
+            agent.id,
+            'agent.yml',
+            'stale replay — must never persist',
+            editorHeldHash,
+        );
+        expect(staleReplay.status()).toBe(400);
+        expect((await staleReplay.json()).message).toBe(CONFLICT_MESSAGE);
 
         // Make another in-browser edit to agent.yml → autosave fires with the
         // now-stale expectedHash → 400 etag-mismatch → status 'conflict'.

--- a/apps/web/e2e/flow-breadcrumbs-navigation.spec.ts
+++ b/apps/web/e2e/flow-breadcrumbs-navigation.spec.ts
@@ -63,6 +63,14 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
 
 const NAV_TIMEOUT = 20_000;
 const RENDER_TIMEOUT = 25_000;
+// First render after a navigation under prebuilt-web/prod `next start` (the CI
+// change under validation) can land well after domcontentloaded: the RSC
+// payload streams in and the client router commits a beat later, and under
+// shard load that beat stretched past 25s (run 27374977059 failed this file
+// with a toBeVisible timeout; the same waits also flaked under next-dev cold
+// compiles). 60s gives the first post-nav paint headroom while staying inside
+// the 90s test budget.
+const FIRST_RENDER_TIMEOUT = 60_000;
 
 const NOT_FOUND_TITLE = 'Page not found';
 const BACK_HOME_LABEL = 'Back to Dashboard';
@@ -129,7 +137,12 @@ function notFoundHeading(page: Page) {
 async function entityRendered(page: Page, name: string): Promise<boolean> {
     const title = workTitleHeading(page, name);
     const notFound = notFoundHeading(page);
-    await expect(title.or(notFound)).toBeVisible({ timeout: RENDER_TIMEOUT });
+    // This helper is ALWAYS the first assertion after a navigation, so it is
+    // the load-complete signal for the destination page — give it the
+    // first-render budget (prebuilt-web/prod next start, run 27374977059).
+    // .or() of two locators + trailing .first() keeps strict mode happy when
+    // both branches momentarily resolve.
+    await expect(title.or(notFound).first()).toBeVisible({ timeout: FIRST_RENDER_TIMEOUT });
     return title.isVisible().catch(() => false);
 }
 
@@ -176,16 +189,25 @@ test.describe('Breadcrumb / nested-route navigation trail', () => {
             .locator(`a[href$="/works/${work.id}/settings/budgets-usage"]`)
             .first();
         const membersLink = page.locator(`a[href$="/works/${work.id}/settings/members"]`).first();
-        const navVisible = await settingsNav
-            .isVisible({ timeout: RENDER_TIMEOUT })
-            .catch(() => false);
-        const budgetsVisible = await budgetsLink.isVisible({ timeout: 5_000 }).catch(() => false);
         // The whole /works/{id}/settings shell may itself 404 locally; if so the
         // entity <h1> is gone — branch truthfully rather than hard-failing.
+        // Load-complete signal FIRST (the URL was awaited above; this is the
+        // concrete element): under prebuilt-web/prod next start the settings
+        // shell paints a beat after the URL commits, and locator.isVisible()
+        // does NOT wait (its timeout option is ignored), so probing visibility
+        // before this await read stale falses (run 27374977059 flake mode).
         const settingsRendered = await entityRendered(page, work.name);
         if (!settingsRendered) {
             test.skip(true, '/works/{id}/settings fell through to the local catch-all');
         }
+        // Awaited, event-based form of the same OR contract (replaces the
+        // immediate isVisible probes); trailing .first() for strict mode.
+        await expect(
+            settingsNav.or(budgetsLink).first(),
+            'no level-2 settings trail (sub-tab nav nor budgets link) found',
+        ).toBeVisible({ timeout: FIRST_RENDER_TIMEOUT });
+        const navVisible = await settingsNav.isVisible().catch(() => false);
+        const budgetsVisible = await budgetsLink.isVisible().catch(() => false);
         expect(
             navVisible || budgetsVisible,
             'no level-2 settings trail (sub-tab nav nor budgets link) found',
@@ -203,12 +225,25 @@ test.describe('Breadcrumb / nested-route navigation trail', () => {
             const leaf404 = notFoundHeading(page);
             // EITHER the budgets page renders under the work <h1> (CI) OR the
             // nested route 404s to the catch-all (local). Both are valid.
-            await expect(leafTitle.or(leaf404)).toBeVisible({ timeout: RENDER_TIMEOUT });
+            // First render after a navigation → first-render budget + trailing
+            // .first() on the .or() chain (strict mode; prebuilt-web/prod
+            // next start, run 27374977059).
+            await expect(leafTitle.or(leaf404).first()).toBeVisible({
+                timeout: FIRST_RENDER_TIMEOUT,
+            });
         }
         // At minimum, the members sibling crumb must also be discoverable so the
-        // trail is provably more than a single leaf.
+        // trail is provably more than a single leaf. waitFor is the event-based
+        // probe (isVisible's timeout option is a no-op); navVisible — captured
+        // on the settings page BEFORE the budgets descent — is the intentional
+        // fallback for the local branch where the budgets leaf 404s and the
+        // sub-tab row is gone.
+        const membersVisible = await membersLink
+            .waitFor({ state: 'visible', timeout: 3_000 })
+            .then(() => true)
+            .catch(() => false);
         expect(
-            (await membersLink.isVisible({ timeout: 3_000 }).catch(() => false)) || navVisible,
+            membersVisible || navVisible,
             'settings trail exposed neither a members crumb nor the sub-tab nav',
         ).toBe(true);
     });
@@ -243,8 +278,11 @@ test.describe('Breadcrumb / nested-route navigation trail', () => {
         );
 
         // Same entity, shallower crumb: the title is unchanged (it tracks the
-        // entity, not the route segment).
-        await expect(workTitleHeading(page, work.name)).toBeVisible({ timeout: RENDER_TIMEOUT });
+        // entity, not the route segment). First render after the click-nav →
+        // first-render budget (prebuilt-web/prod next start, run 27374977059).
+        await expect(workTitleHeading(page, work.name)).toBeVisible({
+            timeout: FIRST_RENDER_TIMEOUT,
+        });
         await expect(page).not.toHaveURL(/\/items(\/)?$/);
     });
 
@@ -278,14 +316,19 @@ test.describe('Breadcrumb / nested-route navigation trail', () => {
         await page.goto(`${origin}/works/${a.id}`, { waitUntil: 'domcontentloaded' });
         const titleA = page.getByRole('heading', { level: 1, name: nameA }).first();
         const nf = notFoundHeading(page);
-        await expect(titleA.or(nf)).toBeVisible({ timeout: RENDER_TIMEOUT });
+        // First render after goto → first-render budget; trailing .first() on
+        // the .or() chain for strict mode (prebuilt-web/prod next start,
+        // run 27374977059).
+        await expect(titleA.or(nf).first()).toBeVisible({ timeout: FIRST_RENDER_TIMEOUT });
         const sawA = await titleA.isVisible().catch(() => false);
         // The other work's name must NEVER leak onto this page regardless of branch.
         await expect(page.getByText(nameB, { exact: true })).toHaveCount(0);
 
         await page.goto(`${origin}/works/${b.id}`, { waitUntil: 'domcontentloaded' });
         const titleB = page.getByRole('heading', { level: 1, name: nameB }).first();
-        await expect(titleB.or(notFoundHeading(page))).toBeVisible({ timeout: RENDER_TIMEOUT });
+        await expect(titleB.or(notFoundHeading(page)).first()).toBeVisible({
+            timeout: FIRST_RENDER_TIMEOUT,
+        });
         const sawB = await titleB.isVisible().catch(() => false);
         await expect(page.getByText(nameA, { exact: true })).toHaveCount(0);
 
@@ -304,8 +347,9 @@ test.describe('Breadcrumb / nested-route navigation trail', () => {
         const bogus = `/works/__no_such_work_${Date.now().toString(36)}__/settings/budgets-usage/ghost`;
         await page.goto(`${origin}${bogus}`, { waitUntil: 'domcontentloaded' });
 
-        // The not-found contract: 404 hero heading.
-        await expect(notFoundHeading(page)).toBeVisible({ timeout: RENDER_TIMEOUT });
+        // The not-found contract: 404 hero heading. First render after goto →
+        // first-render budget (prebuilt-web/prod next start, run 27374977059).
+        await expect(notFoundHeading(page)).toBeVisible({ timeout: FIRST_RENDER_TIMEOUT });
 
         // Both recovery affordances are present. "Back to Dashboard" is a real
         // <Link href="/"> (ROUTES.DASHBOARD); "Go Back" is a router.back() button.
@@ -324,7 +368,11 @@ test.describe('Breadcrumb / nested-route navigation trail', () => {
         await page.waitForURL((url) => !/ghost|__no_such_work/.test(url.pathname), {
             timeout: NAV_TIMEOUT,
         });
-        await expect(notFoundHeading(page)).toHaveCount(0);
+        // The 404 hero detaches once the destination commits — but under
+        // prebuilt-web/prod next start the old tree can linger a beat past the
+        // URL change (run 27374977059), so give the auto-retrying count matcher
+        // the render budget instead of the 5s expect default.
+        await expect(notFoundHeading(page)).toHaveCount(0, { timeout: RENDER_TIMEOUT });
     });
 
     test('keyboard: the work-tab crumb row is focusable and Enter activates a crumb', async ({
@@ -352,15 +400,38 @@ test.describe('Breadcrumb / nested-route navigation trail', () => {
             .locator(`a[aria-label="Items"], a[href$="/works/${work.id}/items"]`)
             .first();
         await expect(itemsCrumb).toBeVisible({ timeout: RENDER_TIMEOUT });
-        await itemsCrumb.focus();
-        const isFocused = await itemsCrumb
-            .evaluate((el) => el === document.activeElement)
-            .catch(() => false);
-        expect(isFocused, 'Items crumb did not accept keyboard focus').toBe(true);
+        // Retried focus probe: under prebuilt-web/prod next start (the CI
+        // change validated by run 27374977059) React hydration can swap the
+        // server-rendered anchor right AFTER .focus() lands, reverting
+        // activeElement to <body> — the one-shot read here was this test's
+        // chronic flake mode. Same contract (the crumb must hold keyboard
+        // focus), asserted as an awaited poll that re-issues focus until the
+        // node holds it, instead of a single unawaited snapshot.
+        await expect
+            .poll(
+                async () => {
+                    await itemsCrumb.focus().catch(() => undefined);
+                    return await itemsCrumb
+                        .evaluate((el) => el === document.activeElement)
+                        .catch(() => false);
+                },
+                {
+                    message: 'Items crumb did not accept keyboard focus',
+                    timeout: RENDER_TIMEOUT,
+                },
+            )
+            .toBe(true);
 
         await page.keyboard.press('Enter');
         await page.waitForURL(/\/works\/[^/]+\/items(\/)?$/, { timeout: NAV_TIMEOUT });
         await expect(page).toHaveURL(/\/items(\/)?$/);
+        // Load-complete signal before the keyboard probe: the URL committing
+        // does not mean the destination tree finished rendering — under
+        // prebuilt-web/prod next start (run 27374977059) pressing Tab against a
+        // half-committed tree made the focus probes read a stale activeElement.
+        // entityRendered awaits the work <h1> OR the local catch-all heading,
+        // so it is environment-adaptive (the branch result is irrelevant here).
+        await entityRendered(page, work.name);
 
         // Tab from the now-focused crumb must move focus to ANOTHER focusable
         // element (the crumb row is part of a normal tab order, not a focus trap).
@@ -395,18 +466,29 @@ test.describe('Breadcrumb / nested-route navigation trail', () => {
         // /settings/data, /settings/api-keys all present).
         const securityCrumb = page.locator('a[href$="/settings/security"]').first();
         const dataCrumb = page.locator('a[href$="/settings/data"]').first();
-        const railVisible =
-            (await securityCrumb.isVisible({ timeout: RENDER_TIMEOUT }).catch(() => false)) ||
-            (await dataCrumb.isVisible({ timeout: 5_000 }).catch(() => false));
+        // Load-complete signal: WAIT for the rail before branching. The old
+        // probe used locator.isVisible({ timeout }), but isVisible does NOT
+        // wait — its timeout option is ignored and it returns immediately, so
+        // under prebuilt-web/prod next start (run 27374977059) it read false
+        // before the first post-goto paint and the test died downstream.
+        // waitFor (event-based) keeps the original skip semantics for builds
+        // where the settings shell genuinely never renders; .or() chain gets a
+        // trailing .first() for strict mode.
+        const railVisible = await securityCrumb
+            .or(dataCrumb)
+            .first()
+            .waitFor({ state: 'visible', timeout: FIRST_RENDER_TIMEOUT })
+            .then(() => true)
+            .catch(() => false);
         test.skip(
             !railVisible,
             '/settings side-nav rail not rendered (settings shell unavailable)',
         );
 
-        // Deep-navigate to a sibling settings leaf via its crumb.
-        const target = (await dataCrumb.isVisible({ timeout: 2_000 }).catch(() => false))
-            ? dataCrumb
-            : securityCrumb;
+        // Deep-navigate to a sibling settings leaf via its crumb. The rail is
+        // visible at this point (awaited above), so an immediate probe picks
+        // the branch without racing the render.
+        const target = (await dataCrumb.isVisible().catch(() => false)) ? dataCrumb : securityCrumb;
         const targetHref = await target.getAttribute('href');
         // The crumb tail we expect the URL to reflect AFTER following the link.
         // Compute it BEFORE the click so we can wait on the SPECIFIC destination
@@ -438,7 +520,12 @@ test.describe('Breadcrumb / nested-route navigation trail', () => {
         // closing the trail (mirror of breadcrumbs-deep.spec's "link back to
         // /settings" but asserted as part of a full descend+ascend walk).
         const settingsRoot = page.locator('a[href$="/settings"]').first();
-        const rootReachable = await settingsRoot.isVisible({ timeout: 5_000 }).catch(() => false);
+        // Event-based wait (isVisible's timeout option is a no-op); the
+        // railVisible fallback below keeps the original contract intact.
+        const rootReachable = await settingsRoot
+            .waitFor({ state: 'visible', timeout: 5_000 })
+            .then(() => true)
+            .catch(() => false);
         // On builds where the root isn't a discrete crumb, the rail siblings still
         // constitute an up-navigation path — accept either.
         expect(

--- a/apps/web/e2e/flow-hydration-no-errors.spec.ts
+++ b/apps/web/e2e/flow-hydration-no-errors.spec.ts
@@ -109,6 +109,19 @@ function classifyError(text: string): string {
     if (/failed to load ai providers|typeerror: failed to fetch|networkerror|load failed/.test(t)) {
         return 'transient-fetch';
     }
+    // Prebuilt-web (prod `next start`) fetch-abort artifact: page transitions
+    // complete fast enough that NotificationDropdown's polls (unread count at
+    // NotificationDropdown.tsx:174, notifications list at :157) still have a
+    // server-action fetch in flight when navigation tears the document down;
+    // the aborted fetch rejects ("TypeError: network error" / "Failed to
+    // fetch") and the component's catch logs it. Benign timing artifact, not
+    // a regression — it never surfaced under slow next-dev and first appeared
+    // on /works reload pass 2 in CI run 27374977059 once CI switched to the
+    // prebuilt prod web server. Deliberately NARROW (two known poll message
+    // prefixes), not a blanket 'other:*' ignore.
+    if (/failed to fetch unread count|failed to fetch notifications/.test(t)) {
+        return 'notification-poll-aborted-fetch';
+    }
     // Anything else is an UNKNOWN error category — the regression signal.
     return `other:${t.slice(0, 60)}`;
 }
@@ -174,6 +187,22 @@ const KNOWN_BASELINE_CATEGORIES = new Set<string>([
     'posthog',
     // Transient dev-server fetch failure under parallel load (see classifyError).
     'transient-fetch',
+    // Prebuilt-web/prod `next start` navigation aborting the notification
+    // polls mid-flight (see classifyError; CI run 27374977059).
+    'notification-poll-aborted-fetch',
+]);
+
+/** Categories that are pure load/abort TIMING artifacts (see classifyError):
+ *  whether they fire depends on how far a poll got before navigation/load
+ *  contention, so they may legitimately appear on one pass and not the next.
+ *  They carry no SSR/CSR-determinism signal, so the reload-idempotency
+ *  fingerprint comparison excludes them — under the prebuilt prod web server
+ *  (`next start`, CI run 27374977059) a fetch-abort on a single pass would
+ *  otherwise read as "fingerprint drift". The per-pass contract is NOT
+ *  weakened: every error must still classify inside KNOWN_BASELINE_CATEGORIES. */
+const TIMING_ARTIFACT_CATEGORIES = new Set<string>([
+    'transient-fetch',
+    'notification-poll-aborted-fetch',
 ]);
 
 /** Categories present in `errors` that are NOT in the allowed set. */
@@ -618,7 +647,16 @@ test.describe('Hydration & console hygiene — baseline-relative, cross-surface'
                 `/works pass ${i} unexpected error categories: ${extra.join(', ')}`,
             ).toEqual([]);
 
-            fingerprints.push([...new Set(passErrors.map(classifyError))].sort());
+            // Fingerprint = the DETERMINISTIC error categories only. Timing
+            // artifacts (aborted polls under fast prebuilt-web transitions —
+            // see TIMING_ARTIFACT_CATEGORIES) are bounded by the per-pass
+            // baseline check above but excluded here, since their presence
+            // varies by pass without implying SSR/CSR non-determinism.
+            fingerprints.push(
+                [...new Set(passErrors.map(classifyError))]
+                    .filter((cat) => !TIMING_ARTIFACT_CATEGORIES.has(cat))
+                    .sort(),
+            );
 
             // Re-load by navigating away and back so each pass is a true fresh
             // document (page.reload would also work; goto keeps offsets clean).

--- a/apps/web/e2e/flow-kb-search-semantic.spec.ts
+++ b/apps/web/e2e/flow-kb-search-semantic.spec.ts
@@ -635,8 +635,30 @@ test.describe('Flow — KB search: keyword + semantic/RRF + scoping', () => {
             timeout: 20_000,
         });
 
-        // The close control dismisses the dialog.
-        await page.getByTestId('kb-workbench-search-palette-close').click();
+        // The close control dismisses the dialog. Under prebuilt-web/prod
+        // `next start` (run 27374977059) the palette re-renders rapidly while
+        // the debounced search resolves (loading → results), and a bare
+        // `.click()` loops "element was detached from the DOM, retrying" until
+        // the test timeout. Settle first — the loading shimmer must be gone,
+        // i.e. the in-flight query has resolved — then click-and-verify in a
+        // toPass retry (mirroring the Ctrl+K open above) so a click swallowed
+        // by a late re-render is re-attempted instead of burning the budget.
+        // The contract is unchanged: the close control still dismisses the
+        // dialog, and the dialog (conditionally rendered on `open`) unmounts.
+        await expect(page.getByTestId('kb-workbench-search-palette-loading')).toBeHidden({
+            timeout: 20_000,
+        });
+        // NOTE: the click can dispatch AND still throw "element was detached"
+        // (the dismissal unmounts the button mid-action under prod next start),
+        // so a retry must treat an already-hidden palette as success. This
+        // cannot mask a phantom dismissal: between the Ctrl+K open above and
+        // this point the close control is the only interaction that can close
+        // the palette (the fill/expects are programmatic and non-dismissing).
+        await expect(async () => {
+            if (await palette.isHidden()) return;
+            await page.getByTestId('kb-workbench-search-palette-close').click({ timeout: 2_000 });
+            await expect(palette).toBeHidden({ timeout: 3_000 });
+        }).toPass({ timeout: 30_000 });
         await expect(palette).toBeHidden({ timeout: 10_000 });
     });
 });

--- a/apps/web/src/app/actions/agents.ts
+++ b/apps/web/src/app/actions/agents.ts
@@ -85,16 +85,36 @@ export async function deleteAgentHardAction(
     return res;
 }
 
+/**
+ * Discriminated result for the instruction-file autosave. EXPECTED
+ * failures (parallel-edit etag conflict, validation rejects) are
+ * returned as DATA, not thrown: Next.js redacts Server Action error
+ * messages in production builds, so the editor's old
+ * `/etag/i.test(err.message)` classification silently degraded every
+ * conflict to the generic "Save failed" banner under `next start`
+ * (it only ever worked in dev, where messages leak through). The
+ * etag detection now happens HERE — server-side, where the API's
+ * real message is still intact.
+ */
+export type WriteAgentFileResult =
+    | { ok: true; newHash: string }
+    | { ok: false; conflict: boolean; message: string };
+
 export async function writeAgentFileAction(
     id: string,
     name: AgentFileName,
     body: string,
     expectedHash?: string,
-): Promise<{ newHash: string }> {
+): Promise<WriteAgentFileResult> {
     await ensureAuth();
-    const res = await agentsAPI.writeFile(id, name, body, expectedHash);
-    revalidatePath(`/agents/${id}/instructions`);
-    return res;
+    try {
+        const res = await agentsAPI.writeFile(id, name, body, expectedHash);
+        revalidatePath(`/agents/${id}/instructions`);
+        return { ok: true, newHash: res.newHash };
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, conflict: /etag/i.test(message), message };
+    }
 }
 
 export async function exportAgentAction(id: string): Promise<AgentExportEnvelope> {

--- a/apps/web/src/components/agents/AgentInstructionsEditor.tsx
+++ b/apps/web/src/components/agents/AgentInstructionsEditor.tsx
@@ -78,12 +78,21 @@ export function AgentInstructionsEditor({
     async function persist(name: AgentFileName, body: string) {
         setStatus((s) => ({ ...s, [name]: 'saving' }));
         try {
-            const { newHash } = await writeAgentFileAction(agentId, name, body, hashes[name]);
-            setHashes((h) => ({ ...h, [name]: newHash }));
-            setStatus((s) => ({ ...s, [name]: 'saved' }));
-        } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            setStatus((s) => ({ ...s, [name]: /etag/i.test(msg) ? 'conflict' : 'error' }));
+            // Expected failures (etag conflict, validation) arrive as DATA —
+            // production Next.js redacts thrown Server Action messages, so the
+            // old `/etag/i.test(err.message)` classification only ever worked
+            // in dev. The action now classifies server-side and returns
+            // { ok:false, conflict } so the conflict banner survives prod.
+            const res = await writeAgentFileAction(agentId, name, body, hashes[name]);
+            if (res.ok) {
+                setHashes((h) => ({ ...h, [name]: res.newHash }));
+                setStatus((s) => ({ ...s, [name]: 'saved' }));
+            } else {
+                setStatus((s) => ({ ...s, [name]: res.conflict ? 'conflict' : 'error' }));
+            }
+        } catch {
+            // Unexpected transport/render failure — generic error state.
+            setStatus((s) => ({ ...s, [name]: 'error' }));
         }
     }
 


### PR DESCRIPTION
@-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized end-to-end testing: increased test parallelism and now run tests against a production-built web server to improve test speed and realism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->