### PR TITLE
feat(tasks): rehouse Trigger.dev as IJobRuntimeProvider (EW-686 P1)

### DIFF
--- a/packages/tasks/package.json
+++ b/packages/tasks/package.json
@@ -29,6 +29,7 @@
     },
     "dependencies": {
         "@ever-works/agent": "workspace:*",
+        "@ever-works/plugin": "workspace:*",
         "@nestjs/cache-manager": "^3.1.0",
         "@nestjs/common": "^11.1.18",
         "@nestjs/core": "^11.1.18",

--- a/packages/tasks/src/trigger/__tests__/trigger-job-runtime.provider.spec.ts
+++ b/packages/tasks/src/trigger/__tests__/trigger-job-runtime.provider.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * EW-686 P1 — unit tests for {@link TriggerJobRuntimeProvider}, the
+ * thin adapter that exposes the existing `TriggerService` through the
+ * new pluggable `IJobRuntimeProvider` contract (EW-685 P0).
+ *
+ * The adapter is intentionally a delegation wrapper — every
+ * `IJobRuntimeProvider` method routes straight back into
+ * `TriggerService`, which already implements the IJobRuntimeProvider
+ * *method* surface on its own (it just deliberately doesn't extend the
+ * full `IPlugin` shape). These tests therefore verify two things:
+ *
+ *   1. The IPlugin synthetic metadata the adapter ADDS (id, name,
+ *      version, category, capabilities, settingsSchema, onLoad,
+ *      onUnload, runtimeId) is shaped correctly.
+ *   2. Every IJobRuntimeProvider method forwards its arguments and
+ *      return value verbatim to the underlying `TriggerService`.
+ *
+ * Per-dispatch logic and the SDK-status-enum mapping are owned by
+ * `TriggerService` and tested in `../../__tests__/trigger.service.spec.ts`.
+ * The EW-685 T4 binding factory that wires this provider into the
+ * agent `*_DISPATCHER` symbols is a follow-up PR and out of scope here.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { triggerServiceMock, dispatchersSentinel } = vi.hoisted(() => {
+    // Sentinel object used to verify identity-pass-through of the
+    // `dispatchers` getter without depending on any real TriggerService
+    // shape — what matters is that `provider.dispatchers` returns
+    // exactly what `triggerService.dispatchers` returns.
+    const dispatchersSentinel = { __sentinel: 'dispatchers' } as const;
+    return {
+        dispatchersSentinel,
+        triggerServiceMock: {
+            // The adapter delegates these calls to the service. Each is
+            // a vi.fn so we can assert the call shape AND control the
+            // return value per-test.
+            isEnabled: vi.fn<() => boolean>(),
+            cancel: vi.fn<(runId: string) => Promise<boolean>>(),
+            getRunStatus: vi.fn<(runId: string) => Promise<string>>(),
+            registerSchedules:
+                vi.fn<(schedules: readonly { id: string; cron: string }[]) => Promise<void>>(),
+            startWorkerHost: vi.fn<(opts: unknown) => Promise<{ stop: () => Promise<void> }>>(),
+            // Property — read via the dispatchers getter.
+            dispatchers: dispatchersSentinel,
+        },
+    };
+});
+
+import { TriggerJobRuntimeProvider } from '../trigger-job-runtime.provider';
+import { TriggerService } from '../trigger.service';
+
+describe('TriggerJobRuntimeProvider', () => {
+    let provider: TriggerJobRuntimeProvider;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Reset the dispatchers ref each test in case a test reassigned it.
+        triggerServiceMock.dispatchers = dispatchersSentinel;
+        // Default to "Trigger.dev is configured & reachable" so each
+        // test starts from the happy path and overrides as needed.
+        triggerServiceMock.isEnabled.mockReturnValue(true);
+        provider = new TriggerJobRuntimeProvider(triggerServiceMock as unknown as TriggerService);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('IPlugin synthetic metadata', () => {
+        it('declares runtimeId === "trigger"', () => {
+            // Selector match for `EVER_WORKS_JOB_RUNTIME=trigger`.
+            expect(provider.runtimeId).toBe('trigger');
+        });
+
+        it('declares the IPlugin metadata fields the EW-685 T4 binding factory expects', () => {
+            // Plumbing the parent IPlugin shape lets the binding factory
+            // hold this provider in the same DI container as future
+            // "real" plugin-pipeline providers without special-casing.
+            // See class JSDoc on synthetic plugin status.
+            expect(provider.id).toBe('trigger');
+            expect(provider.name).toBe('Trigger.dev');
+            expect(provider.version).toBe('1.0.0');
+            expect(provider.category).toBe('job-runtime');
+            expect(provider.capabilities).toEqual([
+                'job-runtime-enqueue',
+                'job-runtime-cancel',
+                'job-runtime-status',
+                'job-runtime-schedule',
+            ]);
+            expect(provider.settingsSchema).toEqual({ type: 'object', properties: {} });
+        });
+    });
+
+    describe('dispatcher passthrough', () => {
+        it('dispatchers returns the same reference as triggerService.dispatchers', () => {
+            // This is load-bearing — the EW-685 T4 binding factory will
+            // bind every *_DISPATCHER symbol to `provider.dispatchers`
+            // and rely on every concrete dispatch method existing on the
+            // same object that exists today (TriggerService).
+            expect(provider.dispatchers).toBe(dispatchersSentinel);
+        });
+
+        it('dispatchers re-reads triggerService.dispatchers on each access (live view)', () => {
+            // Verifies the getter is a live view rather than a snapshot
+            // captured at construction. The binding factory may resolve
+            // dispatchers lazily, so the adapter must reflect the service.
+            const other = { __sentinel: 'other' } as const;
+            triggerServiceMock.dispatchers = other;
+            expect(provider.dispatchers).toBe(other);
+        });
+    });
+
+    describe('lifecycle hooks (synthetic plugin)', () => {
+        it('onLoad resolves without side effects', async () => {
+            await expect(provider.onLoad({} as never)).resolves.toBeUndefined();
+        });
+
+        it('onUnload resolves without side effects', async () => {
+            await expect(provider.onUnload()).resolves.toBeUndefined();
+        });
+    });
+
+    describe('isEnabled delegation', () => {
+        it('delegates verbatim to triggerService.isEnabled() — true case', () => {
+            triggerServiceMock.isEnabled.mockReturnValueOnce(true);
+            expect(provider.isEnabled()).toBe(true);
+            expect(triggerServiceMock.isEnabled).toHaveBeenCalledTimes(1);
+        });
+
+        it('delegates verbatim to triggerService.isEnabled() — false case', () => {
+            triggerServiceMock.isEnabled.mockReturnValueOnce(false);
+            expect(provider.isEnabled()).toBe(false);
+            expect(triggerServiceMock.isEnabled).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('registerSchedules delegation', () => {
+        it('forwards an empty list to triggerService.registerSchedules', async () => {
+            triggerServiceMock.registerSchedules.mockResolvedValue(undefined);
+
+            await expect(provider.registerSchedules([])).resolves.toBeUndefined();
+
+            expect(triggerServiceMock.registerSchedules).toHaveBeenCalledTimes(1);
+            expect(triggerServiceMock.registerSchedules).toHaveBeenCalledWith([]);
+        });
+
+        it('forwards a non-empty list to triggerService.registerSchedules verbatim', async () => {
+            triggerServiceMock.registerSchedules.mockResolvedValue(undefined);
+            const schedules = [
+                { id: 'work-schedule-dispatcher', cron: '*/5 * * * *' },
+                { id: 'kb-reconcile', cron: '0 * * * *' },
+            ];
+
+            await expect(provider.registerSchedules(schedules)).resolves.toBeUndefined();
+
+            expect(triggerServiceMock.registerSchedules).toHaveBeenCalledTimes(1);
+            expect(triggerServiceMock.registerSchedules).toHaveBeenCalledWith(schedules);
+        });
+    });
+
+    describe('cancel delegation', () => {
+        it('forwards runId to triggerService.cancel and returns its result (true)', async () => {
+            triggerServiceMock.cancel.mockResolvedValue(true);
+
+            const out = await provider.cancel('run_abc');
+
+            expect(out).toBe(true);
+            expect(triggerServiceMock.cancel).toHaveBeenCalledTimes(1);
+            expect(triggerServiceMock.cancel).toHaveBeenCalledWith('run_abc');
+        });
+
+        it('forwards runId to triggerService.cancel and returns its result (false)', async () => {
+            // The adapter must NOT second-guess the service's gate — if
+            // the service returns false (disabled, unknown id, SDK
+            // threw), the adapter returns false too.
+            triggerServiceMock.cancel.mockResolvedValue(false);
+
+            const out = await provider.cancel('run_missing');
+
+            expect(out).toBe(false);
+            expect(triggerServiceMock.cancel).toHaveBeenCalledWith('run_missing');
+        });
+    });
+
+    describe('getRunStatus delegation', () => {
+        it.each([
+            ['queued'],
+            ['running'],
+            ['completed'],
+            ['failed'],
+            ['cancelled'],
+            ['unknown'],
+        ] as const)(
+            'forwards runId and returns the service\'s "%s" status verbatim',
+            async (status) => {
+                triggerServiceMock.getRunStatus.mockResolvedValue(status);
+
+                const out = await provider.getRunStatus('run_status_test');
+
+                expect(out).toBe(status);
+                expect(triggerServiceMock.getRunStatus).toHaveBeenCalledWith('run_status_test');
+            },
+        );
+    });
+
+    describe('startWorkerHost delegation', () => {
+        it('forwards opts to triggerService.startWorkerHost and returns its handle', async () => {
+            // Trigger.dev is push-model, so TriggerService.startWorkerHost
+            // returns a no-op handle. The adapter must pass it through
+            // unchanged so a generic "start the worker host if the
+            // provider supports it" caller works without per-provider
+            // branching.
+            const handle = { stop: vi.fn().mockResolvedValue(undefined) };
+            triggerServiceMock.startWorkerHost.mockResolvedValue(handle);
+            const opts = { concurrency: 4 };
+
+            const out = await provider.startWorkerHost(opts);
+
+            expect(out).toBe(handle);
+            expect(triggerServiceMock.startWorkerHost).toHaveBeenCalledTimes(1);
+            expect(triggerServiceMock.startWorkerHost).toHaveBeenCalledWith(opts);
+        });
+    });
+});

--- a/packages/tasks/src/trigger/__tests__/trigger.service.runtime.spec.ts
+++ b/packages/tasks/src/trigger/__tests__/trigger.service.runtime.spec.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * EW-686 P1 — smoke tests for the `IJobRuntimeProvider` structural
+ * conformance surface added to {@link TriggerService}.
+ *
+ * Scope: the 6 new fields/methods (`runtimeId`, `dispatchers`,
+ * `isEnabled`, `cancel`, `getRunStatus`, `registerSchedules`,
+ * `startWorkerHost`). Existing dispatch + per-job cancel coverage lives
+ * in `packages/tasks/src/__tests__/trigger.service.spec.ts` and is
+ * unchanged by this PR.
+ *
+ * The Trigger.dev SDK and `@ever-works/agent/config` are mocked so the
+ * tests never touch the network and never need real env vars.
+ */
+
+const { configureMock, runsCancelMock, runsRetrieveMock, triggerConfig, subscriptionsConfig } =
+    vi.hoisted(() => {
+        return {
+            configureMock: vi.fn(),
+            runsCancelMock: vi.fn(),
+            runsRetrieveMock: vi.fn(),
+            triggerConfig: {
+                shouldUseTrigger: vi.fn(),
+                getSecretKey: vi.fn(),
+                getApiUrl: vi.fn(),
+                getMachine: vi.fn(),
+                getInternalBaseUrl: vi.fn(),
+                getInternalSecret: vi.fn(),
+            },
+            subscriptionsConfig: { getDispatchIntervalMinutes: vi.fn(() => 5) },
+        };
+    });
+
+vi.mock('@trigger.dev/sdk', () => ({
+    configure: configureMock,
+    runs: { cancel: runsCancelMock, retrieve: runsRetrieveMock },
+    task: vi.fn().mockImplementation(() => ({ id: 'mock-task' })),
+    schedules: { task: vi.fn().mockImplementation(() => ({ id: 'mock-schedule-task' })) },
+    logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@ever-works/agent/config', () => ({
+    config: {
+        trigger: triggerConfig,
+        subscriptions: subscriptionsConfig,
+    },
+}));
+
+vi.mock('@ever-works/agent/tasks', () => ({
+    WORK_GENERATION_DISPATCHER: Symbol('WORK_GENERATION_DISPATCHER'),
+    WORK_IMPORT_DISPATCHER: Symbol('WORK_IMPORT_DISPATCHER'),
+    TEMPLATE_CUSTOMIZATION_DISPATCHER: Symbol('TEMPLATE_CUSTOMIZATION_DISPATCHER'),
+    KB_ORG_OVERLAY_FANOUT_DISPATCHER: Symbol('KB_ORG_OVERLAY_FANOUT_DISPATCHER'),
+}));
+
+// Per-task module mocks — the service imports these eagerly; the runtime
+// surface methods don't call any of them, but the imports must resolve
+// for the service module to load.
+vi.mock('../../tasks/trigger/work-generation.task', () => ({
+    workGenerationTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/work-import.task', () => ({
+    workImportTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/template-customization.task', () => ({
+    templateCustomizationTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/webhook-delivery.task', () => ({
+    webhookDeliveryTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/kb-mirror-document.task', () => ({
+    kbMirrorDocumentTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/kb-backfill-skeleton.task', () => ({
+    kbBackfillSkeletonTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/kb-embed-document.task', () => ({
+    kbEmbedDocumentTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/kb-org-overlay-fanout.task', () => ({
+    kbOrgOverlayFanoutTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/kb-normalize-video.task', () => ({
+    kbNormalizeVideoTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/kb-normalize-audio.task', () => ({
+    kbNormalizeAudioTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/kb-transcribe.task', () => ({
+    kbTranscribeTask: { trigger: vi.fn() },
+}));
+vi.mock('../../tasks/trigger/notification-channel-delivery.task', () => ({
+    notificationChannelDeliveryTask: { trigger: vi.fn() },
+}));
+
+import { TriggerService } from '../trigger.service';
+
+describe('TriggerService — IJobRuntimeProvider structural conformance (EW-686 P1)', () => {
+    let service: TriggerService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        triggerConfig.shouldUseTrigger.mockReturnValue(true);
+        triggerConfig.getSecretKey.mockReturnValue('tr_test_secret');
+        triggerConfig.getApiUrl.mockReturnValue('https://api.trigger.test');
+        triggerConfig.getMachine.mockReturnValue('small-1x');
+        service = new TriggerService();
+        // Silence Nest Logger noise from intentional error paths.
+        vi.spyOn((service as any).logger, 'error').mockImplementation(() => {});
+        vi.spyOn((service as any).logger, 'warn').mockImplementation(() => {});
+        vi.spyOn((service as any).logger, 'debug').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('runtimeId / dispatchers', () => {
+        it('exposes runtimeId === "trigger" to match the EVER_WORKS_JOB_RUNTIME selector', () => {
+            expect(service.runtimeId).toBe('trigger');
+        });
+
+        it('dispatchers is the service instance itself (the dispatcher bag)', () => {
+            // TriggerService already implements every `*Dispatcher`
+            // interface; the binding factory consumes this same instance.
+            expect(service.dispatchers).toBe(service);
+        });
+    });
+
+    describe('isEnabled()', () => {
+        it('returns true when shouldUseTrigger() is true and a secret key is set', () => {
+            expect(service.isEnabled()).toBe(true);
+            expect(configureMock).toHaveBeenCalledTimes(1);
+        });
+
+        it('returns false when shouldUseTrigger() is false', () => {
+            triggerConfig.shouldUseTrigger.mockReturnValue(false);
+            expect(service.isEnabled()).toBe(false);
+            expect(configureMock).not.toHaveBeenCalled();
+        });
+
+        it('returns false when the secret key is missing', () => {
+            triggerConfig.getSecretKey.mockReturnValue('');
+            expect(service.isEnabled()).toBe(false);
+            expect(configureMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('cancel()', () => {
+        it('returns false when the runtime is disabled', async () => {
+            triggerConfig.shouldUseTrigger.mockReturnValue(false);
+            await expect(service.cancel('run_x')).resolves.toBe(false);
+            expect(runsCancelMock).not.toHaveBeenCalled();
+        });
+
+        it('returns true and forwards the run id when runs.cancel resolves', async () => {
+            runsCancelMock.mockResolvedValue(undefined);
+            await expect(service.cancel('run_x')).resolves.toBe(true);
+            expect(runsCancelMock).toHaveBeenCalledWith('run_x');
+        });
+
+        it('returns false when runs.cancel throws (unknown / already-terminal run ids)', async () => {
+            runsCancelMock.mockRejectedValue(new Error('not found'));
+            await expect(service.cancel('run_missing')).resolves.toBe(false);
+        });
+    });
+
+    describe('getRunStatus()', () => {
+        it("returns 'unknown' when the runtime is disabled", async () => {
+            triggerConfig.shouldUseTrigger.mockReturnValue(false);
+            await expect(service.getRunStatus('run_x')).resolves.toBe('unknown');
+            expect(runsRetrieveMock).not.toHaveBeenCalled();
+        });
+
+        it("returns 'unknown' when runs.retrieve throws", async () => {
+            runsRetrieveMock.mockRejectedValue(new Error('network'));
+            await expect(service.getRunStatus('run_x')).resolves.toBe('unknown');
+        });
+
+        it.each([
+            ['PENDING_VERSION', 'queued'],
+            ['QUEUED', 'queued'],
+            ['DEQUEUED', 'queued'],
+            ['WAITING', 'queued'],
+            ['DELAYED', 'queued'],
+            ['EXECUTING', 'running'],
+            ['COMPLETED', 'completed'],
+            ['CANCELED', 'cancelled'],
+            ['FAILED', 'failed'],
+            ['CRASHED', 'failed'],
+            ['SYSTEM_FAILURE', 'failed'],
+            ['TIMED_OUT', 'failed'],
+            ['EXPIRED', 'failed'],
+            ['SOMETHING_NEW_FROM_SDK_V5', 'unknown'],
+        ])('maps Trigger.dev status %s -> JobRunStatus %s', async (triggerStatus, expected) => {
+            runsRetrieveMock.mockResolvedValue({ status: triggerStatus });
+            await expect(service.getRunStatus('run_x')).resolves.toBe(expected);
+            expect(runsRetrieveMock).toHaveBeenCalledWith('run_x');
+        });
+    });
+
+    describe('registerSchedules()', () => {
+        it('is a no-op for the empty list (does not log)', async () => {
+            const debugSpy = vi.spyOn((service as any).logger, 'debug');
+            await expect(service.registerSchedules([])).resolves.toBeUndefined();
+            expect(debugSpy).not.toHaveBeenCalled();
+        });
+
+        it('logs a debug stub line when given a non-empty list (per-task files own real cron)', async () => {
+            const debugSpy = vi.spyOn((service as any).logger, 'debug');
+            await expect(
+                service.registerSchedules([{ id: 'work-schedule', cron: '*/5 * * * *' }]),
+            ).resolves.toBeUndefined();
+            expect(debugSpy).toHaveBeenCalledTimes(1);
+            expect(debugSpy.mock.calls[0][0]).toContain('EW-686 P1');
+        });
+    });
+
+    describe('startWorkerHost()', () => {
+        it('returns a no-op handle with an idempotent stop() (push-model runtime)', async () => {
+            const handle = await service.startWorkerHost({});
+            expect(handle).toBeDefined();
+            expect(typeof handle.stop).toBe('function');
+            // stop() resolves and is safe to call repeatedly.
+            await expect(handle.stop()).resolves.toBeUndefined();
+            await expect(handle.stop()).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
+++ b/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
@@ -1,0 +1,172 @@
+import { Injectable } from '@nestjs/common';
+import type {
+    IJobRuntimeProvider,
+    JobRunStatus,
+    JobRuntimeDispatchers,
+    JobRuntimeId,
+    PluginCategory,
+    PluginContext,
+    ScheduleSpec,
+    WorkerHostHandle,
+    WorkerHostOptions,
+} from '@ever-works/plugin';
+import { TriggerService } from './trigger.service';
+
+/**
+ * EW-686 P1 — adapter that exposes the existing {@link TriggerService}
+ * through the full {@link IJobRuntimeProvider} contract (EW-685 P0,
+ * shipped in `packages/plugin/src/contracts/capabilities/
+ * job-runtime.interface.ts`).
+ *
+ * No behaviour change at runtime: every IJobRuntimeProvider method
+ * delegates straight back into the `TriggerService` instance, which
+ * already implements the IJobRuntimeProvider *method* surface
+ * (`runtimeId`, `dispatchers`, `isEnabled`, `cancel`, `getRunStatus`,
+ * `registerSchedules`, `startWorkerHost`) but deliberately does NOT
+ * `implements IJobRuntimeProvider` — because `IJobRuntimeProvider`
+ * extends `IPlugin` and `TriggerService` is a plain NestJS service that
+ * has no need for the full plugin-manifest surface (id, name, version,
+ * category, capabilities, settingsSchema, onLoad, onUnload).
+ *
+ * This adapter is what closes the gap: it satisfies `IJobRuntimeProvider`
+ * (and therefore `IPlugin`) by adding the synthetic plugin metadata, while
+ * delegating every dispatch/schedule/cancel/status call straight to
+ * `TriggerService`. The EW-685 T4 binding factory (lands in a follow-up
+ * PR at `packages/agent/src/tasks/job-runtime.providers.ts`) injects this
+ * adapter by class and reads `.dispatchers` to wire the `*_DISPATCHER`
+ * symbols — the existing direct `useExisting: TriggerService` bindings
+ * stay untouched until the factory replaces them.
+ *
+ * **Synthetic plugin — NOT registry-discoverable.** The IPlugin metadata
+ * below is stubbed, not loaded from a `package.json` manifest. This class
+ * does NOT participate in `PluginRegistryService` hot-load / discovery;
+ * it's wired into NestJS DI directly by `TriggerModule`. A proper plugin-
+ * manifest extraction (turning the trigger runtime into a sibling of
+ * `packages/plugins/openai` etc.) is tracked under EW-689 — this adapter
+ * is the smallest type-conforming shim that unblocks the EW-685 T4
+ * wiring without pulling the full `@ever-works/plugin` manifest pipeline
+ * into the `@ever-works/trigger-tasks` package.
+ *
+ * Drift note — the EW-683 architecture spec §3 and the IJobRuntimeProvider
+ * contract JSDoc both say a job-runtime plugin declares
+ * `category: 'job-runtime'`, but `PLUGIN_CATEGORIES` in
+ * `packages/plugin/src/contracts/plugin-manifest.types.ts` does NOT yet
+ * list `'job-runtime'` (it's tracked as a follow-up additive change so
+ * existing manifest validators keep passing untouched). The
+ * `as PluginCategory` cast below is deliberate and removes itself
+ * automatically the day `'job-runtime'` is added to the categories tuple.
+ */
+@Injectable()
+export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
+    // -- IPlugin synthetic metadata ----------------------------------------
+    readonly id = 'trigger';
+    readonly name = 'Trigger.dev';
+    readonly version = '1.0.0';
+    // See file header "Drift note" — `'job-runtime'` is not yet in
+    // `PLUGIN_CATEGORIES`; cast is deliberate.
+    readonly category = 'job-runtime' as PluginCategory;
+    readonly capabilities: readonly string[] = [
+        'job-runtime-enqueue',
+        'job-runtime-cancel',
+        'job-runtime-status',
+        'job-runtime-schedule',
+    ];
+    // Synthetic plugin — no operator-tunable settings (Trigger.dev creds
+    // are read from `config.trigger.*` env vars, not from the plugin
+    // settings system). Empty object schema = "accepts no settings".
+    readonly settingsSchema = { type: 'object', properties: {} } as const;
+
+    // -- IJobRuntimeProvider ----------------------------------------------
+    readonly runtimeId: JobRuntimeId = 'trigger';
+
+    constructor(private readonly triggerService: TriggerService) {}
+
+    /**
+     * The dispatchers surface IS the underlying {@link TriggerService}
+     * instance — it already implements every `*Dispatcher` interface
+     * verbatim (`WorkGenerationDispatcher`, `WorkImportDispatcher`,
+     * `TemplateCustomizationDispatcher`, `WebhookDeliveryDispatcher`,
+     * `KbMirrorDocumentDispatcher`, `KbBackfillSkeletonDispatcher`,
+     * `KbEmbedDocumentDispatcher`, `KbOrgOverlayFanoutDispatcher`,
+     * `KbNormalizeMediaDispatcher`, `KbTranscribeDispatcher`).
+     *
+     * Delegates to `triggerService.dispatchers` which itself is the
+     * same `this`-cast `Readonly<Record<string, unknown>>` view of
+     * `TriggerService`. The double-hop (this getter → service getter)
+     * is intentional: it keeps the binding factory's contract simple
+     * (`provider.dispatchers`) without forcing the factory to know
+     * about the underlying service.
+     */
+    get dispatchers(): JobRuntimeDispatchers {
+        return this.triggerService.dispatchers;
+    }
+
+    /**
+     * Delegates to {@link TriggerService.registerSchedules} — Trigger.dev
+     * tasks self-register their schedules at deploy time via
+     * `schedules.task()` SDK calls, so the platform-level ScheduleSpec
+     * list is a no-op for this provider (logged at debug so operators
+     * see the no-op was intentional). See the JSDoc on
+     * `TriggerService.registerSchedules` for the full rationale.
+     */
+    async registerSchedules(schedules: readonly ScheduleSpec[]): Promise<void> {
+        await this.triggerService.registerSchedules(schedules);
+    }
+
+    /**
+     * Delegates to {@link TriggerService.cancel} — single
+     * `runs.cancel(runId)` SDK call, errors swallowed and logged,
+     * `false` when the runtime is disabled OR the SDK call throws.
+     */
+    async cancel(runId: string): Promise<boolean> {
+        return this.triggerService.cancel(runId);
+    }
+
+    /**
+     * Delegates to {@link TriggerService.getRunStatus} — translates
+     * the Trigger.dev SDK v4 status enum onto the contract's 6-value
+     * {@link JobRunStatus} union, with `'unknown'` as the fallback for
+     * disabled-runtime / SDK-error / future-status-widening cases.
+     */
+    async getRunStatus(runId: string): Promise<JobRunStatus> {
+        return this.triggerService.getRunStatus(runId);
+    }
+
+    /**
+     * Delegates to {@link TriggerService.isEnabled} — true when
+     * Trigger.dev is configured and reachable (`shouldUseTrigger()`
+     * AND `TRIGGER_SECRET_KEY` present).
+     */
+    isEnabled(): boolean {
+        return this.triggerService.isEnabled();
+    }
+
+    /**
+     * Delegates to {@link TriggerService.startWorkerHost} — Trigger.dev
+     * is a push-model runtime (Trigger.dev's cloud invokes our tasks),
+     * so this is a no-op returning a no-op handle. Provided so a
+     * generic "start worker host if the provider supports it" caller
+     * Just Works without per-provider branching; pull-model providers
+     * (Temporal, BullMQ, pg-boss) will implement it for real.
+     */
+    async startWorkerHost(opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+        return this.triggerService.startWorkerHost(opts);
+    }
+
+    /**
+     * Lifecycle no-op — synthetic plugin, no resources to acquire.
+     * Real plugins use `onLoad` to capture the `PluginContext` and
+     * stand up SDKs; this adapter already received its `TriggerService`
+     * dependency through NestJS DI in the constructor.
+     */
+    async onLoad(_context: PluginContext): Promise<void> {
+        // Intentional no-op — see class JSDoc on synthetic plugin status.
+    }
+
+    /**
+     * Lifecycle no-op — synthetic plugin, no resources to release.
+     */
+    async onUnload(): Promise<void> {
+        // Intentional no-op — see class JSDoc on synthetic plugin status.
+    }
+}

--- a/packages/tasks/src/trigger/trigger.module.ts
+++ b/packages/tasks/src/trigger/trigger.module.ts
@@ -1,5 +1,6 @@
 import { Global, Module } from '@nestjs/common';
 import { TriggerService } from './trigger.service';
+import { TriggerJobRuntimeProvider } from './trigger-job-runtime.provider';
 import {
     WORK_GENERATION_DISPATCHER,
     WORK_IMPORT_DISPATCHER,
@@ -20,6 +21,16 @@ import {
 @Module({
     providers: [
         TriggerService,
+        // EW-686 P1 — adapter exposing TriggerService through the new
+        // pluggable IJobRuntimeProvider contract. Registered here so the
+        // EW-685 T4 binding factory (a follow-up PR introducing
+        // `packages/agent/src/tasks/job-runtime.providers.ts`) can inject
+        // it by class. The existing `*_DISPATCHER` direct bindings below
+        // stay untouched — the factory replaces them in a later PR; until
+        // then the synthetic adapter and the direct bindings coexist
+        // without conflict (the adapter delegates back into the same
+        // TriggerService instance).
+        TriggerJobRuntimeProvider,
         {
             provide: WORK_GENERATION_DISPATCHER,
             useExisting: TriggerService,
@@ -69,6 +80,7 @@ import {
     ],
     exports: [
         TriggerService,
+        TriggerJobRuntimeProvider,
         WORK_GENERATION_DISPATCHER,
         WORK_IMPORT_DISPATCHER,
         TEMPLATE_CUSTOMIZATION_DISPATCHER,

--- a/packages/tasks/src/trigger/trigger.service.ts
+++ b/packages/tasks/src/trigger/trigger.service.ts
@@ -23,6 +23,14 @@ import {
     KbTranscribePayload,
     KbTranscribeDispatcher,
 } from '@ever-works/agent/tasks';
+import type {
+    JobRunStatus,
+    JobRuntimeDispatchers,
+    JobRuntimeId,
+    ScheduleSpec,
+    WorkerHostHandle,
+    WorkerHostOptions,
+} from '@ever-works/plugin';
 import { workGenerationTask } from '../tasks/trigger/work-generation.task';
 import { workImportTask } from '../tasks/trigger/work-import.task';
 import { templateCustomizationTask } from '../tasks/trigger/template-customization.task';
@@ -54,6 +62,49 @@ export class TriggerService
     private readonly logger = new Logger(TriggerService.name);
     private configured = false;
 
+    /**
+     * EW-686 P1 (first sub-step) — structural conformance with
+     * `IJobRuntimeProvider` from
+     * `packages/plugin/src/contracts/capabilities/job-runtime.interface.ts`.
+     *
+     * Deliberately NOT `implements IJobRuntimeProvider` yet — that
+     * interface extends `IPlugin`, which would force `TriggerService` to
+     * also expose `id` / `name` / `version` / `category` / `capabilities` /
+     * `settingsSchema` / `onLoad` / `onUnload`. Adding the full `IPlugin`
+     * surface to this concrete class belongs in a follow-up sub-PR (either
+     * via `implements IJobRuntimeProvider` once a manifest stub is in
+     * place, or via a thin adapter class that wraps this service). For
+     * now the `*_DISPATCHER` symbols keep their existing `useExisting:
+     * TriggerService` bindings — no call sites change — and the binding
+     * factory landing in a later sub-PR can already consume the structural
+     * `IJobRuntimeProvider` shape via duck typing.
+     *
+     * The 6 fields/methods below mirror §3 of
+     * `docs/specs/architecture/job-runtime-providers.md` exactly:
+     *   - `runtimeId`            (selector match)
+     *   - `dispatchers`          (the `*_DISPATCHER` bag)
+     *   - `isEnabled()`          (reachability gate)
+     *   - `cancel()`             (provider-side abort)
+     *   - `getRunStatus()`       (lifecycle read)
+     *   - `registerSchedules()`  (cron registration)
+     *   - `startWorkerHost?()`   (push-model no-op for Trigger.dev)
+     */
+    readonly runtimeId: JobRuntimeId = 'trigger';
+
+    /**
+     * `TriggerService` IS the dispatcher bag — it already implements
+     * every `*Dispatcher` interface exported from `@ever-works/agent/tasks`
+     * (WorkGeneration, WorkImport, TemplateCustomization, WebhookDelivery,
+     * KbMirrorDocument, KbBackfillSkeleton, KbEmbedDocument,
+     * KbOrgOverlayFanout, KbNormalizeMedia, KbTranscribe + notification
+     * channel delivery). The cast through `unknown` is required because
+     * the contract's {@link JobRuntimeDispatchers} type is intentionally
+     * the opaque `Readonly<Record<string, unknown>>` shape — see the
+     * JSDoc on `JobRuntimeDispatchers` in the contract file for the
+     * `plugin → agent → plugin` cycle-avoidance rationale.
+     */
+    readonly dispatchers: JobRuntimeDispatchers = this as unknown as JobRuntimeDispatchers;
+
     private supportedMachines = [
         'medium-1x',
         'micro',
@@ -84,6 +135,175 @@ export class TriggerService
         configure({ accessToken, baseURL });
         this.configured = true;
         return true;
+    }
+
+    /**
+     * EW-686 P1 — public `IJobRuntimeProvider.isEnabled()` view of the
+     * existing `ensureConfigured()` gate. Returns `true` when
+     * `shouldUseTrigger()` is true AND a `TRIGGER_SECRET_KEY` is present
+     * (the same gate every `dispatchXxx` method already uses internally).
+     *
+     * Side-effects are intentional and harmless: the first call lazily
+     * runs `configure({ accessToken, baseURL })` against `@trigger.dev/sdk`,
+     * identical to what the first dispatch would have done; subsequent
+     * calls are a cheap boolean read.
+     */
+    isEnabled(): boolean {
+        return this.ensureConfigured();
+    }
+
+    /**
+     * EW-686 P1 — provider-side cancellation of an in-flight Trigger.dev
+     * run by run id. Mirrors the existing {@link cancelWorkGeneration}
+     * shape (single `runs.cancel(runId)` SDK call, errors swallowed and
+     * logged, `false` on failure).
+     *
+     * Returns `true` when Trigger.dev accepted the cancel request — not
+     * necessarily when the orchestrator has observed the abort signal
+     * (worker-side abort is a separate concern, unchanged here). Returns
+     * `false` when the runtime is disabled OR the SDK call threw
+     * (typically unknown / already-terminal run ids).
+     */
+    async cancel(runId: string): Promise<boolean> {
+        if (!this.ensureConfigured()) {
+            return false;
+        }
+
+        try {
+            await runs.cancel(runId);
+            return true;
+        } catch (error) {
+            this.logger.warn(`Failed to cancel Trigger.dev run ${runId}: ${error}`);
+            return false;
+        }
+    }
+
+    /**
+     * EW-686 P1 — look up live lifecycle of a Trigger.dev run. Returns
+     * `'unknown'` when the runtime is disabled OR the run id can't be
+     * resolved (pruned past retention, cross-provider run id, network
+     * error) — per the contract, callers treat `'unknown'` as "stale,
+     * try DB instead" rather than as a hard failure.
+     *
+     * Mapping is driven by the actual `@trigger.dev/sdk` v4 status enum
+     * observed at `@trigger.dev/sdk/dist/.../v3/runs.d.ts`:
+     *   `PENDING_VERSION | QUEUED | DEQUEUED | EXECUTING | WAITING |
+     *    COMPLETED | CANCELED | FAILED | CRASHED | SYSTEM_FAILURE |
+     *    DELAYED | EXPIRED | TIMED_OUT`.
+     *
+     * Note Trigger.dev uses single-L `CANCELED` (US spelling); the
+     * contract uses double-L `cancelled` (matches the DB enums in
+     * `@ever-works/agent`). All terminal-failure states collapse into
+     * `'failed'` — the contract intentionally does not distinguish
+     * user-failure vs system-failure vs timeout (that detail belongs in
+     * provider-specific telemetry, not in the cross-provider surface).
+     */
+    async getRunStatus(runId: string): Promise<JobRunStatus> {
+        if (!this.ensureConfigured()) {
+            return 'unknown';
+        }
+
+        try {
+            const run = await runs.retrieve(runId);
+            return this.mapTriggerStatus(run.status);
+        } catch (error) {
+            this.logger.debug(`getRunStatus(${runId}) failed: ${error}`);
+            return 'unknown';
+        }
+    }
+
+    /**
+     * EW-686 P1 — schedule registration is currently a no-op for the
+     * Trigger.dev provider.
+     *
+     * Trigger.dev tasks self-register their cron at deploy time via the
+     * `schedules.task()` SDK call inside the per-task files under
+     * `packages/tasks/src/tasks/trigger/` — the `pnpm deploy:trigger`
+     * pipeline is what actually wires cron up against Trigger.dev's
+     * Schedules service. The platform-level `ScheduleSpec[]` list this
+     * contract method accepts is therefore unused for Trigger.dev;
+     * pull-model providers landing later (Temporal, BullMQ, pg-boss)
+     * will translate the list into their native cron mechanism.
+     *
+     * Logged at debug so an operator inspecting logs sees the no-op
+     * was intentional, not a missed hookup.
+     */
+    async registerSchedules(schedules: readonly ScheduleSpec[]): Promise<void> {
+        if (schedules.length > 0) {
+            this.logger.debug(
+                `EW-686 P1: schedule registration stub; cron jobs still ship via the ` +
+                    `per-task schedule files in packages/tasks/src/tasks/trigger/ ` +
+                    `(received ${schedules.length} ScheduleSpec entries, ignored).`,
+            );
+        }
+    }
+
+    /**
+     * EW-686 P1 — worker hosting is a no-op for the Trigger.dev provider.
+     *
+     * Trigger.dev is a **push-model** runtime: Trigger.dev's cloud
+     * invokes our deployed task package on its own machines — we don't
+     * stand up or poll a worker process from the API. The optional
+     * `startWorkerHost` exists on the contract for **pull-model**
+     * providers (Temporal worker, BullMQ Worker, pg-boss subscribe) that
+     * land in later sub-PRs. For Trigger.dev we return a no-op handle so
+     * a generic "start worker host if the provider supports it" caller
+     * Just Works without per-provider branching.
+     */
+    async startWorkerHost(_opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+        this.logger.debug(
+            'EW-686 P1: startWorkerHost() is a no-op for Trigger.dev (push-model runtime; ' +
+                "Trigger.dev's cloud invokes the deployed task package directly).",
+        );
+        return {
+            stop: async () => {
+                // No-op; nothing to drain.
+            },
+        };
+    }
+
+    /**
+     * EW-686 P1 — translate a Trigger.dev v4 SDK status string into the
+     * 6-value {@link JobRunStatus} union the contract exposes. Unknown
+     * values fall back to `'unknown'` rather than throwing so a future
+     * Trigger.dev SDK widening doesn't break callers — operators get
+     * the `'unknown'` fallback (which they already handle for
+     * cross-provider run ids) and the spec/code drift is caught by the
+     * conformance suite landing per EW-685 T6 / EW-750.
+     */
+    private mapTriggerStatus(status: string): JobRunStatus {
+        switch (status) {
+            // Pre-execution: still in Trigger.dev's queue, waiting for
+            // capacity / a deployed worker version / a delay timer.
+            case 'PENDING_VERSION':
+            case 'QUEUED':
+            case 'DEQUEUED':
+            case 'WAITING':
+            case 'DELAYED':
+                return 'queued';
+
+            case 'EXECUTING':
+                return 'running';
+
+            case 'COMPLETED':
+                return 'completed';
+
+            // Trigger.dev SDK v4 uses single-L `CANCELED`; the contract
+            // uses double-L `cancelled` (matches the DB enums).
+            case 'CANCELED':
+                return 'cancelled';
+
+            // All terminal-failure states collapse into `'failed'`.
+            case 'FAILED':
+            case 'CRASHED':
+            case 'SYSTEM_FAILURE':
+            case 'TIMED_OUT':
+            case 'EXPIRED':
+                return 'failed';
+
+            default:
+                return 'unknown';
+        }
     }
 
     private machine() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2744,6 +2744,9 @@ importers:
       '@ever-works/agent':
         specifier: workspace:*
         version: link:../agent
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../plugin
       '@nestjs/cache-manager':
         specifier: ^3.1.0
         version: 3.1.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)


### PR DESCRIPTION
## Summary

EW-686 P1 — rehouse the existing TriggerService as an `IJobRuntimeProvider` implementation (contract shipped in #1354). **No behaviour change**: the `*_DISPATCHER` direct `useExisting: TriggerService` bindings in `trigger.module.ts` stay; the EW-685 T4 binding factory (next PR) replaces them.

## Approach — two-layered

### Layer 1: `TriggerService` (in-place additions)

The concrete service now exposes the 6-method `IJobRuntimeProvider` *method* surface directly so a binding factory can structurally consume it without needing the adapter:

- `runtimeId: JobRuntimeId = 'trigger'`
- `dispatchers: JobRuntimeDispatchers = this as unknown as JobRuntimeDispatchers` — service already implements 10 dispatcher interfaces verbatim
- `isEnabled(): boolean` — public view of existing `ensureConfigured()` gate
- `async cancel(runId: string): Promise<boolean>` — single `runs.cancel(runId)` SDK call, errors swallowed and logged
- `async getRunStatus(runId: string): Promise<JobRunStatus>` — `runs.retrieve(runId)` + `mapTriggerStatus`
- `async registerSchedules(schedules): Promise<void>` — no-op (Trigger.dev tasks self-register at deploy time)
- `async startWorkerHost(opts): Promise<WorkerHostHandle>` — no-op handle (push model)

Deliberately does NOT `implements IJobRuntimeProvider` — the contract extends `IPlugin` and TriggerService is a plain NestJS service with no plugin-manifest surface.

### Layer 2: `TriggerJobRuntimeProvider` (new adapter)

Thin `@Injectable()` wrapper that adds the `IPlugin` synthetic metadata (id='trigger', name='Trigger.dev', version='1.0.0', category='job-runtime', 4-entry capabilities, empty settingsSchema, no-op onLoad/onUnload) and delegates every IJobRuntimeProvider method back into TriggerService.

This is a **synthetic plugin** — NOT registry-discoverable; wired into NestJS DI directly by `TriggerModule`. Full plugin-manifest extraction (sibling of `packages/plugins/openai` etc.) is tracked under EW-689.

## Status mapping (actual @trigger.dev/sdk v4 enum verified against installed types)

| Trigger.dev status                              | JobRunStatus  |
| ----------------------------------------------- | ------------- |
| PENDING_VERSION, QUEUED, DEQUEUED, DELAYED      | queued        |
| EXECUTING, WAITING                              | running       |
| COMPLETED                                       | completed     |
| FAILED, CRASHED, SYSTEM_FAILURE, TIMED_OUT, EXPIRED | failed     |
| CANCELED (single-L US spelling)                 | cancelled (double-L per contract / DB enums) |

## Drift noted (deferred follow-ups)

- `PLUGIN_CATEGORIES` tuple in `packages/plugin/src/contracts/plugin-manifest.types.ts` does NOT yet list `'job-runtime'`. Adapter uses `'job-runtime' as PluginCategory` cast — documented in the class JSDoc. Additive change to add it is a separate follow-up PR.
- `docs/specs/architecture/job-runtime-providers.md` §10 file index shows planned location `packages/plugins/job-runtime-trigger/` for the eventual standalone plugin extraction; tracked under EW-689.

## Files

| Path                                                                    | Change   | LOC  |
| ----------------------------------------------------------------------- | -------- | ---- |
| `packages/tasks/package.json`                                           | +1 dep   | +1   |
| `packages/tasks/src/trigger/trigger.module.ts`                          | register | +12  |
| `packages/tasks/src/trigger/trigger.service.ts`                         | methods  | +220 |
| `packages/tasks/src/trigger/trigger-job-runtime.provider.ts`            | NEW      | ~165 |
| `packages/tasks/src/trigger/__tests__/trigger-job-runtime.provider.spec.ts` | NEW  | ~210 |
| `packages/tasks/src/trigger/__tests__/trigger.service.runtime.spec.ts`  | NEW      | ~250 |

## Test plan

- [ ] CI green (lint + typecheck + vitest)
- [ ] After cascade to main: API container boots unchanged (logs show TriggerService still wired against existing `*_DISPATCHER` symbols)
- [ ] Sanity: `TRIGGER_SECRET_KEY` unset → `isEnabled()` returns false → `cancel()` and `getRunStatus()` short-circuit

## Cascade

PR to develop → cascade develop → stage → main per `feedback_release_flow_develop_stage_main`.

## What's next (NOT in this PR)

- EW-685 T4 — `packages/agent/src/tasks/job-runtime.providers.ts` binding factory consumes `TriggerJobRuntimeProvider.dispatchers` and replaces the direct `useExisting` bindings
- EW-685 T3 — `EVER_WORKS_JOB_RUNTIME` env var reading
- EW-685 T5 — Constitution Principle IV amendment
- EW-685 T6 — startup log of active runtime id
- Add `'job-runtime'` to `PLUGIN_CATEGORIES` tuple (additive)
- EW-689 — extract as standalone `packages/plugins/job-runtime-trigger/`