### PR TITLE
chore(release): cascade EW-742 P3.2 T22 WEBHOOK_DELIVERY wiring (develop → stage)

### DIFF
--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -26,6 +26,7 @@ import {
     TemplateCustomizationRepository,
     UserTemplatePreferenceRepository,
     UserRepository,
+    WebhookSubscriptionRepository,
     WorkKnowledgeDocumentRepository,
 } from '@ever-works/agent/database';
 import { Work, User } from '@ever-works/agent/entities';
@@ -228,6 +229,10 @@ export class TriggerInternalController implements OnModuleInit {
         // an org's tenantId for kb-org-overlay-fanout (the only org-
         // scoped dispatcher today).
         private readonly organizationRepository: OrganizationRepository,
+        // EW-742 P3.2 T22 — exposes WebhookSubscriptionRepository so
+        // the worker-side resolver can derive tenantId for the
+        // webhook-delivery task.
+        private readonly webhookSubscriptionRepository: WebhookSubscriptionRepository,
         @Optional()
         @Inject(forwardRef(() => WorkProposalsApiService))
         private readonly workProposalsApiService?: WorkProposalsApiService,
@@ -277,6 +282,9 @@ export class TriggerInternalController implements OnModuleInit {
             // EW-742 P3.2 T22 — exposed for resolveForOrganization on
             // the worker-host resolver (kb-org-overlay-fanout task).
             OrganizationRepository: this.organizationRepository,
+            // EW-742 P3.2 T22 — exposed for resolveForSubscription on
+            // the worker-host resolver (webhook-delivery task).
+            WebhookSubscriptionRepository: this.webhookSubscriptionRepository,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/apps/api/src/trigger/trigger-internal.module.ts
+++ b/apps/api/src/trigger/trigger-internal.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { DatabaseModule } from '@ever-works/agent/database';
 import { TriggerInternalController } from './trigger-internal.controller';
 import { WorkOperationsModule } from '@ever-works/agent/work-operations';
 import { KnowledgeBaseModule, WorkModule } from '@ever-works/agent/services';
@@ -14,6 +15,11 @@ import { OrganizationsModule } from '../organizations/organizations.module';
 
 @Module({
     imports: [
+        // EW-742 P3.2 T22 — DatabaseModule exports
+        // WebhookSubscriptionRepository (proxied through the
+        // remote-proxy controller for the webhook-delivery task's
+        // resolveForSubscription path).
+        DatabaseModule,
         WorkOperationsModule,
         WorkModule,
         NotificationsModule,

--- a/apps/api/src/webhooks/webhook-event-dispatcher.service.ts
+++ b/apps/api/src/webhooks/webhook-event-dispatcher.service.ts
@@ -9,6 +9,7 @@ import {
     WebhookDeliveryPayload,
     WebhookDeliveryDispatcher,
     WEBHOOK_DELIVERY_DISPATCHER,
+    RuntimeBindingStamperService,
 } from '@ever-works/agent/tasks';
 import {
     WorkCreatedEvent,
@@ -51,7 +52,38 @@ export class WebhookEventDispatcherService {
         @Optional()
         @Inject(WEBHOOK_DELIVERY_DISPATCHER)
         private readonly remoteDispatcher: WebhookDeliveryDispatcher | null = null,
+        // EW-742 P3.2 T22 — enqueue-site tenant runtime binding capture.
+        // Optional so isolated unit tests and pre-overlay deployments
+        // keep constructing — when absent, payload ships null/null and
+        // the worker falls back to the instance default.
+        @Optional()
+        private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
     ) {}
+
+    /**
+     * EW-742 P3.2 T22 — resolve `(providerId, credentialVersion)` for
+     * the worker host via the owning subscription's `tenantId`. Fail-
+     * open per FR-5: any missing dep / lookup error ships null/null
+     * and the worker falls back to the instance default (byte-identical
+     * pre-T22 path).
+     */
+    private async stampForSubscription(
+        subscriptionId: string,
+    ): Promise<{ providerId: string | null; credentialVersion: number | null }> {
+        if (!this.runtimeBindingStamper) {
+            return { providerId: null, credentialVersion: null };
+        }
+        try {
+            const sub = await this.subscriptions.findById(subscriptionId);
+            return await this.runtimeBindingStamper.stamp(sub?.tenantId ?? null);
+        } catch (err) {
+            this.logger.debug(
+                `webhook-delivery: stamper lookup failed for subscription=${subscriptionId} ` +
+                    `(${(err as Error).message}); falling back to instance default.`,
+            );
+            return { providerId: null, credentialVersion: null };
+        }
+    }
 
     @OnEvent(WorkCreatedEvent.EVENT_NAME)
     async onWorkCreated(event: WorkCreatedEvent): Promise<void> {
@@ -251,8 +283,20 @@ export class WebhookEventDispatcherService {
      * configured (or the dispatch threw).
      */
     private async enqueue(payload: WebhookDeliveryPayload): Promise<string | null> {
+        // EW-742 P3.2 T22 — stamp `(providerId, credentialVersion)` for
+        // the worker host's resolveSnapshot lookup. Resolved from the
+        // owning subscription's `tenantId`. Threaded only into the
+        // remote-dispatcher path (the in-process fallback runs in the
+        // API process and uses the instance default credentials by
+        // construction; no payload-borne hint needed).
+        const binding = await this.stampForSubscription(payload.subscriptionId);
+        const stampedPayload: WebhookDeliveryPayload = {
+            ...payload,
+            providerId: binding.providerId,
+            credentialVersion: binding.credentialVersion,
+        };
         if (this.remoteDispatcher) {
-            const runId = await this.remoteDispatcher.dispatchWebhookDelivery(payload);
+            const runId = await this.remoteDispatcher.dispatchWebhookDelivery(stampedPayload);
             if (runId) {
                 // EW-634 Codex P2 follow-up: persist the Trigger run id
                 // on the pending delivery row immediately so the

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -15,6 +15,7 @@ import { WebhooksService } from './webhooks.service';
 import { WebhookSecretService } from './webhook-secret.service';
 import { WebhookEventDispatcherService } from './webhook-event-dispatcher.service';
 import { WebhooksDeliveriesService } from './webhooks-deliveries.service';
+import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
 
 /**
  * `/api/webhooks` surface — subscriptions CRUD, delivery test-fire,
@@ -33,7 +34,15 @@ import { WebhooksDeliveriesService } from './webhooks-deliveries.service';
  *    delivery when Trigger.dev is unconfigured.
  */
 @Module({
-    imports: [DatabaseModule, AuthModule, TasksTriggerModule, WorkModule],
+    imports: [
+        DatabaseModule,
+        AuthModule,
+        TasksTriggerModule,
+        WorkModule,
+        // EW-742 P3.2 T22 — RuntimeBindingStamperService for the
+        // WebhookEventDispatcherService enqueue-site stamping.
+        TenantJobRuntimeModule,
+    ],
     controllers: [WebhooksController],
     providers: [
         WebhooksService,

--- a/packages/agent/src/tasks/webhook-delivery.types.ts
+++ b/packages/agent/src/tasks/webhook-delivery.types.ts
@@ -27,4 +27,13 @@ export interface WebhookDeliveryPayload {
 
     /** Raw JSON payload that will be signed and POSTed verbatim. */
     readonly payload: Record<string, unknown>;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * Resolved from the owning `WebhookSubscription.tenantId`. See
+     * `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }

--- a/packages/tasks/src/tasks/trigger/webhook-delivery.task.ts
+++ b/packages/tasks/src/tasks/trigger/webhook-delivery.task.ts
@@ -1,8 +1,9 @@
-import { task } from '@trigger.dev/sdk';
+import { logger, task } from '@trigger.dev/sdk';
 import { NestFactory } from '@nestjs/core';
 import type { WebhookDeliveryPayload } from '@ever-works/agent/tasks';
 import { WebhookSubscriptionDeliveryService } from '@ever-works/agent/services';
 import { TriggerWebhookDeliveryModule } from '../../trigger/worker/modules/trigger-webhook-delivery.module';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { createTriggerLogger } from '../../trigger/worker/trigger-logger';
 
 /**
@@ -54,6 +55,34 @@ export const webhookDeliveryTask = task<'webhook-delivery', WebhookDeliveryPaylo
         appContext.useLogger(createTriggerLogger('WebhookDelivery'));
 
         try {
+            // EW-742 P3.2 T22 — see kb-embed-document.task.ts for the
+            // pattern. Subscription-scoped variant: resolves tenantId
+            // via the owning WebhookSubscription row. Webhook delivery
+            // is idempotent at the (delivery_id, attempt) grain — a
+            // drained skip-and-ack is safe; the operator can issue a
+            // redeliver against fresh credentials via the deliveries
+            // API once the rotation completes.
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForSubscription(payload, payload.subscriptionId);
+            if (binding.status === 'drained') {
+                logger.warn('webhook-delivery: credentials drained, skipping run', {
+                    deliveryId: payload.deliveryId,
+                    subscriptionId: payload.subscriptionId,
+                    eventName: payload.eventName,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                return {
+                    status: 'skipped' as const,
+                    reason: 'credentials-drained' as const,
+                    deliveryId: payload.deliveryId,
+                    subscriptionId: payload.subscriptionId,
+                    event: payload.eventName,
+                };
+            }
+
             const orchestrator = appContext.get(WebhookSubscriptionDeliveryService);
             // EW-634 Codex P2 follow-up: pass the Trigger run id through
             // to the orchestrator so the `webhook_deliveries.triggerRunId`

--- a/packages/tasks/src/trigger/worker/modules/trigger-webhook-delivery.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-webhook-delivery.module.ts
@@ -5,6 +5,8 @@ import {
     WebhookSubscriptionDeliveryService,
     WebhookSubscriptionSecretService,
 } from '@ever-works/agent/services';
+import { CredentialVersionService } from '@ever-works/agent/tasks';
+import { TenantRuntimeBindingResolverService } from '../services/tenant-runtime-binding-resolver.service';
 
 /**
  * Minimal NestJS module booted inside the Trigger.dev webhook-delivery
@@ -16,6 +18,16 @@ import {
  * The decryptor wiring is done in `onModuleInit` so the orchestrator
  * service has `WebhookSubscriptionSecretService.decrypt` registered
  * before the first dispatch.
+ *
+ * # EW-742 P3.2 T22 — direct (non-proxied) wiring
+ *
+ * Unlike `TriggerWorkerModule`, this module imports `DatabaseModule`
+ * directly so the resolver service uses the real `WebhookSubscription-
+ * Repository` + `CredentialVersionService` instead of an RPC proxy.
+ * The webhook-delivery worker already shares the same database as the
+ * API (it has to — `WebhookSubscriptionDeliveryService` reads the
+ * subscription row directly), so layering an RPC proxy on top would
+ * just add a network hop with zero correctness benefit.
  */
 @Module({
     imports: [DatabaseModule],
@@ -23,11 +35,16 @@ import {
         WebhookDeliveryService,
         WebhookSubscriptionDeliveryService,
         WebhookSubscriptionSecretService,
+        // EW-742 P3.2 T22 — `(providerId, credentialVersion)` lookup +
+        // 4-state binding classifier for the webhook-delivery task.
+        CredentialVersionService,
+        TenantRuntimeBindingResolverService,
     ],
     exports: [
         WebhookDeliveryService,
         WebhookSubscriptionDeliveryService,
         WebhookSubscriptionSecretService,
+        TenantRuntimeBindingResolverService,
     ],
 })
 export class TriggerWebhookDeliveryModule implements OnModuleInit {

--- a/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts
@@ -6,6 +6,7 @@ import {
     TemplateCustomizationRepository,
     UserRepository,
     UserTemplatePreferenceRepository,
+    WebhookSubscriptionRepository,
     WorkKnowledgeDocumentRepository,
     WorkRepository,
 } from '@ever-works/agent/database';
@@ -113,6 +114,14 @@ import { TriggerImportOrchestrator } from '../orchestrators/trigger-import.orche
             provide: OrganizationRepository,
             useFactory: (apiClient: TriggerInternalApiClient) =>
                 createRemoteProxy(apiClient, 'OrganizationRepository'),
+            inject: [TriggerInternalApiClient],
+        },
+        // EW-742 P3.2 T22 — WebhookSubscriptionRepository proxied for
+        // resolveForSubscription (webhook-delivery task).
+        {
+            provide: WebhookSubscriptionRepository,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'WebhookSubscriptionRepository'),
             inject: [TriggerInternalApiClient],
         },
         CategoryIconService,

--- a/packages/tasks/src/trigger/worker/services/__tests__/tenant-runtime-binding-resolver.service.spec.ts
+++ b/packages/tasks/src/trigger/worker/services/__tests__/tenant-runtime-binding-resolver.service.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type {
     OrganizationRepository,
     TemplateCustomizationRepository,
+    WebhookSubscriptionRepository,
     WorkRepository,
 } from '@ever-works/agent/database';
 import type { CredentialVersionService } from '@ever-works/agent/tasks';
@@ -272,6 +273,81 @@ describe('TenantRuntimeBindingResolverService (EW-742 P3.2 T22 worker-host)', ()
             const out = await r.resolveForOrganization(
                 { providerId: 'trigger', credentialVersion: 5 },
                 ORG_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+    });
+
+    describe('resolveForSubscription()', () => {
+        const SUB_ID = '44444444-4444-4444-4444-444444444444';
+        const SNAPSHOT = {
+            tenantId: TENANT_ID,
+            providerId: 'trigger',
+            credentialVersion: 5,
+            mode: 'byo',
+            enabled: true,
+        } as TenantJobRuntimeConfig;
+
+        function build(opts: {
+            subTenantId?: string | null;
+            subFindThrows?: boolean;
+            omitRepository?: boolean;
+            snapshot?: TenantJobRuntimeConfig | null;
+        }) {
+            const credentialVersionService = {
+                resolveSnapshot: vi.fn().mockResolvedValue(opts.snapshot ?? null),
+            } as unknown as CredentialVersionService;
+            const subRepository = {
+                findById: opts.subFindThrows
+                    ? vi.fn().mockRejectedValue(new Error('db boom'))
+                    : vi.fn().mockResolvedValue(
+                          opts.subTenantId === undefined
+                              ? null
+                              : ({ id: SUB_ID, tenantId: opts.subTenantId } as any),
+                      ),
+            } as unknown as WebhookSubscriptionRepository;
+            return new TenantRuntimeBindingResolverService(
+                credentialVersionService,
+                undefined,
+                undefined,
+                undefined,
+                opts.omitRepository ? undefined : subRepository,
+            );
+        }
+
+        it('resolves snapshot via subscription → tenantId', async () => {
+            const r = build({ subTenantId: TENANT_ID, snapshot: SNAPSHOT });
+            const out = await r.resolveForSubscription(
+                { providerId: 'trigger', credentialVersion: 5 },
+                SUB_ID,
+            );
+            expect(out.status).toBe('resolved');
+            expect(out.tenantId).toBe(TENANT_ID);
+        });
+
+        it('returns "no-binding" when WebhookSubscriptionRepository is not wired', async () => {
+            const r = build({ omitRepository: true });
+            const out = await r.resolveForSubscription(
+                { providerId: 'trigger', credentialVersion: 5 },
+                SUB_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when findById throws', async () => {
+            const r = build({ subFindThrows: true });
+            const out = await r.resolveForSubscription(
+                { providerId: 'trigger', credentialVersion: 5 },
+                SUB_ID,
+            );
+            expect(out).toEqual({ status: 'no-binding' });
+        });
+
+        it('returns "no-binding" when subscription has no tenantId', async () => {
+            const r = build({ subTenantId: null });
+            const out = await r.resolveForSubscription(
+                { providerId: 'trigger', credentialVersion: 5 },
+                SUB_ID,
             );
             expect(out).toEqual({ status: 'no-binding' });
         });

--- a/packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts
+++ b/packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import {
     OrganizationRepository,
     TemplateCustomizationRepository,
+    WebhookSubscriptionRepository,
     WorkRepository,
 } from '@ever-works/agent/database';
 import { CredentialVersionService } from '@ever-works/agent/tasks';
@@ -82,6 +83,8 @@ export class TenantRuntimeBindingResolverService {
         @Optional() private readonly organizationRepository?: OrganizationRepository,
         @Optional()
         private readonly templateCustomizationRepository?: TemplateCustomizationRepository,
+        @Optional()
+        private readonly webhookSubscriptionRepository?: WebhookSubscriptionRepository,
     ) {}
 
     /**
@@ -225,6 +228,33 @@ export class TenantRuntimeBindingResolverService {
             this.logger.debug(
                 `TenantRuntimeBindingResolver.resolveForOrganization: organizationRepository.findById ` +
                     `threw for org=${organizationId} (${(err as Error).message}); treating as no-binding.`,
+            );
+            return { status: 'no-binding' };
+        }
+        return this.resolve(payload, tenantId);
+    }
+
+    /**
+     * Convenience wrapper for subscriptionId-scoped tasks (webhook-
+     * delivery). The WebhookSubscription row carries `tenantId`
+     * directly; look it up and delegate.
+     */
+    async resolveForSubscription(
+        payload: { providerId?: string | null; credentialVersion?: number | null },
+        subscriptionId: string,
+    ): Promise<Awaited<ReturnType<TenantRuntimeBindingResolverService['resolve']>>> {
+        if (!this.webhookSubscriptionRepository) {
+            return { status: 'no-binding' };
+        }
+        let tenantId: string | null = null;
+        try {
+            const sub = await this.webhookSubscriptionRepository.findById(subscriptionId);
+            tenantId = sub?.tenantId ?? null;
+        } catch (err) {
+            this.logger.debug(
+                `TenantRuntimeBindingResolver.resolveForSubscription: webhookSubscriptionRepository.findById ` +
+                    `threw for subscription=${subscriptionId} (${(err as Error).message}); ` +
+                    `treating as no-binding.`,
             );
             return { status: 'no-binding' };
         }


### PR DESCRIPTION
Cascades #1445 (WEBHOOK_DELIVERY producer + worker stamping/consumption) develop → stage. All 9 in-platform dispatchers now have closed dispatcher↔task T22 loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)