### PR TITLE
feat(agent): EW-742 P3.2 T22 — KB Tier 1 rollout (Mirror + Normalize + OrgOverlay)

### DIFF
--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -9,7 +9,9 @@ import { KB_STORAGE_PLUGIN, KnowledgeBaseService } from '../knowledge-base.servi
 import { KB_EMBED_DOCUMENT_DISPATCHER } from '../../tasks/kb-embed-document-dispatcher';
 import { KB_ORG_OVERLAY_FANOUT_DISPATCHER } from '../../tasks/kb-org-overlay-fanout-dispatcher';
 import { KB_MIRROR_DOCUMENT_DISPATCHER } from '../../tasks/kb-mirror-document-dispatcher';
+import { KB_NORMALIZE_MEDIA_DISPATCHER } from '../../tasks/kb-normalize-media-dispatcher';
 import { RuntimeBindingStamperService } from '../../tasks/runtime-binding-stamper.service';
+import { OrganizationRepository } from '../../database/repositories/organization.repository';
 import { WorkRepository } from '../../database/repositories/work.repository';
 import { KnowledgeBaseBufferExtractorService } from '../knowledge-base-buffer-extractor.service';
 import { WorkKnowledgeDocumentRepository } from '../../database/repositories/work-knowledge-document.repository';
@@ -1914,6 +1916,205 @@ describe('KnowledgeBaseService', () => {
                 providerId: null,
                 credentialVersion: null,
             });
+        });
+    });
+
+    // EW-742 P3.2 T22 (KB Tier 1 rollout) — same stamping path as the
+    // KB-embed PoC, applied to the three other KB dispatchers that
+    // share KnowledgeBaseService: KB_MIRROR_DOCUMENT_DISPATCHER,
+    // KB_NORMALIZE_MEDIA_DISPATCHER, KB_ORG_OVERLAY_FANOUT_DISPATCHER.
+    describe('KB Tier 1 — T22 stamping for the other KnowledgeBaseService dispatchers', () => {
+        const TENANT_ID = '00000000-0000-0000-0000-00000000aaaa';
+
+        async function buildWithAllDispatchers(opts: {
+            stamperResult?: { providerId: string | null; credentialVersion: number | null };
+            workTenantId?: string | null;
+            orgTenantId?: string | null;
+            orgFindThrows?: boolean;
+        }) {
+            const embedDispatcherMock = {
+                dispatchKbEmbedDocument: jest.fn().mockResolvedValue('embed-run-id'),
+            };
+            const mirrorDispatcherMock = {
+                dispatchKbMirrorDocument: jest.fn().mockResolvedValue('mirror-run-id'),
+            };
+            const normalizeMediaDispatcherMock = {
+                dispatchKbNormalizeMedia: jest.fn().mockResolvedValue('normalize-run-id'),
+            };
+            const orgOverlayFanoutDispatcherMock = {
+                dispatchKbOrgOverlayFanout: jest.fn().mockResolvedValue('fanout-run-id'),
+            };
+            const workRepoMock = {
+                findById: jest.fn().mockResolvedValue(
+                    opts.workTenantId === undefined
+                        ? null
+                        : ({ id: WORK_ID, tenantId: opts.workTenantId } as any),
+                ),
+                findIdsByOrganization: jest.fn().mockResolvedValue(['work-a', 'work-b']),
+            };
+            const orgRepoMock = {
+                findById: opts.orgFindThrows
+                    ? jest.fn().mockRejectedValue(new Error('db boom'))
+                    : jest.fn().mockResolvedValue(
+                          opts.orgTenantId === undefined
+                              ? null
+                              : ({ id: ORG_ID, tenantId: opts.orgTenantId } as any),
+                      ),
+            };
+            const stamperMock = {
+                stamp: jest
+                    .fn()
+                    .mockResolvedValue(
+                        opts.stamperResult ?? {
+                            providerId: null,
+                            credentialVersion: null,
+                        },
+                    ),
+            };
+
+            const module: TestingModule = await Test.createTestingModule({
+                providers: [
+                    KnowledgeBaseService,
+                    { provide: WorkKnowledgeDocumentRepository, useValue: docRepo },
+                    { provide: WorkKnowledgeUploadRepository, useValue: uploadRepo },
+                    { provide: WorkKnowledgeTagRepository, useValue: tagRepo },
+                    {
+                        provide: WorkKnowledgeCitationRepository,
+                        useValue: { listForDocument: jest.fn().mockResolvedValue([]) },
+                    },
+                    { provide: WorkOwnershipService, useValue: ownership },
+                    { provide: KB_STORAGE_PLUGIN, useValue: storage },
+                    { provide: ActivityLogService, useValue: activityLog },
+                    { provide: KB_EMBED_DOCUMENT_DISPATCHER, useValue: embedDispatcherMock },
+                    { provide: KB_MIRROR_DOCUMENT_DISPATCHER, useValue: mirrorDispatcherMock },
+                    {
+                        provide: KB_NORMALIZE_MEDIA_DISPATCHER,
+                        useValue: normalizeMediaDispatcherMock,
+                    },
+                    {
+                        provide: KB_ORG_OVERLAY_FANOUT_DISPATCHER,
+                        useValue: orgOverlayFanoutDispatcherMock,
+                    },
+                    { provide: WorkRepository, useValue: workRepoMock },
+                    { provide: RuntimeBindingStamperService, useValue: stamperMock },
+                    { provide: OrganizationRepository, useValue: orgRepoMock },
+                ],
+            }).compile();
+
+            return {
+                service: module.get(KnowledgeBaseService),
+                embedDispatcherMock,
+                mirrorDispatcherMock,
+                normalizeMediaDispatcherMock,
+                orgOverlayFanoutDispatcherMock,
+                workRepoMock,
+                orgRepoMock,
+                stamperMock,
+            };
+        }
+
+        it('enqueueMirror — stamps payload via stampForWork', async () => {
+            const { service: svc, mirrorDispatcherMock } = await buildWithAllDispatchers({
+                workTenantId: TENANT_ID,
+                stamperResult: { providerId: 'trigger', credentialVersion: 11 },
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'doc-mirror-1' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/voice.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            expect(mirrorDispatcherMock.dispatchKbMirrorDocument).toHaveBeenCalledTimes(1);
+            const payload = mirrorDispatcherMock.dispatchKbMirrorDocument.mock.calls[0][0];
+            expect(payload).toMatchObject({
+                workId: WORK_ID,
+                documentId: 'doc-mirror-1',
+                operation: 'upsert',
+                providerId: 'trigger',
+                credentialVersion: 11,
+            });
+        });
+
+        it('enqueueOrgOverlayFanout — stamps payload via stampForOrganization', async () => {
+            const {
+                service: svc,
+                orgOverlayFanoutDispatcherMock,
+                orgRepoMock,
+                stamperMock,
+            } = await buildWithAllDispatchers({
+                orgTenantId: TENANT_ID,
+                stamperResult: { providerId: 'trigger', credentialVersion: 13 },
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({
+                    ...data,
+                    id: 'org-doc-1',
+                    workId: null,
+                    organizationId: ORG_ID,
+                }),
+            );
+
+            await svc.createOrgDocument(ORG_ID, USER_ID, {
+                path: 'legal/privacy.md',
+                title: 'Privacy policy',
+                class: 'legal' as KbDocumentClass,
+                body: 'verbatim',
+            });
+
+            expect(orgRepoMock.findById).toHaveBeenCalledWith(ORG_ID);
+            expect(stamperMock.stamp).toHaveBeenCalledWith(TENANT_ID);
+            expect(orgOverlayFanoutDispatcherMock.dispatchKbOrgOverlayFanout).toHaveBeenCalledTimes(
+                1,
+            );
+            const payload =
+                orgOverlayFanoutDispatcherMock.dispatchKbOrgOverlayFanout.mock.calls[0][0];
+            expect(payload).toMatchObject({
+                organizationId: ORG_ID,
+                documentId: 'org-doc-1',
+                workIds: ['work-a', 'work-b'],
+                providerId: 'trigger',
+                credentialVersion: 13,
+            });
+        });
+
+        it('enqueueOrgOverlayFanout — fails open when OrganizationRepository.findById throws', async () => {
+            const {
+                service: svc,
+                orgOverlayFanoutDispatcherMock,
+                stamperMock,
+            } = await buildWithAllDispatchers({ orgFindThrows: true });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({
+                    ...data,
+                    id: 'org-doc-2',
+                    workId: null,
+                    organizationId: ORG_ID,
+                }),
+            );
+
+            await svc.createOrgDocument(ORG_ID, USER_ID, {
+                path: 'legal/privacy.md',
+                title: 'Privacy policy',
+                class: 'legal' as KbDocumentClass,
+                body: 'verbatim',
+            });
+
+            // Org lookup failed → stamper never called → payload ships null/null.
+            expect(stamperMock.stamp).not.toHaveBeenCalled();
+            expect(orgOverlayFanoutDispatcherMock.dispatchKbOrgOverlayFanout).toHaveBeenCalledTimes(
+                1,
+            );
+            const payload =
+                orgOverlayFanoutDispatcherMock.dispatchKbOrgOverlayFanout.mock.calls[0][0];
+            expect(payload.providerId).toBeNull();
+            expect(payload.credentialVersion).toBeNull();
         });
     });
 });

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -47,6 +47,7 @@ import { KB_ORG_OVERLAY_FANOUT_DISPATCHER, type KbOrgOverlayFanoutDispatcher } f
 import { KB_NORMALIZE_MEDIA_DISPATCHER, type KbNormalizeMediaDispatcher } from '../tasks';
 import { RuntimeBindingStamperService } from '../tasks';
 import { WorkRepository } from '../database/repositories/work.repository';
+import { OrganizationRepository } from '../database/repositories/organization.repository';
 import { sanitizeDescription } from '../utils/sanitize.util';
 import type {
     CitationDto,
@@ -280,17 +281,23 @@ export class KnowledgeBaseService {
         @Optional()
         @Inject(KB_NORMALIZE_MEDIA_DISPATCHER)
         private readonly normalizeMediaDispatcher?: KbNormalizeMediaDispatcher,
-        // EW-742 P3.2 T22 — KB-embed is the proof-of-concept dispatcher
-        // for enqueue-site tenant-runtime binding capture (see
-        // {@link RuntimeBindingStamperService} JSDoc "Scope of THIS PR"
-        // note for why it's adopted one dispatcher at a time). Optional
-        // so isolated unit tests and pre-overlay deployments keep
-        // constructing — when absent, the enqueue degrades to the
-        // pre-overlay (EW-683) byte-identical path: payload ships
-        // without `providerId`/`credentialVersion`, worker host uses the
-        // instance default.
+        // EW-742 P3.2 T22 — KB-embed shipped the proof-of-concept in
+        // PR #1427; this binding is now used by every workId-bound KB
+        // dispatcher in this service via the {@link stampForWork}
+        // helper. Optional so isolated unit tests and pre-overlay
+        // deployments keep constructing — when absent, the enqueue
+        // degrades to the pre-overlay (EW-683) byte-identical path:
+        // payload ships without `providerId`/`credentialVersion`,
+        // worker host uses the instance default.
         @Optional()
         private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
+        // EW-742 P3.2 T22 (org-overlay branch) — used by
+        // {@link stampForOrganization} to resolve a tenantId from an
+        // organizationId. Optional so the same code path runs in
+        // deployments that don't have organizations wired (per-Work
+        // dispatchers still get stamped via WorkRepository above).
+        @Optional()
+        private readonly organizationRepository?: OrganizationRepository,
     ) {}
 
     /**
@@ -312,6 +319,8 @@ export class KnowledgeBaseService {
         if (!this.mirrorDispatcher) {
             return;
         }
+        // EW-742 P3.2 T22 — see stampForWork JSDoc.
+        const binding = await this.stampForWork(workId, 'enqueueMirror');
         try {
             await this.mirrorDispatcher.dispatchKbMirrorDocument({
                 workId,
@@ -319,6 +328,8 @@ export class KnowledgeBaseService {
                 operation,
                 path: docPath,
                 class: docClass,
+                providerId: binding.providerId,
+                credentialVersion: binding.credentialVersion,
             });
         } catch (error) {
             this.logger.warn(
@@ -342,6 +353,64 @@ export class KnowledgeBaseService {
      * (work-knowledge-chunk.entity.ts) clears chunk rows when the
      * parent document row is dropped — no separate enqueue needed.
      */
+    /**
+     * EW-742 P3.2 T22 — shared per-Work tenant runtime binding helper.
+     *
+     * Resolves the Work's tenantId via WorkRepository.findById, then
+     * delegates to RuntimeBindingStamperService.stamp(tenantId). Returns
+     * `{ providerId: null, credentialVersion: null }` when any link in
+     * the chain is missing or throws — the worker host treats that as
+     * "no overlay was active" and runs against the instance default
+     * (byte-identical pre-overlay path).
+     *
+     * Called by every workId-bound dispatch site in this service
+     * (enqueueEmbed / enqueueMirror / maybeDispatchMediaNormalize). The
+     * org-overlay fanout uses {@link stampForOrganization} instead.
+     */
+    private async stampForWork(
+        workId: string,
+        callSite: string,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper || !this.workRepository) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            const work = await this.workRepository.findById(workId);
+            return await this.runtimeBindingStamper.stamp(work?.tenantId ?? null);
+        } catch (err) {
+            this.logger.debug(
+                `${callSite}: stamper lookup failed for work=${workId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
+    }
+
+    /**
+     * EW-742 P3.2 T22 — shared per-Organization tenant runtime binding
+     * helper. An org belongs to exactly one tenant, so the org-overlay
+     * fanout (which targets multiple Works in that org) still has a
+     * single unambiguous tenant scope.
+     */
+    private async stampForOrganization(
+        organizationId: string,
+        callSite: string,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper || !this.organizationRepository) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            const org = await this.organizationRepository.findById(organizationId);
+            return await this.runtimeBindingStamper.stamp(org?.tenantId ?? null);
+        } catch (err) {
+            this.logger.debug(
+                `${callSite}: stamper lookup failed for org=${organizationId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
+    }
+
     private async enqueueEmbed(workId: string, documentId: string): Promise<void> {
         if (!this.embedDispatcher) {
             return;
@@ -349,26 +418,10 @@ export class KnowledgeBaseService {
         // EW-742 P3.2 T22 — capture the tenant runtime binding at
         // enqueue time so the worker host can resolve the exact
         // credential snapshot that was active when the run was
-        // scheduled (ADR-017 §3 graceful drain). The lookup is
-        // best-effort: a missing WorkRepository, missing tenantId, or
-        // missing stamper all mean we ship the legacy 2-field payload
-        // and the worker uses the instance default — that's the same
-        // byte-identical path that ran pre-T22.
-        let binding: { providerId: string | null; credentialVersion: number | null } = {
-            providerId: null,
-            credentialVersion: null,
-        };
-        if (this.runtimeBindingStamper && this.workRepository) {
-            try {
-                const work = await this.workRepository.findById(workId);
-                binding = await this.runtimeBindingStamper.stamp(work?.tenantId ?? null);
-            } catch (err) {
-                this.logger.debug(
-                    `enqueueEmbed: stamper lookup failed for work=${workId} ` +
-                        `(${(err as Error).message}); falling back to instance default.`,
-                );
-            }
-        }
+        // scheduled (ADR-017 §3 graceful drain). Fail-open per FR-5:
+        // any missing dep / lookup error ships null/null and the
+        // worker uses the instance default (byte-identical pre-T22 path).
+        const binding = await this.stampForWork(workId, 'enqueueEmbed');
         try {
             await this.embedDispatcher.dispatchKbEmbedDocument({
                 workId,
@@ -428,6 +481,11 @@ export class KnowledgeBaseService {
                 );
                 return;
             }
+            // EW-742 P3.2 T22 — see stampForOrganization JSDoc.
+            const binding = await this.stampForOrganization(
+                organizationId,
+                'enqueueOrgOverlayFanout',
+            );
             await this.orgOverlayDispatcher.dispatchKbOrgOverlayFanout({
                 organizationId,
                 documentId,
@@ -435,6 +493,8 @@ export class KnowledgeBaseService {
                 operation,
                 path: docPath,
                 class: docClass,
+                providerId: binding.providerId,
+                credentialVersion: binding.credentialVersion,
             });
         } catch (error) {
             this.logger.warn(
@@ -475,6 +535,8 @@ export class KnowledgeBaseService {
         if (!mediaKind) {
             return;
         }
+        // EW-742 P3.2 T22 — see stampForWork JSDoc.
+        const binding = await this.stampForWork(upload.workId, 'maybeDispatchMediaNormalize');
         try {
             await this.normalizeMediaDispatcher.dispatchKbNormalizeMedia({
                 workId: upload.workId,
@@ -482,6 +544,8 @@ export class KnowledgeBaseService {
                 mediaKind,
                 originalSha256: sha256,
                 originalMimeType: bare,
+                providerId: binding.providerId,
+                credentialVersion: binding.credentialVersion,
             });
         } catch (error) {
             this.logger.warn(

--- a/packages/agent/src/tasks/kb-mirror-document.types.ts
+++ b/packages/agent/src/tasks/kb-mirror-document.types.ts
@@ -37,4 +37,12 @@ export interface KbMirrorDocumentPayload {
      * for symmetry with `path`; the task does not re-query the DB.
      */
     readonly class: string;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }

--- a/packages/agent/src/tasks/kb-normalize-media.types.ts
+++ b/packages/agent/src/tasks/kb-normalize-media.types.ts
@@ -54,4 +54,12 @@ export interface KbNormalizeMediaPayload {
      * extension fallback when the input has no extension.
      */
     readonly originalMimeType: string;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }

--- a/packages/agent/src/tasks/kb-org-overlay-fanout.types.ts
+++ b/packages/agent/src/tasks/kb-org-overlay-fanout.types.ts
@@ -54,4 +54,15 @@ export interface KbOrgOverlayFanoutPayload {
     /** `kbDocumentClass` value (`brand`, `legal`, ...). Required on
      *  delete for symmetry with `path`. */
     readonly class: string;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * Resolved from the OWNING ORGANIZATION's `tenantId` (an org belongs
+     * to exactly one tenant, so the org-overlay fanout has a single
+     * unambiguous tenant scope even though its targets are multiple
+     * Works). See `KbEmbedDocumentPayload` (the PoC dispatcher) for
+     * the full contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }


### PR DESCRIPTION
## Summary

Rolls out the T22 enqueue-site tenant runtime binding capture pattern (PoC shipped in #1427 for KB-embed) to the three remaining KB dispatchers that live in `KnowledgeBaseService`:

- `KB_MIRROR_DOCUMENT_DISPATCHER` (`enqueueMirror`)
- `KB_NORMALIZE_MEDIA_DISPATCHER` (`maybeDispatchMediaNormalize`)
- `KB_ORG_OVERLAY_FANOUT_DISPATCHER` (`enqueueOrgOverlayFanout`)

## What this PR does

1. **Extracts a shared `stampForWork(workId, callSite)` helper** — wraps the existing PoC pattern: resolve work via `WorkRepository`, call `RuntimeBindingStamperService.stamp(tenantId)`, fail-open on any missing dep / lookup error.
2. **Adds a sibling `stampForOrganization(organizationId, callSite)` helper** — an org belongs to exactly one tenant, so the org-overlay fanout (which targets multiple Works) still has a single unambiguous tenant scope. Uses a new `@Optional()` injection of `OrganizationRepository`.
3. **Refactors `enqueueEmbed` (the PoC) to use `stampForWork`** so all four dispatch sites share one helper.
4. **Wires the helpers into the three new sites.**
5. **Extends the three payload types** with the optional T22 fields (`providerId?`, `credentialVersion?`) — matches the `KbEmbedDocumentPayload` shape.

## Fail-open

Per ADR-017 §3 + FR-5, every failure path ships `null/null` and the worker host falls back to the instance default (byte-identical pre-overlay path).

## Tests

- **3 new jest cases**:
  - `enqueueMirror` stamps payload via `stampForWork`
  - `enqueueOrgOverlayFanout` stamps payload via `stampForOrganization`
  - `enqueueOrgOverlayFanout` fails open when `OrganizationRepository` throws
- All existing assertions unchanged (new fields are additive).
- **67/67 KB tests green**; agent package type-check clean.

## What this PR DOES NOT do (deferred)

- **T22 Tier 2** (`WORK_GENERATION_DISPATCHER`, `WORK_IMPORT_DISPATCHER`, `TEMPLATE_CUSTOMIZATION_DISPATCHER`) — those live in their own services and ship in a separate PR.
- **Worker-host `resolveSnapshot` consumption** — still TODO.
- `KB_TRANSCRIBE_DISPATCHER`, `KB_REEMBED_WORK_DISPATCHER`, `KB_BACKFILL_SKELETON_DISPATCHER`, `WEBHOOK_DELIVERY_DISPATCHER` — out of scope here (different services / packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced reliability and error resilience for knowledge base mirroring and organization overlay operations with graceful degradation.
  * Improved operational metadata tracking to support better diagnostics and tenant-aware processing.

* **Tests**
  * Added comprehensive test coverage for binding stamping across multiple knowledge base dispatch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->