### PR TITLE
fix(ci): swap prod docker build runner to ubuntu-latest (Ubicloud startup_failure)

### DIFF
--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ever-works-api:
-    runs-on: ubicloud-standard-8
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-api:latest
 
   ever-works-web:
-    runs-on: ubicloud-standard-8
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Symptom

`Build and Publish Docker Images Prod` returns `startup_failure` after 1 second on every push since 2026-06-18. Manual `workflow_dispatch` same. Zero jobs allocated — runner never spins up.

## Cause

`ubicloud-standard-8` runner allocation failing. Most likely Ubicloud quota/billing.

## Fix

Swap to `ubuntu-latest` (GH-hosted, free). Minimum change to unblock prod docker rebuild → deploy chain so the #1451 `TenantCredentialCache` fix can actually deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)