### PR TITLE
fix(deploy): derive per-Work k8s Ingress host from work.website

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -63,11 +63,14 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
          *  pre-dual-mode tests behaving as before. */
         activitySyncMode?: 'pull' | 'push' | 'disabled';
         githubPluginOverrides?: Record<string, unknown>;
+        /** Work's public `website` URL — drives the per-Work k8s Ingress host. */
+        website?: string;
     }) => {
         const websiteOwner = overrides.websiteOwner ?? 'acme';
         const work = {
             id: 'work-1',
             slug: 'my-site',
+            website: overrides.website,
             deployProvider: overrides.deployProvider ?? 'k8s',
             gitProvider: 'github',
             websiteTemplateId: 'directory-web-template',
@@ -145,6 +148,12 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             getOrGenerate: jest.fn().mockResolvedValue('webhook'.repeat(9) + 'a'), // 64 chars
         };
 
+        const workRuntimeEnvService = {
+            getOrGenerateAuthSecret: jest.fn().mockResolvedValue('auth-secret-base64'),
+            getOrGenerateCookieSecret: jest.fn().mockResolvedValue('cookie-secret-base64'),
+            getDatabaseUrl: jest.fn().mockResolvedValue(null),
+        };
+
         // EW-617 G5: DNS automation no-ops in tests (no env vars). The
         // dns service still needs to be present so the constructor wires
         // — `getProvider` returns null and `ensureWorkSubdomain` is a
@@ -170,6 +179,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             eventEmitter as any,
             platformSyncSecretService as any,
             webhookSecretService as any,
+            workRuntimeEnvService as any,
             dnsService as any,
             funnel as any,
         );
@@ -782,6 +792,50 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             // getDeploymentSecrets when settings.ingressHost is set.
             // (Plugin is mocked here, so we only assert on the call.)
             void githubPlugin; // silence unused
+        });
+
+        it('derives a per-Work k8s Ingress host from work.website (not the shared settings.ingressHost)', async () => {
+            const getDeploymentSecrets = jest.fn().mockResolvedValue({});
+            const { service, dnsService } = buildService({
+                deployProvider: 'k8s',
+                website: 'https://dir.ever.works',
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets,
+                },
+                // Shared plugin setting points at a DIFFERENT Work's host —
+                // the per-Work override must win to avoid Ingress collisions.
+                settings: { kubeconfig: 'apiVersion: v1', ingressHost: 'other-work.ever.works' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const settingsArg = getDeploymentSecrets.mock.calls[0][0];
+            expect(settingsArg.ingressHost).toBe('dir.ever.works');
+            // Not the managed ever-works subdomain path.
+            expect(dnsService.ensureWorkSubdomain).not.toHaveBeenCalled();
+        });
+
+        it('ignores *.vercel.app placeholder websites for the k8s Ingress host', async () => {
+            const getDeploymentSecrets = jest.fn().mockResolvedValue({});
+            const { service } = buildService({
+                deployProvider: 'k8s',
+                website: 'https://my-site.vercel.app',
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets,
+                },
+                settings: { kubeconfig: 'apiVersion: v1', ingressHost: 'fallback.ever.works' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const settingsArg = getDeploymentSecrets.mock.calls[0][0];
+            // Falls back to the plugin-configured host rather than routing on a
+            // provider placeholder domain.
+            expect(settingsArg.ingressHost).toBe('fallback.ever.works');
         });
 
         it('leaves settings unchanged for non-ever-works providers', async () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -484,25 +484,65 @@ export class DeployService {
         work: Work,
         settings: Record<string, unknown> | undefined,
     ): Promise<Record<string, unknown> | undefined> {
-        if (work.deployProvider !== 'ever-works') {
-            return settings;
+        // EW-617 G5: the managed `ever-works` provider auto-derives
+        // `${slug}.ever.works` and provisions the Cloudflare CNAME.
+        if (work.deployProvider === 'ever-works') {
+            const provider = this.dnsService.getProvider();
+            if (!provider) {
+                return settings;
+            }
+
+            const ingressHost = this.dnsService.ingressHostFor(work.slug);
+
+            // Provision asynchronously — DNS propagation runs in parallel with
+            // the workflow dispatch. Errors are logged inside the service so
+            // they never abort the deploy.
+            void this.dnsService.ensureWorkSubdomain(work.slug);
+
+            return {
+                ...(settings ?? {}),
+                ingressHost,
+            };
         }
-        const provider = this.dnsService.getProvider();
-        if (!provider) {
-            return settings;
+
+        // k8s deploys: the per-Work Ingress host MUST come from the Work's own
+        // primary domain, not the k8s plugin's shared `settings.ingressHost`.
+        // That setting is a single user-scoped value (last-write-wins), so
+        // without this every Work would claim the same host and the Ingress
+        // admission webhook rejects the collision. Derive it from `work.website`.
+        if (work.deployProvider === 'k8s') {
+            const websiteHost = this.deriveIngressHostFromWebsite(work);
+            if (websiteHost) {
+                return {
+                    ...(settings ?? {}),
+                    ingressHost: websiteHost,
+                };
+            }
         }
 
-        const ingressHost = this.dnsService.ingressHostFor(work.slug);
+        return settings;
+    }
 
-        // Provision asynchronously — DNS propagation runs in parallel with
-        // the workflow dispatch. Errors are logged inside the service so
-        // they never abort the deploy.
-        void this.dnsService.ensureWorkSubdomain(work.slug);
-
-        return {
-            ...(settings ?? {}),
-            ingressHost,
-        };
+    /**
+     * Parse the routable Ingress host from a Work's `website` URL. Returns
+     * `null` for empty/unparseable values or provider placeholder hosts
+     * (`*.vercel.app`) that aren't real custom domains, so the caller falls
+     * back to the plugin's configured host.
+     */
+    private deriveIngressHostFromWebsite(work: Work): string | null {
+        const raw = work.website?.trim();
+        if (!raw) {
+            return null;
+        }
+        try {
+            const host = new URL(raw.includes('://') ? raw : `https://${raw}`).host.toLowerCase();
+            if (!host || host.endsWith('.vercel.app')) {
+                return null;
+            }
+            return host;
+        } catch {
+            return null;
+        }
     }
 
     private async setRequiredSecrets(


### PR DESCRIPTION
## Problem
`K8S_INGRESS_HOST` came from the k8s plugin's **shared** `settings.ingressHost` (single user-scoped value, last-write-wins). So every k8s Work deploy claimed the same host; the nginx Ingress admission webhook rejected the collision (`host "…" already defined in ingress …/awesome-compliance-automation-website`) and the deploy failed at manifest apply. Hit live while migrating `awesome-time-tracking` (pod booted fine; only the Ingress apply failed).

## Fix
For `deployProvider==='k8s'`, derive the Ingress host from the Work's own `work.website` (skip `*.vercel.app` placeholders), overriding the shared setting. Propagates to `K8S_INGRESS_HOST`, `SITE_URL`, and runtime-env `COOKIE_DOMAIN`/`NEXT_PUBLIC_APP_URL`. The managed `ever-works` provider path (`${slug}.ever.works` + Cloudflare CNAME) is untouched.

## Also
Repairs `deploy.service.spec.ts` — #1306 added `WorkRuntimeEnvService` as a 13th constructor arg but left the manual `new DeployService(...)` at 12 args, so the suite failed to compile. Added the mock + 2 tests. **Full suite: 47/47 pass** (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)