### PR TITLE
fix(agent): TenantCredentialCache bootstrap crash — UnknownDependenciesException (?, Number)

### DIFF
--- a/packages/agent/src/tasks/__tests__/tenant-credential.cache.spec.ts
+++ b/packages/agent/src/tasks/__tests__/tenant-credential.cache.spec.ts
@@ -70,7 +70,7 @@ describe('TenantCredentialCache (EW-742 P3.1 / T21)', () => {
     describe('TTL expiry', () => {
         it('returns null after ttlMs elapses without invalidation', () => {
             jest.useFakeTimers();
-            const cache = new TenantCredentialCache(1024, 30_000);
+            const cache = new TenantCredentialCache({ maxEntries: 1024, ttlMs: 30_000 });
             cache.set('tenant-a', 'trigger', 1, { token: 'a' });
             expect(cache.get('tenant-a', 'trigger', 1)).toEqual({ token: 'a' });
 
@@ -85,7 +85,7 @@ describe('TenantCredentialCache (EW-742 P3.1 / T21)', () => {
 
         it('a fresh set() refreshes the TTL deadline', () => {
             jest.useFakeTimers();
-            const cache = new TenantCredentialCache(1024, 30_000);
+            const cache = new TenantCredentialCache({ maxEntries: 1024, ttlMs: 30_000 });
             cache.set('tenant-a', 'trigger', 1, { token: 'first' });
 
             // 20s in — still alive, refresh with a new value.
@@ -152,7 +152,7 @@ describe('TenantCredentialCache (EW-742 P3.1 / T21)', () => {
 
     describe('LRU eviction at capacity', () => {
         it('evicts the oldest-by-insertion-order entry when at maxEntries', () => {
-            const cache = new TenantCredentialCache(3, 60_000);
+            const cache = new TenantCredentialCache({ maxEntries: 3, ttlMs: 60_000 });
             cache.set('tenant-a', 'trigger', 1, { tag: 'first' });
             cache.set('tenant-a', 'trigger', 2, { tag: 'second' });
             cache.set('tenant-a', 'trigger', 3, { tag: 'third' });
@@ -176,7 +176,7 @@ describe('TenantCredentialCache (EW-742 P3.1 / T21)', () => {
 
     describe('size()', () => {
         it('reflects entry count through inserts, evictions, and invalidations', () => {
-            const cache = new TenantCredentialCache(3, 60_000);
+            const cache = new TenantCredentialCache({ maxEntries: 3, ttlMs: 60_000 });
             expect(cache.size()).toBe(0);
 
             cache.set('tenant-a', 'trigger', 1, { v: 1 });

--- a/packages/agent/src/tasks/tenant-credential.cache.ts
+++ b/packages/agent/src/tasks/tenant-credential.cache.ts
@@ -56,28 +56,56 @@ import { Injectable } from '@nestjs/common';
  * are atomic from the JS-engine's perspective. The cache is safe to
  * share across concurrent dispatcher calls without external locking.
  */
+/**
+ * Defaults for the cache sizing. Inlined as class-level constants
+ * because making them DI-injected primitives breaks NestJS — SWC emits
+ * `Number` as the constructor design-time metadata, which NestJS tries
+ * to resolve as a DI token and fails with
+ * `UnknownDependenciesException: Nest can't resolve dependencies of the
+ * TenantCredentialCache (?, Number)`. Cache sizing is a process-level
+ * concern anyway (not per-tenant), so a class constant is the right shape.
+ */
+const DEFAULT_MAX_ENTRIES = 1024;
+const DEFAULT_TTL_MS = 30_000;
+
 @Injectable()
 export class TenantCredentialCache {
+    /**
+     * Maximum number of `(tenantId, providerId, version)` snapshots held
+     * in memory before the oldest-by-insertion-order entry is evicted.
+     * Sized for a small fleet of tenants × providers × a handful of
+     * in-flight rotation snapshots per pair.
+     *
+     * Override at construction time in tests via `new TenantCredentialCache(
+     * { maxEntries, ttlMs })`. Production never overrides — the values
+     * are sized for hosting capacity, not tuned at runtime.
+     */
     private readonly maxEntries: number;
+    /**
+     * Entry lifetime in milliseconds. Default sits in the middle of the
+     * spec's 15–60s band. After the TTL elapses, {@link get} returns
+     * `null` even if the entry is still in the map; the entry is removed
+     * on the next access.
+     */
     private readonly ttlMs: number;
 
     private readonly entries = new Map<string, CacheEntry>();
     private insertCounter = 0;
 
     /**
-     * @param maxEntries maximum number of `(tenantId, providerId, version)`
-     *   snapshots held in memory before the oldest-by-insertion-order
-     *   entry is evicted. Default `1024` — sized for a small fleet of
-     *   tenants × providers × a handful of in-flight rotation snapshots
-     *   per pair.
-     * @param ttlMs entry lifetime in milliseconds. Default `30_000` (30s),
-     *   sitting in the middle of the spec's 15–60s band. After the TTL
-     *   elapses, {@link get} returns `null` even if the entry is still
-     *   in the map; the entry is removed on the next access.
+     * Construct the cache. The options object pattern is required — a
+     * positional `(maxEntries: number, ttlMs: number)` constructor would
+     * crash NestJS bootstrap because SWC emits the parameter design-time
+     * metadata as `Number`, and NestJS attempts to resolve `Number` as
+     * a DI token (which fails with `UnknownDependenciesException`).
+     *
+     * NestJS instantiates this service with zero args; the options
+     * object only exists so tests can override the defaults without
+     * tripping the same DI metadata trap.
      */
-    constructor(maxEntries: number = 1024, ttlMs: number = 30_000) {
-        this.maxEntries = maxEntries;
-        this.ttlMs = ttlMs;
+    constructor(opts?: { maxEntries?: number; ttlMs?: number }) {
+        this.maxEntries = opts?.maxEntries ?? DEFAULT_MAX_ENTRIES;
+        this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
     }
 
     /**


### PR DESCRIPTION
## Production outage

\`ever-works-api\` prod / stage / dev pods all CrashLoopBackOff with:

\`\`\`
UnknownDependenciesException [Error]: Nest can't resolve dependencies of the TenantCredentialCache (?, Number).
\`\`\`

\`app.ever.works\` returning 401 because the upstream API never came up. CrashLoop has been running ~26h on every replica.

## Root cause

\`TenantCredentialCache\` constructor was \`(maxEntries: number = 1024, ttlMs: number = 30_000)\`. SWC emits primitive \`number\` design-time metadata as the global \`Number\` constructor; NestJS tries to resolve \`Number\` as a DI token and fails.

JS default parameters don't help — NestJS bypasses them by passing already-resolved positional args to \`new Provider(...)\`.

## Fix

Options-object constructor: \`constructor(opts?: { maxEntries?: number; ttlMs?: number })\`. Single \`Object\`-typed param has metadata NestJS treats as "not a DI token" and skips. Defaults applied with \`??\` inside the body; class-level constants encode the sizing decisions.

Three test call sites updated; 4 zero-arg test calls were already correct.

## Verification

- 12/12 \`TenantCredentialCache\` jest cases green
- Agent package build clean

## Cascade

Hotfix branched from \`origin/main\`. Land here, then fast-forward cascade to \`stage\` + \`develop\` so prod recovers without waiting on the next normal release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)