### PR TITLE
feat(trigger): wire IJobRuntimeProvider conformance + fix bind-tenant capability

### DIFF
--- a/packages/tasks/src/trigger/__tests__/trigger-conformance.spec.ts
+++ b/packages/tasks/src/trigger/__tests__/trigger-conformance.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * EW-742 P6 — Trigger.dev provider runs the shared
+ * `IJobRuntimeProvider` conformance suite against itself.
+ *
+ * Mirrors the conformance specs the 4 non-Trigger plugin packages
+ * ship under `packages/plugins/job-runtime-{bullmq,pgboss,temporal,
+ * inngest}/src/__tests__/{provider}-conformance.spec.ts`. The shared
+ * suite lives at `@ever-works/plugin/contracts-conformance` and
+ * encodes the 11 contract invariants from
+ * `docs/specs/architecture/job-runtime-providers.md` §7.
+ *
+ * The Trigger.dev provider is a NestJS-Injectable adapter wrapping
+ * `TriggerService`. To exercise the contract surface in isolation we
+ * inject a minimal stub `TriggerService` — same shape used by
+ * `trigger-job-runtime.provider.spec.ts`.
+ */
+
+import { describe, vi } from 'vitest';
+import { runJobRuntimeContractSuite } from '@ever-works/plugin/contracts-conformance';
+import { TriggerJobRuntimeProvider } from '../trigger-job-runtime.provider';
+import type { TriggerService } from '../trigger.service';
+
+function buildStubService(): TriggerService {
+	return {
+		// IJobRuntimeProvider methods the adapter delegates to.
+		// All return safe defaults — the conformance suite expects
+		// cancel(unknownId)→false, getRunStatus(unknownId)→'unknown',
+		// registerSchedules to no-op, isEnabled to return a boolean.
+		isEnabled: vi.fn(() => true),
+		cancel: vi.fn(async () => false),
+		getRunStatus: vi.fn(async () => 'unknown' as const),
+		registerSchedules: vi.fn(async () => undefined),
+		startWorkerHost: vi.fn(async () => ({ stop: async () => undefined })),
+		// `dispatchers` is a Record<string, unknown> on the real service —
+		// the conformance suite probes property access (must not throw)
+		// and treats undefined return values as valid.
+		dispatchers: {} as Readonly<Record<string, unknown>>
+	} as unknown as TriggerService;
+}
+
+describe('TriggerJobRuntimeProvider — IJobRuntimeProvider conformance', () => {
+	runJobRuntimeContractSuite(() => new TriggerJobRuntimeProvider(buildStubService()));
+});

--- a/packages/tasks/src/trigger/__tests__/trigger-job-runtime.provider.spec.ts
+++ b/packages/tasks/src/trigger/__tests__/trigger-job-runtime.provider.spec.ts
@@ -87,6 +87,11 @@ describe('TriggerJobRuntimeProvider', () => {
                 'job-runtime-cancel',
                 'job-runtime-status',
                 'job-runtime-schedule',
+                // EW-742 P3.2 T21.1 — the adapter does implement
+                // bindToTenant; the capability flag was added when
+                // the shared P6 conformance suite (EW-685 §7) caught
+                // its absence.
+                'job-runtime-bind-tenant',
             ]);
             expect(provider.settingsSchema).toEqual({ type: 'object', properties: {} });
         });

--- a/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
+++ b/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
@@ -72,6 +72,12 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
         'job-runtime-cancel',
         'job-runtime-status',
         'job-runtime-schedule',
+        // EW-742 P3.2 T21.1 — the adapter implements bindToTenant
+        // (memoised view that swaps Trigger.dev project credentials
+        // per tenant). The capability flag was missing from the
+        // initial EW-686 P1 list; the shared P6 conformance suite
+        // caught it.
+        'job-runtime-bind-tenant',
     ];
     // Synthetic plugin — no operator-tunable settings (Trigger.dev creds
     // are read from `config.trigger.*` env vars, not from the plugin


### PR DESCRIPTION
## Summary

EW-742 P6 follow-up to #1462 — applies the shared \`runJobRuntimeContractSuite\` to the Trigger.dev provider (\`TriggerJobRuntimeProvider\` adapter in \`packages/tasks\`), bringing the 5th and final job-runtime provider into the conformance net.

The suite caught a real bug while wiring it: the adapter implements \`bindToTenant\` (EW-742 P3.2 T21.1, shipped in #1426) but its \`capabilities\` list never advertised \`'job-runtime-bind-tenant'\`. Downstream consumers that gate on the capability flag couldn't discover the support. The shared P6 suite asserts (per the EW-685 conformance §7 contract) that any provider implementing \`bindToTenant\` MUST declare the capability.

### Changes

- **\`trigger-job-runtime.provider.ts\`** — add \`'job-runtime-bind-tenant'\` to capabilities (matches BullMQ/pg-boss/Temporal/Inngest).
- **\`trigger-job-runtime.provider.spec.ts\`** — update the exact-match capability expectation.
- **NEW \`trigger-conformance.spec.ts\`** — runs the shared 11-invariant suite via a minimal \`TriggerService\` stub (same stub shape used by the existing adapter spec).

### Test results

Local \`pnpm test\` under \`packages/tasks\`:
- \`trigger-conformance.spec.ts\` — 22/22 green
- \`trigger-job-runtime.provider.spec.ts\` — 26/26 green (1 fixed by the capabilities update)
- Other 42 pre-existing failures in \`work-import.task.spec.ts\` / \`work-generation.task.spec.ts\` are unrelated to this PR (verified by running on develop without my changes — same 42 failures).

## Test plan

- [x] Local \`vitest run src/trigger/__tests__/*conformance*.spec.ts src/trigger/__tests__/trigger-job-runtime.provider.spec.ts\` green
- [ ] CI runs the full Trigger suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added conformance test suite for job runtime provider to ensure contract compliance.
  * Updated unit test expectations to reflect capability alignment.

* **Bug Fixes**
  * Corrected job runtime provider capability declaration to accurately reflect implemented functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->