### PR TITLE
fix(organizations): unmapped 500s on PATCH displayName:null + upgrade-from-account under sqlite

### DIFF
--- a/apps/api/src/organizations/dto/update-organization.dto.ts
+++ b/apps/api/src/organizations/dto/update-organization.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, Length } from 'class-validator';
+import { IsOptional, IsString, Length, ValidateIf } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
@@ -7,8 +7,18 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
  * field is optional; an empty body is a no-op.
  */
 export class UpdateOrganizationDto {
-    @ApiPropertyOptional({ description: 'Display name. 1-200 chars.', maxLength: 200 })
-    @IsOptional()
+    @ApiPropertyOptional({
+        description: 'Display name. 1-200 chars. Required — cannot be set to null.',
+        maxLength: 200,
+    })
+    // `displayName` maps to a NOT NULL column. `@IsOptional()` treats an
+    // explicit `null` like an omitted field (skips validation), so the null
+    // used to reach `repo.update()` and hit the DB constraint → unmapped 500.
+    // `@ValidateIf(o => o.displayName !== undefined)` keeps "omitted = no-op"
+    // but makes an explicit `null` fail `@IsString` → a clean 400. (legalName /
+    // countryCode are NULLABLE columns, so they keep `@IsOptional()` — an
+    // explicit null there is a valid "clear this field" operation.)
+    @ValidateIf((o) => o.displayName !== undefined)
     @IsString()
     @Length(1, 200)
     displayName?: string;

--- a/apps/api/src/organizations/organization.service.ts
+++ b/apps/api/src/organizations/organization.service.ts
@@ -749,6 +749,16 @@ export class OrganizationService {
                 // Non-Postgres adapter — ignore.
             }
 
+            // Emit driver-correct SQL. Postgres uses `$n` placeholders and the
+            // `UPDATE … FROM parent` join form; better-sqlite3 (the e2e in-memory
+            // + self-host driver) uses `?` placeholders and has NO `UPDATE … FROM`
+            // — it needs an `… WHERE fk IN (SELECT id FROM parent WHERE …)`
+            // subquery instead. The previously hard-coded Postgres-only SQL threw
+            // a syntax error under sqlite, 500-ing the whole upgrade on the single-
+            // org happy path. Mirrors the `isPostgres` branch `createOrganization`
+            // already uses for its tenantId backfill. Postgres behaviour unchanged.
+            const isPostgres = manager.connection?.options?.type === 'postgres';
+
             // Tier A: stamp BOTH tenantId AND organizationId on rows
             // owned by this user that haven't been pulled into an Org
             // yet. The WHERE filter is `organizationId IS NULL` (NOT
@@ -766,7 +776,9 @@ export class OrganizationService {
                 this.assertSafeSqlIdentifier(table);
                 this.assertSafeSqlIdentifier(userColumn);
                 const result = (await manager.query(
-                    `UPDATE "${table}" SET "tenantId" = $1, "organizationId" = $2 WHERE "${userColumn}" = $3 AND "organizationId" IS NULL`,
+                    isPostgres
+                        ? `UPDATE "${table}" SET "tenantId" = $1, "organizationId" = $2 WHERE "${userColumn}" = $3 AND "organizationId" IS NULL`
+                        : `UPDATE "${table}" SET "tenantId" = ?, "organizationId" = ? WHERE "${userColumn}" = ? AND "organizationId" IS NULL`,
                     [tenantId, newOrgId, userId],
                 )) as [unknown[], number] | { affected?: number } | undefined;
                 tierARowsUpdated += this.extractAffectedRowCount(result);
@@ -783,7 +795,9 @@ export class OrganizationService {
                 this.assertSafeSqlIdentifier(table);
                 this.assertSafeSqlIdentifier(userColumn);
                 const result = (await manager.query(
-                    `UPDATE "${table}" SET "tenantId" = $1 WHERE "${userColumn}" = $2 AND "tenantId" IS NULL`,
+                    isPostgres
+                        ? `UPDATE "${table}" SET "tenantId" = $1 WHERE "${userColumn}" = $2 AND "tenantId" IS NULL`
+                        : `UPDATE "${table}" SET "tenantId" = ? WHERE "${userColumn}" = ? AND "tenantId" IS NULL`,
                     [tenantId, userId],
                 )) as [unknown[], number] | { affected?: number } | undefined;
                 tierBRowsUpdated += this.extractAffectedRowCount(result);
@@ -801,7 +815,9 @@ export class OrganizationService {
                 this.assertSafeSqlIdentifier(table);
                 this.assertSafeSqlIdentifier(userColumn);
                 const result = (await manager.query(
-                    `UPDATE "${table}" SET "tenantId" = $1, "organizationId" = $2 WHERE "${userColumn}" = $3 AND "organizationId" IS NULL`,
+                    isPostgres
+                        ? `UPDATE "${table}" SET "tenantId" = $1, "organizationId" = $2 WHERE "${userColumn}" = $3 AND "organizationId" IS NULL`
+                        : `UPDATE "${table}" SET "tenantId" = ?, "organizationId" = ? WHERE "${userColumn}" = ? AND "organizationId" IS NULL`,
                     [tenantId, newOrgId, userId],
                 )) as [unknown[], number] | { affected?: number } | undefined;
                 tierCRowsUpdated += this.extractAffectedRowCount(result);
@@ -833,7 +849,9 @@ export class OrganizationService {
                 this.assertSafeSqlIdentifier(parentFkColumn);
                 this.assertSafeSqlIdentifier(parentUserColumn);
                 const result = (await manager.query(
-                    `UPDATE "${table}" SET "tenantId" = $1, "organizationId" = $2 FROM "${parentTable}" p WHERE "${table}"."${parentFkColumn}" = p."id" AND p."${parentUserColumn}" = $3 AND "${table}"."organizationId" IS NULL`,
+                    isPostgres
+                        ? `UPDATE "${table}" SET "tenantId" = $1, "organizationId" = $2 FROM "${parentTable}" p WHERE "${table}"."${parentFkColumn}" = p."id" AND p."${parentUserColumn}" = $3 AND "${table}"."organizationId" IS NULL`
+                        : `UPDATE "${table}" SET "tenantId" = ?, "organizationId" = ? WHERE "${parentFkColumn}" IN (SELECT "id" FROM "${parentTable}" WHERE "${parentUserColumn}" = ?) AND "organizationId" IS NULL`,
                     [tenantId, newOrgId, userId],
                 )) as [unknown[], number] | { affected?: number } | undefined;
                 tierCRowsUpdated += this.extractAffectedRowCount(result);
@@ -856,7 +874,9 @@ export class OrganizationService {
                 this.assertSafeSqlIdentifier(parentTable);
                 this.assertSafeSqlIdentifier(parentUserColumn);
                 const result = (await manager.query(
-                    `UPDATE "${table}" SET "tenantId" = $1, "organizationId" = $2 FROM "${parentTable}" p WHERE "${table}"."${fkColumn}" = p."id" AND p."${parentUserColumn}" = $3 AND "${table}"."organizationId" IS NULL`,
+                    isPostgres
+                        ? `UPDATE "${table}" SET "tenantId" = $1, "organizationId" = $2 FROM "${parentTable}" p WHERE "${table}"."${fkColumn}" = p."id" AND p."${parentUserColumn}" = $3 AND "${table}"."organizationId" IS NULL`
+                        : `UPDATE "${table}" SET "tenantId" = ?, "organizationId" = ? WHERE "${fkColumn}" IN (SELECT "id" FROM "${parentTable}" WHERE "${parentUserColumn}" = ?) AND "organizationId" IS NULL`,
                     [tenantId, newOrgId, userId],
                 )) as [unknown[], number] | { affected?: number } | undefined;
                 indirectRowsUpdated += this.extractAffectedRowCount(result);
@@ -875,7 +895,9 @@ export class OrganizationService {
                 this.assertSafeSqlIdentifier(parentTable);
                 this.assertSafeSqlIdentifier(parentUserColumn);
                 const result = (await manager.query(
-                    `UPDATE "${table}" SET "tenantId" = $1 FROM "${parentTable}" p WHERE "${table}"."${fkColumn}" = p."id" AND p."${parentUserColumn}" = $2 AND "${table}"."tenantId" IS NULL`,
+                    isPostgres
+                        ? `UPDATE "${table}" SET "tenantId" = $1 FROM "${parentTable}" p WHERE "${table}"."${fkColumn}" = p."id" AND p."${parentUserColumn}" = $2 AND "${table}"."tenantId" IS NULL`
+                        : `UPDATE "${table}" SET "tenantId" = ? WHERE "${fkColumn}" IN (SELECT "id" FROM "${parentTable}" WHERE "${parentUserColumn}" = ?) AND "tenantId" IS NULL`,
                     [tenantId, userId],
                 )) as [unknown[], number] | { affected?: number } | undefined;
                 indirectRowsUpdated += this.extractAffectedRowCount(result);

--- a/apps/web/e2e/flow-org-upgrade-from-account.spec.ts
+++ b/apps/web/e2e/flow-org-upgrade-from-account.spec.ts
@@ -47,14 +47,13 @@ import { createTaskViaAPI } from './helpers/agents-tasks';
  *      from tenantId:null to the new tenantId (organizationId STAYS null).
  *
  *  POST /api/organizations/:id/upgrade-from-account
- *    happy path (user has exactly ONE org, :id is that org) → **500** on the
- *      sqlite e2e DB. The Tier-C historical backfill uses Postgres-only
- *      `UPDATE … SET … FROM parent …` syntax (organization.service.ts ~L819/837/851)
- *      which better-sqlite3 rejects, so the whole transaction 500s. This is the
- *      degrade-on-sqlite-only-Postgres-path behaviour this file is themed around
- *      — we assert the TRUTHFUL 500 here (NOT a fictional success), and prove the
- *      data is left coherent (atomic rollback: org/task untouched). On Postgres
- *      (prod) this same call returns 200 UpgradeFromAccountResponse.
+ *    happy path (user has exactly ONE org, :id is that org) → **2xx** and the
+ *      pre-existing unscoped task/work are pulled INTO the org. The backfill SQL
+ *      is now driver-correct: under better-sqlite3 it uses `?` placeholders + an
+ *      `… WHERE fk IN (SELECT id FROM parent WHERE …)` subquery in place of the
+ *      Postgres-only `UPDATE … FROM parent …` join (organization.service.ts), so
+ *      it SUCCEEDS on sqlite exactly as on Postgres prod (it used to 500 here —
+ *      that was the bug, found by the unmapped-500 hunt and fixed in this change).
  *    two orgs → **409** { code:'UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS',
  *      message:'Upgrade is only available before creating a second Organization' }.
  *      The first-org guard fires BEFORE the backfill, so this 409 is reachable
@@ -69,13 +68,11 @@ import { createTaskViaAPI } from './helpers/agents-tasks';
  *      404 not-leak (same shape as unknown), because org.tenantId !== user.tenantId.
  *    no bearer → 401.
  *
- * ── ENVIRONMENT NOTE: because the upgrade happy-path is a Postgres-only feature
- *    that 500s under the CI sqlite driver, the "happy" flow below asserts the
- *    contract is REACHABLE-AND-COHERENT (a 5xx that rolls back cleanly) and
- *    tolerates a 2xx so the SAME spec stays green if it is ever run against a
- *    Postgres-backed stack. Every other flow asserts a deterministic
- *    sqlite-stable status (409/404/400/401/201) that does NOT depend on the
- *    Postgres path.
+ * ── ENVIRONMENT NOTE: the upgrade happy-path now runs end-to-end on BOTH the CI
+ *    sqlite driver and Postgres prod (the backfill SQL is driver-conditional), so
+ *    flow 5 asserts the real success contract (2xx + the task pulled into the
+ *    org). Every flow asserts a deterministic, driver-stable status
+ *    (2xx/409/404/400/401).
  *
  * Cross-spec isolation: every flow runs on a FRESH registerUserViaAPI() user
  * (Date.now()-unique) so the shared in-memory DB stays clean for sibling specs;
@@ -282,8 +279,8 @@ test.describe('Organization register-company — registered Company path mints t
     });
 });
 
-test.describe('Organization upgrade-from-account — first-org guard + sqlite-degraded migration', () => {
-    test('flow 4: the first-org guard 409s deterministically AFTER a second org exists (and never reaches the Postgres-only backfill)', async ({
+test.describe('Organization upgrade-from-account — first-org guard + driver-correct migration', () => {
+    test('flow 4: the first-org guard 409s deterministically AFTER a second org exists (and never reaches the backfill)', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -321,15 +318,15 @@ test.describe('Organization upgrade-from-account — first-org guard + sqlite-de
         expect(new Set(list.map((o) => o.tenantId)).size).toBe(1);
     });
 
-    test('flow 5: the happy upgrade path degrades to a clean 500 on the sqlite CI driver (Postgres-only UPDATE…FROM) and rolls back atomically — no partial migration', async ({
+    test('flow 5: the happy upgrade path SUCCEEDS under the sqlite CI driver (driver-correct backfill SQL) and pulls the pre-existing task into the org', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
         const token = user.access_token;
         const s = stamp();
 
-        // 1. Pre-existing Tier-A rows that an upgrade would migrate: a task + a
-        //    work. Born unscoped (no tenant yet).
+        // 1. Pre-existing Tier-A rows that an upgrade migrates: a task + a work.
+        //    Born unscoped (no tenant yet).
         const task = await createTaskViaAPI(request, token, { title: `Upgrade task ${s}` });
         const bornTask = await getTask(request, token, task.id);
         expect(bornTask.tenantId).toBeNull();
@@ -350,71 +347,36 @@ test.describe('Organization upgrade-from-account — first-org guard + sqlite-de
         expect(preUpgradeTask.tenantId, 'createOrg backfilled tenantId').toBe(org.tenantId);
         expect(preUpgradeTask.organizationId, 'but NOT yet pulled into the org').toBeNull();
 
-        // 3. Call upgrade-from-account. On the sqlite e2e DB this returns 500
-        //    because the Tier-C historical backfill uses Postgres-only
-        //    `UPDATE … FROM` syntax. We assert the TRUTHFUL contract:
-        //      - sqlite (CI): 500 with the generic error body, OR
-        //      - Postgres (prod): 200 UpgradeFromAccountResponse.
-        //    We do NOT assert success (that would be a fictional contract on CI),
-        //    and we do NOT assert a 4xx (it's not a client error — the guards all
-        //    passed; it's a driver-capability gap).
+        // 3. Call upgrade-from-account. The backfill SQL is now driver-correct:
+        //    under better-sqlite3 (CI) it uses `?` placeholders and an
+        //    `… WHERE fk IN (SELECT id FROM parent WHERE …)` subquery in place of
+        //    the Postgres-only `UPDATE … FROM` join — so it SUCCEEDS on the sqlite
+        //    DB exactly as it does on Postgres prod (it used to 500 here).
         const res = await upgradeRaw(request, token, org.id);
-        const status = res.status();
-        // Read the body ONCE — Playwright's APIResponse body is single-consume
-        // (no Fetch-style .clone()); both the assert message and the branch
-        // parsing below reuse this text.
         const bodyText = await res.text().catch(() => '');
-        expect([200, 500], `upgrade returned ${status} body=${bodyText}`).toContain(status);
+        expect([200, 201], `upgrade returned ${res.status()} body=${bodyText}`).toContain(
+            res.status(),
+        );
 
-        const parsed = ((): Record<string, unknown> => {
-            try {
-                return JSON.parse(bodyText) as Record<string, unknown>;
-            } catch {
-                return {};
-            }
-        })();
+        const body = JSON.parse(bodyText) as {
+            organizationId?: string;
+            tenantId?: string;
+            tierARowsUpdated?: number;
+        };
+        expect(body.organizationId).toBe(org.id);
+        expect(body.tenantId).toBe(org.tenantId);
+        expect(typeof body.tierARowsUpdated).toBe('number');
 
-        if (status === 500) {
-            // Degraded path: generic 5xx envelope, never a stack-trace leak.
-            const body = parsed;
-            expect((body as { statusCode?: number }).statusCode ?? 500).toBe(500);
-            const msg = String((body as { message?: unknown }).message ?? '');
-            // Truthful, non-leaky message (no SQL / no internal table names).
-            expect(msg.toLowerCase()).toContain('internal server error');
-            expect(msg).not.toMatch(/UPDATE\s|tenantId\s*=|organizationId\s*=/i);
+        // The task is now pulled INTO the org (organizationId stamped) while its
+        // tenantId is unchanged — the migration ran end-to-end under sqlite.
+        const afterTask = await getTask(request, token, task.id);
+        expect(afterTask.organizationId, 'upgrade pulled the task into the org').toBe(org.id);
+        expect(afterTask.tenantId, 'tenantId unchanged by the upgrade').toBe(org.tenantId);
 
-            // ATOMIC ROLLBACK: the failed upgrade left NOTHING half-migrated.
-            // The task's organizationId is STILL null (it was never pulled in),
-            // and its tenantId is unchanged. The whole txn rolled back.
-            const afterTask = await getTask(request, token, task.id);
-            expect(
-                afterTask.organizationId,
-                'failed upgrade must not partially stamp orgId',
-            ).toBeNull();
-            expect(afterTask.tenantId, 'tenantId is untouched by the rolled-back upgrade').toBe(
-                org.tenantId,
-            );
-
-            // The org itself is intact and the user still has exactly one org —
-            // the failure did not corrupt the tenant/org topology.
-            const list = await listOrganizationsViaAPI(request, token);
-            expect(list.map((o) => o.id)).toContain(org.id);
-            expect(list.length).toBe(1);
-        } else {
-            // Postgres path (kept so this spec stays green on a PG-backed stack):
-            // the migration pulls the task INTO the org. Reuse `parsed` — the
-            // single-consume body was already read into `bodyText` above.
-            const body = parsed as {
-                organizationId?: string;
-                tenantId?: string;
-                tierARowsUpdated?: number;
-            };
-            expect(body.organizationId).toBe(org.id);
-            expect(body.tenantId).toBe(org.tenantId);
-            expect(typeof body.tierARowsUpdated).toBe('number');
-            const afterTask = await getTask(request, token, task.id);
-            expect(afterTask.organizationId).toBe(org.id);
-        }
+        // The user still has exactly one org — topology intact.
+        const list = await listOrganizationsViaAPI(request, token);
+        expect(list.map((o) => o.id)).toContain(org.id);
+        expect(list.length).toBe(1);
     });
 
     test('flow 6: upgrade error surface — non-tenant user 409, cross-tenant 404 (not-leak), unknown uuid 404, non-uuid 400, unauth 401', async ({


### PR DESCRIPTION
## Summary

Two unmapped 500s from the unmapped-500 hunt, both in `apps/api/src/organizations` (triaged chips `task_11832bcf` + `task_e70e607e`).

### 1. `PATCH /api/organizations/:id { "displayName": null }` → 500
`UpdateOrganizationDto.displayName` was `@IsOptional()`, which treats an explicit `null` like an omitted field (skips validation), so the null reached `repo.update()` and violated the NOT NULL `displayName` column. **Fix:** `@ValidateIf(o => o.displayName !== undefined)` — omitted stays a no-op, but explicit null fails `@IsString` → clean **400**. `legalName`/`countryCode` keep `@IsOptional()` (nullable columns — null is a valid "clear").

### 2. `POST /api/organizations/:id/upgrade-from-account` → 500 (sqlite, single-org happy path)
The Tier-A/B/C backfill used hardcoded Postgres `$n` placeholders **and** Postgres-only `UPDATE … FROM parent` join syntax, which better-sqlite3 rejects → the whole transaction 500s. The sibling `createOrganization` was already fixed for this with an `isPostgres` branch; `upgradeFromAccount` never got it. **Fix:** drive every backfill query off `isPostgres` — `?` placeholders + an `… WHERE fk IN (SELECT id FROM parent WHERE …)` subquery (semantically identical, parent id is a PK) in place of `UPDATE … FROM`. **Postgres unchanged.**

## Verification

Live at :3100: `displayName:null` → 400, `legalName:null` → 200, `displayName:"x"` → 200; upgrade-from-account on a fresh single-org user with a pre-existing task → **2xx and the task is pulled INTO the org** (organizationId stamped, tenantId unchanged) — the migration runs end-to-end under sqlite.

## EW-721 test maintenance

`flow-org-upgrade-from-account.spec.ts` flow 5 pinned the sqlite 500 as the "TRUTHFUL" contract — **rewritten** to assert the real success migration (+ docblock/describe-title). `organization.service` unit spec (28) green (its ` FROM "` categorization still holds — the sqlite subquery also contains it); broader org e2e (43) + the upgrade spec (7) green; api build, web tsc, root prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Organization upgrade feature now works correctly on all supported database systems, resolving previous failures on non-Postgres environments
  * Improved API validation error messages for organization data updates, providing clearer feedback when invalid values are submitted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->