### PR TITLE
chore(release): cascade develop → stage — T31 per-provider stamping (4 providers)

### DIFF
--- a/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-enqueue-integration.spec.ts
+++ b/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-enqueue-integration.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { BullMqDispatcherFactory } from '../bullmq-dispatcher-factory.js';
+import type { BullMqDeps, BullMqQueueAdapter, BullMqWorkerAdapter } from '../bullmq-types.js';
+
+interface QueueCall {
+	name: string;
+	data: unknown;
+	opts?: Readonly<Record<string, unknown>>;
+}
+
+class FakeQueue implements BullMqQueueAdapter {
+	static instances: FakeQueue[] = [];
+	readonly calls: QueueCall[] = [];
+	private nextId = 1;
+	constructor(public readonly name: string, public readonly ctorOpts: Readonly<Record<string, unknown>>) {
+		FakeQueue.instances.push(this);
+	}
+	async add(name: string, data: unknown, opts?: Readonly<Record<string, unknown>>) {
+		this.calls.push({ name, data, opts });
+		return { id: `j${this.nextId++}` };
+	}
+	async close() {
+		// noop
+	}
+}
+
+class UnusedWorker implements BullMqWorkerAdapter {
+	on() {
+		// noop
+	}
+	async close() {
+		// noop
+	}
+}
+
+const makeDeps = (): BullMqDeps => ({
+	Queue: FakeQueue as unknown as BullMqDeps['Queue'],
+	Worker: UnusedWorker as unknown as BullMqDeps['Worker']
+});
+
+describe('BullMqDispatcher.enqueue (EW-742 P4 T31)', () => {
+	it('translates JobEnqueueOptions onto BullMQ JobsOptions on the add call', async () => {
+		FakeQueue.instances = [];
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: 'r' });
+		const d = factory.forQueue('kb-embed');
+		const enqueueOpts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-1',
+			tenantId: 't-acme',
+			concurrencyKey: 'work-7',
+			tags: ['kb'],
+			maxDurationSeconds: 600
+		};
+		const id = await d.enqueue('kb-embed', { workId: 'w7' }, enqueueOpts);
+		expect(id).toBe('j1');
+		expect(FakeQueue.instances[0].calls[0]).toEqual({
+			name: 'kb-embed',
+			data: { workId: 'w7' },
+			opts: {
+				jobId: 'idem-1',
+				tenantId: 't-acme',
+				concurrencyKey: 'work-7',
+				tags: ['kb'],
+				maxDurationSeconds: 600
+			}
+		});
+	});
+
+	it('extraOpts shallow-merge OVER the translation (operator wins on conflict)', async () => {
+		FakeQueue.instances = [];
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: 'r' });
+		const d = factory.forQueue('kb-embed');
+		await d.enqueue(
+			'kb-embed',
+			{ x: 1 },
+			{ idempotencyKey: 'idem-from-platform' },
+			{ jobId: 'idem-from-operator', attempts: 5 }
+		);
+		expect(FakeQueue.instances[0].calls[0].opts).toEqual({
+			jobId: 'idem-from-operator',
+			attempts: 5
+		});
+	});
+
+	it('dispatch() path is unchanged — no enqueueOptions translation', async () => {
+		FakeQueue.instances = [];
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: 'r' });
+		const d = factory.forQueue('kb-embed');
+		await d.dispatch('kb-embed', { x: 1 }, { jobId: 'raw' });
+		expect(FakeQueue.instances[0].calls[0].opts).toEqual({ jobId: 'raw' });
+	});
+});

--- a/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-enqueue-options.spec.ts
+++ b/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-enqueue-options.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { mapEnqueueOptions } from '../bullmq-enqueue-options.js';
+
+describe('mapEnqueueOptions (EW-742 P4 T31 BullMQ stamping)', () => {
+	it('translates idempotencyKey → jobId', () => {
+		expect(mapEnqueueOptions({ idempotencyKey: 'idem-1' })).toEqual({ jobId: 'idem-1' });
+	});
+
+	it('translates tenantId → tenantId (custom JobsOptions field)', () => {
+		expect(mapEnqueueOptions({ tenantId: 't-acme' })).toEqual({ tenantId: 't-acme' });
+	});
+
+	it('translates concurrencyKey → concurrencyKey (custom field, worker honours)', () => {
+		expect(mapEnqueueOptions({ concurrencyKey: 'work-42' })).toEqual({
+			concurrencyKey: 'work-42'
+		});
+	});
+
+	it('translates tags / maxDurationSeconds / machineHint as custom passthroughs', () => {
+		expect(
+			mapEnqueueOptions({ tags: ['kb', 'embed'], maxDurationSeconds: 900, machineHint: 'small-2x' })
+		).toEqual({ tags: ['kb', 'embed'], maxDurationSeconds: 900, machineHint: 'small-2x' });
+	});
+
+	it('omits fields that are undefined (no noisy keys)', () => {
+		const out = mapEnqueueOptions({ tenantId: 't' });
+		expect(Object.keys(out)).toEqual(['tenantId']);
+	});
+
+	it('returns an empty object for empty input', () => {
+		expect(mapEnqueueOptions({})).toEqual({});
+	});
+
+	it('translates all fields together', () => {
+		const opts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		};
+		expect(mapEnqueueOptions(opts)).toEqual({
+			jobId: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		});
+	});
+});

--- a/packages/plugins/job-runtime-bullmq/src/bullmq-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-bullmq/src/bullmq-dispatcher-factory.ts
@@ -1,8 +1,10 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
 import type {
 	BullMqDeps,
 	BullMqFactoryOptions,
 	BullMqQueueAdapter
 } from './bullmq-types.js';
+import { mapEnqueueOptions } from './bullmq-enqueue-options.js';
 
 /**
  * EW-742 P3.2 follow-up — operator-facing factory that turns a single
@@ -57,6 +59,27 @@ export interface BullMqDispatcher {
 	 * options shallow-merge over the factory's `defaultJobOptions`.
 	 */
 	dispatch(name: string, payload: unknown, opts?: Readonly<Record<string, unknown>>): Promise<string | null>;
+	/**
+	 * EW-742 P4 T31 — enqueue with platform-canonical `JobEnqueueOptions`.
+	 * The factory translates each field onto the BullMQ-native carrier
+	 * per `providers.md` § BullMQ:
+	 *
+	 *   - `idempotencyKey` → `JobsOptions.jobId`
+	 *   - `tenantId`       → custom `JobsOptions.tenantId`
+	 *   - `concurrencyKey` → custom `JobsOptions.concurrencyKey`
+	 *   - `tags`           → custom `JobsOptions.tags`
+	 *   - `maxDurationSeconds` / `machineHint` → custom passthroughs
+	 *
+	 * `extraOpts` is shallow-merged on top of the translation so the
+	 * operator can still pass bullmq-native options (priority, lifo,
+	 * attempts, backoff) that have no `JobEnqueueOptions` equivalent.
+	 */
+	enqueue(
+		name: string,
+		payload: unknown,
+		enqueueOptions: JobEnqueueOptions,
+		extraOpts?: Readonly<Record<string, unknown>>
+	): Promise<string | null>;
 	/** Underlying queue handle — exposed for advanced lifecycle (drain, pause). */
 	readonly queue: BullMqQueueAdapter;
 }
@@ -91,6 +114,12 @@ export class BullMqDispatcherFactory {
 			queue: q,
 			dispatch: async (name, payload, callOpts) => {
 				const merged = callOpts ? { ...callOpts } : undefined;
+				const job = await q.add(name, payload, merged);
+				return job?.id ?? null;
+			},
+			enqueue: async (name, payload, enqueueOptions, extraOpts) => {
+				const translated = mapEnqueueOptions(enqueueOptions);
+				const merged = extraOpts ? { ...translated, ...extraOpts } : translated;
 				const job = await q.add(name, payload, merged);
 				return job?.id ?? null;
 			}

--- a/packages/plugins/job-runtime-bullmq/src/bullmq-enqueue-options.ts
+++ b/packages/plugins/job-runtime-bullmq/src/bullmq-enqueue-options.ts
@@ -1,0 +1,43 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+
+/**
+ * EW-742 P4 T31 — translator: platform `JobEnqueueOptions` → BullMQ
+ * `JobsOptions` carrier per `providers.md`.
+ *
+ * Mapping rules (locked in `tasks.md` T31):
+ *
+ *   - `idempotencyKey` → `jobId` (BullMQ's dedup mechanism — same
+ *     jobId in the same queue is rejected at `Queue.add` time).
+ *   - `tenantId`       → custom `tenantId` field on `JobsOptions` (the
+ *     "native carrier" per `providers.md` § BullMQ); workers read it
+ *     off `job.opts.tenantId` to route per-tenant.
+ *   - `concurrencyKey` → custom `concurrencyKey` field; BullMQ Pro
+ *     supports `group.id` natively but plain BullMQ doesn't, so the
+ *     worker honours it via the `concurrencyKey` field.
+ *   - `tags`           → custom `tags` field (BullMQ doesn't tag
+ *     natively; preserved for observability).
+ *   - `maxDurationSeconds` → no direct BullMQ option (the worker
+ *     enforces its own `lockDuration`/`lockRenewTime`); we surface
+ *     it on `maxDurationSeconds` for the operator's handler to honor.
+ *   - `machineHint`    → custom `machineHint` field; BullMQ doesn't
+ *     route by machine class.
+ *
+ * Every translated field is `undefined`-safe: a missing entry on the
+ * input is omitted from the output (NOT written as `undefined`) so
+ * downstream `Object.keys` walks see a clean payload.
+ *
+ * The translator is intentionally a pure function — easy to unit-test
+ * and to compose with a per-call `extraOpts` spread.
+ */
+export function mapEnqueueOptions(
+	opts: JobEnqueueOptions
+): Readonly<Record<string, unknown>> {
+	const out: Record<string, unknown> = {};
+	if (opts.idempotencyKey !== undefined) out['jobId'] = opts.idempotencyKey;
+	if (opts.tenantId !== undefined) out['tenantId'] = opts.tenantId;
+	if (opts.concurrencyKey !== undefined) out['concurrencyKey'] = opts.concurrencyKey;
+	if (opts.tags !== undefined) out['tags'] = opts.tags;
+	if (opts.maxDurationSeconds !== undefined) out['maxDurationSeconds'] = opts.maxDurationSeconds;
+	if (opts.machineHint !== undefined) out['machineHint'] = opts.machineHint;
+	return out;
+}

--- a/packages/plugins/job-runtime-bullmq/src/index.ts
+++ b/packages/plugins/job-runtime-bullmq/src/index.ts
@@ -8,6 +8,7 @@ export type {
 } from './bullmq-job-runtime.plugin.js';
 export { BullMqDispatcherFactory } from './bullmq-dispatcher-factory.js';
 export type { BullMqDispatcher } from './bullmq-dispatcher-factory.js';
+export { mapEnqueueOptions as mapBullMqEnqueueOptions } from './bullmq-enqueue-options.js';
 export { BullMqWorkerHostFactory } from './bullmq-worker-host-factory.js';
 export type { BullMqWorkerRegistration } from './bullmq-worker-host-factory.js';
 export type {

--- a/packages/plugins/job-runtime-inngest/src/__tests__/inngest-enqueue-options.spec.ts
+++ b/packages/plugins/job-runtime-inngest/src/__tests__/inngest-enqueue-options.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { mapEnqueueOptions } from '../inngest-enqueue-options.js';
+import { InngestDispatcherFactory } from '../inngest-dispatcher-factory.js';
+import type { InngestClient, InngestSendEvent, InngestSendResult } from '../inngest-types.js';
+
+describe('mapEnqueueOptions (EW-742 P4 T31 Inngest stamping)', () => {
+	it('idempotencyKey → top-level id', () => {
+		expect(mapEnqueueOptions({ idempotencyKey: 'idem-1' })).toEqual({
+			topLevel: { id: 'idem-1' },
+			dataMeta: {}
+		});
+	});
+
+	it('tenantId / concurrencyKey / tags / maxDurationSeconds / machineHint → dataMeta', () => {
+		expect(
+			mapEnqueueOptions({
+				tenantId: 't-acme',
+				concurrencyKey: 'work-7',
+				tags: ['kb'],
+				maxDurationSeconds: 900,
+				machineHint: 'small-2x'
+			})
+		).toEqual({
+			topLevel: {},
+			dataMeta: {
+				tenantId: 't-acme',
+				concurrencyKey: 'work-7',
+				tags: ['kb'],
+				maxDurationSeconds: 900,
+				machineHint: 'small-2x'
+			}
+		});
+	});
+
+	it('empty input returns empty translation', () => {
+		expect(mapEnqueueOptions({})).toEqual({ topLevel: {}, dataMeta: {} });
+	});
+
+	it('all fields together', () => {
+		const opts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		};
+		expect(mapEnqueueOptions(opts)).toEqual({
+			topLevel: { id: 'idem-A' },
+			dataMeta: {
+				tenantId: 'tenant-A',
+				concurrencyKey: 'work-A',
+				tags: ['kb'],
+				maxDurationSeconds: 600,
+				machineHint: 'medium-1x'
+			}
+		});
+	});
+});
+
+class FakeInngest implements InngestClient {
+	sentEvents: (InngestSendEvent | readonly InngestSendEvent[])[] = [];
+	private nextId = 1;
+	async send(event: InngestSendEvent | readonly InngestSendEvent[]): Promise<InngestSendResult> {
+		this.sentEvents.push(event);
+		const count = Array.isArray(event) ? event.length : 1;
+		const ids = Array.from({ length: count }, () => `evt_${this.nextId++}`);
+		return { ids };
+	}
+}
+
+describe('InngestDispatcherFactory.enqueue (EW-742 P4 T31)', () => {
+	it('stamps id + data._ew with translated fields, applies eventNamespace', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client, eventNamespace: 'ever.works' });
+		const id = await factory.enqueue(
+			'kb-embed-document',
+			{ workId: 'w7' },
+			{ idempotencyKey: 'idem-1', tenantId: 't-acme', tags: ['kb'] }
+		);
+		expect(id).toBe('evt_1');
+		const sent = client.sentEvents[0] as InngestSendEvent;
+		expect(sent.name).toBe('ever.works/kb-embed-document');
+		expect(sent.id).toBe('idem-1');
+		expect(sent.data).toEqual({
+			workId: 'w7',
+			_ew: { tenantId: 't-acme', tags: ['kb'] }
+		});
+	});
+
+	it('omits _ew when no dataMeta fields are set', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		await factory.enqueue('evt', { x: 1 }, { idempotencyKey: 'idem' });
+		const sent = client.sentEvents[0] as InngestSendEvent;
+		expect(sent.data).toEqual({ x: 1 });
+	});
+
+	it('extraOverrides shallow-merge OVER translated top-level (operator wins)', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		await factory.enqueue(
+			'evt',
+			{},
+			{ idempotencyKey: 'idem-platform' },
+			{ id: 'idem-operator', user: { uid: 'u' } }
+		);
+		const sent = client.sentEvents[0] as InngestSendEvent;
+		expect(sent.id).toBe('idem-operator');
+		expect(sent.user).toEqual({ uid: 'u' });
+	});
+
+	it('send() path is unchanged', async () => {
+		const client = new FakeInngest();
+		const factory = new InngestDispatcherFactory({ client });
+		await factory.send('evt', { hello: 'world' });
+		const sent = client.sentEvents[0] as InngestSendEvent;
+		expect(sent).toEqual({ name: 'evt', data: { hello: 'world' } });
+	});
+});

--- a/packages/plugins/job-runtime-inngest/src/index.ts
+++ b/packages/plugins/job-runtime-inngest/src/index.ts
@@ -7,6 +7,10 @@ export type {
 	InngestJobRuntimePluginOptions
 } from './inngest-job-runtime.plugin.js';
 export { InngestDispatcherFactory } from './inngest-dispatcher-factory.js';
+export {
+	mapEnqueueOptions as mapInngestEnqueueOptions
+} from './inngest-enqueue-options.js';
+export type { MappedInngestEnqueue } from './inngest-enqueue-options.js';
 export type {
 	InngestClient,
 	InngestSendEvent,

--- a/packages/plugins/job-runtime-inngest/src/inngest-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-inngest/src/inngest-dispatcher-factory.ts
@@ -1,9 +1,11 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
 import type {
 	InngestClient,
 	InngestDispatcherFactoryOptions,
 	InngestFunction,
 	InngestSendEvent
 } from './inngest-types.js';
+import { mapEnqueueOptions } from './inngest-enqueue-options.js';
 
 /**
  * EW-742 P3.2 follow-up — operator-facing factory that wraps an
@@ -69,6 +71,47 @@ export class InngestDispatcherFactory {
 			name: fullName,
 			data,
 			...(overrides ?? {})
+		};
+		const result = await this.opts.client.send(event);
+		return result.ids?.[0] ?? null;
+	}
+
+	/**
+	 * EW-742 P4 T31 — enqueue with platform-canonical
+	 * `JobEnqueueOptions`. Translates each field onto Inngest's
+	 * SendEvent carrier per `providers.md` § Inngest:
+	 *
+	 *   - `idempotencyKey`   → top-level `event.id` (Inngest dedup)
+	 *   - `tenantId`         → `event.data._ew.tenantId`
+	 *   - `concurrencyKey`   → `event.data._ew.concurrencyKey`
+	 *   - `tags`             → `event.data._ew.tags`
+	 *   - `maxDurationSeconds` / `machineHint` → `event.data._ew.*`
+	 *
+	 * Per-tenant Inngest CLIENT selection happens before this call —
+	 * the caller picks the right `Inngest` client via the plugin's
+	 * `dispatchersBuilder` hook (SaaS only per providers.md).
+	 *
+	 * `extraOverrides` is shallow-merged on top so operators can still
+	 * pass Inngest-native top-level event fields (`user`, custom v3
+	 * SDK fields) that have no `JobEnqueueOptions` equivalent.
+	 */
+	async enqueue(
+		eventName: string,
+		data: Readonly<Record<string, unknown>>,
+		enqueueOptions: JobEnqueueOptions,
+		extraOverrides?: Partial<Omit<InngestSendEvent, 'name' | 'data'>>
+	): Promise<string | null> {
+		const { topLevel, dataMeta } = mapEnqueueOptions(enqueueOptions);
+		const fullName = this.opts.eventNamespace
+			? `${this.opts.eventNamespace}/${eventName}`
+			: eventName;
+		const mergedData =
+			Object.keys(dataMeta).length > 0 ? { ...data, _ew: dataMeta } : data;
+		const event: InngestSendEvent = {
+			name: fullName,
+			data: mergedData,
+			...topLevel,
+			...(extraOverrides ?? {})
 		};
 		const result = await this.opts.client.send(event);
 		return result.ids?.[0] ?? null;

--- a/packages/plugins/job-runtime-inngest/src/inngest-enqueue-options.ts
+++ b/packages/plugins/job-runtime-inngest/src/inngest-enqueue-options.ts
@@ -1,0 +1,60 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import type { InngestSendEvent } from './inngest-types.js';
+
+/**
+ * EW-742 P4 T31 — translator: platform `JobEnqueueOptions` → Inngest
+ * `SendEvent` carrier per `providers.md` § Inngest.
+ *
+ * Inngest's `send()` accepts a few top-level fields (`id`, `user`)
+ * and a free-form `data` payload. The platform's enqueue options map
+ * onto a mix of native and `data._ew` passthroughs:
+ *
+ *   - `idempotencyKey`     → top-level `id` (Inngest's native event id
+ *                            de-dup mechanism — same id within the
+ *                            de-dup window collapses to one delivery).
+ *   - `tenantId`           → `data._ew.tenantId` (per providers.md;
+ *                            tenant webhook handler routes per this
+ *                            field).
+ *   - `concurrencyKey`     → `data._ew.concurrencyKey` (operator
+ *                            handles via Inngest function `concurrency`
+ *                            config; we surface the value so the
+ *                            function's concurrency key callback can
+ *                            return it).
+ *   - `tags`               → `data._ew.tags`
+ *   - `maxDurationSeconds` → `data._ew.maxDurationSeconds` (operator
+ *                            handles via per-function `step.run`
+ *                            timeouts; informational here).
+ *   - `machineHint`        → `data._ew.machineHint`
+ *
+ * Per-tenant Inngest CLIENT selection happens BEFORE this call — the
+ * caller picks the right `Inngest` client (eventKey + signingKey) via
+ * the plugin's `dispatchersBuilder` hook (SaaS-only per providers.md).
+ *
+ * The translator returns `{ topLevel, dataMeta }` so the dispatcher
+ * spreads `topLevel` onto the event AND merges `dataMeta` under
+ * `data._ew`.
+ */
+export interface MappedInngestEnqueue {
+	/**
+	 * Fields that go ON the event itself (top-level), NOT under data.
+	 * Currently just `id` for idempotency.
+	 */
+	readonly topLevel: Partial<Pick<InngestSendEvent, 'id'>>;
+	/**
+	 * Fields stamped under `data._ew` so the operator's Inngest function
+	 * (or tenant webhook handler) can read them.
+	 */
+	readonly dataMeta: Readonly<Record<string, unknown>>;
+}
+
+export function mapEnqueueOptions(opts: JobEnqueueOptions): MappedInngestEnqueue {
+	const topLevel: { id?: string } = {};
+	const dataMeta: Record<string, unknown> = {};
+	if (opts.idempotencyKey !== undefined) topLevel.id = opts.idempotencyKey;
+	if (opts.tenantId !== undefined) dataMeta['tenantId'] = opts.tenantId;
+	if (opts.concurrencyKey !== undefined) dataMeta['concurrencyKey'] = opts.concurrencyKey;
+	if (opts.tags !== undefined) dataMeta['tags'] = opts.tags;
+	if (opts.maxDurationSeconds !== undefined) dataMeta['maxDurationSeconds'] = opts.maxDurationSeconds;
+	if (opts.machineHint !== undefined) dataMeta['machineHint'] = opts.machineHint;
+	return { topLevel, dataMeta };
+}

--- a/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-enqueue-options.spec.ts
+++ b/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-enqueue-options.spec.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { mapEnqueueOptions } from '../pgboss-enqueue-options.js';
+import { PgBossDispatcherFactory } from '../pgboss-dispatcher-factory.js';
+import type { PgBossInstance, PgBossJobView } from '../pgboss-types.js';
+
+describe('mapEnqueueOptions (EW-742 P4 T31 pg-boss stamping)', () => {
+	it('translates idempotencyKey → sendOptions.singletonKey', () => {
+		expect(mapEnqueueOptions({ idempotencyKey: 'idem-1' })).toEqual({
+			sendOptions: { singletonKey: 'idem-1' },
+			metaForPayload: {}
+		});
+	});
+
+	it('translates maxDurationSeconds → sendOptions.expireInSeconds', () => {
+		expect(mapEnqueueOptions({ maxDurationSeconds: 600 })).toEqual({
+			sendOptions: { expireInSeconds: 600 },
+			metaForPayload: {}
+		});
+	});
+
+	it('translates tenantId / concurrencyKey / tags / machineHint → payload._ew namespace', () => {
+		const out = mapEnqueueOptions({
+			tenantId: 't-acme',
+			concurrencyKey: 'work-7',
+			tags: ['kb'],
+			machineHint: 'small-2x'
+		});
+		expect(out).toEqual({
+			sendOptions: {},
+			metaForPayload: {
+				_ew: {
+					tenantId: 't-acme',
+					concurrencyKey: 'work-7',
+					tags: ['kb'],
+					machineHint: 'small-2x'
+				}
+			}
+		});
+	});
+
+	it('omits the _ew namespace entirely when no meta fields are set', () => {
+		const out = mapEnqueueOptions({ idempotencyKey: 'idem' });
+		expect(out.metaForPayload).toEqual({});
+	});
+
+	it('omits undefined fields (no noisy keys)', () => {
+		const out = mapEnqueueOptions({ tenantId: 't' });
+		expect(out.metaForPayload).toEqual({ _ew: { tenantId: 't' } });
+		expect(out.sendOptions).toEqual({});
+	});
+
+	it('translates all fields together', () => {
+		const opts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		};
+		expect(mapEnqueueOptions(opts)).toEqual({
+			sendOptions: { singletonKey: 'idem-A', expireInSeconds: 600 },
+			metaForPayload: {
+				_ew: {
+					tenantId: 'tenant-A',
+					concurrencyKey: 'work-A',
+					tags: ['kb'],
+					machineHint: 'medium-1x'
+				}
+			}
+		});
+	});
+});
+
+describe('PgBossDispatcherFactory.enqueue (EW-742 P4 T31)', () => {
+	class FakeBoss implements PgBossInstance {
+		sendCalls: { name: string; data: unknown; options?: Readonly<Record<string, unknown>> }[] = [];
+		async send(name: string, data: unknown, options?: Readonly<Record<string, unknown>>) {
+			this.sendCalls.push({ name, data, options });
+			return 'jb-1';
+		}
+		async work(
+			_n: string,
+			_o: Readonly<Record<string, unknown>>,
+			_h: (j: PgBossJobView | readonly PgBossJobView[]) => Promise<unknown>
+		) {
+			return 'sub-1';
+		}
+		async cancel() {
+			// noop
+		}
+		async start() {
+			return undefined;
+		}
+		async stop() {
+			// noop
+		}
+	}
+
+	it('translates JobEnqueueOptions onto sendOptions + payload._ew', async () => {
+		const boss = new FakeBoss();
+		const factory = new PgBossDispatcherFactory({ boss });
+		const id = await factory.enqueue(
+			'kb-embed',
+			{ workId: 'w7' },
+			{
+				idempotencyKey: 'idem-1',
+				tenantId: 't-acme',
+				maxDurationSeconds: 900,
+				tags: ['kb']
+			}
+		);
+		expect(id).toBe('jb-1');
+		expect(boss.sendCalls[0]).toEqual({
+			name: 'kb-embed',
+			data: {
+				workId: 'w7',
+				_ew: { tenantId: 't-acme', tags: ['kb'] }
+			},
+			options: { singletonKey: 'idem-1', expireInSeconds: 900 }
+		});
+	});
+
+	it('defaultSendOptions merge under translated sendOptions', async () => {
+		const boss = new FakeBoss();
+		const factory = new PgBossDispatcherFactory({
+			boss,
+			defaultSendOptions: { retryLimit: 3, expireInSeconds: 60 }
+		});
+		await factory.enqueue('q', { x: 1 }, { maxDurationSeconds: 900 });
+		expect(boss.sendCalls[0].options).toEqual({
+			retryLimit: 3,
+			expireInSeconds: 900 // translation overrides the default
+		});
+	});
+
+	it('extraOpts shallow-merge OVER translated sendOptions (operator wins)', async () => {
+		const boss = new FakeBoss();
+		const factory = new PgBossDispatcherFactory({ boss });
+		await factory.enqueue(
+			'q',
+			{ x: 1 },
+			{ idempotencyKey: 'idem-platform' },
+			{ singletonKey: 'idem-operator', retryLimit: 5 }
+		);
+		expect(boss.sendCalls[0].options).toEqual({
+			singletonKey: 'idem-operator',
+			retryLimit: 5
+		});
+	});
+
+	it('send() path is unchanged — no JobEnqueueOptions translation', async () => {
+		const boss = new FakeBoss();
+		const sendSpy = vi.spyOn(boss, 'send');
+		const factory = new PgBossDispatcherFactory({ boss });
+		await factory.send('q', { x: 1 }, { singletonKey: 'raw' });
+		expect(sendSpy).toHaveBeenCalledWith('q', { x: 1 }, { singletonKey: 'raw' });
+	});
+
+	it('null payload becomes {} + _ew namespace when present', async () => {
+		const boss = new FakeBoss();
+		const factory = new PgBossDispatcherFactory({ boss });
+		await factory.enqueue('q', null, { tenantId: 't' });
+		expect(boss.sendCalls[0].data).toEqual({ _ew: { tenantId: 't' } });
+	});
+});

--- a/packages/plugins/job-runtime-pgboss/src/index.ts
+++ b/packages/plugins/job-runtime-pgboss/src/index.ts
@@ -7,6 +7,10 @@ export type {
 	PgBossJobRuntimePluginOptions
 } from './pgboss-job-runtime.plugin.js';
 export { PgBossDispatcherFactory } from './pgboss-dispatcher-factory.js';
+export {
+	mapEnqueueOptions as mapPgBossEnqueueOptions
+} from './pgboss-enqueue-options.js';
+export type { MappedPgBossEnqueue } from './pgboss-enqueue-options.js';
 export { PgBossWorkerHostFactory } from './pgboss-worker-host-factory.js';
 export type { PgBossWorkerRegistration } from './pgboss-worker-host-factory.js';
 export type {

--- a/packages/plugins/job-runtime-pgboss/src/pgboss-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-pgboss/src/pgboss-dispatcher-factory.ts
@@ -1,4 +1,6 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
 import type { PgBossFactoryOptions, PgBossInstance, PgBossJobRecord } from './pgboss-types.js';
+import { mapEnqueueOptions } from './pgboss-enqueue-options.js';
 
 /**
  * EW-742 P3.2 follow-up — operator-facing factory that wraps a
@@ -43,6 +45,46 @@ export class PgBossDispatcherFactory {
 			? { ...this.opts.defaultSendOptions, ...(callOpts ?? {}) }
 			: callOpts;
 		return this.opts.boss.send(name, payload, merged);
+	}
+
+	/**
+	 * EW-742 P4 T31 — enqueue with platform-canonical
+	 * `JobEnqueueOptions`. Translates each field onto the pg-boss
+	 * carrier per `providers.md` § pg-boss:
+	 *
+	 *   - `idempotencyKey`    → `sendOptions.singletonKey`
+	 *   - `maxDurationSeconds`→ `sendOptions.expireInSeconds`
+	 *   - `tenantId` / `concurrencyKey` / `tags` / `machineHint` →
+	 *     stamped onto the job payload under a reserved `_ew`
+	 *     namespace so the worker can route per-tenant without
+	 *     requiring custom pg-boss columns.
+	 *
+	 * Per-tenant schema selection happens BEFORE this call — the
+	 * caller picks the right `PgBoss` instance via the plugin's
+	 * `dispatchersBuilder` hook (one `PgBoss` per tenant schema, per
+	 * ADR-017 Q2).
+	 *
+	 * `extraOpts` is shallow-merged on top of the translated
+	 * sendOptions so operators can still pass pg-boss-native fields
+	 * (retryLimit, retryBackoff, startAfter, etc.) that have no
+	 * `JobEnqueueOptions` equivalent.
+	 */
+	async enqueue(
+		name: string,
+		payload: Readonly<Record<string, unknown>> | null,
+		enqueueOptions: JobEnqueueOptions,
+		extraOpts?: Readonly<Record<string, unknown>>
+	): Promise<string | null> {
+		const { sendOptions, metaForPayload } = mapEnqueueOptions(enqueueOptions);
+		const mergedPayload =
+			Object.keys(metaForPayload).length > 0
+				? { ...(payload ?? {}), ...metaForPayload }
+				: (payload ?? {});
+		const baseOpts = this.opts.defaultSendOptions
+			? { ...this.opts.defaultSendOptions, ...sendOptions }
+			: sendOptions;
+		const mergedOpts = extraOpts ? { ...baseOpts, ...extraOpts } : baseOpts;
+		return this.opts.boss.send(name, mergedPayload, mergedOpts);
 	}
 
 	/** Cancel an in-flight job by id. Returns true once the cancel call resolves. */

--- a/packages/plugins/job-runtime-pgboss/src/pgboss-enqueue-options.ts
+++ b/packages/plugins/job-runtime-pgboss/src/pgboss-enqueue-options.ts
@@ -1,0 +1,52 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+
+/**
+ * EW-742 P4 T31 — translator: platform `JobEnqueueOptions` → pg-boss
+ * `send` options + per-job payload field per `providers.md`.
+ *
+ * pg-boss's native options object accepts most of what we need; a few
+ * fields (tenantId, concurrencyKey, tags, machineHint) are not native
+ * and surface as a `meta` field that the worker reads off
+ * `job.data._ew` to route per-tenant (the spec calls this the "payload
+ * field" carrier per `providers.md` § pg-boss).
+ *
+ * Mapping rules:
+ *
+ *   - `idempotencyKey`    → `singletonKey` (pg-boss's dedup mechanism)
+ *   - `tenantId`          → returned in `metaForPayload._ew.tenantId`
+ *                          + the per-tenant schema lookup is done
+ *                          BEFORE publish by the dispatchers builder
+ *                          (caller-side, see plugin
+ *                          `dispatchersBuilder` hook)
+ *   - `concurrencyKey`    → `metaForPayload._ew.concurrencyKey`
+ *                          (pg-boss has no native concurrency-key;
+ *                          worker honours)
+ *   - `maxDurationSeconds`→ `expireInSeconds` (native: pg-boss kills
+ *                          the job once this many seconds elapse)
+ *   - `tags` / `machineHint` → `metaForPayload._ew` passthroughs
+ *
+ * The translator returns TWO outputs so the dispatcher can:
+ *   1. shallow-merge `sendOptions` onto pg-boss's options arg
+ *   2. shallow-merge `metaForPayload` onto the job's `data` arg under
+ *      a reserved `_ew` namespace (workers know to look there)
+ *
+ * Pure function — easy to unit-test and to compose with operator
+ * overrides.
+ */
+export interface MappedPgBossEnqueue {
+	readonly sendOptions: Readonly<Record<string, unknown>>;
+	readonly metaForPayload: Readonly<Record<string, unknown>>;
+}
+
+export function mapEnqueueOptions(opts: JobEnqueueOptions): MappedPgBossEnqueue {
+	const sendOptions: Record<string, unknown> = {};
+	const meta: Record<string, unknown> = {};
+	if (opts.idempotencyKey !== undefined) sendOptions['singletonKey'] = opts.idempotencyKey;
+	if (opts.maxDurationSeconds !== undefined) sendOptions['expireInSeconds'] = opts.maxDurationSeconds;
+	if (opts.tenantId !== undefined) meta['tenantId'] = opts.tenantId;
+	if (opts.concurrencyKey !== undefined) meta['concurrencyKey'] = opts.concurrencyKey;
+	if (opts.tags !== undefined) meta['tags'] = opts.tags;
+	if (opts.machineHint !== undefined) meta['machineHint'] = opts.machineHint;
+	const metaForPayload: Record<string, unknown> = Object.keys(meta).length > 0 ? { _ew: meta } : {};
+	return { sendOptions, metaForPayload };
+}

--- a/packages/plugins/job-runtime-temporal/src/__tests__/temporal-enqueue-options.spec.ts
+++ b/packages/plugins/job-runtime-temporal/src/__tests__/temporal-enqueue-options.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { mapEnqueueOptions } from '../temporal-enqueue-options.js';
+import { TemporalDispatcherFactory } from '../temporal-dispatcher-factory.js';
+import type { TemporalStartWorkflowOptions, TemporalWorkflowClient, TemporalWorkflowHandle } from '../temporal-types.js';
+
+describe('mapEnqueueOptions (EW-742 P4 T31 Temporal stamping)', () => {
+	it('idempotencyKey surfaces as workflowIdFromIdempotency', () => {
+		const out = mapEnqueueOptions({ idempotencyKey: 'kb-embed:work-7' });
+		expect(out.workflowIdFromIdempotency).toBe('kb-embed:work-7');
+		expect(out.startOptions).toEqual({});
+	});
+
+	it('tenantId → searchAttributes.tenantId (list-wrapped)', () => {
+		const out = mapEnqueueOptions({ tenantId: 't-acme' });
+		expect(out.startOptions.searchAttributes).toEqual({ tenantId: ['t-acme'] });
+	});
+
+	it('concurrencyKey + tags → searchAttributes (list-wrapped)', () => {
+		const out = mapEnqueueOptions({ concurrencyKey: 'work-7', tags: ['kb', 'embed'] });
+		expect(out.startOptions.searchAttributes).toEqual({
+			concurrencyKey: ['work-7'],
+			tags: ['kb', 'embed']
+		});
+	});
+
+	it('omits empty tags array', () => {
+		const out = mapEnqueueOptions({ tags: [] });
+		expect(out.startOptions.searchAttributes).toBeUndefined();
+	});
+
+	it('maxDurationSeconds → workflowExecutionTimeout (string form)', () => {
+		expect(mapEnqueueOptions({ maxDurationSeconds: 900 }).startOptions.workflowExecutionTimeout).toBe('900s');
+	});
+
+	it('machineHint → memo.machineHint', () => {
+		expect(mapEnqueueOptions({ machineHint: 'medium-1x' }).startOptions.memo).toEqual({
+			machineHint: 'medium-1x'
+		});
+	});
+
+	it('all together', () => {
+		const opts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		};
+		expect(mapEnqueueOptions(opts)).toEqual({
+			workflowIdFromIdempotency: 'idem-A',
+			startOptions: {
+				searchAttributes: {
+					tenantId: ['tenant-A'],
+					concurrencyKey: ['work-A'],
+					tags: ['kb']
+				},
+				memo: { machineHint: 'medium-1x' },
+				workflowExecutionTimeout: '600s'
+			}
+		});
+	});
+
+	it('empty input returns empty translation', () => {
+		expect(mapEnqueueOptions({})).toEqual({
+			workflowIdFromIdempotency: undefined,
+			startOptions: {}
+		});
+	});
+});
+
+class FakeHandle implements TemporalWorkflowHandle {
+	constructor(public readonly workflowId: string) {}
+	async cancel() {
+		// noop
+	}
+	async describe() {
+		return { status: { name: 'RUNNING' } };
+	}
+}
+
+class FakeClient implements TemporalWorkflowClient {
+	startCalls: { type: string; options: TemporalStartWorkflowOptions }[] = [];
+	async start(workflowType: string, options: TemporalStartWorkflowOptions) {
+		this.startCalls.push({ type: workflowType, options });
+		return new FakeHandle(options.workflowId);
+	}
+	getHandle(workflowId: string) {
+		return new FakeHandle(workflowId);
+	}
+}
+
+describe('TemporalDispatcherFactory.enqueue (EW-742 P4 T31)', () => {
+	it('translates JobEnqueueOptions and starts the workflow', async () => {
+		const client = new FakeClient();
+		const factory = new TemporalDispatcherFactory({ client, defaultTaskQueue: 'ew' });
+		const handle = await factory.enqueue('kbEmbedWorkflow', [{ workId: 'w7' }], {
+			idempotencyKey: 'kb-embed:work-7',
+			tenantId: 't-acme',
+			concurrencyKey: 'work-7',
+			tags: ['kb'],
+			maxDurationSeconds: 900,
+			machineHint: 'medium-1x'
+		});
+		expect(handle.workflowId).toBe('kb-embed:work-7');
+		const call = client.startCalls[0];
+		expect(call.type).toBe('kbEmbedWorkflow');
+		expect(call.options.workflowId).toBe('kb-embed:work-7');
+		expect(call.options.args).toEqual([{ workId: 'w7' }]);
+		expect(call.options.taskQueue).toBe('ew');
+		expect(call.options.searchAttributes).toEqual({
+			tenantId: ['t-acme'],
+			concurrencyKey: ['work-7'],
+			tags: ['kb']
+		});
+		expect(call.options.memo).toEqual({ machineHint: 'medium-1x' });
+		expect(call.options.workflowExecutionTimeout).toBe('900s');
+	});
+
+	it('extraOpts.workflowId wins over idempotencyKey', async () => {
+		const client = new FakeClient();
+		const factory = new TemporalDispatcherFactory({ client, defaultTaskQueue: 'ew' });
+		await factory.enqueue(
+			'wf',
+			[],
+			{ idempotencyKey: 'idem' },
+			{ workflowId: 'explicit-id' }
+		);
+		expect(client.startCalls[0].options.workflowId).toBe('explicit-id');
+	});
+
+	it('throws when neither idempotencyKey nor extraOpts.workflowId is set', async () => {
+		const client = new FakeClient();
+		const factory = new TemporalDispatcherFactory({ client, defaultTaskQueue: 'ew' });
+		await expect(factory.enqueue('wf', [], {})).rejects.toThrow(/no workflowId available/);
+	});
+
+	it('extraOpts shallow-merge OVER translated startOptions', async () => {
+		const client = new FakeClient();
+		const factory = new TemporalDispatcherFactory({ client, defaultTaskQueue: 'ew' });
+		await factory.enqueue(
+			'wf',
+			[],
+			{ idempotencyKey: 'idem', tenantId: 't-from-platform' },
+			{ searchAttributes: { tenantId: ['t-from-operator'] } }
+		);
+		expect(client.startCalls[0].options.searchAttributes).toEqual({
+			tenantId: ['t-from-operator']
+		});
+	});
+});

--- a/packages/plugins/job-runtime-temporal/src/index.ts
+++ b/packages/plugins/job-runtime-temporal/src/index.ts
@@ -7,6 +7,10 @@ export type {
 	TemporalJobRuntimePluginOptions
 } from './temporal-job-runtime.plugin.js';
 export { TemporalDispatcherFactory } from './temporal-dispatcher-factory.js';
+export {
+	mapEnqueueOptions as mapTemporalEnqueueOptions
+} from './temporal-enqueue-options.js';
+export type { MappedTemporalEnqueue } from './temporal-enqueue-options.js';
 export { TemporalWorkerHostFactory } from './temporal-worker-host-factory.js';
 export type {
 	TemporalWorkflowClient,

--- a/packages/plugins/job-runtime-temporal/src/temporal-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-temporal/src/temporal-dispatcher-factory.ts
@@ -1,9 +1,11 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
 import type {
 	TemporalDispatcherFactoryOptions,
 	TemporalStartWorkflowOptions,
 	TemporalWorkflowClient,
 	TemporalWorkflowHandle
 } from './temporal-types.js';
+import { mapEnqueueOptions } from './temporal-enqueue-options.js';
 
 /**
  * EW-742 P3.2 follow-up — operator-facing factory that turns a
@@ -63,6 +65,51 @@ export class TemporalDispatcherFactory {
 			taskQueue
 		};
 		return this.opts.client.start(workflowType, merged);
+	}
+
+	/**
+	 * EW-742 P4 T31 — enqueue with platform-canonical
+	 * `JobEnqueueOptions`. Translates each field onto Temporal's native
+	 * `WorkflowStartOptions` per `providers.md` § Temporal:
+	 *
+	 *   - `idempotencyKey`     → `workflowId` (per-call workflowId wins
+	 *                            if both are provided)
+	 *   - `tenantId`           → `searchAttributes.tenantId`
+	 *   - `concurrencyKey`     → `searchAttributes.concurrencyKey`
+	 *   - `tags`               → `searchAttributes.tags`
+	 *   - `maxDurationSeconds` → `workflowExecutionTimeout` (e.g. '900s')
+	 *   - `machineHint`        → `memo.machineHint`
+	 *
+	 * Per-tenant NAMESPACE selection happens before this call — the
+	 * caller picks the right `WorkflowClient` via the plugin's
+	 * `dispatchersBuilder` hook (one `WorkflowClient` per tenant
+	 * namespace, per ADR-017 Q1).
+	 *
+	 * `extraOpts` is shallow-merged on top so operators can still pass
+	 * Temporal-native fields (retry, workflowIdReusePolicy, etc.) that
+	 * have no `JobEnqueueOptions` equivalent.
+	 */
+	async enqueue(
+		workflowType: string,
+		args: readonly unknown[],
+		enqueueOptions: JobEnqueueOptions,
+		extraOpts?: Partial<TemporalStartWorkflowOptions>
+	): Promise<TemporalWorkflowHandle> {
+		const { workflowIdFromIdempotency, startOptions } = mapEnqueueOptions(enqueueOptions);
+		const workflowId = extraOpts?.workflowId ?? workflowIdFromIdempotency;
+		if (!workflowId) {
+			throw new Error(
+				`TemporalDispatcherFactory.enqueue: no workflowId available — provide either ` +
+					`enqueueOptions.idempotencyKey or extraOpts.workflowId for workflow '${workflowType}'.`
+			);
+		}
+		const startArgs: Partial<TemporalStartWorkflowOptions> & { workflowId: string } = {
+			...startOptions,
+			...(extraOpts ?? {}),
+			workflowId,
+			args
+		};
+		return this.start(workflowType, startArgs);
 	}
 
 	/**

--- a/packages/plugins/job-runtime-temporal/src/temporal-enqueue-options.ts
+++ b/packages/plugins/job-runtime-temporal/src/temporal-enqueue-options.ts
@@ -1,0 +1,76 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import type { TemporalStartWorkflowOptions } from './temporal-types.js';
+
+/**
+ * EW-742 P4 T31 — translator: platform `JobEnqueueOptions` → Temporal
+ * `WorkflowStartOptions` carrier per `providers.md` § Temporal.
+ *
+ * Temporal has rich native fields, so most translations are direct:
+ *
+ *   - `idempotencyKey`    → `workflowId` (Temporal's idempotency key
+ *                           is the workflow id itself — re-starting
+ *                           with the same id is rejected unless the
+ *                           `workflowIdReusePolicy` allows it).
+ *   - `tenantId`          → `searchAttributes.tenantId` (per
+ *                           providers.md). The per-tenant Temporal
+ *                           NAMESPACE selection happens at
+ *                           start-workflow time by the operator's
+ *                           `dispatchersBuilder` (one WorkflowClient
+ *                           per tenant namespace, per ADR-017 Q1).
+ *   - `concurrencyKey`    → `searchAttributes.concurrencyKey` (we use
+ *                           a searchable attribute so the operator's
+ *                           workflow can `await condition()` on it
+ *                           for serialisation, OR they can use
+ *                           workflowIdReusePolicy='reject-duplicate').
+ *   - `maxDurationSeconds`→ `workflowExecutionTimeout` (string form;
+ *                           Temporal accepts seconds via string like
+ *                           '900s').
+ *   - `tags`              → `searchAttributes.tags` (Temporal supports
+ *                           list-valued attributes natively).
+ *   - `machineHint`       → `memo.machineHint` (informational; Temporal
+ *                           doesn't route by machine class).
+ *
+ * # workflowId priority
+ *
+ * If both `idempotencyKey` AND a per-call `workflowId` are provided,
+ * the per-call `workflowId` wins (the operator may want a structured
+ * id like `kb-embed:work-7:rev-2`). When neither is set, the caller
+ * MUST pass `workflowId` to `factory.start()` — the translator never
+ * invents one.
+ *
+ * # searchAttributes shape
+ *
+ * Temporal expects search attributes as `Record<string, unknown[]>`
+ * (list-valued for indexing). We wrap scalar values in single-element
+ * arrays.
+ */
+export interface MappedTemporalEnqueue {
+	/** Workflow id derived from idempotencyKey, or undefined if not set. */
+	readonly workflowIdFromIdempotency: string | undefined;
+	readonly startOptions: Partial<Omit<TemporalStartWorkflowOptions, 'workflowId' | 'args'>>;
+}
+
+export function mapEnqueueOptions(opts: JobEnqueueOptions): MappedTemporalEnqueue {
+	const searchAttributes: Record<string, readonly unknown[]> = {};
+	const memo: Record<string, unknown> = {};
+	if (opts.tenantId !== undefined) searchAttributes['tenantId'] = [opts.tenantId];
+	if (opts.concurrencyKey !== undefined) searchAttributes['concurrencyKey'] = [opts.concurrencyKey];
+	if (opts.tags !== undefined && opts.tags.length > 0) searchAttributes['tags'] = [...opts.tags];
+	if (opts.machineHint !== undefined) memo['machineHint'] = opts.machineHint;
+
+	const mutableStart: {
+		searchAttributes?: Record<string, readonly unknown[]>;
+		memo?: Record<string, unknown>;
+		workflowExecutionTimeout?: string;
+	} = {};
+	if (Object.keys(searchAttributes).length > 0) mutableStart.searchAttributes = searchAttributes;
+	if (Object.keys(memo).length > 0) mutableStart.memo = memo;
+	if (opts.maxDurationSeconds !== undefined) {
+		mutableStart.workflowExecutionTimeout = `${opts.maxDurationSeconds}s`;
+	}
+
+	return {
+		workflowIdFromIdempotency: opts.idempotencyKey,
+		startOptions: mutableStart as Partial<Omit<TemporalStartWorkflowOptions, 'workflowId' | 'args'>>
+	};
+}


### PR DESCRIPTION
Cascade of T31 stamping PRs #1474 (BullMQ) #1475 (pg-boss) #1476 (Temporal) #1477 (Inngest).

Each adds a mapEnqueueOptions translator + .enqueue() convenience method that maps platform JobEnqueueOptions onto the provider's native carrier. Backwards-compatible — existing dispatch()/send()/start() paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)