### PR TITLE
feat(job-runtime-inngest): JobEnqueueOptions → SendEvent carrier (EW-742 P4 T31)

### DIFF
--- a/packages/plugins/job-runtime-inngest/src/__tests__/inngest-enqueue-options.spec.ts
+++ b/packages/plugins/job-runtime-inngest/src/__tests__/inngest-enqueue-options.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { mapEnqueueOptions } from '../inngest-enqueue-options.js';
+import { InngestDispatcherFactory } from '../inngest-dispatcher-factory.js';
+import type { InngestClient, InngestSendEvent, InngestSendResult } from '../inngest-types.js';
+
+describe('mapEnqueueOptions (EW-742 P4 T31 Inngest stamping)', () => {
+	it('idempotencyKey → top-level id', () => {
+		expect(mapEnqueueOptions({ idempotencyKey: 'idem-1' })).toEqual({
+			topLevel: { id: 'idem-1' },
+			dataMeta: {}
+		});
+	});
+
+	it('tenantId / concurrencyKey / tags / maxDurationSeconds / machineHint → dataMeta', () => {
+		expect(
+			mapEnqueueOptions({
+				tenantId: 't-acme',
+				concurrencyKey: 'work-7',
+				tags: ['kb'],
+				maxDurationSeconds: 900,
+				machineHint: 'small-2x'
+			})
+		).toEqual({
+			topLevel: {},
+			dataMeta: {
+				tenantId: 't-acme',
+				concurrencyKey: 'work-7',
+				tags: ['kb'],
+				maxDurationSeconds: 900,
+				machineHint: 'small-2x'
+			}
+		});
+	});
+
+	it('empty input returns empty translation', () => {
+		expect(mapEnqueueOptions({})).toEqual({ topLevel: {}, dataMeta: {} });
+	});
+
+	it('all fields together', () => {
+		const opts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		};
+		expect(mapEnqueueOptions(opts)).toEqual({
+			topLevel: { id: 'idem-A' },
+			dataMeta: {
+				tenantId: 'tenant-A',
+				concurrencyKey: 'work-A',
+				tags: ['kb'],
+				maxDurationSeconds: 600,
+				machineHint: 'medium-1x'
+			}
+		});
+	});
+});
+
+class FakeInngest implements InngestClient {
+	sentEvents: (InngestSendEvent | readonly InngestSendEvent[])[] = [];
+	private nextId = 1;
+	async send(event: InngestSendEvent | readonly InngestSendEvent[]): Promise<InngestSendResult> {
+		this.sentEvents.push(event);
+		const count = Array.isArray(event) ? event.length : 1;
+		const ids = Array.from({ length: count }, () => `evt_${this.nextId++}`);
+		return { ids };
+	}
+}
+
+describe('InngestDispatcherFactory.enqueue (EW-742 P4 T31)', () => {
+	it('stamps id + data._ew with translated fields, applies eventNamespace', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client, eventNamespace: 'ever.works' });
+		const id = await factory.enqueue(
+			'kb-embed-document',
+			{ workId: 'w7' },
+			{ idempotencyKey: 'idem-1', tenantId: 't-acme', tags: ['kb'] }
+		);
+		expect(id).toBe('evt_1');
+		const sent = client.sentEvents[0] as InngestSendEvent;
+		expect(sent.name).toBe('ever.works/kb-embed-document');
+		expect(sent.id).toBe('idem-1');
+		expect(sent.data).toEqual({
+			workId: 'w7',
+			_ew: { tenantId: 't-acme', tags: ['kb'] }
+		});
+	});
+
+	it('omits _ew when no dataMeta fields are set', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		await factory.enqueue('evt', { x: 1 }, { idempotencyKey: 'idem' });
+		const sent = client.sentEvents[0] as InngestSendEvent;
+		expect(sent.data).toEqual({ x: 1 });
+	});
+
+	it('extraOverrides shallow-merge OVER translated top-level (operator wins)', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		await factory.enqueue(
+			'evt',
+			{},
+			{ idempotencyKey: 'idem-platform' },
+			{ id: 'idem-operator', user: { uid: 'u' } }
+		);
+		const sent = client.sentEvents[0] as InngestSendEvent;
+		expect(sent.id).toBe('idem-operator');
+		expect(sent.user).toEqual({ uid: 'u' });
+	});
+
+	it('send() path is unchanged', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		await factory.send('evt', { hello: 'world' });
+		const sent = client.sentEvents[0] as InngestSendEvent;
+		expect(sent).toEqual({ name: 'evt', data: { hello: 'world' } });
+	});
+});

--- a/packages/plugins/job-runtime-inngest/src/index.ts
+++ b/packages/plugins/job-runtime-inngest/src/index.ts
@@ -7,6 +7,10 @@ export type {
 	InngestJobRuntimePluginOptions
 } from './inngest-job-runtime.plugin.js';
 export { InngestDispatcherFactory } from './inngest-dispatcher-factory.js';
+export {
+	mapEnqueueOptions as mapInngestEnqueueOptions
+} from './inngest-enqueue-options.js';
+export type { MappedInngestEnqueue } from './inngest-enqueue-options.js';
 export type {
 	InngestClient,
 	InngestSendEvent,

--- a/packages/plugins/job-runtime-inngest/src/inngest-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-inngest/src/inngest-dispatcher-factory.ts
@@ -1,9 +1,11 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
 import type {
 	InngestClient,
 	InngestDispatcherFactoryOptions,
 	InngestFunction,
 	InngestSendEvent
 } from './inngest-types.js';
+import { mapEnqueueOptions } from './inngest-enqueue-options.js';
 
 /**
  * EW-742 P3.2 follow-up — operator-facing factory that wraps an
@@ -69,6 +71,47 @@ export class InngestDispatcherFactory {
 			name: fullName,
 			data,
 			...(overrides ?? {})
+		};
+		const result = await this.opts.client.send(event);
+		return result.ids?.[0] ?? null;
+	}
+
+	/**
+	 * EW-742 P4 T31 — enqueue with platform-canonical
+	 * `JobEnqueueOptions`. Translates each field onto Inngest's
+	 * SendEvent carrier per `providers.md` § Inngest:
+	 *
+	 *   - `idempotencyKey`   → top-level `event.id` (Inngest dedup)
+	 *   - `tenantId`         → `event.data._ew.tenantId`
+	 *   - `concurrencyKey`   → `event.data._ew.concurrencyKey`
+	 *   - `tags`             → `event.data._ew.tags`
+	 *   - `maxDurationSeconds` / `machineHint` → `event.data._ew.*`
+	 *
+	 * Per-tenant Inngest CLIENT selection happens before this call —
+	 * the caller picks the right `Inngest` client via the plugin's
+	 * `dispatchersBuilder` hook (SaaS only per providers.md).
+	 *
+	 * `extraOverrides` is shallow-merged on top so operators can still
+	 * pass Inngest-native top-level event fields (`user`, custom v3
+	 * SDK fields) that have no `JobEnqueueOptions` equivalent.
+	 */
+	async enqueue(
+		eventName: string,
+		data: Readonly<Record<string, unknown>>,
+		enqueueOptions: JobEnqueueOptions,
+		extraOverrides?: Partial<Omit<InngestSendEvent, 'name' | 'data'>>
+	): Promise<string | null> {
+		const { topLevel, dataMeta } = mapEnqueueOptions(enqueueOptions);
+		const fullName = this.opts.eventNamespace
+			? `${this.opts.eventNamespace}/${eventName}`
+			: eventName;
+		const mergedData =
+			Object.keys(dataMeta).length > 0 ? { ...data, _ew: dataMeta } : data;
+		const event: InngestSendEvent = {
+			name: fullName,
+			data: mergedData,
+			...topLevel,
+			...(extraOverrides ?? {})
 		};
 		const result = await this.opts.client.send(event);
 		return result.ids?.[0] ?? null;

--- a/packages/plugins/job-runtime-inngest/src/inngest-enqueue-options.ts
+++ b/packages/plugins/job-runtime-inngest/src/inngest-enqueue-options.ts
@@ -1,0 +1,60 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import type { InngestSendEvent } from './inngest-types.js';
+
+/**
+ * EW-742 P4 T31 — translator: platform `JobEnqueueOptions` → Inngest
+ * `SendEvent` carrier per `providers.md` § Inngest.
+ *
+ * Inngest's `send()` accepts a few top-level fields (`id`, `user`)
+ * and a free-form `data` payload. The platform's enqueue options map
+ * onto a mix of native and `data._ew` passthroughs:
+ *
+ *   - `idempotencyKey`     → top-level `id` (Inngest's native event id
+ *                            de-dup mechanism — same id within the
+ *                            de-dup window collapses to one delivery).
+ *   - `tenantId`           → `data._ew.tenantId` (per providers.md;
+ *                            tenant webhook handler routes per this
+ *                            field).
+ *   - `concurrencyKey`     → `data._ew.concurrencyKey` (operator
+ *                            handles via Inngest function `concurrency`
+ *                            config; we surface the value so the
+ *                            function's concurrency key callback can
+ *                            return it).
+ *   - `tags`               → `data._ew.tags`
+ *   - `maxDurationSeconds` → `data._ew.maxDurationSeconds` (operator
+ *                            handles via per-function `step.run`
+ *                            timeouts; informational here).
+ *   - `machineHint`        → `data._ew.machineHint`
+ *
+ * Per-tenant Inngest CLIENT selection happens BEFORE this call — the
+ * caller picks the right `Inngest` client (eventKey + signingKey) via
+ * the plugin's `dispatchersBuilder` hook (SaaS-only per providers.md).
+ *
+ * The translator returns `{ topLevel, dataMeta }` so the dispatcher
+ * spreads `topLevel` onto the event AND merges `dataMeta` under
+ * `data._ew`.
+ */
+export interface MappedInngestEnqueue {
+	/**
+	 * Fields that go ON the event itself (top-level), NOT under data.
+	 * Currently just `id` for idempotency.
+	 */
+	readonly topLevel: Partial<Pick<InngestSendEvent, 'id'>>;
+	/**
+	 * Fields stamped under `data._ew` so the operator's Inngest function
+	 * (or tenant webhook handler) can read them.
+	 */
+	readonly dataMeta: Readonly<Record<string, unknown>>;
+}
+
+export function mapEnqueueOptions(opts: JobEnqueueOptions): MappedInngestEnqueue {
+	const topLevel: { id?: string } = {};
+	const dataMeta: Record<string, unknown> = {};
+	if (opts.idempotencyKey !== undefined) topLevel.id = opts.idempotencyKey;
+	if (opts.tenantId !== undefined) dataMeta['tenantId'] = opts.tenantId;
+	if (opts.concurrencyKey !== undefined) dataMeta['concurrencyKey'] = opts.concurrencyKey;
+	if (opts.tags !== undefined) dataMeta['tags'] = opts.tags;
+	if (opts.maxDurationSeconds !== undefined) dataMeta['maxDurationSeconds'] = opts.maxDurationSeconds;
+	if (opts.machineHint !== undefined) dataMeta['machineHint'] = opts.machineHint;
+	return { topLevel, dataMeta };
+}


### PR DESCRIPTION
EW-742 P4 T31 — fourth per-provider stamping PR (after #1474 BullMQ, #1475 pg-boss, #1476 Temporal). Inngest-specific mapping: idempotencyKey→event.id; tenantId/concurrencyKey/tags/maxDurationSeconds/machineHint→event.data._ew namespace.

61/61 tests green. T31 now done for all 4 non-Trigger providers (Trigger already had metadata.tenantId from the earlier bindToTenant work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)