### PR TITLE
fix(security): assertNoSecrets throws BadRequestException (400, was unmapped 500)

### DIFF
--- a/apps/web/e2e/flow-skill-crud-scoping.spec.ts
+++ b/apps/web/e2e/flow-skill-crud-scoping.spec.ts
@@ -273,10 +273,10 @@ test.describe('Skill CRUD + scope/owner validation', () => {
     /**
      * Flow 3 — Body-validation matrix on the write path. Each branch is a
      * distinct guard with a distinct status: required-field 400, oversize-body
-     * 400 (64 KB cap), secret-scan 500 (raw Error), invalid ownerType 400,
+     * 400 (64 KB cap), secret-scan 400 (BadRequestException, #1276), invalid ownerType 400,
      * missing ownerId 400, and ParseUUIDPipe 400 on a malformed :id read.
      */
-    test('write-path validation: required-field/oversize 400, secret-body 500, bad ownerType/ownerId 400, bad-UUID 400', async ({
+    test('write-path validation: required-field/oversize 400, secret-body 400, bad ownerType/ownerId 400, bad-UUID 400', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -317,9 +317,10 @@ test.describe('Skill CRUD + scope/owner validation', () => {
             /instructionsMd must be shorter than or equal to 65536 characters/i,
         );
 
-        // (c) secret-like value in the body → 500. assertNoSecrets throws a plain
-        // Error (no HttpException wrap), so this surfaces as Internal server error.
-        // Truthful assertion: the create is rejected (NOT persisted), not a 201.
+        // (c) secret-like value in the body → 400. Security fix (EW-716
+        // follow-up, #1276): assertNoSecrets now throws BadRequestException —
+        // the old plain-Error 500 mislabeled a user-input rejection as a
+        // server fault. Truthful assertion: rejected (NOT persisted), not 201.
         const secretBody = await request.post(`${API_BASE}/api/skills`, {
             headers,
             data: {
@@ -330,7 +331,7 @@ test.describe('Skill CRUD + scope/owner validation', () => {
                 instructionsMd: 'token: ghp_abcdefghijklmnopqrstuvwxyz0123456789AB',
             },
         });
-        expect(secretBody.status()).toBe(500);
+        expect(secretBody.status()).toBe(400);
         expect(secretBody.ok()).toBe(false);
 
         // (d) invalid ownerType ('user' is not in the lattice) → 400.

--- a/packages/agent/src/utils/__tests__/secret-scan.spec.ts
+++ b/packages/agent/src/utils/__tests__/secret-scan.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { assertNoSecrets, containsSecret, redactSecrets, scanForSecrets } from '../secret-scan';
 
 describe('secret-scan', () => {
@@ -80,6 +81,20 @@ describe('secret-scan', () => {
             }
             // Truncated form uses ellipsis between prefix and tail.
             expect(msg).toMatch(/…/);
+        });
+
+        it('throws BadRequestException (HTTP 400), not a plain Error', () => {
+            // Security (EW-716 follow-up): a plain Error is unmapped by Nest
+            // and surfaced as a 500 to every caller endpoint (task-chat,
+            // agent-file, skills, agent import) — mislabeling a user-input
+            // rejection as a server fault. The exception must carry 400.
+            try {
+                assertNoSecrets('use AKIAABCDEFGHIJ123456 here');
+                throw new Error('expected assertNoSecrets to throw');
+            } catch (e) {
+                expect(e).toBeInstanceOf(BadRequestException);
+                expect((e as BadRequestException).getStatus()).toBe(400);
+            }
         });
     });
 

--- a/packages/agent/src/utils/secret-scan.ts
+++ b/packages/agent/src/utils/secret-scan.ts
@@ -43,6 +43,8 @@
  * "token-". A real secret usually has ≥10 chars after the prefix.
  */
 
+import { BadRequestException } from '@nestjs/common';
+
 export interface SecretMatch {
     pattern: string;
     matched: string; // truncated for safe surfacing in error messages
@@ -135,12 +137,20 @@ export function containsSecret(body: string): boolean {
  * path: throws a precise error message that surfaces the pattern
  * name and (truncated) sample so the user can find + fix the
  * offending content without us leaking the full secret back.
+ *
+ * Security (EW-716 follow-up): throws BadRequestException, NOT a plain
+ * Error — a plain Error is unmapped by Nest's exception layer and
+ * surfaced as an HTTP 500 to every caller endpoint (task-chat POST/
+ * PATCH, agent-file writes, skill bodies, agent import), which both
+ * mislabels a user-input rejection as a server fault and risks raw-
+ * message/stack exposure through generic 500 handling. The message is
+ * already safe to return: the sample is display-truncated upstream.
  */
 export function assertNoSecrets(body: string, fieldHint = 'body'): void {
     const hits = scanForSecrets(body);
     if (hits.length === 0) return;
     const first = hits[0];
-    throw new Error(
+    throw new BadRequestException(
         `Secret-like value (${first.pattern}: "${first.matched}") detected in ${fieldHint}. ` +
             `Remove it before saving — credentials must live in plugin settings, not in Agent files or Skill bodies.`,
     );


### PR DESCRIPTION
@-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secret-like inputs now produce a client-facing HTTP 400 (Bad Request) instead of an HTTP 500, preventing generic server errors and reducing risk of leaking internals.

* **Tests**
  * Updated end-to-end and unit tests to assert secret-detection returns HTTP 400 as expected.

* **Documentation**
  * Clarified how secret-detection validation failures are communicated to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->