### PR TITLE
feat(web): tenant job-runtime admin UI (EW-742 P2.1 / EW-746)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1199,6 +1199,7 @@
                 "data": "Data",
                 "githubApp": "GitHub App",
                 "workAgent": "Work Agent",
+                "jobRuntime": "Job Runtime",
                 "gitProviders": "Git Providers",
                 "dangerZone": "Danger Zone"
             },
@@ -1567,6 +1568,79 @@
                     "revokeSuccess": "API key revoked successfully",
                     "revokeError": "Failed to revoke API key",
                     "copyError": "Failed to copy to clipboard"
+                }
+            },
+            "jobRuntime": {
+                "title": "Job Runtime",
+                "subtitle": "Override the platform-default job-runtime provider with your own credentials. Inherit falls back to the platform default; BYO keeps the same provider with tenant credentials; Override switches both provider and credentials.",
+                "mode": {
+                    "inherit": "Inherit (platform default)",
+                    "byo": "Bring your own credentials",
+                    "override": "Override provider and credentials"
+                },
+                "readout": {
+                    "mode": "Active mode",
+                    "provider": "Active provider",
+                    "providerNone": "Platform default",
+                    "credentialVersion": "Credential version",
+                    "credentialsRef": "Credential pointer",
+                    "noCredentials": "None",
+                    "noOverlay": "No overlay row",
+                    "updatedAt": "Last updated",
+                    "enabled": "Enabled",
+                    "yes": "Yes",
+                    "no": "No"
+                },
+                "fields": {
+                    "providerLabel": "Provider",
+                    "providerHelper": "Picks the worker runtime used to dispatch background jobs for this tenant.",
+                    "modeLabel": "Mode",
+                    "modeHelper": {
+                        "inherit": "Use the platform-default credentials. The dispatcher resolves this tenant to the same runtime as everyone else.",
+                        "byo": "Keep the same provider as the platform default but use your own credentials.",
+                        "override": "Switch to a different provider and supply your own credentials."
+                    },
+                    "enabledLabel": "Enabled",
+                    "enabledHelper": "Soft-disable without dropping the credential pointer. When off, the dispatcher treats this tenant as inherit so operators can quickly fall back."
+                },
+                "credentials": {
+                    "title": "Credentials",
+                    "subtitle": "Provide an opaque pointer into the encrypted secrets store. Plaintext credentials never round-trip through this UI — paste the JSON blob to record what was provisioned; the secret pointer is what the dispatcher resolves.",
+                    "secretRefLabel": "Secret pointer",
+                    "secretRefPlaceholder": "tenant-job-runtime:42a1b8de:trigger:v3",
+                    "jsonLabel": "Credentials JSON (reference only)",
+                    "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
+                    "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
+                },
+                "actions": {
+                    "save": "Save",
+                    "rotate": "Rotate credential",
+                    "forceInvalidate": "Force invalidate",
+                    "revert": "Revert to inherit"
+                },
+                "forceInvalidate": {
+                    "title": "Force-invalidate credential",
+                    "description": "Bumps the credential version and emits an audit row. Rate-limited to once per minute. In-flight runs keep their captured version and drain gracefully; new enqueues see the bumped version.",
+                    "cancel": "Cancel",
+                    "confirm": "Force invalidate"
+                },
+                "revert": {
+                    "title": "Revert to inherit",
+                    "description": "Clears the credential pointer, bumps the credential version, and routes future jobs through the platform default. Idempotent — a tenant already in inherit mode is unchanged.",
+                    "cancel": "Cancel",
+                    "confirm": "Revert to inherit"
+                },
+                "messages": {
+                    "saveSuccess": "Job-runtime configuration saved",
+                    "saveError": "Failed to save job-runtime configuration",
+                    "rotateSuccess": "Credential rotated (now v{version})",
+                    "rotateError": "Failed to rotate credential",
+                    "invalidateSuccess": "Credential invalidated (now v{version})",
+                    "invalidateError": "Failed to force-invalidate credential",
+                    "revertSuccess": "Reverted to inherit",
+                    "revertError": "Failed to revert to inherit",
+                    "invalidJson": "Credentials JSON is not valid JSON",
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit"
                 }
             }
         },
@@ -4726,6 +4800,7 @@
             "profile": "Profile",
             "security": "Security",
             "apiKeys": "API Keys",
+            "jobRuntime": "Job Runtime",
             "dangerZone": "Danger Zone",
             "pluginSettings": "Plugin Settings"
         }

--- a/apps/web/src/app/[locale]/(dashboard)/settings/job-runtime/_components/runtime-form.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/job-runtime/_components/runtime-form.tsx
@@ -1,0 +1,10 @@
+/**
+ * EW-742 P2.1 — route-local re-export so the runtime form lives at the
+ * path called out in the implementing prompt
+ * (`_components/runtime-form.tsx`) while the actual component stays in
+ * `components/settings/` next to its peers (ApiKeysSettings,
+ * NotificationPreferencesSettings, WorkAgentSettings — they're all
+ * surfaced from `components/settings/` so the sidebar nav, plugin
+ * settings, and the settings layout share one component directory).
+ */
+export { JobRuntimeSettings as RuntimeForm } from '@/components/settings/JobRuntimeSettings';

--- a/apps/web/src/app/[locale]/(dashboard)/settings/job-runtime/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/job-runtime/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import {
+    tenantJobRuntimeAPI,
+    type TenantJobRuntimeConfigResponse,
+} from '@/lib/api/tenant-job-runtime';
+import { JobRuntimeSettings } from '@/components/settings/JobRuntimeSettings';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.settings.jobRuntime');
+    return { title: t('title') };
+}
+
+/**
+ * EW-742 P2.1 — tenant admin UI for the job-runtime overlay.
+ *
+ * Server component: fetches the current overlay (server-redacted —
+ * `credentialsSecretRefRedacted` + `hasCredentials` only) and hands it
+ * to the client form. The API endpoint is NULL-safe: when no overlay
+ * row exists the controller returns a synthetic `mode: inherit` default
+ * so the UI never has to special-case 404.
+ *
+ * Graceful degradation: a hard fetch failure (network, 5xx, missing
+ * tenant 403) still renders the form with the same synthetic inherit
+ * default. The form's actions will surface the real error on submit
+ * rather than blowing up the page on first load.
+ */
+function inheritFallback(): TenantJobRuntimeConfigResponse {
+    return {
+        tenantId: '',
+        providerId: null,
+        mode: 'inherit',
+        hasCredentials: false,
+        credentialsSecretRefRedacted: null,
+        credentialVersion: null,
+        enabled: true,
+        createdBy: null,
+        createdAt: null,
+        updatedAt: null,
+    };
+}
+
+export default async function JobRuntimeSettingsPage() {
+    let initialConfig: TenantJobRuntimeConfigResponse;
+    let loadError: string | null = null;
+
+    try {
+        initialConfig = await tenantJobRuntimeAPI.getConfig();
+    } catch (error) {
+        initialConfig = inheritFallback();
+        loadError = error instanceof Error ? error.message : 'Failed to load configuration';
+    }
+
+    return <JobRuntimeSettings initialConfig={initialConfig} loadError={loadError} />;
+}

--- a/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from '@/i18n/navigation';
 import { cn } from '@/lib/utils/cn';
-import { User, Lock, Key, AlertTriangle, HardDrive, Github, Bot } from 'lucide-react';
+import { User, Lock, Key, AlertTriangle, HardDrive, Github, Bot, Cpu } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useMemo } from 'react';
@@ -60,6 +60,12 @@ export function SettingsLayoutClient({ children, settingsMenu }: SettingsLayoutC
                 label: t('tabs.workAgent'),
                 icon: Bot,
                 href: `${baseSettingsPath}/work-agent`,
+            },
+            {
+                id: 'job-runtime',
+                label: t('tabs.jobRuntime'),
+                icon: Cpu,
+                href: `${baseSettingsPath}/job-runtime`,
             },
         ],
         [t],

--- a/apps/web/src/app/actions/settings/job-runtime.ts
+++ b/apps/web/src/app/actions/settings/job-runtime.ts
@@ -1,0 +1,116 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { ROUTES } from '@/lib/constants';
+import { getAuthFromCookie } from '@/lib/auth';
+import { ApiResponseError } from '@/lib/api/server-api';
+import {
+    tenantJobRuntimeAPI,
+    type TenantJobRuntimeConfigResponse,
+    type TenantJobRuntimeRotateResponse,
+    type UpsertTenantJobRuntimeConfigPayload,
+} from '@/lib/api/tenant-job-runtime';
+
+/**
+ * EW-742 P2.1 — Server Actions wrapping the tenant job-runtime overlay
+ * admin API. Returns a discriminated `{ success, data?, error? }` shape
+ * so the client form can surface either a toast or an inline error
+ * without re-throwing across the RSC boundary.
+ *
+ * Each action re-verifies the session at the Server Action boundary
+ * (defense in depth — the API tier is the final guard, but the API only
+ * trusts the JWT, not the action invocation itself). The pattern mirrors
+ * `app/actions/settings/work-agent.ts` and `app/actions/api-keys.ts`.
+ */
+
+// Settings Layout uses `[locale]/(dashboard)/settings`. revalidatePath
+// with a route-group page pattern needs the full segment shape per
+// Next.js 15+ docs.
+const SETTINGS_PAGE_PATTERN = '/[locale]/(dashboard)/settings/job-runtime';
+
+async function ensureAuth() {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+    return user;
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+    if (error instanceof ApiResponseError && error.message) return error.message;
+    if (error instanceof Error && error.message) return error.message;
+    return fallback;
+}
+
+export type JobRuntimeActionResult<T> =
+    | { success: true; data: T; error: null }
+    | { success: false; data: null; error: string };
+
+export async function upsertJobRuntimeConfigAction(
+    payload: UpsertTenantJobRuntimeConfigPayload,
+): Promise<JobRuntimeActionResult<TenantJobRuntimeConfigResponse>> {
+    await ensureAuth();
+    try {
+        const data = await tenantJobRuntimeAPI.upsertConfig(payload);
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to save job-runtime configuration'),
+        };
+    }
+}
+
+export async function rotateJobRuntimeAction(): Promise<
+    JobRuntimeActionResult<TenantJobRuntimeRotateResponse>
+> {
+    await ensureAuth();
+    try {
+        const data = await tenantJobRuntimeAPI.rotate();
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to rotate credential'),
+        };
+    }
+}
+
+export async function forceInvalidateJobRuntimeAction(): Promise<
+    JobRuntimeActionResult<TenantJobRuntimeRotateResponse>
+> {
+    await ensureAuth();
+    try {
+        const data = await tenantJobRuntimeAPI.forceInvalidate();
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to force-invalidate credential'),
+        };
+    }
+}
+
+export async function revertJobRuntimeToInheritAction(): Promise<
+    JobRuntimeActionResult<TenantJobRuntimeConfigResponse>
+> {
+    await ensureAuth();
+    try {
+        const data = await tenantJobRuntimeAPI.revertToInherit();
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to revert to inherit'),
+        };
+    }
+}

--- a/apps/web/src/components/settings/JobRuntimeSettings.tsx
+++ b/apps/web/src/components/settings/JobRuntimeSettings.tsx
@@ -224,7 +224,7 @@ export function JobRuntimeSettings({ initialConfig, loadError }: JobRuntimeSetti
             )}
 
             <div className="grid grid-cols-1 @lg/main:grid-cols-2 gap-4 p-4 rounded-lg border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40">
-                <Readout label={t('readout.mode')} value={t(`mode.${config.mode}`)} />
+                <Readout label={t('readout.mode')} value={t(`mode.${config.mode}` as never)} />
                 <Readout
                     label={t('readout.provider')}
                     value={config.providerId ?? t('readout.providerNone')}
@@ -284,12 +284,12 @@ export function JobRuntimeSettings({ initialConfig, loadError }: JobRuntimeSetti
                     >
                         {MODE_OPTIONS.map((opt) => (
                             <option key={opt.value} value={opt.value}>
-                                {t(opt.labelKey)}
+                                {t(opt.labelKey as never)}
                             </option>
                         ))}
                     </Select>
                     <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
-                        {t(`fields.modeHelper.${mode}`)}
+                        {t(`fields.modeHelper.${mode}` as never)}
                     </p>
                 </div>
 

--- a/apps/web/src/components/settings/JobRuntimeSettings.tsx
+++ b/apps/web/src/components/settings/JobRuntimeSettings.tsx
@@ -1,0 +1,430 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { AlertTriangle, RotateCw, ShieldOff, Undo2, Save } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import type {
+    TenantJobRuntimeConfigResponse,
+    TenantJobRuntimeMode,
+    TenantJobRuntimeProviderId,
+    UpsertTenantJobRuntimeConfigPayload,
+} from '@/lib/api/tenant-job-runtime';
+import {
+    forceInvalidateJobRuntimeAction,
+    revertJobRuntimeToInheritAction,
+    rotateJobRuntimeAction,
+    upsertJobRuntimeConfigAction,
+} from '@/app/actions/settings/job-runtime';
+
+interface JobRuntimeSettingsProps {
+    initialConfig: TenantJobRuntimeConfigResponse;
+    loadError: string | null;
+}
+
+const PROVIDER_OPTIONS: { value: TenantJobRuntimeProviderId; label: string }[] = [
+    { value: 'trigger', label: 'Trigger.dev' },
+    { value: 'temporal', label: 'Temporal' },
+    { value: 'bullmq', label: 'BullMQ' },
+    { value: 'pgboss', label: 'pg-boss' },
+    { value: 'inngest', label: 'Inngest' },
+];
+
+const MODE_OPTIONS: { value: TenantJobRuntimeMode; labelKey: string }[] = [
+    { value: 'inherit', labelKey: 'mode.inherit' },
+    { value: 'byo', labelKey: 'mode.byo' },
+    { value: 'override', labelKey: 'mode.override' },
+];
+
+function formatTimestamp(value: string | null): string {
+    if (!value) return '-';
+    try {
+        return new Date(value).toLocaleString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+    } catch {
+        return value;
+    }
+}
+
+/**
+ * EW-742 P2.1 — tenant admin UI for the job-runtime overlay.
+ *
+ * Renders:
+ *   - Provider picker (`trigger | temporal | bullmq | pgboss | inngest`)
+ *   - Mode toggle (`inherit | byo | override`)
+ *   - Conditional credentials block (only when mode != inherit):
+ *       * `credentialsSecretRef` opaque pointer
+ *       * `credentialsJson` textarea for the underlying blob — collected
+ *         in the UI but NOT yet POSTed (P2.1 scope is the pointer-only
+ *         contract per the controller; per-provider schema-driven forms
+ *         + secrets-store POST land in P2.2).
+ *   - Save / Rotate / Force-invalidate (with confirm) / Revert-to-inherit
+ *   - Credential version + updatedAt readout
+ *
+ * Schema-driven per-provider credentials forms (parsing providers.md
+ * JSON Schemas) are explicitly deferred to a follow-up sub-story per
+ * the implementing prompt.
+ */
+export function JobRuntimeSettings({ initialConfig, loadError }: JobRuntimeSettingsProps) {
+    const t = useTranslations('dashboard.settings.jobRuntime');
+    const [config, setConfig] = useState<TenantJobRuntimeConfigResponse>(initialConfig);
+
+    // Form-local state mirrors the editable shape of the upsert payload.
+    // We initialise providerId with a sane default when the row is the
+    // synthetic inherit (providerId = null) — the dropdown can't render
+    // null so we pre-select trigger; the value only ships if the user
+    // also flips mode away from inherit.
+    const [providerId, setProviderId] = useState<TenantJobRuntimeProviderId>(
+        (initialConfig.providerId ?? 'trigger') as TenantJobRuntimeProviderId,
+    );
+    const [mode, setMode] = useState<TenantJobRuntimeMode>(initialConfig.mode);
+    const [enabled, setEnabled] = useState<boolean>(initialConfig.enabled);
+    const [credentialsSecretRef, setCredentialsSecretRef] = useState<string>('');
+    const [credentialsJson, setCredentialsJson] = useState<string>('');
+
+    const [confirmInvalidate, setConfirmInvalidate] = useState(false);
+    const [confirmRevert, setConfirmRevert] = useState(false);
+    const [isPending, startTransition] = useTransition();
+
+    const needsCredentials = mode !== 'inherit';
+
+    const credentialsJsonError = useMemo(() => {
+        if (!needsCredentials) return null;
+        if (!credentialsJson.trim()) return null;
+        try {
+            JSON.parse(credentialsJson);
+            return null;
+        } catch (error) {
+            return error instanceof Error ? error.message : 'Invalid JSON';
+        }
+    }, [credentialsJson, needsCredentials]);
+
+    const applyConfig = (next: TenantJobRuntimeConfigResponse) => {
+        setConfig(next);
+        setProviderId((next.providerId ?? 'trigger') as TenantJobRuntimeProviderId);
+        setMode(next.mode);
+        setEnabled(next.enabled);
+    };
+
+    const handleSave = () => {
+        if (credentialsJsonError) {
+            toast.error(t('messages.invalidJson'));
+            return;
+        }
+        if (needsCredentials && !credentialsSecretRef.trim()) {
+            toast.error(t('messages.secretRefRequired'));
+            return;
+        }
+
+        const payload: UpsertTenantJobRuntimeConfigPayload = {
+            providerId,
+            mode,
+            enabled,
+        };
+
+        if (needsCredentials) {
+            payload.credentialsSecretRef = credentialsSecretRef.trim();
+        }
+
+        startTransition(async () => {
+            const result = await upsertJobRuntimeConfigAction(payload);
+            if (result.success) {
+                applyConfig(result.data);
+                setCredentialsSecretRef('');
+                setCredentialsJson('');
+                toast.success(t('messages.saveSuccess'));
+            } else {
+                toast.error(result.error || t('messages.saveError'));
+            }
+        });
+    };
+
+    const handleRotate = () => {
+        startTransition(async () => {
+            const result = await rotateJobRuntimeAction();
+            if (result.success) {
+                const { credentialVersion } = result.data;
+                setConfig((prev) => ({
+                    ...prev,
+                    credentialVersion,
+                }));
+                toast.success(t('messages.rotateSuccess', { version: credentialVersion }));
+            } else {
+                toast.error(result.error || t('messages.rotateError'));
+            }
+        });
+    };
+
+    const handleForceInvalidate = () => {
+        startTransition(async () => {
+            const result = await forceInvalidateJobRuntimeAction();
+            setConfirmInvalidate(false);
+            if (result.success) {
+                const { credentialVersion } = result.data;
+                setConfig((prev) => ({
+                    ...prev,
+                    credentialVersion,
+                }));
+                toast.success(t('messages.invalidateSuccess', { version: credentialVersion }));
+            } else {
+                toast.error(result.error || t('messages.invalidateError'));
+            }
+        });
+    };
+
+    const handleRevert = () => {
+        startTransition(async () => {
+            const result = await revertJobRuntimeToInheritAction();
+            setConfirmRevert(false);
+            if (result.success) {
+                applyConfig(result.data);
+                setCredentialsSecretRef('');
+                setCredentialsJson('');
+                toast.success(t('messages.revertSuccess'));
+            } else {
+                toast.error(result.error || t('messages.revertError'));
+            }
+        });
+    };
+
+    const hasOverlayRow = config.credentialVersion !== null;
+
+    return (
+        <div className="space-y-8">
+            <div>
+                <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-2">
+                    {t('title')}
+                </h2>
+                <p className="text-text-muted dark:text-text-muted-dark text-sm">{t('subtitle')}</p>
+            </div>
+
+            {loadError && (
+                <div className="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg">
+                    <AlertTriangle className="w-5 h-5 text-warning flex-shrink-0 mt-0.5" />
+                    <p className="text-sm text-text dark:text-text-dark">{loadError}</p>
+                </div>
+            )}
+
+            <div className="grid grid-cols-1 @lg/main:grid-cols-2 gap-4 p-4 rounded-lg border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40">
+                <Readout label={t('readout.mode')} value={t(`mode.${config.mode}`)} />
+                <Readout
+                    label={t('readout.provider')}
+                    value={config.providerId ?? t('readout.providerNone')}
+                />
+                <Readout
+                    label={t('readout.credentialVersion')}
+                    value={
+                        config.credentialVersion === null
+                            ? t('readout.noOverlay')
+                            : `v${config.credentialVersion}`
+                    }
+                />
+                <Readout
+                    label={t('readout.credentialsRef')}
+                    value={
+                        config.hasCredentials && config.credentialsSecretRefRedacted
+                            ? config.credentialsSecretRefRedacted
+                            : t('readout.noCredentials')
+                    }
+                />
+                <Readout label={t('readout.updatedAt')} value={formatTimestamp(config.updatedAt)} />
+                <Readout
+                    label={t('readout.enabled')}
+                    value={config.enabled ? t('readout.yes') : t('readout.no')}
+                />
+            </div>
+
+            <div className="space-y-6">
+                <div>
+                    <label className="block text-sm font-medium text-text dark:text-text-dark mb-1.5">
+                        {t('fields.providerLabel')}
+                    </label>
+                    <Select
+                        value={providerId}
+                        onValueChange={(value) =>
+                            setProviderId(value as TenantJobRuntimeProviderId)
+                        }
+                    >
+                        {PROVIDER_OPTIONS.map((opt) => (
+                            <option key={opt.value} value={opt.value}>
+                                {opt.label}
+                            </option>
+                        ))}
+                    </Select>
+                    <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                        {t('fields.providerHelper')}
+                    </p>
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium text-text dark:text-text-dark mb-1.5">
+                        {t('fields.modeLabel')}
+                    </label>
+                    <Select
+                        value={mode}
+                        onValueChange={(value) => setMode(value as TenantJobRuntimeMode)}
+                    >
+                        {MODE_OPTIONS.map((opt) => (
+                            <option key={opt.value} value={opt.value}>
+                                {t(opt.labelKey)}
+                            </option>
+                        ))}
+                    </Select>
+                    <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                        {t(`fields.modeHelper.${mode}`)}
+                    </p>
+                </div>
+
+                <div className="flex items-center justify-between gap-4">
+                    <div>
+                        <label className="block text-sm font-medium text-text dark:text-text-dark">
+                            {t('fields.enabledLabel')}
+                        </label>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
+                            {t('fields.enabledHelper')}
+                        </p>
+                    </div>
+                    <Switch checked={enabled} onChange={setEnabled} />
+                </div>
+
+                {needsCredentials && (
+                    <div className="space-y-4 p-4 rounded-lg border border-border dark:border-border-dark">
+                        <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                            {t('credentials.title')}
+                        </h3>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('credentials.subtitle')}
+                        </p>
+
+                        <Input
+                            label={t('credentials.secretRefLabel')}
+                            value={credentialsSecretRef}
+                            onChange={(e) => setCredentialsSecretRef(e.target.value)}
+                            placeholder={t('credentials.secretRefPlaceholder')}
+                            maxLength={128}
+                        />
+
+                        <Textarea
+                            label={t('credentials.jsonLabel')}
+                            value={credentialsJson}
+                            onChange={(e) => setCredentialsJson(e.target.value)}
+                            placeholder={t('credentials.jsonPlaceholder')}
+                            rows={8}
+                            error={credentialsJsonError ?? undefined}
+                            helperText={t('credentials.jsonHelper')}
+                            className="font-mono text-xs"
+                        />
+                    </div>
+                )}
+
+                <div className="flex flex-wrap items-center gap-2 pt-2">
+                    <Button onClick={handleSave} loading={isPending}>
+                        <Save className="w-4 h-4" />
+                        {t('actions.save')}
+                    </Button>
+                    <Button
+                        variant="secondary"
+                        onClick={handleRotate}
+                        disabled={!hasOverlayRow || isPending}
+                    >
+                        <RotateCw className="w-4 h-4" />
+                        {t('actions.rotate')}
+                    </Button>
+                    <Button
+                        variant="danger"
+                        onClick={() => setConfirmInvalidate(true)}
+                        disabled={!hasOverlayRow || isPending}
+                    >
+                        <ShieldOff className="w-4 h-4" />
+                        {t('actions.forceInvalidate')}
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        onClick={() => setConfirmRevert(true)}
+                        disabled={!hasOverlayRow || isPending}
+                    >
+                        <Undo2 className="w-4 h-4" />
+                        {t('actions.revert')}
+                    </Button>
+                </div>
+            </div>
+
+            <Dialog open={confirmInvalidate} onOpenChange={setConfirmInvalidate}>
+                <DialogContent>
+                    <DialogClose onClose={() => setConfirmInvalidate(false)} />
+                    <DialogHeader>
+                        <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                            {t('forceInvalidate.title')}
+                        </DialogTitle>
+                    </DialogHeader>
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                        {t('forceInvalidate.description')}
+                    </p>
+                    <DialogFooter>
+                        <Button variant="secondary" onClick={() => setConfirmInvalidate(false)}>
+                            {t('forceInvalidate.cancel')}
+                        </Button>
+                        <Button
+                            variant="danger"
+                            onClick={handleForceInvalidate}
+                            loading={isPending}
+                        >
+                            {t('forceInvalidate.confirm')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            <Dialog open={confirmRevert} onOpenChange={setConfirmRevert}>
+                <DialogContent>
+                    <DialogClose onClose={() => setConfirmRevert(false)} />
+                    <DialogHeader>
+                        <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                            {t('revert.title')}
+                        </DialogTitle>
+                    </DialogHeader>
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                        {t('revert.description')}
+                    </p>
+                    <DialogFooter>
+                        <Button variant="secondary" onClick={() => setConfirmRevert(false)}>
+                            {t('revert.cancel')}
+                        </Button>
+                        <Button variant="danger" onClick={handleRevert} loading={isPending}>
+                            {t('revert.confirm')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}
+
+function Readout({ label, value }: { label: string; value: string }) {
+    return (
+        <div>
+            <p className="text-xs text-text-muted dark:text-text-muted-dark">{label}</p>
+            <p className="text-sm font-medium text-text dark:text-text-dark mt-1 break-all">
+                {value}
+            </p>
+        </div>
+    );
+}

--- a/apps/web/src/lib/api/tenant-job-runtime.ts
+++ b/apps/web/src/lib/api/tenant-job-runtime.ts
@@ -1,0 +1,102 @@
+import 'server-only';
+import { serverFetch, serverMutation } from './server-api';
+
+/**
+ * EW-742 P2.1 — web client for the tenant job-runtime overlay admin API
+ * (mounted at `/api/account/job-runtime` on the platform API — see
+ * `apps/api/src/account/tenant-job-runtime/tenant-job-runtime.controller.ts`).
+ *
+ * Auth model is 1 User : 1 Tenant so every endpoint targets the
+ * authenticated user's own tenant; there are no path params.
+ *
+ * Credential pointers are NEVER round-tripped through this wrapper.
+ * The GET response is already redacted server-side
+ * (`credentialsSecretRefRedacted`, `hasCredentials` only) and the PUT
+ * payload accepts an opaque `credentialsSecretRef` that the controller
+ * routes into the encrypted secrets store.
+ */
+
+export type TenantJobRuntimeProviderId = 'trigger' | 'temporal' | 'bullmq' | 'pgboss' | 'inngest';
+
+export type TenantJobRuntimeMode = 'inherit' | 'byo' | 'override';
+
+export interface TenantJobRuntimeConfigResponse {
+    tenantId: string;
+    providerId: TenantJobRuntimeProviderId | null;
+    mode: TenantJobRuntimeMode;
+    hasCredentials: boolean;
+    credentialsSecretRefRedacted: string | null;
+    credentialVersion: number | null;
+    enabled: boolean;
+    createdBy: string | null;
+    createdAt: string | null;
+    updatedAt: string | null;
+}
+
+export interface TenantJobRuntimeRotateResponse {
+    credentialVersion: number;
+}
+
+export interface UpsertTenantJobRuntimeConfigPayload {
+    providerId: TenantJobRuntimeProviderId;
+    mode: TenantJobRuntimeMode;
+    credentialsSecretRef?: string | null;
+    enabled?: boolean;
+}
+
+const BASE = '/api/account/job-runtime';
+
+export const tenantJobRuntimeAPI = {
+    getConfig: async () => {
+        return serverFetch<TenantJobRuntimeConfigResponse>(`${BASE}/config`);
+    },
+
+    upsertConfig: async (payload: UpsertTenantJobRuntimeConfigPayload) => {
+        return serverMutation<TenantJobRuntimeConfigResponse>({
+            endpoint: `${BASE}/config`,
+            data: payload,
+            method: 'PUT',
+            wrapInData: false,
+        });
+    },
+
+    rotate: async () => {
+        return serverMutation<TenantJobRuntimeRotateResponse>({
+            endpoint: `${BASE}/rotate`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    forceInvalidate: async () => {
+        return serverMutation<TenantJobRuntimeRotateResponse>({
+            endpoint: `${BASE}/force-invalidate`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    revertToInherit: async () => {
+        return serverMutation<TenantJobRuntimeConfigResponse>({
+            endpoint: `${BASE}/config`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
+};
+
+/**
+ * Convenience aliases that match the function-name shape called out in
+ * the implementing prompt (T15-T19), so call sites that don't want to
+ * thread the namespaced object can `import { getJobRuntimeConfig } from
+ * '@/lib/api/tenant-job-runtime'`.
+ */
+export const getJobRuntimeConfig = () => tenantJobRuntimeAPI.getConfig();
+export const upsertJobRuntimeConfig = (payload: UpsertTenantJobRuntimeConfigPayload) =>
+    tenantJobRuntimeAPI.upsertConfig(payload);
+export const rotateJobRuntimeConfig = () => tenantJobRuntimeAPI.rotate();
+export const forceInvalidateJobRuntimeConfig = () => tenantJobRuntimeAPI.forceInvalidate();
+export const deleteJobRuntimeConfig = () => tenantJobRuntimeAPI.revertToInherit();

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -141,6 +141,7 @@ export const ROUTES = {
     DASHBOARD_SETTINGS_DATA: '/settings/data',
     DASHBOARD_SETTINGS_GITHUB_APP: '/settings/github-app',
     DASHBOARD_SETTINGS_WORK_AGENT: '/settings/work-agent',
+    DASHBOARD_SETTINGS_JOB_RUNTIME: '/settings/job-runtime',
     // Dynamic plugin settings routes
     DASHBOARD_SETTINGS_PLUGIN_CATEGORY: (category: string) => `/settings/plugins/${category}`,
     // Profile (alias of settings — `/profile` redirects to `/settings`)


### PR DESCRIPTION
## Summary

[EW-746](https://evertech.atlassian.net/browse/EW-746) second half — settings page + interactive form for the tenant overlay. P2.0 (REST API) shipped in PR #1341; this completes the UI.

## Files

- `apps/web/src/app/[locale]/(dashboard)/settings/job-runtime/page.tsx` — server component
- `apps/web/src/components/settings/JobRuntimeSettings.tsx` — client form (~430 lines): provider Select, mode Select, enabled Switch, conditional credentials block, Save/Rotate/Force-Invalidate/Revert with confirm dialogs, readout panel
- `apps/web/src/app/actions/settings/job-runtime.ts` — four Server Actions (`upsert` / `rotate` / `forceInvalidate` / `revert`)
- `apps/web/src/lib/api/tenant-job-runtime.ts` — typed API client wrapper
- `apps/web/messages/en.json` — full `dashboard.settings.jobRuntime.*` i18n namespace
- `apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx` — adds Job Runtime nav entry
- `apps/web/src/lib/constants.ts` — adds route constant

## Deferred (P2.2 follow-up)

- Schema-driven per-provider credentials form (parse `providers.md` JSON Schemas + render dynamically). Current generic credentials field is a stand-in.
- Playwright e2e test.
- Reachability probe on PUT (P4).
- Per-tenant operator allow-list filter (P5).
- Other-locale strings — only `en.json` updated; next-intl falls back.

## Refs

- Epic: [EW-742](https://evertech.atlassian.net/browse/EW-742)
- Story: [EW-746](https://evertech.atlassian.net/browse/EW-746) (P2.0 API DONE in #1341; this PR is P2.1 UI)
- Prereq: [EW-745](https://evertech.atlassian.net/browse/EW-745) (DONE, #1338), [EW-744](https://evertech.atlassian.net/browse/EW-744) (DONE, #1335), [EW-743](https://evertech.atlassian.net/browse/EW-743) (DONE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EW-746]: https://evertech.atlassian.net/browse/EW-746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EW-742]: https://evertech.atlassian.net/browse/EW-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Job Runtime” settings panel to the dashboard, including mode and provider selection, credential reference/JSON handling, live readouts, and actions to save, rotate, force-invalidate, or revert back to inherited settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->