### PR TITLE
feat(plugins): EW-742 P3.2 — 4 job-runtime provider plugins (Temporal/BullMQ/pgboss/Inngest)

### DIFF
--- a/packages/plugin/src/contracts/plugin-manifest.types.ts
+++ b/packages/plugin/src/contracts/plugin-manifest.types.ts
@@ -46,7 +46,23 @@ export const PLUGIN_CATEGORIES = [
 	// Defaults (`inline:` + `env:`) live in
 	// `packages/agent/src/tasks/in-process-secret-store-resolver.service.ts`
 	// — no separate plugin package because they have zero external deps.
-	'secret-store-resolver'
+	'secret-store-resolver',
+	// EW-683 / EW-685 / EW-742 P3.2 follow-up — pluggable job-runtime
+	// backends. Each implements `IJobRuntimeProvider` (see
+	// `capabilities/job-runtime.interface.ts`). The selector
+	// `EVER_WORKS_JOB_RUNTIME` picks one registered provider per instance;
+	// the rest stay inert but loaded so a hot-swap stays cheap. Bundled
+	// implementations: `@ever-works/trigger-tasks` (in-tree, the default
+	// for managed deployments), `@ever-works/job-runtime-temporal-plugin`,
+	// `@ever-works/job-runtime-bullmq-plugin`,
+	// `@ever-works/job-runtime-pgboss-plugin`,
+	// `@ever-works/job-runtime-inngest-plugin`. The four standalone
+	// plugin packages ship `bindToTenant` for per-tenant BYO routing
+	// (EW-686 P2 / EW-742 P3.2) — actual per-task dispatching is gated
+	// on real customer demand because each runtime's operational model
+	// differs significantly (push vs pull, namespace vs prefix vs schema
+	// isolation, retry/backoff semantics).
+	'job-runtime'
 ] as const;
 
 export type PluginCategory = (typeof PLUGIN_CATEGORIES)[number];

--- a/packages/plugins/job-runtime-bullmq/package.json
+++ b/packages/plugins/job-runtime-bullmq/package.json
@@ -1,0 +1,70 @@
+{
+	"name": "@ever-works/job-runtime-bullmq-plugin",
+	"version": "1.0.0",
+	"description": "BullMQ IJobRuntimeProvider plugin for Ever Works — implements the BYO/inherit tenant-overlay binding via per-tenant Redis prefix isolation (EW-742 P3.2). Per-task dispatching is operator-provisioned.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "job-runtime-bullmq",
+			"name": "BullMQ Job Runtime",
+			"version": "1.0.0",
+			"category": "job-runtime",
+			"capabilities": [
+				"job-runtime-enqueue",
+				"job-runtime-cancel",
+				"job-runtime-status",
+				"job-runtime-schedule",
+				"job-runtime-bind-tenant"
+			],
+			"description": "BullMQ (https://docs.bullmq.io) IJobRuntimeProvider for the EW-742 tenant overlay. Implements bindToTenant via per-tenant Redis key prefix isolation. Per-task dispatchers throw 'not implemented' until the operator wires per-payload-type queue + worker pairs.",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"autoEnable": false,
+			"systemPlugin": false,
+			"distribution": "core",
+			"builtIn": true,
+			"visibility": "operator",
+			"envVars": [
+				"BULLMQ_REDIS_URL",
+				"BULLMQ_QUEUE_PREFIX"
+			]
+		}
+	}
+}

--- a/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-job-runtime.plugin.spec.ts
+++ b/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-job-runtime.plugin.spec.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { TenantCredentialSnapshot } from '@ever-works/plugin';
+import {
+	BullMqDispatcherNotConfiguredError,
+	BullMqJobRuntimePlugin
+} from '../bullmq-job-runtime.plugin.js';
+
+describe('BullMqJobRuntimePlugin (EW-742 P3.2 follow-up)', () => {
+	let plugin: BullMqJobRuntimePlugin;
+	const origEnv = { ...process.env };
+
+	beforeEach(() => {
+		plugin = new BullMqJobRuntimePlugin();
+	});
+
+	afterEach(() => {
+		for (const key of Object.keys(process.env)) {
+			if (!(key in origEnv)) delete process.env[key];
+		}
+		Object.assign(process.env, origEnv);
+	});
+
+	const snapshot = (overrides: Partial<TenantCredentialSnapshot> = {}): TenantCredentialSnapshot => ({
+		tenantId: '00000000-0000-0000-0000-00000000aaaa',
+		providerId: 'bullmq',
+		credentialVersion: 1,
+		credentials: { queuePrefix: 'tenant-acme', redisUrl: 'redis://tenant-acme:6379' },
+		...overrides
+	});
+
+	it('declares the canonical IPlugin metadata', () => {
+		expect(plugin.id).toBe('job-runtime-bullmq');
+		expect(plugin.category).toBe('job-runtime');
+		expect(plugin.runtimeId).toBe('bullmq');
+	});
+
+	it('isEnabled true when BULLMQ_REDIS_URL is set', () => {
+		process.env.BULLMQ_REDIS_URL = 'redis://localhost:6379';
+		expect(plugin.isEnabled()).toBe(true);
+	});
+
+	it('isEnabled false when BULLMQ_REDIS_URL is missing', () => {
+		delete process.env.BULLMQ_REDIS_URL;
+		expect(plugin.isEnabled()).toBe(false);
+	});
+
+	it('stub dispatchers throw BullMqDispatcherNotConfiguredError', () => {
+		const d = plugin.dispatchers as unknown as { dispatchKbEmbedDocument: () => unknown };
+		expect(() => d.dispatchKbEmbedDocument()).toThrowError(
+			BullMqDispatcherNotConfiguredError
+		);
+	});
+
+	it('lifecycle methods return safe defaults', async () => {
+		await expect(plugin.cancel('r')).resolves.toBe(false);
+		await expect(plugin.getRunStatus('r')).resolves.toBe('unknown');
+		await expect(plugin.registerSchedules([])).resolves.toBeUndefined();
+		const handle = await plugin.startWorkerHost({});
+		await expect(handle.stop()).resolves.toBeUndefined();
+	});
+
+	describe('bindToTenant', () => {
+		it('exposes tenantQueuePrefix + tenantRedisUrl from snapshot.credentials', () => {
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.tenantQueuePrefix).toBe('tenant-acme');
+			expect(view.tenantRedisUrl).toBe('redis://tenant-acme:6379');
+			expect(Object.isFrozen(view)).toBe(true);
+		});
+
+		it('null fields when credentials omit prefix/url', () => {
+			const view = plugin.bindToTenant(snapshot({ credentials: {} }));
+			expect(view.tenantQueuePrefix).toBeNull();
+			expect(view.tenantRedisUrl).toBeNull();
+		});
+
+		it('memoises on (tenantId, credentialVersion)', () => {
+			const a = plugin.bindToTenant(snapshot());
+			const b = plugin.bindToTenant(snapshot());
+			expect(b).toBe(a);
+		});
+
+		it('evicts older view on credentialVersion bump', () => {
+			const v1 = plugin.bindToTenant(snapshot({ credentialVersion: 1 }));
+			const v2 = plugin.bindToTenant(snapshot({ credentialVersion: 2 }));
+			expect(v2).not.toBe(v1);
+		});
+
+		it('view.bindToTenant(self) returns self', () => {
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.bindToTenant?.(snapshot())).toBe(view);
+		});
+	});
+});

--- a/packages/plugins/job-runtime-bullmq/src/bullmq-job-runtime.plugin.ts
+++ b/packages/plugins/job-runtime-bullmq/src/bullmq-job-runtime.plugin.ts
@@ -1,0 +1,223 @@
+import type {
+	IJobRuntimeProvider,
+	JobRunStatus,
+	JobRuntimeDispatchers,
+	JobRuntimeId,
+	JsonSchema,
+	PluginCategory,
+	PluginContext,
+	ScheduleSpec,
+	TenantCredentialSnapshot,
+	WorkerHostHandle,
+	WorkerHostOptions
+} from '@ever-works/plugin';
+
+/**
+ * EW-742 P3.2 follow-up — BullMQ `IJobRuntimeProvider` plugin.
+ *
+ * # What this plugin ships TODAY
+ *
+ *   - Full `IPlugin` + `IJobRuntimeProvider` contract surface so the
+ *     binding factory in `packages/agent/src/tasks/job-runtime.providers.ts`
+ *     can register it alongside the Trigger.dev provider.
+ *   - **Real `bindToTenant` implementation** with per-`(tenantId,
+ *     credentialVersion)` memoisation. The resolved snapshot is
+ *     exposed off-spec as `view.tenantSnapshot` so the T22 stamper
+ *     can stamp `(providerId, credentialVersion)` onto run records.
+ *   - `bindToTenant` extracts the per-tenant **Redis key prefix**
+ *     from `snapshot.credentials.queuePrefix` (and the optional
+ *     `redisUrl` if the tenant uses a dedicated Redis) and exposes
+ *     them on the view so future dispatcher impls can route to a
+ *     per-tenant queue namespace.
+ *
+ * # What this plugin DOES NOT ship (gated on operator demand)
+ *
+ *   - **Per-task queue + worker pairs**. Every `dispatchXxx` method
+ *     throws `BullMqDispatcherNotConfiguredError`. Wiring real queues
+ *     requires defining each `*_DISPATCHER` payload as a BullMQ Queue
+ *     + Worker pair against the operator's own Redis — that's a
+ *     per-deployment design decision (queue concurrency, retry
+ *     policy, dead-letter strategy) that we deliberately defer to
+ *     operator-owned PRs.
+ *   - **`startWorkerHost`**. BullMQ is a pull-model runtime; the
+ *     operator stands up their own worker process(es). The method
+ *     returns a no-op handle so callers that generically "start the
+ *     worker host if the provider supports it" don't branch.
+ *
+ * # Operator setup
+ *
+ *   1. Set `EVER_WORKS_JOB_RUNTIME=bullmq` in the API env.
+ *   2. Configure `BULLMQ_REDIS_URL` and `BULLMQ_QUEUE_PREFIX` (the
+ *      instance default — used when no tenant overlay applies).
+ *   3. For per-tenant BYO: provision tenant credentials with
+ *      `{ queuePrefix: 'tenant-acme', redisUrl?: '...' }` and store
+ *      via the `SECRET_STORE_RESOLVER` binding.
+ *   4. Implement the per-payload-type Queue + Worker pairs in your
+ *      own worker process(es).
+ */
+
+export class BullMqDispatcherNotConfiguredError extends Error {
+	constructor(dispatcherName: string) {
+		super(
+			`@ever-works/job-runtime-bullmq-plugin: ${dispatcherName} is not configured. ` +
+				'Subclass BullMqJobRuntimePlugin (or wrap it with a delegating provider) and ' +
+				'override the dispatchers field with operator-defined BullMQ Queue + Worker pairs ' +
+				'per `docs/specs/features/tenant-job-runtime-overlay/providers.md`.'
+		);
+		this.name = 'BullMqDispatcherNotConfiguredError';
+	}
+}
+
+export interface BullMqTenantBindingView extends IJobRuntimeProvider {
+	readonly tenantSnapshot: TenantCredentialSnapshot;
+	/**
+	 * Per-tenant Redis key prefix (per ADR-017 — Redis prefix
+	 * isolation per tenant worker). Future dispatchers should use
+	 * this as the `prefix` option on every `new Queue(...)`.
+	 */
+	readonly tenantQueuePrefix: string | null;
+	/**
+	 * Per-tenant Redis connection URL (optional — defaults to the
+	 * shared instance Redis when omitted).
+	 */
+	readonly tenantRedisUrl: string | null;
+}
+
+export class BullMqJobRuntimePlugin implements IJobRuntimeProvider {
+	readonly id = 'job-runtime-bullmq';
+	readonly name = 'BullMQ Job Runtime';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'job-runtime';
+	readonly capabilities: readonly string[] = [
+		'job-runtime-enqueue',
+		'job-runtime-cancel',
+		'job-runtime-status',
+		'job-runtime-schedule',
+		'job-runtime-bind-tenant'
+	];
+	readonly runtimeId: JobRuntimeId = 'bullmq';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			redisUrl: {
+				type: 'string',
+				title: 'Redis URL',
+				description: 'BullMQ Redis connection string, e.g. `redis://default:pw@redis:6379`.',
+				'x-secret': true,
+				'x-envVar': 'BULLMQ_REDIS_URL'
+			},
+			queuePrefix: {
+				type: 'string',
+				title: 'Queue prefix',
+				description: 'Instance-default Redis key prefix. Per-tenant overrides come via the credential bag.',
+				'x-envVar': 'BULLMQ_QUEUE_PREFIX'
+			}
+		}
+	};
+
+	readonly dispatchers: JobRuntimeDispatchers = new Proxy(
+		{},
+		{
+			get(_target, prop: string): unknown {
+				if (typeof prop === 'string' && prop.startsWith('dispatch')) {
+					return () => {
+						throw new BullMqDispatcherNotConfiguredError(prop);
+					};
+				}
+				return undefined;
+			}
+		}
+	);
+
+	private context?: PluginContext;
+	private readonly tenantViews = new Map<string, BullMqTenantBindingView>();
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+		this.tenantViews.clear();
+	}
+
+	async registerSchedules(_schedules: readonly ScheduleSpec[]): Promise<void> {
+		// Stub — BullMQ has its own repeat-job DSL; operator wires it.
+	}
+
+	async cancel(_runId: string): Promise<boolean> {
+		return false;
+	}
+
+	async getRunStatus(_runId: string): Promise<JobRunStatus> {
+		return 'unknown';
+	}
+
+	isEnabled(): boolean {
+		return Boolean(process.env.BULLMQ_REDIS_URL);
+	}
+
+	async startWorkerHost(_opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+		return { stop: async () => undefined };
+	}
+
+	bindToTenant(snapshot: TenantCredentialSnapshot): BullMqTenantBindingView {
+		const cacheKey = `${snapshot.tenantId}:${snapshot.credentialVersion}`;
+		const cached = this.tenantViews.get(cacheKey);
+		if (cached) {
+			return cached;
+		}
+
+		const base = this;
+		const tenantQueuePrefix =
+			typeof snapshot.credentials.queuePrefix === 'string'
+				? snapshot.credentials.queuePrefix
+				: null;
+		const tenantRedisUrl =
+			typeof snapshot.credentials.redisUrl === 'string'
+				? snapshot.credentials.redisUrl
+				: null;
+
+		const view: BullMqTenantBindingView = Object.freeze({
+			id: base.id,
+			name: base.name,
+			version: base.version,
+			category: base.category,
+			capabilities: base.capabilities,
+			settingsSchema: base.settingsSchema,
+			runtimeId: base.runtimeId,
+			get dispatchers(): JobRuntimeDispatchers {
+				return base.dispatchers;
+			},
+			registerSchedules: (schedules: readonly ScheduleSpec[]) =>
+				base.registerSchedules(schedules),
+			cancel: (runId: string) => base.cancel(runId),
+			getRunStatus: (runId: string) => base.getRunStatus(runId),
+			isEnabled: () => base.isEnabled(),
+			startWorkerHost: (opts: WorkerHostOptions) => base.startWorkerHost(opts),
+			onLoad: (context: PluginContext) => base.onLoad(context),
+			onUnload: () => base.onUnload(),
+			bindToTenant: (other: TenantCredentialSnapshot) => {
+				if (
+					other.tenantId === snapshot.tenantId &&
+					other.credentialVersion === snapshot.credentialVersion
+				) {
+					return view;
+				}
+				return base.bindToTenant(other);
+			},
+			tenantSnapshot: snapshot,
+			tenantQueuePrefix,
+			tenantRedisUrl
+		});
+
+		for (const key of this.tenantViews.keys()) {
+			if (key.startsWith(`${snapshot.tenantId}:`)) {
+				this.tenantViews.delete(key);
+			}
+		}
+		this.tenantViews.set(cacheKey, view);
+		return view;
+	}
+}

--- a/packages/plugins/job-runtime-bullmq/src/index.ts
+++ b/packages/plugins/job-runtime-bullmq/src/index.ts
@@ -1,0 +1,2 @@
+export { BullMqJobRuntimePlugin } from './bullmq-job-runtime.plugin.js';
+export { BullMqJobRuntimePlugin as default } from './bullmq-job-runtime.plugin.js';

--- a/packages/plugins/job-runtime-bullmq/tsconfig.json
+++ b/packages/plugins/job-runtime-bullmq/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/job-runtime-bullmq/tsup.config.ts
+++ b/packages/plugins/job-runtime-bullmq/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/packages/plugins/job-runtime-inngest/package.json
+++ b/packages/plugins/job-runtime-inngest/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@ever-works/job-runtime-inngest-plugin",
+	"version": "1.0.0",
+	"description": "Inngest IJobRuntimeProvider plugin for Ever Works — implements the BYO/inherit tenant-overlay binding for Inngest signing keys (EW-742 P3.2, SaaS only — self-host blocked at available-providers). Per-task dispatching is operator-provisioned.",
+	"author": { "name": "Ever Co. LTD", "email": "ever@ever.co", "url": "https://ever.co" },
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js", "require": "./dist/index.cjs" } },
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": { "@ever-works/plugin": "workspace:*" },
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "job-runtime-inngest",
+			"name": "Inngest Job Runtime",
+			"version": "1.0.0",
+			"category": "job-runtime",
+			"capabilities": [
+				"job-runtime-enqueue",
+				"job-runtime-cancel",
+				"job-runtime-status",
+				"job-runtime-schedule",
+				"job-runtime-bind-tenant"
+			],
+			"description": "Inngest (https://www.inngest.com) IJobRuntimeProvider for the EW-742 tenant overlay. Implements bindToTenant via per-tenant signing keys (SaaS only — self-host blocked at available-providers per ADR-017 providers.md). Per-task dispatchers throw 'not implemented' until the operator wires per-payload-type Inngest functions.",
+			"author": { "name": "Ever Works Team" },
+			"license": "AGPL-3.0",
+			"autoEnable": false,
+			"systemPlugin": false,
+			"distribution": "core",
+			"builtIn": true,
+			"visibility": "operator",
+			"envVars": ["INNGEST_EVENT_KEY", "INNGEST_SIGNING_KEY"]
+		}
+	}
+}

--- a/packages/plugins/job-runtime-inngest/src/__tests__/inngest-job-runtime.plugin.spec.ts
+++ b/packages/plugins/job-runtime-inngest/src/__tests__/inngest-job-runtime.plugin.spec.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { TenantCredentialSnapshot } from '@ever-works/plugin';
+import {
+	InngestDispatcherNotConfiguredError,
+	InngestJobRuntimePlugin
+} from '../inngest-job-runtime.plugin.js';
+
+describe('InngestJobRuntimePlugin (EW-742 P3.2 follow-up)', () => {
+	let plugin: InngestJobRuntimePlugin;
+	const origEnv = { ...process.env };
+
+	beforeEach(() => {
+		plugin = new InngestJobRuntimePlugin();
+	});
+
+	afterEach(() => {
+		for (const key of Object.keys(process.env)) {
+			if (!(key in origEnv)) delete process.env[key];
+		}
+		Object.assign(process.env, origEnv);
+	});
+
+	const snapshot = (overrides: Partial<TenantCredentialSnapshot> = {}): TenantCredentialSnapshot => ({
+		tenantId: '00000000-0000-0000-0000-00000000aaaa',
+		providerId: 'inngest',
+		credentialVersion: 1,
+		credentials: { eventKey: 'tenant-acme-evk', signingKey: 'tenant-acme-sig' },
+		...overrides
+	});
+
+	it('declares the canonical IPlugin metadata', () => {
+		expect(plugin.id).toBe('job-runtime-inngest');
+		expect(plugin.category).toBe('job-runtime');
+		expect(plugin.runtimeId).toBe('inngest');
+	});
+
+	it('isEnabled true when both INNGEST keys are set', () => {
+		process.env.INNGEST_EVENT_KEY = 'a';
+		process.env.INNGEST_SIGNING_KEY = 'b';
+		expect(plugin.isEnabled()).toBe(true);
+	});
+
+	it('isEnabled false when only one INNGEST key is set', () => {
+		process.env.INNGEST_EVENT_KEY = 'a';
+		delete process.env.INNGEST_SIGNING_KEY;
+		expect(plugin.isEnabled()).toBe(false);
+	});
+
+	it('stub dispatchers throw InngestDispatcherNotConfiguredError', () => {
+		const d = plugin.dispatchers as unknown as { dispatchX: () => unknown };
+		expect(() => d.dispatchX()).toThrowError(InngestDispatcherNotConfiguredError);
+	});
+
+	it('lifecycle methods return safe defaults', async () => {
+		await expect(plugin.cancel('r')).resolves.toBe(false);
+		await expect(plugin.getRunStatus('r')).resolves.toBe('unknown');
+		await expect(plugin.registerSchedules([])).resolves.toBeUndefined();
+		const handle = await plugin.startWorkerHost({});
+		await expect(handle.stop()).resolves.toBeUndefined();
+	});
+
+	describe('bindToTenant', () => {
+		it('exposes tenantEventKey + tenantSigningKey from snapshot.credentials', () => {
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.tenantEventKey).toBe('tenant-acme-evk');
+			expect(view.tenantSigningKey).toBe('tenant-acme-sig');
+			expect(Object.isFrozen(view)).toBe(true);
+		});
+
+		it('null fields when credentials are absent', () => {
+			const view = plugin.bindToTenant(snapshot({ credentials: {} }));
+			expect(view.tenantEventKey).toBeNull();
+			expect(view.tenantSigningKey).toBeNull();
+		});
+
+		it('memoises on (tenantId, credentialVersion)', () => {
+			const a = plugin.bindToTenant(snapshot());
+			const b = plugin.bindToTenant(snapshot());
+			expect(b).toBe(a);
+		});
+
+		it('evicts older view on credentialVersion bump', () => {
+			const v1 = plugin.bindToTenant(snapshot({ credentialVersion: 1 }));
+			const v2 = plugin.bindToTenant(snapshot({ credentialVersion: 2 }));
+			expect(v2).not.toBe(v1);
+		});
+
+		it('view.bindToTenant(self) returns self', () => {
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.bindToTenant?.(snapshot())).toBe(view);
+		});
+	});
+});

--- a/packages/plugins/job-runtime-inngest/src/index.ts
+++ b/packages/plugins/job-runtime-inngest/src/index.ts
@@ -1,0 +1,2 @@
+export { InngestJobRuntimePlugin } from './inngest-job-runtime.plugin.js';
+export { InngestJobRuntimePlugin as default } from './inngest-job-runtime.plugin.js';

--- a/packages/plugins/job-runtime-inngest/src/inngest-job-runtime.plugin.ts
+++ b/packages/plugins/job-runtime-inngest/src/inngest-job-runtime.plugin.ts
@@ -1,0 +1,184 @@
+import type {
+	IJobRuntimeProvider,
+	JobRunStatus,
+	JobRuntimeDispatchers,
+	JobRuntimeId,
+	JsonSchema,
+	PluginCategory,
+	PluginContext,
+	ScheduleSpec,
+	TenantCredentialSnapshot,
+	WorkerHostHandle,
+	WorkerHostOptions
+} from '@ever-works/plugin';
+
+/**
+ * EW-742 P3.2 follow-up — Inngest `IJobRuntimeProvider` plugin.
+ *
+ * Per [`providers.md`](../../../../docs/specs/features/tenant-job-runtime-overlay/providers.md)
+ * (Inngest section), per-tenant BYO is **SaaS only**; self-host is
+ * blocked at the `available-providers` admin gate because self-host
+ * Inngest's signing-key isolation model isn't multi-tenant by design.
+ *
+ * `bindToTenant` extracts the per-tenant signing keys from
+ * `snapshot.credentials.eventKey` + `snapshot.credentials.signingKey`
+ * and exposes them on the view so a future dispatcher can route to
+ * the right Inngest project. Stub dispatchers throw until an operator
+ * wires per-payload-type Inngest functions.
+ */
+
+export class InngestDispatcherNotConfiguredError extends Error {
+	constructor(dispatcherName: string) {
+		super(
+			`@ever-works/job-runtime-inngest-plugin: ${dispatcherName} is not configured. ` +
+				'Subclass InngestJobRuntimePlugin (or wrap it with a delegating provider) and ' +
+				'override the dispatchers field with operator-defined Inngest functions ' +
+				'per `docs/specs/features/tenant-job-runtime-overlay/providers.md`.'
+		);
+		this.name = 'InngestDispatcherNotConfiguredError';
+	}
+}
+
+export interface InngestTenantBindingView extends IJobRuntimeProvider {
+	readonly tenantSnapshot: TenantCredentialSnapshot;
+	/** Per-tenant Inngest event key (for `inngest.send()`). */
+	readonly tenantEventKey: string | null;
+	/** Per-tenant Inngest signing key (for inbound webhook verification). */
+	readonly tenantSigningKey: string | null;
+}
+
+export class InngestJobRuntimePlugin implements IJobRuntimeProvider {
+	readonly id = 'job-runtime-inngest';
+	readonly name = 'Inngest Job Runtime';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'job-runtime';
+	readonly capabilities: readonly string[] = [
+		'job-runtime-enqueue',
+		'job-runtime-cancel',
+		'job-runtime-status',
+		'job-runtime-schedule',
+		'job-runtime-bind-tenant'
+	];
+	readonly runtimeId: JobRuntimeId = 'inngest';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			eventKey: {
+				type: 'string',
+				title: 'Inngest Event Key',
+				description: 'Used by `inngest.send()` to publish events.',
+				'x-secret': true,
+				'x-envVar': 'INNGEST_EVENT_KEY'
+			},
+			signingKey: {
+				type: 'string',
+				title: 'Inngest Signing Key',
+				description: 'Used to verify inbound webhook requests from Inngest.',
+				'x-secret': true,
+				'x-envVar': 'INNGEST_SIGNING_KEY'
+			}
+		}
+	};
+
+	readonly dispatchers: JobRuntimeDispatchers = new Proxy(
+		{},
+		{
+			get(_target, prop: string): unknown {
+				if (typeof prop === 'string' && prop.startsWith('dispatch')) {
+					return () => {
+						throw new InngestDispatcherNotConfiguredError(prop);
+					};
+				}
+				return undefined;
+			}
+		}
+	);
+
+	private context?: PluginContext;
+	private readonly tenantViews = new Map<string, InngestTenantBindingView>();
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+		this.tenantViews.clear();
+	}
+
+	async registerSchedules(_schedules: readonly ScheduleSpec[]): Promise<void> {}
+	async cancel(_runId: string): Promise<boolean> {
+		return false;
+	}
+	async getRunStatus(_runId: string): Promise<JobRunStatus> {
+		return 'unknown';
+	}
+
+	isEnabled(): boolean {
+		return Boolean(process.env.INNGEST_EVENT_KEY && process.env.INNGEST_SIGNING_KEY);
+	}
+
+	async startWorkerHost(_opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+		return { stop: async () => undefined };
+	}
+
+	bindToTenant(snapshot: TenantCredentialSnapshot): InngestTenantBindingView {
+		const cacheKey = `${snapshot.tenantId}:${snapshot.credentialVersion}`;
+		const cached = this.tenantViews.get(cacheKey);
+		if (cached) {
+			return cached;
+		}
+
+		const base = this;
+		const tenantEventKey =
+			typeof snapshot.credentials.eventKey === 'string'
+				? snapshot.credentials.eventKey
+				: null;
+		const tenantSigningKey =
+			typeof snapshot.credentials.signingKey === 'string'
+				? snapshot.credentials.signingKey
+				: null;
+
+		const view: InngestTenantBindingView = Object.freeze({
+			id: base.id,
+			name: base.name,
+			version: base.version,
+			category: base.category,
+			capabilities: base.capabilities,
+			settingsSchema: base.settingsSchema,
+			runtimeId: base.runtimeId,
+			get dispatchers(): JobRuntimeDispatchers {
+				return base.dispatchers;
+			},
+			registerSchedules: (schedules: readonly ScheduleSpec[]) =>
+				base.registerSchedules(schedules),
+			cancel: (runId: string) => base.cancel(runId),
+			getRunStatus: (runId: string) => base.getRunStatus(runId),
+			isEnabled: () => base.isEnabled(),
+			startWorkerHost: (opts: WorkerHostOptions) => base.startWorkerHost(opts),
+			onLoad: (context: PluginContext) => base.onLoad(context),
+			onUnload: () => base.onUnload(),
+			bindToTenant: (other: TenantCredentialSnapshot) => {
+				if (
+					other.tenantId === snapshot.tenantId &&
+					other.credentialVersion === snapshot.credentialVersion
+				) {
+					return view;
+				}
+				return base.bindToTenant(other);
+			},
+			tenantSnapshot: snapshot,
+			tenantEventKey,
+			tenantSigningKey
+		});
+
+		for (const key of this.tenantViews.keys()) {
+			if (key.startsWith(`${snapshot.tenantId}:`)) {
+				this.tenantViews.delete(key);
+			}
+		}
+		this.tenantViews.set(cacheKey, view);
+		return view;
+	}
+}

--- a/packages/plugins/job-runtime-inngest/tsconfig.json
+++ b/packages/plugins/job-runtime-inngest/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/job-runtime-inngest/tsup.config.ts
+++ b/packages/plugins/job-runtime-inngest/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/packages/plugins/job-runtime-pgboss/package.json
+++ b/packages/plugins/job-runtime-pgboss/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@ever-works/job-runtime-pgboss-plugin",
+	"version": "1.0.0",
+	"description": "pg-boss IJobRuntimeProvider plugin for Ever Works — implements the BYO/inherit tenant-overlay binding via per-tenant Postgres schema isolation (EW-742 P3.2, ADR-017 Q2). Per-task dispatching is operator-provisioned.",
+	"author": { "name": "Ever Co. LTD", "email": "ever@ever.co", "url": "https://ever.co" },
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js", "require": "./dist/index.cjs" } },
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": { "@ever-works/plugin": "workspace:*" },
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "job-runtime-pgboss",
+			"name": "pg-boss Job Runtime",
+			"version": "1.0.0",
+			"category": "job-runtime",
+			"capabilities": [
+				"job-runtime-enqueue",
+				"job-runtime-cancel",
+				"job-runtime-status",
+				"job-runtime-schedule",
+				"job-runtime-bind-tenant"
+			],
+			"description": "pg-boss (https://github.com/timgit/pg-boss) IJobRuntimeProvider for the EW-742 tenant overlay. Implements bindToTenant via per-tenant Postgres schema isolation (ADR-017 Q2 schema-per-tenant). Per-task dispatchers throw 'not implemented' until the operator wires the per-payload-type publish/work handlers.",
+			"author": { "name": "Ever Works Team" },
+			"license": "AGPL-3.0",
+			"autoEnable": false,
+			"systemPlugin": false,
+			"distribution": "core",
+			"builtIn": true,
+			"visibility": "operator",
+			"envVars": ["PGBOSS_CONNECTION_STRING", "PGBOSS_SCHEMA"]
+		}
+	}
+}

--- a/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-job-runtime.plugin.spec.ts
+++ b/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-job-runtime.plugin.spec.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { TenantCredentialSnapshot } from '@ever-works/plugin';
+import {
+	PgBossDispatcherNotConfiguredError,
+	PgBossJobRuntimePlugin
+} from '../pgboss-job-runtime.plugin.js';
+
+describe('PgBossJobRuntimePlugin (EW-742 P3.2 follow-up)', () => {
+	let plugin: PgBossJobRuntimePlugin;
+	const origEnv = { ...process.env };
+
+	beforeEach(() => {
+		plugin = new PgBossJobRuntimePlugin();
+	});
+
+	afterEach(() => {
+		for (const key of Object.keys(process.env)) {
+			if (!(key in origEnv)) delete process.env[key];
+		}
+		Object.assign(process.env, origEnv);
+	});
+
+	const snapshot = (overrides: Partial<TenantCredentialSnapshot> = {}): TenantCredentialSnapshot => ({
+		tenantId: '00000000-0000-0000-0000-00000000aaaa',
+		providerId: 'pgboss',
+		credentialVersion: 1,
+		credentials: {
+			schema: 'tenant_acme',
+			connectionString: 'postgres://acme:pw@db:5432/jobs'
+		},
+		...overrides
+	});
+
+	it('declares the canonical IPlugin metadata', () => {
+		expect(plugin.id).toBe('job-runtime-pgboss');
+		expect(plugin.category).toBe('job-runtime');
+		expect(plugin.runtimeId).toBe('pgboss');
+	});
+
+	it('isEnabled true when PGBOSS_CONNECTION_STRING is set', () => {
+		process.env.PGBOSS_CONNECTION_STRING = 'postgres://localhost:5432/x';
+		expect(plugin.isEnabled()).toBe(true);
+	});
+
+	it('stub dispatchers throw PgBossDispatcherNotConfiguredError', () => {
+		const d = plugin.dispatchers as unknown as { dispatchAnything: () => unknown };
+		expect(() => d.dispatchAnything()).toThrowError(PgBossDispatcherNotConfiguredError);
+	});
+
+	it('lifecycle methods return safe defaults', async () => {
+		await expect(plugin.cancel('r')).resolves.toBe(false);
+		await expect(plugin.getRunStatus('r')).resolves.toBe('unknown');
+		await expect(plugin.registerSchedules([])).resolves.toBeUndefined();
+		const handle = await plugin.startWorkerHost({});
+		await expect(handle.stop()).resolves.toBeUndefined();
+	});
+
+	describe('bindToTenant', () => {
+		it('exposes tenantSchema + tenantConnectionString from snapshot.credentials', () => {
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.tenantSchema).toBe('tenant_acme');
+			expect(view.tenantConnectionString).toBe('postgres://acme:pw@db:5432/jobs');
+			expect(Object.isFrozen(view)).toBe(true);
+		});
+
+		it('null fields when credentials are absent', () => {
+			const view = plugin.bindToTenant(snapshot({ credentials: {} }));
+			expect(view.tenantSchema).toBeNull();
+			expect(view.tenantConnectionString).toBeNull();
+		});
+
+		it('memoises on (tenantId, credentialVersion)', () => {
+			const a = plugin.bindToTenant(snapshot());
+			const b = plugin.bindToTenant(snapshot());
+			expect(b).toBe(a);
+		});
+
+		it('evicts older view on credentialVersion bump', () => {
+			const v1 = plugin.bindToTenant(snapshot({ credentialVersion: 1 }));
+			const v2 = plugin.bindToTenant(snapshot({ credentialVersion: 2 }));
+			expect(v2).not.toBe(v1);
+		});
+
+		it('view.bindToTenant(self) returns self', () => {
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.bindToTenant?.(snapshot())).toBe(view);
+		});
+	});
+});

--- a/packages/plugins/job-runtime-pgboss/src/index.ts
+++ b/packages/plugins/job-runtime-pgboss/src/index.ts
@@ -1,0 +1,2 @@
+export { PgBossJobRuntimePlugin } from './pgboss-job-runtime.plugin.js';
+export { PgBossJobRuntimePlugin as default } from './pgboss-job-runtime.plugin.js';

--- a/packages/plugins/job-runtime-pgboss/src/pgboss-job-runtime.plugin.ts
+++ b/packages/plugins/job-runtime-pgboss/src/pgboss-job-runtime.plugin.ts
@@ -1,0 +1,184 @@
+import type {
+	IJobRuntimeProvider,
+	JobRunStatus,
+	JobRuntimeDispatchers,
+	JobRuntimeId,
+	JsonSchema,
+	PluginCategory,
+	PluginContext,
+	ScheduleSpec,
+	TenantCredentialSnapshot,
+	WorkerHostHandle,
+	WorkerHostOptions
+} from '@ever-works/plugin';
+
+/**
+ * EW-742 P3.2 follow-up — pg-boss `IJobRuntimeProvider` plugin.
+ *
+ * Per ADR-017 Q2 (schema-per-tenant), `bindToTenant` extracts a
+ * per-tenant Postgres schema from `snapshot.credentials.schema` (and
+ * optionally a separate `connectionString` if the tenant runs against
+ * a dedicated database). Stub dispatchers throw until an operator
+ * wires per-payload-type publish/work handlers. See the class JSDoc on
+ * {@link TemporalJobRuntimePlugin} for the rationale that applies
+ * identically here.
+ */
+
+export class PgBossDispatcherNotConfiguredError extends Error {
+	constructor(dispatcherName: string) {
+		super(
+			`@ever-works/job-runtime-pgboss-plugin: ${dispatcherName} is not configured. ` +
+				'Subclass PgBossJobRuntimePlugin (or wrap it with a delegating provider) and ' +
+				'override the dispatchers field with operator-defined pg-boss publish/work handlers ' +
+				'per `docs/specs/features/tenant-job-runtime-overlay/providers.md`.'
+		);
+		this.name = 'PgBossDispatcherNotConfiguredError';
+	}
+}
+
+export interface PgBossTenantBindingView extends IJobRuntimeProvider {
+	readonly tenantSnapshot: TenantCredentialSnapshot;
+	/**
+	 * Per-tenant Postgres schema (ADR-017 Q2). Future dispatchers
+	 * should configure `new PgBoss({ schema: tenantSchema })`.
+	 */
+	readonly tenantSchema: string | null;
+	/**
+	 * Optional per-tenant Postgres connection string. When `null` the
+	 * tenant shares the instance Postgres connection.
+	 */
+	readonly tenantConnectionString: string | null;
+}
+
+export class PgBossJobRuntimePlugin implements IJobRuntimeProvider {
+	readonly id = 'job-runtime-pgboss';
+	readonly name = 'pg-boss Job Runtime';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'job-runtime';
+	readonly capabilities: readonly string[] = [
+		'job-runtime-enqueue',
+		'job-runtime-cancel',
+		'job-runtime-status',
+		'job-runtime-schedule',
+		'job-runtime-bind-tenant'
+	];
+	readonly runtimeId: JobRuntimeId = 'pgboss';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			connectionString: {
+				type: 'string',
+				title: 'Postgres connection string',
+				description: 'pg-boss connection string, e.g. `postgres://user:pw@host:5432/db`.',
+				'x-secret': true,
+				'x-envVar': 'PGBOSS_CONNECTION_STRING'
+			},
+			schema: {
+				type: 'string',
+				title: 'pg-boss schema',
+				description: 'Instance-default Postgres schema. Per-tenant overrides come via the credential bag.',
+				'x-envVar': 'PGBOSS_SCHEMA'
+			}
+		}
+	};
+
+	readonly dispatchers: JobRuntimeDispatchers = new Proxy(
+		{},
+		{
+			get(_target, prop: string): unknown {
+				if (typeof prop === 'string' && prop.startsWith('dispatch')) {
+					return () => {
+						throw new PgBossDispatcherNotConfiguredError(prop);
+					};
+				}
+				return undefined;
+			}
+		}
+	);
+
+	private context?: PluginContext;
+	private readonly tenantViews = new Map<string, PgBossTenantBindingView>();
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+		this.tenantViews.clear();
+	}
+
+	async registerSchedules(_schedules: readonly ScheduleSpec[]): Promise<void> {}
+	async cancel(_runId: string): Promise<boolean> {
+		return false;
+	}
+	async getRunStatus(_runId: string): Promise<JobRunStatus> {
+		return 'unknown';
+	}
+
+	isEnabled(): boolean {
+		return Boolean(process.env.PGBOSS_CONNECTION_STRING);
+	}
+
+	async startWorkerHost(_opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+		return { stop: async () => undefined };
+	}
+
+	bindToTenant(snapshot: TenantCredentialSnapshot): PgBossTenantBindingView {
+		const cacheKey = `${snapshot.tenantId}:${snapshot.credentialVersion}`;
+		const cached = this.tenantViews.get(cacheKey);
+		if (cached) {
+			return cached;
+		}
+
+		const base = this;
+		const tenantSchema =
+			typeof snapshot.credentials.schema === 'string' ? snapshot.credentials.schema : null;
+		const tenantConnectionString =
+			typeof snapshot.credentials.connectionString === 'string'
+				? snapshot.credentials.connectionString
+				: null;
+
+		const view: PgBossTenantBindingView = Object.freeze({
+			id: base.id,
+			name: base.name,
+			version: base.version,
+			category: base.category,
+			capabilities: base.capabilities,
+			settingsSchema: base.settingsSchema,
+			runtimeId: base.runtimeId,
+			get dispatchers(): JobRuntimeDispatchers {
+				return base.dispatchers;
+			},
+			registerSchedules: (schedules: readonly ScheduleSpec[]) =>
+				base.registerSchedules(schedules),
+			cancel: (runId: string) => base.cancel(runId),
+			getRunStatus: (runId: string) => base.getRunStatus(runId),
+			isEnabled: () => base.isEnabled(),
+			startWorkerHost: (opts: WorkerHostOptions) => base.startWorkerHost(opts),
+			onLoad: (context: PluginContext) => base.onLoad(context),
+			onUnload: () => base.onUnload(),
+			bindToTenant: (other: TenantCredentialSnapshot) => {
+				if (
+					other.tenantId === snapshot.tenantId &&
+					other.credentialVersion === snapshot.credentialVersion
+				) {
+					return view;
+				}
+				return base.bindToTenant(other);
+			},
+			tenantSnapshot: snapshot,
+			tenantSchema,
+			tenantConnectionString
+		});
+
+		for (const key of this.tenantViews.keys()) {
+			if (key.startsWith(`${snapshot.tenantId}:`)) {
+				this.tenantViews.delete(key);
+			}
+		}
+		this.tenantViews.set(cacheKey, view);
+		return view;
+	}
+}

--- a/packages/plugins/job-runtime-pgboss/tsconfig.json
+++ b/packages/plugins/job-runtime-pgboss/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/job-runtime-pgboss/tsup.config.ts
+++ b/packages/plugins/job-runtime-pgboss/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/packages/plugins/job-runtime-temporal/package.json
+++ b/packages/plugins/job-runtime-temporal/package.json
@@ -1,0 +1,72 @@
+{
+	"name": "@ever-works/job-runtime-temporal-plugin",
+	"version": "1.0.0",
+	"description": "Temporal IJobRuntimeProvider plugin for Ever Works — implements the BYO/inherit tenant-overlay binding for Temporal namespaces (EW-742 P3.2, ADR-017 Q1 namespace-per-tenant). Per-task dispatching is operator-provisioned.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "job-runtime-temporal",
+			"name": "Temporal Job Runtime",
+			"version": "1.0.0",
+			"category": "job-runtime",
+			"capabilities": [
+				"job-runtime-enqueue",
+				"job-runtime-cancel",
+				"job-runtime-status",
+				"job-runtime-schedule",
+				"job-runtime-bind-tenant"
+			],
+			"description": "Temporal (https://temporal.io) IJobRuntimeProvider for the EW-742 tenant overlay. Implements bindToTenant via Temporal namespace-per-tenant routing (ADR-017 Q1). Per-task dispatchers throw 'not implemented' until an operator wires the per-payload-type workflow handlers.",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"autoEnable": false,
+			"systemPlugin": false,
+			"distribution": "core",
+			"builtIn": true,
+			"visibility": "operator",
+			"envVars": [
+				"TEMPORAL_ADDRESS",
+				"TEMPORAL_NAMESPACE",
+				"TEMPORAL_TLS_CERT",
+				"TEMPORAL_TLS_KEY"
+			]
+		}
+	}
+}

--- a/packages/plugins/job-runtime-temporal/src/__tests__/temporal-job-runtime.plugin.spec.ts
+++ b/packages/plugins/job-runtime-temporal/src/__tests__/temporal-job-runtime.plugin.spec.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { TenantCredentialSnapshot } from '@ever-works/plugin';
+import {
+	TemporalDispatcherNotConfiguredError,
+	TemporalJobRuntimePlugin
+} from '../temporal-job-runtime.plugin.js';
+
+describe('TemporalJobRuntimePlugin (EW-742 P3.2 follow-up)', () => {
+	let plugin: TemporalJobRuntimePlugin;
+	const origEnv = { ...process.env };
+
+	beforeEach(() => {
+		plugin = new TemporalJobRuntimePlugin();
+	});
+
+	afterEach(() => {
+		for (const key of Object.keys(process.env)) {
+			if (!(key in origEnv)) delete process.env[key];
+		}
+		Object.assign(process.env, origEnv);
+	});
+
+	const snapshot = (overrides: Partial<TenantCredentialSnapshot> = {}): TenantCredentialSnapshot => ({
+		tenantId: '00000000-0000-0000-0000-00000000aaaa',
+		providerId: 'temporal',
+		credentialVersion: 1,
+		credentials: { namespace: 'tenant-acme' },
+		...overrides
+	});
+
+	describe('manifest', () => {
+		it('declares the canonical IPlugin metadata', () => {
+			expect(plugin.id).toBe('job-runtime-temporal');
+			expect(plugin.category).toBe('job-runtime');
+			expect(plugin.runtimeId).toBe('temporal');
+			expect(plugin.capabilities).toContain('job-runtime-bind-tenant');
+		});
+	});
+
+	describe('isEnabled', () => {
+		it('returns true when TEMPORAL_ADDRESS + TEMPORAL_NAMESPACE are set', () => {
+			process.env.TEMPORAL_ADDRESS = 'temporal:7233';
+			process.env.TEMPORAL_NAMESPACE = 'default';
+			expect(plugin.isEnabled()).toBe(true);
+		});
+		it('returns false when address is missing', () => {
+			delete process.env.TEMPORAL_ADDRESS;
+			expect(plugin.isEnabled()).toBe(false);
+		});
+	});
+
+	describe('stub dispatchers', () => {
+		it('throws TemporalDispatcherNotConfiguredError on any dispatch* call', () => {
+			const dispatcher = plugin.dispatchers as unknown as {
+				dispatchKbEmbedDocument: (p: unknown) => unknown;
+			};
+			expect(() => dispatcher.dispatchKbEmbedDocument({})).toThrowError(
+				TemporalDispatcherNotConfiguredError
+			);
+		});
+	});
+
+	describe('lifecycle no-ops', () => {
+		it('cancel returns false', async () => {
+			await expect(plugin.cancel('run-1')).resolves.toBe(false);
+		});
+		it('getRunStatus returns "unknown"', async () => {
+			await expect(plugin.getRunStatus('run-1')).resolves.toBe('unknown');
+		});
+		it('registerSchedules is a no-op', async () => {
+			await expect(plugin.registerSchedules([])).resolves.toBeUndefined();
+		});
+		it('startWorkerHost returns a no-op handle', async () => {
+			const handle = await plugin.startWorkerHost({});
+			await expect(handle.stop()).resolves.toBeUndefined();
+		});
+	});
+
+	describe('bindToTenant', () => {
+		it('returns a frozen per-tenant view with snapshot + namespace exposed', () => {
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.runtimeId).toBe('temporal');
+			expect(view.tenantSnapshot.tenantId).toBe('00000000-0000-0000-0000-00000000aaaa');
+			expect(view.tenantNamespace).toBe('tenant-acme');
+			expect(Object.isFrozen(view)).toBe(true);
+		});
+
+		it('returns null tenantNamespace when credentials.namespace is absent', () => {
+			const view = plugin.bindToTenant(snapshot({ credentials: {} }));
+			expect(view.tenantNamespace).toBeNull();
+		});
+
+		it('memoises on (tenantId, credentialVersion)', () => {
+			const a = plugin.bindToTenant(snapshot());
+			const b = plugin.bindToTenant(snapshot());
+			expect(b).toBe(a);
+		});
+
+		it('evicts the older view when credentialVersion bumps', () => {
+			const v1 = plugin.bindToTenant(snapshot({ credentialVersion: 1 }));
+			const v2 = plugin.bindToTenant(snapshot({ credentialVersion: 2 }));
+			expect(v2).not.toBe(v1);
+			// v1 entry was evicted by the v2 cache-replace, so asking again
+			// returns a fresh view.
+			const v1Again = plugin.bindToTenant(snapshot({ credentialVersion: 1 }));
+			expect(v1Again).not.toBe(v1);
+		});
+
+		it('view.bindToTenant(self) returns self', () => {
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.bindToTenant?.(snapshot())).toBe(view);
+		});
+
+		it('view delegates lifecycle methods to base plugin', async () => {
+			const view = plugin.bindToTenant(snapshot());
+			await expect(view.cancel('run-x')).resolves.toBe(false);
+			await expect(view.getRunStatus('run-x')).resolves.toBe('unknown');
+		});
+	});
+});

--- a/packages/plugins/job-runtime-temporal/src/index.ts
+++ b/packages/plugins/job-runtime-temporal/src/index.ts
@@ -1,0 +1,2 @@
+export { TemporalJobRuntimePlugin } from './temporal-job-runtime.plugin.js';
+export { TemporalJobRuntimePlugin as default } from './temporal-job-runtime.plugin.js';

--- a/packages/plugins/job-runtime-temporal/src/temporal-job-runtime.plugin.ts
+++ b/packages/plugins/job-runtime-temporal/src/temporal-job-runtime.plugin.ts
@@ -1,0 +1,268 @@
+import type {
+	IJobRuntimeProvider,
+	JobRunStatus,
+	JobRuntimeDispatchers,
+	JobRuntimeId,
+	JsonSchema,
+	PluginCategory,
+	PluginContext,
+	ScheduleSpec,
+	TenantCredentialSnapshot,
+	WorkerHostHandle,
+	WorkerHostOptions
+} from '@ever-works/plugin';
+
+/**
+ * EW-742 P3.2 follow-up — Temporal `IJobRuntimeProvider` plugin.
+ *
+ * # What this plugin ships TODAY
+ *
+ *   - Full `IPlugin` + `IJobRuntimeProvider` contract surface so the
+ *     binding factory in `packages/agent/src/tasks/job-runtime.providers.ts`
+ *     can register it alongside the Trigger.dev provider.
+ *   - **Real `bindToTenant` implementation** with per-`(tenantId,
+ *     credentialVersion)` memoisation, matching the pattern of
+ *     {@link TriggerJobRuntimeProvider.bindToTenant} (#1426). The
+ *     resolved snapshot is exposed off-spec as `view.tenantSnapshot`
+ *     so the T22 stamper can stamp `(providerId, credentialVersion)`
+ *     onto run records.
+ *   - `bindToTenant` extracts the per-tenant Temporal **namespace**
+ *     from `snapshot.credentials.namespace` (per ADR-017 Q1 —
+ *     namespace-per-tenant) and exposes it on the view as
+ *     `tenantNamespace` so a future dispatcher impl can route to it.
+ *
+ * # What this plugin DOES NOT ship (gated on operator demand)
+ *
+ *   - **Per-task workflow dispatchers**. Every `dispatchXxx` method
+ *     throws a typed `TemporalDispatcherNotConfiguredError` with a
+ *     clear operator-facing message. Wiring real workflows requires
+ *     defining each `*_DISPATCHER` payload as a Temporal Workflow
+ *     under the operator's own Temporal Cluster — that's a per-
+ *     deployment design decision (workflow versioning, signal/query
+ *     shape, activity decomposition) that we deliberately defer to
+ *     operator-owned PRs.
+ *   - **`startWorkerHost`**. Temporal is a pull-model runtime; the
+ *     operator stands up their own worker process(es) against their
+ *     cluster + namespace. The method returns a no-op handle so
+ *     callers that generically "start the worker host if the
+ *     provider supports it" don't branch.
+ *
+ * # Operator setup
+ *
+ *   1. Set `EVER_WORKS_JOB_RUNTIME=temporal` in the API env.
+ *   2. Configure `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE` (the
+ *      instance default — used when no tenant overlay applies), and
+ *      mTLS via `TEMPORAL_TLS_CERT` + `TEMPORAL_TLS_KEY`.
+ *   3. For per-tenant BYO: provision tenant credentials with
+ *      `{ namespace: 'tenant-acme', address?, tlsCert?, tlsKey? }`
+ *      and store via the `SECRET_STORE_RESOLVER` binding (Vault,
+ *      K8s, Infisical, Doppler, AWS-SM, GCP-SM, Azure-KV — all
+ *      shipped as plugins).
+ *   4. Implement the per-payload-type Workflows in your own worker
+ *      process and either subclass this plugin to override the
+ *      stub dispatchers, or wrap it with a delegating provider that
+ *      ships your dispatchers.
+ *
+ * Spec: [`docs/specs/features/tenant-job-runtime-overlay/providers.md`](../../../../docs/specs/features/tenant-job-runtime-overlay/providers.md) (Temporal section, ADR-017 Q1).
+ */
+
+export class TemporalDispatcherNotConfiguredError extends Error {
+	constructor(dispatcherName: string) {
+		super(
+			`@ever-works/job-runtime-temporal-plugin: ${dispatcherName} is not configured. ` +
+				'Subclass TemporalJobRuntimePlugin (or wrap it with a delegating provider) and ' +
+				'override the dispatchers field with operator-defined Temporal workflow handlers ' +
+				'per `docs/specs/features/tenant-job-runtime-overlay/providers.md`.'
+		);
+		this.name = 'TemporalDispatcherNotConfiguredError';
+	}
+}
+
+/**
+ * View extension on top of the standard {@link IJobRuntimeProvider}
+ * shape for Temporal-specific binding fields.
+ */
+export interface TemporalTenantBindingView extends IJobRuntimeProvider {
+	readonly tenantSnapshot: TenantCredentialSnapshot;
+	/**
+	 * Per-tenant Temporal namespace (per ADR-017 Q1
+	 * namespace-per-tenant). When the operator's per-payload-type
+	 * dispatchers are wired they should call `namespaces.connect()`
+	 * (or equivalent) against this namespace for every dispatch.
+	 */
+	readonly tenantNamespace: string | null;
+}
+
+export class TemporalJobRuntimePlugin implements IJobRuntimeProvider {
+	readonly id = 'job-runtime-temporal';
+	readonly name = 'Temporal Job Runtime';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'job-runtime';
+	readonly capabilities: readonly string[] = [
+		'job-runtime-enqueue',
+		'job-runtime-cancel',
+		'job-runtime-status',
+		'job-runtime-schedule',
+		'job-runtime-bind-tenant'
+	];
+	readonly runtimeId: JobRuntimeId = 'temporal';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			address: {
+				type: 'string',
+				title: 'Temporal Address',
+				description: 'gRPC endpoint, e.g. `temporal.tenant-acme.svc:7233`.',
+				'x-envVar': 'TEMPORAL_ADDRESS'
+			},
+			namespace: {
+				type: 'string',
+				title: 'Temporal Namespace',
+				description: 'Instance-default namespace. Per-tenant overrides come via the credential bag.',
+				'x-envVar': 'TEMPORAL_NAMESPACE'
+			},
+			tlsCert: {
+				type: 'string',
+				title: 'TLS Client Cert (PEM)',
+				'x-secret': true,
+				'x-envVar': 'TEMPORAL_TLS_CERT'
+			},
+			tlsKey: {
+				type: 'string',
+				title: 'TLS Client Key (PEM)',
+				'x-secret': true,
+				'x-envVar': 'TEMPORAL_TLS_KEY'
+			}
+		}
+	};
+
+	/**
+	 * Stub dispatchers — every method throws
+	 * {@link TemporalDispatcherNotConfiguredError}. Operators override
+	 * by subclassing or wrapping (see class JSDoc "Operator setup").
+	 */
+	readonly dispatchers: JobRuntimeDispatchers = new Proxy(
+		{},
+		{
+			get(_target, prop: string): unknown {
+				if (typeof prop === 'string' && prop.startsWith('dispatch')) {
+					return () => {
+						throw new TemporalDispatcherNotConfiguredError(prop);
+					};
+				}
+				return undefined;
+			}
+		}
+	);
+
+	private context?: PluginContext;
+	private readonly tenantViews = new Map<string, TemporalTenantBindingView>();
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+		this.tenantViews.clear();
+	}
+
+	async registerSchedules(_schedules: readonly ScheduleSpec[]): Promise<void> {
+		// Stub — Temporal Schedules require workflow definitions which
+		// only the operator can supply. No-op so the binding factory
+		// can call this at boot without throwing.
+	}
+
+	async cancel(_runId: string): Promise<boolean> {
+		// Stub — operator-overridden via subclass / wrapper. Return
+		// `false` so callers don't assume cancellation succeeded.
+		return false;
+	}
+
+	async getRunStatus(_runId: string): Promise<JobRunStatus> {
+		return 'unknown';
+	}
+
+	isEnabled(): boolean {
+		// Temporal is enabled when an operator has wired the address +
+		// namespace env vars. We don't actually attempt a connection
+		// here — `isEnabled()` is called at boot; a failed connection
+		// surfaces at first-dispatch time.
+		const address = process.env.TEMPORAL_ADDRESS;
+		const namespace = process.env.TEMPORAL_NAMESPACE;
+		return Boolean(address && namespace);
+	}
+
+	async startWorkerHost(_opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+		// Pull-model runtime — operator runs their own worker
+		// process(es). No-op handle so generic callers don't branch.
+		return { stop: async () => undefined };
+	}
+
+	/**
+	 * EW-742 P3.2 — per-tenant binding for Temporal namespace-per-
+	 * tenant routing (ADR-017 Q1). Returns a frozen view with the
+	 * snapshot + tenant namespace exposed.
+	 *
+	 * Memoised on `(tenantId, credentialVersion)` per the
+	 * `IJobRuntimeProvider.bindToTenant` idempotency clause. On a
+	 * `credentialVersion` bump the older entry is evicted in place so
+	 * the cache stays bounded by tenant count.
+	 */
+	bindToTenant(snapshot: TenantCredentialSnapshot): TemporalTenantBindingView {
+		const cacheKey = `${snapshot.tenantId}:${snapshot.credentialVersion}`;
+		const cached = this.tenantViews.get(cacheKey);
+		if (cached) {
+			return cached;
+		}
+
+		const base = this;
+		const tenantNamespace =
+			typeof snapshot.credentials.namespace === 'string'
+				? snapshot.credentials.namespace
+				: null;
+
+		const view: TemporalTenantBindingView = Object.freeze({
+			id: base.id,
+			name: base.name,
+			version: base.version,
+			category: base.category,
+			capabilities: base.capabilities,
+			settingsSchema: base.settingsSchema,
+			runtimeId: base.runtimeId,
+			get dispatchers(): JobRuntimeDispatchers {
+				return base.dispatchers;
+			},
+			registerSchedules: (schedules: readonly ScheduleSpec[]) =>
+				base.registerSchedules(schedules),
+			cancel: (runId: string) => base.cancel(runId),
+			getRunStatus: (runId: string) => base.getRunStatus(runId),
+			isEnabled: () => base.isEnabled(),
+			startWorkerHost: (opts: WorkerHostOptions) => base.startWorkerHost(opts),
+			onLoad: (context: PluginContext) => base.onLoad(context),
+			onUnload: () => base.onUnload(),
+			bindToTenant: (other: TenantCredentialSnapshot) => {
+				if (
+					other.tenantId === snapshot.tenantId &&
+					other.credentialVersion === snapshot.credentialVersion
+				) {
+					return view;
+				}
+				return base.bindToTenant(other);
+			},
+			tenantSnapshot: snapshot,
+			tenantNamespace
+		});
+
+		// Evict any older entry for this tenant (cache stays bounded
+		// by tenant count, not version count).
+		for (const key of this.tenantViews.keys()) {
+			if (key.startsWith(`${snapshot.tenantId}:`)) {
+				this.tenantViews.delete(key);
+			}
+		}
+		this.tenantViews.set(cacheKey, view);
+		return view;
+	}
+}

--- a/packages/plugins/job-runtime-temporal/tsconfig.json
+++ b/packages/plugins/job-runtime-temporal/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/job-runtime-temporal/tsup.config.ts
+++ b/packages/plugins/job-runtime-temporal/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
+++ b/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
@@ -63,9 +63,10 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
     readonly id = 'trigger';
     readonly name = 'Trigger.dev';
     readonly version = '1.0.0';
-    // See file header "Drift note" — `'job-runtime'` is not yet in
-    // `PLUGIN_CATEGORIES`; cast is deliberate.
-    readonly category = 'job-runtime' as PluginCategory;
+    // EW-742 P3.2 follow-up — `'job-runtime'` is now part of
+    // `PLUGIN_CATEGORIES` (alongside `'secret-store-resolver'`). The
+    // earlier `as PluginCategory` cast is no longer needed.
+    readonly category: PluginCategory = 'job-runtime';
     readonly capabilities: readonly string[] = [
         'job-runtime-enqueue',
         'job-runtime-cancel',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1815,6 +1815,78 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
+  packages/plugins/job-runtime-bullmq:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  packages/plugins/job-runtime-inngest:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  packages/plugins/job-runtime-pgboss:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  packages/plugins/job-runtime-temporal:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
   packages/plugins/k8s:
     dependencies:
       '@kubernetes/client-node':


### PR DESCRIPTION
## Summary

Closes the genuinely-deferred work from the EW-742 P3.2 thread: the four `IJobRuntimeProvider` plugin packages that didn't exist when we wrapped the last batch.

## What this PR ships

### 1. `PLUGIN_CATEGORIES` now includes `'job-runtime'`
Drops the `as PluginCategory` cast TODO from `TriggerJobRuntimeProvider`.

### 2. Four new plugin packages under `packages/plugins/`

| Package | bindToTenant view exposes | Env vars |
|---|---|---|
| `@ever-works/job-runtime-temporal-plugin` | `tenantNamespace` (ADR-017 Q1) | `TEMPORAL_ADDRESS`, `TEMPORAL_NAMESPACE`, `TEMPORAL_TLS_{CERT,KEY}` |
| `@ever-works/job-runtime-bullmq-plugin` | `tenantQueuePrefix` + `tenantRedisUrl` | `BULLMQ_REDIS_URL`, `BULLMQ_QUEUE_PREFIX` |
| `@ever-works/job-runtime-pgboss-plugin` | `tenantSchema` + `tenantConnectionString` (ADR-017 Q2) | `PGBOSS_CONNECTION_STRING`, `PGBOSS_SCHEMA` |
| `@ever-works/job-runtime-inngest-plugin` | `tenantEventKey` + `tenantSigningKey` (SaaS only) | `INNGEST_EVENT_KEY`, `INNGEST_SIGNING_KEY` |

Each plugin:
- Full `IPlugin` + `IJobRuntimeProvider` contract surface
- **Real `bindToTenant`** with per-`(tenantId, credentialVersion)` memoisation + cache-replace on version bump (matches `TriggerJobRuntimeProvider` pattern from #1426)
- Frozen view exposes `tenantSnapshot` off-spec so the T22 stamper can read `(providerId, credentialVersion)` for run-record stamping
- Stub dispatchers via Proxy that throws `<Provider>DispatcherNotConfiguredError` with a clear message pointing the operator at `docs/specs/features/tenant-job-runtime-overlay/providers.md`

## What this PR does NOT ship (intentional — operator-owned)

- **Per-task dispatcher logic.** Each `*_DISPATCHER` payload needs to be defined as a Temporal Workflow / BullMQ Queue+Worker pair / pg-boss publish+work handler / Inngest function in the operator's own worker process. That's a per-deployment design decision (workflow versioning, queue concurrency, retry strategy) we deliberately defer to operator-owned PRs.
- **Real worker host bootstrap.** Pull-model runtimes return a no-op handle from `startWorkerHost`.

## Tests

**43 new vitest cases** across the 4 plugins (14 + 10 + 9 + 10):
- IPlugin manifest assertions
- `isEnabled` env-var gating
- Stub dispatcher throws typed error
- Lifecycle methods return safe defaults
- `bindToTenant`: snapshot exposure, memoisation, cache-replace on version bump, self-return idempotency
- Provider-specific credential bag extraction (namespace / prefix / schema / signing-key) + null-safety on absent fields

Verified: 235 plugin contract tests still green; 26 Trigger.dev provider tests still green; agent + 4 new plugin packages build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `job-runtime` plugin category for pluggable job runtime backends
  * Added four new job runtime provider plugins: BullMQ, Inngest, PgBoss, and Temporal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->