### PR TITLE
fix(account-sync): throw HttpExceptions for sync preconditions (unmapped 500 → 4xx)

### DIFF
--- a/apps/web/e2e/flow-account-sync-lifecycle.spec.ts
+++ b/apps/web/e2e/flow-account-sync-lifecycle.spec.ts
@@ -28,16 +28,16 @@ import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
  *         account is still 200, and status stays { configured:false } after.
  *   - POST /api/account/sync/configure { createNew:true } | { repoFullName }
  *       — `ensureGitHubOAuth` runs FIRST (before any repoFullName format check),
- *         so with NO connected GitHub OAuth it throws a plain Error
- *         ('GitHub OAuth not connected…'). The plain Error has no Nest HTTP
- *         mapping → 500 { statusCode: 500, message: 'Internal server error' }.
+ *         so with NO connected GitHub OAuth it throws a ConflictException
+ *         → 409 { statusCode:409, error:'Conflict', message:'GitHub OAuth not
+ *         connected. Please connect your GitHub account first.' }.
  *         (Empty body, createNew, well-formed repoFullName, AND a malformed
- *         single-segment repoFullName all 500 identically — the OAuth gate
+ *         single-segment repoFullName all 409 identically — the OAuth gate
  *         short-circuits before the body is ever inspected. PROBED.)
  *   - POST /api/account/sync/push | /pull | /pull/apply
- *       — each first loads the sync config; an unconfigured account throws a plain
- *         Error ('Sync not configured…'/'Sync not configured') → 500 with the SAME
- *         generic { statusCode:500, message:'Internal server error' } envelope.
+ *       — each first loads the sync config; an unconfigured account throws a
+ *         ConflictException → 409 { statusCode:409, error:'Conflict',
+ *         message:'Sync not configured. Please configure a repository first.' }.
  *         (The toggle body — includeSecrets/includeAgents/… on push, resolutions[]
  *         on pull/apply — never matters keyless: the not-configured gate precedes
  *         it. PROBED.)

--- a/apps/web/e2e/flow-settings-data-privacy.spec.ts
+++ b/apps/web/e2e/flow-settings-data-privacy.spec.ts
@@ -27,11 +27,11 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  * ─── PROBED LIVE CONTRACT (127.0.0.1:3100, throwaway users) ───────────────
  *   GET  /api/account/sync/status            → 200 { configured:false, hasOAuth:false }
  *                                               (fresh user; never 5xx)
- *   POST /api/account/sync/configure {createNew:true}        → 500 (no GitHub OAuth → service throws)
- *   POST /api/account/sync/configure {repoFullName:"o/r"}    → 500 (no GitHub OAuth)
- *   POST /api/account/sync/configure {}                      → 500 (OAuth check fires first)
- *   POST /api/account/sync/push {includeSecrets:false}       → 500 (not configured AND no OAuth)
- *   POST /api/account/sync/pull  {}                          → 500 (not configured AND no OAuth)
+ *   POST /api/account/sync/configure {createNew:true}        → 409 (no GitHub OAuth → ConflictException)
+ *   POST /api/account/sync/configure {repoFullName:"o/r"}    → 409 (no GitHub OAuth)
+ *   POST /api/account/sync/configure {}                      → 409 (OAuth check fires first)
+ *   POST /api/account/sync/push {includeSecrets:false}       → 409 (not configured)
+ *   POST /api/account/sync/pull  {}                          → 409 (not configured)
  *   DELETE /api/account/sync                                 → 200 { status:'success' } (idempotent)
  *   GET  /api/account/export                 → 200 JSON, version:1,
  *                                               Content-Disposition: attachment; filename="account-export.json"

--- a/packages/agent/src/account-transfer/github-sync.service.ts
+++ b/packages/agent/src/account-transfer/github-sync.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable, Logger } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 import { GitFacadeService } from '../facades/git.facade';
@@ -95,7 +95,7 @@ export class GitHubSyncService {
                 // Verify it's private
                 const repo = await this.gitFacade.getRepository(repoOwner, repoName, gitOptions);
                 if (repo && !repo.isPrivate) {
-                    throw new Error(
+                    throw new BadRequestException(
                         'Repository must be private. Please make it private or choose a different repository.',
                     );
                 }
@@ -103,7 +103,9 @@ export class GitHubSyncService {
         } else if (dto.repoFullName) {
             const parts = dto.repoFullName.split('/');
             if (parts.length !== 2) {
-                throw new Error('Invalid repository name. Expected format: owner/repo');
+                throw new BadRequestException(
+                    'Invalid repository name. Expected format: owner/repo',
+                );
             }
             repoOwner = parts[0];
             repoName = parts[1];
@@ -115,7 +117,7 @@ export class GitHubSyncService {
             // those characters reach the git facade's URL builder.
             const repoCoordPattern = /^[A-Za-z0-9._-]+$/;
             if (!repoCoordPattern.test(repoOwner) || !repoCoordPattern.test(repoName)) {
-                throw new Error(
+                throw new BadRequestException(
                     'Invalid repository name. Owner and repo may only contain letters, digits, dot, underscore, and hyphen.',
                 );
             }
@@ -142,7 +144,9 @@ export class GitHubSyncService {
             // configure sync against this repo".
             const repo = await this.gitFacade.getRepository(repoOwner, repoName, gitOptions);
             if (!repo) {
-                throw new Error(`Repository "${dto.repoFullName}" not found or inaccessible`);
+                throw new BadRequestException(
+                    `Repository "${dto.repoFullName}" not found or inaccessible`,
+                );
             }
             if (!ownsRepo) {
                 // Org repo path — log it so audits can see who's pointing
@@ -152,12 +156,12 @@ export class GitHubSyncService {
                 );
             }
             if (!repo.isPrivate) {
-                throw new Error(
+                throw new BadRequestException(
                     'Repository must be private. Syncing to public repositories is not allowed for security reasons.',
                 );
             }
         } else {
-            throw new Error('Either createNew or repoFullName must be provided');
+            throw new BadRequestException('Either createNew or repoFullName must be provided');
         }
 
         await this.syncConfigRepository.upsert(userId, {
@@ -172,7 +176,9 @@ export class GitHubSyncService {
     async pushToGitHub(userId: string, options: SyncPushOptions = {}): Promise<void> {
         const config = await this.syncConfigRepository.findByUser(userId);
         if (!config) {
-            throw new Error('Sync not configured. Please configure a repository first.');
+            throw new ConflictException(
+                'Sync not configured. Please configure a repository first.',
+            );
         }
 
         const gitOptions = { providerId: PROVIDER_ID, userId };
@@ -231,7 +237,9 @@ export class GitHubSyncService {
     async pullFromGitHub(userId: string): Promise<ImportPreview> {
         const config = await this.syncConfigRepository.findByUser(userId);
         if (!config) {
-            throw new Error('Sync not configured. Please configure a repository first.');
+            throw new ConflictException(
+                'Sync not configured. Please configure a repository first.',
+            );
         }
 
         const gitOptions = { providerId: PROVIDER_ID, userId };
@@ -278,7 +286,9 @@ export class GitHubSyncService {
     async applyPull(userId: string, resolutions: ConflictResolution[]): Promise<ImportResult> {
         const config = await this.syncConfigRepository.findByUser(userId);
         if (!config) {
-            throw new Error('Sync not configured');
+            throw new ConflictException(
+                'Sync not configured. Please configure a repository first.',
+            );
         }
 
         const gitOptions = { providerId: PROVIDER_ID, userId };
@@ -714,7 +724,7 @@ export class GitHubSyncService {
     private async ensureGitHubOAuth(userId: string): Promise<void> {
         const hasOAuth = await this.hasGitHubOAuth(userId);
         if (!hasOAuth) {
-            throw new Error(
+            throw new ConflictException(
                 'GitHub OAuth not connected. Please connect your GitHub account first.',
             );
         }


### PR DESCRIPTION
## Summary

`GitHubSyncService` threw plain `Error`s for every configure/push/pull precondition, which Nest's default filter maps to an unmapped **500**. Found by the unmapped-500 hunt (chip `task_2faacb03`):

```
POST /api/account/sync/configure (no GitHub OAuth)   -> 500  -> 409
POST /api/account/sync/push|pull|pull/apply (no cfg) -> 500  -> 409
```

Same plain-`Error`-from-service class as the already-merged `assertNoSecrets` / content-policy fixes.

## Mapping

- **input-validation** throws (bad repo name, non-private repo, must-provide-one) → `BadRequestException` (400).
- **"GitHub OAuth not connected"** + **"Sync not configured"** preconditions → `ConflictException` (409) — a "do X first" state conflict, matching the `OrganizationService` "create an Organization first" precedent.

## Verification

Live at :3100 (keyless): configure / push / pull / pull-apply all **409** with clear actionable messages; anon still 401.

## EW-721

The two account-sync e2e specs already assert tolerantly (`toBeGreaterThanOrEqual(400)` / `.ok() === false`), so 500→4xx keeps them green — only their **docblocks** were updated 500→409. `github-sync.service` unit spec (39) green (`HttpException` preserves the message its `.rejects.toThrow(/…/)` asserts). 24 account-sync e2e + web tsc + root prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for GitHub account synchronization configuration endpoints. When GitHub OAuth is not connected, the API now returns a more specific `409 Conflict` status code instead of a generic server error response, providing clearer feedback for failed sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->