### PR TITLE
fix(conversations): validate POST /:id/messages body (unmapped 500 → 400)

### DIFF
--- a/apps/api/src/ai-conversation/conversation.controller.ts
+++ b/apps/api/src/ai-conversation/conversation.controller.ts
@@ -12,7 +12,17 @@ import {
     NotFoundException,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiProperty, ApiTags, ApiOperation } from '@nestjs/swagger';
-import { IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+    ArrayMaxSize,
+    IsArray,
+    IsIn,
+    IsObject,
+    IsOptional,
+    IsString,
+    MaxLength,
+    ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import { AuthenticatedUser } from '../auth/types/auth.types';
 import { ConversationRepository } from '@ever-works/agent/database';
@@ -60,14 +70,69 @@ class UpdateConversationDto {
     title: string;
 }
 
-type AIMessage = {
+// Upper bound on messages accepted in a single append. Real clients send 1-2
+// per turn (see apps/web/src/lib/ai/persistence.ts); the cap only stops a
+// pathological mega-batch. Content length is bounded by the JSON body-parser
+// limit, so no per-message length cap is added here (a future tightening can).
+const MAX_MESSAGES_PER_APPEND = 500;
+
+const MESSAGE_ROLES = ['user', 'assistant', 'system', 'tool'] as const;
+
+/**
+ * One message in `POST /api/conversations/:id/messages`.
+ *
+ * Security / robustness: the handler previously took a plain `AIMessage[]`
+ * with NO class-validator metadata, so the global ValidationPipe could not
+ * police it. A malformed element (non-object, null, missing/typed-wrong
+ * `role`/`content`) then threw an UNMAPPED Error mid-loop → HTTP 500 (and,
+ * because the batch is not transaction-wrapped, a partial row could leak).
+ * It also silently persisted an arbitrary `role` string and non-string
+ * `content`. This DTO turns every such shape into a clean 400 BEFORE the
+ * handler runs. Fields mirror exactly what the web BFF serialises.
+ */
+class AppendMessageDto {
+    @ApiProperty({ required: false, maxLength: 200 })
+    @IsOptional()
+    @IsString()
+    @MaxLength(200)
     id?: string;
-    role: string;
+
+    @ApiProperty({ enum: MESSAGE_ROLES })
+    @IsIn(MESSAGE_ROLES)
+    role: (typeof MESSAGE_ROLES)[number];
+
+    @ApiProperty()
+    @IsString()
     content: string;
+
+    @ApiProperty({ required: false, type: [Object] })
+    @IsOptional()
+    @IsArray()
     parts?: unknown[];
+
+    @ApiProperty({ required: false, maxLength: 100 })
+    @IsOptional()
+    @IsString()
+    @MaxLength(100)
     model?: string;
+
+    @ApiProperty({ required: false, type: Object })
+    @IsOptional()
+    @IsObject()
     usage?: { promptTokens: number; completionTokens: number; totalTokens: number };
-};
+}
+
+/**
+ * Body for `POST /api/conversations/:id/messages`.
+ */
+class AppendMessagesDto {
+    @ApiProperty({ type: [AppendMessageDto] })
+    @IsArray()
+    @ArrayMaxSize(MAX_MESSAGES_PER_APPEND)
+    @ValidateNested({ each: true })
+    @Type(() => AppendMessageDto)
+    messages: AppendMessageDto[];
+}
 
 @ApiTags('Conversations')
 @ApiBearerAuth('JWT-auth')
@@ -140,7 +205,7 @@ export class ConversationController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
         @Body()
-        body: { messages: AIMessage[] },
+        body: AppendMessagesDto,
     ) {
         const conversation = await this.repo.findById(id, auth.userId);
         if (!conversation) throw new NotFoundException();
@@ -148,7 +213,7 @@ export class ConversationController {
         await this.repo.appendMessages(
             body.messages.map((m) => ({
                 conversationId: id,
-                role: m.role as 'user' | 'assistant' | 'system' | 'tool',
+                role: m.role,
                 content: m.content,
                 parts: m.parts,
                 model: m.model,

--- a/apps/web/e2e/flow-conversation-messages-validation.spec.ts
+++ b/apps/web/e2e/flow-conversation-messages-validation.spec.ts
@@ -6,12 +6,16 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *
  * Source of truth: apps/api/src/ai-conversation/conversation.controller.ts
  * (mounted under @Controller('api/conversations')), the appendMessages handler.
- * That handler has NO class-validator DTO: it maps the supplied array straight
- * onto ConversationMessage rows, so malformed shapes throw an UNMAPPED Error
- * and surface as HTTP 500 today — and because the batch is NOT transaction
- * wrapped, a value that throws only AFTER a string-coercion+insert leaves a
- * partial row behind. EVERY status/shape below was PROBED live against
- * http://127.0.0.1:3100 before any assertion was written.
+ * That handler now validates its body with AppendMessagesDto (role @IsIn-enum,
+ * content @IsString, nested @ValidateNested) so the global ValidationPipe
+ * rejects every malformed shape with a clean 400 BEFORE the handler runs (and
+ * thus before any insert — so nothing partial leaks). This file was originally
+ * written against the DTO-less handler (malformed → unmapped 500 + non-atomic
+ * partial rows) with TOLERANT [400,422,500] reject sets; those survive the
+ * hardening unchanged, and the two assertions that pinned the exact buggy
+ * behaviour (a coerced numeric role; ownership-before-validation) were flipped
+ * to the corrected contract. EVERY status/shape below was PROBED live against
+ * http://127.0.0.1:3100.
  *
  * ── NON-DUPLICATION ──────────────────────────────────────────────────────────
  * Three sibling specs already own the surfaces below and are NOT repeated here:
@@ -32,22 +36,20 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  * This file pins the GAPS those leave un-asserted — all live-probed:
  *
  * ── PROBED CONTRACTS (live, as throwaway users) ──────────────────────────────
- *  WRONG-TYPE matrix (beyond the deep spec's missing-key matrix). The handler
- *      does NOT type-check field VALUES, so behaviour splits three ways:
- *        • role = number (123)  → 201, persisted with role COERCED to "123"
- *          (a non-string role is silently accepted, like the deep spec's
- *          arbitrary "wizard" string — there is no enum AND no string guard).
- *        • role = null / role = object → 500 + ZERO persist (throws before any
- *          insert for this element).
- *        • content = number (42) / content = boolean (true) → 500 but PARTIAL
- *          persist: the value is string-coerced+inserted ("42" / "1.0") and the
- *          throw happens after, so one row leaks (the non-atomic write).
- *        • content = array / content = object / content = null → 500 + ZERO
+ *  WRONG-TYPE matrix (beyond the deep spec's missing-key matrix). With
+ *      AppendMessagesDto the global ValidationPipe now rejects EVERY wrong-type
+ *      field with a 400 before the handler, so nothing is ever inserted:
+ *        • role = number (123) → 400 (role @IsIn enum) + ZERO persist. (Used to
+ *          be 201, silently coerced to "123"; this assertion was flipped.)
+ *        • role = null / role = object → 400 + ZERO persist.
+ *        • content = number (42) / content = boolean (true) → 400 + ZERO persist.
+ *          (Used to string-coerce+insert one partial row before throwing 500;
+ *          validation-before-handler now eliminates the non-atomic leak.)
+ *        • content = array / content = object / content = null → 400 + ZERO
  *          persist.
- *      Each asserts a TOLERANT hard-reject [400,422,500] (survives a future DTO
- *      fix to 400/422) AND the exact per-shape persist count, so the
- *      non-atomic-write contract is pinned today and the zero-persist invariant
- *      survives a future transactional fix.
+ *      Each asserts a TOLERANT hard-reject [400,422,500] (now always 400) AND
+ *      the ZERO-persist invariant, which the DTO makes unconditional (validation
+ *      runs before any insert, so no partial row can leak).
  *  SINGLE-BATCH ordering: a 5-message interleaved (user/assistant) batch sent in
  *      ONE POST lands in array order (the deep + lifecycle specs pin CROSS-batch
  *      ordering only; neither pins a single >2-element batch's internal order).
@@ -125,28 +127,30 @@ async function appendRaw(
     return { status: res.status(), json };
 }
 
-test.describe('Conversation messages validation — wrong-type field matrix (no DTO → split behaviour)', () => {
-    // Shapes that ACCEPT (the value is coerced and persisted, 201). A non-string
-    // role is silently stored — there is no enum and no string guard on role.
-    test('a numeric role is silently coerced and persisted (201) — no role type guard', async ({
+test.describe('Conversation messages validation — wrong-type field matrix (DTO → 400, never persist)', () => {
+    // A non-string role used to be silently coerced and persisted (no enum / no
+    // string guard). AppendMessageDto now constrains role to @IsIn(...), so a
+    // numeric role is a clean 400 and — because validation runs before the
+    // handler — nothing is written.
+    test('a numeric role is rejected with 400 and persists nothing (role enum enforced)', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
         const token = user.access_token;
         const conv = await createConversation(request, token);
 
-        const { status, json } = await appendRaw(request, token, conv.id, {
+        const { status } = await appendRaw(request, token, conv.id, {
             messages: [{ role: 123, content: 'numeric role body' }],
         });
-        expect(status, 'numeric role → 201 (coerced, not rejected)').toBe(201);
-        expect(json, 'response is exactly { success: true }').toEqual({ success: true });
+        expect(status, 'numeric role → 400 (rejected, not coerced)').toBe(400);
 
         const after = await getConversation(request, token, conv.id);
-        const msgs = after.row?.messages ?? [];
-        expect(msgs, 'the coerced-role message persisted').toHaveLength(1);
-        // The number is string-coerced on the way into the text column.
-        expect(msgs[0].role, 'numeric role stored as its string form').toBe('123');
-        expect(msgs[0].content, 'content stored verbatim').toBe('numeric role body');
+        expect(after.status, 'conversation still readable').toBe(200);
+        expect(
+            after.row?.messages,
+            'the rejected numeric-role message persisted nothing',
+        ).toHaveLength(0);
+        expect(after.row?.title, 'no title set by a rejected append').toBeNull();
     });
 
     // Shapes that throw BEFORE any insert → hard-reject + ZERO persist. A future
@@ -447,37 +451,49 @@ test.describe('Conversation messages validation — param + ownership rejection'
         ).toContain('uuid');
     });
 
-    test('a foreign user appending a malformed body is gated by ownership (404) BEFORE any validation', async ({
+    test('the rejection pipeline is layered: auth (401) → body validation (400) → ownership (404), none leaking the thread', async ({
         request,
     }) => {
         const alice = await registerUserViaAPI(request);
         const bob = await registerUserViaAPI(request);
         const conv = await createConversation(request, alice.access_token);
 
-        // The ownership check (findById(id, userId)) resolves before the body is
-        // touched: Bob gets a 404 even though his body is ALSO malformed (a bare
-        // string element). Ownership wins over the would-be 500 — the endpoint
-        // never reveals "your body is bad" to a non-owner.
-        const { status } = await appendRaw(request, bob.access_token, conv.id, {
+        // Now that AppendMessagesDto exists, the global ValidationPipe runs BEFORE
+        // the controller body (and thus before the ownership findById). So a
+        // non-owner with a MALFORMED body is stopped at validation with a 400 —
+        // which reveals only that the BODY is bad, never anything about the
+        // conversation's existence or ownership.
+        const malformed = await appendRaw(request, bob.access_token, conv.id, {
             messages: ['a malformed bare string'],
         });
-        expect(status, "B's malformed append to A's conversation → 404 (ownership first)").toBe(
-            404,
+        expect(malformed.status, "B's MALFORMED append → 400 (validation precedes ownership)").toBe(
+            400,
         );
 
-        // Raw anon context (independent of any storageState) with a malformed body
-        // is likewise an auth rejection, not a 500 — auth precedes validation.
+        // A non-owner with a WELL-FORMED body passes validation and is then gated
+        // by ownership: findById(id, bob) → null → 404. Same 404 a non-existent id
+        // would give, so it never confirms the thread exists.
+        const wellFormed = await appendRaw(request, bob.access_token, conv.id, {
+            messages: [{ role: 'user', content: 'valid but not my conversation' }],
+        });
+        expect(
+            wellFormed.status,
+            "B's WELL-FORMED append to A's conversation → 404 (ownership)",
+        ).toBe(404);
+
+        // Auth precedes everything: a guard rejects an unauthenticated request
+        // with 401 before the ValidationPipe ever sees the (malformed) body.
         const anon = await pwRequest.newContext();
         try {
             const res = await anon.post(`${API_BASE}/api/conversations/${conv.id}/messages`, {
                 data: { messages: ['still malformed'] },
             });
-            expect(res.status(), 'anon malformed append → 401 (auth before validation)').toBe(401);
+            expect(res.status(), 'anon append → 401 (auth before validation)').toBe(401);
         } finally {
             await anon.dispose();
         }
 
-        // Alice's thread was never touched by either rejected attempt.
+        // Alice's thread was never touched by any of the three rejected attempts.
         const after = await getConversation(request, alice.access_token, conv.id);
         expect(
             after.row?.messages,

--- a/apps/web/e2e/flow-conversations-messages-deep.spec.ts
+++ b/apps/web/e2e/flow-conversations-messages-deep.spec.ts
@@ -41,12 +41,13 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *      tests assert the hard-reject is >=400 (today exactly 500) AND pin the
  *      persist outcome — so a future DTO hardening to 400/422 keeps them green
  *      (the established tolerance pattern from flow-task-chat-messages.spec.ts).
- *  Accepted-but-loose inputs (NO enum / NO size cap, unlike task-chat's
- *      16384 @MaxLength): an arbitrary role string ("wizard") → 201 + persisted;
- *      an empty-string content → 201 + persisted; a 500_000-char content → 201 +
- *      persisted in full (title still truncates to 60). Unknown extra keys on a
- *      message element are STRIPPED (only modeled columns persist) and a
- *      client-supplied `id` is IGNORED (server assigns its own).
+ *  Input policing (AppendMessagesDto now governs this — role is @IsIn-enum'd,
+ *      so an arbitrary role string ("wizard") is REJECTED with 400 + zero
+ *      persist (it used to be accepted verbatim); content has NO non-empty/size
+ *      cap, so an empty-string content → 201 + persisted, and a 500_000-char
+ *      content → 201 + persisted in full (title still truncates to 60). Unknown
+ *      extra keys on a message element are STRIPPED (only modeled columns
+ *      persist) and a client-supplied `id` is IGNORED (server assigns its own).
  *  Auto-title empty-vs-whitespace boundary (the branch the CRUD-deep battery
  *      does not reach): a first USER message whose content is "" (FALSY) leaves
  *      the title NULL; a first USER message that is whitespace-only (TRUTHY, then
@@ -171,34 +172,42 @@ test.describe('Conversation messages deep — append input validation (no DTO �
         expect(after.row?.title, 'no malformed message set a title').toBeNull();
     });
 
-    test('append accepts loose inputs the DTO-less handler does not police: arbitrary role + empty content persist', async ({
+    test('append now enforces the role enum (rejects an arbitrary role) while still accepting empty content', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
         const token = user.access_token;
         const conv = await createConversation(request, token, {});
 
-        // Unlike the task-chat controller (role enum + 16384 @MaxLength), this
-        // endpoint persists an arbitrary role string and an empty content body.
-        const { status, json } = await appendRaw(request, token, conv.id, {
-            messages: [
-                { role: 'wizard', content: 'magic incantation' },
-                { role: 'user', content: '' },
-            ],
+        // AppendMessageDto now constrains role to @IsIn(['user','assistant',
+        // 'system','tool']) — an arbitrary role string that this DTO-less handler
+        // used to persist verbatim is now a clean 400, and (because validation
+        // runs before the handler) nothing is written.
+        const rejected = await appendRaw(request, token, conv.id, {
+            messages: [{ role: 'wizard', content: 'magic incantation' }],
         });
-        expect(status, 'loose roles/content → 201').toBe(201);
+        expect(rejected.status, 'arbitrary role → 400 (role enum enforced)').toBe(400);
+        const afterReject = await getConversation(request, token, conv.id);
+        expect(
+            afterReject.row?.messages,
+            'a rejected arbitrary-role batch persisted nothing',
+        ).toHaveLength(0);
+
+        // content still has NO non-empty constraint (only @IsString), so an
+        // empty-string body with a VALID role is accepted and stored verbatim.
+        const { status, json } = await appendRaw(request, token, conv.id, {
+            messages: [{ role: 'user', content: '' }],
+        });
+        expect(status, 'valid role + empty content → 201').toBe(201);
         expect(json, 'append response shape is exactly { success: true }').toEqual({
             success: true,
         });
 
         const after = await getConversation(request, token, conv.id);
         const msgs = after.row?.messages ?? [];
-        expect(msgs, 'both loose messages persisted in order').toHaveLength(2);
-        expect(
-            msgs.map((m) => m.role),
-            'arbitrary role stored verbatim (no enum)',
-        ).toEqual(['wizard', 'user']);
-        expect(msgs[1].content, 'empty-string content stored verbatim').toBe('');
+        expect(msgs, 'the valid empty-content message persisted').toHaveLength(1);
+        expect(msgs[0].role, 'valid role stored').toBe('user');
+        expect(msgs[0].content, 'empty-string content stored verbatim').toBe('');
     });
 
     test('a mixed batch (valid message followed by a malformed one) hard-rejects without crashing the conversation', async ({
@@ -376,16 +385,28 @@ test.describe('Conversation messages deep — keyless persistence (provider-agno
 });
 
 test.describe('Conversation messages deep — message DTO completeness + id provenance', () => {
-    test('persisted message DTO is server-shaped: client id ignored, unknown keys stripped, parts/usage/scope columns present', async ({
+    test('persisted message DTO is server-shaped: client id ignored, unknown keys rejected, parts/usage/scope columns present', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
         const token = user.access_token;
         const conv = await createConversation(request, token, {});
 
-        // Send a message with a client-supplied id, an unknown field, and the
-        // optional parts/model/usage. The server must assign its OWN id, drop the
-        // unknown key, and round-trip the modeled optional columns.
+        // An unknown extra key on a message element is now REJECTED by the global
+        // ValidationPipe (forbidNonWhitelisted) via AppendMessageDto — 400, zero
+        // persist. (The DTO-less handler used to silently ignore extra keys.)
+        const rejected = await appendRaw(request, token, conv.id, {
+            messages: [{ role: 'assistant', content: 'x', bogusField: 'not allowed' }],
+        });
+        expect(rejected.status, 'unknown message key → 400 (forbidNonWhitelisted)').toBe(400);
+        expect(
+            (await getConversation(request, token, conv.id)).row?.messages,
+            'a rejected unknown-key batch persisted nothing',
+        ).toHaveLength(0);
+
+        // A well-formed message with a client-supplied id + the optional
+        // parts/model/usage: the server assigns its OWN id and round-trips the
+        // modeled optional columns.
         const parts = [{ type: 'text', text: 'structured' }];
         const usage = { promptTokens: 3, completionTokens: 2, totalTokens: 5 };
         const { status } = await appendRaw(request, token, conv.id, {
@@ -397,7 +418,6 @@ test.describe('Conversation messages deep — message DTO completeness + id prov
                     parts,
                     model: 'gpt-4o-mini',
                     usage,
-                    bogusField: 'should be stripped',
                 },
             ],
         });
@@ -412,9 +432,8 @@ test.describe('Conversation messages deep — message DTO completeness + id prov
         expect(msg?.id, 'server id is present').toBeTruthy();
         expect(msg?.conversationId, 'message points back at its conversation').toBe(conv.id);
 
-        // The unknown field never round-trips (only modeled columns persist).
+        // The client-supplied id never round-trips (server assigns its own).
         const asRecord = msg as unknown as Record<string, unknown>;
-        expect('bogusField' in asRecord, 'unknown key stripped from the persisted DTO').toBe(false);
 
         // The modeled optional columns round-trip verbatim.
         expect(msg?.parts, 'parts round-trip').toEqual(parts);


### PR DESCRIPTION
## Summary

`POST /api/conversations/:id/messages` took a plain `{ messages: AIMessage[] }` with **no class-validator DTO**, so the global ValidationPipe couldn't police it. Found by the unmapped-500 hunt — every malformed body crashed the handler mid-loop (TypeError → unmapped **500**), and several invalid shapes were silently **accepted and persisted**. Because the batch isn't transaction-wrapped, a value that threw only after a string-coercion+insert left a **partial row** behind. Every authenticated user could crash (or pollute) their own conversation.

| Body | Before | After |
|---|---|---|
| `{}` / `{messages:null\|"hi"\|123\|{}}` / `[null]` / `[{}]` | 500 | **400** |
| `[{role:"user",content:42}]` | 500 + partial row leak | **400, no leak** |
| `[{role:99\|"wizard",content:"x"}]` | **201, stored verbatim** | **400** |
| `parts:"x"` / `usage:"x"` (wrong-typed nested) | **201, stored** | **400** |
| valid message / empty content / empty-array no-op / 500k content | 201 | 201 (unchanged) |

## Fix

Add `AppendMessagesDto` / `AppendMessageDto` — `role` is `@IsIn`-enum'd, `content` `@IsString`, the array `@ValidateNested` + `@Type` + `@ArrayMaxSize`. The global pipe (whitelist + forbidNonWhitelisted + transform) returns a clean **400 before the handler**, so nothing partial can leak. Fields mirror exactly what the web BFF serialises (`apps/web/src/lib/ai/persistence.ts`: `id, role, content, parts, model?, usage?`), so valid traffic is unaffected. No content length cap added (the JSON body-parser 413 already bounds it), preserving the accepted 500k-char case.

## EW-721 test maintenance (same change)

Two specs pinned the DTO-less behaviour. Their **tolerant `[400,422,500]` + zero-persist** tests pass unchanged (now always 400); the assertions that pinned the exact bug were flipped:
- `flow-conversation-messages-validation.spec.ts`: numeric-role 201→400; the "ownership before validation 404" test reframed to the real pipeline order (**auth 401 → body-validation 400 → ownership 404**, none leaking the thread).
- `flow-conversations-messages-deep.spec.ts`: arbitrary-role `"wizard"` 201→400 (empty-content-with-valid-role still 201); DTO-completeness test now asserts an unknown key is **rejected** (400) instead of stripped.

## Verification

Live at :3100 (all malformed → 400; all valid → 201). Controller unit spec (16) + the full conversation/chat e2e set green (the one streaming-UI failure was the documented workers=4 hydration-race flake — passes in isolation). API build + web tsc + root prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Conversation message submissions now require valid, predefined role values; requests with invalid roles are rejected with HTTP 400
  * Enhanced validation ensures message content conforms to defined structure and length constraints
  * Validation occurs before message processing, preventing partial or corrupted data persistence
  * Invalid request payloads are caught and rejected early, improving overall API robustness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->