### PR TITLE
feat(plugin): EW-686 P2 / EW-742 — IJobRuntimeProvider.bindToTenant contract (unblocks P3 BYO + P4 worker host)

### DIFF
--- a/docs/specs/architecture/job-runtime-providers.md
+++ b/docs/specs/architecture/job-runtime-providers.md
@@ -79,6 +79,23 @@ export interface IJobRuntimeProvider {
 
 	/** Optional: stand up / connect the worker host (see §5). */
 	startWorkerHost?(opts: WorkerHostOptions): Promise<WorkerHostHandle>;
+
+	/**
+	 * EW-686 P2 / EW-742 P3 — optional. Return a provider instance bound
+	 * to the given tenant's credential snapshot (BYO/override mode).
+	 * Returns `undefined` if the provider doesn't support BYO; the
+	 * resolver falls back to the instance default with a `Logger.warn`.
+	 * Implementations MUST memoise behind `credentialVersion` so repeat
+	 * calls with the same snapshot return equivalent providers.
+	 */
+	bindToTenant?(snapshot: TenantCredentialSnapshot): IJobRuntimeProvider | undefined;
+}
+
+export interface TenantCredentialSnapshot {
+	tenantId: string;
+	providerId: JobRuntimeId;
+	credentialVersion: number;
+	credentials: Readonly<Record<string, unknown>>; // opaque, per-provider
 }
 
 export type JobRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled' | 'unknown';

--- a/packages/plugin/src/contracts/__tests__/job-runtime.spec.ts
+++ b/packages/plugin/src/contracts/__tests__/job-runtime.spec.ts
@@ -39,6 +39,7 @@ import type {
 	JobRuntimeDispatchers,
 	JobRuntimeId,
 	ScheduleSpec,
+	TenantCredentialSnapshot,
 	WorkerHostHandle,
 	WorkerHostOptions
 } from '../capabilities/job-runtime.interface.js';
@@ -118,6 +119,31 @@ describe('IJobRuntimeProvider — contract surface', () => {
 
 	it('WorkerHostHandle exposes only a stop() — graceful shutdown coordination', () => {
 		expectTypeOf<WorkerHostHandle['stop']>().toEqualTypeOf<() => Promise<void>>();
+	});
+
+	it('bindToTenant is optional (provider may not support BYO)', () => {
+		// EW-686 P2 / EW-742 — providers that don't support per-tenant
+		// credential binding return undefined; the resolver falls back to
+		// the instance default.
+		type Provider = IJobRuntimeProvider;
+		type BindFn = Provider['bindToTenant'];
+
+		expectTypeOf<BindFn>().toEqualTypeOf<
+			((snapshot: TenantCredentialSnapshot) => IJobRuntimeProvider | undefined) | undefined
+		>();
+	});
+
+	it('TenantCredentialSnapshot carries tenantId + providerId + credentialVersion + opaque credentials', () => {
+		const snapshot: TenantCredentialSnapshot = {
+			tenantId: '00000000-0000-0000-0000-000000000001',
+			providerId: 'trigger',
+			credentialVersion: 1,
+			credentials: { accessToken: 'tr_dev_xxx' }
+		};
+		expectTypeOf(snapshot.tenantId).toEqualTypeOf<string>();
+		expectTypeOf(snapshot.providerId).toEqualTypeOf<JobRuntimeId>();
+		expectTypeOf(snapshot.credentialVersion).toEqualTypeOf<number>();
+		expectTypeOf(snapshot.credentials).toEqualTypeOf<Readonly<Record<string, unknown>>>();
 	});
 });
 

--- a/packages/plugin/src/contracts/capabilities/job-runtime.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/job-runtime.interface.ts
@@ -133,6 +133,32 @@ export interface WorkerHostHandle {
 }
 
 /**
+ * EW-686 P2 / EW-742 — opaque per-tenant credential snapshot handed to a
+ * provider's `bindToTenant` hook. The platform resolves the snapshot from
+ * `tenant_job_runtime_config` + the secrets store; the provider treats the
+ * `credentials` bag as opaque material to thread into its own client
+ * constructor (Trigger.dev access token, Temporal mTLS cert, BullMQ Redis
+ * URL, pg-boss connection string, Inngest signing key — shape is
+ * per-provider).
+ *
+ * The `credentialVersion` field is monotonic per `(tenantId, providerId)`
+ * — it bumps on every rotate / force-invalidate (see ADR-017 §3 / Q4).
+ * Providers use it as a memoisation key on the returned binding so a
+ * repeated `bindToTenant` call with the same snapshot returns the same
+ * provider instance.
+ */
+export interface TenantCredentialSnapshot {
+	/** Tenant id (uuid). */
+	readonly tenantId: string;
+	/** Provider id this snapshot is for (matches IJobRuntimeProvider.runtimeId). */
+	readonly providerId: JobRuntimeId;
+	/** Monotonic per-tenant version — bumps on rotate / force-invalidate. */
+	readonly credentialVersion: number;
+	/** Opaque credential bag — shape is per-provider. */
+	readonly credentials: Readonly<Record<string, unknown>>;
+}
+
+/**
  * Union of the existing dispatcher interfaces a `job-runtime` provider
  * must implement to bind into the `*_DISPATCHER` symbols.
  *
@@ -221,4 +247,31 @@ export interface IJobRuntimeProvider extends IPlugin {
 	 * don't need it.
 	 */
 	startWorkerHost?(opts: WorkerHostOptions): Promise<WorkerHostHandle>;
+
+	/**
+	 * EW-686 P2 / EW-742 P3 — return a provider instance bound to the
+	 * given tenant's credential snapshot. The default
+	 * `IJobRuntimeProvider` implementation uses the operator-supplied
+	 * platform credentials; when a tenant opts into BYO/override mode
+	 * (EW-742), the tenant-aware resolver calls this method to swap in
+	 * a tenant-scoped client without mutating the shared singleton.
+	 *
+	 * Optional: a provider that doesn't support BYO returns `undefined`
+	 * and the resolver falls back to the instance default with a
+	 * `Logger.warn`. Push-model providers (Trigger.dev, Inngest)
+	 * implement this by returning a copy with the credential client
+	 * re-configured against the tenant secret. Pull-model providers
+	 * (Temporal, BullMQ, pg-boss) implement it by returning a copy
+	 * bound to the per-tenant namespace/queue/schema.
+	 *
+	 * Idempotency: calling `bindToTenant` with the same snapshot twice
+	 * MUST return equivalent providers (same `dispatchers`, same
+	 * `runtimeId`); implementations should memoise behind a
+	 * `credentialVersion` key.
+	 *
+	 * The returned `IJobRuntimeProvider` is a TRANSIENT VIEW — callers
+	 * must NOT register it in the provider registry. The original
+	 * singleton is the only thing the registry holds.
+	 */
+	bindToTenant?(snapshot: TenantCredentialSnapshot): IJobRuntimeProvider | undefined;
 }


### PR DESCRIPTION
## Summary

Adds an OPTIONAL `bindToTenant()` method to `IJobRuntimeProvider` and the new `TenantCredentialSnapshot` type. Contract-only addition; no provider implements the method yet.

## What this unblocks

- **EW-742 P3 BYO/override mode** — the `TenantAwareRuntimeResolver` currently has a `Logger.debug` stopgap when a tenant is in byo/override mode because there was no per-provider credential-binding API. With this contract in place, a follow-up resolver PR can call `provider.bindToTenant(snapshot)` and return the tenant-bound view.
- **EW-742 P4 worker host** — the per-tenant worker host needs the same bind primitive to spin up tenant-isolated workers per-namespace (Temporal) / per-queue (BullMQ) / per-schema (pg-boss).

## Why optional, not required

Providers that don't support BYO (e.g. a deployment pinned to a single Trigger.dev project) can omit the method; the resolver warns and falls back to the instance default.

TriggerService and other concrete implementations on develop today don't need to be touched in this PR — they'll add `bindToTenant` in separate per-provider PRs once the BYO secret-resolution pipeline is in place.

## `TenantCredentialSnapshot.credentials` is opaque

`Record<string, unknown>` — shape is per-provider (Trigger.dev access token, Temporal mTLS cert, BullMQ Redis URL, pg-boss connection string, Inngest signing key). The platform resolves the secret-store pointer and hands the bag to the provider.

## Test plan

- [x] `cd packages/plugin && npx vitest run src/contracts/__tests__/job-runtime.spec.ts --no-coverage` — **11/11 pass** locally (was 9, added 2 for bindToTenant + TenantCredentialSnapshot)
- [ ] CI green (lint + typecheck + test)
- [ ] No `apps/api` or `packages/agent` changes — the contract addition is in `@ever-works/plugin` only; no downstream consumer wired yet

## Cascade

PR to develop → cascade develop → stage → main per usual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-tenant credential binding in job runtime providers, enabling providers to return tenant-scoped instances for enhanced security and isolation in multi-tenant environments.
  * Introduced structured credential snapshots with version tracking for improved credential management and memoization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->