### PR TITLE
feat(agent): EW-742 P3.2 T22 — KB-Transcribe dispatcher tenant binding capture

### DIFF
--- a/packages/agent/src/services/knowledge-base-media-normalize.service.spec.ts
+++ b/packages/agent/src/services/knowledge-base-media-normalize.service.spec.ts
@@ -24,8 +24,10 @@ import { WorkKnowledgeUploadRepository } from '../database/repositories/work-kno
 import {
     KB_NORMALIZE_MEDIA_DISPATCHER,
     KB_TRANSCRIBE_DISPATCHER,
+    RuntimeBindingStamperService,
     type KbNormalizeMediaPayload,
 } from '../tasks';
+import { WorkRepository } from '../database/repositories/work.repository';
 import { WorkKnowledgeUpload } from '../entities/work-knowledge-upload.entity';
 import { KbUploadExtractionStatus } from '../entities/kb-types';
 
@@ -270,5 +272,137 @@ describe('KnowledgeBaseMediaNormalizeService', () => {
 
         expect(result.transcribeRunId).toBeNull();
         expect(transcribeDispatcher.dispatchKbTranscribe).not.toHaveBeenCalled();
+    });
+
+    // EW-742 P3.2 T22 — KB-transcribe dispatcher stamping. Builds a
+    // fresh service with WorkRepository + RuntimeBindingStamperService
+    // wired and asserts that the (providerId, credentialVersion) pair
+    // gets threaded onto the transcribe dispatch payload.
+    describe('T22 — KB-transcribe enqueue-site tenant binding capture', () => {
+        const TENANT_ID = '00000000-0000-0000-0000-00000000aaaa';
+
+        async function buildWithStamper(opts: {
+            stamperResult?: { providerId: string | null; credentialVersion: number | null };
+            stamperThrows?: boolean;
+            workTenantId?: string | null;
+            workFindThrows?: boolean;
+        }) {
+            const workRepoMock = {
+                findById: opts.workFindThrows
+                    ? jest.fn().mockRejectedValue(new Error('db boom'))
+                    : jest.fn().mockResolvedValue(
+                          opts.workTenantId === undefined
+                              ? null
+                              : ({ id: WORK_ID, tenantId: opts.workTenantId } as any),
+                      ),
+            };
+            const stamperMock = {
+                stamp: opts.stamperThrows
+                    ? jest.fn().mockRejectedValue(new Error('stamper boom'))
+                    : jest
+                          .fn()
+                          .mockResolvedValue(
+                              opts.stamperResult ?? {
+                                  providerId: null,
+                                  credentialVersion: null,
+                              },
+                          ),
+            };
+            const module: TestingModule = await Test.createTestingModule({
+                providers: [
+                    KnowledgeBaseMediaNormalizeService,
+                    { provide: WorkKnowledgeUploadRepository, useValue: uploadRepo },
+                    { provide: KB_STORAGE_PLUGIN, useValue: storage },
+                    { provide: KB_TRANSCRIBE_DISPATCHER, useValue: transcribeDispatcher },
+                    { provide: KB_NORMALIZE_MEDIA_DISPATCHER, useValue: normalizeDispatcher },
+                    {
+                        provide: RuntimeBindingStamperService,
+                        useValue: stamperMock,
+                    },
+                    { provide: WorkRepository, useValue: workRepoMock },
+                ],
+            }).compile();
+            return {
+                service: module.get(KnowledgeBaseMediaNormalizeService),
+                workRepoMock,
+                stamperMock,
+            };
+        }
+
+        it('stamps transcribe payload with stamper result when overlay is active', async () => {
+            const { service: svc, workRepoMock, stamperMock } = await buildWithStamper({
+                workTenantId: TENANT_ID,
+                stamperResult: { providerId: 'trigger', credentialVersion: 17 },
+            });
+            uploadRepo.findById.mockResolvedValue(buildUpload());
+            stubSpawn(0);
+
+            await svc.normalizeVideo(videoPayload);
+
+            expect(workRepoMock.findById).toHaveBeenCalledWith(WORK_ID);
+            expect(stamperMock.stamp).toHaveBeenCalledWith(TENANT_ID);
+            expect(transcribeDispatcher.dispatchKbTranscribe).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    workId: WORK_ID,
+                    providerId: 'trigger',
+                    credentialVersion: 17,
+                }),
+            );
+        });
+
+        it('ships null/null when work has no tenantId', async () => {
+            const { service: svc, stamperMock } = await buildWithStamper({
+                workTenantId: null,
+                stamperResult: { providerId: null, credentialVersion: null },
+            });
+            uploadRepo.findById.mockResolvedValue(buildUpload());
+            stubSpawn(0);
+
+            await svc.normalizeVideo(videoPayload);
+
+            expect(stamperMock.stamp).toHaveBeenCalledWith(null);
+            expect(transcribeDispatcher.dispatchKbTranscribe).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    providerId: null,
+                    credentialVersion: null,
+                }),
+            );
+        });
+
+        it('fails open on stamper throw', async () => {
+            const { service: svc } = await buildWithStamper({
+                workTenantId: TENANT_ID,
+                stamperThrows: true,
+            });
+            uploadRepo.findById.mockResolvedValue(buildUpload());
+            stubSpawn(0);
+
+            await svc.normalizeVideo(videoPayload);
+
+            expect(transcribeDispatcher.dispatchKbTranscribe).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    providerId: null,
+                    credentialVersion: null,
+                }),
+            );
+        });
+
+        it('fails open on workRepository.findById throw', async () => {
+            const { service: svc, stamperMock } = await buildWithStamper({
+                workFindThrows: true,
+            });
+            uploadRepo.findById.mockResolvedValue(buildUpload());
+            stubSpawn(0);
+
+            await svc.normalizeVideo(videoPayload);
+
+            expect(stamperMock.stamp).not.toHaveBeenCalled();
+            expect(transcribeDispatcher.dispatchKbTranscribe).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    providerId: null,
+                    credentialVersion: null,
+                }),
+            );
+        });
     });
 });

--- a/packages/agent/src/services/knowledge-base-media-normalize.service.ts
+++ b/packages/agent/src/services/knowledge-base-media-normalize.service.ts
@@ -11,8 +11,10 @@ import {
     type KbNormalizeMediaDispatcher,
     type KbNormalizeMediaPayload,
     type KbTranscribeDispatcher,
+    RuntimeBindingStamperService,
 } from '../tasks';
 import { WorkKnowledgeUploadRepository } from '../database/repositories/work-knowledge-upload.repository';
+import { WorkRepository } from '../database/repositories/work.repository';
 import { KB_STORAGE_PLUGIN } from './knowledge-base.service';
 import type { IStoragePlugin } from '@ever-works/plugin';
 
@@ -88,8 +90,45 @@ export class KnowledgeBaseMediaNormalizeService {
         @Optional()
         @Inject(KB_NORMALIZE_MEDIA_DISPATCHER)
         _normalizeDispatcher?: KbNormalizeMediaDispatcher,
+        // EW-742 P3.2 T22 — enqueue-site tenant runtime binding capture
+        // for the kb-transcribe dispatch. Optional so isolated unit tests
+        // and pre-overlay deployments keep constructing — when absent,
+        // payload ships null/null and the worker falls back to the
+        // instance default (byte-identical pre-T22 path).
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
+        // EW-742 P3.2 T22 — used to resolve Work.tenantId for the
+        // stamper lookup. Optional same as the stamper.
+        @Optional()
+        private readonly workRepository?: WorkRepository,
     ) {
         void _normalizeDispatcher;
+    }
+
+    /**
+     * EW-742 P3.2 T22 — stamp `(providerId, credentialVersion)` for the
+     * worker host. Mirrors KnowledgeBaseService.stampForWork (same
+     * helper pattern intentionally not extracted to a shared utility:
+     * the two services have orthogonal DI graphs and a 12-line private
+     * helper is cheaper to read than another `@ever-works/agent/tasks`
+     * indirection). Fail-open per FR-5.
+     */
+    private async stampForWork(
+        workId: string,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper || !this.workRepository) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            const work = await this.workRepository.findById(workId);
+            return await this.runtimeBindingStamper.stamp(work?.tenantId ?? null);
+        } catch (err) {
+            this.logger.debug(
+                `kb-normalize-media: stamper lookup failed for work=${workId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
     }
 
     async normalizeVideo(payload: KbNormalizeMediaPayload): Promise<KbNormalizeResult> {
@@ -166,6 +205,9 @@ export class KnowledgeBaseMediaNormalizeService {
         };
         await this.uploads.updateById(payload.workId, payload.uploadId, { metadata: nextMetadata });
 
+        // EW-742 P3.2 T22 — stamp the transcribe enqueue with the
+        // tenant runtime binding so the worker host can resolveSnapshot.
+        const binding = await this.stampForWork(payload.workId);
         const transcribeRunId =
             (await this.transcribeDispatcher?.dispatchKbTranscribe({
                 workId: payload.workId,
@@ -173,6 +215,8 @@ export class KnowledgeBaseMediaNormalizeService {
                 sourceStoragePath: putResult.key,
                 sourceMimeType: normalizedMimeType,
                 language: config.kb.getTranscriptionLanguage(),
+                providerId: binding.providerId,
+                credentialVersion: binding.credentialVersion,
             })) ?? null;
 
         return {

--- a/packages/agent/src/tasks/kb-transcribe.types.ts
+++ b/packages/agent/src/tasks/kb-transcribe.types.ts
@@ -45,4 +45,12 @@ export interface KbTranscribePayload {
      * absent, but on noisy audio a hint dramatically improves WER.
      */
     readonly language?: string;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }


### PR DESCRIPTION
## Summary

Adds T22 enqueue-site stamping for `KB_TRANSCRIBE_DISPATCHER`. This is the **last KB dispatcher in the agent package** — KB-embed (PoC, #1427), KB-mirror + KB-normalize-media + KB-org-overlay (Tier 1, #1430), and now KB-transcribe round out the full set.

## What this PR does

1. **Extends `KbTranscribePayload`** with optional T22 fields (`providerId?`, `credentialVersion?`) — matches `KbEmbedDocumentPayload`.
2. **Injects `RuntimeBindingStamperService` + `WorkRepository`** as `@Optional()` into `KnowledgeBaseMediaNormalizeService` (which owns the `KB_TRANSCRIBE_DISPATCHER` call site).
3. **Adds a private `stampForWork` helper** mirroring the `KnowledgeBaseService` pattern (independent helper, not extracted to a shared util — the two services have orthogonal DI graphs and a 12-line private helper reads cheaper than indirection).
4. **Threads `(providerId, credentialVersion)`** onto every `dispatchKbTranscribe` payload.

## Fail-open

Per ADR-017 §3 + FR-5: every failure path ships `null/null` and the worker host falls back to the instance default (byte-identical pre-overlay path).

## Tests

- **4 new jest cases** on `KnowledgeBaseMediaNormalizeService`:
  - happy path with overlay → stamper result threaded through
  - null tenantId → stamper called with null, ships null/null
  - stamper throws → ships null/null (fail-open)
  - `workRepository.findById` throws → stamper never called, ships null/null
- Existing 5 tests unaffected (they use `expect.objectContaining` for payload assertions).
- **9/9 normalize tests green**; agent package type-check clean.

## What this PR DOES NOT do (still deferred — out of agent package scope)

- `KB_REEMBED_WORK_DISPATCHER` — dispatched from `pgvector` plugin package; needs its own PR.
- `KB_BACKFILL_SKELETON_DISPATCHER` — call site lives outside the agent package (admin endpoint or unimplemented).
- `WEBHOOK_DELIVERY_DISPATCHER` — lives in `apps/api/src/webhooks/`; separate ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Knowledge base transcription tasks now capture and include tenant runtime binding information, enabling proper credential selection and multi-tenant isolation during processing.

* **Tests**
  * Added comprehensive test coverage for tenant binding capture in transcription task dispatch, including success scenarios and graceful error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->