### PR TITLE
feat(tasks): EW-742 P3.2 T21.1 — Trigger.dev bindToTenant minimal impl

### DIFF
--- a/packages/tasks/src/trigger/__tests__/trigger-job-runtime.provider.spec.ts
+++ b/packages/tasks/src/trigger/__tests__/trigger-job-runtime.provider.spec.ts
@@ -222,4 +222,80 @@ describe('TriggerJobRuntimeProvider', () => {
             expect(triggerServiceMock.startWorkerHost).toHaveBeenCalledWith(opts);
         });
     });
+
+    describe('bindToTenant (EW-742 P3.2 T21.1)', () => {
+        const snapshot = {
+            tenantId: '00000000-0000-0000-0000-00000000aaaa',
+            providerId: 'trigger' as const,
+            credentialVersion: 1,
+            credentials: { accessToken: 'tr_dev_abc' },
+        };
+
+        it('returns a per-tenant view exposing the snapshot', () => {
+            const view = provider.bindToTenant(snapshot);
+            // The contract requires the returned object to satisfy
+            // IJobRuntimeProvider; the snapshot is exposed off-spec on
+            // the view so the T22 stamper can read it without a separate
+            // lookup.
+            expect(view.runtimeId).toBe('trigger');
+            expect((view as { tenantSnapshot: typeof snapshot }).tenantSnapshot).toBe(snapshot);
+        });
+
+        it('memoises on (tenantId, credentialVersion) — same snapshot returns same view', () => {
+            // Per IJobRuntimeProvider.bindToTenant idempotency clause.
+            const a = provider.bindToTenant(snapshot);
+            const b = provider.bindToTenant(snapshot);
+            expect(b).toBe(a);
+        });
+
+        it('evicts the older view when credentialVersion bumps for the same tenant', () => {
+            // Cache stays bounded by tenant count, not version count —
+            // a rotate replaces the old view in place.
+            const v1 = provider.bindToTenant(snapshot);
+            const v2 = provider.bindToTenant({ ...snapshot, credentialVersion: 2 });
+            expect(v2).not.toBe(v1);
+            // Asking again for the v1 snapshot now returns a fresh view
+            // (the v1 entry was evicted by the v2 cache-replace).
+            const v1Again = provider.bindToTenant(snapshot);
+            expect(v1Again).not.toBe(v1);
+        });
+
+        it('view methods delegate back to the singleton TriggerService', async () => {
+            const view = provider.bindToTenant(snapshot);
+            triggerServiceMock.cancel.mockResolvedValue(true);
+            triggerServiceMock.isEnabled.mockReturnValue(true);
+
+            expect(view.isEnabled()).toBe(true);
+            expect(triggerServiceMock.isEnabled).toHaveBeenCalled();
+
+            await view.cancel('run_xyz');
+            expect(triggerServiceMock.cancel).toHaveBeenCalledWith('run_xyz');
+
+            // The dispatchers getter on the view passes through the
+            // singleton's dispatchers identity-equal — that's how the
+            // current "BYO with inherit (inherit only)" path keeps
+            // working in this PR; per-tenant Trigger.dev project
+            // switching is the T22 follow-up.
+            expect(view.dispatchers).toBe(dispatchersSentinel);
+        });
+
+        it('the view is frozen', () => {
+            const view = provider.bindToTenant(snapshot);
+            expect(Object.isFrozen(view)).toBe(true);
+        });
+
+        it('view.bindToTenant(self) returns self', () => {
+            const view = provider.bindToTenant(snapshot);
+            expect(view.bindToTenant?.(snapshot)).toBe(view);
+        });
+
+        it('view.bindToTenant(other) delegates back to the root provider', () => {
+            const view = provider.bindToTenant(snapshot);
+            const other = { ...snapshot, tenantId: '00000000-0000-0000-0000-00000000bbbb' };
+            const otherView = view.bindToTenant?.(other);
+            // Root produced this view, so a second call with the same
+            // `other` snapshot should hit the root's cache.
+            expect(otherView).toBe(provider.bindToTenant(other));
+        });
+    });
 });

--- a/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
+++ b/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
@@ -7,6 +7,7 @@ import type {
     PluginCategory,
     PluginContext,
     ScheduleSpec,
+    TenantCredentialSnapshot,
     WorkerHostHandle,
     WorkerHostOptions,
 } from '@ever-works/plugin';
@@ -168,5 +169,119 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
      */
     async onUnload(): Promise<void> {
         // Intentional no-op — see class JSDoc on synthetic plugin status.
+    }
+
+    /**
+     * Memoisation cache for `bindToTenant` — keyed by
+     * `${tenantId}:${credentialVersion}`. Holds the last frozen tenant
+     * view per tenant so the same snapshot returns the same instance
+     * (per the {@link IJobRuntimeProvider.bindToTenant} idempotency
+     * contract). A new `credentialVersion` evicts and replaces the
+     * previous entry — the cache size is bounded by tenant count.
+     */
+    private readonly tenantViews = new Map<string, IJobRuntimeProvider>();
+
+    /**
+     * EW-742 P3.2 T21.1 — minimal `bindToTenant` impl.
+     *
+     * Returns a per-tenant frozen view of THIS provider with the
+     * snapshot captured. Trigger.dev's underlying SDK client is a
+     * push-model singleton (their cloud invokes our tasks), so no
+     * runtime per-tenant rebinding of the actual Trigger.dev access
+     * token happens in this PR — the view's dispatchers still
+     * delegate to the singleton `TriggerService`.
+     *
+     * What this PR DOES wire up:
+     *   - Returns a fresh wrapper per `credentialVersion` so callers
+     *     get a stable instance identity to memoise on.
+     *   - Exposes the snapshot via `(view as any).tenantSnapshot` so
+     *     T22 per-dispatcher wiring can stamp `(providerId,
+     *     credentialVersion)` onto run records without needing a
+     *     separate stamper service.
+     *
+     * What this PR DOES NOT do (TODO for the next PR):
+     *   - Per-tenant Trigger.dev project switching. Today every
+     *     tenant ships through the same Trigger.dev project the API
+     *     boots against; the platform overlay is "BYO with inherit"
+     *     and the inherit path is the only one wired. BYO Trigger.dev
+     *     project per tenant requires the dispatcher layer to swap
+     *     the underlying `TriggerService` SDK client per call — that's
+     *     the T22 PR.
+     *   - Dispatcher stamping. That's the T22 per-dispatcher PoC
+     *     (KB-embed first).
+     */
+    bindToTenant(snapshot: TenantCredentialSnapshot): IJobRuntimeProvider {
+        const cacheKey = `${snapshot.tenantId}:${snapshot.credentialVersion}`;
+        const cached = this.tenantViews.get(cacheKey);
+        if (cached) {
+            return cached;
+        }
+
+        const base = this;
+        // Build a frozen tenant view. Every method delegates back to
+        // the singleton `TriggerService` (via `base`), but the view
+        // carries the snapshot for downstream stamping.
+        const view: IJobRuntimeProvider & {
+            readonly tenantSnapshot: TenantCredentialSnapshot;
+        } = Object.freeze({
+            // -- IPlugin metadata, copied verbatim ---------------------
+            id: base.id,
+            name: base.name,
+            version: base.version,
+            category: base.category,
+            capabilities: base.capabilities,
+            settingsSchema: base.settingsSchema,
+            // -- IJobRuntimeProvider, delegating ----------------------
+            runtimeId: base.runtimeId,
+            get dispatchers(): JobRuntimeDispatchers {
+                return base.dispatchers;
+            },
+            registerSchedules(schedules: readonly ScheduleSpec[]): Promise<void> {
+                return base.registerSchedules(schedules);
+            },
+            cancel(runId: string): Promise<boolean> {
+                return base.cancel(runId);
+            },
+            getRunStatus(runId: string): Promise<JobRunStatus> {
+                return base.getRunStatus(runId);
+            },
+            isEnabled(): boolean {
+                return base.isEnabled();
+            },
+            startWorkerHost(opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+                return base.startWorkerHost(opts);
+            },
+            onLoad(context: PluginContext): Promise<void> {
+                return base.onLoad(context);
+            },
+            onUnload(): Promise<void> {
+                return base.onUnload();
+            },
+            // The tenant view does NOT re-bind further — calling
+            // `bindToTenant` on a tenant view returns itself for
+            // matching snapshots; mismatched snapshots return the
+            // root provider's bind result (cache-replace semantics).
+            bindToTenant(other: TenantCredentialSnapshot): IJobRuntimeProvider {
+                if (
+                    other.tenantId === snapshot.tenantId &&
+                    other.credentialVersion === snapshot.credentialVersion
+                ) {
+                    return view;
+                }
+                return base.bindToTenant(other);
+            },
+            // -- snapshot exposed for downstream stampers --------------
+            tenantSnapshot: snapshot,
+        });
+
+        // Cache-replace: evict any older version for this tenant so
+        // the cache stays bounded.
+        for (const key of this.tenantViews.keys()) {
+            if (key.startsWith(`${snapshot.tenantId}:`)) {
+                this.tenantViews.delete(key);
+            }
+        }
+        this.tenantViews.set(cacheKey, view);
+        return view;
     }
 }


### PR DESCRIPTION
## Summary

Adds the optional `IJobRuntimeProvider.bindToTenant` hook on the existing `TriggerJobRuntimeProvider` adapter (introduced in #1392 / EW-686 P1).

## What this PR DOES

- Implements `bindToTenant(snapshot)` on `TriggerJobRuntimeProvider`.
- Returns a **frozen per-tenant view** that delegates every `IJobRuntimeProvider` method back to the singleton `TriggerService`.
- **Memoises on `(tenantId, credentialVersion)`** per the contract's idempotency clause; on a version bump the older entry is evicted in place so the cache stays bounded by tenant count.
- **Exposes the snapshot off-spec** as `view.tenantSnapshot` so the T22 per-dispatcher stamper can pick `(providerId, credentialVersion)` for run-record stamping without a separate lookup.
- `view.bindToTenant(self)` is identity; `view.bindToTenant(other)` delegates back to the root provider's cache.

## What this PR DOES NOT do (TODO for the T22 follow-up)

- **Per-tenant Trigger.dev project switching.** Today every tenant ships through the same Trigger.dev project the API boots against; the platform overlay is "BYO with inherit" and the inherit path is the only one wired. BYO per-tenant requires the dispatcher layer to swap the underlying `TriggerService` SDK client per call — that's T22.
- **Dispatcher stamping.** That's the T22 per-dispatcher PoC (KB-embed first, picked because it's the leanest dispatcher surface).

## Tests

7 new vitest cases on top of the existing 19 (26 total, all green):
- view exposes snapshot
- memoises on `(tenantId, credentialVersion)`
- `credentialVersion` bump evicts older view
- view methods delegate to singleton `TriggerService`
- view is frozen
- `view.bindToTenant(self)` returns self
- `view.bindToTenant(other)` delegates back to root

## Risk

Low — `bindToTenant` is an OPTIONAL hook. Existing callers that never invoke it see no behaviour change. The singleton inherit path is untouched.

## Next

T22 per-dispatcher wiring — pick KB-embed first as PoC. Inject `stamper.stamp(tenantId)` before the dispatch, persist `(providerId, credentialVersion)` onto the run record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)