### PR TITLE
docs: address greptile P1+P2 feedback on #1372 and #1376

### DIFF
--- a/packages/agent/src/tasks/job-runtime.providers.ts
+++ b/packages/agent/src/tasks/job-runtime.providers.ts
@@ -104,12 +104,17 @@ export interface JobRuntimeProviderRegistry {
 /**
  * Default in-memory {@link JobRuntimeProviderRegistry} implementation.
  *
- * Module-local mutable singleton because the binding factory in P0 is
- * declared but not wired into a NestJS module — tests instantiate this
- * class directly and the future `TasksModule` wiring will provide a
- * DI-managed instance. Keeping the implementation a plain class (not a
- * `@Injectable()` service) avoids importing the NestJS runtime into
- * `@ever-works/agent/tasks` ahead of need.
+ * Plain instantiable class — NOT a singleton at the class level. The
+ * single-active-runtime invariant (EW-683 §4) is enforced at the DI
+ * layer: the future `TasksModule` wiring registers exactly one
+ * instance as a NestJS provider, and call sites resolve through DI.
+ * Tests freely create fresh `new InMemoryJobRuntimeProviderRegistry()`
+ * instances for isolation; nothing in the class itself guards against
+ * multiple constructions.
+ *
+ * Kept as a plain class (not a `@Injectable()` service) so the binding
+ * factory in P0 — declared but not yet wired — doesn't drag the NestJS
+ * runtime into `@ever-works/agent/tasks` ahead of need.
  */
 export class InMemoryJobRuntimeProviderRegistry implements JobRuntimeProviderRegistry {
     private active: IJobRuntimeProvider | null = null;

--- a/packages/tasks/src/trigger/trigger.service.ts
+++ b/packages/tasks/src/trigger/trigger.service.ts
@@ -275,6 +275,10 @@ export class TriggerService
         switch (status) {
             // Pre-execution: still in Trigger.dev's queue, waiting for
             // capacity / a deployed worker version / a delay timer.
+            // NB Trigger.dev's `WAITING` is a pre-execution state (the
+            // task is waiting for a slot), NOT a within-execution wait
+            // (e.g. a `wait.for(...)` inside a running task). Hence the
+            // mapping to the cross-provider `'queued'`, not `'running'`.
             case 'PENDING_VERSION':
             case 'QUEUED':
             case 'DEQUEUED':


### PR DESCRIPTION
Docs-only follow-up addressing greptile bot review on the just-merged EW-685 T4 + EW-686 P1 PRs.

## PR #1376 (T4 binding factory) — P2

`InMemoryJobRuntimeProviderRegistry` JSDoc rephrased: drop the misleading 'module-local mutable singleton' wording. The class is a plain instantiable class; tests create fresh `new InMemoryJobRuntimeProviderRegistry()` instances freely. The single-active-runtime invariant (EW-683 §4) is a DI-layer concern (NestJS provides exactly one instance), not a class-level guard.

## PR #1372 (TriggerService rehouse) — P1

Bot suggested the test expecting `WAITING -> queued` should change to `running` to match the PR description. The bot misread:

- Trigger.dev's `WAITING` is a **pre-execution** state (the task is waiting for a slot / version / delay timer), NOT a within-execution wait (e.g. `wait.for(...)` inside a running task).
- Mapping to the cross-provider `'queued'` is correct.
- The implementation + test are both right; only the PR description's status table was slightly inconsistent (and the PR is already merged).

Added a clarifying inline comment to the `mapTriggerStatus` switch so future readers (and bots) don't fall into the same trap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for the job runtime provider registry configuration.
  * Improved trigger status mapping documentation to better explain queue state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->