### PR TITLE
docs(ew-742): mark T22 per-dispatcher wiring DONE + add adoption runbook

### DIFF
--- a/docs/runbooks/T22_NEW_DISPATCHER_WIRING.md
+++ b/docs/runbooks/T22_NEW_DISPATCHER_WIRING.md
@@ -1,0 +1,212 @@
+# Adding a new dispatcher with T22 tenant runtime binding
+
+> **Audience**: engineers adding a new `*_DISPATCHER` symbol (or a new
+> Trigger.dev task) and want their enqueue → worker loop to participate
+> in the EW-742 P3.2 T22 tenant runtime binding capture.
+>
+> **Status**: the 10 in-platform dispatchers landed on `main` per the
+> table in `docs/specs/features/tenant-job-runtime-overlay/tasks.md`
+> § "T22 (per-dispatcher wiring)". This runbook is the copy-paste
+> template for dispatcher #11+.
+
+## Why T22
+
+The tenant-overlay system gives each tenant a `(providerId,
+credentialVersion)` snapshot of which job-runtime engine + credentials
+to use. T22 stamping captures that snapshot **at enqueue time** onto
+the run's payload, then the worker host resolves it at run time to
+either run with those credentials, skip-and-ack if the version was
+rotated past (`'drained'`), or fall back to the instance default.
+
+The whole loop is **fail-open per FR-5** — every absent dep / lookup
+error ships `null/null` and the worker runs against the instance
+default (byte-identical to the pre-overlay path).
+
+## The 4 ingredients
+
+| Ingredient | Where |
+|---|---|
+| Payload type | `packages/agent/src/tasks/<name>.types.ts` |
+| Dispatcher interface | `packages/agent/src/tasks/<name>-dispatcher.ts` |
+| Producer (enqueue site) | Wherever the service / event handler / API endpoint constructs the payload and calls `dispatcher.dispatch...()` |
+| Consumer (Trigger.dev task) | `packages/tasks/src/tasks/trigger/<name>.task.ts` |
+
+## Step 1 — extend the payload type
+
+```ts
+export interface Mb<Whatever>Payload {
+    readonly workId: string;  // or organizationId / customizationId / subscriptionId
+    // ... existing fields ...
+
+    /**
+     * EW-742 P3.2 T22 — enqueue-site tenant-runtime binding capture.
+     * See `KbEmbedDocumentPayload` (the PoC dispatcher) for the full
+     * contract; the same null/null fail-open semantics apply.
+     */
+    readonly providerId?: string | null;
+    readonly credentialVersion?: number | null;
+}
+```
+
+## Step 2 — wire stamper into the producer service
+
+Inject `RuntimeBindingStamperService` as `@Optional()` and the
+appropriate repository (`WorkRepository` / `OrganizationRepository` /
+`TemplateCustomizationRepository` / `WebhookSubscriptionRepository`)
+to resolve `tenantId` from the entity id on the payload:
+
+```ts
+constructor(
+    // ... existing ...
+    @Optional()
+    private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
+    @Optional()
+    private readonly workRepository?: WorkRepository,
+) {}
+
+private async stampForWork(workId: string) {
+    if (!this.runtimeBindingStamper || !this.workRepository) {
+        return { providerId: null, credentialVersion: null };
+    }
+    try {
+        const work = await this.workRepository.findById(workId);
+        return await this.runtimeBindingStamper.stamp(work?.tenantId ?? null);
+    } catch (err) {
+        this.logger.debug(
+            `dispatch<name>: stamper lookup failed for work=${workId} ` +
+                `(${(err as Error).message}); falling back to instance default.`,
+        );
+        return { providerId: null, credentialVersion: null };
+    }
+}
+```
+
+Then in the enqueue path:
+
+```ts
+const binding = await this.stampForWork(workId);
+await this.dispatcher.dispatch<Name>({
+    workId,
+    // ... existing ...
+    providerId: binding.providerId,
+    credentialVersion: binding.credentialVersion,
+});
+```
+
+Make sure the producer module imports `TenantJobRuntimeModule` (it
+provides `RuntimeBindingStamperService`).
+
+## Step 3 — wire the worker task
+
+The 4-line block at the top of the Trigger.dev task's `run()`:
+
+```ts
+import { TenantRuntimeBindingResolverService } from '../../trigger/worker/services/tenant-runtime-binding-resolver.service';
+
+// inside run():
+const binding = await appContext
+    .get(TenantRuntimeBindingResolverService)
+    .resolveForWork(payload, payload.workId);  // or resolveForOrganization / resolveForCustomization / resolveForSubscription
+if (binding.status === 'drained') {
+    logger.warn('<task-name>: credentials drained, skipping run', {
+        workId: payload.workId,
+        providerId: binding.providerId,
+        credentialVersion: binding.credentialVersion,
+        tenantId: binding.tenantId,
+    });
+    return {
+        status: 'skipped' as const,
+        reason: 'credentials-drained' as const,
+        workId: payload.workId,
+    };
+}
+// rest of the task...
+```
+
+### Picking the right resolver helper
+
+| Payload field | Helper | Tenant lookup path |
+|---|---|---|
+| `workId` | `resolveForWork(payload, workId)` | `WorkRepository.findById → Work.tenantId` |
+| `organizationId` | `resolveForOrganization(payload, organizationId)` | `OrganizationRepository.findById → Organization.tenantId` |
+| `customizationId` | `resolveForCustomization(payload, customizationId)` | `TemplateCustomizationRepository.findById → TemplateCustomization.tenantId` |
+| `subscriptionId` | `resolveForSubscription(payload, subscriptionId)` | `WebhookSubscriptionRepository.findById → WebhookSubscription.tenantId` |
+| Anything else | `resolve(payload, tenantId)` with task-specific tenantId resolution inline | varies |
+
+### Why skip-and-ack on `'drained'`?
+
+`'drained'` means the tenant rotated their credentials past the
+version stamped at enqueue. Retrying would just keep observing the
+same drained state until the run hits the dead-letter queue. Every
+task that's been wired so far is **idempotent** (re-running produces
+the same final state), so skipping is safe — the next user action
+(or the per-task reconciliation job, if one exists) picks the work
+up against fresh credentials.
+
+If your task is NOT idempotent, branch differently: log the drained
+state and throw a typed error that Trigger.dev's retry policy
+treats as terminal (drops to dead-letter on the first attempt).
+
+## Step 4 — RPC plumbing (only if your repo isn't already proxied)
+
+The worker-side resolver service consumes the host's repositories via
+the existing remote-proxy controller (`apps/api/src/trigger/trigger-
+internal.controller.ts`). If your new dispatcher's tenantId source is
+a NEW repository not already in `remoteMap`, you need to:
+
+1. Add the repository import + constructor injection on
+   `TriggerInternalController`.
+2. Add it to `remoteMap` in `onModuleInit()`.
+3. Ensure the module that provides it is imported by
+   `TriggerInternalModule` (or it transitively comes from
+   `DatabaseModule`).
+4. Add a `createRemoteProxy(apiClient, '<RepoName>')` provider in
+   `packages/tasks/src/trigger/worker/modules/trigger-worker.module.ts`.
+5. Extend `TenantRuntimeBindingResolverService`'s constructor with the
+   new `@Optional()` repo and add a `resolveFor<Entity>(payload, id)`
+   convenience wrapper.
+
+See PR #1442 (org + customization) and #1445 (subscription) for the
+exact diff shape.
+
+## Step 5 — tests
+
+`TenantRuntimeBindingResolverService` already has 24 vitest cases
+covering every branch — if you reuse one of the 4 existing
+convenience wrappers your task is implicitly covered. If you add a
+new `resolveFor<Entity>` wrapper, mirror the 4 cases from the
+existing wrappers (happy / missing repo / repo throws / missing
+tenantId).
+
+For the producer service, add 3-4 jest cases mirroring the existing
+ones (e.g. `enqueueEmbed` cases in
+`packages/agent/src/services/__tests__/knowledge-base.service.spec.ts`):
+
+- happy path with overlay → stamper result threaded onto payload
+- null tenantId → stamper called with null, ships null/null
+- stamper throws → ships null/null (fail-open)
+- repo throws (if applicable) → stamper never called, ships null/null
+
+## Step 6 — when NOT to wire T22
+
+Some dispatchers are intentionally tenant-agnostic. **Skip T22
+stamping entirely** when:
+
+- The payload semantically spans tenants (e.g. fleet-wide operator
+  bootstrap scripts like `KB_BACKFILL_SKELETON` — `workIds: string[]`
+  may cross tenants; stamping would be semantically incorrect).
+- The task runs against platform-default credentials by design
+  (cron sweeps, scheduled dispatchers).
+
+In those cases, document the choice with a comment near the
+dispatcher: `// EW-742 P3.2 T22 — intentionally out of scope:
+fleet-wide ops use instance-default credentials by design.`
+
+## References
+
+- Spec: [`docs/specs/features/tenant-job-runtime-overlay/spec.md`](../specs/features/tenant-job-runtime-overlay/spec.md)
+- Tasks: [`docs/specs/features/tenant-job-runtime-overlay/tasks.md`](../specs/features/tenant-job-runtime-overlay/tasks.md) (§ T22 has the full per-dispatcher PR table)
+- ADR-017: [`docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md`](../specs/decisions/017-tenant-scoped-job-runtime-overlay.md)
+- Stamper helper: `packages/agent/src/tasks/runtime-binding-stamper.service.ts`
+- Resolver service: `packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts`
+- PoC dispatcher (kb-embed): `packages/agent/src/services/knowledge-base.service.ts` + `packages/tasks/src/tasks/trigger/kb-embed-document.task.ts`

--- a/docs/specs/features/tenant-job-runtime-overlay/tasks.md
+++ b/docs/specs/features/tenant-job-runtime-overlay/tasks.md
@@ -1,7 +1,7 @@
 # Task Breakdown: Tenant-Scoped Job-Runtime Overlay
 
 **Feature ID**: `tenant-job-runtime-overlay`
-**Status**: `In progress` — P0 + P1.0 + P1 + P2.0 + P2.1 + P3 (T20+T23+T24 resolver) + P3.1 (T21 cache + T22 stamper helper) + P3.2 (resolver bindToTenant wiring + SecretStoreResolver contract + InProcessSecretStoreResolver default) + P4 (T31 contract — `tenantId` on JobEnqueueOptions) + P5 + P7 (T41+T42+T44) landed on `main` or in this PR. P2.2 (schema-driven form + e2e), P3.1 (T22 per-dispatcher wiring), P4 (per-provider worker hosts T25–T30 + T31 per-provider stamping + T32 isolation tests + per-provider bindToTenant implementations), P5.1 (per-tenant whitelist), P6 (conformance), P7 (docs T43), and non-`inline:` SecretStoreResolver implementations (vault:, k8s:, op:) remain.
+**Status**: `In progress` — P0 + P1.0 + P1 + P2.0 + P2.1 + P3 (T20+T23+T24 resolver) + P3.1 (T21 cache + T22 stamper helper + **T22 per-dispatcher wiring across all 10 in-platform dispatchers, with worker-host `TenantRuntimeBindingResolverService` consumption**) + P3.2 (resolver bindToTenant wiring + SecretStoreResolver contract + InProcessSecretStoreResolver default + Trigger.dev `bindToTenant` minimal impl + non-`inline:` SecretStoreResolver plugin packages: Vault / K8s / Infisical / Doppler / AWS-SM / GCP-SM / Azure-KV) + P4 (T31 contract — `tenantId` on JobEnqueueOptions) + P5 + P7 (T41+T42+T44) landed on `main` (cascades through develop→stage→main where applicable, develop-only for the late-2026 batches). P2.2 (schema-driven form + e2e), P4 (per-provider worker hosts T25–T30 + T31 per-provider stamping + T32 isolation tests + per-provider real `bindToTenant` for Temporal/BullMQ/pg-boss/Inngest), P5.1 (per-tenant whitelist), P6 (conformance), P7 (docs T43), and per-tenant Trigger.dev BYO project switching (requires real per-tenant Trigger.dev infra to validate) remain.
 **Last updated**: 2026-06-19
 **Spec**: [`./spec.md`](./spec.md) · **Plan**: [`./plan.md`](./plan.md) · **Providers**: [`./providers.md`](./providers.md) · **Epic**: [EW-742](https://evertech.atlassian.net/browse/EW-742) · **Story**: [EW-743](https://evertech.atlassian.net/browse/EW-743) · **ADR**: [ADR-017](../../decisions/017-tenant-scoped-job-runtime-overlay.md)
 
@@ -46,13 +46,36 @@ T20 + T23 + T24 ✅ Done in [#1380](https://github.com/ever-works/ever-works/pul
 - [x] **T20.** Tenant-aware resolver at `packages/agent/src/tasks/tenant-aware-runtime.resolver.ts` (`TenantAwareRuntimeResolver`) wraps the EW-685 P0 T4 binding-factory registry: `resolve(tenantId)` returns the instance default for `null` / no-row / inherit / disabled; for `byo` + `override` + `enabled` it logs the deferral and still returns the instance default until EW-686 P2 lands the per-provider credential-binding hook. `getEffectiveBinding(tenantId)` returns the metadata T22 will stamp onto the run record.
 - [x] **T21.** Credential cache with 15–60s TTL in `packages/agent/src/tasks/tenant-credential.cache.ts` — keyed by `(tenantId, providerId, credentialVersion)`, in-process LRU with explicit invalidate on version bump or force-invalidate. Standalone `@Injectable()` class with no DI dependencies (defaults: `maxEntries=1024`, `ttlMs=30_000`); insertion-order LRU (no promotion-on-read so an in-flight runs snapshot does not get kept alive past its rotation window — see ADR-017 §3 / Q4). Provided + exported via `TenantJobRuntimeModule`. PR: [#1381](https://github.com/ever-works/ever-works/pull/1381).
 - [x] **T22 (helper).** `RuntimeBindingStamperService` at `packages/agent/src/tasks/runtime-binding-stamper.service.ts` — standalone `@Injectable()` whose `stamp(tenantId)` returns `{ providerId, credentialVersion }` for byo/override+enabled tenants and `{ null, null }` for inherit/no-row/disabled/no-tenant (fail-open on DB hiccup with `Logger.warn`). Provided + exported via `TenantJobRuntimeModule`. The dispatcher call sites adopt this helper incrementally — each enqueue payload type adds a `credentialVersion?: number` field on its own PR, no big-bang bus stop. The actual per-call-site wiring (the `await stamper.stamp(tenantId)` inside each of the twelve dispatchers + the run-record schema column it writes into) remains open below.
-- [ ] **T22 (per-dispatcher wiring).** Walk the twelve dispatcher call sites in `packages/agent/src/tasks/_tasks-symbols.ts` and call `await stamper.stamp(tenantId)` inside each enqueue path; persist `credentialVersion` onto the matching run / history row so the P4 worker host can later resolve the pinned snapshot via `CredentialVersionService.resolveSnapshot`. Each dispatcher migration is its own PR — no coordinated bus stop.
+- [x] **T22 (per-dispatcher wiring).** Walk the dispatcher call sites in `packages/agent/src/tasks/_tasks-symbols.ts` (plus `KB_REEMBED_WORK_DISPATCHER` wired in `apps/api/src/works/works.module.ts` and `WEBHOOK_DELIVERY_DISPATCHER` in `apps/api/src/webhooks/`), call `await stamper.stamp(tenantId)` inside each enqueue path, and persist `(providerId, credentialVersion)` on the payload so the P4 worker host can later resolve the pinned snapshot via `CredentialVersionService.resolveSnapshot`. Each dispatcher migration shipped as its own PR — no coordinated bus stop.
+
+    **10 stamped + consumed dispatchers (producer ↔ task):**
+
+    | # | Dispatcher | Resolver helper | Producer PR | Worker PR |
+    |---|---|---|---|---|
+    | 1 | `KB_EMBED_DOCUMENT_DISPATCHER` | `resolveForWork` | #1427 (PoC) | #1435 |
+    | 2 | `KB_MIRROR_DOCUMENT_DISPATCHER` | `resolveForWork` | #1430 (Tier 1) | #1439 |
+    | 3 | `KB_NORMALIZE_MEDIA_DISPATCHER` (video+audio) | `resolveForWork` | #1430 (Tier 1) | #1439 |
+    | 4 | `KB_TRANSCRIBE_DISPATCHER` | `resolveForWork` | #1436 | #1439 |
+    | 5 | `WORK_GENERATION_DISPATCHER` | `resolveForWork` | #1431 (Tier 2) | #1439 |
+    | 6 | `WORK_IMPORT_DISPATCHER` | `resolveForWork` | #1431 (Tier 2) | #1439 |
+    | 7 | `KB_ORG_OVERLAY_FANOUT_DISPATCHER` | `resolveForOrganization` | #1430 (Tier 1) | #1442 |
+    | 8 | `TEMPLATE_CUSTOMIZATION_DISPATCHER` | `resolveForCustomization` | #1431 (Tier 2) | #1442 |
+    | 9 | `WEBHOOK_DELIVERY_DISPATCHER` (apps/api) | `resolveForSubscription` | #1445 | #1445 |
+    | 10 | `KB_REEMBED_WORK_DISPATCHER` (pgvector→apps/api) | `resolveForWork` | #1448 | #1448 |
+
+    **Worker-host infrastructure shipped in #1432**: `TenantRuntimeBindingResolverService` at `packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts` exposes `resolve(payload, tenantId)` + 4 convenience wrappers (`resolveForWork`/`Organization`/`Customization`/`Subscription`) returning a 4-state status (`no-binding` / `resolved` / `drained` / `error`, fail-open per FR-5). `CredentialVersionService` proxied through `TriggerInternalController.remoteMap` so worker tasks can call `resolveSnapshot` via the existing RPC channel. The webhook-delivery task uses **direct** providers in `TriggerWebhookDeliveryModule` (avoids a pointless RPC hop since that module already has direct DB access).
+
+    **Intentionally out-of-scope dispatchers** (do NOT need T22 stamping):
+
+    - `KB_BACKFILL_SKELETON_DISPATCHER` — fleet-wide operator bootstrap script. Runs as the instance-default credentials by design (no tenant scope; the caller enumerates `workIds` that may span tenants). Adding T22 stamping here would be semantically incorrect.
+
+    **Per-tenant credential application (deferred to a future PR with real BYO infra):** the resolved `snapshot.credentials` is logged + threaded through the worker but the Trigger.dev SDK is still configured globally at boot. Per-tenant Trigger.dev BYO project switching (calling `configure({ accessToken: snapshot.credentials.accessToken })` per dispatch) needs an actual operator with per-tenant Trigger.dev projects to validate; building speculatively risks getting the design wrong. Today the `'resolved'` status is observability-only — the worker still runs against the instance default credentials.
 - [x] **T23.** Fallback path to instance-global default when a tenant has no overlay row — resolver returns the EW-683 instance binding unchanged; the `getActive() = null` semantic propagates as `null` (in-process dev fallback preserved). Tests in T24 prove the zero-overhead path for tenants that never opt in.
 - [x] **T24.** Unit tests for the resolver under `packages/agent/src/tasks/__tests__/tenant-aware-runtime.resolver.spec.ts` — 12 cases covering inherit fallback, no-row fallback, kill switch, byo/override stopgap + log emission, `getEffectiveBinding` metadata, and the `getActive() = null` propagation.
 
-### Phase 3.1 — Enqueue capture (deferred)
+### Phase 3.1 — Enqueue capture · `[EW-742 P3.1]` ✅ DONE
 
-- [ ] **T22** (above) ships once a follow-up PR walks the enqueue call sites to stamp `credentialVersion` into each run record. The T21 cache is already in place to serve the snapshot lookup at run time.
+- [x] **T22** (above) — per-dispatcher wiring shipped across PRs #1427 / #1430 / #1431 / #1436 / #1442 / #1445 / #1448 (producer side) and #1432 / #1435 / #1439 / #1442 / #1445 / #1448 (worker side). The T21 cache is in place to serve the snapshot lookup at run time; today the worker-host resolver consumes `(providerId, credentialVersion)` from the payload and classifies as `no-binding` / `resolved` / `drained` / `error` (skip-and-ack on drained, fall-through otherwise).
 
 ### Phase 3.2 — Resolver `bindToTenant` wiring · `[EW-742 P3.2]`
 


### PR DESCRIPTION
## Summary

Pure documentation PR that captures the completion state of the EW-742 P3.2 T22 work shipped across PRs #1427 / #1430 / #1431 / #1432 / #1435 / #1436 / #1439 / #1442 / #1445 / #1448.

## What this PR does

1. **`docs/specs/features/tenant-job-runtime-overlay/tasks.md`**:
   - Marks T22 per-dispatcher wiring as ✅ complete.
   - Adds a full table of the 10 stamped + consumed dispatchers (producer PR + worker PR per row).
   - Documents `KB_BACKFILL_SKELETON_DISPATCHER` as intentionally out of scope (fleet-wide ops).
   - Notes per-tenant Trigger.dev BYO project switching as genuinely deferred (needs real per-tenant Trigger.dev infra to validate).
   - Updates the header `Status` line.

2. **`docs/runbooks/T22_NEW_DISPATCHER_WIRING.md`** (new): copy-paste runbook for adding dispatcher #11+ to the T22 loop. Covers payload extension, producer stamping, the 4-line worker template, resolver helper selection, RPC plumbing, test expectations, and when to deliberately NOT wire T22.

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive runbook for integrating new system components into the runtime binding framework.
  * Updated feature status documentation to reflect completion of Phase 3.1 implementation work, including new infrastructure capabilities and scope clarifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->