### PR TITLE
feat(pgvector,api): EW-742 P3.2 T22 — wire KB_REEMBED_WORK dispatcher + task

### DIFF
--- a/apps/api/src/works/works.module.ts
+++ b/apps/api/src/works/works.module.ts
@@ -16,6 +16,7 @@ import {
     KB_NORMALIZE_MEDIA_DISPATCHER,
     KB_REEMBED_WORK_DISPATCHER,
     KB_TRANSCRIBE_DISPATCHER,
+    RuntimeBindingStamperService,
     type KbNormalizeMediaDispatcher,
     type KbNormalizeMediaPayload,
     type KbReembedWorkDispatcher,
@@ -23,6 +24,8 @@ import {
     type KbTranscribeDispatcher,
     type KbTranscribePayload,
 } from '@ever-works/agent/tasks';
+import { WorkRepository } from '@ever-works/agent/database';
+import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
 
 // Controllers
 import { WorksController } from './works.controller';
@@ -58,6 +61,9 @@ import { WorkScheduleDispatcherCronService } from './tasks/work-schedule-dispatc
         // tenant-ownership guard OrgKbController uses to authorize its
         // raw `/api/organizations/:orgId/...` routes.
         OrganizationsModule,
+        // EW-742 P3.2 T22 — RuntimeBindingStamperService for the
+        // KB_REEMBED_WORK_DISPATCHER factory's enqueue-site stamping.
+        TenantJobRuntimeModule,
     ],
     providers: [
         CacheEntryRepository,
@@ -157,11 +163,42 @@ import { WorkScheduleDispatcherCronService } from './tasks/work-schedule-dispatc
         // can surface them as a workbench banner.
         {
             provide: KB_REEMBED_WORK_DISPATCHER,
-            useFactory: (): KbReembedWorkDispatcher => {
+            // EW-742 P3.2 T22 — stamp `(providerId, credentialVersion)`
+            // onto the payload before forwarding to Trigger.dev. The
+            // pgvector plugin call site has no tenant context (it's a
+            // vendor-agnostic vector store), so the stamping happens
+            // here in the host adapter where the WorkRepository +
+            // stamper are reachable. Fail-open per FR-5.
+            inject: [WorkRepository, RuntimeBindingStamperService],
+            useFactory: (
+                workRepository: WorkRepository,
+                stamper: RuntimeBindingStamperService,
+            ): KbReembedWorkDispatcher => {
+                const factoryLogger = new Logger('KbReembedWorkDispatcher');
                 return {
                     async dispatchKbReembedWork(payload: KbReembedWorkPayload): Promise<string> {
+                        let providerId = payload.providerId ?? null;
+                        let credentialVersion = payload.credentialVersion ?? null;
+                        if (providerId === null && credentialVersion === null) {
+                            try {
+                                const work = await workRepository.findById(payload.workId);
+                                const binding = await stamper.stamp(work?.tenantId ?? null);
+                                providerId = binding.providerId;
+                                credentialVersion = binding.credentialVersion;
+                            } catch (err) {
+                                factoryLogger.debug(
+                                    `dispatchKbReembedWork: stamper lookup failed for work=${payload.workId} ` +
+                                        `(${(err as Error).message}); falling back to instance default.`,
+                                );
+                            }
+                        }
+                        const stamped: KbReembedWorkPayload = {
+                            ...payload,
+                            providerId,
+                            credentialVersion,
+                        };
                         const { tasks } = await import('@trigger.dev/sdk');
-                        const handle = await tasks.trigger('kb-reembed-work', payload);
+                        const handle = await tasks.trigger('kb-reembed-work', stamped);
                         return handle.id;
                     },
                 };

--- a/packages/agent/src/tasks/kb-reembed-work.types.ts
+++ b/packages/agent/src/tasks/kb-reembed-work.types.ts
@@ -39,4 +39,12 @@ export interface KbReembedWorkPayload {
      * is still detected by a future sweep).
      */
     readonly newDims: number;
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
 }

--- a/packages/plugins/pgvector/src/pgvector.plugin.ts
+++ b/packages/plugins/pgvector/src/pgvector.plugin.ts
@@ -155,6 +155,18 @@ export interface PgVectorReembedDispatcher {
 		readonly previousModel: string;
 		readonly newModel: string;
 		readonly newDims: number;
+		/**
+		 * EW-742 P3.2 T22 — optional enqueue-site tenant runtime
+		 * binding capture. The pgvector plugin itself has no tenant
+		 * context (it's a vendor-agnostic vector store) — it forwards
+		 * `null/null` and lets the host's `KbReembedWorkDispatcher`
+		 * adapter stamp the real values via `RuntimeBindingStamper-
+		 * Service.stamp(work.tenantId)` before passing to Trigger.dev.
+		 *
+		 * Same null/null fail-open semantics as every other T22 site.
+		 */
+		readonly providerId?: string | null;
+		readonly credentialVersion?: number | null;
 	}): Promise<string>;
 }
 

--- a/packages/tasks/src/tasks/trigger/kb-reembed-work.task.ts
+++ b/packages/tasks/src/tasks/trigger/kb-reembed-work.task.ts
@@ -2,6 +2,7 @@ import { logger, task } from '@trigger.dev/sdk';
 import { KbReembedWorkPayload } from '@ever-works/agent/tasks';
 import { KnowledgeBaseReembedService } from '@ever-works/agent/services';
 import { TriggerPluginHydratorService } from '../../trigger/worker/services/trigger-plugin-hydrator.service';
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 
 /**
@@ -43,6 +44,34 @@ export const kbReembedWorkTask = task<'kb-reembed-work', KbReembedWorkPayload>({
     run: async (payload) => {
         return withWorkerContext('KbReembedWork', async (appContext) => {
             await appContext.get(TriggerPluginHydratorService).initialize();
+
+            // EW-742 P3.2 T22 — see kb-embed-document.task.ts for the
+            // pattern. The kb-reembed-work sweep is idempotent at the
+            // (work, model-pair) grain (the service already skips
+            // coordinate rows already on `newModel`), so a drained
+            // skip-and-ack is safe — the operator can re-fire the
+            // model flip from the pgvector settings UI against fresh
+            // credentials, or the reconciliation cron (slice 5)
+            // catches the drift.
+            const binding = await appContext
+                .get(TenantRuntimeBindingResolverService)
+                .resolveForWork(payload, payload.workId);
+            if (binding.status === 'drained') {
+                logger.warn('kb-reembed-work: credentials drained, skipping run', {
+                    workId: payload.workId,
+                    previousModel: payload.previousModel,
+                    newModel: payload.newModel,
+                    providerId: binding.providerId,
+                    credentialVersion: binding.credentialVersion,
+                    tenantId: binding.tenantId,
+                });
+                return {
+                    status: 'skipped' as const,
+                    reason: 'credentials-drained' as const,
+                    workId: payload.workId,
+                };
+            }
+
             const svc = appContext.get(KnowledgeBaseReembedService);
             logger.info('kb-reembed-work starting', {
                 workId: payload.workId,


### PR DESCRIPTION
## Summary

Closes the last in-platform stamped dispatcher. KB_REEMBED_WORK now ships the same (providerId, credentialVersion) stamping + worker-side consumption as the other 9 dispatchers.

## What this PR does

1. **Extends `KbReembedWorkPayload` + `PgVectorReembedDispatcher`** payload shape with the optional T22 fields. The pgvector plugin itself has no tenant context (vendor-agnostic vector store), so the plugin just type-allows the optionals and forwards `null/null`.
2. **The apps/api `KB_REEMBED_WORK_DISPATCHER` factory becomes the stamping point**: now takes `WorkRepository` + `RuntimeBindingStamperService` via DI, resolves the Work's `tenantId`, calls `stamper.stamp(tenantId)`, and threads the result into the payload before calling `tasks.trigger('kb-reembed-work', ...)`. Fail-open per FR-5.
3. **`WorksModule` imports `TenantJobRuntimeModule`** so the stamper resolves at factory boot.
4. **The `kb-reembed-work.task.ts` worker** gets the standard 4-line `resolveForWork` + skip-and-ack-on-`drained` block. Re-embed is idempotent (service already skips coordinate rows already on `newModel`), so drained skip is safe — operator can re-fire the model flip after rotation completes.

## Tests

- 22/22 pgvector vitest cases green (existing tests; new optional fields are additive).
- Agent + pgvector + trigger-tasks builds clean.
- API type-check clean.

## Closes the dispatcher loop

After this PR all **10 stamped in-platform dispatchers** have producer-side stamping + worker-side consumption. `KB_BACKFILL_SKELETON_DISPATCHER` remains an unimplemented call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced knowledge base re-embedding with improved tenant-specific credential binding and tracking.

* **Bug Fixes**
  * System now gracefully skips re-embedding operations when associated credentials are unavailable, preventing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->