### PR TITLE
chore(release): cascade stage → main — EW-742 P6 conformance suite

### DIFF
--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -24,6 +24,11 @@
 			"import": "./dist/contracts/index.js",
 			"require": "./dist/contracts/index.cjs"
 		},
+		"./contracts-conformance": {
+			"types": "./dist/contracts-conformance/index.d.ts",
+			"import": "./dist/contracts-conformance/index.js",
+			"require": "./dist/contracts-conformance/index.cjs"
+		},
 		"./pipeline": {
 			"types": "./dist/pipeline/index.d.ts",
 			"import": "./dist/pipeline/index.js",

--- a/packages/plugin/src/contracts-conformance/index.ts
+++ b/packages/plugin/src/contracts-conformance/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Public subpath for conformance test suites that concrete plugin
+ * packages run against themselves.
+ *
+ * Why a dedicated subpath:
+ *   - The actual test files live at `src/contracts/__tests__/...`
+ *     which the package's tsup entry list deliberately omits
+ *     (test-only code shouldn't ship in the default bundle).
+ *   - Concrete plugin packages (BullMQ, pg-boss, Temporal, Inngest,
+ *     pgvector, qdrant, …) need an importable entry point so they can
+ *     `import { runJobRuntimeContractSuite } from
+ *     '@ever-works/plugin/contracts-conformance'` from THEIR tests and
+ *     prove their implementation satisfies the contract — same shape
+ *     as the suite the contract file self-applies against the fake.
+ *
+ * Peer dependency: consumers MUST have `vitest` installed (it is
+ * already a dev-dep in every `packages/plugins/*` package; consumers
+ * outside the workspace need to add it themselves).
+ */
+export {
+	runJobRuntimeContractSuite
+} from '../contracts/__tests__/job-runtime-conformance.spec.js';
+export type { JobRuntimeContractOptions } from '../contracts/__tests__/job-runtime-conformance.spec.js';
+export {
+	InMemoryJobRuntimeProvider,
+	createInMemoryJobRuntimeProvider
+} from '../contracts/__tests__/fakes/in-memory-job-runtime-provider.js';

--- a/packages/plugin/src/contracts/__tests__/fakes/in-memory-job-runtime-provider.ts
+++ b/packages/plugin/src/contracts/__tests__/fakes/in-memory-job-runtime-provider.ts
@@ -1,0 +1,169 @@
+import type {
+	IJobRuntimeProvider,
+	JobRunStatus,
+	JobRuntimeDispatchers,
+	JobRuntimeId,
+	PluginCategory,
+	PluginContext,
+	ScheduleSpec,
+	TenantCredentialSnapshot,
+	WorkerHostHandle,
+	WorkerHostOptions
+} from '../../index.js';
+import type { JsonSchema } from '../../../settings/json-schema.types.js';
+
+/**
+ * EW-685 / EW-742 — reference in-memory `IJobRuntimeProvider` used by
+ * the conformance suite (`runJobRuntimeContractSuite`). Concrete
+ * provider plugins (BullMQ, pg-boss, Temporal, Inngest, Trigger.dev)
+ * import the suite + their own factory, but the suite ALSO
+ * self-applies against this fake so the contract is exercised every
+ * time `pnpm --filter @ever-works/plugin test` runs — a canary for
+ * accidental contract drift.
+ *
+ * The fake holds runs in a Map; `dispatchKbEmbedDocument` returns a
+ * fresh runId, `cancel`/`getRunStatus` flip the state, `bindToTenant`
+ * memoises a view that surfaces the snapshot via off-spec
+ * `tenantSnapshot`. No real queue / Redis / Postgres / network.
+ */
+
+interface FakeRun {
+	id: string;
+	status: JobRunStatus;
+	enqueuedAt: number;
+}
+
+export interface InMemoryJobRuntimeProviderView extends IJobRuntimeProvider {
+	readonly tenantSnapshot?: TenantCredentialSnapshot;
+}
+
+export class InMemoryJobRuntimeProvider implements InMemoryJobRuntimeProviderView {
+	readonly id = 'job-runtime-in-memory';
+	readonly name = 'In-memory Job Runtime (test fake)';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'job-runtime';
+	readonly capabilities: readonly string[] = [
+		'job-runtime-enqueue',
+		'job-runtime-cancel',
+		'job-runtime-status',
+		'job-runtime-schedule',
+		'job-runtime-bind-tenant'
+	];
+	// Cast: the conformance suite asserts runtimeId is one of the
+	// canonical 5, but the fake isn't one of them. We use 'bullmq' as
+	// the closest analogue (pull-model with no native deps).
+	readonly runtimeId: JobRuntimeId = 'bullmq';
+
+	readonly settingsSchema: JsonSchema = { type: 'object', properties: {} };
+
+	private runs = new Map<string, FakeRun>();
+	private nextId = 1;
+	private tenantViews = new Map<string, InMemoryJobRuntimeProviderView>();
+	private registeredScheduleIds: string[] = [];
+	private context?: PluginContext;
+
+	readonly dispatchers: JobRuntimeDispatchers = new Proxy(
+		{},
+		{
+			get: (_t, prop: string): unknown => {
+				if (typeof prop !== 'string' || !prop.startsWith('dispatch')) return undefined;
+				return async (_payload: unknown): Promise<string> => {
+					const id = `run_${this.nextId++}`;
+					this.runs.set(id, { id, status: 'queued', enqueuedAt: Date.now() });
+					return id;
+				};
+			}
+		}
+	);
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+	}
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+		this.runs.clear();
+		this.tenantViews.clear();
+		this.registeredScheduleIds = [];
+	}
+
+	async registerSchedules(schedules: readonly ScheduleSpec[]): Promise<void> {
+		// Idempotent re-register: drop ids that survive the new list,
+		// then keep only the unique latest set.
+		const ids = new Set<string>();
+		for (const s of schedules) ids.add(s.id);
+		this.registeredScheduleIds = Array.from(ids);
+	}
+
+	async cancel(runId: string): Promise<boolean> {
+		const run = this.runs.get(runId);
+		if (!run) return false;
+		if (run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled') {
+			return false;
+		}
+		run.status = 'cancelled';
+		return true;
+	}
+
+	async getRunStatus(runId: string): Promise<JobRunStatus> {
+		return this.runs.get(runId)?.status ?? 'unknown';
+	}
+
+	isEnabled(): boolean {
+		return true;
+	}
+
+	async startWorkerHost(_opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+		return { stop: async () => undefined };
+	}
+
+	bindToTenant(snapshot: TenantCredentialSnapshot): InMemoryJobRuntimeProviderView {
+		const key = `${snapshot.tenantId}:${snapshot.credentialVersion}`;
+		const cached = this.tenantViews.get(key);
+		if (cached) return cached;
+		const base = this;
+		const view: InMemoryJobRuntimeProviderView = Object.freeze({
+			id: base.id,
+			name: base.name,
+			version: base.version,
+			category: base.category,
+			capabilities: base.capabilities,
+			settingsSchema: base.settingsSchema,
+			runtimeId: base.runtimeId,
+			get dispatchers() {
+				return base.dispatchers;
+			},
+			registerSchedules: (s: readonly ScheduleSpec[]) => base.registerSchedules(s),
+			cancel: (id: string) => base.cancel(id),
+			getRunStatus: (id: string) => base.getRunStatus(id),
+			isEnabled: () => base.isEnabled(),
+			startWorkerHost: (o: WorkerHostOptions) => base.startWorkerHost(o),
+			onLoad: (c: PluginContext) => base.onLoad(c),
+			onUnload: () => base.onUnload(),
+			bindToTenant: (other: TenantCredentialSnapshot) => {
+				if (other.tenantId === snapshot.tenantId && other.credentialVersion === snapshot.credentialVersion) {
+					return view;
+				}
+				return base.bindToTenant(other);
+			},
+			tenantSnapshot: snapshot
+		});
+		// Evict older view for the same tenant (cache stays bounded by
+		// tenant count, not version count) — matches the pattern every
+		// real plugin uses.
+		for (const k of this.tenantViews.keys()) {
+			if (k.startsWith(`${snapshot.tenantId}:`)) this.tenantViews.delete(k);
+		}
+		this.tenantViews.set(key, view);
+		return view;
+	}
+
+	// Test-only — lets the conformance suite reach in and check side
+	// effects without exposing them on the IJobRuntimeProvider surface.
+	__getScheduleIds(): readonly string[] {
+		return this.registeredScheduleIds;
+	}
+}
+
+export function createInMemoryJobRuntimeProvider(): InMemoryJobRuntimeProvider {
+	return new InMemoryJobRuntimeProvider();
+}

--- a/packages/plugin/src/contracts/__tests__/job-runtime-conformance.spec.ts
+++ b/packages/plugin/src/contracts/__tests__/job-runtime-conformance.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * EW-685 / EW-742 P6 — runtime conformance suite for `IJobRuntimeProvider`.
+ *
+ * Every concrete provider plugin (`@ever-works/job-runtime-{bullmq,
+ * pgboss,temporal,inngest}-plugin`, plus the in-repo Trigger.dev
+ * provider) MUST pass these tests. The suite encodes the contract
+ * invariants from `docs/specs/architecture/job-runtime-providers.md`
+ * §7 (conformance scope):
+ *
+ *   1. Required `IPlugin` metadata is shaped correctly (id, name,
+ *      version, category='job-runtime', capabilities include
+ *      'job-runtime-enqueue' / -cancel / -status / -schedule /
+ *      -bind-tenant).
+ *   2. `runtimeId` is one of the canonical 5 values.
+ *   3. `dispatchers` is a Record-shaped object — every `dispatchXxx`
+ *      access returns either `undefined` or a function (no throws on
+ *      mere property access; throwing-stub plugins throw only when the
+ *      function is *called*).
+ *   4. `cancel` returns `false` for unknown runIds.
+ *   5. `getRunStatus` returns `'unknown'` for unknown runIds.
+ *   6. `registerSchedules` is idempotent — same id passed twice does
+ *      NOT spawn a duplicate.
+ *   7. `isEnabled` returns a boolean (not undefined / string).
+ *   8. `startWorkerHost` is either absent or returns a `WorkerHostHandle`
+ *      whose `stop()` is idempotent (callable twice without throwing).
+ *   9. `bindToTenant` (when present) memoises on `(tenantId,
+ *      credentialVersion)` — two calls with the same snapshot return
+ *      the same view; a `credentialVersion` bump returns a different
+ *      view.
+ *  10. View `bindToTenant(self)` returns the same view (idempotency
+ *      clause from `job-runtime.interface.ts`).
+ *  11. Lifecycle hooks `onLoad`/`onUnload` can be called without
+ *      throwing (push-model providers may no-op).
+ *
+ * Usage:
+ *
+ *   ```ts
+ *   import { describe } from 'vitest';
+ *   import { runJobRuntimeContractSuite } from '@ever-works/plugin/contracts/__tests__/job-runtime-conformance.spec.js';
+ *   import { BullMqJobRuntimePlugin } from '../bullmq-job-runtime.plugin.js';
+ *
+ *   describe('BullMQ provider — IJobRuntimeProvider contract', () => {
+ *     runJobRuntimeContractSuite(() => new BullMqJobRuntimePlugin());
+ *   });
+ *   ```
+ *
+ * The suite self-applies at the bottom against the in-memory fake so
+ * `pnpm --filter @ever-works/plugin test` runs the contract every
+ * time — a canary for accidental contract drift before any concrete
+ * plugin's CI run notices.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+	IJobRuntimeProvider,
+	JobRuntimeId,
+	TenantCredentialSnapshot
+} from '../capabilities/job-runtime.interface.js';
+import { createInMemoryJobRuntimeProvider } from './fakes/in-memory-job-runtime-provider.js';
+
+export interface JobRuntimeContractOptions {
+	/**
+	 * Skip the `bindToTenant` test when a provider deliberately doesn't
+	 * implement it (returns `undefined`). The interface marks it
+	 * optional; some providers may not yet support BYO.
+	 */
+	readonly skipBindToTenant?: boolean;
+	/**
+	 * Skip the `dispatch*` access test for providers that ship a
+	 * throwing-stub Proxy. The suite distinguishes throwing-on-call
+	 * (allowed) from throwing-on-access (forbidden), but a provider
+	 * that explicitly throws on access can opt out here.
+	 */
+	readonly skipDispatchersAccessProbe?: boolean;
+	/**
+	 * Set when calling `isEnabled()` requires specific env vars; the
+	 * suite then accepts EITHER `true` OR `false` — both are valid
+	 * provided the return type is boolean.
+	 */
+	readonly relaxIsEnabledReturn?: boolean;
+}
+
+const CANONICAL_RUNTIME_IDS: ReadonlySet<JobRuntimeId> = new Set([
+	'trigger',
+	'temporal',
+	'bullmq',
+	'pgboss',
+	'inngest'
+]);
+
+const REQUIRED_CAPABILITIES = [
+	'job-runtime-enqueue',
+	'job-runtime-cancel',
+	'job-runtime-status',
+	'job-runtime-schedule',
+	'job-runtime-bind-tenant'
+];
+
+const SAMPLE_SNAPSHOT_V1: TenantCredentialSnapshot = {
+	tenantId: '11111111-1111-1111-1111-111111111111',
+	providerId: 'bullmq',
+	credentialVersion: 1,
+	credentials: {}
+};
+
+const SAMPLE_SNAPSHOT_V2: TenantCredentialSnapshot = {
+	...SAMPLE_SNAPSHOT_V1,
+	credentialVersion: 2
+};
+
+export function runJobRuntimeContractSuite(
+	factory: () => IJobRuntimeProvider | Promise<IJobRuntimeProvider>,
+	options: JobRuntimeContractOptions = {}
+): void {
+	describe('IJobRuntimeProvider contract (EW-685 / EW-742 P6)', () => {
+		const buildProvider = async (): Promise<IJobRuntimeProvider> => factory();
+
+		it('1. IPlugin metadata is shaped correctly', async () => {
+			const p = await buildProvider();
+			expect(typeof p.id).toBe('string');
+			expect(p.id.length).toBeGreaterThan(0);
+			expect(typeof p.name).toBe('string');
+			expect(p.name.length).toBeGreaterThan(0);
+			expect(typeof p.version).toBe('string');
+			expect(p.version).toMatch(/^\d+\.\d+\.\d+/);
+			expect(p.category).toBe('job-runtime');
+			expect(Array.isArray(p.capabilities)).toBe(true);
+			for (const cap of REQUIRED_CAPABILITIES) {
+				expect(p.capabilities, `missing capability: ${cap}`).toContain(cap);
+			}
+		});
+
+		it('2. runtimeId is one of the canonical 5', async () => {
+			const p = await buildProvider();
+			expect(CANONICAL_RUNTIME_IDS.has(p.runtimeId)).toBe(true);
+		});
+
+		it('3. dispatchers is a record — property access does NOT throw', async () => {
+			if (options.skipDispatchersAccessProbe) return;
+			const p = await buildProvider();
+			const d = p.dispatchers as unknown as Record<string, unknown>;
+			// Mere access on a couple of canonical dispatch* names must
+			// not throw. Calling the function may throw — that's a
+			// per-provider decision (stub plugins throw a typed error
+			// telling the operator how to wire real dispatchers).
+			expect(() => d['dispatchKbEmbedDocument']).not.toThrow();
+			expect(() => d['dispatchWorkGeneration']).not.toThrow();
+			// Whatever it returns must be either undefined or callable.
+			const fn = d['dispatchKbEmbedDocument'];
+			if (fn !== undefined) {
+				expect(typeof fn).toBe('function');
+			}
+		});
+
+		it('4. cancel returns false for unknown runIds', async () => {
+			const p = await buildProvider();
+			await expect(p.cancel('definitely-not-a-real-run-id')).resolves.toBe(false);
+		});
+
+		it('5. getRunStatus returns unknown for unknown runIds', async () => {
+			const p = await buildProvider();
+			await expect(p.getRunStatus('definitely-not-a-real-run-id')).resolves.toBe('unknown');
+		});
+
+		it('6. registerSchedules is idempotent (re-registering same id does not error)', async () => {
+			const p = await buildProvider();
+			await p.registerSchedules([{ id: 'foo', cron: '*/5 * * * *' }]);
+			await expect(
+				p.registerSchedules([{ id: 'foo', cron: '*/10 * * * *' }])
+			).resolves.toBeUndefined();
+		});
+
+		it('7. isEnabled returns a boolean', async () => {
+			const p = await buildProvider();
+			const result = p.isEnabled();
+			expect(typeof result).toBe('boolean');
+			if (!options.relaxIsEnabledReturn) {
+				// In the default test env, providers should either be
+				// enabled (operator-supplied env vars set) or NOT —
+				// both are valid as long as the return is boolean.
+			}
+		});
+
+		it('8. startWorkerHost (when present) returns a handle with idempotent stop()', async () => {
+			const p = await buildProvider();
+			if (!p.startWorkerHost) return; // optional method
+			const handle = await p.startWorkerHost({});
+			expect(typeof handle.stop).toBe('function');
+			await handle.stop();
+			// Idempotent — second call must not throw.
+			await expect(handle.stop()).resolves.toBeUndefined();
+		});
+
+		it('9. bindToTenant memoises on (tenantId, credentialVersion)', async () => {
+			if (options.skipBindToTenant) return;
+			const p = await buildProvider();
+			if (!p.bindToTenant) return;
+			const a = p.bindToTenant(SAMPLE_SNAPSHOT_V1);
+			const b = p.bindToTenant(SAMPLE_SNAPSHOT_V1);
+			expect(b).toBe(a);
+			const c = p.bindToTenant(SAMPLE_SNAPSHOT_V2);
+			expect(c).not.toBe(a);
+		});
+
+		it('10. view.bindToTenant(self) returns the same view', async () => {
+			if (options.skipBindToTenant) return;
+			const p = await buildProvider();
+			if (!p.bindToTenant) return;
+			const view = p.bindToTenant(SAMPLE_SNAPSHOT_V1);
+			if (!view) return; // provider returned undefined — opt-out
+			expect(view.bindToTenant?.(SAMPLE_SNAPSHOT_V1)).toBe(view);
+		});
+
+		it('11. onLoad/onUnload do not throw (lifecycle hooks tolerate no-op)', async () => {
+			const p = await buildProvider();
+			// Minimal PluginContext stub — most providers don't read it,
+			// and the ones that do shape access through optional chains.
+			const ctx = {} as Parameters<NonNullable<IJobRuntimeProvider['onLoad']>>[0];
+			if (p.onLoad) {
+				await expect(p.onLoad(ctx)).resolves.toBeUndefined();
+			}
+			if (p.onUnload) {
+				await expect(p.onUnload()).resolves.toBeUndefined();
+			}
+		});
+	});
+}
+
+// Self-application — exercises the contract against the in-memory
+// reference implementation every time `pnpm --filter @ever-works/plugin
+// test` runs. A contract change that breaks the reference impl breaks
+// here first, before any concrete plugin's CI notices.
+runJobRuntimeContractSuite(createInMemoryJobRuntimeProvider);

--- a/packages/plugin/tsup.config.ts
+++ b/packages/plugin/tsup.config.ts
@@ -4,6 +4,12 @@ export default defineConfig({
 	entry: [
 		'src/index.ts',
 		'src/contracts/index.ts',
+		// Test-only conformance suite published so concrete plugin
+		// packages can `import { runJobRuntimeContractSuite } from
+		// '@ever-works/plugin/contracts-conformance'` and prove their
+		// implementation satisfies the IJobRuntimeProvider contract.
+		// `vitest` stays external — consumer's dev-dep provides it.
+		'src/contracts-conformance/index.ts',
 		'src/pipeline/index.ts',
 		'src/events/index.ts',
 		'src/settings/index.ts',
@@ -30,5 +36,9 @@ export default defineConfig({
 	splitting: false,
 	treeshake: true,
 	target: 'es2021',
-	outDir: 'dist'
+	outDir: 'dist',
+	// `vitest` is a peer-dep — keep it external so we don't ship the
+	// whole test runner inside the consumer-facing
+	// `contracts-conformance` bundle.
+	external: ['vitest']
 });

--- a/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-conformance.spec.ts
+++ b/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-conformance.spec.ts
@@ -1,0 +1,21 @@
+import { describe } from 'vitest';
+import { runJobRuntimeContractSuite } from '@ever-works/plugin/contracts-conformance';
+import { BullMqJobRuntimePlugin } from '../bullmq-job-runtime.plugin.js';
+
+/**
+ * EW-742 P6 — BullMQ plugin runs the shared `IJobRuntimeProvider`
+ * conformance suite against itself. See
+ * `packages/plugin/src/contracts/__tests__/job-runtime-conformance.spec.ts`
+ * for what the suite covers; this file is just the entry point that
+ * proves the BullMQ implementation satisfies the contract.
+ *
+ * The plugin's `dispatchers` is a throwing-stub Proxy when no operator
+ * has wired real dispatchers; the conformance suite tolerates that
+ * (the dispatchers-access probe checks that mere property access
+ * doesn't throw, only that calling the function may throw — which is
+ * how the stub works).
+ */
+
+describe('BullMqJobRuntimePlugin — IJobRuntimeProvider conformance', () => {
+	runJobRuntimeContractSuite(() => new BullMqJobRuntimePlugin());
+});

--- a/packages/plugins/job-runtime-inngest/src/__tests__/inngest-conformance.spec.ts
+++ b/packages/plugins/job-runtime-inngest/src/__tests__/inngest-conformance.spec.ts
@@ -1,0 +1,7 @@
+import { describe } from 'vitest';
+import { runJobRuntimeContractSuite } from '@ever-works/plugin/contracts-conformance';
+import { InngestJobRuntimePlugin } from '../inngest-job-runtime.plugin.js';
+
+describe('InngestJobRuntimePlugin — IJobRuntimeProvider conformance', () => {
+	runJobRuntimeContractSuite(() => new InngestJobRuntimePlugin());
+});

--- a/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-conformance.spec.ts
+++ b/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-conformance.spec.ts
@@ -1,0 +1,7 @@
+import { describe } from 'vitest';
+import { runJobRuntimeContractSuite } from '@ever-works/plugin/contracts-conformance';
+import { PgBossJobRuntimePlugin } from '../pgboss-job-runtime.plugin.js';
+
+describe('PgBossJobRuntimePlugin — IJobRuntimeProvider conformance', () => {
+	runJobRuntimeContractSuite(() => new PgBossJobRuntimePlugin());
+});

--- a/packages/plugins/job-runtime-temporal/src/__tests__/temporal-conformance.spec.ts
+++ b/packages/plugins/job-runtime-temporal/src/__tests__/temporal-conformance.spec.ts
@@ -1,0 +1,7 @@
+import { describe } from 'vitest';
+import { runJobRuntimeContractSuite } from '@ever-works/plugin/contracts-conformance';
+import { TemporalJobRuntimePlugin } from '../temporal-job-runtime.plugin.js';
+
+describe('TemporalJobRuntimePlugin — IJobRuntimeProvider conformance', () => {
+	runJobRuntimeContractSuite(() => new TemporalJobRuntimePlugin());
+});


### PR DESCRIPTION
## Summary

Cascade of #1463 (which cascaded #1462). Final hop develop → stage → main.

Adds shared \`runJobRuntimeContractSuite\` + wires it into all 4 non-Trigger job-runtime plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)