### PR TITLE
feat(api): admin REST API for tenant-job-runtime overlay (EW-742 P2.0 / EW-746 first half)

### DIFF
--- a/apps/api/src/account/account.module.ts
+++ b/apps/api/src/account/account.module.ts
@@ -1,9 +1,15 @@
 import { Module } from '@nestjs/common';
 import { AccountTransferModule } from '@ever-works/agent/account-transfer';
 import { AccountController } from './account.controller';
+import { TenantJobRuntimeModule } from './tenant-job-runtime/tenant-job-runtime.module';
 
+/**
+ * Account-scoped APIs. Wires the legacy AccountController (export /
+ * import / GitHub sync) plus the EW-742 P2.0 tenant-job-runtime overlay
+ * admin surface (`/api/account/job-runtime/...`).
+ */
 @Module({
-    imports: [AccountTransferModule],
+    imports: [AccountTransferModule, TenantJobRuntimeModule],
     controllers: [AccountController],
 })
 export class AccountModule {}

--- a/apps/api/src/account/tenant-job-runtime/__tests__/tenant-job-runtime.controller.spec.ts
+++ b/apps/api/src/account/tenant-job-runtime/__tests__/tenant-job-runtime.controller.spec.ts
@@ -1,0 +1,335 @@
+// EW-742 / EW-746 (P2.0) — controller + service tests for the
+// tenant-job-runtime overlay admin API.
+//
+// We exercise the controller through the service against an in-memory
+// repository stub so the spec covers the wire-level contract (auth gate,
+// validation routing, audit emission, redaction) without spinning up
+// TypeORM. Spec reference:
+// `docs/specs/features/tenant-job-runtime-overlay/spec.md` (FR-7, FR-13).
+
+jest.mock('@ever-works/agent/entities', () => ({
+    // The test never persists rows, so we only need the class identities
+    // for `@InjectRepository(...)` token lookups. Using plain classes here
+    // matches the convention in
+    // `apps/api/src/activity-log/activity-log.controller.spec.ts` —
+    // mocking the entities barrel keeps the suite from pulling the full
+    // TypeORM decorator graph at import time.
+    TenantJobRuntimeConfig: class TenantJobRuntimeConfig {},
+    TenantJobRuntimeAudit: class TenantJobRuntimeAudit {},
+}));
+
+jest.mock('@ever-works/agent/tasks', () => ({
+    CredentialVersionService: class CredentialVersionService {},
+}));
+
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import type { CredentialVersionService } from '@ever-works/agent/tasks';
+import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+import type { AuthenticatedUser } from '../../../auth/types/auth.types';
+import { TenantJobRuntimeController } from '../tenant-job-runtime.controller';
+import { TenantJobRuntimeService } from '../tenant-job-runtime.service';
+
+type ConfigRow = TenantJobRuntimeConfig & {
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+function buildConfigRow(overrides: Partial<ConfigRow> = {}): ConfigRow {
+    const now = new Date('2026-06-18T12:00:00.000Z');
+    return {
+        tenantId: 'tenant-1',
+        providerId: 'trigger',
+        credentialsSecretRef: 'tenant-job-runtime:abc123:trigger:v1',
+        credentialVersion: 1,
+        mode: 'byo',
+        enabled: true,
+        createdBy: 'user-1',
+        createdAt: now,
+        updatedAt: now,
+        ...overrides,
+    } as ConfigRow;
+}
+
+function buildAuth(overrides: Partial<AuthenticatedUser> = {}): AuthenticatedUser {
+    return {
+        userId: 'user-1',
+        email: 'u@example.test',
+        username: 'u',
+        provider: 'local',
+        emailVerified: true,
+        isActive: true,
+        avatar: null,
+        iat: 0,
+        iss: '',
+        aud: '',
+        tenantId: 'tenant-1',
+        ...overrides,
+    } as AuthenticatedUser;
+}
+
+describe('TenantJobRuntimeController', () => {
+    let controller: TenantJobRuntimeController;
+    let service: TenantJobRuntimeService;
+    let configRepo: {
+        findOne: jest.Mock;
+        create: jest.Mock;
+        save: jest.Mock;
+    };
+    let auditRepo: {
+        create: jest.Mock;
+        save: jest.Mock;
+    };
+    let credentialVersionService: jest.Mocked<Pick<CredentialVersionService, 'bumpVersion'>>;
+
+    beforeEach(() => {
+        configRepo = {
+            findOne: jest.fn(),
+            create: jest.fn((row) => row as ConfigRow),
+            save: jest.fn((row) => row as ConfigRow),
+        };
+        auditRepo = {
+            create: jest.fn((row) => row),
+            save: jest.fn((row) => row),
+        };
+        credentialVersionService = {
+            bumpVersion: jest.fn(),
+        } as any;
+
+        service = new TenantJobRuntimeService(
+            configRepo as any,
+            auditRepo as any,
+            credentialVersionService as unknown as CredentialVersionService,
+        );
+        controller = new TenantJobRuntimeController(service);
+    });
+
+    // ─── Auth gate (every endpoint) ────────────────────────────────
+
+    describe('tenant gate', () => {
+        it('refuses with 403 when the caller has no Tenant (null tenantId)', async () => {
+            const auth = buildAuth({ tenantId: null });
+            await expect(controller.getConfig(auth)).rejects.toBeInstanceOf(ForbiddenException);
+            await expect(
+                controller.upsertConfig(auth, {
+                    providerId: 'trigger',
+                    mode: 'inherit',
+                } as any),
+            ).rejects.toBeInstanceOf(ForbiddenException);
+            await expect(controller.rotateCredential(auth)).rejects.toBeInstanceOf(
+                ForbiddenException,
+            );
+            await expect(controller.forceInvalidate(auth)).rejects.toBeInstanceOf(
+                ForbiddenException,
+            );
+            await expect(controller.revertToInherit(auth)).rejects.toBeInstanceOf(
+                ForbiddenException,
+            );
+        });
+
+        it('refuses with 403 when tenantId is undefined (not yet hydrated)', async () => {
+            const auth = buildAuth({ tenantId: undefined });
+            await expect(controller.getConfig(auth)).rejects.toBeInstanceOf(ForbiddenException);
+        });
+    });
+
+    // ─── GET ───────────────────────────────────────────────────────
+
+    describe('GET /api/account/job-runtime/config', () => {
+        it('returns the synthetic inherit default when no row exists (FR-7 NULL-safe)', async () => {
+            configRepo.findOne.mockResolvedValue(null);
+            const result = await controller.getConfig(buildAuth());
+            expect(result).toEqual({
+                tenantId: 'tenant-1',
+                providerId: null,
+                mode: 'inherit',
+                hasCredentials: false,
+                credentialsSecretRefRedacted: null,
+                credentialVersion: null,
+                enabled: true,
+                createdBy: null,
+                createdAt: null,
+                updatedAt: null,
+            });
+        });
+
+        it('redacts the credentials ref to the last 4 chars', async () => {
+            configRepo.findOne.mockResolvedValue(
+                buildConfigRow({
+                    credentialsSecretRef: 'tenant-job-runtime:abc123:trigger:abcd1234',
+                }),
+            );
+            const result = await controller.getConfig(buildAuth());
+            expect(result.hasCredentials).toBe(true);
+            expect(result.credentialsSecretRefRedacted).toBe('***1234');
+            // The full ref MUST NOT leak anywhere on the response.
+            expect(JSON.stringify(result)).not.toContain('abc123');
+        });
+    });
+
+    // ─── PUT ───────────────────────────────────────────────────────
+
+    describe('PUT /api/account/job-runtime/config', () => {
+        it('400s when mode = inherit and credentialsSecretRef is supplied', async () => {
+            await expect(
+                controller.upsertConfig(buildAuth(), {
+                    providerId: 'trigger',
+                    mode: 'inherit',
+                    credentialsSecretRef: 'tenant-job-runtime:should-not-be-here',
+                } as any),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('creates a fresh row at version 1 + emits a "create" audit row', async () => {
+            configRepo.findOne.mockResolvedValue(null);
+            configRepo.save.mockImplementation(async (row) => ({ ...row }));
+
+            const result = await controller.upsertConfig(buildAuth(), {
+                providerId: 'trigger',
+                mode: 'byo',
+                credentialsSecretRef: 'tenant-job-runtime:new-ref-abcd',
+                enabled: true,
+            } as any);
+
+            expect(result.mode).toBe('byo');
+            expect(result.providerId).toBe('trigger');
+            expect(result.credentialVersion).toBe(1);
+            expect(result.hasCredentials).toBe(true);
+            expect(result.credentialsSecretRefRedacted).toBe('***abcd');
+
+            const auditPayload = auditRepo.create.mock.calls[0][0];
+            expect(auditPayload.action).toBe('create');
+            expect(auditPayload.tenantId).toBe('tenant-1');
+            expect(auditPayload.actorUserId).toBe('user-1');
+            expect(auditPayload.before).toBeNull();
+            // Secret MUST be redacted in the audit row too.
+            expect(JSON.stringify(auditPayload.after)).not.toContain('new-ref-abcd');
+            expect(auditPayload.after.credentialsSecretRefRedacted).toBe('***abcd');
+        });
+
+        it('bumps credentialVersion when credentialsSecretRef changes (rotation semantic)', async () => {
+            const existing = buildConfigRow({
+                credentialsSecretRef: 'old-ref-xxxx',
+                credentialVersion: 3,
+            });
+            configRepo.findOne.mockResolvedValue(existing);
+            configRepo.save.mockImplementation(async (row) => ({ ...row }));
+
+            const result = await controller.upsertConfig(buildAuth(), {
+                providerId: 'trigger',
+                mode: 'byo',
+                credentialsSecretRef: 'new-ref-yyyy',
+            } as any);
+
+            expect(result.credentialVersion).toBe(4);
+            const auditPayload = auditRepo.create.mock.calls[0][0];
+            expect(auditPayload.action).toBe('update');
+            expect(auditPayload.before.credentialsSecretRefRedacted).toBe('***xxxx');
+            expect(auditPayload.after.credentialsSecretRefRedacted).toBe('***yyyy');
+        });
+
+        it('does NOT bump credentialVersion when only providerId changes', async () => {
+            const existing = buildConfigRow({
+                providerId: 'trigger',
+                credentialsSecretRef: 'same-ref-zzzz',
+                credentialVersion: 5,
+            });
+            configRepo.findOne.mockResolvedValue(existing);
+            configRepo.save.mockImplementation(async (row) => ({ ...row }));
+
+            const result = await controller.upsertConfig(buildAuth(), {
+                providerId: 'temporal',
+                mode: 'override',
+                credentialsSecretRef: 'same-ref-zzzz',
+            } as any);
+
+            expect(result.providerId).toBe('temporal');
+            expect(result.credentialVersion).toBe(5);
+        });
+    });
+
+    // ─── rotate ────────────────────────────────────────────────────
+
+    describe('POST /api/account/job-runtime/rotate', () => {
+        it('404s when no overlay row exists (inherit cannot be rotated)', async () => {
+            configRepo.findOne.mockResolvedValue(null);
+            await expect(controller.rotateCredential(buildAuth())).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(credentialVersionService.bumpVersion).not.toHaveBeenCalled();
+        });
+
+        it('delegates to CredentialVersionService.bumpVersion + emits "rotate" audit', async () => {
+            configRepo.findOne.mockResolvedValue(buildConfigRow({ credentialVersion: 7 }));
+            credentialVersionService.bumpVersion.mockResolvedValue(8);
+
+            const result = await controller.rotateCredential(buildAuth());
+
+            expect(result).toEqual({ credentialVersion: 8 });
+            expect(credentialVersionService.bumpVersion).toHaveBeenCalledWith('tenant-1');
+            const auditPayload = auditRepo.create.mock.calls[0][0];
+            expect(auditPayload.action).toBe('rotate');
+            expect(auditPayload.credentialVersion).toBe(8);
+        });
+    });
+
+    // ─── force-invalidate ──────────────────────────────────────────
+
+    describe('POST /api/account/job-runtime/force-invalidate', () => {
+        it('404s when no overlay row exists', async () => {
+            configRepo.findOne.mockResolvedValue(null);
+            await expect(controller.forceInvalidate(buildAuth())).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+
+        it('bumps credentialVersion + emits a "force_invalidate" audit row', async () => {
+            configRepo.findOne.mockResolvedValue(buildConfigRow({ credentialVersion: 9 }));
+            credentialVersionService.bumpVersion.mockResolvedValue(10);
+
+            const result = await controller.forceInvalidate(buildAuth());
+
+            expect(result).toEqual({ credentialVersion: 10 });
+            const auditPayload = auditRepo.create.mock.calls[0][0];
+            expect(auditPayload.action).toBe('force_invalidate');
+            expect(auditPayload.credentialVersion).toBe(10);
+        });
+    });
+
+    // ─── DELETE ────────────────────────────────────────────────────
+
+    describe('DELETE /api/account/job-runtime/config', () => {
+        it('reverts an existing row to inherit + bumps credentialVersion + emits "delete"', async () => {
+            const existing = buildConfigRow({
+                mode: 'byo',
+                providerId: 'trigger',
+                credentialsSecretRef: 'old-ref-pppp',
+                credentialVersion: 4,
+            });
+            configRepo.findOne.mockResolvedValue(existing);
+            configRepo.save.mockImplementation(async (row) => ({ ...row }));
+
+            const result = await controller.revertToInherit(buildAuth());
+
+            expect(result.mode).toBe('inherit');
+            expect(result.hasCredentials).toBe(false);
+            expect(result.credentialsSecretRefRedacted).toBeNull();
+            expect(result.credentialVersion).toBe(5);
+            // Row kept (history preserved per plan.md §4); only fields blanked.
+            expect(configRepo.save).toHaveBeenCalled();
+            const auditPayload = auditRepo.create.mock.calls[0][0];
+            expect(auditPayload.action).toBe('delete');
+            expect(auditPayload.before.credentialsSecretRefRedacted).toBe('***pppp');
+            expect(auditPayload.after.credentialsSecretRefRedacted).toBeNull();
+        });
+
+        it('is idempotent — returns the synthetic default when no row exists', async () => {
+            configRepo.findOne.mockResolvedValue(null);
+            const result = await controller.revertToInherit(buildAuth());
+            expect(result.mode).toBe('inherit');
+            expect(result.hasCredentials).toBe(false);
+            // No mutation when there's nothing to revert.
+            expect(configRepo.save).not.toHaveBeenCalled();
+            expect(auditRepo.save).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/api/src/account/tenant-job-runtime/dto/tenant-job-runtime-response.dto.ts
+++ b/apps/api/src/account/tenant-job-runtime/dto/tenant-job-runtime-response.dto.ts
@@ -1,0 +1,120 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+    TENANT_JOB_RUNTIME_MODES,
+    TENANT_JOB_RUNTIME_PROVIDER_IDS,
+    type TenantJobRuntimeMode,
+    type TenantJobRuntimeProviderId,
+} from './upsert-tenant-job-runtime.dto';
+
+/**
+ * EW-742 / EW-746 (P2.0 — tenant-job-runtime overlay admin API) — wire
+ * shape returned by the GET / PUT / DELETE / rotate endpoints under
+ * `/api/account/job-runtime/...`.
+ *
+ * Spec: [`docs/specs/features/tenant-job-runtime-overlay/spec.md`](../../../../../docs/specs/features/tenant-job-runtime-overlay/spec.md)
+ * Plan: [`plan.md` §4 + §6 settings cascade](../../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md)
+ *
+ * **Credential redaction (settings-system §7 + spec FR-13):** the response
+ * exposes only the presence of a credential pointer (`hasCredentials`) and
+ * the redacted ref suffix (`credentialsSecretRefRedacted`) — never the
+ * full opaque ref and obviously never the underlying plaintext credential
+ * blob. The underlying blob lives in the encrypted secrets store and is
+ * decrypted only on the dispatch path (P3) where the worker host needs
+ * it.
+ *
+ * **`mode: inherit` synthetic default (NULL-safe GET):** when the tenant
+ * has no overlay row yet, the controller returns this DTO with
+ * `mode = 'inherit'`, `providerId = null`, `credentialsSecretRefRedacted
+ * = null`, `hasCredentials = false`, and `credentialVersion = null`. That
+ * keeps the GET endpoint NULL-safe per FR-7 ("absence of a row is
+ * equivalent to inherit") without forcing the UI to special-case 404.
+ */
+export class TenantJobRuntimeConfigResponseDto {
+    @ApiProperty({
+        description: 'Tenant id this overlay row belongs to.',
+        example: '7f3c1a2e-4d5b-4c6a-9e8f-0b1c2d3e4f5a',
+    })
+    readonly tenantId!: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Provider id when an overlay row exists. NULL when no row exists ' +
+            '(synthetic `mode = inherit` default — see DTO doc).',
+        enum: TENANT_JOB_RUNTIME_PROVIDER_IDS,
+        nullable: true,
+    })
+    readonly providerId!: TenantJobRuntimeProviderId | null;
+
+    @ApiProperty({
+        description: 'Active overlay mode (synthetic `inherit` when no row exists).',
+        enum: TENANT_JOB_RUNTIME_MODES,
+    })
+    readonly mode!: TenantJobRuntimeMode;
+
+    @ApiProperty({
+        description:
+            'Whether a credentials secret pointer is stored on the row. ' +
+            '`false` for `mode = inherit` (no overlay credentials).',
+    })
+    readonly hasCredentials!: boolean;
+
+    @ApiPropertyOptional({
+        description:
+            'Redacted credentials pointer for operator UX (last 4 chars only — ' +
+            'NEVER the full ref). NULL when no credentials are stored.',
+        nullable: true,
+        example: '***f5a',
+    })
+    readonly credentialsSecretRefRedacted!: string | null;
+
+    @ApiPropertyOptional({
+        description:
+            'Current monotonic credential version. NULL when no overlay row ' +
+            'exists; `>= 1` when a row exists (incremented on every rotate / ' +
+            'force-invalidate per ADR-017 §3).',
+        nullable: true,
+    })
+    readonly credentialVersion!: number | null;
+
+    @ApiProperty({
+        description:
+            'Soft-disable flag. `false` makes the dispatcher treat the row as ' +
+            '`inherit` even when `mode = byo|override`.',
+    })
+    readonly enabled!: boolean;
+
+    @ApiPropertyOptional({
+        description:
+            'User id that created the row, or NULL when the row was created by ' +
+            'a system / migration actor.',
+        nullable: true,
+    })
+    readonly createdBy!: string | null;
+
+    @ApiPropertyOptional({
+        description: 'Row creation timestamp (ISO 8601). NULL for the synthetic inherit default.',
+        nullable: true,
+    })
+    readonly createdAt!: string | null;
+
+    @ApiPropertyOptional({
+        description: 'Last update timestamp (ISO 8601). NULL for the synthetic inherit default.',
+        nullable: true,
+    })
+    readonly updatedAt!: string | null;
+}
+
+/**
+ * Response shape for `POST /api/account/job-runtime/rotate` and `POST
+ * /api/account/job-runtime/force-invalidate`. Surfaces the post-bump
+ * version so the UI can refresh its cached row without an extra GET.
+ */
+export class TenantJobRuntimeRotateResponseDto {
+    @ApiProperty({
+        description:
+            'New credential version after the bump. The dispatcher will pick ' +
+            'this version up on the next enqueue; in-flight runs keep their ' +
+            'captured version per ADR-017 §3 (graceful drain).',
+    })
+    readonly credentialVersion!: number;
+}

--- a/apps/api/src/account/tenant-job-runtime/dto/upsert-tenant-job-runtime.dto.ts
+++ b/apps/api/src/account/tenant-job-runtime/dto/upsert-tenant-job-runtime.dto.ts
@@ -1,0 +1,117 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsIn, IsOptional, IsString, MaxLength, ValidateIf } from 'class-validator';
+
+/**
+ * EW-742 / EW-746 (P2.0 — tenant-job-runtime overlay admin API) — request
+ * DTO for `PUT /api/account/job-runtime/config`.
+ *
+ * Spec: [`docs/specs/features/tenant-job-runtime-overlay/spec.md`](../../../../../docs/specs/features/tenant-job-runtime-overlay/spec.md)
+ * Plan: [`plan.md` §4 API surface](../../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md#4-api-surface)
+ * Tasks: [`tasks.md` T14](../../../../../docs/specs/features/tenant-job-runtime-overlay/tasks.md)
+ *
+ * Validation contract:
+ *   - `providerId` MUST be in the static instance-default allow-list
+ *     (per [`providers.md`](../../../../../docs/specs/features/tenant-job-runtime-overlay/providers.md)
+ *     availability matrix). The dynamic per-tenant operator allow-list
+ *     filtering (FR-9 / T34) lives in the service layer and is deferred
+ *     to P5; the static enum here is the floor-level gate that 400s
+ *     unknown provider ids before they touch the database.
+ *   - `mode` MUST be one of `inherit` | `byo` | `override` per ADR-017 §1.
+ *   - `credentialsSecretRef` MUST be present when `mode != 'inherit'`.
+ *     When `mode = 'inherit'` it is forbidden (the row is reverted to
+ *     using the platform-default credentials so a tenant pointer would
+ *     leak across the inherit fall-through).
+ *
+ * The reachability probe (PUT validates against provider's
+ * `provisionTenant`) is deferred to P4 (worker host) per the PR scope
+ * note in the implementing prompt — this DTO only enforces shape.
+ */
+
+/**
+ * Allowed `providerId` values. Mirrors the EW-685 contract enumeration
+ * (`'trigger' | 'temporal' | 'bullmq' | 'pgboss' | 'inngest'`) and the
+ * availability matrix in
+ * [`providers.md`](../../../../../docs/specs/features/tenant-job-runtime-overlay/providers.md).
+ * Kept here as a module-local literal tuple (rather than imported from
+ * the EW-685 plugin contracts) so the DTO file has zero runtime
+ * dependency on the agent / plugin trees and stays cheap to import from
+ * the global ValidationPipe.
+ */
+export const TENANT_JOB_RUNTIME_PROVIDER_IDS = [
+    'trigger',
+    'temporal',
+    'bullmq',
+    'pgboss',
+    'inngest',
+] as const;
+
+export type TenantJobRuntimeProviderId = (typeof TENANT_JOB_RUNTIME_PROVIDER_IDS)[number];
+
+/** Allowed `mode` values per ADR-017 §1. */
+export const TENANT_JOB_RUNTIME_MODES = ['inherit', 'byo', 'override'] as const;
+
+export type TenantJobRuntimeMode = (typeof TENANT_JOB_RUNTIME_MODES)[number];
+
+export class UpsertTenantJobRuntimeConfigDto {
+    @ApiProperty({
+        description: 'Job-runtime provider id from the static allow-list.',
+        enum: TENANT_JOB_RUNTIME_PROVIDER_IDS,
+        example: 'trigger',
+    })
+    @IsString()
+    @IsIn(TENANT_JOB_RUNTIME_PROVIDER_IDS as unknown as string[])
+    readonly providerId!: TenantJobRuntimeProviderId;
+
+    @ApiProperty({
+        description:
+            'Overlay mode. `inherit` falls back to the platform-default credentials; ' +
+            '`byo` uses the tenant-supplied credentials with the same provider as the ' +
+            'default; `override` switches both provider and credentials.',
+        enum: TENANT_JOB_RUNTIME_MODES,
+        example: 'byo',
+    })
+    @IsString()
+    @IsIn(TENANT_JOB_RUNTIME_MODES as unknown as string[])
+    readonly mode!: TenantJobRuntimeMode;
+
+    @ApiPropertyOptional({
+        description:
+            'Opaque pointer into the encrypted secrets store. Required when ' +
+            '`mode != inherit`; forbidden when `mode = inherit` (the row falls back ' +
+            'to platform-default credentials and a tenant pointer would never resolve). ' +
+            'Never holds plaintext secrets — the actual blob is encrypted at rest ' +
+            'under PLUGIN_SECRET_ENCRYPTION_KEY.',
+        maxLength: 128,
+        example: 'tenant-job-runtime:42a1b8de:trigger:v3',
+    })
+    // Required when mode != inherit (validated against the value of `mode` in
+    // the same payload). `@ValidateIf` skips the subsequent validators when
+    // the predicate is FALSE, so:
+    //   - mode = inherit → @ValidateIf returns false → IsString/MaxLength
+    //     skipped → the field passes whether absent OR present (the
+    //     "forbidden when inherit" rule is enforced in the service layer
+    //     with a precise BadRequestException message; modelling
+    //     "absent-required" in class-validator requires the reverse predicate,
+    //     which would emit a generic "must be a string" error for legit
+    //     inherit submissions).
+    //   - mode != inherit → @ValidateIf returns true → IsString runs and
+    //     fails on undefined → required-when-not-inherit holds.
+    // NOTE: we do NOT add @IsOptional() here. @IsOptional skips validators
+    // when the value is null/undefined, which would un-do the
+    // required-when-not-inherit invariant.
+    @ValidateIf((o: UpsertTenantJobRuntimeConfigDto) => o.mode !== 'inherit')
+    @IsString()
+    @MaxLength(128)
+    readonly credentialsSecretRef?: string | null;
+
+    @ApiPropertyOptional({
+        description:
+            'Soft-disable without losing the row. When `false` the dispatcher ' +
+            'treats the tenant as `inherit` so operators can quickly fall back ' +
+            'without dropping the credential pointer.',
+        default: true,
+    })
+    @IsOptional()
+    @IsBoolean()
+    readonly enabled?: boolean;
+}

--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.controller.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.controller.ts
@@ -1,0 +1,191 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    ForbiddenException,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Post,
+    Put,
+} from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../../auth/types/auth.types';
+import {
+    TenantJobRuntimeConfigResponseDto,
+    TenantJobRuntimeRotateResponseDto,
+} from './dto/tenant-job-runtime-response.dto';
+import { UpsertTenantJobRuntimeConfigDto } from './dto/upsert-tenant-job-runtime.dto';
+import { TenantJobRuntimeService } from './tenant-job-runtime.service';
+
+/**
+ * EW-742 / EW-746 (P2.0 — tenant-job-runtime overlay admin API) — five
+ * admin endpoints under `/api/account/job-runtime/...` for the tenant
+ * owner to inspect + edit the per-tenant job-runtime overlay.
+ *
+ * Spec: [`docs/specs/features/tenant-job-runtime-overlay/spec.md`](../../../../docs/specs/features/tenant-job-runtime-overlay/spec.md)
+ * Plan: [`plan.md` §4 API surface](../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md#4-api-surface)
+ * Tasks: [`tasks.md` T14](../../../../docs/specs/features/tenant-job-runtime-overlay/tasks.md)
+ *
+ * **Route shape:** plan.md §4 originally drafted these as
+ * `/api/admin/tenants/:tenantId/job-runtime` (a platform-admin facing
+ * surface acting on any tenant). tasks.md T14 — the actual implementation
+ * directive — places them at `/api/account/job-runtime/config` (the
+ * tenant owner acting on their OWN tenant). We follow tasks.md: the
+ * Ever Works tenant model is 1 User : 1 Tenant (per
+ * [tenants spec §1.1](../../../../docs/specs/features/tenants-and-organizations/spec.md)),
+ * so "admin acting on another tenant" has no caller today. A separate
+ * `/api/admin/tenants/:tenantId/job-runtime` platform-admin surface can
+ * be added later if/when multi-tenant-per-user lands; this controller
+ * stays unchanged because the data model is the same. Inconsistency
+ * flagged in the implementing PR.
+ *
+ * **Auth model:** `AuthSessionGuard` (global) ensures `req.user.userId` is
+ * set. `SessionScopeGuard` (also global) hydrates `req.user.tenantId`
+ * from the User row. Every handler refuses with 403 when `tenantId` is
+ * null — a user with no Tenant cannot own an overlay. There is NO
+ * separate "tenant.admin" role check because of the 1:1 model: the only
+ * user with access to a Tenant's rows IS its owner. A future
+ * Organization-member RBAC layer would slot in as a new guard alongside
+ * the existing checks; nothing here precludes it.
+ *
+ * **Tenant resolution:** `tenantId` is ALWAYS the authenticated user's
+ * own (`req.user.tenantId`). There is no `:tenantId` path param so a
+ * compromised UI client can never confuse the server about which
+ * tenant's row to mutate. This is the explicit decision per the
+ * implementing prompt: "if it's user-scoped (admin manages OWN
+ * tenant), drop the `:tenantId` param".
+ */
+@ApiTags('Account · Tenant Job Runtime')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/account/job-runtime')
+export class TenantJobRuntimeController {
+    constructor(private readonly service: TenantJobRuntimeService) {}
+
+    @Get('config')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Read the current tenant job-runtime overlay (credentials redacted)',
+        description:
+            'Returns the synthetic `mode: inherit` default when no overlay row exists ' +
+            '(FR-7 NULL-safe — the caller never has to special-case 404).',
+    })
+    @ApiResponse({ status: 200, type: TenantJobRuntimeConfigResponseDto })
+    async getConfig(
+        @CurrentUser() auth: AuthenticatedUser,
+    ): Promise<TenantJobRuntimeConfigResponseDto> {
+        const tenantId = this.requireTenant(auth);
+        return this.service.getConfig(tenantId);
+    }
+
+    @Put('config')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Upsert the tenant job-runtime overlay',
+        description:
+            'Validates `providerId` against the static allow-list, enforces ' +
+            '`credentialsSecretRef` presence when `mode != inherit`, writes the row, ' +
+            'and emits a `create` / `update` audit entry. Bumps `credentialVersion` ' +
+            'when `credentialsSecretRef` changes (graceful drain — ADR-017 §3).',
+    })
+    @ApiResponse({ status: 200, type: TenantJobRuntimeConfigResponseDto })
+    @ApiResponse({ status: 400, description: 'Validation failed (invalid provider or mode/ref combination)' })
+    @ApiResponse({ status: 403, description: 'Caller has no Tenant (user not yet upgraded)' })
+    async upsertConfig(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() dto: UpsertTenantJobRuntimeConfigDto,
+    ): Promise<TenantJobRuntimeConfigResponseDto> {
+        const tenantId = this.requireTenant(auth);
+        return this.service.upsertConfig(tenantId, auth.userId, dto);
+    }
+
+    @Post('rotate')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Rotate the tenant credential — graceful drain',
+        description:
+            'Bumps `credentialVersion`. In-flight runs keep their captured ' +
+            'version per ADR-017 §3; new enqueues see the bumped version. Emits a ' +
+            '`rotate` audit row.',
+    })
+    @ApiResponse({ status: 200, type: TenantJobRuntimeRotateResponseDto })
+    @ApiResponse({ status: 404, description: 'Tenant has no overlay row (mode = inherit)' })
+    async rotateCredential(
+        @CurrentUser() auth: AuthenticatedUser,
+    ): Promise<TenantJobRuntimeRotateResponseDto> {
+        const tenantId = this.requireTenant(auth);
+        return this.service.rotateCredential(tenantId, auth.userId);
+    }
+
+    /**
+     * Force-invalidate is the operator break-glass kill (FR-6). Rate
+     * limited to ≤1 call per minute per tenant via the `long` throttler
+     * bucket (60s TTL, limit 1) — a compromised admin session cannot
+     * churn the credential version faster than the worker can drain.
+     *
+     * @nestjs/throttler keys by IP by default, NOT by tenantId. That's
+     * acceptable here: the route requires authentication and a tenant,
+     * and the throttle is per-route per-IP per minute — combined with
+     * the auth + tenant gates it's effectively per-tenant for any
+     * single attacker session. A stricter per-tenant key would require
+     * a custom ThrottlerGuard subclass and is tracked as a follow-up.
+     */
+    @Post('force-invalidate')
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 1, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Force-invalidate the tenant credential — hard kill (P2.0: audit + version bump only)',
+        description:
+            'Rate-limited to 1 call / 60s. P2.0 implementation bumps `credentialVersion` ' +
+            'and emits a `force_invalidate` audit row. The actual in-flight run kill ' +
+            '(FR-6 hard kill) lands with the dispatcher tenancy work in P3+.',
+    })
+    @ApiResponse({ status: 200, type: TenantJobRuntimeRotateResponseDto })
+    @ApiResponse({ status: 404, description: 'Tenant has no overlay row (mode = inherit)' })
+    @ApiResponse({ status: 429, description: 'Rate limited (max 1 call / 60s)' })
+    async forceInvalidate(
+        @CurrentUser() auth: AuthenticatedUser,
+    ): Promise<TenantJobRuntimeRotateResponseDto> {
+        const tenantId = this.requireTenant(auth);
+        return this.service.forceInvalidate(tenantId, auth.userId);
+    }
+
+    @Delete('config')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Revert the tenant job-runtime overlay to inherit',
+        description:
+            'Sets `mode = inherit`, clears `credentialsSecretRef`, bumps ' +
+            '`credentialVersion` so workers holding the old credential snapshot ' +
+            'drain gracefully, and emits a `delete` audit row. Idempotent — a ' +
+            'tenant already in inherit mode returns the synthetic default.',
+    })
+    @ApiResponse({ status: 200, type: TenantJobRuntimeConfigResponseDto })
+    async revertToInherit(
+        @CurrentUser() auth: AuthenticatedUser,
+    ): Promise<TenantJobRuntimeConfigResponseDto> {
+        const tenantId = this.requireTenant(auth);
+        return this.service.revertToInherit(tenantId, auth.userId);
+    }
+
+    /**
+     * Resolve the caller's tenant or refuse with 403. Centralised so the
+     * five handlers don't repeat the null-check + error message and so a
+     * future role-aware tenant resolver has exactly one place to live.
+     */
+    private requireTenant(auth: AuthenticatedUser): string {
+        // `tenantId` is hydrated by `SessionScopeGuard` (global). When the
+        // user hasn't been upgraded to a Tenant yet (no Organization
+        // created — EW-658 lazy bootstrap), the field is `null` and the
+        // overlay concept doesn't apply.
+        const tenantId = auth.tenantId;
+        if (!tenantId) {
+            throw new ForbiddenException(
+                'Tenant required to manage the job-runtime overlay. Create an Organization first.',
+            );
+        }
+        return tenantId;
+    }
+}

--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DatabaseModule } from '@ever-works/agent/database';
+import { TenantJobRuntimeAudit, TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+import { CredentialVersionService } from '@ever-works/agent/tasks';
+import { TenantJobRuntimeController } from './tenant-job-runtime.controller';
+import { TenantJobRuntimeService } from './tenant-job-runtime.service';
+
+/**
+ * EW-742 / EW-746 (P2.0 — tenant-job-runtime overlay admin API) — wires
+ * the controller + service + TypeORM repository registrations for the
+ * five admin endpoints under `/api/account/job-runtime/...`.
+ *
+ * Spec: [`docs/specs/features/tenant-job-runtime-overlay/spec.md`](../../../../docs/specs/features/tenant-job-runtime-overlay/spec.md)
+ * Plan: [`plan.md` §4 API surface](../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md#4-api-surface)
+ * Tasks: [`tasks.md` T14](../../../../docs/specs/features/tenant-job-runtime-overlay/tasks.md)
+ *
+ * Imports the global `DatabaseModule` (provides the TypeORM connection)
+ * plus `TypeOrmModule.forFeature([...])` so the service can inject the
+ * scoped `Repository<TenantJobRuntimeConfig>` and
+ * `Repository<TenantJobRuntimeAudit>`. `CredentialVersionService` is
+ * provided locally rather than imported via a separate module — it lives
+ * in `@ever-works/agent/tasks` and needs the same forFeature
+ * registration to resolve its own `@InjectRepository(TenantJobRuntimeConfig)`.
+ * Co-providing it here keeps the DI graph flat; if another module ever
+ * needs the same service, hoist it into a dedicated providers module
+ * and import.
+ */
+@Module({
+    imports: [
+        DatabaseModule,
+        TypeOrmModule.forFeature([TenantJobRuntimeConfig, TenantJobRuntimeAudit]),
+    ],
+    providers: [TenantJobRuntimeService, CredentialVersionService],
+    controllers: [TenantJobRuntimeController],
+})
+export class TenantJobRuntimeModule {}

--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.service.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.service.ts
@@ -1,0 +1,351 @@
+import {
+    BadRequestException,
+    ConflictException,
+    Injectable,
+    Logger,
+    NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TenantJobRuntimeAudit, TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+import { CredentialVersionService } from '@ever-works/agent/tasks';
+import {
+    TenantJobRuntimeConfigResponseDto,
+    TenantJobRuntimeRotateResponseDto,
+} from './dto/tenant-job-runtime-response.dto';
+import { UpsertTenantJobRuntimeConfigDto } from './dto/upsert-tenant-job-runtime.dto';
+
+/**
+ * EW-742 / EW-746 (P2.0 — tenant-job-runtime overlay admin API) —
+ * service layer for the 5 admin endpoints under
+ * `/api/account/job-runtime/...`.
+ *
+ * Spec: [`docs/specs/features/tenant-job-runtime-overlay/spec.md`](../../../../docs/specs/features/tenant-job-runtime-overlay/spec.md)
+ * Plan: [`plan.md` §4 API surface](../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md#4-api-surface)
+ * Tasks: [`tasks.md` T14](../../../../docs/specs/features/tenant-job-runtime-overlay/tasks.md)
+ * ADR: [ADR-017](../../../../docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md)
+ *
+ * Responsibilities:
+ *   - GET — load the tenant's overlay row, redact credentials, or return
+ *     the synthetic `mode: inherit` default when no row exists (FR-7).
+ *   - PUT — upsert with validation + audit row + `credentialVersion` bump
+ *     on credentials change (FR-13).
+ *   - rotate — bump credential version via `CredentialVersionService`
+ *     (ADR-017 §3 graceful drain) + audit row.
+ *   - force-invalidate — rate-limited in the controller (≤1/min/tenant);
+ *     emits a `force_invalidate` audit row and bumps the credential
+ *     version. The actual in-flight run kill is P3+ concern.
+ *   - DELETE — revert to `inherit` (sets mode='inherit', clears
+ *     credentialsSecretRef, keeps the row, bumps credentialVersion, emits
+ *     audit row).
+ *
+ * **Out of scope here (deferred PRs):**
+ *   - Reachability probe against the provider's `provisionTenant` — P4.
+ *   - Per-tenant operator allow-list filtering (FR-9) — P5.
+ *   - In-flight run kill on force-invalidate (FR-6 hard kill) — P3+.
+ */
+@Injectable()
+export class TenantJobRuntimeService {
+    private readonly logger = new Logger(TenantJobRuntimeService.name);
+
+    constructor(
+        @InjectRepository(TenantJobRuntimeConfig)
+        private readonly configRepository: Repository<TenantJobRuntimeConfig>,
+        @InjectRepository(TenantJobRuntimeAudit)
+        private readonly auditRepository: Repository<TenantJobRuntimeAudit>,
+        private readonly credentialVersionService: CredentialVersionService,
+    ) {}
+
+    /**
+     * GET — returns the tenant's overlay row or a synthetic `mode: inherit`
+     * default. NULL-safe per FR-7 — never throws on missing row. Credentials
+     * are always redacted.
+     */
+    async getConfig(tenantId: string): Promise<TenantJobRuntimeConfigResponseDto> {
+        const row = await this.configRepository.findOne({ where: { tenantId } });
+        if (!row) {
+            return this.toSyntheticInherit(tenantId);
+        }
+        return this.toResponse(row);
+    }
+
+    /**
+     * PUT — upsert the overlay row. Validation invariants enforced here
+     * (in addition to the DTO-level shape checks):
+     *   - `mode = inherit` MUST NOT carry a `credentialsSecretRef` (the
+     *     DTO already enforces presence-when-not-inherit; we cover the
+     *     inverse here to prevent a stale tenant pointer leaking).
+     *
+     * Emits a `create` or `update` audit row. Bumps `credentialVersion`
+     * whenever `credentialsSecretRef` changes (rotation-equivalent semantic
+     * — captures the moment of a new credential pointer landing).
+     */
+    async upsertConfig(
+        tenantId: string,
+        actorUserId: string,
+        dto: UpsertTenantJobRuntimeConfigDto,
+    ): Promise<TenantJobRuntimeConfigResponseDto> {
+        if (dto.mode === 'inherit' && dto.credentialsSecretRef) {
+            throw new BadRequestException(
+                'credentialsSecretRef must be omitted when mode = inherit',
+            );
+        }
+
+        const existing = await this.configRepository.findOne({ where: { tenantId } });
+        const before = existing ? this.redactRowForAudit(existing) : null;
+
+        // Determine whether to bump credentialVersion. A bump fires when:
+        //   - this is a brand-new row (start at version 1 — that's the
+        //     entity default; no bump call needed);
+        //   - the credentialsSecretRef changed (new pointer = new
+        //     credential snapshot from the worker host's POV).
+        // Provider change without ref change does NOT bump on its own —
+        // the cache key includes providerId so the dispatcher already
+        // separates snapshots per provider.
+        const credentialsChanged =
+            !!existing && existing.credentialsSecretRef !== (dto.credentialsSecretRef ?? null);
+
+        let saved: TenantJobRuntimeConfig;
+        if (existing) {
+            existing.providerId = dto.providerId;
+            existing.mode = dto.mode;
+            existing.credentialsSecretRef = dto.credentialsSecretRef ?? null;
+            existing.enabled = dto.enabled ?? existing.enabled;
+            if (credentialsChanged) {
+                existing.credentialVersion = existing.credentialVersion + 1;
+            }
+            saved = await this.configRepository.save(existing);
+        } else {
+            const fresh = this.configRepository.create({
+                tenantId,
+                providerId: dto.providerId,
+                mode: dto.mode,
+                credentialsSecretRef: dto.credentialsSecretRef ?? null,
+                credentialVersion: 1,
+                enabled: dto.enabled ?? true,
+                createdBy: actorUserId,
+            });
+            saved = await this.configRepository.save(fresh);
+        }
+
+        await this.emitAudit({
+            tenantId,
+            actorUserId,
+            action: existing ? 'update' : 'create',
+            before,
+            after: this.redactRowForAudit(saved),
+            credentialVersion: saved.credentialVersion,
+        });
+
+        return this.toResponse(saved);
+    }
+
+    /**
+     * Bump `credentialVersion` for graceful-drain rotation. Errors if no
+     * overlay row exists (rotating `inherit` has no semantic meaning —
+     * inherit uses platform-default credentials, not a tenant-scoped
+     * version).
+     */
+    async rotateCredential(
+        tenantId: string,
+        actorUserId: string,
+    ): Promise<TenantJobRuntimeRotateResponseDto> {
+        const existing = await this.configRepository.findOne({ where: { tenantId } });
+        if (!existing) {
+            throw new NotFoundException(
+                'Cannot rotate: tenant has no overlay row (mode = inherit uses platform credentials)',
+            );
+        }
+        const newVersion = await this.credentialVersionService.bumpVersion(tenantId);
+        if (newVersion === null) {
+            // Shouldn't happen — we just confirmed the row exists. Defensive:
+            // a concurrent DELETE could have removed it between our find +
+            // bump. Surface as 409.
+            throw new ConflictException(
+                'Cannot rotate: overlay row disappeared mid-call (concurrent revert)',
+            );
+        }
+
+        await this.emitAudit({
+            tenantId,
+            actorUserId,
+            action: 'rotate',
+            before: this.redactRowForAudit(existing),
+            after: { ...this.redactRowForAudit(existing), credentialVersion: newVersion },
+            credentialVersion: newVersion,
+        });
+
+        return { credentialVersion: newVersion };
+    }
+
+    /**
+     * Operator-only break-glass kill switch. P2.0 behaviour: bump
+     * `credentialVersion` + emit `force_invalidate` audit row. The actual
+     * in-flight run kill (FR-6 hard kill) is P3+ when the dispatcher knows
+     * how to enumerate runs by `(tenantId, credentialVersion)`.
+     *
+     * Rate limiting (≤1/min/tenant) is owned by the controller via
+     * @Throttle on the route handler.
+     */
+    async forceInvalidate(
+        tenantId: string,
+        actorUserId: string,
+    ): Promise<TenantJobRuntimeRotateResponseDto> {
+        const existing = await this.configRepository.findOne({ where: { tenantId } });
+        if (!existing) {
+            throw new NotFoundException(
+                'Cannot force-invalidate: tenant has no overlay row (mode = inherit uses platform credentials)',
+            );
+        }
+        const newVersion = await this.credentialVersionService.bumpVersion(tenantId);
+        if (newVersion === null) {
+            throw new ConflictException(
+                'Cannot force-invalidate: overlay row disappeared mid-call (concurrent revert)',
+            );
+        }
+
+        await this.emitAudit({
+            tenantId,
+            actorUserId,
+            action: 'force_invalidate',
+            before: this.redactRowForAudit(existing),
+            after: { ...this.redactRowForAudit(existing), credentialVersion: newVersion },
+            credentialVersion: newVersion,
+        });
+
+        return { credentialVersion: newVersion };
+    }
+
+    /**
+     * DELETE — revert to `mode: inherit`. Keeps the row (history +
+     * credentialVersion preserved per plan.md §4), clears
+     * `credentialsSecretRef`, bumps `credentialVersion` (so any worker
+     * still holding the old credential snapshot drains gracefully), and
+     * emits a `delete` audit row.
+     *
+     * Returns the post-revert response so the UI can refresh without an
+     * extra GET.
+     */
+    async revertToInherit(
+        tenantId: string,
+        actorUserId: string,
+    ): Promise<TenantJobRuntimeConfigResponseDto> {
+        const existing = await this.configRepository.findOne({ where: { tenantId } });
+        if (!existing) {
+            // Already inherit — return the synthetic default. Idempotent
+            // DELETE is the expected REST semantic.
+            return this.toSyntheticInherit(tenantId);
+        }
+
+        const before = this.redactRowForAudit(existing);
+        existing.mode = 'inherit';
+        existing.credentialsSecretRef = null;
+        existing.credentialVersion = existing.credentialVersion + 1;
+        const saved = await this.configRepository.save(existing);
+
+        await this.emitAudit({
+            tenantId,
+            actorUserId,
+            action: 'delete',
+            before,
+            after: this.redactRowForAudit(saved),
+            credentialVersion: saved.credentialVersion,
+        });
+
+        return this.toResponse(saved);
+    }
+
+    /**
+     * Maps a persisted row to the wire DTO. Credentials are redacted —
+     * only `hasCredentials` + the last 4 chars of the ref are exposed.
+     */
+    private toResponse(row: TenantJobRuntimeConfig): TenantJobRuntimeConfigResponseDto {
+        return {
+            tenantId: row.tenantId,
+            providerId: row.providerId as TenantJobRuntimeConfigResponseDto['providerId'],
+            mode: row.mode,
+            hasCredentials: row.credentialsSecretRef !== null,
+            credentialsSecretRefRedacted: this.redactRef(row.credentialsSecretRef),
+            credentialVersion: row.credentialVersion,
+            enabled: row.enabled,
+            createdBy: row.createdBy,
+            createdAt: row.createdAt ? row.createdAt.toISOString() : null,
+            updatedAt: row.updatedAt ? row.updatedAt.toISOString() : null,
+        };
+    }
+
+    /**
+     * Synthetic NULL-safe inherit default (FR-7). Returned by GET when no
+     * overlay row exists, and by DELETE when the tenant is already in
+     * inherit mode.
+     */
+    private toSyntheticInherit(tenantId: string): TenantJobRuntimeConfigResponseDto {
+        return {
+            tenantId,
+            providerId: null,
+            mode: 'inherit',
+            hasCredentials: false,
+            credentialsSecretRefRedacted: null,
+            credentialVersion: null,
+            enabled: true,
+            createdBy: null,
+            createdAt: null,
+            updatedAt: null,
+        };
+    }
+
+    /**
+     * Show only the last 4 chars of the secret ref so operators can
+     * distinguish two pointers in the audit log without seeing the full
+     * opaque value. NULL passes through.
+     */
+    private redactRef(ref: string | null): string | null {
+        if (!ref) {
+            return null;
+        }
+        if (ref.length <= 4) {
+            return '***';
+        }
+        return `***${ref.slice(-4)}`;
+    }
+
+    /**
+     * Build the redacted snapshot the audit row stores in `before` / `after`.
+     * Per the entity's documentation, secrets MUST be masked at write time
+     * — the audit log records the LAST 4 chars of the ref only (matching the
+     * GET response redaction), never the full ref or the underlying blob.
+     */
+    private redactRowForAudit(row: TenantJobRuntimeConfig): Record<string, unknown> {
+        return {
+            tenantId: row.tenantId,
+            providerId: row.providerId,
+            mode: row.mode,
+            credentialsSecretRefRedacted: this.redactRef(row.credentialsSecretRef),
+            hasCredentials: row.credentialsSecretRef !== null,
+            credentialVersion: row.credentialVersion,
+            enabled: row.enabled,
+        };
+    }
+
+    /**
+     * Append-only write to `tenant_job_runtime_audit`. Failures are
+     * surfaced (NOT swallowed) — if the audit row can't land we treat the
+     * mutation as failed so the operator never sees a divergent state
+     * (overlay row updated without an audit trail).
+     */
+    private async emitAudit(payload: {
+        tenantId: string;
+        actorUserId: string | null;
+        action: string;
+        before: Record<string, unknown> | null;
+        after: Record<string, unknown> | null;
+        credentialVersion: number | null;
+    }): Promise<void> {
+        const audit = this.auditRepository.create(payload);
+        await this.auditRepository.save(audit);
+        this.logger.debug(
+            `Audit: tenant=${payload.tenantId} action=${payload.action} ` +
+                `version=${payload.credentialVersion ?? 'null'}`,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

[EW-746](https://evertech.atlassian.net/browse/EW-746) first half — five admin REST endpoints under `/api/account/job-runtime` to CRUD + rotate + force-invalidate the tenant overlay row introduced in P1 (PR #1338). UI components (T15-T19) come in a follow-up.

## Endpoints (all auth-gated to the authenticated user's own tenant)

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/account/job-runtime/config` | Return current overlay, **redacted**; NULL-safe synthetic `{mode:'inherit'}` when no row |
| PUT | `/api/account/job-runtime/config` | Upsert with class-validator DTO; required-by-mode validation for credentials |
| POST | `/api/account/job-runtime/rotate` | Bump `credentialVersion` via `CredentialVersionService`; emit audit row |
| POST | `/api/account/job-runtime/force-invalidate` | Rate-limited; bumps version + emits `force_invalidate` audit row (in-flight kill is P3+) |
| DELETE | `/api/account/job-runtime/config` | Revert to inherit (clears secretRef, keeps row, bumps version, audit row) |

## Files

`apps/api/src/account/tenant-job-runtime/`
- `tenant-job-runtime.controller.ts` — 5 handlers, ~280 lines
- `tenant-job-runtime.service.ts` — repo + audit + version orchestration, ~430 lines
- `tenant-job-runtime.module.ts` — `TypeOrmModule.forFeature([TenantJobRuntimeConfig, TenantJobRuntimeAudit])` + locally provides `CredentialVersionService`
- `dto/upsert-tenant-job-runtime.dto.ts` — class-validator DTO + literal tuples for provider/mode
- `dto/tenant-job-runtime-response.dto.ts` — credentials redacted on response
- `__tests__/tenant-job-runtime.controller.spec.ts` — covers auth gate, redaction, validation, version-bump, idempotent DELETE

Plus `apps/api/src/account/account.module.ts` imports `TenantJobRuntimeModule`.

## Decisions

- **Tenant resolution**: globally-applied `AuthSessionGuard` + `SessionScopeGuard` hydrate `req.user.tenantId`; controller's `requireTenant()` throws `ForbiddenException` when missing. No `:tenantId` path param — 1 User : 1 Tenant model.
- **No new role guard**: tenant owner IS the only user with access under today's 1:1 model. Future Organization-member RBAC slots in as a separate guard.
- **`CredentialVersionService` provided locally** in `TenantJobRuntimeModule` (the service lives in `@ever-works/agent/tasks` but has no dedicated NestJS module — co-providing keeps the DI graph flat).
- **Path scheme** follows `tasks.md` T14 (`/api/account/job-runtime/...`) not `plan.md` §4 (`/api/admin/tenants/:tenantId/...`). Platform-admin-acts-on-another-tenant surface deferred to a separate sub-story when Organization RBAC arrives.

## Deferred (out of P2.0 scope, called out in commit message)

- Reachability probe on PUT (call provider's `provisionTenant`) — P4
- Per-tenant operator allow-list filtering — P5
- In-flight run kill on force-invalidate (FR-6 hard kill) — P3+
- Schema-driven credentials form UI + Playwright e2e — P2.1
- Per-tenant throttler key (today's `@nestjs/throttler` keys by IP; per-tenant key needs a custom subclass — noted in controller comment)

## Refs

- Epic: [EW-742](https://evertech.atlassian.net/browse/EW-742)
- This story: [EW-746](https://evertech.atlassian.net/browse/EW-746) (P2.0 half)
- Prereq: [EW-745](https://evertech.atlassian.net/browse/EW-745) P1 storage (DONE, PR #1338), [EW-744](https://evertech.atlassian.net/browse/EW-744) P1.0 grammar (DONE, PR #1335), [EW-743](https://evertech.atlassian.net/browse/EW-743) P0 spec-kit (DONE)
- Plan: `docs/specs/features/tenant-job-runtime-overlay/plan.md` §4 + §10 P2
- Tasks: `docs/specs/features/tenant-job-runtime-overlay/tasks.md` T14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-746]: https://evertech.atlassian.net/browse/EW-746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-742]: https://evertech.atlassian.net/browse/EW-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API endpoints for managing per-tenant job runtime configuration
  * Credential rotation and session force-invalidation operations now available
  * Rate limiting applied to force-invalidate endpoint (max 1 per 60 seconds per IP)
  * Configuration mutations are logged with audit trails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->