### PR TITLE
chore(release): cascade stage -> main

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -273,6 +273,14 @@ EVER_WORKS_DEPLOY_TLS_ISSUER=letsencrypt-prod
 EVER_WORKS_DEPLOY_REGISTRY=
 EVER_WORKS_DEPLOY_MAX_WORKS_PER_USER=3
 
+# EW-734 — collision-safe managed `*.ever.works` subdomain for the k8s
+# deploy path. Default OFF so the 7 already-deployed k8s Works keep
+# deriving their Ingress host from `work.website` (legacy behaviour).
+# Flip to `true` after running the one-off backfill CLI (`cli backfill
+# managed-subdomain --write`) so existing Works own their persisted
+# claim before the allocator starts looking it up.
+K8S_MANAGED_SUBDOMAIN=false
+
 # ─── User Research Agent (EW-584) ───────────────────────────────────────────
 # Tool-calling AI agent that researches new users at signup and generates
 # personalized Work proposals.

--- a/apps/api/src/migrations/1780800000000-AddWorkManagedSubdomain.ts
+++ b/apps/api/src/migrations/1780800000000-AddWorkManagedSubdomain.ts
@@ -1,0 +1,82 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * EW-734 / EW-736 — adds the durable per-Work `managedSubdomain` claim and
+ * its globally-unique partial index.
+ *
+ * Today, the managed `*.ever.works` host is re-derived from `work.slug` on
+ * every deploy (`deploy.service.ts:483-524`,
+ * `cloudflare-dns.provider.ts:ingressHostFor`). The result is two real bugs:
+ *
+ *   1. **No global uniqueness.** `work.slug` is only unique per-`(userId, owner)`
+ *      (`work.repository.ts:32-41`). Two users picking slug `ai-coding` both
+ *      derive `ai-coding.ever.works` → the second deploy silently overwrites
+ *      the first's CNAME.
+ *   2. **Slug rename orphans the old record.** Nothing records "this Work
+ *      owns `ai-coding.ever.works`", so renaming the slug leaks the old CNAME.
+ *
+ * This migration is the DB foundation that lets `SubdomainAllocator` (EW-737)
+ * detect collisions before persisting and the future
+ * `GET/PUT /works/:id/subdomain` (EW-739) edit the claim safely.
+ *
+ * Forward-only and idempotent (`hasColumn` / catalog guard). No backfill is
+ * performed here — the 7 already-migrated Vercel→k8s Works (`dir`,
+ * `mcpserver`, `vectordb`, `timetrack`, `chairs`, `startup-books`,
+ * `compliance-automation`) keep their derive-from-slug fallback. A separate
+ * one-off backfill script (out of scope for this PR — tracked in EW-736
+ * follow-up) will read each Work's live `*.ever.works` record from
+ * Cloudflare and persist the matching `managedSubdomain` so existing
+ * Works also gain orphan-on-rename protection.
+ *
+ * The unique index is **partial** (`WHERE "managedSubdomain" IS NOT NULL`)
+ * so that the NULL-default doesn't collide across rows. This matches the
+ * Postgres pattern used by other partial-unique indexes in this codebase.
+ */
+export class AddWorkManagedSubdomain1780800000000 implements MigrationInterface {
+    name = 'AddWorkManagedSubdomain1780800000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasColumn('works', 'managedSubdomain'))) {
+            await queryRunner.addColumn(
+                'works',
+                new TableColumn({
+                    name: 'managedSubdomain',
+                    type: 'varchar',
+                    length: '63',
+                    isNullable: true,
+                }),
+            );
+        }
+
+        // Partial unique index — Postgres-style `WHERE` clause. Guarded so
+        // re-runs (idempotency / down-then-up) don't double-create.
+        const driver = queryRunner.connection.options.type;
+        if (driver === 'postgres') {
+            await queryRunner.query(
+                `CREATE UNIQUE INDEX IF NOT EXISTS "UQ_works_managedSubdomain_notnull" ` +
+                    `ON "works" ("managedSubdomain") WHERE "managedSubdomain" IS NOT NULL`,
+            );
+        } else {
+            // SQLite (test/CLI adapter) — partial indexes are supported via
+            // the same `WHERE` syntax. Other drivers: skip (the application
+            // layer's `SubdomainAllocator` still does a collision probe before
+            // insert).
+            try {
+                await queryRunner.query(
+                    `CREATE UNIQUE INDEX IF NOT EXISTS "UQ_works_managedSubdomain_notnull" ` +
+                        `ON "works" ("managedSubdomain") WHERE "managedSubdomain" IS NOT NULL`,
+                );
+            } catch {
+                // Best-effort on non-supporting drivers. The allocator still
+                // guards against races by re-checking after insert.
+            }
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "UQ_works_managedSubdomain_notnull"`);
+        if (await queryRunner.hasColumn('works', 'managedSubdomain')) {
+            await queryRunner.dropColumn('works', 'managedSubdomain');
+        }
+    }
+}

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
@@ -80,6 +80,7 @@ describe('DeployController', () => {
     };
     let activityLogService: { log: jest.Mock };
     let workRuntimeEnvService: { getDatabaseUrl: jest.Mock; setDatabaseUrl: jest.Mock };
+    let managedSubdomainService: { getState: jest.Mock; update: jest.Mock };
     let controller: DeployController;
 
     const buildWork = (overrides: Record<string, unknown> = {}) => ({
@@ -131,6 +132,11 @@ describe('DeployController', () => {
             setDatabaseUrl: jest.fn().mockResolvedValue(undefined),
         };
 
+        managedSubdomainService = {
+            getState: jest.fn(),
+            update: jest.fn(),
+        };
+
         controller = new DeployController(
             deployService as unknown as DeployService,
             deployFacade as unknown as DeployFacadeService,
@@ -139,6 +145,7 @@ describe('DeployController', () => {
             deploymentRepository as unknown as WorkDeploymentRepository,
             activityLogService as unknown as ActivityLogService,
             workRuntimeEnvService as never,
+            managedSubdomainService as never,
         );
     });
 
@@ -1317,6 +1324,155 @@ describe('DeployController', () => {
                 controller.verifyDomain(auth, 'work-1', 'example.com'),
             ).rejects.toMatchObject({
                 response: { message: 'Failed to verify domain' },
+            });
+        });
+    });
+
+    // EW-739 — GET/PUT /works/:id/subdomain
+    describe('managed subdomain', () => {
+        const stateOk = {
+            subdomain: 'my-site',
+            fqdn: 'my-site.ever.works',
+            url: 'https://my-site.ever.works',
+            recordOk: true,
+            editable: true,
+        };
+
+        describe('getManagedSubdomain', () => {
+            it('gates on ensureCanView before delegating to the service', async () => {
+                ownershipService.ensureCanView.mockResolvedValue({
+                    work: buildWork({ deployProvider: 'ever-works' }),
+                    isCreator: true,
+                });
+                managedSubdomainService.getState.mockResolvedValue(stateOk);
+
+                const result = await controller.getManagedSubdomain(auth, 'work-1');
+
+                expect(ownershipService.ensureCanView).toHaveBeenCalledWith('work-1', 'caller-1');
+                expect(managedSubdomainService.getState).toHaveBeenCalledWith('work-1');
+                expect(result).toEqual(stateOk);
+            });
+
+            it('propagates an ownership 404 verbatim without touching the service', async () => {
+                ownershipService.ensureCanView.mockRejectedValue(
+                    new BadRequestException('Work not found'),
+                );
+
+                await expect(controller.getManagedSubdomain(auth, 'work-1')).rejects.toBeInstanceOf(
+                    BadRequestException,
+                );
+                expect(managedSubdomainService.getState).not.toHaveBeenCalled();
+            });
+
+            it('returns the unallocated shape verbatim (null fields, recordOk=false)', async () => {
+                ownershipService.ensureCanView.mockResolvedValue({
+                    work: buildWork({ deployProvider: 'ever-works' }),
+                    isCreator: true,
+                });
+                managedSubdomainService.getState.mockResolvedValue({
+                    subdomain: null,
+                    fqdn: null,
+                    url: null,
+                    recordOk: false,
+                    editable: true,
+                });
+
+                const result = await controller.getManagedSubdomain(auth, 'work-1');
+
+                expect(result).toEqual({
+                    subdomain: null,
+                    fqdn: null,
+                    url: null,
+                    recordOk: false,
+                    editable: true,
+                });
+            });
+        });
+
+        describe('updateManagedSubdomain', () => {
+            it('gates on ensureCanEdit, delegates to service, then activity-logs the rename', async () => {
+                const work = buildWork({ deployProvider: 'ever-works' });
+                ownershipService.ensureCanEdit.mockResolvedValue({ work, isCreator: true });
+                managedSubdomainService.update.mockResolvedValue(stateOk);
+
+                const result = await controller.updateManagedSubdomain(auth, 'work-1', {
+                    subdomain: 'my-site',
+                });
+
+                expect(ownershipService.ensureCanEdit).toHaveBeenCalledWith('work-1', 'caller-1');
+                expect(managedSubdomainService.update).toHaveBeenCalledWith('work-1', 'my-site');
+                expect(activityLogService.log).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        userId: 'caller-1',
+                        workId: 'work-1',
+                        action: 'work.managed-subdomain.updated',
+                        details: { subdomain: 'my-site', fqdn: 'my-site.ever.works' },
+                    }),
+                );
+                expect(result).toEqual(stateOk);
+            });
+
+            it('does not call the service when ensureCanEdit rejects', async () => {
+                ownershipService.ensureCanEdit.mockRejectedValue(
+                    new BadRequestException('forbidden'),
+                );
+
+                await expect(
+                    controller.updateManagedSubdomain(auth, 'work-1', { subdomain: 'my-site' }),
+                ).rejects.toBeInstanceOf(BadRequestException);
+
+                expect(managedSubdomainService.update).not.toHaveBeenCalled();
+                expect(activityLogService.log).not.toHaveBeenCalled();
+            });
+
+            it('propagates uniqueness rejection from the service (409 Conflict)', async () => {
+                const work = buildWork({ deployProvider: 'ever-works' });
+                ownershipService.ensureCanEdit.mockResolvedValue({ work, isCreator: true });
+                managedSubdomainService.update.mockRejectedValue(
+                    new BadRequestException({
+                        status: 'error',
+                        message: 'Subdomain "my-site" is already claimed by another work.',
+                    }),
+                );
+
+                await expect(
+                    controller.updateManagedSubdomain(auth, 'work-1', { subdomain: 'my-site' }),
+                ).rejects.toMatchObject({
+                    response: { message: expect.stringContaining('already claimed') },
+                });
+                expect(activityLogService.log).not.toHaveBeenCalled();
+            });
+
+            it('propagates blocklist rejection from the service', async () => {
+                const work = buildWork({ deployProvider: 'ever-works' });
+                ownershipService.ensureCanEdit.mockResolvedValue({ work, isCreator: true });
+                managedSubdomainService.update.mockRejectedValue(
+                    new BadRequestException({
+                        status: 'error',
+                        message:
+                            'Subdomain "www" is reserved by the platform and cannot be claimed.',
+                    }),
+                );
+
+                await expect(
+                    controller.updateManagedSubdomain(auth, 'work-1', { subdomain: 'www' }),
+                ).rejects.toMatchObject({
+                    response: { message: expect.stringContaining('reserved by the platform') },
+                });
+                expect(activityLogService.log).not.toHaveBeenCalled();
+            });
+
+            it('swallows fire-and-forget activity-log rejection without breaking the response', async () => {
+                const work = buildWork({ deployProvider: 'ever-works' });
+                ownershipService.ensureCanEdit.mockResolvedValue({ work, isCreator: true });
+                managedSubdomainService.update.mockResolvedValue(stateOk);
+                activityLogService.log.mockRejectedValue(new Error('log down'));
+
+                const result = await controller.updateManagedSubdomain(auth, 'work-1', {
+                    subdomain: 'my-site',
+                });
+
+                expect(result).toEqual(stateOk);
             });
         });
     });

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -29,6 +29,8 @@ import { DeployWorkDto, RollbackDto } from './dto/deploy.dto';
 import { BatchDeployDto, BatchDeployResponseDto } from './dto/batch-deploy.dto';
 import { AddDomainDto } from './dto/domain.dto';
 import { SetRuntimeEnvDto } from './dto/runtime-env.dto';
+import { SubdomainResponseDto, UpdateSubdomainDto } from './dto/subdomain.dto';
+import { ManagedSubdomainService } from './managed-subdomain.service';
 
 /**
  * Mask a Postgres connection string for display — keep scheme/host/db, hide the
@@ -74,6 +76,7 @@ export class DeployController {
         private readonly deploymentRepository: WorkDeploymentRepository,
         private readonly activityLogService: ActivityLogService,
         private readonly workRuntimeEnvService: WorkRuntimeEnvService,
+        private readonly managedSubdomainService: ManagedSubdomainService,
     ) {}
 
     private getProviderName(deployProvider: string | undefined): string {
@@ -725,6 +728,79 @@ export class DeployController {
                 message: 'Failed to verify domain',
             });
         }
+    }
+
+    /**
+     * EW-739 — read the managed subdomain attached to a Work.
+     *
+     * Returns the persisted `work.managedSubdomain`, the derived FQDN/URL,
+     * a live DNS health probe (`recordOk`), and an `editable` flag so the
+     * UI can hide the "Rename" affordance for providers that don't run
+     * through `applyManagedSubdomain`.
+     */
+    @Get('/works/:id/subdomain')
+    @ApiOperation({
+        summary: 'Get managed subdomain',
+        description: 'Returns the managed *.ever.works subdomain attached to a Work.',
+    })
+    @ApiParam({ name: 'id', description: 'Work ID' })
+    @ApiResponse({
+        status: 200,
+        description: 'Managed subdomain state',
+        type: SubdomainResponseDto,
+    })
+    async getManagedSubdomain(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) id: string,
+    ): Promise<SubdomainResponseDto> {
+        await this.ownershipService.ensureCanView(id, auth.userId);
+        return this.managedSubdomainService.getState(id);
+    }
+
+    /**
+     * EW-739 — re-allocate the managed subdomain to a caller-chosen label.
+     *
+     * Format + blocklist are enforced by the DTO and the service (defence-in-depth).
+     * Global uniqueness is checked before persisting; the DB-level partial
+     * unique index `UQ_works_managedSubdomain_notnull` is the backstop for
+     * concurrent renames. The old CNAME is removed (best-effort) and a new
+     * CNAME is created against the managed zone before the response returns.
+     */
+    @Put('/works/:id/subdomain')
+    @ApiOperation({
+        summary: 'Update managed subdomain',
+        description:
+            'Re-allocates the managed *.ever.works subdomain for a Work. Frees the old DNS record and creates the new one.',
+    })
+    @ApiParam({ name: 'id', description: 'Work ID' })
+    @ApiResponse({ status: 200, description: 'Subdomain updated', type: SubdomainResponseDto })
+    @ApiResponse({
+        status: 400,
+        description: 'Invalid subdomain format / blocklisted / not editable',
+    })
+    @ApiResponse({ status: 409, description: 'Subdomain already claimed by another work' })
+    async updateManagedSubdomain(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) id: string,
+        @Body() dto: UpdateSubdomainDto,
+    ): Promise<SubdomainResponseDto> {
+        const { work } = await this.ownershipService.ensureCanEdit(id, auth.userId);
+
+        const result = await this.managedSubdomainService.update(id, dto.subdomain);
+
+        this.activityLogService
+            .log({
+                userId: auth.userId,
+                workId: id,
+                actionType: ActivityActionType.DEPLOYMENT,
+                action: 'work.managed-subdomain.updated',
+                status: ActivityStatus.COMPLETED,
+                summary: `Updated managed subdomain for ${work.name} to ${result.subdomain}`,
+                details: { subdomain: result.subdomain, fqdn: result.fqdn },
+            })
+            .catch(() => {});
+
+        return result;
     }
 
     @Get('/works/:id/deployments')

--- a/apps/api/src/plugins-capabilities/deploy/deploy.e2e.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.e2e.spec.ts
@@ -175,7 +175,12 @@ describe.skip('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + 
         // service. No deploy path under test reads/writes runtime env, so a
         // typeless stub is fine.
         const workRuntimeEnvService = {};
-        // 13th DI arg — zero-friction funnel telemetry. Stub emit() so
+        // 13th DI arg added by EW-737 — collision-safe subdomain allocator.
+        // The k8s managed-subdomain path is gated by K8S_MANAGED_SUBDOMAIN
+        // (default OFF), and these tests don't enable it, so a typeless stub
+        // is fine.
+        const subdomainAllocator = {};
+        // 14th DI arg — zero-friction funnel telemetry. Stub emit() so
         // calls during a successful deploy don't blow up.
         const funnel = { emit: jest.fn().mockResolvedValue(undefined) };
 
@@ -197,7 +202,10 @@ describe.skip('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + 
             webhookSecretService as any,
             workRuntimeEnvService as any,
             dnsService as any,
+            subdomainAllocator as any,
             funnel as any,
+            // EW-741 customDomainRepository is optional — these e2e tests don't
+            // exercise custom-domain reconciliation, so leave it undefined.
         );
 
         const restoreEnv = () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.module.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.module.ts
@@ -5,10 +5,11 @@ import { WebsiteGeneratorModule } from '@ever-works/agent/generators';
 import { WorkModule } from '@ever-works/agent/services';
 import { AuthModule } from '../../auth/auth.module';
 import { ActivityLogModule } from '@ever-works/agent/activity-log';
-import { EverWorksDnsService } from '@ever-works/agent/ever-works-providers';
+import { EverWorksDnsService, SubdomainAllocator } from '@ever-works/agent/ever-works-providers';
 import { DeployController } from './deploy.controller';
 import { DeployService } from './deploy.service';
 import { DeploymentVerifierService } from './tasks/deployment-verifier.service';
+import { ManagedSubdomainService } from './managed-subdomain.service';
 
 @Module({
     imports: [
@@ -20,7 +21,13 @@ import { DeploymentVerifierService } from './tasks/deployment-verifier.service';
         forwardRef(() => AuthModule),
     ],
     controllers: [DeployController],
-    providers: [DeployService, DeploymentVerifierService, EverWorksDnsService],
-    exports: [DeployService, DeploymentVerifierService],
+    providers: [
+        DeployService,
+        DeploymentVerifierService,
+        EverWorksDnsService,
+        SubdomainAllocator,
+        ManagedSubdomainService,
+    ],
+    exports: [DeployService, DeploymentVerifierService, ManagedSubdomainService],
 })
 export class DeployModule {}

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -1,4 +1,7 @@
-jest.mock('@ever-works/agent/database', () => ({ WorkRepository: class {} }));
+jest.mock('@ever-works/agent/database', () => ({
+    WorkRepository: class {},
+    WorkCustomDomainRepository: class {},
+}));
 jest.mock('@ever-works/agent/entities', () => ({
     Work: class {},
     User: class {},
@@ -168,6 +171,26 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         // EW-617 G8: funnel emit sink — no-op stub by default.
         const funnel = { emit: jest.fn() };
 
+        // EW-734 / EW-737 — collision-safe allocator. Tests that exercise the
+        // gated managed-subdomain path stub `allocate`; the default no-op
+        // keeps the legacy + EW-741 paths working without forcing every test
+        // to wire it explicitly.
+        const subdomainAllocator = {
+            allocate: jest.fn().mockResolvedValue({
+                subdomain: 'allocated',
+                fqdn: 'allocated.ever.works',
+                rootDomain: 'ever.works',
+                allocated: true,
+            }),
+        };
+
+        // EW-741 — `WorkCustomDomain` rows for this Work. Default = none, so
+        // most tests see no `extraHosts` in the merged settings. Tests that
+        // exercise reconciliation override `findByWork` to return rows.
+        const customDomainRepository = {
+            findByWork: jest.fn().mockResolvedValue([]),
+        };
+
         const service = new DeployService(
             deployFacade as any,
             gitFacade as any,
@@ -181,7 +204,9 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             webhookSecretService as any,
             workRuntimeEnvService as any,
             dnsService as any,
+            subdomainAllocator as any,
             funnel as any,
+            customDomainRepository as any,
         );
 
         return {
@@ -197,6 +222,8 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             webhookSecretService,
             dnsService,
             funnel,
+            subdomainAllocator,
+            customDomainRepository,
         };
     };
 
@@ -1173,6 +1200,159 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             expect(secrets.find((s: any) => s.key === 'VERCEL_TOKEN')?.value).toBe(
                 'vercel-deploy-token',
             );
+        });
+    });
+
+    /**
+     * EW-741 — reconcile the managed subdomain with `WorkCustomDomain` rows.
+     *
+     * Spec §4.6 mandates that the managed subdomain stays as the primary
+     * Ingress host whenever the platform allocated one, and that every active
+     * custom domain rides alongside it as an additional Ingress rule. Adding
+     * or removing a custom domain must never mutate `managedSubdomain`, and
+     * `extraHosts` must be deduped + normalized so the workflow secret stays
+     * stable across deploys.
+     */
+    describe('EW-741 — managed subdomain ↔ custom domain reconciliation', () => {
+        const getDeploymentSecrets = jest
+            .fn()
+            // Mirror the real k8s plugin's behavior: forward the orchestrator's
+            // ingressHost / extraHosts into the K8S_* secrets surface so the
+            // workflow gets both. Anything the orchestrator omits stays
+            // omitted — this is what the test assertions key off.
+            .mockImplementation(async (settings: Record<string, unknown>) => {
+                const out: Record<string, string> = { K8S_NAMESPACE: 'apps' };
+                if (typeof settings.ingressHost === 'string' && settings.ingressHost) {
+                    out.K8S_INGRESS_HOST = settings.ingressHost;
+                }
+                if (Array.isArray(settings.extraHosts) && settings.extraHosts.length > 0) {
+                    out.K8S_EXTRA_HOSTS = (settings.extraHosts as string[]).join(',');
+                }
+                return out;
+            });
+
+        beforeEach(() => {
+            getDeploymentSecrets.mockClear();
+        });
+
+        it('combines managed subdomain + custom domains into Ingress hosts (k8s)', async () => {
+            const { service, githubPlugin, customDomainRepository } = buildService({
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets,
+                },
+                deployProvider: 'k8s',
+                // Persisted managed ingress host (k8s legacy path derives this
+                // from `work.website`). Acts as the primary Ingress rule.
+                website: 'https://managed.example.com',
+            });
+            customDomainRepository.findByWork.mockResolvedValueOnce([
+                { domain: 'foo.example.com' },
+                { domain: 'bar.example.com' },
+                // Already-present primary — must be deduped out of extraHosts.
+                { domain: 'MANAGED.example.com' },
+            ]);
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            const byKey = Object.fromEntries(secrets.map((s: any) => [s.key, s.value]));
+            expect(byKey.K8S_INGRESS_HOST).toBe('managed.example.com');
+            // Both custom domains travel as extraHosts; the duplicate of the
+            // primary is dropped. Lowercased + comma-separated.
+            expect(byKey.K8S_EXTRA_HOSTS).toBe('foo.example.com,bar.example.com');
+
+            // Settings passed to the k8s plugin carry the combined shape so
+            // any plugin that wants to render multi-host TLS directly can.
+            const callSettings = getDeploymentSecrets.mock.calls[0][0];
+            expect(callSettings.ingressHost).toBe('managed.example.com');
+            expect(callSettings.extraHosts).toEqual(['foo.example.com', 'bar.example.com']);
+        });
+
+        it('omits K8S_EXTRA_HOSTS when no custom domains exist', async () => {
+            const { service, githubPlugin } = buildService({
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets,
+                },
+                deployProvider: 'k8s',
+                website: 'https://managed.example.com',
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            const keys = secrets.map((s: any) => s.key);
+            expect(keys).toContain('K8S_INGRESS_HOST');
+            expect(keys).not.toContain('K8S_EXTRA_HOSTS');
+        });
+
+        it('preserves extraHosts when the EW-734 allocator runs (flag ON)', async () => {
+            process.env.K8S_MANAGED_SUBDOMAIN = 'true';
+            process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'lb.ever.works';
+            try {
+                const ensureRecord = jest.fn().mockResolvedValue(undefined);
+                const {
+                    service,
+                    githubPlugin,
+                    customDomainRepository,
+                    dnsService,
+                    subdomainAllocator,
+                } = buildService({
+                    plugin: {
+                        id: 'k8s',
+                        getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                        getDeploymentSecrets,
+                    },
+                    deployProvider: 'k8s',
+                    // No `website` so the legacy path leaves `ingressHost`
+                    // unset and the EW-734 allocator wins.
+                });
+                dnsService.getProvider.mockReturnValue({ ensureRecord });
+                subdomainAllocator.allocate.mockResolvedValueOnce({
+                    subdomain: 'fresh',
+                    fqdn: 'fresh.ever.works',
+                    rootDomain: 'ever.works',
+                    allocated: true,
+                });
+                customDomainRepository.findByWork.mockResolvedValueOnce([
+                    { domain: 'tools.example.com' },
+                ]);
+
+                await service.deploy('work-1', 'user-1', {});
+
+                const { secrets } = captureCalls(githubPlugin);
+                const byKey = Object.fromEntries(secrets.map((s: any) => [s.key, s.value]));
+                expect(byKey.K8S_INGRESS_HOST).toBe('fresh.ever.works');
+                expect(byKey.K8S_EXTRA_HOSTS).toBe('tools.example.com');
+            } finally {
+                delete process.env.K8S_MANAGED_SUBDOMAIN;
+                delete process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME;
+            }
+        });
+
+        it('falls back gracefully when the custom-domain lookup fails', async () => {
+            const { service, githubPlugin, customDomainRepository } = buildService({
+                plugin: {
+                    id: 'k8s',
+                    getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+                    getDeploymentSecrets,
+                },
+                deployProvider: 'k8s',
+                website: 'https://managed.example.com',
+            });
+            customDomainRepository.findByWork.mockRejectedValueOnce(new Error('db down'));
+
+            // The deploy must still dispatch with just the managed subdomain.
+            await expect(service.deploy('work-1', 'user-1', {})).resolves.toMatchObject({
+                dispatched: true,
+            });
+            const { secrets } = captureCalls(githubPlugin);
+            const keys = secrets.map((s: any) => s.key);
+            expect(keys).toContain('K8S_INGRESS_HOST');
+            expect(keys).not.toContain('K8S_EXTRA_HOSTS');
         });
     });
 });

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -11,7 +11,11 @@ import {
     GitFacadeService,
     PLATFORM_MANAGED_KUBECONFIG_SENTINEL,
 } from '@ever-works/agent/facades';
-import { WorkRepository, WorkDeploymentRepository } from '@ever-works/agent/database';
+import {
+    WorkRepository,
+    WorkDeploymentRepository,
+    WorkCustomDomainRepository,
+} from '@ever-works/agent/database';
 import { PluginRegistryService } from '@ever-works/agent/plugins';
 import {
     Work,
@@ -25,7 +29,7 @@ import {
     WorkRuntimeEnvService,
     ZeroFrictionFunnelService,
 } from '@ever-works/agent/services';
-import { EverWorksDnsService } from '@ever-works/agent/ever-works-providers';
+import { EverWorksDnsService, SubdomainAllocator } from '@ever-works/agent/ever-works-providers';
 import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
 import {
     WebsiteUpdateService,
@@ -118,8 +122,33 @@ export class DeployService {
         private readonly webhookSecretService: WebhookSecretService,
         private readonly workRuntimeEnvService: WorkRuntimeEnvService,
         private readonly dnsService: EverWorksDnsService,
+        private readonly subdomainAllocator: SubdomainAllocator,
         private readonly funnel: ZeroFrictionFunnelService,
+        // EW-741 — reconcile managed subdomain with `WorkCustomDomain` rows.
+        // Both must be served by the Ingress simultaneously: the managed
+        // subdomain stays as the primary host, and every active custom
+        // domain is appended as an additional Ingress rule via the
+        // `extraHosts` settings field. Optional in DI so legacy test
+        // fixtures that construct DeployService directly (without the
+        // custom-domain repo wired) keep working — the merge code treats
+        // a missing repo as "no extras".
+        private readonly customDomainRepository?: WorkCustomDomainRepository,
     ) {}
+
+    /**
+     * EW-734 — feature flag gating the collision-safe managed-subdomain
+     * extension to the k8s deploy path. When OFF (default), the legacy
+     * `applyEverWorksSubdomain` runs as today and the 7 already-deployed
+     * k8s Works see zero behavior change. When ON, the deploy path ALSO
+     * allocates+persists a unique `*.ever.works` for `deployProvider='k8s'`
+     * via `SubdomainAllocator` and uses it as the Ingress host.
+     *
+     * Read once via the getter — `process.env` mutations between calls
+     * (test setups) are respected without touching DI.
+     */
+    private get isManagedSubdomainForK8sEnabled(): boolean {
+        return process.env.K8S_MANAGED_SUBDOMAIN === 'true';
+    }
 
     /**
      * Optional fields that target a preview or scheduled deploy. When all are
@@ -204,7 +233,7 @@ export class DeployService {
         // the user's directory is reachable at that subdomain without any
         // manual DNS. If env vars are missing the DNS service no-ops; the
         // k8s plugin's default LB hostname remains the fallback.
-        const deploySettings = await this.applyEverWorksSubdomain(work, settings);
+        const deploySettings = await this.applyManagedSubdomain(work, settings);
         await this.setRequiredSecrets(ctx, effectiveDeployToken, work, plugin, deploySettings);
         await this.setKubernetesGhcrPullSecret(ctx, work, userId, plugin);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
@@ -464,6 +493,187 @@ export class DeployService {
 
     private async setVariable(ctx: RepoContext, key: string, value: string) {
         return this.setActionVariable({ key, value, owner: ctx.owner, repo: ctx.repo }, ctx.token);
+    }
+
+    /**
+     * EW-734 — additive wrapper around the legacy `applyEverWorksSubdomain`.
+     *
+     * Always runs the legacy path FIRST (zero behavior change for the
+     * `'ever-works'` provider and for `'k8s'` deploys whose `work.website`
+     * is set). Then, when the `K8S_MANAGED_SUBDOMAIN` env flag is ON,
+     * runs the collision-safe `SubdomainAllocator` extension for k8s
+     * Works that do NOT already have a derived ingress host. The flag is
+     * OFF by default so the 7 already-deployed k8s Works (`dir`,
+     * `mcpserver`, `vectordb`, `timetrack`, `chairs`, `startup-books`,
+     * `compliance-automation`) see exactly today's behavior; operators opt
+     * in per environment.
+     *
+     * Returns the merged settings (with `ingressHost` set when applicable).
+     * Never throws — DNS / allocator failures are logged and the deploy
+     * proceeds with the legacy fallback.
+     */
+    private async applyManagedSubdomain(
+        work: Work,
+        settings: Record<string, unknown> | undefined,
+    ): Promise<Record<string, unknown> | undefined> {
+        // (1) Legacy behavior — unchanged. This handles ever-works deploys
+        // (CNAME + ingressHost) and k8s deploys with an explicit website.
+        const legacy = await this.applyEverWorksSubdomain(work, settings);
+
+        // (1a) EW-741 — reconcile with custom domains. The managed subdomain
+        // (whatever `applyEverWorksSubdomain` produced, or the persisted
+        // `work.managedSubdomain` resolved below) is the PRIMARY/default host.
+        // Every active `WorkCustomDomain` row is appended as an additional
+        // Ingress rule via `extraHosts`. The managed subdomain is never
+        // removed — adding a custom domain is purely additive (spec §4.6).
+        const mergedAfterLegacy = await this.mergeCustomDomainHosts(work, legacy);
+
+        // (2) Gated extension — only fires for k8s + flag ON + no host
+        // already resolved by the legacy path. When OFF, this is a no-op
+        // and the merged-with-custom-domains result is returned unchanged.
+        if (!this.isManagedSubdomainForK8sEnabled) {
+            return mergedAfterLegacy;
+        }
+        if (work.deployProvider !== 'k8s') {
+            return mergedAfterLegacy;
+        }
+        // A non-empty string `ingressHost` in the merged result means the
+        // legacy path resolved a host (today: from `work.website` for k8s).
+        // Respect it (spec §4.4: an explicit user-set host wins). An
+        // empty/whitespace value falls through — Greptile P2 / Augment medium:
+        // prior version would skip allocation on any presence of the key,
+        // including empty.
+        if (
+            mergedAfterLegacy &&
+            typeof mergedAfterLegacy === 'object' &&
+            'ingressHost' in mergedAfterLegacy
+        ) {
+            const existing = (mergedAfterLegacy as Record<string, unknown>).ingressHost;
+            if (typeof existing === 'string' && existing.trim().length > 0) {
+                return mergedAfterLegacy;
+            }
+        }
+
+        // Provider + LB target pre-checks. Greptile P1 + Augment medium:
+        // calling `ensureRecord` with an empty `content` left the Work with a
+        // persisted `managedSubdomain` and an Ingress pointing at a host that
+        // resolves to nothing. Bail BEFORE allocate() so we never persist a
+        // claim we can't back with a real CNAME.
+        const provider = this.dnsService.getProvider();
+        const lbTarget = process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME?.trim() ?? '';
+        if (!provider || !lbTarget) {
+            this.logger.debug(
+                `EW-734 k8s managed-subdomain skipped for work ${work.id}: ` +
+                    `provider=${provider ? 'ok' : 'missing'} lbTarget=${lbTarget ? 'ok' : 'missing'}; falling back to legacy host`,
+            );
+            return mergedAfterLegacy;
+        }
+
+        try {
+            const allocation = await this.subdomainAllocator.allocate(work);
+            // Fire-and-forget DNS record creation, matching the legacy
+            // ever-works path's behavior (errors log but never abort).
+            void provider
+                .ensureRecord({
+                    host: allocation.fqdn,
+                    type: 'CNAME',
+                    target: lbTarget,
+                    proxied: false,
+                    ttl: 1,
+                })
+                .catch((cause) => {
+                    this.logger.error(
+                        `EW-734 k8s managed-subdomain ensureRecord failed for ${allocation.fqdn}: ${(cause as Error).message}`,
+                    );
+                });
+            // EW-741 — when the allocator wins, the previously-merged
+            // `extraHosts` (custom domains) must still travel alongside the
+            // newly-allocated managed subdomain. We re-dedupe against the
+            // fresh ingressHost so the primary host never appears twice.
+            const next: Record<string, unknown> = {
+                ...(mergedAfterLegacy ?? {}),
+                ingressHost: allocation.fqdn,
+            };
+            const merged = mergedAfterLegacy as Record<string, unknown> | undefined;
+            const prior = Array.isArray(merged?.extraHosts) ? (merged.extraHosts as string[]) : [];
+            const deduped = this.dedupeExtraHosts(prior, allocation.fqdn);
+            if (deduped.length > 0) {
+                next.extraHosts = deduped;
+            } else {
+                delete next.extraHosts;
+            }
+            return next;
+        } catch (cause) {
+            this.logger.error(
+                `EW-734 k8s managed-subdomain allocation failed for work ${work.id}: ${(cause as Error).message}`,
+            );
+            return mergedAfterLegacy;
+        }
+    }
+
+    /**
+     * EW-741 — merge `WorkCustomDomain` rows for this Work into the deploy
+     * settings as `extraHosts`. The managed subdomain (current `ingressHost`)
+     * is always retained as the primary host; custom domains never replace it.
+     *
+     * Idempotent and side-effect free against the input — returns a shallow
+     * copy (or the original `settings` when there are no custom domains).
+     * Failures are logged and swallowed: a DB hiccup here must not block a
+     * deploy that would otherwise succeed with just the managed subdomain.
+     */
+    private async mergeCustomDomainHosts(
+        work: Work,
+        settings: Record<string, unknown> | undefined,
+    ): Promise<Record<string, unknown> | undefined> {
+        if (!this.customDomainRepository) {
+            return settings;
+        }
+        let domains;
+        try {
+            domains = await this.customDomainRepository.findByWork(work.id);
+        } catch (cause) {
+            this.logger.warn(
+                `EW-741 custom-domain lookup failed for work ${work.id}: ${(cause as Error).message}`,
+            );
+            return settings;
+        }
+        if (!domains || domains.length === 0) {
+            return settings;
+        }
+        const primary =
+            settings && typeof (settings as Record<string, unknown>).ingressHost === 'string'
+                ? ((settings as Record<string, unknown>).ingressHost as string)
+                : undefined;
+        const rawHosts = domains.map((row) => row.domain);
+        const extras = this.dedupeExtraHosts(rawHosts, primary);
+        if (extras.length === 0) {
+            return settings;
+        }
+        return {
+            ...(settings ?? {}),
+            extraHosts: extras,
+        };
+    }
+
+    /**
+     * Lowercase + trim + drop the primary host + dedupe. Shared by the merge
+     * step and the allocator-extension's re-dedupe so the rules stay in one
+     * place.
+     */
+    private dedupeExtraHosts(hosts: readonly string[], primary?: string): string[] {
+        const primaryNormalized = primary?.trim().toLowerCase();
+        const seen = new Set<string>();
+        const out: string[] = [];
+        for (const host of hosts) {
+            if (typeof host !== 'string') continue;
+            const normalized = host.trim().toLowerCase();
+            if (!normalized) continue;
+            if (primaryNormalized && normalized === primaryNormalized) continue;
+            if (seen.has(normalized)) continue;
+            seen.add(normalized);
+            out.push(normalized);
+        }
+        return out;
     }
 
     /**

--- a/apps/api/src/plugins-capabilities/deploy/dto/subdomain.dto.ts
+++ b/apps/api/src/plugins-capabilities/deploy/dto/subdomain.dto.ts
@@ -1,0 +1,79 @@
+import { IsString, IsNotEmpty, Length, Matches } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * EW-739 — managed-subdomain read/write DTOs.
+ *
+ * `GET /api/deploy/works/:id/subdomain` returns a `SubdomainResponseDto`:
+ *   - `subdomain` — the leftmost label persisted on `work.managedSubdomain`
+ *     (e.g. `my-site`), or `null` if no managed subdomain is allocated yet.
+ *   - `fqdn` — fully qualified host (`${subdomain}.${rootDomain}`), or `null`.
+ *   - `url` — `https://${fqdn}`, or `null`.
+ *   - `recordOk` — `true` iff `provider.recordExists(fqdn)` resolved truthy,
+ *     i.e. the DNS record exists in the managed zone (caller-visible health
+ *     signal). Always `false` when `subdomain` is `null`.
+ *   - `editable` — `true` when the caller can re-allocate; gated on
+ *     `work.deployProvider ∈ {'ever-works','k8s'}` (the only providers that
+ *     run through `applyManagedSubdomain`) AND, for k8s, on the
+ *     `K8S_MANAGED_SUBDOMAIN` env flag being active so the operator
+ *     opt-in is respected.
+ *
+ * `PUT /api/deploy/works/:id/subdomain` validates `UpdateSubdomainDto` per
+ * spec §7: strict `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$` regex (no leading/trailing
+ * dashes), 1–63 chars (RFC 1035 label length cap). The platform also rejects
+ * the blocklist (`www`, `api`, `app`, `admin`, `mail`, …) at the service
+ * layer — that's not expressible cleanly via class-validator decorators
+ * since it's a runtime allowlist, and surfacing the rejection from the
+ * service lets us share the same set with `SubdomainAllocator`.
+ */
+export class SubdomainResponseDto {
+    @ApiProperty({
+        description: 'Leftmost label persisted on work.managedSubdomain',
+        nullable: true,
+        example: 'my-site',
+    })
+    subdomain!: string | null;
+
+    @ApiProperty({
+        description: 'Fully qualified host (${subdomain}.${rootDomain})',
+        nullable: true,
+        example: 'my-site.ever.works',
+    })
+    fqdn!: string | null;
+
+    @ApiProperty({
+        description: 'https://${fqdn}',
+        nullable: true,
+        example: 'https://my-site.ever.works',
+    })
+    url!: string | null;
+
+    @ApiProperty({
+        description: 'true iff the DNS record exists in the managed zone',
+        example: true,
+    })
+    recordOk!: boolean;
+
+    @ApiProperty({
+        description:
+            'true iff the caller can edit (provider ∈ {ever-works,k8s} and managed mode active)',
+        example: true,
+    })
+    editable!: boolean;
+}
+
+export class UpdateSubdomainDto {
+    @ApiProperty({
+        description:
+            'New leftmost label for the managed subdomain. Must match ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ (RFC 1035 host label), 1-63 chars.',
+        example: 'my-site',
+    })
+    @IsString()
+    @IsNotEmpty()
+    @Length(1, 63, { message: 'Subdomain must be 1-63 characters long' })
+    @Matches(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, {
+        message:
+            'Invalid subdomain format. Must be lowercase letters, digits, and dashes (no leading/trailing dash). Example: my-site',
+    })
+    subdomain!: string;
+}

--- a/apps/api/src/plugins-capabilities/deploy/managed-subdomain.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/managed-subdomain.service.spec.ts
@@ -1,0 +1,367 @@
+jest.mock('@ever-works/agent/database', () => ({
+    WorkRepository: class {},
+}));
+jest.mock('@ever-works/agent/ever-works-providers', () => ({
+    EverWorksDnsService: class {},
+    SubdomainAllocator: class {},
+}));
+jest.mock('@ever-works/agent/entities', () => ({
+    Work: class {},
+}));
+
+import {
+    BadRequestException,
+    ConflictException,
+    InternalServerErrorException,
+    NotFoundException,
+} from '@nestjs/common';
+import { ManagedSubdomainService } from './managed-subdomain.service';
+import type { WorkRepository } from '@ever-works/agent/database';
+import type { EverWorksDnsService } from '@ever-works/agent/ever-works-providers';
+
+describe('ManagedSubdomainService', () => {
+    let workRepository: {
+        findById: jest.Mock;
+        findByManagedSubdomain: jest.Mock;
+        update: jest.Mock;
+    };
+    let provider: {
+        rootDomain: jest.Mock;
+        recordExists: jest.Mock;
+        ensureRecord: jest.Mock;
+        removeRecord: jest.Mock;
+    };
+    let dnsService: { getProvider: jest.Mock };
+    let service: ManagedSubdomainService;
+
+    const buildWork = (overrides: Record<string, unknown> = {}) => ({
+        id: '11111111-1111-1111-1111-111111111111',
+        slug: 'my-site',
+        name: 'My Site',
+        deployProvider: 'ever-works',
+        managedSubdomain: null,
+        ...overrides,
+    });
+
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = {
+            ...originalEnv,
+            EVER_WORKS_DEPLOY_LB_HOSTNAME: 'lb.ever.works',
+            K8S_MANAGED_SUBDOMAIN: 'false',
+            EVER_WORKS_DOMAIN: 'ever.works',
+        };
+        workRepository = {
+            findById: jest.fn(),
+            findByManagedSubdomain: jest.fn().mockResolvedValue(null),
+            update: jest.fn().mockResolvedValue(undefined),
+        };
+        provider = {
+            rootDomain: jest.fn().mockReturnValue('ever.works'),
+            recordExists: jest.fn().mockResolvedValue(true),
+            ensureRecord: jest.fn().mockResolvedValue({ id: 'rec-1' }),
+            removeRecord: jest.fn().mockResolvedValue(undefined),
+        };
+        dnsService = { getProvider: jest.fn().mockReturnValue(provider) };
+        service = new ManagedSubdomainService(
+            workRepository as unknown as WorkRepository,
+            dnsService as unknown as EverWorksDnsService,
+        );
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+        jest.restoreAllMocks();
+    });
+
+    describe('getState', () => {
+        it('throws 404 when the work does not exist', async () => {
+            workRepository.findById.mockResolvedValue(null);
+
+            await expect(service.getState('missing')).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('returns the unallocated shape when managedSubdomain is null', async () => {
+            workRepository.findById.mockResolvedValue(buildWork({ managedSubdomain: null }));
+
+            const result = await service.getState('work-1');
+
+            expect(result).toEqual({
+                subdomain: null,
+                fqdn: null,
+                url: null,
+                recordOk: false,
+                editable: true, // ever-works provider
+            });
+            expect(provider.recordExists).not.toHaveBeenCalled();
+        });
+
+        it('returns the allocated shape with recordOk=true when the probe succeeds', async () => {
+            workRepository.findById.mockResolvedValue(buildWork({ managedSubdomain: 'my-site' }));
+
+            const result = await service.getState('work-1');
+
+            expect(provider.recordExists).toHaveBeenCalledWith('my-site.ever.works');
+            expect(result).toEqual({
+                subdomain: 'my-site',
+                fqdn: 'my-site.ever.works',
+                url: 'https://my-site.ever.works',
+                recordOk: true,
+                editable: true,
+            });
+        });
+
+        it('returns recordOk=false (and no throw) when the probe fails', async () => {
+            workRepository.findById.mockResolvedValue(buildWork({ managedSubdomain: 'my-site' }));
+            provider.recordExists.mockRejectedValue(new Error('Cloudflare down'));
+
+            const result = await service.getState('work-1');
+
+            expect(result.recordOk).toBe(false);
+            expect(result.subdomain).toBe('my-site');
+        });
+
+        it('sets editable=false for non-managed providers (vercel)', async () => {
+            workRepository.findById.mockResolvedValue(
+                buildWork({ deployProvider: 'vercel', managedSubdomain: 'my-site' }),
+            );
+
+            const result = await service.getState('work-1');
+
+            expect(result.editable).toBe(false);
+        });
+
+        it('sets editable=true for k8s only when K8S_MANAGED_SUBDOMAIN=true', async () => {
+            workRepository.findById.mockResolvedValue(
+                buildWork({ deployProvider: 'k8s', managedSubdomain: 'my-site' }),
+            );
+
+            process.env.K8S_MANAGED_SUBDOMAIN = 'false';
+            expect((await service.getState('work-1')).editable).toBe(false);
+
+            process.env.K8S_MANAGED_SUBDOMAIN = 'true';
+            expect((await service.getState('work-1')).editable).toBe(true);
+        });
+
+        it('falls back to env EVER_WORKS_DOMAIN when DNS is not configured', async () => {
+            dnsService.getProvider.mockReturnValue(null);
+            workRepository.findById.mockResolvedValue(buildWork({ managedSubdomain: 'my-site' }));
+
+            const result = await service.getState('work-1');
+
+            expect(result.fqdn).toBe('my-site.ever.works');
+            // No provider means we can't probe; recordOk stays false.
+            expect(result.recordOk).toBe(false);
+        });
+    });
+
+    describe('update', () => {
+        it('rejects invalid subdomain format (leading dash)', async () => {
+            await expect(service.update('work-1', '-bad')).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+
+        it('normalizes case + whitespace before persisting (BadCase → badcase)', async () => {
+            const workBefore = buildWork({ managedSubdomain: null });
+            workRepository.findById
+                .mockResolvedValueOnce(workBefore)
+                .mockResolvedValueOnce({ ...workBefore, managedSubdomain: 'badcase' });
+
+            await service.update('work-1', '  BadCase  ');
+
+            expect(workRepository.update).toHaveBeenCalledWith(workBefore.id, {
+                managedSubdomain: 'badcase',
+            });
+        });
+
+        it('rejects characters outside [a-z0-9-]', async () => {
+            await expect(service.update('work-1', 'bad_name')).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+            await expect(service.update('work-1', 'bad.name')).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+
+        it('rejects labels longer than 63 chars', async () => {
+            await expect(service.update('work-1', 'a'.repeat(64))).rejects.toBeInstanceOf(
+                BadRequestException,
+            );
+        });
+
+        it('rejects blocklisted labels (www, api, app, admin, mail)', async () => {
+            workRepository.findById.mockResolvedValue(buildWork({ deployProvider: 'ever-works' }));
+            for (const reserved of ['www', 'api', 'app', 'admin', 'mail']) {
+                await expect(service.update('work-1', reserved)).rejects.toMatchObject({
+                    response: {
+                        message: expect.stringContaining('reserved'),
+                    },
+                });
+            }
+        });
+
+        it('rejects when the work is not editable (vercel provider)', async () => {
+            workRepository.findById.mockResolvedValue(buildWork({ deployProvider: 'vercel' }));
+
+            await expect(service.update('work-1', 'good-name')).rejects.toMatchObject({
+                response: { message: expect.stringContaining('not editable') },
+            });
+        });
+
+        it('short-circuits when requested matches current (idempotent rename)', async () => {
+            workRepository.findById.mockResolvedValue(buildWork({ managedSubdomain: 'my-site' }));
+
+            await service.update('work-1', 'my-site');
+
+            // Critical: no DNS mutation and no DB write when the value is unchanged.
+            expect(workRepository.update).not.toHaveBeenCalled();
+            expect(provider.ensureRecord).not.toHaveBeenCalled();
+            expect(provider.removeRecord).not.toHaveBeenCalled();
+        });
+
+        it('rejects with 409 Conflict when subdomain is claimed by a different work', async () => {
+            workRepository.findById.mockResolvedValue(buildWork());
+            workRepository.findByManagedSubdomain.mockResolvedValue({
+                id: 'other-work',
+                managedSubdomain: 'taken',
+            });
+
+            await expect(service.update('work-1', 'taken')).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+            expect(workRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('allows the rename when findByManagedSubdomain returns the same work (self-claim)', async () => {
+            const work = buildWork({ managedSubdomain: 'old-name' });
+            workRepository.findById.mockResolvedValue(work);
+            workRepository.findByManagedSubdomain.mockResolvedValue(work);
+
+            await service.update('work-1', 'new-name');
+
+            expect(workRepository.update).toHaveBeenCalledWith(work.id, {
+                managedSubdomain: 'new-name',
+            });
+        });
+
+        it('returns 500 when DNS provider is not configured', async () => {
+            dnsService.getProvider.mockReturnValue(null);
+            workRepository.findById.mockResolvedValue(buildWork());
+
+            await expect(service.update('work-1', 'good-name')).rejects.toBeInstanceOf(
+                InternalServerErrorException,
+            );
+            expect(workRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('returns 500 when LB hostname env is missing', async () => {
+            process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = '';
+            workRepository.findById.mockResolvedValue(buildWork());
+
+            await expect(service.update('work-1', 'good-name')).rejects.toBeInstanceOf(
+                InternalServerErrorException,
+            );
+            expect(workRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('happy path: removes old, persists, ensures new, returns refreshed state', async () => {
+            const workBefore = buildWork({ managedSubdomain: 'old-name' });
+            const workAfter = { ...workBefore, managedSubdomain: 'new-name' };
+            workRepository.findById
+                .mockResolvedValueOnce(workBefore) // update()
+                .mockResolvedValueOnce(workAfter); // post-update getState()
+
+            const result = await service.update('work-1', 'new-name');
+
+            expect(provider.removeRecord).toHaveBeenCalledWith({
+                host: 'old-name.ever.works',
+            });
+            expect(workRepository.update).toHaveBeenCalledWith(workBefore.id, {
+                managedSubdomain: 'new-name',
+            });
+            expect(provider.ensureRecord).toHaveBeenCalledWith({
+                host: 'new-name.ever.works',
+                type: 'CNAME',
+                target: 'lb.ever.works',
+                proxied: false,
+                ttl: 1,
+            });
+            // Order: remove → persist → ensure (rollback safety).
+            const removeOrder = provider.removeRecord.mock.invocationCallOrder[0];
+            const updateOrder = workRepository.update.mock.invocationCallOrder[0];
+            const ensureOrder = provider.ensureRecord.mock.invocationCallOrder[0];
+            expect(removeOrder).toBeLessThan(updateOrder);
+            expect(updateOrder).toBeLessThan(ensureOrder);
+
+            expect(result.subdomain).toBe('new-name');
+        });
+
+        it('does NOT call removeRecord when there is no prior subdomain', async () => {
+            const workBefore = buildWork({ managedSubdomain: null });
+            workRepository.findById
+                .mockResolvedValueOnce(workBefore)
+                .mockResolvedValueOnce({ ...workBefore, managedSubdomain: 'first-name' });
+
+            await service.update('work-1', 'first-name');
+
+            expect(provider.removeRecord).not.toHaveBeenCalled();
+            expect(provider.ensureRecord).toHaveBeenCalled();
+        });
+
+        it('proceeds (best-effort) even when removeRecord on the old name throws', async () => {
+            const workBefore = buildWork({ managedSubdomain: 'old-name' });
+            workRepository.findById
+                .mockResolvedValueOnce(workBefore)
+                .mockResolvedValueOnce({ ...workBefore, managedSubdomain: 'new-name' });
+            provider.removeRecord.mockRejectedValue(new Error('cf down'));
+
+            await service.update('work-1', 'new-name');
+
+            expect(workRepository.update).toHaveBeenCalled();
+            expect(provider.ensureRecord).toHaveBeenCalled();
+        });
+
+        it('maps a unique-violation on persist to 409 Conflict', async () => {
+            workRepository.findById.mockResolvedValue(buildWork());
+            workRepository.update.mockRejectedValue({ code: '23505' });
+
+            await expect(service.update('work-1', 'race-loser')).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+        });
+
+        it('rolls back the persisted claim when ensureRecord fails after persist', async () => {
+            const workBefore = buildWork({ managedSubdomain: 'old-name' });
+            workRepository.findById.mockResolvedValue(workBefore);
+            provider.ensureRecord.mockRejectedValue(new Error('cf api down'));
+
+            await expect(service.update('work-1', 'new-name')).rejects.toBeInstanceOf(
+                InternalServerErrorException,
+            );
+
+            // Two updates: forward to 'new-name', rollback to 'old-name'.
+            expect(workRepository.update).toHaveBeenNthCalledWith(1, workBefore.id, {
+                managedSubdomain: 'new-name',
+            });
+            expect(workRepository.update).toHaveBeenNthCalledWith(2, workBefore.id, {
+                managedSubdomain: 'old-name',
+            });
+        });
+
+        it('rolls back to null when ensureRecord fails on first-time allocation', async () => {
+            const workBefore = buildWork({ managedSubdomain: null });
+            workRepository.findById.mockResolvedValue(workBefore);
+            provider.ensureRecord.mockRejectedValue(new Error('cf api down'));
+
+            await expect(service.update('work-1', 'first-name')).rejects.toBeInstanceOf(
+                InternalServerErrorException,
+            );
+
+            expect(workRepository.update).toHaveBeenNthCalledWith(2, workBefore.id, {
+                managedSubdomain: null,
+            });
+        });
+    });
+});

--- a/apps/api/src/plugins-capabilities/deploy/managed-subdomain.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/managed-subdomain.service.ts
@@ -1,0 +1,316 @@
+import {
+    BadRequestException,
+    ConflictException,
+    Injectable,
+    InternalServerErrorException,
+    Logger,
+    NotFoundException,
+} from '@nestjs/common';
+import { WorkRepository } from '@ever-works/agent/database';
+import { EverWorksDnsService } from '@ever-works/agent/ever-works-providers';
+import type { Work } from '@ever-works/agent/entities';
+
+/**
+ * EW-739 — service backing the managed-subdomain API.
+ *
+ * Single source of truth for "read or change the managed subdomain attached
+ * to a Work" so the new `GET/PUT /api/deploy/works/:id/subdomain` endpoints,
+ * the future Deploy-tab UI server actions, and any background reconciler
+ * (EW-741) all flow through the same validation + DNS + persistence chain.
+ *
+ * Stays out of `DeployService` deliberately — that service drives the deploy
+ * pipeline (workflow dispatch, secret pushes). Renaming a subdomain is
+ * orthogonal to a deploy: it touches DNS + the Work row, then either patches
+ * the live Ingress directly (k8s, future EW-740 follow-up) or surfaces a
+ * "redeploy required" hint to the caller. Keeping it separate also lets the
+ * tests stub a much smaller dependency surface than `DeployService`'s.
+ */
+export interface SubdomainState {
+    /** Leftmost label persisted on `work.managedSubdomain`. */
+    readonly subdomain: string | null;
+    /** `${subdomain}.${rootDomain}`. */
+    readonly fqdn: string | null;
+    /** `https://${fqdn}`. */
+    readonly url: string | null;
+    /** `true` iff the DNS provider has a record for `fqdn`. */
+    readonly recordOk: boolean;
+    /**
+     * `true` iff the caller can re-allocate via `PUT`. Gated on
+     * `work.deployProvider ∈ {'ever-works','k8s'}` AND, for k8s, the
+     * `K8S_MANAGED_SUBDOMAIN` env flag being active so operator
+     * opt-in is respected.
+     */
+    readonly editable: boolean;
+}
+
+/**
+ * Reserved platform labels — never let a tenant claim these. Mirrors the
+ * spec §7 blocklist + the `SubdomainAllocator` BLOCKLIST so DB-level state
+ * stays consistent whether the label was assigned via the allocator or via
+ * an explicit `PUT`. Kept module-local (not exported from `@ever-works/agent`)
+ * because the allocator's set is `private static readonly` and exporting
+ * it would couple the API to a private detail.
+ */
+const RESERVED_LABELS: ReadonlySet<string> = new Set([
+    'www',
+    'api',
+    'app',
+    'admin',
+    'mail',
+    'auth',
+    'docs',
+    'status',
+    'platform',
+    'dashboard',
+    'cdn',
+    'static',
+    'root',
+    'mx',
+    'ns',
+    'ns1',
+    'ns2',
+]);
+
+const LABEL_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+@Injectable()
+export class ManagedSubdomainService {
+    private readonly logger = new Logger(ManagedSubdomainService.name);
+
+    constructor(
+        private readonly workRepository: WorkRepository,
+        private readonly dnsService: EverWorksDnsService,
+    ) {}
+
+    /**
+     * Resolve current state for the UI. Never mutates. Always returns a
+     * snapshot — when no managed subdomain is allocated yet, all url-shaped
+     * fields are `null` and `recordOk` is `false`, but `editable` may still
+     * be `true` so the UI can offer a first-time allocation flow.
+     */
+    async getState(workId: string): Promise<SubdomainState> {
+        const work = await this.requireWork(workId);
+        const provider = this.dnsService.getProvider();
+        const rootDomain = provider?.rootDomain() ?? this.fallbackRootDomain();
+        const subdomain = (work.managedSubdomain ?? '').trim().toLowerCase() || null;
+        const fqdn = subdomain ? `${subdomain}.${rootDomain}` : null;
+        const url = fqdn ? `https://${fqdn}` : null;
+
+        let recordOk = false;
+        if (subdomain && fqdn && provider) {
+            try {
+                recordOk = await provider.recordExists(fqdn);
+            } catch (cause) {
+                // A probe failure is a transient health signal, not a hard
+                // error — log + fall through so the UI still renders.
+                this.logger.warn(
+                    `recordExists probe failed for ${fqdn}: ${(cause as Error).message}`,
+                );
+            }
+        }
+
+        return {
+            subdomain,
+            fqdn,
+            url,
+            recordOk,
+            editable: this.isEditable(work),
+        };
+    }
+
+    /**
+     * Re-allocate the managed subdomain to `requested` for `workId`. Steps:
+     *   1. Format guard (defence-in-depth — controller DTO already validated).
+     *   2. Blocklist guard (spec §7).
+     *   3. No-op when `requested` already matches `work.managedSubdomain`.
+     *   4. Global uniqueness via `WorkRepository.findByManagedSubdomain`.
+     *   5. Remove the old DNS record (best-effort) — keeps the zone tidy and
+     *      releases the old label so a sibling Work can re-claim it.
+     *   6. Persist `work.managedSubdomain = requested`. The partial unique
+     *      index is the DB-level backstop against concurrent renames.
+     *   7. Ensure the new DNS record. Failure is hard-error: a successful
+     *      persist without a working CNAME would leave the UI showing a
+     *      claim that doesn't resolve. We try to roll back the persisted
+     *      claim so the caller can retry.
+     *
+     * Returns the post-update `SubdomainState` for the caller.
+     */
+    async update(workId: string, requested: string): Promise<SubdomainState> {
+        const normalized = (requested ?? '').trim().toLowerCase();
+        if (!LABEL_RE.test(normalized) || normalized.length > 63) {
+            throw new BadRequestException({
+                status: 'error',
+                message:
+                    'Invalid subdomain format. Must be lowercase letters, digits, and dashes (no leading/trailing dash), 1-63 characters.',
+            });
+        }
+        if (RESERVED_LABELS.has(normalized)) {
+            throw new BadRequestException({
+                status: 'error',
+                message: `Subdomain "${normalized}" is reserved by the platform and cannot be claimed.`,
+            });
+        }
+
+        const work = await this.requireWork(workId);
+        if (!this.isEditable(work)) {
+            throw new BadRequestException({
+                status: 'error',
+                message:
+                    'Managed subdomain is not editable for this work (requires ever-works or k8s provider with managed mode active).',
+            });
+        }
+
+        const currentSubdomain = (work.managedSubdomain ?? '').trim().toLowerCase();
+        if (currentSubdomain === normalized) {
+            // Idempotent — short-circuit so we don't re-touch DNS unnecessarily.
+            return this.getState(workId);
+        }
+
+        const claimedBy = await this.workRepository.findByManagedSubdomain(normalized);
+        if (claimedBy && claimedBy.id !== work.id) {
+            throw new ConflictException({
+                status: 'error',
+                message: `Subdomain "${normalized}" is already claimed by another work.`,
+            });
+        }
+
+        const provider = this.dnsService.getProvider();
+        const lbTarget = process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME?.trim() ?? '';
+        if (!provider) {
+            throw new InternalServerErrorException({
+                status: 'error',
+                message:
+                    'Managed DNS is not configured on this environment (CLOUDFLARE_API_TOKEN / CLOUDFLARE_ZONE_ID / EVER_WORKS_DEPLOY_LB_HOSTNAME missing).',
+            });
+        }
+        if (!lbTarget) {
+            throw new InternalServerErrorException({
+                status: 'error',
+                message:
+                    'Managed DNS target (EVER_WORKS_DEPLOY_LB_HOSTNAME) is not configured on this environment.',
+            });
+        }
+
+        const rootDomain = provider.rootDomain();
+        const newFqdn = `${normalized}.${rootDomain}`;
+        const oldFqdn = currentSubdomain ? `${currentSubdomain}.${rootDomain}` : null;
+
+        // Step 5: best-effort old-record cleanup. A failure here doesn't
+        // block the rename — the new claim is what the user wants live —
+        // but we log so an operator can clean up a dangling CNAME.
+        if (oldFqdn) {
+            try {
+                await provider.removeRecord({ host: oldFqdn });
+            } catch (cause) {
+                this.logger.warn(
+                    `Failed to remove stale DNS record for ${oldFqdn} during rename of work ${work.id}: ${(cause as Error).message}`,
+                );
+            }
+        }
+
+        // Step 6: persist. A concurrent rename racing to the same label will
+        // surface as a unique-index violation here; we map it to 409 so the
+        // UI shows a friendly retry message instead of a generic 500.
+        try {
+            await this.workRepository.update(work.id, { managedSubdomain: normalized });
+        } catch (cause) {
+            if (this.isUniqueViolation(cause)) {
+                throw new ConflictException({
+                    status: 'error',
+                    message: `Subdomain "${normalized}" was just claimed by another work. Please pick a different one.`,
+                });
+            }
+            throw cause;
+        }
+
+        // Step 7: ensure the new record. On failure, try to roll back the
+        // persisted claim so the user isn't stuck with a half-applied rename.
+        try {
+            await provider.ensureRecord({
+                host: newFqdn,
+                type: 'CNAME',
+                target: lbTarget,
+                proxied: false,
+                ttl: 1,
+            });
+        } catch (cause) {
+            this.logger.error(
+                `ensureRecord failed for ${newFqdn} on work ${work.id}: ${(cause as Error).message}; rolling back persisted claim`,
+            );
+            try {
+                await this.workRepository.update(work.id, {
+                    managedSubdomain: currentSubdomain || null,
+                });
+            } catch (rollbackErr) {
+                this.logger.error(
+                    `Failed to roll back managedSubdomain for work ${work.id}: ${(rollbackErr as Error).message}`,
+                );
+            }
+            throw new InternalServerErrorException({
+                status: 'error',
+                message: `Failed to create DNS record for ${newFqdn}. The rename was not applied.`,
+            });
+        }
+
+        this.logger.log(
+            `Managed subdomain for work ${work.id} updated: ${currentSubdomain || '(unset)'} -> ${normalized}`,
+        );
+
+        // Re-read so the response reflects the persisted state (including
+        // `recordOk` after the freshly ensured record).
+        return this.getState(work.id);
+    }
+
+    /**
+     * For callers that don't have the Work in hand yet — keeps the
+     * controller thin and centralises the 404 message.
+     */
+    private async requireWork(workId: string): Promise<Work> {
+        const work = await this.workRepository.findById(workId);
+        if (!work) {
+            throw new NotFoundException({
+                status: 'error',
+                message: `Work ${workId} not found`,
+            });
+        }
+        return work;
+    }
+
+    /**
+     * Editable iff the deploy provider is one that runs through
+     * `applyManagedSubdomain`. For `'k8s'` we additionally require the
+     * `K8S_MANAGED_SUBDOMAIN` flag so operators opt-in per env —
+     * matches the gate in `DeployService.isManagedSubdomainForK8sEnabled`.
+     * `'ever-works'` is always managed.
+     */
+    private isEditable(work: Work): boolean {
+        const provider = (work.deployProvider ?? '').trim().toLowerCase();
+        if (provider === 'ever-works') {
+            return true;
+        }
+        if (provider === 'k8s') {
+            return process.env.K8S_MANAGED_SUBDOMAIN === 'true';
+        }
+        return false;
+    }
+
+    private fallbackRootDomain(): string {
+        return process.env.EVER_WORKS_DOMAIN?.trim() || 'ever.works';
+    }
+
+    /**
+     * Mirrors `SubdomainAllocator.isUniqueViolation`. Kept duplicated rather
+     * than re-exported because the allocator's helper is `private` and
+     * widening visibility for one cross-module caller would be worse than a
+     * 10-line copy.
+     */
+    private isUniqueViolation(cause: unknown): boolean {
+        if (!cause || typeof cause !== 'object') return false;
+        const err = cause as { code?: string; driverError?: { code?: string }; message?: string };
+        if (err.code === '23505') return true;
+        if (err.driverError?.code === '23505') return true;
+        if (err.code === 'SQLITE_CONSTRAINT_UNIQUE') return true;
+        const msg = (err.message ?? '').toLowerCase();
+        return msg.includes('unique constraint') || msg.includes('uq_works_managedsubdomain');
+    }
+}

--- a/apps/internal-cli/src/cli.module.ts
+++ b/apps/internal-cli/src/cli.module.ts
@@ -18,6 +18,7 @@ import { LocalEventEmitterModule } from './local-event-emitter.module';
 import { ConfigCommands } from './commands/config';
 import { WorkCommands } from './commands/work';
 import { ServeCommands } from './commands/serve';
+import { BackfillCommands } from './commands/backfill';
 import { CacheFactory } from '@ever-works/agent/cache';
 
 @Module({
@@ -43,6 +44,7 @@ import { CacheFactory } from '@ever-works/agent/cache';
         ...ConfigCommands,
         ...WorkCommands,
         ...ServeCommands,
+        ...BackfillCommands,
     ],
 })
 export class CLIModule implements OnApplicationBootstrap {

--- a/apps/internal-cli/src/commands/backfill/__tests__/backfill-managed-subdomain.service.spec.ts
+++ b/apps/internal-cli/src/commands/backfill/__tests__/backfill-managed-subdomain.service.spec.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    BackfillManagedSubdomainService,
+    planForWork,
+    type CloudflareDnsRecord,
+    type CloudflareZoneLister,
+    type WorkBackfillReadWrite,
+} from '../backfill-managed-subdomain.service';
+import type { Work } from '@ever-works/agent/entities';
+
+/**
+ * Test fixtures — mirror the seven legacy Works listed in spec §5 so the
+ * tests actually exercise the same shapes ops will run against.
+ */
+
+function makeWork(partial: Partial<Work> & { id: string; slug: string }): Work {
+    return {
+        deployProvider: 'ever-works',
+        managedSubdomain: null,
+        ...partial,
+    } as Work;
+}
+
+function makeRecord(name: string, type: 'CNAME' | 'A' = 'CNAME'): CloudflareDnsRecord {
+    return {
+        id: `rec_${name.replace(/\W/g, '_')}`,
+        name,
+        type,
+        content: 'platform.k8s-works.ever.works',
+    };
+}
+
+function makeLister(
+    records: CloudflareDnsRecord[],
+    rootDomain = 'ever.works',
+): CloudflareZoneLister {
+    return {
+        listAllRecords: vi.fn(async () => records),
+        rootDomain: () => rootDomain,
+    };
+}
+
+function makeWorksAdapter(works: Work[]): WorkBackfillReadWrite & {
+    update: ReturnType<typeof vi.fn>;
+} {
+    return {
+        findCandidatesForBackfill: vi.fn(async () => works),
+        update: vi.fn(async () => undefined),
+    };
+}
+
+const silentLogger = {
+    log: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+};
+
+beforeEach(() => {
+    silentLogger.log.mockClear();
+    silentLogger.warn.mockClear();
+    silentLogger.error.mockClear();
+});
+
+describe('planForWork', () => {
+    const rootDomain = 'ever.works';
+    const zone = {
+        byLabel: new Map<string, CloudflareDnsRecord>([
+            ['dir', makeRecord('dir.ever.works')],
+            ['mcpserver', makeRecord('mcpserver.ever.works')],
+            ['ai-coding-1234', makeRecord('ai-coding-1234.ever.works')],
+        ]),
+        labels: new Set(['dir', 'mcpserver', 'ai-coding-1234']),
+    };
+
+    it('returns already-set when work already has managedSubdomain', () => {
+        const work = makeWork({ id: 'w1', slug: 'dir', managedSubdomain: 'something' });
+        const entry = planForWork(work, zone, rootDomain);
+        expect(entry.kind).toBe('already-set');
+    });
+
+    it('returns exact-slug match when slug matches a zone label uniquely', () => {
+        const work = makeWork({ id: 'aaaa-bbbb-cccc-dddd', slug: 'dir' });
+        const entry = planForWork(work, zone, rootDomain);
+        expect(entry).toMatchObject({
+            kind: 'match',
+            managedSubdomain: 'dir',
+            fqdn: 'dir.ever.works',
+            via: 'exact-slug',
+        });
+    });
+
+    it('returns slug-with-short-id-suffix match when suffix uniquely matches', () => {
+        // shortId of '12345678-...' is '1234'
+        const work = makeWork({ id: '12345678-0000-0000-0000-000000000000', slug: 'ai-coding' });
+        const entry = planForWork(work, zone, rootDomain);
+        expect(entry).toMatchObject({
+            kind: 'match',
+            managedSubdomain: 'ai-coding-1234',
+            via: 'slug-with-short-id-suffix',
+        });
+    });
+
+    it('returns no-candidate when neither exact nor suffixed label exists in zone', () => {
+        const work = makeWork({ id: 'aaaa-bbbb-cccc-dddd', slug: 'not-in-zone' });
+        const entry = planForWork(work, zone, rootDomain);
+        expect(entry.kind).toBe('no-candidate');
+    });
+
+    it('returns ambiguous when both exact AND suffix labels exist in zone', () => {
+        // Build a zone where both `dir` and `dir-1234` exist.
+        const ambiguousZone = {
+            byLabel: new Map<string, CloudflareDnsRecord>([
+                ['dir', makeRecord('dir.ever.works')],
+                ['dir-1234', makeRecord('dir-1234.ever.works')],
+            ]),
+            labels: new Set(['dir', 'dir-1234']),
+        };
+        const work = makeWork({ id: '12345678-aaaa-bbbb-cccc-dddddddddddd', slug: 'dir' });
+        const entry = planForWork(work, ambiguousZone, rootDomain);
+        expect(entry).toMatchObject({
+            kind: 'ambiguous',
+            candidates: expect.arrayContaining(['dir', 'dir-1234']),
+        });
+    });
+});
+
+describe('BackfillManagedSubdomainService', () => {
+    const rootDomain = 'ever.works';
+
+    it('dry-run logs intended writes but persists nothing', async () => {
+        const records = [
+            makeRecord('dir.ever.works'),
+            makeRecord('mcpserver.ever.works'),
+            makeRecord('unrelated.ever.works'),
+        ];
+        const works = [
+            makeWork({ id: '11111111-aaaa-bbbb-cccc-dddddddddddd', slug: 'dir' }),
+            makeWork({ id: '22222222-aaaa-bbbb-cccc-dddddddddddd', slug: 'mcpserver' }),
+        ];
+        const cloudflare = makeLister(records, rootDomain);
+        const adapter = makeWorksAdapter(works);
+        const svc = new BackfillManagedSubdomainService(adapter, cloudflare, silentLogger);
+
+        const summary = await svc.run({ write: false });
+
+        expect(summary.matched).toBe(2);
+        expect(summary.persisted).toBe(0);
+        expect(summary.totalScanned).toBe(2);
+        expect(adapter.update).not.toHaveBeenCalled();
+        // The PLAN log line is the contract — verify it ran for each match.
+        const planLogs = silentLogger.log.mock.calls
+            .map((args) => String(args[0]))
+            .filter((line) => line.includes('PLAN'));
+        expect(planLogs).toHaveLength(2);
+    });
+
+    it('--write persists matches via the adapter', async () => {
+        const records = [makeRecord('dir.ever.works'), makeRecord('mcpserver.ever.works')];
+        const works = [
+            makeWork({ id: '11111111-aaaa-bbbb-cccc-dddddddddddd', slug: 'dir' }),
+            makeWork({ id: '22222222-aaaa-bbbb-cccc-dddddddddddd', slug: 'mcpserver' }),
+        ];
+        const cloudflare = makeLister(records, rootDomain);
+        const adapter = makeWorksAdapter(works);
+        const svc = new BackfillManagedSubdomainService(adapter, cloudflare, silentLogger);
+
+        const summary = await svc.run({ write: true });
+
+        expect(summary.matched).toBe(2);
+        expect(summary.persisted).toBe(2);
+        expect(adapter.update).toHaveBeenCalledTimes(2);
+        expect(adapter.update).toHaveBeenCalledWith('11111111-aaaa-bbbb-cccc-dddddddddddd', {
+            managedSubdomain: 'dir',
+        });
+        expect(adapter.update).toHaveBeenCalledWith('22222222-aaaa-bbbb-cccc-dddddddddddd', {
+            managedSubdomain: 'mcpserver',
+        });
+    });
+
+    it('ambiguous matches are logged and NOT persisted', async () => {
+        const records = [makeRecord('dir.ever.works'), makeRecord('dir-1111.ever.works')];
+        const work = makeWork({
+            // shortId === '1111'
+            id: '11111111-0000-0000-0000-000000000000',
+            slug: 'dir',
+        });
+        const cloudflare = makeLister(records, rootDomain);
+        const adapter = makeWorksAdapter([work]);
+        const svc = new BackfillManagedSubdomainService(adapter, cloudflare, silentLogger);
+
+        const summary = await svc.run({ write: true });
+
+        expect(summary.ambiguous).toBe(1);
+        expect(summary.persisted).toBe(0);
+        expect(adapter.update).not.toHaveBeenCalled();
+        const ambiguousLogs = silentLogger.warn.mock.calls
+            .map((args) => String(args[0]))
+            .filter((line) => line.includes('AMBIGUOUS'));
+        expect(ambiguousLogs).toHaveLength(1);
+    });
+
+    it('skips Works that already have managedSubdomain set', async () => {
+        const records = [makeRecord('dir.ever.works')];
+        const works = [
+            makeWork({
+                id: '11111111-aaaa-bbbb-cccc-dddddddddddd',
+                slug: 'dir',
+                managedSubdomain: 'dir-old',
+            }),
+        ];
+        const cloudflare = makeLister(records, rootDomain);
+        const adapter = makeWorksAdapter(works);
+        const svc = new BackfillManagedSubdomainService(adapter, cloudflare, silentLogger);
+
+        const summary = await svc.run({ write: true });
+
+        expect(summary.alreadySet).toBe(1);
+        expect(summary.matched).toBe(0);
+        expect(summary.persisted).toBe(0);
+        expect(adapter.update).not.toHaveBeenCalled();
+    });
+
+    it('Works with no candidate in zone are counted but not persisted', async () => {
+        const records = [makeRecord('something-else.ever.works')];
+        const works = [
+            makeWork({ id: '11111111-aaaa-bbbb-cccc-dddddddddddd', slug: 'orphan-work' }),
+        ];
+        const cloudflare = makeLister(records, rootDomain);
+        const adapter = makeWorksAdapter(works);
+        const svc = new BackfillManagedSubdomainService(adapter, cloudflare, silentLogger);
+
+        const summary = await svc.run({ write: true });
+
+        expect(summary.noCandidate).toBe(1);
+        expect(summary.matched).toBe(0);
+        expect(adapter.update).not.toHaveBeenCalled();
+    });
+
+    it('ignores zone records under a different root domain', async () => {
+        const records = [makeRecord('dir.example.com'), makeRecord('dir.ever.works')];
+        const works = [makeWork({ id: '11111111-aaaa-bbbb-cccc-dddddddddddd', slug: 'dir' })];
+        const cloudflare = makeLister(records, 'ever.works');
+        const adapter = makeWorksAdapter(works);
+        const svc = new BackfillManagedSubdomainService(adapter, cloudflare, silentLogger);
+
+        const summary = await svc.run({ write: true });
+        expect(summary.matched).toBe(1);
+        expect(adapter.update).toHaveBeenCalledWith('11111111-aaaa-bbbb-cccc-dddddddddddd', {
+            managedSubdomain: 'dir',
+        });
+    });
+
+    it('ignores multi-label records (foo.bar.ever.works) — not a managed-subdomain shape', async () => {
+        const records = [makeRecord('deep.subdomain.ever.works'), makeRecord('dir.ever.works')];
+        const works = [
+            makeWork({ id: '11111111-aaaa-bbbb-cccc-dddddddddddd', slug: 'subdomain' }),
+            makeWork({ id: '22222222-aaaa-bbbb-cccc-dddddddddddd', slug: 'dir' }),
+        ];
+        const cloudflare = makeLister(records, 'ever.works');
+        const adapter = makeWorksAdapter(works);
+        const svc = new BackfillManagedSubdomainService(adapter, cloudflare, silentLogger);
+
+        const summary = await svc.run({ write: true });
+        // `subdomain` should not match `deep.subdomain.ever.works` (we only
+        // consider single-label managed shapes), so noCandidate=1.
+        expect(summary.noCandidate).toBe(1);
+        expect(summary.matched).toBe(1);
+        expect(adapter.update).toHaveBeenCalledWith('22222222-aaaa-bbbb-cccc-dddddddddddd', {
+            managedSubdomain: 'dir',
+        });
+    });
+
+    it('treats persistence failures as non-fatal — continues with the next work', async () => {
+        const records = [makeRecord('dir.ever.works'), makeRecord('mcpserver.ever.works')];
+        const works = [
+            makeWork({ id: '11111111-aaaa-bbbb-cccc-dddddddddddd', slug: 'dir' }),
+            makeWork({ id: '22222222-aaaa-bbbb-cccc-dddddddddddd', slug: 'mcpserver' }),
+        ];
+        const cloudflare = makeLister(records, 'ever.works');
+        const adapter = makeWorksAdapter(works);
+        adapter.update.mockImplementationOnce(async () => {
+            throw new Error('boom');
+        });
+        const svc = new BackfillManagedSubdomainService(adapter, cloudflare, silentLogger);
+
+        const summary = await svc.run({ write: true });
+
+        expect(summary.matched).toBe(2);
+        // First update threw, second succeeded — only one persisted.
+        expect(summary.persisted).toBe(1);
+        expect(silentLogger.error).toHaveBeenCalled();
+    });
+});

--- a/apps/internal-cli/src/commands/backfill/__tests__/cloudflare-zone-lister.spec.ts
+++ b/apps/internal-cli/src/commands/backfill/__tests__/cloudflare-zone-lister.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CloudflareApiZoneLister } from '../cloudflare-zone-lister';
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+describe('CloudflareApiZoneLister', () => {
+    const baseConfig = {
+        apiToken: 'token-xyz',
+        zoneId: 'zone-abc',
+        rootDomain: 'ever.works',
+        apiBaseUrl: 'https://api.example.test/client/v4',
+        perPage: 2,
+    } as const;
+
+    it('returns rootDomain from config', () => {
+        const lister = new CloudflareApiZoneLister(baseConfig, vi.fn());
+        expect(lister.rootDomain()).toBe('ever.works');
+    });
+
+    it('paginates until totalPages reached', async () => {
+        const fetchImpl = vi.fn(async (url: string) => {
+            const u = new URL(url);
+            const page = Number(u.searchParams.get('page'));
+            if (page === 1) {
+                return jsonResponse({
+                    success: true,
+                    result: [
+                        { id: 'r1', type: 'CNAME', name: 'dir.ever.works' },
+                        { id: 'r2', type: 'CNAME', name: 'mcpserver.ever.works' },
+                    ],
+                    result_info: { total_pages: 2, page: 1 },
+                });
+            }
+            if (page === 2) {
+                return jsonResponse({
+                    success: true,
+                    result: [{ id: 'r3', type: 'A', name: 'foo.ever.works' }],
+                    result_info: { total_pages: 2, page: 2 },
+                });
+            }
+            return jsonResponse({ success: false }, 500);
+        });
+
+        const lister = new CloudflareApiZoneLister(
+            baseConfig,
+            fetchImpl as unknown as typeof fetch,
+        );
+        const records = await lister.listAllRecords();
+        expect(records).toHaveLength(3);
+        expect(records.map((r) => r.id)).toEqual(['r1', 'r2', 'r3']);
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+
+        // Confirm auth header & per_page passthrough.
+        const firstCallInit = fetchImpl.mock.calls[0][1] as RequestInit;
+        const headers = firstCallInit.headers as Record<string, string>;
+        expect(headers.Authorization).toBe('Bearer token-xyz');
+        expect(String(fetchImpl.mock.calls[0][0])).toContain('per_page=2');
+    });
+
+    it('throws CloudflareDnsError on non-OK response', async () => {
+        const fetchImpl = vi.fn(async () =>
+            jsonResponse({ success: false, errors: [{ code: 9999, message: 'nope' }] }, 401),
+        );
+        const lister = new CloudflareApiZoneLister(
+            baseConfig,
+            fetchImpl as unknown as typeof fetch,
+        );
+        await expect(lister.listAllRecords()).rejects.toThrow(/Cloudflare API GET/);
+    });
+
+    it('stops paginating when the page returns an empty result array', async () => {
+        const fetchImpl = vi.fn(async () =>
+            jsonResponse({
+                success: true,
+                result: [],
+                result_info: { total_pages: 99, page: 1 },
+            }),
+        );
+        const lister = new CloudflareApiZoneLister(
+            baseConfig,
+            fetchImpl as unknown as typeof fetch,
+        );
+        const records = await lister.listAllRecords();
+        expect(records).toEqual([]);
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/internal-cli/src/commands/backfill/backfill-managed-subdomain.service.ts
+++ b/apps/internal-cli/src/commands/backfill/backfill-managed-subdomain.service.ts
@@ -1,0 +1,335 @@
+/**
+ * EW-736 — one-off backfill of `works.managedSubdomain` from live Cloudflare DNS.
+ *
+ * Context
+ * -------
+ * The `works.managedSubdomain` column was added by migration
+ * `1780800000000-AddWorkManagedSubdomain` as nullable so existing rows kept
+ * working unchanged. Seven legacy Works were already serving traffic at
+ * `*.ever.works` before the column existed:
+ *
+ *   dir, mcpserver, vectordb, timetrack, chairs, startup-books,
+ *   compliance-automation
+ *
+ * Note: these SLUGS may differ from the Works' current slugs (slug renames
+ * are allowed). The authoritative pairing of "Work ↔ live subdomain" is the
+ * Cloudflare zone, not the Work row. So the backfill must scan the LIVE
+ * Cloudflare records and match each back to a Work — never derive from
+ * `work.slug` blindly.
+ *
+ * Without backfill, a slug rename of one of those Works would orphan its
+ * live CNAME (because the rename path tears down `${oldSlug}.ever.works`,
+ * but the new managed-subdomain code only ever re-uses
+ * `work.managedSubdomain` — which is `NULL` for these rows). Backfilling
+ * gives them the same orphan-on-rename protection every newly-deployed Work
+ * gets via `SubdomainAllocator` (EW-737).
+ *
+ * This is **idempotent** and **safe to re-run**:
+ *  - Works that already have `managedSubdomain` set are skipped.
+ *  - A Work that can't be unambiguously matched is logged and skipped (no write).
+ *  - Dry-run is the default; `--write` is required to persist.
+ *
+ * See `docs/specs/features/cloudflare-dns-plugin/spec.md` §5.
+ */
+
+import type { Logger } from '@nestjs/common';
+// `Work` is type-only so Vitest doesn't need the agent package to be
+// pre-built when running unit tests against this service.
+import type { Work } from '@ever-works/agent/entities';
+
+/**
+ * Minimal Cloudflare DNS record shape returned by
+ * `GET /zones/{id}/dns_records`. We only consume the fields needed for
+ * matching — any extra fields are tolerated.
+ */
+export interface CloudflareDnsRecord {
+    id: string;
+    type: string;
+    name: string;
+    content?: string;
+}
+
+/**
+ * Lists ALL DNS records in the zone with pagination. The provider abstracts
+ * fetch + auth + paging so this service stays unit-testable with a small
+ * in-memory implementation.
+ */
+export interface CloudflareZoneLister {
+    /**
+     * Returns every CNAME (and A — k8s mode uses A records) record in the
+     * configured zone. Implementations should handle pagination internally.
+     */
+    listAllRecords(): Promise<CloudflareDnsRecord[]>;
+    rootDomain(): string;
+}
+
+/**
+ * Subset of `WorkRepository` we actually use. Lets unit tests pass a plain
+ * object literal rather than a TypeORM stub. The repository's real method
+ * `update(id, partial)` is reused so this stays in sync with the persistence
+ * path used by `SubdomainAllocator`.
+ */
+export interface WorkBackfillReadWrite {
+    findCandidatesForBackfill(): Promise<Work[]>;
+    update(id: string, updateData: Partial<Work>): Promise<unknown>;
+}
+
+export interface BackfillOptions {
+    /** When `false` (the default) no DB writes are performed. */
+    write?: boolean;
+    /**
+     * Deploy providers to include — defaults to `['ever-works', 'k8s']` to
+     * match the providers that allocate managed subdomains. Surfaced as an
+     * option mainly for tests.
+     */
+    deployProviders?: string[];
+}
+
+export interface BackfillSummary {
+    /** Total Works inspected (after the deployProvider filter). */
+    totalScanned: number;
+    /** Works already carrying `managedSubdomain` — left untouched. */
+    alreadySet: number;
+    /** Works the script unambiguously matched to a live CNAME. */
+    matched: number;
+    /** Works that had no Cloudflare candidate at all. */
+    noCandidate: number;
+    /**
+     * Works that had MORE than one plausible match (current slug + suffix +
+     * who-knows-what), logged but NOT persisted. Manual intervention.
+     */
+    ambiguous: number;
+    /** Of `matched`, how many DB rows were actually written. 0 in dry-run. */
+    persisted: number;
+    /** Detailed plan entries — useful for assertions + ops review. */
+    plan: BackfillPlanEntry[];
+}
+
+export type BackfillPlanEntry =
+    | {
+          kind: 'match';
+          workId: string;
+          slug: string;
+          managedSubdomain: string;
+          fqdn: string;
+          /** Which matching strategy hit — for debuggability. */
+          via: 'exact-slug' | 'slug-with-short-id-suffix';
+      }
+    | {
+          kind: 'ambiguous';
+          workId: string;
+          slug: string;
+          /** All candidate subdomain labels left after best-effort filtering. */
+          candidates: string[];
+      }
+    | {
+          kind: 'no-candidate';
+          workId: string;
+          slug: string;
+      }
+    | {
+          kind: 'already-set';
+          workId: string;
+          slug: string;
+          managedSubdomain: string;
+      };
+
+/**
+ * Stable index — what the matcher actually consults. Builds two lookups
+ * keyed by the leftmost label:
+ *  - `byLabel`: leftmost label → record (used for exact-slug match).
+ *  - `labels`: set of every label in the zone (used for ambiguity probes).
+ */
+function indexZone(
+    records: CloudflareDnsRecord[],
+    rootDomain: string,
+): { byLabel: Map<string, CloudflareDnsRecord>; labels: Set<string> } {
+    const suffix = `.${rootDomain.toLowerCase()}`;
+    const byLabel = new Map<string, CloudflareDnsRecord>();
+    const labels = new Set<string>();
+    for (const record of records) {
+        const type = record.type?.toUpperCase();
+        // Managed subdomains today are CNAME (Ever Works mode) or A (k8s mode).
+        if (type !== 'CNAME' && type !== 'A') continue;
+        const name = (record.name ?? '').trim().toLowerCase();
+        if (!name.endsWith(suffix)) continue;
+        const label = name.slice(0, name.length - suffix.length);
+        // Only single-label managed subdomains. `foo.bar.ever.works` is not
+        // a managed-subdomain shape — skip it.
+        if (!label || label.includes('.')) continue;
+        labels.add(label);
+        // First record per label wins for exact lookup. Multiple records on
+        // the same label (e.g. CNAME + A) is unusual but tolerated.
+        if (!byLabel.has(label)) {
+            byLabel.set(label, record);
+        }
+    }
+    return { byLabel, labels };
+}
+
+/**
+ * Mirrors `SubdomainAllocator.shortId` — the first 4 hex chars of the Work
+ * id with dashes removed. Used so the backfill script can recognise legacy
+ * subdomains that may have been suffixed for collision-avoidance.
+ */
+function shortIdFor(workId: string): string {
+    return workId.replace(/-/g, '').slice(0, 4).toLowerCase();
+}
+
+/**
+ * Same slug normalization as `SubdomainAllocator.slugifyLabel` — keep the
+ * two in sync so the backfill matches what the allocator would have
+ * produced.
+ */
+function slugifyLabel(raw: string | null | undefined): string {
+    return (raw ?? '')
+        .toString()
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/-{2,}/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 63);
+}
+
+/**
+ * Pure pairing function — given a Work and the zone index, decide whether
+ * we can confidently pick exactly one Cloudflare label for it.
+ *
+ * Strategy (in order):
+ *  1. Exact match: `slugifyLabel(work.slug)` is the unique label.
+ *  2. Suffix match: `${slugifyLabel(work.slug)}-${shortId}` is the unique label.
+ *
+ * Note: we never auto-match on JUST shortId — too low entropy.
+ */
+export function planForWork(
+    work: Work,
+    zone: { byLabel: Map<string, CloudflareDnsRecord>; labels: Set<string> },
+    rootDomain: string,
+): BackfillPlanEntry {
+    if (work.managedSubdomain && work.managedSubdomain.trim()) {
+        return {
+            kind: 'already-set',
+            workId: work.id,
+            slug: work.slug,
+            managedSubdomain: work.managedSubdomain,
+        };
+    }
+    const base = slugifyLabel(work.slug);
+    if (!base) {
+        return { kind: 'no-candidate', workId: work.id, slug: work.slug };
+    }
+    const candidates: string[] = [];
+    if (zone.labels.has(base)) candidates.push(base);
+    const suffixed = `${base}-${shortIdFor(work.id)}`;
+    if (zone.labels.has(suffixed)) candidates.push(suffixed);
+
+    if (candidates.length === 0) {
+        return { kind: 'no-candidate', workId: work.id, slug: work.slug };
+    }
+    if (candidates.length === 1) {
+        const label = candidates[0];
+        return {
+            kind: 'match',
+            workId: work.id,
+            slug: work.slug,
+            managedSubdomain: label,
+            fqdn: `${label}.${rootDomain}`,
+            via: label === base ? 'exact-slug' : 'slug-with-short-id-suffix',
+        };
+    }
+    return {
+        kind: 'ambiguous',
+        workId: work.id,
+        slug: work.slug,
+        candidates,
+    };
+}
+
+/**
+ * Core service that does the backfill. Takes its collaborators as plain
+ * interfaces so it stays unit-testable without TypeORM / NestJS / Cloudflare.
+ */
+export class BackfillManagedSubdomainService {
+    constructor(
+        private readonly works: WorkBackfillReadWrite,
+        private readonly cloudflare: CloudflareZoneLister,
+        private readonly logger: Pick<Logger, 'log' | 'warn' | 'error'>,
+    ) {}
+
+    async run(options: BackfillOptions = {}): Promise<BackfillSummary> {
+        const writeMode = options.write === true;
+        const rootDomain = this.cloudflare.rootDomain();
+        const records = await this.cloudflare.listAllRecords();
+        const zone = indexZone(records, rootDomain);
+        this.logger.log(
+            `[backfill] Cloudflare zone ${rootDomain} has ${zone.labels.size} managed-shape labels in scope (${records.length} total records scanned)`,
+        );
+
+        const works = await this.works.findCandidatesForBackfill();
+        const summary: BackfillSummary = {
+            totalScanned: works.length,
+            alreadySet: 0,
+            matched: 0,
+            noCandidate: 0,
+            ambiguous: 0,
+            persisted: 0,
+            plan: [],
+        };
+
+        for (const work of works) {
+            const entry = planForWork(work, zone, rootDomain);
+            summary.plan.push(entry);
+
+            switch (entry.kind) {
+                case 'already-set':
+                    summary.alreadySet += 1;
+                    this.logger.log(
+                        `[backfill] SKIP work=${entry.workId} slug=${entry.slug} already has managedSubdomain=${entry.managedSubdomain}`,
+                    );
+                    break;
+                case 'no-candidate':
+                    summary.noCandidate += 1;
+                    this.logger.log(
+                        `[backfill] NO_CANDIDATE work=${entry.workId} slug=${entry.slug} — no matching CNAME/A in zone`,
+                    );
+                    break;
+                case 'ambiguous':
+                    summary.ambiguous += 1;
+                    this.logger.warn(
+                        `[backfill] AMBIGUOUS work=${entry.workId} slug=${entry.slug} candidates=[${entry.candidates.join(
+                            ', ',
+                        )}] — skipping; resolve manually`,
+                    );
+                    break;
+                case 'match':
+                    summary.matched += 1;
+                    if (writeMode) {
+                        try {
+                            await this.works.update(entry.workId, {
+                                managedSubdomain: entry.managedSubdomain,
+                            });
+                            summary.persisted += 1;
+                            this.logger.log(
+                                `[backfill] WROTE work=${entry.workId} slug=${entry.slug} managedSubdomain=${entry.managedSubdomain} (via ${entry.via})`,
+                            );
+                        } catch (cause) {
+                            this.logger.error(
+                                `[backfill] FAIL work=${entry.workId} slug=${entry.slug} managedSubdomain=${entry.managedSubdomain}: ${(cause as Error).message}`,
+                            );
+                        }
+                    } else {
+                        this.logger.log(
+                            `[backfill] PLAN work=${entry.workId} slug=${entry.slug} would set managedSubdomain=${entry.managedSubdomain} (via ${entry.via}) [dry-run]`,
+                        );
+                    }
+                    break;
+            }
+        }
+
+        this.logger.log(
+            `[backfill] Summary: scanned=${summary.totalScanned} alreadySet=${summary.alreadySet} matched=${summary.matched} persisted=${summary.persisted} ambiguous=${summary.ambiguous} noCandidate=${summary.noCandidate} writeMode=${writeMode}`,
+        );
+        return summary;
+    }
+}

--- a/apps/internal-cli/src/commands/backfill/backfill-managed-subdomain.subcommand.ts
+++ b/apps/internal-cli/src/commands/backfill/backfill-managed-subdomain.subcommand.ts
@@ -1,0 +1,166 @@
+/**
+ * EW-736 — backfill subcommand: `cli backfill managed-subdomain [--write]`.
+ *
+ * Reads every Cloudflare DNS record under the managed zone, matches each
+ * to a Work in the DB, and persists `works.managedSubdomain` so the seven
+ * legacy `*.ever.works` Works gain the same orphan-on-rename protection
+ * that newly-allocated Works get from `SubdomainAllocator` (EW-737).
+ *
+ * Usage
+ * -----
+ *
+ *   # dry-run (default): print what would be written, persist nothing.
+ *   pnpm --filter @ever-works/cli build:cli && \
+ *     ./apps/internal-cli/dist/cli.js backfill managed-subdomain
+ *
+ *   # write the matched managedSubdomain values:
+ *   ./apps/internal-cli/dist/cli.js backfill managed-subdomain --write
+ *
+ * Or from the published CLI:
+ *
+ *   pnpm dlx @ever-works/cli backfill managed-subdomain --dry-run
+ *   pnpm dlx @ever-works/cli backfill managed-subdomain --write
+ *
+ * When to run
+ * -----------
+ *  - One-off after migration `1780800000000-AddWorkManagedSubdomain` has
+ *    deployed and BEFORE flipping `K8S_MANAGED_SUBDOMAIN=true` in
+ *    production. Idempotent + safe to re-run.
+ *
+ * Required env (read via the same channel as the API/agent providers):
+ *   CLOUDFLARE_API_TOKEN          # zone-scoped DNS:Read (DNS:Edit not required for dry-run)
+ *   CLOUDFLARE_ZONE_ID            # `ever.works` zone id
+ *   EVER_WORKS_DOMAIN             # defaults to `ever.works`
+ */
+
+import { SubCommand, CommandRunner, Option } from 'nest-commander';
+import { Logger } from '@nestjs/common';
+import chalk from 'chalk';
+import { WorkRepository } from '@ever-works/agent/database';
+import {
+    BackfillManagedSubdomainService,
+    type BackfillSummary,
+    type WorkBackfillReadWrite,
+    type CloudflareZoneLister,
+} from './backfill-managed-subdomain.service';
+import { CloudflareApiZoneLister } from './cloudflare-zone-lister';
+
+const DEFAULT_DEPLOY_PROVIDERS = ['ever-works', 'k8s'] as const;
+
+interface BackfillSubcommandOptions {
+    write?: boolean;
+    dryRun?: boolean;
+}
+
+@SubCommand({
+    name: 'managed-subdomain',
+    description:
+        'Backfill works.managedSubdomain from live Cloudflare DNS (EW-736). Dry-run by default; pass --write to persist.',
+})
+export class BackfillManagedSubdomainSubCommand extends CommandRunner {
+    private readonly logger = new Logger(BackfillManagedSubdomainSubCommand.name);
+
+    constructor(private readonly workRepository: WorkRepository) {
+        super();
+    }
+
+    async run(_passedParams: string[], options: BackfillSubcommandOptions = {}): Promise<void> {
+        try {
+            // `--write` is the persist flag. `--dry-run` is accepted as a
+            // human-friendly explicit synonym for "the default behaviour"
+            // so ops can spell out intent in runbooks.
+            const writeMode = options.write === true && options.dryRun !== true;
+
+            console.log(chalk.cyan.bold('\nEW-736 — Backfill works.managedSubdomain\n'));
+            console.log(
+                writeMode
+                    ? chalk.yellow.bold('Mode: WRITE — changes will be persisted')
+                    : chalk.gray('Mode: dry-run (no DB writes; pass --write to persist)'),
+            );
+
+            const cloudflare = this.buildCloudflareLister();
+            const works = this.buildWorkAdapter();
+            const service = new BackfillManagedSubdomainService(works, cloudflare, this.logger);
+
+            const summary = await service.run({ write: writeMode });
+            this.printSummary(summary, writeMode);
+        } catch (cause) {
+            const message = cause instanceof Error ? cause.message : String(cause);
+            this.logger.error(`[backfill] failed: ${message}`);
+            console.log(chalk.red(`\n✗ Backfill failed: ${message}\n`));
+            process.exitCode = 1;
+        }
+    }
+
+    @Option({
+        flags: '--write',
+        description: 'Persist the matched managedSubdomain values (default: dry-run).',
+    })
+    parseWrite(): boolean {
+        return true;
+    }
+
+    @Option({
+        flags: '--dry-run',
+        description: 'Explicit dry-run flag (no DB writes). This is the default.',
+    })
+    parseDryRun(): boolean {
+        return true;
+    }
+
+    private buildCloudflareLister(): CloudflareZoneLister {
+        const apiToken = process.env.CLOUDFLARE_API_TOKEN?.trim();
+        const zoneId = process.env.CLOUDFLARE_ZONE_ID?.trim();
+        const rootDomain = process.env.EVER_WORKS_DOMAIN?.trim() || 'ever.works';
+
+        if (!apiToken || !zoneId) {
+            throw new Error(
+                'CLOUDFLARE_API_TOKEN and CLOUDFLARE_ZONE_ID must be set to run the managed-subdomain backfill',
+            );
+        }
+        return new CloudflareApiZoneLister({ apiToken, zoneId, rootDomain });
+    }
+
+    private buildWorkAdapter(): WorkBackfillReadWrite {
+        const repo = this.workRepository;
+        return {
+            // Re-use the WorkRepository underlying typeorm repo for the
+            // deployProvider filter. `findAll()` doesn't filter by provider,
+            // so we read the full set and filter in-memory — the deployed
+            // set is small (low thousands), and the script is one-off.
+            async findCandidatesForBackfill() {
+                const all = await repo.findAll({ limit: 50000 });
+                const providers = new Set<string>(DEFAULT_DEPLOY_PROVIDERS);
+                return all.filter((w) =>
+                    providers.has((w.deployProvider ?? '').toString().toLowerCase()),
+                );
+            },
+            async update(id, updateData) {
+                return repo.update(id, updateData);
+            },
+        };
+    }
+
+    private printSummary(summary: BackfillSummary, writeMode: boolean): void {
+        console.log(chalk.cyan.bold('\nSummary:'));
+        console.log(chalk.gray(`  Total scanned:   ${summary.totalScanned}`));
+        console.log(chalk.gray(`  Already set:     ${summary.alreadySet}`));
+        console.log(chalk.green(`  Matched:         ${summary.matched}`));
+        console.log(
+            writeMode
+                ? chalk.green(`  Persisted:       ${summary.persisted}`)
+                : chalk.gray(`  Persisted:       ${summary.persisted} (dry-run)`),
+        );
+        console.log(chalk.yellow(`  Ambiguous:       ${summary.ambiguous}`));
+        console.log(chalk.gray(`  No candidate:    ${summary.noCandidate}`));
+        if (!writeMode && summary.matched > 0) {
+            console.log(
+                chalk.gray('\nRe-run with ') +
+                    chalk.cyan('--write') +
+                    chalk.gray(' to persist the matched values.\n'),
+            );
+        } else {
+            console.log('');
+        }
+    }
+}

--- a/apps/internal-cli/src/commands/backfill/backfill.command.ts
+++ b/apps/internal-cli/src/commands/backfill/backfill.command.ts
@@ -1,0 +1,23 @@
+import { Command, CommandRunner } from 'nest-commander';
+import { BackfillManagedSubdomainSubCommand } from './backfill-managed-subdomain.subcommand';
+
+/**
+ * EW-736 — one-off operational backfills.
+ *
+ * Each subcommand is idempotent and dry-run by default. See the individual
+ * subcommand files for the per-task runbook.
+ */
+@Command({
+    name: 'backfill',
+    description: 'One-off operational backfill commands',
+    subCommands: [BackfillManagedSubdomainSubCommand],
+})
+export class BackfillCommand extends CommandRunner {
+    async run(): Promise<void> {
+        console.log('Available backfill commands:');
+        console.log(
+            '  managed-subdomain   - Backfill works.managedSubdomain from Cloudflare (EW-736)',
+        );
+        console.log('\nUse "backfill <command> --help" for more information about a command.');
+    }
+}

--- a/apps/internal-cli/src/commands/backfill/cloudflare-zone-lister.ts
+++ b/apps/internal-cli/src/commands/backfill/cloudflare-zone-lister.ts
@@ -1,0 +1,119 @@
+/**
+ * EW-736 — Cloudflare zone lister for the managed-subdomain backfill.
+ *
+ * Thin pager around `GET /zones/{id}/dns_records` that returns every record
+ * in the zone, regardless of type. The backfill service filters down to
+ * CNAME/A records under the managed domain. Kept separate from the
+ * `CloudflareDnsProvider` in `@ever-works/agent/ever-works-providers`
+ * because that provider is the hot path (per-deploy ensureRecord) and we
+ * don't want a `list all` helper bloating its API surface for a one-off.
+ */
+
+import type {
+    CloudflareDnsRecord,
+    CloudflareZoneLister,
+} from './backfill-managed-subdomain.service';
+
+/**
+ * Local error class mirroring the shape of
+ * `CloudflareDnsError` from `@ever-works/agent/ever-works-providers`
+ * without taking the import — the agent package is a workspace dependency
+ * but only its compiled `dist/` is exposed at build time, and we want the
+ * unit test to run against source without a prebuild step.
+ */
+export class CloudflareZoneListerError extends Error {
+    constructor(
+        message: string,
+        readonly status: number,
+        readonly errors: unknown,
+    ) {
+        super(message);
+        this.name = 'CloudflareZoneListerError';
+    }
+}
+
+export interface CloudflareZoneListerConfig {
+    apiToken: string;
+    zoneId: string;
+    rootDomain: string;
+    /** Optional override (tests). */
+    apiBaseUrl?: string;
+    /** Per-page size — Cloudflare allows up to 100 (which is the default). */
+    perPage?: number;
+}
+
+export class CloudflareApiZoneLister implements CloudflareZoneLister {
+    private readonly baseUrl: string;
+    private readonly perPage: number;
+
+    constructor(
+        private readonly config: CloudflareZoneListerConfig,
+        private readonly fetchImpl: typeof fetch = fetch,
+    ) {
+        this.baseUrl = (config.apiBaseUrl ?? 'https://api.cloudflare.com/client/v4').replace(
+            /\/$/,
+            '',
+        );
+        this.perPage = Math.min(Math.max(config.perPage ?? 100, 1), 100);
+    }
+
+    rootDomain(): string {
+        return this.config.rootDomain;
+    }
+
+    async listAllRecords(): Promise<CloudflareDnsRecord[]> {
+        const out: CloudflareDnsRecord[] = [];
+        let page = 1;
+        for (;;) {
+            const url = new URL(`${this.baseUrl}/zones/${this.config.zoneId}/dns_records`);
+            url.searchParams.set('per_page', String(this.perPage));
+            url.searchParams.set('page', String(page));
+            const body = await this.fetchJson<{
+                result?: CloudflareDnsRecord[];
+                result_info?: { total_pages?: number; page?: number };
+                success?: boolean;
+                errors?: unknown;
+            }>(url.toString());
+
+            const result = Array.isArray(body.result) ? body.result : [];
+            out.push(...result);
+
+            const totalPages = body.result_info?.total_pages ?? 1;
+            if (page >= totalPages || result.length === 0) {
+                break;
+            }
+            page += 1;
+            // Guard against runaway pagination loops on bad servers.
+            if (page > 1000) {
+                throw new Error(
+                    `CloudflareApiZoneLister: pagination did not terminate after ${page} pages`,
+                );
+            }
+        }
+        return out;
+    }
+
+    private async fetchJson<T>(url: string): Promise<T> {
+        const response = await this.fetchImpl(url, {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${this.config.apiToken}`,
+                'Content-Type': 'application/json',
+            },
+        });
+        let body: any;
+        try {
+            body = await response.json();
+        } catch {
+            body = null;
+        }
+        if (!response.ok || (body && body.success === false)) {
+            throw new CloudflareZoneListerError(
+                `Cloudflare API GET ${url} failed: ${response.status}`,
+                response.status,
+                body?.errors ?? body ?? null,
+            );
+        }
+        return body as T;
+    }
+}

--- a/apps/internal-cli/src/commands/backfill/index.ts
+++ b/apps/internal-cli/src/commands/backfill/index.ts
@@ -1,0 +1,6 @@
+import { BackfillCommand } from './backfill.command';
+import { BackfillManagedSubdomainSubCommand } from './backfill-managed-subdomain.subcommand';
+
+export const BackfillCommands = [...BackfillCommand.registerWithSubCommands()];
+
+export { BackfillCommand, BackfillManagedSubdomainSubCommand };

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3140,6 +3140,26 @@
                     "dnsName": "Name:",
                     "dnsValue": "Value:",
                     "copyButton": "Copy"
+                },
+                "subdomain": {
+                    "title": "Site URL / Subdomain",
+                    "description": "Your default, managed address on ever.works. Custom domains can be added below.",
+                    "loading": "Loading subdomain…",
+                    "loadFailed": "Failed to load subdomain",
+                    "loadFailedHint": "Current subdomain unavailable — retry to view or change it.",
+                    "notAllocated": "No managed subdomain yet — it will be allocated on the next deploy.",
+                    "currentLabel": "Current address",
+                    "openLink": "Open {url}",
+                    "pendingDnsBadge": "DNS propagating",
+                    "liveBadge": "Live",
+                    "editLabel": "Change subdomain",
+                    "placeholder": "my-directory",
+                    "saveButton": "Save",
+                    "saveSuccess": "Subdomain updated.",
+                    "saveFailed": "Failed to update subdomain",
+                    "invalidFormat": "Use 3-63 lowercase letters, digits, or hyphens (cannot start or end with a hyphen).",
+                    "helperSuffix": ".ever.works",
+                    "readonlyHint": "Managed subdomain is read-only for this Work."
                 }
             },
             "kb": {

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/deploy/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/deploy/page.tsx
@@ -9,6 +9,7 @@ import { DeployProviderSelector } from '@/components/works/detail/deploy/DeployP
 import { SharedWorkNoTokenAlert } from '@/components/works/detail/deploy/SharedWorkNoTokenAlert';
 import { DomainManagement } from '@/components/works/detail/deploy/DomainManagement';
 import { RuntimeEnvManagement } from '@/components/works/detail/deploy/RuntimeEnvManagement';
+import { SubdomainManagement } from '@/components/works/detail/deploy/SubdomainManagement';
 import { DeployProgressPanel } from '@/components/works/detail/deploy/DeployProgressPanel';
 import { canDeploy } from '@/lib/permissions';
 
@@ -122,6 +123,19 @@ export default async function DeployPage({ params }: DeployPageParams) {
                 websiteTemplates={websiteTemplates}
             />
             <DeployProgressPanel workId={work.id} isDeploying={isDeploying(work)} />
+            {/*
+             * EW-740 — Managed subdomain card. Per spec section 4.6 the
+             * managed `*.ever.works` subdomain is the primary/default
+             * address, so it renders ABOVE `DomainManagement` (which lists
+             * additional custom domains). Only relevant for the
+             * managed-subdomain providers (`ever-works`, `k8s`); for
+             * Vercel/etc the API returns `editable=false` + null state,
+             * which the component handles, but we skip the card entirely
+             * to avoid wasted requests + UI noise.
+             */}
+            {work.id && (work.deployProvider === 'ever-works' || work.deployProvider === 'k8s') && (
+                <SubdomainManagement work={work} />
+            )}
             {work.website && <DomainManagement work={work} />}
             {work.website && <RuntimeEnvManagement work={work} />}
         </div>

--- a/apps/web/src/app/actions/dashboard/deploy.ts
+++ b/apps/web/src/app/actions/dashboard/deploy.ts
@@ -241,6 +241,107 @@ export async function setWorkRuntimeEnv(workId: string, databaseUrl: string) {
     }
 }
 
+/**
+ * EW-740 — read the per-Work managed subdomain ("Site URL / Subdomain"
+ * card) state. Mirrors `getWorkRuntimeEnv` shape: always returns the
+ * `subdomain` payload (filled with nulls on failure) plus an optional
+ * `error` string so the UI can gate Save and avoid claiming "Not
+ * configured" when the load merely failed.
+ */
+export async function getWorkSubdomain(workId: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await deployAPI.getSubdomain(workId);
+        return {
+            success: response.status === 'success',
+            subdomain: {
+                subdomain: response.subdomain ?? null,
+                fqdn: response.fqdn ?? null,
+                url: response.url ?? null,
+                recordOk: response.recordOk ?? false,
+                editable: response.editable ?? false,
+            },
+        };
+    } catch (error) {
+        console.error('Get subdomain error:', error);
+        return {
+            success: false,
+            subdomain: {
+                subdomain: null as string | null,
+                fqdn: null as string | null,
+                url: null as string | null,
+                recordOk: false,
+                editable: false,
+            },
+            error: error instanceof Error ? error.message : 'Failed to get subdomain',
+        };
+    }
+}
+
+/**
+ * EW-740 — set the per-Work managed subdomain. Validates the bare label
+ * against the same regex the API uses (`SLUG_RE` from
+ * `packages/agent/src/services/works-manifest.service.ts`) so the UI
+ * surfaces the format error before round-tripping. Length bounds (3..63)
+ * also mirror the API contract / RFC 1035 label rules.
+ */
+export async function setWorkSubdomain(workId: string, subdomain: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    const trimmed = subdomain.trim().toLowerCase();
+    const SUBDOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+    if (trimmed.length < 3 || trimmed.length > 63 || !SUBDOMAIN_RE.test(trimmed)) {
+        return {
+            success: false,
+            subdomain: {
+                subdomain: null as string | null,
+                fqdn: null as string | null,
+                url: null as string | null,
+                recordOk: false,
+                editable: true,
+            },
+            error: 'Subdomain must be 3-63 characters of lowercase letters, digits, or hyphens, and cannot start or end with a hyphen.',
+        };
+    }
+
+    try {
+        const response = await deployAPI.setSubdomain(workId, trimmed);
+        if (response.status === 'success') {
+            revalidatePath(ROUTES.DASHBOARD_WORK_DEPLOY(workId));
+        }
+        return {
+            success: response.status === 'success',
+            subdomain: {
+                subdomain: response.subdomain ?? null,
+                fqdn: response.fqdn ?? null,
+                url: response.url ?? null,
+                recordOk: response.recordOk ?? false,
+                editable: response.editable ?? false,
+            },
+        };
+    } catch (error) {
+        console.error('Set subdomain error:', error);
+        return {
+            success: false,
+            subdomain: {
+                subdomain: null as string | null,
+                fqdn: null as string | null,
+                url: null as string | null,
+                recordOk: false,
+                editable: true,
+            },
+            error: error instanceof Error ? error.message : 'Failed to set subdomain',
+        };
+    }
+}
+
 export async function addDomain(workId: string, domain: string) {
     const user = await getAuthFromCookie();
     if (!user) {

--- a/apps/web/src/components/works/detail/deploy/SubdomainManagement.tsx
+++ b/apps/web/src/components/works/detail/deploy/SubdomainManagement.tsx
@@ -1,0 +1,244 @@
+'use client';
+
+import { useEffect, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { CheckCircle2, Clock, ExternalLink, Globe2, Loader2, Save } from 'lucide-react';
+
+import type { Work } from '@/lib/api';
+import type { SubdomainState } from '@/lib/api/plugins-capabilities/deploy';
+import { getWorkSubdomain, setWorkSubdomain } from '@/app/actions/dashboard/deploy';
+import { useRouter } from '@/i18n/navigation';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface SubdomainManagementProps {
+    work: Work;
+}
+
+/**
+ * EW-740 — "Site URL / Subdomain" card on the Deploy tab.
+ *
+ * Surfaces the managed `*.ever.works` address that the platform allocates per
+ * Work via `GET/PUT /api/deploy/works/:id/subdomain` (EW-739). The managed
+ * subdomain is the **primary/default** address (per spec section 4.6), so this
+ * card is rendered above `DomainManagement` and is always present for Works on
+ * a managed-subdomain provider (`ever-works` / `k8s`). Custom domains remain
+ * additive — this card does not duplicate or replace `DomainManagement`.
+ *
+ * Pattern follows `RuntimeEnvManagement` (PR #1319):
+ *
+ * - Cancellation guard + `.catch()` on the loader so a transport-level reject
+ *   doesn't leave the spinner stuck forever.
+ * - `loadError` gating — when the load fails we don't claim "Not allocated"
+ *   (the server may actually have one set); instead we surface the error and
+ *   disable Save so the user can't accidentally overwrite a value we never
+ *   read.
+ * - `editable=false` from the API → readonly mode (no Save button).
+ */
+export function SubdomainManagement({ work }: SubdomainManagementProps) {
+    return <SubdomainManagementContent key={work.id} work={work} />;
+}
+
+function SubdomainManagementContent({ work }: SubdomainManagementProps) {
+    const t = useTranslations('dashboard.workDetail.deploy.subdomain');
+    const router = useRouter();
+    const [isPending, startTransition] = useTransition();
+    const [state, setState] = useState<SubdomainState | null>(null);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [value, setValue] = useState('');
+
+    useEffect(() => {
+        let cancelled = false;
+        getWorkSubdomain(work.id)
+            .then((result) => {
+                if (cancelled) return;
+                if (result.success) {
+                    setState(result.subdomain);
+                    setLoadError(null);
+                } else {
+                    // Server-reported failure: leave `state` populated with a
+                    // null payload so the spinner clears, but set `loadError`
+                    // so the UI hides the misleading "not allocated" copy and
+                    // disables Save.
+                    setState(result.subdomain);
+                    setLoadError(result.error ?? t('loadFailed'));
+                }
+            })
+            .catch((err: unknown) => {
+                if (cancelled) return;
+                setState({
+                    subdomain: null,
+                    fqdn: null,
+                    url: null,
+                    recordOk: false,
+                    editable: false,
+                });
+                setLoadError(err instanceof Error ? err.message : t('loadFailed'));
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [work.id, t]);
+
+    const isLoading = state === null;
+    const hasLoadError = loadError !== null;
+
+    const handleSave = () => {
+        const next = value.trim().toLowerCase();
+        if (!next) return;
+        startTransition(async () => {
+            const result = await setWorkSubdomain(work.id, next);
+            if (result.success) {
+                setState(result.subdomain);
+                setValue('');
+                toast.success(t('saveSuccess'));
+                router.refresh();
+            } else {
+                toast.error(result.error ?? t('saveFailed'));
+            }
+        });
+    };
+
+    return (
+        <div className="rounded-lg bg-surface dark:bg-surface-dark border border-border dark:border-border-dark p-6">
+            <div className="flex items-start gap-4">
+                <div
+                    className={cn(
+                        'shrink-0 w-10 h-10 rounded-full flex items-center justify-center',
+                        'bg-primary/10 dark:bg-primary-dark/10',
+                    )}
+                >
+                    <Globe2 className="w-5 h-5 text-primary dark:text-primary-dark" />
+                </div>
+                <div className="flex-1 min-w-0">
+                    <h3 className="text-lg font-semibold text-text dark:text-text-dark mb-2">
+                        {t('title')}
+                    </h3>
+                    <p className="text-text-secondary dark:text-text-secondary-dark mb-4">
+                        {t('description')}
+                    </p>
+
+                    {isLoading ? (
+                        <div className="flex items-center gap-2 text-text-secondary dark:text-text-secondary-dark text-sm py-2">
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                            {t('loading')}
+                        </div>
+                    ) : (
+                        <div className="space-y-4">
+                            {hasLoadError && (
+                                <p className="text-sm text-error dark:text-error-dark">
+                                    {loadError}
+                                </p>
+                            )}
+
+                            <div>
+                                <div className="text-xs font-medium text-text-secondary dark:text-text-secondary-dark mb-1">
+                                    {t('currentLabel')}
+                                </div>
+                                {state?.fqdn && state.url ? (
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        {state.recordOk ? (
+                                            <a
+                                                href={state.url}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="inline-flex items-center gap-1.5 font-mono text-sm text-primary dark:text-primary-dark hover:underline break-all"
+                                            >
+                                                {state.fqdn}
+                                                <ExternalLink className="w-3.5 h-3.5 shrink-0" />
+                                                <span className="sr-only">
+                                                    {t('openLink', { url: state.url })}
+                                                </span>
+                                            </a>
+                                        ) : (
+                                            <span className="font-mono text-sm text-text dark:text-text-dark break-all">
+                                                {state.fqdn}
+                                            </span>
+                                        )}
+                                        {state.recordOk ? (
+                                            <span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-success/10 dark:bg-success-dark/10 text-success dark:text-success-dark">
+                                                <CheckCircle2 className="w-3 h-3" />
+                                                {t('liveBadge')}
+                                            </span>
+                                        ) : (
+                                            <span className="shrink-0 inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-warning/10 dark:bg-warning-dark/10 text-warning dark:text-warning-dark">
+                                                <Clock className="w-3 h-3" />
+                                                {t('pendingDnsBadge')}
+                                            </span>
+                                        )}
+                                    </div>
+                                ) : hasLoadError ? (
+                                    <p className="text-xs text-text-secondary dark:text-text-secondary-dark">
+                                        {t('loadFailedHint')}
+                                    </p>
+                                ) : (
+                                    <p className="text-xs text-text-secondary dark:text-text-secondary-dark">
+                                        {t('notAllocated')}
+                                    </p>
+                                )}
+                            </div>
+
+                            {state?.editable && !hasLoadError ? (
+                                <div>
+                                    <label
+                                        htmlFor={`subdomain-input-${work.id}`}
+                                        className="mb-1 block text-xs font-medium text-text-secondary dark:text-text-secondary-dark"
+                                    >
+                                        {t('editLabel')}
+                                    </label>
+                                    <div className="flex gap-2">
+                                        <div className="flex-1 flex items-center gap-1">
+                                            <Input
+                                                id={`subdomain-input-${work.id}`}
+                                                value={value}
+                                                onChange={(e) =>
+                                                    setValue(e.target.value.toLowerCase())
+                                                }
+                                                placeholder={state.subdomain ?? t('placeholder')}
+                                                variant="form"
+                                                disabled={isPending}
+                                                autoComplete="off"
+                                                spellCheck={false}
+                                                onKeyDown={(e) => {
+                                                    if (e.key === 'Enter') {
+                                                        e.preventDefault();
+                                                        handleSave();
+                                                    }
+                                                }}
+                                                className="font-mono"
+                                            />
+                                            <span className="shrink-0 font-mono text-sm text-text-secondary dark:text-text-secondary-dark">
+                                                {t('helperSuffix')}
+                                            </span>
+                                        </div>
+                                        <Button
+                                            onClick={handleSave}
+                                            disabled={isPending || !value.trim()}
+                                            size="lg"
+                                        >
+                                            {isPending ? (
+                                                <Loader2 className="w-4 h-4 animate-spin" />
+                                            ) : (
+                                                <Save className="w-4 h-4" />
+                                            )}
+                                            <span className="ml-1">{t('saveButton')}</span>
+                                        </Button>
+                                    </div>
+                                    <p className="mt-1 text-xs text-text-secondary dark:text-text-secondary-dark">
+                                        {t('invalidFormat')}
+                                    </p>
+                                </div>
+                            ) : !state?.editable && state?.subdomain ? (
+                                <p className="text-xs text-text-secondary dark:text-text-secondary-dark">
+                                    {t('readonlyHint')}
+                                </p>
+                            ) : null}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/lib/api/plugins-capabilities/deploy.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/deploy.ts
@@ -106,6 +106,32 @@ export interface RuntimeEnvState {
 
 export type RuntimeEnvResponseDto = APIResponse<RuntimeEnvState>;
 
+/**
+ * EW-740 — per-Work managed subdomain ("Site URL / Subdomain") state surfaced
+ * by `GET /api/deploy/works/:id/subdomain`. See `docs/specs/features/cloudflare-dns-plugin/spec.md`
+ * section 4.5 ("Per-Work subdomain UI") for the contract.
+ *
+ * - `subdomain` — bare label (e.g. `acme`); `null` when no managed subdomain
+ *   has been allocated yet (Work hasn't deployed on a managed-subdomain provider).
+ * - `fqdn` — fully-qualified hostname (e.g. `acme.ever.works`); `null` when
+ *   `subdomain` is `null`.
+ * - `url` — full `https://${fqdn}` for direct linking; `null` when `fqdn` is `null`.
+ * - `recordOk` — DNS record exists and points at the expected target. When
+ *   `false` the UI should avoid presenting the URL as a verified live link.
+ * - `editable` — `true` when the user is allowed to change the subdomain
+ *   (owner/editor with a managed-subdomain provider). When `false` the UI
+ *   shows the value read-only.
+ */
+export interface SubdomainState {
+    subdomain: string | null;
+    fqdn: string | null;
+    url: string | null;
+    recordOk: boolean;
+    editable: boolean;
+}
+
+export type SubdomainResponseDto = APIResponse<SubdomainState>;
+
 export const deployAPI = {
     // Get available deployment providers
     getProviders: async () => {
@@ -225,6 +251,32 @@ export const deployAPI = {
             // Security: encode workId to prevent path-segment injection
             endpoint: `/deploy/works/${encodeURIComponent(workId)}/runtime-env`,
             data: { databaseUrl },
+            method: 'PUT',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * EW-740 — get the per-Work managed subdomain state (label, fqdn, url,
+     * recordOk, editable). Returns nullable fields when no managed subdomain
+     * has been allocated.
+     */
+    getSubdomain(workId: string) {
+        // Security: encode workId to prevent path-segment injection
+        return serverFetch<SubdomainResponseDto>(
+            `/deploy/works/${encodeURIComponent(workId)}/subdomain`,
+        );
+    },
+
+    /**
+     * EW-740 — set the per-Work managed subdomain. The API validates the
+     * subdomain format (`SLUG_RE`) and uniqueness, allocates a DNS record,
+     * and returns the updated `SubdomainState`.
+     */
+    setSubdomain(workId: string, subdomain: string) {
+        return serverMutation<SubdomainResponseDto>({
+            endpoint: `/deploy/works/${encodeURIComponent(workId)}/subdomain`,
+            data: { subdomain },
             method: 'PUT',
             wrapInData: false,
         });

--- a/apps/web/src/lib/utils/plugin-category-icons.ts
+++ b/apps/web/src/lib/utils/plugin-category-icons.ts
@@ -16,6 +16,7 @@ import {
     Mail,
     Bell,
     Boxes,
+    Globe,
     type LucideIcon,
 } from 'lucide-react';
 import { PluginCategory, PLUGIN_CATEGORIES } from '@ever-works/plugin';
@@ -44,6 +45,8 @@ export const CATEGORY_ICONS: Record<PluginCategory, LucideIcon> = {
     'notification-channel': Bell,
     // EW-724 — vector store backends (pgvector, Qdrant, …) for KB embeddings
     'vector-store': Boxes,
+    // EW-735 — DNS plugin category (Cloudflare et al.)
+    dns: Globe,
 };
 
 /**
@@ -67,6 +70,7 @@ export const CATEGORY_LABELS: Record<PluginCategory, string> = {
     'email-provider': 'Email Providers',
     'notification-channel': 'Notification Channels',
     'vector-store': 'Vector Stores',
+    dns: 'DNS Providers',
 };
 
 // Type-safe assertion that all categories are covered
@@ -158,6 +162,7 @@ export const CATEGORY_DISPLAY_ORDER: readonly PluginCategory[] = [
     'data-source',
     'storage',
     'vector-store',
+    'dns',
     'email-provider',
     'notification-channel',
     'form',

--- a/docs/specs/features/cloudflare-dns-plugin/spec.md
+++ b/docs/specs/features/cloudflare-dns-plugin/spec.md
@@ -223,6 +223,26 @@ Subdomain"** card:
 6. Deploy-tab "Site URL / Subdomain" UI.
 7. Custom-domain reconciliation in BYO mode.
 
+### Feature flag
+
+The k8s managed-subdomain extension (step 3 above, for `deployProvider='k8s'`)
+is gated behind a single env flag — **`K8S_MANAGED_SUBDOMAIN`** (default `false`).
+When unset/`false`, the deploy path runs exactly as it does today and the 7
+already-deployed k8s Works see zero behavior change. The `ever-works` provider
+path (step 3 for `deployProvider='ever-works'`) is not gated — it keeps
+running, just goes through the same `applyManagedSubdomain` wrapper as before.
+
+Rollout order in production:
+
+1. Merge + cascade the platform PR with `K8S_MANAGED_SUBDOMAIN` unset.
+2. Run `cli backfill managed-subdomain --dry-run`, review the matched set.
+3. Run `cli backfill managed-subdomain --write` to persist `managedSubdomain`
+   for the existing k8s Works (so the allocator finds the existing claim and
+   doesn't try to re-allocate a new `*.ever.works` for them).
+4. Set `K8S_MANAGED_SUBDOMAIN=true` for the API deployment. New k8s Works
+   from this point on get a unique, persisted `*.ever.works` subdomain
+   end-to-end.
+
 ## 9. Acceptance criteria
 
 - Creating + deploying a new Work to k8s (either provider) yields a working

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -4,6 +4,7 @@ export * from './database.module';
 export * from './repositories/api-key.repository';
 export * from './repositories/work.repository';
 export * from './repositories/work-deployment.repository';
+export * from './repositories/work-custom-domain.repository';
 export * from './repositories/work-member.repository';
 export * from './repositories/user.repository';
 export * from './repositories/user-upload.repository';

--- a/packages/agent/src/database/repositories/work.repository.ts
+++ b/packages/agent/src/database/repositories/work.repository.ts
@@ -95,6 +95,24 @@ export class WorkRepository {
             .getOne();
     }
 
+    /**
+     * EW-734 / EW-737 — `SubdomainAllocator` lookup. Returns the Work that
+     * already claims a managed `${subdomain}.ever.works` host (case-insensitive
+     * on the leftmost label, which is the value stored in
+     * `works.managedSubdomain`), or `null` when the label is free. Used to
+     * detect collisions BEFORE inserting/updating — the partial unique index
+     * `UQ_works_managedSubdomain_notnull` is the DB-level backstop.
+     */
+    async findByManagedSubdomain(subdomain: string): Promise<Work | null> {
+        const normalized = (subdomain ?? '').trim().toLowerCase();
+        if (!normalized) {
+            return null;
+        }
+        return this.repository.findOne({
+            where: { managedSubdomain: normalized },
+        });
+    }
+
     async findByIds(ids: string[]): Promise<Work[]> {
         const uniqueIds = [...new Set(ids.filter(Boolean))];
 

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -445,6 +445,29 @@ export class Work {
     @Column({ type: 'text', nullable: true })
     deployDatabaseUrlEncrypted?: string | null;
 
+    /**
+     * EW-734 / EW-736 — globally-unique persisted managed subdomain claim.
+     *
+     * Stores the leftmost label (e.g. `'ai-coding'`) of the Work's
+     * `*.ever.works` hostname. The DB-level partial unique index (created
+     * by migration `1780800000000-AddWorkManagedSubdomain`,
+     * `WHERE "managedSubdomain" IS NOT NULL`) is the backstop that turns
+     * `SubdomainAllocator`'s collision-detect-and-suffix algorithm into a
+     * race-safe claim. NULL until a Work is allocated a managed subdomain
+     * (the default for existing rows — fully backward-compatible with the
+     * legacy `${slug}.ever.works` derivation, which keeps working).
+     *
+     * `type: 'varchar'` + explicit `nullable: true` are required for the
+     * `string | null` union — TypeORM's reflect-metadata fallback infers
+     * `Object` for unions, which the better-sqlite3 test adapter rejects
+     * with `DataTypeNotSupportedError`. Same pattern as
+     * `deployDatabaseUrlEncrypted` above.
+     *
+     * See `docs/specs/features/cloudflare-dns-plugin/spec.md` §4.3 / §5.
+     */
+    @Column({ type: 'varchar', length: 63, nullable: true })
+    managedSubdomain?: string | null;
+
     // Pull-mode observability — drives the degraded banner UX.
     @TimestampColumn({ nullable: true })
     platformSyncLastSuccessAt?: Date | null;

--- a/packages/agent/src/ever-works-providers/__tests__/subdomain-allocator.service.spec.ts
+++ b/packages/agent/src/ever-works-providers/__tests__/subdomain-allocator.service.spec.ts
@@ -1,0 +1,207 @@
+import { SubdomainAllocator } from '../subdomain-allocator.service';
+import type { WorkRepository } from '../../database/repositories/work.repository';
+import type { EverWorksDnsService } from '../cloudflare-dns.provider';
+import type { Work } from '../../entities/work.entity';
+import type { IDnsOperations } from '@ever-works/plugin';
+
+/**
+ * EW-734 / EW-737 — `SubdomainAllocator` unit tests.
+ *
+ * Scope: the allocator's two responsibilities only — (a) collision-safe
+ * label allocation against the DB + provider probe, and (b) idempotent
+ * reuse of a previously-persisted `work.managedSubdomain`. DNS record
+ * creation is the caller's job (`applyManagedSubdomain`) and is covered
+ * by the deploy.service tests.
+ */
+describe('SubdomainAllocator', () => {
+    function makeWork(overrides: Partial<Work> = {}): Work {
+        return {
+            id: '11111111-2222-3333-4444-555555555555',
+            slug: 'ai-coding',
+            managedSubdomain: null,
+            ...overrides,
+        } as Work;
+    }
+
+    function makeRepo(
+        opts: {
+            findByManagedSubdomainReturns?: (label: string) => Work | null;
+            updateImpl?: (id: string, patch: Partial<Work>) => Promise<Work | null>;
+        } = {},
+    ) {
+        const update = jest.fn(
+            opts.updateImpl ?? (async (_id: string, _patch: Partial<Work>) => null),
+        );
+        const findByManagedSubdomain = jest.fn(async (label: string) =>
+            opts.findByManagedSubdomainReturns ? opts.findByManagedSubdomainReturns(label) : null,
+        );
+        return {
+            update,
+            findByManagedSubdomain,
+        } as unknown as WorkRepository & {
+            update: jest.Mock;
+            findByManagedSubdomain: jest.Mock;
+        };
+    }
+
+    function makeDnsService(provider: IDnsOperations | null) {
+        return {
+            getProvider: () => provider,
+        } as unknown as EverWorksDnsService;
+    }
+
+    function makeProbe(
+        recordExistsImpl: (host: string) => Promise<boolean> | boolean,
+    ): IDnsOperations {
+        return {
+            rootDomain: () => 'ever.works',
+            recordExists: jest.fn(async (host: string) => recordExistsImpl(host)),
+            ensureRecord: jest.fn(),
+            removeRecord: jest.fn(),
+        } as unknown as IDnsOperations;
+    }
+
+    it('reuses an already-persisted managedSubdomain (no DB write, no probe)', async () => {
+        const repo = makeRepo();
+        const probe = makeProbe(async () => {
+            throw new Error('should not probe when reusing');
+        });
+        const dns = makeDnsService(probe);
+        const alloc = new SubdomainAllocator(repo, dns);
+
+        const work = makeWork({ managedSubdomain: 'already-claimed' });
+        const result = await alloc.allocate(work, probe);
+
+        expect(result).toEqual({
+            subdomain: 'already-claimed',
+            fqdn: 'already-claimed.ever.works',
+            rootDomain: 'ever.works',
+            allocated: false,
+        });
+        expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it('allocates the slug as-is when the label is free in DB + provider', async () => {
+        const repo = makeRepo();
+        const probe = makeProbe(async () => false);
+        const dns = makeDnsService(probe);
+        const alloc = new SubdomainAllocator(repo, dns);
+
+        const work = makeWork({ slug: 'ai-coding' });
+        const result = await alloc.allocate(work, probe);
+
+        expect(result.subdomain).toBe('ai-coding');
+        expect(result.fqdn).toBe('ai-coding.ever.works');
+        expect(result.allocated).toBe(true);
+        expect(repo.update).toHaveBeenCalledWith(work.id, { managedSubdomain: 'ai-coding' });
+    });
+
+    it('appends a deterministic shortId suffix on DB collision', async () => {
+        const otherWork = { id: 'other-id', managedSubdomain: 'ai-coding' } as Work;
+        const repo = makeRepo({
+            findByManagedSubdomainReturns: (label) => (label === 'ai-coding' ? otherWork : null),
+        });
+        const probe = makeProbe(async () => false);
+        const dns = makeDnsService(probe);
+        const alloc = new SubdomainAllocator(repo, dns);
+
+        const work = makeWork({ id: 'aabbccdd-1111-2222-3333-444444444444' });
+        const result = await alloc.allocate(work, probe);
+
+        // shortId = first 4 hex chars of UUID with dashes removed → 'aabb'
+        expect(result.subdomain).toBe('ai-coding-aabb');
+        expect(repo.update).toHaveBeenCalledWith(work.id, {
+            managedSubdomain: 'ai-coding-aabb',
+        });
+    });
+
+    it('rejects reserved blocklist labels (www) and falls through to the suffixed candidate', async () => {
+        const repo = makeRepo();
+        const probe = makeProbe(async () => false);
+        const dns = makeDnsService(probe);
+        const alloc = new SubdomainAllocator(repo, dns);
+
+        const work = makeWork({ slug: 'www', id: 'cafebabe-0000-0000-0000-000000000000' });
+        const result = await alloc.allocate(work, probe);
+
+        // `www` is blocklisted as a base, so the suffixed candidate wins.
+        expect(result.subdomain).toBe('www-cafe');
+    });
+
+    it('treats a provider-side recordExists collision as taken', async () => {
+        const repo = makeRepo();
+        const probe = makeProbe(async (host) => host === 'ai-coding.ever.works');
+        const dns = makeDnsService(probe);
+        const alloc = new SubdomainAllocator(repo, dns);
+
+        const work = makeWork({ id: 'feedface-1111-2222-3333-444444444444' });
+        const result = await alloc.allocate(work, probe);
+
+        expect(result.subdomain).toBe('ai-coding-feed');
+    });
+
+    it('skips the provider probe gracefully when DNS service returns no provider', async () => {
+        const repo = makeRepo();
+        const dns = makeDnsService(null);
+        const alloc = new SubdomainAllocator(repo, dns);
+
+        const work = makeWork();
+        const result = await alloc.allocate(work);
+
+        expect(result.subdomain).toBe('ai-coding');
+        expect(result.allocated).toBe(true);
+    });
+
+    it('retries on a DB partial-unique-index race (23505) and falls through to the suffixed candidate', async () => {
+        // Simulates: two concurrent first-deploys for slug `ai-coding`. The
+        // in-process DB probe says free, but `update()` raises a Postgres
+        // 23505 unique violation because the other deploy won the race.
+        let firstUpdate = true;
+        const repo = makeRepo({
+            updateImpl: async (id: string, patch: Partial<Work>) => {
+                if (firstUpdate && patch.managedSubdomain === 'ai-coding') {
+                    firstUpdate = false;
+                    const err = new Error(
+                        'duplicate key value violates unique constraint "UQ_works_managedSubdomain_notnull"',
+                    ) as Error & { code?: string };
+                    err.code = '23505';
+                    throw err;
+                }
+                return null;
+            },
+        });
+        const probe = makeProbe(async () => false);
+        const dns = makeDnsService(probe);
+        const alloc = new SubdomainAllocator(repo, dns);
+
+        const work = makeWork({ id: 'deadbeef-1111-2222-3333-444444444444' });
+        const result = await alloc.allocate(work, probe);
+
+        expect(result.subdomain).toBe('ai-coding-dead');
+        expect(repo.update).toHaveBeenCalledTimes(2);
+    });
+
+    it('rethrows non-unique-violation update errors', async () => {
+        const repo = makeRepo({
+            updateImpl: async () => {
+                throw new Error('connection refused');
+            },
+        });
+        const probe = makeProbe(async () => false);
+        const dns = makeDnsService(probe);
+        const alloc = new SubdomainAllocator(repo, dns);
+
+        const work = makeWork();
+        await expect(alloc.allocate(work, probe)).rejects.toThrow(/connection refused/);
+    });
+
+    it('throws when the slug is unusable', async () => {
+        const repo = makeRepo();
+        const probe = makeProbe(async () => false);
+        const dns = makeDnsService(probe);
+        const alloc = new SubdomainAllocator(repo, dns);
+
+        const work = makeWork({ slug: '!!!' });
+        await expect(alloc.allocate(work, probe)).rejects.toThrow(/no usable slug/);
+    });
+});

--- a/packages/agent/src/ever-works-providers/cloudflare-dns.provider.ts
+++ b/packages/agent/src/ever-works-providers/cloudflare-dns.provider.ts
@@ -1,4 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common';
+import type {
+    DnsEnsureRecordInput,
+    DnsRecordSnapshot as DnsRecordSnapshotContract,
+    DnsRecordType,
+    DnsRemoveRecordInput,
+    IDnsOperations,
+} from '@ever-works/plugin';
 
 /**
  * EW-617 G5 — Cloudflare DNS provider for `*.ever.works`.
@@ -34,7 +41,13 @@ export interface CloudflareDnsConfig {
 
 export interface DnsRecordSnapshot {
     id: string;
-    type: 'CNAME';
+    /**
+     * Historically `'CNAME'`-only (the original EW-617 G5 managed flow
+     * only ever created CNAMEs). Widened to A/CNAME in EW-735 so the
+     * new `IDnsOperations.ensureRecord` path can return the same shape
+     * for k8s A-record targets without forking the snapshot type.
+     */
+    type: 'CNAME' | 'A';
     name: string;
     content: string;
 }
@@ -54,7 +67,7 @@ export class CloudflareDnsError extends Error {
  * Pure (testable) Cloudflare client. Construct with a config; tests pass
  * a custom `fetch` impl via the second arg.
  */
-export class CloudflareDnsProvider {
+export class CloudflareDnsProvider implements IDnsOperations {
     private readonly logger = new Logger(CloudflareDnsProvider.name);
     private readonly baseUrl: string;
 
@@ -123,6 +136,95 @@ export class CloudflareDnsProvider {
         this.logger.log(`CloudflareDns CNAME deleted ${fqdn}`);
     }
 
+    // EW-735 — IDnsOperations contract ---------------------------------------
+    //
+    // Thin host-keyed surface that `SubdomainAllocator` + future code paths
+    // talk to. ADDITIVE — the legacy `ensureWorkSubdomain` / `removeWorkSubdomain`
+    // methods above stay unchanged and the existing call sites
+    // (`EverWorksDnsService.ensureWorkSubdomain` → `applyEverWorksSubdomain`)
+    // keep behaving bit-for-bit.
+
+    /**
+     * Idempotent create-or-update for any host the caller specifies.
+     * Generalizes `ensureWorkSubdomain` (which is restricted to slug-shaped
+     * hosts under the managed `rootDomain`) to arbitrary hosts + A/CNAME.
+     */
+    async ensureRecord(input: DnsEnsureRecordInput): Promise<DnsRecordSnapshotContract> {
+        // Augment low: normalize once and use the normalized form everywhere
+        // so a host that passes validation only after trim/lowercase doesn't
+        // miss an existing record (lookup) or get sent verbatim to Cloudflare.
+        const host = this.normalizeHost(input.host);
+        const proxied = input.proxied ?? false;
+        const ttl = input.ttl ?? 1;
+        const existing = await this.findRecord(host, input.type);
+        if (existing) {
+            if (existing.content === input.target && existing.type === input.type) {
+                this.logger.log(
+                    `CloudflareDns ${input.type} already in sync ${host} -> ${input.target}`,
+                );
+                return existing as DnsRecordSnapshotContract;
+            }
+            const updated = await this.patchAnyRecord(existing.id, {
+                type: input.type,
+                name: host,
+                content: input.target,
+                proxied,
+                ttl,
+            });
+            this.logger.log(
+                `CloudflareDns ${input.type} updated ${host}: was ${existing.content} now ${input.target}`,
+            );
+            return updated;
+        }
+        const created = await this.createAnyRecord({
+            type: input.type,
+            name: host,
+            content: input.target,
+            proxied,
+            ttl,
+        });
+        this.logger.log(`CloudflareDns ${input.type} created ${host} -> ${input.target}`);
+        return created;
+    }
+
+    /**
+     * Idempotent delete for any host. No-op when the record does not exist.
+     * When `input.type` is omitted, probes BOTH CNAME and A so a caller that
+     * doesn't know the original record type still removes it (Augment low).
+     */
+    async removeRecord(input: DnsRemoveRecordInput): Promise<void> {
+        const host = this.normalizeHost(input.host);
+        const typesToProbe: DnsRecordType[] = input.type ? [input.type] : ['CNAME', 'A'];
+        for (const type of typesToProbe) {
+            const existing = await this.findRecord(host, type);
+            if (existing) {
+                await this.deleteRecord(existing.id);
+                this.logger.log(
+                    `CloudflareDns ${existing.type} deleted ${host} (id=${existing.id})`,
+                );
+            }
+        }
+    }
+
+    /**
+     * Uniqueness probe — `true` iff any A/CNAME record exists for `host` in
+     * the managed zone, regardless of who owns it. Used by
+     * `SubdomainAllocator` to detect collisions before persisting a claim.
+     */
+    async recordExists(host: string): Promise<boolean> {
+        const normalized = this.normalizeHost(host);
+        // Probe CNAME first (the common case for managed subdomains), then A.
+        const cname = await this.findRecord(normalized, 'CNAME');
+        if (cname) return true;
+        const a = await this.findRecord(normalized, 'A');
+        return a !== null;
+    }
+
+    /** Zone root domain managed by this provider (e.g. `'ever.works'`). */
+    rootDomain(): string {
+        return this.config.rootDomain;
+    }
+
     // Internal helpers ------------------------------------------------------
 
     private assertSlug(slug: string): void {
@@ -131,14 +233,70 @@ export class CloudflareDnsProvider {
         }
     }
 
-    private async findRecord(name: string): Promise<DnsRecordSnapshot | null> {
+    /**
+     * EW-735 — validate + normalize an arbitrary FQDN. Stricter than
+     * `assertSlug` because the host may contain dots (label.label.tld). Each
+     * label follows the same slug-shaped rule as `assertSlug`. Returns the
+     * trim/lowercased form so callers can use it verbatim in Cloudflare
+     * API payloads and lookups (Augment low — previously the validator
+     * normalized but the caller used the raw input).
+     */
+    private normalizeHost(host: string): string {
+        const trimmed = (host ?? '').trim().toLowerCase();
+        if (trimmed.length === 0 || trimmed.length > 253) {
+            throw new Error(`Invalid host for Cloudflare DNS: ${host}`);
+        }
+        const labelRe = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+        for (const label of trimmed.split('.')) {
+            if (!labelRe.test(label) || label.length > 63) {
+                throw new Error(`Invalid host for Cloudflare DNS: ${host}`);
+            }
+        }
+        return trimmed;
+    }
+
+    private async findRecord(
+        name: string,
+        type: DnsRecordType = 'CNAME',
+    ): Promise<DnsRecordSnapshot | null> {
         const url = new URL(`${this.baseUrl}/zones/${this.config.zoneId}/dns_records`);
         url.searchParams.set('name', name);
-        url.searchParams.set('type', 'CNAME');
-        const json = await this.request<{ result: DnsRecordSnapshot[] }>(url.toString(), {
-            method: 'GET',
-        });
-        return json.result[0] ?? null;
+        url.searchParams.set('type', type);
+        const json = await this.request<{
+            result: (DnsRecordSnapshot & { type: DnsRecordType })[];
+        }>(url.toString(), { method: 'GET' });
+        return (json.result[0] ?? null) as DnsRecordSnapshot | null;
+    }
+
+    private async createAnyRecord(payload: {
+        type: DnsRecordType;
+        name: string;
+        content: string;
+        proxied: boolean;
+        ttl: number;
+    }): Promise<DnsRecordSnapshotContract> {
+        const json = await this.request<{ result: DnsRecordSnapshotContract }>(
+            `${this.baseUrl}/zones/${this.config.zoneId}/dns_records`,
+            { method: 'POST', body: JSON.stringify(payload) },
+        );
+        return json.result;
+    }
+
+    private async patchAnyRecord(
+        id: string,
+        payload: {
+            type: DnsRecordType;
+            name: string;
+            content: string;
+            proxied: boolean;
+            ttl: number;
+        },
+    ): Promise<DnsRecordSnapshotContract> {
+        const json = await this.request<{ result: DnsRecordSnapshotContract }>(
+            `${this.baseUrl}/zones/${this.config.zoneId}/dns_records/${id}`,
+            { method: 'PUT', body: JSON.stringify(payload) },
+        );
+        return json.result;
     }
 
     private async createRecord(payload: {

--- a/packages/agent/src/ever-works-providers/index.ts
+++ b/packages/agent/src/ever-works-providers/index.ts
@@ -20,3 +20,4 @@ export {
     type CloudflareDnsConfig,
     type DnsRecordSnapshot,
 } from './cloudflare-dns.provider';
+export { SubdomainAllocator, type SubdomainAllocationResult } from './subdomain-allocator.service';

--- a/packages/agent/src/ever-works-providers/subdomain-allocator.service.ts
+++ b/packages/agent/src/ever-works-providers/subdomain-allocator.service.ts
@@ -1,0 +1,257 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Work } from '../entities/work.entity';
+import { WorkRepository } from '../database/repositories/work.repository';
+import { EverWorksDnsService } from './cloudflare-dns.provider';
+import type { IDnsOperations } from '@ever-works/plugin';
+
+/**
+ * EW-734 / EW-737 — collision-safe managed-subdomain allocator.
+ *
+ * The legacy `applyEverWorksSubdomain` derives `${work.slug}.ever.works` on
+ * every deploy. That's:
+ *  - **not globally unique** (two users with the same slug both claim it),
+ *  - **not persisted** (a slug rename orphans the old CNAME),
+ *  - **not race-safe** (concurrent first-deploys of two new Works can both
+ *    pick the same base and both succeed against an empty zone).
+ *
+ * `SubdomainAllocator` is an **additive** service that fixes all three
+ * without touching the existing path. It is consumed by the new
+ * `applyManagedSubdomain` extension (gated behind the
+ * `K8S_MANAGED_SUBDOMAIN` env flag — see `deploy.service.ts`). When
+ * the flag is OFF — which it is by default in this PR — the legacy
+ * `applyEverWorksSubdomain` runs untouched and this service is unused.
+ *
+ * Algorithm (spec §4.3):
+ *  1. If `work.managedSubdomain` is already persisted, **reuse it** as-is.
+ *     Subsequent deploys never re-allocate (idempotent, also prevents a
+ *     slug rename from orphaning the live CNAME).
+ *  2. Otherwise `base = slugify(work.slug)`. Probe:
+ *     - DB: does another Work already hold `managedSubdomain = base`?
+ *     - Provider: does `recordExists(base.rootDomain)` return true?
+ *     If either says yes, the base is taken.
+ *  3. On collision, append `-${shortId}` where `shortId` is the first 4
+ *     hex chars of `work.id` (deterministic across retries — mirrors
+ *     `EverWorksGitProvider.buildRepoName(work, true)`). Re-probe.
+ *  4. Retry up to `MAX_TRIES`. Persist the winner on `work.managedSubdomain`
+ *     in a single repository `update()`. The partial unique index
+ *     `UQ_works_managedSubdomain_notnull` is the DB-level race backstop.
+ *
+ * Note: this service ONLY allocates + persists. It does NOT create the DNS
+ * record itself — the caller (`applyManagedSubdomain`) decides whether to
+ * fire-and-forget via `EverWorksDnsService` (existing path) or via a
+ * plugin-resolved `IDnsOperations` (future path).
+ */
+export interface SubdomainAllocationResult {
+    /** The leftmost label stored on `work.managedSubdomain` (e.g. `ai-coding`). */
+    readonly subdomain: string;
+    /** Fully-qualified host (`${subdomain}.${rootDomain}`). */
+    readonly fqdn: string;
+    /** Root domain used (`'ever.works'` for managed mode). */
+    readonly rootDomain: string;
+    /** `true` when this call performed a fresh allocation; `false` when it reused. */
+    readonly allocated: boolean;
+}
+
+@Injectable()
+export class SubdomainAllocator {
+    private readonly logger = new Logger(SubdomainAllocator.name);
+    private static readonly MAX_TRIES = 5;
+    private static readonly LABEL_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+    /**
+     * Reserved platform labels — never let a tenant claim these. Mirrors the
+     * blocklist intent in spec §7.
+     */
+    private static readonly BLOCKLIST: ReadonlySet<string> = new Set([
+        'www',
+        'api',
+        'app',
+        'admin',
+        'mail',
+        'auth',
+        'docs',
+        'status',
+        'platform',
+        'dashboard',
+        'cdn',
+        'static',
+        'root',
+        'mx',
+        'ns',
+        'ns1',
+        'ns2',
+    ]);
+
+    constructor(
+        private readonly workRepository: WorkRepository,
+        private readonly dnsService: EverWorksDnsService,
+    ) {}
+
+    /**
+     * Allocate (or reuse) the managed subdomain for `work`. Persists the
+     * choice on `work.managedSubdomain` via `WorkRepository.update`. Does
+     * NOT touch DNS — the caller decides when to (re)ensure the record.
+     *
+     * @param work    The Work to allocate for. Must have a valid `slug`.
+     * @param dnsOps  Optional ops surface used for the collision probe
+     *                (`recordExists`). When omitted, the allocator falls
+     *                back to the managed `EverWorksDnsService` provider;
+     *                when that's also unconfigured (no env vars in dev)
+     *                the probe is skipped — the DB uniqueness check + DB
+     *                unique index alone keep allocation safe.
+     */
+    async allocate(work: Work, dnsOps?: IDnsOperations): Promise<SubdomainAllocationResult> {
+        const rootDomain = dnsOps?.rootDomain?.() ?? this.resolveRootDomain();
+
+        // (1) idempotent reuse
+        const persisted = (work.managedSubdomain ?? '').trim().toLowerCase();
+        if (persisted) {
+            this.assertLabel(persisted);
+            return {
+                subdomain: persisted,
+                fqdn: `${persisted}.${rootDomain}`,
+                rootDomain,
+                allocated: false,
+            };
+        }
+
+        const base = this.slugifyLabel(work.slug);
+        if (!base) {
+            throw new Error(
+                `SubdomainAllocator: work ${work.id} has no usable slug (got: ${JSON.stringify(work.slug)})`,
+            );
+        }
+
+        const probe = dnsOps ?? this.resolveProbe();
+        const shortId = work.id.replace(/-/g, '').slice(0, 4);
+        for (let attempt = 0; attempt < SubdomainAllocator.MAX_TRIES; attempt++) {
+            // Explicit candidate sequence (Greptile P2): the previous version
+            // reused `attempt` as both loop counter and suffix index, which
+            // produced the right strings but was hard to reason about.
+            //   attempt 0 → base
+            //   attempt 1 → base-<shortId>            (mirrors buildRepoName)
+            //   attempt n>1 → base-<shortId>-<n-1 in base36>
+            const candidate =
+                attempt === 0
+                    ? base
+                    : attempt === 1
+                      ? `${base}-${shortId}`
+                      : `${base}-${shortId}-${(attempt - 1).toString(36)}`;
+            if (!(await this.isCandidateFree(candidate, work.id, rootDomain, probe))) {
+                continue;
+            }
+            try {
+                await this.workRepository.update(work.id, { managedSubdomain: candidate });
+                this.logger.log(
+                    `SubdomainAllocator allocated ${candidate} for work ${work.id} (attempt ${attempt + 1})`,
+                );
+                return {
+                    subdomain: candidate,
+                    fqdn: `${candidate}.${rootDomain}`,
+                    rootDomain,
+                    allocated: true,
+                };
+            } catch (cause) {
+                // Augment medium: concurrent first-deploys can race past the
+                // in-process probe and only collide at the DB partial-unique
+                // index. Retry with the next candidate instead of failing.
+                if (this.isUniqueViolation(cause)) {
+                    this.logger.warn(
+                        `SubdomainAllocator unique-index race for ${candidate} on work ${work.id}: retrying`,
+                    );
+                    continue;
+                }
+                throw cause;
+            }
+        }
+        throw new Error(
+            `SubdomainAllocator exhausted ${SubdomainAllocator.MAX_TRIES} candidates for work ${work.id} (base=${base})`,
+        );
+    }
+
+    /**
+     * Postgres unique-violation detection. Matches TypeORM's `QueryFailedError`
+     * shape (`driverError.code === '23505'`) and the standard `code` field on
+     * raw pg errors. SQLite (test adapter) surfaces unique violations with
+     * `SQLITE_CONSTRAINT_UNIQUE`, also covered.
+     */
+    private isUniqueViolation(cause: unknown): boolean {
+        if (!cause || typeof cause !== 'object') return false;
+        const err = cause as { code?: string; driverError?: { code?: string }; message?: string };
+        if (err.code === '23505') return true;
+        if (err.driverError?.code === '23505') return true;
+        if (err.code === 'SQLITE_CONSTRAINT_UNIQUE') return true;
+        const msg = (err.message ?? '').toLowerCase();
+        return msg.includes('unique constraint') || msg.includes('uq_works_managedsubdomain');
+    }
+
+    // --- helpers --------------------------------------------------------------
+
+    private resolveRootDomain(): string {
+        // Mirrors `EverWorksDnsService.ingressHostFor` — kept in sync so the
+        // allocator and the legacy path agree on the FQDN shape.
+        return process.env.EVER_WORKS_DOMAIN?.trim() || 'ever.works';
+    }
+
+    private resolveProbe(): IDnsOperations | null {
+        // The legacy `CloudflareDnsProvider` implements `IDnsOperations` after
+        // EW-735 (see `cloudflare-dns.provider.ts`). When env vars are missing
+        // (dev / preview), `getProvider()` returns null and we skip the probe.
+        // No type assertion needed — the structural implements relationship
+        // is enforced by `CloudflareDnsProvider implements IDnsOperations`.
+        return this.dnsService.getProvider();
+    }
+
+    private async isCandidateFree(
+        candidate: string,
+        ownWorkId: string,
+        rootDomain: string,
+        probe: IDnsOperations | null,
+    ): Promise<boolean> {
+        this.assertLabel(candidate);
+        if (SubdomainAllocator.BLOCKLIST.has(candidate)) {
+            return false;
+        }
+        // DB-level claim by another Work?
+        const other = await this.workRepository.findByManagedSubdomain(candidate);
+        if (other && other.id !== ownWorkId) {
+            return false;
+        }
+        // Provider-level zone collision?
+        if (probe) {
+            try {
+                const exists = await probe.recordExists(`${candidate}.${rootDomain}`);
+                if (exists) {
+                    // Owned by us already → reuse-safe. Owned by anyone else (or
+                    // a stale orphan we can't attribute) → treat as taken.
+                    return false;
+                }
+            } catch (cause) {
+                // A probe failure must not block allocation — the DB unique
+                // index + caller-side ensureRecord drift-correction will catch
+                // any real collision when we actually try to write the record.
+                this.logger.warn(
+                    `SubdomainAllocator probe failed for ${candidate}.${rootDomain}: ${(cause as Error).message}`,
+                );
+            }
+        }
+        return true;
+    }
+
+    private slugifyLabel(raw: string | undefined | null): string {
+        const lower = (raw ?? '').toString().toLowerCase().trim();
+        // Replace any run of non-[a-z0-9] with `-`, collapse, trim edge dashes,
+        // clamp to RFC 1035 label length (63).
+        const slug = lower
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/-{2,}/g, '-')
+            .replace(/^-+|-+$/g, '')
+            .slice(0, 63);
+        return slug;
+    }
+
+    private assertLabel(label: string): void {
+        if (!SubdomainAllocator.LABEL_RE.test(label) || label.length > 63) {
+            throw new Error(`Invalid managed-subdomain label: ${label}`);
+        }
+    }
+}

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -254,4 +254,255 @@ describe('DeployFacadeService', () => {
             ).resolves.toBeNull();
         });
     });
+
+    /**
+     * EW-741 — BYO Cloudflare custom-domain reconciliation.
+     *
+     * When the user has saved settings for a `dns` plugin (full
+     * `IDnsProvider` shape — declares all four `dns-*` capabilities) AND
+     * the LB hostname env is configured, addDomain MUST call `ensureRecord`
+     * on the user-scoped DNS plugin so the custom domain's DNS record is
+     * created in the user's own Cloudflare zone. Failures are best-effort —
+     * the request must still succeed when the plugin throws.
+     *
+     * The operator-managed mode (no user-scoped DNS plugin settings) must
+     * stay guidance-only — `ensureRecord` is NOT called.
+     */
+    describe('EW-741 — addDomain BYO Cloudflare reconciliation', () => {
+        const ORIGINAL_LB = process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME;
+
+        afterEach(() => {
+            if (ORIGINAL_LB === undefined) {
+                delete process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME;
+            } else {
+                process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = ORIGINAL_LB;
+            }
+        });
+
+        // Build a deploy plugin + dns plugin pair, with the domain repository
+        // and a settings service whose `getSettings` returns different values
+        // per plugin id (the deploy plugin's settings vs. the DNS plugin's).
+        const buildAddDomainFixture = (args: {
+            dnsUserSettings?: Record<string, unknown>;
+            ensureRecord?: jest.Mock;
+            includeDnsPlugin?: boolean;
+        }) => {
+            const ensureRecord =
+                args.ensureRecord ??
+                jest.fn().mockResolvedValue({
+                    id: 'rec-1',
+                    type: 'CNAME',
+                    name: 'tools.example.com',
+                    content: 'lb.ever.works',
+                });
+            const deployPlugin = {
+                id: 'k8s',
+                name: 'Kubernetes',
+                providerName: 'kubernetes',
+                capabilities: ['deployment'],
+                addDomain: jest.fn().mockResolvedValue({
+                    domain: { name: 'tools.example.com', verified: false },
+                    verified: false,
+                }),
+            };
+            const dnsPlugin = {
+                id: 'cloudflare-dns',
+                name: 'Cloudflare DNS',
+                providerName: 'cloudflare',
+                capabilities: [
+                    'dns',
+                    'dns-ensure-record',
+                    'dns-remove-record',
+                    'dns-record-exists',
+                    'dns-root-domain',
+                ],
+                ensureRecord,
+                removeRecord: jest.fn(),
+                recordExists: jest.fn().mockResolvedValue(false),
+                rootDomain: () => 'example.com',
+            };
+            const deployRegistered = {
+                plugin: deployPlugin,
+                manifest: {
+                    id: 'k8s',
+                    name: 'Kubernetes',
+                    category: 'deployment',
+                    capabilities: ['deployment'],
+                    description: '',
+                    icon: { type: 'lucide', value: 'Container' },
+                },
+                state: 'loaded',
+            };
+            const dnsRegistered = {
+                plugin: dnsPlugin,
+                manifest: {
+                    id: 'cloudflare-dns',
+                    name: 'Cloudflare DNS',
+                    category: 'dns',
+                    capabilities: dnsPlugin.capabilities,
+                    description: '',
+                    icon: { type: 'lucide', value: 'Cloud' },
+                },
+                state: 'loaded',
+            };
+            const includeDns = args.includeDnsPlugin ?? true;
+            const registry = {
+                get: jest.fn((id: string) => {
+                    if (id === 'k8s') return deployRegistered;
+                    if (id === 'cloudflare-dns' && includeDns) return dnsRegistered;
+                    return undefined;
+                }),
+                getByCapability: jest.fn((cap: string) => {
+                    if (cap === 'deployment') return [deployRegistered];
+                    if (cap === 'dns-ensure-record' && includeDns) return [dnsRegistered];
+                    return [];
+                }),
+            };
+            const settingsService = {
+                getResolvedSettings: jest
+                    .fn()
+                    .mockResolvedValue({ kubeconfig: { value: 'apiVersion: v1' } }),
+                getSettings: jest.fn(async (pluginId: string) => {
+                    if (pluginId === 'cloudflare-dns') {
+                        return args.dnsUserSettings ?? {};
+                    }
+                    return {};
+                }),
+            };
+            const work = {
+                id: 'work-1',
+                slug: 'site',
+                deployProvider: 'k8s',
+                user: { id: 'user-1' },
+                website: 'https://site.ever.works',
+                // Short-circuit `resolveProjectId` — the BYO custom-domain
+                // path doesn't care what projectId resolves to; we just need
+                // the addDomain pipeline to reach the DB persist + DNS hook.
+                deployProjectId: 'project-1',
+            };
+            const workRepository = {
+                findById: jest.fn().mockResolvedValue(work),
+                update: jest.fn(),
+            };
+            const domainRepository = {
+                findByWork: jest.fn().mockResolvedValue([]),
+                findOne: jest.fn().mockResolvedValue(null),
+                addDomain: jest.fn().mockResolvedValue({
+                    workId: 'work-1',
+                    domain: 'tools.example.com',
+                    verified: false,
+                }),
+                updateVerified: jest.fn(),
+                updateProvider: jest.fn(),
+            };
+            const service = new DeployFacadeService(
+                registry as any,
+                settingsService as any,
+                workRepository as any,
+                {} as any,
+                domainRepository as any,
+            );
+            return { service, deployPlugin, dnsPlugin, ensureRecord, domainRepository };
+        };
+
+        it('calls ensureRecord on the user-scoped DNS plugin when BYO settings are present', async () => {
+            process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'lb.ever.works';
+            const { service, ensureRecord, domainRepository } = buildAddDomainFixture({
+                dnsUserSettings: { apiToken: 'cf-tok', zoneId: 'zone-1', proxied: true },
+            });
+
+            await service.addDomain('tools.example.com', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            // Wait one microtask for the void-chained fire-and-forget.
+            await new Promise((r) => setImmediate(r));
+
+            // The custom-domain row is persisted unconditionally — BYO
+            // ensureRecord is purely additive.
+            expect(domainRepository.addDomain).toHaveBeenCalledWith(
+                'work-1',
+                'tools.example.com',
+                'k8s',
+            );
+            expect(ensureRecord).toHaveBeenCalledTimes(1);
+            expect(ensureRecord).toHaveBeenCalledWith({
+                host: 'tools.example.com',
+                type: 'CNAME',
+                target: 'lb.ever.works',
+                proxied: true,
+            });
+        });
+
+        it('does NOT call ensureRecord when the user has no DNS plugin settings (operator-managed)', async () => {
+            process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'lb.ever.works';
+            const { service, ensureRecord, domainRepository } = buildAddDomainFixture({
+                // Empty user settings = operator-managed only.
+                dnsUserSettings: {},
+            });
+
+            await service.addDomain('tools.example.com', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+            await new Promise((r) => setImmediate(r));
+
+            expect(domainRepository.addDomain).toHaveBeenCalled();
+            expect(ensureRecord).not.toHaveBeenCalled();
+        });
+
+        it('does NOT call ensureRecord when no DNS plugin is loaded', async () => {
+            process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'lb.ever.works';
+            const { service, ensureRecord, domainRepository } = buildAddDomainFixture({
+                includeDnsPlugin: false,
+                dnsUserSettings: { apiToken: 'cf-tok' },
+            });
+
+            await service.addDomain('tools.example.com', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+            await new Promise((r) => setImmediate(r));
+
+            expect(domainRepository.addDomain).toHaveBeenCalled();
+            expect(ensureRecord).not.toHaveBeenCalled();
+        });
+
+        it('does NOT call ensureRecord when EVER_WORKS_DEPLOY_LB_HOSTNAME is unset', async () => {
+            delete process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME;
+            const { service, ensureRecord, domainRepository } = buildAddDomainFixture({
+                dnsUserSettings: { apiToken: 'cf-tok' },
+            });
+
+            await service.addDomain('tools.example.com', {
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+            await new Promise((r) => setImmediate(r));
+
+            expect(domainRepository.addDomain).toHaveBeenCalled();
+            expect(ensureRecord).not.toHaveBeenCalled();
+        });
+
+        it('swallows ensureRecord failures (the request still succeeds)', async () => {
+            process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME = 'lb.ever.works';
+            const failing = jest.fn().mockRejectedValue(new Error('cf api 5xx'));
+            const { service, domainRepository } = buildAddDomainFixture({
+                dnsUserSettings: { apiToken: 'cf-tok' },
+                ensureRecord: failing,
+            });
+
+            await expect(
+                service.addDomain('tools.example.com', {
+                    userId: 'user-1',
+                    workId: 'work-1',
+                }),
+            ).resolves.toMatchObject({ verified: false });
+            await new Promise((r) => setImmediate(r));
+
+            expect(domainRepository.addDomain).toHaveBeenCalled();
+            expect(failing).toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -9,7 +9,8 @@ import type {
     DeploymentDomain,
     AddDomainResult,
 } from '@ever-works/plugin';
-import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, isDnsProvider } from '@ever-works/plugin';
+import type { IDnsProvider } from '@ever-works/plugin';
 import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
 import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
 import { WorkPluginRepository } from '../plugins/repositories/work-plugin.repository';
@@ -578,7 +579,93 @@ export class DeployFacadeService implements IDeployFacade {
             await this.promoteVerifiedDomainWebsite(work, result.domain);
         }
 
+        // EW-741 — in BYO Cloudflare mode (user-scoped DNS plugin with the
+        // required settings present), also create the custom-domain DNS
+        // record in the user's zone. Best-effort: a failure here logs but
+        // never fails the request — matches the fire-and-forget pattern the
+        // managed subdomain uses today. When the user is on operator-managed
+        // DNS (no user-scoped plugin settings) this is a no-op so existing
+        // behavior is preserved (custom-domain DNS stays guidance-only).
+        void this.ensureCustomDomainRecordBestEffort(domain, options).catch((cause) => {
+            this.logger.warn(
+                `EW-741 BYO custom-domain ensureRecord failed for ${domain}: ${(cause as Error).message}`,
+            );
+        });
+
         return result;
+    }
+
+    /**
+     * EW-741 — best-effort: create a DNS record for a newly-added custom
+     * domain in the user's own DNS zone, when a user-scoped DNS plugin is
+     * resolvable for them. The plugin must:
+     *   - declare the four `dns-*` capabilities (full `IDnsProvider` shape),
+     *   - have user-scoped settings present for `(userId, workId)` — this is
+     *     the operator-managed → BYO discriminator. The operator-managed
+     *     `EverWorksDnsService` is wired at the agent level (not the plugin
+     *     registry) so it never enters this branch.
+     *
+     * The LB hostname is read from `EVER_WORKS_DEPLOY_LB_HOSTNAME` (same env
+     * the managed subdomain CNAME uses). When unset, this is a no-op — we'd
+     * have nothing meaningful to point the record at.
+     */
+    private async ensureCustomDomainRecordBestEffort(
+        domain: string,
+        options: DeployFacadeOptions,
+    ): Promise<void> {
+        const lbTarget = process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME?.trim() ?? '';
+        if (!lbTarget) {
+            return;
+        }
+        const dnsProviders = this.registry
+            .getByCapability('dns-ensure-record')
+            .filter((p) => p.state === 'loaded');
+        for (const registered of dnsProviders) {
+            const plugin = registered.plugin;
+            if (!isDnsProvider(plugin as IDnsProvider)) {
+                continue;
+            }
+            let userSettings: Record<string, unknown> = {};
+            try {
+                userSettings = await this.settingsService.getSettings(plugin.id, {
+                    userId: options.userId,
+                    workId: options.workId,
+                    includeSecrets: true,
+                });
+            } catch {
+                continue;
+            }
+            // BYO discriminator: the user must have actively configured this
+            // plugin (any non-empty setting). A plugin with no user-scoped
+            // settings is operator-managed only and must not be used for
+            // per-user custom-domain DNS.
+            const hasUserConfig = Object.values(userSettings).some(
+                (value) => value !== undefined && value !== null && value !== '',
+            );
+            if (!hasUserConfig) {
+                continue;
+            }
+            const proxied =
+                typeof userSettings.proxied === 'boolean' ? userSettings.proxied : false;
+            try {
+                await (plugin as IDnsProvider).ensureRecord({
+                    host: domain,
+                    type: 'CNAME',
+                    target: lbTarget,
+                    proxied,
+                });
+                this.logger.log(
+                    `EW-741 BYO custom-domain CNAME ensured for ${domain} via ${plugin.id}`,
+                );
+            } catch (cause) {
+                this.logger.warn(
+                    `EW-741 BYO custom-domain ensureRecord failed for ${domain} via ${plugin.id}: ${(cause as Error).message}`,
+                );
+            }
+            // Stop after the first resolvable user-scoped DNS plugin — we
+            // never fan-out across multiple zones for a single custom domain.
+            return;
+        }
     }
 
     private async findProviderDomain(

--- a/packages/plugin/src/contracts/capabilities/dns.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/dns.interface.ts
@@ -1,0 +1,134 @@
+import type { IPlugin } from '../plugin.interface.js';
+
+/**
+ * EW-734 / EW-735 — pluggable DNS providers.
+ *
+ * This is an **additive** capability contract. It is layered on top of the
+ * existing concrete `CloudflareDnsProvider`
+ * (`packages/agent/src/ever-works-providers/cloudflare-dns.provider.ts`)
+ * without removing or renaming any of its existing methods — the concrete
+ * class continues to expose `ensureWorkSubdomain` / `removeWorkSubdomain`
+ * for the legacy `applyEverWorksSubdomain` code path while ALSO implementing
+ * the smaller `IDnsOperations` ops surface that new code talks to.
+ *
+ * The interface is intentionally split in two:
+ *
+ *   - `IDnsOperations` — the **thin ops surface** (`ensureRecord`,
+ *     `removeRecord`, `recordExists`, `rootDomain`). The existing concrete
+ *     `CloudflareDnsProvider` implements this directly so new code paths
+ *     (`SubdomainAllocator`) don't have to know whether the backend is a
+ *     bundled core class or a future first-class plugin.
+ *
+ *   - `IDnsProvider` — `IPlugin & IDnsOperations`. The first-class plugin
+ *     contract `@ever-works/cloudflare-dns` (EW-738) will implement. Not yet
+ *     wired in this PR.
+ *
+ * Capability strings a DNS plugin manifest declares:
+ *   - `dns-ensure-record` (required) — idempotent create/upsert
+ *   - `dns-remove-record` (required) — idempotent delete
+ *   - `dns-record-exists` (required) — uniqueness probe
+ *   - `dns-root-domain`   (required) — exposes the zone's root domain
+ *
+ * Two operator modes (G4):
+ *   - **Managed**: platform's own zone (`ever.works`) — operator env vars.
+ *   - **Bring-your-own**: a user supplies their own Cloudflare token/zone
+ *     for a custom apex/domain (encrypted plugin settings).
+ *
+ * See `docs/specs/features/cloudflare-dns-plugin/spec.md` §4.1.
+ */
+export type DnsRecordType = 'CNAME' | 'A';
+
+export interface DnsRecordSnapshot {
+	readonly id: string;
+	readonly type: DnsRecordType;
+	readonly name: string;
+	readonly content: string;
+	readonly proxied?: boolean;
+	readonly ttl?: number;
+}
+
+export interface DnsEnsureRecordInput {
+	/** Fully-qualified host, e.g. `ai-coding.ever.works`. */
+	readonly host: string;
+	/** Record type. CNAME for hostname targets, A for IP targets. */
+	readonly type: DnsRecordType;
+	/** Target — hostname for CNAME, IPv4 for A. */
+	readonly target: string;
+	/**
+	 * Cloudflare orange-cloud / equivalent CDN proxy. Defaults are
+	 * provider-specific — Cloudflare's managed `*.ever.works` records
+	 * should default `true` (CF Universal SSL); custom-domain records
+	 * usually default `false`.
+	 */
+	readonly proxied?: boolean;
+	/** TTL in seconds. `1` for `auto`. Provider may clamp. */
+	readonly ttl?: number;
+}
+
+export interface DnsRemoveRecordInput {
+	readonly host: string;
+	readonly type?: DnsRecordType;
+}
+
+/**
+ * Minimal DNS ops surface — the contract `SubdomainAllocator` and the new
+ * code paths depend on. Implemented by:
+ *   - the existing `CloudflareDnsProvider` concrete class (additive — its
+ *     legacy `ensureWorkSubdomain` / `removeWorkSubdomain` methods stay),
+ *   - and the future `@ever-works/cloudflare-dns` plugin (EW-738).
+ */
+export interface IDnsOperations {
+	/**
+	 * Create or upsert a record mapping `host -> target`. Idempotent:
+	 * an existing matching record is returned as-is; a drifted record is
+	 * patched in place. Always returns the resulting record snapshot.
+	 */
+	ensureRecord(input: DnsEnsureRecordInput): Promise<DnsRecordSnapshot>;
+
+	/** Remove a record. Idempotent — missing record is a no-op. */
+	removeRecord(input: DnsRemoveRecordInput): Promise<void>;
+
+	/**
+	 * Cheap "is this host already claimed?" probe used by
+	 * `SubdomainAllocator` to detect collisions before persisting.
+	 * Returns `true` iff ANY record exists for `host` in the provider's
+	 * zone — regardless of who owns it.
+	 */
+	recordExists(host: string): Promise<boolean>;
+
+	/** Root domain managed by this provider — e.g. `'ever.works'`. */
+	rootDomain(): string;
+}
+
+/**
+ * Full DNS plugin interface — capability `dns`.
+ *
+ * Concrete implementations:
+ * - **today**: `CloudflareDnsProvider` in `@ever-works/agent` is a plain
+ *   class (NOT an `IPlugin`) wired via `EverWorksDnsService`. It satisfies
+ *   `IDnsOperations` after EW-735 — that's enough for `SubdomainAllocator`.
+ * - **EW-738**: `@ever-works/cloudflare-dns` plugin (managed + BYO modes,
+ *   resolved through `PluginRegistryService`) will implement the full
+ *   `IDnsProvider`.
+ */
+export interface IDnsProvider extends IPlugin, IDnsOperations {
+	/** Backend name for facade identification (`'cloudflare'`, ...). */
+	readonly providerName: string;
+}
+
+/**
+ * Type guard for full DNS plugins. Capability strings mirror the storage /
+ * vector-store precedent (`put-object`/`get-object`, etc.). Checks ALL four
+ * required capability strings — a plugin that only declares the upsert/delete
+ * pair without the probe + root-domain ops would still satisfy a 2-key check
+ * but break at runtime in `SubdomainAllocator` (Augment low).
+ */
+export function isDnsProvider(plugin: IPlugin): plugin is IDnsProvider {
+	const caps = plugin.capabilities;
+	return (
+		caps.includes('dns-ensure-record') &&
+		caps.includes('dns-remove-record') &&
+		caps.includes('dns-record-exists') &&
+		caps.includes('dns-root-domain')
+	);
+}

--- a/packages/plugin/src/contracts/capabilities/index.ts
+++ b/packages/plugin/src/contracts/capabilities/index.ts
@@ -21,3 +21,7 @@ export * from './notification-channel.interface.js';
 export * from './agent-memory.interface.js';
 // EW-642 — pluggable vector-store backends.
 export * from './vector-store.interface.js';
+// EW-734 / EW-735 — pluggable DNS providers (Cloudflare today; BYO Cloudflare
+// + future Route53/etc. via the plugin registry). Additive — does NOT replace
+// the existing `CloudflareDnsProvider` concrete class in @ever-works/agent.
+export * from './dns.interface.js';

--- a/packages/plugin/src/contracts/plugin-manifest.types.ts
+++ b/packages/plugin/src/contracts/plugin-manifest.types.ts
@@ -26,7 +26,15 @@ export const PLUGIN_CATEGORIES = [
 	// EW-642 — pluggable vector-store backends (pgvector, Qdrant, Pinecone, …).
 	// See `capabilities/vector-store.interface.ts` and the RFC at
 	// `docs/specs/features/knowledge-base/phase-2-vector-plugin-design.md`.
-	'vector-store'
+	'vector-store',
+	// EW-734 / EW-735 — pluggable DNS providers. The managed Cloudflare DNS
+	// provider lives at `packages/agent/src/ever-works-providers/
+	// cloudflare-dns.provider.ts` today and continues to operate as-is; the
+	// future first-class `@ever-works/cloudflare-dns` plugin (EW-738) will
+	// declare itself with this category for both managed + BYO modes.
+	// See `capabilities/dns.interface.ts` and
+	// `docs/specs/features/cloudflare-dns-plugin/spec.md`.
+	'dns'
 ] as const;
 
 export type PluginCategory = (typeof PLUGIN_CATEGORIES)[number];

--- a/packages/plugins/cloudflare-dns/README.md
+++ b/packages/plugins/cloudflare-dns/README.md
@@ -1,0 +1,55 @@
+# @ever-works/cloudflare-dns
+
+Cloudflare DNS provider plugin for the Ever Works platform.
+
+## Plugin metadata
+
+| Field        | Value                                                                                   |
+| ------------ | --------------------------------------------------------------------------------------- |
+| ID           | `cloudflare-dns`                                                                        |
+| Category     | `dns`                                                                                   |
+| Capabilities | `dns`, `dns-ensure-record`, `dns-remove-record`, `dns-record-exists`, `dns-root-domain` |
+| Author       | Ever Works Team                                                                         |
+| License      | AGPL-3.0                                                                                |
+| Built-in     | yes                                                                                     |
+| Auto-enable  | no                                                                                      |
+
+## What is the Cloudflare DNS plugin?
+
+This plugin lets Ever Works create, update, and remove DNS records on Cloudflare for the subdomains and custom domains your Works are served from. It implements the `IDnsProvider` capability (EW-735) and is the registry-resolved successor to the legacy concrete `CloudflareDnsProvider` in `@ever-works/agent` (which continues to operate unchanged — this plugin is **additive**).
+
+## Operator modes
+
+The plugin supports two modes side-by-side, distinguished by where the credentials live:
+
+### Managed mode — `*.ever.works`
+
+Platform operators wire credentials via environment variables. The plugin's `x-envVar` schema entries forward these to plugin settings transparently, so no per-user settings are needed for managed subdomains.
+
+| Env var                         | Purpose                                               |
+| ------------------------------- | ----------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`          | Scoped token with `DNS:Edit` on the `ever.works` zone |
+| `CLOUDFLARE_ZONE_ID`            | `ever.works` zone id                                  |
+| `EVER_WORKS_DOMAIN`             | Defaults to `ever.works`                              |
+| `EVER_WORKS_DEPLOY_LB_HOSTNAME` | CNAME target — the k8s-works ingress LB hostname      |
+
+### Bring-your-own (BYO) mode — custom apex/domain
+
+Users supply their own Cloudflare token + zone for a domain they own (e.g. `acme.com`). Values are persisted to encrypted user-scoped plugin settings. Records are created with the Cloudflare proxy **off** by default so the user keeps serving their own TLS.
+
+Required scopes for the Cloudflare API token: `DNS:Edit` for the target zone. Create one at https://dash.cloudflare.com/profile/api-tokens.
+
+## Capabilities
+
+| Capability          | Method                                           | Notes                                                                      |
+| ------------------- | ------------------------------------------------ | -------------------------------------------------------------------------- |
+| `dns-ensure-record` | `ensureRecord({ host, type, target, proxied? })` | Idempotent create-or-update. Patches drifted records in place.             |
+| `dns-remove-record` | `removeRecord({ host, type? })`                  | Idempotent delete. Omitting `type` probes both `CNAME` and `A`.            |
+| `dns-record-exists` | `recordExists(host)`                             | Uniqueness probe — `true` iff any `CNAME` or `A` record exists for `host`. |
+| `dns-root-domain`   | `rootDomain()`                                   | Returns the zone's root domain (e.g. `ever.works`).                        |
+
+## See also
+
+- `docs/specs/features/cloudflare-dns-plugin/spec.md` — authoritative design doc.
+- `packages/plugin/src/contracts/capabilities/dns.interface.ts` — `IDnsProvider` / `IDnsOperations` contracts.
+- `packages/agent/src/ever-works-providers/cloudflare-dns.provider.ts` — legacy concrete provider this plugin runs alongside.

--- a/packages/plugins/cloudflare-dns/package.json
+++ b/packages/plugins/cloudflare-dns/package.json
@@ -1,0 +1,71 @@
+{
+	"name": "@ever-works/cloudflare-dns",
+	"version": "1.0.0",
+	"description": "Cloudflare DNS provider plugin for Ever Works (managed + bring-your-own modes)",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "cloudflare-dns",
+			"name": "Cloudflare DNS",
+			"version": "1.0.0",
+			"category": "dns",
+			"capabilities": [
+				"dns",
+				"dns-ensure-record",
+				"dns-remove-record",
+				"dns-record-exists",
+				"dns-root-domain"
+			],
+			"description": "Cloudflare DNS provider for managed ever.works subdomains and bring-your-own custom zones",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"builtIn": true,
+			"autoEnable": false,
+			"distribution": "registry"
+		}
+	},
+	"publishConfig": {
+		"access": "restricted",
+		"registry": "https://registry.npmjs.org"
+	}
+}

--- a/packages/plugins/cloudflare-dns/src/__tests__/cloudflare-dns.plugin.spec.ts
+++ b/packages/plugins/cloudflare-dns/src/__tests__/cloudflare-dns.plugin.spec.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { isDnsProvider, type IPlugin, type PluginContext } from '@ever-works/plugin';
+import { CloudflareDnsPlugin, CloudflareDnsPluginError } from '../cloudflare-dns.plugin.js';
+import { cloudflareDnsSettingsSchema } from '../settings.schema.js';
+
+function createMockContext(settings: Record<string, unknown> = {}): PluginContext {
+	return {
+		pluginId: 'cloudflare-dns',
+		logger: { log: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		cache: {
+			get: vi.fn(),
+			set: vi.fn(),
+			delete: vi.fn(),
+			has: vi.fn(),
+			clear: vi.fn()
+		} as unknown as PluginContext['cache'],
+		http: {} as PluginContext['http'],
+		env: {} as PluginContext['env'],
+		envVars: {} as PluginContext['envVars'],
+		services: {} as PluginContext['services'],
+		getSettings: vi.fn().mockResolvedValue(settings),
+		getResolvedSettings: vi.fn().mockResolvedValue(settings),
+		updateSettings: vi.fn(),
+		onEvent: vi.fn(),
+		emitEvent: vi.fn(),
+		registerCustomCapability: vi.fn(),
+		getCustomCapability: vi.fn()
+	} as unknown as PluginContext;
+}
+
+interface FakeRecord {
+	id: string;
+	type: 'CNAME' | 'A';
+	name: string;
+	content: string;
+}
+
+/**
+ * In-memory Cloudflare v4 stub. Implements the four endpoints the plugin
+ * calls: list records by `name`+`type`, POST create, PUT patch, DELETE.
+ */
+function createFakeCloudflare(initial: FakeRecord[] = []) {
+	const store = new Map<string, FakeRecord>();
+	let nextId = 1;
+	for (const r of initial) store.set(r.id, r);
+
+	const fetchImpl: typeof fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = new URL(typeof input === 'string' ? input : input.toString());
+		const method = init?.method ?? 'GET';
+		if (method === 'GET' && url.pathname.endsWith('/dns_records')) {
+			const name = url.searchParams.get('name');
+			const type = url.searchParams.get('type');
+			const result = [...store.values()].filter((r) => r.name === name && r.type === type);
+			return new Response(JSON.stringify({ success: true, result }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+		if (method === 'POST' && url.pathname.endsWith('/dns_records')) {
+			const body = JSON.parse((init?.body as string) ?? '{}');
+			const id = `rec_${nextId++}`;
+			const record: FakeRecord = {
+				id,
+				type: body.type,
+				name: body.name,
+				content: body.content
+			};
+			store.set(id, record);
+			return new Response(JSON.stringify({ success: true, result: record }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+		const putMatch = method === 'PUT' && url.pathname.match(/\/dns_records\/([^/]+)$/);
+		if (putMatch) {
+			const id = putMatch[1];
+			const body = JSON.parse((init?.body as string) ?? '{}');
+			const updated: FakeRecord = {
+				id,
+				type: body.type,
+				name: body.name,
+				content: body.content
+			};
+			store.set(id, updated);
+			return new Response(JSON.stringify({ success: true, result: updated }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+		const delMatch = method === 'DELETE' && url.pathname.match(/\/dns_records\/([^/]+)$/);
+		if (delMatch) {
+			store.delete(delMatch[1]);
+			return new Response(JSON.stringify({ success: true, result: { id: delMatch[1] } }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}
+		return new Response(JSON.stringify({ success: false, errors: [{ code: 404, message: 'not found' }] }), {
+			status: 404,
+			headers: { 'Content-Type': 'application/json' }
+		});
+	}) as unknown as typeof fetch;
+
+	return { fetchImpl, store };
+}
+
+const BASE_SETTINGS = {
+	apiToken: 'cf-token-test',
+	zoneId: 'zone-test',
+	rootDomain: 'ever.works',
+	targetHostname: 'works-lb.example.com',
+	proxied: false
+};
+
+async function loadedPlugin(settings = BASE_SETTINGS, initialRecords: FakeRecord[] = []) {
+	const { fetchImpl, store } = createFakeCloudflare(initialRecords);
+	const plugin = new CloudflareDnsPlugin(fetchImpl);
+	await plugin.onLoad(createMockContext(settings));
+	return { plugin, store, fetchImpl };
+}
+
+describe('CloudflareDnsPlugin', () => {
+	let envSnapshot: NodeJS.ProcessEnv;
+	beforeEach(() => {
+		envSnapshot = { ...process.env };
+		// Clear env vars that the plugin reads as fallbacks so tests
+		// exercising error paths see a clean slate.
+		delete process.env.CLOUDFLARE_API_TOKEN;
+		delete process.env.CLOUDFLARE_ZONE_ID;
+		delete process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME;
+		delete process.env.EVER_WORKS_DOMAIN;
+	});
+	afterEach(() => {
+		process.env = envSnapshot;
+	});
+
+	it('exposes a settingsSchema with the EW-738 spec keys + meta annotations', () => {
+		expect(cloudflareDnsSettingsSchema.type).toBe('object');
+		const props = cloudflareDnsSettingsSchema.properties ?? {};
+		expect(props.apiToken['x-secret']).toBe(true);
+		expect(props.apiToken['x-envVar']).toBe('CLOUDFLARE_API_TOKEN');
+		expect(props.apiToken['x-scope']).toBe('user');
+		expect(props.zoneId['x-envVar']).toBe('CLOUDFLARE_ZONE_ID');
+		expect(props.rootDomain.default).toBe('ever.works');
+		expect(props.targetHostname['x-adminOnly']).toBe(true);
+		expect(props.proxied.default).toBe(true);
+	});
+
+	it('satisfies the EW-735 isDnsProvider type guard', async () => {
+		const { plugin } = await loadedPlugin();
+		// The function only requires `capabilities` + `id`; cast through
+		// `IPlugin` to demonstrate the guard narrows correctly.
+		const asPlugin = plugin as unknown as IPlugin;
+		expect(isDnsProvider(asPlugin)).toBe(true);
+	});
+
+	it('rootDomain() returns the resolved root domain', async () => {
+		const { plugin } = await loadedPlugin();
+		// ensure a settings resolution has happened so the sync getter
+		// returns the configured value instead of the schema default.
+		await plugin.recordExists('foo.ever.works');
+		expect(plugin.rootDomain()).toBe('ever.works');
+	});
+
+	it('ensureRecord creates a brand-new CNAME', async () => {
+		const { plugin, store } = await loadedPlugin();
+		const created = await plugin.ensureRecord({
+			host: 'ai-coding.ever.works',
+			type: 'CNAME',
+			target: 'works-lb.example.com'
+		});
+		expect(created.name).toBe('ai-coding.ever.works');
+		expect(created.type).toBe('CNAME');
+		expect(created.content).toBe('works-lb.example.com');
+		expect([...store.values()]).toHaveLength(1);
+	});
+
+	it('ensureRecord patches a drifted CNAME in place', async () => {
+		const initial: FakeRecord = {
+			id: 'rec_existing',
+			type: 'CNAME',
+			name: 'drift.ever.works',
+			content: 'old-target.example.com'
+		};
+		const { plugin, store } = await loadedPlugin(BASE_SETTINGS, [initial]);
+		const after = await plugin.ensureRecord({
+			host: 'drift.ever.works',
+			type: 'CNAME',
+			target: 'new-target.example.com'
+		});
+		expect(after.id).toBe('rec_existing');
+		expect(after.content).toBe('new-target.example.com');
+		expect(store.get('rec_existing')?.content).toBe('new-target.example.com');
+		// no new records were appended
+		expect([...store.values()]).toHaveLength(1);
+	});
+
+	it('removeRecord deletes an existing CNAME record', async () => {
+		const initial: FakeRecord = {
+			id: 'rec_delete_me',
+			type: 'CNAME',
+			name: 'gone.ever.works',
+			content: 'works-lb.example.com'
+		};
+		const { plugin, store } = await loadedPlugin(BASE_SETTINGS, [initial]);
+		await plugin.removeRecord({ host: 'gone.ever.works', type: 'CNAME' });
+		expect(store.size).toBe(0);
+	});
+
+	it('removeRecord without an explicit type probes both CNAME and A', async () => {
+		const aRecord: FakeRecord = {
+			id: 'rec_a',
+			type: 'A',
+			name: 'apex.ever.works',
+			content: '1.2.3.4'
+		};
+		const { plugin, store } = await loadedPlugin(BASE_SETTINGS, [aRecord]);
+		await plugin.removeRecord({ host: 'apex.ever.works' });
+		expect(store.size).toBe(0);
+	});
+
+	it('recordExists returns true when ANY record (CNAME or A) is present', async () => {
+		const aRecord: FakeRecord = {
+			id: 'rec_collision',
+			type: 'A',
+			name: 'taken.ever.works',
+			content: '1.2.3.4'
+		};
+		const { plugin } = await loadedPlugin(BASE_SETTINGS, [aRecord]);
+		expect(await plugin.recordExists('taken.ever.works')).toBe(true);
+		expect(await plugin.recordExists('free.ever.works')).toBe(false);
+	});
+
+	it('throws CloudflareDnsPluginError on non-2xx Cloudflare responses', async () => {
+		// Stub fetch that always returns 500 with success: false.
+		const failingFetch: typeof fetch = vi.fn(
+			async () =>
+				new Response(JSON.stringify({ success: false, errors: [{ code: 99, message: 'boom' }] }), {
+					status: 500,
+					headers: { 'Content-Type': 'application/json' }
+				})
+		) as unknown as typeof fetch;
+		const plugin = new CloudflareDnsPlugin(failingFetch);
+		await plugin.onLoad(createMockContext(BASE_SETTINGS));
+		await expect(plugin.recordExists('whatever.ever.works')).rejects.toBeInstanceOf(CloudflareDnsPluginError);
+	});
+
+	it('rejects invalid host names', async () => {
+		const { plugin } = await loadedPlugin();
+		await expect(
+			plugin.ensureRecord({ host: 'BAD HOST!', type: 'CNAME', target: 'x.example.com' })
+		).rejects.toThrow(/Invalid host/);
+	});
+});

--- a/packages/plugins/cloudflare-dns/src/cloudflare-dns.plugin.ts
+++ b/packages/plugins/cloudflare-dns/src/cloudflare-dns.plugin.ts
@@ -1,0 +1,370 @@
+import type {
+	DnsEnsureRecordInput,
+	DnsRecordSnapshot,
+	DnsRecordType,
+	DnsRemoveRecordInput,
+	IDnsProvider,
+	IPlugin,
+	JsonSchema,
+	PluginCategory,
+	PluginContext,
+	PluginHealthCheck,
+	PluginManifest,
+	PluginSettings
+} from '@ever-works/plugin';
+
+import { cloudflareDnsSettingsSchema, type CloudflareDnsSettings } from './settings.schema.js';
+
+/**
+ * EW-738 — `@ever-works/cloudflare-dns` plugin.
+ *
+ * Wraps the Cloudflare v4 REST API behind the `IDnsProvider` capability
+ * contract (EW-735). Supports both operator modes:
+ *
+ *   - **Managed** — platform's own zone (`ever.works`). Credentials come
+ *     from `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ZONE_ID` env vars resolved
+ *     through the `x-envVar` fallbacks declared on the settings schema.
+ *   - **Bring-your-own** — user-supplied token + zone for a custom domain.
+ *     Values flow in via encrypted user-scoped plugin settings.
+ *
+ * Additive — this plugin coexists with the legacy
+ * `CloudflareDnsProvider` in `@ever-works/agent`. The new
+ * `PluginRegistryService` resolution path prefers the plugin when present
+ * and falls back to the legacy provider otherwise.
+ */
+export class CloudflareDnsPlugin implements IPlugin, IDnsProvider {
+	readonly id = 'cloudflare-dns';
+	readonly name = 'Cloudflare DNS';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'dns';
+	readonly capabilities: readonly string[] = [
+		'dns',
+		'dns-ensure-record',
+		'dns-remove-record',
+		'dns-record-exists',
+		'dns-root-domain'
+	];
+	readonly providerName = 'cloudflare';
+
+	readonly configurationMode: 'admin-only' | 'user-required' | 'hybrid' = 'hybrid';
+
+	readonly settingsSchema: JsonSchema = cloudflareDnsSettingsSchema;
+
+	/**
+	 * Default base URL. Overridable per-call (or via a test override) — the
+	 * Cloudflare staging mirror occasionally needs a different host.
+	 */
+	private static readonly DEFAULT_API_BASE = 'https://api.cloudflare.com/client/v4';
+
+	private context?: PluginContext;
+
+	/** Test seam — tests can inject a custom fetch impl. */
+	constructor(private readonly fetchImpl: typeof fetch = fetch) {}
+
+	// IPlugin lifecycle -----------------------------------------------------
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+		context.logger.log('Cloudflare DNS plugin loaded');
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		return {
+			status: 'healthy',
+			message: 'Cloudflare DNS plugin is ready (zone reachability is per-token)',
+			checkedAt: Date.now()
+		};
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description:
+				'Manage Cloudflare DNS records for managed *.ever.works subdomains and bring-your-own custom zones',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			author: { name: 'Ever Works Team' },
+			license: 'AGPL-3.0',
+			builtIn: true,
+			autoEnable: false,
+			visibility: 'user-only',
+			distribution: 'registry',
+			uiHints: {
+				completionFields: ['apiToken', 'zoneId']
+			},
+			readme: [
+				'## What is the Cloudflare DNS plugin?',
+				'',
+				'This plugin lets Ever Works create, update, and remove DNS records on Cloudflare for the subdomains and custom domains your Works are served from.',
+				'',
+				'## Modes',
+				'',
+				'- **Managed** — the platform automatically claims `<slug>.ever.works` for every Work you deploy. Operator-side; credentials live in env vars (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID`, `EVER_WORKS_DEPLOY_LB_HOSTNAME`).',
+				'- **Bring your own** — connect a Cloudflare token + zone for a domain you own (e.g. `acme.com`). Records are created with the proxy off by default so you can keep serving your own TLS.',
+				'',
+				'## Required scopes',
+				'',
+				'The Cloudflare API token must include `DNS:Edit` for the target zone. Create one at https://dash.cloudflare.com/profile/api-tokens.'
+			].join('\n'),
+			homepage: 'https://dash.cloudflare.com'
+		};
+	}
+
+	// IDnsOperations contract ------------------------------------------------
+
+	async ensureRecord(input: DnsEnsureRecordInput): Promise<DnsRecordSnapshot> {
+		const settings = await this.resolveSettings();
+		const host = this.normalizeHost(input.host);
+		const proxied = input.proxied ?? settings.proxied ?? false;
+		const ttl = input.ttl ?? 1;
+		const existing = await this.findRecord(settings, host, input.type);
+		if (existing) {
+			if (existing.content === input.target && existing.type === input.type) {
+				this.log(`Cloudflare DNS ${input.type} already in sync ${host} -> ${input.target}`);
+				return existing;
+			}
+			const updated = await this.patchRecord(settings, existing.id, {
+				type: input.type,
+				name: host,
+				content: input.target,
+				proxied,
+				ttl
+			});
+			this.log(`Cloudflare DNS ${input.type} updated ${host}: was ${existing.content} now ${input.target}`);
+			return updated;
+		}
+		const created = await this.createRecord(settings, {
+			type: input.type,
+			name: host,
+			content: input.target,
+			proxied,
+			ttl
+		});
+		this.log(`Cloudflare DNS ${input.type} created ${host} -> ${input.target}`);
+		return created;
+	}
+
+	async removeRecord(input: DnsRemoveRecordInput): Promise<void> {
+		const settings = await this.resolveSettings();
+		const host = this.normalizeHost(input.host);
+		const typesToProbe: DnsRecordType[] = input.type ? [input.type] : ['CNAME', 'A'];
+		for (const type of typesToProbe) {
+			const existing = await this.findRecord(settings, host, type);
+			if (existing) {
+				await this.deleteRecord(settings, existing.id);
+				this.log(`Cloudflare DNS ${existing.type} deleted ${host} (id=${existing.id})`);
+			}
+		}
+	}
+
+	async recordExists(host: string): Promise<boolean> {
+		const settings = await this.resolveSettings();
+		const normalized = this.normalizeHost(host);
+		const cname = await this.findRecord(settings, normalized, 'CNAME');
+		if (cname) return true;
+		const a = await this.findRecord(settings, normalized, 'A');
+		return a !== null;
+	}
+
+	rootDomain(): string {
+		// Resolution happens asynchronously, so this is a sync best-effort
+		// view. When the plugin has been loaded with a context we mirror the
+		// cached settings; otherwise we fall back to the schema default.
+		return this.cachedSettings?.rootDomain ?? 'ever.works';
+	}
+
+	// Settings + auth -------------------------------------------------------
+
+	private cachedSettings?: CloudflareDnsSettings;
+
+	/**
+	 * Resolve settings via PluginContext when available so user/work-scoped
+	 * values + env-var fallbacks (`x-envVar`) are merged consistently with
+	 * the rest of the plugin system. Falls back to reading the env vars
+	 * directly so the plugin remains usable from bootstrap contexts that
+	 * haven't yet wired a `PluginContext` (tests, CLI tools).
+	 */
+	private async resolveSettings(): Promise<CloudflareDnsSettings> {
+		const fromContext = await this.readContextSettings();
+		const apiToken = (fromContext.apiToken ?? process.env.CLOUDFLARE_API_TOKEN ?? '').trim();
+		const zoneId = (fromContext.zoneId ?? process.env.CLOUDFLARE_ZONE_ID ?? '').trim();
+		const rootDomain = (fromContext.rootDomain ?? process.env.EVER_WORKS_DOMAIN ?? 'ever.works').trim();
+		const targetHostname = (fromContext.targetHostname ?? process.env.EVER_WORKS_DEPLOY_LB_HOSTNAME ?? '').trim();
+		const proxied = fromContext.proxied ?? true;
+
+		if (!apiToken) {
+			throw new Error('Cloudflare DNS plugin: apiToken is required');
+		}
+		if (!zoneId) {
+			throw new Error('Cloudflare DNS plugin: zoneId is required');
+		}
+		const settings: CloudflareDnsSettings = {
+			apiToken,
+			zoneId,
+			rootDomain,
+			targetHostname,
+			proxied
+		};
+		this.cachedSettings = settings;
+		return settings;
+	}
+
+	private async readContextSettings(): Promise<Partial<CloudflareDnsSettings>> {
+		if (!this.context) return {};
+		try {
+			// `getResolvedSettings` merges user > work > admin > env > defaults
+			// per `SETTING_SOURCE_PRIORITY`.
+			const resolved = await this.context.getResolvedSettings();
+			return this.coerceSettings(resolved);
+		} catch {
+			try {
+				const raw = await this.context.getSettings();
+				return this.coerceSettings(raw);
+			} catch {
+				return {};
+			}
+		}
+	}
+
+	private coerceSettings(
+		bag: PluginSettings | Record<string, unknown> | null | undefined
+	): Partial<CloudflareDnsSettings> {
+		if (!bag || typeof bag !== 'object') return {};
+		const record = bag as Record<string, unknown>;
+		const out: Partial<CloudflareDnsSettings> = {};
+		if (typeof record.apiToken === 'string') out.apiToken = record.apiToken;
+		if (typeof record.zoneId === 'string') out.zoneId = record.zoneId;
+		if (typeof record.rootDomain === 'string') out.rootDomain = record.rootDomain;
+		if (typeof record.targetHostname === 'string') out.targetHostname = record.targetHostname;
+		if (typeof record.proxied === 'boolean') out.proxied = record.proxied;
+		return out;
+	}
+
+	// HTTP + Cloudflare v4 wire format --------------------------------------
+
+	private baseUrlFor(_settings: CloudflareDnsSettings): string {
+		return CloudflareDnsPlugin.DEFAULT_API_BASE.replace(/\/$/, '');
+	}
+
+	private async findRecord(
+		settings: CloudflareDnsSettings,
+		name: string,
+		type: DnsRecordType = 'CNAME'
+	): Promise<DnsRecordSnapshot | null> {
+		const url = new URL(`${this.baseUrlFor(settings)}/zones/${settings.zoneId}/dns_records`);
+		url.searchParams.set('name', name);
+		url.searchParams.set('type', type);
+		const json = await this.request<{ result: DnsRecordSnapshot[] }>(settings, url.toString(), {
+			method: 'GET'
+		});
+		return json.result[0] ?? null;
+	}
+
+	private async createRecord(
+		settings: CloudflareDnsSettings,
+		payload: {
+			type: DnsRecordType;
+			name: string;
+			content: string;
+			proxied: boolean;
+			ttl: number;
+		}
+	): Promise<DnsRecordSnapshot> {
+		const json = await this.request<{ result: DnsRecordSnapshot }>(
+			settings,
+			`${this.baseUrlFor(settings)}/zones/${settings.zoneId}/dns_records`,
+			{ method: 'POST', body: JSON.stringify(payload) }
+		);
+		return json.result;
+	}
+
+	private async patchRecord(
+		settings: CloudflareDnsSettings,
+		id: string,
+		payload: {
+			type: DnsRecordType;
+			name: string;
+			content: string;
+			proxied: boolean;
+			ttl: number;
+		}
+	): Promise<DnsRecordSnapshot> {
+		const json = await this.request<{ result: DnsRecordSnapshot }>(
+			settings,
+			`${this.baseUrlFor(settings)}/zones/${settings.zoneId}/dns_records/${id}`,
+			{ method: 'PUT', body: JSON.stringify(payload) }
+		);
+		return json.result;
+	}
+
+	private async deleteRecord(settings: CloudflareDnsSettings, id: string): Promise<void> {
+		await this.request(settings, `${this.baseUrlFor(settings)}/zones/${settings.zoneId}/dns_records/${id}`, {
+			method: 'DELETE'
+		});
+	}
+
+	private async request<T = unknown>(settings: CloudflareDnsSettings, url: string, init: RequestInit): Promise<T> {
+		const response = await this.fetchImpl(url, {
+			...init,
+			headers: {
+				Authorization: `Bearer ${settings.apiToken}`,
+				'Content-Type': 'application/json',
+				...(init.headers ?? {})
+			}
+		});
+		let body: unknown;
+		try {
+			body = await response.json();
+		} catch {
+			body = null;
+		}
+		const bodyObj = body as { success?: boolean; errors?: unknown } | null;
+		if (!response.ok || (bodyObj && bodyObj.success === false)) {
+			const message = `Cloudflare API ${init.method ?? 'GET'} ${url} failed: ${response.status}`;
+			const err = new CloudflareDnsPluginError(message, response.status, bodyObj?.errors ?? bodyObj ?? null);
+			throw err;
+		}
+		return body as T;
+	}
+
+	private normalizeHost(host: string): string {
+		const trimmed = (host ?? '').trim().toLowerCase();
+		if (trimmed.length === 0 || trimmed.length > 253) {
+			throw new Error(`Invalid host for Cloudflare DNS: ${host}`);
+		}
+		const labelRe = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+		for (const label of trimmed.split('.')) {
+			if (!labelRe.test(label) || label.length > 63) {
+				throw new Error(`Invalid host for Cloudflare DNS: ${host}`);
+			}
+		}
+		return trimmed;
+	}
+
+	private log(message: string): void {
+		this.context?.logger.log(message);
+	}
+}
+
+/**
+ * Error thrown when the Cloudflare API returns a non-2xx response or a
+ * `success: false` payload.
+ */
+export class CloudflareDnsPluginError extends Error {
+	constructor(
+		message: string,
+		readonly status: number,
+		readonly errors: unknown
+	) {
+		super(message);
+		this.name = 'CloudflareDnsPluginError';
+	}
+}
+
+export default CloudflareDnsPlugin;

--- a/packages/plugins/cloudflare-dns/src/index.ts
+++ b/packages/plugins/cloudflare-dns/src/index.ts
@@ -1,0 +1,6 @@
+export {
+	CloudflareDnsPlugin,
+	CloudflareDnsPluginError,
+	CloudflareDnsPlugin as default
+} from './cloudflare-dns.plugin.js';
+export { cloudflareDnsSettingsSchema, type CloudflareDnsSettings } from './settings.schema.js';

--- a/packages/plugins/cloudflare-dns/src/settings.schema.ts
+++ b/packages/plugins/cloudflare-dns/src/settings.schema.ts
@@ -1,0 +1,74 @@
+import type { JsonSchema } from '@ever-works/plugin';
+
+/**
+ * EW-738 — JSON Schema for the `@ever-works/cloudflare-dns` plugin
+ * settings. Matches the authoritative definition in
+ * `docs/specs/features/cloudflare-dns-plugin/spec.md` §4.2.
+ *
+ * The plugin supports two operator modes (G4 in the spec):
+ *
+ *   - **Managed** — the platform's own zone (`ever.works`). Operators set
+ *     `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID`, and
+ *     `EVER_WORKS_DEPLOY_LB_HOSTNAME` via env vars at the platform tier and
+ *     no user-visible settings UI is exposed for them.
+ *   - **Bring-your-own** — a user supplies their own Cloudflare token + zone
+ *     for a custom apex/domain. Values are persisted to encrypted plugin
+ *     settings (`x-secret` + `x-scope: 'user'`).
+ *
+ * `x-envVar` fallbacks let the plugin keep working in dev environments that
+ * still wire credentials via the `CLOUDFLARE_*` / `EVER_WORKS_*` env vars
+ * the legacy `CloudflareDnsProvider` reads today — the resolver in
+ * `PluginContext.getResolvedSettings` will pick them up automatically.
+ */
+export const cloudflareDnsSettingsSchema: JsonSchema = {
+	type: 'object',
+	properties: {
+		apiToken: {
+			type: 'string',
+			title: 'Cloudflare API token',
+			description:
+				'Scoped Cloudflare API token with DNS:Edit on the target zone. Create one at https://dash.cloudflare.com/profile/api-tokens.',
+			'x-secret': true,
+			'x-envVar': 'CLOUDFLARE_API_TOKEN',
+			'x-scope': 'user'
+		},
+		zoneId: {
+			type: 'string',
+			title: 'Cloudflare zone id',
+			description: 'The Cloudflare zone id that owns the root domain.',
+			'x-envVar': 'CLOUDFLARE_ZONE_ID',
+			'x-scope': 'user'
+		},
+		rootDomain: {
+			type: 'string',
+			title: 'Root domain',
+			description: 'The DNS zone managed by this provider, e.g. ever.works.',
+			default: 'ever.works',
+			'x-envVar': 'EVER_WORKS_DOMAIN'
+		},
+		targetHostname: {
+			type: 'string',
+			title: 'Ingress LB hostname',
+			description:
+				'CNAME target — the load balancer hostname that public Work subdomains should resolve to. Admin-only for the managed mode.',
+			'x-envVar': 'EVER_WORKS_DEPLOY_LB_HOSTNAME',
+			'x-adminOnly': true
+		},
+		proxied: {
+			type: 'boolean',
+			title: 'Cloudflare proxy',
+			description:
+				'Whether new records are created behind the Cloudflare orange-cloud proxy (recommended for managed *.ever.works records — gives Universal SSL out of the box). Set to false for custom-domain records the user already serves TLS for.',
+			default: true
+		}
+	},
+	required: ['apiToken', 'zoneId']
+};
+
+export interface CloudflareDnsSettings {
+	apiToken: string;
+	zoneId: string;
+	rootDomain: string;
+	targetHostname: string;
+	proxied: boolean;
+}

--- a/packages/plugins/cloudflare-dns/tsconfig.json
+++ b/packages/plugins/cloudflare-dns/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/cloudflare-dns/tsup.config.ts
+++ b/packages/plugins/cloudflare-dns/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/cloudflare-dns/vitest.config.ts
+++ b/packages/plugins/cloudflare-dns/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -306,6 +306,49 @@ describe('KubernetesPlugin.getDeploymentSecrets', () => {
 			expect(v).not.toContain('kind: Config');
 		}
 	});
+
+	// EW-741 — additional Ingress hosts (custom domains) ride alongside the
+	// managed subdomain via `K8S_EXTRA_HOSTS`. The plugin dedupes against the
+	// primary, lowercases, drops blanks, and only emits the secret when there
+	// is something to say — so existing single-host Works see zero secret
+	// churn.
+	it('emits K8S_EXTRA_HOSTS (comma-separated, deduped against ingressHost) when extraHosts present', async () => {
+		const out = await plugin.getDeploymentSecrets({
+			ingressHost: 'managed.example.com',
+			extraHosts: ['foo.example.com', 'bar.example.com', 'managed.example.com', 'FOO.example.com']
+		});
+		expect(out.K8S_INGRESS_HOST).toBe('managed.example.com');
+		expect(out.K8S_EXTRA_HOSTS).toBe('foo.example.com,bar.example.com');
+	});
+
+	it('does NOT emit K8S_EXTRA_HOSTS when the array is empty or absent', async () => {
+		const noExtras = await plugin.getDeploymentSecrets({
+			ingressHost: 'managed.example.com'
+		});
+		expect(noExtras.K8S_EXTRA_HOSTS).toBeUndefined();
+		const emptyArray = await plugin.getDeploymentSecrets({
+			ingressHost: 'managed.example.com',
+			extraHosts: []
+		});
+		expect(emptyArray.K8S_EXTRA_HOSTS).toBeUndefined();
+	});
+
+	it('does NOT emit K8S_EXTRA_HOSTS when every extraHost duplicates the primary', async () => {
+		const out = await plugin.getDeploymentSecrets({
+			ingressHost: 'managed.example.com',
+			extraHosts: ['managed.example.com', '  MANAGED.example.com  ', '']
+		});
+		expect(out.K8S_EXTRA_HOSTS).toBeUndefined();
+	});
+
+	it('drops non-string entries in extraHosts silently', async () => {
+		const out = await plugin.getDeploymentSecrets({
+			ingressHost: 'managed.example.com',
+			// Simulates a malformed settings blob that slipped through.
+			extraHosts: ['ok.example.com', null as unknown as string, 42 as unknown as string]
+		});
+		expect(out.K8S_EXTRA_HOSTS).toBe('ok.example.com');
+	});
 });
 
 describe('KubernetesPlugin.getWorkflowFilenames', () => {

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -683,6 +683,25 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		if (cfg.kubeContext) out.K8S_KUBE_CONTEXT = cfg.kubeContext;
 		if (cfg.ingressClass) out.K8S_INGRESS_CLASS = cfg.ingressClass;
 		if (cfg.ingressHost) out.K8S_INGRESS_HOST = cfg.ingressHost;
+		// EW-741 — additional Ingress hosts (custom domains). Deduped against
+		// `ingressHost`; comma-separated for the workflow renderer. Skipped
+		// when the list is empty so the secret is only written for Works that
+		// actually have custom domains attached.
+		if (Array.isArray(cfg.extraHosts) && cfg.extraHosts.length > 0) {
+			const primary = cfg.ingressHost?.trim().toLowerCase();
+			const seen = new Set<string>();
+			const extras: string[] = [];
+			for (const host of cfg.extraHosts) {
+				if (typeof host !== 'string') continue;
+				const normalized = host.trim().toLowerCase();
+				if (!normalized) continue;
+				if (primary && normalized === primary) continue;
+				if (seen.has(normalized)) continue;
+				seen.add(normalized);
+				extras.push(normalized);
+			}
+			if (extras.length > 0) out.K8S_EXTRA_HOSTS = extras.join(',');
+		}
 		if (cfg.tlsIssuer) out.K8S_TLS_ISSUER = cfg.tlsIssuer;
 		if (cfg.replicas) out.K8S_REPLICAS = String(clampReplicas(cfg.replicas));
 
@@ -728,6 +747,12 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		}
 		if (typeof raw.ingressClass === 'string') out.ingressClass = raw.ingressClass;
 		if (typeof raw.ingressHost === 'string') out.ingressHost = raw.ingressHost;
+		// EW-741 — additional hosts injected by the deploy orchestrator. Only
+		// string entries are accepted; non-string elements are silently dropped
+		// so a malformed setting can't surface a TypeError downstream.
+		if (Array.isArray(raw.extraHosts)) {
+			out.extraHosts = raw.extraHosts.filter((h): h is string => typeof h === 'string');
+		}
 		if (typeof raw.tlsIssuer === 'string') out.tlsIssuer = raw.tlsIssuer;
 		if (typeof raw.replicas === 'number') out.replicas = raw.replicas;
 

--- a/packages/plugins/k8s/src/types.ts
+++ b/packages/plugins/k8s/src/types.ts
@@ -96,6 +96,18 @@ export interface KubernetesSettings {
 	ingressClass?: string;
 	/** Default ingress host when a work has no custom domain. */
 	ingressHost?: string;
+	/**
+	 * Additional Ingress hosts (EW-741). Combined with `ingressHost` so the
+	 * Ingress serves the managed subdomain AND every active custom domain
+	 * simultaneously. The deploy orchestrator (`applyManagedSubdomain`) is
+	 * the source of truth — it merges `[managedSubdomain] ++ [custom domains]`
+	 * here so the k8s plugin's `getDeploymentSecrets` can surface a
+	 * comma-separated `K8S_EXTRA_HOSTS` secret for the workflow renderer.
+	 *
+	 * Empty / missing means "no additional hosts" — the Ingress has a single
+	 * rule for `ingressHost`. Never replaces the managed subdomain.
+	 */
+	extraHosts?: string[];
 	/** cert-manager `ClusterIssuer` name. */
 	tlsIssuer?: string;
 	/** Pod replicas (default 1, max 10 in v1). */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,7 +112,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(5a85a5ded3d25f66ced0fbf35319504e)
+        version: 2.3.4(f0dcba1e485c238fc475e14ff5f0d534)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.0)(rxjs@7.8.2)
@@ -245,16 +245,16 @@ importers:
         version: link:../../packages/plugins/minio
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -354,7 +354,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   apps/docs:
     dependencies:
@@ -491,13 +491,13 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -533,7 +533,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   apps/mcp:
     dependencies:
@@ -597,7 +597,7 @@ importers:
         version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   apps/web:
     dependencies:
@@ -944,13 +944,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -1038,7 +1038,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/contracts:
     devDependencies:
@@ -1053,7 +1053,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/email-templates:
     dependencies:
@@ -1084,7 +1084,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/monitoring:
     dependencies:
@@ -1115,7 +1115,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -1209,7 +1209,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/activepieces:
     devDependencies:
@@ -1227,7 +1227,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/agent-pipeline:
     dependencies:
@@ -1276,7 +1276,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/agentmemory:
     devDependencies:
@@ -1294,7 +1294,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/anthropic:
     dependencies:
@@ -1319,7 +1319,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/apify:
     dependencies:
@@ -1344,7 +1344,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/aws-s3:
     dependencies:
@@ -1369,7 +1369,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/brave:
     devDependencies:
@@ -1387,7 +1387,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/brightdata:
     dependencies:
@@ -1409,7 +1409,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/claude-code:
     devDependencies:
@@ -1427,7 +1427,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/claude-managed-agent:
     devDependencies:
@@ -1448,7 +1448,25 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  packages/plugins/cloudflare-dns:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/codex:
     dependencies:
@@ -1470,7 +1488,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/comparison-generator:
     devDependencies:
@@ -1491,7 +1509,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/composio:
     dependencies:
@@ -1513,7 +1531,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/discord-channel:
     dependencies:
@@ -1532,7 +1550,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/everworks-skills:
     dependencies:
@@ -1551,7 +1569,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/everworks-task-tracker:
     dependencies:
@@ -1567,7 +1585,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/exa:
     dependencies:
@@ -1589,7 +1607,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/firecrawl:
     dependencies:
@@ -1611,7 +1629,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/gemini:
     devDependencies:
@@ -1629,7 +1647,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/github:
     dependencies:
@@ -1660,7 +1678,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/github-storage:
     dependencies:
@@ -1682,7 +1700,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/google:
     dependencies:
@@ -1707,7 +1725,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/grok:
     dependencies:
@@ -1732,7 +1750,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/groq:
     dependencies:
@@ -1757,7 +1775,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/hermes-agent:
     devDependencies:
@@ -1775,7 +1793,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/jina:
     devDependencies:
@@ -1793,7 +1811,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/k8s:
     dependencies:
@@ -1821,7 +1839,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/langfuse:
     dependencies:
@@ -1843,7 +1861,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/linkup:
     devDependencies:
@@ -1861,7 +1879,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/lm-studio:
     dependencies:
@@ -1886,7 +1904,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/local-content-extractor:
     dependencies:
@@ -1920,7 +1938,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/local-fs:
     devDependencies:
@@ -1938,7 +1956,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/mailchimp-transactional:
     dependencies:
@@ -1960,7 +1978,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/mailgun:
     dependencies:
@@ -1985,7 +2003,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/make:
     devDependencies:
@@ -2003,7 +2021,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/memory-pipeline-modifier:
     devDependencies:
@@ -2021,7 +2039,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/minio:
     dependencies:
@@ -2049,7 +2067,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/mistral:
     dependencies:
@@ -2074,7 +2092,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/notion-extractor:
     dependencies:
@@ -2099,7 +2117,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/novu-channel:
     dependencies:
@@ -2118,7 +2136,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/ollama:
     dependencies:
@@ -2143,7 +2161,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/openai:
     dependencies:
@@ -2168,7 +2186,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/opencode:
     dependencies:
@@ -2193,7 +2211,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/openrouter:
     dependencies:
@@ -2218,7 +2236,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/pdf-extractor:
     dependencies:
@@ -2243,7 +2261,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/perplexity:
     dependencies:
@@ -2265,7 +2283,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/pgvector:
     dependencies:
@@ -2290,7 +2308,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/postmark:
     dependencies:
@@ -2312,7 +2330,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/qdrant:
     dependencies:
@@ -2334,7 +2352,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/resend:
     dependencies:
@@ -2356,7 +2374,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/scrapfly:
     dependencies:
@@ -2378,7 +2396,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/screenshotone:
     dependencies:
@@ -2400,7 +2418,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/sendgrid:
     dependencies:
@@ -2422,7 +2440,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/serpapi:
     devDependencies:
@@ -2440,7 +2458,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/sim-ai:
     dependencies:
@@ -2462,7 +2480,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/slack-channel:
     dependencies:
@@ -2484,7 +2502,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/standard-pipeline:
     dependencies:
@@ -2515,7 +2533,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/tavily:
     dependencies:
@@ -2537,7 +2555,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/telegram-channel:
     dependencies:
@@ -2559,7 +2577,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/urlbox:
     dependencies:
@@ -2581,7 +2599,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/valyu:
     dependencies:
@@ -2603,7 +2621,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/vercel:
     dependencies:
@@ -2625,7 +2643,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/vercel-ai-gateway:
     dependencies:
@@ -2650,7 +2668,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/vllm:
     dependencies:
@@ -2675,7 +2693,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/whatsapp-channel:
     dependencies:
@@ -2694,7 +2712,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/zapier:
     dependencies:
@@ -2719,7 +2737,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/tasks:
     dependencies:
@@ -2774,7 +2792,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
 packages:
 
@@ -7221,9 +7239,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@oxc-project/types@0.127.0':
-    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
-
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
@@ -8341,34 +8356,16 @@ packages:
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.0.3':
     resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.3':
@@ -8377,36 +8374,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.0.3':
     resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
     resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
@@ -8415,13 +8393,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -8429,24 +8400,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -8457,26 +8414,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
@@ -8485,33 +8428,16 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
   '@rolldown/binding-wasm32-wasi@1.0.3':
     resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
     resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
@@ -8519,20 +8445,11 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
   '@rolldown/binding-win32-x64-msvc@1.0.3':
     resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
-
-  '@rolldown/pluginutils@1.0.0-rc.17':
-    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -17816,11 +17733,6 @@ packages:
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
 
-  rolldown@1.0.0-rc.17:
-    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -19402,49 +19314,6 @@ packages:
     peerDependencies:
       vite: '>=7.3.2'
 
-  vite@8.0.10:
-    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
-      esbuild: '>=0.28.1'
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      esbuild:
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -20141,6 +20010,17 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
+  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      jsonc-parser: 3.3.1
+      picomatch: 4.0.4
+      rxjs: 7.8.1
+      source-map: 0.7.4
+    optionalDependencies:
+      chokidar: 3.6.0
+
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -20162,6 +20042,16 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
+      - chokidar
+
+  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.17
+      ora: 5.4.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -24722,7 +24612,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(5a85a5ded3d25f66ced0fbf35319504e)':
+  '@nestjs-modules/mailer@2.3.4(f0dcba1e485c238fc475e14ff5f0d534)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -24740,7 +24630,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.0
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.1)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@4.0.3)
+      nunjucks: 3.2.4(chokidar@3.6.0)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -24767,7 +24657,36 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
+      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+      ansis: 4.2.0
+      chokidar: 4.0.3
+      cli-table3: 0.6.5
+      commander: 4.1.1
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
+      glob: 13.0.6
+      node-emoji: 1.11.0
+      ora: 5.4.1
+      tsconfig-paths: 4.2.0
+      tsconfig-paths-webpack-plugin: 4.2.0
+      typescript: 5.9.3
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
+      webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@types/node'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -24796,7 +24715,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -24807,17 +24726,17 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21)))
       glob: 13.0.6
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.33(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -24919,6 +24838,17 @@ snapshots:
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
+
+  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
+      comment-json: 4.6.2
+      jsonc-parser: 3.3.1
+      pluralize: 8.0.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - chokidar
 
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
@@ -25798,8 +25728,6 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.0)
-
-  '@oxc-project/types@0.127.0': {}
 
   '@oxc-project/types@0.133.0': {}
 
@@ -27171,83 +27099,40 @@ snapshots:
 
   '@remirror/core-constants@3.0.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.3':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.0.3':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.0.3':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.0.3':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-openharmony-arm64@1.0.3':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.3':
@@ -27257,19 +27142,11 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.3':
     optional: true
-
-  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -27796,6 +27673,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)':
+    dependencies:
+      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 14.2.2
+      commander: 8.3.0
+      minimatch: 10.2.5
+      piscina: 4.9.2
+      semver: 7.8.1
+      slash: 3.0.0
+      source-map: 0.7.6
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      chokidar: 3.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
@@ -29104,15 +29000,6 @@ snapshots:
       msw: 2.12.10(@types/node@20.19.33)(typescript@5.9.3)
       vite: 8.0.16(@types/node@20.19.33)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.0
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.12.10(@types/node@22.19.11)(typescript@5.9.3)
-      vite: 8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
-
   '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.0
@@ -29121,16 +29008,15 @@ snapshots:
     optionalDependencies:
       msw: 2.12.10(@types/node@22.19.11)(typescript@5.9.3)
       vite: 8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
-    optional: true
 
-  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.0(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@24.12.2)(typescript@5.9.3)
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -36474,13 +36360,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@4.0.3):
+  nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 4.0.3
+      chokidar: 3.6.0
     optional: true
 
   nypm@0.6.5:
@@ -38864,27 +38750,6 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rolldown@1.0.0-rc.17:
-    dependencies:
-      '@oxc-project/types': 0.127.0
-      '@rolldown/pluginutils': 1.0.0-rc.17
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
-
   rolldown@1.0.3:
     dependencies:
       '@oxc-project/types': 0.133.0
@@ -40794,36 +40659,6 @@ snapshots:
       - supports-color
       - typescript
 
-  vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.0-rc.17
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 22.19.11
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.46.1
-      yaml: 2.8.3
-
-  vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.0-rc.17
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 24.12.2
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      terser: 5.46.1
-      yaml: 2.8.3
-
   vite@8.0.16(@types/node@20.19.33)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -40853,7 +40688,21 @@ snapshots:
       jiti: 2.6.1
       terser: 5.46.1
       yaml: 2.8.3
-    optional: true
+
+  vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.12.2
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.46.1
+      yaml: 2.8.3
 
   vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3))(vite@8.0.16(@types/node@20.19.33)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
@@ -40880,35 +40729,6 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 20.19.33
-      jsdom: 29.1.1(@noble/hashes@2.2.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.0
-      '@vitest/runner': 4.1.0
-      '@vitest/snapshot': 4.1.0
-      '@vitest/spy': 4.1.0
-      '@vitest/utils': 4.1.0
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 22.19.11
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
@@ -40941,12 +40761,11 @@ snapshots:
       jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - msw
-    optional: true
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.10(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.0(msw@2.12.10(@types/node@24.12.2)(typescript@5.9.3))(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -40963,7 +40782,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+      vite: 8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
Cascades latest stage to main.

Included since the previous stage->main cascade (#1321):

- #1322 (via cascade #1328) — feat(dns): EW-734 epic complete (foundation + EW-735/736/737/738/739/740/741 + #736 backfill). k8s managed-subdomain path gated behind \`K8S_MANAGED_SUBDOMAIN=true\` (default OFF).

Release branches preserved.