### PR TITLE
fix(deploy): wire PLATFORM_ENCRYPTION_KEY into dev/stage/prod (unblock crash-looping deploys)

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -215,6 +215,11 @@ spec:
             # 2026-05-17 audit env (PR ever-works#816)
             - name: PLUGIN_SECRET_ENCRYPTION_KEY
               value: "$PLUGIN_SECRET_ENCRYPTION_KEY"
+            # EW-716 (#1262): master key for at-rest encryption of operator
+            # secrets. REQUIRED at boot in non-local envs (the API crash-loops
+            # without it). Sourced from the PLATFORM_ENCRYPTION_KEY GitHub secret.
+            - name: PLATFORM_ENCRYPTION_KEY
+              value: "$PLATFORM_ENCRYPTION_KEY"
             - name: COMMUNITY_PR_VERIFIED_ORGS
               value: "$COMMUNITY_PR_VERIFIED_ORGS"
             - name: AGENT_BASH_AUDIT_LOG

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -233,6 +233,11 @@ spec:
             # 2026-05-17 audit env (PR ever-works#816 — see THREAT-MODEL.md)
             - name: PLUGIN_SECRET_ENCRYPTION_KEY
               value: "$PLUGIN_SECRET_ENCRYPTION_KEY"
+            # EW-716 (#1262): master key for at-rest encryption of operator
+            # secrets. REQUIRED at boot in non-local envs (the API crash-loops
+            # without it). Sourced from the PLATFORM_ENCRYPTION_KEY GitHub secret.
+            - name: PLATFORM_ENCRYPTION_KEY
+              value: "$PLATFORM_ENCRYPTION_KEY"
             - name: COMMUNITY_PR_VERIFIED_ORGS
               value: "$COMMUNITY_PR_VERIFIED_ORGS"
             - name: AGENT_BASH_AUDIT_LOG

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -213,6 +213,11 @@ spec:
             # 2026-05-17 audit env (PR ever-works#816)
             - name: PLUGIN_SECRET_ENCRYPTION_KEY
               value: "$PLUGIN_SECRET_ENCRYPTION_KEY"
+            # EW-716 (#1262): master key for at-rest encryption of operator
+            # secrets. REQUIRED at boot in non-local envs (the API crash-loops
+            # without it). Sourced from the PLATFORM_ENCRYPTION_KEY GitHub secret.
+            - name: PLATFORM_ENCRYPTION_KEY
+              value: "$PLATFORM_ENCRYPTION_KEY"
             - name: COMMUNITY_PR_VERIFIED_ORGS
               value: "$COMMUNITY_PR_VERIFIED_ORGS"
             - name: AGENT_BASH_AUDIT_LOG

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -144,6 +144,12 @@ jobs:
 
           # 2026-05-17 security audit env knobs (PR ever-works#816).
           PLUGIN_SECRET_ENCRYPTION_KEY: ${{ secrets.PLUGIN_SECRET_ENCRYPTION_KEY }}
+          # EW-716 (#1262): master key for at-rest encryption of operator
+          # secrets (per-Work platform_sync_secret). REQUIRED at boot in
+          # non-local envs — without it the API crash-loops on startup
+          # (config/constants.ts platformEncryptionKey()). 32-byte hex
+          # (openssl rand -hex 32). Create the GitHub secret before deploy.
+          PLATFORM_ENCRYPTION_KEY: ${{ secrets.PLATFORM_ENCRYPTION_KEY }}
           COMMUNITY_PR_VERIFIED_ORGS: ever-works
           AGENT_BASH_AUDIT_LOG: 'true'
           # C-04 host allow-list. Empty = WEB_URL's host only (fine for dev).

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -159,6 +159,12 @@ jobs:
           # Required in prod; without it the encryption service degrades to
           # passthrough.
           PLUGIN_SECRET_ENCRYPTION_KEY: ${{ secrets.PLUGIN_SECRET_ENCRYPTION_KEY }}
+          # EW-716 (#1262): master key for at-rest encryption of operator
+          # secrets (per-Work platform_sync_secret). REQUIRED at boot in
+          # non-local envs — without it the API crash-loops on startup
+          # (config/constants.ts platformEncryptionKey()). 32-byte hex
+          # (openssl rand -hex 32). Create the GitHub secret before deploy.
+          PLATFORM_ENCRYPTION_KEY: ${{ secrets.PLATFORM_ENCRYPTION_KEY }}
           # C-11: PRs auto-applied only when the PR author is a verified
           # member of one of these GitHub orgs. Empty = author check off
           # (the COMMUNITY_PR_AUTO_APPLY default-off gate still applies).

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -144,6 +144,12 @@ jobs:
 
           # 2026-05-17 security audit env knobs (PR ever-works#816).
           PLUGIN_SECRET_ENCRYPTION_KEY: ${{ secrets.PLUGIN_SECRET_ENCRYPTION_KEY }}
+          # EW-716 (#1262): master key for at-rest encryption of operator
+          # secrets (per-Work platform_sync_secret). REQUIRED at boot in
+          # non-local envs — without it the API crash-loops on startup
+          # (config/constants.ts platformEncryptionKey()). 32-byte hex
+          # (openssl rand -hex 32). Create the GitHub secret before deploy.
+          PLATFORM_ENCRYPTION_KEY: ${{ secrets.PLATFORM_ENCRYPTION_KEY }}
           COMMUNITY_PR_VERIFIED_ORGS: ever-works
           AGENT_BASH_AUDIT_LOG: 'true'
           # C-04 host allow-list. Empty = WEB_URL's host only.


### PR DESCRIPTION
## The blocker (pre-existing, since #1262)

[#1262](https://github.com/ever-works/ever-works/pull/1262) (EW-716) added a **required** `PLATFORM_ENCRYPTION_KEY` boot-gate (`config/constants.ts` `platformEncryptionKey()` — master key for at-rest encryption of per-Work `platform_sync_secret`), but the deploy workflows + k8s manifests were never wired for it and **no GitHub secret was created**.

**Every post-#1262 deploy crash-loops on boot:**
```
Error: PLATFORM_ENCRYPTION_KEY environment variable is required in non-local environments.
    at platformEncryptionKey (/app/dist/config/constants.js:84)
```
The rollout stalls (new pod CrashLoopBackOff) and the **old pod keeps serving** — so it's been silent:
- **dev** stuck at Jun-8 (`1ea0551`), new pod 33 restarts
- **stage** stuck at Jun-7 (`540cce1`), new pod 6 restarts
- **prod** at Jun-7 (`370a943`) — would crash on its next deploy

CI/e2e pass because they set the key inline (e2e.yml), masking the gap. Surfaced while cascading #1292 to stage.

## Fix

Wire `PLATFORM_ENCRYPTION_KEY: ${{ secrets.PLATFORM_ENCRYPTION_KEY }}` into `deploy-do-{dev,stage,prod}.yml` + inject it in `k8s-manifest.{dev,stage,prod}.yaml` — mirroring the existing `PLUGIN_SECRET_ENCRYPTION_KEY` wiring exactly. (YAML isn't in the prettier `format:check` glob; lines mirror the existing style; envsubst render verified.)

## ⚠️ Operator action required BEFORE the next deploy

Create the GitHub secret **`PLATFORM_ENCRYPTION_KEY`** = `openssl rand -hex 32` (32-byte hex — the consumer `platform-sync-secret.service.ts` requires hex/32 bytes). No rows are encrypted with it yet on any env, so a fresh key is safe. Per-environment (Environment) secrets recommended over one shared repo secret. Until it's set, `${{ secrets.PLATFORM_ENCRYPTION_KEY }}` resolves to empty → still crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configurations across development, staging, and production environments to initialize platform encryption key during API startup.
  * Updated GitHub deployment workflows to provision the encryption key during manifest application steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->