### PR TITLE
chore(release): cascade EW-742 P3.2 Trigger.dev bindToTenant + T22 KB-embed PoC to main

### DIFF
--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -9,6 +9,7 @@ import { KB_STORAGE_PLUGIN, KnowledgeBaseService } from '../knowledge-base.servi
 import { KB_EMBED_DOCUMENT_DISPATCHER } from '../../tasks/kb-embed-document-dispatcher';
 import { KB_ORG_OVERLAY_FANOUT_DISPATCHER } from '../../tasks/kb-org-overlay-fanout-dispatcher';
 import { KB_MIRROR_DOCUMENT_DISPATCHER } from '../../tasks/kb-mirror-document-dispatcher';
+import { RuntimeBindingStamperService } from '../../tasks/runtime-binding-stamper.service';
 import { WorkRepository } from '../../database/repositories/work.repository';
 import { KnowledgeBaseBufferExtractorService } from '../knowledge-base-buffer-extractor.service';
 import { WorkKnowledgeDocumentRepository } from '../../database/repositories/work-knowledge-document.repository';
@@ -683,9 +684,16 @@ describe('KnowledgeBaseService', () => {
                 body: 'hi',
             });
 
+            // EW-742 P3.2 T22 — payload now always includes the
+            // (providerId, credentialVersion) pair. When the stamper +
+            // workRepository aren't wired (this test fixture), both are
+            // null and the worker falls back to the instance default
+            // (byte-identical to the pre-overlay path).
             expect(embedDispatcher.dispatchKbEmbedDocument).toHaveBeenCalledWith({
                 workId: WORK_ID,
                 documentId: 'doc-99',
+                providerId: null,
+                credentialVersion: null,
             });
         });
     });
@@ -732,6 +740,8 @@ describe('KnowledgeBaseService', () => {
             expect(embedDispatcher.dispatchKbEmbedDocument).toHaveBeenCalledWith({
                 workId: WORK_ID,
                 documentId: 'doc-50',
+                providerId: null,
+                credentialVersion: null,
             });
         });
 
@@ -1701,6 +1711,209 @@ describe('KnowledgeBaseService', () => {
             await expect(
                 service.restoreDocumentFromHistory(WORK_ID, 'docId', USER_ID, 'abc1234'),
             ).rejects.toBeInstanceOf(ServiceUnavailableException);
+        });
+    });
+
+    // EW-742 P3.2 T22 — KB-embed is the proof-of-concept dispatcher
+    // for enqueue-site tenant-runtime binding capture. These tests
+    // build a fresh service with WorkRepository + RuntimeBindingStamperService
+    // wired and assert that the (providerId, credentialVersion) pair
+    // gets threaded onto the dispatch payload.
+    describe('enqueueEmbed — T22 tenant runtime binding capture (KB-embed PoC)', () => {
+        async function buildWithStamper(opts: {
+            stamperResult?: { providerId: string | null; credentialVersion: number | null };
+            stamperThrows?: boolean;
+            workTenantId?: string | null;
+            workFindThrows?: boolean;
+        }) {
+            const embedDispatcherMock = {
+                dispatchKbEmbedDocument: jest.fn().mockResolvedValue('run-id'),
+            };
+            const mirrorDispatcherMock = {
+                dispatchKbMirrorDocument: jest.fn().mockResolvedValue('mirror-run-id'),
+            };
+            const workRepoMock = {
+                findById: opts.workFindThrows
+                    ? jest.fn().mockRejectedValue(new Error('db boom'))
+                    : jest
+                          .fn()
+                          .mockResolvedValue(
+                              opts.workTenantId === undefined
+                                  ? null
+                                  : ({ id: WORK_ID, tenantId: opts.workTenantId } as any),
+                          ),
+            };
+            const stamperMock = {
+                stamp: opts.stamperThrows
+                    ? jest.fn().mockRejectedValue(new Error('stamper boom'))
+                    : jest
+                          .fn()
+                          .mockResolvedValue(
+                              opts.stamperResult ?? {
+                                  providerId: null,
+                                  credentialVersion: null,
+                              },
+                          ),
+            };
+
+            const module: TestingModule = await Test.createTestingModule({
+                providers: [
+                    KnowledgeBaseService,
+                    { provide: WorkKnowledgeDocumentRepository, useValue: docRepo },
+                    { provide: WorkKnowledgeUploadRepository, useValue: uploadRepo },
+                    { provide: WorkKnowledgeTagRepository, useValue: tagRepo },
+                    {
+                        provide: WorkKnowledgeCitationRepository,
+                        useValue: { listForDocument: jest.fn().mockResolvedValue([]) },
+                    },
+                    { provide: WorkOwnershipService, useValue: ownership },
+                    { provide: KB_STORAGE_PLUGIN, useValue: storage },
+                    { provide: ActivityLogService, useValue: activityLog },
+                    { provide: KB_EMBED_DOCUMENT_DISPATCHER, useValue: embedDispatcherMock },
+                    { provide: KB_MIRROR_DOCUMENT_DISPATCHER, useValue: mirrorDispatcherMock },
+                    { provide: WorkRepository, useValue: workRepoMock },
+                    { provide: RuntimeBindingStamperService, useValue: stamperMock },
+                ],
+            }).compile();
+
+            return {
+                service: module.get(KnowledgeBaseService),
+                embedDispatcherMock,
+                workRepoMock,
+                stamperMock,
+            };
+        }
+
+        it('stamps payload with stamper result when overlay is active', async () => {
+            const {
+                service: svc,
+                embedDispatcherMock,
+                workRepoMock,
+                stamperMock,
+            } = await buildWithStamper({
+                workTenantId: '00000000-0000-0000-0000-00000000aaaa',
+                stamperResult: { providerId: 'trigger', credentialVersion: 7 },
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'doc-t22-a' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/v.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            expect(workRepoMock.findById).toHaveBeenCalledWith(WORK_ID);
+            expect(stamperMock.stamp).toHaveBeenCalledWith(
+                '00000000-0000-0000-0000-00000000aaaa',
+            );
+            expect(embedDispatcherMock.dispatchKbEmbedDocument).toHaveBeenCalledWith({
+                workId: WORK_ID,
+                documentId: 'doc-t22-a',
+                providerId: 'trigger',
+                credentialVersion: 7,
+            });
+        });
+
+        it('passes null/null when work has no tenantId (pre-EW-655 row)', async () => {
+            const {
+                service: svc,
+                embedDispatcherMock,
+                stamperMock,
+            } = await buildWithStamper({
+                workTenantId: null,
+                stamperResult: { providerId: null, credentialVersion: null },
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'doc-t22-b' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/v.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            // Stamper still called (it's the contract entry point) but
+            // with `null` tenantId so it short-circuits to null/null.
+            expect(stamperMock.stamp).toHaveBeenCalledWith(null);
+            expect(embedDispatcherMock.dispatchKbEmbedDocument).toHaveBeenCalledWith({
+                workId: WORK_ID,
+                documentId: 'doc-t22-b',
+                providerId: null,
+                credentialVersion: null,
+            });
+        });
+
+        it('fails open on stamper throw — payload ships with null/null, embed still enqueues', async () => {
+            const {
+                service: svc,
+                embedDispatcherMock,
+            } = await buildWithStamper({
+                workTenantId: '00000000-0000-0000-0000-00000000aaaa',
+                stamperThrows: true,
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'doc-t22-c' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/v.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            // FR-5 fail-open: stamper failure MUST NOT block the
+            // enqueue — payload ships with null/null so the worker host
+            // falls back to the instance default.
+            expect(embedDispatcherMock.dispatchKbEmbedDocument).toHaveBeenCalledWith({
+                workId: WORK_ID,
+                documentId: 'doc-t22-c',
+                providerId: null,
+                credentialVersion: null,
+            });
+        });
+
+        it('fails open on workRepository.findById throw', async () => {
+            const {
+                service: svc,
+                embedDispatcherMock,
+                stamperMock,
+            } = await buildWithStamper({
+                workFindThrows: true,
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'doc-t22-d' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/v.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            // The workRepository lookup failed — stamper was never
+            // called (no tenantId available) and payload ships null/null.
+            expect(stamperMock.stamp).not.toHaveBeenCalled();
+            expect(embedDispatcherMock.dispatchKbEmbedDocument).toHaveBeenCalledWith({
+                workId: WORK_ID,
+                documentId: 'doc-t22-d',
+                providerId: null,
+                credentialVersion: null,
+            });
         });
     });
 });

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -45,6 +45,7 @@ import { KB_MIRROR_DOCUMENT_DISPATCHER, type KbMirrorDocumentDispatcher } from '
 import { KB_EMBED_DOCUMENT_DISPATCHER, type KbEmbedDocumentDispatcher } from '../tasks';
 import { KB_ORG_OVERLAY_FANOUT_DISPATCHER, type KbOrgOverlayFanoutDispatcher } from '../tasks';
 import { KB_NORMALIZE_MEDIA_DISPATCHER, type KbNormalizeMediaDispatcher } from '../tasks';
+import { RuntimeBindingStamperService } from '../tasks';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { sanitizeDescription } from '../utils/sanitize.util';
 import type {
@@ -279,6 +280,17 @@ export class KnowledgeBaseService {
         @Optional()
         @Inject(KB_NORMALIZE_MEDIA_DISPATCHER)
         private readonly normalizeMediaDispatcher?: KbNormalizeMediaDispatcher,
+        // EW-742 P3.2 T22 — KB-embed is the proof-of-concept dispatcher
+        // for enqueue-site tenant-runtime binding capture (see
+        // {@link RuntimeBindingStamperService} JSDoc "Scope of THIS PR"
+        // note for why it's adopted one dispatcher at a time). Optional
+        // so isolated unit tests and pre-overlay deployments keep
+        // constructing — when absent, the enqueue degrades to the
+        // pre-overlay (EW-683) byte-identical path: payload ships
+        // without `providerId`/`credentialVersion`, worker host uses the
+        // instance default.
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
     ) {}
 
     /**
@@ -334,8 +346,36 @@ export class KnowledgeBaseService {
         if (!this.embedDispatcher) {
             return;
         }
+        // EW-742 P3.2 T22 — capture the tenant runtime binding at
+        // enqueue time so the worker host can resolve the exact
+        // credential snapshot that was active when the run was
+        // scheduled (ADR-017 §3 graceful drain). The lookup is
+        // best-effort: a missing WorkRepository, missing tenantId, or
+        // missing stamper all mean we ship the legacy 2-field payload
+        // and the worker uses the instance default — that's the same
+        // byte-identical path that ran pre-T22.
+        let binding: { providerId: string | null; credentialVersion: number | null } = {
+            providerId: null,
+            credentialVersion: null,
+        };
+        if (this.runtimeBindingStamper && this.workRepository) {
+            try {
+                const work = await this.workRepository.findById(workId);
+                binding = await this.runtimeBindingStamper.stamp(work?.tenantId ?? null);
+            } catch (err) {
+                this.logger.debug(
+                    `enqueueEmbed: stamper lookup failed for work=${workId} ` +
+                        `(${(err as Error).message}); falling back to instance default.`,
+                );
+            }
+        }
         try {
-            await this.embedDispatcher.dispatchKbEmbedDocument({ workId, documentId });
+            await this.embedDispatcher.dispatchKbEmbedDocument({
+                workId,
+                documentId,
+                providerId: binding.providerId,
+                credentialVersion: binding.credentialVersion,
+            });
         } catch (error) {
             this.logger.warn(
                 `Failed to enqueue KB embed for doc ${documentId} (work=${workId}): ${(error as Error).message}`,

--- a/packages/agent/src/tasks/kb-embed-document-dispatcher.spec.ts
+++ b/packages/agent/src/tasks/kb-embed-document-dispatcher.spec.ts
@@ -60,4 +60,40 @@ describe('KbEmbedDocumentDispatcher contract', () => {
             impl.dispatchKbEmbedDocument({ workId: 'work-1', documentId: 'doc-1' }),
         ).resolves.toBeNull();
     });
+
+    // EW-742 P3.2 T22 — KB-embed is the PoC dispatcher for enqueue-site
+    // (providerId, credentialVersion) capture. The fields are optional
+    // so existing payload sites stay compiling.
+    it('accepts the optional T22 tenant runtime binding fields', async () => {
+        const dispatchMock = jest.fn(async (_p: KbEmbedDocumentPayload) => 'run-99');
+        const impl: KbEmbedDocumentDispatcher = { dispatchKbEmbedDocument: dispatchMock };
+
+        const payload: KbEmbedDocumentPayload = {
+            workId: 'work-1',
+            documentId: 'doc-1',
+            providerId: 'trigger',
+            credentialVersion: 7,
+        };
+
+        await expect(impl.dispatchKbEmbedDocument(payload)).resolves.toBe('run-99');
+        expect(dispatchMock).toHaveBeenCalledWith(payload);
+    });
+
+    it('accepts explicit null T22 fields (no overlay = legacy default path)', async () => {
+        const dispatchMock = jest.fn(async (_p: KbEmbedDocumentPayload) => 'run-100');
+        const impl: KbEmbedDocumentDispatcher = { dispatchKbEmbedDocument: dispatchMock };
+
+        // Per stamper contract: both null means "no tenant overlay was
+        // active when this was enqueued"; worker host runs against the
+        // instance default — byte-identical to the pre-overlay code path.
+        const payload: KbEmbedDocumentPayload = {
+            workId: 'work-1',
+            documentId: 'doc-1',
+            providerId: null,
+            credentialVersion: null,
+        };
+
+        await expect(impl.dispatchKbEmbedDocument(payload)).resolves.toBe('run-100');
+        expect(dispatchMock).toHaveBeenCalledWith(payload);
+    });
 });

--- a/packages/agent/src/tasks/kb-embed-document.types.ts
+++ b/packages/agent/src/tasks/kb-embed-document.types.ts
@@ -29,4 +29,30 @@ export interface KbEmbedDocumentPayload {
     readonly workId: string;
     /** UUID of the `work_knowledge_documents` row whose body to (re)embed. */
     readonly documentId: string;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture
+     * (PoC; KB-embed is the proof-of-concept dispatcher, the other 11
+     * `*_DISPATCHER` symbols adopt the same pair incrementally — see
+     * {@link RuntimeBindingStamperService} JSDoc "Scope of THIS PR"
+     * note).
+     *
+     * When present, identifies the tenant-overlay job-runtime that was
+     * active at enqueue time. The worker host uses these to resolve
+     * THAT exact credential snapshot via
+     * {@link CredentialVersionService.resolveSnapshot} even if the
+     * tenant rotates the overlay mid-run (ADR-017 §3 graceful drain).
+     *
+     * Both fields are absent when:
+     *   - the KnowledgeBaseService doesn't have RuntimeBindingStamperService
+     *     wired (older deployments, isolated unit tests);
+     *   - the Work has no tenant context (pre-EW-655 row);
+     *   - the tenant has no overlay row, or it's `inherit` / disabled.
+     *
+     * In every "absent" case the worker host MUST fall back to the
+     * instance default (the pre-overlay EW-683 path) — same byte-for-byte
+     * code path that existed before T22.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }

--- a/packages/tasks/src/trigger/__tests__/trigger-job-runtime.provider.spec.ts
+++ b/packages/tasks/src/trigger/__tests__/trigger-job-runtime.provider.spec.ts
@@ -222,4 +222,80 @@ describe('TriggerJobRuntimeProvider', () => {
             expect(triggerServiceMock.startWorkerHost).toHaveBeenCalledWith(opts);
         });
     });
+
+    describe('bindToTenant (EW-742 P3.2 T21.1)', () => {
+        const snapshot = {
+            tenantId: '00000000-0000-0000-0000-00000000aaaa',
+            providerId: 'trigger' as const,
+            credentialVersion: 1,
+            credentials: { accessToken: 'tr_dev_abc' },
+        };
+
+        it('returns a per-tenant view exposing the snapshot', () => {
+            const view = provider.bindToTenant(snapshot);
+            // The contract requires the returned object to satisfy
+            // IJobRuntimeProvider; the snapshot is exposed off-spec on
+            // the view so the T22 stamper can read it without a separate
+            // lookup.
+            expect(view.runtimeId).toBe('trigger');
+            expect((view as { tenantSnapshot: typeof snapshot }).tenantSnapshot).toBe(snapshot);
+        });
+
+        it('memoises on (tenantId, credentialVersion) — same snapshot returns same view', () => {
+            // Per IJobRuntimeProvider.bindToTenant idempotency clause.
+            const a = provider.bindToTenant(snapshot);
+            const b = provider.bindToTenant(snapshot);
+            expect(b).toBe(a);
+        });
+
+        it('evicts the older view when credentialVersion bumps for the same tenant', () => {
+            // Cache stays bounded by tenant count, not version count —
+            // a rotate replaces the old view in place.
+            const v1 = provider.bindToTenant(snapshot);
+            const v2 = provider.bindToTenant({ ...snapshot, credentialVersion: 2 });
+            expect(v2).not.toBe(v1);
+            // Asking again for the v1 snapshot now returns a fresh view
+            // (the v1 entry was evicted by the v2 cache-replace).
+            const v1Again = provider.bindToTenant(snapshot);
+            expect(v1Again).not.toBe(v1);
+        });
+
+        it('view methods delegate back to the singleton TriggerService', async () => {
+            const view = provider.bindToTenant(snapshot);
+            triggerServiceMock.cancel.mockResolvedValue(true);
+            triggerServiceMock.isEnabled.mockReturnValue(true);
+
+            expect(view.isEnabled()).toBe(true);
+            expect(triggerServiceMock.isEnabled).toHaveBeenCalled();
+
+            await view.cancel('run_xyz');
+            expect(triggerServiceMock.cancel).toHaveBeenCalledWith('run_xyz');
+
+            // The dispatchers getter on the view passes through the
+            // singleton's dispatchers identity-equal — that's how the
+            // current "BYO with inherit (inherit only)" path keeps
+            // working in this PR; per-tenant Trigger.dev project
+            // switching is the T22 follow-up.
+            expect(view.dispatchers).toBe(dispatchersSentinel);
+        });
+
+        it('the view is frozen', () => {
+            const view = provider.bindToTenant(snapshot);
+            expect(Object.isFrozen(view)).toBe(true);
+        });
+
+        it('view.bindToTenant(self) returns self', () => {
+            const view = provider.bindToTenant(snapshot);
+            expect(view.bindToTenant?.(snapshot)).toBe(view);
+        });
+
+        it('view.bindToTenant(other) delegates back to the root provider', () => {
+            const view = provider.bindToTenant(snapshot);
+            const other = { ...snapshot, tenantId: '00000000-0000-0000-0000-00000000bbbb' };
+            const otherView = view.bindToTenant?.(other);
+            // Root produced this view, so a second call with the same
+            // `other` snapshot should hit the root's cache.
+            expect(otherView).toBe(provider.bindToTenant(other));
+        });
+    });
 });

--- a/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
+++ b/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
@@ -7,6 +7,7 @@ import type {
     PluginCategory,
     PluginContext,
     ScheduleSpec,
+    TenantCredentialSnapshot,
     WorkerHostHandle,
     WorkerHostOptions,
 } from '@ever-works/plugin';
@@ -168,5 +169,119 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
      */
     async onUnload(): Promise<void> {
         // Intentional no-op — see class JSDoc on synthetic plugin status.
+    }
+
+    /**
+     * Memoisation cache for `bindToTenant` — keyed by
+     * `${tenantId}:${credentialVersion}`. Holds the last frozen tenant
+     * view per tenant so the same snapshot returns the same instance
+     * (per the {@link IJobRuntimeProvider.bindToTenant} idempotency
+     * contract). A new `credentialVersion` evicts and replaces the
+     * previous entry — the cache size is bounded by tenant count.
+     */
+    private readonly tenantViews = new Map<string, IJobRuntimeProvider>();
+
+    /**
+     * EW-742 P3.2 T21.1 — minimal `bindToTenant` impl.
+     *
+     * Returns a per-tenant frozen view of THIS provider with the
+     * snapshot captured. Trigger.dev's underlying SDK client is a
+     * push-model singleton (their cloud invokes our tasks), so no
+     * runtime per-tenant rebinding of the actual Trigger.dev access
+     * token happens in this PR — the view's dispatchers still
+     * delegate to the singleton `TriggerService`.
+     *
+     * What this PR DOES wire up:
+     *   - Returns a fresh wrapper per `credentialVersion` so callers
+     *     get a stable instance identity to memoise on.
+     *   - Exposes the snapshot via `(view as any).tenantSnapshot` so
+     *     T22 per-dispatcher wiring can stamp `(providerId,
+     *     credentialVersion)` onto run records without needing a
+     *     separate stamper service.
+     *
+     * What this PR DOES NOT do (TODO for the next PR):
+     *   - Per-tenant Trigger.dev project switching. Today every
+     *     tenant ships through the same Trigger.dev project the API
+     *     boots against; the platform overlay is "BYO with inherit"
+     *     and the inherit path is the only one wired. BYO Trigger.dev
+     *     project per tenant requires the dispatcher layer to swap
+     *     the underlying `TriggerService` SDK client per call — that's
+     *     the T22 PR.
+     *   - Dispatcher stamping. That's the T22 per-dispatcher PoC
+     *     (KB-embed first).
+     */
+    bindToTenant(snapshot: TenantCredentialSnapshot): IJobRuntimeProvider {
+        const cacheKey = `${snapshot.tenantId}:${snapshot.credentialVersion}`;
+        const cached = this.tenantViews.get(cacheKey);
+        if (cached) {
+            return cached;
+        }
+
+        const base = this;
+        // Build a frozen tenant view. Every method delegates back to
+        // the singleton `TriggerService` (via `base`), but the view
+        // carries the snapshot for downstream stamping.
+        const view: IJobRuntimeProvider & {
+            readonly tenantSnapshot: TenantCredentialSnapshot;
+        } = Object.freeze({
+            // -- IPlugin metadata, copied verbatim ---------------------
+            id: base.id,
+            name: base.name,
+            version: base.version,
+            category: base.category,
+            capabilities: base.capabilities,
+            settingsSchema: base.settingsSchema,
+            // -- IJobRuntimeProvider, delegating ----------------------
+            runtimeId: base.runtimeId,
+            get dispatchers(): JobRuntimeDispatchers {
+                return base.dispatchers;
+            },
+            registerSchedules(schedules: readonly ScheduleSpec[]): Promise<void> {
+                return base.registerSchedules(schedules);
+            },
+            cancel(runId: string): Promise<boolean> {
+                return base.cancel(runId);
+            },
+            getRunStatus(runId: string): Promise<JobRunStatus> {
+                return base.getRunStatus(runId);
+            },
+            isEnabled(): boolean {
+                return base.isEnabled();
+            },
+            startWorkerHost(opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+                return base.startWorkerHost(opts);
+            },
+            onLoad(context: PluginContext): Promise<void> {
+                return base.onLoad(context);
+            },
+            onUnload(): Promise<void> {
+                return base.onUnload();
+            },
+            // The tenant view does NOT re-bind further — calling
+            // `bindToTenant` on a tenant view returns itself for
+            // matching snapshots; mismatched snapshots return the
+            // root provider's bind result (cache-replace semantics).
+            bindToTenant(other: TenantCredentialSnapshot): IJobRuntimeProvider {
+                if (
+                    other.tenantId === snapshot.tenantId &&
+                    other.credentialVersion === snapshot.credentialVersion
+                ) {
+                    return view;
+                }
+                return base.bindToTenant(other);
+            },
+            // -- snapshot exposed for downstream stampers --------------
+            tenantSnapshot: snapshot,
+        });
+
+        // Cache-replace: evict any older version for this tenant so
+        // the cache stays bounded.
+        for (const key of this.tenantViews.keys()) {
+            if (key.startsWith(`${snapshot.tenantId}:`)) {
+                this.tenantViews.delete(key);
+            }
+        }
+        this.tenantViews.set(cacheKey, view);
+        return view;
     }
 }


### PR DESCRIPTION
## Summary

Stage→main cascade for #1426 (Trigger.dev `bindToTenant` minimal impl) and #1427 (T22 KB-embed dispatcher tenant runtime binding capture PoC). Cascaded from develop to stage via #1428.

## Risk

Low — both PRs add OPTIONAL behaviour:
- `bindToTenant` is an OPTIONAL `IJobRuntimeProvider` hook; existing callers untouched.
- T22 KB-embed extension uses OPTIONAL payload fields; legacy callers ship `null/null` and the worker falls back to the instance default (byte-identical pre-overlay path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)