### PR TITLE
fix(tasks): return 409/400 for duplicate + self sub-resource adds (unmapped 500s)

### DIFF
--- a/apps/web/e2e/flow-agent-runs-history.spec.ts
+++ b/apps/web/e2e/flow-agent-runs-history.spec.ts
@@ -333,15 +333,15 @@ test.describe('Agent task runs + history', () => {
         // raw `save()` with no pre-check or catch, so the driver's unique-constraint
         // error is unmapped and surfaces as a 500 (probed live: HTTP 500
         // {"statusCode":500,"message":"Internal server error"}). We exercise the
-        // duplicate path to confirm the edge is genuinely unique-constrained, but
-        // we only observe it — no clean 4xx exists today — and the durable
-        // assertion is that exactly ONE assignee row exists for the pair.
+        // duplicate path to confirm the edge is genuinely unique-constrained, and
+        // the durable assertion is that exactly ONE assignee row exists for the pair.
         const dupRes = await request.post(`${API_BASE}/api/tasks/${task.id}/assignees`, {
             headers: authedHeaders(token),
             data: { assigneeType: 'agent', assigneeId: agent.id },
         });
-        // Duplicate-assignee currently 500s server-side (unique-constraint, unmapped).
-        expect(dupRes.status()).toBe(500);
+        // Duplicate-assignee → 409 Conflict (unique-constraint, mapped from the
+        // previously-unmapped 500).
+        expect(dupRes.status()).toBe(409);
 
         // 2. The imperative dispatch: assign-task records a run for the pair.
         await assignTaskToAgent(request, token, agent.id, task.id);

--- a/apps/web/e2e/flow-notifications-per-event.spec.ts
+++ b/apps/web/e2e/flow-notifications-per-event.spec.ts
@@ -240,7 +240,7 @@ test.describe('Per-event notification production (REAL integration)', () => {
 
         // Re-issuing the SAME (taskId, event, actor) is dedup-collapsed at the
         // notification layer. The assignee row itself is UNIQUE — a duplicate
-        // POST /assignees 500s on uq_task_assignee BEFORE re-emitting — so we
+        // POST /assignees 409s on uq_task_assignee BEFORE re-emitting — so we
         // can't drive a second emit through the assignee path. Instead we assert
         // the existing dedup INVARIANT: only one task_assigned row exists for
         // this (task, actor), and a duplicate assignee write is rejected.

--- a/apps/web/e2e/flow-task-approvers-gate.spec.ts
+++ b/apps/web/e2e/flow-task-approvers-gate.spec.ts
@@ -41,7 +41,8 @@ import { createTaskViaAPI, transitionTaskViaAPI, createAgentViaAPI } from './hel
  *         "Invalid actor type" string, which the pipe never reaches).
  *       · approverType:'agent' with a non-owned/unknown agent id → 400
  *         "Agent <id> is not reachable for this user — cannot assign."
- *       · DUPLICATE (same taskId+type+id) → 500 (uq_task_approver unique idx).
+ *       · DUPLICATE (same taskId+type+id) → 409 (uq_task_approver unique idx,
+ *         mapped to a clean Conflict instead of an unmapped 500).
  *       · cross-user (stranger adds approver to my task) → 404
  *         "Task <id> not found." (no existence leak via 403).
  *       · adding an approver to an ALREADY-`done` task → 201 (still 'pending'),
@@ -387,7 +388,7 @@ test.describe('Task approver gate — requireAllApprovers on → done (API)', ()
         expect((await getTask(request, token, dependent.id)).status).toBe('done');
     });
 
-    test('approver lifecycle edges: no approve/remove endpoints, duplicate→500, bad actor→400, cross-user→404, add-on-done is non-retroactive', async ({
+    test('approver lifecycle edges: no approve/remove endpoints, duplicate→409, bad actor→400, cross-user→404, add-on-done is non-retroactive', async ({
         request,
     }) => {
         const u = await registerUserViaAPI(request);
@@ -430,12 +431,13 @@ test.describe('Task approver gate — requireAllApprovers on → done (API)', ()
         const approverId = (await first.json()).id;
         expect(approverId).toBeTruthy();
 
-        // (d) DUPLICATE add (same task+type+id) → 500 (uq_task_approver).
+        // (d) DUPLICATE add (same task+type+id) → 409 Conflict (uq_task_approver
+        // unique-violation, now mapped to a clean 409 instead of an unmapped 500).
         const dup = await rawAddApprover(request, token, task.id, {
             approverType: 'user',
             approverId: u.user.id,
         });
-        expect(dup.status(), `dup body=${await dup.text().catch(() => '')}`).toBe(500);
+        expect(dup.status(), `dup body=${await dup.text().catch(() => '')}`).toBe(409);
 
         // (e) There is NO approve endpoint and NO remove-approver endpoint —
         // document the real contract so the gate's permanence is explicit.

--- a/apps/web/e2e/flow-task-assignees-deep.spec.ts
+++ b/apps/web/e2e/flow-task-assignees-deep.spec.ts
@@ -15,7 +15,7 @@ import {
  * assignee↔agent-dispatch correlation. Deep companion to the shallow
  * `tasks-collaboration.spec.ts` (single human+agent 201 / stranger 404) and
  * `agent-task-assignment-flow.spec.ts` (single happy-path dispatch). None of
- * the existing specs exercise: the duplicate-500 + remove + re-add recovery
+ * the existing specs exercise: the duplicate-409 + remove + re-add recovery
  * loop, the polymorphic same-id-different-type rows, the full validation
  * matrix, remove idempotency / by-PK delete semantics, the activity-log audit
  * trail, or the assignee-independent dispatch path. This file does.
@@ -42,9 +42,10 @@ import {
  *       resolved scoped-to-caller, so cross-user assign reads as not-found,
  *       NOT 403).
  *     - DUPLICATE (same taskId+assigneeType+assigneeId while the row is LIVE)
- *       → 500 Internal server error (the `uq_task_assignee` unique index;
- *       the repo `save()`s with no pre-check). The same (type,id) pair on a
- *       DIFFERENT type is a DIFFERENT row (uq is the triple) → both 201.
+ *       → 409 Conflict (the `uq_task_assignee` unique-violation is now mapped
+ *       to a clean Conflict instead of an unmapped 500; the repo `save()`s with
+ *       no pre-check). The same (type,id) pair on a DIFFERENT type is a
+ *       DIFFERENT row (uq is the triple) → both 201.
  *
  *   DELETE /api/tasks/:id/assignees/:assigneeId
  *     → 200 { deleted:true } ONLY when a LIVE row with that PK exists UNDER the
@@ -64,7 +65,7 @@ import {
  *     therefore audited via GET /api/activity-log?taskId=<id> →
  *     { activities:[{ actionType:'task_assignee_added'|'task_assignee_removed',
  *       details:{ assigneeType, assigneeId }, … }] } (newest-first), AND via
- *     the duplicate-500 / re-add-201 behaviour which reveals whether a row is
+ *     the duplicate-409 / re-add-201 behaviour which reveals whether a row is
  *     currently live.
  *
  *   POST /api/agents/:id/assign-task { taskId } → dispatch. Independent of the
@@ -150,13 +151,13 @@ test.describe('Task assignees — deep integration', () => {
         expect(firstRow.assigneeType).toBe('user');
         expect(firstRow.assigneeId).toBe(A_UUID);
 
-        // Duplicate of the LIVE (taskId,user,A_UUID) triple → 500 (uq index;
+        // Duplicate of the LIVE (taskId,user,A_UUID) triple → 409 (uq index;
         // the repo save()s with no pre-check). Never assert it is a 4xx.
         const dup = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
             assigneeId: A_UUID,
         });
-        expect(dup.status(), `dup body=${await dup.text()}`).toBe(500);
+        expect(dup.status(), `dup body=${await dup.text()}`).toBe(409);
 
         // Remove the live row → idempotent 200 { deleted:true }.
         const removed = await deleteAssignee(request, token, task.id, firstRow.id);
@@ -174,12 +175,12 @@ test.describe('Task assignees — deep integration', () => {
         expect(reRow.assigneeId).toBe(A_UUID);
         expect(reRow.id).not.toBe(firstRow.id);
 
-        // And the recovered row is itself live again → a second duplicate 500s.
+        // And the recovered row is itself live again → a second duplicate 409s.
         const dup2 = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
             assigneeId: A_UUID,
         });
-        expect(dup2.status()).toBe(500);
+        expect(dup2.status()).toBe(409);
     });
 
     test('polymorphic assignee key: same uuid as both user and agent are distinct rows', async ({
@@ -218,20 +219,20 @@ test.describe('Task assignees — deep integration', () => {
         expect(userRow.id).not.toBe(agentRow.id);
 
         // Each (type,id) pair is independently unique: re-adding the agent-type
-        // 500s (live), but its user-type sibling is untouched and still live too.
+        // 409s (live), but its user-type sibling is untouched and still live too.
         const dupAgent = await postAssignee(request, token, task.id, {
             assigneeType: 'agent',
             assigneeId: agent.id,
         });
-        expect(dupAgent.status()).toBe(500);
+        expect(dupAgent.status()).toBe(409);
         const dupUser = await postAssignee(request, token, task.id, {
             assigneeType: 'user',
             assigneeId: agent.id,
         });
-        expect(dupUser.status()).toBe(500);
+        expect(dupUser.status()).toBe(409);
 
         // Removing ONLY the agent-type row frees just that pair: agent-type can
-        // be re-added (201) while the user-type duplicate still 500s.
+        // be re-added (201) while the user-type duplicate still 409s.
         const delAgent = await deleteAssignee(request, token, task.id, agentRow.id);
         expect(delAgent.status()).toBe(200);
         const reAddAgent = await postAssignee(request, token, task.id, {
@@ -243,7 +244,7 @@ test.describe('Task assignees — deep integration', () => {
             assigneeType: 'user',
             assigneeId: agent.id,
         });
-        expect(stillDupUser.status()).toBe(500);
+        expect(stillDupUser.status()).toBe(409);
     });
 
     test('multiple distinct assignees (users + agents) coexist; activity-log audits each add/remove', async ({
@@ -283,7 +284,7 @@ test.describe('Task assignees — deep integration', () => {
         const created = [u1.id, u2.id, ag1.id, ag2.id];
         expect(new Set(created).size, 'all four rows have distinct ids').toBe(4);
 
-        // All four are independently live: each duplicate 500s.
+        // All four are independently live: each duplicate 409s.
         for (const a of [
             { assigneeType: 'user' as const, assigneeId: A_UUID },
             { assigneeType: 'user' as const, assigneeId: B_UUID },
@@ -291,7 +292,7 @@ test.describe('Task assignees — deep integration', () => {
             { assigneeType: 'agent' as const, assigneeId: agent2.id },
         ]) {
             const dup = await postAssignee(request, token, task.id, a);
-            expect(dup.status(), `dup ${a.assigneeType}:${a.assigneeId}`).toBe(500);
+            expect(dup.status(), `dup ${a.assigneeType}:${a.assigneeId}`).toBe(409);
         }
 
         // Audit trail: the activity-log records one add per assignee. The
@@ -313,7 +314,7 @@ test.describe('Task assignees — deep integration', () => {
         }
 
         // Remove one agent from the crew → frees just that pair (re-addable),
-        // the other three remain live (still 500 on duplicate).
+        // the other three remain live (still 409 on duplicate).
         const delAg1 = await deleteAssignee(request, token, task.id, ag1.id);
         expect(delAg1.status()).toBe(200);
         const reAg1 = await postAssignee(request, token, task.id, {
@@ -325,7 +326,7 @@ test.describe('Task assignees — deep integration', () => {
             assigneeType: 'user',
             assigneeId: A_UUID,
         });
-        expect(stillLiveUserA.status(), 'untouched user A still live').toBe(500);
+        expect(stillLiveUserA.status(), 'untouched user A still live').toBe(409);
 
         // And the remove is audited too.
         const afterRemove = await taskActivity(request, token, task.id);
@@ -422,13 +423,13 @@ test.describe('Task assignees — deep integration', () => {
         // (taskId,id) key; 0 rows affected → NotFound, NOT an idempotent 200).
         const ghost = await deleteAssignee(request, token, taskA.id, C_UUID);
         expect(ghost.status(), `ghost delete=${await ghost.text()}`).toBe(404);
-        // A_UUID is still live on task A → duplicate add 500s (ghost delete
+        // A_UUID is still live on task A → duplicate add 409s (ghost delete
         // touched nothing).
         const stillLive = await postAssignee(request, token, taskA.id, {
             assigneeType: 'user',
             assigneeId: A_UUID,
         });
-        expect(stillLive.status(), 'A still live after ghost delete').toBe(500);
+        expect(stillLive.status(), 'A still live after ghost delete').toBe(409);
 
         // The :id is BOTH an ownership gate AND part of the delete key
         // (removeForTask deletes the (taskId,id) pair — IDOR hardening). So
@@ -439,13 +440,13 @@ test.describe('Task assignees — deep integration', () => {
             404,
         );
         // Proof the cross-task delete did NOT touch A's row: A_UUID is still
-        // live on task A, so a duplicate add still 500s.
+        // live on task A, so a duplicate add still 409s.
         const stillLiveAfterCross = await postAssignee(request, token, taskA.id, {
             assigneeType: 'user',
             assigneeId: A_UUID,
         });
         expect(stillLiveAfterCross.status(), 'A still live after cross-task delete attempt').toBe(
-            500,
+            409,
         );
 
         // A correct remove (right task + right id) succeeds → 200 { deleted:true }.

--- a/apps/web/e2e/flow-tasks-advanced-deep.spec.ts
+++ b/apps/web/e2e/flow-tasks-advanced-deep.spec.ts
@@ -64,7 +64,7 @@ import { createAgentViaAPI, createTaskViaAPI, transitionTaskViaAPI } from './hel
  *       · SELF relation (A→A) → 201 ALLOWED — there is NO self-guard here
  *         (deliberate contrast with the blocker's self-block 400).
  *       · UNIQUENESS is (taskId, relatedTaskId), KIND-AGNOSTIC + DIRECTIONAL:
- *         A→B related then A→B duplicates → 500 (same pair, any kind);
+ *         A→B related then A→B duplicates → 409 (same pair, any kind);
  *         BUT reverse B→A related → 201, and A→C related → 201.
  *       · cross-user (stranger on my task) → 404 ; no auth → 401.
  *       · no DELETE route: DELETE /api/tasks/:id/relations/:rid → 404.
@@ -190,7 +190,7 @@ test.describe('Task reviewers — add lifecycle (API)', () => {
         expect(fresh.status).toBe('backlog');
     });
 
-    test('reviewer validation + uniqueness: bad actor 400, unknown agent 400, missing id 400, duplicate 500; no approve/remove-reviewer route (404)', async ({
+    test('reviewer validation + uniqueness: bad actor 400, unknown agent 400, missing id 400, duplicate 409; no approve/remove-reviewer route (404)', async ({
         request,
     }) => {
         const u = await registerUserViaAPI(request);
@@ -231,7 +231,7 @@ test.describe('Task reviewers — add lifecycle (API)', () => {
             reviewerType: 'user',
             reviewerId: u.user.id,
         });
-        expect(dup.status(), `dup reviewer body=${await dup.text().catch(() => '')}`).toBe(500);
+        expect(dup.status(), `dup reviewer body=${await dup.text().catch(() => '')}`).toBe(409);
 
         // (e) There is NO approve route and NO remove-reviewer route — reviewers
         // are write-once + advisory on this build (no review-gate is wired).
@@ -286,13 +286,13 @@ test.describe('Task reviewers — add lifecycle (API)', () => {
         expect((await assignee.json()).assigneeId).toBe(u.user.id);
 
         // The duplicate guard is PER-ROLE: a second reviewer(user, same id) still
-        // 500s on the reviewer table even though approver/assignee rows exist for
+        // 409s on the reviewer table even though approver/assignee rows exist for
         // the same actor — the tables don't share a key.
         const dupReviewer = await addReviewer(request, token, task.id, {
             reviewerType: 'user',
             reviewerId: u.user.id,
         });
-        expect(dupReviewer.status(), 'reviewer dup is per-table, still 500').toBe(500);
+        expect(dupReviewer.status(), 'reviewer dup is per-table → 409 Conflict').toBe(409);
     });
 
     test('reviewer closure: cross-user add → 404 (no existence leak), no auth → 401, bad task uuid → 400', async ({
@@ -375,36 +375,30 @@ test.describe('Task relations — related / duplicates / follow-up edges (API)',
         expect((await followUp.json()).kind).toBe('follow-up');
     });
 
-    test('self-relation (A→A) is ALLOWED (201) — deliberate contrast with the blocker self-block 400', async ({
+    test('self-relation (A→A) is REJECTED (400) — now consistent with the blocker self-block guard', async ({
         request,
     }) => {
         const u = await registerUserViaAPI(request);
         const token = u.access_token;
         const a = await createTaskViaAPI(request, token, { title: uniq('Self rel') });
 
-        // Relations carry NO self-guard (unlike POST /blocks which 400s on
-        // self-block). A task may relate to itself.
+        // Relations now carry a self-guard (mirroring POST /blocks which 400s on
+        // self-block). A task may NOT relate to itself — the guard fires before
+        // any insert, so no self-relation row is ever created.
         const selfRel = await addRelation(request, token, a.id, {
             relatedTaskId: a.id,
             kind: 'related',
         });
         expect(selfRel.status(), `self-relation body=${await selfRel.text().catch(() => '')}`).toBe(
-            201,
+            400,
         );
-        const row = await selfRel.json();
-        expect(row.taskId).toBe(a.id);
-        expect(row.relatedTaskId).toBe(a.id);
-
-        // Cross-check the asymmetry: the SAME (taskId,relatedTaskId)=self pair is
-        // now unique-locked → a second self `related` add is a 500.
-        const selfDup = await addRelation(request, token, a.id, {
-            relatedTaskId: a.id,
-            kind: 'related',
-        });
-        expect(selfDup.status(), 'duplicate self-relation hits the unique index').toBe(500);
+        expect(
+            String((await selfRel.json()).message ?? ''),
+            'the 400 names the self-relation rejection',
+        ).toContain('itself');
     });
 
-    test('uniqueness is (taskId, relatedTaskId) — KIND-AGNOSTIC and DIRECTIONAL: same pair any kind → 500, reverse → 201, different target → 201', async ({
+    test('uniqueness is (taskId, relatedTaskId) — KIND-AGNOSTIC and DIRECTIONAL: same pair any kind → 409, reverse → 201, different target → 201', async ({
         request,
     }) => {
         const u = await registerUserViaAPI(request);
@@ -420,9 +414,10 @@ test.describe('Task relations — related / duplicates / follow-up edges (API)',
         });
         expect(first.status()).toBe(201);
 
-        // A→B again with a DIFFERENT kind → STILL 500: the unique key is the
+        // A→B again with a DIFFERENT kind → 409 Conflict: the unique key is the
         // (taskId, relatedTaskId) pair, NOT the kind. This is the load-bearing
-        // truth — a relation pair is single-valued regardless of edge type.
+        // truth — a relation pair is single-valued regardless of edge type. (The
+        // unique-violation is now mapped to a clean 409 instead of an unmapped 500.)
         const sameKindlessDup = await addRelation(request, token, a.id, {
             relatedTaskId: b.id,
             kind: 'duplicates',
@@ -430,7 +425,7 @@ test.describe('Task relations — related / duplicates / follow-up edges (API)',
         expect(
             sameKindlessDup.status(),
             `kind-agnostic dup body=${await sameKindlessDup.text().catch(() => '')}`,
-        ).toBe(500);
+        ).toBe(409);
 
         // REVERSE direction B→A is a DISTINCT pair → 201 (the key is ordered).
         const reverse = await addRelation(request, token, b.id, {

--- a/apps/web/e2e/flow-tasks-recurring-reviewers.spec.ts
+++ b/apps/web/e2e/flow-tasks-recurring-reviewers.spec.ts
@@ -12,7 +12,7 @@ import { createTaskViaAPI } from './helpers/agents-tasks';
  *   - `flow-tasks-advanced-deep.spec.ts` (Batch 5) OWNS the reviewer ADD
  *     lifecycle: the born-`pending` row shape, the OWNED-agent polymorphic
  *     reviewer, bad reviewerType→400, unknown-agent→400, missing-id→400,
- *     duplicate→500, the three-roles-coexist case, cross-user→404, and the
+ *     duplicate→409, the three-roles-coexist case, cross-user→404, and the
  *     "no GET-list / no DELETE-reviewer route (404)" facts. It does NOT touch
  *     RECURRING at all, nor the reviewer DTO WHITELIST strip, nor the reviewer
  *     bad-uuid / no-auth closure pair, nor recurring↔reviewer orthogonality.

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -350,6 +350,25 @@ export class TasksService {
 
     // ── Members ───────────────────────────────────────────────────
 
+    /**
+     * Wrap a sub-resource insert so a DB UNIQUE-violation surfaces as a clean
+     * 409 Conflict instead of an unmapped 500. Mirrors the inline guard that
+     * `addBlocker` / `addAttachment` already use — extracted so the assignee /
+     * reviewer / approver / relation adds (which previously 500'd on a duplicate)
+     * share one tested path.
+     */
+    private async insertOrConflict<T>(op: () => Promise<T>, conflictMessage: string): Promise<T> {
+        try {
+            return await op();
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (/unique|duplicate|UNIQUE/i.test(message)) {
+                throw new ConflictException(conflictMessage);
+            }
+            throw err;
+        }
+    }
+
     async addAssignee(
         userId: string,
         taskId: string,
@@ -359,7 +378,10 @@ export class TasksService {
         const task = await this.getOne(userId, taskId);
         // Review-fix I4: validate the actor exists / belongs to user.
         await this.assertActorIsValid(userId, assigneeType, assigneeId);
-        const row = await this.assignees.add(taskId, assigneeType, assigneeId);
+        const row = await this.insertOrConflict(
+            () => this.assignees.add(taskId, assigneeType, assigneeId),
+            `Task ${taskId} already has assignee ${assigneeId}.`,
+        );
         await this.logActivity({
             userId,
             taskId,
@@ -411,7 +433,10 @@ export class TasksService {
         await this.getOne(userId, taskId);
         // Review-fix I4: validate the actor exists / belongs to user.
         await this.assertActorIsValid(userId, reviewerType, reviewerId);
-        return this.reviewers.add(taskId, reviewerType, reviewerId);
+        return this.insertOrConflict(
+            () => this.reviewers.add(taskId, reviewerType, reviewerId),
+            `Task ${taskId} already has reviewer ${reviewerId}.`,
+        );
     }
 
     async addApprover(
@@ -423,7 +448,10 @@ export class TasksService {
         await this.getOne(userId, taskId);
         // Review-fix I4: validate the actor exists / belongs to user.
         await this.assertActorIsValid(userId, approverType, approverId);
-        return this.approvers.add(taskId, approverType, approverId);
+        return this.insertOrConflict(
+            () => this.approvers.add(taskId, approverType, approverId),
+            `Task ${taskId} already has approver ${approverId}.`,
+        );
     }
 
     async addBlocker(userId: string, taskId: string, blockedByTaskId: string) {
@@ -484,11 +512,21 @@ export class TasksService {
         kind: 'related' | 'duplicates' | 'follow-up',
     ) {
         await this.getOne(userId, taskId);
+        // A task cannot relate to itself (mirrors the addBlocker self-guard).
+        if (taskId === relatedTaskId) {
+            throw new BadRequestException('Task cannot relate to itself.');
+        }
         const related = await this.tasks.findByIdAndUser(relatedTaskId, userId);
         if (!related) {
             throw new BadRequestException(`Related Task ${relatedTaskId} not found.`);
         }
-        return this.relations.add(taskId, relatedTaskId, kind);
+        // The unique index is on (taskId, relatedTaskId) and EXCLUDES `kind`, so
+        // a second relation on the same ordered pair (even with a different kind)
+        // collides — surface that as 409, not an unmapped 500.
+        return this.insertOrConflict(
+            () => this.relations.add(taskId, relatedTaskId, kind),
+            `Task ${taskId} already has a relation to ${relatedTaskId}.`,
+        );
     }
 
     // ── Phase 13.5 — attachments ──────────────────────────────────


### PR DESCRIPTION
## Summary

Found by the unmapped-500 hunt. The task sub-resource add paths each hit a DB UNIQUE index, but only `addBlocker` / `addAttachment` caught the violation — `addAssignee`, `addReviewer`, `addApprover`, `addRelation` let the raw `QueryFailedError` bubble to an **unmapped 500**. And `addRelation` had no self-reference guard (unlike `addBlocker`'s self-block 400), so a task could relate to itself.

| Operation | Before | After |
|---|---|---|
| duplicate assignee / reviewer / approver | 500 | **409 Conflict** |
| duplicate relation (same pair, **any** kind) | 500 | **409** |
| self-relation (`relatedTaskId == :id`) | 201 | **400** "Task cannot relate to itself." |
| first add of any of these | 201 | 201 (unchanged) |

## Fix

Extract the unique-violation→409 guard `addBlocker` already used into a private `insertOrConflict()` helper, apply it to the four add paths, and add the self-relation guard mirroring `addBlocker`. The relations unique index is on `(taskId, relatedTaskId)` and **excludes** `kind`, so a second relation on the same ordered pair — even a different kind — correctly conflicts.

## EW-721 test maintenance (same change)

The duplicate-500 behaviour was pinned across many task specs (even used as a row-existence oracle). Flipped to 409/400 in: `flow-task-assignees-deep` (9 assertions + docs), `flow-tasks-advanced-deep` (reviewer dup ×2, kind-agnostic dup; **self-relation test rewritten** from "allowed 201" → "rejected 400"), `flow-task-approvers-gate` (dup approver + title + docblock), `flow-agent-runs-history` (dup assignee), and stale comments in `flow-tasks-recurring-reviewers` / `flow-notifications-per-event` (their assertions were already tolerant). The unrelated enqueue-without-Trigger-secret 500s were left untouched.

## Verification

Live at :3100 (all duplicates → 409, self-relation → 400, first adds → 201). 52 affected task tests green; agent + api build, web tsc, root prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Fixed error response handling: attempting to add duplicate assignments (assignees, reviewers, approvers, and task relations) now returns proper conflict messages instead of generic server errors
* Added validation to prevent tasks from being related to themselves

<!-- end of auto-generated comment: release notes by coderabbit.ai -->