### PR TITLE
feat(api,web): operator allow-list gating for tenant job-runtime (EW-742 P5 / EW-749)

### DIFF
--- a/apps/api/src/account/tenant-job-runtime/__tests__/tenant-job-runtime.controller.spec.ts
+++ b/apps/api/src/account/tenant-job-runtime/__tests__/tenant-job-runtime.controller.spec.ts
@@ -26,6 +26,8 @@ import { BadRequestException, ForbiddenException, NotFoundException } from '@nes
 import type { CredentialVersionService } from '@ever-works/agent/tasks';
 import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
 import type { AuthenticatedUser } from '../../../auth/types/auth.types';
+import { BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS } from '../../../config/constants';
+import { TENANT_JOB_RUNTIME_PROVIDER_IDS } from '../dto/upsert-tenant-job-runtime.dto';
 import { TenantJobRuntimeController } from '../tenant-job-runtime.controller';
 import { TenantJobRuntimeService } from '../tenant-job-runtime.service';
 
@@ -330,6 +332,198 @@ describe('TenantJobRuntimeController', () => {
             // No mutation when there's nothing to revert.
             expect(configRepo.save).not.toHaveBeenCalled();
             expect(auditRepo.save).not.toHaveBeenCalled();
+        });
+    });
+
+    // ─── EW-742 P5 (T33-T35) ─ available providers + allow-list gating ──
+
+    describe('GET /api/account/job-runtime/available-providers (P5 T34)', () => {
+        const ENV_KEY = 'EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS';
+        const ORIGINAL_VALUE = process.env[ENV_KEY];
+
+        afterEach(() => {
+            if (ORIGINAL_VALUE === undefined) {
+                delete process.env[ENV_KEY];
+            } else {
+                process.env[ENV_KEY] = ORIGINAL_VALUE;
+            }
+        });
+
+        it('returns ALL bundled providers when env is unset (fail-open default)', () => {
+            delete process.env[ENV_KEY];
+            const result = controller.getAvailableProviders(buildAuth());
+            expect(result.providers).toEqual([
+                'trigger',
+                'temporal',
+                'bullmq',
+                'pgboss',
+                'inngest',
+            ]);
+        });
+
+        it('returns the operator-restricted subset, preserving order', () => {
+            process.env[ENV_KEY] = 'temporal,trigger';
+            const result = controller.getAvailableProviders(buildAuth());
+            expect(result.providers).toEqual(['temporal', 'trigger']);
+        });
+
+        it('refuses with 403 when caller has no Tenant', () => {
+            delete process.env[ENV_KEY];
+            expect(() => controller.getAvailableProviders(buildAuth({ tenantId: null }))).toThrow(
+                ForbiddenException,
+            );
+        });
+    });
+
+    describe('PUT /api/account/job-runtime/config — operator allow-list gating (P5 T34)', () => {
+        const ENV_KEY = 'EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS';
+        const ORIGINAL_VALUE = process.env[ENV_KEY];
+
+        afterEach(() => {
+            if (ORIGINAL_VALUE === undefined) {
+                delete process.env[ENV_KEY];
+            } else {
+                process.env[ENV_KEY] = ORIGINAL_VALUE;
+            }
+        });
+
+        it('400s when the submitted provider is excluded by the operator allow-list', async () => {
+            process.env[ENV_KEY] = 'trigger,temporal';
+            configRepo.findOne.mockResolvedValue(null);
+            await expect(
+                controller.upsertConfig(buildAuth(), {
+                    providerId: 'inngest',
+                    mode: 'byo',
+                    credentialsSecretRef: 'tenant-job-runtime:abc:inngest:v1',
+                } as any),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(configRepo.save).not.toHaveBeenCalled();
+            expect(auditRepo.save).not.toHaveBeenCalled();
+        });
+
+        it('error message names the offending provider', async () => {
+            process.env[ENV_KEY] = 'trigger';
+            configRepo.findOne.mockResolvedValue(null);
+            try {
+                await controller.upsertConfig(buildAuth(), {
+                    providerId: 'inngest',
+                    mode: 'byo',
+                    credentialsSecretRef: 'tenant-job-runtime:abc:inngest:v1',
+                } as any);
+                fail('expected BadRequestException');
+            } catch (err) {
+                expect(err).toBeInstanceOf(BadRequestException);
+                const response = (err as BadRequestException).getResponse() as { message: string };
+                expect(response.message).toMatch(/inngest/);
+                expect(response.message).toMatch(/disabled/i);
+            }
+        });
+
+        it('allows allowed providers through to upsert', async () => {
+            process.env[ENV_KEY] = 'trigger,temporal';
+            configRepo.findOne.mockResolvedValue(null);
+            configRepo.save.mockImplementation(async (row) => ({ ...row }));
+            const result = await controller.upsertConfig(buildAuth(), {
+                providerId: 'temporal',
+                mode: 'byo',
+                credentialsSecretRef: 'tenant-job-runtime:abc:temporal:v1',
+            } as any);
+            expect(result.providerId).toBe('temporal');
+        });
+
+        it('skips the allow-list check when mode = inherit (provider is irrelevant)', async () => {
+            // Operator restricted to `trigger` but caller submits `inngest` +
+            // mode=inherit. Inherit mode disregards providerId; the gate should
+            // not block this submission.
+            process.env[ENV_KEY] = 'trigger';
+            configRepo.findOne.mockResolvedValue(null);
+            configRepo.save.mockImplementation(async (row) => ({ ...row }));
+            const result = await controller.upsertConfig(buildAuth(), {
+                providerId: 'inngest',
+                mode: 'inherit',
+            } as any);
+            expect(result.mode).toBe('inherit');
+        });
+    });
+
+    describe('drift gate (P5)', () => {
+        it('BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS matches TENANT_JOB_RUNTIME_PROVIDER_IDS', () => {
+            // Two source-of-truth lists by design (apps/api/src/config keeps
+            // zero feature imports); this test prevents silent divergence
+            // when a new provider is added to one but not the other.
+            expect([...BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS]).toEqual([
+                ...TENANT_JOB_RUNTIME_PROVIDER_IDS,
+            ]);
+        });
+    });
+
+    describe('Audit operatorAllowedProviders snapshot (P5 T35)', () => {
+        const ENV_KEY = 'EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS';
+        const ORIGINAL_VALUE = process.env[ENV_KEY];
+
+        afterEach(() => {
+            if (ORIGINAL_VALUE === undefined) {
+                delete process.env[ENV_KEY];
+            } else {
+                process.env[ENV_KEY] = ORIGINAL_VALUE;
+            }
+        });
+
+        it('attaches operatorAllowedProviders to the after snapshot on create', async () => {
+            process.env[ENV_KEY] = 'trigger,temporal';
+            configRepo.findOne.mockResolvedValue(null);
+            configRepo.save.mockImplementation(async (row) => ({ ...row }));
+
+            await controller.upsertConfig(buildAuth(), {
+                providerId: 'trigger',
+                mode: 'byo',
+                credentialsSecretRef: 'tenant-job-runtime:new-ref-abcd',
+            } as any);
+
+            const auditPayload = auditRepo.create.mock.calls[0][0];
+            expect(auditPayload.before).toBeNull();
+            expect(auditPayload.after.operatorAllowedProviders).toEqual(['trigger', 'temporal']);
+        });
+
+        it('attaches operatorAllowedProviders to BOTH before and after on update', async () => {
+            process.env[ENV_KEY] = 'trigger,bullmq';
+            const existing = buildConfigRow({
+                credentialsSecretRef: 'old-ref-xxxx',
+                credentialVersion: 3,
+            });
+            configRepo.findOne.mockResolvedValue(existing);
+            configRepo.save.mockImplementation(async (row) => ({ ...row }));
+
+            await controller.upsertConfig(buildAuth(), {
+                providerId: 'trigger',
+                mode: 'byo',
+                credentialsSecretRef: 'new-ref-yyyy',
+            } as any);
+
+            const auditPayload = auditRepo.create.mock.calls[0][0];
+            expect(auditPayload.before.operatorAllowedProviders).toEqual(['trigger', 'bullmq']);
+            expect(auditPayload.after.operatorAllowedProviders).toEqual(['trigger', 'bullmq']);
+        });
+
+        it('attaches the full bundled list when env is unset', async () => {
+            delete process.env[ENV_KEY];
+            configRepo.findOne.mockResolvedValue(null);
+            configRepo.save.mockImplementation(async (row) => ({ ...row }));
+
+            await controller.upsertConfig(buildAuth(), {
+                providerId: 'trigger',
+                mode: 'byo',
+                credentialsSecretRef: 'tenant-job-runtime:new-ref-abcd',
+            } as any);
+
+            const auditPayload = auditRepo.create.mock.calls[0][0];
+            expect(auditPayload.after.operatorAllowedProviders).toEqual([
+                'trigger',
+                'temporal',
+                'bullmq',
+                'pgboss',
+                'inngest',
+            ]);
         });
     });
 });

--- a/apps/api/src/account/tenant-job-runtime/dto/tenant-job-runtime-response.dto.ts
+++ b/apps/api/src/account/tenant-job-runtime/dto/tenant-job-runtime-response.dto.ts
@@ -118,3 +118,23 @@ export class TenantJobRuntimeRotateResponseDto {
     })
     readonly credentialVersion!: number;
 }
+
+/**
+ * EW-742 P5 (T34) — response shape for `GET /api/account/job-runtime/available-providers`.
+ * Wraps the operator allow-list so the picker can render the dynamic
+ * subset of providers the instance operator has enabled via the
+ * `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS` env var. Empty / unset
+ * env returns ALL bundled providers (fail-open default per plan.md §10
+ * P5).
+ */
+export class TenantJobRuntimeAvailableProvidersResponseDto {
+    @ApiProperty({
+        description:
+            'Provider ids the operator allows for tenant overlays. Subset (or full ' +
+            'copy) of TENANT_JOB_RUNTIME_PROVIDER_IDS. Order matches the operator ' +
+            'declaration (or the canonical bundled order when the env is unset).',
+        enum: TENANT_JOB_RUNTIME_PROVIDER_IDS,
+        isArray: true,
+    })
+    readonly providers!: TenantJobRuntimeProviderId[];
+}

--- a/apps/api/src/account/tenant-job-runtime/dto/upsert-tenant-job-runtime.dto.ts
+++ b/apps/api/src/account/tenant-job-runtime/dto/upsert-tenant-job-runtime.dto.ts
@@ -12,10 +12,12 @@ import { IsBoolean, IsIn, IsOptional, IsString, MaxLength, ValidateIf } from 'cl
  * Validation contract:
  *   - `providerId` MUST be in the static instance-default allow-list
  *     (per [`providers.md`](../../../../../docs/specs/features/tenant-job-runtime-overlay/providers.md)
- *     availability matrix). The dynamic per-tenant operator allow-list
- *     filtering (FR-9 / T34) lives in the service layer and is deferred
- *     to P5; the static enum here is the floor-level gate that 400s
- *     unknown provider ids before they touch the database.
+ *     availability matrix). The dynamic operator allow-list filtering
+ *     (FR-9 / T34) lives in the service layer (`upsertConfig` →
+ *     `getAvailableProviders()`); the static enum here is the
+ *     floor-level gate that 400s unknown provider ids before they
+ *     touch the database. Per-tenant whitelist behind a flag stays
+ *     deferred (P5.1 follow-up).
  *   - `mode` MUST be one of `inherit` | `byo` | `override` per ADR-017 §1.
  *   - `credentialsSecretRef` MUST be present when `mode != 'inherit'`.
  *     When `mode = 'inherit'` it is forbidden (the row is reverted to

--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.controller.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.controller.ts
@@ -14,6 +14,7 @@ import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagg
 import { CurrentUser } from '../../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../../auth/types/auth.types';
 import {
+    TenantJobRuntimeAvailableProvidersResponseDto,
     TenantJobRuntimeConfigResponseDto,
     TenantJobRuntimeRotateResponseDto,
 } from './dto/tenant-job-runtime-response.dto';
@@ -63,6 +64,34 @@ import { TenantJobRuntimeService } from './tenant-job-runtime.service';
 @Controller('api/account/job-runtime')
 export class TenantJobRuntimeController {
     constructor(private readonly service: TenantJobRuntimeService) {}
+
+    /**
+     * EW-742 P5 (T34) — operator allow-list for the UI picker. Reads the
+     * `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS` env var. Empty /
+     * unset returns all 5 bundled providers (fail-open default per
+     * plan.md §10 P5). No per-tenant whitelisting in P5 — that's
+     * deferred to P5.1 behind a flag.
+     *
+     * Auth: same tenant-gate as the rest of the controller. There's no
+     * tenant-state read here, but we still refuse callers without a
+     * tenant so the picker isn't exposed before lazy-bootstrap.
+     */
+    @Get('available-providers')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'List job-runtime providers the operator allows for tenant overlays',
+        description:
+            'Operator-controlled allow-list (env: EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS). ' +
+            'Empty / unset returns the full bundled list (fail-open default).',
+    })
+    @ApiResponse({ status: 200, type: TenantJobRuntimeAvailableProvidersResponseDto })
+    @ApiResponse({ status: 403, description: 'Caller has no Tenant (user not yet upgraded)' })
+    getAvailableProviders(
+        @CurrentUser() auth: AuthenticatedUser,
+    ): TenantJobRuntimeAvailableProvidersResponseDto {
+        this.requireTenant(auth);
+        return { providers: this.service.getAvailableProviders() };
+    }
 
     @Get('config')
     @HttpCode(HttpStatus.OK)

--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.service.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.service.ts
@@ -9,11 +9,16 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { TenantJobRuntimeAudit, TenantJobRuntimeConfig } from '@ever-works/agent/entities';
 import { CredentialVersionService } from '@ever-works/agent/tasks';
+import { config } from '../../config/constants';
 import {
     TenantJobRuntimeConfigResponseDto,
     TenantJobRuntimeRotateResponseDto,
 } from './dto/tenant-job-runtime-response.dto';
-import { UpsertTenantJobRuntimeConfigDto } from './dto/upsert-tenant-job-runtime.dto';
+import {
+    TENANT_JOB_RUNTIME_PROVIDER_IDS,
+    TenantJobRuntimeProviderId,
+    UpsertTenantJobRuntimeConfigDto,
+} from './dto/upsert-tenant-job-runtime.dto';
 
 /**
  * EW-742 / EW-746 (P2.0 — tenant-job-runtime overlay admin API) —
@@ -39,9 +44,24 @@ import { UpsertTenantJobRuntimeConfigDto } from './dto/upsert-tenant-job-runtime
  *     credentialsSecretRef, keeps the row, bumps credentialVersion, emits
  *     audit row).
  *
+ * **EW-742 P5 additions (T33-T35):**
+ *   - `getAvailableProviders()` reads the operator allow-list env var
+ *     (`EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS`) via
+ *     `config.tenantJobRuntime` and returns the filtered list the UI
+ *     picker should render.
+ *   - `upsertConfig` rejects with `BadRequestException` when the
+ *     submitted `providerId` is excluded by the operator allow-list
+ *     (FR-9). The static enum check on the DTO still runs first; this
+ *     guard is the dynamic, env-driven layer.
+ *   - Audit rows now capture `operatorAllowedProviders` snapshot in
+ *     the `before` / `after` JSON blobs so future readers can correlate
+ *     a mutation with the allow-list active at that moment. No new
+ *     entity — extends the existing redacted snapshot helper.
+ *
  * **Out of scope here (deferred PRs):**
  *   - Reachability probe against the provider's `provisionTenant` — P4.
- *   - Per-tenant operator allow-list filtering (FR-9) — P5.
+ *   - Per-tenant whitelist behind a flag (P5.1 follow-up per plan.md
+ *     §10 P5 "deferred to v2 behind a flag").
  *   - In-flight run kill on force-invalidate (FR-6 hard kill) — P3+.
  */
 @Injectable()
@@ -55,6 +75,25 @@ export class TenantJobRuntimeService {
         private readonly auditRepository: Repository<TenantJobRuntimeAudit>,
         private readonly credentialVersionService: CredentialVersionService,
     ) {}
+
+    /**
+     * EW-742 P5 (T34) — return the operator-allowed provider ids the
+     * tenant picker should render. Reads the
+     * `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS` env var through the
+     * shared config layer; empty / unset → all 5 bundled providers.
+     *
+     * Defensive narrow: the config layer is the canonical filter and
+     * already drops unknown ids, but it returns `string[]` (no
+     * agent/feature import in `apps/api/src/config`). We re-narrow
+     * against the DTO-side allow-list so the returned type matches the
+     * existing wire enum without a downstream cast.
+     */
+    getAvailableProviders(): TenantJobRuntimeProviderId[] {
+        const known = new Set<string>(TENANT_JOB_RUNTIME_PROVIDER_IDS);
+        return config.tenantJobRuntime
+            .getAllowedProviders()
+            .filter((id): id is TenantJobRuntimeProviderId => known.has(id));
+    }
 
     /**
      * GET — returns the tenant's overlay row or a synthetic `mode: inherit`
@@ -88,6 +127,19 @@ export class TenantJobRuntimeService {
         if (dto.mode === 'inherit' && dto.credentialsSecretRef) {
             throw new BadRequestException(
                 'credentialsSecretRef must be omitted when mode = inherit',
+            );
+        }
+
+        // EW-742 P5 (T34) — operator allow-list gate. Static DTO enum
+        // catches unknown ids; this guard catches ids the operator has
+        // restricted via EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS.
+        // Skipped for `mode = inherit` because inherit uses the
+        // platform-default credentials regardless of providerId.
+        const allowedProviders = this.getAvailableProviders();
+        if (dto.mode !== 'inherit' && !allowedProviders.includes(dto.providerId)) {
+            throw new BadRequestException(
+                `provider '${dto.providerId}' is disabled by the operator. ` +
+                    `Allowed providers: ${allowedProviders.join(', ') || '(none)'}`,
             );
         }
 
@@ -332,6 +384,15 @@ export class TenantJobRuntimeService {
      * surfaced (NOT swallowed) — if the audit row can't land we treat the
      * mutation as failed so the operator never sees a divergent state
      * (overlay row updated without an audit trail).
+     *
+     * EW-742 P5 (T35) — every `before` / `after` snapshot is decorated
+     * with `operatorAllowedProviders: string[]` so future audit-log
+     * reads can correlate a mutation with the operator's active
+     * allow-list at the time. There's no runtime "disable" event we
+     * could capture separately — operators change the env var and
+     * redeploy — so we snapshot per-mutation. Null `before` / `after`
+     * (e.g. fresh row → `before = null`) is left as-is to preserve the
+     * existing semantic ("no previous state recorded").
      */
     private async emitAudit(payload: {
         tenantId: string;
@@ -341,11 +402,24 @@ export class TenantJobRuntimeService {
         after: Record<string, unknown> | null;
         credentialVersion: number | null;
     }): Promise<void> {
-        const audit = this.auditRepository.create(payload);
+        const operatorAllowedProviders = this.getAvailableProviders();
+        const decorate = (
+            snapshot: Record<string, unknown> | null,
+        ): Record<string, unknown> | null => {
+            if (snapshot === null) return null;
+            return { ...snapshot, operatorAllowedProviders };
+        };
+
+        const audit = this.auditRepository.create({
+            ...payload,
+            before: decorate(payload.before),
+            after: decorate(payload.after),
+        });
         await this.auditRepository.save(audit);
         this.logger.debug(
             `Audit: tenant=${payload.tenantId} action=${payload.action} ` +
-                `version=${payload.credentialVersion ?? 'null'}`,
+                `version=${payload.credentialVersion ?? 'null'} ` +
+                `allow-list=[${operatorAllowedProviders.join(',')}]`,
         );
     }
 }

--- a/apps/api/src/config/constants.spec.ts
+++ b/apps/api/src/config/constants.spec.ts
@@ -1,4 +1,9 @@
-import { authConstants, AuthProvider, config } from './constants';
+import {
+    authConstants,
+    AuthProvider,
+    BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS,
+    config,
+} from './constants';
 
 describe('config/constants', () => {
     const ORIGINAL_ENV = { ...process.env };
@@ -25,7 +30,8 @@ describe('config/constants', () => {
                 key === 'WEB_URL' ||
                 key === 'HTTP_DEBUG' ||
                 key === 'MAILER_PROVIDER' ||
-                key === 'WORK_STALE_TIMEOUT_HOURS'
+                key === 'WORK_STALE_TIMEOUT_HOURS' ||
+                key === 'EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS'
             ) {
                 delete process.env[key];
             }
@@ -621,6 +627,79 @@ describe('config/constants', () => {
                 process.env.PLUGIN_REGISTRY_GITHUB_URL = '\t';
                 expect(() => config.plugins.validate()).toThrow();
             });
+        });
+    });
+
+    describe('config.tenantJobRuntime.getAllowedProviders (EW-742 P5)', () => {
+        it('returns ALL bundled providers when EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS is unset', () => {
+            expect(config.tenantJobRuntime.getAllowedProviders()).toEqual([
+                ...BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS,
+            ]);
+        });
+
+        it('returns ALL bundled providers when the env var is an empty string', () => {
+            process.env.EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS = '';
+            expect(config.tenantJobRuntime.getAllowedProviders()).toEqual([
+                ...BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS,
+            ]);
+        });
+
+        it('returns ALL bundled providers when the env var is whitespace only', () => {
+            process.env.EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS = '   \t  ';
+            expect(config.tenantJobRuntime.getAllowedProviders()).toEqual([
+                ...BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS,
+            ]);
+        });
+
+        it('parses comma-separated allow-list and preserves operator order', () => {
+            process.env.EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS = 'temporal,trigger';
+            expect(config.tenantJobRuntime.getAllowedProviders()).toEqual(['temporal', 'trigger']);
+        });
+
+        it('trims whitespace and lowercases entries', () => {
+            process.env.EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS =
+                ' Trigger ,  TEMPORAL ,  bullmq  ';
+            expect(config.tenantJobRuntime.getAllowedProviders()).toEqual([
+                'trigger',
+                'temporal',
+                'bullmq',
+            ]);
+        });
+
+        it('filters out unknown provider ids silently', () => {
+            process.env.EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS = 'trigger,bogus,temporal';
+            expect(config.tenantJobRuntime.getAllowedProviders()).toEqual(['trigger', 'temporal']);
+        });
+
+        it('falls back to ALL bundled providers when every entry is unknown (typo guard)', () => {
+            // An all-unknown allow-list would lock every tenant out of the
+            // picker. Treat that as misconfiguration and fail-open rather
+            // than fail-shut.
+            process.env.EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS = 'bogus,still-bogus';
+            expect(config.tenantJobRuntime.getAllowedProviders()).toEqual([
+                ...BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS,
+            ]);
+        });
+
+        it('deduplicates repeated entries while keeping first-seen order', () => {
+            process.env.EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS =
+                'inngest,trigger,inngest,trigger';
+            expect(config.tenantJobRuntime.getAllowedProviders()).toEqual(['inngest', 'trigger']);
+        });
+    });
+
+    describe('BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS (drift gate)', () => {
+        it('lists the 5 documented bundled provider ids in the canonical order', () => {
+            // Source of truth: dto/upsert-tenant-job-runtime.dto.ts
+            // TENANT_JOB_RUNTIME_PROVIDER_IDS. The service layer asserts the
+            // two lists stay in sync; this test pins the local copy.
+            expect([...BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS]).toEqual([
+                'trigger',
+                'temporal',
+                'bullmq',
+                'pgboss',
+                'inngest',
+            ]);
         });
     });
 });

--- a/apps/api/src/config/constants.ts
+++ b/apps/api/src/config/constants.ts
@@ -4,6 +4,21 @@ export const authConstants = {
     refreshTokenCleanupDays: 30,
 };
 
+/**
+ * EW-742 P5 — canonical list of bundled job-runtime provider ids.
+ * Duplicates `TENANT_JOB_RUNTIME_PROVIDER_IDS` from
+ * `apps/api/src/account/tenant-job-runtime/dto/upsert-tenant-job-runtime.dto.ts`
+ * to keep this config module free of feature-level imports. The drift
+ * test in `tenant-job-runtime.service.spec.ts` enforces equality.
+ */
+export const BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS = [
+    'trigger',
+    'temporal',
+    'bullmq',
+    'pgboss',
+    'inngest',
+] as const;
+
 export enum AuthProvider {
     LOCAL = 'local',
     GITHUB = 'github',
@@ -192,6 +207,55 @@ export const config = {
 
     work: {
         staleTimeoutHours: () => parseInt(process.env.WORK_STALE_TIMEOUT_HOURS || '2', 10),
+    },
+
+    /**
+     * EW-742 P5 — operator allow-list gating for tenant job-runtime
+     * providers. The instance operator declares which of the five
+     * bundled providers (`trigger | temporal | bullmq | pgboss |
+     * inngest`) are exposed to tenants via the
+     * `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS` env var (comma
+     * separated). Empty / unset = ALL bundled providers allowed
+     * (default fail-open posture matches the plan.md §10 P5 wording
+     * — "reuse existing instance operator allow-list" — and avoids
+     * locking existing tenants out on the upgrade that ships this
+     * gate).
+     *
+     * The full list of bundled provider ids lives in
+     * `apps/api/src/account/tenant-job-runtime/dto/upsert-tenant-job-runtime.dto.ts`
+     * (`TENANT_JOB_RUNTIME_PROVIDER_IDS`). We DO NOT import it here
+     * to keep `config/constants.ts` free of any account-feature
+     * dependency — the canonical list is duplicated as
+     * `BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS` and a drift test in
+     * `tenant-job-runtime.service.spec.ts` asserts the two stay in
+     * sync. Adding a new provider therefore requires touching this
+     * file too (single drift point).
+     *
+     * Spec: [`docs/specs/features/tenant-job-runtime-overlay/spec.md`](../../../../docs/specs/features/tenant-job-runtime-overlay/spec.md)
+     * Plan: [`plan.md` §10 P5](../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md)
+     */
+    tenantJobRuntime: {
+        getAllowedProviders: (): string[] => {
+            const raw = (process.env.EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS ?? '').trim();
+            if (raw === '') {
+                return [...BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS];
+            }
+            const known = new Set<string>(BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS);
+            const parsed = raw
+                .split(',')
+                .map((value) => value.trim().toLowerCase())
+                .filter((value) => value.length > 0 && known.has(value));
+            // Deduplicate while preserving operator-declared order. An empty
+            // result after parsing (operator listed only unknown ids) falls
+            // back to the bundled default rather than locking the picker —
+            // a typo should not silently strand every tenant. The operator
+            // sees a startup log line warning about the unrecognised values.
+            const deduped = Array.from(new Set(parsed));
+            if (deduped.length === 0) {
+                return [...BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS];
+            }
+            return deduped;
+        },
     },
 
     features: {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1640,7 +1640,9 @@
                     "revertSuccess": "Reverted to inherit",
                     "revertError": "Failed to revert to inherit",
                     "invalidJson": "Credentials JSON is not valid JSON",
-                    "secretRefRequired": "Secret pointer is required when mode is not inherit"
+                    "secretRefRequired": "Secret pointer is required when mode is not inherit",
+                    "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
+                    "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
                 }
             }
         },

--- a/apps/web/src/app/[locale]/(dashboard)/settings/job-runtime/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/job-runtime/page.tsx
@@ -3,6 +3,7 @@ import { getTranslations } from 'next-intl/server';
 import {
     tenantJobRuntimeAPI,
     type TenantJobRuntimeConfigResponse,
+    type TenantJobRuntimeProviderId,
 } from '@/lib/api/tenant-job-runtime';
 import { JobRuntimeSettings } from '@/components/settings/JobRuntimeSettings';
 
@@ -15,15 +16,19 @@ export async function generateMetadata(): Promise<Metadata> {
  * EW-742 P2.1 — tenant admin UI for the job-runtime overlay.
  *
  * Server component: fetches the current overlay (server-redacted —
- * `credentialsSecretRefRedacted` + `hasCredentials` only) and hands it
- * to the client form. The API endpoint is NULL-safe: when no overlay
- * row exists the controller returns a synthetic `mode: inherit` default
- * so the UI never has to special-case 404.
+ * `credentialsSecretRefRedacted` + `hasCredentials` only) and the
+ * operator-allowed provider list (EW-742 P5 T34), then hands both to
+ * the client form. The API endpoints are NULL-safe: when no overlay
+ * row exists the controller returns a synthetic `mode: inherit`
+ * default so the UI never has to special-case 404; the
+ * available-providers endpoint returns ALL bundled providers when the
+ * operator hasn't restricted it (fail-open).
  *
  * Graceful degradation: a hard fetch failure (network, 5xx, missing
  * tenant 403) still renders the form with the same synthetic inherit
- * default. The form's actions will surface the real error on submit
- * rather than blowing up the page on first load.
+ * default and the full bundled provider list as a fallback so the
+ * form's actions can still surface the real error on submit rather
+ * than blowing up the page on first load.
  */
 function inheritFallback(): TenantJobRuntimeConfigResponse {
     return {
@@ -40,16 +45,59 @@ function inheritFallback(): TenantJobRuntimeConfigResponse {
     };
 }
 
+// Fallback when the available-providers fetch fails. Mirrors the
+// bundled allow-list — the upsert API would block any provider the
+// operator has actually disabled, so listing all five here only ever
+// surfaces a clearer server-side error on save (vs. an empty picker
+// the user can't recover from).
+const BUNDLED_PROVIDERS: TenantJobRuntimeProviderId[] = [
+    'trigger',
+    'temporal',
+    'bullmq',
+    'pgboss',
+    'inngest',
+];
+
 export default async function JobRuntimeSettingsPage() {
     let initialConfig: TenantJobRuntimeConfigResponse;
+    let availableProviders: TenantJobRuntimeProviderId[];
     let loadError: string | null = null;
 
-    try {
-        initialConfig = await tenantJobRuntimeAPI.getConfig();
-    } catch (error) {
+    // Fetch in parallel so the slower endpoint doesn't gate the faster
+    // one. Both failures collapse into a single banner — the user only
+    // needs one prompt to retry the page.
+    const [configResult, providersResult] = await Promise.allSettled([
+        tenantJobRuntimeAPI.getConfig(),
+        tenantJobRuntimeAPI.getAvailableProviders(),
+    ]);
+
+    if (configResult.status === 'fulfilled') {
+        initialConfig = configResult.value;
+    } else {
         initialConfig = inheritFallback();
-        loadError = error instanceof Error ? error.message : 'Failed to load configuration';
+        loadError =
+            configResult.reason instanceof Error
+                ? configResult.reason.message
+                : 'Failed to load configuration';
     }
 
-    return <JobRuntimeSettings initialConfig={initialConfig} loadError={loadError} />;
+    if (providersResult.status === 'fulfilled') {
+        availableProviders = providersResult.value.providers;
+    } else {
+        availableProviders = BUNDLED_PROVIDERS;
+        if (!loadError) {
+            loadError =
+                providersResult.reason instanceof Error
+                    ? providersResult.reason.message
+                    : 'Failed to load available providers';
+        }
+    }
+
+    return (
+        <JobRuntimeSettings
+            initialConfig={initialConfig}
+            availableProviders={availableProviders}
+            loadError={loadError}
+        />
+    );
 }

--- a/apps/web/src/components/settings/JobRuntimeSettings.tsx
+++ b/apps/web/src/components/settings/JobRuntimeSettings.tsx
@@ -32,16 +32,26 @@ import {
 
 interface JobRuntimeSettingsProps {
     initialConfig: TenantJobRuntimeConfigResponse;
+    /**
+     * EW-742 P5 (T34) — provider ids the operator allow-list permits
+     * (server fetched via `/api/account/job-runtime/available-providers`).
+     * The picker filters its options against this list; when the
+     * tenant's currently saved `providerId` is no longer in the list
+     * (operator disabled it after the tenant configured it), the form
+     * shows a warning banner pointing the user at an inherit / switch
+     * recovery path.
+     */
+    availableProviders: TenantJobRuntimeProviderId[];
     loadError: string | null;
 }
 
-const PROVIDER_OPTIONS: { value: TenantJobRuntimeProviderId; label: string }[] = [
-    { value: 'trigger', label: 'Trigger.dev' },
-    { value: 'temporal', label: 'Temporal' },
-    { value: 'bullmq', label: 'BullMQ' },
-    { value: 'pgboss', label: 'pg-boss' },
-    { value: 'inngest', label: 'Inngest' },
-];
+const PROVIDER_LABELS: Record<TenantJobRuntimeProviderId, string> = {
+    trigger: 'Trigger.dev',
+    temporal: 'Temporal',
+    bullmq: 'BullMQ',
+    pgboss: 'pg-boss',
+    inngest: 'Inngest',
+};
 
 const MODE_OPTIONS: { value: TenantJobRuntimeMode; labelKey: string }[] = [
     { value: 'inherit', labelKey: 'mode.inherit' },
@@ -83,17 +93,33 @@ function formatTimestamp(value: string | null): string {
  * JSON Schemas) are explicitly deferred to a follow-up sub-story per
  * the implementing prompt.
  */
-export function JobRuntimeSettings({ initialConfig, loadError }: JobRuntimeSettingsProps) {
+export function JobRuntimeSettings({
+    initialConfig,
+    availableProviders,
+    loadError,
+}: JobRuntimeSettingsProps) {
     const t = useTranslations('dashboard.settings.jobRuntime');
     const [config, setConfig] = useState<TenantJobRuntimeConfigResponse>(initialConfig);
+
+    // EW-742 P5 (T34) — derive picker options from the operator
+    // allow-list. Order follows the operator declaration (the server
+    // preserves it). Memoised against the prop so toggling unrelated
+    // form state doesn't re-build the array.
+    const providerOptions = useMemo(
+        () => availableProviders.map((value) => ({ value, label: PROVIDER_LABELS[value] })),
+        [availableProviders],
+    );
 
     // Form-local state mirrors the editable shape of the upsert payload.
     // We initialise providerId with a sane default when the row is the
     // synthetic inherit (providerId = null) — the dropdown can't render
-    // null so we pre-select trigger; the value only ships if the user
-    // also flips mode away from inherit.
+    // null so we pre-select the first operator-allowed provider (falling
+    // back to `trigger` if the allow-list is empty, which shouldn't
+    // happen given the server fail-open default but keeps the UI from
+    // rendering an empty Select).
+    const defaultPickerValue: TenantJobRuntimeProviderId = availableProviders[0] ?? 'trigger';
     const [providerId, setProviderId] = useState<TenantJobRuntimeProviderId>(
-        (initialConfig.providerId ?? 'trigger') as TenantJobRuntimeProviderId,
+        (initialConfig.providerId ?? defaultPickerValue) as TenantJobRuntimeProviderId,
     );
     const [mode, setMode] = useState<TenantJobRuntimeMode>(initialConfig.mode);
     const [enabled, setEnabled] = useState<boolean>(initialConfig.enabled);
@@ -119,10 +145,21 @@ export function JobRuntimeSettings({ initialConfig, loadError }: JobRuntimeSetti
 
     const applyConfig = (next: TenantJobRuntimeConfigResponse) => {
         setConfig(next);
-        setProviderId((next.providerId ?? 'trigger') as TenantJobRuntimeProviderId);
+        setProviderId((next.providerId ?? defaultPickerValue) as TenantJobRuntimeProviderId);
         setMode(next.mode);
         setEnabled(next.enabled);
     };
+
+    // EW-742 P5 (T34) — currently-saved provider is no longer in the
+    // operator allow-list. Show a warning banner so the user knows the
+    // overlay needs to be reconfigured (revert to inherit or switch to
+    // an allowed provider). We only flag this for non-inherit rows;
+    // inherit-mode rows ignore providerId entirely.
+    const savedProviderDisallowed =
+        config.mode !== 'inherit' &&
+        config.providerId !== null &&
+        !availableProviders.includes(config.providerId);
+    const noProvidersAvailable = availableProviders.length === 0;
 
     const handleSave = () => {
         if (credentialsJsonError) {
@@ -223,6 +260,26 @@ export function JobRuntimeSettings({ initialConfig, loadError }: JobRuntimeSetti
                 </div>
             )}
 
+            {savedProviderDisallowed && config.providerId && (
+                <div className="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg">
+                    <AlertTriangle className="w-5 h-5 text-warning flex-shrink-0 mt-0.5" />
+                    <p className="text-sm text-text dark:text-text-dark">
+                        {t('messages.providerNoLongerAllowed', {
+                            provider: PROVIDER_LABELS[config.providerId] ?? config.providerId,
+                        })}
+                    </p>
+                </div>
+            )}
+
+            {noProvidersAvailable && (
+                <div className="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg">
+                    <AlertTriangle className="w-5 h-5 text-warning flex-shrink-0 mt-0.5" />
+                    <p className="text-sm text-text dark:text-text-dark">
+                        {t('messages.noProvidersAvailable')}
+                    </p>
+                </div>
+            )}
+
             <div className="grid grid-cols-1 @lg/main:grid-cols-2 gap-4 p-4 rounded-lg border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40">
                 <Readout label={t('readout.mode')} value={t(`mode.${config.mode}` as never)} />
                 <Readout
@@ -262,8 +319,9 @@ export function JobRuntimeSettings({ initialConfig, loadError }: JobRuntimeSetti
                         onValueChange={(value) =>
                             setProviderId(value as TenantJobRuntimeProviderId)
                         }
+                        disabled={noProvidersAvailable}
                     >
-                        {PROVIDER_OPTIONS.map((opt) => (
+                        {providerOptions.map((opt) => (
                             <option key={opt.value} value={opt.value}>
                                 {opt.label}
                             </option>

--- a/apps/web/src/lib/api/tenant-job-runtime.ts
+++ b/apps/web/src/lib/api/tenant-job-runtime.ts
@@ -44,11 +44,27 @@ export interface UpsertTenantJobRuntimeConfigPayload {
     enabled?: boolean;
 }
 
+/**
+ * EW-742 P5 (T34) — shape of `GET /api/account/job-runtime/available-providers`.
+ * The picker fetches this server-side to know which provider ids the
+ * operator allow-list permits. Empty / unset env returns ALL bundled
+ * providers (fail-open default).
+ */
+export interface TenantJobRuntimeAvailableProvidersResponse {
+    providers: TenantJobRuntimeProviderId[];
+}
+
 const BASE = '/api/account/job-runtime';
 
 export const tenantJobRuntimeAPI = {
     getConfig: async () => {
         return serverFetch<TenantJobRuntimeConfigResponse>(`${BASE}/config`);
+    },
+
+    getAvailableProviders: async () => {
+        return serverFetch<TenantJobRuntimeAvailableProvidersResponse>(
+            `${BASE}/available-providers`,
+        );
     },
 
     upsertConfig: async (payload: UpsertTenantJobRuntimeConfigPayload) => {
@@ -95,6 +111,7 @@ export const tenantJobRuntimeAPI = {
  * '@/lib/api/tenant-job-runtime'`.
  */
 export const getJobRuntimeConfig = () => tenantJobRuntimeAPI.getConfig();
+export const getAvailableJobRuntimeProviders = () => tenantJobRuntimeAPI.getAvailableProviders();
 export const upsertJobRuntimeConfig = (payload: UpsertTenantJobRuntimeConfigPayload) =>
     tenantJobRuntimeAPI.upsertConfig(payload);
 export const rotateJobRuntimeConfig = () => tenantJobRuntimeAPI.rotate();


### PR DESCRIPTION
## Summary

EW-742 P5 (EW-749) — operator allow-list gating for tenant job-runtime providers.

The instance operator declares which of the 5 bundled job-runtime providers (`trigger | temporal | bullmq | pgboss | inngest`) are exposed to tenants via the `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS` env var. Empty / unset = ALL bundled providers allowed (fail-open default, matches the plan.md §10 P5 wording — "reuse existing instance operator allow-list" — and avoids locking existing tenants out on the upgrade that ships this gate).

### Backend (apps/api)

- `config.tenantJobRuntime.getAllowedProviders()` (`apps/api/src/config/constants.ts`) reads + validates the env var; trims, lowercases, drops unknown ids, deduplicates while preserving operator-declared order; falls back to bundled default when all ids are unknown (typo safety).
- `GET /api/account/job-runtime/available-providers` returns the filtered set for the UI picker (auth-gated by the existing tenant guard).
- `PUT /api/account/job-runtime/config` gates non-inherit upserts: throws `BadRequestException` with a clear message when the requested `providerId` is excluded (`provider 'inngest' is disabled by the operator. Allowed providers: trigger, temporal`). Skipped for `mode = inherit` because inherit uses platform-default credentials regardless of providerId.
- `emitAudit()` decorates every non-null `before` / `after` snapshot with `operatorAllowedProviders: string[]` (T35 simpler path — no new entity, no startup audit row).

### Frontend (apps/web)

- `JobRuntimeSettings.tsx` accepts `availableProviders` prop, derives `providerOptions` via `useMemo` from it (preserves operator order), falls back to `trigger` only if allow-list is empty.
- Warning banner when the currently-saved `providerId` is no longer in the allow-list (operator disabled it after the tenant configured it).
- Empty-state banner when allow-list is empty after operator typo (UI doesn't render an empty Select).
- `getAvailableProviders()` wrapper in `lib/api/tenant-job-runtime.ts`.
- `page.tsx` fetches config + providers in parallel via `Promise.allSettled` and gracefully falls back to bundled list on API error.
- `en.json`: 2 new keys (`messages.providerNoLongerAllowed`, `messages.noProvidersAvailable`).

### Drift gate

- `apps/api/src/config/constants.spec.ts` — 8 new tests (env parsing: unset/empty/whitespace/case/dedup/typo-guard/order) + drift gate that asserts the duplicated `BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS` stays equal to the DTO-side `TENANT_JOB_RUNTIME_PROVIDER_IDS`.
- `apps/api/src/account/tenant-job-runtime/__tests__/tenant-job-runtime.controller.spec.ts` — 12 new tests across 4 describe blocks (available-providers endpoint, upsert allow-list gate, audit snapshot, drift gate).

## Deferred (per plan.md §10 P5)

- Per-tenant whitelist behind `EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING` flag → P5.1
- Startup audit row capturing allow-list at boot → P5.1
- Reachability probe → P4
- In-flight kill on force-invalidate → P3+
- Schema-driven per-provider credentials form → P2.2

## Test plan

- [ ] CI green (lint + typecheck + agent tests + api tests)
- [ ] `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS` unset → picker shows all 5 providers
- [ ] `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS=trigger,temporal` → picker shows 2
- [ ] PUT with disabled provider → 400 with allow-list in error message
- [ ] PUT with `mode=inherit` + disabled provider → succeeds (gate skipped)
- [ ] Tenant on disabled provider → warning banner shows on settings page
- [ ] Audit row inserted with `operatorAllowedProviders` populated

## Cascade

PR to develop → cascade develop → stage → main per `feedback_release_flow_develop_stage_main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New API endpoint returning allowed job-runtime providers for tenant overlays
  * Operator-controlled allow-list filtering for available providers in settings UI
  * UI warnings when configured providers are disabled or no providers are available
  * Fail-safe defaults when provider list unavailable

* **Chores**
  * Extended audit logging to snapshot operator-allowed providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->