### PR TITLE
feat(plugin): IJobRuntimeProvider contract (EW-683 / EW-685 P0)

### DIFF
--- a/docs/specs/architecture/job-runtime-providers.md
+++ b/docs/specs/architecture/job-runtime-providers.md
@@ -1,7 +1,7 @@
 # Architecture: Job-Runtime Providers (pluggable background-job runtime)
 
-**Status**: `Proposed` (tracking [EW-683](https://evertech.atlassian.net/browse/EW-683))
-**Last updated**: 2026-05-28
+**Status**: `In progress` — EW-685 P0 contract shipped (no behaviour change). EW-686 P1 (rehouse Trigger.dev as the `trigger` plugin) + binding factory + per-provider plugins remain.
+**Last updated**: 2026-06-18
 **Audience**: AI agents and engineers who need to understand how the platform's long-running work is dispatched, scheduled, cancelled, and executed — and how that runtime becomes a **swappable provider** (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest optional).
 
 > This spec describes the **target architecture**. Nothing here is built yet. It generalises the existing [`trigger-integration`](./trigger-integration.md) and [`trigger-worker`](./trigger-worker.md) specs into a provider-neutral form. Read those two first — this spec assumes them. Decision rationale: [ADR-015](../decisions/015-job-runtime-provider-pluggability.md). Per-provider detail: [`features/job-runtime-providers/providers.md`](../features/job-runtime-providers/providers.md).
@@ -54,10 +54,10 @@ The API depends only on these symbols; it has **no** `@trigger.dev/sdk` import. 
 
 ## 3. The `IJobRuntimeProvider` contract
 
-A new capability `job-runtime` is registered in `packages/plugin/src/job-runtime/`. A provider plugin extends `BasePlugin` (category `job-runtime`, `configurationMode: 'admin-only'`) and exposes:
+A new capability `job-runtime` is registered in `packages/plugin/src/contracts/capabilities/`. A provider plugin extends `BasePlugin` (category `job-runtime`, `configurationMode: 'admin-only'`) and exposes:
 
 ```ts
-// packages/plugin/src/job-runtime/job-runtime.contract.ts (proposed)
+// packages/plugin/src/contracts/capabilities/job-runtime.interface.ts (shipped in EW-685 P0)
 export interface IJobRuntimeProvider {
 	/** Stable provider id: 'trigger' | 'temporal' | 'bullmq' | 'pgboss' | 'inngest' */
 	readonly runtimeId: JobRuntimeId;

--- a/packages/plugin/src/contracts/__tests__/job-runtime.spec.ts
+++ b/packages/plugin/src/contracts/__tests__/job-runtime.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * EW-683 / EW-685 P0 — type-level shape assertions for `IJobRuntimeProvider`.
+ *
+ * This is a contract-only PR; no concrete provider implements the
+ * interface yet, so the runtime conformance suite (mirroring
+ * `vector-store.spec.ts`) lands with EW-686 P1 once `TriggerService` is
+ * rehoused as the first `IJobRuntimeProvider` implementation. What this
+ * spec locks in the meantime:
+ *
+ *   1. The interface is exported from `@ever-works/plugin` so downstream
+ *      packages (`@ever-works/agent/tasks` once EW-686 lands) can
+ *      `import type` it without reaching into a deep subpath.
+ *   2. The literal-union `JobRuntimeId` matches the 5-provider matrix
+ *      in `docs/specs/architecture/job-runtime-providers.md` §4. A new
+ *      provider added without updating both this union and the spec
+ *      breaks this test loudly.
+ *   3. `JobRunStatus` covers the 6 states the architecture spec §3
+ *      defines (5 lifecycle + `'unknown'` fallback).
+ *   4. `IJobRuntimeProvider` is structurally `IPlugin`-shaped so the
+ *      plugin registry can hold it without special-casing.
+ *
+ * The runtime conformance suite (per architecture spec §7) tests:
+ *   - enqueue returns an id; worker runs and writes terminal state
+ *   - idempotency: same key → one logical run
+ *   - concurrency: same key serialises
+ *   - cancel: in-flight aborts and orchestrator observes
+ *   - schedule: registered cron fires on cadence
+ *   - disabled runtime: enqueue returns `null`, API falls back
+ *
+ * Those land per provider once a provider exists to run them against
+ * (EW-686 for `trigger`, EW-689+ for the rest).
+ */
+
+import { describe, expectTypeOf, it } from 'vitest';
+import type {
+	IJobRuntimeProvider,
+	JobEnqueueOptions,
+	JobRunStatus,
+	JobRuntimeDispatchers,
+	JobRuntimeId,
+	ScheduleSpec,
+	WorkerHostHandle,
+	WorkerHostOptions
+} from '../capabilities/job-runtime.interface.js';
+import type { IPlugin } from '../plugin.interface.js';
+
+describe('IJobRuntimeProvider — contract surface', () => {
+	it('JobRuntimeId matches the 5 supported providers from the architecture spec §4', () => {
+		// If this union is widened without updating the architecture
+		// spec + selector docs, this test fails — keep both in sync.
+		expectTypeOf<JobRuntimeId>().toEqualTypeOf<'trigger' | 'temporal' | 'bullmq' | 'pgboss' | 'inngest'>();
+	});
+
+	it('JobRunStatus covers the 5 lifecycle states + unknown fallback', () => {
+		expectTypeOf<JobRunStatus>().toEqualTypeOf<
+			'queued' | 'running' | 'completed' | 'failed' | 'cancelled' | 'unknown'
+		>();
+	});
+
+	it('IJobRuntimeProvider extends IPlugin (registry-compatible)', () => {
+		expectTypeOf<IJobRuntimeProvider>().toMatchTypeOf<IPlugin>();
+	});
+
+	it('IJobRuntimeProvider exposes the 6-concern method shape from the architecture spec §3', () => {
+		type Provider = IJobRuntimeProvider;
+
+		expectTypeOf<Provider['runtimeId']>().toEqualTypeOf<JobRuntimeId>();
+		expectTypeOf<Provider['dispatchers']>().toEqualTypeOf<JobRuntimeDispatchers>();
+		expectTypeOf<Provider['registerSchedules']>().toEqualTypeOf<
+			(schedules: readonly ScheduleSpec[]) => Promise<void>
+		>();
+		expectTypeOf<Provider['cancel']>().toEqualTypeOf<(runId: string) => Promise<boolean>>();
+		expectTypeOf<Provider['getRunStatus']>().toEqualTypeOf<(runId: string) => Promise<JobRunStatus>>();
+		expectTypeOf<Provider['isEnabled']>().toEqualTypeOf<() => boolean>();
+	});
+
+	it('startWorkerHost is optional (pull vs push hosting model)', () => {
+		// Push providers (trigger, inngest) implement startWorkerHost as
+		// a no-op or as their HTTP `serve()` mount; pull providers
+		// (temporal, bullmq, pgboss) start a long-lived worker. Both
+		// models are valid — the type allows `undefined`.
+		type Provider = IJobRuntimeProvider;
+		type StartFn = Provider['startWorkerHost'];
+
+		expectTypeOf<StartFn>().toEqualTypeOf<((opts: WorkerHostOptions) => Promise<WorkerHostHandle>) | undefined>();
+	});
+
+	it('ScheduleSpec carries id + cron + optional payload', () => {
+		const example: ScheduleSpec = {
+			id: 'work-schedule-dispatcher',
+			cron: '*/5 * * * *',
+			payload: { tick: true }
+		};
+		expectTypeOf(example.id).toEqualTypeOf<string>();
+		expectTypeOf(example.cron).toEqualTypeOf<string>();
+		expectTypeOf(example.payload).toEqualTypeOf<unknown>();
+	});
+
+	it('JobEnqueueOptions are all optional (sensible per-provider defaults)', () => {
+		// Every field optional — call sites that don't care about
+		// idempotency/concurrency/tags can omit the argument entirely.
+		const minimal: JobEnqueueOptions = {};
+		expectTypeOf(minimal).toEqualTypeOf<JobEnqueueOptions>();
+
+		const full: JobEnqueueOptions = {
+			tags: ['kb', 'embed'],
+			idempotencyKey: 'work-42-doc-7',
+			concurrencyKey: 'work-42',
+			maxDurationSeconds: 300,
+			machineHint: 'medium-1x'
+		};
+		expectTypeOf(full.tags).toEqualTypeOf<readonly string[] | undefined>();
+		expectTypeOf(full.idempotencyKey).toEqualTypeOf<string | undefined>();
+		expectTypeOf(full.concurrencyKey).toEqualTypeOf<string | undefined>();
+		expectTypeOf(full.maxDurationSeconds).toEqualTypeOf<number | undefined>();
+		expectTypeOf(full.machineHint).toEqualTypeOf<string | undefined>();
+	});
+
+	it('WorkerHostHandle exposes only a stop() — graceful shutdown coordination', () => {
+		expectTypeOf<WorkerHostHandle['stop']>().toEqualTypeOf<() => Promise<void>>();
+	});
+});
+
+describe('IJobRuntimeProvider — barrel export', () => {
+	it('the interface is reachable from the package root via capabilities barrel', async () => {
+		// Smoke check: import via the barrel and verify the type
+		// exports surface there. If the barrel re-export line is
+		// dropped from `capabilities/index.ts`, this fails because the
+		// type isn't reachable from the package root.
+		const mod = await import('../capabilities/index.js');
+		// The interface itself is type-erased, but if the file's
+		// re-export line is wired the dynamic import succeeds.
+		expectTypeOf(mod).not.toBeAny();
+	});
+});

--- a/packages/plugin/src/contracts/capabilities/index.ts
+++ b/packages/plugin/src/contracts/capabilities/index.ts
@@ -25,3 +25,8 @@ export * from './vector-store.interface.js';
 // + future Route53/etc. via the plugin registry). Additive — does NOT replace
 // the existing `CloudflareDnsProvider` concrete class in @ever-works/agent.
 export * from './dns.interface.js';
+// EW-683 / EW-685 P0 — pluggable job-runtime providers (Trigger.dev today;
+// Temporal / BullMQ / pg-boss / Inngest via plugin packages once EW-686+
+// land). Additive contract-only — no call site is bound through this yet.
+// See docs/specs/architecture/job-runtime-providers.md §2 (seam) + §3 (contract).
+export * from './job-runtime.interface.js';

--- a/packages/plugin/src/contracts/capabilities/job-runtime.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/job-runtime.interface.ts
@@ -1,0 +1,224 @@
+import type { IPlugin } from '../plugin.interface.js';
+
+/**
+ * EW-683 / EW-685 P0 — pluggable background-job runtime providers.
+ *
+ * This is an **additive, contract-only** capability declaration. No call
+ * site is wired through it yet. The `TriggerService` in
+ * `packages/tasks/src/trigger/trigger.service.ts` remains the single concrete
+ * binding for every `*_DISPATCHER` symbol exported from
+ * `@ever-works/agent/tasks` — see [`docs/specs/architecture/job-runtime-providers.md`](../../../../docs/specs/architecture/job-runtime-providers.md)
+ * §2 for the seam, §3 for this contract, and §5 for the per-provider
+ * worker-hosting models that the optional `startWorkerHost` accommodates.
+ *
+ * Why ship the interface before any provider implements it:
+ *
+ *   - The cluster runtime keeps booting against Trigger.dev exactly as today.
+ *   - EW-686 P1 ("rehouse Trigger.dev as the `trigger` job-runtime provider")
+ *     becomes a focused refactor — implement this contract once against
+ *     the existing `TriggerService`, no architectural surprises.
+ *   - EW-742 P3+ (tenant-aware dispatcher resolver) gets the type it
+ *     needs to express "the active provider for this `(tenantId, jobName)`
+ *     pair" without further plugin-package churn.
+ *   - The conformance suite plan in §7 of the architecture spec gets a
+ *     stable target signature to test against.
+ *
+ * Capability strings a `job-runtime` plugin manifest declares (mirror
+ * what `dns.interface.ts` does for DNS plugins):
+ *   - `job-runtime-enqueue` (required) — produce a `runId` (or `null`)
+ *   - `job-runtime-cancel` (required) — abort an in-flight run
+ *   - `job-runtime-status` (required) — read live run lifecycle
+ *   - `job-runtime-schedule` (required) — register cron-like recurrence
+ *   - `job-runtime-worker-host` (optional) — pull-model worker hosting
+ *
+ * The single selector knob (one runtime per deployment) lives at
+ * `EVER_WORKS_JOB_RUNTIME=trigger|temporal|bullmq|pgboss|inngest` per
+ * §4 of the architecture spec. Tenant-scoped overlay on top of that is
+ * the EW-742 epic.
+ *
+ * Design constraints carried from the architecture spec into the
+ * contract shape (§3 "Design constraints the contract must hold"):
+ *
+ *   - **`string | null` enqueue return is preserved.** A disabled or
+ *     unreachable runtime returns `null`; the API's existing in-process
+ *     dev fallback is the provider-neutral safety net.
+ *   - **Idempotency is first-class** via `JobEnqueueOptions.idempotencyKey`.
+ *     Providers map it onto their native mechanism (Trigger.dev
+ *     `idempotencyKey`, Temporal workflow id, BullMQ/pg-boss job id,
+ *     Inngest event idempotency) so retries reuse the original
+ *     `WorkGenerationHistory` row.
+ *   - **Concurrency keys are preserved** via `concurrencyKey`. Today
+ *     KB mirror/embed serialise on `workId` and org overlay on
+ *     `organizationId`; the contract carries this through.
+ *   - **Cancellation must propagate an `AbortSignal` into the
+ *     orchestrator** so in-flight AI/search/git calls abort — exactly
+ *     as the Trigger.dev `onCancel`/`signal` path does today. The
+ *     dispatcher contract owns the cancel-request side; the
+ *     orchestrator-side `AbortSignal` plumbing is per-worker-host code
+ *     (P4 / EW-748) and not part of this interface.
+ */
+
+/**
+ * Canonical id of the currently-supported job-runtime providers. Kept
+ * as a string-literal union (NOT a runtime enum) so plugin packages can
+ * declare their `runtimeId` without importing a runtime symbol from
+ * `@ever-works/plugin`. The selector env var `EVER_WORKS_JOB_RUNTIME`
+ * accepts these and only these values; unknown values fall back to
+ * `trigger` (the default).
+ */
+export type JobRuntimeId = 'trigger' | 'temporal' | 'bullmq' | 'pgboss' | 'inngest';
+
+/**
+ * Run lifecycle states observable via `getRunStatus(runId)`. Providers
+ * map their native state machine onto this 6-value union. `'unknown'`
+ * is the fallback when a provider can't resolve a runId — typically
+ * because the run has been pruned past retention or the runId is from
+ * a different provider entirely.
+ */
+export type JobRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled' | 'unknown';
+
+/**
+ * One recurring job. The provider's `registerSchedules` translates each
+ * spec into its native cron mechanism (Trigger.dev `schedules.task`,
+ * Temporal Schedules API, BullMQ repeatable jobs, pg-boss `schedule()`,
+ * Inngest cron functions).
+ */
+export interface ScheduleSpec {
+	/** Stable id, e.g. `work-schedule-dispatcher`. Drives idempotent re-registration. */
+	readonly id: string;
+	/** Standard 5-field cron expression. */
+	readonly cron: string;
+	/** Optional static payload handed to the job on every fire. */
+	readonly payload?: unknown;
+}
+
+/**
+ * Per-enqueue knobs the call site can supply. All optional — sensible
+ * defaults applied per-provider when absent. Anything that affects
+ * idempotency / concurrency / cost belongs here; payload shape itself
+ * stays in the typed per-job `*_DISPATCHER` interface.
+ */
+export interface JobEnqueueOptions {
+	/** Arbitrary tags for observability / filtering in the provider UI. */
+	readonly tags?: readonly string[];
+	/** Stable identity across retries — providers map onto their native idempotency. */
+	readonly idempotencyKey?: string;
+	/** Serialise per key (e.g. per `workId` for KB embed). */
+	readonly concurrencyKey?: string;
+	/** Hard upper bound on run wall-clock; providers cap at their own ceiling. */
+	readonly maxDurationSeconds?: number;
+	/** Provider-specific sizing hint (Trigger.dev machine preset, BullMQ priority lane, …). */
+	readonly machineHint?: string;
+}
+
+/**
+ * Worker-host options for the pull model. Push-model providers
+ * (Trigger.dev, Inngest) implement `startWorkerHost` as a no-op or as
+ * the HTTP `serve()` mount; pull-model providers (Temporal, BullMQ,
+ * pg-boss) start a long-lived worker process. Returned handle exposes
+ * a `stop()` for graceful shutdown coordination.
+ */
+export interface WorkerHostOptions {
+	/** Concurrency cap for the worker process. Provider-specific defaults if omitted. */
+	readonly concurrency?: number;
+	/** Optional polling tuning (only meaningful for pull-model providers). */
+	readonly pollIntervalMs?: number;
+	/** Optional abort signal so process-level shutdown propagates cooperatively. */
+	readonly signal?: AbortSignal;
+}
+
+export interface WorkerHostHandle {
+	/** Stop polling / draining and release resources. Idempotent. */
+	stop(): Promise<void>;
+}
+
+/**
+ * Union of the existing dispatcher interfaces a `job-runtime` provider
+ * must implement to bind into the `*_DISPATCHER` symbols.
+ *
+ * **Deliberately untyped here.** The concrete dispatcher interfaces
+ * (`WorkGenerationDispatcher`, `KbEmbedDocumentDispatcher`, …) live in
+ * `@ever-works/agent/tasks`, which already depends on
+ * `@ever-works/plugin`. Importing them back into this contract file
+ * would introduce a package-dependency cycle (plugin → agent → plugin).
+ *
+ * Provider implementations should:
+ *   1. Declare their `dispatchers` field with the full intersection
+ *      type, importing it from `@ever-works/agent/tasks` (downstream
+ *      packages already depend on agent, so the cycle stays one-way).
+ *   2. Satisfy the structural shape — every `*_DISPATCHER` symbol in
+ *      `_tasks-symbols.ts` has a corresponding `dispatchXxx` method.
+ *
+ * The conformance suite (P6 / EW-750) is what enforces "every
+ * dispatcher symbol gets a binding" — this contract just opens the
+ * door for the binding to exist.
+ */
+export type JobRuntimeDispatchers = Readonly<Record<string, unknown>>;
+
+/**
+ * The capability surface a `job-runtime` plugin contributes. Sized to
+ * exactly the six concerns in §1 of the architecture spec (enqueue,
+ * schedule, cancel, status, retry/idempotency, worker hosting).
+ *
+ * `IJobRuntimeProvider` extends `IPlugin` because a job-runtime is
+ * registered through the standard plugin pipeline (manifest →
+ * `PluginRegistryService` → DI binding). The selector
+ * (`EVER_WORKS_JOB_RUNTIME`) picks one registered provider; the rest
+ * stay inert but loaded so a hot-swap stays cheap.
+ */
+export interface IJobRuntimeProvider extends IPlugin {
+	/** Stable provider id matching the `EVER_WORKS_JOB_RUNTIME` selector value. */
+	readonly runtimeId: JobRuntimeId;
+
+	/**
+	 * One object that implements every agent dispatcher interface
+	 * (enqueue + cancel for each job type). Bound into the
+	 * `*_DISPATCHER` DI symbols by the binding factory in
+	 * `packages/agent/src/tasks/job-runtime.providers.ts` (P0
+	 * scaffolding, P1 wiring per EW-686).
+	 */
+	readonly dispatchers: JobRuntimeDispatchers;
+
+	/**
+	 * Register or refresh the recurring jobs the platform needs. Called
+	 * once at boot (and again on hot-config-reload). MUST be idempotent
+	 * — re-registering an existing `id` updates its cron expression
+	 * in-place rather than spawning a duplicate.
+	 */
+	registerSchedules(schedules: readonly ScheduleSpec[]): Promise<void>;
+
+	/**
+	 * Cancel an in-flight run by the id returned at enqueue time.
+	 * Returns `true` when the cancellation was accepted by the
+	 * provider (not necessarily when the orchestrator has actually
+	 * observed the abort signal). Returns `false` for unknown/already-
+	 * terminal runIds.
+	 */
+	cancel(runId: string): Promise<boolean>;
+
+	/**
+	 * Look up live run lifecycle. Used where webhooks/callbacks aren't
+	 * available (CLI status command, future "live runtime status" UI
+	 * panel). Returns `'unknown'` for unresolvable runIds rather than
+	 * throwing — callers treat unknown as "stale, try DB instead".
+	 */
+	getRunStatus(runId: string): Promise<JobRunStatus>;
+
+	/**
+	 * True when this provider is configured and reachable in the
+	 * current environment. The binding factory calls this at boot;
+	 * `false` triggers fallback to the in-process dev path so the API
+	 * never refuses to start because (e.g.) Trigger.dev credentials
+	 * weren't supplied to a local-dev container.
+	 */
+	isEnabled(): boolean;
+
+	/**
+	 * Optional: stand up / connect the worker host. Pull-model
+	 * providers (Temporal, BullMQ, pg-boss) start a long-lived worker;
+	 * push-model providers (Trigger.dev, Inngest) implement as a no-op
+	 * or as their HTTP `serve()` mount. Absent on providers that
+	 * don't need it.
+	 */
+	startWorkerHost?(opts: WorkerHostOptions): Promise<WorkerHostHandle>;
+}


### PR DESCRIPTION
## Summary

Additive, contract-only capability declaration for pluggable job-runtime providers per [`docs/specs/architecture/job-runtime-providers.md`](https://github.com/ever-works/ever-works/blob/develop/docs/specs/architecture/job-runtime-providers.md) §3.

**No call site is wired through this yet.** `TriggerService` remains the single concrete binding for every `*_DISPATCHER` symbol exported from `@ever-works/agent/tasks`. The cluster runtime boots unchanged.

## What this PR ships

- `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts` — the `IJobRuntimeProvider` contract + supporting types
- Barrel export wired into `packages/plugin/src/contracts/capabilities/index.ts`
- `packages/plugin/src/contracts/__tests__/job-runtime.spec.ts` — 9 type-level shape assertions via vitest's `expectTypeOf` + barrel re-export smoke test (all 9 pass locally)

## Why ship the interface ahead of any provider implementation

- **EW-686 P1** ("rehouse Trigger.dev as the `trigger` job-runtime provider") becomes a focused refactor — implement this contract once against the existing `TriggerService`, no architectural surprises.
- **EW-742 P3+** (tenant-aware dispatcher resolver) gets the type it needs to express "the active provider for this `(tenantId, jobName)` pair" without further plugin-package churn.
- The conformance suite plan in §7 of the architecture spec gets a stable target signature to test against.

## Shape locked

| Type                      | Notes                                                                       |
| ------------------------- | --------------------------------------------------------------------------- |
| `JobRuntimeId`            | `'trigger' \| 'temporal' \| 'bullmq' \| 'pgboss' \| 'inngest'` (literal union; matches `EVER_WORKS_JOB_RUNTIME` selector) |
| `JobRunStatus`            | 5 lifecycle states + `'unknown'` fallback                                   |
| `IJobRuntimeProvider`     | Extends `IPlugin`. 6-concern surface: enqueue / schedule / cancel / status / retry-via-options / worker-host |
| `ScheduleSpec`            | `{ id, cron, payload? }`                                                    |
| `JobEnqueueOptions`       | `tags`, `idempotencyKey`, `concurrencyKey`, `maxDurationSeconds`, `machineHint` — all optional |
| `WorkerHostOptions/Handle` | Pull-model start + idempotent stop                                         |
| `JobRuntimeDispatchers`   | Deliberately `Record<string, unknown>` to avoid plugin → agent → plugin package-dep cycle. Concrete implementations import the typed dispatcher interfaces from `@ever-works/agent/tasks`; conformance suite (P6 / EW-750) will enforce "every `*_DISPATCHER` symbol gets a binding". |

## Design constraints carried from the architecture spec §3

- `string | null` enqueue return preserved (disabled / unreachable provider returns `null`; API falls back in-process for dev)
- `JobEnqueueOptions.idempotencyKey` is first-class so retries reuse the original `WorkGenerationHistory` row
- `concurrencyKey` preserved (KB mirror/embed serialise on `workId`; org overlay on `organizationId`)
- `cancel(runId)` returns `boolean` ack of acceptance (not actual abort observation); `AbortSignal` plumbing into the orchestrator is per-worker-host code (P4 / EW-748)

## Test plan

- [x] `npx vitest run src/contracts/__tests__/job-runtime.spec.ts` — 9/9 pass locally
- [ ] CI green (lint + typecheck + test)
- [ ] No `apps/api` or `packages/agent` changes — the contract is in `@ever-works/plugin` only, no downstream consumer wired yet

## Cascade

PR to develop → cascade develop → stage → main per `feedback_release_flow_develop_stage_main`.

## Related

- Epic: [EW-683](https://evertech.atlassian.net/browse/EW-683) Job-runtime provider pluggability
- Story: [EW-685](https://evertech.atlassian.net/browse/EW-685) P0 contract & seam (this PR is the contract half; the seam — `packages/agent/src/tasks/job-runtime.providers.ts` binding factory — lands with EW-686 P1)
- Unblocks: EW-742 P3 (EW-747) tenant-aware dispatcher resolver

[EW-683]: https://evertech.atlassian.net/browse/EW-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized job-runtime provider contract enabling consistent integration of scheduling and runtime implementations across different providers
  * Support for runtime identification, job lifecycle tracking, scheduling, enqueueing with concurrency/idempotency controls, and optional worker-host provisioning

* **Tests**
  * Contract test suite ensuring job-runtime provider interface compliance and package accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->