### PR TITLE
feat(web): per-Work Database & environment card (Deploy tab)

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/deploy/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/deploy/page.tsx
@@ -8,6 +8,7 @@ import { DeployTokenAlert } from '@/components/works/detail/deploy/DeployTokenAl
 import { DeployProviderSelector } from '@/components/works/detail/deploy/DeployProviderSelector';
 import { SharedWorkNoTokenAlert } from '@/components/works/detail/deploy/SharedWorkNoTokenAlert';
 import { DomainManagement } from '@/components/works/detail/deploy/DomainManagement';
+import { RuntimeEnvManagement } from '@/components/works/detail/deploy/RuntimeEnvManagement';
 import { DeployProgressPanel } from '@/components/works/detail/deploy/DeployProgressPanel';
 import { canDeploy } from '@/lib/permissions';
 
@@ -122,6 +123,7 @@ export default async function DeployPage({ params }: DeployPageParams) {
             />
             <DeployProgressPanel workId={work.id} isDeploying={isDeploying(work)} />
             {work.website && <DomainManagement work={work} />}
+            {work.website && <RuntimeEnvManagement work={work} />}
         </div>
     );
 }

--- a/apps/web/src/app/actions/dashboard/deploy.ts
+++ b/apps/web/src/app/actions/dashboard/deploy.ts
@@ -185,6 +185,62 @@ export async function getDomains(workId: string) {
     }
 }
 
+export async function getWorkRuntimeEnv(workId: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await deployAPI.getRuntimeEnv(workId);
+        return {
+            success: response.status === 'success',
+            databaseUrl: response.databaseUrl ?? { configured: false, masked: null },
+            managed: response.managed ?? [],
+        };
+    } catch (error) {
+        console.error('Get runtime env error:', error);
+        return {
+            success: false,
+            databaseUrl: { configured: false, masked: null as string | null },
+            managed: [] as string[],
+            error: error instanceof Error ? error.message : 'Failed to get runtime env',
+        };
+    }
+}
+
+export async function setWorkRuntimeEnv(workId: string, databaseUrl: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    const trimmed = databaseUrl.trim();
+    if (!/^postgres(ql)?:\/\/.+/i.test(trimmed)) {
+        return {
+            success: false,
+            databaseUrl: { configured: false, masked: null as string | null },
+            error: 'DATABASE_URL must be a postgres:// or postgresql:// connection string',
+        };
+    }
+
+    try {
+        const response = await deployAPI.setRuntimeEnv(workId, trimmed);
+        revalidatePath(ROUTES.DASHBOARD_WORK_DEPLOY(workId));
+        return {
+            success: response.status === 'success',
+            databaseUrl: response.databaseUrl ?? { configured: false, masked: null },
+        };
+    } catch (error) {
+        console.error('Set runtime env error:', error);
+        return {
+            success: false,
+            databaseUrl: { configured: false, masked: null as string | null },
+            error: error instanceof Error ? error.message : 'Failed to set runtime env',
+        };
+    }
+}
+
 export async function addDomain(workId: string, domain: string) {
     const user = await getAuthFromCookie();
     if (!user) {

--- a/apps/web/src/components/works/detail/deploy/RuntimeEnvManagement.tsx
+++ b/apps/web/src/components/works/detail/deploy/RuntimeEnvManagement.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import type { Work } from '@/lib/api';
+import { toast } from 'sonner';
+import { useRouter } from '@/i18n/navigation';
+import { getWorkRuntimeEnv, setWorkRuntimeEnv } from '@/app/actions/dashboard/deploy';
+import { Database, Lock, Loader2, Save } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface RuntimeEnvManagementProps {
+    work: Work;
+}
+
+/**
+ * Per-Work runtime environment surface (Deploy tab).
+ *
+ * Shows + edits the one piece of deploy runtime env that is user-managed —
+ * `DATABASE_URL` (e.g. the site's Postgres/Neon connection) — via the
+ * `/deploy/works/:id/runtime-env` API. The value is shown **masked** (host/db
+ * only, never the password) and applied on the next deploy. The auto-managed
+ * secrets (AUTH_SECRET/COOKIE_SECRET) are listed read-only as "managed by
+ * Ever Works" so it's clear what the platform handles vs what the owner sets.
+ */
+export function RuntimeEnvManagement({ work }: RuntimeEnvManagementProps) {
+    return <RuntimeEnvContent key={work.id} work={work} />;
+}
+
+function RuntimeEnvContent({ work }: RuntimeEnvManagementProps) {
+    const router = useRouter();
+    const [isPending, startTransition] = useTransition();
+    const [databaseUrl, setDatabaseUrl] = useState<{ configured: boolean; masked: string | null } | null>(
+        null,
+    );
+    const [managed, setManaged] = useState<string[]>([]);
+    const [value, setValue] = useState('');
+    const [loadError, setLoadError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        getWorkRuntimeEnv(work.id).then((result) => {
+            if (cancelled) return;
+            if (result.success) {
+                setDatabaseUrl(result.databaseUrl);
+                setManaged(result.managed);
+                setLoadError(null);
+            } else {
+                setDatabaseUrl({ configured: false, masked: null });
+                setLoadError(result.error ?? 'Failed to load runtime env');
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [work.id]);
+
+    const isLoading = databaseUrl === null;
+
+    const handleSave = () => {
+        const next = value.trim();
+        if (!next) return;
+        startTransition(async () => {
+            const result = await setWorkRuntimeEnv(work.id, next);
+            if (result.success) {
+                setDatabaseUrl(result.databaseUrl);
+                setValue('');
+                toast.success('DATABASE_URL saved — redeploy to apply it to the live site.');
+                router.refresh();
+            } else {
+                toast.error(result.error ?? 'Failed to save DATABASE_URL');
+            }
+        });
+    };
+
+    return (
+        <div className="rounded-lg border border-border bg-card p-4">
+            <div className="mb-3 flex items-center gap-2">
+                <Database className="h-4 w-4 text-muted-foreground" />
+                <h3 className="text-sm font-semibold">Database &amp; environment</h3>
+            </div>
+
+            {isLoading ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+                </div>
+            ) : (
+                <div className="space-y-4">
+                    {loadError && <p className="text-sm text-destructive">{loadError}</p>}
+
+                    <div>
+                        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                            DATABASE_URL
+                        </label>
+                        {databaseUrl?.configured ? (
+                            <p className="break-all font-mono text-xs text-foreground">
+                                {databaseUrl.masked}
+                            </p>
+                        ) : (
+                            <p className="text-xs text-muted-foreground">
+                                Not configured — DB-backed features (logins, submissions, favorites)
+                                are unavailable on this site until set.
+                            </p>
+                        )}
+                        <div className="mt-2 flex gap-2">
+                            <Input
+                                type="password"
+                                placeholder="postgresql://user:password@host/db"
+                                value={value}
+                                onChange={(e) => setValue(e.target.value)}
+                                disabled={isPending}
+                                className="font-mono text-xs"
+                            />
+                            <Button onClick={handleSave} disabled={isPending || !value.trim()} size="sm">
+                                {isPending ? (
+                                    <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                    <Save className="h-4 w-4" />
+                                )}
+                                <span className="ml-1">Save</span>
+                            </Button>
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                            Applied on the next deploy. Stored encrypted; shown masked.
+                        </p>
+                    </div>
+
+                    {managed.length > 0 && (
+                        <div>
+                            <div className="mb-1 flex items-center gap-1 text-xs font-medium text-muted-foreground">
+                                <Lock className="h-3 w-3" /> Managed by Ever Works
+                            </div>
+                            <div className="flex flex-wrap gap-1">
+                                {managed.map((name) => (
+                                    <span
+                                        key={name}
+                                        className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                                    >
+                                        {name}
+                                    </span>
+                                ))}
+                            </div>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                                Auto-generated and rotated by the platform — not editable.
+                            </p>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/deploy/RuntimeEnvManagement.tsx
+++ b/apps/web/src/components/works/detail/deploy/RuntimeEnvManagement.tsx
@@ -39,23 +39,39 @@ function RuntimeEnvContent({ work }: RuntimeEnvManagementProps) {
 
     useEffect(() => {
         let cancelled = false;
-        getWorkRuntimeEnv(work.id).then((result) => {
-            if (cancelled) return;
-            if (result.success) {
-                setDatabaseUrl(result.databaseUrl);
-                setManaged(result.managed);
-                setLoadError(null);
-            } else {
+        getWorkRuntimeEnv(work.id)
+            .then((result) => {
+                if (cancelled) return;
+                if (result.success) {
+                    setDatabaseUrl(result.databaseUrl);
+                    setManaged(result.managed);
+                    setLoadError(null);
+                } else {
+                    // Server-reported failure: mark databaseUrl as
+                    // "unknown-configured" (configured=false, masked=null) and
+                    // surface the error. We deliberately suppress the
+                    // "Not configured" copy + disable Save while `loadError`
+                    // is set so the user cannot accidentally overwrite an
+                    // existing DATABASE_URL when the load merely failed.
+                    setDatabaseUrl({ configured: false, masked: null });
+                    setLoadError(result.error ?? 'Failed to load runtime env');
+                }
+            })
+            .catch((err: unknown) => {
+                if (cancelled) return;
+                // Transport-level rejection (network, JSON parse, redirect).
+                // Without this catch the promise rejects unhandled and the
+                // component stays stuck on the loading spinner forever.
                 setDatabaseUrl({ configured: false, masked: null });
-                setLoadError(result.error ?? 'Failed to load runtime env');
-            }
-        });
+                setLoadError(err instanceof Error ? err.message : 'Failed to load runtime env');
+            });
         return () => {
             cancelled = true;
         };
     }, [work.id]);
 
     const isLoading = databaseUrl === null;
+    const hasLoadError = loadError !== null;
 
     const handleSave = () => {
         const next = value.trim();
@@ -96,6 +112,14 @@ function RuntimeEnvContent({ work }: RuntimeEnvManagementProps) {
                             <p className="break-all font-mono text-xs text-foreground">
                                 {databaseUrl.masked}
                             </p>
+                        ) : hasLoadError ? (
+                            // Don't claim "Not configured" when we never
+                            // successfully read the value — the server may
+                            // actually have a DATABASE_URL set; we just
+                            // failed to retrieve it.
+                            <p className="text-xs text-muted-foreground">
+                                Current value unavailable — retry to view or change it.
+                            </p>
                         ) : (
                             <p className="text-xs text-muted-foreground">
                                 Not configured — DB-backed features (logins, submissions, favorites)
@@ -108,10 +132,14 @@ function RuntimeEnvContent({ work }: RuntimeEnvManagementProps) {
                                 placeholder="postgresql://user:password@host/db"
                                 value={value}
                                 onChange={(e) => setValue(e.target.value)}
-                                disabled={isPending}
+                                disabled={isPending || hasLoadError}
                                 className="font-mono text-xs"
                             />
-                            <Button onClick={handleSave} disabled={isPending || !value.trim()} size="sm">
+                            <Button
+                                onClick={handleSave}
+                                disabled={isPending || hasLoadError || !value.trim()}
+                                size="sm"
+                            >
                                 {isPending ? (
                                     <Loader2 className="h-4 w-4 animate-spin" />
                                 ) : (

--- a/apps/web/src/lib/api/plugins-capabilities/deploy.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/deploy.ts
@@ -98,6 +98,14 @@ export type VerifyDomainResponseDto = APIResponse<{
     domain: DeploymentDomain;
 }>;
 
+export interface RuntimeEnvState {
+    databaseUrl: { configured: boolean; masked: string | null };
+    /** Secrets auto-managed by the deploy feature (not user-editable). */
+    managed: string[];
+}
+
+export type RuntimeEnvResponseDto = APIResponse<RuntimeEnvState>;
+
 export const deployAPI = {
     // Get available deployment providers
     getProviders: async () => {
@@ -195,6 +203,29 @@ export const deployAPI = {
             endpoint: `/deploy/works/${encodeURIComponent(workId)}/domains`,
             data: { domain },
             method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * Get the per-Work runtime env (masked DATABASE_URL + auto-managed secrets)
+     */
+    getRuntimeEnv(workId: string) {
+        return serverFetch<RuntimeEnvResponseDto>(
+            // Security: encode workId to prevent path-segment injection
+            `/deploy/works/${encodeURIComponent(workId)}/runtime-env`,
+        );
+    },
+
+    /**
+     * Set the per-Work DATABASE_URL (applied on next deploy)
+     */
+    setRuntimeEnv(workId: string, databaseUrl: string) {
+        return serverMutation<RuntimeEnvResponseDto>({
+            // Security: encode workId to prevent path-segment injection
+            endpoint: `/deploy/works/${encodeURIComponent(workId)}/runtime-env`,
+            data: { databaseUrl },
+            method: 'PUT',
             wrapInData: false,
         });
     },


### PR DESCRIPTION
Surfaces per-Work `DATABASE_URL` in the UI — the gap you flagged (Work-specific config must be visible/editable in the platform, not set out-of-band). Adds a **Database & environment** card to the Work Deploy tab: shows DATABASE_URL configured/not + **masked** value, lets the owner set/replace it (encrypted, applied on next deploy), and lists auto-managed secrets read-only ("Managed by Ever Works").

Consumes the #1315 `GET/PUT /deploy/works/:id/runtime-env` API. Mirrors the `DomainManagement` pattern (API client → server actions → component).

**Left for your review — not cascaded to prod.** Verified: the 4 touched files typecheck clean (remaining web tsc errors are pre-existing missing-local-deps).

Follow-ups: i18n strings (currently English); the managed-subdomain "Site URL" card is **EW-740** under epic **EW-734**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime environment management to the deployment settings, letting users view and configure a per-work database connection value with input validation and masked display of sensitive details.
  * Auto-managed secret names are shown as read-only.
  * Saving prompts a redeploy to apply changes, and includes success/error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->