### PR TITLE
chore(release): cascade EW-742 P3.2 T22 trio (KB Tier 1 + Tier 2 + worker-host) develop → stage

### DIFF
--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
@@ -72,6 +72,14 @@ import { TenantJobRuntimeService } from './tenant-job-runtime.service';
         },
     ],
     controllers: [TenantJobRuntimeController],
-    exports: [TenantCredentialCache, TenantAwareRuntimeResolver, RuntimeBindingStamperService],
+    exports: [
+        TenantCredentialCache,
+        TenantAwareRuntimeResolver,
+        RuntimeBindingStamperService,
+        // EW-742 P3.2 T22 — exported so TriggerInternalModule can expose
+        // resolveSnapshot through the remote-proxy controller for the
+        // worker-host consumption path.
+        CredentialVersionService,
+    ],
 })
 export class TenantJobRuntimeModule {}

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -45,6 +45,7 @@ import {
     TaskRecurrenceDispatcherService,
     TasksService,
 } from '@ever-works/agent/tasks-domain';
+import { CredentialVersionService } from '@ever-works/agent/tasks';
 import { AgentRepository, AgentRunRepository } from '@ever-works/agent/database';
 import { DataSyncDispatcherService } from '../data-sync/data-sync-dispatcher.service';
 import { NotificationService } from '@ever-works/agent/notifications';
@@ -215,6 +216,12 @@ export class TriggerInternalController implements OnModuleInit {
         // notification-channel-delivery Trigger task to run a single
         // channel attempt (plugins are loaded here, not in the worker).
         private readonly notificationChannelFacade: NotificationChannelFacadeService,
+        // EW-742 P3.2 T22 — exposes CredentialVersionService.resolveSnapshot
+        // through the remote-proxy controller so Trigger.dev worker tasks
+        // can verify the (providerId, credentialVersion) pair stamped at
+        // enqueue time and decide whether to run, fail with
+        // CREDENTIAL_DRAINED, or fall back to the instance default.
+        private readonly credentialVersionService: CredentialVersionService,
         @Optional()
         @Inject(forwardRef(() => WorkProposalsApiService))
         private readonly workProposalsApiService?: WorkProposalsApiService,
@@ -257,6 +264,10 @@ export class TriggerInternalController implements OnModuleInit {
             // Notifications v2 (EW-663) — notification-channel-delivery task
             // calls `deliverToChannelOrThrow` here (allow-list auto-derived).
             NotificationChannelFacadeService: this.notificationChannelFacade,
+            // EW-742 P3.2 T22 — exposed for the worker-host resolveSnapshot
+            // consumption (see TenantRuntimeBindingResolverService in
+            // packages/tasks/src/trigger/worker/services/).
+            CredentialVersionService: this.credentialVersionService,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/apps/api/src/trigger/trigger-internal.module.ts
+++ b/apps/api/src/trigger/trigger-internal.module.ts
@@ -9,6 +9,7 @@ import { AgentsModule } from '@ever-works/agent/agents';
 import { TasksDomainModule } from '@ever-works/agent/tasks-domain';
 import { WorkProposalsModule } from '../work-proposals/work-proposals.module';
 import { DataSyncModule } from '../data-sync/data-sync.module';
+import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
 
 @Module({
     imports: [
@@ -17,6 +18,10 @@ import { DataSyncModule } from '../data-sync/data-sync.module';
         NotificationsModule,
         FacadesModule,
         WorkProposalsModule,
+        // EW-742 P3.2 T22 — exposes CredentialVersionService through the
+        // remote-proxy controller so the Trigger.dev worker can verify
+        // the (providerId, credentialVersion) pair stamped at enqueue time.
+        TenantJobRuntimeModule,
         // EW-628 G7 — exposes DataSyncDispatcherService through the
         // remote-proxy controller so the Trigger.dev worker can call it
         // each cron tick without importing the full API stack.

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -9,7 +9,9 @@ import { KB_STORAGE_PLUGIN, KnowledgeBaseService } from '../knowledge-base.servi
 import { KB_EMBED_DOCUMENT_DISPATCHER } from '../../tasks/kb-embed-document-dispatcher';
 import { KB_ORG_OVERLAY_FANOUT_DISPATCHER } from '../../tasks/kb-org-overlay-fanout-dispatcher';
 import { KB_MIRROR_DOCUMENT_DISPATCHER } from '../../tasks/kb-mirror-document-dispatcher';
+import { KB_NORMALIZE_MEDIA_DISPATCHER } from '../../tasks/kb-normalize-media-dispatcher';
 import { RuntimeBindingStamperService } from '../../tasks/runtime-binding-stamper.service';
+import { OrganizationRepository } from '../../database/repositories/organization.repository';
 import { WorkRepository } from '../../database/repositories/work.repository';
 import { KnowledgeBaseBufferExtractorService } from '../knowledge-base-buffer-extractor.service';
 import { WorkKnowledgeDocumentRepository } from '../../database/repositories/work-knowledge-document.repository';
@@ -1914,6 +1916,205 @@ describe('KnowledgeBaseService', () => {
                 providerId: null,
                 credentialVersion: null,
             });
+        });
+    });
+
+    // EW-742 P3.2 T22 (KB Tier 1 rollout) — same stamping path as the
+    // KB-embed PoC, applied to the three other KB dispatchers that
+    // share KnowledgeBaseService: KB_MIRROR_DOCUMENT_DISPATCHER,
+    // KB_NORMALIZE_MEDIA_DISPATCHER, KB_ORG_OVERLAY_FANOUT_DISPATCHER.
+    describe('KB Tier 1 — T22 stamping for the other KnowledgeBaseService dispatchers', () => {
+        const TENANT_ID = '00000000-0000-0000-0000-00000000aaaa';
+
+        async function buildWithAllDispatchers(opts: {
+            stamperResult?: { providerId: string | null; credentialVersion: number | null };
+            workTenantId?: string | null;
+            orgTenantId?: string | null;
+            orgFindThrows?: boolean;
+        }) {
+            const embedDispatcherMock = {
+                dispatchKbEmbedDocument: jest.fn().mockResolvedValue('embed-run-id'),
+            };
+            const mirrorDispatcherMock = {
+                dispatchKbMirrorDocument: jest.fn().mockResolvedValue('mirror-run-id'),
+            };
+            const normalizeMediaDispatcherMock = {
+                dispatchKbNormalizeMedia: jest.fn().mockResolvedValue('normalize-run-id'),
+            };
+            const orgOverlayFanoutDispatcherMock = {
+                dispatchKbOrgOverlayFanout: jest.fn().mockResolvedValue('fanout-run-id'),
+            };
+            const workRepoMock = {
+                findById: jest.fn().mockResolvedValue(
+                    opts.workTenantId === undefined
+                        ? null
+                        : ({ id: WORK_ID, tenantId: opts.workTenantId } as any),
+                ),
+                findIdsByOrganization: jest.fn().mockResolvedValue(['work-a', 'work-b']),
+            };
+            const orgRepoMock = {
+                findById: opts.orgFindThrows
+                    ? jest.fn().mockRejectedValue(new Error('db boom'))
+                    : jest.fn().mockResolvedValue(
+                          opts.orgTenantId === undefined
+                              ? null
+                              : ({ id: ORG_ID, tenantId: opts.orgTenantId } as any),
+                      ),
+            };
+            const stamperMock = {
+                stamp: jest
+                    .fn()
+                    .mockResolvedValue(
+                        opts.stamperResult ?? {
+                            providerId: null,
+                            credentialVersion: null,
+                        },
+                    ),
+            };
+
+            const module: TestingModule = await Test.createTestingModule({
+                providers: [
+                    KnowledgeBaseService,
+                    { provide: WorkKnowledgeDocumentRepository, useValue: docRepo },
+                    { provide: WorkKnowledgeUploadRepository, useValue: uploadRepo },
+                    { provide: WorkKnowledgeTagRepository, useValue: tagRepo },
+                    {
+                        provide: WorkKnowledgeCitationRepository,
+                        useValue: { listForDocument: jest.fn().mockResolvedValue([]) },
+                    },
+                    { provide: WorkOwnershipService, useValue: ownership },
+                    { provide: KB_STORAGE_PLUGIN, useValue: storage },
+                    { provide: ActivityLogService, useValue: activityLog },
+                    { provide: KB_EMBED_DOCUMENT_DISPATCHER, useValue: embedDispatcherMock },
+                    { provide: KB_MIRROR_DOCUMENT_DISPATCHER, useValue: mirrorDispatcherMock },
+                    {
+                        provide: KB_NORMALIZE_MEDIA_DISPATCHER,
+                        useValue: normalizeMediaDispatcherMock,
+                    },
+                    {
+                        provide: KB_ORG_OVERLAY_FANOUT_DISPATCHER,
+                        useValue: orgOverlayFanoutDispatcherMock,
+                    },
+                    { provide: WorkRepository, useValue: workRepoMock },
+                    { provide: RuntimeBindingStamperService, useValue: stamperMock },
+                    { provide: OrganizationRepository, useValue: orgRepoMock },
+                ],
+            }).compile();
+
+            return {
+                service: module.get(KnowledgeBaseService),
+                embedDispatcherMock,
+                mirrorDispatcherMock,
+                normalizeMediaDispatcherMock,
+                orgOverlayFanoutDispatcherMock,
+                workRepoMock,
+                orgRepoMock,
+                stamperMock,
+            };
+        }
+
+        it('enqueueMirror — stamps payload via stampForWork', async () => {
+            const { service: svc, mirrorDispatcherMock } = await buildWithAllDispatchers({
+                workTenantId: TENANT_ID,
+                stamperResult: { providerId: 'trigger', credentialVersion: 11 },
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({ ...data, id: 'doc-mirror-1' }),
+            );
+
+            await svc.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'brand/voice.md',
+                title: 'v',
+                class: 'brand' as KbDocumentClass,
+                body: 'hi',
+            });
+
+            expect(mirrorDispatcherMock.dispatchKbMirrorDocument).toHaveBeenCalledTimes(1);
+            const payload = mirrorDispatcherMock.dispatchKbMirrorDocument.mock.calls[0][0];
+            expect(payload).toMatchObject({
+                workId: WORK_ID,
+                documentId: 'doc-mirror-1',
+                operation: 'upsert',
+                providerId: 'trigger',
+                credentialVersion: 11,
+            });
+        });
+
+        it('enqueueOrgOverlayFanout — stamps payload via stampForOrganization', async () => {
+            const {
+                service: svc,
+                orgOverlayFanoutDispatcherMock,
+                orgRepoMock,
+                stamperMock,
+            } = await buildWithAllDispatchers({
+                orgTenantId: TENANT_ID,
+                stamperResult: { providerId: 'trigger', credentialVersion: 13 },
+            });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({
+                    ...data,
+                    id: 'org-doc-1',
+                    workId: null,
+                    organizationId: ORG_ID,
+                }),
+            );
+
+            await svc.createOrgDocument(ORG_ID, USER_ID, {
+                path: 'legal/privacy.md',
+                title: 'Privacy policy',
+                class: 'legal' as KbDocumentClass,
+                body: 'verbatim',
+            });
+
+            expect(orgRepoMock.findById).toHaveBeenCalledWith(ORG_ID);
+            expect(stamperMock.stamp).toHaveBeenCalledWith(TENANT_ID);
+            expect(orgOverlayFanoutDispatcherMock.dispatchKbOrgOverlayFanout).toHaveBeenCalledTimes(
+                1,
+            );
+            const payload =
+                orgOverlayFanoutDispatcherMock.dispatchKbOrgOverlayFanout.mock.calls[0][0];
+            expect(payload).toMatchObject({
+                organizationId: ORG_ID,
+                documentId: 'org-doc-1',
+                workIds: ['work-a', 'work-b'],
+                providerId: 'trigger',
+                credentialVersion: 13,
+            });
+        });
+
+        it('enqueueOrgOverlayFanout — fails open when OrganizationRepository.findById throws', async () => {
+            const {
+                service: svc,
+                orgOverlayFanoutDispatcherMock,
+                stamperMock,
+            } = await buildWithAllDispatchers({ orgFindThrows: true });
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument({
+                    ...data,
+                    id: 'org-doc-2',
+                    workId: null,
+                    organizationId: ORG_ID,
+                }),
+            );
+
+            await svc.createOrgDocument(ORG_ID, USER_ID, {
+                path: 'legal/privacy.md',
+                title: 'Privacy policy',
+                class: 'legal' as KbDocumentClass,
+                body: 'verbatim',
+            });
+
+            // Org lookup failed → stamper never called → payload ships null/null.
+            expect(stamperMock.stamp).not.toHaveBeenCalled();
+            expect(orgOverlayFanoutDispatcherMock.dispatchKbOrgOverlayFanout).toHaveBeenCalledTimes(
+                1,
+            );
+            const payload =
+                orgOverlayFanoutDispatcherMock.dispatchKbOrgOverlayFanout.mock.calls[0][0];
+            expect(payload.providerId).toBeNull();
+            expect(payload.credentialVersion).toBeNull();
         });
     });
 });

--- a/packages/agent/src/services/__tests__/work-generation.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-generation.service.spec.ts
@@ -102,6 +102,7 @@ describe('WorkGenerationService', () => {
     ): WorkGenerationService => {
         const withDispatcher = opts.withDispatcher ?? false;
         const withNotifications = opts.withNotifications ?? true;
+        const withStamper = (opts as { withStamper?: unknown }).withStamper;
         return new WorkGenerationService(
             dataGenerator,
             markdownGenerator,
@@ -123,6 +124,8 @@ describe('WorkGenerationService', () => {
             pluginRegistryService,
             withDispatcher ? generationDispatcher : undefined,
             withNotifications ? notificationService : undefined,
+            // EW-742 P3.2 T22 — Optional() stamper, undefined by default.
+            withStamper as never,
         );
     };
 
@@ -3913,6 +3916,88 @@ describe('WorkGenerationService', () => {
             await service.processGeneration(work, buildUser(), {} as any);
 
             expect(service['generationAbortControllers'].has('work-9')).toBe(false);
+        });
+    });
+
+    // EW-742 P3.2 T22 — Tier 2 dispatcher wiring. WorkGenerationService
+    // resolves tenantId directly from `work.tenantId` (no extra lookup
+    // needed) and stamps the payload via the optional stamper.
+    describe('dispatchGenerationTask — T22 tenant runtime binding capture', () => {
+        const TENANT_ID = '00000000-0000-0000-0000-00000000aaaa';
+
+        async function dispatchOnce(opts: {
+            stamperResult?: { providerId: string | null; credentialVersion: number | null };
+            stamperThrows?: boolean;
+            workTenantId?: string | null;
+        }) {
+            const stamperMock = {
+                stamp: opts.stamperThrows
+                    ? jest.fn().mockRejectedValue(new Error('stamper boom'))
+                    : jest
+                          .fn()
+                          .mockResolvedValue(
+                              opts.stamperResult ?? {
+                                  providerId: null,
+                                  credentialVersion: null,
+                              },
+                          ),
+            };
+            const service = buildService({
+                withDispatcher: true,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                withStamper: stamperMock as any,
+            } as any) as any;
+            generationDispatcher.dispatchWorkGeneration.mockResolvedValue('run-t22');
+            const work = buildWork({
+                id: 'work-t22',
+                tenantId: opts.workTenantId ?? null,
+            });
+            const user = buildUser();
+            await service.dispatchGenerationTask(
+                'create' as any,
+                work,
+                user,
+                {} as any,
+                'h-1',
+                { startedAt: new Date() } as any,
+                { triggeredBy: 'user' } as any,
+            );
+            return {
+                payload: generationDispatcher.dispatchWorkGeneration.mock.calls.at(-1)?.[0],
+                stamperMock,
+            };
+        }
+
+        it('stamps payload with stamper result when overlay is active', async () => {
+            const { payload, stamperMock } = await dispatchOnce({
+                workTenantId: TENANT_ID,
+                stamperResult: { providerId: 'trigger', credentialVersion: 12 },
+            });
+            expect(stamperMock.stamp).toHaveBeenCalledWith(TENANT_ID);
+            expect(payload).toMatchObject({
+                workId: 'work-t22',
+                providerId: 'trigger',
+                credentialVersion: 12,
+            });
+        });
+
+        it('ships null/null when work has no tenantId', async () => {
+            const { payload, stamperMock } = await dispatchOnce({
+                workTenantId: null,
+                stamperResult: { providerId: null, credentialVersion: null },
+            });
+            expect(stamperMock.stamp).toHaveBeenCalledWith(null);
+            expect(payload.providerId).toBeNull();
+            expect(payload.credentialVersion).toBeNull();
+        });
+
+        it('fails open on stamper throw', async () => {
+            const { payload } = await dispatchOnce({
+                workTenantId: TENANT_ID,
+                stamperThrows: true,
+            });
+            expect(payload.providerId).toBeNull();
+            expect(payload.credentialVersion).toBeNull();
         });
     });
 });

--- a/packages/agent/src/services/__tests__/work-import.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-import.service.spec.ts
@@ -742,3 +742,117 @@ describe('WorkImportService.syncWork', () => {
         );
     });
 });
+
+// EW-742 P3.2 T22 — WorkImportService is the second Tier 2 dispatcher
+// site (after WorkGen). Work entity has tenantId directly so we call
+// `stamper.stamp(work.tenantId ?? null)` without an extra Work lookup.
+describe('WorkImportService.dispatchImportTask — T22 tenant runtime binding capture', () => {
+    const TENANT_ID = '00000000-0000-0000-0000-00000000aaaa';
+
+    async function dispatchOnce(opts: {
+        stamperResult?: { providerId: string | null; credentialVersion: number | null };
+        stamperThrows?: boolean;
+        workTenantId?: string | null;
+    }) {
+        const workRepository = {
+            recordGenerationStartTime: jest.fn().mockResolvedValue(undefined),
+            updateGenerateStatus: jest.fn().mockResolvedValue(undefined),
+        };
+        const generationHistoryRepository = {
+            updateEntry: jest.fn().mockResolvedValue(undefined),
+        };
+        const importDispatcher = {
+            dispatchWorkImport: jest.fn().mockResolvedValue('import-run-t22'),
+        };
+        const stamperMock = {
+            stamp: opts.stamperThrows
+                ? jest.fn().mockRejectedValue(new Error('stamper boom'))
+                : jest
+                      .fn()
+                      .mockResolvedValue(
+                          opts.stamperResult ?? {
+                              providerId: null,
+                              credentialVersion: null,
+                          },
+                      ),
+        };
+
+        const service = new WorkImportService(
+            workRepository as any,
+            generationHistoryRepository as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            { emit: jest.fn() } as any,
+            importDispatcher as any,
+            stamperMock as any,
+        );
+
+        const work: any = {
+            id: 'work-t22',
+            tenantId: opts.workTenantId ?? null,
+        };
+        const user: any = { id: 'user-1' };
+        const dto: any = {
+            sourceUrl: 'https://github.com/ever-works/foo',
+            sourceType: ImportSourceTypeEnum.DATA_REPO,
+        };
+        const parsed = { owner: 'ever-works', repo: 'foo' };
+        const history: any = { id: 'h-1', startedAt: new Date() };
+        const context: any = { triggeredBy: 'user' };
+
+        await (service as any).dispatchImportTask(
+            work,
+            user,
+            dto,
+            parsed,
+            history,
+            context,
+            null,
+        );
+
+        return {
+            payload: importDispatcher.dispatchWorkImport.mock.calls.at(-1)?.[0] as any,
+            stamperMock,
+        };
+    }
+
+    it('stamps payload with stamper result when overlay is active', async () => {
+        const { payload, stamperMock } = await dispatchOnce({
+            workTenantId: TENANT_ID,
+            stamperResult: { providerId: 'trigger', credentialVersion: 14 },
+        });
+        expect(stamperMock.stamp).toHaveBeenCalledWith(TENANT_ID);
+        expect(payload).toMatchObject({
+            workId: 'work-t22',
+            providerId: 'trigger',
+            credentialVersion: 14,
+        });
+    });
+
+    it('ships null/null when work has no tenantId', async () => {
+        const { payload, stamperMock } = await dispatchOnce({
+            workTenantId: null,
+            stamperResult: { providerId: null, credentialVersion: null },
+        });
+        expect(stamperMock.stamp).toHaveBeenCalledWith(null);
+        expect(payload.providerId).toBeNull();
+        expect(payload.credentialVersion).toBeNull();
+    });
+
+    it('fails open on stamper throw', async () => {
+        const { payload } = await dispatchOnce({
+            workTenantId: TENANT_ID,
+            stamperThrows: true,
+        });
+        expect(payload.providerId).toBeNull();
+        expect(payload.credentialVersion).toBeNull();
+    });
+});

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -47,6 +47,7 @@ import { KB_ORG_OVERLAY_FANOUT_DISPATCHER, type KbOrgOverlayFanoutDispatcher } f
 import { KB_NORMALIZE_MEDIA_DISPATCHER, type KbNormalizeMediaDispatcher } from '../tasks';
 import { RuntimeBindingStamperService } from '../tasks';
 import { WorkRepository } from '../database/repositories/work.repository';
+import { OrganizationRepository } from '../database/repositories/organization.repository';
 import { sanitizeDescription } from '../utils/sanitize.util';
 import type {
     CitationDto,
@@ -280,17 +281,23 @@ export class KnowledgeBaseService {
         @Optional()
         @Inject(KB_NORMALIZE_MEDIA_DISPATCHER)
         private readonly normalizeMediaDispatcher?: KbNormalizeMediaDispatcher,
-        // EW-742 P3.2 T22 — KB-embed is the proof-of-concept dispatcher
-        // for enqueue-site tenant-runtime binding capture (see
-        // {@link RuntimeBindingStamperService} JSDoc "Scope of THIS PR"
-        // note for why it's adopted one dispatcher at a time). Optional
-        // so isolated unit tests and pre-overlay deployments keep
-        // constructing — when absent, the enqueue degrades to the
-        // pre-overlay (EW-683) byte-identical path: payload ships
-        // without `providerId`/`credentialVersion`, worker host uses the
-        // instance default.
+        // EW-742 P3.2 T22 — KB-embed shipped the proof-of-concept in
+        // PR #1427; this binding is now used by every workId-bound KB
+        // dispatcher in this service via the {@link stampForWork}
+        // helper. Optional so isolated unit tests and pre-overlay
+        // deployments keep constructing — when absent, the enqueue
+        // degrades to the pre-overlay (EW-683) byte-identical path:
+        // payload ships without `providerId`/`credentialVersion`,
+        // worker host uses the instance default.
         @Optional()
         private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
+        // EW-742 P3.2 T22 (org-overlay branch) — used by
+        // {@link stampForOrganization} to resolve a tenantId from an
+        // organizationId. Optional so the same code path runs in
+        // deployments that don't have organizations wired (per-Work
+        // dispatchers still get stamped via WorkRepository above).
+        @Optional()
+        private readonly organizationRepository?: OrganizationRepository,
     ) {}
 
     /**
@@ -312,6 +319,8 @@ export class KnowledgeBaseService {
         if (!this.mirrorDispatcher) {
             return;
         }
+        // EW-742 P3.2 T22 — see stampForWork JSDoc.
+        const binding = await this.stampForWork(workId, 'enqueueMirror');
         try {
             await this.mirrorDispatcher.dispatchKbMirrorDocument({
                 workId,
@@ -319,6 +328,8 @@ export class KnowledgeBaseService {
                 operation,
                 path: docPath,
                 class: docClass,
+                providerId: binding.providerId,
+                credentialVersion: binding.credentialVersion,
             });
         } catch (error) {
             this.logger.warn(
@@ -342,6 +353,64 @@ export class KnowledgeBaseService {
      * (work-knowledge-chunk.entity.ts) clears chunk rows when the
      * parent document row is dropped — no separate enqueue needed.
      */
+    /**
+     * EW-742 P3.2 T22 — shared per-Work tenant runtime binding helper.
+     *
+     * Resolves the Work's tenantId via WorkRepository.findById, then
+     * delegates to RuntimeBindingStamperService.stamp(tenantId). Returns
+     * `{ providerId: null, credentialVersion: null }` when any link in
+     * the chain is missing or throws — the worker host treats that as
+     * "no overlay was active" and runs against the instance default
+     * (byte-identical pre-overlay path).
+     *
+     * Called by every workId-bound dispatch site in this service
+     * (enqueueEmbed / enqueueMirror / maybeDispatchMediaNormalize). The
+     * org-overlay fanout uses {@link stampForOrganization} instead.
+     */
+    private async stampForWork(
+        workId: string,
+        callSite: string,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper || !this.workRepository) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            const work = await this.workRepository.findById(workId);
+            return await this.runtimeBindingStamper.stamp(work?.tenantId ?? null);
+        } catch (err) {
+            this.logger.debug(
+                `${callSite}: stamper lookup failed for work=${workId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
+    }
+
+    /**
+     * EW-742 P3.2 T22 — shared per-Organization tenant runtime binding
+     * helper. An org belongs to exactly one tenant, so the org-overlay
+     * fanout (which targets multiple Works in that org) still has a
+     * single unambiguous tenant scope.
+     */
+    private async stampForOrganization(
+        organizationId: string,
+        callSite: string,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper || !this.organizationRepository) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            const org = await this.organizationRepository.findById(organizationId);
+            return await this.runtimeBindingStamper.stamp(org?.tenantId ?? null);
+        } catch (err) {
+            this.logger.debug(
+                `${callSite}: stamper lookup failed for org=${organizationId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
+    }
+
     private async enqueueEmbed(workId: string, documentId: string): Promise<void> {
         if (!this.embedDispatcher) {
             return;
@@ -349,26 +418,10 @@ export class KnowledgeBaseService {
         // EW-742 P3.2 T22 — capture the tenant runtime binding at
         // enqueue time so the worker host can resolve the exact
         // credential snapshot that was active when the run was
-        // scheduled (ADR-017 §3 graceful drain). The lookup is
-        // best-effort: a missing WorkRepository, missing tenantId, or
-        // missing stamper all mean we ship the legacy 2-field payload
-        // and the worker uses the instance default — that's the same
-        // byte-identical path that ran pre-T22.
-        let binding: { providerId: string | null; credentialVersion: number | null } = {
-            providerId: null,
-            credentialVersion: null,
-        };
-        if (this.runtimeBindingStamper && this.workRepository) {
-            try {
-                const work = await this.workRepository.findById(workId);
-                binding = await this.runtimeBindingStamper.stamp(work?.tenantId ?? null);
-            } catch (err) {
-                this.logger.debug(
-                    `enqueueEmbed: stamper lookup failed for work=${workId} ` +
-                        `(${(err as Error).message}); falling back to instance default.`,
-                );
-            }
-        }
+        // scheduled (ADR-017 §3 graceful drain). Fail-open per FR-5:
+        // any missing dep / lookup error ships null/null and the
+        // worker uses the instance default (byte-identical pre-T22 path).
+        const binding = await this.stampForWork(workId, 'enqueueEmbed');
         try {
             await this.embedDispatcher.dispatchKbEmbedDocument({
                 workId,
@@ -428,6 +481,11 @@ export class KnowledgeBaseService {
                 );
                 return;
             }
+            // EW-742 P3.2 T22 — see stampForOrganization JSDoc.
+            const binding = await this.stampForOrganization(
+                organizationId,
+                'enqueueOrgOverlayFanout',
+            );
             await this.orgOverlayDispatcher.dispatchKbOrgOverlayFanout({
                 organizationId,
                 documentId,
@@ -435,6 +493,8 @@ export class KnowledgeBaseService {
                 operation,
                 path: docPath,
                 class: docClass,
+                providerId: binding.providerId,
+                credentialVersion: binding.credentialVersion,
             });
         } catch (error) {
             this.logger.warn(
@@ -475,6 +535,8 @@ export class KnowledgeBaseService {
         if (!mediaKind) {
             return;
         }
+        // EW-742 P3.2 T22 — see stampForWork JSDoc.
+        const binding = await this.stampForWork(upload.workId, 'maybeDispatchMediaNormalize');
         try {
             await this.normalizeMediaDispatcher.dispatchKbNormalizeMedia({
                 workId: upload.workId,
@@ -482,6 +544,8 @@ export class KnowledgeBaseService {
                 mediaKind,
                 originalSha256: sha256,
                 originalMimeType: bare,
+                providerId: binding.providerId,
+                credentialVersion: binding.credentialVersion,
             });
         } catch (error) {
             this.logger.warn(

--- a/packages/agent/src/services/work-generation.service.ts
+++ b/packages/agent/src/services/work-generation.service.ts
@@ -47,6 +47,7 @@ import {
     WorkGenerationPayload,
     WORK_GENERATION_DISPATCHER,
     WorkGenerationDispatcher,
+    RuntimeBindingStamperService,
 } from '@src/tasks';
 import { WorkScheduleBillingMode, GenerateStatusType } from '@src/entities/types';
 import { WorkOwnershipService } from './work-ownership.service';
@@ -151,6 +152,14 @@ export class WorkGenerationService {
         private readonly generationDispatcher?: WorkGenerationDispatcher,
         @Optional()
         private readonly notificationService?: NotificationService,
+        // EW-742 P3.2 T22 — enqueue-site tenant runtime binding capture.
+        // Optional so isolated unit tests and pre-overlay deployments
+        // keep constructing — when absent, payload ships null/null and
+        // the worker falls back to the instance default (byte-identical
+        // pre-T22 path). See `KnowledgeBaseService.stampForWork` for the
+        // shared pattern.
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
     ) {}
 
     async generateItems(
@@ -1313,6 +1322,29 @@ Only include image URLs that are absolute URLs (starting with http).`;
         });
     }
 
+    /**
+     * EW-742 P3.2 T22 — resolve `(providerId, credentialVersion)` for
+     * the worker host's `resolveSnapshot` lookup. Returns null/null
+     * when stamper isn't wired, tenantId is null, or stamper throws
+     * (fail-open per FR-5; worker uses instance default).
+     */
+    private async stampForWork(
+        tenantId: string | null,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            return await this.runtimeBindingStamper.stamp(tenantId);
+        } catch (err) {
+            this.logger.debug(
+                `dispatchGenerationTask: stamper lookup failed for tenant=${tenantId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
+    }
+
     private async dispatchGenerationTask(
         mode: WorkGenerationMode,
         work: Work,
@@ -1331,6 +1363,12 @@ Only include image URLs that are absolute URLs (starting with http).`;
             }),
         ]);
 
+        // EW-742 P3.2 T22 — stamp `(providerId, credentialVersion)` for
+        // the worker host. Work entity has `tenantId` already on hand
+        // (passed in by the caller) so we skip the redundant Work
+        // lookup and call the stamper directly. Fail-open per FR-5.
+        const binding = await this.stampForWork(work.tenantId ?? null);
+
         const payload: WorkGenerationPayload = {
             workId: work.id,
             userId: user.id,
@@ -1343,6 +1381,8 @@ Only include image URLs that are absolute URLs (starting with http).`;
                 new Date().toISOString(),
             triggerSource: context.triggeredBy,
             scheduleId: context.scheduleId,
+            providerId: binding.providerId,
+            credentialVersion: binding.credentialVersion,
         };
 
         const dispatchedId = this.generationDispatcher

--- a/packages/agent/src/services/work-import.service.ts
+++ b/packages/agent/src/services/work-import.service.ts
@@ -47,6 +47,7 @@ import {
     WorkImportErrorCode,
     WorkImportDispatcher,
     WORK_IMPORT_DISPATCHER,
+    RuntimeBindingStamperService,
 } from '@src/tasks';
 import { WorkScheduleService } from './work-schedule.service';
 import { WorkScheduleCadence, GenerateStatusType } from '@src/entities/types';
@@ -101,6 +102,12 @@ export class WorkImportService {
         @Optional()
         @Inject(WORK_IMPORT_DISPATCHER)
         private readonly importDispatcher?: WorkImportDispatcher,
+        // EW-742 P3.2 T22 — enqueue-site tenant runtime binding capture.
+        // Optional so isolated unit tests and pre-overlay deployments
+        // keep constructing — when absent, payload ships null/null and
+        // the worker falls back to the instance default.
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
     ) {}
 
     /**
@@ -546,6 +553,29 @@ export class WorkImportService {
         );
     }
 
+    /**
+     * EW-742 P3.2 T22 — resolve `(providerId, credentialVersion)` for
+     * the worker host's `resolveSnapshot` lookup. Returns null/null
+     * when stamper isn't wired, tenantId is null, or stamper throws
+     * (fail-open per FR-5; worker uses instance default).
+     */
+    private async stampForTenant(
+        tenantId: string | null,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            return await this.runtimeBindingStamper.stamp(tenantId);
+        } catch (err) {
+            this.logger.debug(
+                `dispatchImportTask: stamper lookup failed for tenant=${tenantId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
+    }
+
     private async dispatchImportTask(
         work: Work,
         user: User,
@@ -561,6 +591,10 @@ export class WorkImportService {
                 status: GenerateStatusType.GENERATING,
             }),
         ]);
+
+        // EW-742 P3.2 T22 — stamp `(providerId, credentialVersion)` for
+        // the worker host. Fail-open per FR-5.
+        const binding = await this.stampForTenant(work.tenantId ?? null);
 
         const payload: WorkImportPayload = {
             workId: work.id,
@@ -583,6 +617,8 @@ export class WorkImportService {
             providers: dto.providers,
             enrichmentConfig: dto.enrichmentConfig,
             worksConfig: worksConfig ?? null,
+            providerId: binding.providerId,
+            credentialVersion: binding.credentialVersion,
         };
 
         const dispatchedId = this.importDispatcher

--- a/packages/agent/src/tasks/kb-mirror-document.types.ts
+++ b/packages/agent/src/tasks/kb-mirror-document.types.ts
@@ -37,4 +37,12 @@ export interface KbMirrorDocumentPayload {
      * for symmetry with `path`; the task does not re-query the DB.
      */
     readonly class: string;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }

--- a/packages/agent/src/tasks/kb-normalize-media.types.ts
+++ b/packages/agent/src/tasks/kb-normalize-media.types.ts
@@ -54,4 +54,12 @@ export interface KbNormalizeMediaPayload {
      * extension fallback when the input has no extension.
      */
     readonly originalMimeType: string;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }

--- a/packages/agent/src/tasks/kb-org-overlay-fanout.types.ts
+++ b/packages/agent/src/tasks/kb-org-overlay-fanout.types.ts
@@ -54,4 +54,15 @@ export interface KbOrgOverlayFanoutPayload {
     /** `kbDocumentClass` value (`brand`, `legal`, ...). Required on
      *  delete for symmetry with `path`. */
     readonly class: string;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * Resolved from the OWNING ORGANIZATION's `tenantId` (an org belongs
+     * to exactly one tenant, so the org-overlay fanout has a single
+     * unambiguous tenant scope even though its targets are multiple
+     * Works). See `KbEmbedDocumentPayload` (the PoC dispatcher) for
+     * the full contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }

--- a/packages/agent/src/tasks/template-customization.types.ts
+++ b/packages/agent/src/tasks/template-customization.types.ts
@@ -1,3 +1,10 @@
 export type TemplateCustomizationPayload = {
     customizationId: string;
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    providerId?: string | null;
+    credentialVersion?: number | null;
 };

--- a/packages/agent/src/tasks/work-generation.types.ts
+++ b/packages/agent/src/tasks/work-generation.types.ts
@@ -46,4 +46,11 @@ export type WorkGenerationPayload = {
     historyStartedAt?: string;
     triggerSource?: 'user' | 'schedule' | 'api';
     scheduleId?: string;
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    providerId?: string | null;
+    credentialVersion?: number | null;
 };

--- a/packages/agent/src/tasks/work-import.types.ts
+++ b/packages/agent/src/tasks/work-import.types.ts
@@ -21,6 +21,13 @@ export type WorkImportPayload = {
     providers?: ProvidersDto;
     enrichmentConfig?: ImportEnrichmentConfigDto;
     worksConfig?: ResolvedWorksConfig | null;
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    providerId?: string | null;
+    credentialVersion?: number | null;
 };
 
 export type WorkImportMetrics = {

--- a/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
+++ b/packages/agent/src/template-catalog/__tests__/template-customization.service.spec.ts
@@ -262,8 +262,14 @@ describe('TemplateCustomizationService.createAndStart', () => {
 
         const result = await service.createAndStart('user-1', baseInput);
 
+        // EW-742 P3.2 T22 — payload now always includes the
+        // (providerId, credentialVersion) pair. Stamper isn't wired in
+        // this test fixture, so both are null and the worker falls
+        // back to the instance default (byte-identical pre-T22 path).
         expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
             customizationId: result.customization.id,
+            providerId: null,
+            credentialVersion: null,
         });
         expect(mocks.customizationRepository.updateById).toHaveBeenCalledWith(
             result.customization.id,
@@ -629,5 +635,121 @@ describe('TemplateCustomizationService.syncFromBase', () => {
         );
         expect(result.method).toBe('duplicate');
         expect(result.changed).toBe(true);
+    });
+});
+
+// EW-742 P3.2 T22 — TemplateCustomizationService is the third Tier 2
+// dispatcher site (after WorkGen + WorkImport). Customization rows
+// carry `tenantId` directly so we resolve via
+// `customizationRepository.findById(customizationId)` and stamp.
+describe('TemplateCustomizationService.start — T22 tenant runtime binding capture', () => {
+    function buildWithStamper(opts: {
+        stamperResult?: { providerId: string | null; credentialVersion: number | null };
+        stamperThrows?: boolean;
+        rowTenantId?: string | null;
+        rowFindThrows?: boolean;
+    }) {
+        const { service, mocks } = makeService();
+        // Patch dispatcher to resolve to a non-null runId so the start()
+        // happy path runs.
+        (mocks.dispatcher.dispatchTemplateCustomization as jest.Mock).mockResolvedValue(
+            'run-tpl-t22',
+        );
+        // Patch the customization repo `findById` for the stamper lookup.
+        (mocks.customizationRepository as any).findById = opts.rowFindThrows
+            ? jest.fn().mockRejectedValue(new Error('db boom'))
+            : jest.fn().mockResolvedValue(
+                  opts.rowTenantId === undefined
+                      ? null
+                      : ({ id: 'cust-1', tenantId: opts.rowTenantId } as any),
+              );
+        const stamperMock = {
+            stamp: opts.stamperThrows
+                ? jest.fn().mockRejectedValue(new Error('stamper boom'))
+                : jest
+                      .fn()
+                      .mockResolvedValue(
+                          opts.stamperResult ?? {
+                              providerId: null,
+                              credentialVersion: null,
+                          },
+                      ),
+        };
+        // Replace the service with one wired to the stamper.
+        const TenantService = service.constructor as new (
+            ...args: unknown[]
+        ) => typeof service;
+        const wired = new TenantService(
+            mocks.templateRepository as any,
+            mocks.customizationRepository as any,
+            mocks.userRepository as any,
+            mocks.gitFacade as any,
+            mocks.codeEditFacade as any,
+            mocks.aiFacade as any,
+            mocks.dispatcher as any,
+            stamperMock as any,
+        );
+        return { service: wired, mocks, stamperMock };
+    }
+
+    it('stamps payload with stamper result when overlay is active', async () => {
+        const { service: svc, mocks, stamperMock } = buildWithStamper({
+            rowTenantId: '00000000-0000-0000-0000-00000000aaaa',
+            stamperResult: { providerId: 'trigger', credentialVersion: 9 },
+        });
+        // The dispatch site lives inside `start(customizationId)` — invoke
+        // it via the public createAndStart path so we exercise the same
+        // call shape as production.
+        const result = await svc.createAndStart('user-1', baseInput);
+
+        expect(stamperMock.stamp).toHaveBeenCalledWith('00000000-0000-0000-0000-00000000aaaa');
+        expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
+            customizationId: result.customization.id,
+            providerId: 'trigger',
+            credentialVersion: 9,
+        });
+    });
+
+    it('ships null/null when customization row has no tenantId', async () => {
+        const { service: svc, mocks, stamperMock } = buildWithStamper({
+            rowTenantId: null,
+            stamperResult: { providerId: null, credentialVersion: null },
+        });
+        const result = await svc.createAndStart('user-1', baseInput);
+
+        expect(stamperMock.stamp).toHaveBeenCalledWith(null);
+        expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
+            customizationId: result.customization.id,
+            providerId: null,
+            credentialVersion: null,
+        });
+    });
+
+    it('fails open on customizationRepository.findById throw', async () => {
+        const { service: svc, mocks, stamperMock } = buildWithStamper({
+            rowFindThrows: true,
+        });
+        const result = await svc.createAndStart('user-1', baseInput);
+
+        expect(stamperMock.stamp).not.toHaveBeenCalled();
+        expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
+            customizationId: result.customization.id,
+            providerId: null,
+            credentialVersion: null,
+        });
+    });
+
+    it('fails open on stamper throw', async () => {
+        const { service: svc, mocks } = buildWithStamper({
+            rowTenantId: '00000000-0000-0000-0000-00000000aaaa',
+            stamperThrows: true,
+        });
+        const result = await svc.createAndStart('user-1', baseInput);
+
+        expect(mocks.dispatcher.dispatchTemplateCustomization).toHaveBeenCalledWith({
+            customizationId: result.customization.id,
+            providerId: null,
+            credentialVersion: null,
+        });
     });
 });

--- a/packages/agent/src/template-catalog/template-customization.service.ts
+++ b/packages/agent/src/template-catalog/template-customization.service.ts
@@ -19,6 +19,7 @@ import { AiFacadeService } from '@src/facades/ai.facade';
 import {
     TEMPLATE_CUSTOMIZATION_DISPATCHER,
     type TemplateCustomizationDispatcher,
+    RuntimeBindingStamperService,
 } from '@src/tasks';
 import {
     findWebsiteTemplateConfig,
@@ -118,6 +119,12 @@ export class TemplateCustomizationService {
         @Optional()
         @Inject(TEMPLATE_CUSTOMIZATION_DISPATCHER)
         private readonly dispatcher?: TemplateCustomizationDispatcher,
+        // EW-742 P3.2 T22 — enqueue-site tenant runtime binding capture.
+        // Optional so isolated unit tests and pre-overlay deployments
+        // keep constructing — when absent, payload ships null/null and
+        // the worker falls back to the instance default.
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
     ) {}
 
     async createAndStart(
@@ -312,8 +319,32 @@ export class TemplateCustomizationService {
         };
     }
     private async start(customizationId: string): Promise<void> {
+        // EW-742 P3.2 T22 — resolve `(providerId, credentialVersion)`
+        // for the worker host. TemplateCustomization has tenantId
+        // directly on the row; look it up if the stamper is wired.
+        // Fail-open per FR-5: any failure ships null/null.
+        let binding: { providerId: string | null; credentialVersion: number | null } = {
+            providerId: null,
+            credentialVersion: null,
+        };
+        if (this.runtimeBindingStamper) {
+            try {
+                const row = await this.customizationRepository.findById(customizationId);
+                binding = await this.runtimeBindingStamper.stamp(row?.tenantId ?? null);
+            } catch (err) {
+                this.logger.debug(
+                    `start: stamper lookup failed for customization=${customizationId} ` +
+                        `(${(err as Error).message}); falling back to instance default.`,
+                );
+            }
+        }
+
         const dispatchedId = this.dispatcher
-            ? await this.dispatcher.dispatchTemplateCustomization({ customizationId })
+            ? await this.dispatcher.dispatchTemplateCustomization({
+                  customizationId,
+                  providerId: binding.providerId,
+                  credentialVersion: binding.credentialVersion,
+              })
             : null;
 
         if (dispatchedId) {

--- a/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
@@ -8,7 +8,9 @@ import {
     WorkKnowledgeDocumentRepository,
     WorkRepository,
 } from '@ever-works/agent/database';
+import { CredentialVersionService } from '@ever-works/agent/tasks';
 import { NotificationService } from '@ever-works/agent/notifications';
+import { TenantRuntimeBindingResolverService } from '../services/tenant-runtime-binding-resolver.service';
 import { DataGeneratorService } from '@ever-works/agent/generators';
 import { MarkdownGeneratorService } from '@ever-works/agent/generators';
 import {
@@ -95,6 +97,15 @@ import { TriggerImportOrchestrator } from '../orchestrators/trigger-import.orche
         // DataGeneratorService consumes CategoryIconService for icon enrichment (EW-357).
         // CACHE_MANAGER is provided globally via TriggerRemoteCacheModule; AiFacadeService
         // comes from TriggerFacadesModule — both deps reachable in worker scope.
+        // EW-742 P3.2 T22 — CredentialVersionService is proxied to the
+        // API so the worker-host TenantRuntimeBindingResolverService
+        // can call resolveSnapshot through the existing RPC channel.
+        {
+            provide: CredentialVersionService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'CredentialVersionService'),
+            inject: [TriggerInternalApiClient],
+        },
         CategoryIconService,
         DataGeneratorService,
         MarkdownGeneratorService,
@@ -109,12 +120,18 @@ import { TriggerImportOrchestrator } from '../orchestrators/trigger-import.orche
         TriggerImportOrchestrator,
         TemplateCustomizationService,
         KnowledgeBaseGitMirrorService,
+        // EW-742 P3.2 T22 — consumes (providerId, credentialVersion) from
+        // dispatcher payloads + WorkRepository.findById for tenantId, and
+        // reports the binding state for observability + per-tenant
+        // routing decisions.
+        TenantRuntimeBindingResolverService,
     ],
     exports: [
         TriggerGenerationOrchestrator,
         TriggerImportOrchestrator,
         TemplateCustomizationService,
         KnowledgeBaseGitMirrorService,
+        TenantRuntimeBindingResolverService,
         TriggerInternalModule,
     ],
 })

--- a/packages/tasks/src/trigger/worker/services/__tests__/tenant-runtime-binding-resolver.service.spec.ts
+++ b/packages/tasks/src/trigger/worker/services/__tests__/tenant-runtime-binding-resolver.service.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { WorkRepository } from '@ever-works/agent/database';
+import type { CredentialVersionService } from '@ever-works/agent/tasks';
+import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+import { TenantRuntimeBindingResolverService } from '../tenant-runtime-binding-resolver.service';
+
+/**
+ * EW-742 P3.2 T22 (worker-host consumption) — unit tests for the
+ * resolver service that picks up `(providerId, credentialVersion)` off
+ * worker payloads and calls `CredentialVersionService.resolveSnapshot`.
+ *
+ * Covers every branch in the JSDoc state machine:
+ *   - no-binding (missing field, missing tenantId, missing service)
+ *   - resolved (happy path)
+ *   - drained (snapshot rotated past requested version)
+ *   - error (resolveSnapshot threw)
+ *
+ * Plus the `resolveForWork` convenience wrapper.
+ */
+describe('TenantRuntimeBindingResolverService (EW-742 P3.2 T22 worker-host)', () => {
+    const TENANT_ID = '00000000-0000-0000-0000-00000000aaaa';
+    const WORK_ID = '11111111-1111-1111-1111-111111111111';
+
+    function buildResolver(opts: {
+        snapshot?: TenantJobRuntimeConfig | null;
+        resolveThrows?: boolean;
+        workTenantId?: string | null;
+        workFindThrows?: boolean;
+        omitCredentialVersionService?: boolean;
+        omitWorkRepository?: boolean;
+    }) {
+        const credentialVersionService = {
+            resolveSnapshot: opts.resolveThrows
+                ? vi.fn().mockRejectedValue(new Error('boom'))
+                : vi.fn().mockResolvedValue(opts.snapshot ?? null),
+        } as unknown as CredentialVersionService;
+
+        const workRepository = {
+            findById: opts.workFindThrows
+                ? vi.fn().mockRejectedValue(new Error('db boom'))
+                : vi.fn().mockResolvedValue(
+                      opts.workTenantId === undefined
+                          ? null
+                          : ({ id: WORK_ID, tenantId: opts.workTenantId } as any),
+                  ),
+        } as unknown as WorkRepository;
+
+        return new TenantRuntimeBindingResolverService(
+            opts.omitCredentialVersionService ? undefined : credentialVersionService,
+            opts.omitWorkRepository ? undefined : workRepository,
+        );
+    }
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('resolve()', () => {
+        it('returns "no-binding" when providerId is null (pre-T22 payload)', async () => {
+            const r = buildResolver({});
+            const out = await r.resolve(
+                { providerId: null, credentialVersion: 5 },
+                TENANT_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when credentialVersion is null', async () => {
+            const r = buildResolver({});
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: null },
+                TENANT_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when both fields are absent', async () => {
+            const r = buildResolver({});
+            const out = await r.resolve({}, TENANT_ID);
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when tenantId is null even with valid fields', async () => {
+            const r = buildResolver({});
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: 5 },
+                null,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when CredentialVersionService is not wired', async () => {
+            const r = buildResolver({ omitCredentialVersionService: true });
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: 5 },
+                TENANT_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "resolved" with the snapshot on the happy path', async () => {
+            const snapshot = {
+                tenantId: TENANT_ID,
+                providerId: 'trigger',
+                credentialVersion: 5,
+                mode: 'byo',
+                enabled: true,
+            } as TenantJobRuntimeConfig;
+            const r = buildResolver({ snapshot });
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: 5 },
+                TENANT_ID,
+            );
+            expect(out).toEqual({
+                status: 'resolved',
+                snapshot,
+                providerId: 'trigger',
+                credentialVersion: 5,
+                tenantId: TENANT_ID,
+            });
+        });
+
+        it('returns "drained" when resolveSnapshot returns null (rotated past version)', async () => {
+            const r = buildResolver({ snapshot: null });
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: 5 },
+                TENANT_ID,
+            );
+            expect(out).toEqual({
+                status: 'drained',
+                providerId: 'trigger',
+                credentialVersion: 5,
+                tenantId: TENANT_ID,
+            });
+        });
+
+        it('returns "error" + fails open when resolveSnapshot throws', async () => {
+            const r = buildResolver({ resolveThrows: true });
+            const out = await r.resolve(
+                { providerId: 'trigger', credentialVersion: 5 },
+                TENANT_ID,
+            );
+            expect(out).toEqual({ status: 'error' });
+        });
+    });
+
+    describe('resolveForWork()', () => {
+        it('looks up tenantId via WorkRepository and delegates to resolve()', async () => {
+            const snapshot = {
+                tenantId: TENANT_ID,
+                providerId: 'trigger',
+                credentialVersion: 5,
+                mode: 'override',
+                enabled: true,
+            } as TenantJobRuntimeConfig;
+            const r = buildResolver({ snapshot, workTenantId: TENANT_ID });
+
+            const out = await r.resolveForWork(
+                { providerId: 'trigger', credentialVersion: 5 },
+                WORK_ID,
+            );
+            expect(out.status).toBe('resolved');
+            expect(out.tenantId).toBe(TENANT_ID);
+        });
+
+        it('returns "no-binding" when WorkRepository is not wired', async () => {
+            const r = buildResolver({ omitWorkRepository: true });
+            const out = await r.resolveForWork(
+                { providerId: 'trigger', credentialVersion: 5 },
+                WORK_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when WorkRepository.findById throws', async () => {
+            const r = buildResolver({ workFindThrows: true });
+            const out = await r.resolveForWork(
+                { providerId: 'trigger', credentialVersion: 5 },
+                WORK_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when Work has no tenantId (pre-EW-655 row)', async () => {
+            const r = buildResolver({ workTenantId: null });
+            const out = await r.resolveForWork(
+                { providerId: 'trigger', credentialVersion: 5 },
+                WORK_ID,
+            );
+            // tenantId is null → resolve() short-circuits to no-binding.
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('passes through the pre-T22 no-binding when payload lacks the pair', async () => {
+            const r = buildResolver({ workTenantId: TENANT_ID });
+            const out = await r.resolveForWork({}, WORK_ID);
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+    });
+});

--- a/packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts
+++ b/packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts
@@ -1,0 +1,198 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { WorkRepository } from '@ever-works/agent/database';
+import { CredentialVersionService } from '@ever-works/agent/tasks';
+import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+
+/**
+ * EW-742 P3.2 T22 (worker-host consumption) — reads the
+ * `(providerId, credentialVersion)` pair captured at enqueue time by
+ * {@link RuntimeBindingStamperService} and resolves the matching
+ * tenant credential snapshot via
+ * {@link CredentialVersionService.resolveSnapshot}.
+ *
+ * # Why this exists
+ *
+ * The dispatcher-side T22 rollout (PRs #1427, #1430, #1431) stamps
+ * `(providerId, credentialVersion)` onto every supported dispatcher's
+ * payload. Without a consumer, those fields are pure metadata. This
+ * service is the first consumer — it gives every Trigger.dev worker
+ * task the ability to:
+ *
+ *   1. **Verify the binding is still valid** — if the tenant rotated
+ *      credentials past this run's version (`resolveSnapshot` returns
+ *      null), the run can either retry against the current credentials
+ *      (idempotent operations) or fail with `CREDENTIAL_DRAINED` and
+ *      defer to a fresh enqueue (per ADR-017 §3 graceful drain).
+ *
+ *   2. **Observe binding state** — every call logs the resolved
+ *      provider + version + tenant for production traces, so the
+ *      operator can see "this kb-embed run used tenant overlay v7"
+ *      without instrumenting each task individually.
+ *
+ *   3. **Bind the runtime to the snapshot** (future) — once
+ *      per-provider `bindToTenant` impls land for the non-Trigger
+ *      runtimes, this service is the seam where the resolved snapshot
+ *      becomes the per-run binding passed to the dispatcher's
+ *      transient view. For Trigger.dev today, that's a no-op (the
+ *      Trigger SDK is a singleton; see TriggerJobRuntimeProvider
+ *      `bindToTenant` JSDoc "What this PR DOES NOT do" note).
+ *
+ * # API
+ *
+ * Single public method:
+ *
+ *   `resolve(payload, tenantIdResolver) -> { status, snapshot?, ... }`
+ *
+ * - `status: 'no-binding'` — payload has no `(providerId, credentialVersion)`
+ *   pair (pre-T22 enqueue, or tenant has no overlay). Worker MUST fall
+ *   back to the instance default (byte-identical pre-overlay path).
+ * - `status: 'resolved'` — snapshot matches the requested version.
+ *   Worker uses it.
+ * - `status: 'drained'` — snapshot was rotated past the requested
+ *   version. Worker MUST either fail with `CREDENTIAL_DRAINED` (strict
+ *   tasks) or fall back to instance default (idempotent tasks).
+ * - `status: 'error'` — RPC / DB error during resolution. Treated as
+ *   `'no-binding'` for fail-open per FR-5 — better to run with the
+ *   instance default than to block a run on a transient lookup error.
+ *
+ * `tenantIdResolver` is task-specific: KB-embed resolves via
+ * `WorkRepository.findById(workId)`; work-generation already has the
+ * tenantId on `work.tenantId`; etc. The service accepts a callback so
+ * the resolver pattern stays per-task without leaking task knowledge
+ * into this generic service.
+ *
+ * # Scope of THIS PR (PoC)
+ *
+ * Only the service + tests. The kb-embed-document task picks it up in
+ * a follow-up (one-line `appContext.get` + `await resolve(...)` + log).
+ * The same per-task wiring deferral the dispatcher-side T22 rollout
+ * used — adopt incrementally, no bus-stop PR.
+ */
+@Injectable()
+export class TenantRuntimeBindingResolverService {
+    private readonly logger = new Logger(TenantRuntimeBindingResolverService.name);
+
+    constructor(
+        @Optional() private readonly credentialVersionService?: CredentialVersionService,
+        @Optional() private readonly workRepository?: WorkRepository,
+    ) {}
+
+    /**
+     * Resolve the tenant credential snapshot for an inbound worker
+     * payload. See class JSDoc for the return-shape semantics.
+     *
+     * @param payload    The inbound worker payload. Only the
+     *                   `providerId` + `credentialVersion` fields are
+     *                   read; everything else is ignored.
+     * @param tenantId   The tenantId for THIS run. Pass `null` when
+     *                   unknown (the result will be `'no-binding'`).
+     */
+    async resolve(
+        payload: { providerId?: string | null; credentialVersion?: number | null },
+        tenantId: string | null,
+    ): Promise<{
+        status: 'no-binding' | 'resolved' | 'drained' | 'error';
+        snapshot?: TenantJobRuntimeConfig;
+        providerId?: string;
+        credentialVersion?: number;
+        tenantId?: string;
+    }> {
+        const providerId = payload.providerId ?? null;
+        const credentialVersion = payload.credentialVersion ?? null;
+
+        // Fast path: no overlay was active at enqueue time, OR the
+        // payload was enqueued before T22 landed. Either way the
+        // worker MUST behave byte-identically to the pre-overlay
+        // (EW-683) path — no log noise for the common case.
+        if (providerId === null || credentialVersion === null) {
+            return { status: 'no-binding' };
+        }
+
+        if (!tenantId) {
+            this.logger.debug(
+                `TenantRuntimeBindingResolver: payload has provider=${providerId} v=${credentialVersion} ` +
+                    `but tenantId is null. Treating as no-binding (worker falls back to instance default).`,
+            );
+            return { status: 'no-binding' };
+        }
+
+        if (!this.credentialVersionService) {
+            this.logger.debug(
+                `TenantRuntimeBindingResolver: CredentialVersionService not wired. ` +
+                    `Returning no-binding (worker falls back to instance default).`,
+            );
+            return { status: 'no-binding' };
+        }
+
+        let snapshot: TenantJobRuntimeConfig | null;
+        try {
+            snapshot = await this.credentialVersionService.resolveSnapshot(
+                tenantId,
+                credentialVersion,
+            );
+        } catch (err) {
+            // RPC / DB hiccup. Per FR-5 fail-open: never block a run on
+            // a transient lookup error. The worker uses instance default.
+            this.logger.warn(
+                `TenantRuntimeBindingResolver: resolveSnapshot threw for tenant=${tenantId} ` +
+                    `v=${credentialVersion} (${err instanceof Error ? err.message : String(err)}); ` +
+                    `treating as 'error' status (worker falls back to instance default).`,
+            );
+            return { status: 'error' };
+        }
+
+        if (!snapshot) {
+            this.logger.warn(
+                `TenantRuntimeBindingResolver: tenant=${tenantId} requested v=${credentialVersion} ` +
+                    `but resolveSnapshot returned null (rotated past this version). ` +
+                    `Status: 'drained'. Worker decides retry-with-current vs CREDENTIAL_DRAINED.`,
+            );
+            return {
+                status: 'drained',
+                providerId,
+                credentialVersion,
+                tenantId,
+            };
+        }
+
+        this.logger.debug(
+            `TenantRuntimeBindingResolver: resolved tenant=${tenantId} provider=${providerId} ` +
+                `v=${credentialVersion} (mode=${snapshot.mode}, enabled=${snapshot.enabled}).`,
+        );
+        return {
+            status: 'resolved',
+            snapshot,
+            providerId,
+            credentialVersion,
+            tenantId,
+        };
+    }
+
+    /**
+     * Convenience wrapper for workId-scoped tasks (KB-embed, KB-mirror,
+     * KB-normalize-media, work-generation, work-import — i.e. every
+     * dispatcher whose payload carries a `workId`). Resolves the
+     * Work's `tenantId` via WorkRepository.findById, then delegates to
+     * {@link resolve}.
+     */
+    async resolveForWork(
+        payload: { providerId?: string | null; credentialVersion?: number | null },
+        workId: string,
+    ): Promise<Awaited<ReturnType<TenantRuntimeBindingResolverService['resolve']>>> {
+        if (!this.workRepository) {
+            return { status: 'no-binding' };
+        }
+        let tenantId: string | null = null;
+        try {
+            const work = await this.workRepository.findById(workId);
+            tenantId = work?.tenantId ?? null;
+        } catch (err) {
+            this.logger.debug(
+                `TenantRuntimeBindingResolver.resolveForWork: workRepository.findById ` +
+                    `threw for work=${workId} (${(err as Error).message}); treating as no-binding.`,
+            );
+            return { status: 'no-binding' };
+        }
+        return this.resolve(payload, tenantId);
+    }
+}


### PR DESCRIPTION
## Summary

Cascades the EW-742 P3.2 T22 trio from develop to stage:

- **#1430** — KB Tier 1 (Mirror + Normalize + OrgOverlay stamping in KnowledgeBaseService)
- **#1431** — Tier 2 (WorkGeneration + WorkImport + TemplateCustomization stamping)
- **#1432** — Worker-host `resolveSnapshot` consumption (PoC service)

## Risk

Low — every change is **additive optional behaviour**:
- All new payload fields are OPTIONAL — legacy callers ship `null/null`.
- All stamper injections are `@Optional()` — pre-overlay deployments degrade to instance default (byte-identical pre-T22 path).
- Worker-host resolver service is added but NOT YET wired into any task — adoption per-task lands incrementally.

## Verification

- 67/67 KB service tests (#1430)
- 208/208 Tier 2 service tests (#1431)
- 13/13 new resolver tests + 55/55 affected API tests (#1432)
- Agent + API type-checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)