### PR TITLE
docs(agent): cross-link tasks barrel to EW-685 P0 IJobRuntimeProvider contract

### DIFF
--- a/packages/agent/src/tasks/index.ts
+++ b/packages/agent/src/tasks/index.ts
@@ -1,3 +1,16 @@
+/**
+ * EW-683 / EW-685 — the `*_DISPATCHER` symbols re-exported below ARE
+ * the seam that makes the job runtime pluggable. The API depends only
+ * on these symbols; today `TriggerService` (`packages/tasks/src/trigger/trigger.service.ts`)
+ * implements every one of them. EW-686 P1 will refactor `TriggerService`
+ * to implement the `IJobRuntimeProvider` contract
+ * (`packages/plugin/src/contracts/capabilities/job-runtime.interface.ts`,
+ * shipped EW-685 P0) and a binding factory at
+ * `packages/agent/src/tasks/job-runtime.providers.ts` will bind whichever
+ * provider is active (env: `EVER_WORKS_JOB_RUNTIME`) to all of these symbols.
+ * Call sites do not change. See `docs/specs/architecture/job-runtime-providers.md`
+ * §2 (seam) and §3 (contract) for the full picture.
+ */
 export * from './work-generation.types';
 export * from './work-generation-dispatcher';
 export * from './work-import.types';


### PR DESCRIPTION
Adds a top-of-barrel JSDoc block in `packages/agent/src/tasks/index.ts` pointing the next reader at:

- The seam the `*_DISPATCHER` symbols represent (architecture spec §2)
- The `IJobRuntimeProvider` contract shipped in EW-685 P0 (`packages/plugin/src/contracts/capabilities/job-runtime.interface.ts`)
- The upcoming EW-686 P1 binding factory at `packages/agent/src/tasks/job-runtime.providers.ts` that will bind whichever provider is active to all of these symbols, call sites unchanged

No behaviour change. JSDoc-only.

The dispatcher seams look bare on purpose (small interfaces + DI Symbols) — this comment block makes that load-bearing intent obvious to anyone landing on the barrel for the first time, especially while EW-686 is in flight.

## Test plan

- [ ] CI green (lint + typecheck — JSDoc-only)