### PR TITLE
docs(runbooks): tenant + operator runbooks for job-runtime overlay (EW-742 P7 / EW-751)

### DIFF
--- a/docs/runbooks/OPERATOR_JOB_RUNTIME_OVERLAY.md
+++ b/docs/runbooks/OPERATOR_JOB_RUNTIME_OVERLAY.md
@@ -1,0 +1,276 @@
+# Operator runbook — tenant job-runtime overlay (EW-742)
+
+> Companion to [`docs/specs/features/tenant-job-runtime-overlay/`](../specs/features/tenant-job-runtime-overlay/).
+> ADR: [ADR-017](../specs/decisions/017-tenant-scoped-job-runtime-overlay.md).
+> Tenant counterpart: [`TENANT_JOB_RUNTIME.md`](TENANT_JOB_RUNTIME.md).
+> Provider matrix: [`providers.md`](../specs/features/tenant-job-runtime-overlay/providers.md).
+
+What's documented here today:
+
+- **Allow-list gating** (P5, shipped) — controlling which of the 5
+  bundled providers tenants can pick.
+- **Force-invalidate** procedure with on-call checklist (P2.0, shipped).
+- **Per-tenant overlay rollback** — how to put a tenant back on the
+  instance default (`mode: inherit`) when a BYO setup goes sideways.
+
+What's _not_ yet here (waiting on phases that haven't landed):
+
+- **Q5 hosting modes** (`shared` / `per-tenant` / `tiered`) — these
+  are a P4 worker-host concern. The env var name (`EVER_WORKS_JOB_RUNTIME_HOSTING`)
+  is fixed by ADR-017, but the runtime that consumes it lands with P4.
+- **Per-tenant whitelist** (P5.1 deferred) — currently a single
+  global allow-list applies to every tenant. The fine-grained version
+  ships behind the `EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING` flag.
+- **Reachability probe** (`provisionTenant`) — the form would call it
+  on save, but P4 owns implementing it.
+
+## Allow-list gating
+
+The instance operator declares which of the 5 bundled job-runtime
+providers (`trigger | temporal | bullmq | pgboss | inngest`) are
+exposed to tenants via:
+
+```env
+EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS=trigger,temporal
+```
+
+Semantics enforced by `config.tenantJobRuntime.getAllowedProviders()`
+in `apps/api/src/config/constants.ts`:
+
+| Env value                  | Result                                                                   |
+| -------------------------- | ------------------------------------------------------------------------ |
+| Unset                      | All 5 bundled providers allowed (default fail-open)                      |
+| Empty string / whitespace  | All 5 bundled providers allowed (treated as unset)                       |
+| `trigger,temporal`         | Only `trigger` and `temporal` shown to tenants                           |
+| `Trigger, TEMPORAL`        | Trimmed + lowercased → `trigger`, `temporal`. Order preserved.           |
+| `trigger,trigger,temporal` | Deduped → `trigger`, `temporal`. Operator order preserved.               |
+| `unknownid,anotherbadid`   | All-unknown falls back to bundled default (typo safety). Boot log warns. |
+| `trigger,unknownid`        | Only `trigger` allowed; unknown silently dropped.                        |
+
+The list order is **preserved** — tenants see providers in the order
+you declared them. Use this to nudge the picker default (P5 picks
+`availableProviders[0]` when the row is fresh).
+
+### When tenants are on a now-disabled provider
+
+The allow-list is **picker-side + write-side** gated. Existing
+overlay rows for a now-disabled provider are NOT migrated, NOT
+silently disabled, and NOT auto-reverted to inherit. The rationale:
+disabling a provider in the env var is a deployment-time operator
+decision; tearing down in-flight tenants without notice would be
+worse than leaving the snapshot in place.
+
+What happens:
+
+- The tenant's saved row stays as-is. Runs continue executing against
+  the pinned `credentialVersion`.
+- The tenant's Settings page shows a warning banner pointing them at
+  `Revert to inherit` or a re-pick.
+- `PUT /api/account/job-runtime/config` rejects new writes against
+  the disabled provider with `400`:
+  `provider 'inngest' is disabled by the operator. Allowed providers: trigger, temporal`.
+
+If you need to forcibly revert a tenant's overlay (e.g. you're
+retiring a provider entirely and want zero in-flight work against
+it), see [Operator-driven rollback](#operator-driven-rollback) below.
+
+### Audit trail
+
+Every overlay-row mutation writes a row to `tenant_job_runtime_audit`
+with `operatorAllowedProviders` captured in the `before` / `after`
+JSON blobs. Useful for "why does tenant X have provider Y saved
+even though we removed Y from the allow-list a month ago?" — the
+audit log answers exactly when the operator dropped it from the list
+relative to when the tenant wrote the row.
+
+Sample query (PostgreSQL):
+
+```sql
+SELECT
+    tenant_id,
+    occurred_at,
+    action,
+    after->>'providerId' AS provider,
+    after->'operatorAllowedProviders' AS allow_list_at_time
+FROM tenant_job_runtime_audit
+WHERE tenant_id = '<tenant-uuid>'
+ORDER BY occurred_at DESC
+LIMIT 20;
+```
+
+## Force-invalidate — on-call checklist
+
+`POST /api/account/job-runtime/force-invalidate` is the break-glass
+path: bumps `credentialVersion` AND signals worker hosts to drop
+in-flight runs against the old snapshot (`reason='credential_force_invalidated'`).
+
+Use only when:
+
+- A tenant's credentials are confirmed compromised (leaked secret,
+  contractor offboarding, exposed in a screenshot).
+- You're testing the rotation drop path.
+
+Do NOT use for routine rotation — that's `POST /rotate`, which keeps
+in-flight work running on the old snapshot until completion.
+
+### Pre-flight
+
+1. **Confirm the tenant ID.** `tenant_job_runtime_config.tenant_id`
+   in the DB. Match it against the user/org context that prompted
+   the alert.
+2. **Check rate-limit window.** Force-invalidate is throttled to
+   ≤ 1 / min / tenant in the controller. If the button is greyed,
+   wait or escalate (the throttle is a deliberate guard against
+   double-firing).
+3. **Notify the tenant if possible.** Force-invalidate kills
+   in-flight jobs. If you can give them 30 s heads-up via Slack /
+   email / status page, do.
+
+### Execute
+
+From the operator console (when wired) or via direct API call (use
+your operator credentials, NOT the tenant's):
+
+```bash
+curl -X POST https://<api-host>/api/account/job-runtime/force-invalidate \
+    -H "Authorization: Bearer $OPERATOR_TOKEN" \
+    -H "X-Tenant-Id: <tenant-uuid>"
+```
+
+> Note: operator-impersonation header (`X-Tenant-Id`) is a P5.1+
+> follow-up. Today, force-invalidate must be triggered _by_ the
+> tenant admin (the route uses the auth-session tenant). For
+> operator-driven invalidation today, see the SQL fallback in
+> [Operator-driven rollback](#operator-driven-rollback).
+
+### Post-flight
+
+1. **Verify the audit row.** A `force_invalidate` row should land
+   in `tenant_job_runtime_audit` with the new `credentialVersion`.
+2. **Verify in-flight runs failed.** Look for worker host logs with
+   `reason=credential_force_invalidated` and matching run records marked
+   `FAILED`. (P4 wires this end-to-end; until then the worker host is the
+   instance default and force-invalidate bumps the version but cannot drop
+   runs the instance worker doesn't know belong to this tenant.)
+3. **Confirm the tenant has saved new credentials** before unblocking
+   new enqueues — otherwise their next save will be the first
+   non-failing run since invalidation.
+
+## Operator-driven rollback
+
+Scenario: you need to put a tenant back on the platform default,
+either because BYO blew up or because you're retiring a provider.
+
+### Soft path (preferred)
+
+Ask the tenant admin to click `Revert to inherit` in the Settings
+page. This calls `DELETE /api/account/job-runtime/config`, leaves
+the audit trail intact, and bumps `credentialVersion`. After this,
+the resolver behaves identically to "no overlay row" — instance
+default takes over for every new enqueue.
+
+### Hard path (operator-only)
+
+If the tenant is unreachable / the UI is broken / you're retiring a
+provider mid-incident, you can force the row to inherit directly:
+
+```sql
+BEGIN;
+
+-- Capture the current state for the audit row
+WITH old AS (
+    SELECT * FROM tenant_job_runtime_config
+    WHERE tenant_id = '<tenant-uuid>'
+)
+UPDATE tenant_job_runtime_config
+SET mode = 'inherit',
+    credentials_secret_ref = NULL,
+    credential_version = credential_version + 1,
+    updated_at = NOW()
+WHERE tenant_id = '<tenant-uuid>';
+
+-- Write the operator-driven audit row
+INSERT INTO tenant_job_runtime_audit
+    (id, tenant_id, actor_user_id, action, before, after, credential_version, occurred_at)
+VALUES (
+    gen_random_uuid(),
+    '<tenant-uuid>',
+    NULL,                                       -- NULL actor = operator/SQL path
+    'operator_revert_to_inherit',
+    (SELECT row_to_json(old) FROM old),
+    (SELECT row_to_json(t) FROM tenant_job_runtime_config t
+        WHERE tenant_id = '<tenant-uuid>'),
+    (SELECT credential_version FROM tenant_job_runtime_config
+        WHERE tenant_id = '<tenant-uuid>'),
+    NOW()
+);
+
+COMMIT;
+```
+
+Document the reason in your operator incident log AND post a
+follow-up to the tenant admin so they see why their setup changed.
+
+## Removing a provider from the bundled set
+
+The 5 bundled providers (`trigger | temporal | bullmq | pgboss |
+inngest`) are pinned in two places:
+
+- `BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS` in `apps/api/src/config/constants.ts`
+- `TENANT_JOB_RUNTIME_PROVIDER_IDS` in
+  `apps/api/src/account/tenant-job-runtime/dto/upsert-tenant-job-runtime.dto.ts`
+
+A drift spec asserts they stay equal. To add/remove a provider:
+
+1. Edit both constants in lockstep.
+2. Run `pnpm test --filter ever-works-api -- tenant-job-runtime` to
+   confirm the drift spec passes.
+3. If removing: file a migration story — the DTO enum change is a
+   hard contract break for any tenant currently on the removed
+   provider. Coordinate with affected tenants BEFORE the deploy.
+
+Note that removing a provider from the env var (`EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS`)
+is a soft disable — tenants stay on the snapshot and can revert.
+Removing it from the bundled set is a hard disable — the API enum
+itself rejects the value, so even existing rows can't be re-saved.
+
+## Pre-deploy checklist
+
+Before deploying a change that touches `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS`:
+
+- [ ] `kubectl get secret -n ever-works runtime-env -o yaml` confirms
+      the env var is being set at the secret layer (k8s deployments
+      ride on the runtime-env Secret forwarding pipeline; see
+      `directory-web-template` deploy workflow).
+- [ ] Diff the new value against the previous: any provider being
+      removed?
+- [ ] If yes — query the audit DB for tenants currently on the
+      removed provider:
+
+          ```sql
+          SELECT tenant_id, provider_id, updated_at
+          FROM tenant_job_runtime_config
+          WHERE provider_id = '<removing>' AND mode != 'inherit';
+          ```
+
+- [ ] Notify any tenants found before rolling out, or accept they'll
+      hit the picker-side warning banner on next visit.
+- [ ] Verify the new allow-list parses correctly post-deploy via the
+      API: `curl https://<api>/api/account/job-runtime/available-providers`
+      (auth required; use any tenant's token).
+
+## Glossary
+
+- **Bundled providers** — the 5 hard-coded provider ids in the API
+  enum: `trigger`, `temporal`, `bullmq`, `pgboss`, `inngest`.
+- **Allow-list** — subset of bundled providers the operator exposes
+  to tenants via `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS`.
+- **Soft disable** — provider removed from the allow-list. Existing
+  rows preserved; new writes rejected.
+- **Hard disable** — provider removed from `BUNDLED_TENANT_JOB_RUNTIME_PROVIDERS` /
+  `TENANT_JOB_RUNTIME_PROVIDER_IDS`. Existing rows can't be re-saved
+  because the DTO enum rejects the value.
+- **Inherit** — overlay row delegates to the instance default. Same
+  resolver behaviour as "no overlay row".
+- **Force-invalidate** — break-glass: bump version + drop in-flight.
+  Rate-limited.

--- a/docs/runbooks/OPERATOR_JOB_RUNTIME_OVERLAY.md
+++ b/docs/runbooks/OPERATOR_JOB_RUNTIME_OVERLAY.md
@@ -245,19 +245,20 @@ Before deploying a change that touches `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVID
 - [ ] Diff the new value against the previous: any provider being
       removed?
 - [ ] If yes — query the audit DB for tenants currently on the
-      removed provider:
-
-          ```sql
-          SELECT tenant_id, provider_id, updated_at
-          FROM tenant_job_runtime_config
-          WHERE provider_id = '<removing>' AND mode != 'inherit';
-          ```
-
+      removed provider (see SQL snippet below).
 - [ ] Notify any tenants found before rolling out, or accept they'll
       hit the picker-side warning banner on next visit.
 - [ ] Verify the new allow-list parses correctly post-deploy via the
-      API: `curl https://<api>/api/account/job-runtime/available-providers`
+      API call `curl https://<api>/api/account/job-runtime/available-providers`
       (auth required; use any tenant's token).
+
+Removed-provider lookup snippet:
+
+```sql
+SELECT tenant_id, provider_id, updated_at
+FROM tenant_job_runtime_config
+WHERE provider_id = '<removing>' AND mode != 'inherit';
+```
 
 ## Glossary
 

--- a/docs/runbooks/TENANT_JOB_RUNTIME.md
+++ b/docs/runbooks/TENANT_JOB_RUNTIME.md
@@ -1,0 +1,227 @@
+# Tenant job-runtime overlay — tenant admin runbook (EW-742)
+
+> Companion to [`docs/specs/features/tenant-job-runtime-overlay/`](../specs/features/tenant-job-runtime-overlay/).
+> ADR: [ADR-017](../specs/decisions/017-tenant-scoped-job-runtime-overlay.md).
+> Provider matrix: [`providers.md`](../specs/features/tenant-job-runtime-overlay/providers.md).
+> Operator counterpart: [`OPERATOR_JOB_RUNTIME_OVERLAY.md`](OPERATOR_JOB_RUNTIME_OVERLAY.md).
+
+This runbook covers what a tenant admin can do today from the in-product
+**Settings → Job Runtime** page (P0–P2.1 + P5 on `main`). It is the
+canonical "how do I do X" for tenants who want to pick a different
+background-jobs provider than the platform default, bring their own
+credentials, or rotate them.
+
+What is _not_ here yet:
+
+- Worker-host wiring (P3/P4) — until it lands, BYO/override is a
+  configuration-only knob: the platform records the choice + version,
+  but every run still executes against the instance default. The
+  in-app banner says this explicitly when you opt in.
+- Schema-driven per-provider credentials form (P2.2). The current UI
+  collects an opaque `credentialsSecretRef` pointer; per-provider
+  fields (e.g. Temporal namespace + address + cert) come in the next
+  UI sub-phase.
+
+## When to use this
+
+Three concrete scenarios:
+
+1. **You want to keep using the platform default** — do nothing. The
+   row defaults to `mode: inherit`. The picker on the Settings page
+   shows a banner ("currently inheriting from the instance default").
+2. **You want to bring your own Trigger.dev / Temporal / etc.** — pick
+   `mode: byo`, select a provider, save a `credentialsSecretRef`
+   pointing at your secret-store entry (Vault / k8s Secret / 1Password
+   reference depending on the operator's secrets layer).
+3. **You want to fully override the platform's choice of provider** —
+   pick `mode: override`. Semantically identical to BYO at the API
+   level today; the distinction exists so the platform can later
+   gate certain providers to "operator must explicitly approve" vs
+   "self-serve allowed" (a P5.1 follow-up — currently both modes
+   resolve the same way).
+
+## What you'll see on the Settings page
+
+Navigate to **Dashboard → Settings → Job Runtime** (`/[locale]/dashboard/settings/job-runtime`).
+
+The page renders four read-only state badges at the top:
+
+| Badge                | What it means                                                                            |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| `Mode`               | `inherit` / `byo` / `override` — current overlay row                                     |
+| `Provider`           | One of the operator-allowed providers (or `—` when `mode: inherit`)                      |
+| `Credential version` | Monotonic per-tenant counter; bumps on every credential change, rotate, force-invalidate |
+| `Last updated`       | `updatedAt` of the overlay row (defaults to row creation if never touched)               |
+
+Below the badges, an editable form:
+
+- **Provider picker** — a `Select` populated from `GET /api/account/job-runtime/available-providers`.
+  Only providers the instance operator has allow-listed via
+  `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS` appear here.
+  See [Why is provider X missing?](#why-is-provider-x-missing).
+- **Mode picker** — `inherit | byo | override`.
+- **Enabled switch** — soft kill-switch for the overlay row without
+  deleting it. `enabled: false` + `mode: byo` means "the overlay is
+  saved but the resolver should skip me and inherit instead". Useful
+  for debugging.
+- **Credentials block** (only when `mode != inherit`):
+    - `credentialsSecretRef` — opaque pointer (string ≤ 128 chars) into
+      the operator's secret store. Examples: `vault:secret/tenants/acme/temporal`,
+      `k8s:tenant-acme-temporal-credentials`, `op://Vault/Temporal-acme/cert`.
+      The platform never stores plaintext credentials — only this
+      pointer + the encrypted version stamped against the resolved
+      snapshot when a run is enqueued.
+    - `credentialsJson` (textarea) — collected by the UI today but **not
+      yet POSTed** to the API. P2.2 will replace this with per-provider
+      schema-driven fields (Temporal namespace + address, Inngest event
+      key + signing key, BullMQ Redis URL, etc.) parsed from each
+      provider's JSON Schema export.
+
+## Action buttons
+
+### Save
+
+Persists the current form state via `PUT /api/account/job-runtime/config`.
+Backend behaviour:
+
+1. Static enum check on `providerId` (rejects anything outside the
+   bundled `trigger | temporal | bullmq | pgboss | inngest` set).
+2. Dynamic operator allow-list check (rejects providers the operator
+   has restricted via `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS`).
+   Skipped when `mode: inherit` because inherit ignores `providerId`
+   entirely.
+3. Upserts the `tenant_job_runtime_config` row (PK `tenantId`).
+4. If `credentialsSecretRef` changed, `credentialVersion` bumps by 1
+   via `CredentialVersionService`.
+5. Emits a `tenant_job_runtime_audit` row decorated with
+   `operatorAllowedProviders` snapshot so the active allow-list at
+   write time is preserved for the audit trail.
+
+The button is disabled when the JSON textarea contains invalid JSON
+(client-side check) or when `credentialsSecretRef` is empty in a
+non-inherit mode.
+
+### Rotate
+
+Bumps `credentialVersion` without changing any other field. Use this
+when you've rotated the underlying secret in your secret store and
+want to force runs enqueued from this moment forward to resolve
+against the new version. Calls `POST /api/account/job-runtime/rotate`.
+
+In-flight runs that already captured the previous version continue
+running against their pinned snapshot — this is the **graceful drain**
+behaviour locked in [ADR-017 Q4](../specs/decisions/017-tenant-scoped-job-runtime-overlay.md#q4--credential-rotation-strategy).
+A worker host that has been spun up against version N stays on N
+until the run completes; the dispatcher resolves new enqueues against
+N+1.
+
+### Force-invalidate
+
+The break-glass version of rotate. Bumps `credentialVersion`, emits a
+`force_invalidate` audit row, and signals worker hosts to drop their
+in-flight runs against the old version (`reason='credential_force_invalidated'`).
+
+Rate-limited by the controller to ≤ 1 / min / tenant to prevent
+operator footguns. The button surfaces the throttle response inline
+("force-invalidate rate-limited — try again in 47 s").
+
+Use force-invalidate only when:
+
+- You suspect credentials are compromised (e.g. a contractor with
+  access left, the secret leaked into a screenshot, etc.).
+- You're testing the rotation path and want to verify worker hosts
+  drop the old snapshot cleanly.
+
+Use Rotate (not force-invalidate) for routine rotation — force-invalidate
+deliberately drops in-flight work.
+
+### Revert to inherit
+
+Calls `DELETE /api/account/job-runtime/config`. Leaves the row in
+place (so the audit trail stays intact) but sets `mode = inherit`,
+clears `credentialsSecretRef`, and bumps `credentialVersion`. After
+this completes, the resolver behaves identically to "no overlay row
+at all" — the instance default takes over for every subsequent
+enqueue.
+
+This is the safe rollback when:
+
+- A BYO credential blew up and you want to fall back fast.
+- The operator just disabled the provider you were on (see the next
+  section) and you need to disengage before re-picking.
+
+## Why is provider X missing?
+
+If the picker doesn't show a provider you expected (e.g. only
+`trigger` and `temporal` appear when you expected all 5):
+
+The operator has allow-listed only a subset via the
+`EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS` env var. Talk to your
+operator if you need a provider added. They flip the env var and
+redeploy — there's no per-tenant override today (deferred to P5.1
+behind a feature flag).
+
+If you were previously on a provider that the operator has since
+removed from the allow-list, the Settings page shows a warning banner:
+
+> The provider currently saved for your tenant (`inngest`) is no longer
+> enabled by the operator. New runs will continue against your saved
+> snapshot, but you cannot save a new configuration for this provider.
+> Revert to `inherit` or pick a different provider.
+
+The overlay row stays in place; the API blocks new `PUT /config`
+writes that target the disabled provider with
+`400 BadRequestException: provider 'inngest' is disabled by the
+operator. Allowed providers: trigger, temporal`.
+
+## API quick reference
+
+| Method   | Path                                           | Purpose                                                         |
+| -------- | ---------------------------------------------- | --------------------------------------------------------------- |
+| `GET`    | `/api/account/job-runtime/config`              | Load current overlay row (redacted) or synthetic `mode:inherit` |
+| `PUT`    | `/api/account/job-runtime/config`              | Upsert overlay row                                              |
+| `POST`   | `/api/account/job-runtime/rotate`              | Bump `credentialVersion`                                        |
+| `POST`   | `/api/account/job-runtime/force-invalidate`    | Bump + drop in-flight (rate-limited)                            |
+| `DELETE` | `/api/account/job-runtime/config`              | Revert to inherit (bumps version)                               |
+| `GET`    | `/api/account/job-runtime/available-providers` | Returns the operator allow-list                                 |
+
+All routes require an authenticated request from a user attached to
+exactly one tenant (the 1 User : 1 Tenant model). There is no
+`:tenantId` path parameter — the tenant is resolved from the auth
+session. Cross-tenant reads / writes return `403 ForbiddenException`.
+
+## Audit log
+
+Every overlay-row mutation writes a row to `tenant_job_runtime_audit`
+with columns `(id, tenantId, actorUserId, action, before, after,
+credentialVersion, occurredAt)`. `before` / `after` JSON blobs carry
+the redacted row state (no plaintext credentials — only the pointer +
+version) plus the `operatorAllowedProviders` snapshot active at write
+time.
+
+Reading the audit log surface from the UI is a future story; today
+the rows are inspectable via direct DB query for operators and via
+the upcoming admin runbook. Self-serve tenant access to the audit
+log is part of the schema-driven admin UI follow-up (P2.2+).
+
+## Glossary
+
+- **Inherit** — the tenant overlay row delegates to the instance
+  default. Identical to "no overlay row exists" from the resolver's
+  point of view.
+- **BYO** — Bring Your Own credentials. The tenant supplies a secret
+  pointer; the operator hasn't pre-provisioned the credentials. Most
+  common mode.
+- **Override** — Tenant explicitly chooses a different provider than
+  the operator's default. Semantically the same as BYO today; the
+  distinction lets future policy gate certain providers as
+  "operator-must-approve".
+- **Credential version** — monotonic per-tenant counter on the overlay
+  row. Stamped onto every run at enqueue time so worker hosts resolve
+  the same snapshot the dispatcher saw.
+- **Graceful drain** — rotation strategy where in-flight runs keep
+  their pinned snapshot while new enqueues resolve against the new
+  version. Implemented by `CredentialVersionService`. See
+  [ADR-017 Q4](../specs/decisions/017-tenant-scoped-job-runtime-overlay.md#q4--credential-rotation-strategy).
+- **Force-invalidate** — break-glass: bump version AND drop in-flight
+  runs against the old snapshot. Rate-limited.

--- a/docs/specs/features/tenant-job-runtime-overlay/tasks.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/tasks.md
@@ -72,10 +72,12 @@
 
 ## Phase 7 — Docs · `[EW-742 P7]`
 
-- [ ] **T41.** Tenant admin runbook in `docs/runbooks/tenant-job-runtime.md` — how to pick a provider, enter BYO credentials, rotate, and read the audit log; cross-link `spec.md` and `providers.md`.
-- [ ] **T42.** Operator runbook in `docs/runbooks/operator-job-runtime-overlay.md` — covers Q5 modes (`shared` / `per-tenant` / `tiered`), allow-list gating, force-invalidate procedure with on-call checklist, and rollback to inherit-only.
-- [ ] **T43.** Per-provider tenant-config docs — add a "Tenant overlay" section to each provider plugin README (`packages/plugins/job-runtime-{trigger,temporal,bullmq,pgboss,inngest}/README.md`) and cross-link [`./providers.md`](./providers.md).
-- [ ] **T44.** Migration guide for existing tenants in `docs/runbooks/tenant-job-runtime-migration.md` — how to opt into BYO without losing in-flight work (graceful drain procedure, version-pinning checklist, fallback to inherit if BYO probe fails).
+T41 + T42 ✅ Done in [#1352](https://github.com/ever-works/ever-works/pull/1352) (pending cascade). T43 + T44 deferred until P3/P4 + provider plugins exist.
+
+- [x] **T41.** Tenant admin runbook in `docs/runbooks/TENANT_JOB_RUNTIME.md` — how to pick a provider, enter BYO credentials, rotate, force-invalidate, revert to inherit, and read the audit log; cross-link `spec.md` and `providers.md`. (Filed under `docs/runbooks/` UPPERCASE per the existing `EVER_WORKS_ZERO_FRICTION_FLOW.md` convention.)
+- [x] **T42.** Operator runbook in `docs/runbooks/OPERATOR_JOB_RUNTIME_OVERLAY.md` — covers allow-list gating, force-invalidate procedure with on-call checklist, operator-driven rollback to inherit, removing a provider from the bundled set, pre-deploy checklist. (Q5 hosting modes deferred to a follow-up edit once P4 worker-host wiring is in place; doc calls this out explicitly so operators don't expect the env var to do anything yet.)
+- [ ] **T43.** Per-provider tenant-config docs — add a "Tenant overlay" section to each provider plugin README (`packages/plugins/job-runtime-{trigger,temporal,bullmq,pgboss,inngest}/README.md`) and cross-link [`./providers.md`](./providers.md). (Deferred — the per-provider plugin packages don't exist yet; they ship with EW-686 P1 / EW-683 P2-P5.)
+- [ ] **T44.** Migration guide for existing tenants in `docs/runbooks/tenant-job-runtime-migration.md` — how to opt into BYO without losing in-flight work (graceful drain procedure, version-pinning checklist, fallback to inherit if BYO probe fails). (Deferred — the migration story needs the P3 dispatcher + P4 worker host to exist before the drain procedure is a real thing to document.)
 
 ## Dependency notes
 


### PR DESCRIPTION
## Summary

Two new runbooks for the EW-742 P0-P5 surface already on `main`:

- **[`docs/runbooks/TENANT_JOB_RUNTIME.md`](docs/runbooks/TENANT_JOB_RUNTIME.md)** (T41) — tenant-admin runbook. Settings page walkthrough, action button semantics, allow-list-disabled-provider recovery, API quick reference, audit log.
- **[`docs/runbooks/OPERATOR_JOB_RUNTIME_OVERLAY.md`](docs/runbooks/OPERATOR_JOB_RUNTIME_OVERLAY.md)** (T42) — operator runbook. Allow-list semantics table, audit-trail SQL, force-invalidate on-call checklist (pre/execute/post-flight), operator-driven rollback (soft + hard SQL paths), removing a provider from the bundled set, pre-deploy checklist.

Both runbooks honestly call out what's NOT yet implemented (P3/P4 worker host, P2.2 schema-driven form, P5.1 per-tenant whitelist) so readers don't expect behaviour the platform doesn't have yet.

## tasks.md sync

- T41 + T42 marked `[x]` done with PR link.
- T43 (per-provider plugin READMEs) explicitly deferred — per-provider plugin packages don't exist yet (they ship with EW-686 P1 / EW-683 P2-P5).
- T44 (migration guide) explicitly deferred — needs P3 dispatcher + P4 worker host for graceful drain to be a real thing to document.

## Test plan

- [ ] CI green (docs-only — should pass trivially)
- [ ] Visual review of both rendered runbooks on GitHub
- [ ] Cross-references work (ADR-017 link, spec.md link, providers.md link, tenant↔operator runbook cross-link)

## Cascade

PR to develop → cascade develop → stage → main per `feedback_release_flow_develop_stage_main`.