### PR TITLE
feat(job-runtime): per-tenant worker host extensions (EW-742 T25-T30/T32)

### DIFF
--- a/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-tenant-isolation.spec.ts
+++ b/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-tenant-isolation.spec.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IJobRuntimeProvider, TenantCredentialSnapshot } from '@ever-works/plugin';
+import { BullMqJobRuntimePlugin } from '../bullmq-job-runtime.plugin.js';
+import { TenantAwareBullMqWorkerHostFactory } from '../bullmq-tenant-aware-worker-host-factory.js';
+import type {
+	BullMqDeps,
+	BullMqJobView,
+	BullMqQueueAdapter,
+	BullMqWorkerAdapter
+} from '../bullmq-types.js';
+
+/**
+ * EW-742 P4 T28/T30/T32 — tenant-isolation contract for the BullMQ
+ * tenant-aware worker host. Uses the FakeQueue / FakeWorker mock
+ * pattern from `bullmq-worker-host-factory.spec.ts`; no real bullmq or
+ * ioredis is constructed.
+ */
+
+class UnusedFakeQueue implements BullMqQueueAdapter {
+	async add() {
+		return { id: 'x' };
+	}
+	async close() {
+		// noop
+	}
+}
+
+class FakeWorker implements BullMqWorkerAdapter {
+	static instances: FakeWorker[] = [];
+	closed = false;
+
+	constructor(
+		public readonly queueName: string,
+		public readonly processor: (job: BullMqJobView) => Promise<unknown>,
+		public readonly opts: Readonly<Record<string, unknown>>
+	) {
+		FakeWorker.instances.push(this);
+	}
+	on() {
+		// noop
+	}
+	async close() {
+		this.closed = true;
+	}
+}
+
+const makeDeps = (): BullMqDeps => ({
+	Queue: UnusedFakeQueue as unknown as BullMqDeps['Queue'],
+	Worker: FakeWorker as unknown as BullMqDeps['Worker']
+});
+
+const TENANT_A_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const TENANT_B_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+/**
+ * Construct a job view with the `opts.tenantId` carrier T31 writes.
+ * `BullMqJobView` in `bullmq-types.ts` doesn't type `opts`, so the
+ * factory reads it via a widened cast — we mirror that here.
+ */
+function jobWithTenant(name: string, tenantId: string | undefined, data: unknown = {}): BullMqJobView {
+	const job: Record<string, unknown> = { id: `${name}-${tenantId ?? 'none'}`, name, data };
+	if (tenantId !== undefined) {
+		job['opts'] = { tenantId };
+	}
+	return job as unknown as BullMqJobView;
+}
+
+describe('TenantAwareBullMqWorkerHostFactory — tenant isolation', () => {
+	it("routes job with tenant A's id to tenant A's binding", async () => {
+		FakeWorker.instances = [];
+		const plugin = new BullMqJobRuntimePlugin();
+		const captured: IJobRuntimeProvider[] = [];
+
+		const factory = new TenantAwareBullMqWorkerHostFactory({
+			deps: makeDeps(),
+			plugin,
+			connection: 'r'
+		});
+		factory.register('q1', async (_job, binding) => {
+			captured.push(binding);
+		});
+		await factory.start();
+
+		await FakeWorker.instances[0].processor(jobWithTenant('q1', TENANT_A_ID));
+
+		expect(captured).toHaveLength(1);
+		const bindingA = captured[0];
+		expect(bindingA).not.toBe(plugin);
+		// `bindToTenant` on the per-tenant view returns the SAME view when
+		// called with the same (tenantId, credentialVersion) — that's how
+		// we assert it's tied to tenant A.
+		expect(
+			bindingA.bindToTenant?.({
+				tenantId: TENANT_A_ID,
+				providerId: 'bullmq',
+				credentialVersion: 1,
+				credentials: {}
+			})
+		).toBe(bindingA);
+	});
+
+	it('routes tenant B to a distinct binding from A', async () => {
+		FakeWorker.instances = [];
+		const plugin = new BullMqJobRuntimePlugin();
+		const captured: IJobRuntimeProvider[] = [];
+
+		const factory = new TenantAwareBullMqWorkerHostFactory({
+			deps: makeDeps(),
+			plugin,
+			connection: 'r'
+		});
+		factory.register('q1', async (_job, binding) => {
+			captured.push(binding);
+		});
+		await factory.start();
+
+		await FakeWorker.instances[0].processor(jobWithTenant('q1', TENANT_A_ID));
+		await FakeWorker.instances[0].processor(jobWithTenant('q1', TENANT_B_ID));
+
+		expect(captured).toHaveLength(2);
+		const [bindingA, bindingB] = captured;
+		expect(bindingA).not.toBe(bindingB);
+		expect(bindingA).not.toBe(plugin);
+		expect(bindingB).not.toBe(plugin);
+	});
+
+	it("two concurrent jobs from different tenants don't cross contexts", async () => {
+		FakeWorker.instances = [];
+		const plugin = new BullMqJobRuntimePlugin();
+		const observed: { jobId: string; binding: IJobRuntimeProvider }[] = [];
+
+		// Gate handlers so they actually overlap.
+		let releaseA: () => void = () => undefined;
+		let releaseB: () => void = () => undefined;
+		const aReady = new Promise<void>((r) => (releaseA = r));
+		const bReady = new Promise<void>((r) => (releaseB = r));
+
+		const factory = new TenantAwareBullMqWorkerHostFactory({
+			deps: makeDeps(),
+			plugin,
+			connection: 'r'
+		});
+		factory.register('q1', async (job, binding) => {
+			if (job.id?.includes('A')) {
+				await aReady;
+			} else {
+				await bReady;
+			}
+			observed.push({ jobId: job.id ?? '', binding });
+		});
+		await factory.start();
+
+		const worker = FakeWorker.instances[0];
+		const jobA = { id: 'jA', name: 'q1', data: {}, opts: { tenantId: TENANT_A_ID } } as unknown as BullMqJobView;
+		const jobB = { id: 'jB', name: 'q1', data: {}, opts: { tenantId: TENANT_B_ID } } as unknown as BullMqJobView;
+
+		const pA = worker.processor(jobA);
+		const pB = worker.processor(jobB);
+
+		// Release in reversed order to maximise interleaving.
+		releaseB();
+		releaseA();
+		await Promise.all([pA, pB]);
+
+		expect(observed).toHaveLength(2);
+		const aObs = observed.find((o) => o.jobId === 'jA');
+		const bObs = observed.find((o) => o.jobId === 'jB');
+		expect(aObs).toBeDefined();
+		expect(bObs).toBeDefined();
+		expect(aObs!.binding).not.toBe(bObs!.binding);
+
+		// Each binding self-reports its own tenant via bindToTenant
+		// memoisation identity (same snapshot → same view).
+		expect(
+			aObs!.binding.bindToTenant?.({
+				tenantId: TENANT_A_ID,
+				providerId: 'bullmq',
+				credentialVersion: 1,
+				credentials: {}
+			})
+		).toBe(aObs!.binding);
+		expect(
+			bObs!.binding.bindToTenant?.({
+				tenantId: TENANT_B_ID,
+				providerId: 'bullmq',
+				credentialVersion: 1,
+				credentials: {}
+			})
+		).toBe(bObs!.binding);
+	});
+
+	it('job without tenantId falls back to plugin default binding', async () => {
+		FakeWorker.instances = [];
+		const plugin = new BullMqJobRuntimePlugin();
+		const captured: IJobRuntimeProvider[] = [];
+
+		const factory = new TenantAwareBullMqWorkerHostFactory({
+			deps: makeDeps(),
+			plugin,
+			connection: 'r'
+		});
+		factory.register('q1', async (_job, binding) => {
+			captured.push(binding);
+		});
+		await factory.start();
+
+		await FakeWorker.instances[0].processor({ id: 'jX', name: 'q1', data: {} });
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]).toBe(plugin);
+	});
+
+	it('resolveSnapshot is called per tenantId; downstream bindings are memoised by plugin.bindToTenant', async () => {
+		FakeWorker.instances = [];
+		const plugin = new BullMqJobRuntimePlugin();
+		const captured: IJobRuntimeProvider[] = [];
+
+		const resolveSnapshot = vi.fn(
+			async (tenantId: string): Promise<TenantCredentialSnapshot> => ({
+				tenantId,
+				providerId: 'bullmq',
+				credentialVersion: 1,
+				credentials: { queuePrefix: `tenant-${tenantId.slice(0, 1)}` }
+			})
+		);
+
+		const factory = new TenantAwareBullMqWorkerHostFactory({
+			deps: makeDeps(),
+			plugin,
+			connection: 'r',
+			resolveSnapshot
+		});
+		factory.register('q1', async (_job, binding) => {
+			captured.push(binding);
+		});
+		await factory.start();
+
+		const worker = FakeWorker.instances[0];
+		await worker.processor(jobWithTenant('q1', TENANT_A_ID));
+		await worker.processor(jobWithTenant('q1', TENANT_A_ID));
+		await worker.processor(jobWithTenant('q1', TENANT_B_ID));
+
+		// resolveSnapshot fires once per job (the factory does not cache
+		// snapshots — that's the operator's resolveSnapshot impl's job).
+		expect(resolveSnapshot).toHaveBeenCalledTimes(3);
+		expect(resolveSnapshot.mock.calls.map((c) => c[0])).toEqual([
+			TENANT_A_ID,
+			TENANT_A_ID,
+			TENANT_B_ID
+		]);
+
+		// But plugin.bindToTenant memoises by (tenantId, credentialVersion):
+		// the two A-tenant jobs share a binding identity.
+		expect(captured).toHaveLength(3);
+		expect(captured[0]).toBe(captured[1]);
+		expect(captured[0]).not.toBe(captured[2]);
+	});
+
+	it('falls back to job.data._ew.tenantId when opts.tenantId is absent', async () => {
+		FakeWorker.instances = [];
+		const plugin = new BullMqJobRuntimePlugin();
+		const captured: IJobRuntimeProvider[] = [];
+
+		const factory = new TenantAwareBullMqWorkerHostFactory({
+			deps: makeDeps(),
+			plugin,
+			connection: 'r'
+		});
+		factory.register('q1', async (_job, binding) => {
+			captured.push(binding);
+		});
+		await factory.start();
+
+		// pg-boss-style stamping — tenantId on the payload, no opts.
+		const pgbossStyle: BullMqJobView = {
+			id: 'jPg',
+			name: 'q1',
+			data: { _ew: { tenantId: TENANT_A_ID }, foo: 1 }
+		};
+		await FakeWorker.instances[0].processor(pgbossStyle);
+
+		expect(captured).toHaveLength(1);
+		const binding = captured[0];
+		expect(binding).not.toBe(plugin);
+		expect(
+			binding.bindToTenant?.({
+				tenantId: TENANT_A_ID,
+				providerId: 'bullmq',
+				credentialVersion: 1,
+				credentials: {}
+			})
+		).toBe(binding);
+	});
+});

--- a/packages/plugins/job-runtime-bullmq/src/bullmq-tenant-aware-worker-host-factory.ts
+++ b/packages/plugins/job-runtime-bullmq/src/bullmq-tenant-aware-worker-host-factory.ts
@@ -1,0 +1,224 @@
+import type {
+	BullMqDeps,
+	BullMqFactoryOptions,
+	BullMqJobView,
+	BullMqWorkerAdapter
+} from './bullmq-types.js';
+import type {
+	IJobRuntimeProvider,
+	TenantCredentialSnapshot,
+	WorkerHostHandle,
+	WorkerHostOptions
+} from '@ever-works/plugin';
+import type { BullMqJobRuntimePlugin } from './bullmq-job-runtime.plugin.js';
+
+/**
+ * EW-742 P4 T28/T30/T32 — tenant-aware BullMQ worker host.
+ *
+ * Sibling of {@link import('./bullmq-worker-host-factory.js').BullMqWorkerHostFactory}
+ * that routes each in-flight job to the tenant's overlay binding before
+ * invoking the operator-supplied handler.
+ *
+ * # Why a separate factory
+ *
+ * The base {@link BullMqWorkerHostFactory} hands `BullMqJobView` to the
+ * handler verbatim — fine for instance-default workers that don't need
+ * tenant isolation. This variant adds three responsibilities the base
+ * MUST NOT take on (separation per ADR-017 §4 — tenant routing is a
+ * separate concern from worker hosting):
+ *
+ *   1. Extract `tenantId` from the BullMQ job (`opts.tenantId` per T31
+ *      mapEnqueueOptions; `data._ew.tenantId` as the pg-boss-style
+ *      fallback for operators who chose to stamp it on the payload).
+ *   2. Resolve the tenant credential snapshot — either via the operator-
+ *      supplied {@link TenantAwareBullMqWorkerHostFactoryOptions.resolveSnapshot}
+ *      callback (which typically reads `tenant_job_runtime_config` +
+ *      secrets) or via a synthetic empty-credentials snapshot suitable
+ *      for inherit-mode tenants and unit tests.
+ *   3. Call `plugin.bindToTenant(snapshot)` and pass the returned
+ *      `IJobRuntimeProvider` view to the handler as `binding`. Per FR-5
+ *      of the tenant-overlay spec, jobs without a tenantId fall back to
+ *      the platform-default binding (the plugin singleton itself).
+ *
+ * # Memoisation
+ *
+ * The factory does NOT cache snapshots or bindings itself — both layers
+ * already memoise:
+ *   - `plugin.bindToTenant` memoises views by `(tenantId, credentialVersion)`.
+ *   - The operator's `resolveSnapshot` is expected to memoise too (the
+ *     real impl reads from a secrets-store cache with TTL invalidation).
+ *
+ * Concurrent jobs for the same tenant therefore share the same binding
+ * without this factory adding another cache layer.
+ */
+export interface TenantAwareBullMqWorkerHostFactoryOptions extends BullMqFactoryOptions {
+	readonly deps: BullMqDeps;
+	readonly plugin: BullMqJobRuntimePlugin;
+	/**
+	 * Optional resolver that turns a tenantId into a full
+	 * {@link TenantCredentialSnapshot}. Falls back to a synthetic
+	 * `{ tenantId, providerId: 'bullmq', credentialVersion: 1, credentials: {} }`
+	 * when omitted — sufficient for unit tests + inherit-mode tenants
+	 * where no real credential bag is stored.
+	 */
+	readonly resolveSnapshot?: (tenantId: string) => TenantCredentialSnapshot | Promise<TenantCredentialSnapshot>;
+}
+
+/**
+ * Handler signature for tenant-aware workers — the second arg is the
+ * `IJobRuntimeProvider` view bound to the job's tenant (or the plugin
+ * itself for tenant-less jobs per FR-5).
+ */
+export type TenantAwareHandler = (job: BullMqJobView, binding: IJobRuntimeProvider) => Promise<unknown>;
+
+interface InternalRegistration {
+	readonly queueName: string;
+	readonly handler: TenantAwareHandler;
+	readonly concurrency?: number;
+	readonly workerOpts?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Reads the per-job tenantId, preferring the BullMQ-native carrier
+ * (`opts.tenantId` written by T31 `mapEnqueueOptions`) and falling back
+ * to `data._ew.tenantId` for operators who stamp it on the payload
+ * (pg-boss pattern — `bullmq-types.ts#BullMqJobView` doesn't type
+ * `opts`, so we widen the cast).
+ */
+function extractTenantId(job: BullMqJobView): string | undefined {
+	const opts = (job as unknown as { opts?: { tenantId?: unknown } }).opts;
+	if (opts && typeof opts.tenantId === 'string' && opts.tenantId.length > 0) {
+		return opts.tenantId;
+	}
+	const data = job.data;
+	if (data && typeof data === 'object') {
+		const ew = (data as { _ew?: { tenantId?: unknown } })._ew;
+		if (ew && typeof ew.tenantId === 'string' && ew.tenantId.length > 0) {
+			return ew.tenantId;
+		}
+	}
+	return undefined;
+}
+
+function syntheticSnapshot(tenantId: string): TenantCredentialSnapshot {
+	return {
+		tenantId,
+		providerId: 'bullmq',
+		credentialVersion: 1,
+		credentials: {}
+	};
+}
+
+export class TenantAwareBullMqWorkerHostFactory {
+	private readonly registrations: InternalRegistration[] = [];
+	private workers: BullMqWorkerAdapter[] = [];
+	private started = false;
+	private readonly deps: BullMqDeps;
+	private readonly plugin: BullMqJobRuntimePlugin;
+	private readonly resolveSnapshot:
+		| ((tenantId: string) => TenantCredentialSnapshot | Promise<TenantCredentialSnapshot>)
+		| undefined;
+
+	constructor(private readonly opts: TenantAwareBullMqWorkerHostFactoryOptions) {
+		this.deps = opts.deps;
+		this.plugin = opts.plugin;
+		this.resolveSnapshot = opts.resolveSnapshot;
+	}
+
+	/**
+	 * Register a tenant-aware worker. Mirrors {@link BullMqWorkerHostFactory.register}
+	 * — throws if `start()` has already been called.
+	 */
+	register(
+		queueName: string,
+		handler: TenantAwareHandler,
+		opts?: { concurrency?: number; workerOpts?: Readonly<Record<string, unknown>> }
+	): this {
+		if (this.started) {
+			throw new Error(
+				`TenantAwareBullMqWorkerHostFactory: cannot register '${queueName}' after start() — register all workers before plugin.startWorkerHost runs.`
+			);
+		}
+		const reg: InternalRegistration = {
+			queueName,
+			handler,
+			...(opts?.concurrency !== undefined && { concurrency: opts.concurrency }),
+			...(opts?.workerOpts !== undefined && { workerOpts: opts.workerOpts })
+		};
+		this.registrations.push(reg);
+		return this;
+	}
+
+	/**
+	 * Start every registered worker. Returns a handle whose `stop()`
+	 * closes every worker (idempotent). The shared connection is NOT
+	 * closed — the operator owns it.
+	 */
+	async start(hostOpts: WorkerHostOptions = {}): Promise<WorkerHostHandle> {
+		if (this.started) {
+			throw new Error('TenantAwareBullMqWorkerHostFactory: start() called twice — already running.');
+		}
+		this.started = true;
+
+		const defaultConcurrency = hostOpts.concurrency;
+		const workers = this.registrations.map((reg) => {
+			const concurrency = reg.concurrency ?? defaultConcurrency;
+			const workerOpts: Record<string, unknown> = {
+				connection: this.opts.connection,
+				...(reg.workerOpts ?? {})
+			};
+			if (this.opts.prefix !== undefined) workerOpts['prefix'] = this.opts.prefix;
+			if (concurrency !== undefined) workerOpts['concurrency'] = concurrency;
+
+			const processor = async (job: BullMqJobView): Promise<unknown> => {
+				const binding = await this.resolveBinding(job);
+				return reg.handler(job, binding);
+			};
+			return new this.deps.Worker(reg.queueName, processor, workerOpts);
+		});
+		this.workers = workers;
+
+		if (hostOpts.signal) {
+			const signal = hostOpts.signal;
+			const onAbort = () => {
+				void this.stopAll();
+			};
+			if (signal.aborted) onAbort();
+			else signal.addEventListener('abort', onAbort, { once: true });
+		}
+
+		const handle: WorkerHostHandle = {
+			stop: () => this.stopAll()
+		};
+		return handle;
+	}
+
+	/**
+	 * Visible for tests / metrics — the per-job routing path. Returns
+	 * the plugin itself for tenant-less jobs (FR-5 fallback), otherwise
+	 * the per-tenant view from `plugin.bindToTenant`.
+	 */
+	private async resolveBinding(job: BullMqJobView): Promise<IJobRuntimeProvider> {
+		const tenantId = extractTenantId(job);
+		if (!tenantId) {
+			return this.plugin;
+		}
+		const snapshot = this.resolveSnapshot
+			? await this.resolveSnapshot(tenantId)
+			: syntheticSnapshot(tenantId);
+		const bound = this.plugin.bindToTenant(snapshot);
+		return bound ?? this.plugin;
+	}
+
+	private async stopAll(): Promise<void> {
+		const workers = this.workers;
+		this.workers = [];
+		this.started = false;
+		await Promise.allSettled(workers.map((w) => w.close()));
+	}
+
+	/** Number of registrations — useful for tests/metrics. */
+	get registrationCount(): number {
+		return this.registrations.length;
+	}
+}

--- a/packages/plugins/job-runtime-bullmq/src/index.ts
+++ b/packages/plugins/job-runtime-bullmq/src/index.ts
@@ -11,6 +11,11 @@ export type { BullMqDispatcher } from './bullmq-dispatcher-factory.js';
 export { mapEnqueueOptions as mapBullMqEnqueueOptions } from './bullmq-enqueue-options.js';
 export { BullMqWorkerHostFactory } from './bullmq-worker-host-factory.js';
 export type { BullMqWorkerRegistration } from './bullmq-worker-host-factory.js';
+export { TenantAwareBullMqWorkerHostFactory } from './bullmq-tenant-aware-worker-host-factory.js';
+export type {
+	TenantAwareBullMqWorkerHostFactoryOptions,
+	TenantAwareHandler as BullMqTenantAwareHandler
+} from './bullmq-tenant-aware-worker-host-factory.js';
 export type {
 	BullMqDeps,
 	BullMqConnection,

--- a/packages/plugins/job-runtime-inngest/src/__tests__/inngest-tenant-isolation.spec.ts
+++ b/packages/plugins/job-runtime-inngest/src/__tests__/inngest-tenant-isolation.spec.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IJobRuntimeProvider, TenantCredentialSnapshot } from '@ever-works/plugin';
+import { InngestJobRuntimePlugin } from '../inngest-job-runtime.plugin.js';
+import {
+	tenantAwareInngestFunctionHandler,
+	type InngestFunctionContext
+} from '../inngest-tenant-aware-handler.js';
+import type { InngestSendEvent } from '../inngest-types.js';
+
+/**
+ * EW-742 P4 T26/T30/T32 — tenant-isolation contract for the Inngest
+ * tenant-aware handler wrapper. No Inngest SDK is required — we call the
+ * wrapped handler with crafted `InngestFunctionContext` objects.
+ */
+
+const TENANT_A_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const TENANT_B_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+function ctxWithTenant(
+	tenantId: string | undefined,
+	eventName = 'ever.works/test',
+	extra: Readonly<Record<string, unknown>> = {}
+): InngestFunctionContext {
+	const data: Record<string, unknown> = { ...extra };
+	if (tenantId !== undefined) {
+		data['_ew'] = { tenantId };
+	}
+	const event: InngestSendEvent = { name: eventName, data };
+	return { event, runId: `run-${tenantId ?? 'none'}` };
+}
+
+describe('tenantAwareInngestFunctionHandler — tenant isolation', () => {
+	it("routes event with tenant A's id to tenant A's binding", async () => {
+		const plugin = new InngestJobRuntimePlugin();
+		const captured: IJobRuntimeProvider[] = [];
+
+		const wrap = tenantAwareInngestFunctionHandler({ plugin });
+		const wrapped = wrap(async (_ctx, binding) => {
+			captured.push(binding);
+		});
+
+		await wrapped(ctxWithTenant(TENANT_A_ID));
+
+		expect(captured).toHaveLength(1);
+		const bindingA = captured[0];
+		expect(bindingA).not.toBe(plugin);
+		expect(
+			bindingA.bindToTenant?.({
+				tenantId: TENANT_A_ID,
+				providerId: 'inngest',
+				credentialVersion: 1,
+				credentials: {}
+			})
+		).toBe(bindingA);
+	});
+
+	it('routes tenant B to a distinct binding from A', async () => {
+		const plugin = new InngestJobRuntimePlugin();
+		const captured: IJobRuntimeProvider[] = [];
+
+		const wrap = tenantAwareInngestFunctionHandler({ plugin });
+		const wrapped = wrap(async (_ctx, binding) => {
+			captured.push(binding);
+		});
+
+		await wrapped(ctxWithTenant(TENANT_A_ID));
+		await wrapped(ctxWithTenant(TENANT_B_ID));
+
+		expect(captured).toHaveLength(2);
+		const [bindingA, bindingB] = captured;
+		expect(bindingA).not.toBe(bindingB);
+		expect(bindingA).not.toBe(plugin);
+		expect(bindingB).not.toBe(plugin);
+	});
+
+	it("two concurrent invocations from different tenants don't cross contexts", async () => {
+		const plugin = new InngestJobRuntimePlugin();
+		const observed: { runId: string; binding: IJobRuntimeProvider }[] = [];
+
+		let releaseA: () => void = () => undefined;
+		let releaseB: () => void = () => undefined;
+		const aReady = new Promise<void>((r) => (releaseA = r));
+		const bReady = new Promise<void>((r) => (releaseB = r));
+
+		const wrap = tenantAwareInngestFunctionHandler({ plugin });
+		const wrapped = wrap(async (ctx, binding) => {
+			if (ctx.runId?.includes('A')) {
+				await aReady;
+			} else {
+				await bReady;
+			}
+			observed.push({ runId: ctx.runId ?? '', binding });
+		});
+
+		const ctxA: InngestFunctionContext = {
+			event: { name: 'ever.works/test', data: { _ew: { tenantId: TENANT_A_ID } } },
+			runId: 'runA'
+		};
+		const ctxB: InngestFunctionContext = {
+			event: { name: 'ever.works/test', data: { _ew: { tenantId: TENANT_B_ID } } },
+			runId: 'runB'
+		};
+
+		const pA = wrapped(ctxA);
+		const pB = wrapped(ctxB);
+
+		// Release in reversed order to maximise interleaving.
+		releaseB();
+		releaseA();
+		await Promise.all([pA, pB]);
+
+		expect(observed).toHaveLength(2);
+		const aObs = observed.find((o) => o.runId === 'runA');
+		const bObs = observed.find((o) => o.runId === 'runB');
+		expect(aObs).toBeDefined();
+		expect(bObs).toBeDefined();
+		expect(aObs!.binding).not.toBe(bObs!.binding);
+
+		expect(
+			aObs!.binding.bindToTenant?.({
+				tenantId: TENANT_A_ID,
+				providerId: 'inngest',
+				credentialVersion: 1,
+				credentials: {}
+			})
+		).toBe(aObs!.binding);
+		expect(
+			bObs!.binding.bindToTenant?.({
+				tenantId: TENANT_B_ID,
+				providerId: 'inngest',
+				credentialVersion: 1,
+				credentials: {}
+			})
+		).toBe(bObs!.binding);
+	});
+
+	it('event without _ew.tenantId falls back to plugin default binding', async () => {
+		const plugin = new InngestJobRuntimePlugin();
+		const captured: IJobRuntimeProvider[] = [];
+
+		const wrap = tenantAwareInngestFunctionHandler({ plugin });
+		const wrapped = wrap(async (_ctx, binding) => {
+			captured.push(binding);
+		});
+
+		await wrapped(ctxWithTenant(undefined));
+
+		expect(captured).toHaveLength(1);
+		expect(captured[0]).toBe(plugin);
+	});
+
+	it('resolveSnapshot is called per tenantId; downstream bindings are memoised by plugin.bindToTenant', async () => {
+		const plugin = new InngestJobRuntimePlugin();
+		const captured: IJobRuntimeProvider[] = [];
+
+		const resolveSnapshot = vi.fn(
+			async (tenantId: string): Promise<TenantCredentialSnapshot> => ({
+				tenantId,
+				providerId: 'inngest',
+				credentialVersion: 1,
+				credentials: { eventKey: `key-${tenantId.slice(0, 1)}` }
+			})
+		);
+
+		const wrap = tenantAwareInngestFunctionHandler({ plugin, resolveSnapshot });
+		const wrapped = wrap(async (_ctx, binding) => {
+			captured.push(binding);
+		});
+
+		await wrapped(ctxWithTenant(TENANT_A_ID));
+		await wrapped(ctxWithTenant(TENANT_A_ID));
+		await wrapped(ctxWithTenant(TENANT_B_ID));
+
+		// resolveSnapshot fires once per invocation (the wrapper does NOT
+		// cache snapshots — that's the operator's resolveSnapshot impl's job).
+		expect(resolveSnapshot).toHaveBeenCalledTimes(3);
+		expect(resolveSnapshot.mock.calls.map((c) => c[0])).toEqual([
+			TENANT_A_ID,
+			TENANT_A_ID,
+			TENANT_B_ID
+		]);
+
+		// But plugin.bindToTenant memoises by (tenantId, credentialVersion):
+		// the two A-tenant invocations share a binding identity.
+		expect(captured).toHaveLength(3);
+		expect(captured[0]).toBe(captured[1]);
+		expect(captured[0]).not.toBe(captured[2]);
+	});
+
+	it("preserves the operator handler's return value", async () => {
+		const plugin = new InngestJobRuntimePlugin();
+		const wrap = tenantAwareInngestFunctionHandler({ plugin });
+		const wrapped = wrap(async (_ctx, _binding) => {
+			return { ok: true, value: 42 } as const;
+		});
+
+		const result = await wrapped(ctxWithTenant(TENANT_A_ID));
+		expect(result).toEqual({ ok: true, value: 42 });
+	});
+
+	it('propagates handler errors', async () => {
+		const plugin = new InngestJobRuntimePlugin();
+		const wrap = tenantAwareInngestFunctionHandler({ plugin });
+		const boom = new Error('handler exploded');
+		const wrapped = wrap(async () => {
+			throw boom;
+		});
+
+		await expect(wrapped(ctxWithTenant(TENANT_A_ID))).rejects.toBe(boom);
+	});
+});

--- a/packages/plugins/job-runtime-inngest/src/index.ts
+++ b/packages/plugins/job-runtime-inngest/src/index.ts
@@ -18,4 +18,10 @@ export type {
 	InngestFunction,
 	InngestDispatcherFactoryOptions
 } from './inngest-types.js';
+export { tenantAwareInngestFunctionHandler } from './inngest-tenant-aware-handler.js';
+export type {
+	InngestFunctionContext,
+	TenantAwareInngestHandler,
+	TenantAwareInngestWrapperOptions
+} from './inngest-tenant-aware-handler.js';
 export { InngestJobRuntimePlugin as default } from './inngest-job-runtime.plugin.js';

--- a/packages/plugins/job-runtime-inngest/src/inngest-tenant-aware-handler.ts
+++ b/packages/plugins/job-runtime-inngest/src/inngest-tenant-aware-handler.ts
@@ -1,0 +1,139 @@
+import type { IJobRuntimeProvider, TenantCredentialSnapshot } from '@ever-works/plugin';
+import type { InngestJobRuntimePlugin } from './inngest-job-runtime.plugin.js';
+import type { InngestSendEvent } from './inngest-types.js';
+
+/**
+ * EW-742 P4 T26/T30/T32 — tenant-aware Inngest function handler wrapper.
+ *
+ * Sibling of `TenantAwareBullMqWorkerHostFactory` /
+ * `TenantAwarePgBossWorkerHostFactory` for Inngest — but because Inngest
+ * has **no worker host process** (operator-defined functions are invoked
+ * over HTTP via `serve()`), this module exposes a higher-order function
+ * (HOF) that wraps the operator's per-function handler rather than a
+ * factory that starts long-lived workers.
+ *
+ * # Why a wrapper, not a factory
+ *
+ * Inngest's dispatch model is push: the platform invokes the operator's
+ * HTTP `serve()` mount when an event matches a registered function. The
+ * "worker" is just the route handler. So tenant routing has to happen
+ * inside each function's `handler({ event, step })` body — wrap once,
+ * register the wrapped handler with `factory.defineFunction(...)`, and
+ * each invocation gets the right tenant binding injected as the second
+ * arg.
+ *
+ * # Tenant carrier
+ *
+ * Per T31 `mapEnqueueOptions`, `tenantId` is stamped on
+ * `event.data._ew.tenantId` (Inngest has no native carrier — we use a
+ * reserved `_ew` namespace on `event.data`). The wrapper reads it from
+ * there, resolves the snapshot via the optional
+ * {@link TenantAwareInngestWrapperOptions.resolveSnapshot} callback (or a
+ * synthetic empty-credentials snapshot for inherit-mode tenants + unit
+ * tests), and calls `plugin.bindToTenant(snapshot)`.
+ *
+ * # Memoisation
+ *
+ * The wrapper does NOT cache snapshots or bindings itself — both layers
+ * already memoise:
+ *   - `plugin.bindToTenant` memoises views by `(tenantId, credentialVersion)`.
+ *   - The operator's `resolveSnapshot` is expected to memoise too (the
+ *     real impl reads from a secrets-store cache with TTL invalidation).
+ *
+ * Concurrent invocations for the same tenant therefore share the same
+ * binding without this wrapper adding another cache layer.
+ *
+ * # FR-5 fallback
+ *
+ * Events without `data._ew.tenantId` (instance-default routing — the
+ * EW-683 pre-tenancy path) get the plugin singleton itself as the
+ * binding, byte-identical to a non-tenant-aware handler.
+ */
+
+export interface InngestFunctionContext {
+	readonly event: InngestSendEvent;
+	readonly step?: unknown;
+	readonly runId?: string;
+	readonly attempt?: number;
+}
+
+/**
+ * Handler signature for tenant-aware Inngest functions — the second arg
+ * is the `IJobRuntimeProvider` view bound to the event's tenant (or the
+ * plugin itself for tenant-less events per FR-5).
+ */
+export type TenantAwareInngestHandler<T = unknown> = (
+	ctx: InngestFunctionContext,
+	binding: IJobRuntimeProvider
+) => Promise<T>;
+
+export interface TenantAwareInngestWrapperOptions {
+	readonly plugin: InngestJobRuntimePlugin;
+	/**
+	 * Optional resolver that turns a tenantId into a full
+	 * {@link TenantCredentialSnapshot}. Falls back to a synthetic
+	 * `{ tenantId, providerId: 'inngest', credentialVersion: 1, credentials: {} }`
+	 * when omitted — sufficient for unit tests + inherit-mode tenants
+	 * where no real credential bag is stored.
+	 */
+	readonly resolveSnapshot?: (tenantId: string) => TenantCredentialSnapshot | Promise<TenantCredentialSnapshot>;
+}
+
+function extractTenantId(ctx: InngestFunctionContext): string | undefined {
+	const data = ctx.event?.data as Record<string, unknown> | undefined;
+	if (!data || typeof data !== 'object') {
+		return undefined;
+	}
+	const ew = (data as { _ew?: { tenantId?: unknown } })._ew;
+	if (ew && typeof ew.tenantId === 'string' && ew.tenantId.length > 0) {
+		return ew.tenantId;
+	}
+	return undefined;
+}
+
+function syntheticSnapshot(tenantId: string): TenantCredentialSnapshot {
+	return {
+		tenantId,
+		providerId: 'inngest',
+		credentialVersion: 1,
+		credentials: {}
+	};
+}
+
+/**
+ * Returns a higher-order function:
+ *   `(operatorHandler) => (ctx) => operatorHandler(ctx, binding)`.
+ *
+ * On each invocation the wrapper:
+ *   1. Extracts `tenantId` from `ctx.event.data._ew.tenantId`.
+ *   2. Resolves the snapshot via `resolveSnapshot(tenantId)` (or
+ *      synthesises an empty-credential snapshot when no resolver was
+ *      supplied — useful for inherit-mode tenants and unit tests).
+ *   3. Calls `plugin.bindToTenant(snapshot)` and forwards the returned
+ *      `IJobRuntimeProvider` view to the operator handler as `binding`.
+ *   4. For events without a tenantId, hands the plugin itself to the
+ *      handler (FR-5 fallback — instance-default routing).
+ *
+ * The wrapper preserves the handler's return value and propagates errors
+ * unchanged.
+ */
+export function tenantAwareInngestFunctionHandler(
+	opts: TenantAwareInngestWrapperOptions
+): <T>(handler: TenantAwareInngestHandler<T>) => (ctx: InngestFunctionContext) => Promise<T> {
+	const { plugin, resolveSnapshot } = opts;
+	return <T>(handler: TenantAwareInngestHandler<T>) =>
+		async (ctx: InngestFunctionContext): Promise<T> => {
+			const tenantId = extractTenantId(ctx);
+			let binding: IJobRuntimeProvider;
+			if (!tenantId) {
+				binding = plugin;
+			} else {
+				const snapshot = resolveSnapshot
+					? await resolveSnapshot(tenantId)
+					: syntheticSnapshot(tenantId);
+				const bound = plugin.bindToTenant(snapshot);
+				binding = bound ?? plugin;
+			}
+			return handler(ctx, binding);
+		};
+}

--- a/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-tenant-isolation.spec.ts
+++ b/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-tenant-isolation.spec.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IJobRuntimeProvider, TenantCredentialSnapshot } from '@ever-works/plugin';
+import { PgBossJobRuntimePlugin } from '../pgboss-job-runtime.plugin.js';
+import { TenantAwarePgBossWorkerHostFactory } from '../pgboss-tenant-aware-worker-host-factory.js';
+import type { PgBossInstance, PgBossJobView } from '../pgboss-types.js';
+
+/**
+ * EW-742 P4 T29/T30/T32 — tenant-isolation spec for the pg-boss
+ * tenant-aware worker host. Mirrors the BullMQ T28 tenant-isolation
+ * coverage:
+ *
+ *   1. tenantA → A's binding
+ *   2. tenantB → distinct binding
+ *   3. concurrent A+B never cross-route
+ *   4. missing `_ew.tenantId` → plugin default (FR-5 fallback)
+ *   5. `resolveSnapshot` is called per tenant; bindings memoise via the
+ *      plugin's `(tenantId, credentialVersion)` cache
+ *   6. when pg-boss hands a batch (array of jobs), each job in the
+ *      batch routes to the right tenant independently
+ *
+ * pg-boss itself is mocked with a minimal `FakeBoss` (matching the
+ * `pgboss-factories.spec.ts` pattern) that records `boss.work(...)`
+ * calls and lets the test drive the captured processor by hand.
+ */
+
+interface WorkCall {
+	name: string;
+	options: Readonly<Record<string, unknown>>;
+	handler: (job: PgBossJobView | readonly PgBossJobView[]) => Promise<unknown>;
+}
+
+class FakeBoss implements PgBossInstance {
+	workCalls: WorkCall[] = [];
+	stopped = false;
+	private nextSubId = 1;
+
+	async send(): Promise<string | null> {
+		return null;
+	}
+
+	async work(
+		name: string,
+		options: Readonly<Record<string, unknown>>,
+		handler: (job: PgBossJobView | readonly PgBossJobView[]) => Promise<unknown>
+	): Promise<string> {
+		this.workCalls.push({ name, options, handler });
+		return `sub${this.nextSubId++}`;
+	}
+
+	async cancel(): Promise<void> {
+		return undefined;
+	}
+
+	async start(): Promise<unknown> {
+		return undefined;
+	}
+
+	async stop(): Promise<void> {
+		this.stopped = true;
+	}
+}
+
+function makeJob(id: string, data: Record<string, unknown>): PgBossJobView {
+	return { id, name: 'q1', data };
+}
+
+function stampedJob(id: string, tenantId: string, extra: Record<string, unknown> = {}): PgBossJobView {
+	return makeJob(id, { ...extra, _ew: { tenantId } });
+}
+
+const tenantA = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const tenantB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+describe('TenantAwarePgBossWorkerHostFactory', () => {
+	it('routes a tenantA job to a binding scoped to tenantA', async () => {
+		const boss = new FakeBoss();
+		const plugin = new PgBossJobRuntimePlugin();
+		const f = new TenantAwarePgBossWorkerHostFactory({ boss, plugin });
+
+		const seen: IJobRuntimeProvider[] = [];
+		f.register('q1', {}, async (_job, binding) => {
+			seen.push(binding);
+		});
+		await f.start();
+
+		const processor = boss.workCalls[0]!.handler;
+		await processor(stampedJob('job-a', tenantA));
+
+		expect(seen).toHaveLength(1);
+		const view = seen[0]! as IJobRuntimeProvider & { tenantSnapshot?: TenantCredentialSnapshot };
+		expect(view.tenantSnapshot?.tenantId).toBe(tenantA);
+		expect(view).not.toBe(plugin);
+	});
+
+	it('routes a tenantB job to a binding distinct from tenantA', async () => {
+		const boss = new FakeBoss();
+		const plugin = new PgBossJobRuntimePlugin();
+		const f = new TenantAwarePgBossWorkerHostFactory({ boss, plugin });
+
+		const seen: IJobRuntimeProvider[] = [];
+		f.register('q1', {}, async (_job, binding) => {
+			seen.push(binding);
+		});
+		await f.start();
+
+		const processor = boss.workCalls[0]!.handler;
+		await processor(stampedJob('job-a', tenantA));
+		await processor(stampedJob('job-b', tenantB));
+
+		expect(seen).toHaveLength(2);
+		const viewA = seen[0]! as IJobRuntimeProvider & { tenantSnapshot?: TenantCredentialSnapshot };
+		const viewB = seen[1]! as IJobRuntimeProvider & { tenantSnapshot?: TenantCredentialSnapshot };
+		expect(viewA.tenantSnapshot?.tenantId).toBe(tenantA);
+		expect(viewB.tenantSnapshot?.tenantId).toBe(tenantB);
+		expect(viewA).not.toBe(viewB);
+	});
+
+	it('concurrent jobs for A and B never cross-route', async () => {
+		const boss = new FakeBoss();
+		const plugin = new PgBossJobRuntimePlugin();
+		const f = new TenantAwarePgBossWorkerHostFactory({ boss, plugin });
+
+		const seen: { tenantId: string; binding: IJobRuntimeProvider }[] = [];
+		f.register('q1', {}, async (job, binding) => {
+			// Read the tenantId from the job and pair it with the binding we got.
+			const ew = (job.data as { _ew?: { tenantId?: string } })._ew;
+			seen.push({ tenantId: ew?.tenantId ?? '<none>', binding });
+		});
+		await f.start();
+
+		const processor = boss.workCalls[0]!.handler;
+		// Fire 6 jobs in parallel, alternating tenants.
+		const jobs = [
+			stampedJob('a1', tenantA),
+			stampedJob('b1', tenantB),
+			stampedJob('a2', tenantA),
+			stampedJob('b2', tenantB),
+			stampedJob('a3', tenantA),
+			stampedJob('b3', tenantB)
+		];
+		await Promise.all(jobs.map((j) => processor(j)));
+
+		expect(seen).toHaveLength(6);
+		for (const entry of seen) {
+			const view = entry.binding as IJobRuntimeProvider & {
+				tenantSnapshot?: TenantCredentialSnapshot;
+			};
+			// Each binding's snapshot.tenantId MUST equal the job's stamped tenantId.
+			expect(view.tenantSnapshot?.tenantId).toBe(entry.tenantId);
+		}
+	});
+
+	it('falls back to the plugin default binding when _ew.tenantId is missing', async () => {
+		const boss = new FakeBoss();
+		const plugin = new PgBossJobRuntimePlugin();
+		const f = new TenantAwarePgBossWorkerHostFactory({ boss, plugin });
+
+		const seen: IJobRuntimeProvider[] = [];
+		f.register('q1', {}, async (_job, binding) => {
+			seen.push(binding);
+		});
+		await f.start();
+
+		const processor = boss.workCalls[0]!.handler;
+		await processor(makeJob('untenanted', { hello: 'world' })); // no _ew
+		await processor(makeJob('empty-ew', { _ew: {} })); // _ew present but no tenantId
+
+		expect(seen).toHaveLength(2);
+		// FR-5: tenant-less jobs use the plugin singleton itself.
+		expect(seen[0]).toBe(plugin);
+		expect(seen[1]).toBe(plugin);
+	});
+
+	it('calls resolveSnapshot per tenant; bindings memoise via plugin.bindToTenant', async () => {
+		const boss = new FakeBoss();
+		const plugin = new PgBossJobRuntimePlugin();
+		const resolveSnapshot = vi.fn(
+			async (tenantId: string): Promise<TenantCredentialSnapshot> => ({
+				tenantId,
+				providerId: 'pgboss',
+				credentialVersion: 1,
+				credentials: { schema: `tenant_${tenantId.slice(0, 8)}` }
+			})
+		);
+		const f = new TenantAwarePgBossWorkerHostFactory({ boss, plugin, resolveSnapshot });
+
+		const seen: IJobRuntimeProvider[] = [];
+		f.register('q1', {}, async (_job, binding) => {
+			seen.push(binding);
+		});
+		await f.start();
+
+		const processor = boss.workCalls[0]!.handler;
+		await processor(stampedJob('a1', tenantA));
+		await processor(stampedJob('a2', tenantA));
+		await processor(stampedJob('b1', tenantB));
+		await processor(stampedJob('a3', tenantA));
+
+		// resolveSnapshot is called every job (operator's responsibility to
+		// cache); but plugin.bindToTenant memoises so the returned view
+		// instance is shared across same-tenant calls.
+		expect(resolveSnapshot).toHaveBeenCalledTimes(4);
+		expect(resolveSnapshot.mock.calls.map((c) => c[0])).toEqual([
+			tenantA,
+			tenantA,
+			tenantB,
+			tenantA
+		]);
+
+		// Same tenantA snapshot → identical view returned by the plugin.
+		expect(seen[0]).toBe(seen[1]);
+		expect(seen[0]).toBe(seen[3]);
+		// tenantB is a different view.
+		expect(seen[2]).not.toBe(seen[0]);
+	});
+
+	it('routes each job of a pg-boss batch (array) to its own tenant', async () => {
+		const boss = new FakeBoss();
+		const plugin = new PgBossJobRuntimePlugin();
+		const f = new TenantAwarePgBossWorkerHostFactory({ boss, plugin });
+
+		const seen: { id: string; tenantId: string | null; binding: IJobRuntimeProvider }[] = [];
+		f.register('q1', {}, async (job, binding) => {
+			const ew = (job.data as { _ew?: { tenantId?: string } })._ew;
+			seen.push({ id: job.id, tenantId: ew?.tenantId ?? null, binding });
+		});
+		await f.start();
+
+		const processor = boss.workCalls[0]!.handler;
+		// pg-boss hands an array when `batchSize > 1`. Mix tenants + a
+		// tenant-less entry to confirm independent routing per element.
+		const batch: readonly PgBossJobView[] = [
+			stampedJob('b-a1', tenantA),
+			stampedJob('b-b1', tenantB),
+			makeJob('b-none', { payload: 1 })
+		];
+		await processor(batch);
+
+		expect(seen.map((s) => s.id)).toEqual(['b-a1', 'b-b1', 'b-none']);
+
+		const v0 = seen[0]!.binding as IJobRuntimeProvider & {
+			tenantSnapshot?: TenantCredentialSnapshot;
+		};
+		const v1 = seen[1]!.binding as IJobRuntimeProvider & {
+			tenantSnapshot?: TenantCredentialSnapshot;
+		};
+		expect(v0.tenantSnapshot?.tenantId).toBe(tenantA);
+		expect(v1.tenantSnapshot?.tenantId).toBe(tenantB);
+		// The untenanted entry falls back to the plugin singleton.
+		expect(seen[2]!.binding).toBe(plugin);
+	});
+});

--- a/packages/plugins/job-runtime-pgboss/src/index.ts
+++ b/packages/plugins/job-runtime-pgboss/src/index.ts
@@ -13,6 +13,11 @@ export {
 export type { MappedPgBossEnqueue } from './pgboss-enqueue-options.js';
 export { PgBossWorkerHostFactory } from './pgboss-worker-host-factory.js';
 export type { PgBossWorkerRegistration } from './pgboss-worker-host-factory.js';
+export { TenantAwarePgBossWorkerHostFactory } from './pgboss-tenant-aware-worker-host-factory.js';
+export type {
+	TenantAwarePgBossWorkerHostFactoryOptions,
+	PgBossTenantAwareHandler
+} from './pgboss-tenant-aware-worker-host-factory.js';
 export type {
 	PgBossInstance,
 	PgBossJobView,

--- a/packages/plugins/job-runtime-pgboss/src/pgboss-tenant-aware-worker-host-factory.ts
+++ b/packages/plugins/job-runtime-pgboss/src/pgboss-tenant-aware-worker-host-factory.ts
@@ -1,0 +1,231 @@
+import type {
+	IJobRuntimeProvider,
+	TenantCredentialSnapshot,
+	WorkerHostHandle,
+	WorkerHostOptions
+} from '@ever-works/plugin';
+import type { PgBossFactoryOptions, PgBossInstance, PgBossJobView } from './pgboss-types.js';
+import type { PgBossJobRuntimePlugin } from './pgboss-job-runtime.plugin.js';
+
+/**
+ * EW-742 P4 T29/T30/T32 — tenant-aware pg-boss worker host.
+ *
+ * Sibling of {@link import('./pgboss-worker-host-factory.js').PgBossWorkerHostFactory}
+ * that routes each in-flight job to the tenant's overlay binding before
+ * invoking the operator-supplied handler.
+ *
+ * # Why a separate factory
+ *
+ * pg-boss has no native tenantId carrier on its `Job` object — the T31
+ * `mapEnqueueOptions` translator stamps tenantId (plus concurrencyKey /
+ * tags / machineHint) onto a reserved `_ew` namespace on the payload
+ * (`job.data._ew.tenantId`). The base {@link PgBossWorkerHostFactory}
+ * hands `PgBossJobView` to the handler verbatim — fine for instance-
+ * default workers that don't need tenant isolation. This variant adds
+ * three responsibilities the base MUST NOT take on (ADR-017 §4 —
+ * tenant routing is a separate concern from worker hosting):
+ *
+ *   1. Extract `tenantId` from `job.data._ew.tenantId` (the T31 stamping
+ *      namespace).
+ *   2. Resolve the tenant credential snapshot — either via the operator-
+ *      supplied {@link TenantAwarePgBossWorkerHostFactoryOptions.resolveSnapshot}
+ *      callback (which typically reads `tenant_job_runtime_config` +
+ *      secrets) or via a synthetic empty-credentials snapshot suitable
+ *      for inherit-mode tenants and unit tests.
+ *   3. Call `plugin.bindToTenant(snapshot)` and pass the returned
+ *      `IJobRuntimeProvider` view to the handler as `binding`. Per FR-5
+ *      of the tenant-overlay spec, jobs without a tenantId fall back to
+ *      the platform-default binding (the plugin singleton itself).
+ *
+ * # Batched workers
+ *
+ * pg-boss can hand the worker either a single job (`batchSize` defaults
+ * to 1) or an array (when the operator configures `batchSize > 1`). To
+ * keep the tenant-routing surface area minimal, this factory accepts a
+ * single-job handler and iterates per job when pg-boss hands an array —
+ * each entry routes through `bindToTenant` independently so a batch can
+ * contain mixed tenants. Operators who need true batched handlers
+ * (single call, single response array) should use the base
+ * {@link PgBossWorkerHostFactory} directly and do tenant routing
+ * themselves.
+ *
+ * # Memoisation
+ *
+ * The factory does NOT cache snapshots or bindings itself — both layers
+ * already memoise:
+ *   - `plugin.bindToTenant` memoises views by `(tenantId, credentialVersion)`.
+ *   - The operator's `resolveSnapshot` is expected to memoise too (the
+ *     real impl reads from a secrets-store cache with TTL invalidation).
+ *
+ * Concurrent jobs for the same tenant therefore share the same binding
+ * without this factory adding another cache layer.
+ */
+export interface TenantAwarePgBossWorkerHostFactoryOptions extends PgBossFactoryOptions {
+	readonly plugin: PgBossJobRuntimePlugin;
+	/**
+	 * Optional resolver that turns a tenantId into a full
+	 * {@link TenantCredentialSnapshot}. Falls back to a synthetic
+	 * `{ tenantId, providerId: 'pgboss', credentialVersion: 1, credentials: {} }`
+	 * when omitted — sufficient for unit tests + inherit-mode tenants
+	 * where no real credential bag is stored.
+	 */
+	readonly resolveSnapshot?: (tenantId: string) => TenantCredentialSnapshot | Promise<TenantCredentialSnapshot>;
+}
+
+/**
+ * Handler signature for tenant-aware workers — the second arg is the
+ * `IJobRuntimeProvider` view bound to the job's tenant (or the plugin
+ * itself for tenant-less jobs per FR-5).
+ */
+export type PgBossTenantAwareHandler = (job: PgBossJobView, binding: IJobRuntimeProvider) => Promise<unknown>;
+
+interface InternalRegistration {
+	readonly queueName: string;
+	readonly handler: PgBossTenantAwareHandler;
+	readonly workOptions: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Reads the per-job tenantId from `data._ew.tenantId` — the namespace
+ * T31 `mapEnqueueOptions` stamps onto the payload before publish (pg-boss
+ * has no native `opts.tenantId` carrier, unlike BullMQ).
+ */
+function extractTenantId(job: PgBossJobView): string | undefined {
+	const data = job.data;
+	if (data && typeof data === 'object') {
+		const ew = (data as { _ew?: { tenantId?: unknown } })._ew;
+		if (ew && typeof ew.tenantId === 'string' && ew.tenantId.length > 0) {
+			return ew.tenantId;
+		}
+	}
+	return undefined;
+}
+
+function syntheticSnapshot(tenantId: string): TenantCredentialSnapshot {
+	return {
+		tenantId,
+		providerId: 'pgboss',
+		credentialVersion: 1,
+		credentials: {}
+	};
+}
+
+export class TenantAwarePgBossWorkerHostFactory {
+	private readonly registrations: InternalRegistration[] = [];
+	private subscriptionIds: string[] = [];
+	private started = false;
+	private readonly plugin: PgBossJobRuntimePlugin;
+	private readonly resolveSnapshot:
+		| ((tenantId: string) => TenantCredentialSnapshot | Promise<TenantCredentialSnapshot>)
+		| undefined;
+
+	constructor(private readonly opts: TenantAwarePgBossWorkerHostFactoryOptions) {
+		this.plugin = opts.plugin;
+		this.resolveSnapshot = opts.resolveSnapshot;
+	}
+
+	get boss(): PgBossInstance {
+		return this.opts.boss;
+	}
+
+	/**
+	 * Register a tenant-aware worker. Mirrors {@link PgBossWorkerHostFactory.register}
+	 * — throws if `start()` has already been called.
+	 */
+	register(
+		queueName: string,
+		workOptions: Readonly<Record<string, unknown>>,
+		handler: PgBossTenantAwareHandler
+	): this {
+		if (this.started) {
+			throw new Error(
+				`TenantAwarePgBossWorkerHostFactory: cannot register '${queueName}' after start() — register all workers before plugin.startWorkerHost runs.`
+			);
+		}
+		this.registrations.push({ queueName, workOptions, handler });
+		return this;
+	}
+
+	/**
+	 * Start every registered worker by calling `boss.work(name, opts, h)`
+	 * sequentially. Returns a handle whose `stop()` calls `boss.stop()`
+	 * — pg-boss's canonical graceful-drain.
+	 */
+	async start(hostOpts: WorkerHostOptions = {}): Promise<WorkerHostHandle> {
+		if (this.started) {
+			throw new Error('TenantAwarePgBossWorkerHostFactory: start() called twice — already running.');
+		}
+		this.started = true;
+
+		const defaults = this.opts.defaultWorkOptions ?? {};
+		const ids: string[] = [];
+		for (const reg of this.registrations) {
+			const merged: Record<string, unknown> = { ...defaults, ...(reg.workOptions ?? {}) };
+			if (hostOpts.concurrency !== undefined && merged['teamSize'] === undefined) {
+				merged['teamSize'] = hostOpts.concurrency;
+			}
+			const processor = async (
+				jobOrJobs: PgBossJobView | readonly PgBossJobView[]
+			): Promise<unknown> => {
+				if (Array.isArray(jobOrJobs)) {
+					const results: unknown[] = [];
+					for (const j of jobOrJobs) {
+						const binding = await this.resolveBinding(j);
+						results.push(await reg.handler(j, binding));
+					}
+					return results;
+				}
+				const job = jobOrJobs as PgBossJobView;
+				const binding = await this.resolveBinding(job);
+				return reg.handler(job, binding);
+			};
+			const id = await this.opts.boss.work(reg.queueName, merged, processor);
+			ids.push(id);
+		}
+		this.subscriptionIds = ids;
+
+		if (hostOpts.signal) {
+			const signal = hostOpts.signal;
+			const onAbort = () => {
+				void this.stopAll();
+			};
+			if (signal.aborted) onAbort();
+			else signal.addEventListener('abort', onAbort, { once: true });
+		}
+
+		return { stop: () => this.stopAll() };
+	}
+
+	/**
+	 * Visible for tests / metrics — the per-job routing path. Returns
+	 * the plugin itself for tenant-less jobs (FR-5 fallback), otherwise
+	 * the per-tenant view from `plugin.bindToTenant`.
+	 */
+	private async resolveBinding(job: PgBossJobView): Promise<IJobRuntimeProvider> {
+		const tenantId = extractTenantId(job);
+		if (!tenantId) {
+			return this.plugin;
+		}
+		const snapshot = this.resolveSnapshot
+			? await this.resolveSnapshot(tenantId)
+			: syntheticSnapshot(tenantId);
+		const bound = this.plugin.bindToTenant(snapshot);
+		return bound ?? this.plugin;
+	}
+
+	private async stopAll(): Promise<void> {
+		if (!this.started) return;
+		this.started = false;
+		const ids = this.subscriptionIds;
+		this.subscriptionIds = [];
+		await this.opts.boss.stop({ graceful: true }).catch(() => {
+			// Operator may have already stopped pg-boss; swallow.
+		});
+		void ids;
+	}
+
+	/** Number of registrations — useful for tests/metrics. */
+	get registrationCount(): number {
+		return this.registrations.length;
+	}
+}

--- a/packages/plugins/job-runtime-temporal/src/__tests__/temporal-tenant-isolation.spec.ts
+++ b/packages/plugins/job-runtime-temporal/src/__tests__/temporal-tenant-isolation.spec.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import type { IJobRuntimeProvider, TenantCredentialSnapshot } from '@ever-works/plugin';
+import { TemporalJobRuntimePlugin, type TemporalTenantBindingView } from '../temporal-job-runtime.plugin.js';
+import { TenantAwareTemporalWorkerHostFactory } from '../temporal-tenant-aware-worker-host-factory.js';
+import type { TemporalWorker } from '../temporal-types.js';
+
+class FakeWorker implements TemporalWorker {
+	static instances: FakeWorker[] = [];
+	runResolver: (() => void) | null = null;
+	runPromise: Promise<void>;
+	shutdownCount = 0;
+	constructor(public readonly tenantId: string, public readonly taskQueue: string, public readonly binding: IJobRuntimeProvider) {
+		FakeWorker.instances.push(this);
+		this.runPromise = new Promise<void>((resolve) => {
+			this.runResolver = resolve;
+		});
+	}
+	run() {
+		return this.runPromise;
+	}
+	async shutdown() {
+		this.shutdownCount += 1;
+		this.runResolver?.();
+	}
+}
+
+function makeSnapshot(tenantId: string, namespace: string, credentialVersion = 1): TenantCredentialSnapshot {
+	return {
+		tenantId,
+		providerId: 'temporal',
+		credentialVersion,
+		credentials: { namespace }
+	};
+}
+
+describe('TenantAwareTemporalWorkerHostFactory', () => {
+	it('register accumulates without instantiation', () => {
+		FakeWorker.instances = [];
+		const plugin = new TemporalJobRuntimePlugin();
+		const f = new TenantAwareTemporalWorkerHostFactory({ plugin });
+		f.register({
+			tenantId: 'tenant-a',
+			taskQueue: 'ew',
+			build: async (binding) => new FakeWorker('tenant-a', 'ew', binding)
+		});
+		f.register({
+			tenantId: 'tenant-b',
+			taskQueue: 'ew',
+			build: async (binding) => new FakeWorker('tenant-b', 'ew', binding)
+		});
+		expect(f.registrationCount).toBe(2);
+		expect(FakeWorker.instances).toHaveLength(0);
+	});
+
+	it('start materialises one worker per tenant, each with its own binding', async () => {
+		FakeWorker.instances = [];
+		const plugin = new TemporalJobRuntimePlugin();
+		const snapshots: Record<string, TenantCredentialSnapshot> = {
+			'tenant-a': makeSnapshot('tenant-a', 'ns-a'),
+			'tenant-b': makeSnapshot('tenant-b', 'ns-b')
+		};
+		const f = new TenantAwareTemporalWorkerHostFactory({
+			plugin,
+			resolveSnapshot: (tenantId) => snapshots[tenantId]
+		});
+		f.register({
+			tenantId: 'tenant-a',
+			taskQueue: 'ew-a',
+			build: async (binding) => new FakeWorker('tenant-a', 'ew-a', binding)
+		});
+		f.register({
+			tenantId: 'tenant-b',
+			taskQueue: 'ew-b',
+			build: async (binding) => new FakeWorker('tenant-b', 'ew-b', binding)
+		});
+
+		await f.start();
+
+		expect(FakeWorker.instances).toHaveLength(2);
+		const [workerA, workerB] = FakeWorker.instances;
+		expect(workerA.tenantId).toBe('tenant-a');
+		expect(workerA.taskQueue).toBe('ew-a');
+		expect(workerA.binding).toBeDefined();
+		expect((workerA.binding as TemporalTenantBindingView).tenantNamespace).toBe('ns-a');
+		expect((workerA.binding as TemporalTenantBindingView).tenantSnapshot.tenantId).toBe('tenant-a');
+
+		expect(workerB.tenantId).toBe('tenant-b');
+		expect(workerB.taskQueue).toBe('ew-b');
+		expect((workerB.binding as TemporalTenantBindingView).tenantNamespace).toBe('ns-b');
+		expect((workerB.binding as TemporalTenantBindingView).tenantSnapshot.tenantId).toBe('tenant-b');
+	});
+
+	it('tenant A and tenant B yield distinct bindings (memoised per tenant)', async () => {
+		FakeWorker.instances = [];
+		const plugin = new TemporalJobRuntimePlugin();
+		const snapshots: Record<string, TenantCredentialSnapshot> = {
+			'tenant-a': makeSnapshot('tenant-a', 'ns-a'),
+			'tenant-b': makeSnapshot('tenant-b', 'ns-b')
+		};
+		const f = new TenantAwareTemporalWorkerHostFactory({
+			plugin,
+			resolveSnapshot: (tenantId) => snapshots[tenantId]
+		});
+		f.register({
+			tenantId: 'tenant-a',
+			taskQueue: 'ew',
+			build: async (binding) => new FakeWorker('tenant-a', 'ew', binding)
+		});
+		f.register({
+			tenantId: 'tenant-b',
+			taskQueue: 'ew',
+			build: async (binding) => new FakeWorker('tenant-b', 'ew', binding)
+		});
+
+		await f.start();
+		const [workerA, workerB] = FakeWorker.instances;
+		// Distinct binding views per tenant.
+		expect(workerA.binding).not.toBe(workerB.binding);
+		// Same snapshot through plugin.bindToTenant returns the SAME view
+		// (memoised on (tenantId, credentialVersion) per the
+		// `IJobRuntimeProvider.bindToTenant` idempotency clause).
+		const reboundA = plugin.bindToTenant(snapshots['tenant-a']);
+		expect(reboundA).toBe(workerA.binding);
+	});
+
+	it('handle.stop() shuts down all workers + awaits run promises (idempotent)', async () => {
+		FakeWorker.instances = [];
+		const plugin = new TemporalJobRuntimePlugin();
+		const f = new TenantAwareTemporalWorkerHostFactory({
+			plugin,
+			resolveSnapshot: (tenantId) => makeSnapshot(tenantId, `ns-${tenantId}`)
+		});
+		f.register({
+			tenantId: 'tenant-a',
+			taskQueue: 'ew',
+			build: async (binding) => new FakeWorker('tenant-a', 'ew', binding)
+		});
+		f.register({
+			tenantId: 'tenant-b',
+			taskQueue: 'ew',
+			build: async (binding) => new FakeWorker('tenant-b', 'ew', binding)
+		});
+
+		const handle = await f.start();
+		await handle.stop();
+		expect(FakeWorker.instances.every((w) => w.shutdownCount === 1)).toBe(true);
+		// Second stop is a no-op (idempotent).
+		await expect(handle.stop()).resolves.toBeUndefined();
+		expect(FakeWorker.instances.every((w) => w.shutdownCount === 1)).toBe(true);
+	});
+
+	it('AbortSignal triggers stopAll', async () => {
+		FakeWorker.instances = [];
+		const plugin = new TemporalJobRuntimePlugin();
+		const f = new TenantAwareTemporalWorkerHostFactory({
+			plugin,
+			resolveSnapshot: (tenantId) => makeSnapshot(tenantId, `ns-${tenantId}`)
+		});
+		f.register({
+			tenantId: 'tenant-a',
+			taskQueue: 'ew',
+			build: async (binding) => new FakeWorker('tenant-a', 'ew', binding)
+		});
+
+		const ctrl = new AbortController();
+		await f.start({ signal: ctrl.signal });
+		ctrl.abort();
+		await new Promise((r) => setImmediate(r));
+		expect(FakeWorker.instances[0].shutdownCount).toBeGreaterThan(0);
+	});
+
+	it('register-after-start throws; double-start throws', async () => {
+		FakeWorker.instances = [];
+		const plugin = new TemporalJobRuntimePlugin();
+		const f = new TenantAwareTemporalWorkerHostFactory({
+			plugin,
+			resolveSnapshot: (tenantId) => makeSnapshot(tenantId, `ns-${tenantId}`)
+		});
+		f.register({
+			tenantId: 'tenant-a',
+			taskQueue: 'ew',
+			build: async (binding) => new FakeWorker('tenant-a', 'ew', binding)
+		});
+		await f.start();
+		expect(() =>
+			f.register({
+				tenantId: 'tenant-b',
+				taskQueue: 'ew',
+				build: async (binding) => new FakeWorker('tenant-b', 'ew', binding)
+			})
+		).toThrow(/cannot register/);
+		await expect(f.start()).rejects.toThrow(/start\(\) called twice/);
+	});
+});

--- a/packages/plugins/job-runtime-temporal/src/index.ts
+++ b/packages/plugins/job-runtime-temporal/src/index.ts
@@ -12,6 +12,11 @@ export {
 } from './temporal-enqueue-options.js';
 export type { MappedTemporalEnqueue } from './temporal-enqueue-options.js';
 export { TemporalWorkerHostFactory } from './temporal-worker-host-factory.js';
+export { TenantAwareTemporalWorkerHostFactory } from './temporal-tenant-aware-worker-host-factory.js';
+export type {
+	TenantAwareTemporalWorkerHostFactoryOptions,
+	TenantWorkerBuilder
+} from './temporal-tenant-aware-worker-host-factory.js';
 export type {
 	TemporalWorkflowClient,
 	TemporalWorkflowHandle,

--- a/packages/plugins/job-runtime-temporal/src/temporal-tenant-aware-worker-host-factory.ts
+++ b/packages/plugins/job-runtime-temporal/src/temporal-tenant-aware-worker-host-factory.ts
@@ -1,0 +1,154 @@
+import type {
+	IJobRuntimeProvider,
+	TenantCredentialSnapshot,
+	WorkerHostHandle,
+	WorkerHostOptions
+} from '@ever-works/plugin';
+import type { TemporalWorker } from './temporal-types.js';
+import type { TemporalJobRuntimePlugin } from './temporal-job-runtime.plugin.js';
+
+/**
+ * EW-742 P4 T27/T30/T32 — Temporal tenant-aware worker host factory.
+ *
+ * # Why this factory exists separately from `TemporalWorkerHostFactory`
+ *
+ * Temporal Activities receive their inputs as positional args, NOT a
+ * `job` object — there's no "BullMQ-style job.opts" to read tenantId
+ * off the running Activity. Per `providers.md` § Temporal + ADR-017 Q1,
+ * the tenant routing model is **one Worker per (tenant, taskQueue)**,
+ * each Worker bound to the right NAMESPACE via its `NativeConnection`
+ * at construction time.
+ *
+ * So this factory is a **registry mapper**, not a per-job router:
+ *
+ *   - The operator registers one `TenantWorkerBuilder` per tenant
+ *     (each carries its own `build(binding)` callback).
+ *   - On `start()` the factory iterates the registry, resolves the
+ *     tenant's `TenantCredentialSnapshot`, threads it through
+ *     `plugin.bindToTenant(snapshot)` to get the namespace-bound view,
+ *     and hands that binding to the operator's `build()` callback so
+ *     the resulting `Worker.create()` call can configure its
+ *     `NativeConnection` against the tenant's namespace.
+ *   - The shutdown path mirrors `TemporalWorkerHostFactory.stopAll`:
+ *     call `shutdown()` on every Worker AND await the `run()` promises
+ *     so graceful drain completes before the operator's bootstrap
+ *     returns.
+ *
+ * # Why an operator-supplied `build()` callback
+ *
+ * Same reason as `TemporalWorkerHostFactory`: `@temporalio/worker`
+ * carries native deps (`@temporalio/core-bridge`) that this plugin
+ * package intentionally does not depend on. The operator constructs
+ * the Worker just-in-time inside `build(binding)` so the heavy native
+ * import stays on the operator side.
+ */
+export interface TenantWorkerBuilder {
+	readonly tenantId: string;
+	readonly taskQueue: string;
+	/**
+	 * Operator-supplied build callback. Receives the tenant binding
+	 * (result of `plugin.bindToTenant(snapshot)`) so the operator's
+	 * `Worker.create()` call can configure its `NativeConnection`
+	 * against the tenant's namespace per ADR-017 Q1.
+	 */
+	build(binding: IJobRuntimeProvider): Promise<TemporalWorker>;
+}
+
+export interface TenantAwareTemporalWorkerHostFactoryOptions {
+	readonly plugin: TemporalJobRuntimePlugin;
+	/**
+	 * Resolve the per-tenant credential snapshot. When omitted, a
+	 * synthetic snapshot is generated (`providerId: 'temporal'`,
+	 * `credentialVersion: 0`, empty `credentials`) so smoke-tests /
+	 * dev wiring still pass through `plugin.bindToTenant`. Production
+	 * operators are expected to supply this from their secrets store.
+	 */
+	readonly resolveSnapshot?: (
+		tenantId: string
+	) => TenantCredentialSnapshot | Promise<TenantCredentialSnapshot>;
+}
+
+export class TenantAwareTemporalWorkerHostFactory {
+	private readonly specs: TenantWorkerBuilder[] = [];
+	private workers: TemporalWorker[] = [];
+	private runPromises: Promise<void>[] = [];
+	private started = false;
+
+	constructor(private readonly opts: TenantAwareTemporalWorkerHostFactoryOptions) {}
+
+	/** Register one Worker spec for a given tenant. Throws after start(). */
+	register(spec: TenantWorkerBuilder): this {
+		if (this.started) {
+			throw new Error(
+				`TenantAwareTemporalWorkerHostFactory: cannot register tenant '${spec.tenantId}' ` +
+					`(taskQueue '${spec.taskQueue}') after start() — register all tenant workers ` +
+					`before plugin.startWorkerHost runs.`
+			);
+		}
+		this.specs.push(spec);
+		return this;
+	}
+
+	/**
+	 * Materialise one Worker per registered tenant via `spec.build(binding)`,
+	 * then run them all. Returned handle's `stop()` shuts down every
+	 * Worker AND awaits the `run()` promises (graceful drain).
+	 */
+	async start(hostOpts: WorkerHostOptions = {}): Promise<WorkerHostHandle> {
+		if (this.started) {
+			throw new Error('TenantAwareTemporalWorkerHostFactory: start() called twice — already running.');
+		}
+		this.started = true;
+
+		const workers: TemporalWorker[] = [];
+		for (const spec of this.specs) {
+			const snapshot = await this.resolveSnapshot(spec.tenantId);
+			const binding = this.opts.plugin.bindToTenant(snapshot);
+			workers.push(await spec.build(binding));
+		}
+		this.workers = workers;
+		// Temporal's `Worker.run()` returns a Promise that resolves on
+		// shutdown. Capture them so stop() can await graceful drain.
+		this.runPromises = workers.map((w) => w.run());
+
+		if (hostOpts.signal) {
+			const signal = hostOpts.signal;
+			const onAbort = () => {
+				void this.stopAll();
+			};
+			if (signal.aborted) onAbort();
+			else signal.addEventListener('abort', onAbort, { once: true });
+		}
+
+		return { stop: () => this.stopAll() };
+	}
+
+	get registrationCount(): number {
+		return this.specs.length;
+	}
+
+	private async resolveSnapshot(tenantId: string): Promise<TenantCredentialSnapshot> {
+		if (this.opts.resolveSnapshot) {
+			return this.opts.resolveSnapshot(tenantId);
+		}
+		return {
+			tenantId,
+			providerId: 'temporal',
+			credentialVersion: 0,
+			credentials: {}
+		};
+	}
+
+	private async stopAll(): Promise<void> {
+		if (!this.started) return;
+		this.started = false;
+		const workers = this.workers;
+		const runs = this.runPromises;
+		this.workers = [];
+		this.runPromises = [];
+		// `shutdown()` is sync in older worker versions; await unconditionally.
+		await Promise.allSettled(workers.map((w) => Promise.resolve(w.shutdown())));
+		// Then wait for `.run()` promises to settle (graceful drain).
+		await Promise.allSettled(runs);
+	}
+}


### PR DESCRIPTION
Adds TenantAware{Plugin}WorkerHostFactory / TenantAwareInngestFunctionHandler to all 4 non-Trigger plugins.

## Design

Routing follows the T31 stamping convention:
- BullMQ: `job.opts.tenantId` (with `job.data._ew.tenantId` fallback)
- pg-boss: `job.data._ew.tenantId` (batched workers iterate per-job)
- Temporal: registry mapper — one Worker per tenant, operator's `build(binding)` callback receives the tenant binding so it can configure NativeConnection against the right namespace per ADR-017 Q1
- Inngest: `event.data._ew.tenantId` HOF wrapper (serverless; no worker host process)

Fail-open per FR-5: missing tenantId → handler receives plugin itself as binding.

## Tests (T32 — mocks only)

Per-plugin tenant isolation specs verifying: route A → A's binding, route B → distinct binding, concurrent A+B no cross-contamination, missing-tenantId fallback, resolveSnapshot called per tenant with bindings memoised by `plugin.bindToTenant`, plus per-provider extras (pg-boss batch routing, Inngest preserve-return-value/propagate-errors, Temporal registry lifecycle).

Test totals: bullmq 117 (+6), pgboss 114 (+6), temporal 119 (+6), inngest 109 (+7) — 459 green across the 4 packages. tsc + tsup + DTS clean.

Mocks-only; never instantiates real bullmq/pg-boss/@temporalio/inngest. Real-infra T32 isolation tests remain gated on CI per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-tenant isolation support across BullMQ, Inngest, PgBoss, and Temporal job runtime plugins
  * Jobs are now routed to tenant-specific runtime bindings with proper credential handling and memoization
  * Concurrent jobs from different tenants maintain isolated execution contexts

* **Tests**
  * Added comprehensive tenant isolation test suites for all job runtime plugins

<!-- end of auto-generated comment: release notes by coderabbit.ai -->