### PR TITLE
feat(job-runtime-inngest): operator-pluggable real dispatcher + function defs

### DIFF
--- a/packages/plugins/job-runtime-inngest/src/__tests__/inngest-dispatcher-factory.spec.ts
+++ b/packages/plugins/job-runtime-inngest/src/__tests__/inngest-dispatcher-factory.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import { InngestDispatcherFactory } from '../inngest-dispatcher-factory.js';
+import type { InngestClient, InngestFunction, InngestSendEvent, InngestSendResult } from '../inngest-types.js';
+
+class FakeInngest implements InngestClient {
+	sendCalls: (InngestSendEvent | readonly InngestSendEvent[])[] = [];
+	createFunctionCalls: { config: unknown; trigger: unknown }[] = [];
+	private nextId = 1;
+
+	async send(event: InngestSendEvent | readonly InngestSendEvent[]): Promise<InngestSendResult> {
+		this.sendCalls.push(event);
+		const count = Array.isArray(event) ? event.length : 1;
+		const ids = Array.from({ length: count }, () => `evt_${this.nextId++}`);
+		return { ids };
+	}
+
+	createFunction(
+		config: Readonly<Record<string, unknown>>,
+		trigger: Readonly<Record<string, unknown>>,
+		_handler: (...args: unknown[]) => Promise<unknown>
+	): InngestFunction {
+		this.createFunctionCalls.push({ config, trigger });
+		return { __fn: config['id'] };
+	}
+}
+
+describe('InngestDispatcherFactory', () => {
+	it('send prepends eventNamespace and returns the first event id', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client, eventNamespace: 'ever.works' });
+		const id = await factory.send('kb-embed-document', { workId: 'w1' });
+		expect(id).toBe('evt_1');
+		expect(client.sendCalls[0]).toEqual({
+			name: 'ever.works/kb-embed-document',
+			data: { workId: 'w1' }
+		});
+	});
+
+	it('send without namespace uses the raw event name', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		await factory.send('raw.event', { x: 1 });
+		expect(client.sendCalls[0]).toEqual({ name: 'raw.event', data: { x: 1 } });
+	});
+
+	it('send merges overrides (id, user) into the event', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		await factory.send('evt', { x: 1 }, { id: 'idem-1', user: { uid: 'u' } });
+		const sent = client.sendCalls[0] as InngestSendEvent;
+		expect(sent.id).toBe('idem-1');
+		expect(sent.user).toEqual({ uid: 'u' });
+	});
+
+	it('send returns null when client returns no ids', async () => {
+		const client = new FakeInngest();
+		client.send = vi.fn(async () => ({ ids: [] }));
+		const factory = new InngestDispatcherFactory({ client });
+		await expect(factory.send('evt', {})).resolves.toBeNull();
+	});
+
+	it('sendBatch namespaces every event and returns ids', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client, eventNamespace: 'ew' });
+		const ids = await factory.sendBatch([
+			{ name: 'evt-a', data: { x: 1 } },
+			{ name: 'evt-b', data: { x: 2 } }
+		]);
+		expect(ids).toEqual(['evt_1', 'evt_2']);
+		expect(client.sendCalls[0]).toEqual([
+			{ name: 'ew/evt-a', data: { x: 1 } },
+			{ name: 'ew/evt-b', data: { x: 2 } }
+		]);
+	});
+
+	it('defineFunction registers + collects functions for serve()', () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		const fn = factory.defineFunction(
+			{ id: 'kb-embed-document' },
+			{ event: 'ever.works/kb-embed-document' },
+			async () => undefined
+		);
+		expect(client.createFunctionCalls).toHaveLength(1);
+		expect(client.createFunctionCalls[0].config).toEqual({ id: 'kb-embed-document' });
+		expect(factory.functions).toEqual([fn]);
+	});
+
+	it('defineFunction throws when client.createFunction is missing', () => {
+		const minimal: InngestClient = {
+			async send() {
+				return { ids: [] };
+			}
+		};
+		const factory = new InngestDispatcherFactory({ client: minimal });
+		expect(() =>
+			factory.defineFunction({ id: 'x' }, { event: 'x' }, async () => undefined)
+		).toThrow(/createFunction is unavailable/);
+	});
+});

--- a/packages/plugins/job-runtime-inngest/src/__tests__/inngest-plugin-operator-hooks.spec.ts
+++ b/packages/plugins/job-runtime-inngest/src/__tests__/inngest-plugin-operator-hooks.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import type { JobRuntimeDispatchers, TenantCredentialSnapshot } from '@ever-works/plugin';
+import {
+	InngestDispatcherFactory,
+	InngestDispatcherNotConfiguredError,
+	InngestJobRuntimePlugin
+} from '../index.js';
+import type { InngestClient, InngestSendEvent, InngestSendResult, InngestFunction } from '../inngest-types.js';
+
+class StubInngest implements InngestClient {
+	sentNames: string[] = [];
+	createdCount = 0;
+	private nextId = 1;
+
+	async send(event: InngestSendEvent | readonly InngestSendEvent[]): Promise<InngestSendResult> {
+		const events = Array.isArray(event) ? event : [event as InngestSendEvent];
+		for (const e of events) this.sentNames.push(e.name);
+		return { ids: events.map(() => `evt_${this.nextId++}`) };
+	}
+	createFunction(): InngestFunction {
+		this.createdCount += 1;
+		return { id: this.createdCount };
+	}
+}
+
+const snapshot = (overrides: Partial<TenantCredentialSnapshot> = {}): TenantCredentialSnapshot => ({
+	tenantId: '00000000-0000-0000-0000-00000000aaaa',
+	providerId: 'inngest',
+	credentialVersion: 1,
+	credentials: { eventKey: 'ek-tenant', signingKey: 'sk-tenant' },
+	...overrides
+});
+
+describe('InngestJobRuntimePlugin — operator hooks', () => {
+	it('useDispatchers replaces the throwing stub', async () => {
+		const client = new StubInngest();
+		const factory = new InngestDispatcherFactory({ client, eventNamespace: 'ever.works' });
+		const plugin = new InngestJobRuntimePlugin().useDispatchers({
+			dispatchKbEmbedDocument: (payload: unknown) =>
+				factory.send('kb-embed-document', payload)
+		});
+		const d = plugin.dispatchers as unknown as {
+			dispatchKbEmbedDocument: (p: unknown) => Promise<string | null>;
+		};
+		await expect(d.dispatchKbEmbedDocument({ workId: 'w' })).resolves.toBe('evt_1');
+		expect(client.sentNames).toEqual(['ever.works/kb-embed-document']);
+	});
+
+	it('without useDispatchers the throwing stub still fires', () => {
+		const plugin = new InngestJobRuntimePlugin();
+		const d = plugin.dispatchers as unknown as { dispatchKbEmbedDocument: () => unknown };
+		expect(() => d.dispatchKbEmbedDocument()).toThrow(InngestDispatcherNotConfiguredError);
+	});
+
+	it('plugin.functions surfaces factory-registered functions', () => {
+		const client = new StubInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		factory.defineFunction({ id: 'f1' }, { event: 'ew/f1' }, async () => undefined);
+		factory.defineFunction({ id: 'f2' }, { event: 'ew/f2' }, async () => undefined);
+		const plugin = new InngestJobRuntimePlugin().useDispatcherFactory(factory);
+		expect(plugin.functions).toHaveLength(2);
+	});
+
+	it('plugin.functions empty without a factory', () => {
+		const plugin = new InngestJobRuntimePlugin();
+		expect(plugin.functions).toEqual([]);
+	});
+
+	it('startWorkerHost is no-op even with factory wired (serverless model)', async () => {
+		const client = new StubInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		const plugin = new InngestJobRuntimePlugin().useDispatcherFactory(factory);
+		const handle = await plugin.startWorkerHost({});
+		await expect(handle.stop()).resolves.toBeUndefined();
+	});
+
+	it('cancel and getRunStatus return safe defaults (Inngest exposes via REST not the SDK)', async () => {
+		const plugin = new InngestJobRuntimePlugin();
+		await expect(plugin.cancel('any')).resolves.toBe(false);
+		await expect(plugin.getRunStatus('any')).resolves.toBe('unknown');
+	});
+
+	describe('dispatchersBuilder', () => {
+		it('bindToTenant view uses tenant-built dispatchers when builder set', () => {
+			const plugin = new InngestJobRuntimePlugin({
+				dispatchersBuilder: (snap): JobRuntimeDispatchers => ({
+					dispatchKbEmbedDocument: () => Promise.resolve(`tenant:${snap.credentials.eventKey}`)
+				})
+			});
+			const view = plugin.bindToTenant(snapshot());
+			const d = view.dispatchers as unknown as {
+				dispatchKbEmbedDocument: () => Promise<string>;
+			};
+			return expect(d.dispatchKbEmbedDocument()).resolves.toBe('tenant:ek-tenant');
+		});
+
+		it('useDispatchers clears the tenant view cache', () => {
+			const plugin = new InngestJobRuntimePlugin().useDispatchers({
+				dispatchKbEmbedDocument: () => Promise.resolve('v1')
+			});
+			const v1 = plugin.bindToTenant(snapshot());
+			plugin.useDispatchers({
+				dispatchKbEmbedDocument: () => Promise.resolve('v2')
+			});
+			const v2 = plugin.bindToTenant(snapshot());
+			expect(v2).not.toBe(v1);
+		});
+	});
+});

--- a/packages/plugins/job-runtime-inngest/src/index.ts
+++ b/packages/plugins/job-runtime-inngest/src/index.ts
@@ -1,2 +1,17 @@
-export { InngestJobRuntimePlugin } from './inngest-job-runtime.plugin.js';
+export {
+	InngestJobRuntimePlugin,
+	InngestDispatcherNotConfiguredError
+} from './inngest-job-runtime.plugin.js';
+export type {
+	InngestTenantBindingView,
+	InngestJobRuntimePluginOptions
+} from './inngest-job-runtime.plugin.js';
+export { InngestDispatcherFactory } from './inngest-dispatcher-factory.js';
+export type {
+	InngestClient,
+	InngestSendEvent,
+	InngestSendResult,
+	InngestFunction,
+	InngestDispatcherFactoryOptions
+} from './inngest-types.js';
 export { InngestJobRuntimePlugin as default } from './inngest-job-runtime.plugin.js';

--- a/packages/plugins/job-runtime-inngest/src/inngest-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-inngest/src/inngest-dispatcher-factory.ts
@@ -1,0 +1,113 @@
+import type {
+	InngestClient,
+	InngestDispatcherFactoryOptions,
+	InngestFunction,
+	InngestSendEvent
+} from './inngest-types.js';
+
+/**
+ * EW-742 P3.2 follow-up — operator-facing factory that wraps an
+ * Inngest client and exposes per-event dispatcher functions.
+ *
+ * # Usage (operator-side serverless app)
+ *
+ * ```ts
+ * import { Inngest } from 'inngest';
+ * import { serve } from 'inngest/next';
+ * import {
+ *   InngestJobRuntimePlugin,
+ *   InngestDispatcherFactory
+ * } from '@ever-works/job-runtime-inngest-plugin';
+ *
+ * const client = new Inngest({ id: 'ever-works', eventKey: process.env.INNGEST_EVENT_KEY });
+ * const factory = new InngestDispatcherFactory({ client, eventNamespace: 'ever.works' });
+ *
+ * const kbEmbedFn = factory.defineFunction(
+ *   { id: 'kb-embed-document' },
+ *   { event: 'ever.works/kb-embed-document' },
+ *   async ({ event }) => { ... }
+ * );
+ *
+ * const plugin = new InngestJobRuntimePlugin()
+ *   .useDispatchers({
+ *     dispatchKbEmbedDocument: (payload) => factory.send('kb-embed-document', payload)
+ *   })
+ *   .useDispatcherFactory(factory);
+ *
+ * // Mount the Inngest serve handler at /api/inngest:
+ * export default serve({ client, functions: factory.functions });
+ * ```
+ *
+ * # Per-tenant routing (SaaS only)
+ *
+ * For SaaS BYO, build one `Inngest` client per tenant (per the
+ * snapshot's eventKey/signingKey) and one factory per client; pass the
+ * per-tenant factory through
+ * `InngestJobRuntimePluginOptions.dispatchersBuilder` so
+ * `bindToTenant(snapshot)` views route to the right Inngest project.
+ */
+export class InngestDispatcherFactory {
+	private readonly registeredFunctions: InngestFunction[] = [];
+
+	constructor(private readonly opts: InngestDispatcherFactoryOptions) {}
+
+	get client(): InngestClient {
+		return this.opts.client;
+	}
+
+	/**
+	 * Send one event. Returns the Inngest-assigned id (always the
+	 * first element of `result.ids` — single-event sends always come
+	 * back with one id). Returns `null` if Inngest's response is
+	 * shaped unexpectedly.
+	 */
+	async send(eventName: string, data: unknown, overrides?: Partial<Omit<InngestSendEvent, 'name' | 'data'>>): Promise<string | null> {
+		const fullName = this.opts.eventNamespace
+			? `${this.opts.eventNamespace}/${eventName}`
+			: eventName;
+		const event: InngestSendEvent = {
+			name: fullName,
+			data,
+			...(overrides ?? {})
+		};
+		const result = await this.opts.client.send(event);
+		return result.ids?.[0] ?? null;
+	}
+
+	/** Send a batch of events in one call. Returns Inngest-assigned ids. */
+	async sendBatch(events: readonly { name: string; data: unknown }[]): Promise<readonly string[]> {
+		const namespaced = events.map((e) => ({
+			name: this.opts.eventNamespace ? `${this.opts.eventNamespace}/${e.name}` : e.name,
+			data: e.data
+		}));
+		const result = await this.opts.client.send(namespaced);
+		return result.ids ?? [];
+	}
+
+	/**
+	 * Define an Inngest function and remember it for `factory.functions`
+	 * (which the operator typically hands to `serve({ functions })`).
+	 *
+	 * Returns the function object so the operator can also reference it
+	 * directly if they want fine-grained control.
+	 */
+	defineFunction(
+		config: Readonly<Record<string, unknown>>,
+		trigger: Readonly<Record<string, unknown>>,
+		handler: (...args: unknown[]) => Promise<unknown>
+	): InngestFunction {
+		if (!this.opts.client.createFunction) {
+			throw new Error(
+				'InngestDispatcherFactory: client.createFunction is unavailable. Ensure you pass a v3 Inngest client.'
+			);
+		}
+		const fn = this.opts.client.createFunction(config, trigger, handler);
+		this.registeredFunctions.push(fn);
+		return fn;
+	}
+
+	/** All functions defined through this factory — pass to `serve({ functions })`. */
+	get functions(): readonly InngestFunction[] {
+		return this.registeredFunctions;
+	}
+}

--- a/packages/plugins/job-runtime-inngest/src/inngest-job-runtime.plugin.ts
+++ b/packages/plugins/job-runtime-inngest/src/inngest-job-runtime.plugin.ts
@@ -11,29 +11,40 @@ import type {
 	WorkerHostHandle,
 	WorkerHostOptions
 } from '@ever-works/plugin';
+import { InngestDispatcherFactory } from './inngest-dispatcher-factory.js';
 
 /**
  * EW-742 P3.2 follow-up — Inngest `IJobRuntimeProvider` plugin.
  *
- * Per [`providers.md`](../../../../docs/specs/features/tenant-job-runtime-overlay/providers.md)
- * (Inngest section), per-tenant BYO is **SaaS only**; self-host is
- * blocked at the `available-providers` admin gate because self-host
- * Inngest's signing-key isolation model isn't multi-tenant by design.
+ * Per `providers.md` (Inngest section), per-tenant BYO is **SaaS
+ * only**; self-host Inngest's signing-key isolation model isn't
+ * multi-tenant by design, so this plugin's `bindToTenant` view
+ * surfaces the per-tenant eventKey/signingKey but operators must
+ * build per-tenant `Inngest` clients themselves.
  *
- * `bindToTenant` extracts the per-tenant signing keys from
- * `snapshot.credentials.eventKey` + `snapshot.credentials.signingKey`
- * and exposes them on the view so a future dispatcher can route to
- * the right Inngest project. Stub dispatchers throw until an operator
- * wires per-payload-type Inngest functions.
+ * Operators wire real send/function pairs via:
+ *   - `useDispatchers(map)` — replace throwing-stub Proxy.
+ *   - `useDispatcherFactory(factory)` — surface the registered
+ *     Inngest functions through `plugin.functions` for the
+ *     operator's `serve({ functions })` mount.
+ *   - `dispatchersBuilder` ctor option — per-tenant routing.
+ *
+ * # No worker host
+ *
+ * Inngest invokes operator-defined functions over HTTP via the
+ * `serve()` handler the operator mounts. There is no separate worker
+ * process. `startWorkerHost` therefore stays a no-op even when
+ * operator hooks are wired — the operator's HTTP route IS the worker
+ * host.
  */
 
 export class InngestDispatcherNotConfiguredError extends Error {
 	constructor(dispatcherName: string) {
 		super(
 			`@ever-works/job-runtime-inngest-plugin: ${dispatcherName} is not configured. ` +
-				'Subclass InngestJobRuntimePlugin (or wrap it with a delegating provider) and ' +
-				'override the dispatchers field with operator-defined Inngest functions ' +
-				'per `docs/specs/features/tenant-job-runtime-overlay/providers.md`.'
+				'Call plugin.useDispatchers({ ... }) with operator-supplied Inngest dispatchers ' +
+				'built via InngestDispatcherFactory (see plugin header for an example), ' +
+				'or pass dispatchersBuilder when constructing the plugin for per-tenant routing.'
 		);
 		this.name = 'InngestDispatcherNotConfiguredError';
 	}
@@ -45,6 +56,11 @@ export interface InngestTenantBindingView extends IJobRuntimeProvider {
 	readonly tenantEventKey: string | null;
 	/** Per-tenant Inngest signing key (for inbound webhook verification). */
 	readonly tenantSigningKey: string | null;
+}
+
+export interface InngestJobRuntimePluginOptions {
+	/** Per-tenant dispatcher builder — see plugin header. */
+	readonly dispatchersBuilder?: (snapshot: TenantCredentialSnapshot) => JobRuntimeDispatchers;
 }
 
 export class InngestJobRuntimePlugin implements IJobRuntimeProvider {
@@ -81,7 +97,7 @@ export class InngestJobRuntimePlugin implements IJobRuntimeProvider {
 		}
 	};
 
-	readonly dispatchers: JobRuntimeDispatchers = new Proxy(
+	private readonly stubDispatchers: JobRuntimeDispatchers = new Proxy(
 		{},
 		{
 			get(_target, prop: string): unknown {
@@ -95,8 +111,37 @@ export class InngestJobRuntimePlugin implements IJobRuntimeProvider {
 		}
 	);
 
+	private dispatchersImpl: JobRuntimeDispatchers = this.stubDispatchers;
+	private dispatcherFactory: InngestDispatcherFactory | null = null;
+
 	private context?: PluginContext;
 	private readonly tenantViews = new Map<string, InngestTenantBindingView>();
+
+	constructor(private readonly opts: InngestJobRuntimePluginOptions = {}) {}
+
+	get dispatchers(): JobRuntimeDispatchers {
+		return this.dispatchersImpl;
+	}
+
+	/**
+	 * Inngest functions registered through the bound factory. Operator
+	 * passes these to `serve({ client, functions })` at their HTTP
+	 * mount point.
+	 */
+	get functions(): readonly unknown[] {
+		return this.dispatcherFactory?.functions ?? [];
+	}
+
+	useDispatchers(map: JobRuntimeDispatchers): this {
+		this.dispatchersImpl = Object.freeze({ ...map });
+		this.tenantViews.clear();
+		return this;
+	}
+
+	useDispatcherFactory(factory: InngestDispatcherFactory): this {
+		this.dispatcherFactory = factory;
+		return this;
+	}
 
 	async onLoad(context: PluginContext): Promise<void> {
 		this.context = context;
@@ -107,10 +152,22 @@ export class InngestJobRuntimePlugin implements IJobRuntimeProvider {
 		this.tenantViews.clear();
 	}
 
-	async registerSchedules(_schedules: readonly ScheduleSpec[]): Promise<void> {}
+	async registerSchedules(_schedules: readonly ScheduleSpec[]): Promise<void> {
+		// Inngest cron schedules live on individual function defs
+		// (`{ cron: '...' }` triggers). Operators wire them via
+		// `factory.defineFunction(...)` directly. No-op here so the
+		// binding factory's boot path doesn't throw.
+	}
+
 	async cancel(_runId: string): Promise<boolean> {
+		// Inngest exposes cancellation via REST API
+		// (`https://api.inngest.com/v1/runs/{id}/cancel`). The plugin
+		// package doesn't ship a REST client — operators that need
+		// cancellation can override this method via a thin wrapper
+		// provider in their app code.
 		return false;
 	}
+
 	async getRunStatus(_runId: string): Promise<JobRunStatus> {
 		return 'unknown';
 	}
@@ -120,6 +177,8 @@ export class InngestJobRuntimePlugin implements IJobRuntimeProvider {
 	}
 
 	async startWorkerHost(_opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+		// Inngest is a serverless dispatch model — the operator's
+		// `serve()` HTTP route IS the worker host. No process to start.
 		return { stop: async () => undefined };
 	}
 
@@ -140,6 +199,10 @@ export class InngestJobRuntimePlugin implements IJobRuntimeProvider {
 				? snapshot.credentials.signingKey
 				: null;
 
+		const dispatchersForView: JobRuntimeDispatchers = this.opts.dispatchersBuilder
+			? Object.freeze({ ...this.opts.dispatchersBuilder(snapshot) })
+			: base.dispatchersImpl;
+
 		const view: InngestTenantBindingView = Object.freeze({
 			id: base.id,
 			name: base.name,
@@ -149,7 +212,7 @@ export class InngestJobRuntimePlugin implements IJobRuntimeProvider {
 			settingsSchema: base.settingsSchema,
 			runtimeId: base.runtimeId,
 			get dispatchers(): JobRuntimeDispatchers {
-				return base.dispatchers;
+				return dispatchersForView;
 			},
 			registerSchedules: (schedules: readonly ScheduleSpec[]) =>
 				base.registerSchedules(schedules),

--- a/packages/plugins/job-runtime-inngest/src/inngest-types.ts
+++ b/packages/plugins/job-runtime-inngest/src/inngest-types.ts
@@ -1,0 +1,67 @@
+/**
+ * EW-742 P3.2 follow-up — structural Inngest shapes the plugin depends on.
+ *
+ * We do NOT take a hard dependency on `inngest` from this plugin
+ * package. The operator installs `inngest` in their app and injects a
+ * fully-constructed `Inngest` client through the factories below.
+ *
+ * Reasons mirror the BullMQ / pg-boss / Temporal plugins. Inngest is
+ * additionally distinguished by the **serverless** dispatch model:
+ *   - Outbound: HTTP POST via `inngest.send(events)`.
+ *   - Inbound: Inngest invokes the operator's `serve()` HTTP route
+ *     when an event matches a registered function.
+ *
+ * There is no separate worker host process. The plugin's
+ * `startWorkerHost` stays a no-op even when operator hooks are wired.
+ *
+ * For tenant-scoped overlay (SaaS only — self-host is blocked at
+ * `available-providers` per ADR-017 providers.md), the operator builds
+ * one `Inngest` client per tenant (using the tenant's eventKey +
+ * signingKey from the credential snapshot) and routes through the
+ * right client via `dispatchersBuilder`.
+ */
+
+export interface InngestSendEvent {
+	readonly name: string;
+	readonly data: unknown;
+	/** Optional Inngest event id — providers use it for idempotency. */
+	readonly id?: string;
+	readonly user?: Readonly<Record<string, unknown>>;
+	/** Pass-through fields for v3 SDK (`v`, `ts`, etc.). */
+	readonly [extra: string]: unknown;
+}
+
+export interface InngestSendResult {
+	/** Server-assigned ids — one per event in input order. */
+	readonly ids: readonly string[];
+}
+
+/**
+ * Structural subset of `Inngest` client. Maps to inngest >=3.0.
+ */
+export interface InngestClient {
+	send(event: InngestSendEvent | readonly InngestSendEvent[]): Promise<InngestSendResult>;
+	/**
+	 * v3 `createFunction` signature — used only by the operator's
+	 * function-definition glue; the plugin holds the array of returned
+	 * function objects for `serve()`-time pickup.
+	 */
+	createFunction?(
+		config: Readonly<Record<string, unknown>>,
+		trigger: Readonly<Record<string, unknown>>,
+		handler: (...args: unknown[]) => Promise<unknown>
+	): unknown;
+}
+
+/** Returned by `client.createFunction(...)` — opaque object the operator hands to `serve(...)`. */
+export type InngestFunction = unknown;
+
+export interface InngestDispatcherFactoryOptions {
+	readonly client: InngestClient;
+	/**
+	 * Default event-name prefix prepended to every `send(name, ...)`.
+	 * E.g. `'ever.works'` produces `'ever.works/kb-embed-document'`.
+	 * Leave undefined for raw names.
+	 */
+	readonly eventNamespace?: string;
+}


### PR DESCRIPTION
## Summary

EW-742 P3.2 follow-up — closes the operator side of the Inngest job-runtime plugin. Last of the 4-plugin batch (sibling to #1455 BullMQ, #1456 pg-boss, #1457 Temporal).

Inngest is the **serverless** member of the family — no separate worker process. The operator's HTTP `serve()` route IS the worker host, so `startWorkerHost` stays a no-op intentionally. Per ADR-017 providers.md, per-tenant BYO is **SaaS only**; self-host is blocked at the `available-providers` admin gate.

### New surface

- `InngestDispatcherFactory({ client, eventNamespace? })`:
  - `.send(name, data, overrides?)` → first assigned event id (or `null` on empty result)
  - `.sendBatch(events)` → all assigned ids
  - `.defineFunction(config, trigger, handler)` registers via `client.createFunction` and accumulates them
  - `.functions` getter returns the array for `serve({ client, functions })`
- `InngestJobRuntimePlugin` operator hooks:
  - `useDispatchers(map)` — replace throwing stub.
  - `useDispatcherFactory(factory)` — `plugin.functions` surfaces the factory's registered functions.
  - `dispatchersBuilder` ctor option — per-tenant routing (SaaS only).
- `cancel` / `getRunStatus` return safe defaults — Inngest's cancellation lives on the REST API rather than the SDK. Operators that need it extend the plugin in their app.

### Tests

25/25 green: 10 pre-existing + 7 new dispatcher-factory tests + 8 new operator-hook integration tests. tsc + tsup + DTS clean.

## Test plan

- [x] \`pnpm test\` under \`packages/plugins/job-runtime-inngest\` — 25/25
- [x] \`pnpm build\` — clean (6.7 KB ESM, 8.8 KB d.ts)
- [ ] Cascade — develop only per standing directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)