### PR TITLE
chore(release): cascade EW-742 P3.2 T22 — kb-embed task PoC + KB-Transcribe (stage → main)

### DIFF
--- a/packages/agent/src/services/knowledge-base-media-normalize.service.spec.ts
+++ b/packages/agent/src/services/knowledge-base-media-normalize.service.spec.ts
@@ -24,8 +24,10 @@ import { WorkKnowledgeUploadRepository } from '../database/repositories/work-kno
 import {
     KB_NORMALIZE_MEDIA_DISPATCHER,
     KB_TRANSCRIBE_DISPATCHER,
+    RuntimeBindingStamperService,
     type KbNormalizeMediaPayload,
 } from '../tasks';
+import { WorkRepository } from '../database/repositories/work.repository';
 import { WorkKnowledgeUpload } from '../entities/work-knowledge-upload.entity';
 import { KbUploadExtractionStatus } from '../entities/kb-types';
 
@@ -270,5 +272,137 @@ describe('KnowledgeBaseMediaNormalizeService', () => {
 
         expect(result.transcribeRunId).toBeNull();
         expect(transcribeDispatcher.dispatchKbTranscribe).not.toHaveBeenCalled();
+    });
+
+    // EW-742 P3.2 T22 — KB-transcribe dispatcher stamping. Builds a
+    // fresh service with WorkRepository + RuntimeBindingStamperService
+    // wired and asserts that the (providerId, credentialVersion) pair
+    // gets threaded onto the transcribe dispatch payload.
+    describe('T22 — KB-transcribe enqueue-site tenant binding capture', () => {
+        const TENANT_ID = '00000000-0000-0000-0000-00000000aaaa';
+
+        async function buildWithStamper(opts: {
+            stamperResult?: { providerId: string | null; credentialVersion: number | null };
+            stamperThrows?: boolean;
+            workTenantId?: string | null;
+            workFindThrows?: boolean;
+        }) {
+            const workRepoMock = {
+                findById: opts.workFindThrows
+                    ? jest.fn().mockRejectedValue(new Error('db boom'))
+                    : jest.fn().mockResolvedValue(
+                          opts.workTenantId === undefined
+                              ? null
+                              : ({ id: WORK_ID, tenantId: opts.workTenantId } as any),
+                      ),
+            };
+            const stamperMock = {
+                stamp: opts.stamperThrows
+                    ? jest.fn().mockRejectedValue(new Error('stamper boom'))
+                    : jest
+                          .fn()
+                          .mockResolvedValue(
+                              opts.stamperResult ?? {
+                                  providerId: null,
+                                  credentialVersion: null,
+                              },
+                          ),
+            };
+            const module: TestingModule = await Test.createTestingModule({
+                providers: [
+                    KnowledgeBaseMediaNormalizeService,
+                    { provide: WorkKnowledgeUploadRepository, useValue: uploadRepo },
+                    { provide: KB_STORAGE_PLUGIN, useValue: storage },
+                    { provide: KB_TRANSCRIBE_DISPATCHER, useValue: transcribeDispatcher },
+                    { provide: KB_NORMALIZE_MEDIA_DISPATCHER, useValue: normalizeDispatcher },
+                    {
+                        provide: RuntimeBindingStamperService,
+                        useValue: stamperMock,
+                    },
+                    { provide: WorkRepository, useValue: workRepoMock },
+                ],
+            }).compile();
+            return {
+                service: module.get(KnowledgeBaseMediaNormalizeService),
+                workRepoMock,
+                stamperMock,
+            };
+        }
+
+        it('stamps transcribe payload with stamper result when overlay is active', async () => {
+            const { service: svc, workRepoMock, stamperMock } = await buildWithStamper({
+                workTenantId: TENANT_ID,
+                stamperResult: { providerId: 'trigger', credentialVersion: 17 },
+            });
+            uploadRepo.findById.mockResolvedValue(buildUpload());
+            stubSpawn(0);
+
+            await svc.normalizeVideo(videoPayload);
+
+            expect(workRepoMock.findById).toHaveBeenCalledWith(WORK_ID);
+            expect(stamperMock.stamp).toHaveBeenCalledWith(TENANT_ID);
+            expect(transcribeDispatcher.dispatchKbTranscribe).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    workId: WORK_ID,
+                    providerId: 'trigger',
+                    credentialVersion: 17,
+                }),
+            );
+        });
+
+        it('ships null/null when work has no tenantId', async () => {
+            const { service: svc, stamperMock } = await buildWithStamper({
+                workTenantId: null,
+                stamperResult: { providerId: null, credentialVersion: null },
+            });
+            uploadRepo.findById.mockResolvedValue(buildUpload());
+            stubSpawn(0);
+
+            await svc.normalizeVideo(videoPayload);
+
+            expect(stamperMock.stamp).toHaveBeenCalledWith(null);
+            expect(transcribeDispatcher.dispatchKbTranscribe).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    providerId: null,
+                    credentialVersion: null,
+                }),
+            );
+        });
+
+        it('fails open on stamper throw', async () => {
+            const { service: svc } = await buildWithStamper({
+                workTenantId: TENANT_ID,
+                stamperThrows: true,
+            });
+            uploadRepo.findById.mockResolvedValue(buildUpload());
+            stubSpawn(0);
+
+            await svc.normalizeVideo(videoPayload);
+
+            expect(transcribeDispatcher.dispatchKbTranscribe).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    providerId: null,
+                    credentialVersion: null,
+                }),
+            );
+        });
+
+        it('fails open on workRepository.findById throw', async () => {
+            const { service: svc, stamperMock } = await buildWithStamper({
+                workFindThrows: true,
+            });
+            uploadRepo.findById.mockResolvedValue(buildUpload());
+            stubSpawn(0);
+
+            await svc.normalizeVideo(videoPayload);
+
+            expect(stamperMock.stamp).not.toHaveBeenCalled();
+            expect(transcribeDispatcher.dispatchKbTranscribe).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    providerId: null,
+                    credentialVersion: null,
+                }),
+            );
+        });
     });
 });

--- a/packages/agent/src/services/knowledge-base-media-normalize.service.ts
+++ b/packages/agent/src/services/knowledge-base-media-normalize.service.ts
@@ -11,8 +11,10 @@ import {
     type KbNormalizeMediaDispatcher,
     type KbNormalizeMediaPayload,
     type KbTranscribeDispatcher,
+    RuntimeBindingStamperService,
 } from '../tasks';
 import { WorkKnowledgeUploadRepository } from '../database/repositories/work-knowledge-upload.repository';
+import { WorkRepository } from '../database/repositories/work.repository';
 import { KB_STORAGE_PLUGIN } from './knowledge-base.service';
 import type { IStoragePlugin } from '@ever-works/plugin';
 
@@ -88,8 +90,45 @@ export class KnowledgeBaseMediaNormalizeService {
         @Optional()
         @Inject(KB_NORMALIZE_MEDIA_DISPATCHER)
         _normalizeDispatcher?: KbNormalizeMediaDispatcher,
+        // EW-742 P3.2 T22 — enqueue-site tenant runtime binding capture
+        // for the kb-transcribe dispatch. Optional so isolated unit tests
+        // and pre-overlay deployments keep constructing — when absent,
+        // payload ships null/null and the worker falls back to the
+        // instance default (byte-identical pre-T22 path).
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
+        // EW-742 P3.2 T22 — used to resolve Work.tenantId for the
+        // stamper lookup. Optional same as the stamper.
+        @Optional()
+        private readonly workRepository?: WorkRepository,
     ) {
         void _normalizeDispatcher;
+    }
+
+    /**
+     * EW-742 P3.2 T22 — stamp `(providerId, credentialVersion)` for the
+     * worker host. Mirrors KnowledgeBaseService.stampForWork (same
+     * helper pattern intentionally not extracted to a shared utility:
+     * the two services have orthogonal DI graphs and a 12-line private
+     * helper is cheaper to read than another `@ever-works/agent/tasks`
+     * indirection). Fail-open per FR-5.
+     */
+    private async stampForWork(
+        workId: string,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper || !this.workRepository) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            const work = await this.workRepository.findById(workId);
+            return await this.runtimeBindingStamper.stamp(work?.tenantId ?? null);
+        } catch (err) {
+            this.logger.debug(
+                `kb-normalize-media: stamper lookup failed for work=${workId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
     }
 
     async normalizeVideo(payload: KbNormalizeMediaPayload): Promise<KbNormalizeResult> {
@@ -166,6 +205,9 @@ export class KnowledgeBaseMediaNormalizeService {
         };
         await this.uploads.updateById(payload.workId, payload.uploadId, { metadata: nextMetadata });
 
+        // EW-742 P3.2 T22 — stamp the transcribe enqueue with the
+        // tenant runtime binding so the worker host can resolveSnapshot.
+        const binding = await this.stampForWork(payload.workId);
         const transcribeRunId =
             (await this.transcribeDispatcher?.dispatchKbTranscribe({
                 workId: payload.workId,
@@ -173,6 +215,8 @@ export class KnowledgeBaseMediaNormalizeService {
                 sourceStoragePath: putResult.key,
                 sourceMimeType: normalizedMimeType,
                 language: config.kb.getTranscriptionLanguage(),
+                providerId: binding.providerId,
+                credentialVersion: binding.credentialVersion,
             })) ?? null;
 
         return {

--- a/packages/agent/src/tasks/kb-transcribe.types.ts
+++ b/packages/agent/src/tasks/kb-transcribe.types.ts
@@ -45,4 +45,12 @@ export interface KbTranscribePayload {
      * absent, but on noisy audio a hint dramatically improves WER.
      */
     readonly language?: string;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }

--- a/packages/tasks/src/tasks/trigger/kb-embed-document.task.ts
+++ b/packages/tasks/src/tasks/trigger/kb-embed-document.task.ts
@@ -5,6 +5,7 @@ import { KnowledgeBaseService, chunkMarkdown } from '@ever-works/agent/services'
 import { WorkKnowledgeChunkRepository, type ChunkUpsertInput } from '@ever-works/agent/database';
 import { AiFacadeService } from '@ever-works/agent/facades';
 import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 
 /**
@@ -29,6 +30,12 @@ import { withWorkerContext } from '../../trigger/worker/utils/worker-context.uti
  * instead of throwing — Trigger.dev retries would otherwise loop on
  * payloads that legitimately have nothing to embed):
  *
+ *  - `credentials-drained` (EW-742 P3.2 T22) — the
+ *    `(providerId, credentialVersion)` pair stamped at enqueue time
+ *    no longer matches the current tenant overlay (rotated past).
+ *    Skip-and-ack rather than retry: KB embedding is idempotent and
+ *    the next enqueue (or the spec §17.7 reconciliation job) will
+ *    pick the doc up against the new credentials.
  *  - `document-not-found` — race-with-delete: the doc row was removed
  *    between enqueue and run. `replaceForDocument` is NOT called (the
  *    `onDelete: 'CASCADE'` FK already cleared any chunks).
@@ -63,6 +70,43 @@ export const kbEmbedDocumentTask = task<'kb-embed-document', KbEmbedDocumentPayl
     run: async (payload) => {
         return withWorkerContext('KbEmbedDocument', async (appContext) => {
             await appContext.get(TriggerPluginHydratorService).initialize();
+
+            // EW-742 P3.2 T22 (worker-host consumption) — kb-embed is
+            // the first task to adopt the resolver service shipped in
+            // #1432. The same 4-line pattern is the template every
+            // other Trigger.dev task will copy as it's wired up.
+            //
+            // Skip-and-ack on 'drained': the credentials this run was
+            // enqueued against have been rotated past the version we
+            // hold. KB embedding is idempotent — the next enqueue (or
+            // the reconciliation job per spec §17.7) will pick up the
+            // doc against the new credentials. Returning a skipped
+            // result here avoids burning Trigger.dev retry budget on a
+            // run that would just keep observing the same 'drained'
+            // state until the row hits the dead-letter queue.
+            //
+            // 'no-binding' / 'resolved' / 'error' all fall through to
+            // the legacy code path (instance default credentials) —
+            // byte-identical to the pre-T22 behaviour, no surprise
+            // change in production semantics.
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForWork(payload, payload.workId);
+            if (binding.status === 'drained') {
+                logger.warn('kb-embed-document: credentials drained, skipping run', {
+                    workId: payload.workId,
+                    documentId: payload.documentId,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                return {
+                    status: 'skipped',
+                    reason: 'credentials-drained',
+                    workId: payload.workId,
+                    documentId: payload.documentId,
+                };
+            }
 
             const kbService = appContext.get(KnowledgeBaseService);
             const aiFacade = appContext.get(AiFacadeService);


### PR DESCRIPTION
Stage→main cascade for #1435 + #1436 (via #1437). Low-risk additive behavior; payloads without T22 fields run byte-identical pre-T22 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)