### PR TITLE
feat(tasks): EW-742 P3.2 T22 — worker-host resolveSnapshot consumption (PoC service)

### DIFF
--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
@@ -72,6 +72,14 @@ import { TenantJobRuntimeService } from './tenant-job-runtime.service';
         },
     ],
     controllers: [TenantJobRuntimeController],
-    exports: [TenantCredentialCache, TenantAwareRuntimeResolver, RuntimeBindingStamperService],
+    exports: [
+        TenantCredentialCache,
+        TenantAwareRuntimeResolver,
+        RuntimeBindingStamperService,
+        // EW-742 P3.2 T22 — exported so TriggerInternalModule can expose
+        // resolveSnapshot through the remote-proxy controller for the
+        // worker-host consumption path.
+        CredentialVersionService,
+    ],
 })
 export class TenantJobRuntimeModule {}

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -45,6 +45,7 @@ import {
     TaskRecurrenceDispatcherService,
     TasksService,
 } from '@ever-works/agent/tasks-domain';
+import { CredentialVersionService } from '@ever-works/agent/tasks';
 import { AgentRepository, AgentRunRepository } from '@ever-works/agent/database';
 import { DataSyncDispatcherService } from '../data-sync/data-sync-dispatcher.service';
 import { NotificationService } from '@ever-works/agent/notifications';
@@ -215,6 +216,12 @@ export class TriggerInternalController implements OnModuleInit {
         // notification-channel-delivery Trigger task to run a single
         // channel attempt (plugins are loaded here, not in the worker).
         private readonly notificationChannelFacade: NotificationChannelFacadeService,
+        // EW-742 P3.2 T22 — exposes CredentialVersionService.resolveSnapshot
+        // through the remote-proxy controller so Trigger.dev worker tasks
+        // can verify the (providerId, credentialVersion) pair stamped at
+        // enqueue time and decide whether to run, fail with
+        // CREDENTIAL_DRAINED, or fall back to the instance default.
+        private readonly credentialVersionService: CredentialVersionService,
         @Optional()
         @Inject(forwardRef(() => WorkProposalsApiService))
         private readonly workProposalsApiService?: WorkProposalsApiService,
@@ -257,6 +264,10 @@ export class TriggerInternalController implements OnModuleInit {
             // Notifications v2 (EW-663) — notification-channel-delivery task
             // calls `deliverToChannelOrThrow` here (allow-list auto-derived).
             NotificationChannelFacadeService: this.notificationChannelFacade,
+            // EW-742 P3.2 T22 — exposed for the worker-host resolveSnapshot
+            // consumption (see TenantRuntimeBindingResolverService in
+            // packages/tasks/src/trigger/worker/services/).
+            CredentialVersionService: this.credentialVersionService,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/apps/api/src/trigger/trigger-internal.module.ts
+++ b/apps/api/src/trigger/trigger-internal.module.ts
@@ -9,6 +9,7 @@ import { AgentsModule } from '@ever-works/agent/agents';
 import { TasksDomainModule } from '@ever-works/agent/tasks-domain';
 import { WorkProposalsModule } from '../work-proposals/work-proposals.module';
 import { DataSyncModule } from '../data-sync/data-sync.module';
+import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
 
 @Module({
     imports: [
@@ -17,6 +18,10 @@ import { DataSyncModule } from '../data-sync/data-sync.module';
         NotificationsModule,
         FacadesModule,
         WorkProposalsModule,
+        // EW-742 P3.2 T22 — exposes CredentialVersionService through the
+        // remote-proxy controller so the Trigger.dev worker can verify
+        // the (providerId, credentialVersion) pair stamped at enqueue time.
+        TenantJobRuntimeModule,
         // EW-628 G7 — exposes DataSyncDispatcherService through the
         // remote-proxy controller so the Trigger.dev worker can call it
         // each cron tick without importing the full API stack.

--- a/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
@@ -8,7 +8,9 @@ import {
     WorkKnowledgeDocumentRepository,
     WorkRepository,
 } from '@ever-works/agent/database';
+import { CredentialVersionService } from '@ever-works/agent/tasks';
 import { NotificationService } from '@ever-works/agent/notifications';
+import { TenantRuntimeBindingResolverService } from '../services/tenant-runtime-binding-resolver.service';
 import { DataGeneratorService } from '@ever-works/agent/generators';
 import { MarkdownGeneratorService } from '@ever-works/agent/generators';
 import {
@@ -95,6 +97,15 @@ import { TriggerImportOrchestrator } from '../orchestrators/trigger-import.orche
         // DataGeneratorService consumes CategoryIconService for icon enrichment (EW-357).
         // CACHE_MANAGER is provided globally via TriggerRemoteCacheModule; AiFacadeService
         // comes from TriggerFacadesModule — both deps reachable in worker scope.
+        // EW-742 P3.2 T22 — CredentialVersionService is proxied to the
+        // API so the worker-host TenantRuntimeBindingResolverService
+        // can call resolveSnapshot through the existing RPC channel.
+        {
+            provide: CredentialVersionService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'CredentialVersionService'),
+            inject: [TriggerInternalApiClient],
+        },
         CategoryIconService,
         DataGeneratorService,
         MarkdownGeneratorService,
@@ -109,12 +120,18 @@ import { TriggerImportOrchestrator } from '../orchestrators/trigger-import.orche
         TriggerImportOrchestrator,
         TemplateCustomizationService,
         KnowledgeBaseGitMirrorService,
+        // EW-742 P3.2 T22 — consumes (providerId, credentialVersion) from
+        // dispatcher payloads + WorkRepository.findById for tenantId, and
+        // reports the binding state for observability + per-tenant
+        // routing decisions.
+        TenantRuntimeBindingResolverService,
     ],
     exports: [
         TriggerGenerationOrchestrator,
         TriggerImportOrchestrator,
         TemplateCustomizationService,
         KnowledgeBaseGitMirrorService,
+        TenantRuntimeBindingResolverService,
         TriggerInternalModule,
     ],
 })

--- a/packages/tasks/src/trigger/worker/services/__tests__/tenant-runtime-binding-resolver.service.spec.ts
+++ b/packages/tasks/src/trigger/worker/services/__tests__/tenant-runtime-binding-resolver.service.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { WorkRepository } from '@ever-works/agent/database';
+import type { CredentialVersionService } from '@ever-works/agent/tasks';
+import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+import { TenantRuntimeBindingResolverService } from '../tenant-runtime-binding-resolver.service';
+
+/**
+ * EW-742 P3.2 T22 (worker-host consumption) — unit tests for the
+ * resolver service that picks up `(providerId, credentialVersion)` off
+ * worker payloads and calls `CredentialVersionService.resolveSnapshot`.
+ *
+ * Covers every branch in the JSDoc state machine:
+ *   - no-binding (missing field, missing tenantId, missing service)
+ *   - resolved (happy path)
+ *   - drained (snapshot rotated past requested version)
+ *   - error (resolveSnapshot threw)
+ *
+ * Plus the `resolveForWork` convenience wrapper.
+ */
+describe('TenantRuntimeBindingResolverService (EW-742 P3.2 T22 worker-host)', () => {
+    const TENANT_ID = '00000000-0000-0000-0000-00000000aaaa';
+    const WORK_ID = '11111111-1111-1111-1111-111111111111';
+
+    function buildResolver(opts: {
+        snapshot?: TenantJobRuntimeConfig | null;
+        resolveThrows?: boolean;
+        workTenantId?: string | null;
+        workFindThrows?: boolean;
+        omitCredentialVersionService?: boolean;
+        omitWorkRepository?: boolean;
+    }) {
+        const credentialVersionService = {
+            resolveSnapshot: opts.resolveThrows
+                ? vi.fn().mockRejectedValue(new Error('boom'))
+                : vi.fn().mockResolvedValue(opts.snapshot ?? null),
+        } as unknown as CredentialVersionService;
+
+        const workRepository = {
+            findById: opts.workFindThrows
+                ? vi.fn().mockRejectedValue(new Error('db boom'))
+                : vi.fn().mockResolvedValue(
+                      opts.workTenantId === undefined
+                          ? null
+                          : ({ id: WORK_ID, tenantId: opts.workTenantId } as any),
+                  ),
+        } as unknown as WorkRepository;
+
+        return new TenantRuntimeBindingResolverService(
+            opts.omitCredentialVersionService ? undefined : credentialVersionService,
+            opts.omitWorkRepository ? undefined : workRepository,
+        );
+    }
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('resolve()', () => {
+        it('returns "no-binding" when providerId is null (pre-T22 payload)', async () => {
+            const r = buildResolver({});
+            const out = await r.resolve(
+                { providerId: null, credentialVersion: 5 },
+                TENANT_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when credentialVersion is null', async () => {
+            const r = buildResolver({});
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: null },
+                TENANT_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when both fields are absent', async () => {
+            const r = buildResolver({});
+            const out = await r.resolve({}, TENANT_ID);
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when tenantId is null even with valid fields', async () => {
+            const r = buildResolver({});
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: 5 },
+                null,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when CredentialVersionService is not wired', async () => {
+            const r = buildResolver({ omitCredentialVersionService: true });
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: 5 },
+                TENANT_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "resolved" with the snapshot on the happy path', async () => {
+            const snapshot = {
+                tenantId: TENANT_ID,
+                providerId: 'trigger',
+                credentialVersion: 5,
+                mode: 'byo',
+                enabled: true,
+            } as TenantJobRuntimeConfig;
+            const r = buildResolver({ snapshot });
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: 5 },
+                TENANT_ID,
+            );
+            expect(out).toEqual({
+                status: 'resolved',
+                snapshot,
+                providerId: 'trigger',
+                credentialVersion: 5,
+                tenantId: TENANT_ID,
+            });
+        });
+
+        it('returns "drained" when resolveSnapshot returns null (rotated past version)', async () => {
+            const r = buildResolver({ snapshot: null });
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: 5 },
+                TENANT_ID,
+            );
+            expect(out).toEqual({
+                status: 'drained',
+                providerId: 'trigger',
+                credentialVersion: 5,
+                tenantId: TENANT_ID,
+            });
+        });
+
+        it('returns "error" + fails open when resolveSnapshot throws', async () => {
+            const r = buildResolver({ resolveThrows: true });
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: 5 },
+                TENANT_ID,
+            );
+            expect(out).toEqual({ status: 'error' });
+        });
+    });
+
+    describe('resolveForWork()', () => {
+        it('looks up tenantId via WorkRepository and delegates to resolve()', async () => {
+            const snapshot = {
+                tenantId: TENANT_ID,
+                providerId: 'trigger',
+                credentialVersion: 5,
+                mode: 'override',
+                enabled: true,
+            } as TenantJobRuntimeConfig;
+            const r = buildResolver({ snapshot, workTenantId: TENANT_ID });
+
+            const out = await r.resolveForWork(
+                { providerId: 'trigger', credentialVersion: 5 },
+                WORK_ID,
+            );
+            expect(out.status).toBe('resolved');
+            expect(out.tenantId).toBe(TENANT_ID);
+        });
+
+        it('returns "no-binding" when WorkRepository is not wired', async () => {
+            const r = buildResolver({ omitWorkRepository: true });
+            const out = await r.resolveForWork(
+                { providerId: 'trigger', credentialVersion: 5 },
+                WORK_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when WorkRepository.findById throws', async () => {
+            const r = buildResolver({ workFindThrows: true });
+            const out = await r.resolveForWork(
+                { providerId: 'trigger', credentialVersion: 5 },
+                WORK_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when Work has no tenantId (pre-EW-655 row)', async () => {
+            const r = buildResolver({ workTenantId: null });
+            const out = await r.resolveForWork(
+                { providerId: 'trigger', credentialVersion: 5 },
+                WORK_ID,
+            );
+            // tenantId is null → resolve() short-circuits to no-binding.
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('passes through the pre-T22 no-binding when payload lacks the pair', async () => {
+            const r = buildResolver({ workTenantId: TENANT_ID });
+            const out = await r.resolveForWork({}, WORK_ID);
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+    });
+});

--- a/packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts
+++ b/packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts
@@ -1,0 +1,198 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { WorkRepository } from '@ever-works/agent/database';
+import { CredentialVersionService } from '@ever-works/agent/tasks';
+import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+
+/**
+ * EW-742 P3.2 T22 (worker-host consumption) — reads the
+ * `(providerId, credentialVersion)` pair captured at enqueue time by
+ * {@link RuntimeBindingStamperService} and resolves the matching
+ * tenant credential snapshot via
+ * {@link CredentialVersionService.resolveSnapshot}.
+ *
+ * # Why this exists
+ *
+ * The dispatcher-side T22 rollout (PRs #1427, #1430, #1431) stamps
+ * `(providerId, credentialVersion)` onto every supported dispatcher's
+ * payload. Without a consumer, those fields are pure metadata. This
+ * service is the first consumer — it gives every Trigger.dev worker
+ * task the ability to:
+ *
+ *   1. **Verify the binding is still valid** — if the tenant rotated
+ *      credentials past this run's version (`resolveSnapshot` returns
+ *      null), the run can either retry against the current credentials
+ *      (idempotent operations) or fail with `CREDENTIAL_DRAINED` and
+ *      defer to a fresh enqueue (per ADR-017 §3 graceful drain).
+ *
+ *   2. **Observe binding state** — every call logs the resolved
+ *      provider + version + tenant for production traces, so the
+ *      operator can see "this kb-embed run used tenant overlay v7"
+ *      without instrumenting each task individually.
+ *
+ *   3. **Bind the runtime to the snapshot** (future) — once
+ *      per-provider `bindToTenant` impls land for the non-Trigger
+ *      runtimes, this service is the seam where the resolved snapshot
+ *      becomes the per-run binding passed to the dispatcher's
+ *      transient view. For Trigger.dev today, that's a no-op (the
+ *      Trigger SDK is a singleton; see TriggerJobRuntimeProvider
+ *      `bindToTenant` JSDoc "What this PR DOES NOT do" note).
+ *
+ * # API
+ *
+ * Single public method:
+ *
+ *   `resolve(payload, tenantIdResolver) -> { status, snapshot?, ... }`
+ *
+ * - `status: 'no-binding'` — payload has no `(providerId, credentialVersion)`
+ *   pair (pre-T22 enqueue, or tenant has no overlay). Worker MUST fall
+ *   back to the instance default (byte-identical pre-overlay path).
+ * - `status: 'resolved'` — snapshot matches the requested version.
+ *   Worker uses it.
+ * - `status: 'drained'` — snapshot was rotated past the requested
+ *   version. Worker MUST either fail with `CREDENTIAL_DRAINED` (strict
+ *   tasks) or fall back to instance default (idempotent tasks).
+ * - `status: 'error'` — RPC / DB error during resolution. Treated as
+ *   `'no-binding'` for fail-open per FR-5 — better to run with the
+ *   instance default than to block a run on a transient lookup error.
+ *
+ * `tenantIdResolver` is task-specific: KB-embed resolves via
+ * `WorkRepository.findById(workId)`; work-generation already has the
+ * tenantId on `work.tenantId`; etc. The service accepts a callback so
+ * the resolver pattern stays per-task without leaking task knowledge
+ * into this generic service.
+ *
+ * # Scope of THIS PR (PoC)
+ *
+ * Only the service + tests. The kb-embed-document task picks it up in
+ * a follow-up (one-line `appContext.get` + `await resolve(...)` + log).
+ * The same per-task wiring deferral the dispatcher-side T22 rollout
+ * used — adopt incrementally, no bus-stop PR.
+ */
+@Injectable()
+export class TenantRuntimeBindingResolverService {
+    private readonly logger = new Logger(TenantRuntimeBindingResolverService.name);
+
+    constructor(
+        @Optional() private readonly credentialVersionService?: CredentialVersionService,
+        @Optional() private readonly workRepository?: WorkRepository,
+    ) {}
+
+    /**
+     * Resolve the tenant credential snapshot for an inbound worker
+     * payload. See class JSDoc for the return-shape semantics.
+     *
+     * @param payload    The inbound worker payload. Only the
+     *                   `providerId` + `credentialVersion` fields are
+     *                   read; everything else is ignored.
+     * @param tenantId   The tenantId for THIS run. Pass `null` when
+     *                   unknown (the result will be `'no-binding'`).
+     */
+    async resolve(
+        payload: { providerId?: string | null; credentialVersion?: number | null },
+        tenantId: string | null,
+    ): Promise<{
+        status: 'no-binding' | 'resolved' | 'drained' | 'error';
+        snapshot?: TenantJobRuntimeConfig;
+        providerId?: string;
+        credentialVersion?: number;
+        tenantId?: string;
+    }> {
+        const providerId = payload.providerId ?? null;
+        const credentialVersion = payload.credentialVersion ?? null;
+
+        // Fast path: no overlay was active at enqueue time, OR the
+        // payload was enqueued before T22 landed. Either way the
+        // worker MUST behave byte-identically to the pre-overlay
+        // (EW-683) path — no log noise for the common case.
+        if (providerId === null || credentialVersion === null) {
+            return { status: 'no-binding' };
+        }
+
+        if (!tenantId) {
+            this.logger.debug(
+                `TenantRuntimeBindingResolver: payload has provider=${providerId} v=${credentialVersion} ` +
+                    `but tenantId is null. Treating as no-binding (worker falls back to instance default).`,
+            );
+            return { status: 'no-binding' };
+        }
+
+        if (!this.credentialVersionService) {
+            this.logger.debug(
+                `TenantRuntimeBindingResolver: CredentialVersionService not wired. ` +
+                    `Returning no-binding (worker falls back to instance default).`,
+            );
+            return { status: 'no-binding' };
+        }
+
+        let snapshot: TenantJobRuntimeConfig | null;
+        try {
+            snapshot = await this.credentialVersionService.resolveSnapshot(
+                tenantId,
+                credentialVersion,
+            );
+        } catch (err) {
+            // RPC / DB hiccup. Per FR-5 fail-open: never block a run on
+            // a transient lookup error. The worker uses instance default.
+            this.logger.warn(
+                `TenantRuntimeBindingResolver: resolveSnapshot threw for tenant=${tenantId} ` +
+                    `v=${credentialVersion} (${err instanceof Error ? err.message : String(err)}); ` +
+                    `treating as 'error' status (worker falls back to instance default).`,
+            );
+            return { status: 'error' };
+        }
+
+        if (!snapshot) {
+            this.logger.warn(
+                `TenantRuntimeBindingResolver: tenant=${tenantId} requested v=${credentialVersion} ` +
+                    `but resolveSnapshot returned null (rotated past this version). ` +
+                    `Status: 'drained'. Worker decides retry-with-current vs CREDENTIAL_DRAINED.`,
+            );
+            return {
+                status: 'drained',
+                providerId,
+                credentialVersion,
+                tenantId,
+            };
+        }
+
+        this.logger.debug(
+            `TenantRuntimeBindingResolver: resolved tenant=${tenantId} provider=${providerId} ` +
+                `v=${credentialVersion} (mode=${snapshot.mode}, enabled=${snapshot.enabled}).`,
+        );
+        return {
+            status: 'resolved',
+            snapshot,
+            providerId,
+            credentialVersion,
+            tenantId,
+        };
+    }
+
+    /**
+     * Convenience wrapper for workId-scoped tasks (KB-embed, KB-mirror,
+     * KB-normalize-media, work-generation, work-import — i.e. every
+     * dispatcher whose payload carries a `workId`). Resolves the
+     * Work's `tenantId` via WorkRepository.findById, then delegates to
+     * {@link resolve}.
+     */
+    async resolveForWork(
+        payload: { providerId?: string | null; credentialVersion?: number | null },
+        workId: string,
+    ): Promise<Awaited<ReturnType<TenantRuntimeBindingResolverService['resolve']>>> {
+        if (!this.workRepository) {
+            return { status: 'no-binding' };
+        }
+        let tenantId: string | null = null;
+        try {
+            const work = await this.workRepository.findById(workId);
+            tenantId = work?.tenantId ?? null;
+        } catch (err) {
+            this.logger.debug(
+                `TenantRuntimeBindingResolver.resolveForWork: workRepository.findById ` +
+                    `threw for work=${workId} (${(err as Error).message}); treating as no-binding.`,
+            );
+            return { status: 'no-binding' };
+        }
+        return this.resolve(payload, tenantId);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the loop on T22: the dispatcher-side rollout (PRs #1427, #1430, #1431) stamps `(providerId, credentialVersion)` onto worker payloads; this PR adds the worker-host service that **consumes** them.

## What this PR does

### API side — exposes CredentialVersionService through the internal RPC channel

- Imports `TenantJobRuntimeModule` into `TriggerInternalModule`.
- Exports `CredentialVersionService` from `TenantJobRuntimeModule`.
- Registers it in `TriggerInternalController.remoteMap` with name `'CredentialVersionService'`.

### Worker side — `TenantRuntimeBindingResolverService`

Reads `(providerId, credentialVersion)` off worker payloads + uses `CredentialVersionService.resolveSnapshot` (RPC-proxied) to classify the binding state:

| Status | Meaning | Worker action |
|---|---|---|
| `no-binding` | pre-T22 payload OR overlay-less tenant | falls back to instance default (byte-identical pre-overlay path) |
| `resolved` | snapshot matches the requested version | uses it (logs for observability today; passes to `provider.bindToTenant` once per-provider impls ship) |
| `drained` | snapshot rotated past requested version (ADR-017 §3 graceful drain) | task decides retry-with-current vs `CREDENTIAL_DRAINED` |
| `error` | RPC / DB hiccup | treated as `no-binding` (fail-open per FR-5) |

Two public methods:
- `resolve(payload, tenantId)` — generic.
- `resolveForWork(payload, workId)` — convenience wrapper that pulls `tenantId` via `WorkRepository` (used by every workId-bound dispatcher: KB-embed/mirror/normalize, work-generation, work-import).

### DI wiring

- Added to `TriggerWorkerModule` providers + exports.
- `CredentialVersionService` added as a remote-proxy provider in the same module.

## What this PR DOES NOT do (deferred)

- **Per-task wiring.** Same one-dispatcher-at-a-time pattern the dispatcher-side T22 rollout used; the `kb-embed-document` task picks it up in a follow-up (one-line `appContext.get` + `await resolve(...)` + log + branch on status).
- **Per-provider `bindToTenant` application** for non-Trigger runtimes (Temporal/BullMQ/pg-boss/Inngest). Today the Trigger.dev provider's `bindToTenant` is a stamping-only frozen wrapper (see #1426). The resolved snapshot's `credentials` field becomes the input to those provider impls once they ship.

## Tests

- **13 new vitest cases** on `TenantRuntimeBindingResolverService`:
  - 5x `resolve()` no-binding branches (missing providerId, missing version, both absent, missing tenantId, missing service)
  - 1x `resolve()` happy path
  - 1x `resolve()` drained
  - 1x `resolve()` error (fail-open)
  - 5x `resolveForWork()` (happy + 4 fail-open paths)
- **55/55 affected API tests** still green (controller + module + tenant-job-runtime).
- Agent build clean; API type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credential versioning support to enable workers to properly resolve and manage different versions of tenant credentials during runtime.

* **Tests**
  * Added test coverage for credential version resolution service across multiple resolution scenarios.

* **Chores**
  * Updated module configurations and internal API routing to expose credential management capabilities across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->