### PR TITLE
feat(plugin): add x-scope: tenant grammar (EW-742 P1.0)

### DIFF
--- a/docs/specs/architecture/settings-system.md
+++ b/docs/specs/architecture/settings-system.md
@@ -19,15 +19,24 @@ This spec covers the **resolution algorithm**, **scope model**, **secret
 hygiene**, and **environment-variable fallback** that make plugin
 settings safe to use across admin, user, and per-work contexts.
 
-## 2. The Three Tiers
+## 2. The Tiers
 
-Plugin settings can be set at three scopes:
+Plugin settings can be set at four scopes (three originally; `tenant` was added by [EW-742](https://evertech.atlassian.net/browse/EW-742) for multi-tenant deployments):
 
-| Scope    | Storage table     | Configured by | Lifetime                  |
-| -------- | ----------------- | ------------- | ------------------------- |
-| `global` | `plugin_settings` | Admin         | Survives all sessions     |
-| `user`   | `user_plugins`    | The user      | Per-user                  |
-| `work`   | `work_plugins`    | Work editor   | Per-work (overrides user) |
+| Scope    | Storage table              | Configured by    | Lifetime                                              |
+| -------- | -------------------------- | ---------------- | ----------------------------------------------------- |
+| `global` | `plugin_settings`          | Admin            | Survives all sessions                                 |
+| `tenant` | `tenant_plugin_settings`   | Tenant admin     | Per-tenant; overrides `global` for tenant-scoped keys |
+| `user`   | `user_plugins`             | The user         | Per-user; overrides `tenant`/`global`                 |
+| `work`   | `work_plugins`             | Work editor      | Per-work (overrides user)                             |
+
+> **`tenant` scope status (2026-06):** the `x-scope: 'tenant'` JSON-Schema value
+> is recognised by the plugin contracts (see `packages/plugin/src/settings/json-schema.types.ts`).
+> Storage tier `tenant_plugin_settings` and the corresponding cascade step are
+> introduced by [EW-742](https://evertech.atlassian.net/browse/EW-742) P1
+> (data model + migration). For single-tenant or pre-overlay deployments, a
+> `tenant` value resolves identically to `global` — adding the scope is a
+> grammar-only change (P1.0) and ships ahead of the storage tier.
 
 The **resolution cascade** for a key is, in order of precedence:
 
@@ -35,11 +44,14 @@ The **resolution cascade** for a key is, in order of precedence:
    has its own value for the key.
 2. **User** — if the call carries a `userId` and the user has their own
    value.
-3. **Admin (global)** — the platform-wide default an admin set.
-4. **Environment variable** — the value of `x-envVar` from the schema,
+3. **Tenant** — if the call carries a `tenantId` and the tenant has its
+   own value for a `x-scope: 'tenant'` key (EW-742 P1+; pre-P1 deployments
+   skip this step and fall through to `global`).
+4. **Admin (global)** — the platform-wide default an admin set.
+5. **Environment variable** — the value of `x-envVar` from the schema,
    if defined and present in the process env.
-5. **Schema default** — the JSON Schema `default` value.
-6. **Undefined** — caller must handle the missing value.
+6. **Schema default** — the JSON Schema `default` value.
+7. **Undefined** — caller must handle the missing value.
 
 The cascade is implemented in `PluginSettingsService.resolve(...)`. It's
 the same code path for plugin enablement, settings UI rendering, and

--- a/packages/plugin/src/api/__tests__/api-response.types.spec.ts
+++ b/packages/plugin/src/api/__tests__/api-response.types.spec.ts
@@ -63,4 +63,24 @@ describe('toPluginSettingsSchemaProperty', () => {
 		const out = toPluginSettingsSchemaProperty(schema);
 		expect(out.oneOf).toBeUndefined();
 	});
+
+	it('passes through x-scope: tenant for fields scoped to a tenant overlay (EW-742)', () => {
+		const schema: JsonSchema = {
+			type: 'object',
+			title: 'Job-runtime tenant overlay',
+			properties: {
+				apiKey: {
+					type: 'string',
+					title: 'Tenant Trigger.dev secret key',
+					'x-secret': true,
+					'x-scope': 'tenant'
+				}
+			}
+		};
+
+		const out = toPluginSettingsSchemaProperty(schema);
+
+		expect(out.properties?.apiKey?.scope).toBe('tenant');
+		expect(out.properties?.apiKey?.secret).toBe(true);
+	});
 });

--- a/packages/plugin/src/api/api-response.types.ts
+++ b/packages/plugin/src/api/api-response.types.ts
@@ -19,8 +19,12 @@ import type { ProviderModelSummary } from '../contracts/capabilities/form-schema
 
 /**
  * Setting scope determines where the setting value is stored and who can configure it.
+ * The `tenant` scope was added by EW-742 (tenant-scoped job-runtime overlay) for
+ * settings that one tenant on a multi-tenant deployment configures separately from
+ * the global / per-user / per-work tiers. For single-tenant deployments, `tenant`
+ * resolves identically to `global`.
  */
-export type SettingScopeApi = 'global' | 'user' | 'work';
+export type SettingScopeApi = 'global' | 'tenant' | 'user' | 'work';
 
 /**
  * Plugin settings schema property for API responses.
@@ -44,7 +48,7 @@ export interface PluginSettingsSchemaProperty {
 	adminOnly?: boolean;
 	/** Environment variable name if field is env-only (from JsonSchema x-envVar) */
 	envVar?: string;
-	/** Setting scope: global, user, or work (from JsonSchema x-scope) */
+	/** Setting scope: global, tenant, user, or work (from JsonSchema x-scope) */
 	scope?: SettingScopeApi;
 	/** Enumerated allowed values */
 	enum?: readonly unknown[];

--- a/packages/plugin/src/settings/json-schema.types.ts
+++ b/packages/plugin/src/settings/json-schema.types.ts
@@ -19,8 +19,14 @@ export interface PluginSchemaExtensions {
 	readonly 'x-secret'?: boolean;
 	/** Environment variable fallback (checked when no other setting is found) */
 	readonly 'x-envVar'?: string;
-	/** Setting scope: global, user, or work */
-	readonly 'x-scope'?: 'global' | 'user' | 'work';
+	/**
+	 * Setting scope: global, tenant, user, or work.
+	 * Hint to the UI; actual scope is inferred from where the user clicks. The
+	 * `tenant` value is consumed by the multi-tenant overlay introduced in EW-742
+	 * (see docs/specs/features/tenant-job-runtime-overlay/spec.md). For non-tenant
+	 * deployments, `tenant` behaves identically to `global` at resolution time.
+	 */
+	readonly 'x-scope'?: 'global' | 'tenant' | 'user' | 'work';
 	/** Whether field is admin-only (not visible to regular users) */
 	readonly 'x-adminOnly'?: boolean;
 	/** Whether field should be hidden from the settings UI entirely */


### PR DESCRIPTION
## Summary

Phase 1, sub-story P1.0 of [EW-742](https://evertech.atlassian.net/browse/EW-742) — strict prerequisite for all subsequent tenant-overlay work.

Widens the `x-scope` JSON Schema extension union (and the parallel `SettingScopeApi` API response type) to include `'tenant'`. Updates the settings-system architecture doc to enumerate the four scopes and the updated cascade order.

## Why this is safe to ship ahead of P1's storage tier

Pure type-widening. No runtime change.

- For pre-overlay plugins (zero schemas declare `x-scope: 'tenant'`): the new union member is unused — existing plugins compile unchanged.
- For pre-P1 deployments (no `tenant_plugin_settings` table, no tenant cascade step): the resolver doesn't yet route to tenant, so a hypothetical `x-scope: 'tenant'` field resolves identically to `global`. Documented explicitly in settings-system.md §2 with the storage-tier-status note.
- No exhaustive switch on the scope union exists in the codebase (verified by grep across packages/plugin, packages/agent, apps/api).

## What's in this PR

- `packages/plugin/src/settings/json-schema.types.ts` — `x-scope` union widened from `'global' | 'user' | 'work'` → `'global' | 'tenant' | 'user' | 'work'` with JSDoc cross-link to the EW-742 tenant overlay spec.
- `packages/plugin/src/api/api-response.types.ts` — `SettingScopeApi` widened symmetrically; comment on the `scope` field updated.
- `packages/plugin/src/api/__tests__/api-response.types.spec.ts` — new test case verifying `x-scope: 'tenant'` passes through the schema flattener correctly alongside `x-secret`.
- `docs/specs/architecture/settings-system.md` — §2 table now has 4 rows (global/tenant/user/work); cascade list updated from 6 → 7 steps (tenant inserted between user and global); explicit status note flagging that this PR is grammar-only.

## What's NOT in this PR (lands in subsequent P1.x sub-stories)

- `tenant_plugin_settings` storage table + TypeORM entity + migration (P1.1-P1.3).
- Cascade resolver step that actually consults the tenant tier in `PluginSettingsService.resolve()` (P1.4).
- `TenantJobRuntimeConfig` entity + the broader runtime overlay schema (P1.5+).

## Refs

- Epic: [EW-742](https://evertech.atlassian.net/browse/EW-742)
- Spec-kit story: [EW-743](https://evertech.atlassian.net/browse/EW-743) (Done)
- Plan source: `docs/specs/features/tenant-job-runtime-overlay/plan.md` §10 Phase 1 sub-story P1.0
- Spec FR mapping: `docs/specs/features/tenant-job-runtime-overlay/spec.md` (`x-scope: tenant` referenced throughout)
- Tasks: `docs/specs/features/tenant-job-runtime-overlay/tasks.md` T8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-742]: https://evertech.atlassian.net/browse/EW-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-742]: https://evertech.atlassian.net/browse/EW-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced tenant scope as a new fourth configuration tier for settings management. This expands the available scope hierarchy to include global, tenant, user, and work scopes.

* **Documentation**
  * Updated architecture specifications and system documentation to describe the new tenant scope tier, its resolution precedence, storage mechanisms, and integration within the settings system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->