### PR TITLE
feat(tasks): EW-742 P3.2 T22 — wire kb-org-overlay-fanout + template-customization tasks

### DIFF
--- a/apps/api/src/organizations/organizations.module.ts
+++ b/apps/api/src/organizations/organizations.module.ts
@@ -67,6 +67,10 @@ import { WorkRegisteredListener } from './work-registered.listener';
         OrganizationMembershipService,
         OrganizationOwnershipGuard,
         TenantBootstrapService,
+        // EW-742 P3.2 T22 — exported so TriggerInternalModule can
+        // expose findById through the remote-proxy controller for
+        // the worker-host resolveForOrganization path.
+        OrganizationRepository,
     ],
 })
 export class OrganizationsModule {}

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -21,6 +21,7 @@ import { config } from '@ever-works/agent/config';
 import {
     WorkRepository,
     AuthAccountRepository,
+    OrganizationRepository,
     TemplateRepository,
     TemplateCustomizationRepository,
     UserTemplatePreferenceRepository,
@@ -222,6 +223,11 @@ export class TriggerInternalController implements OnModuleInit {
         // enqueue time and decide whether to run, fail with
         // CREDENTIAL_DRAINED, or fall back to the instance default.
         private readonly credentialVersionService: CredentialVersionService,
+        // EW-742 P3.2 T22 — exposes OrganizationRepository so the
+        // worker-side TenantRuntimeBindingResolverService can resolve
+        // an org's tenantId for kb-org-overlay-fanout (the only org-
+        // scoped dispatcher today).
+        private readonly organizationRepository: OrganizationRepository,
         @Optional()
         @Inject(forwardRef(() => WorkProposalsApiService))
         private readonly workProposalsApiService?: WorkProposalsApiService,
@@ -268,6 +274,9 @@ export class TriggerInternalController implements OnModuleInit {
             // consumption (see TenantRuntimeBindingResolverService in
             // packages/tasks/src/trigger/worker/services/).
             CredentialVersionService: this.credentialVersionService,
+            // EW-742 P3.2 T22 — exposed for resolveForOrganization on
+            // the worker-host resolver (kb-org-overlay-fanout task).
+            OrganizationRepository: this.organizationRepository,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/apps/api/src/trigger/trigger-internal.module.ts
+++ b/apps/api/src/trigger/trigger-internal.module.ts
@@ -10,6 +10,7 @@ import { TasksDomainModule } from '@ever-works/agent/tasks-domain';
 import { WorkProposalsModule } from '../work-proposals/work-proposals.module';
 import { DataSyncModule } from '../data-sync/data-sync.module';
 import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
+import { OrganizationsModule } from '../organizations/organizations.module';
 
 @Module({
     imports: [
@@ -22,6 +23,9 @@ import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job
         // remote-proxy controller so the Trigger.dev worker can verify
         // the (providerId, credentialVersion) pair stamped at enqueue time.
         TenantJobRuntimeModule,
+        // EW-742 P3.2 T22 — exposes OrganizationRepository for the
+        // resolveForOrganization path on the worker-host resolver.
+        OrganizationsModule,
         // EW-628 G7 — exposes DataSyncDispatcherService through the
         // remote-proxy controller so the Trigger.dev worker can call it
         // each cron tick without importing the full API stack.

--- a/packages/tasks/src/tasks/trigger/kb-org-overlay-fanout.task.ts
+++ b/packages/tasks/src/tasks/trigger/kb-org-overlay-fanout.task.ts
@@ -1,7 +1,8 @@
-import { task } from '@trigger.dev/sdk';
+import { logger, task } from '@trigger.dev/sdk';
 import { KbOrgOverlayFanoutPayload } from '@ever-works/agent/tasks';
 import { KnowledgeBaseGitMirrorService } from '@ever-works/agent/services';
 import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 
 /**
@@ -38,6 +39,33 @@ export const kbOrgOverlayFanoutTask = task<'kb-org-overlay-fanout', KbOrgOverlay
     run: async (payload) => {
         return withWorkerContext('KbOrgOverlayFanout', async (appContext) => {
             await appContext.get(TriggerPluginHydratorService).initialize();
+
+            // EW-742 P3.2 T22 — see kb-embed-document.task.ts for the
+            // pattern. Org-scope variant: resolves tenantId via the
+            // OWNING ORGANIZATION's tenantId (an org belongs to exactly
+            // one tenant so the fanout has a single unambiguous tenant
+            // scope even though it targets multiple Works).
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForOrganization(payload, payload.organizationId);
+            if (binding.status === 'drained') {
+                logger.warn('kb-org-overlay-fanout: credentials drained, skipping run', {
+                    organizationId: payload.organizationId,
+                    documentId: payload.documentId,
+                    operation: payload.operation,
+                    workCount: payload.workIds.length,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                return {
+                    status: 'skipped' as const,
+                    reason: 'credentials-drained' as const,
+                    organizationId: payload.organizationId,
+                    documentId: payload.documentId,
+                };
+            }
+
             const mirror = appContext.get(KnowledgeBaseGitMirrorService);
 
             let succeeded = 0;

--- a/packages/tasks/src/tasks/trigger/template-customization.task.ts
+++ b/packages/tasks/src/tasks/trigger/template-customization.task.ts
@@ -1,7 +1,8 @@
-import { task } from '@trigger.dev/sdk';
+import { logger, task } from '@trigger.dev/sdk';
 import { TemplateCustomizationPayload } from '@ever-works/agent/tasks';
 import { TemplateCustomizationService } from '@ever-works/agent/template-catalog';
 import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 
 export const templateCustomizationTask = task<
@@ -13,6 +14,28 @@ export const templateCustomizationTask = task<
     run: async (payload) => {
         return withWorkerContext('TemplateCustomization', async (appContext) => {
             await appContext.get(TriggerPluginHydratorService).initialize();
+
+            // EW-742 P3.2 T22 — customization-scoped variant: resolves
+            // tenantId via the TemplateCustomization row (carries
+            // `tenantId` directly). See kb-embed-document.task.ts for
+            // the full pattern rationale.
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForCustomization(payload, payload.customizationId);
+            if (binding.status === 'drained') {
+                logger.warn('template-customization: credentials drained, skipping run', {
+                    customizationId: payload.customizationId,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                return {
+                    status: 'skipped' as const,
+                    reason: 'credentials-drained' as const,
+                    customizationId: payload.customizationId,
+                };
+            }
+
             const service = appContext.get(TemplateCustomizationService);
             await service.execute(payload.customizationId);
             return { status: 'completed', customizationId: payload.customizationId };

--- a/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { WorkOperationsService } from '@ever-works/agent/work-operations';
 import {
+    OrganizationRepository,
     TemplateRepository,
     TemplateCustomizationRepository,
     UserRepository,
@@ -104,6 +105,14 @@ import { TriggerImportOrchestrator } from '../orchestrators/trigger-import.orche
             provide: CredentialVersionService,
             useFactory: (apiClient: TriggerInternalApiClient) =>
                 createRemoteProxy(apiClient, 'CredentialVersionService'),
+            inject: [TriggerInternalApiClient],
+        },
+        // EW-742 P3.2 T22 — OrganizationRepository proxied for
+        // resolveForOrganization (kb-org-overlay-fanout task).
+        {
+            provide: OrganizationRepository,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'OrganizationRepository'),
             inject: [TriggerInternalApiClient],
         },
         CategoryIconService,

--- a/packages/tasks/src/trigger/worker/services/__tests__/tenant-runtime-binding-resolver.service.spec.ts
+++ b/packages/tasks/src/trigger/worker/services/__tests__/tenant-runtime-binding-resolver.service.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { WorkRepository } from '@ever-works/agent/database';
+import type {
+    OrganizationRepository,
+    TemplateCustomizationRepository,
+    WorkRepository,
+} from '@ever-works/agent/database';
 import type { CredentialVersionService } from '@ever-works/agent/tasks';
 import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
 import { TenantRuntimeBindingResolverService } from '../tenant-runtime-binding-resolver.service';
@@ -194,6 +198,146 @@ describe('TenantRuntimeBindingResolverService (EW-742 P3.2 T22 worker-host)', ()
         it('passes through the pre-T22 no-binding when payload lacks the pair', async () => {
             const r = buildResolver({ workTenantId: TENANT_ID });
             const out = await r.resolveForWork({}, WORK_ID);
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+    });
+
+    // EW-742 P3.2 T22 — non-workId convenience wrappers.
+    describe('resolveForOrganization()', () => {
+        const ORG_ID = '22222222-2222-2222-2222-222222222222';
+        const SNAPSHOT = {
+            tenantId: TENANT_ID,
+            providerId: 'trigger',
+            credentialVersion: 5,
+            mode: 'byo',
+            enabled: true,
+        } as TenantJobRuntimeConfig;
+
+        function build(opts: {
+            orgTenantId?: string | null;
+            orgFindThrows?: boolean;
+            omitOrgRepository?: boolean;
+            snapshot?: TenantJobRuntimeConfig | null;
+        }) {
+            const credentialVersionService = {
+                resolveSnapshot: vi.fn().mockResolvedValue(opts.snapshot ?? null),
+            } as unknown as CredentialVersionService;
+            const orgRepository = {
+                findById: opts.orgFindThrows
+                    ? vi.fn().mockRejectedValue(new Error('db boom'))
+                    : vi.fn().mockResolvedValue(
+                          opts.orgTenantId === undefined
+                              ? null
+                              : ({ id: ORG_ID, tenantId: opts.orgTenantId } as any),
+                      ),
+            } as unknown as OrganizationRepository;
+            return new TenantRuntimeBindingResolverService(
+                credentialVersionService,
+                undefined,
+                opts.omitOrgRepository ? undefined : orgRepository,
+                undefined,
+            );
+        }
+
+        it('resolves snapshot via org → tenantId', async () => {
+            const r = build({ orgTenantId: TENANT_ID, snapshot: SNAPSHOT });
+            const out = await r.resolveForOrganization(
+                { providerId: 'trigger', credentialVersion: 5 },
+                ORG_ID,
+            );
+            expect(out.status).toBe('resolved');
+            expect(out.tenantId).toBe(TENANT_ID);
+        });
+
+        it('returns "no-binding" when OrganizationRepository is not wired', async () => {
+            const r = build({ omitOrgRepository: true });
+            const out = await r.resolveForOrganization(
+                { providerId: 'trigger', credentialVersion: 5 },
+                ORG_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when OrganizationRepository.findById throws', async () => {
+            const r = build({ orgFindThrows: true });
+            const out = await r.resolveForOrganization(
+                { providerId: 'trigger', credentialVersion: 5 },
+                ORG_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when org has no tenantId', async () => {
+            const r = build({ orgTenantId: null });
+            const out = await r.resolveForOrganization(
+                { providerId: 'trigger', credentialVersion: 5 },
+                ORG_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+    });
+
+    describe('resolveForCustomization()', () => {
+        const CUST_ID = '33333333-3333-3333-3333-333333333333';
+        const SNAPSHOT = {
+            tenantId: TENANT_ID,
+            providerId: 'trigger',
+            credentialVersion: 5,
+            mode: 'override',
+            enabled: true,
+        } as TenantJobRuntimeConfig;
+
+        function build(opts: {
+            rowTenantId?: string | null;
+            rowFindThrows?: boolean;
+            omitRepository?: boolean;
+            snapshot?: TenantJobRuntimeConfig | null;
+        }) {
+            const credentialVersionService = {
+                resolveSnapshot: vi.fn().mockResolvedValue(opts.snapshot ?? null),
+            } as unknown as CredentialVersionService;
+            const repo = {
+                findById: opts.rowFindThrows
+                    ? vi.fn().mockRejectedValue(new Error('db boom'))
+                    : vi.fn().mockResolvedValue(
+                          opts.rowTenantId === undefined
+                              ? null
+                              : ({ id: CUST_ID, tenantId: opts.rowTenantId } as any),
+                      ),
+            } as unknown as TemplateCustomizationRepository;
+            return new TenantRuntimeBindingResolverService(
+                credentialVersionService,
+                undefined,
+                undefined,
+                opts.omitRepository ? undefined : repo,
+            );
+        }
+
+        it('resolves snapshot via customization row → tenantId', async () => {
+            const r = build({ rowTenantId: TENANT_ID, snapshot: SNAPSHOT });
+            const out = await r.resolveForCustomization(
+                { providerId: 'trigger', credentialVersion: 5 },
+                CUST_ID,
+            );
+            expect(out.status).toBe('resolved');
+            expect(out.tenantId).toBe(TENANT_ID);
+        });
+
+        it('returns "no-binding" when TemplateCustomizationRepository is not wired', async () => {
+            const r = build({ omitRepository: true });
+            const out = await r.resolveForCustomization(
+                { providerId: 'trigger', credentialVersion: 5 },
+                CUST_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when findById throws', async () => {
+            const r = build({ rowFindThrows: true });
+            const out = await r.resolveForCustomization(
+                { providerId: 'trigger', credentialVersion: 5 },
+                CUST_ID,
+            );
             expect(out).toEqual({ status: 'no-binding' });
         });
     });

--- a/packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts
+++ b/packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
-import { WorkRepository } from '@ever-works/agent/database';
+import {
+    OrganizationRepository,
+    TemplateCustomizationRepository,
+    WorkRepository,
+} from '@ever-works/agent/database';
 import { CredentialVersionService } from '@ever-works/agent/tasks';
 import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
 
@@ -75,6 +79,9 @@ export class TenantRuntimeBindingResolverService {
     constructor(
         @Optional() private readonly credentialVersionService?: CredentialVersionService,
         @Optional() private readonly workRepository?: WorkRepository,
+        @Optional() private readonly organizationRepository?: OrganizationRepository,
+        @Optional()
+        private readonly templateCustomizationRepository?: TemplateCustomizationRepository,
     ) {}
 
     /**
@@ -190,6 +197,60 @@ export class TenantRuntimeBindingResolverService {
             this.logger.debug(
                 `TenantRuntimeBindingResolver.resolveForWork: workRepository.findById ` +
                     `threw for work=${workId} (${(err as Error).message}); treating as no-binding.`,
+            );
+            return { status: 'no-binding' };
+        }
+        return this.resolve(payload, tenantId);
+    }
+
+    /**
+     * Convenience wrapper for organizationId-scoped tasks (kb-org-overlay-
+     * fanout). An organization belongs to exactly one tenant, so the fanout
+     * (which targets multiple Works in that org) still has a single
+     * unambiguous tenant scope. Resolves the Org's `tenantId` via
+     * OrganizationRepository.findById, then delegates to {@link resolve}.
+     */
+    async resolveForOrganization(
+        payload: { providerId?: string | null; credentialVersion?: number | null },
+        organizationId: string,
+    ): Promise<Awaited<ReturnType<TenantRuntimeBindingResolverService['resolve']>>> {
+        if (!this.organizationRepository) {
+            return { status: 'no-binding' };
+        }
+        let tenantId: string | null = null;
+        try {
+            const org = await this.organizationRepository.findById(organizationId);
+            tenantId = org?.tenantId ?? null;
+        } catch (err) {
+            this.logger.debug(
+                `TenantRuntimeBindingResolver.resolveForOrganization: organizationRepository.findById ` +
+                    `threw for org=${organizationId} (${(err as Error).message}); treating as no-binding.`,
+            );
+            return { status: 'no-binding' };
+        }
+        return this.resolve(payload, tenantId);
+    }
+
+    /**
+     * Convenience wrapper for customizationId-scoped tasks (template-
+     * customization). The TemplateCustomization row carries `tenantId`
+     * directly; look it up and delegate.
+     */
+    async resolveForCustomization(
+        payload: { providerId?: string | null; credentialVersion?: number | null },
+        customizationId: string,
+    ): Promise<Awaited<ReturnType<TenantRuntimeBindingResolverService['resolve']>>> {
+        if (!this.templateCustomizationRepository) {
+            return { status: 'no-binding' };
+        }
+        let tenantId: string | null = null;
+        try {
+            const row = await this.templateCustomizationRepository.findById(customizationId);
+            tenantId = row?.tenantId ?? null;
+        } catch (err) {
+            this.logger.debug(
+                `TenantRuntimeBindingResolver.resolveForCustomization: templateCustomizationRepository.findById ` +
+                    `threw for customization=${customizationId} (${(err as Error).message}); treating as no-binding.`,
             );
             return { status: 'no-binding' };
         }


### PR DESCRIPTION
## Summary

Closes the remaining 2 non-workId Trigger.dev tasks that had dispatcher-side T22 stamping (PRs #1430 + #1431) but no worker-side consumption.

## What this PR does

1. **Extends `TenantRuntimeBindingResolverService`** with two new convenience wrappers:
   - `resolveForOrganization(payload, organizationId)` — looks up tenantId via `OrganizationRepository.findById`.
   - `resolveForCustomization(payload, customizationId)` — looks up tenantId via `TemplateCustomizationRepository.findById`.

2. **Wires the 2 remaining tasks**:
   - `kb-org-overlay-fanout.task.ts` → `resolveForOrganization`
   - `template-customization.task.ts` → `resolveForCustomization`

   Both branch on `binding.status === 'drained'` → skip-and-ack with `reason='credentials-drained'` + structured warn log. Other statuses fall through to the legacy code path (byte-identical pre-T22).

3. **Exposes `OrganizationRepository` through the internal RPC proxy**:
   - Adds `OrganizationsModule` import to `TriggerInternalModule`.
   - Adds `OrganizationRepository` to `OrganizationsModule` exports.
   - Registers it in `TriggerInternalController.remoteMap` as `'OrganizationRepository'`.
   - Adds the worker-side proxy provider in `TriggerWorkerModule`.

   (`TemplateCustomizationRepository` was already proxied — no API change needed for it.)

## Tests

7 new vitest cases on `TenantRuntimeBindingResolverService`:
- `resolveForOrganization`: 4 (happy + 3 fail-open paths)
- `resolveForCustomization`: 3 (happy + 2 fail-open paths)

All **20 resolver tests pass**; agent + tasks builds clean; API type-check clean.

## Closes the dispatcher-↔-task loop

After this PR every dispatcher in the agent + tasks packages that got stamped (PRs #1427 / #1430 / #1431 / #1436) has its corresponding worker-side consumer (PRs #1435 / #1439 / this PR). **8 dispatchers, 8 consumer paths** — same `skip-and-ack on drained` + fail-open pattern across all of them.

## Still genuinely out of scope (different package ownership)

- `KB_REEMBED_WORK_DISPATCHER` → pgvector plugin
- `KB_BACKFILL_SKELETON_DISPATCHER` → unimplemented call site
- `WEBHOOK_DELIVERY_DISPATCHER` → `apps/api/src/webhooks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)