### PR TITLE
chore(release): cascade EW-742 P3.2 cloud-vendor SecretStoreResolver plugins to main

### DIFF
--- a/packages/plugins/secret-store-aws-sm/package.json
+++ b/packages/plugins/secret-store-aws-sm/package.json
@@ -1,0 +1,82 @@
+{
+	"name": "@ever-works/secret-store-aws-sm-plugin",
+	"version": "1.0.0",
+	"description": "AWS Secrets Manager SecretStoreResolver plugin for Ever Works — resolves aws-sm:<region>/<secretName> pointers via the AWS Secrets Manager REST API.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "secret-store-aws-sm",
+			"name": "AWS Secrets Manager Secret Store",
+			"version": "1.0.0",
+			"category": "secret-store-resolver",
+			"capabilities": [
+				"secret-store-resolve"
+			],
+			"description": "Resolves aws-sm:<region>/<secretName> pointers via the AWS Secrets Manager REST API. Uses AWS Signature v4 from AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY env vars (optionally AWS_SESSION_TOKEN).",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"autoEnable": false,
+			"systemPlugin": false,
+			"distribution": "core",
+			"builtIn": true,
+			"visibility": "operator",
+			"envVars": [
+				{
+					"name": "AWS_ACCESS_KEY_ID",
+					"required": true,
+					"secret": false,
+					"description": "AWS access key id."
+				},
+				{
+					"name": "AWS_SECRET_ACCESS_KEY",
+					"required": true,
+					"secret": true,
+					"description": "AWS secret access key."
+				},
+				{
+					"name": "AWS_SESSION_TOKEN",
+					"required": false,
+					"secret": true,
+					"description": "Optional STS session token (e.g. when assuming a role / IRSA)."
+				}
+			]
+		}
+	}
+}

--- a/packages/plugins/secret-store-aws-sm/src/__tests__/aws-sm-secret-store.plugin.spec.ts
+++ b/packages/plugins/secret-store-aws-sm/src/__tests__/aws-sm-secret-store.plugin.spec.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AwsSmSecretStorePlugin } from '../aws-sm-secret-store.plugin.js';
+
+describe('AwsSmSecretStorePlugin (EW-742 P3.2 T20.10a plugin package)', () => {
+	let plugin: AwsSmSecretStorePlugin;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	const orig = {
+		ak: process.env.AWS_ACCESS_KEY_ID,
+		sk: process.env.AWS_SECRET_ACCESS_KEY,
+		st: process.env.AWS_SESSION_TOKEN
+	};
+
+	beforeEach(() => {
+		plugin = new AwsSmSecretStorePlugin();
+		fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+			throw new Error('fetch not mocked');
+		});
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		process.env.AWS_ACCESS_KEY_ID = 'AKIAIOSFODNN7EXAMPLE';
+		process.env.AWS_SECRET_ACCESS_KEY = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+		delete process.env.AWS_SESSION_TOKEN;
+	});
+
+	afterEach(() => {
+		fetchSpy.mockRestore();
+		warnSpy.mockRestore();
+		process.env.AWS_ACCESS_KEY_ID = orig.ak;
+		process.env.AWS_SECRET_ACCESS_KEY = orig.sk;
+		if (orig.st === undefined) delete process.env.AWS_SESSION_TOKEN;
+		else process.env.AWS_SESSION_TOKEN = orig.st;
+	});
+
+	function mockResponse(opts: { ok?: boolean; status?: number; body?: unknown }): Response {
+		const status = opts.status ?? (opts.ok === false ? 500 : 200);
+		return {
+			ok: opts.ok ?? (status >= 200 && status < 300),
+			status,
+			json: () => Promise.resolve(opts.body)
+		} as unknown as Response;
+	}
+
+	it('declares manifest fields', () => {
+		expect(plugin.id).toBe('secret-store-aws-sm');
+		expect(plugin.category).toBe('secret-store-resolver');
+		expect(plugin.capabilities).toContain('secret-store-resolve');
+	});
+
+	it('returns null for non-aws-sm: scheme', async () => {
+		expect(await plugin.resolveSecret('vault:secret/foo')).toBeNull();
+	});
+
+	it('returns null for malformed pointer', async () => {
+		expect(await plugin.resolveSecret('aws-sm:us-east-1')).toBeNull();
+	});
+
+	it('returns null when AWS_ACCESS_KEY_ID missing', async () => {
+		delete process.env.AWS_ACCESS_KEY_ID;
+		expect(await plugin.resolveSecret('aws-sm:us-east-1/my-secret')).toBeNull();
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('returns null when AWS_SECRET_ACCESS_KEY missing', async () => {
+		delete process.env.AWS_SECRET_ACCESS_KEY;
+		expect(await plugin.resolveSecret('aws-sm:us-east-1/my-secret')).toBeNull();
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('returns null on fetch network error', async () => {
+		fetchSpy.mockRejectedValue(new Error('ECONNRESET'));
+		expect(await plugin.resolveSecret('aws-sm:us-east-1/x')).toBeNull();
+	});
+
+	it('returns null on HTTP 400', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: false, status: 400 }));
+		expect(await plugin.resolveSecret('aws-sm:us-east-1/x')).toBeNull();
+	});
+
+	it('returns null when SecretString is missing', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { Name: 'x' } }));
+		expect(await plugin.resolveSecret('aws-sm:us-east-1/x')).toBeNull();
+	});
+
+	it('returns null when SecretString is not JSON', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { SecretString: 'not json' } }));
+		expect(await plugin.resolveSecret('aws-sm:us-east-1/x')).toBeNull();
+	});
+
+	it('returns parsed bag from SecretString JSON', async () => {
+		const credentials = { accessToken: 'tr_dev_xxx', region: 'us-east-1' };
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { SecretString: JSON.stringify(credentials) } }));
+		expect(await plugin.resolveSecret('aws-sm:us-east-1/prod/acme')).toEqual(credentials);
+	});
+
+	it('composes URL with region in host', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { SecretString: '{"k":"v"}' } }));
+		await plugin.resolveSecret('aws-sm:eu-west-2/my-secret');
+		const [calledUrl] = fetchSpy.mock.calls[0] as [string];
+		expect(calledUrl).toBe('https://secretsmanager.eu-west-2.amazonaws.com/');
+	});
+
+	it('sends X-Amz-Date, X-Amz-Target, and SigV4 Authorization headers', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { SecretString: '{"k":"v"}' } }));
+		await plugin.resolveSecret('aws-sm:us-east-1/x');
+		const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		const headers = init.headers as Record<string, string>;
+		expect(headers['X-Amz-Target']).toBe('secretsmanager.GetSecretValue');
+		expect(headers['X-Amz-Date']).toMatch(/^\d{8}T\d{6}Z$/);
+		expect(headers['Authorization']).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE\//);
+		expect(headers['Authorization']).toContain('Signature=');
+	});
+
+	it('includes X-Amz-Security-Token when AWS_SESSION_TOKEN is set', async () => {
+		process.env.AWS_SESSION_TOKEN = 'sts-token-xxx';
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { SecretString: '{"k":"v"}' } }));
+		await plugin.resolveSecret('aws-sm:us-east-1/x');
+		const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		const headers = init.headers as Record<string, string>;
+		expect(headers['X-Amz-Security-Token']).toBe('sts-token-xxx');
+	});
+});

--- a/packages/plugins/secret-store-aws-sm/src/aws-sm-secret-store.plugin.ts
+++ b/packages/plugins/secret-store-aws-sm/src/aws-sm-secret-store.plugin.ts
@@ -1,0 +1,257 @@
+import { createHash, createHmac } from 'node:crypto';
+import type { IPlugin, ISecretStoreProvider, JsonSchema, PluginCategory, PluginContext } from '@ever-works/plugin';
+import { SECRET_STORE_CAPABILITIES } from '@ever-works/plugin';
+
+/**
+ * EW-742 P3.2 T20.10a -- AWS Secrets Manager SecretStoreResolver plugin.
+ *
+ * Resolves `aws-sm:<region>/<secretName>` pointers via the AWS Secrets
+ * Manager REST API. Uses AWS Signature v4 from the standard
+ * `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + (optional)
+ * `AWS_SESSION_TOKEN` env vars.
+ *
+ * # Pointer format
+ *
+ *   `aws-sm:<region>/<secretName>` -- e.g. `aws-sm:us-east-1/prod/tenants/acme`
+ *
+ * The secret name can contain slashes (AWS supports them in names).
+ * Everything after the first `/` is the secret id.
+ *
+ * # Auth
+ *
+ * Uses SigV4 (no AWS SDK dependency). Operators provision AWS access
+ * via the standard env-var conventions:
+ *   - Static keys: `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`
+ *   - STS / IRSA / EC2-IMDS: tooling layer (IRSA mutating webhook,
+ *     `aws sts assume-role`, etc.) writes the same env vars
+ *     including `AWS_SESSION_TOKEN`.
+ *
+ * Pure SigV4 — Node 22+ built-ins only (crypto + fetch).
+ *
+ * # Fail-open
+ *
+ * Every failure path returns null + warn. Never throws.
+ */
+export class AwsSmSecretStorePlugin implements IPlugin, ISecretStoreProvider {
+	readonly id = 'secret-store-aws-sm';
+	readonly name = 'AWS Secrets Manager Secret Store';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'secret-store-resolver';
+	readonly capabilities: readonly string[] = [SECRET_STORE_CAPABILITIES.RESOLVE];
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			awsAccessKeyId: {
+				type: 'string',
+				title: 'AWS Access Key Id',
+				'x-envVar': 'AWS_ACCESS_KEY_ID'
+			},
+			awsSecretAccessKey: {
+				type: 'string',
+				title: 'AWS Secret Access Key',
+				'x-secret': true,
+				'x-envVar': 'AWS_SECRET_ACCESS_KEY'
+			},
+			awsSessionToken: {
+				type: 'string',
+				title: 'AWS Session Token (STS)',
+				'x-secret': true,
+				'x-envVar': 'AWS_SESSION_TOKEN'
+			}
+		}
+	};
+
+	private context?: PluginContext;
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+	}
+
+	async resolveSecret(pointer: string): Promise<Record<string, unknown> | null> {
+		if (!pointer.startsWith('aws-sm:')) {
+			const scheme = pointer.split(':', 1)[0] ?? 'unknown';
+			this.warn(`AwsSmSecretStorePlugin: pointer scheme "${scheme}:" not handled. Returning null (fail-open).`);
+			return null;
+		}
+
+		const rest = pointer.slice('aws-sm:'.length);
+		const slashIdx = rest.indexOf('/');
+		if (slashIdx <= 0) {
+			this.warn(
+				`AwsSmSecretStorePlugin: malformed pointer "${pointer}" (expected ` +
+					`aws-sm:<region>/<secretName>). Returning null (fail-open).`
+			);
+			return null;
+		}
+		const region = rest.slice(0, slashIdx);
+		const secretId = rest.slice(slashIdx + 1);
+		if (!region || !secretId) {
+			this.warn(`AwsSmSecretStorePlugin: empty region or secretName in "${pointer}". Returning null.`);
+			return null;
+		}
+
+		const accessKey = process.env.AWS_ACCESS_KEY_ID;
+		const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
+		const sessionToken = process.env.AWS_SESSION_TOKEN;
+		if (!accessKey || !secretKey) {
+			this.warn(
+				`AwsSmSecretStorePlugin: AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY not set. ` +
+					`Returning null (fail-open).`
+			);
+			return null;
+		}
+
+		const host = `secretsmanager.${region}.amazonaws.com`;
+		const url = `https://${host}/`;
+		const body = JSON.stringify({ SecretId: secretId });
+		const headers = this.signRequest({
+			method: 'POST',
+			host,
+			region,
+			service: 'secretsmanager',
+			body,
+			accessKey,
+			secretKey,
+			sessionToken,
+			target: 'secretsmanager.GetSecretValue'
+		});
+
+		let response: Response;
+		try {
+			response = await fetch(url, { method: 'POST', headers, body });
+		} catch (err) {
+			this.warn(
+				`AwsSmSecretStorePlugin: fetch failed for ${url} ` +
+					`(${err instanceof Error ? err.message : String(err)}). Returning null (fail-open).`
+			);
+			return null;
+		}
+
+		if (!response.ok) {
+			this.warn(`AwsSmSecretStorePlugin: AWS responded ${response.status}. Returning null.`);
+			return null;
+		}
+
+		let json: { SecretString?: unknown; SecretBinary?: unknown } | unknown;
+		try {
+			json = await response.json();
+		} catch (err) {
+			this.warn(
+				`AwsSmSecretStorePlugin: response is not JSON ` +
+					`(${err instanceof Error ? err.message : String(err)}). Returning null.`
+			);
+			return null;
+		}
+
+		if (json === null || typeof json !== 'object') {
+			this.warn(`AwsSmSecretStorePlugin: response is not an object. Returning null.`);
+			return null;
+		}
+
+		const secretString = (json as { SecretString?: unknown }).SecretString;
+		if (typeof secretString === 'string') {
+			try {
+				const parsed = JSON.parse(secretString);
+				if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+					return parsed as Record<string, unknown>;
+				}
+				this.warn(`AwsSmSecretStorePlugin: SecretString is not a JSON object. Returning null.`);
+				return null;
+			} catch {
+				this.warn(`AwsSmSecretStorePlugin: SecretString is not valid JSON. Returning null.`);
+				return null;
+			}
+		}
+
+		this.warn(`AwsSmSecretStorePlugin: response missing SecretString. Returning null.`);
+		return null;
+	}
+
+	/**
+	 * AWS Signature Version 4 (SigV4) — pure-Node implementation. Returns
+	 * the headers to send with the POST request. See AWS docs:
+	 * https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+	 */
+	private signRequest(opts: {
+		method: string;
+		host: string;
+		region: string;
+		service: string;
+		body: string;
+		accessKey: string;
+		secretKey: string;
+		sessionToken?: string;
+		target: string;
+	}): Record<string, string> {
+		const { method, host, region, service, body, accessKey, secretKey, sessionToken, target } = opts;
+		const now = new Date();
+		const amzDate = now
+			.toISOString()
+			.replace(/[-:]/g, '')
+			.replace(/\.\d{3}/, '');
+		const dateStamp = amzDate.slice(0, 8);
+
+		const payloadHash = createHash('sha256').update(body).digest('hex');
+
+		const canonicalUri = '/';
+		const canonicalQuerystring = '';
+		const baseHeaders: Record<string, string> = {
+			'content-type': 'application/x-amz-json-1.1',
+			host,
+			'x-amz-date': amzDate,
+			'x-amz-target': target
+		};
+		if (sessionToken) baseHeaders['x-amz-security-token'] = sessionToken;
+
+		const sortedHeaderNames = Object.keys(baseHeaders).sort();
+		const canonicalHeaders = sortedHeaderNames.map((k) => `${k}:${baseHeaders[k]}\n`).join('');
+		const signedHeaders = sortedHeaderNames.join(';');
+
+		const canonicalRequest = [
+			method,
+			canonicalUri,
+			canonicalQuerystring,
+			canonicalHeaders,
+			signedHeaders,
+			payloadHash
+		].join('\n');
+
+		const algorithm = 'AWS4-HMAC-SHA256';
+		const credentialScope = `${dateStamp}/${region}/${service}/aws4_request`;
+		const stringToSign = [
+			algorithm,
+			amzDate,
+			credentialScope,
+			createHash('sha256').update(canonicalRequest).digest('hex')
+		].join('\n');
+
+		const kDate = createHmac('sha256', `AWS4${secretKey}`).update(dateStamp).digest();
+		const kRegion = createHmac('sha256', kDate).update(region).digest();
+		const kService = createHmac('sha256', kRegion).update(service).digest();
+		const kSigning = createHmac('sha256', kService).update('aws4_request').digest();
+		const signature = createHmac('sha256', kSigning).update(stringToSign).digest('hex');
+
+		const authorization =
+			`${algorithm} Credential=${accessKey}/${credentialScope}, ` +
+			`SignedHeaders=${signedHeaders}, Signature=${signature}`;
+
+		const headers: Record<string, string> = {
+			'Content-Type': 'application/x-amz-json-1.1',
+			Host: host,
+			'X-Amz-Date': amzDate,
+			'X-Amz-Target': target,
+			Authorization: authorization
+		};
+		if (sessionToken) headers['X-Amz-Security-Token'] = sessionToken;
+		return headers;
+	}
+
+	private warn(message: string): void {
+		this.context?.logger?.warn?.(message) ?? console.warn(message);
+	}
+}

--- a/packages/plugins/secret-store-aws-sm/src/index.ts
+++ b/packages/plugins/secret-store-aws-sm/src/index.ts
@@ -1,0 +1,2 @@
+export { AwsSmSecretStorePlugin } from './aws-sm-secret-store.plugin.js';
+export { AwsSmSecretStorePlugin as default } from './aws-sm-secret-store.plugin.js';

--- a/packages/plugins/secret-store-aws-sm/tsconfig.json
+++ b/packages/plugins/secret-store-aws-sm/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/secret-store-aws-sm/tsup.config.ts
+++ b/packages/plugins/secret-store-aws-sm/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/packages/plugins/secret-store-azure-kv/package.json
+++ b/packages/plugins/secret-store-azure-kv/package.json
@@ -1,0 +1,56 @@
+{
+	"name": "@ever-works/secret-store-azure-kv-plugin",
+	"version": "1.0.0",
+	"description": "Azure Key Vault SecretStoreResolver plugin for Ever Works — resolves azure-kv:<vaultName>/<secretName> pointers via the Azure Key Vault REST API.",
+	"author": { "name": "Ever Co. LTD", "email": "ever@ever.co", "url": "https://ever.co" },
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": { "types": "./dist/index.d.ts", "import": "./dist/index.js", "require": "./dist/index.cjs" }
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": { "@ever-works/plugin": "workspace:*" },
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "secret-store-azure-kv",
+			"name": "Azure Key Vault Secret Store",
+			"version": "1.0.0",
+			"category": "secret-store-resolver",
+			"capabilities": ["secret-store-resolve"],
+			"description": "Resolves azure-kv:<vaultName>/<secretName> pointers via the Azure Key Vault REST API. Uses a pre-fetched bearer token from AZURE_KV_TOKEN env var (operators provision via Managed Identity, az cli, or sidecar token-refresher).",
+			"author": { "name": "Ever Works Team" },
+			"license": "AGPL-3.0",
+			"autoEnable": false,
+			"systemPlugin": false,
+			"distribution": "core",
+			"builtIn": true,
+			"visibility": "operator",
+			"envVars": [
+				{
+					"name": "AZURE_KV_TOKEN",
+					"required": true,
+					"secret": true,
+					"description": "Azure AD bearer token (scope https://vault.azure.net/.default). Operators refresh out-of-band via Managed Identity, az cli, or sidecar."
+				}
+			]
+		}
+	}
+}

--- a/packages/plugins/secret-store-azure-kv/src/__tests__/azure-kv-secret-store.plugin.spec.ts
+++ b/packages/plugins/secret-store-azure-kv/src/__tests__/azure-kv-secret-store.plugin.spec.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AzureKvSecretStorePlugin } from '../azure-kv-secret-store.plugin.js';
+
+describe('AzureKvSecretStorePlugin (EW-742 P3.2 T20.10c plugin package)', () => {
+	let plugin: AzureKvSecretStorePlugin;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	const origToken = process.env.AZURE_KV_TOKEN;
+
+	beforeEach(() => {
+		plugin = new AzureKvSecretStorePlugin();
+		fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+			throw new Error('fetch not mocked');
+		});
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		process.env.AZURE_KV_TOKEN = 'eyJ0eXAiOiJKV1Q.test';
+	});
+
+	afterEach(() => {
+		fetchSpy.mockRestore();
+		warnSpy.mockRestore();
+		process.env.AZURE_KV_TOKEN = origToken;
+	});
+
+	function mockResponse(opts: { ok?: boolean; status?: number; body?: unknown }): Response {
+		const status = opts.status ?? (opts.ok === false ? 500 : 200);
+		return {
+			ok: opts.ok ?? (status >= 200 && status < 300),
+			status,
+			json: () => Promise.resolve(opts.body)
+		} as unknown as Response;
+	}
+
+	it('declares manifest fields', () => {
+		expect(plugin.id).toBe('secret-store-azure-kv');
+		expect(plugin.category).toBe('secret-store-resolver');
+		expect(plugin.capabilities).toContain('secret-store-resolve');
+	});
+
+	it('returns null for non-azure-kv: scheme', async () => {
+		expect(await plugin.resolveSecret('vault:secret/foo')).toBeNull();
+	});
+
+	it('returns null for malformed pointer', async () => {
+		expect(await plugin.resolveSecret('azure-kv:my-vault')).toBeNull();
+	});
+
+	it('returns null when AZURE_KV_TOKEN missing', async () => {
+		delete process.env.AZURE_KV_TOKEN;
+		expect(await plugin.resolveSecret('azure-kv:my-vault/my-secret')).toBeNull();
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('returns null on fetch error', async () => {
+		fetchSpy.mockRejectedValue(new Error('ETIMEDOUT'));
+		expect(await plugin.resolveSecret('azure-kv:my-vault/x')).toBeNull();
+	});
+
+	it('returns null on HTTP 404', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: false, status: 404 }));
+		expect(await plugin.resolveSecret('azure-kv:my-vault/missing')).toBeNull();
+	});
+
+	it('returns null on HTTP 401', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: false, status: 401 }));
+		expect(await plugin.resolveSecret('azure-kv:my-vault/forbidden')).toBeNull();
+	});
+
+	it('returns null when response.value missing', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { id: 'x' } }));
+		expect(await plugin.resolveSecret('azure-kv:my-vault/x')).toBeNull();
+	});
+
+	it('returns parsed bag from JSON-encoded value', async () => {
+		const credentials = { accessToken: 'tr_dev_xxx', region: 'westus' };
+		fetchSpy.mockResolvedValue(
+			mockResponse({ ok: true, body: { value: JSON.stringify(credentials) } })
+		);
+		expect(await plugin.resolveSecret('azure-kv:my-vault/tenants-acme')).toEqual(credentials);
+	});
+
+	it('wraps non-JSON string value as { value }', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { value: 'simple-secret-string' } }));
+		expect(await plugin.resolveSecret('azure-kv:my-vault/x')).toEqual({
+			value: 'simple-secret-string'
+		});
+	});
+
+	it('composes URL with vaultName + secretName + api-version', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { value: '{"k":"v"}' } }));
+		await plugin.resolveSecret('azure-kv:my-vault/my-secret');
+		const [calledUrl] = fetchSpy.mock.calls[0] as [string];
+		expect(calledUrl).toBe(
+			'https://my-vault.vault.azure.net/secrets/my-secret?api-version=7.4'
+		);
+	});
+
+	it('sends Bearer token in Authorization header', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { value: '{"k":"v"}' } }));
+		await plugin.resolveSecret('azure-kv:my-vault/x');
+		const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		const headers = init.headers as Record<string, string>;
+		expect(headers['Authorization']).toBe('Bearer eyJ0eXAiOiJKV1Q.test');
+	});
+});

--- a/packages/plugins/secret-store-azure-kv/src/azure-kv-secret-store.plugin.ts
+++ b/packages/plugins/secret-store-azure-kv/src/azure-kv-secret-store.plugin.ts
@@ -1,0 +1,179 @@
+import type {
+	IPlugin,
+	ISecretStoreProvider,
+	JsonSchema,
+	PluginCategory,
+	PluginContext
+} from '@ever-works/plugin';
+import { SECRET_STORE_CAPABILITIES } from '@ever-works/plugin';
+
+/**
+ * EW-742 P3.2 T20.10c -- Azure Key Vault SecretStoreResolver plugin.
+ *
+ * Resolves `azure-kv:<vaultName>/<secretName>` pointers via the Azure
+ * Key Vault REST API. Uses a pre-fetched Azure AD bearer token from
+ * the `AZURE_KV_TOKEN` env var.
+ *
+ * # Pointer format
+ *
+ *   `azure-kv:<vaultName>/<secretName>`
+ *   e.g. `azure-kv:my-vault/prod-tenant-acme`
+ *
+ * # Auth
+ *
+ * Azure AD OAuth2 client-credentials flow requires posting to
+ * `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token` with
+ * `client_id` + `client_secret` + `scope=https://vault.azure.net/.default`,
+ * then using the returned access token as Bearer on the KV API. That's
+ * 2 HTTP calls + token caching + expiry handling — we deliberately
+ * push it to the operator's tooling layer.
+ *
+ * Operators provision `AZURE_KV_TOKEN` out-of-band:
+ *   - Managed Identity (Azure VMs / AKS) — IMDS endpoint provides
+ *     the token at `http://169.254.169.254/metadata/identity/...`
+ *   - Sidecar — `az account get-access-token --resource https://vault.azure.net`
+ *     refresher
+ *
+ * # API
+ *
+ *   GET https://{vaultName}.vault.azure.net/secrets/{secretName}?api-version=7.4
+ *   Response: `{ value: "<secret-value>", id: "...", ... }`
+ *
+ * The `value` field is the raw secret. We parse it as JSON if possible
+ * (matches the convention of the other resolvers); if not, returns
+ * `{ value: "<raw>" }` so simple string secrets still work.
+ *
+ * # Fail-open — every failure path returns null.
+ */
+export class AzureKvSecretStorePlugin implements IPlugin, ISecretStoreProvider {
+	readonly id = 'secret-store-azure-kv';
+	readonly name = 'Azure Key Vault Secret Store';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'secret-store-resolver';
+	readonly capabilities: readonly string[] = [SECRET_STORE_CAPABILITIES.RESOLVE];
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			azureKvToken: {
+				type: 'string',
+				title: 'Azure Key Vault Access Token',
+				description: 'Azure AD bearer token (scope https://vault.azure.net/.default).',
+				'x-secret': true,
+				'x-envVar': 'AZURE_KV_TOKEN'
+			}
+		}
+	};
+
+	private static readonly API_VERSION = '7.4';
+
+	private context?: PluginContext;
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+	}
+
+	async resolveSecret(pointer: string): Promise<Record<string, unknown> | null> {
+		if (!pointer.startsWith('azure-kv:')) {
+			const scheme = pointer.split(':', 1)[0] ?? 'unknown';
+			this.warn(
+				`AzureKvSecretStorePlugin: pointer scheme "${scheme}:" not handled. Returning null (fail-open).`
+			);
+			return null;
+		}
+
+		const rest = pointer.slice('azure-kv:'.length);
+		const slashIdx = rest.indexOf('/');
+		if (slashIdx <= 0) {
+			this.warn(
+				`AzureKvSecretStorePlugin: malformed pointer "${pointer}" (expected ` +
+					`azure-kv:<vaultName>/<secretName>). Returning null (fail-open).`
+			);
+			return null;
+		}
+		const vaultName = rest.slice(0, slashIdx);
+		const secretName = rest.slice(slashIdx + 1);
+		if (!vaultName || !secretName) {
+			this.warn(
+				`AzureKvSecretStorePlugin: empty vaultName or secretName in "${pointer}". Returning null.`
+			);
+			return null;
+		}
+
+		const token = process.env.AZURE_KV_TOKEN;
+		if (!token) {
+			this.warn(
+				`AzureKvSecretStorePlugin: AZURE_KV_TOKEN not set. Provision via Managed Identity, ` +
+					`az cli, or sidecar. Returning null (fail-open).`
+			);
+			return null;
+		}
+
+		const url =
+			`https://${encodeURIComponent(vaultName)}.vault.azure.net/secrets/` +
+			`${encodeURIComponent(secretName)}?api-version=${AzureKvSecretStorePlugin.API_VERSION}`;
+
+		let response: Response;
+		try {
+			response = await fetch(url, {
+				method: 'GET',
+				headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' }
+			});
+		} catch (err) {
+			this.warn(
+				`AzureKvSecretStorePlugin: fetch failed for ${url} ` +
+					`(${err instanceof Error ? err.message : String(err)}). Returning null (fail-open).`
+			);
+			return null;
+		}
+
+		if (!response.ok) {
+			this.warn(`AzureKvSecretStorePlugin: Azure responded ${response.status}. Returning null.`);
+			return null;
+		}
+
+		let json: unknown;
+		try {
+			json = await response.json();
+		} catch (err) {
+			this.warn(
+				`AzureKvSecretStorePlugin: response is not JSON ` +
+					`(${err instanceof Error ? err.message : String(err)}). Returning null.`
+			);
+			return null;
+		}
+
+		if (json === null || typeof json !== 'object') {
+			this.warn(`AzureKvSecretStorePlugin: response is not an object. Returning null.`);
+			return null;
+		}
+
+		const value = (json as { value?: unknown }).value;
+		if (typeof value !== 'string') {
+			this.warn(`AzureKvSecretStorePlugin: response missing value string. Returning null.`);
+			return null;
+		}
+
+		// Try JSON-parse first (matches convention of other resolvers
+		// where secrets are JSON-encoded credential bags). If parsing
+		// fails, fall back to wrapping the raw string under `{ value }`
+		// so simple string secrets still work.
+		try {
+			const parsed = JSON.parse(value);
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+				return parsed as Record<string, unknown>;
+			}
+		} catch {
+			// not JSON — fall through to wrap as { value }
+		}
+		return { value };
+	}
+
+	private warn(message: string): void {
+		this.context?.logger?.warn?.(message) ?? console.warn(message);
+	}
+}

--- a/packages/plugins/secret-store-azure-kv/src/index.ts
+++ b/packages/plugins/secret-store-azure-kv/src/index.ts
@@ -1,0 +1,2 @@
+export { AzureKvSecretStorePlugin } from './azure-kv-secret-store.plugin.js';
+export { AzureKvSecretStorePlugin as default } from './azure-kv-secret-store.plugin.js';

--- a/packages/plugins/secret-store-azure-kv/tsconfig.json
+++ b/packages/plugins/secret-store-azure-kv/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/secret-store-azure-kv/tsup.config.ts
+++ b/packages/plugins/secret-store-azure-kv/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/packages/plugins/secret-store-gcp-sm/package.json
+++ b/packages/plugins/secret-store-gcp-sm/package.json
@@ -1,0 +1,70 @@
+{
+	"name": "@ever-works/secret-store-gcp-sm-plugin",
+	"version": "1.0.0",
+	"description": "GCP Secret Manager SecretStoreResolver plugin for Ever Works — resolves gcp-sm:<project>/<secretName> pointers via the GCP Secret Manager REST API.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "secret-store-gcp-sm",
+			"name": "GCP Secret Manager Secret Store",
+			"version": "1.0.0",
+			"category": "secret-store-resolver",
+			"capabilities": [
+				"secret-store-resolve"
+			],
+			"description": "Resolves gcp-sm:<project>/<secretName> pointers via the GCP Secret Manager REST API. Uses a pre-fetched bearer token from GCP_ACCESS_TOKEN env var (operators provision via Workload Identity, gcloud auth print-access-token, or sidecar token-refresher).",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"autoEnable": false,
+			"systemPlugin": false,
+			"distribution": "core",
+			"builtIn": true,
+			"visibility": "operator",
+			"envVars": [
+				{
+					"name": "GCP_ACCESS_TOKEN",
+					"required": true,
+					"secret": true,
+					"description": "OAuth2 access token with secretmanager.secretAccessor role on the requested secrets. Operators refresh out-of-band (Workload Identity sidecar, gcloud, etc.)."
+				}
+			]
+		}
+	}
+}

--- a/packages/plugins/secret-store-gcp-sm/src/__tests__/gcp-sm-secret-store.plugin.spec.ts
+++ b/packages/plugins/secret-store-gcp-sm/src/__tests__/gcp-sm-secret-store.plugin.spec.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GcpSmSecretStorePlugin } from '../gcp-sm-secret-store.plugin.js';
+
+describe('GcpSmSecretStorePlugin (EW-742 P3.2 T20.10b plugin package)', () => {
+	let plugin: GcpSmSecretStorePlugin;
+	let fetchSpy: ReturnType<typeof vi.spyOn>;
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	const origToken = process.env.GCP_ACCESS_TOKEN;
+
+	beforeEach(() => {
+		plugin = new GcpSmSecretStorePlugin();
+		fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+			throw new Error('fetch not mocked');
+		});
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+		process.env.GCP_ACCESS_TOKEN = 'ya29.a0Test-Token';
+	});
+
+	afterEach(() => {
+		fetchSpy.mockRestore();
+		warnSpy.mockRestore();
+		process.env.GCP_ACCESS_TOKEN = origToken;
+	});
+
+	function mockResponse(opts: { ok?: boolean; status?: number; body?: unknown }): Response {
+		const status = opts.status ?? (opts.ok === false ? 500 : 200);
+		return {
+			ok: opts.ok ?? (status >= 200 && status < 300),
+			status,
+			json: () => Promise.resolve(opts.body)
+		} as unknown as Response;
+	}
+
+	function b64(s: string): string {
+		return Buffer.from(s, 'utf8').toString('base64');
+	}
+
+	it('declares manifest fields', () => {
+		expect(plugin.id).toBe('secret-store-gcp-sm');
+		expect(plugin.category).toBe('secret-store-resolver');
+		expect(plugin.capabilities).toContain('secret-store-resolve');
+	});
+
+	it('returns null for non-gcp-sm: scheme', async () => {
+		expect(await plugin.resolveSecret('vault:secret/foo')).toBeNull();
+	});
+
+	it('returns null for malformed pointer', async () => {
+		expect(await plugin.resolveSecret('gcp-sm:my-project')).toBeNull();
+	});
+
+	it('returns null when GCP_ACCESS_TOKEN missing', async () => {
+		delete process.env.GCP_ACCESS_TOKEN;
+		expect(await plugin.resolveSecret('gcp-sm:my-project/my-secret')).toBeNull();
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('returns null on fetch error', async () => {
+		fetchSpy.mockRejectedValue(new Error('ECONNREFUSED'));
+		expect(await plugin.resolveSecret('gcp-sm:my-project/x')).toBeNull();
+	});
+
+	it('returns null on HTTP 404', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: false, status: 404 }));
+		expect(await plugin.resolveSecret('gcp-sm:my-project/missing')).toBeNull();
+	});
+
+	it('returns null on HTTP 403', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: false, status: 403 }));
+		expect(await plugin.resolveSecret('gcp-sm:my-project/forbidden')).toBeNull();
+	});
+
+	it('returns null when payload.data missing', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { name: 'x' } }));
+		expect(await plugin.resolveSecret('gcp-sm:my-project/x')).toBeNull();
+	});
+
+	it('returns null when payload.data is not valid JSON after base64 decode', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { payload: { data: b64('not json') } } }));
+		expect(await plugin.resolveSecret('gcp-sm:my-project/x')).toBeNull();
+	});
+
+	it('returns parsed bag from base64-encoded JSON payload', async () => {
+		const credentials = { accessToken: 'tr_dev_xxx', region: 'us-central1' };
+		fetchSpy.mockResolvedValue(
+			mockResponse({ ok: true, body: { payload: { data: b64(JSON.stringify(credentials)) } } })
+		);
+		expect(await plugin.resolveSecret('gcp-sm:my-project/tenants/acme')).toEqual(credentials);
+	});
+
+	it('composes URL with project + secretName URL-encoded', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { payload: { data: b64('{"k":"v"}') } } }));
+		await plugin.resolveSecret('gcp-sm:my-project/my-secret');
+		const [calledUrl] = fetchSpy.mock.calls[0] as [string];
+		expect(calledUrl).toBe(
+			'https://secretmanager.googleapis.com/v1/projects/my-project/secrets/my-secret/versions/latest:access'
+		);
+	});
+
+	it('sends Bearer token in Authorization header', async () => {
+		fetchSpy.mockResolvedValue(mockResponse({ ok: true, body: { payload: { data: b64('{"k":"v"}') } } }));
+		await plugin.resolveSecret('gcp-sm:my-project/x');
+		const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		const headers = init.headers as Record<string, string>;
+		expect(headers['Authorization']).toBe('Bearer ya29.a0Test-Token');
+	});
+});

--- a/packages/plugins/secret-store-gcp-sm/src/gcp-sm-secret-store.plugin.ts
+++ b/packages/plugins/secret-store-gcp-sm/src/gcp-sm-secret-store.plugin.ts
@@ -1,0 +1,174 @@
+import type { IPlugin, ISecretStoreProvider, JsonSchema, PluginCategory, PluginContext } from '@ever-works/plugin';
+import { SECRET_STORE_CAPABILITIES } from '@ever-works/plugin';
+
+/**
+ * EW-742 P3.2 T20.10b -- GCP Secret Manager SecretStoreResolver plugin.
+ *
+ * Resolves `gcp-sm:<project>/<secretName>` pointers via the GCP Secret
+ * Manager REST API. Uses a pre-fetched OAuth2 bearer token from the
+ * `GCP_ACCESS_TOKEN` env var.
+ *
+ * # Pointer format
+ *
+ *   `gcp-sm:<projectId>/<secretName>` — fetches the `latest` version.
+ *
+ * # Auth
+ *
+ * GCP OAuth2 requires JWT-signing a service-account key to obtain an
+ * access token. That's an entire flow we deliberately push to the
+ * operator's tooling layer (the SDK does it under the hood, but doing
+ * it from scratch here would add ~150 LoC of JWT/crypto code + key
+ * loading).
+ *
+ * Operators provision GCP_ACCESS_TOKEN out-of-band:
+ *   - Workload Identity (GKE) — auto-mounted token at
+ *     `/var/run/secrets/tokens/gcp-token`
+ *   - Sidecar — `gcloud auth print-access-token` refresher
+ *   - Service account JSON + cron — refresh via the metadata server
+ *
+ * # API
+ *
+ *   GET https://secretmanager.googleapis.com/v1/projects/{project}/secrets/{name}/versions/latest:access
+ *   Response: `{ payload: { data: "<base64-string>" } }`
+ *
+ * # Fail-open — every failure path returns null.
+ */
+export class GcpSmSecretStorePlugin implements IPlugin, ISecretStoreProvider {
+	readonly id = 'secret-store-gcp-sm';
+	readonly name = 'GCP Secret Manager Secret Store';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'secret-store-resolver';
+	readonly capabilities: readonly string[] = [SECRET_STORE_CAPABILITIES.RESOLVE];
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			gcpAccessToken: {
+				type: 'string',
+				title: 'GCP Access Token',
+				description: 'OAuth2 access token with secretmanager.secretAccessor role.',
+				'x-secret': true,
+				'x-envVar': 'GCP_ACCESS_TOKEN'
+			}
+		}
+	};
+
+	private static readonly API_HOST = 'https://secretmanager.googleapis.com';
+
+	private context?: PluginContext;
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+	}
+
+	async resolveSecret(pointer: string): Promise<Record<string, unknown> | null> {
+		if (!pointer.startsWith('gcp-sm:')) {
+			const scheme = pointer.split(':', 1)[0] ?? 'unknown';
+			this.warn(`GcpSmSecretStorePlugin: pointer scheme "${scheme}:" not handled. Returning null (fail-open).`);
+			return null;
+		}
+
+		const rest = pointer.slice('gcp-sm:'.length);
+		const slashIdx = rest.indexOf('/');
+		if (slashIdx <= 0) {
+			this.warn(
+				`GcpSmSecretStorePlugin: malformed pointer "${pointer}" (expected ` +
+					`gcp-sm:<project>/<secretName>). Returning null (fail-open).`
+			);
+			return null;
+		}
+		const project = rest.slice(0, slashIdx);
+		const secretName = rest.slice(slashIdx + 1);
+		if (!project || !secretName) {
+			this.warn(`GcpSmSecretStorePlugin: empty project or secretName in "${pointer}". Returning null.`);
+			return null;
+		}
+
+		const token = process.env.GCP_ACCESS_TOKEN;
+		if (!token) {
+			this.warn(
+				`GcpSmSecretStorePlugin: GCP_ACCESS_TOKEN not set. Provision via Workload Identity, ` +
+					`gcloud, or a sidecar refresher. Returning null (fail-open).`
+			);
+			return null;
+		}
+
+		const url =
+			`${GcpSmSecretStorePlugin.API_HOST}/v1/projects/${encodeURIComponent(project)}` +
+			`/secrets/${encodeURIComponent(secretName)}/versions/latest:access`;
+
+		let response: Response;
+		try {
+			response = await fetch(url, {
+				method: 'GET',
+				headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' }
+			});
+		} catch (err) {
+			this.warn(
+				`GcpSmSecretStorePlugin: fetch failed for ${url} ` +
+					`(${err instanceof Error ? err.message : String(err)}). Returning null (fail-open).`
+			);
+			return null;
+		}
+
+		if (!response.ok) {
+			this.warn(`GcpSmSecretStorePlugin: GCP responded ${response.status}. Returning null.`);
+			return null;
+		}
+
+		let json: unknown;
+		try {
+			json = await response.json();
+		} catch (err) {
+			this.warn(
+				`GcpSmSecretStorePlugin: response is not JSON ` +
+					`(${err instanceof Error ? err.message : String(err)}). Returning null.`
+			);
+			return null;
+		}
+
+		if (json === null || typeof json !== 'object') {
+			this.warn(`GcpSmSecretStorePlugin: response is not an object. Returning null.`);
+			return null;
+		}
+
+		const payload = (json as { payload?: { data?: unknown } }).payload;
+		const data = payload?.data;
+		if (typeof data !== 'string') {
+			this.warn(`GcpSmSecretStorePlugin: response missing payload.data string. Returning null.`);
+			return null;
+		}
+
+		// payload.data is base64-encoded — decode to utf8 then parse as JSON.
+		let decoded: string;
+		try {
+			decoded = Buffer.from(data, 'base64').toString('utf8');
+		} catch (err) {
+			this.warn(
+				`GcpSmSecretStorePlugin: payload.data base64-decode failed ` +
+					`(${err instanceof Error ? err.message : String(err)}). Returning null.`
+			);
+			return null;
+		}
+
+		try {
+			const parsed = JSON.parse(decoded);
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+				return parsed as Record<string, unknown>;
+			}
+			this.warn(`GcpSmSecretStorePlugin: decoded payload is not a JSON object. Returning null.`);
+			return null;
+		} catch {
+			this.warn(`GcpSmSecretStorePlugin: decoded payload is not valid JSON. Returning null.`);
+			return null;
+		}
+	}
+
+	private warn(message: string): void {
+		this.context?.logger?.warn?.(message) ?? console.warn(message);
+	}
+}

--- a/packages/plugins/secret-store-gcp-sm/src/index.ts
+++ b/packages/plugins/secret-store-gcp-sm/src/index.ts
@@ -1,0 +1,2 @@
+export { GcpSmSecretStorePlugin } from './gcp-sm-secret-store.plugin.js';
+export { GcpSmSecretStorePlugin as default } from './gcp-sm-secret-store.plugin.js';

--- a/packages/plugins/secret-store-gcp-sm/tsconfig.json
+++ b/packages/plugins/secret-store-gcp-sm/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/secret-store-gcp-sm/tsup.config.ts
+++ b/packages/plugins/secret-store-gcp-sm/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2458,6 +2458,24 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
+  packages/plugins/secret-store-gcp-sm:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
   packages/plugins/secret-store-infisical:
     devDependencies:
       '@ever-works/plugin':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2440,6 +2440,24 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
+  packages/plugins/secret-store-azure-kv:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
   packages/plugins/secret-store-doppler:
     devDependencies:
       '@ever-works/plugin':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2422,6 +2422,24 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
+  packages/plugins/secret-store-aws-sm:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
   packages/plugins/secret-store-doppler:
     devDependencies:
       '@ever-works/plugin':


### PR DESCRIPTION
## Summary

Stage→main cascade for the three new cloud-vendor `SecretStoreResolver` plugin packages (originally landed in develop via #1421/#1422/#1423, cascaded to stage via #1424):

- `@ever-works/secret-store-aws-sm-plugin` (AWS Secrets Manager, pure SigV4)
- `@ever-works/secret-store-gcp-sm-plugin` (GCP Secret Manager, pre-fetched OAuth2 bearer)
- `@ever-works/secret-store-azure-kv-plugin` (Azure Key Vault, pre-fetched AAD bearer)

## Risk

Low — pure new packages, no production wiring change, no edits to existing dispatchers. Each plugin has vitest coverage and follows the fail-open `ISecretStoreProvider` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)