### PR TITLE
feat(tasks): wire buildJobRuntimeProviders into TriggerModule (EW-685 T4 cutover)

### DIFF
--- a/packages/agent/src/tasks/__tests__/job-runtime.providers.spec.ts
+++ b/packages/agent/src/tasks/__tests__/job-runtime.providers.spec.ts
@@ -208,6 +208,29 @@ describe('job-runtime.providers (EW-685 P0 T4 binding factory)', () => {
             }
         });
 
+        it('symbols filter binds only the requested subset (EW-685 T4 partial cutover)', () => {
+            // The TriggerModule cutover passes 8 of the 11 symbols because
+            // the remaining 3 (KB_NORMALIZE_MEDIA / KB_TRANSCRIBE /
+            // KB_REEMBED_WORK) are bound in works.module.ts under custom
+            // Trigger.dev SDK adapters with their own soft-error contracts.
+            // The factory must honour the subset and return EXACTLY those
+            // providers — no fewer, no more.
+            const subset: readonly symbol[] = [
+                WORK_GENERATION_DISPATCHER,
+                WORK_IMPORT_DISPATCHER,
+                TEMPLATE_CUSTOMIZATION_DISPATCHER,
+            ];
+            const providers = buildJobRuntimeProviders({ symbols: subset });
+            expect(providers).toHaveLength(3);
+            const provideTokens = new Set(providers.map((p) => (p as { provide: symbol }).provide));
+            expect(provideTokens).toEqual(new Set(subset));
+        });
+
+        it('symbols filter with empty array binds nothing', () => {
+            const providers = buildJobRuntimeProviders({ symbols: [] });
+            expect(providers).toEqual([]);
+        });
+
         it('reflects later register() calls — providers are resolved per-call, not memoised', () => {
             // If the factory cached the active provider at module-init
             // time, the EW-742 P3 tenant-aware resolver (which dispatches

--- a/packages/agent/src/tasks/index.ts
+++ b/packages/agent/src/tasks/index.ts
@@ -50,14 +50,19 @@ export * from './tenant-credential.cache';
 // barrel so DI modules (e.g. `TenantJobRuntimeModule` for EW-742 P3 /
 // EW-747) can bind `{ provide: JOB_RUNTIME_PROVIDER_REGISTRY, useClass:
 // InMemoryJobRuntimeProviderRegistry }` without reaching into
-// `./job-runtime.providers` directly. `buildJobRuntimeProviders()` stays
-// behind the file boundary because it's a one-shot module-wiring helper,
-// not a DI consumer entry point.
+// `./job-runtime.providers` directly. EW-685 T4 cutover added
+// `buildJobRuntimeProviders` to the export set so TriggerModule can
+// replace its 8 direct `useExisting: TriggerService` dispatcher
+// bindings with the registry-backed factory output.
 export {
     InMemoryJobRuntimeProviderRegistry,
     JOB_RUNTIME_PROVIDER_REGISTRY,
+    buildJobRuntimeProviders,
 } from './job-runtime.providers';
-export type { JobRuntimeProviderRegistry } from './job-runtime.providers';
+export type {
+    JobRuntimeProviderRegistry,
+    BuildJobRuntimeProvidersOptions,
+} from './job-runtime.providers';
 
 // EW-742 P3 / EW-747 (T20 + T23) — tenant-aware job-runtime resolver.
 // Wraps the EW-685 binding factory registry so callers can resolve the

--- a/packages/agent/src/tasks/job-runtime.providers.ts
+++ b/packages/agent/src/tasks/job-runtime.providers.ts
@@ -176,12 +176,38 @@ const DISPATCHER_SYMBOLS: readonly symbol[] = [
  * Provider arity is pinned at 11 — one per entry in {@link DISPATCHER_SYMBOLS}
  * — and verified by `__tests__/job-runtime.providers.spec.ts`.
  *
- * @returns A frozen NestJS `Provider[]` ready to be spread into a module's
- *   `providers` array. Currently no module imports it; see the file
- *   header "Critical constraint — declared but NOT wired in this PR".
+ * @param opts Optional `symbols` filter — when supplied, only those
+ *   tokens are bound (the rest stay wherever the operator's module
+ *   tree binds them today). Used by the EW-685 T4 partial cutover in
+ *   `packages/tasks/src/trigger/trigger.module.ts` to swap the 8
+ *   TriggerService-owned dispatchers onto the registry while leaving
+ *   `KB_NORMALIZE_MEDIA_DISPATCHER` / `KB_TRANSCRIBE_DISPATCHER` /
+ *   `KB_REEMBED_WORK_DISPATCHER` in `apps/api/src/works/works.module.ts`
+ *   under their existing soft-error custom adapters (each calls
+ *   `@trigger.dev/sdk` directly + returns `null` on dispatch failure
+ *   — a contract the binding-factory path doesn't yet model).
+ *   Default is the full set (all 11 — used by tests + by a future
+ *   PR that consolidates the 3 stragglers into TriggerService).
+ *
+ * @returns A frozen NestJS `Provider[]` ready to be spread into a
+ *   module's `providers` array. EW-685 T4 cutover landed in
+ *   `trigger.module.ts` with the 8-symbol subset; the 3 remaining
+ *   bindings are pending consolidation per the JSDoc on the `symbols`
+ *   option above.
  */
-export function buildJobRuntimeProviders(): Provider[] {
-    return DISPATCHER_SYMBOLS.map((token) => ({
+export interface BuildJobRuntimeProvidersOptions {
+    /**
+     * Subset of `DISPATCHER_SYMBOLS` to bind. When omitted, all 11 are
+     * bound (default — used by the conformance spec + by a future
+     * PR that consolidates the 3 currently-custom-adapter symbols
+     * under TriggerService).
+     */
+    readonly symbols?: readonly symbol[];
+}
+
+export function buildJobRuntimeProviders(opts: BuildJobRuntimeProvidersOptions = {}): Provider[] {
+    const symbols = opts.symbols ?? DISPATCHER_SYMBOLS;
+    return symbols.map((token) => ({
         provide: token,
         // Cast through `unknown` because each `*_DISPATCHER` symbol expects
         // a concrete dispatcher shape but the registry hands back the

--- a/packages/tasks/src/trigger/trigger.module.ts
+++ b/packages/tasks/src/trigger/trigger.module.ts
@@ -10,6 +10,9 @@ import {
     KB_BACKFILL_SKELETON_DISPATCHER,
     KB_EMBED_DOCUMENT_DISPATCHER,
     KB_ORG_OVERLAY_FANOUT_DISPATCHER,
+    JOB_RUNTIME_PROVIDER_REGISTRY,
+    InMemoryJobRuntimeProviderRegistry,
+    buildJobRuntimeProviders,
 } from '@ever-works/agent/tasks';
 import {
     NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
@@ -17,57 +20,79 @@ import {
     type NotificationChannelDeliveryPayload,
 } from '@ever-works/agent/facades';
 
+/**
+ * EW-685 T4 cutover — the 8 dispatcher symbols TriggerModule owns. The
+ * remaining 3 (`KB_NORMALIZE_MEDIA_DISPATCHER`, `KB_TRANSCRIBE_DISPATCHER`,
+ * `KB_REEMBED_WORK_DISPATCHER`) are bound separately in
+ * `apps/api/src/works/works.module.ts` under custom Trigger.dev SDK
+ * adapters with soft-error contracts (each call returns `null` on
+ * dispatch failure → the slice-5 reconciliation cron catches the drift).
+ * Consolidating those 3 onto TriggerService.dispatchers — and thus
+ * routing them through this same factory — is a follow-up PR; the partial
+ * cutover here proves the architecture without touching the
+ * soft-error path.
+ */
+const TRIGGER_OWNED_DISPATCHER_SYMBOLS = [
+    WORK_GENERATION_DISPATCHER,
+    WORK_IMPORT_DISPATCHER,
+    TEMPLATE_CUSTOMIZATION_DISPATCHER,
+    WEBHOOK_DELIVERY_DISPATCHER,
+    KB_MIRROR_DOCUMENT_DISPATCHER,
+    KB_BACKFILL_SKELETON_DISPATCHER,
+    KB_EMBED_DOCUMENT_DISPATCHER,
+    KB_ORG_OVERLAY_FANOUT_DISPATCHER,
+] as const;
+
 @Global()
 @Module({
     providers: [
         TriggerService,
-        // EW-686 P1 — adapter exposing TriggerService through the new
-        // pluggable IJobRuntimeProvider contract. Registered here so the
-        // EW-685 T4 binding factory (a follow-up PR introducing
-        // `packages/agent/src/tasks/job-runtime.providers.ts`) can inject
-        // it by class. The existing `*_DISPATCHER` direct bindings below
-        // stay untouched — the factory replaces them in a later PR; until
-        // then the synthetic adapter and the direct bindings coexist
-        // without conflict (the adapter delegates back into the same
-        // TriggerService instance).
+        // EW-686 P1 — adapter exposing TriggerService through the
+        // pluggable IJobRuntimeProvider contract. The registry below
+        // registers it as the active provider at boot.
         TriggerJobRuntimeProvider,
+        // EW-685 T4 cutover — the in-memory registry + active-provider
+        // registration. `JOB_RUNTIME_PROVIDER_REGISTRY` is the DI token
+        // every `*_DISPATCHER` binding (below) injects through.
+        //
+        // Runtime no-op vs the old `useExisting: TriggerService` bindings:
+        // `TriggerService.dispatchers` is literally `this as unknown as
+        // JobRuntimeDispatchers` (see trigger.service.ts), so the
+        // resolved injection is the same TriggerService instance. Every
+        // existing `@Inject(WORK_GENERATION_DISPATCHER) dispatcher`
+        // continues to receive the same object — no call-site changes.
+        //
+        // What the indirection BUYS: when the EW-742 P3 tenant-aware
+        // resolver replaces `InMemoryJobRuntimeProviderRegistry` with a
+        // per-request resolver, the binding sites stay identical. And
+        // when the operator flips `EVER_WORKS_JOB_RUNTIME=bullmq`, the
+        // registry hands out the BullMQ provider's dispatchers map
+        // instead — without redeploying or editing this file.
         {
-            provide: WORK_GENERATION_DISPATCHER,
-            useExisting: TriggerService,
+            provide: JOB_RUNTIME_PROVIDER_REGISTRY,
+            useFactory: (adapter: TriggerJobRuntimeProvider) => {
+                const registry = new InMemoryJobRuntimeProviderRegistry();
+                registry.register(adapter);
+                return registry;
+            },
+            inject: [TriggerJobRuntimeProvider],
         },
-        {
-            provide: WORK_IMPORT_DISPATCHER,
-            useExisting: TriggerService,
-        },
-        {
-            provide: TEMPLATE_CUSTOMIZATION_DISPATCHER,
-            useExisting: TriggerService,
-        },
-        {
-            provide: WEBHOOK_DELIVERY_DISPATCHER,
-            useExisting: TriggerService,
-        },
-        {
-            provide: KB_MIRROR_DOCUMENT_DISPATCHER,
-            useExisting: TriggerService,
-        },
-        {
-            provide: KB_BACKFILL_SKELETON_DISPATCHER,
-            useExisting: TriggerService,
-        },
-        {
-            provide: KB_EMBED_DOCUMENT_DISPATCHER,
-            useExisting: TriggerService,
-        },
-        {
-            provide: KB_ORG_OVERLAY_FANOUT_DISPATCHER,
-            useExisting: TriggerService,
-        },
+        // EW-685 T4 cutover — the 8 dispatcher symbols TriggerModule owns,
+        // now bound via the registry. See TRIGGER_OWNED_DISPATCHER_SYMBOLS
+        // header for the deferred 3.
+        ...buildJobRuntimeProviders({ symbols: TRIGGER_OWNED_DISPATCHER_SYMBOLS }),
         // Notifications v2 (EW-663) — the facade's delivery dispatcher
         // contract is `enqueue(payload) → { runId }`, so a thin adapter
         // bridges to TriggerService.dispatchNotificationChannelDelivery
         // (which returns the run id, or null when Trigger is disabled →
         // the facade falls back to in-process delivery).
+        //
+        // NOT routed through the binding factory because its method
+        // shape (`enqueue` returning `{ runId }`) differs from the
+        // `JobRuntimeDispatchers` `dispatchXxx → string | null` shape
+        // every other `*_DISPATCHER` symbol exposes. Migrating it
+        // onto the registry would require either widening the contract
+        // or adding a wrapper layer — neither is in scope here.
         {
             provide: NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
             useFactory: (trigger: TriggerService): NotificationChannelDeliveryDispatcher => ({
@@ -81,6 +106,9 @@ import {
     exports: [
         TriggerService,
         TriggerJobRuntimeProvider,
+        // The registry is exported so EW-742 P3 (tenant-aware resolver)
+        // can replace it without re-importing the whole TriggerModule.
+        JOB_RUNTIME_PROVIDER_REGISTRY,
         WORK_GENERATION_DISPATCHER,
         WORK_IMPORT_DISPATCHER,
         TEMPLATE_CUSTOMIZATION_DISPATCHER,


### PR DESCRIPTION
Partial cutover — replaces the 8 direct `useExisting: TriggerService` dispatcher bindings in TriggerModule with the registry-backed factory output.

## Runtime no-op

`TriggerService.dispatchers = this as unknown as JobRuntimeDispatchers` so the resolved injection through the registry is the same TriggerService instance every existing call site already receives. Zero call-site changes; zero behaviour change.

## What the indirection buys

- EW-742 P3 tenant-aware resolver can swap `InMemoryJobRuntimeProviderRegistry` for a per-request resolver without touching the binding sites
- Operator can flip `EVER_WORKS_JOB_RUNTIME=bullmq` and the registry hands out BullMQ's dispatchers — without redeploying or editing trigger.module.ts

## Symbols filter (new API)

`buildJobRuntimeProviders({ symbols?: readonly symbol[] })` — when supplied, only those tokens are bound. TriggerModule passes 8; the remaining 3 (KB_NORMALIZE_MEDIA / KB_TRANSCRIBE / KB_REEMBED_WORK) stay in works.module.ts under their existing soft-error custom Trigger.dev SDK adapters (each returns `null` on dispatch failure — a contract the binding-factory path doesn't yet model). Consolidating those 3 onto TriggerService.dispatchers is a follow-up.

NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER stays as a custom adapter because its method shape differs.

## Tests

job-runtime.providers suite: 14/14 (+2 new). packages/agent build clean. packages/tasks build clean. Pre-existing apps/api trigger-internal failures unchanged (ESM config drift, predates this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for job runtime provider initialization with different configuration options.

* **Refactor**
  * Enhanced job runtime provider binding to support selective, granular initialization of job components.
  * Improved registry export capabilities for better downstream module integration and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->