### PR TITLE
feat(job-runtime-bullmq): JobEnqueueOptions → JobsOptions translator (EW-742 P4 T31)

### DIFF
--- a/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-enqueue-integration.spec.ts
+++ b/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-enqueue-integration.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { BullMqDispatcherFactory } from '../bullmq-dispatcher-factory.js';
+import type { BullMqDeps, BullMqQueueAdapter, BullMqWorkerAdapter } from '../bullmq-types.js';
+
+interface QueueCall {
+	name: string;
+	data: unknown;
+	opts?: Readonly<Record<string, unknown>>;
+}
+
+class FakeQueue implements BullMqQueueAdapter {
+	static instances: FakeQueue[] = [];
+	readonly calls: QueueCall[] = [];
+	private nextId = 1;
+	constructor(public readonly name: string, public readonly ctorOpts: Readonly<Record<string, unknown>>) {
+		FakeQueue.instances.push(this);
+	}
+	async add(name: string, data: unknown, opts?: Readonly<Record<string, unknown>>) {
+		this.calls.push({ name, data, opts });
+		return { id: `j${this.nextId++}` };
+	}
+	async close() {
+		// noop
+	}
+}
+
+class UnusedWorker implements BullMqWorkerAdapter {
+	on() {
+		// noop
+	}
+	async close() {
+		// noop
+	}
+}
+
+const makeDeps = (): BullMqDeps => ({
+	Queue: FakeQueue as unknown as BullMqDeps['Queue'],
+	Worker: UnusedWorker as unknown as BullMqDeps['Worker']
+});
+
+describe('BullMqDispatcher.enqueue (EW-742 P4 T31)', () => {
+	it('translates JobEnqueueOptions onto BullMQ JobsOptions on the add call', async () => {
+		FakeQueue.instances = [];
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: 'r' });
+		const d = factory.forQueue('kb-embed');
+		const enqueueOpts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-1',
+			tenantId: 't-acme',
+			concurrencyKey: 'work-7',
+			tags: ['kb'],
+			maxDurationSeconds: 600
+		};
+		const id = await d.enqueue('kb-embed', { workId: 'w7' }, enqueueOpts);
+		expect(id).toBe('j1');
+		expect(FakeQueue.instances[0].calls[0]).toEqual({
+			name: 'kb-embed',
+			data: { workId: 'w7' },
+			opts: {
+				jobId: 'idem-1',
+				tenantId: 't-acme',
+				concurrencyKey: 'work-7',
+				tags: ['kb'],
+				maxDurationSeconds: 600
+			}
+		});
+	});
+
+	it('extraOpts shallow-merge OVER the translation (operator wins on conflict)', async () => {
+		FakeQueue.instances = [];
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: 'r' });
+		const d = factory.forQueue('kb-embed');
+		await d.enqueue(
+			'kb-embed',
+			{ x: 1 },
+			{ idempotencyKey: 'idem-from-platform' },
+			{ jobId: 'idem-from-operator', attempts: 5 }
+		);
+		expect(FakeQueue.instances[0].calls[0].opts).toEqual({
+			jobId: 'idem-from-operator',
+			attempts: 5
+		});
+	});
+
+	it('dispatch() path is unchanged — no enqueueOptions translation', async () => {
+		FakeQueue.instances = [];
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: 'r' });
+		const d = factory.forQueue('kb-embed');
+		await d.dispatch('kb-embed', { x: 1 }, { jobId: 'raw' });
+		expect(FakeQueue.instances[0].calls[0].opts).toEqual({ jobId: 'raw' });
+	});
+});

--- a/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-enqueue-options.spec.ts
+++ b/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-enqueue-options.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { mapEnqueueOptions } from '../bullmq-enqueue-options.js';
+
+describe('mapEnqueueOptions (EW-742 P4 T31 BullMQ stamping)', () => {
+	it('translates idempotencyKey → jobId', () => {
+		expect(mapEnqueueOptions({ idempotencyKey: 'idem-1' })).toEqual({ jobId: 'idem-1' });
+	});
+
+	it('translates tenantId → tenantId (custom JobsOptions field)', () => {
+		expect(mapEnqueueOptions({ tenantId: 't-acme' })).toEqual({ tenantId: 't-acme' });
+	});
+
+	it('translates concurrencyKey → concurrencyKey (custom field, worker honours)', () => {
+		expect(mapEnqueueOptions({ concurrencyKey: 'work-42' })).toEqual({
+			concurrencyKey: 'work-42'
+		});
+	});
+
+	it('translates tags / maxDurationSeconds / machineHint as custom passthroughs', () => {
+		expect(
+			mapEnqueueOptions({ tags: ['kb', 'embed'], maxDurationSeconds: 900, machineHint: 'small-2x' })
+		).toEqual({ tags: ['kb', 'embed'], maxDurationSeconds: 900, machineHint: 'small-2x' });
+	});
+
+	it('omits fields that are undefined (no noisy keys)', () => {
+		const out = mapEnqueueOptions({ tenantId: 't' });
+		expect(Object.keys(out)).toEqual(['tenantId']);
+	});
+
+	it('returns an empty object for empty input', () => {
+		expect(mapEnqueueOptions({})).toEqual({});
+	});
+
+	it('translates all fields together', () => {
+		const opts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		};
+		expect(mapEnqueueOptions(opts)).toEqual({
+			jobId: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		});
+	});
+});

--- a/packages/plugins/job-runtime-bullmq/src/bullmq-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-bullmq/src/bullmq-dispatcher-factory.ts
@@ -1,8 +1,10 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
 import type {
 	BullMqDeps,
 	BullMqFactoryOptions,
 	BullMqQueueAdapter
 } from './bullmq-types.js';
+import { mapEnqueueOptions } from './bullmq-enqueue-options.js';
 
 /**
  * EW-742 P3.2 follow-up — operator-facing factory that turns a single
@@ -57,6 +59,27 @@ export interface BullMqDispatcher {
 	 * options shallow-merge over the factory's `defaultJobOptions`.
 	 */
 	dispatch(name: string, payload: unknown, opts?: Readonly<Record<string, unknown>>): Promise<string | null>;
+	/**
+	 * EW-742 P4 T31 — enqueue with platform-canonical `JobEnqueueOptions`.
+	 * The factory translates each field onto the BullMQ-native carrier
+	 * per `providers.md` § BullMQ:
+	 *
+	 *   - `idempotencyKey` → `JobsOptions.jobId`
+	 *   - `tenantId`       → custom `JobsOptions.tenantId`
+	 *   - `concurrencyKey` → custom `JobsOptions.concurrencyKey`
+	 *   - `tags`           → custom `JobsOptions.tags`
+	 *   - `maxDurationSeconds` / `machineHint` → custom passthroughs
+	 *
+	 * `extraOpts` is shallow-merged on top of the translation so the
+	 * operator can still pass bullmq-native options (priority, lifo,
+	 * attempts, backoff) that have no `JobEnqueueOptions` equivalent.
+	 */
+	enqueue(
+		name: string,
+		payload: unknown,
+		enqueueOptions: JobEnqueueOptions,
+		extraOpts?: Readonly<Record<string, unknown>>
+	): Promise<string | null>;
 	/** Underlying queue handle — exposed for advanced lifecycle (drain, pause). */
 	readonly queue: BullMqQueueAdapter;
 }
@@ -91,6 +114,12 @@ export class BullMqDispatcherFactory {
 			queue: q,
 			dispatch: async (name, payload, callOpts) => {
 				const merged = callOpts ? { ...callOpts } : undefined;
+				const job = await q.add(name, payload, merged);
+				return job?.id ?? null;
+			},
+			enqueue: async (name, payload, enqueueOptions, extraOpts) => {
+				const translated = mapEnqueueOptions(enqueueOptions);
+				const merged = extraOpts ? { ...translated, ...extraOpts } : translated;
 				const job = await q.add(name, payload, merged);
 				return job?.id ?? null;
 			}

--- a/packages/plugins/job-runtime-bullmq/src/bullmq-enqueue-options.ts
+++ b/packages/plugins/job-runtime-bullmq/src/bullmq-enqueue-options.ts
@@ -1,0 +1,43 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+
+/**
+ * EW-742 P4 T31 — translator: platform `JobEnqueueOptions` → BullMQ
+ * `JobsOptions` carrier per `providers.md`.
+ *
+ * Mapping rules (locked in `tasks.md` T31):
+ *
+ *   - `idempotencyKey` → `jobId` (BullMQ's dedup mechanism — same
+ *     jobId in the same queue is rejected at `Queue.add` time).
+ *   - `tenantId`       → custom `tenantId` field on `JobsOptions` (the
+ *     "native carrier" per `providers.md` § BullMQ); workers read it
+ *     off `job.opts.tenantId` to route per-tenant.
+ *   - `concurrencyKey` → custom `concurrencyKey` field; BullMQ Pro
+ *     supports `group.id` natively but plain BullMQ doesn't, so the
+ *     worker honours it via the `concurrencyKey` field.
+ *   - `tags`           → custom `tags` field (BullMQ doesn't tag
+ *     natively; preserved for observability).
+ *   - `maxDurationSeconds` → no direct BullMQ option (the worker
+ *     enforces its own `lockDuration`/`lockRenewTime`); we surface
+ *     it on `maxDurationSeconds` for the operator's handler to honor.
+ *   - `machineHint`    → custom `machineHint` field; BullMQ doesn't
+ *     route by machine class.
+ *
+ * Every translated field is `undefined`-safe: a missing entry on the
+ * input is omitted from the output (NOT written as `undefined`) so
+ * downstream `Object.keys` walks see a clean payload.
+ *
+ * The translator is intentionally a pure function — easy to unit-test
+ * and to compose with a per-call `extraOpts` spread.
+ */
+export function mapEnqueueOptions(
+	opts: JobEnqueueOptions
+): Readonly<Record<string, unknown>> {
+	const out: Record<string, unknown> = {};
+	if (opts.idempotencyKey !== undefined) out['jobId'] = opts.idempotencyKey;
+	if (opts.tenantId !== undefined) out['tenantId'] = opts.tenantId;
+	if (opts.concurrencyKey !== undefined) out['concurrencyKey'] = opts.concurrencyKey;
+	if (opts.tags !== undefined) out['tags'] = opts.tags;
+	if (opts.maxDurationSeconds !== undefined) out['maxDurationSeconds'] = opts.maxDurationSeconds;
+	if (opts.machineHint !== undefined) out['machineHint'] = opts.machineHint;
+	return out;
+}

--- a/packages/plugins/job-runtime-bullmq/src/index.ts
+++ b/packages/plugins/job-runtime-bullmq/src/index.ts
@@ -8,6 +8,7 @@ export type {
 } from './bullmq-job-runtime.plugin.js';
 export { BullMqDispatcherFactory } from './bullmq-dispatcher-factory.js';
 export type { BullMqDispatcher } from './bullmq-dispatcher-factory.js';
+export { mapEnqueueOptions as mapBullMqEnqueueOptions } from './bullmq-enqueue-options.js';
 export { BullMqWorkerHostFactory } from './bullmq-worker-host-factory.js';
 export type { BullMqWorkerRegistration } from './bullmq-worker-host-factory.js';
 export type {


### PR DESCRIPTION
EW-742 P4 T31 — first of 4 per-provider stamping PRs. Translates platform JobEnqueueOptions onto BullMQ's native JobsOptions carrier per providers.md § BullMQ.

New: mapEnqueueOptions translator (pure, undefined-safe) + BullMqDispatcher.enqueue(name, payload, opts, extraOpts?) convenience method. extraOpts shallow-merge on top so native bullmq opts (priority, attempts, backoff) still work.

70/70 tests green. tsc + tsup + DTS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added job enqueue functionality with comprehensive option support: idempotency keys to prevent duplicate submissions, tenant identification for multi-tenant deployments, concurrency constraints, task tagging, and maximum duration limits for enhanced queue management and execution control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->