### PR TITLE
feat(agent): EW-742 P3.2 T22 — Tier 2 rollout (WorkGen + WorkImport + TemplateCustomization)

### DIFF
--- a/packages/agent/src/services/__tests__/work-generation.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-generation.service.spec.ts
@@ -102,6 +102,7 @@ describe('WorkGenerationService', () => {
     ): WorkGenerationService => {
         const withDispatcher = opts.withDispatcher ?? false;
         const withNotifications = opts.withNotifications ?? true;
+        const withStamper = (opts as { withStamper?: unknown }).withStamper;
         return new WorkGenerationService(
             dataGenerator,
             markdownGenerator,
@@ -123,6 +124,8 @@ describe('WorkGenerationService', () => {
             pluginRegistryService,
             withDispatcher ? generationDispatcher : undefined,
             withNotifications ? notificationService : undefined,
+            // EW-742 P3.2 T22 — Optional() stamper, undefined by default.
+            withStamper as never,
         );
     };
 
@@ -3913,6 +3916,88 @@ describe('WorkGenerationService', () => {
             await service.processGeneration(work, buildUser(), {} as any);
 
             expect(service['generationAbortControllers'].has('work-9')).toBe(false);
+        });
+    });
+
+    // EW-742 P3.2 T22 — Tier 2 dispatcher wiring. WorkGenerationService
+    // resolves tenantId directly from `work.tenantId` (no extra lookup
+    // needed) and stamps the payload via the optional stamper.
+    describe('dispatchGenerationTask — T22 tenant runtime binding capture', () => {
+        const TENANT_ID = '00000000-0000-0000-0000-00000000aaaa';
+
+        async function dispatchOnce(opts: {
+            stamperResult?: { providerId: string | null; credentialVersion: number | null };
+            stamperThrows?: boolean;
+            workTenantId?: string | null;
+        }) {
+            const stamperMock = {
+                stamp: opts.stamperThrows
+                    ? jest.fn().mockRejectedValue(new Error('stamper boom'))
+                    : jest
+                          .fn()
+                          .mockResolvedValue(
+                              opts.stamperResult ?? {
+                                  providerId: null,
+                                  credentialVersion: null,
+                              },
+                          ),
+            };
+            const service = buildService({
+                withDispatcher: true,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                withStamper: stamperMock as any,
+            } as any) as any;
+            generationDispatcher.dispatchWorkGeneration.mockResolvedValue('run-t22');
+            const work = buildWork({
+                id: 'work-t22',
+                tenantId: opts.workTenantId ?? null,
+            });
+            const user = buildUser();
+            await service.dispatchGenerationTask(
+                'create' as any,
+                work,
+                user,
+                {} as any,
+                'h-1',
+                { startedAt: new Date() } as any,
+                { triggeredBy: 'user' } as any,
+            );
+            return {
+                payload: generationDispatcher.dispatchWorkGeneration.mock.calls.at(-1)?.[0],
+                stamperMock,
+            };
+        }
+
+        it('stamps payload with stamper result when overlay is active', async () => {
+            const { payload, stamperMock } = await dispatchOnce({
+                workTenantId: TENANT_ID,
+                stamperResult: { providerId: 'trigger', credentialVersion: 12 },
+            });
+            expect(stamperMock.stamp).toHaveBeenCalledWith(TENANT_ID);
+            expect(payload).toMatchObject({
+                workId: 'work-t22',
+                providerId: 'trigger',
+                credentialVersion: 12,
+            });
+        });
+
+        it('ships null/null when work has no tenantId', async () => {
+            const { payload, stamperMock } = await dispatchOnce({
+                workTenantId: null,
+                stamperResult: { providerId: null, credentialVersion: null },
+            });
+            expect(stamperMock.stamp).toHaveBeenCalledWith(null);
+            expect(payload.providerId).toBeNull();
+            expect(payload.credentialVersion).toBeNull();
+        });
+
+        it('fails open on stamper throw', async () => {
+            const { payload } = await dispatchOnce({
+                workTenantId: TENANT_ID,
+                stamperThrows: true,
+            });
+            expect(payload.providerId).toBeNull();
+            expect(payload.credentialVersion).toBeNull();
         });
     });
 });

--- a/packages/agent/src/services/__tests__/work-import.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-import.service.spec.ts
@@ -742,3 +742,117 @@ describe('WorkImportService.syncWork', () => {
         );
     });
 });
+
+// EW-742 P3.2 T22 — WorkImportService is the second Tier 2 dispatcher
+// site (after WorkGen). Work entity has tenantId directly so we call
+// `stamper.stamp(work.tenantId ?? null)` without an extra Work lookup.
+describe('WorkImportService.dispatchImportTask — T22 tenant runtime binding capture', () => {
+    const TENANT_ID = '00000000-0000-0000-0000-00000000aaaa';
+
+    async function dispatchOnce(opts: {
+        stamperResult?: { providerId: string | null; credentialVersion: number | null };
+        stamperThrows?: boolean;
+        workTenantId?: string | null;
+    }) {
+        const workRepository = {
+            recordGenerationStartTime: jest.fn().mockResolvedValue(undefined),
+            updateGenerateStatus: jest.fn().mockResolvedValue(undefined),
+        };
+        const generationHistoryRepository = {
+            updateEntry: jest.fn().mockResolvedValue(undefined),
+        };
+        const importDispatcher = {
+            dispatchWorkImport: jest.fn().mockResolvedValue('import-run-t22'),
+        };
+        const stamperMock = {
+            stamp: opts.stamperThrows
+                ? jest.fn().mockRejectedValue(new Error('stamper boom'))
+                : jest
+                      .fn()
+                      .mockResolvedValue(
+                          opts.stamperResult ?? {
+                              providerId: null,
+                              credentialVersion: null,
+                          },
+                      ),
+        };
+
+        const service = new WorkImportService(
+            workRepository as any,
+            generationHistoryRepository as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            { emit: jest.fn() } as any,
+            importDispatcher as any,
+            stamperMock as any,
+        );
+
+        const work: any = {
+            id: 'work-t22',
+            tenantId: opts.workTenantId ?? null,
+        };
+        const user: any = { id: 'user-1' };
+        const dto: any = {
+            sourceUrl: 'https://github.com/ever-works/foo',
+            sourceType: ImportSourceTypeEnum.DATA_REPO,
+        };
+        const parsed = { owner: 'ever-works', repo: 'foo' };
+        const history: any = { id: 'h-1', startedAt: new Date() };
+        const context: any = { triggeredBy: 'user' };
+
+        await (service as any).dispatchImportTask(
+            work,
+            user,
+            dto,
+            parsed,
+            history,
+            context,
+            null,
+        );
+
+        return {
+            payload: importDispatcher.dispatchWorkImport.mock.calls.at(-1)?.[0] as any,
+            stamperMock,
+        };
+    }
+
+    it('stamps payload with stamper result when overlay is active', async () => {
+        const { payload, stamperMock } = await dispatchOnce({
+            workTenantId: TENANT_ID,
+            stamperResult: { providerId: 'trigger', credentialVersion: 14 },
+        });
+        expect(stamperMock.stamp).toHaveBeenCalledWith(TENANT_ID);
+        expect(payload).toMatchObject({
+            workId: 'work-t22',
+            providerId: 'trigger',
+            credentialVersion: 14,
+        });
+    });
+
+    it('ships null/null when work has no tenantId', async () => {
+        const { payload, stamperMock } = await dispatchOnce({
+            workTenantId: null,
+            stamperResult: { providerId: null, credentialVersion: null },
+        });
+        expect(stamperMock.stamp).toHaveBeenCalledWith(null);
+        expect(payload.providerId).toBeNull();
+        expect(payload.credentialVersion).toBeNull();
+    });
+
+    it('fails open on stamper throw', async () => {
+        const { payload } = await dispatchOnce({
+            workTenantId: TENANT_ID,
+            stamperThrows: true,
+        });
+        expect(payload.providerId).toBeNull();
+        expect(payload.credentialVersion).toBeNull();
+    });
+});

--- a/packages/agent/src/services/work-generation.service.ts
+++ b/packages/agent/src/services/work-generation.service.ts
@@ -47,6 +47,7 @@ import {
     WorkGenerationPayload,
     WORK_GENERATION_DISPATCHER,
     WorkGenerationDispatcher,
+    RuntimeBindingStamperService,
 } from '@src/tasks';
 import { WorkScheduleBillingMode, GenerateStatusType } from '@src/entities/types';
 import { WorkOwnershipService } from './work-ownership.service';
@@ -151,6 +152,14 @@ export class WorkGenerationService {
         private readonly generationDispatcher?: WorkGenerationDispatcher,
         @Optional()
         private readonly notificationService?: NotificationService,
+        // EW-742 P3.2 T22 — enqueue-site tenant runtime binding capture.
+        // Optional so isolated unit tests and pre-overlay deployments
+        // keep constructing — when absent, payload ships null/null and
+        // the worker falls back to the instance default (byte-identical
+        // pre-T22 path). See `KnowledgeBaseService.stampForWork` for the
+        // shared pattern.
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
     ) {}
 
     async generateItems(
@@ -1313,6 +1322,29 @@ Only include image URLs that are absolute URLs (starting with http).`;
         });
     }
 
+    /**
+     * EW-742 P3.2 T22 — resolve `(providerId, credentialVersion)` for
+     * the worker host's `resolveSnapshot` lookup. Returns null/null
+     * when stamper isn't wired, tenantId is null, or stamper throws
+     * (fail-open per FR-5; worker uses instance default).
+     */
+    private async stampForWork(
+        tenantId: string | null,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            return await this.runtimeBindingStamper.stamp(tenantId);
+        } catch (err) {
+            this.logger.debug(
+                `dispatchGenerationTask: stamper lookup failed for tenant=${tenantId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
+    }
+
     private async dispatchGenerationTask(
         mode: WorkGenerationMode,
         work: Work,
@@ -1331,6 +1363,12 @@ Only include image URLs that are absolute URLs (starting with http).`;
             }),
         ]);
 
+        // EW-742 P3.2 T22 — stamp `(providerId, credentialVersion)` for
+        // the worker host. Work entity has `tenantId` already on hand
+        // (passed in by the caller) so we skip the redundant Work
+        // lookup and call the stamper directly. Fail-open per FR-5.
+        const binding = await this.stampForWork(work.tenantId ?? null);
+
         const payload: WorkGenerationPayload = {
             workId: work.id,
             userId: user.id,
@@ -1343,6 +1381,8 @@ Only include image URLs that are absolute URLs (starting with http).`;
                 new Date().toISOString(),
             triggerSource: context.triggeredBy,
             scheduleId: context.scheduleId,
+            providerId: binding.providerId,
+            credentialVersion: binding.credentialVersion,
         };
 
         const dispatchedId = this.generationDispatcher

--- a/packages/agent/src/services/work-import.service.ts
+++ b/packages/agent/src/services/work-import.service.ts
@@ -47,6 +47,7 @@ import {
     WorkImportErrorCode,
     WorkImportDispatcher,
     WORK_IMPORT_DISPATCHER,
+    RuntimeBindingStamperService,
 } from '@src/tasks';
 import { WorkScheduleService } from './work-schedule.service';
 import { WorkScheduleCadence, GenerateStatusType } from '@src/entities/types';
@@ -101,6 +102,12 @@ export class WorkImportService {
         @Optional()
         @Inject(WORK_IMPORT_DISPATCHER)
         private readonly importDispatcher?: WorkImportDispatcher,
+        // EW-742 P3.2 T22 — enqueue-site tenant runtime binding capture.
+        // Optional so isolated unit tests and pre-overlay deployments
+        // keep constructing — when absent, payload ships null/null and
+        // the worker falls back to the instance default.
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
     ) {}
 
     /**
@@ -546,6 +553,29 @@ export class WorkImportService {
         );
     }
 
+    /**
+     * EW-742 P3.2 T22 — resolve `(providerId, credentialVersion)` for
+     * the worker host's `resolveSnapshot` lookup. Returns null/null
+     * when stamper isn't wired, tenantId is null, or stamper throws
+     * (fail-open per FR-5; worker uses instance default).
+     */
+    private async stampForTenant(
+        tenantId: string | null,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            return await this.runtimeBindingStamper.stamp(tenantId);
+        } catch (err) {
+            this.logger.debug(
+                `dispatchImportTask: stamper lookup failed for tenant=${tenantId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
+    }
+
     private async dispatchImportTask(
         work: Work,
         user: User,
@@ -561,6 +591,10 @@ export class WorkImportService {
                 status: GenerateStatusType.GENERATING,
             }),
         ]);
+
+        // EW-742 P3.2 T22 — stamp `(providerId, credentialVersion)` for
+        // the worker host. Fail-open per FR-5.
+        const binding = await this.stampForTenant(work.tenantId ?? null);
 
         const payload: WorkImportPayload = {
             workId: work.id,
@@ -583,6 +617,8 @@ export class WorkImportService {
             providers: dto.providers,
             enrichmentConfig: dto.enrichmentConfig,
             worksConfig: worksConfig ?? null,
+            providerId: binding.providerId,
+            credentialVersion: binding.credentialVersion,
         };
 
         const dispatchedId = this.importDispatcher

--- a/packages/agent/src/tasks/template-customization.types.ts
+++ b/packages/agent/src/tasks/template-customization.types.ts
@@ -1,3 +1,10 @@
 export type TemplateCustomizationPayload = {
     customizationId: string;
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    providerId?: string | null;
+    credentialVersion?: number | null;
 };

--- a/packages/agent/src/tasks/work-generation.types.ts
+++ b/packages/agent/src/tasks/work-generation.types.ts
@@ -46,4 +46,11 @@ export type WorkGenerationPayload = {
     historyStartedAt?: string;
     triggerSource?: 'user' | 'schedule' | 'api';
     scheduleId?: string;
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    providerId?: string | null;
+    credentialVersion?: number | null;
 };

--- a/packages/agent/src/tasks/work-import.types.ts
+++ b/packages/agent/src/tasks/work-import.types.ts
@@ -21,6 +21,13 @@ export type WorkImportPayload = {
     providers?: ProvidersDto;
     enrichmentConfig?: ImportEnrichmentConfigDto;
     worksConfig?: ResolvedWorksConfig | null;
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    providerId?: string | null;
+    credentialVersion?: number | null;
 };
 
 export type WorkImportMetrics = {

--- a/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
+++ b/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
@@ -262,8 +262,14 @@ describe('TemplateCustomizationService.createAndStart', () => {
 
         const result = await service.createAndStart('user-1', baseInput);
 
+        // EW-742 P3.2 T22 — payload now always includes the
+        // (providerId, credentialVersion) pair. Stamper isn't wired in
+        // this test fixture, so both are null and the worker falls
+        // back to the instance default (byte-identical pre-T22 path).
         expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
             customizationId: result.customization.id,
+            providerId: null,
+            credentialVersion: null,
         });
         expect(mocks.customizationRepository.updateById).toHaveBeenCalledWith(
             result.customization.id,
@@ -629,5 +635,121 @@ describe('TemplateCustomizationService.syncFromBase', () => {
         );
         expect(result.method).toBe('duplicate');
         expect(result.changed).toBe(true);
+    });
+});
+
+// EW-742 P3.2 T22 — TemplateCustomizationService is the third Tier 2
+// dispatcher site (after WorkGen + WorkImport). Customization rows
+// carry `tenantId` directly so we resolve via
+// `customizationRepository.findById(customizationId)` and stamp.
+describe('TemplateCustomizationService.start — T22 tenant runtime binding capture', () => {
+    function buildWithStamper(opts: {
+        stamperResult?: { providerId: string | null; credentialVersion: number | null };
+        stamperThrows?: boolean;
+        rowTenantId?: string | null;
+        rowFindThrows?: boolean;
+    }) {
+        const { service, mocks } = makeService();
+        // Patch dispatcher to resolve to a non-null runId so the start()
+        // happy path runs.
+        (mocks.dispatcher.dispatchTemplateCustomization as jest.Mock).mockResolvedValue(
+            'run-tpl-t22',
+        );
+        // Patch the customization repo `findById` for the stamper lookup.
+        (mocks.customizationRepository as any).findById = opts.rowFindThrows
+            ? jest.fn().mockRejectedValue(new Error('db boom'))
+            : jest.fn().mockResolvedValue(
+                  opts.rowTenantId === undefined
+                      ? null
+                      : ({ id: 'cust-1', tenantId: opts.rowTenantId } as any),
+              );
+        const stamperMock = {
+            stamp: opts.stamperThrows
+                ? jest.fn().mockRejectedValue(new Error('stamper boom'))
+                : jest
+                      .fn()
+                      .mockResolvedValue(
+                          opts.stamperResult ?? {
+                              providerId: null,
+                              credentialVersion: null,
+                          },
+                      ),
+        };
+        // Replace the service with one wired to the stamper.
+        const TenantService = service.constructor as new (
+            ...args: unknown[]
+        ) => typeof service;
+        const wired = new TenantService(
+            mocks.templateRepository as any,
+            mocks.customizationRepository as any,
+            mocks.userRepository as any,
+            mocks.gitFacade as any,
+            mocks.codeEditFacade as any,
+            mocks.aiFacade as any,
+            mocks.dispatcher as any,
+            stamperMock as any,
+        );
+        return { service: wired, mocks, stamperMock };
+    }
+
+    it('stamps payload with stamper result when overlay is active', async () => {
+        const { service: svc, mocks, stamperMock } = buildWithStamper({
+            rowTenantId: '00000000-0000-0000-0000-00000000aaaa',
+            stamperResult: { providerId: 'trigger', credentialVersion: 9 },
+        });
+        // The dispatch site lives inside `start(customizationId)` — invoke
+        // it via the public createAndStart path so we exercise the same
+        // call shape as production.
+        const result = await svc.createAndStart('user-1', baseInput);
+
+        expect(stamperMock.stamp).toHaveBeenCalledWith('00000000-0000-0000-0000-00000000aaaa');
+        expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
+            customizationId: result.customization.id,
+            providerId: 'trigger',
+            credentialVersion: 9,
+        });
+    });
+
+    it('ships null/null when customization row has no tenantId', async () => {
+        const { service: svc, mocks, stamperMock } = buildWithStamper({
+            rowTenantId: null,
+            stamperResult: { providerId: null, credentialVersion: null },
+        });
+        const result = await svc.createAndStart('user-1', baseInput);
+
+        expect(stamperMock.stamp).toHaveBeenCalledWith(null);
+        expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
+            customizationId: result.customization.id,
+            providerId: null,
+            credentialVersion: null,
+        });
+    });
+
+    it('fails open on customizationRepository.findById throw', async () => {
+        const { service: svc, mocks, stamperMock } = buildWithStamper({
+            rowFindThrows: true,
+        });
+        const result = await svc.createAndStart('user-1', baseInput);
+
+        expect(stamperMock.stamp).not.toHaveBeenCalled();
+        expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
+            customizationId: result.customization.id,
+            providerId: null,
+            credentialVersion: null,
+        });
+    });
+
+    it('fails open on stamper throw', async () => {
+        const { service: svc, mocks } = buildWithStamper({
+            rowTenantId: '00000000-0000-0000-0000-00000000aaaa',
+            stamperThrows: true,
+        });
+        const result = await svc.createAndStart('user-1', baseInput);
+
+        expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
+            customizationId: result.customization.id,
+            providerId: null,
+            credentialVersion: null,
+        });
     });
 });

--- a/packages/agent/src/template-catalog/template-customization.service.ts
+++ b/packages/agent/src/template-catalog/template-customization.service.ts
@@ -19,6 +19,7 @@ import { AiFacadeService } from '@src/facades/ai.facade';
 import {
     TEMPLATE_CUSTOMIZATION_DISPATCHER,
     type TemplateCustomizationDispatcher,
+    RuntimeBindingStamperService,
 } from '@src/tasks';
 import {
     findWebsiteTemplateConfig,
@@ -118,6 +119,12 @@ export class TemplateCustomizationService {
         @Optional()
         @Inject(TEMPLATE_CUSTOMIZATION_DISPATCHER)
         private readonly dispatcher?: TemplateCustomizationDispatcher,
+        // EW-742 P3.2 T22 — enqueue-site tenant runtime binding capture.
+        // Optional so isolated unit tests and pre-overlay deployments
+        // keep constructing — when absent, payload ships null/null and
+        // the worker falls back to the instance default.
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
     ) {}
 
     async createAndStart(
@@ -312,8 +319,32 @@ export class TemplateCustomizationService {
         };
     }
     private async start(customizationId: string): Promise<void> {
+        // EW-742 P3.2 T22 — resolve `(providerId, credentialVersion)`
+        // for the worker host. TemplateCustomization has tenantId
+        // directly on the row; look it up if the stamper is wired.
+        // Fail-open per FR-5: any failure ships null/null.
+        let binding: { providerId: string | null; credentialVersion: number | null } = {
+            providerId: null,
+            credentialVersion: null,
+        };
+        if (this.runtimeBindingStamper) {
+            try {
+                const row = await this.customizationRepository.findById(customizationId);
+                binding = await this.runtimeBindingStamper.stamp(row?.tenantId ?? null);
+            } catch (err) {
+                this.logger.debug(
+                    `start: stamper lookup failed for customization=${customizationId} ` +
+                        `(${(err as Error).message}); falling back to instance default.`,
+                );
+            }
+        }
+
         const dispatchedId = this.dispatcher
-            ? await this.dispatcher.dispatchTemplateCustomization({ customizationId })
+            ? await this.dispatcher.dispatchTemplateCustomization({
+                  customizationId,
+                  providerId: binding.providerId,
+                  credentialVersion: binding.credentialVersion,
+              })
             : null;
 
         if (dispatchedId) {


### PR DESCRIPTION
## Summary

Rolls out the T22 enqueue-site tenant runtime binding capture pattern to the three non-KB dispatcher sites (after KB-embed PoC in #1427 and KB Tier 1 in #1430):

- `WORK_GENERATION_DISPATCHER` (work-generation.service.ts)
- `WORK_IMPORT_DISPATCHER` (work-import.service.ts)
- `TEMPLATE_CUSTOMIZATION_DISPATCHER` (template-customization.service.ts)

## What this PR does

1. **Extends 3 payload types** with the optional T22 fields:
   - `WorkGenerationPayload`
   - `WorkImportPayload`
   - `TemplateCustomizationPayload`

2. **Injects `RuntimeBindingStamperService`** as `@Optional()` into each service (isolated unit tests and pre-overlay deployments keep constructing).

3. **Each dispatch site resolves tenantId and stamps:**
   - **WorkGen + WorkImport:** Work entity has `tenantId` directly → `stamper.stamp(work.tenantId ?? null)` (no extra lookup; each service has its own private helper to centralize the fail-open logic).
   - **TemplateCustomization:** row carries `tenantId` → look up via existing `customizationRepository.findById(customizationId)`, then stamp.

## Fail-open

Same as the KB-embed PoC (#1427) and KB Tier 1 (#1430): every failure path ships `null/null` and the worker host falls back to the instance default (byte-identical pre-overlay path).

## Tests

- **10 new jest cases** (3-4 each per dispatcher):
  - happy path → stamper result threaded through
  - null tenantId → ships null/null
  - stamper throw → ships null/null (fail-open)
  - template-only: repo throw → ships null/null
- Updated existing template assertion to include the null/null fields (additive, documents the contract inline).
- **208/208 affected tests pass**; agent package type-check clean.

## What this PR does NOT do (deferred)

- **Worker-host `resolveSnapshot` consumption** — still TODO (ships next).
- `KB_TRANSCRIBE_DISPATCHER`, `KB_REEMBED_WORK_DISPATCHER`, `KB_BACKFILL_SKELETON_DISPATCHER` — different services / packages.
- `WEBHOOK_DELIVERY_DISPATCHER` — lives in apps/api, separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tenant-aware provider and credential binding for work generation, import, and template customization dispatches
  * Dispatch payloads now include provider ID and credential version fields
  * Implements fail-open behavior: defaults to null values if binding resolution fails

* **Tests**
  * Added comprehensive test coverage for tenant-specific runtime binding capture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->