### PR TITLE
feat(uploads): first-class user_uploads record + attachment upload-ownership validation

### DIFF
--- a/apps/api/src/agents/dto/agent.dto.ts
+++ b/apps/api/src/agents/dto/agent.dto.ts
@@ -10,6 +10,7 @@ import {
     IsOptional,
     IsString,
     IsUUID,
+    Matches,
     Max,
     MaxLength,
     Min,
@@ -339,7 +340,12 @@ export class AssignTaskToAgentDto {
  * raw inline `{ uploadId: string }` object with no decorators.
  */
 export class AddAgentAttachmentDto {
-    @ApiProperty()
-    @IsUUID()
+    // `uploadId` is the SHA-256 hex id returned by `POST /api/uploads/file`
+    // (NOT a UUID). The previous `@IsUUID()` rejected every real upload id and
+    // contradicted the service's own `SHA256_RE` guard, so agent attachments
+    // could never succeed. Align with the Mission / Idea attachment DTOs.
+    @ApiProperty({ pattern: '^[0-9a-fA-F]{64}$' })
+    @IsString()
+    @Matches(/^[0-9a-f]{64}$/i)
     uploadId: string;
 }

--- a/apps/api/src/migrations/1780600000000-CreateUserUploads.ts
+++ b/apps/api/src/migrations/1780600000000-CreateUserUploads.ts
@@ -1,0 +1,81 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Creates the `user_uploads` table — a first-class, ownable record of a file
+ * uploaded via `POST /api/uploads/{file,image}`.
+ *
+ * Plain uploads previously left no DB trace (bytes in a Storage plugin, the
+ * sha256 returned as the upload id), so an attachment's `uploadId` could not be
+ * validated against a real, caller-owned upload — letting a ghost/foreign id
+ * persist a dangling attachment edge (unmapped-500-hunt finding). This row makes
+ * the upload owned (`userId`, NULL = anonymous), keyed by `sha256`, and
+ * optionally associated with a work / mission / idea / tenant / org scope.
+ *
+ * Forward-only, idempotent (`ifNotExists`). The file bytes are unchanged; this
+ * is the metadata / ownership index only.
+ */
+export class CreateUserUploads1780600000000 implements MigrationInterface {
+    name = 'CreateUserUploads1780600000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: 'user_uploads',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid', isNullable: true },
+                    { name: 'sha256', type: 'varchar', length: '64' },
+                    { name: 'workId', type: 'uuid', isNullable: true },
+                    { name: 'missionId', type: 'uuid', isNullable: true },
+                    { name: 'ideaId', type: 'uuid', isNullable: true },
+                    { name: 'tenantId', type: 'uuid', isNullable: true },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    { name: 'storage_provider', type: 'varchar', length: '64' },
+                    { name: 'storage_path', type: 'varchar', length: '1024' },
+                    { name: 'original_filename', type: 'varchar', length: '512', isNullable: true },
+                    { name: 'mime_type', type: 'varchar', length: '128', isNullable: true },
+                    { name: 'file_size', type: 'bigint', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createForeignKey(
+            'user_uploads',
+            new TableForeignKey({
+                columnNames: ['userId'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+
+        await queryRunner.createIndex(
+            'user_uploads',
+            new TableIndex({
+                name: 'idx_user_uploads_user_sha',
+                columnNames: ['userId', 'sha256'],
+            }),
+        );
+
+        await queryRunner.createIndex(
+            'user_uploads',
+            new TableIndex({
+                name: 'idx_user_uploads_sha',
+                columnNames: ['sha256'],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable('user_uploads', true);
+    }
+}

--- a/apps/api/src/uploads/uploads.module.ts
+++ b/apps/api/src/uploads/uploads.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
-import { DatabaseModule } from '@ever-works/agent/database';
+import { DatabaseModule, UserUploadRepository } from '@ever-works/agent/database';
 import { FacadesModule } from '@ever-works/agent/facades';
 import { AuthModule } from '../auth/auth.module';
 import { UploadsController } from './uploads.controller';
-import { UploadsService, WORK_REPO_RESOLVER } from './uploads.service';
+import { UploadsService, WORK_REPO_RESOLVER, USER_UPLOAD_REPOSITORY } from './uploads.service';
 import { WorkRepoResolverService } from './work-repo-resolver.service';
 
 @Module({
@@ -26,6 +26,9 @@ import { WorkRepoResolverService } from './work-repo-resolver.service';
         UploadsService,
         WorkRepoResolverService,
         { provide: WORK_REPO_RESOLVER, useExisting: WorkRepoResolverService },
+        // Bind the upload-ownership repo (from DatabaseModule) to the Symbol token
+        // so UploadsService records every upload in `user_uploads`.
+        { provide: USER_UPLOAD_REPOSITORY, useExisting: UserUploadRepository },
     ],
     exports: [UploadsService],
 })

--- a/apps/api/src/uploads/uploads.service.ts
+++ b/apps/api/src/uploads/uploads.service.ts
@@ -10,7 +10,18 @@ import { createHash } from 'node:crypto';
 import { extname } from 'node:path';
 import type { IStoragePlugin } from '@ever-works/plugin';
 import type { WorkRepoResolver } from '@ever-works/github-storage-plugin';
+// Type-only import + Symbol token (mirrors WORK_REPO_RESOLVER below): pulling the
+// `@ever-works/agent/database` VALUE barrel into UploadsService would drag TypeORM
+// into the upload unit-test import graph (path-scurry-under-Jest crash). The
+// UploadsModule binds the token to the real repo via `useExisting`.
+import type { UserUploadRepository } from '@ever-works/agent/database';
 import { getActiveStorageBackend } from './storage-backend.factory';
+
+/**
+ * DI token for the optional `UserUploadRepository`. The UploadsModule provides
+ * this token via `{ provide: USER_UPLOAD_REPOSITORY, useExisting: ... }`.
+ */
+export const USER_UPLOAD_REPOSITORY = Symbol.for('ever-works:user-upload-repository');
 
 /**
  * DI token for the optional `WorkRepoResolver` (EW-644).
@@ -256,6 +267,14 @@ export class UploadsService {
         @Optional()
         @Inject(WORK_REPO_RESOLVER)
         private readonly workRepoResolver?: WorkRepoResolver,
+        // Ownership index for plain uploads. `@Optional()` so the unit tests
+        // that construct `new UploadsService(backend)` still work; in
+        // production / E2E the UploadsModule binds USER_UPLOAD_REPOSITORY to the
+        // real repo, so every upload is recorded and attachments can validate
+        // ownership.
+        @Optional()
+        @Inject(USER_UPLOAD_REPOSITORY)
+        private readonly userUploads?: UserUploadRepository,
     ) {
         this.maxSize = Number(process.env.UPLOADS_MAX_BYTES) || DEFAULT_MAX_SIZE;
         if (backend) {
@@ -275,6 +294,43 @@ export class UploadsService {
             );
         }
         return this.backendPromise;
+    }
+
+    /**
+     * Best-effort: index the upload's ownership (`userId`) + storage location in
+     * `user_uploads` so an attachment can later validate that its `uploadId`
+     * (the sha256) references a real, caller-owned upload. The bytes are already
+     * stored when this runs, so a failure here MUST NOT fail the upload — log
+     * and continue (deduped per `(userId, sha256)` in the repo).
+     */
+    private async recordUpload(input: {
+        userId: string;
+        sha256: string;
+        key: string;
+        originalFilename?: string;
+        mimeType: string;
+        fileSize: number;
+        workId?: string;
+    }): Promise<void> {
+        if (!this.userUploads) return;
+        try {
+            await this.userUploads.record({
+                userId: input.userId,
+                sha256: input.sha256,
+                workId: input.workId ?? null,
+                storageProvider: (process.env.STORAGE_BACKEND || 'local-fs').toLowerCase(),
+                storagePath: input.key,
+                originalFilename: input.originalFilename ?? null,
+                mimeType: input.mimeType,
+                fileSize: input.fileSize,
+            });
+        } catch (err) {
+            this.logger.warn(
+                `Failed to record upload ownership (sha256=${input.sha256.slice(0, 12)}…): ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+        }
     }
 
     /**
@@ -354,6 +410,16 @@ export class UploadsService {
             size: file.size,
             ownerId: userId,
             ...(workId ? { workId } : {}),
+        });
+
+        await this.recordUpload({
+            userId,
+            sha256: hash,
+            key,
+            originalFilename: file.originalname,
+            mimeType: sniffed.mime,
+            fileSize: file.size,
+            workId,
         });
 
         // Codex P1 finding on PR #890: returning the plugin's backend-native
@@ -486,6 +552,15 @@ export class UploadsService {
                 ownerId: userId,
                 ...(workId ? { workId } : {}),
             });
+            await this.recordUpload({
+                userId,
+                sha256: hash,
+                key,
+                originalFilename: file.originalname,
+                mimeType: declared,
+                fileSize: file.size,
+                workId,
+            });
             const url = workId
                 ? `/api/uploads/${encodeURIComponent(userId)}/${filename}?workId=${encodeURIComponent(workId)}`
                 : `/api/uploads/${encodeURIComponent(userId)}/${filename}`;
@@ -527,6 +602,15 @@ export class UploadsService {
                 size: file.size,
                 ownerId: userId,
                 ...(workId ? { workId } : {}),
+            });
+            await this.recordUpload({
+                userId,
+                sha256: hash,
+                key,
+                originalFilename: file.originalname,
+                mimeType: declared,
+                fileSize: file.size,
+                workId,
             });
             const url = workId
                 ? `/api/uploads/${encodeURIComponent(userId)}/${filename}?workId=${encodeURIComponent(workId)}`

--- a/apps/web/e2e/flow-mission-attachments.spec.ts
+++ b/apps/web/e2e/flow-mission-attachments.spec.ts
@@ -407,6 +407,41 @@ test.describe('FLOW: mission attachments — validation + ownership', () => {
         expect((await list.json()).message).toBe('Mission not found');
     });
 
+    test('upload-ownership: a well-formed uploadId the caller does NOT own → 404, even on their OWN mission (no dangling/foreign edge)', async ({
+        request,
+    }) => {
+        const alice = await registerUserViaAPI(request);
+        const bob = await registerUserViaAPI(request);
+
+        // Alice mints a real upload; Bob owns a mission of his own.
+        const aliceUpload = await mintUploadId(request, alice.access_token);
+        const bobMission = await createMission(request, bob.access_token, 'bob upload-own mission');
+
+        // Bob attaches ALICE's upload to BOB's own mission → 404: the uploadId
+        // does not reference an upload Bob owns (user_uploads is keyed by owner).
+        const foreign = await request.post(
+            `${API_BASE}/api/me/missions/${bobMission}/attachments`,
+            { headers: authedHeaders(bob.access_token), data: { uploadId: aliceUpload } },
+        );
+        expect(foreign.status(), `foreign upload body=${await foreign.text()}`).toBe(404);
+        expect(String((await foreign.json()).message)).toContain('Upload');
+
+        // A never-uploaded (ghost) hash on Bob's own mission → the same 404.
+        const ghost = await request.post(`${API_BASE}/api/me/missions/${bobMission}/attachments`, {
+            headers: authedHeaders(bob.access_token),
+            data: { uploadId: 'f'.repeat(64) },
+        });
+        expect(ghost.status()).toBe(404);
+
+        // Nothing was attached.
+        const list = await (
+            await request.get(`${API_BASE}/api/me/missions/${bobMission}/attachments`, {
+                headers: authedHeaders(bob.access_token),
+            })
+        ).json();
+        expect(list).toEqual([]);
+    });
+
     test('cross-user isolation: B cannot list/attach/delete on A’s mission -> 404 (opaque)', async ({
         request,
     }) => {

--- a/apps/web/e2e/flow-work-proposals-deep.spec.ts
+++ b/apps/web/e2e/flow-work-proposals-deep.spec.ts
@@ -83,6 +83,29 @@ function msgOf(body: { message?: unknown }): string {
     return Array.isArray(body?.message) ? body.message.join(' ') : String(body?.message);
 }
 
+/**
+ * Upload a tiny file via `POST /api/uploads/file` and return its content-addressed
+ * sha256 `id` — a REAL, caller-owned uploadId. Attachment-add now validates the
+ * uploadId against `user_uploads` (owned by the caller), so an arbitrary 64-hex
+ * value no longer lands an edge; mint a real one.
+ */
+async function mintUploadId(request: APIRequestContext, token: string): Promise<string> {
+    const res = await request.post(`${API_BASE}/api/uploads/file`, {
+        headers: authedHeaders(token),
+        multipart: {
+            file: {
+                name: `${uniq('idea-attach')}.md`,
+                mimeType: 'text/markdown',
+                buffer: Buffer.from(`# idea attachment ${uniq('body')}\n`),
+            },
+        },
+    });
+    expect(res.status(), `upload body=${await res.text()}`).toBe(201);
+    const id = (await res.json()).id as string;
+    expect(id, 'upload id is a sha256 hex').toMatch(/^[0-9a-f]{64}$/i);
+    return id;
+}
+
 interface IdeaRow {
     id: string;
     title: string;
@@ -403,10 +426,11 @@ test.describe('Work-Proposals — Idea attachments edge surface', () => {
         expect(empty.status()).toBe(200);
         expect(await empty.json()).toEqual([]);
 
-        // A well-formed 64-hex uploadId creates the WorkProposalAttachment edge.
-        // The keyless stack does NOT FK-check the upload's existence here — the
-        // edge lands as long as the id matches the hash shape.
-        const uploadId = 'a'.repeat(64);
+        // Attach a REAL, caller-owned upload (its sha256 id). Attachment-add now
+        // validates the uploadId against `user_uploads`, so the edge lands only
+        // for an upload the caller actually owns (a ghost/foreign id is 404 —
+        // see the negatives test below).
+        const uploadId = await mintUploadId(request, user.access_token);
         const add = await request.post(`${API_BASE}/api/me/work-proposals/${idea.id}/attachments`, {
             headers,
             data: { uploadId },

--- a/apps/web/e2e/sec-pin-agent-run-scoping.spec.ts
+++ b/apps/web/e2e/sec-pin-agent-run-scoping.spec.ts
@@ -81,6 +81,9 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 /** Well-formed RFC-4122 v4 UUIDs that exist nowhere in the DB. */
 const UNKNOWN_UPLOAD_UUID = 'a6c1f0e2-3b4d-4e5f-8a9b-0c1d2e3f4a5b';
+/** A well-formed sha256 (64-hex) that no real upload owns — passes the DTO,
+ *  fails the upload-ownership gate. */
+const UNKNOWN_UPLOAD_SHA = 'a'.repeat(64);
 const UNKNOWN_AGENT_UUID = '9e8d7c6b-5a4f-4321-9876-fedcba987654';
 const UNKNOWN_ATTACHMENT_UUID = 'b7d2e1f3-4c5a-4b6d-9e8f-1a2b3c4d5e6f';
 /** UUID-shaped but RFC-invalid (variant nibble '4' — must be 8/9/a/b). */
@@ -323,11 +326,14 @@ test.describe('sec-pin: agent run scoping (Wave M #133) + attachment uploadId va
             const body = (await res.json()) as ErrorBody;
             expect(body.error).toBe('Bad Request');
             expect(Array.isArray(body.message), 'class-validator message array').toBe(true);
-            expect(body.message).toContain('uploadId must be a UUID');
+            // `uploadId` is the sha256 content hash (NOT a UUID) — aligned with the
+            // Mission/Idea attachment DTOs and the service's own SHA256 guard, so a
+            // malformed/missing/typed-wrong value is a field-scoped sha256 rejection.
+            expect(String(body.message)).toContain('uploadId');
         }
     });
 
-    test('IsUUID is strict RFC-4122: a UUID-shaped id with an invalid variant nibble still 400s', async ({
+    test('a UUID-shaped uploadId is rejected by the DTO — uploadId is a sha256 hash, not a UUID', async ({
         request,
     }) => {
         const u = await registerUserViaAPI(request);
@@ -335,11 +341,9 @@ test.describe('sec-pin: agent run scoping (Wave M #133) + attachment uploadId va
             name: `Att Variant ${stamp()}`,
         });
 
-        // '44444444-4444-4444-4444-…' LOOKS like a UUID but its variant
-        // nibble is '4' (RFC-4122 requires 8/9/a/b). class-validator's
-        // IsUUID checks the variant bits, so this is a DTO 400 — NOT the
-        // service-layer "Invalid uploadId" (probed: the lookalike never
-        // reaches the service).
+        // The agent-attachment DTO now `@Matches(/^[0-9a-f]{64}$/i)` (aligned with
+        // Mission/Idea + the service guard, fixing the prior `@IsUUID` that rejected
+        // every real upload id). A UUID-shaped value is therefore a clean field 400.
         const res = await request.post(`${API_BASE}/api/agents/${agent.id}/attachments`, {
             headers: authedHeaders(u.access_token),
             data: { uploadId: BAD_VARIANT_UUID },
@@ -347,10 +351,10 @@ test.describe('sec-pin: agent run scoping (Wave M #133) + attachment uploadId va
         expect(res.status()).toBe(400);
         const body = (await res.json()) as ErrorBody;
         expect(Array.isArray(body.message)).toBe(true);
-        expect(body.message).toContain('uploadId must be a UUID');
+        expect(String(body.message)).toContain('uploadId must match');
     });
 
-    test('a well-formed unknown uploadId passes the DTO but the service guard rejects it — nothing persists', async ({
+    test('a well-formed sha256 uploadId that the caller does NOT own is rejected by the ownership gate (404) — nothing persists', async ({
         request,
     }) => {
         const u = await registerUserViaAPI(request);
@@ -358,19 +362,17 @@ test.describe('sec-pin: agent run scoping (Wave M #133) + attachment uploadId va
             name: `Att Service ${stamp()}`,
         });
 
-        // A textbook v4 UUID clears @IsUUID() and reaches the service, whose
-        // own guard (sha-256-hex check from PR #1044) rejects it with a
-        // STRING-message 400 — a different shape than the DTO's array. (The
-        // two layers currently disagree about the uploadId id-space; this
-        // pins the reachable rejection, not any success path.)
+        // A well-formed sha256 clears the DTO and reaches the service, whose
+        // ownership gate (user_uploads lookup) 404s it because no upload with that
+        // hash is owned by the caller — closing the dangling-attachment edge.
         const res = await request.post(`${API_BASE}/api/agents/${agent.id}/attachments`, {
             headers: authedHeaders(u.access_token),
-            data: { uploadId: UNKNOWN_UPLOAD_UUID },
+            data: { uploadId: UNKNOWN_UPLOAD_SHA },
         });
-        expect(res.status()).toBe(400);
+        expect(res.status()).toBe(404);
         const body = (await res.json()) as ErrorBody;
-        expect(body.message).toBe('Invalid uploadId');
-        expect(body.error).toBe('Bad Request');
+        expect(String(body.message)).toContain('Upload');
+        expect(body.error).toBe('Not Found');
 
         // Every rejected write above left zero attachment rows behind.
         const list = await request.get(`${API_BASE}/api/agents/${agent.id}/attachments`, {
@@ -397,15 +399,16 @@ test.describe('sec-pin: agent run scoping (Wave M #133) + attachment uploadId va
             data: { uploadId: 'nope' },
         });
         expect(malformed.status()).toBe(400);
-        expect(((await malformed.json()) as ErrorBody).message).toContain(
-            'uploadId must be a UUID',
+        expect(String(((await malformed.json()) as ErrorBody).message)).toContain(
+            'uploadId must match',
         );
 
-        // (b) Well-formed uploadId from B → now the ownership gate answers:
-        // 404 "Agent <id> not found.", the same as a never-existed agent.
+        // (b) Well-formed (sha256) uploadId from B → the AGENT-ownership gate
+        // (requireOwned) answers first: 404 "Agent <id> not found.", the same as a
+        // never-existed agent (it precedes the upload-ownership lookup).
         const wellFormed = await request.post(`${API_BASE}/api/agents/${agent.id}/attachments`, {
             headers: authedHeaders(b.access_token),
-            data: { uploadId: UNKNOWN_UPLOAD_UUID },
+            data: { uploadId: UNKNOWN_UPLOAD_SHA },
         });
         expect(wellFormed.status()).toBe(404);
         const wfBody = (await wellFormed.json()) as ErrorBody;

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -5,6 +5,7 @@ import { AgentAttachment } from '../entities/agent-attachment.entity';
 import { Work } from '../entities/work.entity';
 import { Mission } from '../entities/mission.entity';
 import { WorkProposal } from '../entities/work-proposal.entity';
+import { UserUpload } from '../entities/user-upload.entity';
 import { AgentRun } from '../entities/agent-run.entity';
 import { AgentRunLog } from '../entities/agent-run-log.entity';
 import { AgentBudget } from '../entities/agent-budget.entity';
@@ -50,6 +51,8 @@ import { FacadesModule } from '../facades/facades.module';
             Work,
             Mission,
             WorkProposal,
+            // Upload-ownership validation for addAttachment (user_uploads).
+            UserUpload,
         ]),
         ActivityLogModule,
         // Phase 10 — AgentRunService resolves active skills via

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -23,6 +23,7 @@ import { Repository } from 'typeorm';
 import { Work } from '../entities/work.entity';
 import { Mission } from '../entities/mission.entity';
 import { WorkProposal } from '../entities/work-proposal.entity';
+import { UserUpload } from '../entities/user-upload.entity';
 import { AgentRepository, type ListAgentsFilter } from '../database/repositories/agent.repository';
 import { AgentMembershipRepository } from '../database/repositories/agent-membership.repository';
 import { AgentBudgetRepository } from '../database/repositories/agent-budget.repository';
@@ -151,6 +152,11 @@ export class AgentsService {
         @Optional()
         @InjectRepository(WorkProposal)
         private readonly ideaRepo?: Repository<WorkProposal>,
+        // Upload-ownership validation for addAttachment — `user_uploads` indexes
+        // every upload by (userId, sha256). `@Optional()` + raw repo, same as above.
+        @Optional()
+        @InjectRepository(UserUpload)
+        private readonly uploadsRepo?: Repository<UserUpload>,
     ) {}
 
     async list(
@@ -453,6 +459,18 @@ export class AgentsService {
         await this.requireOwned(userId, id);
         if (!uploadId || !SHA256_RE.test(uploadId)) {
             throw new BadRequestException(`Invalid uploadId`);
+        }
+        // Security: the uploadId must reference a real upload owned by the
+        // caller — without this a ghost/foreign id persisted a dangling
+        // attachment edge. `user_uploads` records every upload by (userId,
+        // sha256). 404 (not 403) — don't leak whether the upload exists.
+        if (this.uploadsRepo) {
+            // sha256 is a case-insensitive content hash stored lowercase; the DTO
+            // accepts /i, so normalize before the ownership lookup.
+            const owned = await this.uploadsRepo.findOne({
+                where: { sha256: uploadId.toLowerCase(), userId },
+            });
+            if (!owned) throw new NotFoundException(`Upload ${uploadId} not found.`);
         }
         if (!this.agentAttachments) {
             throw new BadRequestException(

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -106,6 +106,7 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'UserSubscription',
     'UserTaskCounter',
     'UserTemplatePreference',
+    'UserUpload',
     'WebhookDelivery',
     'WebhookSubscription',
     'Work',

--- a/packages/agent/src/database/_repository-inventory.ts
+++ b/packages/agent/src/database/_repository-inventory.ts
@@ -61,6 +61,7 @@ import { UserNotificationSubscriptionRepository } from './repositories/user-noti
 import { UserRepository } from './repositories/user.repository';
 import { UserSubscriptionRepository } from './repositories/user-subscription.repository';
 import { UserTemplatePreferenceRepository } from './repositories/user-template-preference.repository';
+import { UserUploadRepository } from './repositories/user-upload.repository';
 import { WebhookDeliveryRepository } from './repositories/webhook-delivery.repository';
 import { WebhookSubscriptionRepository } from './repositories/webhook-subscription.repository';
 import { WorkAdvancedPromptsRepository } from './repositories/work-advanced-prompts.repository';
@@ -106,6 +107,7 @@ export const REPOSITORY_PROVIDERS: ReadonlyArray<Type<unknown>> = [
     UserRepository,
     UserSubscriptionRepository,
     UserTemplatePreferenceRepository,
+    UserUploadRepository,
     WebhookDeliveryRepository,
     WebhookSubscriptionRepository,
     WorkAdvancedPromptsRepository,

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -5,6 +5,7 @@ import {
     ApiKey,
     RefreshToken,
     User,
+    UserUpload,
     Work,
     WorkAdvancedPrompts,
     WorkCustomDomain,
@@ -125,6 +126,7 @@ export interface DatabaseConfig extends Omit<TypeOrmModuleOptions, 'type'> {
 
 export const ENTITIES = [
     ApiKey,
+    UserUpload,
     Work,
     WorkAdvancedPrompts,
     WorkCustomDomain,

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -6,6 +6,7 @@ export * from './repositories/work.repository';
 export * from './repositories/work-deployment.repository';
 export * from './repositories/work-member.repository';
 export * from './repositories/user.repository';
+export * from './repositories/user-upload.repository';
 export * from './repositories/refresh-token.repository';
 export * from './repositories/auth-account.repository';
 export * from './repositories/work-generation-history.repository';

--- a/packages/agent/src/database/repositories/user-upload.repository.ts
+++ b/packages/agent/src/database/repositories/user-upload.repository.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserUpload } from '../../entities/user-upload.entity';
+
+export interface RecordUploadInput {
+    userId?: string | null;
+    sha256: string;
+    workId?: string | null;
+    missionId?: string | null;
+    ideaId?: string | null;
+    tenantId?: string | null;
+    organizationId?: string | null;
+    storageProvider: string;
+    storagePath: string;
+    originalFilename?: string | null;
+    mimeType?: string | null;
+    fileSize?: number | null;
+}
+
+/**
+ * Ownership / metadata index for files uploaded via
+ * `POST /api/uploads/{file,image}`. The bytes live in the Storage plugin; this
+ * row records WHO owns the upload (`userId`, NULL = anonymous) and what scope it
+ * is optionally associated with, keyed by `sha256` (the upload id clients see).
+ */
+@Injectable()
+export class UserUploadRepository {
+    constructor(
+        @InjectRepository(UserUpload)
+        private readonly repo: Repository<UserUpload>,
+    ) {}
+
+    /**
+     * Insert the upload-ownership record, deduped per `(userId, sha256)` — a
+     * repeat upload of the same file by the same user returns the existing row.
+     * Best-effort by contract: the bytes are already stored, so the caller must
+     * not let a failure here fail the upload (swallow + log).
+     */
+    async record(input: RecordUploadInput): Promise<UserUpload> {
+        const existing = await this.repo.findOne({
+            where: { userId: input.userId ?? null, sha256: input.sha256 },
+        });
+        if (existing) return existing;
+        const entity = this.repo.create(input);
+        return this.repo.save(entity);
+    }
+
+    /** An upload with this `sha256` owned by `userId`, else null. */
+    async findOwnedByUser(sha256: string, userId: string): Promise<UserUpload | null> {
+        return this.repo.findOne({ where: { sha256, userId } });
+    }
+}

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -6,6 +6,7 @@ export * from './work-deployment.entity';
 export * from './work-member.entity';
 export * from './work-invitation.entity';
 export * from './user.entity';
+export * from './user-upload.entity';
 export * from './refresh-token.entity';
 export * from './work-generation-history.entity';
 export * from './subscription-plan.entity';

--- a/packages/agent/src/entities/user-upload.entity.ts
+++ b/packages/agent/src/entities/user-upload.entity.ts
@@ -1,0 +1,93 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+import { User } from './user.entity';
+
+/**
+ * A first-class record of a file uploaded via `POST /api/uploads/{file,image}`.
+ *
+ * Plain uploads previously left NO DB trace: `UploadsService.saveFile` stored
+ * the bytes in a Storage plugin and returned the `sha256` as the upload `id`
+ * (URL `/api/uploads/<userId>/<filename>`), so the only "ownership" was the
+ * per-user storage namespace and there was no way to validate that an
+ * attachment's `uploadId` referenced a real, caller-owned upload — which let a
+ * ghost/foreign `uploadId` persist a dangling attachment edge (the
+ * unmapped-500-hunt finding this entity closes).
+ *
+ * This row makes an upload an OWNABLE, QUERYABLE record:
+ *   - `userId` — the owner (NULL for an anonymous upload).
+ *   - `sha256` — the content hash returned to clients as the upload id; what
+ *     attachments reference. Deduped per `(userId, sha256)`.
+ *   - OPTIONAL scope links — `workId` is stamped today (from `?workId=`); the
+ *     `missionId` / `ideaId` / `tenantId` / `organizationId` columns let an
+ *     upload also be associated with those scopes as the upload surface grows
+ *     (additive — the existing work + storage behaviour is unchanged).
+ *
+ * The file BYTES still live in the Storage plugin at `storagePath`; this is the
+ * metadata / ownership index only.
+ */
+@Entity({ name: 'user_uploads' })
+@Index('idx_user_uploads_user_sha', ['userId', 'sha256'])
+@Index('idx_user_uploads_sha', ['sha256'])
+export class UserUpload {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Owner. NULL for an anonymous upload. */
+    @Column({ type: 'uuid', nullable: true })
+    userId?: string | null;
+
+    @ManyToOne(() => User, { onDelete: 'CASCADE', nullable: true })
+    @JoinColumn({ name: 'userId' })
+    user?: User | null;
+
+    /** Content hash — the upload id returned to clients + referenced by attachments. */
+    @Column({ type: 'varchar', length: 64 })
+    sha256: string;
+
+    /** Optional scope associations (all nullable — an upload need not belong to any). */
+    @Column({ type: 'uuid', nullable: true })
+    workId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    missionId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    ideaId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    /** Plugin id of the Storage backend holding the bytes. */
+    @Column({ type: 'varchar', length: 64, name: 'storage_provider' })
+    storageProvider: string;
+
+    /** Object key / path inside the Storage backend. */
+    @Column({ type: 'varchar', length: 1024, name: 'storage_path' })
+    storagePath: string;
+
+    @Column({ type: 'varchar', length: 512, nullable: true, name: 'original_filename' })
+    originalFilename?: string | null;
+
+    @Column({ type: 'varchar', length: 128, nullable: true, name: 'mime_type' })
+    mimeType?: string | null;
+
+    @Column({ type: 'bigint', nullable: true, name: 'file_size' })
+    fileSize?: number | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/missions/missions.module.ts
+++ b/packages/agent/src/missions/missions.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Mission } from '../entities/mission.entity';
 import { MissionAttachment } from '../entities/mission-attachment.entity';
 import { WorkProposal } from '../entities/work-proposal.entity';
+import { UserUpload } from '../entities/user-upload.entity';
 import { MissionAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { TitlerModule } from '../titler/titler.module';
 import { UserResearchModule } from '../user-research/user-research.module';
@@ -33,7 +34,7 @@ import { MissionTickService } from './mission-tick.service';
         // Repository<WorkProposal> for the Idea-copy half of Full
         // Fork, so the entity is registered here as well as via
         // UserResearchModule.
-        TypeOrmModule.forFeature([Mission, MissionAttachment, WorkProposal]),
+        TypeOrmModule.forFeature([Mission, MissionAttachment, WorkProposal, UserUpload]),
         TitlerModule,
         UserResearchModule,
         WorkAgentModule,

--- a/packages/agent/src/missions/missions.service.ts
+++ b/packages/agent/src/missions/missions.service.ts
@@ -14,6 +14,7 @@ import {
     type MissionGuardrailsOverride,
 } from '../entities/mission.entity';
 import { MissionAttachment } from '../entities/mission-attachment.entity';
+import { UserUpload } from '../entities/user-upload.entity';
 import { MissionAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { TitlerService } from '../titler/titler.service';
 import { MissionTickService } from './mission-tick.service';
@@ -165,6 +166,12 @@ export class MissionsService {
         // Production DI provides it via MissionsModule.
         @Optional()
         private readonly missionAttachments?: MissionAttachmentRepository,
+        // Upload-ownership validation for addAttachment — `user_uploads` indexes
+        // every upload by (userId, sha256). `@Optional()` so hand-rolled tests
+        // (no repo) skip; production/e2e DI provides it.
+        @Optional()
+        @InjectRepository(UserUpload)
+        private readonly uploadsRepo?: Repository<UserUpload>,
     ) {}
 
     /**
@@ -436,6 +443,15 @@ export class MissionsService {
         await this.findOrThrow(userId, missionId);
         if (!uploadId || !SHA256_RE.test(uploadId)) {
             throw new BadRequestException(`Invalid uploadId`);
+        }
+        // Security: the uploadId must reference a real upload owned by the
+        // caller (404 — don't leak existence). Closes the dangling/foreign
+        // attachment edge the hunt found.
+        if (this.uploadsRepo) {
+            const owned = await this.uploadsRepo.findOne({
+                where: { sha256: uploadId.toLowerCase(), userId },
+            });
+            if (!owned) throw new NotFoundException(`Upload ${uploadId} not found.`);
         }
         if (!this.missionAttachments) {
             throw new BadRequestException(

--- a/packages/agent/src/user-research/user-research.module.ts
+++ b/packages/agent/src/user-research/user-research.module.ts
@@ -5,6 +5,7 @@ import { FacadesModule } from '../facades/facades.module';
 import { TitlerModule } from '../titler/titler.module';
 import { WorkProposal } from '../entities/work-proposal.entity';
 import { WorkProposalAttachment } from '../entities/work-proposal-attachment.entity';
+import { UserUpload } from '../entities/user-upload.entity';
 import { WorkProposalAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { UserResearchService } from './user-research.service';
 import { WorkProposalService } from './work-proposal.service';
@@ -23,7 +24,7 @@ import {
         DatabaseModule,
         FacadesModule,
         TitlerModule,
-        TypeOrmModule.forFeature([WorkProposal, WorkProposalAttachment]),
+        TypeOrmModule.forFeature([WorkProposal, WorkProposalAttachment, UserUpload]),
     ],
     providers: [
         UserResearchService,

--- a/packages/agent/src/user-research/work-proposal.service.ts
+++ b/packages/agent/src/user-research/work-proposal.service.ts
@@ -12,6 +12,9 @@ import { PluginRegistryService } from '../plugins/services/plugin-registry.servi
 import { WorkProposalRepository } from './work-proposal.repository';
 import { WorkProposalAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { WorkProposalAttachment } from '../entities/work-proposal-attachment.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserUpload } from '../entities/user-upload.entity';
 
 // Upload IDs are SHA-256 hex strings (the `id` field returned by
 // POST /api/uploads/file). 64 lowercase hex chars — NOT UUID-shaped
@@ -165,6 +168,12 @@ export class WorkProposalService {
         // Production DI provides it via UserResearchModule.
         @Optional()
         private readonly proposalAttachments?: WorkProposalAttachmentRepository,
+        // Upload-ownership validation for addAttachment — `user_uploads` indexes
+        // every upload by (userId, sha256). `@Optional()` so hand-rolled tests
+        // skip; production/e2e DI provides it.
+        @Optional()
+        @InjectRepository(UserUpload)
+        private readonly uploadsRepo?: Repository<UserUpload>,
     ) {}
 
     /**
@@ -195,6 +204,15 @@ export class WorkProposalService {
         }
         if (!uploadId || !SHA256_RE.test(uploadId)) {
             throw new BadRequestException(`Invalid uploadId`);
+        }
+        // Security: the uploadId must reference a real upload owned by the
+        // caller (404 — don't leak existence). Closes the dangling/foreign
+        // attachment edge the hunt found.
+        if (this.uploadsRepo) {
+            const owned = await this.uploadsRepo.findOne({
+                where: { sha256: uploadId.toLowerCase(), userId },
+            });
+            if (!owned) throw new NotFoundException(`Upload ${uploadId} not found.`);
         }
         if (!this.proposalAttachments) {
             throw new BadRequestException(


### PR DESCRIPTION
## Summary

Closes the last unmapped-500-hunt finding (chip `task_c1573333`): agent / mission / idea attachment-add accepted a well-formed-but-**non-existent or foreign** `uploadId` and persisted a **dangling attachment edge** (201). Plain uploads (`POST /api/uploads/file`) left **no DB trace** (bytes in a Storage plugin, sha256 returned as the id), so there was nothing to validate ownership against.

Per the product decision (**extension, not replacement**): make an upload an ownable, queryable record while keeping the existing storage + work behaviour.

## New `user_uploads` table + entity

(+ migration, registered in `ENTITIES` / `_entity-names` / the repo inventory — the #1283 discipline)
- `userId` (NULL = anonymous) — the owner; `sha256` — the upload id clients see + attachments reference (deduped per `(userId, sha256)`).
- **Optional** `workId` / `missionId` / `ideaId` / `tenantId` / `organizationId` scope links (`workId` stamped today; the rest ready as the upload surface grows).
- storage provider/path + filename/mime/size metadata.

## Wiring

- `UploadsService.saveFile/saveImage` record the row after `putObject` (best-effort — bytes already stored). Bound via a **Symbol token** + `import type` (mirrors `WORK_REPO_RESOLVER`) so the upload unit-test graph never pulls in TypeORM.
- agents / missions / work-proposal `addAttachment` look the uploadId up by `(sha256, userId)` and **404** (not 403) when missing/foreign. `@Optional() @InjectRepository(UserUpload)` so unit tests skip; prod/e2e provide it. sha256 lowercased before lookup (case-insensitive hash; DTO accepts `/i`).

## Also fixes a pre-existing agent bug

`AddAgentAttachmentDto.uploadId` was `@IsUUID()` while the service guards `SHA256_RE` and uploads return a sha256 — so **agent attachments could never succeed**. Aligned to `@Matches(/^[0-9a-f]{64}$/i)` like the Mission/Idea DTOs; agent attachments now work.

## Verification

Live at :3100: upload → real owned attach **201** (agent/mission/idea); ghost + foreign uploadId → **404** across all three; a UUID uploadId → 400.

**EW-721:** `flow-work-proposals-deep` (the `'a'×64` dangling-edge test) + the mission uppercase test now mint a **real** upload; `sec-pin-agent-run-scoping`'s 4 tests that pinned the old `@IsUUID` / "two-layers-disagree" behaviour rewritten to the new consistent contract; added an upload-ownership cross-user regression to `flow-mission-attachments`. Unit specs green (agent 105, uploads 32); 55 attachment e2e + 15 mission + 11 sec-pin green; agent + api build, web tsc, root prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced upload ownership tracking to associate uploads with their creators.

* **Security Improvements**
  * Enforced upload ownership validation; users can now only attach uploads they own to missions and work proposals.

* **Tests**
  * Added end-to-end tests verifying upload ownership validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->