### PR TITLE
feat(deploy): provision per-Work k8s runtime env (AUTH_SECRET/COOKIE_SECRET/DATABASE_URL)

### DIFF
--- a/apps/api/src/migrations/1780700000000-AddWorkDeployRuntimeEnv.ts
+++ b/apps/api/src/migrations/1780700000000-AddWorkDeployRuntimeEnv.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Adds the per-Work encrypted runtime-env columns used by the k8s deploy
+ * feature to inject `AUTH_SECRET` / `COOKIE_SECRET` / `DATABASE_URL` into a
+ * deployed site's container.
+ *
+ * Vercel supplied these from project env + the Neon Marketplace integration;
+ * the k8s deploy path had no equivalent, so a freshly-built directory site
+ * 500'd at runtime (`[auth] AUTH_SECRET must be set in production`). The
+ * deploy feature now generates + persists the auth/cookie secrets (stable
+ * across redeploys) and stores the per-Work database URL, all AES-256-GCM
+ * encrypted-at-rest with `PLATFORM_ENCRYPTION_KEY` — mirroring the existing
+ * `webhookSecretEncrypted` / `platformSyncSecretEncrypted` columns.
+ *
+ * Forward-only and idempotent (`hasColumn` guard). Columns are nullable;
+ * no backfill — values are lazily provisioned on the next k8s deploy (or
+ * seeded out-of-band for the existing Vercel→k8s migration Works).
+ */
+export class AddWorkDeployRuntimeEnv1780700000000 implements MigrationInterface {
+	name = 'AddWorkDeployRuntimeEnv1780700000000';
+
+	private readonly columns = [
+		'deployAuthSecretEncrypted',
+		'deployCookieSecretEncrypted',
+		'deployDatabaseUrlEncrypted',
+	];
+
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		for (const name of this.columns) {
+			if (!(await queryRunner.hasColumn('works', name))) {
+				await queryRunner.addColumn(
+					'works',
+					new TableColumn({ name, type: 'text', isNullable: true }),
+				);
+			}
+		}
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		for (const name of this.columns) {
+			if (await queryRunner.hasColumn('works', name)) {
+				await queryRunner.dropColumn('works', name);
+			}
+		}
+	}
+}

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -22,6 +22,7 @@ import {
 import {
     PlatformSyncSecretService,
     WebhookSecretService,
+    WorkRuntimeEnvService,
     ZeroFrictionFunnelService,
 } from '@ever-works/agent/services';
 import { EverWorksDnsService } from '@ever-works/agent/ever-works-providers';
@@ -115,6 +116,7 @@ export class DeployService {
         private readonly eventEmitter: EventEmitter2,
         private readonly platformSyncSecretService: PlatformSyncSecretService,
         private readonly webhookSecretService: WebhookSecretService,
+        private readonly workRuntimeEnvService: WorkRuntimeEnvService,
         private readonly dnsService: EverWorksDnsService,
         private readonly funnel: ZeroFrictionFunnelService,
     ) {}
@@ -208,6 +210,7 @@ export class DeployService {
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
         await this.ensureCronSecret(ctx);
         await this.ensureWebhookSecret(ctx, work);
+        await this.ensureRuntimeEnv(ctx, work, plugin);
 
         const template = await this.websiteTemplateResolver.resolveForWork(work);
         const targetBranch = env.branch ?? template.branch;
@@ -860,6 +863,55 @@ export class DeployService {
         } catch (error: any) {
             this.logger.warn(
                 `Failed to push WEBHOOK_SECRET for ${ctx.owner}/${ctx.repo}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /**
+     * Provision the per-Work application runtime env that a k8s-deployed
+     * directory site needs to boot in production. Vercel supplied these from
+     * project env + the Neon integration; k8s has no such source, so without
+     * this the deployed site 500s (`[auth] AUTH_SECRET must be set in
+     * production`). Pushed as GitHub secrets; `deploy_k8s.yaml` materializes
+     * them into a `${slug}-runtime-env` k8s Secret the Deployment mounts via
+     * `envFrom`. No-op for non-k8s providers (Vercel manages its own env).
+     *
+     * `AUTH_SECRET`/`COOKIE_SECRET` are generated once and persisted (stable
+     * across redeploys — rotating would drop every live session). `DATABASE_URL`
+     * is the per-Work Postgres (e.g. reused Neon) connection string when
+     * configured. `NEXT_PUBLIC_APP_URL`/`COOKIE_DOMAIN` are derived from the
+     * ingress host inside the manifest, not here.
+     */
+    private async ensureRuntimeEnv(ctx: RepoContext, work: Work, plugin?: IDeploymentPlugin) {
+        if (!this.isKubernetesDeploy(work.deployProvider, plugin?.id)) {
+            return;
+        }
+        try {
+            await this.setSecret(
+                ctx,
+                'AUTH_SECRET',
+                await this.workRuntimeEnvService.getOrGenerateAuthSecret(work.id),
+            );
+            await this.setSecret(
+                ctx,
+                'COOKIE_SECRET',
+                await this.workRuntimeEnvService.getOrGenerateCookieSecret(work.id),
+            );
+            await this.setSecret(ctx, 'COOKIE_SECURE', 'true');
+
+            const databaseUrl = await this.workRuntimeEnvService.getDatabaseUrl(work.id);
+            if (databaseUrl) {
+                await this.setSecret(ctx, 'DATABASE_URL', databaseUrl);
+            } else {
+                this.logger.warn(
+                    `No DATABASE_URL configured for work ${work.id}; DB-backed features (auth users, favorites, submissions) will be unavailable on k8s until one is set.`,
+                );
+            }
+        } catch (error: any) {
+            this.logger.warn(
+                `Failed to push runtime env for ${ctx.owner}/${ctx.repo}: ${
                     error instanceof Error ? error.message : String(error)
                 }`,
             );

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -375,6 +375,40 @@ export class WorkRepository {
     }
 
     /**
+     * Conditional UPDATE for the lazy bootstrap of the per-Work k8s deploy
+     * `AUTH_SECRET` (`deployAuthSecretEncrypted`). Same race-safe semantics as
+     * `setWebhookSecretIfNull` — the first deploy to win persists its value;
+     * concurrent deploys re-read. Stable across redeploys (rotating would
+     * invalidate live sessions).
+     */
+    async setDeployAuthSecretIfNull(workId: string, encrypted: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(Work)
+            .set({ deployAuthSecretEncrypted: encrypted })
+            .where('id = :id', { id: workId })
+            .andWhere('deployAuthSecretEncrypted IS NULL')
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Conditional UPDATE for the lazy bootstrap of the per-Work k8s deploy
+     * `COOKIE_SECRET` (`deployCookieSecretEncrypted`). Race-safe; see
+     * `setDeployAuthSecretIfNull`.
+     */
+    async setDeployCookieSecretIfNull(workId: string, encrypted: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(Work)
+            .set({ deployCookieSecretEncrypted: encrypted })
+            .where('id = :id', { id: workId })
+            .andWhere('deployCookieSecretEncrypted IS NULL')
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
      * Update platform-sync observability columns after a pull-transport
      * round-trip. Pass `lastSuccessAt` on success or
      * `{ lastErrorAt, lastErrorMessage }` on failure — partial updates are

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -427,6 +427,24 @@ export class Work {
     @Column({ type: 'text', nullable: true })
     webhookSecretEncrypted?: string | null;
 
+    // AES-256-GCM-encrypted per-Work runtime env injected into a k8s-deployed
+    // site's container (deploy_k8s renders a `${slug}-runtime-env` Secret that
+    // deployment.yaml mounts via envFrom). Vercel supplied these from project
+    // env + the Neon integration; k8s has no such source, so the deploy
+    // feature provisions them (EW: k8s runtime-env). `AUTH_SECRET`/
+    // `COOKIE_SECRET` are generated once and persisted so they stay stable
+    // across redeploys (rotating would invalidate live sessions); the database
+    // URL is the per-Work Postgres connection string (e.g. the reused Neon DB).
+    // All NULL until the first k8s deploy / explicit set.
+    @Column({ type: 'text', nullable: true })
+    deployAuthSecretEncrypted?: string | null;
+
+    @Column({ type: 'text', nullable: true })
+    deployCookieSecretEncrypted?: string | null;
+
+    @Column({ type: 'text', nullable: true })
+    deployDatabaseUrlEncrypted?: string | null;
+
     // Pull-mode observability — drives the degraded banner UX.
     @TimestampColumn({ nullable: true })
     platformSyncLastSuccessAt?: Date | null;

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -22,6 +22,7 @@ export * from './state-marker.service';
 export * from './anonymous-user-cleanup.service';
 export * from './platform-sync-secret.service';
 export * from './webhook-secret.service';
+export * from './work-runtime-env.service';
 export * from './webhook-subscription-secret.service';
 export * from './zero-friction-funnel.service';
 export * from './deploy-ready-poller.service';

--- a/packages/agent/src/services/work-runtime-env.service.ts
+++ b/packages/agent/src/services/work-runtime-env.service.ts
@@ -1,0 +1,161 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { config } from '../config';
+import { WorkRepository } from '../database/repositories/work.repository';
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH_BYTES = 32;
+const IV_LENGTH_BYTES = 12;
+const AUTH_TAG_LENGTH_BYTES = 16;
+const SECRET_LENGTH_BYTES = 32;
+
+/**
+ * Provisions the per-Work **application runtime env** that a k8s-deployed
+ * directory site needs to boot in production — `AUTH_SECRET`, `COOKIE_SECRET`,
+ * and `DATABASE_URL`. `DeployService` reads these on a k8s deploy and pushes
+ * them so `deploy_k8s.yaml` materializes a `${slug}-runtime-env` Secret the
+ * Deployment mounts via `envFrom`.
+ *
+ * **Why this exists**: Vercel injected these from project env + the Neon
+ * Marketplace integration. The k8s deploy path had no equivalent, so a
+ * freshly-built site 500'd at first render (`[auth] AUTH_SECRET must be set in
+ * production`). This service is the platform-side source of truth.
+ *
+ * **Persistence + stability**: `AUTH_SECRET` / `COOKIE_SECRET` are generated
+ * once and persisted (AES-256-GCM, `PLATFORM_ENCRYPTION_KEY`) so they stay
+ * stable across redeploys — rotating either would silently invalidate every
+ * live session/cookie. `DATABASE_URL` is set explicitly (e.g. the reused Neon
+ * connection string) rather than generated. This mirrors `WebhookSecretService`
+ * / `PlatformSyncSecretService` exactly, including the race-safe conditional
+ * UPDATE (`set*IfNull`) so concurrent deploys converge on one value.
+ */
+@Injectable()
+export class WorkRuntimeEnvService {
+	private readonly logger = new Logger(WorkRuntimeEnvService.name);
+	private cachedKey: Buffer | null = null;
+
+	constructor(private readonly workRepository: WorkRepository) {}
+
+	/** Lazily provision the per-Work `AUTH_SECRET` (base64). Stable across deploys. */
+	async getOrGenerateAuthSecret(workId: string): Promise<string> {
+		return this.getOrGenerate(
+			workId,
+			(w) => w.deployAuthSecretEncrypted,
+			(id, enc) => this.workRepository.setDeployAuthSecretIfNull(id, enc),
+		);
+	}
+
+	/** Lazily provision the per-Work `COOKIE_SECRET` (base64). Stable across deploys. */
+	async getOrGenerateCookieSecret(workId: string): Promise<string> {
+		return this.getOrGenerate(
+			workId,
+			(w) => w.deployCookieSecretEncrypted,
+			(id, enc) => this.workRepository.setDeployCookieSecretIfNull(id, enc),
+		);
+	}
+
+	/** The per-Work `DATABASE_URL`, or null when none is configured yet. */
+	async getDatabaseUrl(workId: string): Promise<string | null> {
+		const work = await this.workRepository.findById(workId);
+		if (!work?.deployDatabaseUrlEncrypted) {
+			return null;
+		}
+		return this.decrypt(work.deployDatabaseUrlEncrypted);
+	}
+
+	/** Set (or replace) the per-Work `DATABASE_URL`. */
+	async setDatabaseUrl(workId: string, databaseUrl: string): Promise<void> {
+		const existing = await this.workRepository.findById(workId);
+		if (!existing) {
+			throw new Error(`Work not found: ${workId}`);
+		}
+		await this.workRepository.update(workId, {
+			deployDatabaseUrlEncrypted: this.encrypt(databaseUrl),
+		});
+	}
+
+	/**
+	 * Shared race-safe getOrGenerate for a base64 secret stored in an encrypted
+	 * Work column. First deploy generates + persists; concurrent deploys re-read.
+	 */
+	private async getOrGenerate(
+		workId: string,
+		read: (work: { [k: string]: unknown }) => string | null | undefined,
+		setIfNull: (workId: string, encrypted: string) => Promise<boolean>,
+	): Promise<string> {
+		const existing = await this.workRepository.findById(workId);
+		if (!existing) {
+			throw new Error(`Work not found: ${workId}`);
+		}
+		const current = read(existing as unknown as { [k: string]: unknown });
+		if (current) {
+			return this.decrypt(current);
+		}
+		const plaintext = randomBytes(SECRET_LENGTH_BYTES).toString('base64');
+		const encrypted = this.encrypt(plaintext);
+		const won = await setIfNull(workId, encrypted);
+		if (won) {
+			return plaintext;
+		}
+		// Lost the race — another deploy generated it first. Read back.
+		const reread = await this.workRepository.findById(workId);
+		const rereadValue = reread
+			? read(reread as unknown as { [k: string]: unknown })
+			: undefined;
+		if (!rereadValue) {
+			throw new Error(`Runtime-env secret bootstrap race lost but no value found for work ${workId}`);
+		}
+		return this.decrypt(rereadValue);
+	}
+
+	private getKey(): Buffer {
+		if (this.cachedKey) {
+			return this.cachedKey;
+		}
+		const hex = config.platformSync.getEncryptionKey();
+		if (!hex) {
+			throw new Error(
+				'PLATFORM_ENCRYPTION_KEY is not set. Required for encrypting per-Work deploy runtime env.',
+			);
+		}
+		if (!/^[0-9a-fA-F]+$/.test(hex)) {
+			throw new Error('PLATFORM_ENCRYPTION_KEY must be a hex string.');
+		}
+		const key = Buffer.from(hex, 'hex');
+		if (key.length !== KEY_LENGTH_BYTES) {
+			throw new Error(
+				`PLATFORM_ENCRYPTION_KEY must decode to ${KEY_LENGTH_BYTES} bytes (got ${key.length}).`,
+			);
+		}
+		this.cachedKey = key;
+		return key;
+	}
+
+	private encrypt(plaintext: string): string {
+		const key = this.getKey();
+		const iv = randomBytes(IV_LENGTH_BYTES);
+		const cipher = createCipheriv(ALGORITHM, key, iv);
+		const ciphertext = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+		const authTag = cipher.getAuthTag();
+		return Buffer.concat([iv, authTag, ciphertext]).toString('base64');
+	}
+
+	private decrypt(envelope: string): string {
+		const key = this.getKey();
+		const buf = Buffer.from(envelope, 'base64');
+		if (buf.length < IV_LENGTH_BYTES + AUTH_TAG_LENGTH_BYTES + 1) {
+			throw new Error('deploy runtime-env envelope is malformed (too short).');
+		}
+		const iv = buf.subarray(0, IV_LENGTH_BYTES);
+		const authTag = buf.subarray(IV_LENGTH_BYTES, IV_LENGTH_BYTES + AUTH_TAG_LENGTH_BYTES);
+		const ciphertext = buf.subarray(IV_LENGTH_BYTES + AUTH_TAG_LENGTH_BYTES);
+		const decipher = createDecipheriv(ALGORITHM, key, iv);
+		decipher.setAuthTag(authTag);
+		try {
+			return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+		} catch (err) {
+			this.logger.error('Failed to decrypt deploy runtime-env', err);
+			throw new Error('deploy runtime-env decryption failed (auth tag mismatch).');
+		}
+	}
+}

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -34,6 +34,7 @@ import { WorksConfigSyncListener } from '@src/works-config/services/works-config
 import { WorksConfigWriterService } from '@src/works-config/services/works-config-writer.service';
 import { PlatformSyncSecretService } from './platform-sync-secret.service';
 import { WebhookSecretService } from './webhook-secret.service';
+import { WorkRuntimeEnvService } from './work-runtime-env.service';
 import { ZeroFrictionFunnelService } from './zero-friction-funnel.service';
 import { DeployReadyPollerService } from './deploy-ready-poller.service';
 import { ItemHealthService } from './item-health.service';
@@ -105,6 +106,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         EverWorksDeployQuotaService,
         PlatformSyncSecretService,
         WebhookSecretService,
+        WorkRuntimeEnvService,
         ZeroFrictionFunnelService,
         DeployReadyPollerService,
         // EW-614 — `EverWorksGitProvider` creates the per-Work repository in
@@ -154,6 +156,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorksConfigRepositorySyncService,
         PlatformSyncSecretService,
         WebhookSecretService,
+        WorkRuntimeEnvService,
         ZeroFrictionFunnelService,
         DeployReadyPollerService,
         CommunityPrModule,


### PR DESCRIPTION
## Why
k8s-deployed directory sites 500 at runtime (`[auth] AUTH_SECRET must be set in production`) — the k8s deploy path injects only `NODE_ENV/PORT/HOSTNAME`, none of the app runtime env that **Vercel** supplied via project env + the Neon integration. This makes the deploy feature provision it, so the Vercel→k8s migration (and every future customer Work) actually runs.

## What
- **Work entity**: `deployAuthSecretEncrypted` / `deployCookieSecretEncrypted` / `deployDatabaseUrlEncrypted` (AES-256-GCM, mirroring `webhookSecretEncrypted`).
- **Migration `1780700000000`** — forward-only, idempotent.
- **`WorkRuntimeEnvService`** — generate+persist auth/cookie secrets (stable across redeploys), get/set `DATABASE_URL`; mirrors `WebhookSecretService` incl. race-safe `set*IfNull`.
- **`DeployService.ensureRuntimeEnv`** — on a **k8s** deploy, pushes `AUTH_SECRET`/`COOKIE_SECRET`/`COOKIE_SECURE`/`DATABASE_URL` as repo secrets (no-op for Vercel).

## Companion (separate PRs)
- Template `deploy_k8s.yaml` materializes a `${slug}-runtime-env` Secret + `deployment.yaml` `envFrom` it (+ `NEXT_PUBLIC_APP_URL`/`COOKIE_DOMAIN` from the ingress host).
- One-time `DATABASE_URL` seed for the 6 migrating Works (reused Neon DBs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added encrypted runtime environment secret storage for per-work deployments, including authentication and session credentials.
  * Enabled secure database URL configuration for Kubernetes deployments.
  * Implemented automatic secret provisioning to ensure consistent deployment environments across multiple deploys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->