### PR TITLE
docs(constitution): amend Principle IV for pluggable job-runtime providers (EW-685 T5)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -71,28 +71,45 @@ keep their work running. They can edit content via PRs. Governance
 - Database rows for items/categories/tags are derived state, not the source
   of truth.
 
-## IV. Background Work Goes Through Trigger.dev
+## IV. Background Work Goes Through the Configured Job-Runtime Provider
 
-Long-running, retryable, scheduled, or fan-out work runs as a **Trigger.dev
-task**, not as an in-process async function. Cron schedules use the
-`schedules.task()` API; one-shot fan-out uses regular `task()`. In-process
-execution remains an option only as a fallback when Trigger.dev is not
-configured.
+Long-running, retryable, scheduled, or fan-out work runs as a task on the
+**configured job-runtime provider** (Trigger.dev default), not as an in-process
+async function. The provider abstraction lives in
+`packages/plugin/src/contracts/capabilities/job-runtime.interface.ts`
+([`IJobRuntimeProvider`](../../packages/plugin/src/contracts/capabilities/job-runtime.interface.ts), shipped EW-685 P0); the active runtime is selected
+by `EVER_WORKS_JOB_RUNTIME={trigger|temporal|bullmq|pgboss|inngest}` (default
+`trigger`). Cron schedules use the provider's native cron mechanism
+(Trigger.dev `schedules.task()` today; Temporal Schedules, BullMQ repeatable
+jobs, pg-boss `schedule()`, Inngest cron functions for the alternative
+providers). One-shot fan-out uses the provider's enqueue primitive.
+In-process execution remains an option only as a fallback when the active
+provider is not configured / unreachable. Tenant-scoped overlay on top of the
+instance-global selection is the EW-742 epic.
 
 **Why**: Generation runs are long (minutes), use heavy resources, and must
-survive worker restarts. Trigger.dev gives us idempotent retries, durable
-state, observability, cancellation, and concurrency control out of the box.
-Re-implementing those primitives in the API process is busywork.
+survive worker restarts. A job runtime — whichever provider — gives us
+idempotent retries, durable state, observability, cancellation, and
+concurrency control out of the box. Re-implementing those primitives in the
+API process is busywork. Making it pluggable (per
+[ADR-015](../../docs/specs/decisions/015-job-runtime-provider-pluggability.md)
+and [ADR-017](../../docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md))
+lets operators pick the runtime that fits their deployment (SaaS, Temporal
+self-host, Redis+BullMQ, Postgres-native pg-boss, Inngest Cloud) without
+touching call sites.
 
 **Implications**:
 
-- New "I need to run X every N minutes" → Trigger.dev cron task.
-- New "I need to fan out work for each work in a batch" → Trigger.dev
-  task triggered by a parent.
+- New "I need to run X every N minutes" → register a `ScheduleSpec` with the
+  active provider (today: Trigger.dev cron task).
+- New "I need to fan out work for each work in a batch" → enqueue via a
+  `*_DISPATCHER` symbol; the binding factory routes it to the active provider.
 - Mutual exclusion across overlapping ticks → atomic SQL `UPDATE … WHERE` if
   you have an owning row, else `DistributedTaskLockService`.
 - API endpoints that kick off work return `202 Accepted` immediately; they
   must not block on the worker.
+- Call sites depend ONLY on the agent-package `*_DISPATCHER` DI symbols; they
+  never `import` `@trigger.dev/sdk` (or any other vendor SDK) directly.
 
 ## V. Database Migrations Are Forward-Only
 
@@ -228,7 +245,8 @@ For any feature spec or plan, run through these gates before merging:
       (Principle I).
 - [ ] No hardcoded plugin id outside the plugin package itself (Principle II).
 - [ ] Content lives in user repos, not the database (Principle III).
-- [ ] Long-running work uses Trigger.dev (Principle IV).
+- [ ] Long-running work uses the configured job-runtime provider via the
+      `*_DISPATCHER` DI symbols (Principle IV, [ADR-015](../../docs/specs/decisions/015-job-runtime-provider-pluggability.md)).
 - [ ] Schema changes ship as forward-only migrations (Principle V).
 - [ ] Tests accompany the change (Principle VI).
 - [ ] Secrets carry `x-secret: true` and are never logged (Principle VII).

--- a/docs/specs/architecture/job-runtime-providers.md
+++ b/docs/specs/architecture/job-runtime-providers.md
@@ -177,7 +177,7 @@ Today the worker writes terminal state itself (orchestrator + `onFailure`/`onCan
 
 ## 7. Conformance suite (parity guarantee)
 
-A provider-agnostic contract test in `packages/plugin/src/job-runtime/testing/` exercises every provider identically (mirrors ADR-005's `LockProvider` contract suite):
+A provider-agnostic contract test in `packages/plugin/src/contracts/__tests__/` (type-level shape spec in `job-runtime.spec.ts` shipped EW-685 P0; runtime conformance `job-runtime.conformance.spec.ts` lands with the first concrete provider) exercises every provider identically (mirrors ADR-005's `LockProvider` contract suite):
 
 - enqueue returns an id; the worker runs and writes terminal state
 - idempotency: same `idempotencyKey` → one logical run, retries reuse the history row
@@ -224,18 +224,19 @@ The internal SuperJSON callback channel (`TRIGGER_INTERNAL_SECRET`, internal bas
 - **Switching runtimes is a deploy-time action**, not a live migration. In-flight runs drain on the old runtime (or are re-enqueued idempotently). Documented in the per-provider deploy guide.
 - **Self-hosted Trigger.dev** ([EW-592](https://evertech.atlassian.net/browse/EW-592)) = `trigger` provider with `TRIGGER_API_URL` pointed at the self-hosted instance. No new provider needed for that case.
 
-## 10. File index (proposed)
+## 10. File index
 
 ```
-packages/plugin/src/job-runtime/
-├── job-runtime.contract.ts          # IJobRuntimeProvider, JobRunStatus, ScheduleSpec, options
-├── job-runtime.category.ts          # capability registration ('job-runtime')
-└── testing/
-    └── job-runtime.contract.spec.ts # provider-agnostic conformance suite
+packages/plugin/src/contracts/capabilities/
+└── job-runtime.interface.ts         # IJobRuntimeProvider, JobRunStatus, ScheduleSpec, options (shipped EW-685 P0)
+
+packages/plugin/src/contracts/__tests__/
+├── job-runtime.spec.ts              # type-level shape assertions (shipped EW-685 P0)
+└── job-runtime.conformance.spec.ts  # runtime conformance suite (lands with first provider, EW-686 P1)
 
 packages/agent/src/tasks/
 ├── *.dispatcher.ts                  # EXISTING dispatcher interfaces (unchanged)
-└── job-runtime.providers.ts         # NEW factory: EVER_WORKS_JOB_RUNTIME → bind symbols
+└── job-runtime.providers.ts         # NEW factory: EVER_WORKS_JOB_RUNTIME → bind symbols (EW-685 P0 seam half, lands with EW-686 P1)
 
 packages/plugins/
 ├── job-runtime-trigger/             # re-housed TriggerService (default)

--- a/docs/specs/features/job-runtime-providers/tasks.md
+++ b/docs/specs/features/job-runtime-providers/tasks.md
@@ -11,7 +11,7 @@
 
 ## Phase 0 — Contract & seam (no behaviour change) · `[EW-683 P0]`
 
-T1 + T2 ✅ Done in [#1354](https://github.com/ever-works/ever-works/pull/1354) (cascaded [#1360](https://github.com/ever-works/ever-works/pull/1360) -> [#1362](https://github.com/ever-works/ever-works/pull/1362)). T3 + T4 remain (factory + selector env var). T5 + T6 trail.
+T1 + T2 ✅ Done in [#1354](https://github.com/ever-works/ever-works/pull/1354) (cascaded [#1360](https://github.com/ever-works/ever-works/pull/1360) -> [#1362](https://github.com/ever-works/ever-works/pull/1362)). T3 ✅ Done in [#1369](https://github.com/ever-works/ever-works/pull/1369). T4 binding factory, T5 Constitution amendment, T6 startup log in progress.
 
 - [x] **T1.** Define the `job-runtime` capability via `IJobRuntimeProvider` exported from `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts` (the existing capabilities barrel was the natural home alongside the other 25+ capability contracts; no separate `job-runtime.category.ts` file needed since capability strings are declared in JSDoc on the interface itself, matching how `dns.interface.ts` handles it).
 - [x] **T2.** Defined `IJobRuntimeProvider`, `JobRunStatus`, `ScheduleSpec`, `JobEnqueueOptions`, `JobRuntimeDispatchers` (plus `JobRuntimeId`, `WorkerHostOptions`, `WorkerHostHandle`) in `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts`. Run id naming: kept opaque `string` (was originally going to decide `triggerRunId` vs `runtimeRunId` — punted, both shipping providers will produce strings that fit the existing `triggerRunId` column without rename).

--- a/docs/specs/features/tenant-job-runtime-overlay/tasks.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/tasks.md
@@ -71,11 +71,11 @@ P2.0 (REST API) ✅ Done in [#1341](https://github.com/ever-works/ever-works/pul
 
 ## Phase 6 — Conformance · `[EW-742 P6]`
 
-- [ ] **T36.** Per-tenant test harness extending EW-683's conformance suite under `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — parameterised by `(providerId, tenantA, tenantB)`, reuses the base contract suite then layers tenant-isolation, rotation, and force-invalidate assertions.
+- [ ] **T36.** Per-tenant test harness extending EW-683's conformance suite under `packages/plugin/src/contracts/__tests__/job-runtime-tenant.conformance.spec.ts` — parameterised by `(providerId, tenantA, tenantB)`, reuses the base contract suite then layers tenant-isolation, rotation, and force-invalidate assertions.
 - [ ] **T37.** Parameterised per-tenant conformance run per provider in CI — extend the existing `JOB_RUNTIME={trigger|temporal|bullmq|pgboss|inngest}` matrix in `.github/workflows/` with a `TENANT_OVERLAY={off|on}` axis; both axes must be green per provider.
-- [ ] **T38.** Graceful drain test (Q4) in `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — enqueue run with credential version N, rotate to N+1 mid-run, verify the in-flight run completes with N's credential snapshot and a newly enqueued run uses N+1.
-- [ ] **T39.** Force-invalidate test in `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — invoke the admin `POST /api/account/job-runtime/force-invalidate` action, verify in-flight runs are marked `FAILED` (with `reason='credential_force_invalidated'`) and new enqueues are blocked until a new credential is saved.
-- [ ] **T40.** Cross-provider isolation test in `packages/plugin/src/job-runtime/testing/tenant-conformance.ts` — tenant A on `pgboss`, tenant B on `temporal`; concurrent enqueues, verify zero cross-talk in run records, webhooks, and worker logs.
+- [ ] **T38.** Graceful drain test (Q4) in `packages/plugin/src/contracts/__tests__/job-runtime-tenant.conformance.spec.ts` — enqueue run with credential version N, rotate to N+1 mid-run, verify the in-flight run completes with N's credential snapshot and a newly enqueued run uses N+1.
+- [ ] **T39.** Force-invalidate test in `packages/plugin/src/contracts/__tests__/job-runtime-tenant.conformance.spec.ts` — invoke the admin `POST /api/account/job-runtime/force-invalidate` action, verify in-flight runs are marked `FAILED` (with `reason='credential_force_invalidated'`) and new enqueues are blocked until a new credential is saved.
+- [ ] **T40.** Cross-provider isolation test in `packages/plugin/src/contracts/__tests__/job-runtime-tenant.conformance.spec.ts` — tenant A on `pgboss`, tenant B on `temporal`; concurrent enqueues, verify zero cross-talk in run records, webhooks, and worker logs.
 
 ## Phase 7 — Docs · `[EW-742 P7]`
 


### PR DESCRIPTION
## Summary

EW-685 P0 T5 — amend Constitution Principle IV from \"Background Work Goes Through Trigger.dev\" to \"Background Work Goes Through the Configured Job-Runtime Provider\" so the principle matches the IS-state of the runtime layer after PR #1354 (the IJobRuntimeProvider contract).

## Changes

**Section IV body** — generalised:
- \"Trigger.dev task\" → \"task on the configured job-runtime provider (Trigger.dev default)\"
- Selector env var `EVER_WORKS_JOB_RUNTIME={trigger|temporal|bullmq|pgboss|inngest}` now documented inline
- Cron mechanism enumerates the 5 providers' native cron primitives
- Cross-links to [ADR-015](../../docs/specs/decisions/015-job-runtime-provider-pluggability.md) (pluggability) + [ADR-017](../../docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md) (tenant overlay) in the Why section
- New implication added: **call sites depend ONLY on the `*_DISPATCHER` DI symbols; they never `import` `@trigger.dev/sdk` (or any other vendor SDK) directly**. This was already the enforced pattern but the principle didn't spell it out — now it does, so future contributors don't reach for the SDK from a feature module.

**Quality gates checklist line** — updated:
- \"Long-running work uses Trigger.dev (Principle IV).\" → \"Long-running work uses the configured job-runtime provider via the `*_DISPATCHER` DI symbols (Principle IV, ADR-015).\"

## Behaviour preserved

- In-process fallback when the active provider isn't configured stays called out.
- Today the only concrete provider is Trigger.dev — EW-686 P1 lands the actual rehouse of `TriggerService` into a plugin. This PR only amends the principle so it matches the contract surface; it doesn't change any runtime code.

## Test plan

- [ ] CI green (docs-only — should pass trivially)
- [ ] Visual review on GitHub that the rendered principle reads well

## Cascade

PR to develop → cascade develop → stage → main per `feedback_release_flow_develop_stage_main`.

## Related

- ADR: [ADR-015](https://github.com/ever-works/ever-works/blob/main/docs/specs/decisions/015-job-runtime-provider-pluggability.md)
- Contract: PR #1354 (merged, on `main`)
- Spec xref sweep: PR #1366 (in flight; sibling to this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture specifications to reflect job-runtime provider conformance structure and testing organization.
  * Updated feature task status to track implementation progress on job-runtime provider support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->