### PR TITLE
feat(job-runtime-temporal): JobEnqueueOptions → WorkflowStartOptions (EW-742 P4 T31)

### DIFF
--- a/packages/plugins/job-runtime-temporal/src/__tests__/temporal-enqueue-options.spec.ts
+++ b/packages/plugins/job-runtime-temporal/src/__tests__/temporal-enqueue-options.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { mapEnqueueOptions } from '../temporal-enqueue-options.js';
+import { TemporalDispatcherFactory } from '../temporal-dispatcher-factory.js';
+import type { TemporalStartWorkflowOptions, TemporalWorkflowClient, TemporalWorkflowHandle } from '../temporal-types.js';
+
+describe('mapEnqueueOptions (EW-742 P4 T31 Temporal stamping)', () => {
+	it('idempotencyKey surfaces as workflowIdFromIdempotency', () => {
+		const out = mapEnqueueOptions({ idempotencyKey: 'kb-embed:work-7' });
+		expect(out.workflowIdFromIdempotency).toBe('kb-embed:work-7');
+		expect(out.startOptions).toEqual({});
+	});
+
+	it('tenantId → searchAttributes.tenantId (list-wrapped)', () => {
+		const out = mapEnqueueOptions({ tenantId: 't-acme' });
+		expect(out.startOptions.searchAttributes).toEqual({ tenantId: ['t-acme'] });
+	});
+
+	it('concurrencyKey + tags → searchAttributes (list-wrapped)', () => {
+		const out = mapEnqueueOptions({ concurrencyKey: 'work-7', tags: ['kb', 'embed'] });
+		expect(out.startOptions.searchAttributes).toEqual({
+			concurrencyKey: ['work-7'],
+			tags: ['kb', 'embed']
+		});
+	});
+
+	it('omits empty tags array', () => {
+		const out = mapEnqueueOptions({ tags: [] });
+		expect(out.startOptions.searchAttributes).toBeUndefined();
+	});
+
+	it('maxDurationSeconds → workflowExecutionTimeout (string form)', () => {
+		expect(mapEnqueueOptions({ maxDurationSeconds: 900 }).startOptions.workflowExecutionTimeout).toBe('900s');
+	});
+
+	it('machineHint → memo.machineHint', () => {
+		expect(mapEnqueueOptions({ machineHint: 'medium-1x' }).startOptions.memo).toEqual({
+			machineHint: 'medium-1x'
+		});
+	});
+
+	it('all together', () => {
+		const opts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		};
+		expect(mapEnqueueOptions(opts)).toEqual({
+			workflowIdFromIdempotency: 'idem-A',
+			startOptions: {
+				searchAttributes: {
+					tenantId: ['tenant-A'],
+					concurrencyKey: ['work-A'],
+					tags: ['kb']
+				},
+				memo: { machineHint: 'medium-1x' },
+				workflowExecutionTimeout: '600s'
+			}
+		});
+	});
+
+	it('empty input returns empty translation', () => {
+		expect(mapEnqueueOptions({})).toEqual({
+			workflowIdFromIdempotency: undefined,
+			startOptions: {}
+		});
+	});
+});
+
+class FakeHandle implements TemporalWorkflowHandle {
+	constructor(public readonly workflowId: string) {}
+	async cancel() {
+		// noop
+	}
+	async describe() {
+		return { status: { name: 'RUNNING' } };
+	}
+}
+
+class FakeClient implements TemporalWorkflowClient {
+	startCalls: { type: string; options: TemporalStartWorkflowOptions }[] = [];
+	async start(workflowType: string, options: TemporalStartWorkflowOptions) {
+		this.startCalls.push({ type: workflowType, options });
+		return new FakeHandle(options.workflowId);
+	}
+	getHandle(workflowId: string) {
+		return new FakeHandle(workflowId);
+	}
+}
+
+describe('TemporalDispatcherFactory.enqueue (EW-742 P4 T31)', () => {
+	it('translates JobEnqueueOptions and starts the workflow', async () => {
+		const client = new FakeClient();
+		const factory = new TemporalDispatcherFactory({ client, defaultTaskQueue: 'ew' });
+		const handle = await factory.enqueue('kbEmbedWorkflow', [{ workId: 'w7' }], {
+			idempotencyKey: 'kb-embed:work-7',
+			tenantId: 't-acme',
+			concurrencyKey: 'work-7',
+			tags: ['kb'],
+			maxDurationSeconds: 900,
+			machineHint: 'medium-1x'
+		});
+		expect(handle.workflowId).toBe('kb-embed:work-7');
+		const call = client.startCalls[0];
+		expect(call.type).toBe('kbEmbedWorkflow');
+		expect(call.options.workflowId).toBe('kb-embed:work-7');
+		expect(call.options.args).toEqual([{ workId: 'w7' }]);
+		expect(call.options.taskQueue).toBe('ew');
+		expect(call.options.searchAttributes).toEqual({
+			tenantId: ['t-acme'],
+			concurrencyKey: ['work-7'],
+			tags: ['kb']
+		});
+		expect(call.options.memo).toEqual({ machineHint: 'medium-1x' });
+		expect(call.options.workflowExecutionTimeout).toBe('900s');
+	});
+
+	it('extraOpts.workflowId wins over idempotencyKey', async () => {
+		const client = new FakeClient();
+		const factory = new TemporalDispatcherFactory({ client, defaultTaskQueue: 'ew' });
+		await factory.enqueue(
+			'wf',
+			[],
+			{ idempotencyKey: 'idem' },
+			{ workflowId: 'explicit-id' }
+		);
+		expect(client.startCalls[0].options.workflowId).toBe('explicit-id');
+	});
+
+	it('throws when neither idempotencyKey nor extraOpts.workflowId is set', async () => {
+		const client = new FakeClient();
+		const factory = new TemporalDispatcherFactory({ client, defaultTaskQueue: 'ew' });
+		await expect(factory.enqueue('wf', [], {})).rejects.toThrow(/no workflowId available/);
+	});
+
+	it('extraOpts shallow-merge OVER translated startOptions', async () => {
+		const client = new FakeClient();
+		const factory = new TemporalDispatcherFactory({ client, defaultTaskQueue: 'ew' });
+		await factory.enqueue(
+			'wf',
+			[],
+			{ idempotencyKey: 'idem', tenantId: 't-from-platform' },
+			{ searchAttributes: { tenantId: ['t-from-operator'] } }
+		);
+		expect(client.startCalls[0].options.searchAttributes).toEqual({
+			tenantId: ['t-from-operator']
+		});
+	});
+});

--- a/packages/plugins/job-runtime-temporal/src/index.ts
+++ b/packages/plugins/job-runtime-temporal/src/index.ts
@@ -7,6 +7,10 @@ export type {
 	TemporalJobRuntimePluginOptions
 } from './temporal-job-runtime.plugin.js';
 export { TemporalDispatcherFactory } from './temporal-dispatcher-factory.js';
+export {
+	mapEnqueueOptions as mapTemporalEnqueueOptions
+} from './temporal-enqueue-options.js';
+export type { MappedTemporalEnqueue } from './temporal-enqueue-options.js';
 export { TemporalWorkerHostFactory } from './temporal-worker-host-factory.js';
 export type {
 	TemporalWorkflowClient,

--- a/packages/plugins/job-runtime-temporal/src/temporal-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-temporal/src/temporal-dispatcher-factory.ts
@@ -1,9 +1,11 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
 import type {
 	TemporalDispatcherFactoryOptions,
 	TemporalStartWorkflowOptions,
 	TemporalWorkflowClient,
 	TemporalWorkflowHandle
 } from './temporal-types.js';
+import { mapEnqueueOptions } from './temporal-enqueue-options.js';
 
 /**
  * EW-742 P3.2 follow-up — operator-facing factory that turns a
@@ -63,6 +65,51 @@ export class TemporalDispatcherFactory {
 			taskQueue
 		};
 		return this.opts.client.start(workflowType, merged);
+	}
+
+	/**
+	 * EW-742 P4 T31 — enqueue with platform-canonical
+	 * `JobEnqueueOptions`. Translates each field onto Temporal's native
+	 * `WorkflowStartOptions` per `providers.md` § Temporal:
+	 *
+	 *   - `idempotencyKey`     → `workflowId` (per-call workflowId wins
+	 *                            if both are provided)
+	 *   - `tenantId`           → `searchAttributes.tenantId`
+	 *   - `concurrencyKey`     → `searchAttributes.concurrencyKey`
+	 *   - `tags`               → `searchAttributes.tags`
+	 *   - `maxDurationSeconds` → `workflowExecutionTimeout` (e.g. '900s')
+	 *   - `machineHint`        → `memo.machineHint`
+	 *
+	 * Per-tenant NAMESPACE selection happens before this call — the
+	 * caller picks the right `WorkflowClient` via the plugin's
+	 * `dispatchersBuilder` hook (one `WorkflowClient` per tenant
+	 * namespace, per ADR-017 Q1).
+	 *
+	 * `extraOpts` is shallow-merged on top so operators can still pass
+	 * Temporal-native fields (retry, workflowIdReusePolicy, etc.) that
+	 * have no `JobEnqueueOptions` equivalent.
+	 */
+	async enqueue(
+		workflowType: string,
+		args: readonly unknown[],
+		enqueueOptions: JobEnqueueOptions,
+		extraOpts?: Partial<TemporalStartWorkflowOptions>
+	): Promise<TemporalWorkflowHandle> {
+		const { workflowIdFromIdempotency, startOptions } = mapEnqueueOptions(enqueueOptions);
+		const workflowId = extraOpts?.workflowId ?? workflowIdFromIdempotency;
+		if (!workflowId) {
+			throw new Error(
+				`TemporalDispatcherFactory.enqueue: no workflowId available — provide either ` +
+					`enqueueOptions.idempotencyKey or extraOpts.workflowId for workflow '${workflowType}'.`
+			);
+		}
+		const startArgs: Partial<TemporalStartWorkflowOptions> & { workflowId: string } = {
+			...startOptions,
+			...(extraOpts ?? {}),
+			workflowId,
+			args
+		};
+		return this.start(workflowType, startArgs);
 	}
 
 	/**

--- a/packages/plugins/job-runtime-temporal/src/temporal-enqueue-options.ts
+++ b/packages/plugins/job-runtime-temporal/src/temporal-enqueue-options.ts
@@ -1,0 +1,76 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import type { TemporalStartWorkflowOptions } from './temporal-types.js';
+
+/**
+ * EW-742 P4 T31 — translator: platform `JobEnqueueOptions` → Temporal
+ * `WorkflowStartOptions` carrier per `providers.md` § Temporal.
+ *
+ * Temporal has rich native fields, so most translations are direct:
+ *
+ *   - `idempotencyKey`    → `workflowId` (Temporal's idempotency key
+ *                           is the workflow id itself — re-starting
+ *                           with the same id is rejected unless the
+ *                           `workflowIdReusePolicy` allows it).
+ *   - `tenantId`          → `searchAttributes.tenantId` (per
+ *                           providers.md). The per-tenant Temporal
+ *                           NAMESPACE selection happens at
+ *                           start-workflow time by the operator's
+ *                           `dispatchersBuilder` (one WorkflowClient
+ *                           per tenant namespace, per ADR-017 Q1).
+ *   - `concurrencyKey`    → `searchAttributes.concurrencyKey` (we use
+ *                           a searchable attribute so the operator's
+ *                           workflow can `await condition()` on it
+ *                           for serialisation, OR they can use
+ *                           workflowIdReusePolicy='reject-duplicate').
+ *   - `maxDurationSeconds`→ `workflowExecutionTimeout` (string form;
+ *                           Temporal accepts seconds via string like
+ *                           '900s').
+ *   - `tags`              → `searchAttributes.tags` (Temporal supports
+ *                           list-valued attributes natively).
+ *   - `machineHint`       → `memo.machineHint` (informational; Temporal
+ *                           doesn't route by machine class).
+ *
+ * # workflowId priority
+ *
+ * If both `idempotencyKey` AND a per-call `workflowId` are provided,
+ * the per-call `workflowId` wins (the operator may want a structured
+ * id like `kb-embed:work-7:rev-2`). When neither is set, the caller
+ * MUST pass `workflowId` to `factory.start()` — the translator never
+ * invents one.
+ *
+ * # searchAttributes shape
+ *
+ * Temporal expects search attributes as `Record<string, unknown[]>`
+ * (list-valued for indexing). We wrap scalar values in single-element
+ * arrays.
+ */
+export interface MappedTemporalEnqueue {
+	/** Workflow id derived from idempotencyKey, or undefined if not set. */
+	readonly workflowIdFromIdempotency: string | undefined;
+	readonly startOptions: Partial<Omit<TemporalStartWorkflowOptions, 'workflowId' | 'args'>>;
+}
+
+export function mapEnqueueOptions(opts: JobEnqueueOptions): MappedTemporalEnqueue {
+	const searchAttributes: Record<string, readonly unknown[]> = {};
+	const memo: Record<string, unknown> = {};
+	if (opts.tenantId !== undefined) searchAttributes['tenantId'] = [opts.tenantId];
+	if (opts.concurrencyKey !== undefined) searchAttributes['concurrencyKey'] = [opts.concurrencyKey];
+	if (opts.tags !== undefined && opts.tags.length > 0) searchAttributes['tags'] = [...opts.tags];
+	if (opts.machineHint !== undefined) memo['machineHint'] = opts.machineHint;
+
+	const mutableStart: {
+		searchAttributes?: Record<string, readonly unknown[]>;
+		memo?: Record<string, unknown>;
+		workflowExecutionTimeout?: string;
+	} = {};
+	if (Object.keys(searchAttributes).length > 0) mutableStart.searchAttributes = searchAttributes;
+	if (Object.keys(memo).length > 0) mutableStart.memo = memo;
+	if (opts.maxDurationSeconds !== undefined) {
+		mutableStart.workflowExecutionTimeout = `${opts.maxDurationSeconds}s`;
+	}
+
+	return {
+		workflowIdFromIdempotency: opts.idempotencyKey,
+		startOptions: mutableStart as Partial<Omit<TemporalStartWorkflowOptions, 'workflowId' | 'args'>>
+	};
+}


### PR DESCRIPTION
EW-742 P4 T31 — third per-provider stamping PR (after #1474 BullMQ, #1475 pg-boss). Maps JobEnqueueOptions onto Temporal's native fields: idempotencyKey→workflowId, tenantId/concurrencyKey/tags→searchAttributes, maxDurationSeconds→workflowExecutionTimeout (string '900s'), machineHint→memo.

72/72 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job enqueueing support for Temporal workflows with configuration options for idempotency, tenant management, concurrency control, tagging, execution timeouts, and machine preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->