### PR TITLE
fix(deploy): normalize getWorkflowFilenames so the lazy plugin proxy can't crash k8s deploys

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -226,6 +226,27 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         expect(workflows).toEqual(['deploy_k8s.yaml']);
     });
 
+    it('normalizes a Promise-returning getWorkflowFilenames (EW-693 lazy plugin proxy)', async () => {
+        // The lazy plugin proxy wraps method calls to return Promises so it can
+        // materialize the real plugin on first use. getWorkflowFilenames is
+        // declared synchronous, so a raw `for…of` over that Promise previously
+        // threw "workflowFiles is not iterable" and blocked every k8s deploy.
+        const { service, githubPlugin } = buildService({
+            plugin: {
+                id: 'k8s',
+                getWorkflowFilenames: (() =>
+                    Promise.resolve(['deploy_k8s.yaml'])) as unknown as () => string[],
+                getDeploymentSecrets: jest.fn().mockResolvedValue({}),
+            },
+        });
+
+        await service.deploy('work-1', 'user-1', {});
+
+        const { dispatches } = captureCalls(githubPlugin);
+        const workflows = dispatches.map((d: any) => d.workflow);
+        expect(workflows).toEqual(['deploy_k8s.yaml']);
+    });
+
     it('syncs the website template before dispatch when the required workflow is missing', async () => {
         const notFound = Object.assign(new Error('Not found'), { status: 404 });
         const getFileContent = jest

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -961,9 +961,23 @@ export class DeployService {
         prNumber?: number,
         commitSha?: string,
     ): Promise<boolean> {
-        const workflowFilesToTry = plugin?.getWorkflowFilenames
-            ? plugin.getWorkflowFilenames()
+        // The plugin may be a lazy proxy (EW-693 dynamic distribution) that
+        // wraps every method call to return a Promise so it can materialize
+        // the real plugin on first use. `getWorkflowFilenames` is declared
+        // synchronous, so without normalizing here the value reaching the
+        // `for…of` in findMissingWorkflowFiles would be a Promise (or
+        // `undefined` when the proxy over-reports a method the underlying
+        // plugin lacks) — which threw `TypeError: workflowFiles is not
+        // iterable` and blocked every k8s deploy. `Promise.resolve` collapses
+        // both the sync-array and proxied-Promise cases; the Array guard falls
+        // back to the defaults if the result is still not a usable list.
+        const rawWorkflowFiles = plugin?.getWorkflowFilenames
+            ? await Promise.resolve(plugin.getWorkflowFilenames())
             : [...DEFAULT_WORKFLOW_FILES];
+        const workflowFilesToTry =
+            Array.isArray(rawWorkflowFiles) && rawWorkflowFiles.length > 0
+                ? rawWorkflowFiles
+                : [...DEFAULT_WORKFLOW_FILES];
         const owner = work.getRepoOwner('website');
         const repo = work.getWebsiteRepo();
         const template = await this.websiteTemplateResolver.resolveForWork(work);


### PR DESCRIPTION
## Summary

Every k8s deploy through the platform feature currently **500s in prod** with `TypeError: workflowFiles is not iterable` — *after* it has already pushed the deploy secrets to the website repo. This blocks the entire Vercel→k8s Work migration.

## Root cause

`DeployService.dispatchWithRetry` does:

```ts
const workflowFilesToTry = plugin?.getWorkflowFilenames
    ? plugin.getWorkflowFilenames()   // ← Promise via the lazy proxy
    : [...DEFAULT_WORKFLOW_FILES];
```

The **EW-693 lazy plugin proxy** wraps every method call to return a Promise (so it can materialize the real plugin on first use). `getWorkflowFilenames()` is declared **synchronous** (`string[]`), so at runtime the call returns a `Promise<string[]>`, which is then iterated with `for…of` in `findMissingWorkflowFiles` → "not iterable". The async methods in the deploy path (`getDeploymentSecrets`, etc.) are already awaited, which is why secret-pushing succeeds and only the workflow-file preflight crashes.

This is the documented *“lazy proxy over-reports / wraps optional methods”* class — an unfixed call site.

## Fix

Normalize the result before iterating:

```ts
const rawWorkflowFiles = plugin?.getWorkflowFilenames
    ? await Promise.resolve(plugin.getWorkflowFilenames())
    : [...DEFAULT_WORKFLOW_FILES];
const workflowFilesToTry =
    Array.isArray(rawWorkflowFiles) && rawWorkflowFiles.length > 0
        ? rawWorkflowFiles
        : [...DEFAULT_WORKFLOW_FILES];
```

`Promise.resolve` collapses both the sync-array (Vercel, tests) and proxied-Promise (runtime) cases; the Array guard falls back to defaults if a plugin returns something unusable. `getWorkflowFilenames` was the only un-awaited sync plugin call in the deploy path.

## Test

Adds a regression test that simulates the proxy returning a `Promise<string[]>` and asserts the dispatch list still resolves to `['deploy_k8s.yaml']`.

## Notes

- No entity/schema change → no migration.
- Prod impact: this is the blocker for deploying Works to `k8s-works`; needs to cascade `develop → stage → main` to reach the prod API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment failures that occurred when plugins provided workflow filenames asynchronously. The deploy service now robustly handles both synchronous and asynchronous configurations, with automatic fallback to default workflows. This prevents runtime errors during workflow preflight and dispatch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->