### PR TITLE
feat(deploy): per-Work runtime-env API (get/set DATABASE_URL)

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
@@ -79,6 +79,7 @@ describe('DeployController', () => {
         findByWork: jest.Mock;
     };
     let activityLogService: { log: jest.Mock };
+    let workRuntimeEnvService: { getDatabaseUrl: jest.Mock; setDatabaseUrl: jest.Mock };
     let controller: DeployController;
 
     const buildWork = (overrides: Record<string, unknown> = {}) => ({
@@ -125,6 +126,11 @@ describe('DeployController', () => {
         };
         activityLogService = { log: jest.fn().mockResolvedValue(undefined) };
 
+        workRuntimeEnvService = {
+            getDatabaseUrl: jest.fn().mockResolvedValue(null),
+            setDatabaseUrl: jest.fn().mockResolvedValue(undefined),
+        };
+
         controller = new DeployController(
             deployService as unknown as DeployService,
             deployFacade as unknown as DeployFacadeService,
@@ -132,7 +138,53 @@ describe('DeployController', () => {
             deploymentVerifier as unknown as DeploymentVerifierService,
             deploymentRepository as unknown as WorkDeploymentRepository,
             activityLogService as unknown as ActivityLogService,
+            workRuntimeEnvService as never,
         );
+    });
+
+    describe('runtime-env (per-Work DATABASE_URL)', () => {
+        it('getRuntimeEnv returns masked DATABASE_URL (no password) when configured', async () => {
+            ownershipService.ensureCanEdit.mockResolvedValue({ work: buildWork(), isCreator: true });
+            workRuntimeEnvService.getDatabaseUrl.mockResolvedValue(
+                'postgresql://neondb_owner:supersecret@ep-x-pooler.us-east-1.aws.neon.tech/neondb?sslmode=require',
+            );
+
+            const res: any = await controller.getRuntimeEnv({ userId: 'user-1' } as never, 'work-1');
+
+            expect(ownershipService.ensureCanEdit).toHaveBeenCalledWith('work-1', 'user-1');
+            expect(res.databaseUrl.configured).toBe(true);
+            expect(res.databaseUrl.masked).toContain('neondb_owner:***@');
+            expect(res.databaseUrl.masked).not.toContain('supersecret');
+            expect(res.managed).toEqual(expect.arrayContaining(['AUTH_SECRET', 'COOKIE_SECRET']));
+        });
+
+        it('getRuntimeEnv reports not-configured when unset', async () => {
+            ownershipService.ensureCanEdit.mockResolvedValue({ work: buildWork(), isCreator: true });
+            workRuntimeEnvService.getDatabaseUrl.mockResolvedValue(null);
+
+            const res: any = await controller.getRuntimeEnv({ userId: 'user-1' } as never, 'work-1');
+
+            expect(res.databaseUrl).toEqual({ configured: false, masked: null });
+        });
+
+        it('setRuntimeEnv persists via setDatabaseUrl and returns masked state', async () => {
+            ownershipService.ensureCanEdit.mockResolvedValue({ work: buildWork(), isCreator: true });
+            workRuntimeEnvService.getDatabaseUrl.mockResolvedValue(
+                'postgresql://u:p@host.neon.tech/db',
+            );
+
+            const res: any = await controller.setRuntimeEnv({ userId: 'user-1' } as never, 'work-1', {
+                databaseUrl: 'postgresql://u:p@host.neon.tech/db',
+            });
+
+            expect(workRuntimeEnvService.setDatabaseUrl).toHaveBeenCalledWith(
+                'work-1',
+                'postgresql://u:p@host.neon.tech/db',
+            );
+            expect(res.status).toBe('success');
+            expect(res.databaseUrl.configured).toBe(true);
+            expect(res.databaseUrl.masked).not.toContain(':p@'); // password masked
+        });
     });
 
     afterEach(() => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -7,13 +7,14 @@ import {
     Param,
     ParseUUIDPipe,
     Post,
+    Put,
     UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiParam } from '@nestjs/swagger';
 import { AuthSessionGuard, CurrentUser } from '../../auth';
 import { AuthenticatedUser } from '../../auth/types/auth.types';
 import { DeployFacadeService } from '@ever-works/agent/facades';
-import { WorkOwnershipService } from '@ever-works/agent/services';
+import { WorkOwnershipService, WorkRuntimeEnvService } from '@ever-works/agent/services';
 import { WorkDeploymentRepository } from '@ever-works/agent/database';
 import { DeployService } from './deploy.service';
 import { DeploymentVerifierService } from './tasks/deployment-verifier.service';
@@ -27,6 +28,22 @@ import {
 import { DeployWorkDto, RollbackDto } from './dto/deploy.dto';
 import { BatchDeployDto, BatchDeployResponseDto } from './dto/batch-deploy.dto';
 import { AddDomainDto } from './dto/domain.dto';
+import { SetRuntimeEnvDto } from './dto/runtime-env.dto';
+
+/**
+ * Mask a Postgres connection string for display — keep scheme/host/db, hide the
+ * username and password so the value can be shown in the UI/API without leaking
+ * the credential.
+ */
+function maskDatabaseUrl(url: string): string {
+    try {
+        const u = new URL(url);
+        const userPart = u.username ? `${u.username}:***@` : '';
+        return `${u.protocol}//${userPart}${u.host}${u.pathname}`;
+    } catch {
+        return '***';
+    }
+}
 
 const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
 const EVER_WORKS_DEPLOY_PROVIDER_ID = 'ever-works';
@@ -56,6 +73,7 @@ export class DeployController {
         private readonly deploymentVerifier: DeploymentVerifierService,
         private readonly deploymentRepository: WorkDeploymentRepository,
         private readonly activityLogService: ActivityLogService,
+        private readonly workRuntimeEnvService: WorkRuntimeEnvService,
     ) {}
 
     private getProviderName(deployProvider: string | undefined): string {
@@ -219,6 +237,76 @@ export class DeployController {
             owner: work.getRepoOwner('website'),
             repository: `${work.getRepoOwner('website')}/${work.getWebsiteRepo()}`,
             message: 'Deployment started',
+        };
+    }
+
+    /**
+     * Get the per-Work deploy runtime env state. Only `DATABASE_URL` is
+     * user-managed (and returned masked); `AUTH_SECRET`/`COOKIE_SECRET` are
+     * auto-minted by the deploy feature and intentionally not exposed.
+     */
+    @Get('/works/:id/runtime-env')
+    @ApiOperation({
+        summary: 'Get Work runtime env',
+        description: 'Per-Work DATABASE_URL state (masked) for the k8s-deployed site.',
+    })
+    @ApiParam({ name: 'id', description: 'Work ID' })
+    @ApiResponse({ status: 200, description: 'Runtime env state' })
+    async getRuntimeEnv(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) id: string,
+    ) {
+        await this.ownershipService.ensureCanEdit(id, auth.userId);
+        const databaseUrl = await this.workRuntimeEnvService.getDatabaseUrl(id);
+        return {
+            status: 'success',
+            databaseUrl: {
+                configured: Boolean(databaseUrl),
+                masked: databaseUrl ? maskDatabaseUrl(databaseUrl) : null,
+            },
+            // Auto-managed by the deploy feature (minted + rotated server-side),
+            // so they are not editable here.
+            managed: ['AUTH_SECRET', 'COOKIE_SECRET', 'COOKIE_SECURE'],
+        };
+    }
+
+    /**
+     * Set the per-Work `DATABASE_URL`. Persisted AES-256-GCM-encrypted on the
+     * Work and pushed into the `${slug}-runtime-env` k8s Secret on the next
+     * deploy (so the change applies after a redeploy).
+     */
+    @Put('/works/:id/runtime-env')
+    @ApiOperation({
+        summary: 'Set Work runtime env',
+        description: 'Sets the per-Work DATABASE_URL used by the k8s-deployed site.',
+    })
+    @ApiParam({ name: 'id', description: 'Work ID' })
+    @ApiResponse({ status: 200, description: 'Runtime env updated' })
+    async setRuntimeEnv(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) id: string,
+        @Body() dto: SetRuntimeEnvDto,
+    ) {
+        const { work } = await this.ownershipService.ensureCanEdit(id, auth.userId);
+        await this.workRuntimeEnvService.setDatabaseUrl(id, dto.databaseUrl);
+        this.activityLogService
+            .log({
+                userId: auth.userId,
+                workId: id,
+                actionType: ActivityActionType.DEPLOYMENT,
+                action: 'work.runtime-env.updated',
+                status: ActivityStatus.COMPLETED,
+                summary: `Updated DATABASE_URL for ${work.name}`,
+            })
+            .catch(() => {});
+        const databaseUrl = await this.workRuntimeEnvService.getDatabaseUrl(id);
+        return {
+            status: 'success',
+            databaseUrl: {
+                configured: Boolean(databaseUrl),
+                masked: databaseUrl ? maskDatabaseUrl(databaseUrl) : null,
+            },
+            message: 'Runtime env updated. Redeploy to apply it to the live site.',
         };
     }
 

--- a/apps/api/src/plugins-capabilities/deploy/dto/runtime-env.dto.ts
+++ b/apps/api/src/plugins-capabilities/deploy/dto/runtime-env.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+/**
+ * Body for `PUT /api/deploy/works/:id/runtime-env`.
+ *
+ * Sets the per-Work `DATABASE_URL` — the one piece of deploy runtime env that
+ * is NOT auto-generated (unlike `AUTH_SECRET` / `COOKIE_SECRET`, which the deploy
+ * feature mints and rotates itself). On Vercel this was injected by the Neon
+ * Marketplace integration; on k8s the operator/owner supplies it here so it can
+ * be seen and edited from the platform rather than set out-of-band.
+ */
+export class SetRuntimeEnvDto {
+    @ApiProperty({
+        description: 'Postgres connection string used as the Work site DATABASE_URL',
+        example: 'postgresql://user:password@host.neon.tech/dbname?sslmode=require',
+    })
+    @IsString()
+    @IsNotEmpty()
+    @Matches(/^postgres(ql)?:\/\/.+/i, {
+        message: 'databaseUrl must be a postgres:// or postgresql:// connection string',
+    })
+    databaseUrl!: string;
+}


### PR DESCRIPTION
## Why
The deploy feature auto-mints `AUTH_SECRET`/`COOKIE_SECRET`, but per-Work `DATABASE_URL` had **no set-path** — `WorkRuntimeEnvService.setDatabaseUrl` had zero callers, so the only way to set `Work.deployDatabaseUrlEncrypted` was a raw DB write (invisible/uncontrollable from the platform). On Vercel the Neon Marketplace integration injected it; k8s has no equivalent.

## What
Ownership-guarded endpoints on the deploy controller:
- `GET /api/deploy/works/:id/runtime-env` — **masked** read (configured? + host/db, credentials hidden) + lists server-managed secrets.
- `PUT /api/deploy/works/:id/runtime-env` — sets `DATABASE_URL` via the existing encryption-correct setter; applied to the `${slug}-runtime-env` k8s Secret on next deploy. Activity-logged.

This is the set-path the per-Work **Environment UI** (next PR) will call, and the mechanism to wire each migrated directory Work's Neon DB into k8s. 3 new controller tests; **60/60 green** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime environment management enabling configuration and retrieval of database settings for deployed works
  * Database credentials are securely masked in API responses
  * Configuration changes require redeployment to take effect

<!-- end of auto-generated comment: release notes by coderabbit.ai -->