### PR TITLE
chore: cascade develop→stage (deploy wiring fix #1294 — PLATFORM_ENCRYPTION_KEY)

### DIFF
--- a/.deploy/k8s/k8s-manifest.dev.yaml
+++ b/.deploy/k8s/k8s-manifest.dev.yaml
@@ -215,6 +215,11 @@ spec:
             # 2026-05-17 audit env (PR ever-works#816)
             - name: PLUGIN_SECRET_ENCRYPTION_KEY
               value: "$PLUGIN_SECRET_ENCRYPTION_KEY"
+            # EW-716 (#1262): master key for at-rest encryption of operator
+            # secrets. REQUIRED at boot in non-local envs (the API crash-loops
+            # without it). Sourced from the PLATFORM_ENCRYPTION_KEY GitHub secret.
+            - name: PLATFORM_ENCRYPTION_KEY
+              value: "$PLATFORM_ENCRYPTION_KEY"
             - name: COMMUNITY_PR_VERIFIED_ORGS
               value: "$COMMUNITY_PR_VERIFIED_ORGS"
             - name: AGENT_BASH_AUDIT_LOG

--- a/.deploy/k8s/k8s-manifest.prod.yaml
+++ b/.deploy/k8s/k8s-manifest.prod.yaml
@@ -233,6 +233,11 @@ spec:
             # 2026-05-17 audit env (PR ever-works#816 — see THREAT-MODEL.md)
             - name: PLUGIN_SECRET_ENCRYPTION_KEY
               value: "$PLUGIN_SECRET_ENCRYPTION_KEY"
+            # EW-716 (#1262): master key for at-rest encryption of operator
+            # secrets. REQUIRED at boot in non-local envs (the API crash-loops
+            # without it). Sourced from the PLATFORM_ENCRYPTION_KEY GitHub secret.
+            - name: PLATFORM_ENCRYPTION_KEY
+              value: "$PLATFORM_ENCRYPTION_KEY"
             - name: COMMUNITY_PR_VERIFIED_ORGS
               value: "$COMMUNITY_PR_VERIFIED_ORGS"
             - name: AGENT_BASH_AUDIT_LOG

--- a/.deploy/k8s/k8s-manifest.stage.yaml
+++ b/.deploy/k8s/k8s-manifest.stage.yaml
@@ -213,6 +213,11 @@ spec:
             # 2026-05-17 audit env (PR ever-works#816)
             - name: PLUGIN_SECRET_ENCRYPTION_KEY
               value: "$PLUGIN_SECRET_ENCRYPTION_KEY"
+            # EW-716 (#1262): master key for at-rest encryption of operator
+            # secrets. REQUIRED at boot in non-local envs (the API crash-loops
+            # without it). Sourced from the PLATFORM_ENCRYPTION_KEY GitHub secret.
+            - name: PLATFORM_ENCRYPTION_KEY
+              value: "$PLATFORM_ENCRYPTION_KEY"
             - name: COMMUNITY_PR_VERIFIED_ORGS
               value: "$COMMUNITY_PR_VERIFIED_ORGS"
             - name: AGENT_BASH_AUDIT_LOG

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -144,6 +144,12 @@ jobs:
 
           # 2026-05-17 security audit env knobs (PR ever-works#816).
           PLUGIN_SECRET_ENCRYPTION_KEY: ${{ secrets.PLUGIN_SECRET_ENCRYPTION_KEY }}
+          # EW-716 (#1262): master key for at-rest encryption of operator
+          # secrets (per-Work platform_sync_secret). REQUIRED at boot in
+          # non-local envs — without it the API crash-loops on startup
+          # (config/constants.ts platformEncryptionKey()). 32-byte hex
+          # (openssl rand -hex 32). Create the GitHub secret before deploy.
+          PLATFORM_ENCRYPTION_KEY: ${{ secrets.PLATFORM_ENCRYPTION_KEY }}
           COMMUNITY_PR_VERIFIED_ORGS: ever-works
           AGENT_BASH_AUDIT_LOG: 'true'
           # C-04 host allow-list. Empty = WEB_URL's host only (fine for dev).

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -159,6 +159,12 @@ jobs:
           # Required in prod; without it the encryption service degrades to
           # passthrough.
           PLUGIN_SECRET_ENCRYPTION_KEY: ${{ secrets.PLUGIN_SECRET_ENCRYPTION_KEY }}
+          # EW-716 (#1262): master key for at-rest encryption of operator
+          # secrets (per-Work platform_sync_secret). REQUIRED at boot in
+          # non-local envs — without it the API crash-loops on startup
+          # (config/constants.ts platformEncryptionKey()). 32-byte hex
+          # (openssl rand -hex 32). Create the GitHub secret before deploy.
+          PLATFORM_ENCRYPTION_KEY: ${{ secrets.PLATFORM_ENCRYPTION_KEY }}
           # C-11: PRs auto-applied only when the PR author is a verified
           # member of one of these GitHub orgs. Empty = author check off
           # (the COMMUNITY_PR_AUTO_APPLY default-off gate still applies).

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -144,6 +144,12 @@ jobs:
 
           # 2026-05-17 security audit env knobs (PR ever-works#816).
           PLUGIN_SECRET_ENCRYPTION_KEY: ${{ secrets.PLUGIN_SECRET_ENCRYPTION_KEY }}
+          # EW-716 (#1262): master key for at-rest encryption of operator
+          # secrets (per-Work platform_sync_secret). REQUIRED at boot in
+          # non-local envs — without it the API crash-loops on startup
+          # (config/constants.ts platformEncryptionKey()). 32-byte hex
+          # (openssl rand -hex 32). Create the GitHub secret before deploy.
+          PLATFORM_ENCRYPTION_KEY: ${{ secrets.PLATFORM_ENCRYPTION_KEY }}
           COMMUNITY_PR_VERIFIED_ORGS: ever-works
           AGENT_BASH_AUDIT_LOG: 'true'
           # C-04 host allow-list. Empty = WEB_URL's host only.


### PR DESCRIPTION
Brings #1294 (wire PLATFORM_ENCRYPTION_KEY into deploy-do-stage.yml + k8s-manifest.stage.yaml) to stage so the stuck rollout can boot. The GitHub secret PLATFORM_ENCRYPTION_KEY is now set. Merge fires docker-build-publish-stage → deploy-do-stage → clean roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)