### PR TITLE
chore(release): cascade EW-742 P3.2 T22 — 6-task per-task wiring (stage → main)

### DIFF
--- a/packages/tasks/src/tasks/trigger/kb-mirror-document.task.ts
+++ b/packages/tasks/src/tasks/trigger/kb-mirror-document.task.ts
@@ -1,7 +1,8 @@
-import { task } from '@trigger.dev/sdk';
+import { logger, task } from '@trigger.dev/sdk';
 import { KbMirrorDocumentPayload } from '@ever-works/agent/tasks';
 import { KnowledgeBaseGitMirrorService } from '@ever-works/agent/services';
 import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 
 /**
@@ -25,6 +26,32 @@ export const kbMirrorDocumentTask = task<'kb-mirror-document', KbMirrorDocumentP
     run: async (payload) => {
         return withWorkerContext('KbMirrorDocument', async (appContext) => {
             await appContext.get(TriggerPluginHydratorService).initialize();
+
+            // EW-742 P3.2 T22 — see kb-embed-document.task.ts for the
+            // full pattern rationale. Idempotent mirror task: a drained
+            // skip-and-ack is safe — the next enqueue (or the
+            // reconciliation job per spec §17.7) picks up the latest
+            // doc state against fresh credentials.
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForWork(payload, payload.workId);
+            if (binding.status === 'drained') {
+                logger.warn('kb-mirror-document: credentials drained, skipping run', {
+                    workId: payload.workId,
+                    documentId: payload.documentId,
+                    operation: payload.operation,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                return {
+                    status: 'skipped' as const,
+                    reason: 'credentials-drained' as const,
+                    workId: payload.workId,
+                    documentId: payload.documentId,
+                };
+            }
+
             const mirror = appContext.get(KnowledgeBaseGitMirrorService);
 
             if (payload.operation === 'delete') {

--- a/packages/tasks/src/tasks/trigger/kb-normalize-audio.task.ts
+++ b/packages/tasks/src/tasks/trigger/kb-normalize-audio.task.ts
@@ -2,6 +2,7 @@ import { logger, task } from '@trigger.dev/sdk';
 import { KbNormalizeMediaPayload } from '@ever-works/agent/tasks';
 import { KnowledgeBaseMediaNormalizeService } from '@ever-works/agent/services';
 import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 
 /**
@@ -28,6 +29,27 @@ export const kbNormalizeAudioTask = task<'kb-normalize-audio', KbNormalizeMediaP
         }
         return withWorkerContext('KbNormalizeAudio', async (appContext) => {
             await appContext.get(TriggerPluginHydratorService).initialize();
+
+            // EW-742 P3.2 T22 — see kb-embed-document.task.ts for pattern.
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForWork(payload, payload.workId);
+            if (binding.status === 'drained') {
+                logger.warn('kb-normalize-audio: credentials drained, skipping run', {
+                    workId: payload.workId,
+                    uploadId: payload.uploadId,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                return {
+                    status: 'skipped' as const,
+                    reason: 'credentials-drained' as const,
+                    workId: payload.workId,
+                    uploadId: payload.uploadId,
+                };
+            }
+
             const svc = appContext.get(KnowledgeBaseMediaNormalizeService);
             logger.info('kb-normalize-audio starting', {
                 workId: payload.workId,

--- a/packages/tasks/src/tasks/trigger/kb-normalize-video.task.ts
+++ b/packages/tasks/src/tasks/trigger/kb-normalize-video.task.ts
@@ -2,6 +2,7 @@ import { logger, task } from '@trigger.dev/sdk';
 import { KbNormalizeMediaPayload } from '@ever-works/agent/tasks';
 import { KnowledgeBaseMediaNormalizeService } from '@ever-works/agent/services';
 import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 
 /**
@@ -45,6 +46,27 @@ export const kbNormalizeVideoTask = task<'kb-normalize-video', KbNormalizeMediaP
         }
         return withWorkerContext('KbNormalizeVideo', async (appContext) => {
             await appContext.get(TriggerPluginHydratorService).initialize();
+
+            // EW-742 P3.2 T22 — see kb-embed-document.task.ts for pattern.
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForWork(payload, payload.workId);
+            if (binding.status === 'drained') {
+                logger.warn('kb-normalize-video: credentials drained, skipping run', {
+                    workId: payload.workId,
+                    uploadId: payload.uploadId,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                return {
+                    status: 'skipped' as const,
+                    reason: 'credentials-drained' as const,
+                    workId: payload.workId,
+                    uploadId: payload.uploadId,
+                };
+            }
+
             const svc = appContext.get(KnowledgeBaseMediaNormalizeService);
             logger.info('kb-normalize-video starting', {
                 workId: payload.workId,

--- a/packages/tasks/src/tasks/trigger/kb-transcribe.task.ts
+++ b/packages/tasks/src/tasks/trigger/kb-transcribe.task.ts
@@ -2,6 +2,7 @@ import { logger, task } from '@trigger.dev/sdk';
 import { KbTranscribePayload } from '@ever-works/agent/tasks';
 import { KnowledgeBaseTranscribeService } from '@ever-works/agent/services';
 import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 
 /**
@@ -33,6 +34,27 @@ export const kbTranscribeTask = task<'kb-transcribe', KbTranscribePayload>({
     run: async (payload) => {
         return withWorkerContext('KbTranscribe', async (appContext) => {
             await appContext.get(TriggerPluginHydratorService).initialize();
+
+            // EW-742 P3.2 T22 — see kb-embed-document.task.ts for pattern.
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForWork(payload, payload.workId);
+            if (binding.status === 'drained') {
+                logger.warn('kb-transcribe: credentials drained, skipping run', {
+                    workId: payload.workId,
+                    uploadId: payload.uploadId,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                return {
+                    status: 'skipped' as const,
+                    reason: 'credentials-drained' as const,
+                    workId: payload.workId,
+                    uploadId: payload.uploadId,
+                };
+            }
+
             const svc = appContext.get(KnowledgeBaseTranscribeService);
             logger.info('kb-transcribe starting', {
                 workId: payload.workId,

--- a/packages/tasks/src/tasks/trigger/work-generation.task.ts
+++ b/packages/tasks/src/tasks/trigger/work-generation.task.ts
@@ -1,8 +1,9 @@
-import { task } from '@trigger.dev/sdk';
+import { logger, task } from '@trigger.dev/sdk';
 import { WorkGenerationPayload } from '@ever-works/agent/tasks';
 import { GenerateStatusType } from '@ever-works/agent/entities';
 import { WorkScheduleService, normalizeGeneratorError } from '@ever-works/agent/services';
 import { TriggerGenerationOrchestrator } from '../../trigger/worker/orchestrators/trigger-generation.orchestrator';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 import { createTaskContext } from '../../trigger/worker/utils/task-context.utils';
 
@@ -93,6 +94,39 @@ export const workGenerationTask = task<'work-generation', WorkGenerationPayload>
     },
     run: async (payload: WorkGenerationPayload, { signal }) => {
         return withWorkerContext('WorkGeneration', async (appContext) => {
+            // EW-742 P3.2 T22 — see kb-embed-document.task.ts for the
+            // pattern. WorkGeneration is idempotent at the run-history
+            // grain (failure modes are recorded via the schedule service
+            // and the entry re-runs cleanly on the next enqueue), so a
+            // drained skip-and-ack is the right move.
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForWork(payload, payload.workId);
+            if (binding.status === 'drained') {
+                logger.warn('work-generation: credentials drained, skipping run', {
+                    workId: payload.workId,
+                    historyId: payload.historyId,
+                    triggerSource: payload.triggerSource,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                // Mark the schedule run failed with a distinctive reason
+                // so an operator can spot drained runs at a glance.
+                if (payload.triggerSource === 'schedule' && payload.scheduleId) {
+                    const scheduleService = appContext.get(WorkScheduleService);
+                    await scheduleService.markRunFailed(
+                        payload.scheduleId,
+                        'credentials-drained',
+                    );
+                }
+                return {
+                    status: 'skipped' as const,
+                    reason: 'credentials-drained' as const,
+                    workId: payload.workId,
+                };
+            }
+
             const { orchestrator, work, user } = await createTaskContext(
                 appContext,
                 payload,

--- a/packages/tasks/src/tasks/trigger/work-import.task.ts
+++ b/packages/tasks/src/tasks/trigger/work-import.task.ts
@@ -1,7 +1,8 @@
-import { task } from '@trigger.dev/sdk';
+import { logger, task } from '@trigger.dev/sdk';
 import { WorkImportPayload } from '@ever-works/agent/tasks';
 import { normalizeGeneratorError } from '@ever-works/agent/services';
 import { TriggerImportOrchestrator } from '../../trigger/worker/orchestrators/trigger-import.orchestrator';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 import { createTaskContext } from '../../trigger/worker/utils/task-context.utils';
 
@@ -55,6 +56,26 @@ export const workImportTask = task({
     },
     run: async (payload: WorkImportPayload) => {
         return withWorkerContext('WorkImport', async (appContext) => {
+            // EW-742 P3.2 T22 — see kb-embed-document.task.ts for pattern.
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForWork(payload, payload.workId);
+            if (binding.status === 'drained') {
+                logger.warn('work-import: credentials drained, skipping run', {
+                    workId: payload.workId,
+                    historyId: payload.historyId,
+                    triggerSource: payload.triggerSource,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                return {
+                    status: 'skipped' as const,
+                    reason: 'credentials-drained' as const,
+                    workId: payload.workId,
+                };
+            }
+
             const { orchestrator, work, user, gitToken } = await createTaskContext(
                 appContext,
                 payload,


### PR DESCRIPTION
Stage→main cascade for #1439 (via #1440). Low-risk additive behavior; pre-T22 payloads run byte-identical to legacy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)