### PR TITLE
fix(security): close IDOR in Idea-accept — verify workId ownership

### DIFF
--- a/apps/web/e2e/flow-idea-lifecycle-deep.spec.ts
+++ b/apps/web/e2e/flow-idea-lifecycle-deep.spec.ts
@@ -28,9 +28,9 @@ import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from '.
  * Those pin the STATE MACHINE and SCOPING. THIS file pins the INPUT EDGE:
  * Idea-create title/slug DERIVATION, the create whitelist (privilege-field
  * rejection), the length boundaries (5000/120), the ParseUUIDPipe path guard,
- * accept's missing WORK-ownership check (foreign workId accepted), accept's
- * ghost-workId FK rollback (idea stays PENDING), and the Mission create
- * validation lattice (cap/type) + mission-scoped budget shape.
+ * accept's WORK-ownership guard (foreign/ghost workId → 404, #1280 IDOR fix),
+ * and the Mission create validation lattice (cap/type) + mission-scoped budget
+ * shape.
  *
  * ── PROBED CONTRACTS (verified live) ─────────────────────────────────────
  *
@@ -56,11 +56,12 @@ import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from '.
  *  POST   /api/me/work-proposals/<stranger>/build|retry|rebuild → 404 "Proposal not found"
  *
  *  POST /api/me/work-proposals/:id/accept  { workId:UUID }
- *    · workId belonging to ANOTHER user → 200 { ok:true } — accept does NOT
- *      enforce Work ownership (the Idea is stamped with the foreign workId).
- *      [SECURITY NOTE: cross-user Work linkage IDOR — flagged separately.]
- *    · workId well-formed but NON-EXISTENT → 500 (FK violation) and the Idea
- *      transaction ROLLS BACK — it stays PENDING with acceptedWorkId:null.
+ *    · workId belonging to ANOTHER user → 404 (#1280 IDOR fix: acceptInternal
+ *      verifies work.userId === caller; the Idea stays PENDING, no foreign
+ *      stamp). Was a 200 cross-user-linkage IDOR before the fix.
+ *    · workId well-formed but NON-EXISTENT → 404 (the same ownership guard
+ *      short-circuits when findById returns null); the Idea stays PENDING.
+ *    · workId the CALLER owns → 200 { ok:true }, Idea ACCEPTED + stamped.
  *    · ACCEPTED Idea → rebuild commits ACCEPTED→building, acceptedWorkId PRESERVED.
  *
  *  POST /api/me/missions  validation lattice
@@ -465,7 +466,7 @@ test.describe('Idea list — combined ?missionId × ?statuses composition', () =
 });
 
 test.describe('Idea → Work accept — Work-side edge cases (FK, ownership, rollback)', () => {
-    test('accept against a FOREIGN user’s workId succeeds (accept does not enforce Work ownership) and stamps the foreign workId', async ({
+    test('accept against a FOREIGN user’s workId is REFUSED (404) and never stamps the foreign workId — IDOR guard', async ({
         request,
     }) => {
         const owner = await registerUserViaAPI(request);
@@ -480,26 +481,25 @@ test.describe('Idea → Work accept — Work-side edge cases (FK, ownership, rol
         });
         expect(foreignWork.id).toMatch(UUID_RE);
 
-        // Owner accepts THEIR Idea against the OTHER user's workId. The accept
-        // endpoint validates the Idea ownership + status but NOT the Work's
-        // ownership, so the FK (the Work row exists) is satisfied and it lands.
-        // [SECURITY: cross-user Work linkage — flagged via spawn_task.]
+        // Owner accepts THEIR Idea against the OTHER user's workId. SECURITY
+        // (#1280, EW-711 IDOR fix): acceptInternal now verifies the supplied
+        // workId belongs to the SAME user (work.userId === caller). A foreign
+        // work fails that check and the service returns false → the controller's
+        // existence-leak-safe 404 ("Proposal not found or already finalized").
+        // Previously this SUCCEEDED (200) and stamped the foreign workId onto
+        // the Idea's acceptedWorkId — a cross-owner dangling reference.
         const accept = await request.post(`${API_BASE}/api/me/work-proposals/${idea.id}/accept`, {
             headers: ownerHeaders,
             data: { workId: foreignWork.id },
         });
-        expect(accept.status(), `accept body=${await accept.text()}`).toBe(200);
-        expect(await accept.json()).toEqual({ ok: true });
+        expect(accept.status(), `accept body=${await accept.text()}`).toBe(404);
 
-        // The owner's Idea is now ACCEPTED and stamped with the FOREIGN workId.
+        // The owner's Idea is UNTOUCHED — still PENDING, no foreign stamp.
         const accepted = await readIdea(request, ownerHeaders, idea.id);
-        expect(accepted.status).toBe('accepted');
-        expect(accepted.acceptedWorkId).toBe(foreignWork.id);
+        expect(accepted.status).toBe('pending');
+        expect(accepted.acceptedWorkId).toBeNull();
 
-        // The IDOR is a one-way dangling forward reference: the other user's
-        // Work is NOT mutated — its `acceptedFromIdeaId` back-pointer stays null
-        // (that field is written only by the Goal-completion handler, never by
-        // the user-facing accept). The stranger's Work read confirms it.
+        // The stranger's Work is likewise untouched (no back-pointer).
         const otherWorkRead = await request.get(`${API_BASE}/api/works/${foreignWork.id}`, {
             headers: authedHeaders(other.access_token),
         });
@@ -509,7 +509,7 @@ test.describe('Idea → Work accept — Work-side edge cases (FK, ownership, rol
         expect(otherWorkEntity?.acceptedFromIdeaId ?? null).toBeNull();
     });
 
-    test('accept against a GHOST (non-existent) workId is a 500 FK violation and the transaction ROLLS BACK — the Idea stays PENDING', async ({
+    test('accept against a GHOST (non-existent) workId is REFUSED (404) and the Idea stays PENDING — IDOR guard short-circuits before the FK', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -518,25 +518,19 @@ test.describe('Idea → Work accept — Work-side edge cases (FK, ownership, rol
         const idea = await createIdea(request, headers, `${IDEA_DESC_MIN} ${uniq('ghost-work')}`);
 
         // A well-formed but non-existent workId passes the @IsUUID DTO + the
-        // ownership/status guard, then violates the acceptedWorkId FK. Truthful
-        // tolerance: 200 (no FK enforced anywhere) OR 500 (FK fires). We never
-        // assert a fictional FK-404.
+        // Idea ownership/status guard, then hits the new workId-ownership guard
+        // (#1280): `works.findById(workId)` returns null → service returns false
+        // → controller 404. (Before the fix this fell through to the
+        // acceptedWorkId FK and surfaced as a 200-or-500.) No state change.
         const ghost = await request.post(`${API_BASE}/api/me/work-proposals/${idea.id}/accept`, {
             headers,
             data: { workId: UNKNOWN_UUID },
         });
-        expect([200, 500]).toContain(ghost.status());
+        expect(ghost.status()).toBe(404);
 
         const after = await readIdea(request, headers, idea.id);
-        if (ghost.status() === 500) {
-            // The accept tx rolled back — no half-finalized state leaked.
-            expect(after.status).toBe('pending');
-            expect(after.acceptedWorkId).toBeNull();
-        } else {
-            // If a future stack tolerates the ghost (no FK), it's a clean accept.
-            expect(after.status).toBe('accepted');
-            expect(after.acceptedWorkId).toBe(UNKNOWN_UUID);
-        }
+        expect(after.status).toBe('pending');
+        expect(after.acceptedWorkId).toBeNull();
     });
 
     test('the accept body DTO is strict: a null workId, a non-UUID workId, and an extra field are each rejected BEFORE any state change', async ({

--- a/apps/web/e2e/flow-idea-to-work-accept.spec.ts
+++ b/apps/web/e2e/flow-idea-to-work-accept.spec.ts
@@ -43,8 +43,9 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *   3. accept with an empty body → 400 ["workId must be a UUID"] (the @IsUUID DTO
  *      check runs before the controller's `!body?.workId` guard, so the
  *      "workId is required" string is unreachable). A well-formed but NON-EXISTENT
- *      workId → 500 (FK violation on acceptedWorkId) — we tolerate [200,500] and
- *      never assert a fictional FK-404 contract.
+ *      workId → 404 (#1280 IDOR fix: the workId-ownership guard's findById
+ *      returns null → false → 404, before the acceptedWorkId FK is reached);
+ *      a FOREIGN-owned workId likewise → 404; only the caller's OWN work → 200.
  *   4. Mission linkage: user-manual Ideas are born `missionId:null` and CANNOT be
  *      linked at create (the DTO rejects `missionId`). Linking is an AI-tick
  *      outcome (no AI here), so we assert the testable truth: an accepted Idea's
@@ -416,14 +417,17 @@ test.describe('Idea → Work accept flow (fresh API user)', () => {
         expect((await readIdea(request, ownerToken, ideaId)).status).toBe('pending');
 
         // ── 4. A well-formed but NON-EXISTENT workId — the accept passes
-        //      validation + the ownership/status guard, then hits the FK on
-        //      acceptedWorkId. Truthful tolerance: 200 (no FK enforced) OR 500
-        //      (FK violation). We never assert a fictional FK-404 contract. ──
+        //      validation + the Idea ownership/status guard, then hits the new
+        //      workId-ownership guard (#1280 IDOR fix): `works.findById` returns
+        //      null → the service returns false → controller 404, BEFORE the
+        //      acceptedWorkId FK is reached. (Was a 200/500 FK tolerance before
+        //      the fix.) The Idea stays pending. ──
         const ghostWork = await request.post(`${API_BASE}/api/me/work-proposals/${ideaId}/accept`, {
             headers: authedHeaders(ownerToken),
             data: { workId: UNKNOWN_UUID },
         });
-        expect([200, 500]).toContain(ghostWork.status());
+        expect(ghostWork.status()).toBe(404);
+        expect((await readIdea(request, ownerToken, ideaId)).status).toBe('pending');
 
         // ── 5. Ownership: user B cannot accept user A's Idea → 404, and the
         //      Idea stays in user A's pre-existing state ─────────────────────

--- a/packages/agent/src/user-research/__tests__/work-proposal.service.spec.ts
+++ b/packages/agent/src/user-research/__tests__/work-proposal.service.spec.ts
@@ -43,7 +43,13 @@ function makeService(
             },
         }),
     };
-    const works = { findByUser: jest.fn().mockResolvedValue([]) };
+    const works = {
+        findByUser: jest.fn().mockResolvedValue([]),
+        // Owns work 'w1'; the IDOR guard in acceptInternal reads this.
+        findById: jest.fn(async (id: string) =>
+            id === 'w1' ? { id: 'w1', userId: 'u1' } : { id, userId: 'other-user' },
+        ),
+    };
     const registry = {
         getReady: jest.fn().mockReturnValue([{ plugin: { id: 'github' } }]),
         getEnabledPluginsScoped: jest.fn().mockResolvedValue([
@@ -79,6 +85,12 @@ function makeService(
         bulkInsert: jest.fn(async (items) =>
             items.map((item: object, index: number) => ({ ...item, id: `p${index}` })),
         ),
+        // acceptInternal path: proposal 'p1' exists for 'u1'; markAccepted
+        // succeeds. The IDOR guard sits between these two.
+        findByIdForUser: jest.fn(async (id: string) =>
+            id === 'p1' ? { id: 'p1', userId: 'u1', status: 'pending' } : null,
+        ),
+        markAccepted: jest.fn().mockResolvedValue(true),
     };
     const titler = { generateTitle: jest.fn().mockResolvedValue('Manual idea') };
 
@@ -91,7 +103,7 @@ function makeService(
         titler as never,
     );
 
-    return { service, aiFacade, repo };
+    return { service, aiFacade, repo, works };
 }
 
 describe('WorkProposalService proposal limits and dedupe', () => {
@@ -155,5 +167,47 @@ describe('WorkProposalService proposal limits and dedupe', () => {
         expect(repo.bulkInsert).toHaveBeenCalledWith([
             expect.objectContaining({ title: 'AI Agent Frameworks' }),
         ]);
+    });
+});
+
+describe('WorkProposalService.acceptInternal — workId ownership (IDOR guard)', () => {
+    it('accepts when the supplied Work belongs to the caller', async () => {
+        const { service, repo, works } = makeService();
+
+        const ok = await service.acceptInternal('u1', 'p1', 'w1');
+
+        expect(ok).toBe(true);
+        expect(works.findById).toHaveBeenCalledWith('w1');
+        expect(repo.markAccepted).toHaveBeenCalledWith('p1', 'u1', 'w1', ['pending']);
+    });
+
+    it('refuses (false, no write) when the supplied Work belongs to ANOTHER user', async () => {
+        const { service, repo } = makeService();
+
+        // 'w-foreign' resolves to { userId: 'other-user' } in the works mock.
+        const ok = await service.acceptInternal('u1', 'p1', 'w-foreign');
+
+        expect(ok).toBe(false);
+        expect(repo.markAccepted).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the supplied Work does not exist', async () => {
+        const { service, repo, works } = makeService();
+        works.findById.mockResolvedValueOnce(null);
+
+        const ok = await service.acceptInternal('u1', 'p1', 'w-missing');
+
+        expect(ok).toBe(false);
+        expect(repo.markAccepted).not.toHaveBeenCalled();
+    });
+
+    it('refuses when the proposal is not the caller’s (guard order: proposal first)', async () => {
+        const { service, repo, works } = makeService();
+
+        const ok = await service.acceptInternal('u1', 'p-foreign', 'w1');
+
+        expect(ok).toBe(false);
+        expect(works.findById).not.toHaveBeenCalled();
+        expect(repo.markAccepted).not.toHaveBeenCalled();
     });
 });

--- a/packages/agent/src/user-research/work-proposal.service.ts
+++ b/packages/agent/src/user-research/work-proposal.service.ts
@@ -535,6 +535,17 @@ export class WorkProposalService {
     ): Promise<boolean> {
         const proposal = await this.repo.findByIdForUser(proposalId, userId);
         if (!proposal) return false;
+        // Security (IDOR): the caller supplies `workId` in the accept body, so
+        // it must be verified to belong to the SAME user before it is written
+        // onto the Idea's `acceptedWorkId`. Without this a user could link
+        // their own Idea to ANOTHER user's Work id (cross-owner reference;
+        // downstream surfaces keyed on acceptedWorkId — detail links, budget/
+        // usage rollups — would then point across the ownership boundary).
+        // Return false (→ controller 404, existence-leak-safe) on mismatch.
+        // The internal Goal-completion caller always passes the freshly-built
+        // Work owned by this user, so the legitimate path is unaffected.
+        const work = await this.works.findById(workId);
+        if (!work || work.userId !== userId) return false;
         return this.repo.markAccepted(proposalId, userId, workId, fromStatuses);
     }
 


### PR DESCRIPTION
@-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added ownership verification when accepting a work proposal: attempts to accept using another user’s workId or a non-existent workId are refused (404) and leave the proposal in pending.

* **Tests**
  * Expanded unit and end-to-end tests to cover ownership/IDOR guard scenarios, refusal cases, and preservation of pending state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->