### PR TITLE
docs(specs): point all job-runtime cross-refs at the EW-685 P0 shipped contract location

### DIFF
--- a/docs/specs/architecture/job-runtime-providers.md
+++ b/docs/specs/architecture/job-runtime-providers.md
@@ -177,7 +177,7 @@ Today the worker writes terminal state itself (orchestrator + `onFailure`/`onCan
 
 ## 7. Conformance suite (parity guarantee)
 
-A provider-agnostic contract test in `packages/plugin/src/job-runtime/testing/` exercises every provider identically (mirrors ADR-005's `LockProvider` contract suite):
+A provider-agnostic contract test in `packages/plugin/src/contracts/__tests__/` (type-level shape spec in `job-runtime.spec.ts` shipped EW-685 P0; runtime conformance `job-runtime.conformance.spec.ts` lands with the first concrete provider) exercises every provider identically (mirrors ADR-005's `LockProvider` contract suite):
 
 - enqueue returns an id; the worker runs and writes terminal state
 - idempotency: same `idempotencyKey` → one logical run, retries reuse the history row
@@ -224,18 +224,19 @@ The internal SuperJSON callback channel (`TRIGGER_INTERNAL_SECRET`, internal bas
 - **Switching runtimes is a deploy-time action**, not a live migration. In-flight runs drain on the old runtime (or are re-enqueued idempotently). Documented in the per-provider deploy guide.
 - **Self-hosted Trigger.dev** ([EW-592](https://evertech.atlassian.net/browse/EW-592)) = `trigger` provider with `TRIGGER_API_URL` pointed at the self-hosted instance. No new provider needed for that case.
 
-## 10. File index (proposed)
+## 10. File index
 
 ```
-packages/plugin/src/job-runtime/
-├── job-runtime.contract.ts          # IJobRuntimeProvider, JobRunStatus, ScheduleSpec, options
-├── job-runtime.category.ts          # capability registration ('job-runtime')
-└── testing/
-    └── job-runtime.contract.spec.ts # provider-agnostic conformance suite
+packages/plugin/src/contracts/capabilities/
+└── job-runtime.interface.ts         # IJobRuntimeProvider, JobRunStatus, ScheduleSpec, options (shipped EW-685 P0)
+
+packages/plugin/src/contracts/__tests__/
+├── job-runtime.spec.ts              # type-level shape assertions (shipped EW-685 P0)
+└── job-runtime.conformance.spec.ts  # runtime conformance suite (lands with first provider, EW-686 P1)
 
 packages/agent/src/tasks/
 ├── *.dispatcher.ts                  # EXISTING dispatcher interfaces (unchanged)
-└── job-runtime.providers.ts         # NEW factory: EVER_WORKS_JOB_RUNTIME → bind symbols
+└── job-runtime.providers.ts         # NEW factory: EVER_WORKS_JOB_RUNTIME → bind symbols (EW-685 P0 seam half, lands with EW-686 P1)
 
 packages/plugins/
 ├── job-runtime-trigger/             # re-housed TriggerService (default)

--- a/docs/specs/decisions/015-job-runtime-provider-pluggability.md
+++ b/docs/specs/decisions/015-job-runtime-provider-pluggability.md
@@ -88,10 +88,10 @@ The background-job runtime becomes a **pluggable provider** selected at deployme
 
 Tracked in [EW-683](https://evertech.atlassian.net/browse/EW-683). Full detail in the feature spec set under [`features/job-runtime-providers/`](../features/job-runtime-providers/spec.md). High-level shape:
 
-1. Define the `job-runtime` capability + `IJobRuntimeProvider` contract in `packages/plugin/src/job-runtime/`.
+1. Define the `job-runtime` capability + `IJobRuntimeProvider` contract in `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts` (shipped EW-685 P0).
 2. Generalise the dispatcher wiring so the active provider is bound to all `*_DISPATCHER` symbols via a factory that reads `EVER_WORKS_JOB_RUNTIME`.
 3. Re-house the current Trigger.dev integration as the `trigger` provider (no behaviour change) and prove the conformance suite green against it.
-4. Build the provider conformance test harness (`packages/plugin/src/job-runtime/testing/`).
+4. Build the provider conformance test harness — type-level shape in `packages/plugin/src/contracts/__tests__/job-runtime.spec.ts` (shipped EW-685 P0); runtime conformance suite alongside lands with the first concrete provider.
 5. Implement Temporal, BullMQ, pg-boss, Inngest providers behind experimental flags, each green on the conformance suite.
 6. Worker-hosting: define how each provider hosts the worker that runs `@ever-works/agent` orchestrators (Docker/compose + k8s manifests + `pnpm` scripts per provider).
 7. Docs: provider matrix, per-provider deploy guides, `EVER_WORKS_JOB_RUNTIME` env, and amend Principle IV in the constitution.

--- a/docs/specs/features/job-runtime-providers/plan.md
+++ b/docs/specs/features/job-runtime-providers/plan.md
@@ -60,7 +60,7 @@ Optional (later): a small `job_runtime_runs` mirror table if we want a provider-
 
 ### DTOs / contracts
 
-`@ever-works/contracts` unchanged for external API consumers. New internal types (`JobRunStatus`, `ScheduleSpec`, `JobEnqueueOptions`) live in `packages/plugin/src/job-runtime/`.
+`@ever-works/contracts` unchanged for external API consumers. New internal types (`JobRunStatus`, `ScheduleSpec`, `JobEnqueueOptions`, `JobRuntimeId`, `IJobRuntimeProvider`) live in `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts` (shipped EW-685 P0; re-exported from `@ever-works/plugin` via the capabilities barrel).
 
 ## 4. API Surface
 
@@ -73,7 +73,7 @@ No new public endpoints. The internal callback controller (`/internal/trigger/*`
 
 ## 5. Plugin Surface
 
-- **New capability** `job-runtime` → declare in `packages/plugin/src/job-runtime/job-runtime.category.ts` + `IJobRuntimeProvider` contract.
+- **Capability `job-runtime`** → contract at `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts` (shipped EW-685 P0). No separate `job-runtime.category.ts` registration file — capability strings (`job-runtime-enqueue`, `job-runtime-cancel`, `job-runtime-status`, `job-runtime-schedule`, `job-runtime-worker-host`) live in JSDoc on the interface itself, mirroring how `dns.interface.ts` (EW-734/735) declares its capability strings.
 - **New plugins** under `packages/plugins/`: `job-runtime-trigger` (re-house), `job-runtime-temporal`, `job-runtime-bullmq`, `job-runtime-pgboss`, `job-runtime-inngest`. Each: `package.json` with `everworks.plugin` (category `job-runtime`, `configurationMode: 'admin-only'`), tsup build, vitest, settings JSON-Schema with `x-secret`/`x-envVar`/`x-scope: global`.
 - **Binding factory** `packages/agent/src/tasks/job-runtime.providers.ts` resolves the active provider and binds all `*_DISPATCHER` symbols to it.
 

--- a/docs/specs/features/job-runtime-providers/tasks.md
+++ b/docs/specs/features/job-runtime-providers/tasks.md
@@ -11,8 +11,10 @@
 
 ## Phase 0 — Contract & seam (no behaviour change) · `[EW-683 P0]`
 
-- [ ] **T1.** Define the `job-runtime` capability: `packages/plugin/src/job-runtime/job-runtime.category.ts` (register capability) + export from `packages/plugin` entrypoint.
-- [ ] **T2.** Define `IJobRuntimeProvider`, `JobRunStatus`, `ScheduleSpec`, `JobEnqueueOptions`, `JobRuntimeDispatchers` in `packages/plugin/src/job-runtime/job-runtime.contract.ts`. Decide `triggerRunId` (keep) vs `runtimeRunId` (rename, two-phase migration) — default: keep `triggerRunId` as the opaque run id.
+T1 + T2 ✅ Done in [#1354](https://github.com/ever-works/ever-works/pull/1354). T3 + T4 remain (factory + selector env var). T5 + T6 trail.
+
+- [x] **T1.** Define the `job-runtime` capability via `IJobRuntimeProvider` exported from `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts` (the existing capabilities barrel was the natural home alongside the other 25+ capability contracts; no separate `job-runtime.category.ts` file needed since capability strings are declared in JSDoc on the interface itself, matching how `dns.interface.ts` handles it).
+- [x] **T2.** Defined `IJobRuntimeProvider`, `JobRunStatus`, `ScheduleSpec`, `JobEnqueueOptions`, `JobRuntimeDispatchers` (plus `JobRuntimeId`, `WorkerHostOptions`, `WorkerHostHandle`) in `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts`. Run id naming: kept opaque `string` (was originally going to decide `triggerRunId` vs `runtimeRunId` — punted, both shipping providers will produce strings that fit the existing `triggerRunId` column without rename).
 - [ ] **T3.** Add `EVER_WORKS_JOB_RUNTIME` to config (`packages/agent/src/config/index.ts`): `getJobRuntime()` default `'trigger'`, validated enum.
 - [ ] **T4.** Binding factory `packages/agent/src/tasks/job-runtime.providers.ts`: resolve active provider from registry by `EVER_WORKS_JOB_RUNTIME`, bind all `*_DISPATCHER` symbols to `provider.dispatchers`. Bound to `trigger` by default.
 - [ ] **T5.** Amend Constitution Principle IV (`.specify/memory/constitution.md`) → "via the configured job-runtime provider (Trigger.dev default)"; cross-link [ADR-015](../../decisions/015-job-runtime-provider-pluggability.md). (Lands in this phase's PR.)
@@ -27,7 +29,7 @@
 
 ## Phase 2 — Conformance harness · `[EW-683 P2]`
 
-- [ ] **T11.** Provider-agnostic suite `packages/plugin/src/job-runtime/testing/job-runtime.contract.spec.ts`: enqueue→run→status, idempotency (same key → one logical run), concurrency (same key serialises), cancel (in-flight aborts → `CANCELLED`), schedule fires, disabled→`null`+in-process fallback.
+- [ ] **T11.** Provider-agnostic runtime conformance suite, e.g. at `packages/plugin/src/contracts/__tests__/job-runtime.conformance.spec.ts` (parallel to the type-level shape spec at `job-runtime.spec.ts` already shipped in EW-685 P0): enqueue→run→status, idempotency (same key → one logical run), concurrency (same key serialises), cancel (in-flight aborts → `CANCELLED`), schedule fires, disabled→`null`+in-process fallback.
 - [ ] **T12.** Run harness green against `trigger`. Add a CI matrix axis `JOB_RUNTIME={trigger}` (extend per provider in later phases).
 
 ## Phase 3 — pg-boss provider (Postgres-native, GA-track) · `[EW-683 P3]`

--- a/docs/specs/features/tenant-job-runtime-overlay/plan.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/plan.md
@@ -83,7 +83,7 @@ Indexes: PK on `tenant_id`; partial index `WHERE enabled = true` on `(provider_i
 
 ### DTOs / contracts
 
-New types in `packages/plugin/src/job-runtime/tenant-overlay.contract.ts`:
+New types in `packages/plugin/src/contracts/capabilities/job-runtime-tenant.interface.ts` (sibling to the EW-685 P0 `job-runtime.interface.ts`; lands with P3 alongside the tenant-aware resolver):
 
 ```ts
 export type TenantRuntimeMode = 'inherit' | 'byo' | 'override';
@@ -186,7 +186,7 @@ Phases map to the EW-742 description. Each phase is a candidate sub-PR (or sub-P
     - `apps/api/src/works/services/tenant-job-runtime-config.service.ts`
     - `apps/api/src/migrations/<timestamp>-TenantJobRuntimeOverlay.ts`
     - `packages/plugin/src/settings/extensions.ts` (add `tenant` to `x-scope`)
-    - `packages/plugin/src/job-runtime/tenant-overlay.contract.ts`
+    - `packages/plugin/src/contracts/capabilities/job-runtime-tenant.interface.ts` (sibling to the EW-685 P0 `job-runtime.interface.ts`)
     - `apps/api/src/plugins/services/plugin-settings.service.ts` (extend cascade with `tenant` tier)
 - **Tech choices**: TypeORM entity with `@PrimaryColumn('uuid')`, `@Column({type: 'enum'})` for `mode`; AES-256-GCM secret envelope reused via existing `SecretsService`.
 - **Test plan**:
@@ -273,8 +273,8 @@ Phases map to the EW-742 description. Each phase is a candidate sub-PR (or sub-P
 
 - **Scope**: extend EW-683's shared conformance suite with a per-tenant variant parameterised across N tenants × M providers. Add graceful-drain + force-invalidate cases.
 - **Files touched**:
-    - `packages/plugin/src/job-runtime/testing/job-runtime.contract.spec.ts` (parameterise existing cases over `tenantId`)
-    - `packages/plugin/src/job-runtime/testing/tenant-overlay.contract.spec.ts` (NEW — drain + force-invalidate + version capture)
+    - `packages/plugin/src/contracts/__tests__/job-runtime.conformance.spec.ts` (parameterise existing cases over `tenantId`; the runtime conformance suite — sibling of the type-level `job-runtime.spec.ts` shipped in EW-685 P0 — lands with EW-686 P1 once there's a provider to run it against)
+    - `packages/plugin/src/contracts/__tests__/job-runtime-tenant.conformance.spec.ts` (NEW — drain + force-invalidate + version capture)
     - CI matrix in `.github/workflows/ci.yml` — add axis `TENANT_COUNT={1,3}` against existing `JOB_RUNTIME={trigger,pgboss,bullmq,temporal,inngest}`.
 - **Tech choices**: Vitest parameterised `describe.each`; per-tenant fixtures created in `beforeAll` via the provider's `provisionTenant()` hook; teardown via `deprovisionTenant()`.
 - **Test plan**:

--- a/docs/specs/features/tenant-job-runtime-overlay/tasks.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/tasks.md
@@ -55,7 +55,7 @@ P2.0 (REST API) ✅ Done in [#1341](https://github.com/ever-works/ever-works/pul
 - [ ] **T28.** Per-tenant queue polling for BullMQ in `packages/plugins/job-runtime-bullmq/src/tenant-worker-host.ts` — one worker per `(tenantId, queueName)` with BullMQ `prefix` set to the tenant id; reuses `lockDuration`/`lockRenewTime` from EW-683's host config.
 - [ ] **T29.** Per-tenant schema polling for pg-boss in `packages/plugins/job-runtime-pgboss/src/tenant-worker-host.ts` — one `boss` instance per `(tenantId, schema)` (Q2: schema-per-tenant), reusing the platform `DATABASE_URL` by default.
 - [ ] **T30.** Multiplexing worker option (config flag) in each provider's worker host — one worker process polls all tenants and routes per `tenant_id` in job metadata; selected via `EVER_WORKS_JOB_RUNTIME_HOSTING={per-tenant|shared|tiered}` matching Q5's operator-gated platform-default.
-- [ ] **T31.** Tenant-id propagation in run metadata for all providers — extend `JobEnqueueOptions` in `packages/plugin/src/job-runtime/job-runtime.contract.ts` with a `tenantId` field and ensure every provider's dispatcher stamps it (Trigger `metadata`, Inngest `data`, Temporal `searchAttributes`, BullMQ `opts.tenantId`, pg-boss payload field).
+- [ ] **T31.** Tenant-id propagation in run metadata for all providers — extend `JobEnqueueOptions` in `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts` (shipped EW-685 P0) with a `tenantId` field and ensure every provider's dispatcher stamps it (Trigger `metadata`, Inngest `data`, Temporal `searchAttributes`, BullMQ `opts.tenantId`, pg-boss payload field).
 - [ ] **T32.** Integration tests per provider × per-tenant scenario under each plugin's `__tests__/tenant-isolation.spec.ts` — two tenants on the same provider, verify no cross-tenant run leakage and that webhook/poller routing lands on the correct tenant.
 
 ## Phase 5 — Plugin gating · `[EW-742 P5]` ✅ Done in [#1350](https://github.com/ever-works/ever-works/pull/1350) (pending cascade)
@@ -71,11 +71,11 @@ P2.0 (REST API) ✅ Done in [#1341](https://github.com/ever-works/ever-works/pul
 
 ## Phase 6 — Conformance · `[EW-742 P6]`
 
-- [ ] **T36.** Per-tenant test harness extending EW-683's conformance suite under `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — parameterised by `(providerId, tenantA, tenantB)`, reuses the base contract suite then layers tenant-isolation, rotation, and force-invalidate assertions.
+- [ ] **T36.** Per-tenant test harness extending EW-683's conformance suite under `packages/plugin/src/contracts/__tests__/job-runtime-tenant.conformance.spec.ts` — parameterised by `(providerId, tenantA, tenantB)`, reuses the base contract suite then layers tenant-isolation, rotation, and force-invalidate assertions.
 - [ ] **T37.** Parameterised per-tenant conformance run per provider in CI — extend the existing `JOB_RUNTIME={trigger|temporal|bullmq|pgboss|inngest}` matrix in `.github/workflows/` with a `TENANT_OVERLAY={off|on}` axis; both axes must be green per provider.
-- [ ] **T38.** Graceful drain test (Q4) in `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — enqueue run with credential version N, rotate to N+1 mid-run, verify the in-flight run completes with N's credential snapshot and a newly enqueued run uses N+1.
-- [ ] **T39.** Force-invalidate test in `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — invoke the admin `POST /api/account/job-runtime/force-invalidate` action, verify in-flight runs are marked `FAILED` (with `reason='credential_force_invalidated'`) and new enqueues are blocked until a new credential is saved.
-- [ ] **T40.** Cross-provider isolation test in `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — tenant A on `pgboss`, tenant B on `temporal`; concurrent enqueues, verify zero cross-talk in run records, webhooks, and worker logs.
+- [ ] **T38.** Graceful drain test (Q4) in `packages/plugin/src/contracts/__tests__/job-runtime-tenant.conformance.spec.ts` — enqueue run with credential version N, rotate to N+1 mid-run, verify the in-flight run completes with N's credential snapshot and a newly enqueued run uses N+1.
+- [ ] **T39.** Force-invalidate test in `packages/plugin/src/contracts/__tests__/job-runtime-tenant.conformance.spec.ts` — invoke the admin `POST /api/account/job-runtime/force-invalidate` action, verify in-flight runs are marked `FAILED` (with `reason='credential_force_invalidated'`) and new enqueues are blocked until a new credential is saved.
+- [ ] **T40.** Cross-provider isolation test in `packages/plugin/src/contracts/__tests__/job-runtime-tenant.conformance.spec.ts` — tenant A on `pgboss`, tenant B on `temporal`; concurrent enqueues, verify zero cross-talk in run records, webhooks, and worker logs.
 
 ## Phase 7 — Docs · `[EW-742 P7]`
 


### PR DESCRIPTION
## Summary

Docs-only sweep. Six spec files still pointed at the originally-proposed `packages/plugin/src/job-runtime/` subpath; the EW-685 P0 contract (PR #1354) actually shipped at `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts` (alongside the other 25+ capability contracts, mirroring how `dns.interface.ts` (EW-734/735) is sited).

Without this update, future contributors implementing EW-685 T3-T6, EW-686 P1 (rehouse Trigger.dev), EW-742 P3+ (tenant-aware resolver), and the conformance suite would be guided to the wrong file location.

## Files updated

| File | What changed |
|---|---|
| `decisions/015-job-runtime-provider-pluggability.md` | "Implementation outline" steps 1+4 path corrections |
| `features/job-runtime-providers/tasks.md` | T1, T2 marked `[x]` done with PR #1354 link + path correction; T11 conformance suite path |
| `features/job-runtime-providers/plan.md` | §3 DTOs/contracts + §5 Plugin Surface |
| `architecture/job-runtime-providers.md` | §7 conformance + §10 file index |
| `features/tenant-job-runtime-overlay/tasks.md` | T31 (JobEnqueueOptions extension) + T36/T38/T39/T40 (per-tenant conformance) |
| `features/tenant-job-runtime-overlay/plan.md` | §3 DTOs + §10 P1 files + §10 P6 conformance |

The path corrections describe the IS-state of the codebase after PR #1354 landed; they don't change any behaviour or contract surface. Comment "(proposed)" → "(shipped EW-685 P0)" wherever applicable.

## Test plan

- [ ] CI green (docs-only — should pass trivially)
- [ ] Visual review on GitHub that the rendered tables/numbering didn't break

## Cascade

PR to develop → cascade develop → stage → main per `feedback_release_flow_develop_stage_main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated architectural specifications and feature plans to reflect the current organization of job-runtime capabilities and testing infrastructure
* Refined implementation guidelines in decision records to clarify contract interface locations and conformance test suite organization
* Enhanced documentation for job-runtime-providers and tenant-job-runtime-overlay features to ensure accuracy with revised internal structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->