### PR TITLE
feat(agent): EW-742 P3 / EW-747 — tenant-aware runtime resolver (minimal: T20 + T23 + T24)

### DIFF
--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
@@ -2,7 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from '@ever-works/agent/database';
 import { TenantJobRuntimeAudit, TenantJobRuntimeConfig } from '@ever-works/agent/entities';
-import { CredentialVersionService, TenantCredentialCache } from '@ever-works/agent/tasks';
+import {
+    CredentialVersionService,
+    InMemoryJobRuntimeProviderRegistry,
+    JOB_RUNTIME_PROVIDER_REGISTRY,
+    TenantAwareRuntimeResolver,
+    TenantCredentialCache,
+} from '@ever-works/agent/tasks';
 import { TenantJobRuntimeController } from './tenant-job-runtime.controller';
 import { TenantJobRuntimeService } from './tenant-job-runtime.service';
 
@@ -13,35 +19,47 @@ import { TenantJobRuntimeService } from './tenant-job-runtime.service';
  *
  * Spec: [`docs/specs/features/tenant-job-runtime-overlay/spec.md`](../../../../docs/specs/features/tenant-job-runtime-overlay/spec.md)
  * Plan: [`plan.md` §4 API surface](../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md#4-api-surface)
- * Tasks: [`tasks.md` T14](../../../../docs/specs/features/tenant-job-runtime-overlay/tasks.md)
+ * Tasks: [`tasks.md` T14 + T20 + T21](../../../../docs/specs/features/tenant-job-runtime-overlay/tasks.md)
  *
  * Imports the global `DatabaseModule` (provides the TypeORM connection)
  * plus `TypeOrmModule.forFeature([...])` so the service can inject the
  * scoped `Repository<TenantJobRuntimeConfig>` and
- * `Repository<TenantJobRuntimeAudit>`. `CredentialVersionService` is
- * provided locally rather than imported via a separate module — it lives
- * in `@ever-works/agent/tasks` and needs the same forFeature
- * registration to resolve its own `@InjectRepository(TenantJobRuntimeConfig)`.
- * Co-providing it here keeps the DI graph flat; if another module ever
- * needs the same service, hoist it into a dedicated providers module
- * and import.
+ * `Repository<TenantJobRuntimeAudit>`. `CredentialVersionService`,
+ * `TenantAwareRuntimeResolver` (EW-742 P3 / EW-747 T20), and
+ * `TenantCredentialCache` (EW-742 P3.1 / T21) are provided locally rather
+ * than imported via a separate module — they live in
+ * `@ever-works/agent/tasks` and need the same forFeature registration
+ * to resolve their own `@InjectRepository(TenantJobRuntimeConfig)`.
+ * Co-providing here keeps the DI graph flat; if another module ever
+ * needs the same services, hoist them into a dedicated providers
+ * module and import.
  *
- * `TenantCredentialCache` (EW-742 P3.1 / T21) is also provided + exported
- * here. It has zero DI dependencies (a dumb in-memory LRU+TTL bag) but
- * lives in `@ever-works/agent/tasks` alongside `CredentialVersionService`
- * for the same packaging reasons, so co-providing it here keeps the wiring
- * symmetric. Consumers (the P3 tenant-aware resolver and the future P4
- * worker host) inject it directly — this module is not their entry point
- * yet, the cache simply needs SOMEONE to register it as a NestJS provider
- * so it shows up in the app's DI container as a singleton.
+ * The `JOB_RUNTIME_PROVIDER_REGISTRY` provider binds the in-memory
+ * default implementation per EW-685 P0 T4 — same single-active-runtime
+ * semantic as before. The resolver wraps it without changing the
+ * registry contract; non-overridden tenants still resolve to whatever
+ * the registry returns from `getActive()`.
+ *
+ * `TenantCredentialCache` is a dumb in-memory LRU+TTL bag (zero DI deps)
+ * exposed via `exports` so the P3 resolver and future P4 worker host
+ * can inject it. This module is its registration point.
  */
 @Module({
     imports: [
         DatabaseModule,
         TypeOrmModule.forFeature([TenantJobRuntimeConfig, TenantJobRuntimeAudit]),
     ],
-    providers: [TenantJobRuntimeService, CredentialVersionService, TenantCredentialCache],
+    providers: [
+        TenantJobRuntimeService,
+        CredentialVersionService,
+        TenantAwareRuntimeResolver,
+        TenantCredentialCache,
+        {
+            provide: JOB_RUNTIME_PROVIDER_REGISTRY,
+            useClass: InMemoryJobRuntimeProviderRegistry,
+        },
+    ],
     controllers: [TenantJobRuntimeController],
-    exports: [TenantCredentialCache],
+    exports: [TenantCredentialCache, TenantAwareRuntimeResolver],
 })
 export class TenantJobRuntimeModule {}

--- a/docs/specs/features/tenant-job-runtime-overlay/tasks.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/tasks.md
@@ -1,7 +1,7 @@
 # Task Breakdown: Tenant-Scoped Job-Runtime Overlay
 
 **Feature ID**: `tenant-job-runtime-overlay`
-**Status**: `In progress` — P0 + P1.0 + P1 + P2.0 + P2.1 + P3.1 (credential cache only) + P5 landed on `main`. P2.2 (schema-driven form + e2e), the rest of P3 (T20/T22/T23/T24 — resolver + version-capture + tests, paired with #1380), P4 (worker host, blocked on EW-685/EW-686), P5.1 (per-tenant whitelist), P6 (conformance), and P7 (docs) remain.
+**Status**: `In progress` — P0 + P1.0 + P1 + P2.0 + P2.1 + P3 (T20+T23+T24 resolver) + P3.1 (T21 cache) + P5 + P7 (T41+T42) landed on `main` or in this PR. P2.2 (schema-driven form + e2e), P3.1 (T22 enqueue capture), P4 (worker host, blocked on EW-686 P2), P5.1 (per-tenant whitelist), P6 (conformance), and P7 (docs T43/T44) remain.
 **Last updated**: 2026-06-18
 **Spec**: [`./spec.md`](./spec.md) · **Plan**: [`./plan.md`](./plan.md) · **Providers**: [`./providers.md`](./providers.md) · **Epic**: [EW-742](https://evertech.atlassian.net/browse/EW-742) · **Story**: [EW-743](https://evertech.atlassian.net/browse/EW-743) · **ADR**: [ADR-017](../../decisions/017-tenant-scoped-job-runtime-overlay.md)
 
@@ -41,13 +41,17 @@ P2.0 (REST API) ✅ Done in [#1341](https://github.com/ever-works/ever-works/pul
 
 ## Phase 3 — Dispatcher routing · `[EW-742 P3]`
 
-P3.1 (T21 credential cache) ships as a standalone class so it can be layered into both the P3 resolver (paired with #1380) and the future P4 worker host without coupling those PRs. T20 / T22 / T23 / T24 remain.
+T20 + T23 + T24 ✅ Done in this PR (#1380, EW-747 — minimal viable resolver, byo/override modes return instance default with `Logger.debug` deferral note until per-provider credential-binding API lands). T21 (cache) ✅ shipped in [#1381](https://github.com/ever-works/ever-works/pull/1381). T22 (enqueue capture) deferred to Phase 3.1.
 
-- [ ] **T20.** Extend EW-685's binding factory (`packages/agent/src/tasks/job-runtime.providers.ts`) with a tenant-aware resolver that takes `(tenantId, jobName)` and returns the active `IJobRuntimeProvider` bound to that tenant's overlay credentials (or the inherited instance default).
-- [x] **T21.** Credential cache with 15–60s TTL in `packages/agent/src/tasks/tenant-credential.cache.ts` — keyed by `(tenantId, providerId, credentialVersion)`, in-process LRU with explicit invalidate on version bump or force-invalidate. Standalone `@Injectable()` class with no DI dependencies (defaults: `maxEntries=1024`, `ttlMs=30_000`); insertion-order LRU (no promotion-on-read so an in-flight run's snapshot does not get kept alive past its rotation window — see ADR-017 §3 / Q4). Provided + exported via `TenantJobRuntimeModule`. Consumer wiring (P3 resolver + P4 worker host) lands in their respective PRs. PR: [#1381](https://github.com/ever-works/ever-works/pull/1381).
-- [ ] **T22.** Credential version capture at every enqueue (Q4) — extend dispatch call sites to read the current `(tenantId, providerId)` version from `CredentialVersionService` and stamp `credentialVersion` into the run record so the worker host resolves the same snapshot when the job runs.
-- [ ] **T23.** Fallback path to instance-global default when a tenant has no overlay row — resolver returns the EW-683 instance binding unchanged; tests in T24 prove zero-overhead for tenants that never opt in.
-- [ ] **T24.** Unit tests for the resolver under `packages/agent/src/tasks/__tests__/tenant-job-runtime.resolver.spec.ts` covering inherit fallback, BYO overlay, cache hit/miss, version-snapshot resolution, and cache invalidation on rotation.
+- [x] **T20.** Tenant-aware resolver at `packages/agent/src/tasks/tenant-aware-runtime.resolver.ts` (`TenantAwareRuntimeResolver`) wraps the EW-685 P0 T4 binding-factory registry: `resolve(tenantId)` returns the instance default for `null` / no-row / inherit / disabled; for `byo` + `override` + `enabled` it logs the deferral and still returns the instance default until EW-686 P2 lands the per-provider credential-binding hook. `getEffectiveBinding(tenantId)` returns the metadata T22 will stamp onto the run record.
+- [x] **T21.** Credential cache with 15–60s TTL in `packages/agent/src/tasks/tenant-credential.cache.ts` — keyed by `(tenantId, providerId, credentialVersion)`, in-process LRU with explicit invalidate on version bump or force-invalidate. Standalone `@Injectable()` class with no DI dependencies (defaults: `maxEntries=1024`, `ttlMs=30_000`); insertion-order LRU (no promotion-on-read so an in-flight runs snapshot does not get kept alive past its rotation window — see ADR-017 §3 / Q4). Provided + exported via `TenantJobRuntimeModule`. PR: [#1381](https://github.com/ever-works/ever-works/pull/1381).
+- [ ] **T22.** Credential version capture at every enqueue (Q4) — extend dispatch call sites to read the current `(tenantId, providerId)` version from `CredentialVersionService` and stamp `credentialVersion` into the run record so the worker host resolves the same snapshot when the job runs. **(Deferred to P3.1.)**
+- [x] **T23.** Fallback path to instance-global default when a tenant has no overlay row — resolver returns the EW-683 instance binding unchanged; the `getActive() = null` semantic propagates as `null` (in-process dev fallback preserved). Tests in T24 prove the zero-overhead path for tenants that never opt in.
+- [x] **T24.** Unit tests for the resolver under `packages/agent/src/tasks/__tests__/tenant-aware-runtime.resolver.spec.ts` — 12 cases covering inherit fallback, no-row fallback, kill switch, byo/override stopgap + log emission, `getEffectiveBinding` metadata, and the `getActive() = null` propagation.
+
+### Phase 3.1 — Enqueue capture (deferred)
+
+- [ ] **T22** (above) ships once a follow-up PR walks the enqueue call sites to stamp `credentialVersion` into each run record. The T21 cache is already in place to serve the snapshot lookup at run time.
 
 ## Phase 4 — Worker host · `[EW-742 P4]`
 

--- a/packages/agent/src/tasks/__tests__/tenant-aware-runtime.resolver.spec.ts
+++ b/packages/agent/src/tasks/__tests__/tenant-aware-runtime.resolver.spec.ts
@@ -1,0 +1,323 @@
+import type { IJobRuntimeProvider, JobRuntimeDispatchers } from '@ever-works/plugin';
+import { Logger } from '@nestjs/common';
+import type { Repository } from 'typeorm';
+import { CredentialVersionService } from '../credential-version.service';
+import { TenantJobRuntimeConfig } from '../../entities/tenant-job-runtime-config.entity';
+import { InMemoryJobRuntimeProviderRegistry } from '../job-runtime.providers';
+import { TenantAwareRuntimeResolver } from '../tenant-aware-runtime.resolver';
+
+/**
+ * EW-742 P3 / EW-747 (T24) — tenant-aware resolver unit tests.
+ *
+ * Covers the minimal-viable subset of T20 + T23 that ships this PR:
+ *
+ *   - null / undefined / no-row / inherit / disabled → instance default
+ *     (T23 fallback, plus the kill switch path);
+ *   - byo + override modes with `enabled = true` → instance default
+ *     (P3.1 honest stopgap — see resolver class JSDoc), with
+ *     `Logger.debug` proving the deferral was logged;
+ *   - `getEffectiveBinding` returns the metadata T22 will need to stamp
+ *     onto the run record at enqueue time;
+ *   - `registry.getActive()` returning `null` propagates as `null` (the
+ *     EW-683 in-process dev fallback semantic — preserved).
+ *
+ * Deliberately NOT covered here (deferred PRs own these):
+ *   - T21 (cache hit/miss + invalidation on rotation)
+ *   - T22 (enqueue-site `credentialVersion` capture)
+ *   - per-provider credential injection (EW-686 P2)
+ */
+describe('TenantAwareRuntimeResolver (EW-742 P3 / EW-747 T20 + T23 + T24)', () => {
+    /**
+     * Build a minimal {@link IJobRuntimeProvider} test double. We only
+     * exercise identity here — the resolver hands the registry's
+     * provider back as-is — so the `dispatchers` payload is just a
+     * sentinel string keyed by `which`.
+     */
+    function mockProvider(
+        dispatchers: JobRuntimeDispatchers = { sentinel: 'instance-default' },
+    ): IJobRuntimeProvider {
+        return {
+            id: 'mock',
+            name: 'Mock Provider',
+            version: '0.0.0-test',
+            category: 'job-runtime' as IJobRuntimeProvider['category'],
+            capabilities: [],
+            settingsSchema: { type: 'object', properties: {} },
+            runtimeId: 'trigger',
+            dispatchers,
+            async registerSchedules() {
+                /* no-op */
+            },
+            async cancel() {
+                return false;
+            },
+            async getRunStatus() {
+                return 'unknown';
+            },
+            isEnabled() {
+                return true;
+            },
+            async onLoad() {
+                /* no-op */
+            },
+            async onUnload() {
+                /* no-op */
+            },
+        } satisfies IJobRuntimeProvider;
+    }
+
+    function buildConfigRow(
+        overrides: Partial<TenantJobRuntimeConfig> = {},
+    ): TenantJobRuntimeConfig {
+        const now = new Date('2026-06-18T12:00:00.000Z');
+        return {
+            tenantId: 'tenant-1',
+            providerId: 'trigger',
+            credentialsSecretRef: 'tenant-job-runtime:abc123:trigger:v1',
+            credentialVersion: 7,
+            mode: 'byo',
+            enabled: true,
+            createdBy: 'user-1',
+            createdAt: now,
+            updatedAt: now,
+            ...overrides,
+        } as TenantJobRuntimeConfig;
+    }
+
+    type ConfigRepoMock = Pick<Repository<TenantJobRuntimeConfig>, 'findOne'> & {
+        findOne: jest.Mock;
+    };
+
+    type CredentialVersionServiceMock = Pick<CredentialVersionService, 'getCurrentVersion'> & {
+        getCurrentVersion: jest.Mock;
+    };
+
+    function buildResolver(
+        opts: {
+            registry?: InMemoryJobRuntimeProviderRegistry;
+            repoFindOneReturn?: TenantJobRuntimeConfig | null;
+            credentialVersion?: number | null;
+        } = {},
+    ): {
+        resolver: TenantAwareRuntimeResolver;
+        registry: InMemoryJobRuntimeProviderRegistry;
+        configRepo: ConfigRepoMock;
+        credentialVersionService: CredentialVersionServiceMock;
+    } {
+        const registry = opts.registry ?? new InMemoryJobRuntimeProviderRegistry();
+        const configRepo: ConfigRepoMock = {
+            findOne: jest.fn().mockResolvedValue(opts.repoFindOneReturn ?? null),
+        };
+        const credentialVersionService: CredentialVersionServiceMock = {
+            getCurrentVersion: jest.fn().mockResolvedValue(opts.credentialVersion ?? null),
+        };
+        const resolver = new TenantAwareRuntimeResolver(
+            registry,
+            configRepo as unknown as Repository<TenantJobRuntimeConfig>,
+            credentialVersionService as unknown as CredentialVersionService,
+        );
+        return { resolver, registry, configRepo, credentialVersionService };
+    }
+
+    describe('resolve(tenantId)', () => {
+        it('returns the instance default when tenantId is null (no DB hit)', async () => {
+            const provider = mockProvider({ which: 'instance-default' });
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(provider);
+            const { resolver, configRepo } = buildResolver({ registry });
+
+            await expect(resolver.resolve(null)).resolves.toBe(provider);
+            // Pre-tenancy code path is byte-identical — no DB read at all.
+            expect(configRepo.findOne).not.toHaveBeenCalled();
+        });
+
+        it('returns the instance default when tenantId is undefined (no DB hit)', async () => {
+            const provider = mockProvider({ which: 'instance-default' });
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(provider);
+            const { resolver, configRepo } = buildResolver({ registry });
+
+            await expect(resolver.resolve(undefined)).resolves.toBe(provider);
+            expect(configRepo.findOne).not.toHaveBeenCalled();
+        });
+
+        it('returns the instance default when the tenant has no overlay row (T23 fallback)', async () => {
+            const provider = mockProvider({ which: 'instance-default' });
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(provider);
+            const { resolver, configRepo } = buildResolver({
+                registry,
+                repoFindOneReturn: null,
+            });
+
+            await expect(resolver.resolve('tenant-1')).resolves.toBe(provider);
+            expect(configRepo.findOne).toHaveBeenCalledWith({ where: { tenantId: 'tenant-1' } });
+        });
+
+        it("returns the instance default when overlay row mode = 'inherit' (T23 fallback)", async () => {
+            const provider = mockProvider({ which: 'instance-default' });
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(provider);
+            const { resolver } = buildResolver({
+                registry,
+                repoFindOneReturn: buildConfigRow({ mode: 'inherit', credentialsSecretRef: null }),
+            });
+
+            await expect(resolver.resolve('tenant-1')).resolves.toBe(provider);
+        });
+
+        it("returns the instance default when overlay row mode = 'byo' + enabled (P3 stopgap), and logs the deferral", async () => {
+            const debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+            try {
+                const provider = mockProvider({ which: 'instance-default' });
+                const registry = new InMemoryJobRuntimeProviderRegistry();
+                registry.register(provider);
+                const { resolver } = buildResolver({
+                    registry,
+                    repoFindOneReturn: buildConfigRow({ mode: 'byo', enabled: true }),
+                });
+
+                await expect(resolver.resolve('tenant-1')).resolves.toBe(provider);
+                expect(debugSpy).toHaveBeenCalledTimes(1);
+                const message = debugSpy.mock.calls[0][0] as string;
+                expect(message).toContain('tenant tenant-1 overlay mode=byo');
+                expect(message).toContain('tenant override deferred to P3.1');
+            } finally {
+                debugSpy.mockRestore();
+            }
+        });
+
+        it("returns the instance default when overlay row mode = 'override' + enabled (P3 stopgap), and logs the deferral", async () => {
+            const debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+            try {
+                const provider = mockProvider({ which: 'instance-default' });
+                const registry = new InMemoryJobRuntimeProviderRegistry();
+                registry.register(provider);
+                const { resolver } = buildResolver({
+                    registry,
+                    repoFindOneReturn: buildConfigRow({
+                        mode: 'override',
+                        enabled: true,
+                        providerId: 'temporal',
+                    }),
+                });
+
+                await expect(resolver.resolve('tenant-1')).resolves.toBe(provider);
+                expect(debugSpy).toHaveBeenCalledTimes(1);
+                const message = debugSpy.mock.calls[0][0] as string;
+                expect(message).toContain('overlay mode=override');
+                expect(message).toContain('providerId=temporal');
+            } finally {
+                debugSpy.mockRestore();
+            }
+        });
+
+        it("returns the instance default when overlay row enabled = false (kill switch, even with mode = 'byo')", async () => {
+            // Soft kill switch behaves exactly like inherit so the operator
+            // can quickly fall back without dropping the credential pointer.
+            const provider = mockProvider({ which: 'instance-default' });
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(provider);
+            const debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+            try {
+                const { resolver } = buildResolver({
+                    registry,
+                    repoFindOneReturn: buildConfigRow({ mode: 'byo', enabled: false }),
+                });
+
+                await expect(resolver.resolve('tenant-1')).resolves.toBe(provider);
+                // Kill switch is silent — no "deferred to P3.1" log because
+                // the resolver short-circuits before the byo/override branch.
+                expect(debugSpy).not.toHaveBeenCalled();
+            } finally {
+                debugSpy.mockRestore();
+            }
+        });
+
+        it('returns null when no provider is registered (preserves EW-683 in-process dev fallback)', async () => {
+            // The whole point of `getActive(): IJobRuntimeProvider | null`
+            // returning null is so the API's existing in-process fallback
+            // kicks in. The resolver MUST surface that null through to the
+            // caller, not swallow it.
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            const { resolver } = buildResolver({ registry });
+
+            await expect(resolver.resolve('tenant-1')).resolves.toBeNull();
+            await expect(resolver.resolve(null)).resolves.toBeNull();
+        });
+    });
+
+    describe('getEffectiveBinding(tenantId)', () => {
+        it("returns mode='inherit' + credentialVersion=null when tenantId is null (no DB hit)", async () => {
+            const provider = mockProvider({ which: 'instance-default' });
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(provider);
+            const { resolver, configRepo, credentialVersionService } = buildResolver({ registry });
+
+            await expect(resolver.getEffectiveBinding(null)).resolves.toEqual({
+                provider,
+                mode: 'inherit',
+                credentialVersion: null,
+            });
+            expect(configRepo.findOne).not.toHaveBeenCalled();
+            expect(credentialVersionService.getCurrentVersion).not.toHaveBeenCalled();
+        });
+
+        it("returns mode='inherit' + credentialVersion=null when the overlay row is in inherit mode", async () => {
+            const provider = mockProvider({ which: 'instance-default' });
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(provider);
+            const { resolver, credentialVersionService } = buildResolver({
+                registry,
+                repoFindOneReturn: buildConfigRow({ mode: 'inherit', credentialsSecretRef: null }),
+            });
+
+            await expect(resolver.getEffectiveBinding('tenant-1')).resolves.toEqual({
+                provider,
+                mode: 'inherit',
+                credentialVersion: null,
+            });
+            // Version lookup is skipped on inherit — it's a meaningless
+            // call for the platform-default credentials (P1 semantic).
+            expect(credentialVersionService.getCurrentVersion).not.toHaveBeenCalled();
+        });
+
+        it("returns mode='tenant-override' + credentialVersion from the service when overlay row is byo + enabled", async () => {
+            const provider = mockProvider({ which: 'instance-default' });
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(provider);
+            const { resolver, credentialVersionService } = buildResolver({
+                registry,
+                repoFindOneReturn: buildConfigRow({ mode: 'byo', enabled: true }),
+                credentialVersion: 42,
+            });
+
+            await expect(resolver.getEffectiveBinding('tenant-1')).resolves.toEqual({
+                provider,
+                mode: 'tenant-override',
+                credentialVersion: 42,
+            });
+            expect(credentialVersionService.getCurrentVersion).toHaveBeenCalledWith('tenant-1');
+        });
+    });
+
+    describe('robustness', () => {
+        it('does not throw when the repository returns null for an unknown tenant', async () => {
+            // Explicit no-throw guarantee: the resolver MUST treat a
+            // missing overlay row as "use the instance default" rather
+            // than surfacing a 500. Test sibling to the no-row T23
+            // fallback case above — that one proves the return value,
+            // this one pins the no-throw promise so a future refactor
+            // (e.g. switching to `findOneOrFail`) can't silently regress.
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(mockProvider({ which: 'instance-default' }));
+            const { resolver } = buildResolver({ registry, repoFindOneReturn: null });
+
+            await expect(resolver.resolve('unknown-tenant')).resolves.not.toThrow;
+            await expect(resolver.getEffectiveBinding('unknown-tenant')).resolves.toMatchObject({
+                mode: 'inherit',
+                credentialVersion: null,
+            });
+        });
+    });
+});

--- a/packages/agent/src/tasks/_tasks-symbols.ts
+++ b/packages/agent/src/tasks/_tasks-symbols.ts
@@ -30,6 +30,10 @@ export const TASKS_BARREL_RUNTIME_SYMBOLS: ReadonlyArray<string> = [
     // Tenant-scoped job-runtime overlay (EW-742 P1 / EW-745) — credential
     // versioning service for graceful drain on rotation. See ADR-017 §3.
     'CredentialVersionService',
+    // EW-685 P0 T4 — default in-memory implementation of
+    // `JobRuntimeProviderRegistry`, exposed via the barrel so DI modules
+    // can bind it as the `JOB_RUNTIME_PROVIDER_REGISTRY` useClass.
+    'InMemoryJobRuntimeProviderRegistry',
     // EW-685 P0 T4 — DI token for the in-memory job-runtime provider
     // registry consumed by the binding factory `buildJobRuntimeProviders()`.
     // Declared but not wired into any NestJS module yet; see
@@ -43,9 +47,14 @@ export const TASKS_BARREL_RUNTIME_SYMBOLS: ReadonlyArray<string> = [
     'KB_REEMBED_WORK_DISPATCHER',
     'KB_TRANSCRIBE_DISPATCHER',
     'TEMPLATE_CUSTOMIZATION_DISPATCHER',
+    // EW-742 P3 / EW-747 (T20 + T23) — tenant-aware resolver wrapping
+    // the EW-685 binding factory registry. See
+    // `tenant-aware-runtime.resolver.ts` header for the P3 stopgap +
+    // T21 / T22 deferral notes.
+    'TenantAwareRuntimeResolver',
     // Tenant-scoped job-runtime overlay (EW-742 P3.1 / T21) — in-process
     // LRU+TTL credential snapshot cache. Standalone class; the P3
-    // resolver follow-up and P4 worker host layer it in independently.
+    // resolver and P4 worker host layer it in independently.
     'TenantCredentialCache',
     'WEBHOOK_DELIVERY_DISPATCHER',
     'WORK_GENERATION_DISPATCHER',

--- a/packages/agent/src/tasks/index.ts
+++ b/packages/agent/src/tasks/index.ts
@@ -46,11 +46,23 @@ export * from './tenant-credential.cache';
 
 // EW-685 P0 T4 — job-runtime binding factory + registry token.
 //
-// Only the DI token surfaces through the barrel here so the
-// `TASKS_BARREL_RUNTIME_SYMBOLS` pin stays minimal — consumers that need
-// the registry class or `buildJobRuntimeProviders()` import them directly
-// from `./job-runtime.providers`. The factory is declared but not wired
-// into any NestJS module yet; see the file header for the deferred-wiring
-// rationale.
-export { JOB_RUNTIME_PROVIDER_REGISTRY } from './job-runtime.providers';
+// The DI token + the default in-memory registry surface through the
+// barrel so DI modules (e.g. `TenantJobRuntimeModule` for EW-742 P3 /
+// EW-747) can bind `{ provide: JOB_RUNTIME_PROVIDER_REGISTRY, useClass:
+// InMemoryJobRuntimeProviderRegistry }` without reaching into
+// `./job-runtime.providers` directly. `buildJobRuntimeProviders()` stays
+// behind the file boundary because it's a one-shot module-wiring helper,
+// not a DI consumer entry point.
+export {
+    InMemoryJobRuntimeProviderRegistry,
+    JOB_RUNTIME_PROVIDER_REGISTRY,
+} from './job-runtime.providers';
 export type { JobRuntimeProviderRegistry } from './job-runtime.providers';
+
+// EW-742 P3 / EW-747 (T20 + T23) — tenant-aware job-runtime resolver.
+// Wraps the EW-685 binding factory registry so callers can resolve the
+// active provider for a specific tenant; non-overridden tenants pass
+// through to `registry.getActive()`. See the file header on the
+// resolver for the P3 stopgap behaviour and the P3.1 / T21 / T22
+// deferral notes.
+export { TenantAwareRuntimeResolver } from './tenant-aware-runtime.resolver';

--- a/packages/agent/src/tasks/tenant-aware-runtime.resolver.ts
+++ b/packages/agent/src/tasks/tenant-aware-runtime.resolver.ts
@@ -1,0 +1,184 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { IJobRuntimeProvider } from '@ever-works/plugin';
+import { TenantJobRuntimeConfig } from '../entities/tenant-job-runtime-config.entity';
+import { CredentialVersionService } from './credential-version.service';
+import {
+    JOB_RUNTIME_PROVIDER_REGISTRY,
+    type JobRuntimeProviderRegistry,
+} from './job-runtime.providers';
+
+/**
+ * EW-742 P3 / EW-747 (T20 + T23) — tenant-aware job-runtime resolver.
+ *
+ * Sits between the dispatch call sites and the EW-685 P0 T4 binding
+ * factory registry, so the same `*_DISPATCHER` seam can pick a tenant's
+ * overlay provider rather than always returning the instance-global
+ * active provider. Today every call site still goes through the binding
+ * factory and the instance default; this resolver is the next step
+ * toward the per-tenant overlay described in
+ * [`plan.md` §10 P3](../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md#p3--dispatcher-routing-tenant-aware-resolver--credential-version-capture)
+ * and [ADR-017](../../../../docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md).
+ *
+ * # Scope of THIS PR (minimal viable T20 + T23 + T24)
+ *
+ *   - `null` / `undefined` tenantId → instance default (the EW-683
+ *     pre-tenancy code path, byte-identical — no DB hit).
+ *   - No overlay row → instance default (T23 fallback).
+ *   - `mode === 'inherit'` → instance default (T23 fallback).
+ *   - `enabled === false` → instance default (soft kill switch).
+ *   - `mode === 'byo' | 'override'` with `enabled === true` → returns the
+ *     instance default for now with a `Logger.debug` noting the deferral.
+ *     The honest stopgap: the entity exists, the row is read, the
+ *     decision is made, but actually swapping the active provider's
+ *     credentials requires the per-provider credential-binding API that
+ *     lives in EW-686 P2 territory (see TODO block below).
+ *
+ * # Deferred to follow-up PRs (called out as TODO, NOT silently skipped)
+ *
+ *   - **T21 — credential cache (15–60s LRU keyed by
+ *     `(tenantId, providerId, credentialVersion)`)**: every `resolve()`
+ *     call hits the database today. Will land in
+ *     `packages/agent/src/tasks/tenant-credential.cache.ts`.
+ *   - **T22 — credential version capture at every enqueue**: dispatch
+ *     call sites need to stamp `credentialVersion` into the run record
+ *     so the worker host can resolve the same snapshot when the job
+ *     runs. {@link getEffectiveBinding} already returns the metadata
+ *     callers will need; no enqueue-site changes ship in this PR.
+ *   - **Per-provider credential-binding API (EW-686 P2)**: until the
+ *     active `IJobRuntimeProvider` exposes a way to bind a specific
+ *     credential snapshot for one call, `byo` and `override` cannot
+ *     functionally swap credentials. The resolver reads the row and
+ *     logs the decision, but returns the instance default's provider —
+ *     the code path is in place, only the per-provider hook is missing.
+ *
+ * # Why no `getActive(tenantId)` extension on the registry
+ *
+ * EW-685 P0 T4 kept the registry interface deliberately minimal —
+ * `register` + `getActive()`. Pushing the tenant lookup into the
+ * registry would force every registry consumer to think about tenants
+ * even when they don't have one (e.g. boot-time `register()` of the
+ * default provider). The resolver wraps the registry instead: the
+ * registry stays concerned with "what provider is bound for this
+ * deployment", the resolver decides "which provider does THIS tenant
+ * resolve to right now". Same separation `CredentialVersionService`
+ * and the overlay entity already use.
+ */
+@Injectable()
+export class TenantAwareRuntimeResolver {
+    private readonly logger = new Logger(TenantAwareRuntimeResolver.name);
+
+    constructor(
+        @Inject(JOB_RUNTIME_PROVIDER_REGISTRY)
+        private readonly registry: JobRuntimeProviderRegistry,
+        @InjectRepository(TenantJobRuntimeConfig)
+        private readonly configRepository: Repository<TenantJobRuntimeConfig>,
+        private readonly credentialVersionService: CredentialVersionService,
+    ) {}
+
+    /**
+     * Resolves the {@link IJobRuntimeProvider} that should service work
+     * for `tenantId`. Returns `null` when no provider is registered
+     * (the EW-683 in-process dev fallback semantic — preserved from
+     * `JobRuntimeProviderRegistry.getActive()`).
+     *
+     * Honest stopgap for `byo` / `override` modes: see the class JSDoc
+     * — we read the row, log the decision, and return the instance
+     * default because the per-provider credential-binding hook isn't
+     * shipped yet.
+     */
+    async resolve(tenantId: string | null | undefined): Promise<IJobRuntimeProvider | null> {
+        if (!tenantId) {
+            // Preserve the pre-tenancy code path byte-identically: no
+            // tenant context → instance default, no DB hit.
+            return this.registry.getActive();
+        }
+
+        const row = await this.configRepository.findOne({ where: { tenantId } });
+        if (!row) {
+            // T23 fallback: tenant has never opted in to the overlay,
+            // behave exactly like the instance default.
+            return this.registry.getActive();
+        }
+
+        if (!row.enabled) {
+            // Soft kill switch (plan.md §3 / entity JSDoc): operator or
+            // tenant can disable the overlay row without dropping the
+            // credential pointer; resolver MUST treat as inherit.
+            return this.registry.getActive();
+        }
+
+        if (row.mode === 'inherit') {
+            // Same as no row — explicit inherit. Defensive branch so a
+            // future audit-log diff can distinguish "row exists but
+            // inherit" from "no row" at the resolver level.
+            return this.registry.getActive();
+        }
+
+        // mode === 'byo' | 'override' AND enabled — honest stopgap.
+        // See the class JSDoc "Scope of THIS PR" + the per-provider
+        // credential-binding API note. Logger.debug rather than warn
+        // because this is the documented behaviour for P3, not a fault.
+        this.logger.debug(
+            `tenant ${tenantId} overlay mode=${row.mode} providerId=${row.providerId} ` +
+                `credentialVersion=${row.credentialVersion}: returning instance default ` +
+                `(tenant override deferred to P3.1 — credential injection wiring lands ` +
+                `once per-provider credential-binding API exists)`,
+        );
+        return this.registry.getActive();
+    }
+
+    /**
+     * Returns the same provider as {@link resolve} plus the metadata
+     * callers need for run-record stamping (T22 will use this to
+     * capture `credentialVersion` at enqueue time so the worker host
+     * resolves the same snapshot via
+     * {@link CredentialVersionService.resolveSnapshot}).
+     *
+     * Mode mapping:
+     *   - `null` / `undefined` tenantId → `mode = 'inherit'`,
+     *     `credentialVersion = null`.
+     *   - No overlay row OR `mode = 'inherit'` OR `enabled = false` →
+     *     `mode = 'inherit'`, `credentialVersion = null`.
+     *   - `mode = 'byo' | 'override'` AND `enabled = true` →
+     *     `mode = 'tenant-override'`, `credentialVersion` from
+     *     {@link CredentialVersionService.getCurrentVersion}.
+     *
+     * The returned `provider` is whatever {@link resolve} would return
+     * today — including the honest-stopgap behaviour for byo/override.
+     */
+    async getEffectiveBinding(tenantId: string | null | undefined): Promise<{
+        provider: IJobRuntimeProvider | null;
+        mode: 'inherit' | 'tenant-override';
+        credentialVersion: number | null;
+    }> {
+        if (!tenantId) {
+            return {
+                provider: this.registry.getActive(),
+                mode: 'inherit',
+                credentialVersion: null,
+            };
+        }
+
+        const row = await this.configRepository.findOne({ where: { tenantId } });
+        if (!row || !row.enabled || row.mode === 'inherit') {
+            return {
+                provider: this.registry.getActive(),
+                mode: 'inherit',
+                credentialVersion: null,
+            };
+        }
+
+        // byo / override + enabled — read the current version so T22
+        // can stamp it onto the run record. The provider itself is
+        // still the instance default (see class JSDoc on the
+        // per-provider credential-binding API deferral).
+        const credentialVersion = await this.credentialVersionService.getCurrentVersion(tenantId);
+        return {
+            provider: this.registry.getActive(),
+            mode: 'tenant-override',
+            credentialVersion,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Ships the minimal-viable subset of EW-742 P3 (per [`tasks.md` Phase 3](../blob/develop/docs/specs/features/tenant-job-runtime-overlay/tasks.md)) — the `TenantAwareRuntimeResolver` that wraps the EW-685 P0 T4 binding-factory registry so the `*_DISPATCHER` seam can resolve a tenant's overlay provider.

- **T20** — `packages/agent/src/tasks/tenant-aware-runtime.resolver.ts`: resolver class wraps the registry, reads `TenantJobRuntimeConfig`, returns the instance default for `null` / `undefined` / no-row / `inherit` / `enabled = false`. For `byo` / `override` with `enabled = true` it logs a deferral note via `Logger.debug` and still returns the instance default — the honest stopgap until EW-686 P2 ships the per-provider credential-binding API. `getEffectiveBinding()` returns provider + mode + `credentialVersion` for run-record stamping (T22 consumer).
- **T23** — fallback path covered: every non-overridden branch delegates to `registry.getActive()`, including the `null` provider semantic from EW-683's in-process dev fallback.
- **T24** — `packages/agent/src/tasks/__tests__/tenant-aware-runtime.resolver.spec.ts`: 12 cases (null / undefined / no-row / inherit / disabled / byo+enabled / override+enabled / null-provider, `getEffectiveBinding` metadata for null / inherit / byo, robustness no-throw).
- **DI wiring** — `TenantJobRuntimeModule` provides the resolver + binds `{ provide: JOB_RUNTIME_PROVIDER_REGISTRY, useClass: InMemoryJobRuntimeProviderRegistry }`; barrel exports `TenantAwareRuntimeResolver` + `InMemoryJobRuntimeProviderRegistry`; `_tasks-symbols.ts` pins both.
- **Spec sync** — marks T20 + T23 + T24 done in `tasks.md`, adds a Phase 3.1 section for the deferred T21 (cache) + T22 (enqueue capture), updates the Phase 3 summary line.

## What is NOT in this PR

- **T21 — credential cache (15–60s LRU keyed by `(tenantId, providerId, credentialVersion)`)**: every `resolve()` call hits the database today. Lands in `packages/agent/src/tasks/tenant-credential.cache.ts` as part of P3.1.
- **T22 — credential version capture at every enqueue**: dispatch call sites are unchanged. `getEffectiveBinding()` already returns the metadata callers will need; the enqueue-site walk lands with T21 in P3.1.
- **Per-provider credential injection**: actually swapping the active provider's credentials for `byo` / `override` requires a per-provider credential-binding API that is EW-686 P2 territory. The resolver reads the overlay row and logs the decision, but returns the instance default's provider — the code path is in place, only the per-provider hook is missing. The class JSDoc + the `Logger.debug` message both call this out explicitly.

## Base-branch note

This branch is based on `session/1516-ew685-t4-binding-factory` rather than `develop` because PR #1376 (EW-685 T4 binding factory) had not yet merged when the work started. Once #1376 lands on `develop`, this PR will be a clean diff on top.

## Test plan

- [ ] `cd packages/agent && npx jest --testPathPattern='tenant-aware-runtime.resolver'` — 12/12 pass locally.
- [ ] `cd packages/agent && npx jest --testPathPattern='tasks.spec'` — 25/25 pass (barrel symbol pin includes the two new exports).
- [ ] `cd packages/agent && npx jest --testPathPattern='job-runtime.providers'` — 13/13 pass (T4 binding-factory tests unchanged).
- [ ] `pnpm prettier --check` clean on every touched file.
- [ ] No call sites changed — dispatch path remains the pre-tenancy EW-683 code path for every tenant until P3.1 + EW-686 P2 land.