### PR TITLE
fix(deploy): type WorkRuntimeEnv read callback against Work entity (unblocks #1306 build)

### DIFF
--- a/packages/agent/src/services/work-runtime-env.service.ts
+++ b/packages/agent/src/services/work-runtime-env.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
 import { config } from '../config';
 import { WorkRepository } from '../database/repositories/work.repository';
+import { Work } from '../entities/work.entity';
 
 const ALGORITHM = 'aes-256-gcm';
 const KEY_LENGTH_BYTES = 32;
@@ -80,14 +81,14 @@ export class WorkRuntimeEnvService {
 	 */
 	private async getOrGenerate(
 		workId: string,
-		read: (work: { [k: string]: unknown }) => string | null | undefined,
+		read: (work: Work) => string | null | undefined,
 		setIfNull: (workId: string, encrypted: string) => Promise<boolean>,
 	): Promise<string> {
 		const existing = await this.workRepository.findById(workId);
 		if (!existing) {
 			throw new Error(`Work not found: ${workId}`);
 		}
-		const current = read(existing as unknown as { [k: string]: unknown });
+		const current = read(existing);
 		if (current) {
 			return this.decrypt(current);
 		}
@@ -99,9 +100,7 @@ export class WorkRuntimeEnvService {
 		}
 		// Lost the race — another deploy generated it first. Read back.
 		const reread = await this.workRepository.findById(workId);
-		const rereadValue = reread
-			? read(reread as unknown as { [k: string]: unknown })
-			: undefined;
+		const rereadValue = reread ? read(reread) : undefined;
 		if (!rereadValue) {
 			throw new Error(`Runtime-env secret bootstrap race lost but no value found for work ${workId}`);
 		}


### PR DESCRIPTION
## What
`WorkRuntimeEnvService.getOrGenerate`'s `read` callback was typed `(work: { [k: string]: unknown })`, making `w.deployAuthSecretEncrypted` `unknown` → **TS2322** at both call sites (lines 43, 52).

## Impact
`tsc -p tsconfig.types.json` runs in the agent Docker image build, so **the #1306 prod build failed and no image was published** — dev (`apidev`) and prod (`api.ever.works`) silently kept the *prior* image. This is why the runtime-env feature wasn't actually live.

## Fix
Type the callback against the real `Work` entity (the 3 deploy columns are `string | null`); the `as unknown as {…}` casts drop out.

## Verification
Ran the **exact failing step** locally — `tsc -p tsconfig.types.json` in `packages/agent` after building `@ever-works/plugin` + `@ever-works/contracts` fresh: `work-runtime-env.service.ts` is clean (remaining local errors are stale-node_modules artifacts, e.g. `pacote` not installed, which Docker's `pnpm install` resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)