### PR TITLE
fix(agents): validate parent existence + ownership on scoped Agent create (IDOR)

### DIFF
--- a/apps/web/e2e/flow-agent-scoping-matrix-deep.spec.ts
+++ b/apps/web/e2e/flow-agent-scoping-matrix-deep.spec.ts
@@ -110,6 +110,69 @@ async function listAgents(
 }
 
 test.describe('Agent scoping matrix — deep cascade rules', () => {
+    test('SECURITY: a scoped Agent create validates parent existence + ownership — ghost or foreign work/mission/idea → 404 (no dangling-FK / IDOR)', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const token = owner.access_token;
+        const stranger = await registerUserViaAPI(request);
+        const s = stamp();
+
+        // Owner's REAL parents (one of each kind).
+        const missionId = await createMission(request, token, `Sec Mission ${s}`);
+        const ideaId = await createIdea(request, token, `Sec Idea ${s} — a directory of tools`);
+        const { id: workId } = await createWorkViaAPI(request, token, {
+            name: `Sec Work ${s}`,
+            slug: `sec-work-${s}`,
+        });
+
+        const rawCreate = (auth: string, body: Record<string, unknown>) =>
+            request.post(`${API_BASE}/api/agents`, { headers: authedHeaders(auth), data: body });
+
+        // GHOST parent (well-formed but non-existent uuid) → 404 for every scope.
+        // `validateScopeOwnership` (cardinality) passes; the new parent-existence
+        // guard then 404s before any row is created. This used to be a 201 that
+        // persisted an Agent bound to a non-existent parent (dangling FK / IDOR).
+        for (const [scope, key] of [
+            ['work', 'workId'],
+            ['mission', 'missionId'],
+            ['idea', 'ideaId'],
+        ] as const) {
+            const ghost = await rawCreate(token, {
+                scope,
+                name: `Ghost ${scope} ${s}`,
+                [key]: UNKNOWN_UUID,
+            });
+            expect(ghost.status(), `ghost ${scope} parent → 404`).toBe(404);
+        }
+
+        // FOREIGN parent: the stranger references the OWNER's REAL ids → 404,
+        // indistinguishable from a ghost (the parent is resolved scoped-to-caller,
+        // so it reads as not-found — no existence leak, no cross-user binding).
+        const strangerToken = stranger.access_token;
+        for (const [scope, key, id] of [
+            ['work', 'workId', workId],
+            ['mission', 'missionId', missionId],
+            ['idea', 'ideaId', ideaId],
+        ] as const) {
+            const foreign = await rawCreate(strangerToken, {
+                scope,
+                name: `Foreign ${scope} ${s}`,
+                [key]: id,
+            });
+            expect(foreign.status(), `foreign ${scope} parent → 404 (ownership)`).toBe(404);
+        }
+
+        // OWNED parent → 201: the guard never blocks a legitimate scoped create.
+        const okAgent = await createAgentViaAPI(request, token, {
+            scope: 'work',
+            name: `Owned Work Agent ${s}`,
+            workId,
+        });
+        expect(okAgent.id).toMatch(UUID_RE);
+        expect(okAgent.scope).toBe('work');
+    });
+
     test('parent-id filter ALONE isolates by parent; cross-parent ANDs always return empty', async ({
         request,
     }) => {

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -2,6 +2,9 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Agent } from '../entities/agent.entity';
 import { AgentAttachment } from '../entities/agent-attachment.entity';
+import { Work } from '../entities/work.entity';
+import { Mission } from '../entities/mission.entity';
+import { WorkProposal } from '../entities/work-proposal.entity';
 import { AgentRun } from '../entities/agent-run.entity';
 import { AgentRunLog } from '../entities/agent-run-log.entity';
 import { AgentBudget } from '../entities/agent-budget.entity';
@@ -42,6 +45,11 @@ import { FacadesModule } from '../facades/facades.module';
             AgentRunLog,
             AgentBudget,
             AgentMembership,
+            // Parent-existence validation for scoped Agents (IDOR fix): raw
+            // repositories for the work/mission/idea a scoped Agent references.
+            Work,
+            Mission,
+            WorkProposal,
         ]),
         ActivityLogModule,
         // Phase 10 — AgentRunService resolves active skills via

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -18,6 +18,11 @@ import {
     type AgentTarget,
 } from '../entities/agent.entity';
 import { AgentAttachment } from '../entities/agent-attachment.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Work } from '../entities/work.entity';
+import { Mission } from '../entities/mission.entity';
+import { WorkProposal } from '../entities/work-proposal.entity';
 import { AgentRepository, type ListAgentsFilter } from '../database/repositories/agent.repository';
 import { AgentMembershipRepository } from '../database/repositories/agent-membership.repository';
 import { AgentBudgetRepository } from '../database/repositories/agent-budget.repository';
@@ -131,6 +136,21 @@ export class AgentsService {
         // AgentsModule.
         @Optional()
         private readonly agentAttachments?: AgentAttachmentRepository,
+        // Parent-existence validation for scoped Agents (work/mission/idea).
+        // Raw TypeORM repositories (not the custom repos) so we only need the
+        // three entities in `forFeature` — no cross-module/custom-repo deps.
+        // `@Optional()` keeps the hand-rolled unit-test surface (which never
+        // wires these) working; production + e2e DI provide them so the check
+        // runs for every real create.
+        @Optional()
+        @InjectRepository(Work)
+        private readonly workRepo?: Repository<Work>,
+        @Optional()
+        @InjectRepository(Mission)
+        private readonly missionRepo?: Repository<Mission>,
+        @Optional()
+        @InjectRepository(WorkProposal)
+        private readonly ideaRepo?: Repository<WorkProposal>,
     ) {}
 
     async list(
@@ -151,6 +171,7 @@ export class AgentsService {
 
     async create(userId: string, input: CreateAgentInput): Promise<AgentDto> {
         this.validateScopeOwnership(input);
+        await this.assertScopeParentExists(userId, input);
 
         const slug = slugifyText(input.name);
         // `slugifyText('---')` returns `-` (dash), not the empty string,
@@ -515,6 +536,50 @@ export class AgentsService {
                 break;
             default:
                 throw new BadRequestException(`Unknown scope: ${input.scope}`);
+        }
+    }
+
+    /**
+     * Security (IDOR / dangling-FK): `validateScopeOwnership` only checks scope
+     * CARDINALITY — it never confirmed the referenced parent actually exists or
+     * belongs to the caller, so a work/mission/idea-scoped Agent could be created
+     * against a ghost or another user's id (201). Look the parent up scoped to the
+     * caller and 404 (not 403 — don't leak existence) when it's missing. Resolved
+     * via raw `findOne({ where: { id, userId } })` so a cross-user parent reads as
+     * not-found, matching the rest of the Agents surface.
+     */
+    private async assertScopeParentExists(
+        userId: string,
+        input: Pick<CreateAgentInput, 'scope' | 'missionId' | 'ideaId' | 'workId'>,
+    ): Promise<void> {
+        switch (input.scope) {
+            case AgentScope.WORK: {
+                if (!input.workId || !this.workRepo) return;
+                const work = await this.workRepo.findOne({
+                    where: { id: input.workId, userId },
+                });
+                if (!work) throw new NotFoundException(`Work ${input.workId} not found.`);
+                break;
+            }
+            case AgentScope.MISSION: {
+                if (!input.missionId || !this.missionRepo) return;
+                const mission = await this.missionRepo.findOne({
+                    where: { id: input.missionId, userId },
+                });
+                if (!mission) throw new NotFoundException(`Mission ${input.missionId} not found.`);
+                break;
+            }
+            case AgentScope.IDEA: {
+                if (!input.ideaId || !this.ideaRepo) return;
+                const idea = await this.ideaRepo.findOne({
+                    where: { id: input.ideaId, userId },
+                });
+                if (!idea) throw new NotFoundException(`Idea ${input.ideaId} not found.`);
+                break;
+            }
+            default:
+                // Tenant-scoped Agents have no parent row to validate.
+                break;
         }
     }
 


### PR DESCRIPTION
## Summary

Found by the unmapped-500 hunt (chip `task_ecd26cd1`). `POST /api/agents` for a work/mission/idea-scoped Agent only validated scope **cardinality** (`validateScopeOwnership` — exactly one parent id present) and never checked the referenced parent actually **exists** or **belongs to the caller**. So a scoped Agent could be created against a **ghost or another user's** parent id → 201, persisting an Agent bound to a non-existent / foreign Work/Mission/Idea (dangling FK + **IDOR**).

```
POST /api/agents {scope:'work',   workId:<ghost|foreign>}    -> 201  -> 404
POST /api/agents {scope:'mission', missionId:<ghost|foreign>} -> 201  -> 404
POST /api/agents {scope:'idea',   ideaId:<ghost|foreign>}    -> 201  -> 404
```

## Fix

`assertScopeParentExists(userId, input)` resolves the parent scoped to the caller (`findOne({ where: { id, userId } })`) and throws **NotFoundException** (404, not 403 — don't leak existence, matching the rest of the Agents surface) when it's missing/foreign. Runs after `validateScopeOwnership`, before any insert. Consistent with the sibling checks (`addAttachment` validates uploadId; agent-memory `ensureCanView`; the Idea-accept workId IDOR fix #1280).

**Wiring:** inject raw `Repository<Work|Mission|WorkProposal>` via `@InjectRepository` + `@Optional()` (hand-rolled unit tests that don't wire them still construct the service — the guard is skipped there; production + e2e DI provide them). Added the three entities to `AgentsModule`'s `forFeature` (no custom-repo deps → no circular-dep risk).

## Verification

Live at :3100: ghost + foreign work/mission/idea → **404**; owned parent → 201; tenant-scoped → 201; API boots cleanly. Pinned the contract with a **SECURITY regression test** in `flow-agent-scoping-matrix-deep.spec.ts` (ghost ×3 → 404, foreign ×3 → 404, owned → 201). `agents.service` unit (24) + the full agent e2e set (~96 across 14 specs) green — the guard never blocks a legitimate scoped create; **no EW-721 flips** needed (every existing scoped-agent spec already creates a real parent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation during agent creation to prevent using non-existent or inaccessible parent references across all scopes.

* **Tests**
  * Added end-to-end test verifying proper rejection of invalid parent IDs and successful creation with authorized references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->