### PR TITLE
feat(agent): EW-742 P3.2 — resolver bindToTenant wiring + SecretStoreResolver

### DIFF
--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
@@ -5,8 +5,10 @@ import { TenantJobRuntimeAudit, TenantJobRuntimeConfig } from '@ever-works/agent
 import {
     CredentialVersionService,
     InMemoryJobRuntimeProviderRegistry,
+    InProcessSecretStoreResolver,
     JOB_RUNTIME_PROVIDER_REGISTRY,
     RuntimeBindingStamperService,
+    SECRET_STORE_RESOLVER,
     TenantAwareRuntimeResolver,
     TenantCredentialCache,
 } from '@ever-works/agent/tasks';
@@ -59,6 +61,14 @@ import { TenantJobRuntimeService } from './tenant-job-runtime.service';
         {
             provide: JOB_RUNTIME_PROVIDER_REGISTRY,
             useClass: InMemoryJobRuntimeProviderRegistry,
+        },
+        {
+            // EW-742 P3.2 — default in-process SecretStoreResolver.
+            // Supports `inline:` only; production deployments override
+            // this binding with a scheme-specific resolver via a module
+            // override or environment-keyed factory.
+            provide: SECRET_STORE_RESOLVER,
+            useClass: InProcessSecretStoreResolver,
         },
     ],
     controllers: [TenantJobRuntimeController],

--- a/docs/specs/features/tenant-job-runtime-overlay/tasks.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/tasks.md
@@ -1,7 +1,7 @@
 # Task Breakdown: Tenant-Scoped Job-Runtime Overlay
 
 **Feature ID**: `tenant-job-runtime-overlay`
-**Status**: `In progress` — P0 + P1.0 + P1 + P2.0 + P2.1 + P3 (T20+T23+T24 resolver) + P3.1 (T21 cache + T22 stamper helper) + P4 (T31 contract — `tenantId` on JobEnqueueOptions) + P5 + P7 (T41+T42+T44) landed on `main` or in this PR. P2.2 (schema-driven form + e2e), P3.1 (T22 per-dispatcher wiring), P3.2 (resolver bindToTenant wiring), P4 (per-provider worker hosts T25–T30 + T31 per-provider stamping + T32 isolation tests), P5.1 (per-tenant whitelist), P6 (conformance), and P7 (docs T43) remain.
+**Status**: `In progress` — P0 + P1.0 + P1 + P2.0 + P2.1 + P3 (T20+T23+T24 resolver) + P3.1 (T21 cache + T22 stamper helper) + P3.2 (resolver bindToTenant wiring + SecretStoreResolver contract + InProcessSecretStoreResolver default) + P4 (T31 contract — `tenantId` on JobEnqueueOptions) + P5 + P7 (T41+T42+T44) landed on `main` or in this PR. P2.2 (schema-driven form + e2e), P3.1 (T22 per-dispatcher wiring), P4 (per-provider worker hosts T25–T30 + T31 per-provider stamping + T32 isolation tests + per-provider bindToTenant implementations), P5.1 (per-tenant whitelist), P6 (conformance), P7 (docs T43), and non-`inline:` SecretStoreResolver implementations (vault:, k8s:, op:) remain.
 **Last updated**: 2026-06-19
 **Spec**: [`./spec.md`](./spec.md) · **Plan**: [`./plan.md`](./plan.md) · **Providers**: [`./providers.md`](./providers.md) · **Epic**: [EW-742](https://evertech.atlassian.net/browse/EW-742) · **Story**: [EW-743](https://evertech.atlassian.net/browse/EW-743) · **ADR**: [ADR-017](../../decisions/017-tenant-scoped-job-runtime-overlay.md)
 
@@ -53,6 +53,15 @@ T20 + T23 + T24 ✅ Done in [#1380](https://github.com/ever-works/ever-works/pul
 ### Phase 3.1 — Enqueue capture (deferred)
 
 - [ ] **T22** (above) ships once a follow-up PR walks the enqueue call sites to stamp `credentialVersion` into each run record. The T21 cache is already in place to serve the snapshot lookup at run time.
+
+### Phase 3.2 — Resolver `bindToTenant` wiring · `[EW-742 P3.2]`
+
+✅ Done in this PR. The resolver's byo/override branch now actively binds the active provider to per-tenant credentials:
+
+- [x] **T20.1.** `SecretStoreResolver` contract at `packages/agent/src/tasks/secret-store-resolver.interface.ts` — operator-pluggable credential-pointer resolution. `SECRET_STORE_RESOLVER` DI token + `resolve(pointer): Promise<Record<string, unknown> | null>` interface. Contract is fail-open: implementations MUST NOT throw on missing / malformed pointers — return `null` + log at warn instead.
+- [x] **T20.2.** `InProcessSecretStoreResolver` default at `packages/agent/src/tasks/in-process-secret-store-resolver.service.ts` — supports only `inline:<base64-of-json-object>` for dev/test. Every other scheme (`vault:`, `k8s:`, `op:`) returns `null` + `Logger.warn` telling the operator to wire a real implementation for that scheme.
+- [x] **T20.3.** `TenantAwareRuntimeResolver.resolve()` byo/override branch now does the full bind path: (a) check `TenantCredentialCache` keyed by `(tenantId, providerId, credentialVersion)`; (b) on miss, resolve credentials via `SecretStoreResolver`; (c) call `provider.bindToTenant(snapshot)` (EW-686 P2 contract); (d) cache + return the bound provider. Any null/undefined/throw anywhere in the chain falls back to the instance default with a `Logger.warn` carrying enough tenant context for operators to diagnose. 20+ tests cover happy path + 5 fallback paths + cache-hit behaviour.
+- [ ] **T20.4.** Non-`inline:` `SecretStoreResolver` implementations — one PR per scheme (`VaultSecretStoreResolver`, `K8sSecretStoreResolver`, `OnePasswordSecretStoreResolver`, etc.). Each plugin package opt-in; default deployment keeps `InProcessSecretStoreResolver` so `inline:` works for dev/test out of the box.
 
 ## Phase 4 — Worker host · `[EW-742 P4]`
 

--- a/packages/agent/src/tasks/__tests__/in-process-secret-store-resolver.service.spec.ts
+++ b/packages/agent/src/tasks/__tests__/in-process-secret-store-resolver.service.spec.ts
@@ -1,0 +1,97 @@
+import { Logger } from '@nestjs/common';
+import { InProcessSecretStoreResolver } from '../in-process-secret-store-resolver.service';
+
+/**
+ * EW-742 P3.2 — default `InProcessSecretStoreResolver` unit tests.
+ *
+ * Covers the seven branches the default resolver supports:
+ *   - unknown scheme → null + Logger.warn
+ *   - inline: empty payload → null + Logger.warn
+ *   - inline: base64-decode error → null + Logger.warn
+ *   - inline: not JSON → null + Logger.warn
+ *   - inline: JSON null → null + Logger.warn
+ *   - inline: JSON array → null + Logger.warn (must be object)
+ *   - inline: JSON object → returns the parsed bag
+ */
+describe('InProcessSecretStoreResolver (EW-742 P3.2)', () => {
+    let resolver: InProcessSecretStoreResolver;
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        resolver = new InProcessSecretStoreResolver();
+        warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    function inline(obj: unknown): string {
+        return `inline:${Buffer.from(JSON.stringify(obj), 'utf8').toString('base64')}`;
+    }
+
+    it('returns null + warn for unknown scheme', async () => {
+        const result = await resolver.resolve('vault:secret/tenants/acme/temporal');
+        expect(result).toBeNull();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0]?.[0]).toMatch(/pointer scheme "vault:"/);
+        expect(warnSpy.mock.calls[0]?.[0]).toMatch(/fail-open/);
+    });
+
+    it('returns null + warn for empty inline: payload', async () => {
+        const result = await resolver.resolve('inline:');
+        expect(result).toBeNull();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0]?.[0]).toMatch(/empty payload/);
+    });
+
+    it('returns null + warn when base64 decode produces invalid utf8 JSON', async () => {
+        // base64 of binary garbage that's not utf8 JSON
+        const result = await resolver.resolve('inline:!!!not-valid-base64-or-json!!!');
+        expect(result).toBeNull();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        // Could be either the base64-decode error OR the JSON-parse
+        // error depending on how Node tolerates the input.
+        expect(warnSpy.mock.calls[0]?.[0]).toMatch(/base64-decode failed|not valid JSON/);
+    });
+
+    it('returns null + warn when payload is not JSON', async () => {
+        const notJson = Buffer.from('this is not JSON at all', 'utf8').toString('base64');
+        const result = await resolver.resolve(`inline:${notJson}`);
+        expect(result).toBeNull();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0]?.[0]).toMatch(/not valid JSON/);
+    });
+
+    it('returns null + warn when payload is JSON null', async () => {
+        const result = await resolver.resolve(inline(null));
+        expect(result).toBeNull();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0]?.[0]).toMatch(/must be a JSON object/);
+        expect(warnSpy.mock.calls[0]?.[0]).toMatch(/got null/);
+    });
+
+    it('returns null + warn when payload is JSON array (must be object)', async () => {
+        const result = await resolver.resolve(inline(['a', 'b']));
+        expect(result).toBeNull();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0]?.[0]).toMatch(/got array/);
+    });
+
+    it('returns the parsed bag for a well-formed inline: object', async () => {
+        const credentials = { accessToken: 'tr_dev_xxx', region: 'us-east-1' };
+        const result = await resolver.resolve(inline(credentials));
+        expect(result).toEqual(credentials);
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('preserves nested values in the parsed bag', async () => {
+        const credentials = {
+            token: 'abc',
+            tls: { ca: '-----BEGIN CERTIFICATE-----...', clientCert: 'x', clientKey: 'y' },
+            tags: ['prod', 'us'],
+        };
+        const result = await resolver.resolve(inline(credentials));
+        expect(result).toEqual(credentials);
+    });
+});

--- a/packages/agent/src/tasks/__tests__/tenant-aware-runtime.resolver.spec.ts
+++ b/packages/agent/src/tasks/__tests__/tenant-aware-runtime.resolver.spec.ts
@@ -4,37 +4,50 @@ import type { Repository } from 'typeorm';
 import { CredentialVersionService } from '../credential-version.service';
 import { TenantJobRuntimeConfig } from '../../entities/tenant-job-runtime-config.entity';
 import { InMemoryJobRuntimeProviderRegistry } from '../job-runtime.providers';
+import type { SecretStoreResolver } from '../secret-store-resolver.interface';
+import { TenantCredentialCache } from '../tenant-credential.cache';
 import { TenantAwareRuntimeResolver } from '../tenant-aware-runtime.resolver';
 
 /**
- * EW-742 P3 / EW-747 (T24) — tenant-aware resolver unit tests.
+ * EW-742 P3 / EW-747 (T24) + P3.2 — tenant-aware resolver unit tests.
  *
- * Covers the minimal-viable subset of T20 + T23 that ships this PR:
+ * Covers:
  *
  *   - null / undefined / no-row / inherit / disabled → instance default
  *     (T23 fallback, plus the kill switch path);
- *   - byo + override modes with `enabled = true` → instance default
- *     (P3.1 honest stopgap — see resolver class JSDoc), with
- *     `Logger.debug` proving the deferral was logged;
- *   - `getEffectiveBinding` returns the metadata T22 will need to stamp
- *     onto the run record at enqueue time;
+ *   - byo + override modes with `enabled = true`:
+ *     - happy path: resolver builds the snapshot, calls
+ *       `provider.bindToTenant()`, caches the binding, returns the
+ *       bound provider;
+ *     - fallback 1: provider doesn't expose `bindToTenant?` →
+ *       instance default + `Logger.warn`;
+ *     - fallback 2: `SecretStoreResolver.resolve` returns `null` →
+ *       instance default + `Logger.warn`;
+ *     - fallback 3: `provider.bindToTenant` returns `undefined` →
+ *       instance default + `Logger.warn`;
+ *     - fallback 4: throws anywhere → instance default + `Logger.warn`
+ *       (defence-in-depth, contract says implementations don't throw);
+ *     - cache hit: second resolve for the same
+ *       `(tenantId, providerId, credentialVersion)` skips the secret
+ *       store + bind call entirely;
+ *   - `getEffectiveBinding` returns the metadata T22 / stamper uses;
  *   - `registry.getActive()` returning `null` propagates as `null` (the
  *     EW-683 in-process dev fallback semantic — preserved).
- *
- * Deliberately NOT covered here (deferred PRs own these):
- *   - T21 (cache hit/miss + invalidation on rotation)
- *   - T22 (enqueue-site `credentialVersion` capture)
- *   - per-provider credential injection (EW-686 P2)
  */
-describe('TenantAwareRuntimeResolver (EW-742 P3 / EW-747 T20 + T23 + T24)', () => {
+describe('TenantAwareRuntimeResolver (EW-742 P3 / EW-747 T20 + T23 + T24 + P3.2)', () => {
     /**
      * Build a minimal {@link IJobRuntimeProvider} test double. We only
      * exercise identity here — the resolver hands the registry's
-     * provider back as-is — so the `dispatchers` payload is just a
-     * sentinel string keyed by `which`.
+     * provider back as-is (or the bound result of `bindToTenant`) — so
+     * the `dispatchers` payload is just a sentinel string keyed by
+     * `which`.
+     *
+     * `bindToTenant` is optional in the type; pass it explicitly when a
+     * test needs to exercise the new P3.2 bind path.
      */
     function mockProvider(
         dispatchers: JobRuntimeDispatchers = { sentinel: 'instance-default' },
+        bindToTenant?: IJobRuntimeProvider['bindToTenant'],
     ): IJobRuntimeProvider {
         return {
             id: 'mock',
@@ -63,6 +76,7 @@ describe('TenantAwareRuntimeResolver (EW-742 P3 / EW-747 T20 + T23 + T24)', () =
             async onUnload() {
                 /* no-op */
             },
+            bindToTenant,
         } satisfies IJobRuntimeProvider;
     }
 
@@ -73,7 +87,7 @@ describe('TenantAwareRuntimeResolver (EW-742 P3 / EW-747 T20 + T23 + T24)', () =
         return {
             tenantId: 'tenant-1',
             providerId: 'trigger',
-            credentialsSecretRef: 'tenant-job-runtime:abc123:trigger:v1',
+            credentialsSecretRef: 'inline:eyJhY2Nlc3NUb2tlbiI6InRyX2Rldl94eHgifQ==',
             credentialVersion: 7,
             mode: 'byo',
             enabled: true,
@@ -92,17 +106,26 @@ describe('TenantAwareRuntimeResolver (EW-742 P3 / EW-747 T20 + T23 + T24)', () =
         getCurrentVersion: jest.Mock;
     };
 
+    type SecretStoreResolverMock = SecretStoreResolver & {
+        resolve: jest.Mock;
+    };
+
     function buildResolver(
         opts: {
             registry?: InMemoryJobRuntimeProviderRegistry;
             repoFindOneReturn?: TenantJobRuntimeConfig | null;
             credentialVersion?: number | null;
+            secretStoreResolve?: Record<string, unknown> | null;
+            secretStoreThrows?: Error;
+            cache?: TenantCredentialCache;
         } = {},
     ): {
         resolver: TenantAwareRuntimeResolver;
         registry: InMemoryJobRuntimeProviderRegistry;
         configRepo: ConfigRepoMock;
         credentialVersionService: CredentialVersionServiceMock;
+        secretStoreResolver: SecretStoreResolverMock;
+        cache: TenantCredentialCache;
     } {
         const registry = opts.registry ?? new InMemoryJobRuntimeProviderRegistry();
         const configRepo: ConfigRepoMock = {
@@ -111,12 +134,33 @@ describe('TenantAwareRuntimeResolver (EW-742 P3 / EW-747 T20 + T23 + T24)', () =
         const credentialVersionService: CredentialVersionServiceMock = {
             getCurrentVersion: jest.fn().mockResolvedValue(opts.credentialVersion ?? null),
         };
+        const secretStoreResolver: SecretStoreResolverMock = {
+            resolve: opts.secretStoreThrows
+                ? jest.fn().mockRejectedValue(opts.secretStoreThrows)
+                : jest
+                      .fn()
+                      .mockResolvedValue(
+                          'secretStoreResolve' in opts
+                              ? opts.secretStoreResolve
+                              : { accessToken: 'tr_dev_xxx' },
+                      ),
+        };
+        const cache = opts.cache ?? new TenantCredentialCache();
         const resolver = new TenantAwareRuntimeResolver(
             registry,
             configRepo as unknown as Repository<TenantJobRuntimeConfig>,
             credentialVersionService as unknown as CredentialVersionService,
+            secretStoreResolver,
+            cache,
         );
-        return { resolver, registry, configRepo, credentialVersionService };
+        return {
+            resolver,
+            registry,
+            configRepo,
+            credentialVersionService,
+            secretStoreResolver,
+            cache,
+        };
     }
 
     describe('resolve(tenantId)', () => {
@@ -166,9 +210,12 @@ describe('TenantAwareRuntimeResolver (EW-742 P3 / EW-747 T20 + T23 + T24)', () =
             await expect(resolver.resolve('tenant-1')).resolves.toBe(provider);
         });
 
-        it("returns the instance default when overlay row mode = 'byo' + enabled (P3 stopgap), and logs the deferral", async () => {
-            const debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+        it('returns the instance default + warn when byo + enabled but provider has no bindToTenant', async () => {
+            const warnSpy = jest
+                .spyOn(Logger.prototype, 'warn')
+                .mockImplementation(() => undefined);
             try {
+                // mockProvider() with no bindToTenant arg ⇒ undefined
                 const provider = mockProvider({ which: 'instance-default' });
                 const registry = new InMemoryJobRuntimeProviderRegistry();
                 registry.register(provider);
@@ -178,37 +225,163 @@ describe('TenantAwareRuntimeResolver (EW-742 P3 / EW-747 T20 + T23 + T24)', () =
                 });
 
                 await expect(resolver.resolve('tenant-1')).resolves.toBe(provider);
-                expect(debugSpy).toHaveBeenCalledTimes(1);
-                const message = debugSpy.mock.calls[0][0] as string;
-                expect(message).toContain('tenant tenant-1 overlay mode=byo');
-                expect(message).toContain('tenant override deferred to P3.1');
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                expect(warnSpy.mock.calls[0]?.[0]).toMatch(/does not implement bindToTenant/);
             } finally {
-                debugSpy.mockRestore();
+                warnSpy.mockRestore();
             }
         });
 
-        it("returns the instance default when overlay row mode = 'override' + enabled (P3 stopgap), and logs the deferral", async () => {
-            const debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
+        it('returns the bound provider when byo + enabled and bindToTenant is wired (happy path)', async () => {
+            const boundProvider = mockProvider({ which: 'tenant-bound' });
+            const bindToTenant = jest.fn().mockReturnValue(boundProvider);
+            const instanceProvider = mockProvider({ which: 'instance-default' }, bindToTenant);
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(instanceProvider);
+            const { resolver, secretStoreResolver, cache } = buildResolver({
+                registry,
+                repoFindOneReturn: buildConfigRow({
+                    mode: 'byo',
+                    enabled: true,
+                    providerId: 'trigger',
+                    credentialVersion: 7,
+                }),
+                secretStoreResolve: { accessToken: 'tr_dev_xxx' },
+            });
+
+            const result = await resolver.resolve('tenant-1');
+            expect(result).toBe(boundProvider);
+            expect(secretStoreResolver.resolve).toHaveBeenCalledWith(
+                'inline:eyJhY2Nlc3NUb2tlbiI6InRyX2Rldl94eHgifQ==',
+            );
+            expect(bindToTenant).toHaveBeenCalledWith({
+                tenantId: 'tenant-1',
+                providerId: 'trigger',
+                credentialVersion: 7,
+                credentials: { accessToken: 'tr_dev_xxx' },
+            });
+            // Cache is populated against (tenantId, providerId, version)
+            // for the next call to skip the secret resolution + bind.
+            expect(cache.get('tenant-1', 'trigger', 7)).toBe(boundProvider);
+        });
+
+        it('hits the cache on a repeat resolve for the same (tenantId, providerId, credentialVersion)', async () => {
+            const boundProvider = mockProvider({ which: 'tenant-bound' });
+            const bindToTenant = jest.fn().mockReturnValue(boundProvider);
+            const instanceProvider = mockProvider({ which: 'instance-default' }, bindToTenant);
+            const registry = new InMemoryJobRuntimeProviderRegistry();
+            registry.register(instanceProvider);
+            const { resolver, secretStoreResolver } = buildResolver({
+                registry,
+                repoFindOneReturn: buildConfigRow({ mode: 'byo', enabled: true }),
+            });
+
+            await resolver.resolve('tenant-1');
+            await resolver.resolve('tenant-1');
+
+            // First call resolves + binds; second call short-circuits
+            // on cache hit. Both calls still read the DB row (the cache
+            // is keyed by version, which the row carries).
+            expect(secretStoreResolver.resolve).toHaveBeenCalledTimes(1);
+            expect(bindToTenant).toHaveBeenCalledTimes(1);
+        });
+
+        it('falls back to instance default + warn when SecretStoreResolver returns null', async () => {
+            const warnSpy = jest
+                .spyOn(Logger.prototype, 'warn')
+                .mockImplementation(() => undefined);
             try {
-                const provider = mockProvider({ which: 'instance-default' });
+                const bindToTenant = jest.fn();
+                const instanceProvider = mockProvider({ which: 'instance-default' }, bindToTenant);
                 const registry = new InMemoryJobRuntimeProviderRegistry();
-                registry.register(provider);
+                registry.register(instanceProvider);
                 const { resolver } = buildResolver({
                     registry,
-                    repoFindOneReturn: buildConfigRow({
-                        mode: 'override',
-                        enabled: true,
-                        providerId: 'temporal',
-                    }),
+                    repoFindOneReturn: buildConfigRow({ mode: 'byo', enabled: true }),
+                    secretStoreResolve: null,
                 });
 
-                await expect(resolver.resolve('tenant-1')).resolves.toBe(provider);
-                expect(debugSpy).toHaveBeenCalledTimes(1);
-                const message = debugSpy.mock.calls[0][0] as string;
-                expect(message).toContain('overlay mode=override');
-                expect(message).toContain('providerId=temporal');
+                await expect(resolver.resolve('tenant-1')).resolves.toBe(instanceProvider);
+                expect(bindToTenant).not.toHaveBeenCalled();
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringMatching(/SecretStoreResolver returned null/),
+                );
             } finally {
-                debugSpy.mockRestore();
+                warnSpy.mockRestore();
+            }
+        });
+
+        it('falls back to instance default + warn when SecretStoreResolver throws', async () => {
+            const warnSpy = jest
+                .spyOn(Logger.prototype, 'warn')
+                .mockImplementation(() => undefined);
+            try {
+                const bindToTenant = jest.fn();
+                const instanceProvider = mockProvider({ which: 'instance-default' }, bindToTenant);
+                const registry = new InMemoryJobRuntimeProviderRegistry();
+                registry.register(instanceProvider);
+                const { resolver } = buildResolver({
+                    registry,
+                    repoFindOneReturn: buildConfigRow({ mode: 'byo', enabled: true }),
+                    secretStoreThrows: new Error('vault timeout'),
+                });
+
+                await expect(resolver.resolve('tenant-1')).resolves.toBe(instanceProvider);
+                expect(bindToTenant).not.toHaveBeenCalled();
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringMatching(/SecretStoreResolver threw.*vault timeout/),
+                );
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        it('falls back to instance default + warn when bindToTenant returns undefined', async () => {
+            const warnSpy = jest
+                .spyOn(Logger.prototype, 'warn')
+                .mockImplementation(() => undefined);
+            try {
+                const bindToTenant = jest.fn().mockReturnValue(undefined);
+                const instanceProvider = mockProvider({ which: 'instance-default' }, bindToTenant);
+                const registry = new InMemoryJobRuntimeProviderRegistry();
+                registry.register(instanceProvider);
+                const { resolver } = buildResolver({
+                    registry,
+                    repoFindOneReturn: buildConfigRow({ mode: 'byo', enabled: true }),
+                });
+
+                await expect(resolver.resolve('tenant-1')).resolves.toBe(instanceProvider);
+                expect(bindToTenant).toHaveBeenCalledTimes(1);
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringMatching(/bindToTenant returned undefined/),
+                );
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        it('falls back to instance default + warn when bindToTenant throws', async () => {
+            const warnSpy = jest
+                .spyOn(Logger.prototype, 'warn')
+                .mockImplementation(() => undefined);
+            try {
+                const bindToTenant = jest.fn().mockImplementation(() => {
+                    throw new Error('provider misconfigured');
+                });
+                const instanceProvider = mockProvider({ which: 'instance-default' }, bindToTenant);
+                const registry = new InMemoryJobRuntimeProviderRegistry();
+                registry.register(instanceProvider);
+                const { resolver } = buildResolver({
+                    registry,
+                    repoFindOneReturn: buildConfigRow({ mode: 'byo', enabled: true }),
+                });
+
+                await expect(resolver.resolve('tenant-1')).resolves.toBe(instanceProvider);
+                expect(warnSpy).toHaveBeenCalledWith(
+                    expect.stringMatching(/bindToTenant threw.*provider misconfigured/),
+                );
+            } finally {
+                warnSpy.mockRestore();
             }
         });
 
@@ -218,20 +391,15 @@ describe('TenantAwareRuntimeResolver (EW-742 P3 / EW-747 T20 + T23 + T24)', () =
             const provider = mockProvider({ which: 'instance-default' });
             const registry = new InMemoryJobRuntimeProviderRegistry();
             registry.register(provider);
-            const debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => {});
-            try {
-                const { resolver } = buildResolver({
-                    registry,
-                    repoFindOneReturn: buildConfigRow({ mode: 'byo', enabled: false }),
-                });
+            const { resolver, secretStoreResolver } = buildResolver({
+                registry,
+                repoFindOneReturn: buildConfigRow({ mode: 'byo', enabled: false }),
+            });
 
-                await expect(resolver.resolve('tenant-1')).resolves.toBe(provider);
-                // Kill switch is silent — no "deferred to P3.1" log because
-                // the resolver short-circuits before the byo/override branch.
-                expect(debugSpy).not.toHaveBeenCalled();
-            } finally {
-                debugSpy.mockRestore();
-            }
+            await expect(resolver.resolve('tenant-1')).resolves.toBe(provider);
+            // Kill switch short-circuits BEFORE the bind path — neither
+            // the resolver nor bindToTenant should be called.
+            expect(secretStoreResolver.resolve).not.toHaveBeenCalled();
         });
 
         it('returns null when no provider is registered (preserves EW-683 in-process dev fallback)', async () => {

--- a/packages/agent/src/tasks/_tasks-symbols.ts
+++ b/packages/agent/src/tasks/_tasks-symbols.ts
@@ -34,6 +34,10 @@ export const TASKS_BARREL_RUNTIME_SYMBOLS: ReadonlyArray<string> = [
     // `JobRuntimeProviderRegistry`, exposed via the barrel so DI modules
     // can bind it as the `JOB_RUNTIME_PROVIDER_REGISTRY` useClass.
     'InMemoryJobRuntimeProviderRegistry',
+    // EW-742 P3.2 — default in-process SecretStoreResolver bound at the
+    // SECRET_STORE_RESOLVER DI token. Only supports `inline:` scheme;
+    // other schemes (vault:, k8s:, op:) require a non-default binding.
+    'InProcessSecretStoreResolver',
     // EW-685 P0 T4 — DI token for the in-memory job-runtime provider
     // registry consumed by the binding factory `buildJobRuntimeProviders()`.
     // Declared but not wired into any NestJS module yet; see
@@ -53,6 +57,9 @@ export const TASKS_BARREL_RUNTIME_SYMBOLS: ReadonlyArray<string> = [
     // `runtime-binding-stamper.service.ts` header for the per-dispatcher
     // wiring deferral.
     'RuntimeBindingStamperService',
+    // EW-742 P3.2 — DI token for SecretStoreResolver implementations.
+    // Symbol, not string — the value's reference is the unique identity.
+    'SECRET_STORE_RESOLVER',
     'TEMPLATE_CUSTOMIZATION_DISPATCHER',
     // EW-742 P3 / EW-747 (T20 + T23) — tenant-aware resolver wrapping
     // the EW-685 binding factory registry. See

--- a/packages/agent/src/tasks/in-process-secret-store-resolver.service.ts
+++ b/packages/agent/src/tasks/in-process-secret-store-resolver.service.ts
@@ -1,0 +1,117 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { SecretStoreResolver } from './secret-store-resolver.interface';
+
+/**
+ * EW-742 P3.2 — default {@link SecretStoreResolver} implementation.
+ *
+ * Supports ONE scheme, `inline:`, which carries a base64-encoded JSON
+ * object directly in the pointer string. Useful for:
+ *   - dev / preview deployments that don't have a real secret store;
+ *   - integration tests that need a deterministic credential without
+ *     standing up Vault / k8s Secrets / 1Password;
+ *   - operators evaluating the tenant overlay before wiring a
+ *     production secret store.
+ *
+ * Every other scheme (`vault:`, `k8s:`, `op:`, etc.) returns `null` +
+ * `Logger.warn` so operators see a load-bearing log line on every
+ * unresolved enqueue: "we received a pointer we don't know how to
+ * resolve — the run is falling back to the instance default and you
+ * need to bind a real {@link SecretStoreResolver} for this scheme."
+ *
+ * # Why this is the bundled default
+ *
+ *   - Zero runtime dependencies (no Vault SDK, no kubectl, no
+ *     1Password CLI in the build).
+ *   - Lets the contract land + the resolver wire-up land on `main`
+ *     without committing the platform to a specific secret-store
+ *     vendor.
+ *   - Bundled implementations for the four major schemes ship as
+ *     follow-up PRs (one per scheme) so a deployment can opt in by
+ *     swapping the DI binding — no rip-and-replace.
+ *
+ * # `inline:` format
+ *
+ *   `inline:<base64-of-utf8-json-object>`
+ *
+ * Example:
+ *
+ *   ```ts
+ *   const credentials = { accessToken: 'tr_dev_xxx', region: 'us-east-1' };
+ *   const pointer = `inline:${Buffer.from(JSON.stringify(credentials), 'utf8').toString('base64')}`;
+ *   // → 'inline:eyJhY2Nlc3NUb2tlbiI6InRyX2Rldl94eHgiLCJyZWdpb24iOiJ1cy1lYXN0LTEifQ=='
+ *   ```
+ *
+ * The resolver decodes the base64, parses as JSON, and returns the
+ * resulting object if it's a non-null record. Anything else (invalid
+ * base64, non-JSON, non-object, array, null) returns `null` + a
+ * specific `Logger.warn` so operators can fix the pointer.
+ *
+ * **Security note:** `inline:` pointers carry the plaintext credential
+ * IN THE POINTER ITSELF. The platform's `tenant_job_runtime_config`
+ * table is operator-readable; using `inline:` in production leaks the
+ * credential to anyone with DB read access. The default implementation
+ * tolerates it for dev convenience — production deployments should
+ * use Vault / k8s / 1Password schemes via a non-default resolver.
+ */
+@Injectable()
+export class InProcessSecretStoreResolver implements SecretStoreResolver {
+    private readonly logger = new Logger(InProcessSecretStoreResolver.name);
+
+    async resolve(pointer: string): Promise<Record<string, unknown> | null> {
+        if (!pointer.startsWith('inline:')) {
+            // Operator wired a non-inline scheme but no concrete resolver
+            // for it. Fail-open: log + null so resolver falls back to
+            // instance default.
+            const scheme = pointer.split(':', 1)[0] ?? 'unknown';
+            this.logger.warn(
+                `InProcessSecretStoreResolver: pointer scheme "${scheme}:" is not ` +
+                    `supported by the default resolver. Bind a concrete SecretStoreResolver ` +
+                    `for this scheme via the SECRET_STORE_RESOLVER DI token. Returning null ` +
+                    `(fail-open — resolver falls back to instance default).`,
+            );
+            return null;
+        }
+
+        const encoded = pointer.slice('inline:'.length);
+        if (!encoded) {
+            this.logger.warn(
+                `InProcessSecretStoreResolver: inline: pointer carries empty payload. ` +
+                    `Returning null (fail-open).`,
+            );
+            return null;
+        }
+
+        let decoded: string;
+        try {
+            decoded = Buffer.from(encoded, 'base64').toString('utf8');
+        } catch (err) {
+            this.logger.warn(
+                `InProcessSecretStoreResolver: inline: pointer base64-decode failed ` +
+                    `(${err instanceof Error ? err.message : String(err)}). Returning null (fail-open).`,
+            );
+            return null;
+        }
+
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(decoded);
+        } catch (err) {
+            this.logger.warn(
+                `InProcessSecretStoreResolver: inline: payload is not valid JSON ` +
+                    `(${err instanceof Error ? err.message : String(err)}). Returning null (fail-open).`,
+            );
+            return null;
+        }
+
+        if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            this.logger.warn(
+                `InProcessSecretStoreResolver: inline: payload must be a JSON object ` +
+                    `(got ${parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed}). ` +
+                    `Returning null (fail-open).`,
+            );
+            return null;
+        }
+
+        return parsed as Record<string, unknown>;
+    }
+}

--- a/packages/agent/src/tasks/index.ts
+++ b/packages/agent/src/tasks/index.ts
@@ -75,3 +75,13 @@ export { TenantAwareRuntimeResolver } from './tenant-aware-runtime.resolver';
 // lands incrementally on top — see the file header for the
 // deliberate-seam rationale.
 export { RuntimeBindingStamperService } from './runtime-binding-stamper.service';
+
+// EW-742 P3.2 — SecretStoreResolver contract + default in-process
+// implementation. The resolver wires it into the byo/override branch
+// to construct TenantCredentialSnapshot before calling
+// provider.bindToTenant(). Default impl only supports `inline:` scheme
+// — production deployments swap the SECRET_STORE_RESOLVER binding to
+// a scheme-specific implementation (vault:, k8s:, op:, etc.).
+export { SECRET_STORE_RESOLVER } from './secret-store-resolver.interface';
+export type { SecretStoreResolver } from './secret-store-resolver.interface';
+export { InProcessSecretStoreResolver } from './in-process-secret-store-resolver.service';

--- a/packages/agent/src/tasks/secret-store-resolver.interface.ts
+++ b/packages/agent/src/tasks/secret-store-resolver.interface.ts
@@ -1,0 +1,79 @@
+/**
+ * EW-742 P3.2 — secret-store-pointer resolution for the tenant overlay.
+ *
+ * The platform's tenant overlay stores `credentialsSecretRef` as an
+ * opaque string pointer (≤128 chars) — e.g. `vault:secret/tenants/acme/temporal`,
+ * `k8s:tenant-acme-trigger-credentials`, `op://Vault/Trigger-acme/access-token`,
+ * `inline:eyJ...` (base64-encoded JSON, dev/test only). The pointer
+ * scheme is operator-specific because the underlying secret-store
+ * pipeline lives in the deployment, not the code.
+ *
+ * The `TenantAwareRuntimeResolver` calls
+ * {@link SecretStoreResolver.resolve} when it needs to construct a
+ * {@link TenantCredentialSnapshot} for `provider.bindToTenant()` — i.e.
+ * when a tenant's overlay row has `mode = 'byo' | 'override'` and
+ * `enabled = true`. The resolver's behaviour on `null` is fail-open:
+ * fall back to the instance default and log, never block an enqueue
+ * because credentials couldn't be resolved.
+ *
+ * # Why an interface (not a class with conditional branches)
+ *
+ * The set of supported schemes is operator-controlled. A self-hoster
+ * who only uses `inline:` doesn't want the Vault SDK as a runtime
+ * dependency; a Vault shop doesn't want the 1Password CLI bundled.
+ * The DI binding lets each deployment swap the implementation:
+ *
+ *   - Default: `InProcessSecretStoreResolver` (this PR) — only
+ *     `inline:` works; everything else returns `null` + `Logger.warn`
+ *     telling the operator to wire a real implementation.
+ *   - Future: per-scheme wrappers (`VaultSecretStoreResolver`,
+ *     `K8sSecretStoreResolver`, etc.) under separate plugin packages
+ *     or apps/api binding overrides.
+ *   - Composite: a chain-of-responsibility resolver that dispatches by
+ *     scheme prefix to the right concrete implementation.
+ *
+ * # Contract
+ *
+ *   - `resolve(pointer)` MUST return the credential bag as an opaque
+ *     `Record<string, unknown>` (the shape is per-provider; the
+ *     resolver doesn't interpret it).
+ *   - MUST return `null` when:
+ *     - the pointer scheme is unknown to this implementation;
+ *     - the secret-store lookup itself failed (network, auth, missing
+ *       entry, malformed data);
+ *     - the resolved value isn't a JSON object.
+ *   - MUST NOT throw on missing / malformed pointers — fail-open is the
+ *     contract; the caller logs at warn and falls back to the instance
+ *     default. Throwing would block enqueue, which the tenant runbook
+ *     promises will NEVER happen on overlay misconfiguration.
+ *   - SHOULD log at `warn` when returning `null` so operators can
+ *     diagnose silent-fallback scenarios from logs alone.
+ */
+export interface SecretStoreResolver {
+    /**
+     * Resolves a `credentialsSecretRef` pointer to the credential bag
+     * (or `null` — see contract above).
+     *
+     * @param pointer the opaque pointer string from
+     *   {@link TenantJobRuntimeConfig.credentialsSecretRef}.
+     *   Will never be `null` / empty when called from the resolver
+     *   (only `byo` / `override` rows with `enabled = true` reach this
+     *   path).
+     */
+    resolve(pointer: string): Promise<Record<string, unknown> | null>;
+}
+
+/**
+ * DI token for the `SecretStoreResolver` binding. Modules MUST provide
+ * a concrete implementation:
+ *
+ *   {@includeCode ../docs/runbooks/TENANT_JOB_RUNTIME.md}
+ *   ```ts
+ *   { provide: SECRET_STORE_RESOLVER, useClass: InProcessSecretStoreResolver }
+ *   ```
+ *
+ * The token is a `Symbol(...)` rather than a `string` so it can't
+ * accidentally collide with a plain-text DI token elsewhere. The
+ * unique identity is the value's reference, not the symbol description.
+ */
+export const SECRET_STORE_RESOLVER = Symbol('SECRET_STORE_RESOLVER');

--- a/packages/agent/src/tasks/tenant-aware-runtime.resolver.ts
+++ b/packages/agent/src/tasks/tenant-aware-runtime.resolver.ts
@@ -1,13 +1,15 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import type { IJobRuntimeProvider } from '@ever-works/plugin';
+import type { IJobRuntimeProvider, JobRuntimeId } from '@ever-works/plugin';
 import { TenantJobRuntimeConfig } from '../entities/tenant-job-runtime-config.entity';
 import { CredentialVersionService } from './credential-version.service';
 import {
     JOB_RUNTIME_PROVIDER_REGISTRY,
     type JobRuntimeProviderRegistry,
 } from './job-runtime.providers';
+import { SECRET_STORE_RESOLVER, type SecretStoreResolver } from './secret-store-resolver.interface';
+import { TenantCredentialCache } from './tenant-credential.cache';
 
 /**
  * EW-742 P3 / EW-747 (T20 + T23) — tenant-aware job-runtime resolver.
@@ -21,37 +23,42 @@ import {
  * [`plan.md` §10 P3](../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md#p3--dispatcher-routing-tenant-aware-resolver--credential-version-capture)
  * and [ADR-017](../../../../docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md).
  *
- * # Scope of THIS PR (minimal viable T20 + T23 + T24)
+ * # Scope on `main` after EW-742 P3.2 (this PR)
  *
  *   - `null` / `undefined` tenantId → instance default (the EW-683
  *     pre-tenancy code path, byte-identical — no DB hit).
  *   - No overlay row → instance default (T23 fallback).
  *   - `mode === 'inherit'` → instance default (T23 fallback).
  *   - `enabled === false` → instance default (soft kill switch).
- *   - `mode === 'byo' | 'override'` with `enabled === true` → returns the
- *     instance default for now with a `Logger.debug` noting the deferral.
- *     The honest stopgap: the entity exists, the row is read, the
- *     decision is made, but actually swapping the active provider's
- *     credentials requires the per-provider credential-binding API that
- *     lives in EW-686 P2 territory (see TODO block below).
+ *   - `mode === 'byo' | 'override'` with `enabled === true`:
+ *     1. cache check against `(tenantId, providerId, credentialVersion)`;
+ *     2. on miss, resolve `credentialsSecretRef` via
+ *        {@link SecretStoreResolver};
+ *     3. call `activeProvider.bindToTenant(snapshot)` (EW-686 P2
+ *        contract);
+ *     4. cache the bound provider; return it.
+ *     Any null/undefined/throw anywhere in this chain falls back to
+ *     the instance default and logs at `warn`.
  *
- * # Deferred to follow-up PRs (called out as TODO, NOT silently skipped)
+ * # What's STILL deferred
  *
- *   - **T21 — credential cache (15–60s LRU keyed by
- *     `(tenantId, providerId, credentialVersion)`)**: every `resolve()`
- *     call hits the database today. Will land in
- *     `packages/agent/src/tasks/tenant-credential.cache.ts`.
- *   - **T22 — credential version capture at every enqueue**: dispatch
- *     call sites need to stamp `credentialVersion` into the run record
- *     so the worker host can resolve the same snapshot when the job
- *     runs. {@link getEffectiveBinding} already returns the metadata
- *     callers will need; no enqueue-site changes ship in this PR.
- *   - **Per-provider credential-binding API (EW-686 P2)**: until the
- *     active `IJobRuntimeProvider` exposes a way to bind a specific
- *     credential snapshot for one call, `byo` and `override` cannot
- *     functionally swap credentials. The resolver reads the row and
- *     logs the decision, but returns the instance default's provider —
- *     the code path is in place, only the per-provider hook is missing.
+ *   - **T22 per-dispatcher wiring**: dispatch call sites still need to
+ *     call `RuntimeBindingStamperService.stamp(tenantId)` and persist
+ *     `credentialVersion` into each run record. {@link getEffectiveBinding}
+ *     already returns the metadata callers will use; each dispatcher
+ *     migration is its own PR.
+ *   - **Per-provider `bindToTenant` implementations**: each
+ *     `IJobRuntimeProvider` implementation needs to actually wire the
+ *     hook (Trigger.dev/TriggerService is the first — EW-686 P2 only
+ *     shipped the contract). Until each provider implements it, this
+ *     resolver's path 1 fallback (`provider.bindToTenant is not a
+ *     function`) fires and we silently revert to the instance default
+ *     for that provider.
+ *   - **Non-`inline:` secret-store schemes**: the bundled
+ *     `InProcessSecretStoreResolver` only supports `inline:` for dev /
+ *     test. Production deployments must bind a real
+ *     {@link SecretStoreResolver} for their scheme (`vault:`, `k8s:`,
+ *     `op:`, etc.).
  *
  * # Why no `getActive(tenantId)` extension on the registry
  *
@@ -75,6 +82,9 @@ export class TenantAwareRuntimeResolver {
         @InjectRepository(TenantJobRuntimeConfig)
         private readonly configRepository: Repository<TenantJobRuntimeConfig>,
         private readonly credentialVersionService: CredentialVersionService,
+        @Inject(SECRET_STORE_RESOLVER)
+        private readonly secretStoreResolver: SecretStoreResolver,
+        private readonly credentialCache: TenantCredentialCache,
     ) {}
 
     /**
@@ -83,10 +93,11 @@ export class TenantAwareRuntimeResolver {
      * (the EW-683 in-process dev fallback semantic — preserved from
      * `JobRuntimeProviderRegistry.getActive()`).
      *
-     * Honest stopgap for `byo` / `override` modes: see the class JSDoc
-     * — we read the row, log the decision, and return the instance
-     * default because the per-provider credential-binding hook isn't
-     * shipped yet.
+     * For `byo` / `override` modes with `enabled = true`, delegates to
+     * {@link bindForOverlay} which resolves credentials + calls
+     * `provider.bindToTenant(snapshot)` + memoises via
+     * {@link TenantCredentialCache}. See the class JSDoc for the full
+     * happy-path + fallback contract.
      */
     async resolve(tenantId: string | null | undefined): Promise<IJobRuntimeProvider | null> {
         if (!tenantId) {
@@ -116,17 +127,137 @@ export class TenantAwareRuntimeResolver {
             return this.registry.getActive();
         }
 
-        // mode === 'byo' | 'override' AND enabled — honest stopgap.
-        // See the class JSDoc "Scope of THIS PR" + the per-provider
-        // credential-binding API note. Logger.debug rather than warn
-        // because this is the documented behaviour for P3, not a fault.
-        this.logger.debug(
-            `tenant ${tenantId} overlay mode=${row.mode} providerId=${row.providerId} ` +
-                `credentialVersion=${row.credentialVersion}: returning instance default ` +
-                `(tenant override deferred to P3.1 — credential injection wiring lands ` +
-                `once per-provider credential-binding API exists)`,
+        // mode === 'byo' | 'override' AND enabled — actual tenant
+        // binding path. EW-742 P3.2 wiring: resolve the credential
+        // snapshot, call provider.bindToTenant(snapshot), memoise via
+        // TenantCredentialCache. Every failure mode falls back to the
+        // instance default and logs at warn so operators can diagnose.
+        return this.bindForOverlay(tenantId, row);
+    }
+
+    /**
+     * EW-742 P3.2 — drives the actual byo/override bind path. Factored
+     * out of {@link resolve} so the happy path stays readable and the
+     * cache-miss flow (resolve secret → snapshot → bindToTenant) is one
+     * linear function.
+     *
+     * Five fallback-to-instance-default paths, each logged at warn:
+     *   1. Active provider doesn't expose `bindToTenant?` at all
+     *      (provider doesn't support per-tenant binding).
+     *   2. `SecretStoreResolver.resolve` returns `null` (unknown scheme,
+     *      missing entry, malformed payload).
+     *   3. `provider.bindToTenant(snapshot)` returns `undefined`
+     *      (provider rejects the snapshot for its own reasons).
+     *   4. Anywhere in the chain throws (defence-in-depth — the contract
+     *      says implementations don't throw, but if one does, an
+     *      enqueue MUST NOT fail because of overlay resolution).
+     *   5. `this.registry.getActive()` returns `null` (EW-683 in-process
+     *      dev fallback — preserved).
+     */
+    private async bindForOverlay(
+        tenantId: string,
+        row: TenantJobRuntimeConfig,
+    ): Promise<IJobRuntimeProvider | null> {
+        const activeProvider = this.registry.getActive();
+        if (!activeProvider) {
+            // EW-683 in-process dev fallback — preserved.
+            return null;
+        }
+
+        if (typeof activeProvider.bindToTenant !== 'function') {
+            // Path 1: provider doesn't support per-tenant binding.
+            // Push providers that don't expose a way to swap credentials
+            // (or providers whose implementation doesn't override the
+            // optional contract) fall through to the instance default.
+            this.logger.warn(
+                `tenant ${tenantId} overlay mode=${row.mode} providerId=${row.providerId} ` +
+                    `credentialVersion=${row.credentialVersion}: active provider ` +
+                    `"${activeProvider.runtimeId}" does not implement bindToTenant() — ` +
+                    `falling back to instance default. Either upgrade the provider or set ` +
+                    `mode=inherit on the overlay.`,
+            );
+            return activeProvider;
+        }
+
+        // Cache check — keyed by (tenantId, providerId, credentialVersion).
+        // Same key the worker host will resolve against when handling the
+        // run later, so an in-flight run keeps its pinned snapshot.
+        const cacheKey = activeProvider.runtimeId;
+        const cached = this.credentialCache.get<IJobRuntimeProvider>(
+            tenantId,
+            cacheKey,
+            row.credentialVersion,
         );
-        return this.registry.getActive();
+        if (cached) {
+            return cached;
+        }
+
+        // Cache miss — resolve the credentials, build the snapshot, ask
+        // the provider to bind, cache the binding.
+        let credentials: Record<string, unknown> | null;
+        try {
+            credentials = await this.secretStoreResolver.resolve(row.credentialsSecretRef);
+        } catch (err) {
+            // Path 4 — contract says resolvers fail-open with null, but
+            // defend against a thrown error anyway. Never let overlay
+            // resolution block an enqueue.
+            this.logger.warn(
+                `tenant ${tenantId} overlay mode=${row.mode}: SecretStoreResolver threw ` +
+                    `(${err instanceof Error ? err.message : String(err)}) — falling back ` +
+                    `to instance default.`,
+            );
+            return activeProvider;
+        }
+
+        if (!credentials) {
+            // Path 2: resolver returned null. Already logged warn inside
+            // the resolver itself; add the tenant context here for
+            // operators tracing from the enqueue side.
+            this.logger.warn(
+                `tenant ${tenantId} overlay mode=${row.mode}: SecretStoreResolver returned ` +
+                    `null for credentialsSecretRef "${row.credentialsSecretRef}" — falling back ` +
+                    `to instance default.`,
+            );
+            return activeProvider;
+        }
+
+        let bound: IJobRuntimeProvider | undefined;
+        try {
+            bound = activeProvider.bindToTenant({
+                tenantId,
+                providerId: activeProvider.runtimeId as JobRuntimeId,
+                credentialVersion: row.credentialVersion,
+                credentials,
+            });
+        } catch (err) {
+            // Path 4 — same defence as the resolver branch above.
+            this.logger.warn(
+                `tenant ${tenantId} overlay mode=${row.mode}: provider.bindToTenant threw ` +
+                    `(${err instanceof Error ? err.message : String(err)}) — falling back ` +
+                    `to instance default.`,
+            );
+            return activeProvider;
+        }
+
+        if (!bound) {
+            // Path 3: provider rejected the snapshot. Already explained
+            // in the contract — provider returns undefined when it
+            // doesn't want to bind THIS particular snapshot (e.g. the
+            // credentials are valid-shaped but unusable). Fall back.
+            this.logger.warn(
+                `tenant ${tenantId} overlay mode=${row.mode}: provider.bindToTenant returned ` +
+                    `undefined — falling back to instance default.`,
+            );
+            return activeProvider;
+        }
+
+        // Cache the bound provider for subsequent enqueues against the
+        // same (tenantId, providerId, credentialVersion). Eviction is
+        // version-bump-driven (CredentialVersionService bumps + the
+        // controller invalidates the cache), so no need to scope the
+        // TTL tighter than the cache's default.
+        this.credentialCache.set(tenantId, cacheKey, row.credentialVersion, bound);
+        return bound;
     }
 
     /**


### PR DESCRIPTION
## Summary

Replaces the byo/override **\"honest stopgap\"** (Logger.debug + instance default) with the real bind path that EW-686 P2 unlocked:

1. cache check against \`(tenantId, providerId, credentialVersion)\`;
2. on miss, resolve \`credentialsSecretRef\` via \`SecretStoreResolver\`;
3. call \`provider.bindToTenant(snapshot)\` (EW-686 P2 contract);
4. cache + return the bound provider.

## New: secret-store-pointer resolution layer

The platform's tenant overlay stores \`credentialsSecretRef\` as an opaque pointer (\`vault://...\`, \`k8s:...\`, \`op://...\`, \`inline:...\`). The resolver needs the actual credential bag to call \`provider.bindToTenant(snapshot)\`. Two new files:

| File | Role |
| --- | --- |
| \`secret-store-resolver.interface.ts\` | \`SecretStoreResolver\` contract + \`SECRET_STORE_RESOLVER\` DI token. Fail-open: implementations MUST NOT throw — return \`null\` + log at warn. |
| \`in-process-secret-store-resolver.service.ts\` | Default \`InProcessSecretStoreResolver\`. Supports ONE scheme, \`inline:<base64-of-json>\`. Every other scheme returns \`null\` + \`Logger.warn\` telling the operator to bind a real implementation. |

Production deployments override the \`SECRET_STORE_RESOLVER\` binding with a scheme-specific resolver — one PR per scheme on top of this contract. The \`inline:\` default ships out-of-the-box so the wiring lands without committing to any specific secret-store vendor.

## Five fallback-to-instance-default paths (each logged at warn)

1. Active provider doesn't expose \`bindToTenant?\` (e.g. EW-686 P2 contract not yet implemented by that provider).
2. \`SecretStoreResolver.resolve\` returns \`null\` (unknown scheme, missing entry, malformed payload).
3. \`SecretStoreResolver.resolve\` throws (defence-in-depth — contract says it doesn't, but if it does we mustn't block enqueue).
4. \`provider.bindToTenant(snapshot)\` returns \`undefined\` (provider rejected the snapshot).
5. \`provider.bindToTenant\` throws.
Plus the always-preserved EW-683 in-process dev fallback when \`registry.getActive()\` itself returns \`null\`.

## Tests: 58/58 jest pass

- \`InProcessSecretStoreResolver\` — **8/8** (each scheme, each malformed-payload branch)
- \`TenantAwareRuntimeResolver\` — **18/18** (happy path, 4 fallback paths, cache-hit short-circuit, kill switch ordering)
- \`tasks.spec.ts\` drift gate — **25/25** (\`InProcessSecretStoreResolver\` + \`SECRET_STORE_RESOLVER\` symbols registered)
- \`RuntimeBindingStamperService\` — **8/8** unchanged

## Files

| File | Change |
| --- | --- |
| \`packages/agent/src/tasks/secret-store-resolver.interface.ts\` | **new** — contract + DI token |
| \`packages/agent/src/tasks/in-process-secret-store-resolver.service.ts\` | **new** — \`inline:\` default impl |
| \`packages/agent/src/tasks/__tests__/in-process-secret-store-resolver.service.spec.ts\` | **new** — 8 cases |
| \`packages/agent/src/tasks/tenant-aware-runtime.resolver.ts\` | byo/override branch now calls \`bindForOverlay()\` (real bind + cache) instead of Logger.debug stopgap |
| \`packages/agent/src/tasks/__tests__/tenant-aware-runtime.resolver.spec.ts\` | extended with 6 new test cases + updated existing byo/override assertions |
| \`packages/agent/src/tasks/_tasks-symbols.ts\` + \`index.ts\` | register new symbols |
| \`apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts\` | bind \`InProcessSecretStoreResolver\` at the \`SECRET_STORE_RESOLVER\` DI token |
| \`docs/specs/features/tenant-job-runtime-overlay/tasks.md\` | new \"Phase 3.2\" subsection + status header update |

## What's still deferred

- **T22 per-dispatcher wiring** — 12 incremental call-site adoptions of \`RuntimeBindingStamperService\`.
- **Per-provider \`bindToTenant\` implementations** — only the contract exists today (EW-686 P2). Each \`IJobRuntimeProvider\` impl wires it on its own PR (Trigger.dev/TriggerService is the first target).
- **Non-\`inline:\` SecretStoreResolver implementations** (\`vault:\`, \`k8s:\`, \`op:\`) — one PR per scheme.

## Test plan

- [x] \`cd packages/agent && npx jest --testPathPattern='in-process-secret-store-resolver|tenant-aware-runtime|tasks.spec|runtime-binding-stamper' --no-coverage\` — 58/58 pass
- [x] Prettier clean
- [x] No regressions to existing test cases (kill switch, no-row, inherit, getEffectiveBinding all unchanged behaviour)

## Refs

- Epic: [EW-742](https://evertech.atlassian.net/browse/EW-742)
- Story: [EW-747](https://evertech.atlassian.net/browse/EW-747) (Phase 3 dispatcher routing)
- Sibling: [EW-686](https://evertech.atlassian.net/browse/EW-686) P2 \`bindToTenant\` contract (#1387) — consumed by this PR

[EW-742]: https://evertech.atlassian.net/browse/EW-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credential resolution support with inline format encoding and automatic fallback handling when resolution fails.

* **Tests**
  * Added comprehensive test coverage for credential resolution scenarios, including validation of input formats and fallback behavior.

* **Documentation**
  * Updated feature specifications to document credential binding workflow and supported resolution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->