### PR TITLE
feat(job-runtime-pgboss): JobEnqueueOptions → pg-boss carrier (EW-742 P4 T31)

### DIFF
--- a/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-enqueue-options.spec.ts
+++ b/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-enqueue-options.spec.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { mapEnqueueOptions } from '../pgboss-enqueue-options.js';
+import { PgBossDispatcherFactory } from '../pgboss-dispatcher-factory.js';
+import type { PgBossInstance, PgBossJobView } from '../pgboss-types.js';
+
+describe('mapEnqueueOptions (EW-742 P4 T31 pg-boss stamping)', () => {
+	it('translates idempotencyKey → sendOptions.singletonKey', () => {
+		expect(mapEnqueueOptions({ idempotencyKey: 'idem-1' })).toEqual({
+			sendOptions: { singletonKey: 'idem-1' },
+			metaForPayload: {}
+		});
+	});
+
+	it('translates maxDurationSeconds → sendOptions.expireInSeconds', () => {
+		expect(mapEnqueueOptions({ maxDurationSeconds: 600 })).toEqual({
+			sendOptions: { expireInSeconds: 600 },
+			metaForPayload: {}
+		});
+	});
+
+	it('translates tenantId / concurrencyKey / tags / machineHint → payload._ew namespace', () => {
+		const out = mapEnqueueOptions({
+			tenantId: 't-acme',
+			concurrencyKey: 'work-7',
+			tags: ['kb'],
+			machineHint: 'small-2x'
+		});
+		expect(out).toEqual({
+			sendOptions: {},
+			metaForPayload: {
+				_ew: {
+					tenantId: 't-acme',
+					concurrencyKey: 'work-7',
+					tags: ['kb'],
+					machineHint: 'small-2x'
+				}
+			}
+		});
+	});
+
+	it('omits the _ew namespace entirely when no meta fields are set', () => {
+		const out = mapEnqueueOptions({ idempotencyKey: 'idem' });
+		expect(out.metaForPayload).toEqual({});
+	});
+
+	it('omits undefined fields (no noisy keys)', () => {
+		const out = mapEnqueueOptions({ tenantId: 't' });
+		expect(out.metaForPayload).toEqual({ _ew: { tenantId: 't' } });
+		expect(out.sendOptions).toEqual({});
+	});
+
+	it('translates all fields together', () => {
+		const opts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		};
+		expect(mapEnqueueOptions(opts)).toEqual({
+			sendOptions: { singletonKey: 'idem-A', expireInSeconds: 600 },
+			metaForPayload: {
+				_ew: {
+					tenantId: 'tenant-A',
+					concurrencyKey: 'work-A',
+					tags: ['kb'],
+					machineHint: 'medium-1x'
+				}
+			}
+		});
+	});
+});
+
+describe('PgBossDispatcherFactory.enqueue (EW-742 P4 T31)', () => {
+	class FakeBoss implements PgBossInstance {
+		sendCalls: { name: string; data: unknown; options?: Readonly<Record<string, unknown>> }[] = [];
+		async send(name: string, data: unknown, options?: Readonly<Record<string, unknown>>) {
+			this.sendCalls.push({ name, data, options });
+			return 'jb-1';
+		}
+		async work(
+			_n: string,
+			_o: Readonly<Record<string, unknown>>,
+			_h: (j: PgBossJobView | readonly PgBossJobView[]) => Promise<unknown>
+		) {
+			return 'sub-1';
+		}
+		async cancel() {
+			// noop
+		}
+		async start() {
+			return undefined;
+		}
+		async stop() {
+			// noop
+		}
+	}
+
+	it('translates JobEnqueueOptions onto sendOptions + payload._ew', async () => {
+		const boss = new FakeBoss();
+		const factory = new PgBossDispatcherFactory({ boss });
+		const id = await factory.enqueue(
+			'kb-embed',
+			{ workId: 'w7' },
+			{
+				idempotencyKey: 'idem-1',
+				tenantId: 't-acme',
+				maxDurationSeconds: 900,
+				tags: ['kb']
+			}
+		);
+		expect(id).toBe('jb-1');
+		expect(boss.sendCalls[0]).toEqual({
+			name: 'kb-embed',
+			data: {
+				workId: 'w7',
+				_ew: { tenantId: 't-acme', tags: ['kb'] }
+			},
+			options: { singletonKey: 'idem-1', expireInSeconds: 900 }
+		});
+	});
+
+	it('defaultSendOptions merge under translated sendOptions', async () => {
+		const boss = new FakeBoss();
+		const factory = new PgBossDispatcherFactory({
+			boss,
+			defaultSendOptions: { retryLimit: 3, expireInSeconds: 60 }
+		});
+		await factory.enqueue('q', { x: 1 }, { maxDurationSeconds: 900 });
+		expect(boss.sendCalls[0].options).toEqual({
+			retryLimit: 3,
+			expireInSeconds: 900 // translation overrides the default
+		});
+	});
+
+	it('extraOpts shallow-merge OVER translated sendOptions (operator wins)', async () => {
+		const boss = new FakeBoss();
+		const factory = new PgBossDispatcherFactory({ boss });
+		await factory.enqueue(
+			'q',
+			{ x: 1 },
+			{ idempotencyKey: 'idem-platform' },
+			{ singletonKey: 'idem-operator', retryLimit: 5 }
+		);
+		expect(boss.sendCalls[0].options).toEqual({
+			singletonKey: 'idem-operator',
+			retryLimit: 5
+		});
+	});
+
+	it('send() path is unchanged — no JobEnqueueOptions translation', async () => {
+		const boss = new FakeBoss();
+		const sendSpy = vi.spyOn(boss, 'send');
+		const factory = new PgBossDispatcherFactory({ boss });
+		await factory.send('q', { x: 1 }, { singletonKey: 'raw' });
+		expect(sendSpy).toHaveBeenCalledWith('q', { x: 1 }, { singletonKey: 'raw' });
+	});
+
+	it('null payload becomes {} + _ew namespace when present', async () => {
+		const boss = new FakeBoss();
+		const factory = new PgBossDispatcherFactory({ boss });
+		await factory.enqueue('q', null, { tenantId: 't' });
+		expect(boss.sendCalls[0].data).toEqual({ _ew: { tenantId: 't' } });
+	});
+});

--- a/packages/plugins/job-runtime-pgboss/src/index.ts
+++ b/packages/plugins/job-runtime-pgboss/src/index.ts
@@ -7,6 +7,10 @@ export type {
 	PgBossJobRuntimePluginOptions
 } from './pgboss-job-runtime.plugin.js';
 export { PgBossDispatcherFactory } from './pgboss-dispatcher-factory.js';
+export {
+	mapEnqueueOptions as mapPgBossEnqueueOptions
+} from './pgboss-enqueue-options.js';
+export type { MappedPgBossEnqueue } from './pgboss-enqueue-options.js';
 export { PgBossWorkerHostFactory } from './pgboss-worker-host-factory.js';
 export type { PgBossWorkerRegistration } from './pgboss-worker-host-factory.js';
 export type {

--- a/packages/plugins/job-runtime-pgboss/src/pgboss-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-pgboss/src/pgboss-dispatcher-factory.ts
@@ -1,4 +1,6 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
 import type { PgBossFactoryOptions, PgBossInstance, PgBossJobRecord } from './pgboss-types.js';
+import { mapEnqueueOptions } from './pgboss-enqueue-options.js';
 
 /**
  * EW-742 P3.2 follow-up — operator-facing factory that wraps a
@@ -43,6 +45,46 @@ export class PgBossDispatcherFactory {
 			? { ...this.opts.defaultSendOptions, ...(callOpts ?? {}) }
 			: callOpts;
 		return this.opts.boss.send(name, payload, merged);
+	}
+
+	/**
+	 * EW-742 P4 T31 — enqueue with platform-canonical
+	 * `JobEnqueueOptions`. Translates each field onto the pg-boss
+	 * carrier per `providers.md` § pg-boss:
+	 *
+	 *   - `idempotencyKey`    → `sendOptions.singletonKey`
+	 *   - `maxDurationSeconds`→ `sendOptions.expireInSeconds`
+	 *   - `tenantId` / `concurrencyKey` / `tags` / `machineHint` →
+	 *     stamped onto the job payload under a reserved `_ew`
+	 *     namespace so the worker can route per-tenant without
+	 *     requiring custom pg-boss columns.
+	 *
+	 * Per-tenant schema selection happens BEFORE this call — the
+	 * caller picks the right `PgBoss` instance via the plugin's
+	 * `dispatchersBuilder` hook (one `PgBoss` per tenant schema, per
+	 * ADR-017 Q2).
+	 *
+	 * `extraOpts` is shallow-merged on top of the translated
+	 * sendOptions so operators can still pass pg-boss-native fields
+	 * (retryLimit, retryBackoff, startAfter, etc.) that have no
+	 * `JobEnqueueOptions` equivalent.
+	 */
+	async enqueue(
+		name: string,
+		payload: Readonly<Record<string, unknown>> | null,
+		enqueueOptions: JobEnqueueOptions,
+		extraOpts?: Readonly<Record<string, unknown>>
+	): Promise<string | null> {
+		const { sendOptions, metaForPayload } = mapEnqueueOptions(enqueueOptions);
+		const mergedPayload =
+			Object.keys(metaForPayload).length > 0
+				? { ...(payload ?? {}), ...metaForPayload }
+				: (payload ?? {});
+		const baseOpts = this.opts.defaultSendOptions
+			? { ...this.opts.defaultSendOptions, ...sendOptions }
+			: sendOptions;
+		const mergedOpts = extraOpts ? { ...baseOpts, ...extraOpts } : baseOpts;
+		return this.opts.boss.send(name, mergedPayload, mergedOpts);
 	}
 
 	/** Cancel an in-flight job by id. Returns true once the cancel call resolves. */

--- a/packages/plugins/job-runtime-pgboss/src/pgboss-enqueue-options.ts
+++ b/packages/plugins/job-runtime-pgboss/src/pgboss-enqueue-options.ts
@@ -1,0 +1,52 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+
+/**
+ * EW-742 P4 T31 — translator: platform `JobEnqueueOptions` → pg-boss
+ * `send` options + per-job payload field per `providers.md`.
+ *
+ * pg-boss's native options object accepts most of what we need; a few
+ * fields (tenantId, concurrencyKey, tags, machineHint) are not native
+ * and surface as a `meta` field that the worker reads off
+ * `job.data._ew` to route per-tenant (the spec calls this the "payload
+ * field" carrier per `providers.md` § pg-boss).
+ *
+ * Mapping rules:
+ *
+ *   - `idempotencyKey`    → `singletonKey` (pg-boss's dedup mechanism)
+ *   - `tenantId`          → returned in `metaForPayload._ew.tenantId`
+ *                          + the per-tenant schema lookup is done
+ *                          BEFORE publish by the dispatchers builder
+ *                          (caller-side, see plugin
+ *                          `dispatchersBuilder` hook)
+ *   - `concurrencyKey`    → `metaForPayload._ew.concurrencyKey`
+ *                          (pg-boss has no native concurrency-key;
+ *                          worker honours)
+ *   - `maxDurationSeconds`→ `expireInSeconds` (native: pg-boss kills
+ *                          the job once this many seconds elapse)
+ *   - `tags` / `machineHint` → `metaForPayload._ew` passthroughs
+ *
+ * The translator returns TWO outputs so the dispatcher can:
+ *   1. shallow-merge `sendOptions` onto pg-boss's options arg
+ *   2. shallow-merge `metaForPayload` onto the job's `data` arg under
+ *      a reserved `_ew` namespace (workers know to look there)
+ *
+ * Pure function — easy to unit-test and to compose with operator
+ * overrides.
+ */
+export interface MappedPgBossEnqueue {
+	readonly sendOptions: Readonly<Record<string, unknown>>;
+	readonly metaForPayload: Readonly<Record<string, unknown>>;
+}
+
+export function mapEnqueueOptions(opts: JobEnqueueOptions): MappedPgBossEnqueue {
+	const sendOptions: Record<string, unknown> = {};
+	const meta: Record<string, unknown> = {};
+	if (opts.idempotencyKey !== undefined) sendOptions['singletonKey'] = opts.idempotencyKey;
+	if (opts.maxDurationSeconds !== undefined) sendOptions['expireInSeconds'] = opts.maxDurationSeconds;
+	if (opts.tenantId !== undefined) meta['tenantId'] = opts.tenantId;
+	if (opts.concurrencyKey !== undefined) meta['concurrencyKey'] = opts.concurrencyKey;
+	if (opts.tags !== undefined) meta['tags'] = opts.tags;
+	if (opts.machineHint !== undefined) meta['machineHint'] = opts.machineHint;
+	const metaForPayload: Record<string, unknown> = Object.keys(meta).length > 0 ? { _ew: meta } : {};
+	return { sendOptions, metaForPayload };
+}


### PR DESCRIPTION
EW-742 P4 T31 — second per-provider stamping PR (after #1474). Same pattern: map JobEnqueueOptions onto provider-native carrier. pg-boss has a two-channel approach (sendOptions + payload._ew namespace) because pg-boss lacks native fields for tenantId/concurrencyKey/tags/machineHint.

67/67 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced job enqueue functionality with support for idempotency keys, configurable job duration limits, and tenant/routing metadata handling.
  * New public APIs for mapping enqueue options.

* **Tests**
  * Added comprehensive test coverage for job enqueue option translation and dispatcher integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->