### PR TITLE
docs(specs): ADR-017 + spec-kit for tenant-scoped job-runtime overlay (EW-742 P0 / EW-743)

### DIFF
--- a/docs/specs/architecture/job-runtime-providers.md
+++ b/docs/specs/architecture/job-runtime-providers.md
@@ -248,7 +248,17 @@ packages/tasks/                      # remains the trigger provider's worker pac
                                      # (other pull providers get sibling worker entrypoints)
 ```
 
-## 11. See Also
+## 11. Tenant-Scoped Overlay (multi-tenant extension)
+
+This document defines the **instance-global** runtime selection (`EVER_WORKS_JOB_RUNTIME` chooses one provider per deployment). For multi-tenant deployments — Ever Works Cloud and any operator hosting multiple tenants on one instance — that single selection is the **fallback**; each tenant can layer an overlay on top to inherit, BYO credentials for the same provider, or override to a different *enabled* provider. The overlay reuses the dispatcher seam from this doc unchanged — it plugs in via a `TenantAwareRuntimeResolver` placed in front of the EW-685 binding factory.
+
+See the dedicated feature set for the overlay design:
+
+- [ADR-017](../decisions/017-tenant-scoped-job-runtime-overlay.md) — decision + rationale.
+- [`features/tenant-job-runtime-overlay/spec.md`](../features/tenant-job-runtime-overlay/spec.md) · [`plan.md`](../features/tenant-job-runtime-overlay/plan.md) · [`tasks.md`](../features/tenant-job-runtime-overlay/tasks.md) · [`providers.md`](../features/tenant-job-runtime-overlay/providers.md)
+- Jira: [EW-742](https://evertech.atlassian.net/browse/EW-742) (epic) · [EW-743](https://evertech.atlassian.net/browse/EW-743) (P0 spec-kit story).
+
+## 12. See Also
 
 - [ADR-015](../decisions/015-job-runtime-provider-pluggability.md) — decision + rationale.
 - [`features/job-runtime-providers/spec.md`](../features/job-runtime-providers/spec.md) · [`plan.md`](../features/job-runtime-providers/plan.md) · [`tasks.md`](../features/job-runtime-providers/tasks.md) · [`providers.md`](../features/job-runtime-providers/providers.md)

--- a/docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md
+++ b/docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md
@@ -1,0 +1,165 @@
+# ADR-017: Tenant-Scoped Job-Runtime Configuration Overlay — Per-tenant runtime selection + BYO credentials on top of the instance-global engine swap
+
+## Status
+
+**Proposed** — Tracking implementation in [EW-742](https://evertech.atlassian.net/browse/EW-742). This ADR is forward-looking; **nothing changes today**. Until the overlay exists, every tenant on a deployment uses the deployment's instance-global runtime selection from [ADR-015](./015-job-runtime-provider-pluggability.md) / [EW-683](https://evertech.atlassian.net/browse/EW-683) — that path is preserved as `inherit` mode and remains the default for every tenant after this ADR ships, so single-tenant self-hosters see zero behaviour change.
+
+## Date
+
+- 2026-06-17 — Initial.
+
+## Context
+
+[ADR-015](./015-job-runtime-provider-pluggability.md) makes the background-job runtime a pluggable provider chosen by the operator at deploy time, via the instance-global selector `EVER_WORKS_JOB_RUNTIME`. That ADR's [`spec.md` §6 "Out of Scope"](../features/job-runtime-providers/spec.md) and [FR-3](../features/job-runtime-providers/spec.md) both pin v1 to **one active runtime per deployment** — no per-tenant routing, no per-work routing. That was the correct call for the engine-swap problem; it is no longer sufficient for the **multi-tenant** deployment story.
+
+Two converging forces force the question now:
+
+1. **Ever Works Cloud is multi-tenant by definition.** The hosted platform must let one tenant run Trigger.dev SaaS on the operator's account, another tenant bring its own Trigger.dev project, a third use Temporal Cloud on its own namespace, all on the same API process. Instance-global selection cannot express that — every tenant gets whichever runtime the operator picked.
+
+2. **The directory-web-template demo→k8s-works cutover (June 2026) hit the gap in practice.** Eight Works belonging to a single tenant on `k8s-works` all needed their Trigger.dev wiring provisioned by hand: per-Work secret rows, per-Work env propagation, manual project creation in the operator's Trigger.dev SaaS dashboard. That work is wrong at the per-Work layer — **Works don't own credentials, tenants do**. Tenants own the billing relationship, the plugin entitlements, and the operator-of-record for whichever third-party SaaS the runtime points at. A Work is a deployed instance of generated content; it has no business holding a Trigger.dev secret.
+
+The plugin settings system already separates `global` / `user` / `work` scopes and resolves them through a cascade ([`settings-system.md` §2 "The Three Tiers"](../architecture/settings-system.md), §9 "Setting Resolution API"). The `x-scope` JSON-Schema extension currently exists only as a UI hint — the spec describes it as "Hint to the UI; the actual scope is inferred from where the user clicks" ([`settings-system.md` §3](../architecture/settings-system.md)). There is **no `tenant` value enumerated** for `x-scope` today, no `tenant_plugins` table parallel to `user_plugins` / `work_plugins`, and no tier between `global` and `user` in the resolution cascade. Phase 1 of this initiative's first sub-story therefore must either confirm `tenant` as a first-class value of `x-scope` (and add the storage tier behind it) or flag the gap explicitly — see Implementation outline P1.
+
+**Why per-tenant and not per-Work.** Tenants are the unit of billing, plugin entitlement, and operator-of-record. They are the unit that signs up for a Trigger.dev account, that holds a Temporal Cloud namespace, that pays for an Inngest seat. Works are derived: a Work belongs to a tenant; its background jobs run against the tenant's runtime, with the tenant's credentials. Per-Work routing creates N×M credential proliferation (N tenants × M works each) for zero credential authority gain. Per-Work routing remains **explicitly out of scope** and is still deferred from [EW-683 §6](../features/job-runtime-providers/spec.md).
+
+**Why not a separate selector environment variable per tenant.** Env vars are deploy-time, instance-wide, and singular — they cannot express per-tenant choice without a tenant-aware indirection layer in front, at which point we have rebuilt this overlay in a worse form (no UI, no audit, no rotation). The settings system already gives us encrypted-at-rest storage, redaction in API responses, env-var fallback for un-overridden keys, and the three-tier resolver. Adding a tenant tier is strictly less work than building a parallel mechanism.
+
+## Decision
+
+The job runtime gains a **tenant-scoped configuration overlay** on top of [ADR-015](./015-job-runtime-provider-pluggability.md)'s instance-global selection. The overlay is expressed as a new resolution tier in the settings system and a new `tenant_job_runtime_config` row per opted-in tenant; the existing `EVER_WORKS_JOB_RUNTIME` env continues to be the deployment-wide fallback when a tenant has no overlay row.
+
+### 1. Three-mode tenant trichotomy: INHERIT / BYO / OVERRIDE
+
+Each tenant resolves to exactly one of three modes. The mode is stored on `tenant_job_runtime_config.mode`; absence of a row is equivalent to `inherit`.
+
+- **`inherit`** (default for every tenant on overlay rollout) — the tenant uses the deployment's instance-global runtime selection from `EVER_WORKS_JOB_RUNTIME` and the deployment's instance-global provider credentials. Behaviour is byte-for-byte identical to pre-overlay; single-tenant self-hosters never leave this mode.
+- **`byo`** — the tenant uses the **same provider** as the instance-global selection but supplies its **own credentials** (own Trigger.dev project token, own Temporal Cloud namespace + mTLS bundle, own Inngest event/signing keys, etc.). The dispatcher routes to the tenant's provider instance; the worker host subscribes to the tenant's queue/namespace/project as well.
+- **`override`** — the tenant chooses a **different provider entirely** from the instance default, AND supplies its credentials. The chosen provider must be one of the instance's enabled `job-runtime` plugins (see point 4); the operator's plugin enable/disable list is the kill-switch.
+
+`byo` and `override` differ only in whether the tenant's provider id matches the instance default; the credential storage, dispatcher routing, and worker subscription mechanics are the same.
+
+### 2. Per-provider isolation choices (locked Q1–Q3; do not reopen)
+
+These are the multi-tenant isolation models per provider, decided in the spec-kit Q&A pass and recorded here as authoritative:
+
+- **Temporal — one namespace per tenant.** The Temporal plugin's tenant-scope settings schema supplies `temporalHost`, `namespace`, and either mTLS cert/key OR API key per tenant. Strong isolation (Temporal namespaces are the native multi-tenancy boundary), maps cleanly to Temporal Cloud's billing-per-namespace model, and lets a tenant move to its own Temporal Cloud account by changing the connection bundle. **Cost**: workers must subscribe per-namespace, so worker fleet sizing scales with active-tenant count under non-inherit modes — quantified in Consequences below.
+- **pg-boss — one Postgres schema per tenant (`pgboss_tenant_<id>`).** Owned by the pg-boss plugin: the plugin creates the schema via its own migration on tenant onboarding, runs pg-boss `.start({ schema })` per tenant, and `DROP SCHEMA … CASCADE` on offboarding. Clean teardown story (no orphaned queue rows), per-tenant queue depth visibility via `pg_catalog`, and a clear boundary that satisfies "your jobs do not sit in a table next to another tenant's jobs."
+- **Inngest — uniform inherit/BYO trichotomy with Trigger.dev. No instance-only mode.** Inherit-mode tenants share the operator's Inngest Cloud account (same event key, same signing key, same app id) — operator pays. BYO/override tenants paste their own keys AND get a per-tenant webhook path (`/api/inngest/tenant/<tenantId>`) so the per-tenant signing key validates only that tenant's traffic. We deliberately rejected an "instance-only Inngest" middle mode: it would force every tenant onto operator credentials with no exit ramp, contradicting the "you own everything" principle.
+
+### 3. Credential rotation — graceful drain (locked Q4; do not reopen)
+
+Credentials are versioned. A `tenant_job_runtime_credential` row carries a monotonic `version`. The behaviour at rotation:
+
+- An enqueued run **captures the credential version** at enqueue time (stored on the run record / history row).
+- Status polls, cancels, and retries for that run use the **captured version** until the run reaches a terminal state — even if a newer credential version has been written in the meantime. This is the "graceful drain" guarantee: rotating a credential never strands an in-flight run.
+- New enqueues use the **latest** version. Once all runs captured under version N are terminal, version N can be garbage-collected (background job, not in this ADR's scope).
+
+There is a **separate admin action** for compromised-key incidents: `force-invalidate <credential-version>`. This immediately fails any in-flight run that captured the invalidated version (status → `FAILED` with reason `credential_invalidated`), forcing manual re-enqueue with current creds. It is **explicitly NOT coupled to routine rotation** — operators rotate keys all the time for hygiene; failing live runs on every routine rotation would make rotation operationally expensive and discourage it. Force-invalidate is the break-glass path; routine rotation is graceful.
+
+### 4. Platform-default for inherit-mode tenants — hybrid, operator-policy gated (locked Q5; do not reopen)
+
+When a tenant is in `inherit` mode and the deployment's instance-global provider is `trigger`, the operator picks one of three policies (instance-global env `EVER_WORKS_JOB_RUNTIME_TRIGGER_INHERIT_POLICY`):
+
+- **`shared`** (default) — all inherit-mode tenants route to **one platform Trigger.dev project** (the operator's). Simplest, cheapest, no signup-time provisioning latency. Acceptable for free tiers and for operators who don't want per-tenant Trigger.dev billing exposure.
+- **`per-tenant`** — on tenant signup, the platform auto-provisions a Trigger.dev project via the Trigger.dev management API (`POST /api/v1/orgs/{orgId}/projects` using the operator's PAT) and stores the resulting project ref + key on the tenant. Strongest isolation under inherit mode, at the cost of **signup latency** (one round-trip to Trigger.dev's management API per new tenant) — see Consequences.
+- **`tiered`** — free-plan tenants share (as `shared`); paid-plan tenants get auto-provisioned projects (as `per-tenant`). Plan→policy mapping is read from the billing tier metadata. Same provisioning-latency caveat applies on paid-tenant signup.
+
+The same trichotomy generalises naturally to `inngest` (shared event key vs per-tenant app) but is in scope here only for `trigger`, since that is the only provider where we already programmatically create top-level account objects today.
+
+### 5. Storage — `tenant_job_runtime_config` row in DB; env stays the fallback
+
+The overlay lives in a new DB table:
+
+```
+tenant_job_runtime_config
+  tenantId             uuid (pk)
+  mode                 enum('inherit','byo','override')
+  providerId           varchar  null  -- set when mode != 'inherit'
+  inheritPolicyVariant enum('shared','per-tenant','tiered') null
+  createdAt / updatedAt
+```
+
+Per-tenant credentials live in the existing settings-system encrypted column pattern (`secrets` jsonb, AES-256-GCM under `PLUGIN_SECRETS_ENCRYPTION_KEY`; see [`settings-system.md` §5 "Storage Layer"](../architecture/settings-system.md) and §7 "Secret Hygiene Boundary"). The provider plugin declares its tenant-scoped fields with `x-secret: true` and `x-scope: tenant`; the resolver routes those values into a new `tenant_plugins` storage row keyed by `(tenantId, pluginId)`. **The instance-global env `EVER_WORKS_JOB_RUNTIME` remains the fallback** for any tenant whose `tenant_job_runtime_config` row resolves to `inherit` or is absent.
+
+The resolution cascade in [`settings-system.md` §2](../architecture/settings-system.md) gains a `tenant` tier between `user` and `admin (global)`:
+
+```
+work → user → tenant → admin (global) → env var → schema default
+```
+
+### 6. Plugin gating — tenant override picker only shows instance-enabled providers
+
+A tenant in `override` mode can only choose from `job-runtime` plugins the operator has enabled at the instance level. The operator retains the kill-switch: disabling a plugin removes it from the tenant's override picker on the next render and causes any tenant currently in `override` mode against that plugin to fall back to `inherit` on next dispatch (with an operator-visible alert). This is the standard plugin-enablement guard, not a new mechanism.
+
+### What does NOT change
+
+- **Instance-global selection still works exactly as today.** A deployment with no tenant overlay rows behaves identically to ADR-015 v1; `EVER_WORKS_JOB_RUNTIME` is read at boot, bound to all dispatcher symbols, and serves every tenant via `inherit`.
+- **Single-tenant self-host deployments are unaffected** — they have one tenant, `inherit` mode, no overlay rows. No UI surface, no migration impact beyond an additive table.
+- **The [ADR-015](./015-job-runtime-provider-pluggability.md) dispatcher seam is unchanged.** This overlay plugs INTO the seam via a credential-resolver hook: the dispatcher factory now consults `tenant_job_runtime_config.resolve(tenantId)` before binding the provider's credential context to the call. Provider implementations themselves do not change shape — they receive a credential bundle as today, just resolved per-tenant.
+- **Per-Work routing stays out of scope** — still deferred from [EW-683 §6](../features/job-runtime-providers/spec.md). Works inherit their tenant's runtime, period.
+- **The agent business logic, the SuperJSON internal callback channel, and the pre-created `historyId` contract** are all unchanged from [ADR-015 "What does NOT change"](./015-job-runtime-provider-pluggability.md) — runtime credentials are the only new dimension.
+
+### Out of scope for this ADR
+
+- **Per-Work routing.** Still deferred, as above. A later ADR can address it if and when a real need appears (none today).
+- **Live migration of in-flight runs across providers.** Switching a tenant from one provider to another is a tenant-admin action; the old provider drains existing runs to terminal state, new enqueues route to the new provider from the cutover moment. No mid-run handoff. Same posture as [ADR-015 §"Out of scope"](./015-job-runtime-provider-pluggability.md).
+- **Self-serve Trigger.dev project provisioning from a tenant-facing UI.** Tenants in `byo`/`override` paste credentials they obtained themselves; the platform does not programmatically create Trigger.dev projects on the tenant's behalf. (The `per-tenant` inherit-policy auto-provisioning in §4 uses the **operator's** account, not the tenant's — different concern.) Self-serve provisioning could be a later UX layer; it is not load-bearing for this ADR.
+- **Cross-tenant queue sharing optimisations.** Each tenant's BYO/override runtime is isolated by design; we do not attempt to multiplex tenants onto shared workers behind the scenes.
+- **Choosing the runtime per-conversation, per-agent, per-skill.** Routing dimensions other than tenant are not addressed.
+
+### Constitution note
+
+No further amendment needed beyond [EW-685](https://evertech.atlassian.net/browse/EW-685)'s already-pending change to [Constitution Principle IV](https://github.com/ever-works/ever-works/blob/develop/.specify/memory/constitution.md). EW-685 generalises Principle IV from "Long-running work via Trigger.dev" to "Long-running work via the configured job-runtime provider." The new dimension this ADR introduces is **which tenant's** config resolves the runtime; the amended principle text already accommodates per-tenant resolution because it speaks to "the configured provider" without prescribing whose config configures it. The gate check in [`spec.md` §9](../features/job-runtime-providers/spec.md) inherits the same posture.
+
+## Consequences
+
+**Positive**
+
+- **Multi-tenant SaaS becomes a first-class deployment model**, not a workaround. Ever Works Cloud can host tenants with conflicting runtime choices side-by-side without per-tenant deployments or per-Work credential hacks.
+- **Tenants own their runtime spend and isolation.** A tenant moving to Temporal Cloud or a dedicated Trigger.dev project changes one settings page, not an operator ticket — strengthens the "you own everything, nothing locked in" promise at the tenant tier, not just the instance tier.
+- **Operator kill-switch is preserved.** The instance-enabled plugin list bounds what tenants may choose; the operator never loses the ability to retire a provider deployment-wide.
+- **Credential rotation no longer interrupts in-flight work.** Routine key hygiene becomes cheap, which makes it more likely to actually happen — a security win that compounds over time.
+- **The directory-web-template cutover pattern stops being manual.** Per-tenant Trigger.dev wiring becomes a self-serve settings flow rather than per-Work secret provisioning.
+
+**Negative**
+
+- **Signup latency under `per-tenant` inherit policy (Q5).** Auto-provisioning a Trigger.dev project on tenant signup adds a synchronous round-trip to the Trigger.dev management API (~300–1500 ms typical). Mitigations: provision asynchronously after signup with a "background runtime ready" indicator; back off to `shared` if provisioning fails; clearly document the trade vs `shared` default.
+- **Temporal Cloud namespace quota becomes a planning concern (Q1).** Each non-inherit Temporal tenant consumes a Temporal Cloud namespace, and namespace count is a billed dimension. Operators running large fleets on Temporal Cloud must plan capacity; the docs must surface this explicitly. Self-hosted Temporal has no equivalent hard limit but still pays in cluster ops.
+- **Postgres catalog bloat under `pg-boss` (Q2).** One schema per tenant means `pg_catalog` grows linearly with tenant count — schemas, sequences, indexes, triggers per tenant. Manageable up to low thousands of tenants on a well-tuned Postgres; beyond that, planner overhead and `pg_dump` time become real concerns. Mitigations: documented upper bound, optional "shared schema with `tenant_id` column" provider variant as a future opt-in for very large fleets.
+- **Worker fleet sizing under non-inherit modes.** Pull-model providers (Temporal, BullMQ, pg-boss) require a worker subscription per tenant queue/namespace. Worker count scales with active-tenant count, not just job volume. Sidecar/replica strategies are documented per provider in [`providers.md`](../features/job-runtime-providers/providers.md).
+- **Force-invalidate is a footgun if misused.** Operators must understand it fails live runs; the admin UI must surface that consequence prominently and require a typed confirmation.
+
+**Neutral**
+
+- **Additive DB schema only.** New `tenant_job_runtime_config` table + new storage tier for the settings system. No existing column or row changes shape. Forward-only migration, no rollback risk for existing data (Principle V).
+- **Per-tenant credentials reuse the existing `x-secret` boundary** ([`settings-system.md` §7](../architecture/settings-system.md)). Storage encryption, redaction, export masking, and MCP-response stripping all already apply — adding a tenant scope does not introduce a new secret-hygiene surface, only a new key dimension into the existing one.
+- **Inngest's licensing posture (SSPL, [`providers.md`](../features/job-runtime-providers/providers.md#inngest)) is unchanged** — still SaaS-only, still inherit/BYO only. The trichotomy uniformity with Trigger.dev is a clarity win, not a licensing change.
+- **Plugin SDK is forward-compatible.** Provider plugins that don't opt into tenant-scoped settings (e.g. a future provider authored before the tenant tier existed) keep working under `inherit` mode for every tenant — they simply do not expose a tenant-override path. Per Principle X.
+
+## Implementation outline
+
+Tracked in [EW-742](https://evertech.atlassian.net/browse/EW-742). Phasing mirrors [EW-683](https://evertech.atlassian.net/browse/EW-683)'s outline:
+
+1. **P0 — Spec-Kit writeup** ([EW-743](https://evertech.atlassian.net/browse/EW-743), this PR). ADR-017 + the parallel `spec.md` / `plan.md` / `tasks.md` updates under [`features/job-runtime-providers/`](../features/job-runtime-providers/spec.md), cross-linking to ADR-015. Flag the `x-scope: tenant` gap in [`settings-system.md` §3](../architecture/settings-system.md) and either confirm or queue Phase 1's first sub-story to add the value.
+2. **P1 — Data model + migration.** New `tenant_job_runtime_config` table; new `tenant_plugins` storage tier parallel to `user_plugins` / `work_plugins`; extend `PluginSettingsService.resolve` with the tenant tier; add `tenant` to `x-scope`'s accepted values + schema validator. Forward-only migration per Principle V.
+3. **P2 — Admin UI.** Tenant-admin settings page: mode picker (inherit/BYO/override), provider picker bounded by instance-enabled plugins, per-provider credential form rendered from the plugin's `settingsSchema` filtered to `x-scope: tenant` fields. Audit-log entries on every change per Principle VII.
+4. **P3 — Dispatcher routing.** Generalise the [ADR-015](./015-job-runtime-provider-pluggability.md) factory binding so each `*_DISPATCHER` symbol resolves to a tenant-aware delegate: at call time it reads the current `tenantId` from the call context, looks up `tenant_job_runtime_config`, and routes to the appropriate provider instance + credential version. Credential version captured onto the run/history row.
+5. **P4 — Worker host.** Worker entrypoints subscribe per-tenant for pull-model providers (Temporal namespaces, BullMQ queues, pg-boss schemas); push-model providers (Trigger.dev, Inngest) wire per-tenant webhook paths or per-tenant project tokens at boot, reloading on tenant-config changes. Per-provider sidecar/replica strategy documented in [`providers.md`](../features/job-runtime-providers/providers.md).
+6. **P5 — Plugin gating + inherit-policy enforcement.** Tenant override picker bounded by enabled plugins; instance env `EVER_WORKS_JOB_RUNTIME_TRIGGER_INHERIT_POLICY` enforced on inherit-mode tenants; auto-provisioning hook for `per-tenant` policy calls Trigger.dev management API via the operator's PAT.
+7. **P6 — Multi-tenant conformance.** Extend [ADR-015](./015-job-runtime-provider-pluggability.md)'s shared conformance suite with a tenant-isolation axis: two tenants with different credentials on the same provider MUST NOT see each other's runs, status, or cancellations. Force-invalidate path covered. Graceful-drain rotation covered.
+8. **P7 — Docs.** Per-provider tenant-onboarding guides; operator policy guide for the inherit-policy choice; security/rotation runbook; capacity-planning notes (Temporal namespace quotas, Postgres schema bloat thresholds).
+
+## References
+
+- [EW-742 — Tenant-scoped job-runtime configuration overlay (epic)](https://evertech.atlassian.net/browse/EW-742)
+- [EW-743 — [EW-742 P0] Spec-Kit writeup](https://evertech.atlassian.net/browse/EW-743)
+- [EW-683 — Job-runtime provider pluggability (parent epic)](https://evertech.atlassian.net/browse/EW-683)
+- [EW-685 — Job-runtime provider pluggability P0 (constitution amendment + contract)](https://evertech.atlassian.net/browse/EW-685)
+- [EW-686 — Job-runtime provider pluggability P1 (trigger plugin re-housing)](https://evertech.atlassian.net/browse/EW-686)
+- [ADR-015 — Job-Runtime Provider Pluggability](./015-job-runtime-provider-pluggability.md) — the instance-global engine swap this ADR overlays.
+- [ADR-005 — Cache and Lock Pluggability](./005-cache-and-lock-pluggability.md) — sibling pattern at the infra tier (env-selected backends); the tenant overlay is the same shape one level up.
+- [`architecture/job-runtime-providers.md`](../architecture/job-runtime-providers.md) — the provider contract this overlay plugs INTO via the credential-resolver hook.
+- [`architecture/settings-system.md`](../architecture/settings-system.md) — the resolution cascade and `x-secret` boundary the tenant tier extends.
+- [`features/job-runtime-providers/spec.md`](../features/job-runtime-providers/spec.md) · [`plan.md`](../features/job-runtime-providers/plan.md) · [`tasks.md`](../features/job-runtime-providers/tasks.md) · [`providers.md`](../features/job-runtime-providers/providers.md) — parent EW-683 spec set; this ADR's Phase 1+ updates extend them.
+- [Constitution Principle IV](https://github.com/ever-works/ever-works/blob/develop/.specify/memory/constitution.md) — amended under EW-685; this ADR relies on the amended text.
+- Platform repo PR #1092 — EW-683 spec-kit reference (structural template for this initiative's PR shape).

--- a/docs/specs/features/tenant-job-runtime-overlay/plan.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/plan.md
@@ -1,0 +1,344 @@
+# Implementation Plan: Tenant Job-Runtime Overlay
+
+> Translates [`spec.md`](./spec.md) into architecture and tech choices for tenant-scoped overlays atop the instance-global job-runtime selection of [EW-683](https://evertech.atlassian.net/browse/EW-683). Behaviour lives in the spec; this owns the "how." Per-provider research stays in the parent feature's [`providers.md`](../job-runtime-providers/providers.md). Rationale: [ADR-017](../../decisions/017-tenant-scoped-job-runtime-overlay.md). Deep architecture (the seam this extends): [`architecture/job-runtime-providers.md`](../../architecture/job-runtime-providers.md).
+
+**Feature ID**: `tenant-job-runtime-overlay`
+**Spec**: `./spec.md`
+**Tasks**: `./tasks.md`
+**Status**: `Draft`
+**Last updated**: 2026-06-18
+**Epic**: [EW-742](https://evertech.atlassian.net/browse/EW-742) · **Spec-kit story**: [EW-743](https://evertech.atlassian.net/browse/EW-743) · **Parent (instance-global runtime)**: [EW-683](https://evertech.atlassian.net/browse/EW-683) · **Dispatcher seam**: [EW-685](https://evertech.atlassian.net/browse/EW-685) · **Worker host**: [EW-686](https://evertech.atlassian.net/browse/EW-686)
+
+---
+
+## 1. Architecture Summary
+
+```mermaid
+flowchart LR
+	A[API dispatch call sites] -->|*_DISPATCHER symbols| R[TenantAwareRuntimeResolver]
+	R -->|tenant override| TC[(tenant_job_runtime_config)]
+	R -->|no override| G[Instance-global runtime\nEW-685 binding factory]
+	R --> P[Active IJobRuntimeProvider\n+ tenant credentials]
+	P -. inherit .-> SH[Shared platform deployment]
+	P -. byo / override .-> BYO[Tenant-supplied creds\n(secret ref + version)]
+	P --> W[Worker host\n(tenant-routed)]
+	W -->|/internal/jobs/webhook/:tenantId/*| A
+	W --> H[(WorkGenerationHistory\n+ runtime_credential_version)]
+```
+
+The instance-global seam built in [EW-683](https://evertech.atlassian.net/browse/EW-683) / [EW-685](https://evertech.atlassian.net/browse/EW-685) stays load-bearing. This feature inserts a `TenantAwareRuntimeResolver` in front of the existing binding factory: on every dispatch the resolver consults `tenant_job_runtime_config` for the tenant in scope; if a row exists and is `enabled`, its provider+credentials win; otherwise the call falls through to the instance-global provider with `mode = inherit`. Credential identity (`credential_version`) is captured into `WorkGenerationHistory` at enqueue so an in-flight run keeps using the credentials it started with, even if the tenant rotates them mid-run (Q4 graceful drain).
+
+## 2. Tech Choices
+
+| Concern                 | Choice                                                                                              | Rationale                                                                                              |
+| ----------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Persistence             | TypeORM entity `TenantJobRuntimeConfig` + forward-only migration in `apps/api/src/migrations/`      | Matches platform `database.md` rules; self-applied at API boot via `migrationsRun: true`               |
+| Secret storage          | `secret_ref` pointer into the existing AES-256-GCM `secrets` jsonb envelope used by plugin settings | Reuses `PLUGIN_SECRETS_ENCRYPTION_KEY` rotation envelope from [`settings-system.md`](../../architecture/settings-system.md) §5 |
+| Settings scope          | NEW `x-scope: tenant` value in plugin schema extensions                                             | First sub-story of P1; `x-scope` today is `global`/`user`/`work` only ([`settings-system.md`](../../architecture/settings-system.md) §3) |
+| Resolver placement      | NestJS request-scoped service `TenantAwareRuntimeResolver` in `packages/agent/src/tasks/`           | Sits in front of EW-685's binding factory; constructor-injected per dispatcher symbol                  |
+| Tenant credential cache | In-memory LRU keyed by `(tenant_id, credential_version)`, TTL ≤ 60s                                 | Avoids per-dispatch decrypt; version pinning makes invalidation deterministic                          |
+| Temporal multi-tenancy  | One **namespace per tenant** (Q1 locked); namespace name derived from `tenant_id`                   | Native isolation; control-plane quota risk tracked in §end                                             |
+| pg-boss multi-tenancy   | One **schema per tenant** (Q2 locked); schema name `pgboss_<tenant_id>`                             | Reuses tenant's existing Postgres; isolated migrations per schema                                      |
+| Inngest tenancy mode    | Uniform inherit / BYO with Trigger.dev (Q3 locked)                                                  | Both push-model SaaS; treated identically                                                              |
+| Push-model webhooks     | Per-tenant routes `/api/jobs/webhook/:tenantId/...` (Trigger.dev, Inngest)                          | Lets SaaS provider's webhook hit the right tenant context; signature verified per tenant signing key   |
+| Pull-model workers      | Multiplexing worker reads `tenant_id` from job metadata + injects per-tenant credentials at handler entry (BullMQ, pg-boss). Temporal uses per-namespace pollers (one Worker per active namespace; cold-start lazily) | Multiplex avoids N worker processes for queue-based runtimes; Temporal SDK binds a Worker to one namespace by design |
+| Inherit default mode    | Operator-gated `shared` / `per-tenant` / `tiered` (Q5 locked, env: `EVER_WORKS_INHERIT_DEFAULT_MODE`)| Lets ops trade signup latency vs blast-radius without code changes                                     |
+| Plugin gating           | Reuse existing instance operator allow-list from EW-683                                             | Per-tenant whitelist/blacklist deferred to v2 behind a flag                                            |
+
+## 3. Data Model
+
+### New entities
+
+`TenantJobRuntimeConfig` (`apps/api/src/works/entities/tenant-job-runtime-config.entity.ts`):
+
+| Column                     | Type                                              | Notes                                                                          |
+| -------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `tenant_id`                | `uuid` PRIMARY KEY                                | One row per tenant; FK to `tenants.id` ON DELETE CASCADE                       |
+| `provider_id`              | `varchar(64)` NOT NULL                            | Matches `IJobRuntimeProvider.runtimeId` (`trigger`/`temporal`/`bullmq`/`pgboss`/`inngest`) |
+| `credentials_secret_ref`   | `varchar(128)` NULL                               | Pointer into the encrypted secrets store; NULL when `mode = inherit`           |
+| `credential_version`       | `integer` NOT NULL DEFAULT 1                      | Bumped on every credential rotation; captured into `WorkGenerationHistory`     |
+| `mode`                     | `enum('inherit','byo','override')` NOT NULL       | `inherit` = use instance defaults; `byo` = tenant-owned creds; `override` = ops-imposed override |
+| `enabled`                  | `boolean` NOT NULL DEFAULT true                   | Soft-disable without losing config; resolver treats false as inherit           |
+| `created_by`               | `uuid` NULL                                       | FK to `users.id`; NULL for system-created rows                                 |
+| `created_at`               | `timestamptz` NOT NULL DEFAULT `now()`            |                                                                                |
+| `updated_at`               | `timestamptz` NOT NULL DEFAULT `now()`            | Bumped by `@UpdateDateColumn`                                                  |
+
+Indexes: PK on `tenant_id`; partial index `WHERE enabled = true` on `(provider_id)` for ops dashboards.
+
+### Extensions to existing entities
+
+`WorkGenerationHistory` (and the other `*_history` tables that mirror it) gains:
+
+| Column                       | Type            | Notes                                                                  |
+| ---------------------------- | --------------- | ---------------------------------------------------------------------- |
+| `runtime_provider_id`        | `varchar(64)` NULL | Provider that owned the enqueue; NULL = legacy/in-process              |
+| `runtime_credential_version` | `integer` NULL  | Snapshot of `tenant_job_runtime_config.credential_version` at enqueue  |
+| `tenant_id`                  | `uuid` NULL     | Denormalised for fast tenant-filtered history queries                  |
+
+### Migrations
+
+- Generated via `pnpm typeorm migration:generate -d typeorm.config.ts src/migrations/TenantJobRuntimeOverlay` per platform CLAUDE.md.
+- **Forward-only, two-phase** for the `*_history` column adds (per `database.md` §6.2 + workstation NN #16): add columns nullable → backfill `runtime_provider_id` from existing rows (set to `trigger` for any row with non-null `triggerRunId`) → switch reads → leave nullable forever.
+- Tenant-side provider schemas (Temporal namespaces, pg-boss schemas) are provisioned on first use by P4 worker code, **not** by a TypeORM migration — they live in the runtime's own control plane.
+
+### DTOs / contracts
+
+New types in `packages/plugin/src/job-runtime/tenant-overlay.contract.ts`:
+
+```ts
+export type TenantRuntimeMode = 'inherit' | 'byo' | 'override';
+
+export interface TenantRuntimeBinding {
+	tenantId: string;
+	providerId: JobRuntimeId;
+	mode: TenantRuntimeMode;
+	credentialVersion: number;
+	resolvedAt: Date;
+}
+
+export interface ITenantRuntimeResolver {
+	resolve(tenantId: string): Promise<TenantRuntimeBinding>;
+	invalidate(tenantId: string): Promise<void>;
+}
+```
+
+`@ever-works/contracts` is unchanged for external API consumers.
+
+## 4. API Surface
+
+Internal callback channel from EW-683 gains a tenant-routed variant. Aliases preserved for in-flight runs during rollout.
+
+| Method | Endpoint                                              | Description                                                          | Status      |
+| ------ | ----------------------------------------------------- | -------------------------------------------------------------------- | ----------- |
+| `POST` | `/internal/jobs/webhook/:tenantId/:provider`          | Push-model webhook ingress (Trigger.dev, Inngest); signature-verified| New         |
+| `POST` | `/internal/jobs/remote/call`                          | SuperJSON RPC (existing; gains `tenantId` header)                    | Extended    |
+| `GET`  | `/internal/jobs/works/:id/context`                    | Worker work/user/token context (existing; tenant-aware)              | Extended    |
+
+Tenant admin surface (under existing admin shell):
+
+| Method   | Endpoint                                              | Description                                                          | Status      |
+| -------- | ----------------------------------------------------- | -------------------------------------------------------------------- | ----------- |
+| `GET`    | `/api/admin/tenants/:tenantId/job-runtime`            | Read current overlay (secrets redacted per [`settings-system.md`](../../architecture/settings-system.md) §7) | New |
+| `PUT`    | `/api/admin/tenants/:tenantId/job-runtime`            | Upsert overlay; validates against provider's tenant-scope JSON Schema| New         |
+| `POST`   | `/api/admin/tenants/:tenantId/job-runtime/rotate`     | Bump `credential_version` (graceful drain — Q4)                      | New         |
+| `POST`   | `/api/admin/tenants/:tenantId/job-runtime/force-invalidate` | Hard credential kill switch; cancels in-flight runs (Q4)       | New         |
+| `DELETE` | `/api/admin/tenants/:tenantId/job-runtime`            | Revert to `inherit` (preserves history)                              | New         |
+
+## 5. Plugin Surface
+
+- **NEW schema extension** `x-scope: tenant` registered in `packages/plugin/src/settings/extensions.ts`; resolver step inserted between `work` and `user` in [`settings-system.md`](../../architecture/settings-system.md) §2 cascade.
+- Every job-runtime provider plugin (`packages/plugins/job-runtime-{trigger,temporal,bullmq,pgboss,inngest}`) **ships a second JSON Schema** alongside its global one: `tenantSettingsSchema` describing the BYO credential shape. The admin shell renders this schema-driven form dynamically — no provider-specific React.
+- Provider plugins gain two optional contract methods:
+	- `provisionTenant(tenantId, settings): Promise<{ secretRef, version }>` — called on first BYO save; for Temporal creates a namespace, for pg-boss creates `pgboss_<tenant_id>`, for Trigger.dev/Inngest documents the dashboard-paste workaround.
+	- `deprovisionTenant(tenantId): Promise<void>` — called on `DELETE` overlay if `mode = byo`.
+- Binding factory `packages/agent/src/tasks/job-runtime.providers.ts` (from EW-685) is wrapped — not replaced — by `packages/agent/src/tasks/tenant-aware-runtime.resolver.ts`.
+
+## 6. Web / CLI Surface
+
+- **Web (admin)**: new page `apps/web/src/app/admin/tenants/[tenantId]/job-runtime/page.tsx`. Reuses the existing JSON-Schema settings renderer (`components/settings/SchemaForm.tsx`) — the only new UI primitive is the provider picker, which is a `Select` driven by the operator allow-list.
+- **Web (tenant self-serve)**: deferred to v2 (admin-imposed first; tenant self-edit gated behind ops flag).
+- **CLI / internal-cli**: new `tenant-job-runtime` diagnostic command — print resolved binding + version for a given tenant id. Mirrors EW-683's `job-runtime status`.
+- **MCP**: none.
+
+## 7. Background Jobs
+
+This feature **does not introduce new recurring jobs**. Every existing schedule from EW-683 §7 (`schedule dispatcher`, `deploy-ready poller`, `agent heartbeat`, etc.) now routes through the tenant resolver. Two operational concerns drop out:
+
+- **Per-tenant schedule registration**: when a tenant flips to `byo`/`override`, the worker calls `provider.registerSchedules(schedules, { tenantId })`. Each provider maps `tenantId` onto its native namespacing (Temporal namespace, pg-boss schema, BullMQ key prefix, Trigger.dev project, Inngest app id).
+- **Drain job**: a one-shot internal task `tenant-runtime-drain` runs when `credential_version` bumps — it waits for all in-flight runs at the old version to terminate before deleting old credentials (Q4 graceful drain).
+
+## 8. Security & Permissions
+
+- Tenant credentials are `x-secret: true`, `x-scope: tenant`, stored in the encrypted envelope; never returned in API responses (same redactor as plugin settings).
+- The admin overlay endpoints require `tenant.admin` role; tenant self-serve (deferred v2) will require `tenant.owner`.
+- `/internal/jobs/webhook/:tenantId/*` validates the per-tenant signing key (Trigger.dev `TRIGGER_SECRET_KEY`, Inngest `INNGEST_SIGNING_KEY`) **bound to the tenant**, not the platform. Wrong signature for a tenant's webhook ⇒ 401, audit-logged.
+- `force-invalidate` is rate-limited (≤1/min/tenant) and emits a critical activity-log entry.
+- Air-gap providers (Temporal/BullMQ/pg-boss) MUST NOT contact any SaaS during tenant provisioning; verified by the air-gap compose profile test extended in P6.
+
+## 9. Observability
+
+- `WorkGenerationHistory` keeps being the canonical status surface, now carrying `runtime_provider_id` + `runtime_credential_version` + `tenant_id` so the admin UI can answer "which runtime ran this, on which credential version, for which tenant."
+- Sentry breadcrumbs include `tenant_id` + `runtime_provider_id` as tags (NOT credential values; see [`settings-system.md`](../../architecture/settings-system.md) §7).
+- PostHog event `tenant_runtime_overlay_changed` fires on every mutation (provider id, mode, who, when — no secrets).
+- Startup log per worker enumerates: instance-global runtime + count of tenants on each provider + count by mode.
+
+## 10. Phased Rollout
+
+Phases map to the EW-742 description. Each phase is a candidate sub-PR (or sub-PR stack).
+
+### P0 — Spec-Kit deliverables (this story, [EW-743](https://evertech.atlassian.net/browse/EW-743))
+
+- **Scope**: ADR-017, `spec.md`, this `plan.md`, `tasks.md`, parent `providers.md` cross-link, architecture cross-link in [`architecture/job-runtime-providers.md`](../../architecture/job-runtime-providers.md).
+- **Files touched**: `docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md`, `docs/specs/features/tenant-job-runtime-overlay/{spec,plan,tasks,providers}.md`, link in `docs/specs/architecture/job-runtime-providers.md`.
+- **Tech choices**: docs only.
+- **Test plan**: markdown lint + internal link check (existing CI).
+- **Exit gate**: all five docs merged on one PR; ADR-017 status `Proposed`; Jira EW-743 closed.
+- **Dependencies**: none.
+- **Risks**: spec drifts from parent EW-683 architecture if reviewers don't read both — mitigate by cross-link blocks at top of every doc.
+
+### P1 — Data model + migration
+
+- **Sub-story P1.0 (conditional)**: if `x-scope: tenant` is not yet a recognised value in [`settings-system.md`](../../architecture/settings-system.md), this becomes the FIRST sub-story — extend the extension registry, update the resolver cascade docs, ship as its own PR. Confirmed needed: today `x-scope` is `global`/`user`/`work` only.
+- **Scope**: `TenantJobRuntimeConfig` entity + migration + repository + service.
+- **Files touched**:
+	- `apps/api/src/works/entities/tenant-job-runtime-config.entity.ts`
+	- `apps/api/src/works/repositories/tenant-job-runtime-config.repository.ts`
+	- `apps/api/src/works/services/tenant-job-runtime-config.service.ts`
+	- `apps/api/src/migrations/<timestamp>-TenantJobRuntimeOverlay.ts`
+	- `packages/plugin/src/settings/extensions.ts` (add `tenant` to `x-scope`)
+	- `packages/plugin/src/job-runtime/tenant-overlay.contract.ts`
+	- `apps/api/src/plugins/services/plugin-settings.service.ts` (extend cascade with `tenant` tier)
+- **Tech choices**: TypeORM entity with `@PrimaryColumn('uuid')`, `@Column({type: 'enum'})` for `mode`; AES-256-GCM secret envelope reused via existing `SecretsService`.
+- **Test plan**:
+	- Entity tests in `apps/api/test/tenant-job-runtime-config.entity.spec.ts`.
+	- Migration up/down test in `apps/api/test/migrations/tenant-job-runtime-overlay.spec.ts`.
+	- Cascade resolver tests proving `work > user > tenant > global > env > default` precedence.
+- **Exit gate**: migration runs idempotently on a fresh DB and on a prod-snapshot replica; cascade test green; plugin settings UI still renders global plugins unchanged.
+- **Dependencies**: P0.
+- **Risks**: cascade ordering ambiguity (does `tenant` win over `user` or vice versa?) — locked by ADR-017 §"Cascade Precedence"; covered by the cascade test matrix.
+
+### P2 — Tenant admin UI (schema-driven)
+
+- **Scope**: provider picker + dynamic credentials form in the admin shell.
+- **Files touched**:
+	- `apps/web/src/app/admin/tenants/[tenantId]/job-runtime/page.tsx`
+	- `apps/web/src/app/admin/tenants/[tenantId]/job-runtime/RuntimePickerForm.tsx`
+	- `apps/web/src/components/settings/SchemaForm.tsx` (reuse; pass `scope: 'tenant'`)
+	- `apps/api/src/works/controllers/tenant-job-runtime.controller.ts` (REST surface from §4)
+	- Each `packages/plugins/job-runtime-*/src/tenant-schema.ts` ships its tenant JSON Schema.
+- **Tech choices**: NestJS controller + `@CurrentUser()` guard; Next.js server component for page shell, client component for form (`'use client'` only on `RuntimePickerForm.tsx`). Reuses Ajv validator from settings-system.
+- **Test plan**:
+	- Vitest schema-render tests per provider (form mounts, secret fields show "set"/"rotate", no plaintext leak).
+	- Playwright e2e in `apps/web/e2e/admin/tenant-runtime.spec.ts` — pick provider, paste creds, save, verify masked redisplay.
+	- API integration test: PUT with `mode=byo` requires a valid secret payload; PUT with `mode=inherit` clears `credentials_secret_ref`.
+- **Exit gate**: admin can switch a test tenant from `inherit` to `byo` for every bundled provider; redacted on read; activity log entry written.
+- **Dependencies**: P1 (storage + cascade).
+- **Risks**: Ajv server/client schema drift — mitigate by sharing the schema export from the plugin package, not duplicating in `apps/web`.
+
+### P3 — Dispatcher routing (tenant-aware resolver + credential version capture)
+
+- **Scope**: wrap EW-685's binding factory; capture credential version at enqueue.
+- **Files touched**:
+	- `packages/agent/src/tasks/tenant-aware-runtime.resolver.ts` (NEW)
+	- `packages/agent/src/tasks/job-runtime.providers.ts` (extend from EW-685 — resolver consulted before fallback)
+	- `packages/agent/src/tasks/work-generation-dispatcher.ts` and the other 7 dispatcher impls — accept `{tenantId}` in payload, pass through
+	- `apps/api/src/works/services/work-generation.service.ts` (and siblings) — capture `runtime_provider_id` + `runtime_credential_version` into history row before `dispatch()`
+- **Tech choices**: request-scoped NestJS provider for the resolver (per-request tenant context already exists via `@CurrentUser()` + tenant guard). LRU cache: `lru-cache` package, max 10k entries, TTL 60s.
+- **Test plan**:
+	- Unit: resolver returns global binding when no overlay; returns overlay binding when present + enabled; returns global when overlay exists but `enabled=false`.
+	- Unit: enqueue path writes `runtime_credential_version` matching the resolver snapshot.
+	- Integration: rotate credentials mid-test → in-flight run keeps old version; new enqueue picks new version.
+- **Exit gate**: every dispatcher call site exercises the resolver in a parameterised test across 3 tenants × 5 providers.
+- **Dependencies**: P1, P2.
+- **Risks**: resolver-cache staleness allowing a window where new dispatches use revoked credentials — mitigate by `invalidate(tenantId)` on every mutation endpoint + 60s hard TTL.
+
+### P4 — Worker host (multi-tenant credential injection)
+
+- **Scope**: extend EW-686 worker host to accept tenant context and inject the right credentials per job.
+- **Push-model providers (Trigger.dev, Inngest)**: per-tenant webhook routing `/api/jobs/webhook/:tenantId/...`. SaaS provider's webhook signature is verified against the tenant's signing key; tenant context attached before handing to the orchestrator.
+- **Pull-model providers**:
+	- **BullMQ** + **pg-boss** — single multiplexing worker per provider, reads `tenant_id` from job metadata, fetches the binding via the resolver, injects credentials at handler entry. Avoids N processes for N tenants.
+	- **Temporal** — Temporal SDK binds a `Worker` to a single namespace, so we run **one Worker per active namespace**, lazily cold-started on first job. Worker registry tracks active namespaces; idle namespaces drop their Worker after 30 min.
+- **Files touched**:
+	- `packages/tasks/src/worker/tenant-worker-router.ts` (NEW)
+	- `packages/tasks/src/worker/multiplex-worker.ts` (NEW; used by BullMQ + pg-boss)
+	- `packages/tasks/src/worker/temporal-worker-registry.ts` (NEW)
+	- `apps/api/src/works/controllers/internal-jobs-webhook.controller.ts` (NEW)
+	- `packages/plugins/job-runtime-{trigger,inngest}/src/webhook.ts` — signature verification helpers
+- **Tech choices**: vendor SDKs only (NN #17): `@trigger.dev/sdk`, `@temporalio/{client,worker}`, `bullmq`, `pg-boss`, `inngest`. No hand-rolled REST.
+- **Test plan**:
+	- Per-provider integration test: enqueue from tenant A and tenant B; verify each handler sees its own credentials.
+	- Webhook signature-mismatch returns 401 + audit log entry.
+	- Temporal: lazy-start a Worker for a previously unseen namespace; idle-evict after the configured TTL.
+	- Multiplex: pg-boss + BullMQ workers correctly route 100 interleaved jobs across 5 tenants.
+- **Exit gate**: end-to-end run on every provider, for ≥2 tenants in parallel, with distinct credentials, with run history correctly attributing each run.
+- **Dependencies**: P3.
+- **Risks**: Trigger.dev REST API can't read prod secret keys nor delete projects (documented in §end) — `per-tenant` mode requires worker self-registration OR a dashboard manual-paste workflow; doc this in the admin runbook P7.
+
+### P5 — Plugin gating
+
+- **Scope**: instance operator's plugin allow-list filters the tenant picker.
+- **Files touched**:
+	- `apps/api/src/works/services/tenant-job-runtime-config.service.ts` (filter `availableProviders()` against `PluginRegistryService` enablement)
+	- `apps/web/src/app/admin/tenants/[tenantId]/job-runtime/RuntimePickerForm.tsx` (consume `availableProviders`)
+- **Tech choices**: default = bundled-and-not-explicitly-disabled is available; per-tenant whitelist/blacklist deferred to v2 behind feature flag `EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING`.
+- **Test plan**:
+	- Disable `temporal` instance-globally → tenant picker no longer offers it; existing tenants on `temporal` retain config but get a warning banner.
+	- v2 flag off ⇒ no per-tenant whitelist UI rendered.
+- **Exit gate**: admin can disable a provider and verify tenant pickers update without redeploy.
+- **Dependencies**: P2, P4.
+- **Risks**: in-flight tenant on a now-disabled provider — banner + read-only edit; force-revert requires explicit ops action.
+
+### P6 — Multi-tenant conformance
+
+- **Scope**: extend EW-683's shared conformance suite with a per-tenant variant parameterised across N tenants × M providers. Add graceful-drain + force-invalidate cases.
+- **Files touched**:
+	- `packages/plugin/src/job-runtime/testing/job-runtime.contract.spec.ts` (parameterise existing cases over `tenantId`)
+	- `packages/plugin/src/job-runtime/testing/tenant-overlay.contract.spec.ts` (NEW — drain + force-invalidate + version capture)
+	- CI matrix in `.github/workflows/ci.yml` — add axis `TENANT_COUNT={1,3}` against existing `JOB_RUNTIME={trigger,pgboss,bullmq,temporal,inngest}`.
+- **Tech choices**: Vitest parameterised `describe.each`; per-tenant fixtures created in `beforeAll` via the provider's `provisionTenant()` hook; teardown via `deprovisionTenant()`.
+- **Test plan**:
+	- All existing EW-683 conformance cases run green with N=3 tenants on every provider.
+	- Graceful drain: rotate credentials while a 30-s job is in-flight → job completes on old credentials → new enqueue uses new credentials.
+	- Force-invalidate: trigger admin force-invalidate → in-flight runs cancelled within 5 s → fresh runs use new credentials.
+- **Exit gate**: CI matrix green; conformance suite covers ≥95% of resolver branches.
+- **Dependencies**: P3, P4, P5.
+- **Risks**: CI cost balloons (N×M); mitigate by sharding the matrix and only running full matrix on `develop`/`stage`/`main` cascades, not feature branches.
+
+### P7 — Docs + admin runbook + migration guide
+
+- **Scope**: ops-facing runbooks + migration guide for existing tenants.
+- **Files touched**:
+	- `docs/devops/tenant-job-runtime-overlay.md` (NEW — admin runbook)
+	- `docs/devops/migration-tenant-runtime-byo.md` (NEW — opt-in-without-losing-in-flight-work guide)
+	- `docs/environment-variables.md` — add `EVER_WORKS_INHERIT_DEFAULT_MODE`, `EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING`
+	- `docs/plugin-system/built-in-plugins.md` — note `tenantSettingsSchema` on each job-runtime plugin
+	- `docs/specs/architecture/job-runtime-providers.md` — append tenant-overlay section linking back here
+- **Tech choices**: docs only.
+- **Test plan**: markdown lint + Docusaurus build (CI).
+- **Exit gate**: runbook reviewed by an operator who is not the author; migration guide validates on a staging tenant.
+- **Dependencies**: P6.
+- **Risks**: doc rot — owner assigned per file in `docs/internal/ownership.md`.
+
+### Dependency overview
+
+- P0 blocks everything (specs/ADR drive the rest).
+- P1 blocks every post-P1 phase.
+- P2 depends on P1; P3 depends on P1 (resolver needs the entity).
+- P4 depends on P3; P5 depends on P2 + P4; P6 depends on P3 + P4 + P5; P7 trails P6.
+- P2 and P3 can parallelise once P1 lands.
+
+## 11. Cross-Cutting Risks
+
+| Risk                                                                                | Likelihood | Impact | Mitigation                                                                                                                                                  |
+| ----------------------------------------------------------------------------------- | ---------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Per-tenant Temporal namespace ops (control-plane quota)                             | Med        | High   | Hybrid `shared`/`per-tenant`/`tiered` default (Q5) lets ops keep small tenants on shared namespace; quota alerts in Temporal Cloud dashboard.                |
+| Per-tenant pg-boss schema migration ops (N schemas to migrate on pg-boss version bump) | High      | Med    | `MultiSchemaMigrator` utility iterates `pgboss_*` schemas on platform boot; rate-limited to avoid lock storms; explicit runbook step in `docs/devops/`.      |
+| Secret-encryption key rotation across N tenants × M providers                       | Med        | High   | Reuses existing AES-256-GCM `keyId`-tagged envelope from [`settings-system.md`](../../architecture/settings-system.md) §5; rotation is read-old-write-new; covered by P6 conformance. |
+| Multi-tenant test isolation in CI (cross-tenant credential bleed during parallel runs) | Med      | High   | Vitest fixtures use `crypto.randomUUID()` tenant ids per test file; conformance suite asserts handler sees only its tenant's creds (negative test).          |
+| Signup latency from per-tenant Trigger.dev provisioning under Q5 `per-tenant` mode | High       | Med    | Lazy provisioning (first-job-triggers-provision) + async warmup queue; ops can flip to `shared` if latency budget breached.                                  |
+| Trigger.dev REST limitations: PAT cannot read prod secret keys nor delete projects via REST | High | Med | Document workaround in `docs/devops/tenant-job-runtime-overlay.md`: either worker self-registration via Trigger.dev project-token bootstrap, OR dashboard manual paste; `deprovisionTenant` for Trigger.dev no-ops with a warning. |
+| Inngest signing-key bound to platform, not tenant — wrong key ⇒ webhook 401         | Med        | Med    | Per-tenant `INNGEST_SIGNING_KEY` stored in `credentials_secret_ref`; webhook handler picks tenant from URL path THEN verifies signature; mismatched tenant gets audit-logged + 401. |
+| Resolver cache staleness window (≤60 s) lets a revoked credential enqueue one more job | Low      | Med    | `invalidate(tenantId)` on every mutation endpoint; force-invalidate path also flushes the cache cluster-wide via pub/sub.                                    |
+| EW-683 binding factory churn during P3 wrap                                         | Low        | Med    | Resolver wraps factory rather than replacing it; existing instance-global tests run unchanged as a regression gate.                                          |
+
+## 12. Constitution Reconciliation
+
+- **I Plugin-first** — tenant overlay is consumed by the same plugin contracts; no new platform-special-case. ✓
+- **II Capability-driven** — `job-runtime` capability gains a tenant scope; resolution unchanged in shape. ✓
+- **III Source-of-truth repos** — tenant overlay is platform-side metadata, not work content. ✓
+- **IV Long-running work via configured job-runtime provider** — already amended by [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md); ADR-017 adds the tenant overlay clause. ✓
+- **V Forward-only migrations** — entity additive; `*_history` column adds two-phase. ✓
+- **VI Tests** — multi-tenant conformance extends EW-683's suite. ✓
+- **VII Secrets** — tenant credentials reuse the existing encrypted envelope + redactor. ✓
+- **VIII Plugin-count canonical doc** — no new plugins; existing job-runtime plugins gain `tenantSettingsSchema`. ✓
+- **IX Behaviour-first** — behaviour in `spec.md`; impl here. ✓
+- **X Backwards-compatible** — tenants without an overlay row inherit instance-global; zero behaviour change. ✓
+
+## 13. References
+
+- Spec: [`./spec.md`](./spec.md) · Tasks: [`./tasks.md`](./tasks.md) · Providers: [`./providers.md`](./providers.md)
+- ADRs: [ADR-017](../../decisions/017-tenant-scoped-job-runtime-overlay.md), [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md), [ADR-005](../../decisions/005-cache-and-lock-pluggability.md)
+- Architecture: [`job-runtime-providers.md`](../../architecture/job-runtime-providers.md), [`settings-system.md`](../../architecture/settings-system.md), [`database.md`](../../architecture/database.md)
+- Parent feature: [`features/job-runtime-providers/plan.md`](../job-runtime-providers/plan.md) · [`tasks.md`](../job-runtime-providers/tasks.md) · [`providers.md`](../job-runtime-providers/providers.md)
+- Jira: [EW-742 (epic)](https://evertech.atlassian.net/browse/EW-742) · [EW-743 (this story)](https://evertech.atlassian.net/browse/EW-743) · [EW-683 (parent epic)](https://evertech.atlassian.net/browse/EW-683) · [EW-685 (dispatcher seam)](https://evertech.atlassian.net/browse/EW-685) · [EW-686 (worker host)](https://evertech.atlassian.net/browse/EW-686)

--- a/docs/specs/features/tenant-job-runtime-overlay/providers.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/providers.md
@@ -1,0 +1,471 @@
+# Tenant-Scope Provider Overlay
+
+This document specifies the **tenant-level overlay** on top of the instance-level job-runtime provider matrix. It complements (does not replace) the instance-scope provider doc at [`docs/specs/features/job-runtime-providers/providers.md`](../job-runtime-providers/providers.md), which defines what each provider can do at the operator scope. Here we describe what changes — schema, isolation, inherit/BYO/override behaviour, worker hosting, gotchas, conformance — when a tenant overrides or extends the instance default.
+
+Scope, FR mapping, and the locked design decisions (Q1-Q5) are owned by:
+
+- Spec: [`./spec.md`](./spec.md)
+- ADR: [`../../decisions/017-tenant-scoped-job-runtime-overlay.md`](../../decisions/017-tenant-scoped-job-runtime-overlay.md)
+- Jira: [EW-742](https://evertech.atlassian.net/browse/EW-742) (epic), [EW-743](https://evertech.atlassian.net/browse/EW-743) (this story)
+- Settings-schema conventions (`x-secret`, `x-scope`, `x-envVar`): [`../../architecture/settings-system.md`](../../architecture/settings-system.md)
+
+The three resolution modes referenced throughout this doc are:
+
+- **inherit** — tenant uses the instance default; no tenant-scope credentials stored. Hybrid operator-gated platform-default policy applies (`shared` / `per-tenant` / `tiered`) per Q5.
+- **BYO** — tenant brings its own provider account/instance; tenant pastes credentials; operator never sees workload data plane.
+- **override** — tenant runs the same provider as the instance default but on a different account/cluster (a special case of BYO where the provider kind matches).
+
+## Availability matrix (tenant scope)
+
+| Provider     | inherit / shared | inherit / per-tenant                | inherit / tiered | BYO  | override | Notes                                                                          |
+| ------------ | ---------------- | ----------------------------------- | ---------------- | ---- | -------- | ------------------------------------------------------------------------------ |
+| Trigger.dev  | yes              | yes (PAT-provisioned, see gotcha)   | yes              | yes  | yes      | `per-tenant` cannot fully auto-provision prod key (dashboard-only); see below  |
+| Temporal     | yes              | yes (control-plane call)            | yes              | yes  | yes      | Per-tenant namespace creation adds ~5-10s to tenant signup                     |
+| BullMQ       | yes              | yes (DB or instance per tenant)     | yes              | yes  | yes      | >16 tenants in DB-per-tenant mode requires Redis Cluster (flag)                |
+| pg-boss      | yes              | yes (DB or instance per tenant)     | yes              | yes  | yes      | `shared` policy still uses per-tenant **schemas** (Q2); tenant_id column forbidden |
+| Inngest      | yes (tenant tag) | manual (no project-create REST)     | yes              | yes  | yes      | `per-tenant` mode needs operator hand-provisioning today (flag)                |
+
+---
+
+## Trigger.dev
+
+### Tenant config JSON Schema
+
+```json
+{
+	"$id": "https://ever.works/schemas/tenant/jobs/trigger-dev.json",
+	"title": "Trigger.dev (tenant scope)",
+	"type": "object",
+	"x-scope": "tenant",
+	"description": "Tenant overlay for Trigger.dev. When mode=inherit, all fields below are ignored and the instance default applies under the operator-selected platform-default policy (shared/per-tenant/tiered).",
+	"properties": {
+		"mode": {
+			"type": "string",
+			"enum": ["inherit", "byo", "override"],
+			"default": "inherit"
+		},
+		"projectRef": {
+			"type": "string",
+			"pattern": "^proj_[a-z0-9]+$",
+			"description": "Trigger.dev project reference. Required for byo/override."
+		},
+		"environment": {
+			"type": "string",
+			"enum": ["prod", "staging"],
+			"default": "prod"
+		},
+		"secretKey": {
+			"type": "string",
+			"x-secret": true,
+			"x-envVar": "TRIGGER_SECRET_KEY",
+			"description": "Server-side prod secret (tr_prod_*). Required for byo/override."
+		},
+		"apiUrl": {
+			"type": "string",
+			"format": "uri",
+			"default": "https://api.trigger.dev",
+			"description": "Override for self-hosted Trigger.dev. Validated by the conformance probe on save."
+		}
+	},
+	"allOf": [
+		{
+			"if": { "properties": { "mode": { "const": "inherit" } } },
+			"then": { "required": ["mode"] },
+			"else": { "required": ["mode", "projectRef", "secretKey"] }
+		}
+	]
+}
+```
+
+### Isolation model
+
+Per **Trigger.dev project**. Every tenant in `byo` or `override` gets its own project. In `inherit / per-tenant`, the platform auto-provisions a project under the operator's Trigger.dev org. In `inherit / shared`, all tenants share the operator project and are demultiplexed by tag on the run metadata.
+
+### Inherit-mode behaviour
+
+- **shared** — One operator project; tenant id injected as a run tag (`tenant:<id>`) and a `tenantId` payload field. Webhook handler dispatches by tag. Cheapest; weakest isolation.
+- **per-tenant** — On tenant signup, platform calls `POST /api/v1/orgs/{orgId}/projects` with the operator's PAT (`tr_pat_*`) sourced from `TRIGGER_OPERATOR_PAT`. Project ref is persisted to the tenant record. See gotcha for the prod-key step.
+- **tiered** — Free/low-tier tenants land in `shared`; paid tier triggers a per-tenant provision. Selection is driven by a tenant-tier predicate evaluated at signup and at tier-change events.
+
+### BYO-mode behaviour
+
+Tenant admin pastes `projectRef` and `secretKey` in the tenant admin UI. On save, the platform runs the EW-683 conformance probe (enqueue → status → cancel of a no-op task) against the tenant credentials before persisting. Credentials are written through the secret store, never logged. Webhook URL is `/api/jobs/webhook/<tenant-id>/trigger-dev`.
+
+### Override-mode behaviour
+
+Identical to BYO at the data-plane layer. The only difference is intent — the instance default is also Trigger.dev, so the tenant is moving to its own project (typically for stronger isolation, separate billing, or geo locality) rather than switching provider kinds. UI surfaces this as a one-click "use my own Trigger.dev project" option.
+
+### Worker-hosting impact at tenant scope
+
+Trigger.dev is push-model. Workers are hosted by Trigger.dev; the operator does not run pollers. Per-tenant routing is achieved via per-tenant webhook URLs: `POST /api/jobs/webhook/<tenant-id>/trigger-dev`. The handler resolves the tenant from the path segment, loads the tenant overlay, and validates the signature against the tenant's `secretKey`.
+
+### Per-provider gotchas at tenant scope
+
+- The operator PAT (`tr_pat_*`) can **create** projects via `POST /api/v1/orgs/{orgId}/projects` but **cannot** read the resulting `tr_prod_*` secret key, and cannot delete or rename projects via REST (all dashboard-only as of 2026-06). This breaks the zero-touch promise of `inherit / per-tenant`. Workarounds:
+	1. **Worker self-registration (preferred)** — the deployed worker registers itself against an internal Ever Works callback and reports the prod key back. Requires a worker-side patch and a one-time bootstrap token.
+	2. **Manual paste** — after auto-provision, surface the project URL in the admin UI and prompt the tenant operator to copy the prod key from the Trigger.dev dashboard. Degrades the `per-tenant` UX to a two-step flow.
+- Per-project rate limits apply at the Trigger.dev account level; large `inherit / per-tenant` deployments must monitor org-wide project counts against Trigger.dev plan limits.
+
+### Conformance scope at tenant level
+
+Per-tenant subset of EW-683's conformance suite: enqueue, run, status, cancel, schedule, idempotency — each executed against the tenant's resolved credentials. Plus graceful-drain (enqueue under credential version `v1`, rotate to `v2`, confirm `v1`-enqueued jobs still complete) and force-invalidate (admin action immediately fails in-flight `v1` jobs and refuses `v1`-tagged dequeues).
+
+---
+
+## Temporal
+
+### Tenant config JSON Schema
+
+```json
+{
+	"$id": "https://ever.works/schemas/tenant/jobs/temporal.json",
+	"title": "Temporal (tenant scope)",
+	"type": "object",
+	"x-scope": "tenant",
+	"description": "Tenant overlay for Temporal. Q1: one Temporal namespace per tenant always. Namespace lifecycle is owned by the temporal plugin.",
+	"properties": {
+		"mode": {
+			"type": "string",
+			"enum": ["inherit", "byo", "override"],
+			"default": "inherit"
+		},
+		"address": {
+			"type": "string",
+			"description": "Temporal frontend address (host:port). Required for byo/override.",
+			"x-envVar": "TEMPORAL_ADDRESS"
+		},
+		"namespace": {
+			"type": "string",
+			"description": "Temporal namespace. Plugin-managed; tenant cannot edit when mode!=byo."
+		},
+		"tlsCert": {
+			"type": "string",
+			"x-secret": true,
+			"description": "PEM-encoded client cert for mTLS (Temporal Cloud and most self-hosted setups)."
+		},
+		"tlsKey": {
+			"type": "string",
+			"x-secret": true,
+			"description": "PEM-encoded client key matching tlsCert."
+		},
+		"apiKey": {
+			"type": "string",
+			"x-secret": true,
+			"x-envVar": "TEMPORAL_API_KEY",
+			"description": "Temporal Cloud API key (alternative to mTLS)."
+		}
+	},
+	"allOf": [
+		{
+			"if": { "properties": { "mode": { "const": "byo" } } },
+			"then": { "required": ["mode", "address", "namespace"] }
+		}
+	]
+}
+```
+
+### Isolation model
+
+Per **Temporal namespace** (Q1, locked). Every tenant — regardless of inherit/BYO/override — gets a dedicated namespace. The temporal plugin owns the create/describe/deprecate lifecycle.
+
+### Inherit-mode behaviour
+
+- **shared** — One platform Temporal cluster; the plugin creates a namespace per tenant (still per-tenant per Q1) on the shared cluster. "Shared" here refers to the cluster, not the namespace.
+- **per-tenant** — On tenant signup, plugin calls the Temporal operator API (`OperatorService.CreateNamespace`) on the operator's cluster. Adds ~5-10s on Temporal Cloud; longer on cold self-hosted.
+- **tiered** — Low-tier tenants land on a shared cluster (namespace-per-tenant); paid tier provisions a dedicated cluster or a dedicated Temporal Cloud account.
+
+### BYO-mode behaviour
+
+Tenant admin pastes `address`, `namespace`, and either an mTLS cert/key pair or an API key. Conformance probe runs a workflow-start + signal + query + cancel cycle against the tenant namespace. Persisted via the secret store.
+
+### Override-mode behaviour
+
+Identical to BYO; the distinction is that the underlying provider is also Temporal at instance scope, so the tenant is moving its namespace to a different cluster (often for region/compliance reasons).
+
+### Worker-hosting impact at tenant scope
+
+Temporal is pull-model. Two deployment patterns:
+
+- **Per-tenant pollers** — one worker process per tenant namespace. Simplest, highest isolation, scales linearly with tenant count.
+- **Multiplexed worker** — single worker process registers task queues across multiple tenant namespaces; tenant context derived from the namespace it polled. Cheaper at scale; requires careful credential/keyring management when tenant credentials differ.
+
+### Per-provider gotchas at tenant scope
+
+- Namespace creation requires a control-plane API call against the operator's Temporal cluster (Cloud or self-host). Signup latency budget must accommodate ~5-10s on Temporal Cloud.
+- Temporal Cloud enforces a per-account namespace cap (defaults around 10, raisable on request) — flag this for any operator planning >10 tenants in `inherit / per-tenant` on a single Temporal Cloud account.
+- Namespace deletion via REST is asynchronous and not immediate; "deprovision" in our model marks the tenant overlay deleted but leaves the namespace until the temporal plugin's GC sweeps it.
+
+### Conformance scope at tenant level
+
+Enqueue (workflow-start), run, status (describe-workflow), cancel, schedule (Temporal Schedules), idempotency (workflow-id reuse policy) — each against the tenant namespace. Graceful drain by credential version on the worker's client factory; force-invalidate rejects new workflow starts tagged with the rotated version.
+
+---
+
+## BullMQ
+
+### Tenant config JSON Schema
+
+```json
+{
+	"$id": "https://ever.works/schemas/tenant/jobs/bullmq.json",
+	"title": "BullMQ (tenant scope)",
+	"type": "object",
+	"x-scope": "tenant",
+	"description": "Tenant overlay for BullMQ. Isolation is per-queue-prefix on a shared Redis or per-Redis-DB on a per-tenant Redis. Redis Cluster required for >16 tenants in DB-per-tenant mode.",
+	"properties": {
+		"mode": {
+			"type": "string",
+			"enum": ["inherit", "byo", "override"],
+			"default": "inherit"
+		},
+		"redisUrl": {
+			"type": "string",
+			"format": "uri",
+			"x-secret": true,
+			"x-envVar": "BULLMQ_REDIS_URL",
+			"description": "Full Redis connection string (redis:// or rediss://). Required for byo/override."
+		},
+		"db": {
+			"type": "integer",
+			"minimum": 0,
+			"maximum": 15,
+			"description": "Redis DB index. Mutually exclusive with cluster mode."
+		},
+		"queuePrefix": {
+			"type": "string",
+			"description": "BullMQ key prefix; plugin defaults to bull:tenant:<id>: when not set."
+		},
+		"tls": {
+			"type": "boolean",
+			"default": false,
+			"description": "Force TLS regardless of redis:// vs rediss:// scheme."
+		}
+	},
+	"allOf": [
+		{
+			"if": { "properties": { "mode": { "enum": ["byo", "override"] } } },
+			"then": { "required": ["mode", "redisUrl"] }
+		}
+	]
+}
+```
+
+### Isolation model
+
+Two axes, operator-selected per the platform-default policy:
+
+- **per-queue-prefix** on a shared Redis (cheapest)
+- **per-Redis-DB** on a shared Redis (max 16 tenants per Redis instance; Redis Cluster does not support DB selection, so DB-per-tenant + Cluster is incompatible — must use prefix-per-tenant in Cluster)
+
+For `>16` tenants in DB-per-tenant mode the operator must front a Redis Cluster and switch to prefix-per-tenant within the cluster — flag this trade-off at operator config time.
+
+### Inherit-mode behaviour
+
+- **shared** — One platform Redis; queue prefix `bull:tenant:<id>:` per tenant.
+- **per-tenant** — One Redis DB per tenant (up to 16) or one Redis instance per tenant beyond that.
+- **tiered** — Free tier on shared prefix; paid tier on dedicated DB or instance.
+
+### BYO-mode behaviour
+
+Tenant pastes full Redis URL; optional explicit `queuePrefix` (defaults to `bull:tenant:<id>:`). Conformance probe enqueues + drains a no-op job. Credentials secret-stored.
+
+### Override-mode behaviour
+
+Identical to BYO at the data-plane layer; differs only by intent (tenant runs same provider kind as instance default).
+
+### Worker-hosting impact at tenant scope
+
+BullMQ is pull-model. Patterns:
+
+- **Per-tenant pollers** — one Worker per tenant queue prefix; tenant context resolved from prefix at boot.
+- **Multiplexed worker** — single Worker subscribes to all tenant prefixes via dynamic queue registration; tenant id derived from the job's queue name or job metadata.
+
+### Per-provider gotchas at tenant scope
+
+- Redis ACL granularity is per-key-pattern; per-tenant ACL rules are recommended when multiple tenants share a Redis instance, to prevent a compromised tenant credential from reading other prefixes.
+- The 16-DB cap on stock Redis is a hard limit; document the path from DB-per-tenant (small operator) to Cluster + prefix-per-tenant (large operator) and flag the migration cost.
+- BullMQ does not have a native concept of credential versioning — graceful drain is implemented at the worker connection-factory layer (drain old connection's in-flight, switch new pulls to the new credential).
+
+### Conformance scope at tenant level
+
+Enqueue, run, status, cancel, schedule (BullMQ repeatable jobs), idempotency (jobId reuse) — per-tenant prefix or DB. Plus graceful drain on credential rotation and force-invalidate rejecting jobs whose enqueue-time credential version is below the active floor.
+
+---
+
+## pg-boss
+
+### Tenant config JSON Schema
+
+```json
+{
+	"$id": "https://ever.works/schemas/tenant/jobs/pg-boss.json",
+	"title": "pg-boss (tenant scope)",
+	"type": "object",
+	"x-scope": "tenant",
+	"description": "Tenant overlay for pg-boss. Q2: one Postgres schema per tenant always. pg-boss plugin owns CREATE SCHEMA, the per-tenant pg-boss migrate, and DROP SCHEMA on deprovision.",
+	"properties": {
+		"mode": {
+			"type": "string",
+			"enum": ["inherit", "byo", "override"],
+			"default": "inherit"
+		},
+		"connectionString": {
+			"type": "string",
+			"format": "uri",
+			"x-secret": true,
+			"x-envVar": "PGBOSS_CONNECTION_STRING",
+			"description": "Postgres connection string. Required for byo/override."
+		},
+		"schema": {
+			"type": "string",
+			"description": "Postgres schema name. Plugin-managed; defaults to pgboss_tenant_<id>. Tenant cannot edit in inherit mode."
+		},
+		"ssl": {
+			"type": "object",
+			"description": "Optional SSL config block forwarded to pg.",
+			"properties": {
+				"rejectUnauthorized": { "type": "boolean", "default": true },
+				"ca": { "type": "string", "x-secret": true }
+			}
+		}
+	},
+	"allOf": [
+		{
+			"if": { "properties": { "mode": { "enum": ["byo", "override"] } } },
+			"then": { "required": ["mode", "connectionString"] }
+		}
+	]
+}
+```
+
+### Isolation model
+
+Per **Postgres schema** named `pgboss_tenant_<id>` (Q2, locked). A `tenant_id` discriminator column inside a shared schema is **explicitly forbidden** — even in `inherit / shared` policy, each tenant gets its own schema inside the shared platform database.
+
+### Inherit-mode behaviour
+
+- **shared** — One platform Postgres database; one schema per tenant inside it (`pgboss_tenant_<id>`). The "shared" axis is the database, not the schema.
+- **per-tenant** — One Postgres database per tenant or one Postgres instance per tenant for stronger isolation (separate WAL, backup, and IO budget).
+- **tiered** — Free tier on shared DB / per-tenant schema; paid tier on dedicated DB or dedicated instance.
+
+### BYO-mode behaviour
+
+Tenant pastes a connection string; the plugin connects, runs `CREATE SCHEMA IF NOT EXISTS pgboss_tenant_<id>`, applies the pg-boss migration suite inside that schema, and runs the conformance probe (publish/subscribe of a no-op job).
+
+### Override-mode behaviour
+
+Identical to BYO; intent-only distinction.
+
+### Worker-hosting impact at tenant scope
+
+pg-boss is pull-model. Each tenant schema needs polling; patterns are the same as BullMQ:
+
+- **Per-tenant pollers** — one pg-boss instance per tenant schema.
+- **Multiplexed worker** — one pg-boss instance per Postgres DB, configured with the tenant's schema via `pgboss({ schema: 'pgboss_tenant_<id>' })`; tenant context derived from the schema the job came from.
+
+### Per-provider gotchas at tenant scope
+
+- `CREATE SCHEMA` plus the per-tenant pg-boss migration runs on every tenant create — budget ~1-3s per tenant signup.
+- `DROP SCHEMA pgboss_tenant_<id> CASCADE` on tenant deprovision is destructive and irreversible — guard behind the same confirmation flow used for tenant deletion.
+- Catalog bloat (pg_class rows) scales linearly with tenant count; comfortable up to low thousands of tenants per database — beyond that, switch to DB-per-tenant or instance-per-tenant in `inherit / per-tenant` policy.
+- pg-boss credential rotation = Postgres credential rotation; graceful drain runs at the pg pool layer, force-invalidate revokes the role.
+
+### Conformance scope at tenant level
+
+Publish (enqueue), run, status (`getJobById`), cancel, schedule (pg-boss cron), idempotency (singleton keys) — per-tenant schema. Plus graceful drain and force-invalidate by credential version.
+
+---
+
+## Inngest
+
+### Tenant config JSON Schema
+
+```json
+{
+	"$id": "https://ever.works/schemas/tenant/jobs/inngest.json",
+	"title": "Inngest (tenant scope)",
+	"type": "object",
+	"x-scope": "tenant",
+	"description": "Tenant overlay for Inngest. Q3: uniform inherit/BYO/override; no instance-only mode. Inngest Cloud project-create is not REST-exposed; per-tenant inherit requires a manual operator step today.",
+	"properties": {
+		"mode": {
+			"type": "string",
+			"enum": ["inherit", "byo", "override"],
+			"default": "inherit"
+		},
+		"eventKey": {
+			"type": "string",
+			"x-secret": true,
+			"x-envVar": "INNGEST_EVENT_KEY",
+			"description": "Inngest event key used by the producer SDK. Required for byo/override."
+		},
+		"signingKey": {
+			"type": "string",
+			"x-secret": true,
+			"x-envVar": "INNGEST_SIGNING_KEY",
+			"description": "Signing key used to verify Inngest -> webhook callbacks."
+		},
+		"appId": {
+			"type": "string",
+			"description": "Inngest app id; defaults to ever-works-tenant-<id>."
+		},
+		"baseUrl": {
+			"type": "string",
+			"format": "uri",
+			"default": "https://api.inngest.com",
+			"description": "Override for self-hosted Inngest or a non-default Inngest Cloud region."
+		}
+	},
+	"allOf": [
+		{
+			"if": { "properties": { "mode": { "enum": ["byo", "override"] } } },
+			"then": { "required": ["mode", "eventKey", "signingKey"] }
+		}
+	]
+}
+```
+
+### Isolation model
+
+- **BYO / override** — per Inngest **account** (tenant brings its own Inngest Cloud account or points at a tenant-controlled self-hosted Inngest).
+- **inherit / shared** — one operator Inngest account; tenant identity carried as a tag in event metadata (`data.tenantId`) and as part of the event name namespace (`tenant.<id>.<event>`).
+
+### Inherit-mode behaviour
+
+- **shared** — One operator account; tenant tag on every event; webhook handler demultiplexes by tag.
+- **per-tenant** — One Inngest project per tenant under the operator's account. Inngest does **not** expose a project-create REST endpoint today, so this mode requires a manual operator step (or a future browser-automation workaround) — flag.
+- **tiered** — Low tier on shared tag; paid tier triggers the manual per-tenant project provisioning.
+
+### BYO-mode behaviour
+
+Tenant admin pastes `eventKey` and `signingKey` from their own Inngest account. Conformance probe sends a test event and confirms the per-tenant webhook delivery is signed correctly.
+
+### Override-mode behaviour
+
+Identical to BYO; the intent is that the instance default is also Inngest but the tenant runs against its own Inngest account (typically for billing isolation).
+
+### Worker-hosting impact at tenant scope
+
+Inngest is push-model. Per-tenant webhook URLs: `POST /api/jobs/webhook/<tenant-id>/inngest`. The handler verifies the signature against the tenant's `signingKey`, loads the tenant overlay, dispatches into the application function registry with tenant context.
+
+### Per-provider gotchas at tenant scope
+
+- Inngest Cloud does not expose project-create via REST (verified 2026-06); `inherit / per-tenant` cannot be fully automated and requires an operator hand-provisioning step. Flag this in the admin UI and in the operator runbook.
+- BYO tenants are billed directly by Inngest under their own Inngest Cloud account; `shared` tenants accrue against the operator's Inngest plan — surface this trade-off in the tenant admin UI.
+- Signing-key rotation: Inngest supports key rotation at the account level; graceful drain is implemented by accepting both old and new signing keys during the rotation window (typically 24h), then dropping the old key on force-invalidate.
+
+### Conformance scope at tenant level
+
+Send (enqueue), run, status (Inngest run lookup), cancel (cancellation events), schedule (cron functions), idempotency (event id dedup) — per-tenant account or per-tenant tag. Plus graceful drain (dual-key acceptance) and force-invalidate (immediate old-key rejection).
+
+---
+
+## Cross-references
+
+- Instance-scope baseline: [`../job-runtime-providers/providers.md`](../job-runtime-providers/providers.md)
+- ADR: [`../../decisions/017-tenant-scoped-job-runtime-overlay.md`](../../decisions/017-tenant-scoped-job-runtime-overlay.md)
+- Spec & FR mapping: [`./spec.md`](./spec.md)
+- Plan & phasing: [`./plan.md`](./plan.md)
+- Tasks: [`./tasks.md`](./tasks.md)
+- Settings-schema conventions: [`../../architecture/settings-system.md`](../../architecture/settings-system.md)
+- Jira: [EW-742](https://evertech.atlassian.net/browse/EW-742), [EW-743](https://evertech.atlassian.net/browse/EW-743)

--- a/docs/specs/features/tenant-job-runtime-overlay/spec.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/spec.md
@@ -1,0 +1,148 @@
+# Feature Specification: Tenant-Scoped Job-Runtime Overlay
+
+> Behaviour-first spec. Describes **what** the system does once each tenant can inherit, BYO, or override the platform's background-job runtime — not how it's wired. Implementation lives in [`plan.md`](./plan.md); rationale in [ADR-017](../../decisions/017-tenant-scoped-job-runtime-overlay.md); the instance-global baseline this overlays sits in [`../job-runtime-providers/spec.md`](../job-runtime-providers/spec.md) ([ADR-015](../../decisions/015-job-runtime-provider-pluggability.md)).
+
+**Feature ID**: `tenant-job-runtime-overlay`
+**Branch**: `feat/tenant-job-runtime-overlay`
+**Status**: `Draft`
+**Created**: 2026-06-17
+**Last updated**: 2026-06-17
+**Owner**: Ever Works Team
+**Epic**: [EW-742](https://evertech.atlassian.net/browse/EW-742)
+
+---
+
+## 1. Overview
+
+EW-683 made the background-job runtime a deployment-wide selectable provider (`EVER_WORKS_JOB_RUNTIME`). This feature adds a **tenant-scoped overlay** on top of that selector so a single Ever Works instance can serve many tenants whose jobs land in different runtimes, different credentials, or both — without operators having to spin up an instance per tenant. Every tenant resolves to one of three modes: **inherit** (use the instance default exactly as today), **BYO** (same provider as the instance default, but the tenant supplies their own credentials so runs land in their own SaaS dashboard or self-hosted cluster), or **override** (the tenant picks a different provider from the operator-curated allow-list and supplies its credentials).
+
+The feature draws three role boundaries clearly: the **operator** (deployment owner) sets the instance default, the allow-list of pickable providers, and the platform-default policy (`shared` / `per-tenant` / `tiered` — see Q5); the **tenant admin** chooses inherit / BYO / override and manages their credentials; the **end user** notices nothing — work generation, cancellation, scheduling, and status behave identically regardless of which runtime or credentials a given run executes against. Isolation between tenants is **provider-owned and uniform per provider**: one Temporal namespace per tenant (Q1), one Postgres schema per tenant for pg-boss (Q2), uniform inherit/BYO trichotomy across all five providers including Inngest (Q3). Credentials rotate via graceful drain by default, with a separate `force-invalidate` admin action for compromised-key incidents (Q4).
+
+## 2. User Scenarios
+
+The "user" splits three ways: the **operator** configuring the instance, the **tenant admin** configuring their tenant, and the **end user** triggering work — who should notice nothing.
+
+### 2.1 Primary scenarios
+
+- **Given** a tenant has no job-runtime config row, **when** any of its jobs are enqueued, **then** the platform routes them through the instance-global `EVER_WORKS_JOB_RUNTIME` provider using the operator's platform-default credentials — i.e. today's exact behaviour, zero-config (the inherit mode).
+- **Given** the instance default is `trigger` and a tenant admin pastes their own Trigger.dev project keys, **when** they save the BYO config, **then** subsequent runs for that tenant appear in **their** Trigger.dev dashboard while other tenants on the same instance keep landing in the platform-default project.
+- **Given** the instance default is `trigger` and a tenant picks `temporal` with their own namespace + mTLS certs, **when** that tenant enqueues a job, **then** the run executes against their Temporal cluster while all inherit-mode tenants on the same instance continue using the Trigger.dev SaaS default.
+- **Given** an operator narrows the allow-list to `{trigger, pgboss}`, **when** any tenant opens the runtime picker, **then** only `trigger` and `pgboss` are selectable — even if the plugin for `temporal` is installed on the instance.
+- **Given** an operator changes the instance-global default from `trigger` to `pgboss`, **when** the API rolls out, **then** every inherit-mode tenant's new jobs flow to pg-boss automatically while override-mode tenants stay on their chosen provider with their own credentials.
+- **Given** a tenant rotates its credentials, **when** the rotation is saved, **then** in-flight runs continue to completion using the cached credential **version** they captured at enqueue time and only newly enqueued runs see the new credentials (graceful drain — Q4).
+- **Given** an operator triggers `force-invalidate` on a compromised credential, **when** the action commits, **then** in-flight runs holding the old version are marked `FAILED` with a `CREDENTIAL_REVOKED` reason and new enqueues are blocked for that tenant until the tenant admin re-saves valid credentials.
+- **Given** the operator has chosen `per-tenant` as the platform-default policy (Q5), **when** a brand-new tenant finishes signup in inherit mode, **then** the platform auto-provisions a dedicated Trigger.dev project for that tenant via the Trigger.dev PAT REST API and stores the resulting project keys as the tenant's effective credentials.
+
+### 2.2 Edge cases & failures
+
+- **Given** a tenant saves BYO credentials that don't authenticate, **when** the first enqueue attempt runs, **then** it fails fast with a friendly "credentials invalid — see tenant admin settings" message rather than a 500 and the failure surfaces in the tenant admin UI alongside the offending config.
+- **Given** a tenant's BYO provider becomes unreachable mid-run, **when** the run's heartbeats time out, **then** the run transitions to `FAILED` with provider-error context (HTTP code / SDK error class) and the tenant admin can replay it once their provider recovers — the platform never silently swallows or retries indefinitely.
+- **Given** a tenant is on `temporal` and the operator removes `temporal` from the allow-list, **when** the next enqueue arrives, **then** the tenant's config row is retained (not deleted) and surfaces a "provider disabled by operator" warning in the tenant admin UI, while new enqueues fall back to the instance default until the tenant picks an allowed provider.
+- **Given** two inherit-mode tenants share one platform Trigger.dev project under the `shared` platform-default policy, **when** their runs interleave, **then** per-tenant tags (`tenantId`, `tenantSlug`) attached to every run's metadata let the operator filter the Trigger.dev dashboard by tenant.
+- **Given** a tenant is offboarded, **when** the offboarding completes, **then** the per-tenant pg-boss schema (`pgboss_tenant_<id>`) is dropped, the per-tenant Temporal namespace is deleted, and (under `per-tenant` mode only) the auto-provisioned Trigger.dev project is archived — leaving no orphan tenant artefacts in any provider.
+- **Given** the operator has selected `per-tenant` mode and Trigger.dev PAT REST cannot fetch the prod secret key for the freshly-provisioned project (a documented REST limitation), **when** signup runs, **then** the platform either (a) flags the tenant as `pending_prod_key` and requires the tenant admin to paste the prod key once after auto-provision, or (b) performs a worker-self-registration workaround — the chosen tradeoff is recorded in this spec's open questions and `plan.md`.
+
+## 3. Functional Requirements
+
+- **FR-1** The system MUST resolve a tenant's effective job-runtime config in this order: tenant overlay row → instance-global `EVER_WORKS_JOB_RUNTIME` fallback. Absent a tenant overlay row, behaviour MUST be byte-identical to the EW-683 instance-global path.
+- **FR-2** The system MUST expose three explicit modes per tenant: `inherit`, `byo`, `override`. `inherit` means "use the instance default provider AND the platform-default credentials"; `byo` means "use the instance default provider with tenant-supplied credentials"; `override` means "use a tenant-chosen provider from the allow-list with tenant-supplied credentials."
+- **FR-3** The system MUST restrict the tenant runtime picker to the operator-controlled allow-list — providers installed but not allow-listed MUST NOT appear in tenant admin UI and MUST be rejected if requested via API.
+- **FR-4** Tenant credentials MUST be declared via the standard plugin settings schema with `x-secret` + `x-scope: tenant`, stored encrypted at rest, and never returned in API responses (only their presence + last-rotated timestamp is readable).
+- **FR-5** Every credential write MUST bump a monotonic `credential_version` on the tenant's config row; every enqueue MUST capture the current version into the run record and the worker MUST use the credentials matching that version for the lifetime of the run (graceful drain — Q4).
+- **FR-6** The system MUST expose a separate operator-only `force-invalidate` admin action that marks a `credential_version` as `REVOKED`, fails in-flight runs holding that version with reason `CREDENTIAL_REVOKED`, and blocks new enqueues for that tenant until valid credentials are re-saved.
+- **FR-7** The system MUST support three operator-gated platform-default policies for inherit-mode tenants (Q5): `shared` (all inherit-mode tenants share one platform-owned credential set; default), `per-tenant` (each new tenant gets an auto-provisioned per-tenant credential set), and `tiered` (the policy looks up the tenant's subscription tier to choose shared vs per-tenant). The operator selects exactly one policy at the instance level.
+- **FR-8** When the platform-default policy is `per-tenant`, the system MUST auto-provision the per-tenant credentials at tenant signup using the provider's native provisioning API (e.g. Trigger.dev PAT REST), MUST persist the resulting credentials as the tenant's effective credentials, and MUST archive/delete those resources on tenant offboarding.
+- **FR-9** Temporal isolation MUST be **one namespace per tenant** (Q1), created/managed by the Temporal provider plugin via the Temporal admin SDK; the platform MUST NOT share a namespace across tenants.
+- **FR-10** pg-boss isolation MUST be **one Postgres schema per tenant** named `pgboss_tenant_<id>` (Q2), created/migrated/dropped by the pg-boss provider plugin; the platform MUST NOT share a schema across tenants.
+- **FR-11** The inherit/BYO/override trichotomy MUST be uniform across all five providers (Q3) — including Inngest. The system MUST NOT introduce an Inngest-only "instance-only" mode.
+- **FR-12** Every run MUST carry per-tenant tags (`tenantId`, `tenantSlug`) in its native run metadata so the operator can filter the provider's native dashboard by tenant (especially relevant under the `shared` policy).
+- **FR-13** Every tenant config change (mode switch, allow-list refusal, credential rotation, force-invalidate) MUST be written to the per-tenant audit log with actor (operator vs tenant admin), before/after state (credential values masked), and timestamp.
+- **FR-14** Telemetry (Sentry events, PostHog metrics, structured logs) MUST tag every run/error with `tenantId` so per-tenant blast-radius and per-tenant error rates are queryable.
+- **FR-15** The system MUST allow per-tenant retention overrides where the provider supports it (Trigger.dev run retention, Temporal namespace retention) and MUST silently no-op (with a documented warning in tenant admin UI) where it does not (BullMQ, pg-boss, Inngest).
+- **FR-16** Credential reads at enqueue time MUST be cached with a short TTL (15–30 s) to keep enqueue latency within the NFR budget; cache invalidation MUST happen on the same API replica that wrote the rotation and propagate to peers within the eventual-consistency window (see NFR).
+- **FR-17** Tenant offboarding MUST be a single idempotent operation that drops/archives all per-tenant runtime artefacts (Postgres schema, Temporal namespace, auto-provisioned Trigger.dev project under `per-tenant` mode) and MUST be safe to re-run on a partially-offboarded tenant.
+- **FR-18** The system MUST NOT regress any EW-683 acceptance criterion — every existing instance-global behaviour (e.g. `EVER_WORKS_JOB_RUNTIME=pgboss` on a single-tenant instance) MUST continue to pass unchanged.
+- **FR-19** Provider plugins MUST own their tenant lifecycle hooks (`onTenantCreated`, `onTenantOffboarded`, `onCredentialRotated`, `onCredentialForceInvalidated`) via the `job-runtime` capability — the platform MUST NOT hard-code per-provider tenant logic.
+- **FR-20** The system MUST surface a tenant-scoped "runtime health" status (last successful enqueue, last failure, in-flight run count, credential version, credential age) in the tenant admin UI so tenant admins can self-diagnose without operator intervention.
+
+## 4. Non-Functional Requirements
+
+- **Performance**: enqueue overhead from the tenant-overlay layer (config resolution + credential lookup) MUST be < 5 ms p95 vs. the EW-683 instance-global baseline. Credential reads MUST be cached for 15–30 s to amortise DB hits.
+- **Reliability**: credential rotation MUST be eventually consistent across all API replicas within N seconds (target: 30 s; configurable). Graceful-drain runs MUST complete using the captured credential version even if rotation or force-invalidate fires mid-run, with the single exception of `force-invalidate` which intentionally aborts in-flight runs (FR-6).
+- **Isolation**: per-tenant blast-radius MUST be bounded by the chosen isolation mechanism — a Temporal-tenant outage MUST NOT affect a pg-boss-tenant; a tenant exhausting their own Trigger.dev quota MUST NOT affect inherit-mode tenants; a poison job in `pgboss_tenant_A` MUST NOT block `pgboss_tenant_B`.
+- **Security & privacy**: all tenant credentials are `x-secret` and `x-scope: tenant`, encrypted at rest, never returned in API responses, never logged in plaintext, and never crossed between tenants. `force-invalidate` MUST be operator-only (no tenant-admin route). Audit logs MUST be tamper-evident (append-only).
+- **Observability**: every run, error, log line, Sentry event, and PostHog metric MUST carry `tenantId`. Operator dashboards MUST be able to filter "all runs for tenant X" across all providers without per-provider custom code.
+- **Compatibility**: zero-config tenants (no overlay row, no platform-default policy change) MUST behave byte-identically to EW-683. Adding the overlay table MUST be a forward-only migration. Existing single-tenant operators MUST be unaffected.
+
+## 5. Key Entities & Domain Concepts
+
+| Entity / concept                | Description                                                                                                                                                |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `tenant_job_runtime_config`     | The per-tenant overlay row: `(tenantId, mode, providerId, credentialBlob, credentialVersion, status, createdAt, updatedAt)`.                               |
+| Mode                            | Enum `inherit | byo | override` — the three resolution paths a tenant can take against the instance default.                                              |
+| Plugin allow-list               | Operator-controlled list of provider IDs that are pickable by tenant admins; subset of the providers actually installed on the instance.                   |
+| Platform-default policy         | Operator-chosen policy for inherit-mode tenants: `shared` (one platform cred set, default) / `per-tenant` (auto-provision per tenant) / `tiered` (by sub). |
+| `credential_version`            | Monotonic per-tenant integer bumped on every credential write; captured at enqueue and used for the run's lifetime (graceful drain — Q4).                  |
+| Credential status               | Enum `active | draining | revoked` — `revoked` is set by the operator-only `force-invalidate` action and blocks new enqueues until re-saved.               |
+| Per-tenant isolation primitive  | The provider-owned unit of isolation: Temporal namespace per tenant (Q1), Postgres schema per tenant for pg-boss (Q2), separate project for Trigger.dev.   |
+| Tenant lifecycle hook           | Provider-plugin callback (`onTenantCreated`, `onTenantOffboarded`, `onCredentialRotated`, `onCredentialForceInvalidated`) the platform invokes uniformly.  |
+| Run tenant tags                 | `tenantId` + `tenantSlug` attached to every run's native metadata so provider dashboards stay tenant-filterable under the `shared` policy.                 |
+
+## 6. Out of Scope
+
+- **Per-Work routing** to different runtimes (still deferred per [`../job-runtime-providers/spec.md`](../job-runtime-providers/spec.md#6-out-of-scope) §6) — overlay resolution is per-tenant, not per-work.
+- **Live migration of in-flight runs** across providers when a tenant switches mode/provider — switch is "new runs use the new config; old runs drain on the old config."
+- **Self-serve Trigger.dev project provisioning from a tenant UI button** — `per-tenant` mode (Q5) is an operator-set policy that auto-provisions at signup; tenant admins do not initiate provisioning themselves.
+- **Cross-region routing of tenant credentials** — if a tenant's BYO Temporal Cloud lives in a different region from the API, latency is the operator's problem in v1 (see open question on cross-region worker fleets).
+- **Per-tenant choice of cache/lock backend** — that's [ADR-005](../../decisions/005-cache-and-lock-pluggability.md)'s concern; this feature is scoped to the job-runtime overlay only.
+- **A user-facing UI for end users** to see which runtime ran their job — runtime is operator/tenant-admin concern, not end-user surface.
+
+## 7. Acceptance Criteria
+
+- [ ] With no `tenant_job_runtime_config` rows and no platform-default policy change, every EW-683 acceptance criterion MUST continue to pass unchanged ([`../job-runtime-providers/spec.md`](../job-runtime-providers/spec.md#7-acceptance-criteria) §7 is the baseline).
+- [ ] **inherit / trigger**: a tenant with no overlay row runs against the instance-default Trigger.dev exactly as today.
+- [ ] **inherit / temporal**, **inherit / bullmq**, **inherit / pgboss**, **inherit / inngest**: a tenant with no overlay row runs against whichever instance-default the operator has set; all five providers behave identically from the tenant POV.
+- [ ] **byo / trigger**: a tenant supplies their own Trigger.dev project keys; runs land in their dashboard; the inherit-mode tenant on the same instance is unaffected.
+- [ ] **byo / temporal**, **byo / bullmq**, **byo / pgboss**, **byo / inngest**: same as above for the other four providers, with each provider's isolation primitive (namespace, schema, project) created on first enqueue.
+- [ ] **override / trigger→temporal** (instance default `trigger`, tenant picks `temporal`): tenant's runs execute against their Temporal namespace; instance default unchanged.
+- [ ] **override** for every (instance-default × tenant-chosen) pair where tenant-chosen ≠ instance-default and tenant-chosen is in the allow-list.
+- [ ] **Allow-list enforcement**: tenant admin UI hides non-allow-listed providers; API rejects them with 403.
+- [ ] **Platform-default `shared`**: two inherit-mode tenants share one platform Trigger.dev project; runs are tenant-tag-filterable in the Trigger.dev dashboard.
+- [ ] **Platform-default `per-tenant`**: new tenant signup auto-provisions a Trigger.dev project; tenant offboarding archives it.
+- [ ] **Platform-default `tiered`**: tenant in tier `free` lands on shared; tenant in tier `pro` lands on per-tenant.
+- [ ] **Credential rotation**: in-flight run completes on captured version; next enqueue uses new version; cache invalidates within the configured window.
+- [ ] **`force-invalidate`**: in-flight runs holding the revoked version fail with `CREDENTIAL_REVOKED`; new enqueues blocked until tenant re-saves.
+- [ ] **Tenant offboarding**: per-tenant Postgres schema dropped; Temporal namespace deleted; per-tenant Trigger.dev project archived (where applicable); operation is idempotent on partial state.
+- [ ] **NFR-Perf**: enqueue overhead < 5 ms p95 vs EW-683 baseline.
+- [ ] **NFR-Isolation**: poison job in tenant A's pg-boss schema does not block tenant B's pg-boss schema.
+- [ ] All FRs have a passing test (unit, conformance, or e2e).
+
+## 8. Open Questions
+
+- `[NEEDS CLARIFICATION: Tenant credential encryption — KMS (AWS/GCP/Vault) vs Postgres-native pgcrypto? KMS gives operator key-rotation hooks and audit trails out of the box; pgcrypto keeps the deploy single-binary and self-host-friendly. Proposal: support both via an `x-encryption-backend` setting and default to pgcrypto for OSS parity.]`
+- `[NEEDS CLARIFICATION: Cross-region — when a tenant BYOs Temporal Cloud in eu-west-1 and the API runs in us-east-1, do we accept the cross-region latency, require a per-region worker fleet, or reject the config? v1 proposal: accept the latency and document it; per-region worker fleets are a v2 question tied to the multi-region API roadmap.]`
+- `[NEEDS CLARIFICATION: BullMQ and pg-boss tenant onboarding latency budget — creating a Postgres schema + running pg-boss migrations on first enqueue can add seconds. Do we eagerly provision the schema at tenant-create time or lazily on first enqueue? Eager = faster first job, more wasted resources for tenants who never enqueue; lazy = the inverse.]`
+- `[NEEDS CLARIFICATION: \`force-invalidate\` UI ergonomics — single-click in the operator admin (fastest for true incident response) vs require type-to-confirm + reason text (safer against fat-finger / misuse). Proposal: type-to-confirm with reason, captured into the audit log.]`
+- `[NEEDS CLARIFICATION: Under \`per-tenant\` mode for Trigger.dev, when PAT REST cannot retrieve the freshly-provisioned project's prod secret key (documented Trigger.dev REST limitation), do we (a) require the tenant admin to paste the prod key after auto-provision, or (b) run a worker-self-registration step that exchanges PAT for a usable runtime key? (a) is simpler; (b) is fully zero-touch but adds a moving part.]`
+
+## 9. Constitution Gates
+
+- [x] **Plugin-first (Principle I)** — tenant lifecycle hooks are owned by each `job-runtime-*` provider plugin; the platform owns only the overlay table + resolver.
+- [x] **Capability-driven resolution (Principle II)** — overlay extends the existing `job-runtime` capability resolver from EW-683; no new capability category.
+- [x] **Source-of-truth repos preserved (Principle III)** — no change to code/content-in-Git semantics.
+- [x] **Long-running work via Trigger.dev (Principle IV)** — covered by [EW-685](https://evertech.atlassian.net/browse/EW-685)'s pending amendment ("via the configured job-runtime provider") from [`../job-runtime-providers/spec.md`](../job-runtime-providers/spec.md#9-constitution-gates) §9; **no additional amendment required** by this feature.
+- [x] **Forward-only migrations (Principle V)** — overlay table is additive; per-tenant Postgres schemas are created (never altering platform schema destructively).
+- [x] **Tests accompany the change (Principle VI)** — per-mode × per-provider matrix in the conformance suite + e2e for rotation / force-invalidate / offboarding.
+- [x] **Secrets per `x-secret` (Principle VII)** — all tenant creds `x-secret` + `x-scope: tenant`; never returned by the API.
+- [x] **Plugin counts touch canonical doc only (Principle VIII)** — no new plugins added by this feature; the existing five `job-runtime-*` plugins grow tenant-lifecycle hooks.
+- [x] **Behaviour-first (Principle IX)** — this spec describes behaviour; implementation in `plan.md`.
+- [x] **Backwards-compatible (Principle X)** — zero-config tenants behave byte-identically to EW-683; overlay is purely additive.
+
+## 10. References
+
+- ADR: [ADR-017](../../decisions/017-tenant-scoped-job-runtime-overlay.md) (this feature), [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md) (instance-global baseline)
+- Architecture: [`../../architecture/job-runtime-providers.md`](../../architecture/job-runtime-providers.md), [`../../architecture/settings-system.md`](../../architecture/settings-system.md)
+- Baseline feature: [`../job-runtime-providers/spec.md`](../job-runtime-providers/spec.md)
+- Related ADRs: [ADR-005](../../decisions/005-cache-and-lock-pluggability.md) (composes — cache/lock pluggability is orthogonal to runtime overlay)
+- Related features: [`../tenants-and-organizations`](../tenants-and-organizations/), [`../plugin-system`](../plugin-system/), [`../scheduled-updates/spec.md`](../scheduled-updates/spec.md), [`../generation-cancellation/spec.md`](../generation-cancellation/spec.md)
+- Jira: [EW-742](https://evertech.atlassian.net/browse/EW-742) (epic), [EW-743](https://evertech.atlassian.net/browse/EW-743) (this story), [EW-683](https://evertech.atlassian.net/browse/EW-683) (instance-global runtime selector — prereq), [EW-685](https://evertech.atlassian.net/browse/EW-685) (Principle IV amendment — prereq), [EW-686](https://evertech.atlassian.net/browse/EW-686) (prereq)

--- a/docs/specs/features/tenant-job-runtime-overlay/tasks.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/tasks.md
@@ -1,0 +1,89 @@
+# Task Breakdown: Tenant-Scoped Job-Runtime Overlay
+
+**Feature ID**: `tenant-job-runtime-overlay`
+**Status**: `Draft` (not started)
+**Last updated**: 2026-06-18
+**Spec**: [`./spec.md`](./spec.md) · **Plan**: [`./plan.md`](./plan.md) · **Providers**: [`./providers.md`](./providers.md) · **Epic**: [EW-742](https://evertech.atlassian.net/browse/EW-742) · **Story**: [EW-743](https://evertech.atlassian.net/browse/EW-743) · **ADR**: [ADR-017](../../decisions/017-tenant-scoped-job-runtime-overlay.md)
+
+> Ordered, granular tasks with explicit paths. Phases map to `plan.md` §10. Each phase is a candidate sub-PR. Mark `[x]` as landed. Suggested Jira child-issue grouping noted per phase (e.g. `[EW-742 P1]`). Builds on EW-683's instance-level job-runtime contract; nothing here re-opens [ADR-017 Q1–Q5](../../decisions/017-tenant-scoped-job-runtime-overlay.md) (Temporal namespace-per-tenant, pg-boss schema-per-tenant, Inngest inherit/BYO uniform with Trigger.dev, credential rotation via graceful drain + separate `force-invalidate`, hybrid operator-gated platform-default `shared`/`per-tenant`/`tiered`).
+
+---
+
+## Phase 0 — Spec-Kit (this PR, EW-743) · `[EW-743 P0]`
+
+- [ ] **T1.** Write [ADR-017](../../decisions/017-tenant-scoped-job-runtime-overlay.md) at `docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md` capturing Q1–Q5 locked decisions and the inherit/BYO overlay rationale on top of EW-683.
+- [ ] **T2.** Write `docs/specs/features/tenant-job-runtime-overlay/spec.md` — behaviour-first user stories (tenant picks provider, operator gates allow-list, graceful drain on rotation, force-invalidate path) with no implementation detail.
+- [ ] **T3.** Write `docs/specs/features/tenant-job-runtime-overlay/plan.md` — architecture, data model, API surface, phased rollout, constitution reconciliation; mirrors structure of [`job-runtime-providers/plan.md`](../job-runtime-providers/plan.md).
+- [ ] **T4.** Write `docs/specs/features/tenant-job-runtime-overlay/tasks.md` (this file) — numbered T1..TN per phase with file paths.
+- [ ] **T5.** Write `docs/specs/features/tenant-job-runtime-overlay/providers.md` — per-provider tenant-isolation matrix (Temporal namespace, pg-boss schema, BullMQ prefix, Trigger.dev project, Inngest app) and inherit-vs-BYO knob per provider.
+- [ ] **T6.** Cross-link from `docs/specs/architecture/job-runtime-providers.md` to the tenant-overlay docs by adding a "Tenant-scoped overlay" see-also section pointing at `spec.md`, `plan.md`, and [ADR-017](../../decisions/017-tenant-scoped-job-runtime-overlay.md).
+- [ ] **T7.** Verify constitution gates against `.specify/memory/constitution.md` — confirm Principle IV ("via the configured job-runtime provider") already covers tenant overlay; no new amendment required, document the verification in `plan.md` §Constitution Reconciliation.
+
+## Phase 1 — Data model + migration · `[EW-742 P1]`
+
+- [ ] **T8.** Audit `docs/specs/architecture/settings-system.md` for `x-scope: tenant`; if missing, add it to the scope taxonomy alongside `x-scope: global` (verify in worktree before writing — this is a prerequisite for tenant-scoped credentials).
+- [ ] **T9.** Define TypeORM entity `TenantJobRuntimeConfig` in `apps/api/src/works/entities/tenant-job-runtime-config.entity.ts` — columns: `tenantId` (PK), `providerId`, `mode` (`inherit` | `byo` | `override`), `credentialsSecretRef`, `credentialVersion`, `enabled`, `createdBy`, `createdAt`, `updatedAt`.
+- [ ] **T10.** Write TypeORM migration `apps/api/src/migrations/<timestamp>-AddTenantJobRuntimeConfig.ts` for the new table plus indexes on `tenantId` and `providerId`; forward-only per `docs/specs/architecture/database-migrations.md`.
+- [ ] **T11.** Implement `CredentialVersionService` for graceful drain (Q4) in `packages/agent/src/tasks/credential-version.service.ts` — issues monotonic per-tenant version ids and resolves a snapshot for a given `(tenantId, version)` tuple so in-flight runs keep their original credentials.
+- [ ] **T12.** Add audit-log table + entity for tenant runtime config changes in `apps/api/src/works/entities/tenant-job-runtime-audit.entity.ts` plus matching migration; records `(tenantId, actorUserId, action, before, after, credentialVersion, occurredAt)`.
+- [ ] **T13.** Repository + unit tests under `apps/api/src/works/__tests__/tenant-job-runtime-config.repository.spec.ts` covering insert, update, version bump, audit-row emission, and tenant isolation (one tenant cannot read another's row).
+
+## Phase 2 — Admin UI · `[EW-742 P2]`
+
+- [ ] **T14.** API endpoints `GET /api/account/job-runtime/config` and `PUT /api/account/job-runtime/config` in `apps/api/src/account/job-runtime.controller.ts` — guarded by tenant-admin role, returns redacted credentials on GET, accepts `{ providerId, mode, credentials }` on PUT and writes through the repository + audit log.
+- [ ] **T15.** Tenant settings page in `apps/web/src/app/(account)/settings/job-runtime/page.tsx` — server component that loads current config and renders the picker + credentials form.
+- [ ] **T16.** Provider picker component in `apps/web/src/components/job-runtime/provider-picker.tsx` — radio list of operator-enabled providers with `inherit` vs `BYO` vs `override` mode toggle per provider.
+- [ ] **T17.** Schema-driven credentials form component in `apps/web/src/components/job-runtime/credentials-form.tsx` reusing the existing settings-system JSON-Schema renderer (`x-secret`, `x-widget`, `x-envVar`) so no per-provider bespoke form is needed.
+- [ ] **T18.** Validation + error surfacing — show "provider disabled by operator", "credentials rejected by provider reachability probe", and "force-invalidate in progress" states via toast + inline field errors; reachability probe lives in `apps/api/src/account/job-runtime.controller.ts`.
+- [ ] **T19.** Playwright e2e test for the tenant config flow at `apps/web/e2e/tenant-job-runtime.spec.ts` — covers picker selection, BYO credential save, inherit fallback, validation error surfacing, and audit-row verification via API.
+
+## Phase 3 — Dispatcher routing · `[EW-742 P3]`
+
+- [ ] **T20.** Extend EW-685's binding factory (`packages/agent/src/tasks/job-runtime.providers.ts`) with a tenant-aware resolver that takes `(tenantId, jobName)` and returns the active `IJobRuntimeProvider` bound to that tenant's overlay credentials (or the inherited instance default).
+- [ ] **T21.** Credential cache with 15–60s TTL in `packages/agent/src/tasks/tenant-credential.cache.ts` — keyed by `(tenantId, providerId, credentialVersion)`, in-process LRU with explicit invalidate on version bump or force-invalidate.
+- [ ] **T22.** Credential version capture at every enqueue (Q4) — extend dispatch call sites to read the current `(tenantId, providerId)` version from `CredentialVersionService` and stamp `credentialVersion` into the run record so the worker host resolves the same snapshot when the job runs.
+- [ ] **T23.** Fallback path to instance-global default when a tenant has no overlay row — resolver returns the EW-683 instance binding unchanged; tests in T24 prove zero-overhead for tenants that never opt in.
+- [ ] **T24.** Unit tests for the resolver under `packages/agent/src/tasks/__tests__/tenant-job-runtime.resolver.spec.ts` covering inherit fallback, BYO overlay, cache hit/miss, version-snapshot resolution, and cache invalidation on rotation.
+
+## Phase 4 — Worker host · `[EW-742 P4]`
+
+- [ ] **T25.** Per-tenant webhook routing for Trigger.dev in `packages/tasks/src/trigger/tenant-webhook.handler.ts` — dispatches incoming Trigger.dev webhook events to the tenant whose `triggerRunId` matches the run, validating signing key against the tenant's BYO credential snapshot.
+- [ ] **T26.** Per-tenant webhook routing for Inngest in `packages/plugins/job-runtime-inngest/src/tenant-webhook.handler.ts` — analogous to T25, validates Inngest signing key per tenant; doc cross-link to [`./providers.md`](./providers.md) for the SaaS-only constraint.
+- [ ] **T27.** Per-tenant namespace polling for Temporal in `packages/plugins/job-runtime-temporal/src/tenant-worker-host.ts` — one worker per `(tenantId, namespace)` (Q1: namespace-per-tenant) bound to the task queue resolved from the tenant overlay.
+- [ ] **T28.** Per-tenant queue polling for BullMQ in `packages/plugins/job-runtime-bullmq/src/tenant-worker-host.ts` — one worker per `(tenantId, queueName)` with BullMQ `prefix` set to the tenant id; reuses `lockDuration`/`lockRenewTime` from EW-683's host config.
+- [ ] **T29.** Per-tenant schema polling for pg-boss in `packages/plugins/job-runtime-pgboss/src/tenant-worker-host.ts` — one `boss` instance per `(tenantId, schema)` (Q2: schema-per-tenant), reusing the platform `DATABASE_URL` by default.
+- [ ] **T30.** Multiplexing worker option (config flag) in each provider's worker host — one worker process polls all tenants and routes per `tenant_id` in job metadata; selected via `EVER_WORKS_JOB_RUNTIME_HOSTING={per-tenant|shared|tiered}` matching Q5's operator-gated platform-default.
+- [ ] **T31.** Tenant-id propagation in run metadata for all providers — extend `JobEnqueueOptions` in `packages/plugin/src/job-runtime/job-runtime.contract.ts` with a `tenantId` field and ensure every provider's dispatcher stamps it (Trigger `metadata`, Inngest `data`, Temporal `searchAttributes`, BullMQ `opts.tenantId`, pg-boss payload field).
+- [ ] **T32.** Integration tests per provider × per-tenant scenario under each plugin's `__tests__/tenant-isolation.spec.ts` — two tenants on the same provider, verify no cross-tenant run leakage and that webhook/poller routing lands on the correct tenant.
+
+## Phase 5 — Plugin gating · `[EW-742 P5]`
+
+- [ ] **T33.** Instance plugin allow-list config in `apps/api/src/config/plugins.config.ts` — operator-controlled list of `job-runtime.*` plugin ids exposed to tenants, plus the Q5 platform-default mode (`shared`/`per-tenant`/`tiered`); resolved through the settings hierarchy with `x-scope: global`.
+- [ ] **T34.** Picker filter in tenant admin UI — `apps/web/src/components/job-runtime/provider-picker.tsx` only renders providers that appear in the operator allow-list resolved from a new `GET /api/account/job-runtime/available-providers` endpoint.
+- [ ] **T35.** Audit-log entry on operator disable/enable — emit a `tenant_job_runtime_audit` row with `action='operator_allowlist_change'` for every tenant whose current provider becomes disabled, surfacing a banner in the tenant settings page on next load.
+
+## Phase 6 — Conformance · `[EW-742 P6]`
+
+- [ ] **T36.** Per-tenant test harness extending EW-683's conformance suite under `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — parameterised by `(providerId, tenantA, tenantB)`, reuses the base contract suite then layers tenant-isolation, rotation, and force-invalidate assertions.
+- [ ] **T37.** Parameterised per-tenant conformance run per provider in CI — extend the existing `JOB_RUNTIME={trigger|temporal|bullmq|pgboss|inngest}` matrix in `.github/workflows/` with a `TENANT_OVERLAY={off|on}` axis; both axes must be green per provider.
+- [ ] **T38.** Graceful drain test (Q4) in `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — enqueue run with credential version N, rotate to N+1 mid-run, verify the in-flight run completes with N's credential snapshot and a newly enqueued run uses N+1.
+- [ ] **T39.** Force-invalidate test in `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — invoke the admin `POST /api/account/job-runtime/force-invalidate` action, verify in-flight runs are marked `FAILED` (with `reason='credential_force_invalidated'`) and new enqueues are blocked until a new credential is saved.
+- [ ] **T40.** Cross-provider isolation test in `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — tenant A on `pgboss`, tenant B on `temporal`; concurrent enqueues, verify zero cross-talk in run records, webhooks, and worker logs.
+
+## Phase 7 — Docs · `[EW-742 P7]`
+
+- [ ] **T41.** Tenant admin runbook in `docs/runbooks/tenant-job-runtime.md` — how to pick a provider, enter BYO credentials, rotate, and read the audit log; cross-link `spec.md` and `providers.md`.
+- [ ] **T42.** Operator runbook in `docs/runbooks/operator-job-runtime-overlay.md` — covers Q5 modes (`shared` / `per-tenant` / `tiered`), allow-list gating, force-invalidate procedure with on-call checklist, and rollback to inherit-only.
+- [ ] **T43.** Per-provider tenant-config docs — add a "Tenant overlay" section to each provider plugin README (`packages/plugins/job-runtime-{trigger,temporal,bullmq,pgboss,inngest}/README.md`) and cross-link [`./providers.md`](./providers.md).
+- [ ] **T44.** Migration guide for existing tenants in `docs/runbooks/tenant-job-runtime-migration.md` — how to opt into BYO without losing in-flight work (graceful drain procedure, version-pinning checklist, fallback to inherit if BYO probe fails).
+
+## Dependency notes
+
+- T1–T7 (spec-kit) block everything else; this PR ships only Phase 0.
+- T8 (`x-scope: tenant`) blocks T9–T13 (data model needs the scope token).
+- T9–T13 (data model) block T14–T19 (admin UI writes through the repository) and T20–T24 (resolver reads from the repository).
+- T20–T24 (dispatcher) block T25–T32 (worker host needs the tenant-aware resolver to know which credentials a run belongs to).
+- T31 (`tenantId` in `JobEnqueueOptions`) blocks T25–T30 (all per-tenant routing depends on the metadata field).
+- T33–T35 (gating) can land in parallel with Phase 4 but must precede T19 going green (e2e validates the operator-gated picker).
+- T36–T40 (conformance) trail each provider's worker-host task (T27/T28/T29 for self-host, T25/T26 for SaaS).
+- T41–T44 (docs) trail each phase as it lands.


### PR DESCRIPTION
## Summary

Phase 0 (spec-kit writeup) of [EW-742](https://evertech.atlassian.net/browse/EW-742) — *Tenant-scoped job-runtime configuration overlay*. Tracked as [EW-743](https://evertech.atlassian.net/browse/EW-743).

Layers a **tenant configuration overlay** on top of [EW-683](https://evertech.atlassian.net/browse/EW-683)'s instance-global job-runtime selection. Each tenant on a multi-tenant deployment can:

1. **Inherit** the platform default runtime + its credentials (zero-config — behaviourally identical to today after EW-683 lands)
2. **Bring own credentials** for the same provider (e.g. instance default = `trigger` pointing at platform's Trigger.dev account; tenant ships own Trigger.dev project + prod secret key)
3. **Override** the runtime to a different *enabled* provider (e.g. instance default = `trigger`; tenant chooses `temporal` with own Temporal Cloud namespace)

## What's in this PR

Pure docs. No code, no behaviour change.

- `docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md` — ADR
- `docs/specs/features/tenant-job-runtime-overlay/spec.md` — behaviour-first spec (FRs, NFRs, user scenarios, acceptance criteria, constitution gates)
- `docs/specs/features/tenant-job-runtime-overlay/plan.md` — architecture, data model, API surface, P0-P7 phased rollout, risks
- `docs/specs/features/tenant-job-runtime-overlay/tasks.md` — 44 numbered tasks (T1-T44) across P0-P7, file paths included
- `docs/specs/features/tenant-job-runtime-overlay/providers.md` — per-provider tenant config schema, isolation, gotchas (Trigger.dev / Temporal / BullMQ / pg-boss / Inngest)
- `docs/specs/architecture/job-runtime-providers.md` — new "Tenant-Scoped Overlay" §11 cross-link

## Five locked design decisions (resolved before drafting)

| # | Decision |
|---|---|
| 1 | Temporal — one namespace per tenant (temporal plugin config) |
| 2 | pg-boss — one Postgres schema per tenant (pg-boss plugin config) |
| 3 | Inngest — uniform inherit/BYO trichotomy with Trigger.dev (no instance-only mode) |
| 4 | Credential rotation — graceful drain via credential-version capture; separate `force-invalidate` admin action for compromised keys |
| 5 | Platform-default for inherit — hybrid operator-gated: `shared` (default) / `per-tenant` / `tiered` |

## Surfaced from

The directory-web-template demo → k8s-works cutover (June 2026): 8 Works under one tenant on k8s-works all needed Trigger.dev wiring manually. Per-Work secret provisioning is the wrong layer — tenants own billing relationships, plugin entitlements, and operator-of-record; the right layer is per-tenant.

## What's NOT in this PR

- **No code.** Spec-kit only. Implementation phases P1-P7 will each be their own PR(s) tracked under EW-742.
- **No constitution amendment.** [EW-685](https://evertech.atlassian.net/browse/EW-685)'s pending Principle IV change ("via the configured job-runtime provider") already covers the tenant overlay; cross-referenced rather than duplicated.
- **No per-Work routing.** Still deferred per EW-683 §6.

## Test plan

- [ ] Markdown lint + Docusaurus build (CI) — docs render under docs.ever.works.
- [ ] All cross-references resolve (ADR-015, ADR-005, EW-683 spec/plan/tasks/providers, settings-system.md, database.md, .specify/memory/constitution.md).
- [ ] Reviewer reads ADR-017 and confirms the five locked decisions are clearly stated and not re-litigated in spec/plan/tasks/providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-742]: https://evertech.atlassian.net/browse/EW-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-743]: https://evertech.atlassian.net/browse/EW-743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-683]: https://evertech.atlassian.net/browse/EW-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-685]: https://evertech.atlassian.net/browse/EW-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specification for tenant job-runtime overlay feature, enabling tenants to inherit, customize, or override instance-level job runtime configuration.
  * Documented provider-specific isolation models and three tenant configuration modes (inherit, bring-your-own, override) across supported runtime providers.
  * Included architecture decision record, implementation plan, phased rollout strategy, and detailed task breakdown for feature development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->