### PR TITLE
feat(agent): EW-742 P3.2 T22 — KB-embed dispatcher tenant runtime binding capture (PoC)

### DIFF
--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -9,6 +9,7 @@ import { KB_STORAGE_PLUGIN, KnowledgeBaseService } from '../knowledge-base.servi
 import { KB_EMBED_DOCUMENT_DISPATCHER } from '../../tasks/kb-embed-document-dispatcher';
 import { KB_ORG_OVERLAY_FANOUT_DISPATCHER } from '../../tasks/kb-org-overlay-fanout-dispatcher';
 import { KB_MIRROR_DOCUMENT_DISPATCHER } from '../../tasks/kb-mirror-document-dispatcher';
+import { RuntimeBindingStamperService } from '../../tasks/runtime-binding-stamper.service';
 import { WorkRepository } from '../../database/repositories/work.repository';
 import { KnowledgeBaseBufferExtractorService } from '../knowledge-base-buffer-extractor.service';
 import { WorkKnowledgeDocumentRepository } from '../../database/repositories/work-knowledge-document.repository';
@@ -683,9 +684,16 @@ describe('KnowledgeBaseService', () => {
                 body: 'hi',
             });
 
+            // EW-742 P3.2 T22 — payload now always includes the
+            // (providerId, credentialVersion) pair. When the stamper +
+            // workRepository aren't wired (this test fixture), both are
+            // null and the worker falls back to the instance default
+            // (byte-identical to the pre-overlay path).
             expect(embedDispatcher.dispatchKbEmbedDocument).toHaveBeenCalledWith({
                 workId: WORK_ID,
                 documentId: 'doc-99',
+                providerId: null,
+                credentialVersion: null,
             });
         });
     });
@@ -732,6 +740,8 @@ describe('KnowledgeBaseService', () => {
             expect(embedDispatcher.dispatchKbEmbedDocument).toHaveBeenCalledWith({
                 workId: WORK_ID,
                 documentId: 'doc-50',
+                providerId: null,
+                credentialVersion: null,
             });
         });
 
@@ -1701,6 +1711,209 @@ describe('KnowledgeBaseService', () => {
             await expect(
                 service.restoreDocumentFromHistory(WORK_ID, 'docId', USER_ID, 'abc1234'),
             ).rejects.toBeInstanceOf(ServiceUnavailableException);
+        });
+    });
+
+    // EW-742 P3.2 T22 — KB-embed is the proof-of-concept dispatcher
+    // for enqueue-site tenant-runtime binding capture. These tests
+    // build a fresh service with WorkRepository + RuntimeBindingStamperService
+    // wired and assert that the (providerId, credentialVersion) pair
+    // gets threaded onto the dispatch payload.
+    describe('enqueueEmbed — T22 tenant runtime binding capture (KB-embed PoC)', () => {
+        async function buildWithStamper(opts: {
+            stamperResult?: { providerId: string | null; credentialVersion: number | null };
+            stamperThrows?: boolean;
+            workTenantId?: string | null;
+            workFindThrows?: boolean;
+        }) {
+            const embedDispatcherMock = {
+                dispatchKbEmbedDocument: jest.fn().mockResolvedValue('run-id'),
+            };
+            const mirrorDispatcherMock = {
+                dispatchKbMirrorDocument: jest.fn().mockResolvedValue('mirror-run-id'),
+            };
+            const workRepoMock = {
+                findById: opts.workFindThrows
+                    ? jest.fn().mockRejectedValue(new Error('db boom'))
+                    : jest
+                          .fn()
+                          .mockResolvedValue(
+                              opts.workTenantId === undefined
+                                  ? null
+                                  : ({ id: WORK_ID, tenantId: opts.workTenantId } as any),
+                          ),
+            };
+            const stamperMock = {
+                stamp: opts.stamperThrows
+                    ? jest.fn().mockRejectedValue(new Error('stamper boom'))
+                    : jest
+                          .fn()
+                          .mockResolvedValue(
+                              opts.stamperResult ?? {
+                                  providerId: null,
+                                  credentialVersion: null,
+                              },
+                          ),
+            };
+
+            const module: TestingModule = await Test.createTestingModule({
+                providers: [
+                    KnowledgeBaseService,
+                    { provide: WorkKnowledgeDocumentRepository, useValue: docRepo },
+                    { provide: WorkKnowledgeUploadRepository, useValue: uploadRepo },
+                    { provide: WorkKnowledgeTagRepository, useValue: tagRepo },
+                    {
+                        provide: WorkKnowledgeCitationRepository,
+                        useValue: { listForDocument: jest.fn().mockResolvedValue([]) },
+                    },
+                    { provide: WorkOwnershipService, useValue: ownership },
+                    { provide: KB_STORAGE_PLUGIN, useValue: storage },
+                    { provide: ActivityLogService, useValue: activityLog },
+                    { provide: KB_EMBED_DOCUMENT_DISPATCHER, useValue: embedDispatcherMock },
+                    { provide: KB_MIRROR_DOCUMENT_DISPATCHER, useValue: mirrorDispatcherMock },
+                    { provide: WorkRepository, useValue: workRepoMock },
+                    { provide: RuntimeBindingStamperService, useValue: stamperMock },
+                ],
+            }).compile();
+
+            return {
+                service: module.get(KnowledgeBaseService),
+                embedDispatcherMock,
+                workRepoMock,
+                stamperMock,
+            };
+        }
+
+        it('stamps payload with stamper result when overlay is active', async () => {
+            const {
+                service: svc,
+                embedDispatcherMock,
+                workRepoMock,
+                stamperMock,
+            } = await buildWithStamper({
+                workTenantId: '00000000-0000-0000-0000-00000000aaaa',
+                stamperResult: { providerId: 'trigger', credentialVersion: 7 },
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'doc-t22-a' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/v.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            expect(workRepoMock.findById).toHaveBeenCalledWith(WORK_ID);
+            expect(stamperMock.stamp).toHaveBeenCalledWith(
+                '00000000-0000-0000-0000-00000000aaaa',
+            );
+            expect(embedDispatcherMock.dispatchKbEmbedDocument).toHaveBeenCalledWith({
+                workId: WORK_ID,
+                documentId: 'doc-t22-a',
+                providerId: 'trigger',
+                credentialVersion: 7,
+            });
+        });
+
+        it('passes null/null when work has no tenantId (pre-EW-655 row)', async () => {
+            const {
+                service: svc,
+                embedDispatcherMock,
+                stamperMock,
+            } = await buildWithStamper({
+                workTenantId: null,
+                stamperResult: { providerId: null, credentialVersion: null },
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'doc-t22-b' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/v.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            // Stamper still called (it's the contract entry point) but
+            // with `null` tenantId so it short-circuits to null/null.
+            expect(stamperMock.stamp).toHaveBeenCalledWith(null);
+            expect(embedDispatcherMock.dispatchKbEmbedDocument).toHaveBeenCalledWith({
+                workId: WORK_ID,
+                documentId: 'doc-t22-b',
+                providerId: null,
+                credentialVersion: null,
+            });
+        });
+
+        it('fails open on stamper throw — payload ships with null/null, embed still enqueues', async () => {
+            const {
+                service: svc,
+                embedDispatcherMock,
+            } = await buildWithStamper({
+                workTenantId: '00000000-0000-0000-0000-00000000aaaa',
+                stamperThrows: true,
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'doc-t22-c' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/v.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            // FR-5 fail-open: stamper failure MUST NOT block the
+            // enqueue — payload ships with null/null so the worker host
+            // falls back to the instance default.
+            expect(embedDispatcherMock.dispatchKbEmbedDocument).toHaveBeenCalledWith({
+                workId: WORK_ID,
+                documentId: 'doc-t22-c',
+                providerId: null,
+                credentialVersion: null,
+            });
+        });
+
+        it('fails open on workRepository.findById throw', async () => {
+            const {
+                service: svc,
+                embedDispatcherMock,
+                stamperMock,
+            } = await buildWithStamper({
+                workFindThrows: true,
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'doc-t22-d' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/v.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            // The workRepository lookup failed — stamper was never
+            // called (no tenantId available) and payload ships null/null.
+            expect(stamperMock.stamp).not.toHaveBeenCalled();
+            expect(embedDispatcherMock.dispatchKbEmbedDocument).toHaveBeenCalledWith({
+                workId: WORK_ID,
+                documentId: 'doc-t22-d',
+                providerId: null,
+                credentialVersion: null,
+            });
         });
     });
 });

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -45,6 +45,7 @@ import { KB_MIRROR_DOCUMENT_DISPATCHER, type KbMirrorDocumentDispatcher } from '
 import { KB_EMBED_DOCUMENT_DISPATCHER, type KbEmbedDocumentDispatcher } from '../tasks';
 import { KB_ORG_OVERLAY_FANOUT_DISPATCHER, type KbOrgOverlayFanoutDispatcher } from '../tasks';
 import { KB_NORMALIZE_MEDIA_DISPATCHER, type KbNormalizeMediaDispatcher } from '../tasks';
+import { RuntimeBindingStamperService } from '../tasks';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { sanitizeDescription } from '../utils/sanitize.util';
 import type {
@@ -279,6 +280,17 @@ export class KnowledgeBaseService {
         @Optional()
         @Inject(KB_NORMALIZE_MEDIA_DISPATCHER)
         private readonly normalizeMediaDispatcher?: KbNormalizeMediaDispatcher,
+        // EW-742 P3.2 T22 — KB-embed is the proof-of-concept dispatcher
+        // for enqueue-site tenant-runtime binding capture (see
+        // {@link RuntimeBindingStamperService} JSDoc "Scope of THIS PR"
+        // note for why it's adopted one dispatcher at a time). Optional
+        // so isolated unit tests and pre-overlay deployments keep
+        // constructing — when absent, the enqueue degrades to the
+        // pre-overlay (EW-683) byte-identical path: payload ships
+        // without `providerId`/`credentialVersion`, worker host uses the
+        // instance default.
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
     ) {}
 
     /**
@@ -334,8 +346,36 @@ export class KnowledgeBaseService {
         if (!this.embedDispatcher) {
             return;
         }
+        // EW-742 P3.2 T22 — capture the tenant runtime binding at
+        // enqueue time so the worker host can resolve the exact
+        // credential snapshot that was active when the run was
+        // scheduled (ADR-017 §3 graceful drain). The lookup is
+        // best-effort: a missing WorkRepository, missing tenantId, or
+        // missing stamper all mean we ship the legacy 2-field payload
+        // and the worker uses the instance default — that's the same
+        // byte-identical path that ran pre-T22.
+        let binding: { providerId: string | null; credentialVersion: number | null } = {
+            providerId: null,
+            credentialVersion: null,
+        };
+        if (this.runtimeBindingStamper && this.workRepository) {
+            try {
+                const work = await this.workRepository.findById(workId);
+                binding = await this.runtimeBindingStamper.stamp(work?.tenantId ?? null);
+            } catch (err) {
+                this.logger.debug(
+                    `enqueueEmbed: stamper lookup failed for work=${workId} ` +
+                        `(${(err as Error).message}); falling back to instance default.`,
+                );
+            }
+        }
         try {
-            await this.embedDispatcher.dispatchKbEmbedDocument({ workId, documentId });
+            await this.embedDispatcher.dispatchKbEmbedDocument({
+                workId,
+                documentId,
+                providerId: binding.providerId,
+                credentialVersion: binding.credentialVersion,
+            });
         } catch (error) {
             this.logger.warn(
                 `Failed to enqueue KB embed for doc ${documentId} (work=${workId}): ${(error as Error).message}`,

--- a/packages/agent/src/tasks/kb-embed-document-dispatcher.spec.ts
+++ b/packages/agent/src/tasks/kb-embed-document-dispatcher.spec.ts
@@ -60,4 +60,40 @@ describe('KbEmbedDocumentDispatcher contract', () => {
             impl.dispatchKbEmbedDocument({ workId: 'work-1', documentId: 'doc-1' }),
         ).resolves.toBeNull();
     });
+
+    // EW-742 P3.2 T22 — KB-embed is the PoC dispatcher for enqueue-site
+    // (providerId, credentialVersion) capture. The fields are optional
+    // so existing payload sites stay compiling.
+    it('accepts the optional T22 tenant runtime binding fields', async () => {
+        const dispatchMock = jest.fn(async (_p: KbEmbedDocumentPayload) => 'run-99');
+        const impl: KbEmbedDocumentDispatcher = { dispatchKbEmbedDocument: dispatchMock };
+
+        const payload: KbEmbedDocumentPayload = {
+            workId: 'work-1',
+            documentId: 'doc-1',
+            providerId: 'trigger',
+            credentialVersion: 7,
+        };
+
+        await expect(impl.dispatchKbEmbedDocument(payload)).resolves.toBe('run-99');
+        expect(dispatchMock).toHaveBeenCalledWith(payload);
+    });
+
+    it('accepts explicit null T22 fields (no overlay = legacy default path)', async () => {
+        const dispatchMock = jest.fn(async (_p: KbEmbedDocumentPayload) => 'run-100');
+        const impl: KbEmbedDocumentDispatcher = { dispatchKbEmbedDocument: dispatchMock };
+
+        // Per stamper contract: both null means "no tenant overlay was
+        // active when this was enqueued"; worker host runs against the
+        // instance default — byte-identical to the pre-overlay code path.
+        const payload: KbEmbedDocumentPayload = {
+            workId: 'work-1',
+            documentId: 'doc-1',
+            providerId: null,
+            credentialVersion: null,
+        };
+
+        await expect(impl.dispatchKbEmbedDocument(payload)).resolves.toBe('run-100');
+        expect(dispatchMock).toHaveBeenCalledWith(payload);
+    });
 });

--- a/packages/agent/src/tasks/kb-embed-document.types.ts
+++ b/packages/agent/src/tasks/kb-embed-document.types.ts
@@ -29,4 +29,30 @@ export interface KbEmbedDocumentPayload {
     readonly workId: string;
     /** UUID of the `work_knowledge_documents` row whose body to (re)embed. */
     readonly documentId: string;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture
+     * (PoC; KB-embed is the proof-of-concept dispatcher, the other 11
+     * `*_DISPATCHER` symbols adopt the same pair incrementally — see
+     * {@link RuntimeBindingStamperService} JSDoc "Scope of THIS PR"
+     * note).
+     *
+     * When present, identifies the tenant-overlay job-runtime that was
+     * active at enqueue time. The worker host uses these to resolve
+     * THAT exact credential snapshot via
+     * {@link CredentialVersionService.resolveSnapshot} even if the
+     * tenant rotates the overlay mid-run (ADR-017 §3 graceful drain).
+     *
+     * Both fields are absent when:
+     *   - the KnowledgeBaseService doesn't have RuntimeBindingStamperService
+     *     wired (older deployments, isolated unit tests);
+     *   - the Work has no tenant context (pre-EW-655 row);
+     *   - the tenant has no overlay row, or it's `inherit` / disabled.
+     *
+     * In every "absent" case the worker host MUST fall back to the
+     * instance default (the pre-overlay EW-683 path) — same byte-for-byte
+     * code path that existed before T22.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }


### PR DESCRIPTION
## Summary

First per-dispatcher wiring of the `RuntimeBindingStamperService` (landed in P3.1). **KB-embed is the proof-of-concept dispatcher** — picked because it's the leanest enqueue surface in the agent package (one payload type, one private call site, fire-and-forget shape). The other 11 `*_DISPATCHER` symbols can adopt the same pair incrementally without coordinating a bus-stop PR.

## What this PR does

1. **Extends `KbEmbedDocumentPayload`** with two OPTIONAL fields:
   - `providerId?: string | null`
   - `credentialVersion?: number | null`

   Both default to `null` — legacy callers see no change.

2. **Wires `RuntimeBindingStamperService`** into `KnowledgeBaseService` as `@Optional()` so isolated unit tests and pre-overlay deployments keep constructing.

3. **`enqueueEmbed()` now:**
   - resolves the Work via the existing `@Optional()` `WorkRepository` to get `tenantId`,
   - calls `stamper.stamp(tenantId)` for the `(providerId, credentialVersion)` tuple,
   - threads the result onto the dispatch payload.

## Fail-open

Per ADR-017 §3 + FR-5 (graceful drain):
- stamper not wired → `null/null` shipped
- workRepository not wired → `null/null` shipped
- `workRepository.findById` throws → debug log + `null/null`
- `stamper.stamp` throws → already fail-open inside the stamper (warn + `null/null` return)

In every "absent" case the worker host falls back to the instance default — **byte-identical to the pre-overlay (EW-683) path**.

## What this PR does NOT do (deferred)

- **Worker-host `resolveSnapshot` consumption** of `(providerId, credentialVersion)`. The fields are written but the worker still reads the singleton. The "live" tenant routing PR comes after `bindToTenant` lands per-provider (EW-686 P2 + per-dispatcher T22 rollout to the remaining 11 symbols).
- **Rollout to the other 11 dispatcher symbols.** Each one needs a 3-line patch following this template (add fields to payload type → wire stamper into the call-site service → thread the pair onto the payload). Filed as a follow-up tracking issue.

## Tests

- **4 new vitest cases** in `knowledge-base.service.spec.ts` covering:
  - active overlay → stamper result threaded through
  - null `tenantId` → stamp called with null, ships null/null
  - stamper throws → still ships null/null (fail-open)
  - `workRepository.findById` throws → stamper never called, ships null/null

- **2 new vitest cases** in `kb-embed-document-dispatcher.spec.ts` pinning the new optional payload fields.

- **2 existing assertions updated** to include the new explicit `null/null` pair so the legacy-shape contract is documented inline.

All 81 KB tests green; agent package type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)