### PR TITLE
feat(ci+api): e2e develop-only + FacadeError→4xx (git-not-connected → 409)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,24 +3,43 @@ name: E2E Tests
 # Playwright e2e suite — auto-starts API (sqlite in-memory) + Next.js dev
 # server in the runner, then runs all specs from apps/web/e2e/.
 #
-# Scope (intentionally BRANCH-ONLY — never runs on feature/fix branches):
-#   - push to `develop` / `stage` / `main` (+ `master`) → run (release-line gate)
-#   - workflow_dispatch on any branch                   → run (one-off verification)
+# Scope (intentionally DEVELOP-ONLY — never runs on feature/fix branches,
+# and no longer re-runs on the stage/main release cascade):
+#   - push to `develop`              → run (the single integration gate)
+#   - workflow_dispatch on any branch → run (one-off pre-merge verification)
 #
-# There is deliberately NO `pull_request` trigger. The full suite is
-# sharded 4× across the matrix (~25 min wall-clock per shard on
-# ubicloud-standard-8), so running it on every feature/fix PR burned
-# runners without gating anything the post-merge branch push doesn't
-# already catch. e2e now runs only once code lands on a release-line
-# branch (`develop`, `stage`, `main`/`master`). The `concurrency` block
-# below cancels a superseded run when a newer commit reaches the same
-# branch, so only the latest commit per branch is ever validated.
+# There is deliberately NO `pull_request` trigger, and (since 2026-06-12)
+# NO `stage` / `main` / `master` push trigger either. The full suite is
+# sharded 16× (~25 min wall-clock per shard on ubicloud-standard-8), so:
+#   - running it on every feature/fix PR burned runners without gating
+#     anything the post-merge develop push doesn't already catch; and
+#   - re-running the IDENTICAL suite again when develop cascades to stage
+#     and then to main was pure duplicate work — the code is byte-for-byte
+#     what already passed e2e on develop. `develop` is the integration
+#     point: once code is green there, promotion to stage/main is a
+#     fast-forward cascade, not a re-test.
+#
+# Nothing downstream depends on this workflow (no `workflow_run` consumer),
+# so trimming the cascade triggers cannot break a deploy/release chain —
+# unlike `CI` (ci.yml), whose stage/main push runs are load-bearing for
+# the `release-trigger-{stage,prod}` Trigger.dev releases and MUST stay.
+#
+# Release-branch-SPECIFIC tests still run on stage/main where they belong:
+# `k8s-e2e.yml` (kind-cluster plugin e2e, path-filtered) is deliberately
+# scoped to stage/main and is untouched by this policy.
+#
+# To validate a large feature branch BEFORE merge, dispatch this workflow
+# manually on the branch (`gh workflow run e2e.yml --ref <branch>`); that
+# one-off run is the pre-merge signal, replacing the old auto-on-push runs.
+#
+# The `concurrency` block below cancels a superseded run when a newer
+# commit reaches develop, so only the latest commit is ever validated.
 #
 # See Workspace/knowledge/runbooks/CI_RELEASE_GATES.md for the policy.
 
 on:
   push:
-    branches: [develop, stage, main, master]
+    branches: [develop]
   workflow_dispatch:
 
 # M-12: minimum default permissions. Individual jobs can elevate where needed.

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -1,5 +1,6 @@
 import { Module, OnApplicationBootstrap } from '@nestjs/common';
-import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { FacadeExceptionFilter } from './common/filters/facade-exception.filter';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AuthModule } from './auth/auth.module';
@@ -214,6 +215,16 @@ import { DatabaseModule } from '@ever-works/agent/database';
         {
             provide: APP_INTERCEPTOR,
             useClass: PostHogInterceptor,
+        },
+        // Maps the `@ever-works/agent` FacadeError hierarchy (git / deploy /
+        // oauth / content-extractor "no provider / not connected / not found"
+        // errors) to the correct 4xx instead of the generic 500 Nest's
+        // default filter would emit. Additive: only nets FacadeErrors that
+        // reach a controller UNCAUGHT (e.g. POST /api/templates/fork →
+        // NoGitProviderError). See facade-exception.filter.ts.
+        {
+            provide: APP_FILTER,
+            useClass: FacadeExceptionFilter,
         },
     ],
     controllers: [APIController],

--- a/apps/api/src/common/filters/facade-exception.filter.spec.ts
+++ b/apps/api/src/common/filters/facade-exception.filter.spec.ts
@@ -1,0 +1,114 @@
+// Mock the agent facades barrel so importing the filter doesn't pull the
+// real facade runtime (TypeORM / plugin registry / NestJS wiring). The
+// filter only references `FacadeError` for its `@Catch()` decorator and
+// reads duck-typed fields off the thrown error, so a bare stand-in class
+// is enough. Mirrors work-repo-resolver.service.spec.ts.
+jest.mock('@ever-works/agent/facades', () => ({
+    FacadeError: class FacadeError extends Error {},
+}));
+
+import { HttpStatus, Logger } from '@nestjs/common';
+import type { ArgumentsHost } from '@nestjs/common';
+import type { HttpAdapterHost } from '@nestjs/core';
+import { FacadeExceptionFilter } from './facade-exception.filter';
+
+/** A minimal FacadeError-shaped object — the filter only reads these fields. */
+function facadeError(name: string, message = `${name} happened`) {
+    return Object.assign(new Error(message), {
+        name,
+        operation: 'getPlugin',
+        provider: 'github',
+    });
+}
+
+describe('FacadeExceptionFilter', () => {
+    let filter: FacadeExceptionFilter;
+    let reply: jest.Mock;
+    let host: ArgumentsHost;
+
+    beforeEach(() => {
+        reply = jest.fn();
+        const httpAdapterHost = {
+            httpAdapter: {
+                reply,
+                getRequestMethod: () => 'POST',
+                getRequestUrl: () => '/api/templates/fork',
+            },
+        } as unknown as HttpAdapterHost;
+        filter = new FacadeExceptionFilter(httpAdapterHost);
+
+        host = {
+            switchToHttp: () => ({
+                getRequest: () => ({}),
+                getResponse: () => ({ res: true }),
+            }),
+        } as unknown as ArgumentsHost;
+
+        // Silence the error-level log the 500 path emits.
+        jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    const lastBody = () => reply.mock.calls[0][1];
+    const lastStatus = () => reply.mock.calls[0][2];
+
+    it.each([
+        ['NoGitProviderError', HttpStatus.CONFLICT],
+        ['NoProviderError', HttpStatus.CONFLICT],
+        ['NoDeployProviderError', HttpStatus.CONFLICT],
+        ['NoOAuthProviderError', HttpStatus.CONFLICT],
+        ['NoContentExtractorProviderError', HttpStatus.CONFLICT],
+        ['NoGitCredentialsError', HttpStatus.CONFLICT],
+        ['NoDeployCredentialsError', HttpStatus.CONFLICT],
+        ['ProviderNotFoundError', HttpStatus.NOT_FOUND],
+        ['GitProviderNotFoundError', HttpStatus.NOT_FOUND],
+        ['DeployProviderNotFoundError', HttpStatus.NOT_FOUND],
+        ['OAuthProviderNotFoundError', HttpStatus.NOT_FOUND],
+        ['ContentExtractorProviderNotFoundError', HttpStatus.NOT_FOUND],
+        ['OAuthNotSupportedError', HttpStatus.BAD_REQUEST],
+    ])('maps %s → %d and surfaces the (safe) facade message', (name, status) => {
+        filter.catch(facadeError(name) as never, host);
+        expect(lastStatus()).toBe(status);
+        expect(lastBody()).toEqual({
+            statusCode: status,
+            message: `${name} happened`,
+            error: name,
+        });
+    });
+
+    it('falls through to 500 for a generic facade wrapper AND hides the internal message', () => {
+        filter.catch(
+            facadeError('AiFacadeError', 'upstream model 503 with secret detail') as never,
+            host,
+        );
+        expect(lastStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+        // Critical: the original message must NOT leak — Nest's default
+        // filter would have hidden it, and we preserve that.
+        expect(lastBody()).toEqual({
+            statusCode: 500,
+            message: 'Internal server error',
+            error: 'Internal Server Error',
+        });
+    });
+
+    it('logs unmapped (500) facade errors with operation/provider context', () => {
+        const spy = jest.spyOn(Logger.prototype, 'error');
+        filter.catch(facadeError('SearchFacadeError', 'boom') as never, host);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(String(spy.mock.calls[0][0])).toContain('SearchFacadeError');
+        expect(String(spy.mock.calls[0][0])).toContain('op=getPlugin');
+    });
+
+    it('does NOT log the mapped 4xx cases (they are expected, caller-actionable)', () => {
+        const spy = jest.spyOn(Logger.prototype, 'error');
+        filter.catch(facadeError('NoGitProviderError') as never, host);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('treats an unknown FacadeError name as a 500 (conservative default)', () => {
+        filter.catch(facadeError('SomeBrandNewFacadeError', 'leak me') as never, host);
+        expect(lastStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+        expect(lastBody().message).toBe('Internal server error');
+    });
+});

--- a/apps/api/src/common/filters/facade-exception.filter.ts
+++ b/apps/api/src/common/filters/facade-exception.filter.ts
@@ -1,0 +1,118 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpStatus, Logger } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { FacadeError } from '@ever-works/agent/facades';
+
+/**
+ * Maps the `@ever-works/agent` `FacadeError` hierarchy to HTTP status
+ * codes at the API boundary.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Facade methods (git / deploy / oauth / content-extractor / …) throw
+ * `FacadeError` subclasses, which are plain `Error`s — NOT NestJS
+ * `HttpException`s. When such an error reaches a controller WITHOUT a
+ * local try/catch (e.g. `POST /api/templates/fork` → `NoGitProviderError`
+ * because no git provider is connected), Nest's built-in
+ * `BaseExceptionFilter` turns it into a generic HTTP 500. That mislabels
+ * caller-actionable precondition failures ("connect GitHub first",
+ * "enable a provider") as server faults.
+ *
+ * This filter converts the SPECIFIC, semantically-meaningful leaf errors
+ * to the correct 4xx. Everything else — the generic `*FacadeError`
+ * wrappers (`AiFacadeError`, `SearchFacadeError`, the bare bases, …),
+ * which represent genuine upstream/internal failures — stays a 500,
+ * exactly as before this filter existed.
+ *
+ * DESIGN NOTES
+ * ------------
+ * - The hierarchy is intentionally INCONSISTENT: `NoGitProviderError`
+ *   extends `GitFacadeError` (not `NoProviderError`), `NoDeployProviderError`
+ *   extends `DeployFacadeError`, etc. So we cannot map by a single base
+ *   `instanceof`. Each leaf assigns a stable `this.name` in its
+ *   constructor, so we map by that name string — robust to minification
+ *   (the name is an explicit assignment, not `constructor.name`) and
+ *   immune to the inconsistent class tree.
+ * - HTTP-ONLY by construction: a global exception filter runs only in
+ *   the HTTP request pipeline. FacadeErrors thrown in BullMQ workers,
+ *   Trigger.dev tasks, the internal-CLI, or generation pipelines are
+ *   never touched — so this can't wrongly 4xx a background failure.
+ * - ADDITIVE: controllers that already catch a `FacadeError` and convert
+ *   it to an `HttpException` (search / screenshot / agent-memory) are
+ *   unaffected — their `HttpException` is not a `FacadeError`, so
+ *   `@Catch(FacadeError)` never sees it. This filter only nets the
+ *   currently-UNCAUGHT cases.
+ * - NO INFO LEAK: Nest's default filter hides a non-HttpException's
+ *   message behind "Internal server error". We preserve that for the
+ *   500 fall-through (only the intentional, safe 4xx messages — "No Git
+ *   provider configured" — are surfaced to the client).
+ */
+
+/**
+ * `error.name` → HTTP status for the caller-actionable facade leaves.
+ * Anything not listed falls through to 500 (unchanged behaviour).
+ */
+const FACADE_ERROR_STATUS: Readonly<Record<string, HttpStatus>> = {
+    // "no provider configured / enabled for this capability" — a
+    // precondition the caller resolves by enabling a plugin.
+    NoProviderError: HttpStatus.CONFLICT,
+    NoGitProviderError: HttpStatus.CONFLICT,
+    NoDeployProviderError: HttpStatus.CONFLICT,
+    NoOAuthProviderError: HttpStatus.CONFLICT,
+    NoContentExtractorProviderError: HttpStatus.CONFLICT,
+    // "the named providerId does not exist among loaded plugins".
+    ProviderNotFoundError: HttpStatus.NOT_FOUND,
+    GitProviderNotFoundError: HttpStatus.NOT_FOUND,
+    DeployProviderNotFoundError: HttpStatus.NOT_FOUND,
+    OAuthProviderNotFoundError: HttpStatus.NOT_FOUND,
+    ContentExtractorProviderNotFoundError: HttpStatus.NOT_FOUND,
+    // "no connected account / credentials for this user+provider" —
+    // resolved by connecting the account or adding a token.
+    NoGitCredentialsError: HttpStatus.CONFLICT,
+    NoDeployCredentialsError: HttpStatus.CONFLICT,
+    // "the resolved plugin does not implement this operation".
+    OAuthNotSupportedError: HttpStatus.BAD_REQUEST,
+};
+
+@Catch(FacadeError)
+export class FacadeExceptionFilter implements ExceptionFilter {
+    private readonly logger = new Logger(FacadeExceptionFilter.name);
+
+    constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+    catch(exception: FacadeError, host: ArgumentsHost): void {
+        const { httpAdapter } = this.httpAdapterHost;
+        const ctx = host.switchToHttp();
+        const request = ctx.getRequest();
+
+        const status = FACADE_ERROR_STATUS[exception.name] ?? HttpStatus.INTERNAL_SERVER_ERROR;
+        const isClientError = status < HttpStatus.INTERNAL_SERVER_ERROR;
+
+        if (!isClientError) {
+            // Unmapped facade wrapper → genuine 500. Log it with the
+            // operation/provider context the facade attached (these are a
+            // signal that an upstream provider failed, or that a new leaf
+            // class needs a mapping above).
+            this.logger.error(
+                `Unmapped facade error (${exception.name}) [op=${exception.operation}` +
+                    `${exception.provider ? ` provider=${exception.provider}` : ''}] ` +
+                    `on ${httpAdapter.getRequestMethod(request)} ${httpAdapter.getRequestUrl(request)}: ` +
+                    `${exception.message}`,
+                exception.stack,
+            );
+        }
+
+        // Mirror Nest's HttpException JSON shape. Surface the facade's own
+        // message ONLY for the mapped 4xx (those messages are intentional
+        // and caller-facing); keep the generic body for the 500 so we
+        // don't leak internal detail the default filter would have hidden.
+        const body = isClientError
+            ? { statusCode: status, message: exception.message, error: exception.name }
+            : {
+                  statusCode: status,
+                  message: 'Internal server error',
+                  error: 'Internal Server Error',
+              };
+
+        httpAdapter.reply(ctx.getResponse(), body, status);
+    }
+}

--- a/apps/api/src/uploads/work-repo-resolver.service.spec.ts
+++ b/apps/api/src/uploads/work-repo-resolver.service.spec.ts
@@ -5,6 +5,7 @@
 jest.mock('@ever-works/agent/database', () => ({}));
 jest.mock('@ever-works/agent/facades', () => ({}));
 
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { WorkRepoResolverService } from './work-repo-resolver.service';
 import type { WorkRepository } from '@ever-works/agent/database';
 import type { GitFacadeService } from '@ever-works/agent/facades';
@@ -104,24 +105,28 @@ describe('WorkRepoResolverService (EW-644)', () => {
         expect(gitFacade.getRepository).toHaveBeenCalledTimes(1);
     });
 
-    it('throws a clear error when the Work is not found', async () => {
+    it('throws NotFoundException (404, not 500) when the Work is not found', async () => {
         workRepo.findById.mockResolvedValueOnce(null);
-        await expect(resolver.resolve(workId)).rejects.toThrow(/Work not found/);
+        const err = await resolver.resolve(workId).catch((e) => e);
+        expect(err).toBeInstanceOf(NotFoundException);
+        expect(err.message).toMatch(/Work not found/);
         expect(gitFacade.getAccessToken).not.toHaveBeenCalled();
     });
 
-    it('throws a clear error when the Work has no resolvable repo coordinates', async () => {
+    it('throws ConflictException (409, not 500) when the Work has no resolvable repo coordinates', async () => {
         const work = makeWork({ owner: '' });
         work.getDataRepo = jest.fn().mockReturnValue('');
         workRepo.findById.mockResolvedValueOnce(work as never);
-        await expect(resolver.resolve(workId)).rejects.toThrow(/no resolvable data repo/);
+        const err = await resolver.resolve(workId).catch((e) => e);
+        expect(err).toBeInstanceOf(ConflictException);
+        expect(err.message).toMatch(/no resolvable data repo/);
     });
 
-    it('throws when no GitHub token can be resolved for the Work owner', async () => {
+    it('throws ConflictException (409, not 500) when no GitHub token can be resolved for the Work owner', async () => {
         workRepo.findById.mockResolvedValueOnce(makeWork() as never);
         gitFacade.getAccessToken.mockResolvedValueOnce(null);
-        await expect(resolver.resolve(workId)).rejects.toThrow(
-            /no GitHub token available for user/,
-        );
+        const err = await resolver.resolve(workId).catch((e) => e);
+        expect(err).toBeInstanceOf(ConflictException);
+        expect(err.message).toMatch(/no GitHub token available for user/);
     });
 });

--- a/apps/api/src/uploads/work-repo-resolver.service.ts
+++ b/apps/api/src/uploads/work-repo-resolver.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { ConflictException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { WorkRepository } from '@ever-works/agent/database';
 import { GitFacadeService } from '@ever-works/agent/facades';
 import type { WorkRepoResolver, ResolvedWorkRepo } from '@ever-works/github-storage-plugin';
@@ -51,13 +51,19 @@ export class WorkRepoResolverService implements WorkRepoResolver {
     async resolve(workId: string): Promise<ResolvedWorkRepo> {
         const work = await this.workRepository.findById(workId);
         if (!work) {
-            throw new Error(`Work not found: ${workId}`);
+            // The upload controller already 404s on a Work the caller can't
+            // access; a miss here is a TOCTOU (deleted between the access
+            // check and the storage write) — still a not-found, never a 500.
+            throw new NotFoundException(`Work not found: ${workId}`);
         }
 
         const owner = work.getRepoOwner('data');
         const repo = work.getDataRepo();
         if (!owner || !repo) {
-            throw new Error(
+            // The Work exists and is owned by the caller, but it isn't
+            // configured with a data repo — a caller-actionable precondition
+            // for `data-repo` mode, not a server fault.
+            throw new ConflictException(
                 `Work ${workId} has no resolvable data repo coordinates ` +
                     `(owner=${JSON.stringify(owner)}, repo=${JSON.stringify(repo)}). ` +
                     `Mode 'data-repo' on the github-storage plugin requires a configured data repo.`,
@@ -70,7 +76,10 @@ export class WorkRepoResolverService implements WorkRepoResolver {
             workId,
         });
         if (!token) {
-            throw new Error(
+            // No connected GitHub credentials for the Work owner — the
+            // message tells the caller exactly how to resolve it, so this is
+            // a precondition (409), not an internal error (500).
+            throw new ConflictException(
                 `Work ${workId}: no GitHub token available for user ${work.userId} ` +
                     `(no GitHub App installation, no connected OAuth account with 'repo' scope, ` +
                     `no PAT in plugin settings). Connect GitHub for this user before using ` +

--- a/apps/web/e2e/flow-collections-deep.spec.ts
+++ b/apps/web/e2e/flow-collections-deep.spec.ts
@@ -37,22 +37,23 @@ import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from '.
  *       route does not exist; a DIFFERENT shape from the ownership 404 below)
  *   - GET  /works/:id/collections/:cid                 → 404 routing-404 (no GET child)
  *   - PATCH /works/:id/collections/:cid                → 404 routing-404 (only PUT/DELETE)
- *   - POST /works/:id/collections (owner, DTO-valid)   → 500 { statusCode:500,
- *       message:'Internal server error' }  (git-gated save on a non-connected work)
- *   - PUT/DELETE /works/:id/collections/:cid (owner)   → 500 git-gate (the gated read
+ *   - POST /works/:id/collections (owner, DTO-valid)   → 409 { statusCode:409,
+ *       error:'NoGitCredentialsError' }  (git-gated save on a non-connected work;
+ *       FacadeExceptionFilter maps NoGitCredentialsError → 409; was 500 pre-filter)
+ *   - PUT/DELETE /works/:id/collections/:cid (owner)   → 409 git-gate (the gated read
  *       inside the service fires before the per-child not-found check)
  *   - POST collections, name a NUMBER                  → 400 ["name must be shorter than
  *       or equal to 100 characters","name must be a string"]
- *   - POST collections, name '' (empty string)         → 500 (passes @IsString+@MaxLength,
+ *   - POST collections, name '' (empty string)         → 409 (passes @IsString+@MaxLength,
  *       no @IsNotEmpty → falls through to the git-gate)
- *   - POST collections, name 'z'×101 (STRING)          → 500 (sanitize @Transform truncates
+ *   - POST collections, name 'z'×101 (STRING)          → 409 (sanitize @Transform truncates
  *       to 100 BEFORE @MaxLength → valid → git-gate; contrast the NUMBER probe's 400)
  *   - POST collections, description a NUMBER            → 400 [both 500-char + must-be-string]
  *   - POST collections, icon_url 'h'×501               → 400 ["icon_url must be shorter than
  *       or equal to 500 characters"]
  *   - POST collections, priority -1                    → 400 ["priority must not be less than 0"]
  *   - POST collections, priority 'high'                → 400 [must-not-be-less-than-0 + must-be-number]
- *   - POST collections, priority 0 (inclusive bound)   → 500 (valid → git-gate)
+ *   - POST collections, priority 0 (inclusive bound)   → 409 (valid → git-gate)
  *   - POST collections, unknown prop                   → 400 ["property <x> should not exist"]
  *   - anon POST collections                            → 401 { statusCode:401 }
  *   - stranger POST/PUT/DELETE collections             → 403 { status:'error', message:
@@ -176,11 +177,17 @@ async function freshWork(
     return { token: u.access_token, workId };
 }
 
-/** The GENERIC Nest 500 envelope — the git-gate signature for the dedicated endpoints. */
-function expectGitGate500(status: number, body: ErrorEnvelope, label: string): void {
-    expect(status, `${label} hits the git-gate → 500`).toBe(500);
-    expect(body.statusCode, `${label} 500 carries statusCode`).toBe(500);
-    expect(body.status, `${label} 500 is NOT a success envelope`).not.toBe('success');
+/**
+ * The git-gate signature for the dedicated collection endpoints: a DTO-valid
+ * write on a work whose owner has NOT connected a git provider fails when the
+ * data-generator calls `gitFacade.cloneOrPull` → `NoGitCredentialsError`. The
+ * global FacadeExceptionFilter maps that to a clean 409 precondition — it was
+ * a generic 500 before that filter (see apps/api/src/common/filters).
+ */
+function expectGitGate409(status: number, body: ErrorEnvelope, label: string): void {
+    expect(status, `${label} hits the git-gate → 409 (no git provider connected)`).toBe(409);
+    expect(body.statusCode, `${label} 409 carries statusCode`).toBe(409);
+    expect(body.status, `${label} 409 is NOT a success envelope`).not.toBe('success');
 }
 
 /** A class-validator 400 envelope naming a field. */
@@ -286,7 +293,7 @@ test.describe('flow: collection CREATE validation gradient — the per-field DTO
         // Create*CollectionDto.name is @IsString @MaxLength(100) with NO @IsNotEmpty.
         // A number can't be sanitized → both @IsString and @MaxLength(100) fire (400).
         // `{}` (undefined) → @IsString fails (400). But `''` is a length-0 STRING → it
-        // passes type + length and the DTO-valid write reaches the git-gated save (500).
+        // passes type + length and the DTO-valid write reaches the git-gated save (409).
         const { token, workId } = await freshWork(request, 'name-field');
 
         const numberName = await postCollection(request, token, workId, { name: 98765 });
@@ -312,7 +319,7 @@ test.describe('flow: collection CREATE validation gradient — the per-field DTO
         );
 
         const emptyName = await postCollection(request, token, workId, { name: '' });
-        expectGitGate500(emptyName.status, emptyName.body, 'collection empty-string name');
+        expectGitGate409(emptyName.status, emptyName.body, 'collection empty-string name');
     });
 
     test('the optional fields on a collection: description NON-STRING (400 both messages), icon_url over-500 (400), and the priority gradient (-1 → 400, "high" → 400, 0 → valid git-gate)', async ({
@@ -323,7 +330,7 @@ test.describe('flow: collection CREATE validation gradient — the per-field DTO
         // sanitized → @IsString + @MaxLength(500) BOTH fire. icon_url has no transform →
         // an over-500 STRING trips @MaxLength directly. priority @IsNumber @Min(0):
         // -1 trips @Min, a string trips @IsNumber (and @Min), but 0 is the INCLUSIVE
-        // floor → valid → git-gate 500.
+        // floor → valid → git-gate 409.
         const { token, workId } = await freshWork(request, 'opt-fields');
 
         const badDesc = await postCollection(request, token, workId, {
@@ -375,21 +382,21 @@ test.describe('flow: collection CREATE validation gradient — the per-field DTO
         );
 
         const zero = await postCollection(request, token, workId, { name: 'Coll', priority: 0 });
-        expectGitGate500(zero.status, zero.body, 'collection priority:0 inclusive boundary');
+        expectGitGate409(zero.status, zero.body, 'collection priority:0 inclusive boundary');
     });
 
-    test('an over-bound STRING name on a collection is sanitize-truncated to 100 (so it PASSES @MaxLength) and falls through to the git-gate 500 — the @Transform runs before the validator', async ({
+    test('an over-bound STRING name on a collection is sanitize-truncated to 100 (so it PASSES @MaxLength) and falls through to the git-gate 409 — the @Transform runs before the validator', async ({
         request,
     }) => {
         // CreateCollectionDto.name carries @Transform(sanitizeName(_,100)) which runs
         // (class-transformer) BEFORE @MaxLength (class-validator). A raw STRING longer
         // than 100 is truncated to 100 → validation passes → the DTO-valid write reaches
-        // the git-gated save → 500. This is the load-bearing contrast with the NUMBER
+        // the git-gated save → 409. This is the load-bearing contrast with the NUMBER
         // probe above (which can't be truncated and so 400s on @IsString + @MaxLength).
         const { token, workId } = await freshWork(request, 'sanitize-name');
 
         const overLong = await postCollection(request, token, workId, { name: 'z'.repeat(101) });
-        expectGitGate500(overLong.status, overLong.body, 'collection over-length STRING name');
+        expectGitGate409(overLong.status, overLong.body, 'collection over-length STRING name');
     });
 
     test('the create whitelist rejects an unknown property on a collection by name (forbidNonWhitelisted), before any ownership/git work', async ({
@@ -413,27 +420,27 @@ test.describe('flow: collection CREATE validation gradient — the per-field DTO
     });
 });
 
-test.describe('flow: collection WRITE git-gate — every verb 500s on a non-connected work and persists NOTHING', () => {
-    test('a DTO-valid owner CREATE/UPDATE/DELETE on a collection each hits the git-gate (500), and the collections array stays empty (no partial state leaked)', async ({
+test.describe('flow: collection WRITE git-gate — every verb 409s on a non-connected work and persists NOTHING', () => {
+    test('a DTO-valid owner CREATE/UPDATE/DELETE on a collection each hits the git-gate (409), and the collections array stays empty (no partial state leaked)', async ({
         request,
     }) => {
         // All three collection write verbs route through ensureCanEdit → the data-repo
         // save (create) or the git-gated taxonomy READ (update/delete, which fires
         // BEFORE the per-child not-found check). On a non-connected work each surfaces
-        // the GENERIC 500. After all three blocked writes the combined read still shows
+        // the git-gate 409. After all three blocked writes the combined read still shows
         // collections:[] — nothing was half-committed.
         const { token, workId } = await freshWork(request, 'gate-all-verbs');
         const s = uniq('gate');
         const headers = authedHeaders(token);
 
         const created = await postCollection(request, token, workId, { name: `Gated Coll ${s}` });
-        expectGitGate500(created.status, created.body, 'collection CREATE');
+        expectGitGate409(created.status, created.body, 'collection CREATE');
 
         const updated = await request.put(
             `${API_BASE}/api/works/${workId}/collections/ghost-${s}`,
             { headers, data: { name: `Renamed ${s}` } },
         );
-        expectGitGate500(
+        expectGitGate409(
             updated.status(),
             await readJson<ErrorEnvelope>(updated),
             'collection UPDATE (non-existent child → gate dominates)',
@@ -443,7 +450,7 @@ test.describe('flow: collection WRITE git-gate — every verb 500s on a non-conn
             `${API_BASE}/api/works/${workId}/collections/ghost-${s}`,
             { headers },
         );
-        expectGitGate500(
+        expectGitGate409(
             deleted.status(),
             await readJson<ErrorEnvelope>(deleted),
             'collection DELETE (non-existent child → gate dominates)',
@@ -457,11 +464,11 @@ test.describe('flow: collection WRITE git-gate — every verb 500s on a non-conn
         );
     });
 
-    test('repeated gated collection CREATEs are idempotent against state — each 500s and the collections array is STILL empty (no accumulation)', async ({
+    test('repeated gated collection CREATEs are idempotent against state — each 409s and the collections array is STILL empty (no accumulation)', async ({
         request,
     }) => {
-        // A gated write that 500s must not partially commit, so retrying it can never
-        // accumulate collections. Fire the SAME create three times; each 500s and the
+        // A gated write that 409s must not partially commit, so retrying it can never
+        // accumulate collections. Fire the SAME create three times; each 409s and the
         // read stays empty — proving the failure is atomic at the data-repo boundary.
         const { token, workId } = await freshWork(request, 'idempotent');
         const s = uniq('retry');
@@ -471,7 +478,7 @@ test.describe('flow: collection WRITE git-gate — every verb 500s on a non-conn
                 name: `Retry Coll ${s}`,
                 priority: attempt,
             });
-            expectGitGate500(write.status, write.body, `collection create attempt ${attempt}`);
+            expectGitGate409(write.status, write.body, `collection create attempt ${attempt}`);
         }
 
         const read = await readTaxonomy(request, token, workId);
@@ -482,7 +489,7 @@ test.describe('flow: collection WRITE git-gate — every verb 500s on a non-conn
     test('collection writes are isolated PER-WORK — a gated CREATE on work A never materialises a collection on work B (same owner)', async ({
         request,
     }) => {
-        // One owner, TWO works. A gated collection create on work A is a 500 and leaves
+        // One owner, TWO works. A gated collection create on work A is a 409 and leaves
         // A's collections empty; crucially it also leaves work B's collections empty —
         // the per-(workId,userId) data path does not bleed a half-committed taxonomy
         // across sibling works.
@@ -503,7 +510,7 @@ test.describe('flow: collection WRITE git-gate — every verb 500s on a non-conn
         const gated = await postCollection(request, u.access_token, workA, {
             name: `Iso Coll ${s}`,
         });
-        expectGitGate500(gated.status, gated.body, 'collection create on work A');
+        expectGitGate409(gated.status, gated.body, 'collection create on work A');
 
         const readA = await readTaxonomy(request, u.access_token, workA);
         expect(readA.body.collections!.length, 'work A has no collection').toBe(0);
@@ -547,7 +554,7 @@ test.describe('flow: collection WRITE authz — auth + ownership precede the git
     }) => {
         // ensureCanEdit fires before the data-repo save, so a non-member's DTO-valid
         // write to every collection verb is a 403 with the canonical { status:'error',
-        // message:'You do not have permission…' } envelope — NOT a 500 (it never reaches
+        // message:'You do not have permission…' } envelope — NOT the git-gate 409 (it never reaches
         // the git-gate) and NOT a 404 (the work exists). The siblings pin stranger-403
         // for collection POST only; here we pin PUT and DELETE on collections too.
         const owner = await registerUserViaAPI(request);
@@ -589,13 +596,13 @@ test.describe('flow: collection WRITE authz — auth + ownership precede the git
         ).toMatch(PERMISSION_RE);
     });
 
-    test('an owner CREATE/PUT/DELETE on a collection of a GHOST (well-formed but absent) work is a precise 404 (the work-row lookup precedes the git save), NOT a 500 or a leak', async ({
+    test('an owner CREATE/PUT/DELETE on a collection of a GHOST (well-formed but absent) work is a precise 404 (the work-row lookup precedes the git save), NOT the git-gate 409 or a leak', async ({
         request,
     }) => {
         // ensureCanEdit looks up the work row before the data-repo save, so a DTO-valid
         // OWNER write to a non-existent work id is the ownership 404 — { status:'error',
         // message:"Work with id '…' not found" } — on ALL THREE collection verbs, never
-        // the owner's own git-gate 500 and never a 200 leak.
+        // the owner's own git-gate 409 and never a 200 leak.
         const owner = await registerUserViaAPI(request);
         const s = uniq('ghost');
         const headers = authedHeaders(owner.access_token);

--- a/apps/web/e2e/flow-comparison-generator.spec.ts
+++ b/apps/web/e2e/flow-comparison-generator.spec.ts
@@ -52,7 +52,7 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *                                'itemASlug must be a string', ...]
  *       extra property   → 400 ['property bogus should not exist']
  *                          (global ValidationPipe forbidNonWhitelisted)
- *   - GET/DELETE /works/:id/comparisons/:slug → git-gated 5xx on a fresh Work.
+ *   - GET/DELETE /works/:id/comparisons/:slug → git-gated 409 on a fresh Work (NoGitCredentialsError via FacadeExceptionFilter; was 5xx).
  *
  * COMPARISON-GENERATOR PLUGIN (category: 'utility', id 'comparison-generator'):
  *   - POST /works/:id/plugins/comparison-generator/enable on a user that has
@@ -77,9 +77,9 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
 const COMP_TIMEOUT = 30_000;
 const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
 
-/** A git-gated comparison subresource on a fresh Work yields 5xx, never 404. */
+/** A git-gated comparison subresource on a fresh Work yields 409, never 404. */
 function isGitGated(status: number): boolean {
-    return status >= 500 && status < 600;
+    return status === 409;
 }
 
 async function makeWork(request: APIRequestContext, token: string, label: string): Promise<string> {

--- a/apps/web/e2e/flow-facade-error-mapping.spec.ts
+++ b/apps/web/e2e/flow-facade-error-mapping.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from './helpers/api';
+
+/**
+ * flow-facade-error-mapping — pins the contract of the global
+ * `FacadeExceptionFilter` (apps/api/src/common/filters/facade-exception.filter.ts).
+ *
+ * The `@ever-works/agent` facades (git / deploy / oauth / content-extractor)
+ * throw `FacadeError` subclasses — plain `Error`s, NOT NestJS HttpExceptions.
+ * Before this filter, any such error that reached a controller UNCAUGHT became
+ * a generic HTTP 500 ("the git-gate signature"). The filter now maps the
+ * caller-actionable leaves to the correct 4xx:
+ *   - NoGitProviderError / NoGitCredentialsError / No*ProviderError → 409
+ *   - *ProviderNotFoundError                                        → 404
+ *   - OAuthNotSupportedError                                        → 400
+ * while generic facade wrappers stay 500 with NO internal-message leak.
+ *
+ * The CI driver has NO connected git provider (no GitHub OAuth, no PAT), so any
+ * data-repo operation resolves a token and throws `NoGitCredentialsError`. This
+ * file pins that as a clean 409 PRECONDITION (error name + envelope shape), the
+ * new first-class contract the per-feature specs (collections / taxonomy /
+ * comparison / community-pr) now assert as a status only.
+ *
+ * Every probe registers a FRESH user (isolated, no shared seeded state). Filename
+ * uses the safe `flow-` prefix. TS strict.
+ */
+
+let counter = 0;
+function uniq(): string {
+    counter += 1;
+    return `${counter}-${Math.random().toString(36).slice(2, 7)}`;
+}
+
+interface FacadeEnvelope {
+    statusCode?: number;
+    message?: unknown;
+    error?: string;
+    status?: string;
+}
+
+async function freshWork(request: APIRequestContext): Promise<{ token: string; workId: string }> {
+    const u = await registerUserViaAPI(request);
+    const s = uniq();
+    const { id } = await createWorkViaAPI(request, u.access_token, {
+        name: `Facade ${s}`,
+        slug: `facade-${s}`,
+    });
+    return { token: u.access_token, workId: id };
+}
+
+test.describe('FacadeExceptionFilter — git-not-connected maps to a clean 409 precondition', () => {
+    test('a git-gated taxonomy write on a non-connected work → 409 NoGitCredentialsError (not a 500)', async ({
+        request,
+    }) => {
+        const { token, workId } = await freshWork(request);
+
+        const res = await request.post(`${API_BASE}/api/works/${workId}/collections`, {
+            headers: authedHeaders(token),
+            data: { name: `Collection ${uniq()}` },
+        });
+
+        expect(res.status(), 'git-gated write is a 409 precondition, never a 500').toBe(409);
+        const body = (await res.json()) as FacadeEnvelope;
+        expect(body.statusCode).toBe(409);
+        // The filter surfaces the facade's intentional, caller-facing class name
+        // + message (this is the SAFE 4xx path; 500s keep the generic body).
+        expect(body.error).toBe('NoGitCredentialsError');
+        expect(String(body.message)).toMatch(
+            /No connected account found for user .* with provider github/i,
+        );
+        // It is NOT a success envelope and does NOT leak a stack trace.
+        expect(body.status).not.toBe('success');
+        expect(JSON.stringify(body)).not.toMatch(/\bat \w+.*\(.*\.ts:\d+/); // no stack
+    });
+
+    test('community-PR processing on a non-connected work → 409 (was a generic 500)', async ({
+        request,
+    }) => {
+        const { token, workId } = await freshWork(request);
+
+        const enable = await request.patch(`${API_BASE}/api/works/${workId}`, {
+            headers: authedHeaders(token),
+            data: { communityPrEnabled: true },
+        });
+        expect(enable.status()).toBe(200);
+
+        // Poll the gate open (findById can lag the PATCH under sqlite), then assert 409.
+        let res!: Awaited<ReturnType<typeof request.post>>;
+        await expect
+            .poll(
+                async () => {
+                    res = await request.post(
+                        `${API_BASE}/api/works/${workId}/process-community-prs`,
+                        {
+                            headers: authedHeaders(token),
+                        },
+                    );
+                    return res.status();
+                },
+                { timeout: 20_000 },
+            )
+            .not.toBe(400);
+        expect(res.status(), 'no git provider connected → 409 precondition').toBe(409);
+        const body = (await res.json()) as FacadeEnvelope;
+        expect(body.error).toBe('NoGitCredentialsError');
+    });
+
+    test('DTO validation still precedes the facade filter: an invalid body is 400, not 409', async ({
+        request,
+    }) => {
+        const { token, workId } = await freshWork(request);
+
+        // Unknown property → ValidationPipe 400 BEFORE the service ever reaches git.
+        const res = await request.post(`${API_BASE}/api/works/${workId}/collections`, {
+            headers: authedHeaders(token),
+            data: { name: `OK ${uniq()}`, bogusField: 'nope' },
+        });
+        expect(res.status(), 'validation fires before the git-gate').toBe(400);
+        const body = (await res.json()) as FacadeEnvelope;
+        expect(body.statusCode).toBe(400);
+        expect(String(body.message)).toMatch(/should not exist/i);
+    });
+
+    test('ownership still precedes the facade filter: a ghost work is 404, not 409', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const ghost = '00000000-0000-0000-0000-000000000000';
+
+        const res = await request.post(`${API_BASE}/api/works/${ghost}/collections`, {
+            headers: authedHeaders(u.access_token),
+            data: { name: `Ghost ${uniq()}` },
+        });
+        // The work-row lookup (404) precedes the data-repo save (would-be 409).
+        expect(res.status(), 'absent work id is a 404 before the git-gate').toBe(404);
+    });
+});

--- a/apps/web/e2e/flow-kb-document-lifecycle-deep.spec.ts
+++ b/apps/web/e2e/flow-kb-document-lifecycle-deep.spec.ts
@@ -283,7 +283,7 @@ test.describe('Flow — KB document lifecycle (deep)', () => {
             { headers: authedHeaders(access_token) },
         );
         expect(
-            [200, 500, 502, 503].includes(hist.status()),
+            [200, 409, 500, 502, 503].includes(hist.status()),
             `history reachable (got ${hist.status()})`,
         ).toBeTruthy();
         if (hist.status() === 200) {

--- a/apps/web/e2e/flow-kb-document-lifecycle.spec.ts
+++ b/apps/web/e2e/flow-kb-document-lifecycle.spec.ts
@@ -364,7 +364,7 @@ test.describe('Flow — KB document lifecycle', () => {
             { headers: authedHeaders(token) },
         );
         expect(
-            [200, 500, 502, 503].includes(histRes.status()),
+            [200, 409, 500, 502, 503].includes(histRes.status()),
             `history endpoint reachable (got ${histRes.status()})`,
         ).toBeTruthy();
         if (histRes.status() === 200) {

--- a/apps/web/e2e/flow-kb-document-lock-restore.spec.ts
+++ b/apps/web/e2e/flow-kb-document-lock-restore.spec.ts
@@ -97,8 +97,8 @@ const MISSING_DOC = '00000000-0000-0000-0000-000000000000';
  * portable — we annotate which branch ran. We NEVER assert a populated git
  * result (that needs a real repo).
  */
-const RESTORE_REACHED_MIRROR = [200, 404, 500, 502, 503] as const;
-const HISTORY_REACHABLE = [200, 500, 502, 503] as const;
+const RESTORE_REACHED_MIRROR = [200, 404, 409, 500, 502, 503] as const;
+const HISTORY_REACHABLE = [200, 409, 500, 502, 503] as const;
 
 /** Per-test unique suffix — a closure counter, NOT a module-scope clock. */
 let seq = 0;

--- a/apps/web/e2e/flow-kb-locking-history.spec.ts
+++ b/apps/web/e2e/flow-kb-locking-history.spec.ts
@@ -137,10 +137,11 @@ const LOCK_FULL = 'full';
 const LOCK_ADDITIONS_ONLY = 'additions-only';
 
 /** Documented status sets — the CI mirror has no repo so the mirror-backed
- *  reads 500, but a deployment with a real repo would 200/404. Accept both so
+ *  reads 500 (or 409 — the FacadeExceptionFilter maps the no-git-credentials
+ *  precondition), but a deployment with a real repo would 200/404. Accept all so
  *  the contract assertion is portable; annotate which branch executed. */
-const HISTORY_OK_OR_MIRROR_DOWN = [200, 500, 502, 503] as const;
-const RESTORE_MIRROR_DOWN_OR_NOT_FOUND = [404, 500, 502, 503] as const;
+const HISTORY_OK_OR_MIRROR_DOWN = [200, 409, 500, 502, 503] as const;
+const RESTORE_MIRROR_DOWN_OR_NOT_FOUND = [404, 409, 500, 502, 503] as const;
 
 interface KbBodyDto {
     id: string;

--- a/apps/web/e2e/flow-subscription-billing-grace.spec.ts
+++ b/apps/web/e2e/flow-subscription-billing-grace.spec.ts
@@ -450,7 +450,7 @@ test.describe('Flow: subscription billing grace / past-due / dunning / reactivat
             headers: authedHeaders(user.access_token),
         });
         expect(
-            [200, 500],
+            [200, 409, 500],
             `cancel schedule status ${cancel.status()} (500 is the known non-generated-Work artifact)`,
         ).toContain(cancel.status());
 

--- a/apps/web/e2e/flow-taxonomy-git-gating-deep.spec.ts
+++ b/apps/web/e2e/flow-taxonomy-git-gating-deep.spec.ts
@@ -6,7 +6,7 @@ import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from '.
  * git-gate matrix for the Missions/Ideas/Works surface. Every per-work
  * taxonomy WRITE (POST/PUT/DELETE /api/works/:id/{categories,tags,collections})
  * commits to the work's data repo; on a fresh work with NO connected git
- * provider the save throws and the dedicated endpoints surface a GENERIC 500.
+ * provider the save throws and the dedicated endpoints surface a 409 (NoGitCredentialsError via the FacadeExceptionFilter; was a generic 500).
  * BEFORE that git-gate fire, three layers are exercised independently: the
  * class-validator DTO (ValidationPipe), the AuthSessionGuard (401), and the
  * ownership guard (403 stranger / 404 ghost). This file pins the DTO BOUND
@@ -34,7 +34,7 @@ import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from '.
  *       (categories-tags + count), the gate-ORDER walk (validation → auth →
  *       ownership → git) demonstrated with category-missing-name + tag-NON-
  *       string-50, stranger-403/ghost-404 on the CATEGORIES write only, the
- *       count↔read invariant, PUT/DELETE git-gate 500, and the submit-item 400
+ *       count↔read invariant, PUT/DELETE git-gate 409, and the submit-item 400
  *       reconnect-git contrast.
  *   · flow-git-provider-connection.spec.ts — that a disconnected user's
  *       categories AND tags AND collections writes are all >=400 git-gated
@@ -58,7 +58,7 @@ import { API_BASE, authedHeaders, registerUserViaAPI, createWorkViaAPI } from '.
  *      should not exist", and a CATEGORY-only field (description) on a TAG is
  *      rejected because CreateTagDto carries ONLY name.
  *   4. The sanitize @Transform truncates an over-long STRING name to the bound
- *      so it PASSES validation and falls through to the git-gate 500 (proving
+ *      so it PASSES validation and falls through to the git-gate 409 (proving
  *      the transform runs before the validator) — for all three kinds.
  *   5. Cross-user isolation on EACH write verb/kind: a DTO-valid stranger
  *      POST/PUT/DELETE is 403 (ownership precedes the git save) for tags AND
@@ -150,11 +150,17 @@ async function freshWork(
     return { token: u.access_token, workId };
 }
 
-/** A generic Nest 500 envelope — the git-gate signature for the dedicated endpoints. */
-function expectGitGate500(status: number, body: ErrorEnvelope, label: string): void {
-    expect(status, `${label} hits the git-gate → 500`).toBe(500);
-    expect(body.statusCode, `${label} 500 carries statusCode`).toBe(500);
-    expect(body.status, `${label} 500 is NOT a success envelope`).not.toBe('success');
+/**
+ * The git-gate signature for the dedicated taxonomy endpoints: a DTO-valid op
+ * on a work whose owner has NOT connected a git provider hits
+ * `gitFacade.cloneOrPull` → `NoGitCredentialsError`, which the global
+ * FacadeExceptionFilter maps to a clean 409 precondition (was a generic 500
+ * before that filter — see apps/api/src/common/filters).
+ */
+function expectGitGate409(status: number, body: ErrorEnvelope, label: string): void {
+    expect(status, `${label} hits the git-gate → 409 (no git provider connected)`).toBe(409);
+    expect(body.statusCode, `${label} 409 carries statusCode`).toBe(409);
+    expect(body.status, `${label} 409 is NOT a success envelope`).not.toBe('success');
 }
 
 /** A class-validator 400 envelope naming a field. */
@@ -231,7 +237,7 @@ test.describe('flow: taxonomy WRITE — the per-kind name @IsString+@MaxLength b
     }) => {
         // Probed: `{}` → 400 (@IsString fails on undefined). But `{ name: '' }` is a
         // STRING of length 0 — it passes @IsString + @MaxLength, so the DTO is valid
-        // and the request reaches the git-gated save → 500. This pins that the name
+        // and the request reaches the git-gated save → 409. This pins that the name
         // is validated for TYPE/length, NOT for non-emptiness (no @IsNotEmpty).
         const { token, workId } = await freshWork(request, 'name-required');
 
@@ -244,7 +250,7 @@ test.describe('flow: taxonomy WRITE — the per-kind name @IsString+@MaxLength b
         );
 
         const empty = await postTaxonomy(request, token, workId, 'categories', { name: '' });
-        expectGitGate500(empty.status, empty.body, 'empty-string category name');
+        expectGitGate409(empty.status, empty.body, 'empty-string category name');
     });
 });
 
@@ -301,7 +307,7 @@ test.describe('flow: taxonomy WRITE — the optional category/collection field b
     }) => {
         // priority floors at 0. -1 trips @Min(0); a string trips @IsNumber (and the
         // @Min comparison too). priority:0 is the inclusive boundary → it passes
-        // validation and the DTO-valid write falls through to the git-gate 500.
+        // validation and the DTO-valid write falls through to the git-gate 409.
         const { token, workId } = await freshWork(request, 'priority');
 
         const negative = await postTaxonomy(request, token, workId, 'categories', {
@@ -330,7 +336,7 @@ test.describe('flow: taxonomy WRITE — the optional category/collection field b
             name: 'Cat',
             priority: 0,
         });
-        expectGitGate500(zero.status, zero.body, 'priority:0 boundary write');
+        expectGitGate409(zero.status, zero.body, 'priority:0 boundary write');
     });
 });
 
@@ -372,14 +378,14 @@ test.describe('flow: taxonomy WRITE — the create whitelist (forbidNonWhitelist
 });
 
 test.describe('flow: taxonomy WRITE — the sanitize @Transform truncates an over-long STRING name through to the git-gate', () => {
-    test('an over-bound STRING name on each kind is sanitize-truncated to the bound (so it PASSES @MaxLength) and falls through to the git-gate 500 — proving the transform runs before the validator', async ({
+    test('an over-bound STRING name on each kind is sanitize-truncated to the bound (so it PASSES @MaxLength) and falls through to the git-gate 409 — proving the transform runs before the validator', async ({
         request,
     }) => {
         // CreateTagDto.name / Create{Category,Collection}Dto.name carry a
         // @Transform(sanitizeName(value, bound)) that runs (class-transformer)
         // BEFORE @MaxLength (class-validator). A raw STRING longer than the bound is
         // truncated to the bound → validation passes → the DTO-valid write reaches
-        // the git-gated save → 500. Contrast with the NON-string probe above, which
+        // the git-gated save → 409. Contrast with the NON-string probe above, which
         // can't be truncated and so trips @IsString+@MaxLength → 400.
         const { token, workId } = await freshWork(request, 'sanitize');
 
@@ -392,13 +398,13 @@ test.describe('flow: taxonomy WRITE — the sanitize @Transform truncates an ove
             const over = await postTaxonomy(request, token, workId, kind, {
                 name: overByKind[kind],
             });
-            expectGitGate500(over.status, over.body, `${kind} over-length STRING name (truncated)`);
+            expectGitGate409(over.status, over.body, `${kind} over-length STRING name (truncated)`);
         }
     });
 });
 
 test.describe('flow: taxonomy WRITE — the INCLUSIVE @MaxLength boundaries are valid and reach the git-gate', () => {
-    test('a tag name of EXACTLY 50 chars and a category description of EXACTLY 500 chars (the inclusive bounds) both PASS validation and fall through to the git-gate 500', async ({
+    test('a tag name of EXACTLY 50 chars and a category description of EXACTLY 500 chars (the inclusive bounds) both PASS validation and fall through to the git-gate 409', async ({
         request,
     }) => {
         // @MaxLength(n) is INCLUSIVE: a value of exactly n passes. We assert the
@@ -408,13 +414,13 @@ test.describe('flow: taxonomy WRITE — the INCLUSIVE @MaxLength boundaries are 
         const { token, workId } = await freshWork(request, 'boundary');
 
         const tag50 = await postTaxonomy(request, token, workId, 'tags', { name: 't'.repeat(50) });
-        expectGitGate500(tag50.status, tag50.body, 'tag name exactly 50 chars');
+        expectGitGate409(tag50.status, tag50.body, 'tag name exactly 50 chars');
 
         const desc500 = await postTaxonomy(request, token, workId, 'categories', {
             name: 'Cat',
             description: 'd'.repeat(500),
         });
-        expectGitGate500(desc500.status, desc500.body, 'category description exactly 500 chars');
+        expectGitGate409(desc500.status, desc500.body, 'category description exactly 500 chars');
     });
 });
 
@@ -422,7 +428,7 @@ test.describe('flow: taxonomy WRITE — the dedicated endpoints are git-gated fo
     test('a DTO-valid create for categories AND tags AND collections each 500s on a non-connected work and persists NOTHING (the read stays the empty success envelope)', async ({
         request,
     }) => {
-        // The core git-gate, asserted per kind with the GENERIC-500 envelope (distinct
+        // The core git-gate, asserted per kind with the git-gate 409 envelope (distinct
         // from submit-item's friendly 400). After all three blocked writes the
         // categories-tags read still reports the empty success envelope — no partial
         // taxonomy leaked from a half-committed save.
@@ -433,7 +439,7 @@ test.describe('flow: taxonomy WRITE — the dedicated endpoints are git-gated fo
             const write = await postTaxonomy(request, token, workId, kind, {
                 name: `Gated ${kind} ${s}`,
             });
-            expectGitGate500(write.status, write.body, `${kind} create`);
+            expectGitGate409(write.status, write.body, `${kind} create`);
         }
 
         const read = await request.get(`${API_BASE}/api/works/${workId}/categories-tags`, {
@@ -519,7 +525,7 @@ test.describe('flow: taxonomy WRITE — auth + ownership precede the git-gate on
         // DELETE is 403 (ownership precedes the git-gated read inside the service).
         // But the ValidationPipe still runs FIRST: an owner PUT with a non-string
         // name is a 400 (the body never reaches ownership/git), while an owner PUT
-        // with a VALID body reaches the git-gate → 500.
+        // with a VALID body reaches the git-gate → 409.
         const owner = await registerUserViaAPI(request);
         const stranger = await registerUserViaAPI(request);
         const s = uniq('putdel');
@@ -569,7 +575,7 @@ test.describe('flow: taxonomy WRITE — auth + ownership precede the git-gate on
             'owner PUT invalid name',
         );
 
-        // Owner PUT with a VALID name → reaches the git-gate → 500.
+        // Owner PUT with a VALID name → reaches the git-gate → 409.
         const ownerGoodPut = await request.put(
             `${API_BASE}/api/works/${workId}/categories/ghost-${s}`,
             {
@@ -577,18 +583,18 @@ test.describe('flow: taxonomy WRITE — auth + ownership precede the git-gate on
                 data: { name: `Renamed ${s}` },
             },
         );
-        expectGitGate500(
+        expectGitGate409(
             ownerGoodPut.status(),
             await readJson<ErrorEnvelope>(ownerGoodPut),
             'owner PUT valid name',
         );
 
-        // Owner DELETE a non-existent tag id → git-gate 500 (the gated read fires
+        // Owner DELETE a non-existent tag id → git-gate 409 (the gated read fires
         // before the per-child not-found check, so it's a 500, not a 404).
         const ownerDel = await request.delete(`${API_BASE}/api/works/${workId}/tags/ghost-${s}`, {
             headers: ownerH,
         });
-        expectGitGate500(
+        expectGitGate409(
             ownerDel.status(),
             await readJson<ErrorEnvelope>(ownerDel),
             'owner DELETE non-existent tag',
@@ -602,7 +608,7 @@ test.describe('flow: Missions/Ideas taxonomy CHAIN — accepting an Idea onto a 
     }) => {
         // An Idea (WorkProposal) becomes a Work via accept; accept stamps the
         // acceptedWorkId pointer but does NOT connect a git provider. So the linked
-        // Work's taxonomy writes are STILL git-gated (500) and its read is STILL the
+        // Work's taxonomy writes are STILL git-gated (409) and its read is STILL the
         // empty success envelope — proving the gate is about the git connection, not
         // the Idea→Work linkage state.
         const user = await registerUserViaAPI(request);
@@ -636,7 +642,7 @@ test.describe('flow: Missions/Ideas taxonomy CHAIN — accepting an Idea onto a 
         const write = await postTaxonomy(request, user.access_token, workId, 'categories', {
             name: `Chain Cat ${s}`,
         });
-        expectGitGate500(write.status, write.body, 'taxonomy write on accepted-linked work');
+        expectGitGate409(write.status, write.body, 'taxonomy write on accepted-linked work');
 
         // And its read is still the empty success envelope (no taxonomy materialized
         // by the accept).

--- a/apps/web/e2e/flow-work-community-pr.spec.ts
+++ b/apps/web/e2e/flow-work-community-pr.spec.ts
@@ -48,7 +48,7 @@
  *   PUT|PATCH /api/works/:id  body {communityPrEnabled?, communityPrAutoClose?} -> 200 { status:'success', work:{...} }
  *                                                            | 400 {message:["communityPrEnabled must be a boolean value"]} (bad type, per field)
  *   POST  /api/works/:id/process-community-prs            -> 400 "Community PR processing is not enabled for this work." (disabled)
- *                                                            | 500 {statusCode:500,message:"Internal server error"} (ENABLED but NO git provider — the DEGRADE path; PROBED)
+ *                                                            | 409 {statusCode:409,message:"No Git provider configured or available"} (ENABLED but NO git provider — precondition via FacadeExceptionFilter; was a generic 500 before that filter)
  *                                                            | 404 {status:'error',message:"Work with id '<id>' not found"} (ghost)
  *                                                            | 403 {status:'error',message:"You do not have permission to access this work"} (stranger)
  *                                                            | 401 {message:"Unauthorized"} (no token)
@@ -65,11 +65,13 @@
  *
  * KEY DEGRADE CONTRACT (PROBED): with the flag ENABLED but no connected git
  * provider (the CI reality — no GitHub OAuth, no plugin creds), the processor
- * calls `gitFacade.listPullRequests` which throws (NoGitProviderError /
- * GitFacadeError — none are HttpExceptions), and the un-try/catch controller
- * surfaces a 500. That IS the truthful "git not connected" degradation: we
- * assert the gate flips from a 400 ("not enabled") to a NON-400 *attempt*
- * (500 here), never a fictional 200.
+ * calls `gitFacade.listPullRequests` which throws `NoGitProviderError` (a
+ * `GitFacadeError`/`FacadeError`, not an HttpException). The global
+ * `FacadeExceptionFilter` (apps/api/src/common/filters) maps that to a clean
+ * 409 precondition ("No Git provider configured or available") — BEFORE that
+ * filter existed it surfaced as a generic 500. That IS the truthful "git not
+ * connected" degradation: we assert the gate flips from a 400 ("not enabled")
+ * to a 409 *precondition attempt*, never a fictional 200 and no longer a 500.
  *
  * Gotchas honored:
  *   - login DTO accepts ONLY {email,password}; register helper sends {username,email,password}.
@@ -230,9 +232,11 @@ test.describe('Work community-PR flags + processing (integration)', () => {
 
         // The gate is now OPEN: the endpoint stops returning the "not enabled" 400
         // and instead ATTEMPTS to process. With no connected git provider in CI it
-        // cannot list pull requests, so the attempt degrades to a 500 (PROBED). We
-        // assert the gate transition (no longer 400-"not enabled") rather than a
-        // fictional 200. findById can briefly lag the PUT under sqlite, so poll.
+        // cannot list pull requests, so the attempt surfaces a clean 409 precondition
+        // ("No Git provider configured or available") via the FacadeExceptionFilter —
+        // it was a generic 500 before that filter landed. We assert the gate
+        // transition (no longer 400-"not enabled") and the specific 409.
+        // findById can briefly lag the PUT under sqlite, so poll.
         let processed!: Awaited<ReturnType<typeof process>>;
         await expect
             .poll(
@@ -244,7 +248,8 @@ test.describe('Work community-PR flags + processing (integration)', () => {
             )
             .not.toBe(400);
         expect(processed.status()).not.toBe(400);
-        expect(processed.status()).toBeGreaterThanOrEqual(200);
+        // No git provider connected → 409 precondition (was 500 pre-FacadeExceptionFilter).
+        expect(processed.status()).toBe(409);
         expect(JSON.stringify(await processed.json())).not.toContain(
             'Community PR processing is not enabled',
         );
@@ -349,8 +354,9 @@ test.describe('Work community-PR flags + processing (integration)', () => {
         await setFlags(request, token, work.id, { communityPrEnabled: true });
 
         // Drive the degrade path a few times. Each attempt must (a) leave the
-        // enablement 400 behind and (b) stay a bounded server response (< 600),
-        // never hang or surface the "not enabled" gate again.
+        // enablement 400 behind and (b) settle on the same clean 409 precondition
+        // (no git provider) via the FacadeExceptionFilter — deterministic, never a
+        // 500/hang, never the "not enabled" gate again.
         await expect
             .poll(async () => (await process(request, token, work.id)).status(), {
                 timeout: 20_000,
@@ -359,7 +365,8 @@ test.describe('Work community-PR flags + processing (integration)', () => {
         for (let i = 0; i < 2; i++) {
             const attempt = await process(request, token, work.id);
             expect(attempt.status()).not.toBe(400);
-            expect(attempt.status()).toBeLessThan(600);
+            // No git provider connected → 409 precondition (was an unbounded 500 before).
+            expect(attempt.status()).toBe(409);
             expect(JSON.stringify(await attempt.json())).not.toContain(
                 'Community PR processing is not enabled',
             );

--- a/apps/web/e2e/flow-work-taxonomy-deep.spec.ts
+++ b/apps/web/e2e/flow-work-taxonomy-deep.spec.ts
@@ -39,11 +39,11 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *         anon                       -> 401 { message:'Unauthorized', statusCode:401 }
  *         stranger (DTO-valid)       -> 403 { status:'error', message:'You do not have permission…' }
  *         ghost id (DTO-valid)       -> 404 { status:'error', message:"Work with id '<id>' not found" }
- *         OWNER, DTO-valid, NON-git-connected work -> 500 { statusCode:500, message:'Internal server error' }
+ *         OWNER, DTO-valid, NON-git-connected work -> 409 { statusCode:409, error:'NoGitCredentialsError' }
  *           — the dataGenerator save throws (no connected data repo); the dedicated taxonomy-write
- *             endpoints surface this as a GENERIC 500 (distinct from submit-item's 400 reconnect-git).
+ *             endpoints surface this as a 409 git-gate (NoGitCredentialsError; was a generic 500) (distinct from submit-item's 400 reconnect-git).
  *     PUT/DELETE /api/works/:id/{categories|tags|collections}/:childId
- *         OWNER on a real non-connected work -> 500 (the git-gated getCategoriesTags read inside the
+ *         OWNER on a real non-connected work -> 409 (the git-gated getCategoriesTags read inside the
  *         service fires BEFORE the per-child not-found check, so the gate dominates).
  *
  *   The legacy POST /api/works/:id/submit-item carries an item's category+tags; a DTO-VALID body
@@ -54,7 +54,7 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  * NON-DUPLICATION: the sibling specs (work-items-crud, flow-work-items-crud-deep,
  * flow-work-full-lifecycle) assert the empty owner-side read envelope and the submit-item gate.
  * These 6 flows add the surface they LACK: the DEDICATED taxonomy-WRITE endpoints
- * (categories/tags/collections) and their exact 500 git-gate, the gate-ORDER invariant
+ * (categories/tags/collections) and their exact 409 git-gate, the gate-ORDER invariant
  * (validation -> ownership -> git, asserted by switching one variable at a time), stranger-403
  * and ghost-404 on BOTH reads AND writes with their precise envelopes, the count<->read accuracy
  * invariant after a NO-OP gated write, PUT/DELETE git-gate dominance, and per-work isolation.
@@ -277,13 +277,13 @@ test.describe('Work taxonomy (deep) — per-work categories / tags / collections
         assertDenialEnvelope(ghostCount.body, NOT_FOUND_RE, 'ghost count');
     });
 
-    test('dedicated taxonomy WRITES (categories/tags/collections) are git-gated: a DTO-valid owner write 500s on a non-connected work and persists NOTHING', async ({
+    test('dedicated taxonomy WRITES (categories/tags/collections) are git-gated: a DTO-valid owner write 409s on a non-connected work and persists NOTHING', async ({
         request,
     }) => {
         // THE uncovered surface: the dedicated POST /works/:id/{categories,tags,collections} endpoints.
         // On a work with no connected data repo, an owner DTO-VALID write reaches the dataGenerator
-        // save which throws -> the controller surfaces a GENERIC 500 (distinct from submit-item's 400
-        // reconnect-git gate). We assert the 500 for ALL THREE kinds, then prove the gated writes
+        // save which throws -> the controller surfaces a 409 git-gate (NoGitCredentialsError; was a generic 500) (distinct from submit-item's 400
+        // reconnect-git gate). We assert the 409 for ALL THREE kinds, then prove the gated writes
         // committed NOTHING: the read + count still report the empty envelope (no partial taxonomy).
         const u = await registerUserViaAPI(request);
         const s = stamp();
@@ -297,10 +297,11 @@ test.describe('Work taxonomy (deep) — per-work categories / tags / collections
             const write = await postTaxonomy(request, u.access_token, workId, kind, {
                 name: `Gated ${kind} ${s}`,
             });
-            expect(write.status, `git-gated ${kind} write -> 500; body=${write.text}`).toBe(500);
-            // Generic Nest 500 envelope: a statusCode (no success status, no validator array).
-            expect(write.body.statusCode, `${kind} write 500 carries statusCode`).toBe(500);
-            expect(write.body.status, `${kind} write 500 is NOT a success envelope`).not.toBe(
+            expect(write.status, `git-gated ${kind} write -> 409; body=${write.text}`).toBe(409);
+            // 409 git-gate envelope (NoGitCredentialsError via FacadeExceptionFilter; was a
+            // generic 500): a statusCode (no success status, no validator array).
+            expect(write.body.statusCode, `${kind} write 409 carries statusCode`).toBe(409);
+            expect(write.body.status, `${kind} write 409 is NOT a success envelope`).not.toBe(
                 'success',
             );
         }
@@ -348,7 +349,7 @@ test.describe('Work taxonomy (deep) — per-work categories / tags / collections
         // SAME validation layer. We can't probe it with an over-long STRING: CreateTagDto.name has a
         // @Transform(sanitizeName(value, 50)) that runs (class-transformer) BEFORE @MaxLength (class-
         // validator), truncating 'x'.repeat(51) to 50 chars so it passes validation and falls through
-        // to the git-gated save -> 500 (live-probed 2026-06-01). A NON-string name (12345) can't be
+        // to the git-gated save -> 409 (NoGitCredentialsError; live-probed pre-filter as 500). A NON-string name (12345) can't be
         // truncated, so @IsString + @MaxLength(50) both fire -> 400 with the tighter 50-char message
         // — proving the per-kind tag DTO with its 50-bound is the FIRST gate, before ownership/git.
         const tooLong = await postTaxonomy(request, a.access_token, workId, 'tags', {
@@ -383,21 +384,22 @@ test.describe('Work taxonomy (deep) — per-work categories / tags / collections
         assertDenialEnvelope(ghost.body, NOT_FOUND_RE, 'ghost write');
 
         // (e) GIT last — only when validation+ownership+existence all pass does the owner reach the
-        //     git-gated save -> 500 on this non-connected work.
+        //     git-gated save -> 409 on this non-connected work (NoGitCredentialsError → 409 via
+        //     the FacadeExceptionFilter; was a generic 500 before that filter).
         const gated = await postTaxonomy(request, a.access_token, workId, 'categories', {
             name: `Gated ${s}`,
         });
-        expect(gated.status, `owner DTO-valid write hits git-gate -> 500; body=${gated.text}`).toBe(
-            500,
+        expect(gated.status, `owner DTO-valid write hits git-gate -> 409; body=${gated.text}`).toBe(
+            409,
         );
-        expect(gated.body.statusCode).toBe(500);
+        expect(gated.body.statusCode).toBe(409);
     });
 
     test('PUT/DELETE taxonomy writes are equally git-gated, and submit-item exposes the DISTINCT reconnect-git 400 contract', async ({
         request,
     }) => {
         // The update/delete child endpoints read the existing taxonomy from the data repo BEFORE the
-        // per-child not-found check, so on a non-connected work the git-gated read dominates -> 500
+        // per-child not-found check, so on a non-connected work the git-gated read dominates -> 409
         // (NOT a 404 for the bogus child id). Contrast with the legacy submit-item write, which
         // surfaces the human-readable reconnect-git 400 — proving two write paths, two gate shapes.
         const u = await registerUserViaAPI(request);
@@ -408,24 +410,24 @@ test.describe('Work taxonomy (deep) — per-work categories / tags / collections
         });
         expect(workId).toMatch(UUID_RE);
 
-        // PUT a (necessarily) non-existent category id with a DTO-valid body -> git-gate 500.
+        // PUT a (necessarily) non-existent category id with a DTO-valid body -> git-gate 409.
         const put = await request.put(`${API_BASE}/api/works/${workId}/categories/ghost-${s}`, {
             headers: authedHeaders(u.access_token),
             data: { name: `Renamed ${s}` },
         });
         expect(
             put.status(),
-            `PUT category git-gate -> 500; body=${await put.text().catch(() => '')}`,
-        ).toBe(500);
+            `PUT category git-gate -> 409; body=${await put.text().catch(() => '')}`,
+        ).toBe(409);
 
-        // DELETE a non-existent tag id -> git-gate 500 (the read fires before the not-found check).
+        // DELETE a non-existent tag id -> git-gate 409 (the read fires before the not-found check).
         const del = await request.delete(`${API_BASE}/api/works/${workId}/tags/ghost-${s}`, {
             headers: authedHeaders(u.access_token),
         });
         expect(
             del.status(),
-            `DELETE tag git-gate -> 500; body=${await del.text().catch(() => '')}`,
-        ).toBe(500);
+            `DELETE tag git-gate -> 409; body=${await del.text().catch(() => '')}`,
+        ).toBe(409);
 
         // submit-item: a DTO-VALID, taxonomy-bearing item on the same non-connected work returns the
         // DISTINCT reconnect-git 400 (validation passes -> reaches the git gate with a friendly msg).

--- a/docs/architecture/error-handling-patterns.md
+++ b/docs/architecture/error-handling-patterns.md
@@ -46,6 +46,54 @@ flowchart TD
 | `packages/agent/src/facades/base.facade.ts`                       | Facade-level error classes (`FacadeError`, `NoProviderError`)         |
 | `packages/agent/src/facades/ai.facade.ts`                         | AI-specific error class (`AiFacadeError`)                             |
 | `packages/agent/src/pipeline/pipeline-builder.service.ts`         | Pipeline errors (`CircularDependencyError`, `MissingDependencyError`) |
+| `apps/api/src/common/filters/facade-exception.filter.ts`          | Global filter mapping the `FacadeError` hierarchy → HTTP status codes |
+
+## HTTP boundary: the FacadeException filter
+
+**Rule of thumb:** a service must never let a non-`HttpException` reach a
+controller expecting it to become a meaningful status. Nest's default filter
+turns any non-`HttpException` into a generic **500** (and hides its message).
+For domain errors that are caller-actionable — "no provider configured",
+"GitHub not connected", "provider not found" — a 500 is wrong: it implies a
+server fault when the caller can fix it.
+
+The `FacadeError` hierarchy (`git` / `deploy` / `oauth` / `content-extractor`
+facades) is mapped to the correct 4xx by a single **global** exception filter,
+`FacadeExceptionFilter`, registered via `APP_FILTER` in `api.module.ts`:
+
+| Facade error (by `.name`)                                                                                                                                 | HTTP    | Meaning                                                                     |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------------------------------------------------- |
+| `NoProviderError`, `NoGitProviderError`, `NoDeployProviderError`, `NoOAuthProviderError`, `NoContentExtractorProviderError`                               | **409** | No provider enabled for the capability — enable a plugin                    |
+| `NoGitCredentialsError`, `NoDeployCredentialsError`                                                                                                       | **409** | The user hasn't connected the account / added credentials                   |
+| `ProviderNotFoundError`, `GitProviderNotFoundError`, `DeployProviderNotFoundError`, `OAuthProviderNotFoundError`, `ContentExtractorProviderNotFoundError` | **404** | The named `providerId` doesn't exist among loaded plugins                   |
+| `OAuthNotSupportedError`                                                                                                                                  | **400** | The resolved plugin doesn't implement the operation                         |
+| any other `FacadeError` (generic `*FacadeError` wrappers)                                                                                                 | **500** | Genuine upstream/internal failure — body stays generic, **no message leak** |
+
+Design invariants:
+
+- **Map by `.name`, not `instanceof`.** The hierarchy is intentionally
+  inconsistent (`NoGitProviderError extends GitFacadeError`, not
+  `NoProviderError`). Each class assigns a stable `this.name` in its
+  constructor, so the filter keys off that — robust to minification and immune
+  to the class tree.
+- **HTTP-only by construction.** A global filter runs only in the HTTP request
+  pipeline. FacadeErrors thrown in BullMQ workers, Trigger.dev tasks, the
+  internal-CLI, or generation pipelines are never touched — so this can't
+  wrongly 4xx a background failure.
+- **Additive.** Controllers that already catch a `FacadeError` and convert it
+  to an `HttpException` (e.g. `search` / `screenshot` / `agent-memory`) are
+  unaffected; their `HttpException` is not a `FacadeError`, so `@Catch(FacadeError)`
+  never sees it. The filter only nets the previously-UNCAUGHT cases.
+- **No info leak on 500.** For the unmapped wrappers, the filter returns the
+  same generic `"Internal server error"` body Nest's default filter would —
+  the facade's raw message is surfaced ONLY for the mapped 4xx (those messages
+  are intentional and caller-facing).
+
+**Concrete effect.** A data-repo operation on a work whose owner has not
+connected a git provider (`gitFacade.cloneOrPull` → `NoGitCredentialsError`)
+now returns **409** instead of a generic 500. This covers taxonomy writes
+(categories / tags / collections), comparison generation, community-PR
+processing, and `POST /api/templates/fork`.
 
 ## Key Classes
 


### PR DESCRIPTION
One coherent chunk bundling two related hardening changes (amortizes the expensive e2e run).

## A · CI — e2e.yml is develop-only
The 16-shard Playwright suite re-ran **identically** on the stage→main cascade — pure duplicate work, since promotion is a fast-forward of code that already passed e2e on `develop`. Trimmed `push: [develop, stage, main, master]` → `[develop]` (kept `workflow_dispatch` for one-off pre-merge branch validation).

- **Safe**: nothing consumes `e2e.yml` via `workflow_run` (it's a leaf).
- **Deliberately NOT touched**: `ci.yml` — its stage/main push runs are **load-bearing** for `release-trigger-{stage,prod}` (`on: workflow_run: ["CI"]`); `k8s-e2e.yml` (release-branch-specific, path-filtered) stays on stage/main.
- Runbook amended (`CI_RELEASE_GATES.md`, 2026-06-12 amendment).

## B · API — FacadeException filter (domain errors → HTTP at the boundary)
The `@ever-works/agent` `FacadeError` hierarchy (git/deploy/oauth/content-extractor) are plain `Error`s. When one reached a controller **uncaught** (`POST /api/templates/fork` → `NoGitProviderError`; any data-repo write whose owner hasn't connected GitHub → `NoGitCredentialsError`), Nest's default filter made it a generic **500** — mislabeling caller-actionable preconditions as server faults.

New global `FacadeExceptionFilter` (`APP_FILTER`) maps by stable `.name`:
| error | HTTP |
|---|---|
| `No*ProviderError` / `No*CredentialsError` | **409** precondition |
| `*ProviderNotFoundError` | **404** |
| `OAuthNotSupportedError` | **400** |
| generic `*FacadeError` wrappers | **500** (unchanged, **no message leak**) |

Maps by `.name` not `instanceof` (the hierarchy is intentionally inconsistent); **HTTP-only** so background/worker throws are untouched; **additive** (controllers already catching FacadeError→HttpException are unaffected); preserves Nest's no-leak generic body for the 500 fall-through.

A 12-agent controller-reachable sweep of **all 219** service `throw new Error` sites confirmed this filter + 3 `work-repo-resolver` throws (→ 404/409) were the **only** remaining 4xx-as-500 bugs; the rest were already HttpException-guarded by prior security waves.

**Operator-approved BROAD effect:** every "git not connected" path now returns a clean **409** instead of 500 — taxonomy writes (categories/tags/collections), comparison generation, community-PR processing, templates/fork.

## C · Specs (EW-721 — pinned behavior updated in the same PR)
- `flow-collections-deep`, `flow-taxonomy-git-gating-deep`: git-gate helper 500→409
- `flow-work-taxonomy-deep`: 5 inline 500→409
- `flow-comparison-generator`: `isGitGated()` 5xx → `===409`
- `flow-work-community-pr`: process degrade 500→409
- **NEW** `flow-facade-error-mapping.spec.ts`: pins the filter contract (409 error name + envelope, no stack leak, validation/ownership still precede the gate)
- An exhaustive scan confirmed **no other spec** pins a git-gate 500.

## Verification (local, sqlite e2e API)
collection write → 409 `NoGitCredentialsError`, community-pr → 409, fork DTO → 400, ghost → 404; new spec 4/4; **50 reconciled-spec passes, zero assertion failures**; api unit **2825 passed**; web tsc **0**; prettier clean.

> e2e no longer auto-runs on branches — dispatched manually on this branch as the pre-merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Operations that previously surfaced as generic 500 errors due to backend facade issues now return appropriate 4xx/5xx responses—notably 409 (Conflict) for missing git credentials—and avoid leaking internal stack traces.
  * Some service error cases now surface as proper HTTP 404/409 statuses instead of generic errors.

* **Documentation**
  * Added documentation describing the new HTTP error boundary and facade error mapping behavior.

* **Tests**
  * Updated and added end-to-end and unit tests to assert the new 4xx error contracts (including 409) and logging/visibility guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->