### PR TITLE
feat(agent): EVER_WORKS_JOB_RUNTIME selector + isExperimentalProvider (EW-685 P0 T3)

### DIFF
--- a/packages/agent/src/config/config.spec.ts
+++ b/packages/agent/src/config/config.spec.ts
@@ -149,6 +149,66 @@ describe('agent/config', () => {
         });
     });
 
+    describe('config.jobRuntime (EW-683 / EW-685 P0 T3 — pluggable runtime selector)', () => {
+        describe('getActiveProviderId', () => {
+            it("defaults to 'trigger' when EVER_WORKS_JOB_RUNTIME is unset", () => {
+                expect(config.jobRuntime.getActiveProviderId()).toBe('trigger');
+            });
+
+            it("defaults to 'trigger' when EVER_WORKS_JOB_RUNTIME is empty string", () => {
+                process.env.EVER_WORKS_JOB_RUNTIME = '';
+                expect(config.jobRuntime.getActiveProviderId()).toBe('trigger');
+            });
+
+            it("defaults to 'trigger' when EVER_WORKS_JOB_RUNTIME is whitespace only", () => {
+                process.env.EVER_WORKS_JOB_RUNTIME = '   ';
+                expect(config.jobRuntime.getActiveProviderId()).toBe('trigger');
+            });
+
+            it.each(['trigger', 'temporal', 'bullmq', 'pgboss', 'inngest'] as const)(
+                "returns '%s' when set verbatim",
+                (id) => {
+                    process.env.EVER_WORKS_JOB_RUNTIME = id;
+                    expect(config.jobRuntime.getActiveProviderId()).toBe(id);
+                },
+            );
+
+            it('trims surrounding whitespace before matching', () => {
+                process.env.EVER_WORKS_JOB_RUNTIME = '  temporal  ';
+                expect(config.jobRuntime.getActiveProviderId()).toBe('temporal');
+            });
+
+            it("normalises case to lowercase ('TEMPORAL' → 'temporal')", () => {
+                process.env.EVER_WORKS_JOB_RUNTIME = 'TEMPORAL';
+                expect(config.jobRuntime.getActiveProviderId()).toBe('temporal');
+            });
+
+            it("falls back to 'trigger' (fail-open) on unknown id — typo safety", () => {
+                process.env.EVER_WORKS_JOB_RUNTIME = 'sidekiq';
+                expect(config.jobRuntime.getActiveProviderId()).toBe('trigger');
+            });
+        });
+
+        describe('isExperimentalProvider', () => {
+            it("returns false when active provider is the default 'trigger'", () => {
+                expect(config.jobRuntime.isExperimentalProvider()).toBe(false);
+            });
+
+            it.each(['temporal', 'bullmq', 'pgboss', 'inngest'] as const)(
+                "returns true for non-default provider '%s'",
+                (id) => {
+                    process.env.EVER_WORKS_JOB_RUNTIME = id;
+                    expect(config.jobRuntime.isExperimentalProvider()).toBe(true);
+                },
+            );
+
+            it("returns false when an unknown id falls back to 'trigger'", () => {
+                process.env.EVER_WORKS_JOB_RUNTIME = 'sidekiq';
+                expect(config.jobRuntime.isExperimentalProvider()).toBe(false);
+            });
+        });
+    });
+
     describe('config.database', () => {
         describe('getType', () => {
             it("defaults to 'better-sqlite3' when DATABASE_TYPE is unset", () => {
@@ -704,6 +764,12 @@ describe('agent/config', () => {
                 'github',
                 'githubApp',
                 'isCli',
+                // EW-683 / EW-685 P0 T3 — `jobRuntime.*` group adds the
+                // `EVER_WORKS_JOB_RUNTIME` selector for the pluggable
+                // background-job runtime (Trigger.dev default; Temporal /
+                // BullMQ / pg-boss / Inngest behind feature plugins).
+                // Pinned alphabetically.
+                'jobRuntime',
                 // EW-643 Phase 3 slice 2b — `kb.*` group adds ffmpeg
                 // + transcribe operator knobs (KB_FFMPEG_BIN,
                 // KB_MEDIA_NORMALIZE, KB_VIDEO_OUTPUT_CODEC/EXT,

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -37,6 +37,54 @@ export const config = {
         },
     },
 
+    /**
+     * EW-683 / EW-685 P0 T3 — selector for the active job-runtime provider.
+     *
+     * Single instance-global knob per
+     * [`docs/specs/architecture/job-runtime-providers.md`](../../../../docs/specs/architecture/job-runtime-providers.md)
+     * §4. The shape of the contract lives in
+     * `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts`
+     * (`JobRuntimeId` literal-union shipped EW-685 P0); the binding factory
+     * that consumes this selector (`packages/agent/src/tasks/job-runtime.providers.ts`)
+     * lands with EW-686 P1, alongside the rehoused `TriggerService` as the
+     * first concrete provider.
+     *
+     * Until then this getter is **read but not bound** — every dispatcher
+     * symbol still routes through `TriggerService` directly. Adding it
+     * here ahead of the binding factory means:
+     *   - Operators can set the env var in deploy manifests without
+     *     waiting for the binding to land (the value sits inert).
+     *   - The startup-log line that surfaces "active runtime id =
+     *     `<id>`" (EW-685 P0 T6) has somewhere to read from.
+     *   - The unknown-value fail-open path is exercised by tests today.
+     */
+    jobRuntime: {
+        /**
+         * Returns the active job-runtime provider id. Unknown / unset / empty
+         * → falls back to `'trigger'` (the default per ADR-015) and emits a
+         * startup-log warning when the value was set but unrecognised (T6
+         * lands the log emitter). Lowercased + trimmed for resilience to
+         * deploy-manifest typos (`Trigger ` → `trigger`).
+         */
+        getActiveProviderId(): 'trigger' | 'temporal' | 'bullmq' | 'pgboss' | 'inngest' {
+            const raw = (process.env.EVER_WORKS_JOB_RUNTIME ?? '').trim().toLowerCase();
+            if (raw === 'temporal' || raw === 'bullmq' || raw === 'pgboss' || raw === 'inngest') {
+                return raw;
+            }
+            return 'trigger';
+        },
+        /**
+         * True when the env var was set to a value other than `'trigger'`.
+         * Surfaces "experimental runtime active" warnings until every
+         * provider passes the conformance suite (per
+         * [ADR-015](../../../../docs/specs/decisions/015-job-runtime-provider-pluggability.md)
+         * §"All providers pass one shared conformance suite").
+         */
+        isExperimentalProvider(): boolean {
+            return this.getActiveProviderId() !== 'trigger';
+        },
+    },
+
     // Database configuration
     database: {
         getType() {


### PR DESCRIPTION
## Summary

EW-685 P0 T3 — adds `config.jobRuntime.getActiveProviderId()` reading the `EVER_WORKS_JOB_RUNTIME` env var per [`docs/specs/architecture/job-runtime-providers.md`](https://github.com/ever-works/ever-works/blob/main/docs/specs/architecture/job-runtime-providers.md) §4. Single instance-global knob for picking the active background-job runtime (Trigger.dev default; Temporal / BullMQ / pg-boss / Inngest behind feature plugins).

**No behaviour change yet.** Every dispatcher symbol still routes through `TriggerService` directly. The binding factory that consumes this selector (`packages/agent/src/tasks/job-runtime.providers.ts`, EW-685 T4) lands with EW-686 P1 alongside the rehoused `TriggerService` as the first concrete `IJobRuntimeProvider` implementation.

Until then this getter is **read but not bound** — operators can pre-set the env var in deploy manifests; the value sits inert.

## Why ship the getter ahead of the binding factory

- Operators can set the env var in deploy manifests without waiting for the binding to land.
- The startup-log line that surfaces \"active runtime id = `<id>`\" (EW-685 T6, follow-up PR) has somewhere to read from.
- The unknown-value fail-open path is exercised by tests today (operator deploys `EVER_WORKS_JOB_RUNTIME=sidekiq` → silently falls back to `trigger` instead of refusing to boot).

## Semantics

- Unset / empty / whitespace → `'trigger'` (default per [ADR-015](https://github.com/ever-works/ever-works/blob/main/docs/specs/decisions/015-job-runtime-provider-pluggability.md)).
- Trim + lowercase before matching — deploy-manifest typo resilience (`Trigger ` → `trigger`).
- Unknown value (e.g. `sidekiq`) → falls back to `'trigger'` (fail-open, mirrors the per-feature allow-list typo guard pattern from EW-742 P5).

`isExperimentalProvider()` returns `true` for any non-`trigger` active id — drives the upcoming startup-log warning (T6) until every provider passes the conformance suite.

## Test plan

- [x] `npx jest src/config/config.spec.ts` — 143/143 pass (13 new cases + existing 130)
- [ ] CI green (lint + typecheck + agent tests)

### New test coverage

| Group | Cases |
|---|---|
| `getActiveProviderId` defaults | unset / empty / whitespace → `trigger` |
| `getActiveProviderId` valid ids | all 5 (`trigger`, `temporal`, `bullmq`, `pgboss`, `inngest`) |
| `getActiveProviderId` normalisation | trim, lowercase |
| `getActiveProviderId` fail-open | unknown id (`sidekiq`) → `trigger` |
| `isExperimentalProvider` | false for trigger / default / unknown; true for 4 alternative providers |
| Top-level shape regression | `'jobRuntime'` added alphabetically |

## Cascade

PR to develop → cascade develop → stage → main per `feedback_release_flow_develop_stage_main`.

## Related

- ADR: [ADR-015](https://github.com/ever-works/ever-works/blob/main/docs/specs/decisions/015-job-runtime-provider-pluggability.md)
- Contract: PR #1354 (merged, on `main`)
- Constitution amendment: PR #1368 (in flight)
- Spec xref sweep: PR #1366 (in flight)