### PR TITLE
feat(api): boot-time log line for active job-runtime provider (EW-685 P0 T6)

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,6 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { configDotenv } from 'dotenv';
-import { ValidationPipe } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { SwaggerModule } from '@nestjs/swagger';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { apiReference } from '@scalar/nestjs-api-reference';
@@ -13,6 +13,7 @@ import * as path from 'path';
 import { json, urlencoded } from 'express';
 import { assertProductionCorsConfig } from './cors-validation';
 import { config as appConfig } from './config/constants';
+import { config as agentConfig } from '@ever-works/agent/config';
 import { resolveTrustProxyHops } from './config/trust-proxy';
 
 async function bootstrap() {
@@ -39,6 +40,36 @@ async function bootstrap() {
     // Initialize Sentry and PostHog
     initSentry();
     initPostHog();
+
+    // EW-683 / EW-685 P0 T6 — surface the active job-runtime provider at
+    // boot so operators can verify their EVER_WORKS_JOB_RUNTIME selector
+    // landed (or notice typos that silently fall back to `trigger`).
+    // Until EW-686 P1 lands the binding factory + IJobRuntimeProvider
+    // implementations, the value is informational only — every dispatcher
+    // symbol still routes through TriggerService directly. We log it now
+    // so the env var is observable from the moment the variable starts
+    // being deployed; the bound-but-experimental warning becomes accurate
+    // automatically once T4 wires it.
+    const bootLogger = new Logger('JobRuntime');
+    const activeRuntime = agentConfig.jobRuntime.getActiveProviderId();
+    const requestedRaw = (process.env.EVER_WORKS_JOB_RUNTIME ?? '').trim();
+    if (requestedRaw && requestedRaw.toLowerCase() !== activeRuntime) {
+        bootLogger.warn(
+            `EVER_WORKS_JOB_RUNTIME='${requestedRaw}' is not a recognised provider id; ` +
+                `falling back to the default ('${activeRuntime}'). ` +
+                `Valid ids: trigger | temporal | bullmq | pgboss | inngest. ` +
+                `See docs/specs/architecture/job-runtime-providers.md §4.`,
+        );
+    }
+    if (agentConfig.jobRuntime.isExperimentalProvider()) {
+        bootLogger.warn(
+            `Active job-runtime provider: '${activeRuntime}' (experimental). ` +
+                `Non-default providers ship behind the EW-683 conformance suite — ` +
+                `green-on-suite providers will drop this warning in a future release.`,
+        );
+    } else {
+        bootLogger.log(`Active job-runtime provider: '${activeRuntime}' (default).`);
+    }
 
     const app = await NestFactory.create<NestExpressApplication>(ApiModule);
 


### PR DESCRIPTION
## Summary

EW-685 P0 T6 — boot-time log line surfacing the active job-runtime provider so operators can verify their `EVER_WORKS_JOB_RUNTIME` selector landed (or notice typos that silently fall back to `trigger`).

## Three log states from `main.ts` after Sentry / PostHog init

1. **Unknown id supplied** → WARN
   `EVER_WORKS_JOB_RUNTIME='sidekiq' is not a recognised provider id; falling back to the default ('trigger'). Valid ids: trigger | temporal | bullmq | pgboss | inngest. See docs/specs/architecture/job-runtime-providers.md §4.`

2. **Non-default provider active** → WARN
   `Active job-runtime provider: 'temporal' (experimental). Non-default providers ship behind the EW-683 conformance suite — green-on-suite providers will drop this warning in a future release.`

3. **Default `trigger` active** → INFO
   `Active job-runtime provider: 'trigger' (default).`

## No behaviour change

Until EW-686 P1 lands the binding factory + `IJobRuntimeProvider` implementations, the value is informational only — every dispatcher symbol still routes through `TriggerService` directly. We log it now so the env var is observable from the moment operators start deploying it; the bound-but-experimental warning becomes accurate automatically once T4 wires it.

## Test plan

- [ ] CI green (lint + typecheck + e2e)
- [ ] Local boot with `EVER_WORKS_JOB_RUNTIME=temporal` → see the experimental warning
- [ ] Local boot with `EVER_WORKS_JOB_RUNTIME=sidekiq` → see the unknown-id warning
- [ ] Local boot unset → see the default INFO

No unit tests added: this is a pure side-effect log line, easier to verify by reading the boot output than by mocking NestJS Logger. The underlying `jobRuntime.getActiveProviderId()` + `isExperimentalProvider()` helpers are unit-tested in `config.spec.ts` (EW-685 T3, 13 cases shipped in PR #1369).

## Cascade

PR to develop → cascade develop → stage → main per `feedback_release_flow_develop_stage_main`.

## Related

- ADR: [ADR-015](https://github.com/ever-works/ever-works/blob/main/docs/specs/decisions/015-job-runtime-provider-pluggability.md)
- Contract: PR #1354 (merged, on `main`)
- Selector getter: PR #1369 (in flight; this PR uses it)
- Constitution amendment: PR #1368 (in flight)
- Spec xref sweep: PR #1366 (in flight)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced API startup logging to display the active job-runtime provider configuration and validation status.
  * Added diagnostic messages for experimental providers to improve operational visibility during application initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->