### PR TITLE
feat(plugin): @ever-works/job-runtime-trigger-plugin (EW-686 P2)

### DIFF
--- a/packages/plugins/job-runtime-trigger/README.md
+++ b/packages/plugins/job-runtime-trigger/README.md
@@ -1,0 +1,125 @@
+# @ever-works/job-runtime-trigger-plugin
+
+Trigger.dev `IJobRuntimeProvider` plugin for the Ever Works platform — canonical pluggable form of the `trigger` runtime, peer of the BullMQ / pg-boss / Temporal / Inngest plugins.
+
+> **Note:** The synthetic `TriggerJobRuntimeProvider` shim at `packages/tasks/src/trigger/` stays as the operator's NestJS-bound reference implementation (wired directly into `TriggerModule` for the in-monorepo API). This package is the canonical pluggable form that the standard plugin pipeline discovers via the `everworks.plugin` manifest block.
+
+## Plugin metadata
+
+| Field        | Value                                                                                                                       |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| ID           | `job-runtime-trigger`                                                                                                       |
+| Category     | `job-runtime`                                                                                                               |
+| Capabilities | `job-runtime-enqueue`, `job-runtime-cancel`, `job-runtime-status`, `job-runtime-schedule`, `job-runtime-bind-tenant`        |
+| Runtime id   | `trigger` (selected via `EVER_WORKS_JOB_RUNTIME=trigger`)                                                                   |
+| License      | AGPL-3.0                                                                                                                    |
+| Built-in     | yes                                                                                                                         |
+| Auto-enable  | no                                                                                                                          |
+
+## What this plugin ships
+
+- **Full `IJobRuntimeProvider` contract surface**.
+- **Real `bindToTenant`** with per-`(tenantId, credentialVersion)` memoisation. Exposes the per-tenant `projectAccessToken` on the bound view (`TriggerTenantBindingView`).
+- **Operator-pluggable real dispatchers** via `TriggerDispatcherFactory` (`dispatch`, `enqueue`, `cancel`). The plugin package itself does NOT depend on `@trigger.dev/sdk` — operators install and pin it.
+- **`mapTriggerEnqueueOptions`** — translator from platform `JobEnqueueOptions` onto Trigger.dev's native option carriers (`idempotencyKey`, `concurrencyKey`, `tags`, `maxDuration`, `machine`, `metadata.tenantId`).
+- **`mapTriggerStatus`** — projection from the Trigger.dev SDK v4 status enum onto the contract's 6-value `JobRunStatus` union, matching the in-repo reference implementation exactly.
+
+Trigger.dev is the **push-model** member of the family — Trigger.dev's cloud invokes the operator's deployed task package on its own machines. `startWorkerHost` intentionally stays a no-op even when operator hooks are wired (there is no worker process to start; mirrors Inngest).
+
+## Operator setup
+
+1. Install peer dep:
+   ```bash
+   pnpm add @trigger.dev/sdk
+   ```
+2. Configure env vars:
+   - `TRIGGER_SECRET_KEY` — server-side prod secret (`tr_prod_*`) used by `tasks.trigger`
+   - `TRIGGER_PROJECT_REF` — Trigger.dev project reference (e.g. `proj_abc123`)
+   - `TRIGGER_API_URL` (optional) — override for self-hosted Trigger.dev
+3. Set `EVER_WORKS_JOB_RUNTIME=trigger` on the API (this is the default).
+4. Build a `TriggerDispatcherFactory` from the SDK's module-level `tasks` / `runs` namespaces and wire dispatchers:
+
+   ```ts
+   import { runs, tasks } from '@trigger.dev/sdk';
+   import {
+       TriggerJobRuntimePlugin,
+       TriggerDispatcherFactory
+   } from '@ever-works/job-runtime-trigger-plugin';
+
+   // Trigger.dev v4 — the SDK reads TRIGGER_SECRET_KEY from env, and the
+   // `tasks` / `runs` namespaces are imported as module-level objects.
+   // The plugin only needs a structural { tasks, runs } client.
+   const client = { tasks, runs };
+   const factory = new TriggerDispatcherFactory({
+       client,
+       defaultTaskQueue: 'platform-default'
+   });
+
+   const plugin = new TriggerJobRuntimePlugin({ client })
+       .useDispatchers({
+           dispatchKbEmbedDocument: (payload) =>
+               factory.enqueue('kb-embed-document', payload, { tags: ['kb'] })
+       })
+       .useDispatcherFactory(factory);
+   ```
+
+   The plugin's own `cancel` / `getRunStatus` calls into `client.runs.cancel` / `client.runs.retrieve` when the optional `client` opt is set; without it they return safe defaults (`false` / `'unknown'`) and operators call `factory.cancel(runId)` directly.
+
+## Tenant overlay (EW-742)
+
+> **Per-tenant projects required for BYO/override.** Per [`providers.md` § Trigger.dev](../../../docs/specs/features/tenant-job-runtime-overlay/providers.md#triggerdev), the Trigger.dev SDK is project-scoped — there's no in-process per-call project switching. BYO and override modes both require the operator to maintain one Trigger.dev project per tenant (auto-provisioned in `inherit / per-tenant`, tenant-supplied in `byo`).
+
+| Mode       | Behaviour                                                                                                                   |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `inherit`  | (default) Use the operator's instance-default Trigger.dev project. In `shared` sub-mode, tenant id stamps onto `metadata.tenantId` / run tag for demultiplexing. |
+| `byo`      | Tenant supplies their own `projectRef` + `projectAccessToken`. Per-tenant webhook URL: `POST /api/jobs/webhook/<tenant-id>/trigger-dev`. |
+| `override` | Same data plane as BYO — UI distinction only (one-click "use my own Trigger.dev project").                                  |
+
+### Tenant credential bag shape
+
+```jsonc
+{
+    "projectRef": "proj_...",           // tenant project reference
+    "projectAccessToken": "tr_prod_..." // tenant prod secret (server-side)
+}
+```
+
+Surface on the view as `tenantProjectAccessToken`.
+
+### Per-tenant routing constraints
+
+Trigger.dev's SDK pins to a single project at module load — there is no in-process project switching. For BYO/override:
+
+1. Build one `{ tasks, runs }` client per tenant project (each constructed against the tenant's `projectAccessToken`).
+2. Thread per-tenant `TriggerDispatcherFactory` instances via `dispatchersBuilder` so `bindToTenant(snapshot)` views route to the right Trigger.dev project.
+3. Per-tenant webhook URLs (`/api/jobs/webhook/<tenant-id>/trigger-dev`) handle inbound invocations — the operator's tenant resolver loads the overlay from the path segment and validates the signature against the tenant's `projectAccessToken`.
+
+### Per-provider gotchas
+
+- The operator PAT (`tr_pat_*`) can **create** projects via `POST /api/v1/orgs/{orgId}/projects` but **cannot** read the resulting `tr_prod_*` secret — it must be copied from the dashboard. This breaks the zero-touch promise of `inherit / per-tenant`; see `providers.md` § Trigger.dev for the worker-self-registration workaround.
+- Per-project rate limits apply at the Trigger.dev account level; large `inherit / per-tenant` deployments must monitor org-wide project counts.
+
+### Cross-references
+
+- Tenant overlay spec: [`docs/specs/features/tenant-job-runtime-overlay/spec.md`](../../../docs/specs/features/tenant-job-runtime-overlay/spec.md)
+- Per-provider matrix: [`docs/specs/features/tenant-job-runtime-overlay/providers.md` § Trigger.dev](../../../docs/specs/features/tenant-job-runtime-overlay/providers.md#triggerdev)
+- ADR-017 (per-tenant project constraint): [`docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md`](../../../docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md)
+- Conformance suites: `src/__tests__/trigger-conformance.spec.ts` runs `runJobRuntimeContractSuite`; `src/__tests__/trigger-tenant-conformance.spec.ts` runs `runJobRuntimeTenantContractSuite`.
+
+## Local development
+
+```bash
+pnpm install
+pnpm --filter @ever-works/job-runtime-trigger-plugin build
+pnpm --filter @ever-works/job-runtime-trigger-plugin test
+```
+
+## Documentation
+
+- [Ever Works documentation](https://docs.ever.works)
+- [Trigger.dev documentation](https://trigger.dev/docs)
+- [Plugin system](../../plugin/README.md)
+
+## License
+
+AGPL-3.0

--- a/packages/plugins/job-runtime-trigger/package.json
+++ b/packages/plugins/job-runtime-trigger/package.json
@@ -1,0 +1,53 @@
+{
+	"name": "@ever-works/job-runtime-trigger-plugin",
+	"version": "1.0.0",
+	"description": "Trigger.dev IJobRuntimeProvider plugin for Ever Works — canonical pluggable form of the trigger runtime, peer to BullMQ/pg-boss/Temporal/Inngest plugins. Per-task dispatching is operator-provisioned (operator pins @trigger.dev/sdk and wires per-payload-type tasks).",
+	"author": { "name": "Ever Co. LTD", "email": "ever@ever.co", "url": "https://ever.co" },
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js", "require": "./dist/index.cjs" } },
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": { "@ever-works/plugin": "workspace:*" },
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "job-runtime-trigger",
+			"name": "Trigger.dev Job Runtime",
+			"version": "1.0.0",
+			"category": "job-runtime",
+			"capabilities": [
+				"job-runtime-enqueue",
+				"job-runtime-cancel",
+				"job-runtime-status",
+				"job-runtime-schedule",
+				"job-runtime-bind-tenant"
+			],
+			"description": "Trigger.dev (https://trigger.dev) IJobRuntimeProvider — canonical pluggable form for the EW-742 tenant overlay. Implements bindToTenant via per-tenant project access tokens (BYO/override require per-tenant projects per ADR-017 providers.md § Trigger.dev). Per-task dispatchers throw 'not implemented' until the operator wires per-payload-type Trigger.dev tasks via TriggerDispatcherFactory.",
+			"author": { "name": "Ever Works Team" },
+			"license": "AGPL-3.0",
+			"autoEnable": false,
+			"systemPlugin": false,
+			"distribution": "core",
+			"builtIn": true,
+			"visibility": "operator",
+			"envVars": ["TRIGGER_SECRET_KEY", "TRIGGER_PROJECT_REF"]
+		}
+	}
+}

--- a/packages/plugins/job-runtime-trigger/src/__tests__/trigger-conformance.spec.ts
+++ b/packages/plugins/job-runtime-trigger/src/__tests__/trigger-conformance.spec.ts
@@ -1,0 +1,7 @@
+import { describe } from 'vitest';
+import { runJobRuntimeContractSuite } from '@ever-works/plugin/contracts-conformance';
+import { TriggerJobRuntimePlugin } from '../trigger-job-runtime.plugin.js';
+
+describe('TriggerJobRuntimePlugin — IJobRuntimeProvider conformance', () => {
+	runJobRuntimeContractSuite(() => new TriggerJobRuntimePlugin());
+});

--- a/packages/plugins/job-runtime-trigger/src/__tests__/trigger-dispatcher-factory.spec.ts
+++ b/packages/plugins/job-runtime-trigger/src/__tests__/trigger-dispatcher-factory.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TriggerDispatcherFactory } from '../trigger-dispatcher-factory.js';
+import type {
+	TriggerClient,
+	TriggerRunHandle,
+	TriggerRunRecord,
+	TriggerTaskOptions
+} from '../trigger-types.js';
+
+interface TriggerCall {
+	readonly taskId: string;
+	readonly payload: unknown;
+	readonly options?: TriggerTaskOptions;
+}
+
+class FakeTrigger implements TriggerClient {
+	triggerCalls: TriggerCall[] = [];
+	cancelCalls: string[] = [];
+	cancelShouldThrow = false;
+	private nextId = 1;
+
+	readonly tasks = {
+		trigger: async (
+			taskId: string,
+			payload: unknown,
+			options?: TriggerTaskOptions
+		): Promise<TriggerRunHandle> => {
+			this.triggerCalls.push({ taskId, payload, options });
+			return { id: `run_${this.nextId++}` };
+		}
+	};
+
+	readonly runs = {
+		cancel: async (runId: string): Promise<unknown> => {
+			this.cancelCalls.push(runId);
+			if (this.cancelShouldThrow) throw new Error('boom');
+			return undefined;
+		},
+		retrieve: async (runId: string): Promise<TriggerRunRecord> => ({
+			id: runId,
+			status: 'EXECUTING'
+		})
+	};
+}
+
+describe('TriggerDispatcherFactory', () => {
+	it('dispatch returns the run id and forwards the payload', async () => {
+		const client = new FakeTrigger();
+		const factory = new TriggerDispatcherFactory({ client });
+		const id = await factory.dispatch('kb-embed-document', { workId: 'w1' });
+		expect(id).toBe('run_1');
+		expect(client.triggerCalls).toEqual([
+			{ taskId: 'kb-embed-document', payload: { workId: 'w1' }, options: {} }
+		]);
+	});
+
+	it('dispatch applies defaultTaskQueue when no extra options', async () => {
+		const client = new FakeTrigger();
+		const factory = new TriggerDispatcherFactory({
+			client,
+			defaultTaskQueue: 'platform-default'
+		});
+		await factory.dispatch('kb-embed-document', { workId: 'w1' });
+		expect(client.triggerCalls[0].options).toEqual({ queue: 'platform-default' });
+	});
+
+	it('dispatch extra options shallow-merge over defaultTaskQueue', async () => {
+		const client = new FakeTrigger();
+		const factory = new TriggerDispatcherFactory({
+			client,
+			defaultTaskQueue: 'platform-default'
+		});
+		await factory.dispatch(
+			'kb-embed-document',
+			{ workId: 'w1' },
+			{ queue: 'override-q', tags: ['kb'] }
+		);
+		expect(client.triggerCalls[0].options).toEqual({
+			queue: 'override-q',
+			tags: ['kb']
+		});
+	});
+
+	it('dispatch returns null when SDK handle has no id', async () => {
+		const client = new FakeTrigger();
+		client.tasks.trigger = vi.fn(async () => ({}) as TriggerRunHandle);
+		const factory = new TriggerDispatcherFactory({ client });
+		await expect(factory.dispatch('t', {})).resolves.toBeNull();
+	});
+
+	it('cancel returns true on success and forwards the run id', async () => {
+		const client = new FakeTrigger();
+		const factory = new TriggerDispatcherFactory({ client });
+		await expect(factory.cancel('run_42')).resolves.toBe(true);
+		expect(client.cancelCalls).toEqual(['run_42']);
+	});
+
+	it('cancel returns false when the SDK throws', async () => {
+		const client = new FakeTrigger();
+		client.cancelShouldThrow = true;
+		const factory = new TriggerDispatcherFactory({ client });
+		await expect(factory.cancel('run_42')).resolves.toBe(false);
+	});
+
+	it('exposes the bound client read-only', () => {
+		const client = new FakeTrigger();
+		const factory = new TriggerDispatcherFactory({ client });
+		expect(factory.client).toBe(client);
+	});
+});

--- a/packages/plugins/job-runtime-trigger/src/__tests__/trigger-enqueue-options.spec.ts
+++ b/packages/plugins/job-runtime-trigger/src/__tests__/trigger-enqueue-options.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import { mapEnqueueOptions } from '../trigger-enqueue-options.js';
+import { TriggerDispatcherFactory } from '../trigger-dispatcher-factory.js';
+import type {
+	TriggerClient,
+	TriggerRunHandle,
+	TriggerRunRecord,
+	TriggerTaskOptions
+} from '../trigger-types.js';
+
+describe('mapEnqueueOptions (EW-742 P4 T31 Trigger.dev stamping)', () => {
+	it('idempotencyKey → idempotencyKey', () => {
+		expect(mapEnqueueOptions({ idempotencyKey: 'idem-1' })).toEqual({
+			options: { idempotencyKey: 'idem-1' }
+		});
+	});
+
+	it('tenantId → metadata.tenantId', () => {
+		expect(mapEnqueueOptions({ tenantId: 't-acme' })).toEqual({
+			options: { metadata: { tenantId: 't-acme' } }
+		});
+	});
+
+	it('concurrencyKey → concurrencyKey (SDK native)', () => {
+		expect(mapEnqueueOptions({ concurrencyKey: 'work-7' })).toEqual({
+			options: { concurrencyKey: 'work-7' }
+		});
+	});
+
+	it('tags → tags (SDK native)', () => {
+		expect(mapEnqueueOptions({ tags: ['kb', 'embed'] })).toEqual({
+			options: { tags: ['kb', 'embed'] }
+		});
+	});
+
+	it('maxDurationSeconds → maxDuration', () => {
+		expect(mapEnqueueOptions({ maxDurationSeconds: 600 })).toEqual({
+			options: { maxDuration: 600 }
+		});
+	});
+
+	it('machineHint → machine (passed through verbatim)', () => {
+		expect(mapEnqueueOptions({ machineHint: 'small-2x' })).toEqual({
+			options: { machine: 'small-2x' }
+		});
+	});
+
+	it('empty input returns empty options', () => {
+		expect(mapEnqueueOptions({})).toEqual({ options: {} });
+	});
+
+	it('all fields together stamp the full Trigger.dev options bag', () => {
+		const opts: JobEnqueueOptions = {
+			idempotencyKey: 'idem-A',
+			tenantId: 'tenant-A',
+			concurrencyKey: 'work-A',
+			tags: ['kb'],
+			maxDurationSeconds: 600,
+			machineHint: 'medium-1x'
+		};
+		expect(mapEnqueueOptions(opts)).toEqual({
+			options: {
+				idempotencyKey: 'idem-A',
+				concurrencyKey: 'work-A',
+				tags: ['kb'],
+				maxDuration: 600,
+				machine: 'medium-1x',
+				metadata: { tenantId: 'tenant-A' }
+			}
+		});
+	});
+});
+
+interface TriggerCall {
+	readonly taskId: string;
+	readonly payload: unknown;
+	readonly options?: TriggerTaskOptions;
+}
+
+class FakeTrigger implements TriggerClient {
+	calls: TriggerCall[] = [];
+	private nextId = 1;
+	readonly tasks = {
+		trigger: async (
+			taskId: string,
+			payload: unknown,
+			options?: TriggerTaskOptions
+		): Promise<TriggerRunHandle> => {
+			this.calls.push({ taskId, payload, options });
+			return { id: `run_${this.nextId++}` };
+		}
+	};
+	readonly runs = {
+		cancel: async (): Promise<unknown> => undefined,
+		retrieve: async (runId: string): Promise<TriggerRunRecord> => ({
+			id: runId,
+			status: 'EXECUTING'
+		})
+	};
+}
+
+describe('TriggerDispatcherFactory.enqueue (EW-742 P4 T31)', () => {
+	it('stamps translated options onto tasks.trigger and returns the run id', async () => {
+		const client = new FakeTrigger();
+		const factory = new TriggerDispatcherFactory({ client });
+		const id = await factory.enqueue(
+			'kb-embed-document',
+			{ workId: 'w7' },
+			{ idempotencyKey: 'idem-1', tenantId: 't-acme', tags: ['kb'] }
+		);
+		expect(id).toBe('run_1');
+		expect(client.calls[0].taskId).toBe('kb-embed-document');
+		expect(client.calls[0].payload).toEqual({ workId: 'w7' });
+		expect(client.calls[0].options).toEqual({
+			idempotencyKey: 'idem-1',
+			tags: ['kb'],
+			metadata: { tenantId: 't-acme' }
+		});
+	});
+
+	it('applies defaultTaskQueue when neither mapped nor extra override queue', async () => {
+		const client = new FakeTrigger();
+		const factory = new TriggerDispatcherFactory({
+			client,
+			defaultTaskQueue: 'platform-default'
+		});
+		await factory.enqueue('evt', { x: 1 }, { idempotencyKey: 'idem' });
+		expect(client.calls[0].options).toEqual({
+			queue: 'platform-default',
+			idempotencyKey: 'idem'
+		});
+	});
+
+	it('extraOptions shallow-merge OVER mapped translation (operator wins)', async () => {
+		const client = new FakeTrigger();
+		const factory = new TriggerDispatcherFactory({ client });
+		await factory.enqueue(
+			'evt',
+			{},
+			{ idempotencyKey: 'idem-platform', machineHint: 'small-1x' },
+			{ machine: 'large-1x' }
+		);
+		expect(client.calls[0].options).toEqual({
+			idempotencyKey: 'idem-platform',
+			machine: 'large-1x'
+		});
+	});
+
+	it('dispatch() path is unchanged', async () => {
+		const client = new FakeTrigger();
+		const factory = new TriggerDispatcherFactory({ client });
+		await factory.dispatch('evt', { hello: 'world' });
+		expect(client.calls[0]).toEqual({
+			taskId: 'evt',
+			payload: { hello: 'world' },
+			options: {}
+		});
+	});
+});

--- a/packages/plugins/job-runtime-trigger/src/__tests__/trigger-plugin-operator-hooks.spec.ts
+++ b/packages/plugins/job-runtime-trigger/src/__tests__/trigger-plugin-operator-hooks.spec.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import type { JobRuntimeDispatchers, TenantCredentialSnapshot } from '@ever-works/plugin';
+import {
+	TriggerDispatcherFactory,
+	TriggerDispatcherNotConfiguredError,
+	TriggerJobRuntimePlugin,
+	mapTriggerStatus
+} from '../index.js';
+import type {
+	TriggerClient,
+	TriggerRunHandle,
+	TriggerRunRecord,
+	TriggerTaskOptions
+} from '../trigger-types.js';
+
+class StubTrigger implements TriggerClient {
+	triggeredTasks: string[] = [];
+	cancelCalls: string[] = [];
+	retrieveCalls: string[] = [];
+	retrieveStatus = 'EXECUTING';
+	cancelShouldThrow = false;
+	retrieveShouldThrow = false;
+	private nextId = 1;
+
+	readonly tasks = {
+		trigger: async (
+			taskId: string,
+			_payload: unknown,
+			_options?: TriggerTaskOptions
+		): Promise<TriggerRunHandle> => {
+			this.triggeredTasks.push(taskId);
+			return { id: `run_${this.nextId++}` };
+		}
+	};
+
+	readonly runs = {
+		cancel: async (runId: string): Promise<unknown> => {
+			this.cancelCalls.push(runId);
+			if (this.cancelShouldThrow) throw new Error('boom');
+			return undefined;
+		},
+		retrieve: async (runId: string): Promise<TriggerRunRecord> => {
+			this.retrieveCalls.push(runId);
+			if (this.retrieveShouldThrow) throw new Error('boom');
+			return { id: runId, status: this.retrieveStatus };
+		}
+	};
+}
+
+const snapshot = (
+	overrides: Partial<TenantCredentialSnapshot> = {}
+): TenantCredentialSnapshot => ({
+	tenantId: '00000000-0000-0000-0000-00000000aaaa',
+	providerId: 'trigger',
+	credentialVersion: 1,
+	credentials: { projectAccessToken: 'tr_pat_tenant_a', projectRef: 'proj_a' },
+	...overrides
+});
+
+describe('TriggerJobRuntimePlugin — operator hooks', () => {
+	it('useDispatchers replaces the throwing stub', async () => {
+		const client = new StubTrigger();
+		const factory = new TriggerDispatcherFactory({ client });
+		const plugin = new TriggerJobRuntimePlugin().useDispatchers({
+			dispatchKbEmbedDocument: (payload: unknown) =>
+				factory.dispatch('kb-embed-document', payload)
+		});
+		const d = plugin.dispatchers as unknown as {
+			dispatchKbEmbedDocument: (p: unknown) => Promise<string | null>;
+		};
+		await expect(d.dispatchKbEmbedDocument({ workId: 'w' })).resolves.toBe('run_1');
+		expect(client.triggeredTasks).toEqual(['kb-embed-document']);
+	});
+
+	it('without useDispatchers the throwing stub still fires', () => {
+		const plugin = new TriggerJobRuntimePlugin();
+		const d = plugin.dispatchers as unknown as { dispatchKbEmbedDocument: () => unknown };
+		expect(() => d.dispatchKbEmbedDocument()).toThrow(TriggerDispatcherNotConfiguredError);
+	});
+
+	it('useDispatcherFactory holds the factory reference', () => {
+		const client = new StubTrigger();
+		const factory = new TriggerDispatcherFactory({ client });
+		const plugin = new TriggerJobRuntimePlugin().useDispatcherFactory(factory);
+		expect(plugin.factory).toBe(factory);
+	});
+
+	it('factory is null without useDispatcherFactory', () => {
+		const plugin = new TriggerJobRuntimePlugin();
+		expect(plugin.factory).toBeNull();
+	});
+
+	it('startWorkerHost is no-op even with factory wired (push-model)', async () => {
+		const client = new StubTrigger();
+		const factory = new TriggerDispatcherFactory({ client });
+		const plugin = new TriggerJobRuntimePlugin().useDispatcherFactory(factory);
+		const handle = await plugin.startWorkerHost({});
+		await expect(handle.stop()).resolves.toBeUndefined();
+	});
+
+	describe('cancel / getRunStatus', () => {
+		it('return safe defaults without a client opt', async () => {
+			const plugin = new TriggerJobRuntimePlugin();
+			await expect(plugin.cancel('any')).resolves.toBe(false);
+			await expect(plugin.getRunStatus('any')).resolves.toBe('unknown');
+		});
+
+		it('cancel forwards to client.runs.cancel when client is wired', async () => {
+			const client = new StubTrigger();
+			const plugin = new TriggerJobRuntimePlugin({ client });
+			await expect(plugin.cancel('run_42')).resolves.toBe(true);
+			expect(client.cancelCalls).toEqual(['run_42']);
+		});
+
+		it('cancel returns false when the SDK throws', async () => {
+			const client = new StubTrigger();
+			client.cancelShouldThrow = true;
+			const plugin = new TriggerJobRuntimePlugin({ client });
+			await expect(plugin.cancel('run_42')).resolves.toBe(false);
+		});
+
+		it('getRunStatus projects SDK status through mapTriggerStatus', async () => {
+			const client = new StubTrigger();
+			client.retrieveStatus = 'EXECUTING';
+			const plugin = new TriggerJobRuntimePlugin({ client });
+			await expect(plugin.getRunStatus('run_1')).resolves.toBe('running');
+
+			client.retrieveStatus = 'COMPLETED';
+			await expect(plugin.getRunStatus('run_2')).resolves.toBe('completed');
+
+			client.retrieveStatus = 'CANCELED';
+			await expect(plugin.getRunStatus('run_3')).resolves.toBe('cancelled');
+
+			client.retrieveStatus = 'SYSTEM_FAILURE';
+			await expect(plugin.getRunStatus('run_4')).resolves.toBe('failed');
+
+			client.retrieveStatus = 'QUEUED';
+			await expect(plugin.getRunStatus('run_5')).resolves.toBe('queued');
+
+			client.retrieveStatus = 'NEW_FUTURE_STATUS';
+			await expect(plugin.getRunStatus('run_6')).resolves.toBe('unknown');
+		});
+
+		it('getRunStatus returns "unknown" when the SDK throws', async () => {
+			const client = new StubTrigger();
+			client.retrieveShouldThrow = true;
+			const plugin = new TriggerJobRuntimePlugin({ client });
+			await expect(plugin.getRunStatus('run_1')).resolves.toBe('unknown');
+		});
+	});
+
+	describe('mapTriggerStatus', () => {
+		it('maps all canonical SDK v4 status values', () => {
+			expect(mapTriggerStatus('QUEUED')).toBe('queued');
+			expect(mapTriggerStatus('DEQUEUED')).toBe('queued');
+			expect(mapTriggerStatus('WAITING')).toBe('queued');
+			expect(mapTriggerStatus('DELAYED')).toBe('queued');
+			expect(mapTriggerStatus('PENDING_VERSION')).toBe('queued');
+			expect(mapTriggerStatus('EXECUTING')).toBe('running');
+			expect(mapTriggerStatus('REATTEMPTING')).toBe('running');
+			expect(mapTriggerStatus('COMPLETED')).toBe('completed');
+			expect(mapTriggerStatus('COMPLETED_SUCCESSFULLY')).toBe('completed');
+			expect(mapTriggerStatus('CANCELED')).toBe('cancelled');
+			expect(mapTriggerStatus('FAILED')).toBe('failed');
+			expect(mapTriggerStatus('CRASHED')).toBe('failed');
+			expect(mapTriggerStatus('SYSTEM_FAILURE')).toBe('failed');
+			expect(mapTriggerStatus('TIMED_OUT')).toBe('failed');
+			expect(mapTriggerStatus('EXPIRED')).toBe('failed');
+			expect(mapTriggerStatus('COMPLETED_WITH_ERRORS')).toBe('failed');
+		});
+
+		it('falls back to "unknown" for unrecognised statuses', () => {
+			expect(mapTriggerStatus('SOMETHING_NEW')).toBe('unknown');
+			expect(mapTriggerStatus('')).toBe('unknown');
+		});
+	});
+
+	describe('bindToTenant', () => {
+		it('exposes tenantProjectAccessToken from snapshot.credentials', () => {
+			const plugin = new TriggerJobRuntimePlugin();
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.tenantProjectAccessToken).toBe('tr_pat_tenant_a');
+			expect(view.tenantSnapshot.tenantId).toBe(snapshot().tenantId);
+			expect(Object.isFrozen(view)).toBe(true);
+		});
+
+		it('null projectAccessToken when credentials are absent', () => {
+			const plugin = new TriggerJobRuntimePlugin();
+			const view = plugin.bindToTenant(snapshot({ credentials: {} }));
+			expect(view.tenantProjectAccessToken).toBeNull();
+		});
+
+		it('memoises on (tenantId, credentialVersion)', () => {
+			const plugin = new TriggerJobRuntimePlugin();
+			const a = plugin.bindToTenant(snapshot());
+			const b = plugin.bindToTenant(snapshot());
+			expect(b).toBe(a);
+		});
+
+		it('evicts older view on credentialVersion bump', () => {
+			const plugin = new TriggerJobRuntimePlugin();
+			const v1 = plugin.bindToTenant(snapshot({ credentialVersion: 1 }));
+			const v2 = plugin.bindToTenant(snapshot({ credentialVersion: 2 }));
+			expect(v2).not.toBe(v1);
+		});
+
+		it('view.bindToTenant(self) returns self', () => {
+			const plugin = new TriggerJobRuntimePlugin();
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.bindToTenant?.(snapshot())).toBe(view);
+		});
+
+		it('view uses tenant-built dispatchers when builder is set', async () => {
+			const plugin = new TriggerJobRuntimePlugin({
+				dispatchersBuilder: (snap): JobRuntimeDispatchers => ({
+					dispatchKbEmbedDocument: () =>
+						Promise.resolve(`tenant:${snap.credentials.projectAccessToken}`)
+				})
+			});
+			const view = plugin.bindToTenant(snapshot());
+			const d = view.dispatchers as unknown as {
+				dispatchKbEmbedDocument: () => Promise<string>;
+			};
+			await expect(d.dispatchKbEmbedDocument()).resolves.toBe('tenant:tr_pat_tenant_a');
+		});
+
+		it('useDispatchers clears the tenant view cache', () => {
+			const plugin = new TriggerJobRuntimePlugin().useDispatchers({
+				dispatchKbEmbedDocument: () => Promise.resolve('v1')
+			});
+			const v1 = plugin.bindToTenant(snapshot());
+			plugin.useDispatchers({
+				dispatchKbEmbedDocument: () => Promise.resolve('v2')
+			});
+			const v2 = plugin.bindToTenant(snapshot());
+			expect(v2).not.toBe(v1);
+		});
+	});
+});

--- a/packages/plugins/job-runtime-trigger/src/__tests__/trigger-tenant-conformance.spec.ts
+++ b/packages/plugins/job-runtime-trigger/src/__tests__/trigger-tenant-conformance.spec.ts
@@ -1,0 +1,23 @@
+import { describe } from 'vitest';
+import { runJobRuntimeTenantContractSuite } from '@ever-works/plugin/contracts-conformance';
+import { TriggerJobRuntimePlugin } from '../trigger-job-runtime.plugin.js';
+
+describe('TriggerJobRuntimePlugin — tenant overlay conformance', () => {
+	runJobRuntimeTenantContractSuite(
+		() => new TriggerJobRuntimePlugin(),
+		{
+			tenantA: {
+				tenantId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+				providerId: 'trigger',
+				credentialVersion: 1,
+				credentials: { projectAccessToken: 'tr_pat_a', projectRef: 'proj_a' }
+			},
+			tenantB: {
+				tenantId: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+				providerId: 'trigger',
+				credentialVersion: 1,
+				credentials: { projectAccessToken: 'tr_pat_b', projectRef: 'proj_b' }
+			}
+		}
+	);
+});

--- a/packages/plugins/job-runtime-trigger/src/index.ts
+++ b/packages/plugins/job-runtime-trigger/src/index.ts
@@ -1,0 +1,24 @@
+export {
+	TriggerJobRuntimePlugin,
+	TriggerDispatcherNotConfiguredError,
+	mapTriggerStatus
+} from './trigger-job-runtime.plugin.js';
+export type {
+	TriggerTenantBindingView,
+	TriggerJobRuntimePluginOptions
+} from './trigger-job-runtime.plugin.js';
+export { TriggerDispatcherFactory } from './trigger-dispatcher-factory.js';
+export {
+	mapEnqueueOptions as mapTriggerEnqueueOptions
+} from './trigger-enqueue-options.js';
+export type { MappedTriggerEnqueue } from './trigger-enqueue-options.js';
+export type {
+	TriggerClient,
+	TriggerTasksApi,
+	TriggerRunsApi,
+	TriggerRunHandle,
+	TriggerRunRecord,
+	TriggerTaskOptions,
+	TriggerDispatcherFactoryOptions
+} from './trigger-types.js';
+export { TriggerJobRuntimePlugin as default } from './trigger-job-runtime.plugin.js';

--- a/packages/plugins/job-runtime-trigger/src/trigger-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-trigger/src/trigger-dispatcher-factory.ts
@@ -1,0 +1,131 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import type {
+	TriggerClient,
+	TriggerDispatcherFactoryOptions,
+	TriggerTaskOptions
+} from './trigger-types.js';
+import { mapEnqueueOptions } from './trigger-enqueue-options.js';
+
+/**
+ * EW-686 P2 — operator-facing factory that wraps a Trigger.dev client
+ * (`@trigger.dev/sdk`) and exposes per-task dispatcher functions.
+ *
+ * # Usage (operator-side app)
+ *
+ * ```ts
+ * import { runs, tasks } from '@trigger.dev/sdk';
+ * import {
+ *   TriggerJobRuntimePlugin,
+ *   TriggerDispatcherFactory
+ * } from '@ever-works/job-runtime-trigger-plugin';
+ *
+ * // Trigger.dev v4 — the SDK reads TRIGGER_SECRET_KEY from env, the
+ * // `tasks` / `runs` namespaces are imported as module-level objects.
+ * // The plugin only needs a structural { tasks, runs } client:
+ * const client = { tasks, runs };
+ * const factory = new TriggerDispatcherFactory({
+ *   client,
+ *   defaultTaskQueue: 'platform-default'
+ * });
+ *
+ * const plugin = new TriggerJobRuntimePlugin().useDispatchers({
+ *   dispatchKbEmbedDocument: (payload) =>
+ *     factory.dispatch('kb-embed-document', payload)
+ * });
+ * ```
+ *
+ * # Per-tenant routing
+ *
+ * For BYO/override per ADR-017 providers.md § Trigger.dev, build one
+ * Trigger.dev client per tenant project (configured with the tenant's
+ * `projectAccessToken` from the credential snapshot) and one factory
+ * per client; pass the per-tenant factory through
+ * `TriggerJobRuntimePluginOptions.dispatchersBuilder` so
+ * `bindToTenant(snapshot)` views route to the right Trigger.dev project.
+ */
+export class TriggerDispatcherFactory {
+	constructor(private readonly opts: TriggerDispatcherFactoryOptions) {}
+
+	get client(): TriggerClient {
+		return this.opts.client;
+	}
+
+	/**
+	 * Dispatch a single Trigger.dev task. Returns the run id assigned
+	 * by Trigger.dev (`handle.id`) or `null` if the SDK response is
+	 * shaped unexpectedly (`handle` missing / no `id`).
+	 *
+	 * `extraOptions` shallow-merges OVER the factory default queue so
+	 * operator-supplied per-call overrides win.
+	 */
+	async dispatch(
+		taskId: string,
+		payload: unknown,
+		extraOptions?: TriggerTaskOptions
+	): Promise<string | null> {
+		const options: TriggerTaskOptions = {
+			...(this.opts.defaultTaskQueue !== undefined
+				? { queue: this.opts.defaultTaskQueue }
+				: {}),
+			...(extraOptions ?? {})
+		};
+		const handle = await this.opts.client.tasks.trigger(taskId, payload, options);
+		return handle?.id ?? null;
+	}
+
+	/**
+	 * EW-742 P4 T31 — dispatch with platform-canonical
+	 * `JobEnqueueOptions`. Translates each field onto the Trigger.dev
+	 * SDK's native carriers per `providers.md` § Trigger.dev:
+	 *
+	 *   - `idempotencyKey`     → `idempotencyKey`
+	 *   - `tenantId`           → `metadata.tenantId`
+	 *   - `concurrencyKey`     → `concurrencyKey`
+	 *   - `tags`               → `tags`
+	 *   - `maxDurationSeconds` → `maxDuration`
+	 *   - `machineHint`        → `machine`
+	 *
+	 * Per-tenant Trigger.dev CLIENT selection happens BEFORE this call
+	 * — the caller picks the right `TriggerClient` (per the snapshot's
+	 * `projectAccessToken`) via the plugin's `dispatchersBuilder` hook.
+	 *
+	 * `extraOptions` is shallow-merged on top so operators can still
+	 * pass SDK-native fields (`queue`, custom metadata, etc.) that the
+	 * platform enqueue options don't expose. Operator-supplied values
+	 * win on key collision (e.g. an explicit `extraOptions.metadata`
+	 * fully replaces the translated `metadata.tenantId` — operators
+	 * must spread it themselves if they want both).
+	 */
+	async enqueue(
+		taskId: string,
+		payload: unknown,
+		enqueueOptions: JobEnqueueOptions,
+		extraOptions?: TriggerTaskOptions
+	): Promise<string | null> {
+		const { options: mapped } = mapEnqueueOptions(enqueueOptions);
+		const merged: TriggerTaskOptions = {
+			...(this.opts.defaultTaskQueue !== undefined
+				? { queue: this.opts.defaultTaskQueue }
+				: {}),
+			...mapped,
+			...(extraOptions ?? {})
+		};
+		const handle = await this.opts.client.tasks.trigger(taskId, payload, merged);
+		return handle?.id ?? null;
+	}
+
+	/**
+	 * Cancel a Trigger.dev run by id. Returns `true` when the SDK call
+	 * resolves without throwing (Trigger.dev accepts the cancel
+	 * request), `false` if the SDK rejects (unknown / already-terminal
+	 * run id).
+	 */
+	async cancel(runId: string): Promise<boolean> {
+		try {
+			await this.opts.client.runs.cancel(runId);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+}

--- a/packages/plugins/job-runtime-trigger/src/trigger-enqueue-options.ts
+++ b/packages/plugins/job-runtime-trigger/src/trigger-enqueue-options.ts
@@ -1,0 +1,66 @@
+import type { JobEnqueueOptions } from '@ever-works/plugin';
+import type { TriggerTaskOptions } from './trigger-types.js';
+
+/**
+ * EW-742 P4 T31 — translator: platform `JobEnqueueOptions` →
+ * Trigger.dev `TriggerOptions` carrier per `providers.md` § Trigger.dev.
+ *
+ * Trigger.dev's `tasks.trigger(taskId, payload, opts)` accepts a rich
+ * native options bag — most of the platform enqueue knobs have direct
+ * counterparts. Tenant routing lands on `metadata.tenantId` so the
+ * tenant-aware webhook handler can demultiplex by tag/payload field per
+ * § Trigger.dev "shared" inherit mode (per-tenant projects switch the
+ * underlying client instead).
+ *
+ *   - `idempotencyKey`     → `idempotencyKey` (Trigger.dev SDK native;
+ *                            same key within the configured dedup
+ *                            window collapses to one run).
+ *   - `tenantId`           → `metadata.tenantId` (Trigger.dev's per-run
+ *                            `metadata` is JSON-shaped; the tenant
+ *                            webhook handler reads it for routing in
+ *                            shared / tagged-shared inherit mode).
+ *   - `concurrencyKey`     → `concurrencyKey` (SDK native).
+ *   - `tags`               → `tags` (SDK native, array of strings; used
+ *                            for filtering in the Trigger.dev UI).
+ *   - `maxDurationSeconds` → `maxDuration` (SDK native, in seconds).
+ *   - `machineHint`        → `machine` (SDK native — `'small-1x'` /
+ *                            `'small-2x'` / etc. Operator-supplied
+ *                            string passed through verbatim; Trigger.dev
+ *                            validates against its accepted preset list
+ *                            at trigger time).
+ *
+ * Per-tenant Trigger.dev CLIENT selection happens BEFORE this call —
+ * the caller picks the right `TriggerClient` (per the snapshot's
+ * `projectAccessToken`) via the plugin's `dispatchersBuilder` hook.
+ *
+ * The translator returns the full `TriggerTaskOptions` shape so the
+ * dispatcher can spread it onto the SDK call directly.
+ */
+export interface MappedTriggerEnqueue {
+	/**
+	 * Translated options ready to spread into
+	 * `client.tasks.trigger(taskId, payload, mapped)`. Includes
+	 * `metadata.tenantId` when `JobEnqueueOptions.tenantId` was set.
+	 */
+	readonly options: TriggerTaskOptions;
+}
+
+export function mapEnqueueOptions(opts: JobEnqueueOptions): MappedTriggerEnqueue {
+	const options: {
+		idempotencyKey?: string;
+		concurrencyKey?: string;
+		tags?: readonly string[];
+		maxDuration?: number;
+		machine?: string;
+		metadata?: Record<string, unknown>;
+	} = {};
+
+	if (opts.idempotencyKey !== undefined) options.idempotencyKey = opts.idempotencyKey;
+	if (opts.concurrencyKey !== undefined) options.concurrencyKey = opts.concurrencyKey;
+	if (opts.tags !== undefined) options.tags = opts.tags;
+	if (opts.maxDurationSeconds !== undefined) options.maxDuration = opts.maxDurationSeconds;
+	if (opts.machineHint !== undefined) options.machine = opts.machineHint;
+	if (opts.tenantId !== undefined) options.metadata = { tenantId: opts.tenantId };
+
+	return { options };
+}

--- a/packages/plugins/job-runtime-trigger/src/trigger-job-runtime.plugin.ts
+++ b/packages/plugins/job-runtime-trigger/src/trigger-job-runtime.plugin.ts
@@ -1,0 +1,336 @@
+import type {
+	IJobRuntimeProvider,
+	JobRunStatus,
+	JobRuntimeDispatchers,
+	JobRuntimeId,
+	JsonSchema,
+	PluginCategory,
+	PluginContext,
+	ScheduleSpec,
+	TenantCredentialSnapshot,
+	WorkerHostHandle,
+	WorkerHostOptions
+} from '@ever-works/plugin';
+import type { TriggerClient } from './trigger-types.js';
+
+/**
+ * EW-686 P2 — Trigger.dev `IJobRuntimeProvider` plugin (canonical
+ * pluggable form).
+ *
+ * Peer of `BullMqJobRuntimePlugin`, `PgBossJobRuntimePlugin`,
+ * `TemporalJobRuntimePlugin`, `InngestJobRuntimePlugin`. The existing
+ * `TriggerJobRuntimeProvider` shim at `packages/tasks/src/trigger/`
+ * stays as the operator's reference implementation (NestJS-bound,
+ * directly wired into `TriggerModule`); this package is what the
+ * standard plugin pipeline discovers via the `everworks.plugin`
+ * manifest block in `package.json`.
+ *
+ * Per `providers.md` § Trigger.dev, per-tenant BYO requires per-tenant
+ * Trigger.dev **projects** (the SDK is project-scoped). This plugin's
+ * `bindToTenant` view surfaces the per-tenant `projectAccessToken` but
+ * operators must build per-tenant `TriggerClient` instances themselves
+ * and route via `dispatchersBuilder` — same per-tenant-client model as
+ * the Inngest plugin.
+ *
+ * Operators wire real dispatchers via:
+ *   - `useDispatchers(map)` — replace throwing-stub Proxy.
+ *   - `useDispatcherFactory(factory)` — keep a reference to the bound
+ *     `TriggerDispatcherFactory` for the operator's own access (does
+ *     not auto-register dispatchers; use `useDispatchers` for that).
+ *   - `dispatchersBuilder` ctor option — per-tenant routing.
+ *
+ * # No worker host
+ *
+ * Trigger.dev is push-model — Trigger.dev's cloud invokes the
+ * operator's deployed task package on its own machines. There is no
+ * separate worker process the API needs to start. `startWorkerHost`
+ * therefore stays a no-op even when operator hooks are wired (mirrors
+ * Inngest).
+ */
+
+export class TriggerDispatcherNotConfiguredError extends Error {
+	constructor(dispatcherName: string) {
+		super(
+			`@ever-works/job-runtime-trigger-plugin: ${dispatcherName} is not configured. ` +
+				'Call plugin.useDispatchers({ ... }) with operator-supplied Trigger.dev dispatchers ' +
+				'built via TriggerDispatcherFactory (see plugin header for an example), ' +
+				'or pass dispatchersBuilder when constructing the plugin for per-tenant routing.'
+		);
+		this.name = 'TriggerDispatcherNotConfiguredError';
+	}
+}
+
+export interface TriggerTenantBindingView extends IJobRuntimeProvider {
+	readonly tenantSnapshot: TenantCredentialSnapshot;
+	/** Per-tenant Trigger.dev project access token (for the operator-built per-tenant client). */
+	readonly tenantProjectAccessToken: string | null;
+}
+
+export interface TriggerJobRuntimePluginOptions {
+	/** Per-tenant dispatcher builder — see plugin header. */
+	readonly dispatchersBuilder?: (snapshot: TenantCredentialSnapshot) => JobRuntimeDispatchers;
+	/**
+	 * Optional default Trigger.dev client used by the plugin's own
+	 * `cancel` / `getRunStatus` (so callers don't need to reach into
+	 * the per-task dispatchers for these contract methods). Operators
+	 * that want real cancel / status calls inject the same `{ tasks,
+	 * runs }` they handed to `TriggerDispatcherFactory`.
+	 *
+	 * When omitted, the plugin falls back to safe defaults (`cancel`
+	 * returns `false`, `getRunStatus` returns `'unknown'`) — same
+	 * shape as the Inngest plugin which has no SDK-side equivalents.
+	 */
+	readonly client?: TriggerClient;
+}
+
+export class TriggerJobRuntimePlugin implements IJobRuntimeProvider {
+	readonly id = 'job-runtime-trigger';
+	readonly name = 'Trigger.dev Job Runtime';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'job-runtime';
+	readonly capabilities: readonly string[] = [
+		'job-runtime-enqueue',
+		'job-runtime-cancel',
+		'job-runtime-status',
+		'job-runtime-schedule',
+		'job-runtime-bind-tenant'
+	];
+	readonly runtimeId: JobRuntimeId = 'trigger';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			projectRef: {
+				type: 'string',
+				title: 'Trigger.dev Project Ref',
+				description: 'Trigger.dev project reference (e.g. proj_abc123).',
+				'x-envVar': 'TRIGGER_PROJECT_REF'
+			},
+			secretKey: {
+				type: 'string',
+				title: 'Trigger.dev Secret Key',
+				description: 'Server-side prod secret (tr_prod_*). Used by the SDK to authenticate tasks.trigger calls.',
+				'x-secret': true,
+				'x-envVar': 'TRIGGER_SECRET_KEY'
+			},
+			apiUrl: {
+				type: 'string',
+				title: 'Trigger.dev API URL',
+				description: 'Override for self-hosted Trigger.dev (default https://api.trigger.dev).',
+				'x-envVar': 'TRIGGER_API_URL'
+			}
+		}
+	};
+
+	private readonly stubDispatchers: JobRuntimeDispatchers = new Proxy(
+		{},
+		{
+			get(_target, prop: string): unknown {
+				if (typeof prop === 'string' && prop.startsWith('dispatch')) {
+					return () => {
+						throw new TriggerDispatcherNotConfiguredError(prop);
+					};
+				}
+				return undefined;
+			}
+		}
+	);
+
+	private dispatchersImpl: JobRuntimeDispatchers = this.stubDispatchers;
+	private dispatcherFactory: unknown | null = null;
+
+	private context?: PluginContext;
+	private readonly tenantViews = new Map<string, TriggerTenantBindingView>();
+
+	constructor(private readonly opts: TriggerJobRuntimePluginOptions = {}) {}
+
+	get dispatchers(): JobRuntimeDispatchers {
+		return this.dispatchersImpl;
+	}
+
+	/**
+	 * Reference to the bound `TriggerDispatcherFactory` (if any). Held
+	 * loose-typed (`unknown`) so this plugin file doesn't have to
+	 * import the factory class and create a circular module graph;
+	 * operators that need the typed reference import the factory
+	 * directly.
+	 */
+	get factory(): unknown | null {
+		return this.dispatcherFactory;
+	}
+
+	useDispatchers(map: JobRuntimeDispatchers): this {
+		this.dispatchersImpl = Object.freeze({ ...map });
+		this.tenantViews.clear();
+		return this;
+	}
+
+	useDispatcherFactory(factory: unknown): this {
+		this.dispatcherFactory = factory;
+		return this;
+	}
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+	}
+
+	async onUnload(): Promise<void> {
+		this.context = undefined;
+		this.tenantViews.clear();
+	}
+
+	async registerSchedules(_schedules: readonly ScheduleSpec[]): Promise<void> {
+		// Trigger.dev tasks self-register their cron at deploy time via
+		// `schedules.task()` SDK calls in the operator's task files —
+		// the `pnpm deploy:trigger` pipeline wires the cron up against
+		// Trigger.dev's Schedules service. Platform-level ScheduleSpec
+		// is therefore unused; no-op so the binding factory's boot path
+		// doesn't throw.
+	}
+
+	async cancel(runId: string): Promise<boolean> {
+		if (!this.opts.client) {
+			// Mirror Inngest: without an SDK client wired the plugin
+			// can't reach Trigger.dev; operators that need cancel
+			// either inject the client via the `client` opt or call
+			// `factory.cancel(runId)` directly through their own
+			// wrapper.
+			return false;
+		}
+		try {
+			await this.opts.client.runs.cancel(runId);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async getRunStatus(runId: string): Promise<JobRunStatus> {
+		if (!this.opts.client) {
+			return 'unknown';
+		}
+		try {
+			const run = await this.opts.client.runs.retrieve(runId);
+			return mapTriggerStatus(run.status);
+		} catch {
+			return 'unknown';
+		}
+	}
+
+	isEnabled(): boolean {
+		return Boolean(process.env.TRIGGER_SECRET_KEY);
+	}
+
+	async startWorkerHost(_opts: WorkerHostOptions): Promise<WorkerHostHandle> {
+		// Trigger.dev is push-model — Trigger.dev's cloud invokes the
+		// deployed task package directly. No process to start.
+		return { stop: async () => undefined };
+	}
+
+	bindToTenant(snapshot: TenantCredentialSnapshot): TriggerTenantBindingView {
+		const cacheKey = `${snapshot.tenantId}:${snapshot.credentialVersion}`;
+		const cached = this.tenantViews.get(cacheKey);
+		if (cached) {
+			return cached;
+		}
+
+		const base = this;
+		const tenantProjectAccessToken =
+			typeof snapshot.credentials.projectAccessToken === 'string'
+				? snapshot.credentials.projectAccessToken
+				: null;
+
+		const dispatchersForView: JobRuntimeDispatchers = this.opts.dispatchersBuilder
+			? Object.freeze({ ...this.opts.dispatchersBuilder(snapshot) })
+			: base.dispatchersImpl;
+
+		const view: TriggerTenantBindingView = Object.freeze({
+			id: base.id,
+			name: base.name,
+			version: base.version,
+			category: base.category,
+			capabilities: base.capabilities,
+			settingsSchema: base.settingsSchema,
+			runtimeId: base.runtimeId,
+			get dispatchers(): JobRuntimeDispatchers {
+				return dispatchersForView;
+			},
+			registerSchedules: (schedules: readonly ScheduleSpec[]) =>
+				base.registerSchedules(schedules),
+			cancel: (runId: string) => base.cancel(runId),
+			getRunStatus: (runId: string) => base.getRunStatus(runId),
+			isEnabled: () => base.isEnabled(),
+			startWorkerHost: (opts: WorkerHostOptions) => base.startWorkerHost(opts),
+			onLoad: (context: PluginContext) => base.onLoad(context),
+			onUnload: () => base.onUnload(),
+			bindToTenant: (other: TenantCredentialSnapshot) => {
+				if (
+					other.tenantId === snapshot.tenantId &&
+					other.credentialVersion === snapshot.credentialVersion
+				) {
+					return view;
+				}
+				return base.bindToTenant(other);
+			},
+			tenantSnapshot: snapshot,
+			tenantProjectAccessToken
+		});
+
+		for (const key of this.tenantViews.keys()) {
+			if (key.startsWith(`${snapshot.tenantId}:`)) {
+				this.tenantViews.delete(key);
+			}
+		}
+		this.tenantViews.set(cacheKey, view);
+		return view;
+	}
+}
+
+/**
+ * Translate a Trigger.dev v4 SDK status string into the 6-value
+ * {@link JobRunStatus} union the contract exposes. Mirrors the mapping
+ * in `packages/tasks/src/trigger/trigger.service.ts` exactly so both
+ * code paths (synthetic in-repo provider + canonical plugin) agree on
+ * cross-provider lifecycle reads. Unknown values fall back to
+ * `'unknown'` rather than throwing so a future SDK widening doesn't
+ * break callers.
+ */
+export function mapTriggerStatus(status: string): JobRunStatus {
+	switch (status) {
+		// Pre-execution — task is in Trigger.dev's queue / waiting for
+		// a slot / version. `WAITING` here is the queue-side wait, NOT
+		// an in-task `wait.for(...)` call.
+		case 'PENDING_VERSION':
+		case 'QUEUED':
+		case 'DEQUEUED':
+		case 'WAITING':
+		case 'DELAYED':
+			return 'queued';
+
+		case 'EXECUTING':
+		// Synonym kept by some SDK versions — same lifecycle state.
+		// eslint-disable-next-line no-fallthrough
+		case 'REATTEMPTING':
+			return 'running';
+
+		case 'COMPLETED':
+		case 'COMPLETED_SUCCESSFULLY':
+			return 'completed';
+
+		// Trigger.dev SDK v4 uses single-L `CANCELED`; the contract
+		// uses double-L `cancelled` (matches the DB enums).
+		case 'CANCELED':
+			return 'cancelled';
+
+		case 'FAILED':
+		case 'CRASHED':
+		case 'SYSTEM_FAILURE':
+		case 'TIMED_OUT':
+		case 'EXPIRED':
+		case 'COMPLETED_WITH_ERRORS':
+			return 'failed';
+
+		default:
+			return 'unknown';
+	}
+}

--- a/packages/plugins/job-runtime-trigger/src/trigger-types.ts
+++ b/packages/plugins/job-runtime-trigger/src/trigger-types.ts
@@ -1,0 +1,108 @@
+/**
+ * EW-686 P2 — structural Trigger.dev shapes the plugin depends on.
+ *
+ * We do NOT take a hard dependency on `@trigger.dev/sdk` from this
+ * plugin package. The operator installs `@trigger.dev/sdk` in their app
+ * and injects a fully-constructed Trigger.dev client through the
+ * factories below.
+ *
+ * Reasons mirror the BullMQ / pg-boss / Temporal / Inngest plugins.
+ * Trigger.dev is additionally distinguished by the **push-model**
+ * dispatch model with cloud-hosted workers:
+ *   - Outbound: `client.tasks.trigger(taskId, payload, opts)` enqueues
+ *     a run and returns a handle `{ id }`.
+ *   - Inbound: Trigger.dev's cloud invokes the operator's deployed
+ *     task package on its own machines — the operator does NOT run a
+ *     poller from the API.
+ *
+ * There is no separate worker host process. The plugin's
+ * `startWorkerHost` stays a no-op even when operator hooks are wired
+ * (mirrors Inngest).
+ *
+ * For tenant-scoped overlay (per ADR-017 providers.md § Trigger.dev),
+ * the operator builds one Trigger.dev client per tenant project (using
+ * the tenant's project-scoped access token from the credential
+ * snapshot) and routes through the right client via `dispatchersBuilder`.
+ */
+
+/**
+ * Result of a successful `tasks.trigger` call — the Trigger.dev SDK
+ * returns a run handle whose `id` is the runId every other contract
+ * method (`cancel`, `getRunStatus`) keys on.
+ */
+export interface TriggerRunHandle {
+	readonly id: string;
+	/** Pass-through fields from the SDK (publicAccessToken, etc.). */
+	readonly [extra: string]: unknown;
+}
+
+/**
+ * Per-trigger options accepted by `client.tasks.trigger`. Mirrors the
+ * fields of `@trigger.dev/sdk` v4 `TriggerOptions`. Optional everywhere
+ * so the dispatcher can spread translated values onto it.
+ */
+export interface TriggerTaskOptions {
+	readonly idempotencyKey?: string;
+	readonly concurrencyKey?: string;
+	readonly tags?: readonly string[];
+	readonly maxDuration?: number;
+	readonly machine?: string;
+	readonly queue?: string;
+	readonly metadata?: Readonly<Record<string, unknown>>;
+	readonly [extra: string]: unknown;
+}
+
+/**
+ * Status as reported by `client.runs.retrieve(...)`. Trigger.dev SDK v4
+ * exposes a `status` field on the returned run record; the plugin's
+ * `getRunStatus` projects this onto the contract's 6-value
+ * `JobRunStatus` union. Kept as a free-form string here so future SDK
+ * widenings don't break compilation — the mapper falls back to
+ * `'unknown'`.
+ */
+export interface TriggerRunRecord {
+	readonly id: string;
+	readonly status: string;
+	readonly [extra: string]: unknown;
+}
+
+/**
+ * The `tasks` subnamespace of the Trigger.dev client — only the calls
+ * the plugin makes are typed.
+ */
+export interface TriggerTasksApi {
+	trigger(
+		taskId: string,
+		payload: unknown,
+		options?: TriggerTaskOptions
+	): Promise<TriggerRunHandle>;
+}
+
+/**
+ * The `runs` subnamespace of the Trigger.dev client — only the calls
+ * the plugin makes are typed.
+ */
+export interface TriggerRunsApi {
+	cancel(runId: string): Promise<unknown>;
+	retrieve(runId: string): Promise<TriggerRunRecord>;
+}
+
+/**
+ * Structural subset of the Trigger.dev SDK client (v4). Maps to
+ * `@trigger.dev/sdk` >=4.0. Operators inject the real client; the
+ * plugin only reaches into `tasks` and `runs`.
+ */
+export interface TriggerClient {
+	readonly tasks: TriggerTasksApi;
+	readonly runs: TriggerRunsApi;
+}
+
+export interface TriggerDispatcherFactoryOptions {
+	readonly client: TriggerClient;
+	/**
+	 * Default queue handed to every `tasks.trigger(...)` when the per-
+	 * call options don't override it. Leave undefined for the
+	 * task-default queue.
+	 */
+	readonly defaultTaskQueue?: string;
+}

--- a/packages/plugins/job-runtime-trigger/tsconfig.json
+++ b/packages/plugins/job-runtime-trigger/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/job-runtime-trigger/tsup.config.ts
+++ b/packages/plugins/job-runtime-trigger/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1887,6 +1887,24 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
+  packages/plugins/job-runtime-trigger:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
   packages/plugins/k8s:
     dependencies:
       '@kubernetes/client-node':


### PR DESCRIPTION
Trigger.dev rehoused as a proper plugin package — peer of the 4 existing job-runtime plugin packages (BullMQ, pg-boss, Temporal, Inngest). The existing `TriggerJobRuntimeProvider` in `packages/tasks/src/trigger/` stays untouched as the operator's reference implementation; this new package is the canonical pluggable form that the standard plugin pipeline discovers via the `everworks.plugin` manifest.

## Shape (mirrors Inngest 1:1 — serverless model, no worker host)

- `TriggerJobRuntimePlugin` implements `IJobRuntimeProvider` with operator-pluggable real dispatchers via `useDispatchers / useDispatcherFactory / dispatchersBuilder`
- `TriggerDispatcherFactory({ client })` — operator injects structurally-typed `TriggerClient` (peer dep, operator pins `@trigger.dev/sdk`)
- `bindToTenant` exposes `tenantProjectAccessToken` from `snapshot.credentials.projectAccessToken`
- No worker-host factory — Trigger.dev is push-model (operator's webhook IS the worker)

## T31 stamping

- idempotencyKey/concurrencyKey/tags/maxDurationSeconds(→maxDuration)/machineHint(→machine) — SDK-native
- tenantId → `metadata.tenantId` (Trigger.dev's per-run JSON metadata is the only structured carrier; BYO/override routes via per-tenant client in `dispatchersBuilder`)

## getRunStatus

`mapTriggerStatus` exported separately so apps/api's existing TriggerService can re-use the same projection. Mirrors v4 SDK status names + alias synonyms.

## Tests

107/107 vitest cases across 5 spec files (dispatcher-factory + enqueue-options + plugin-operator-hooks + conformance + tenant-conformance). tsc + tsup + DTS clean (9.7 KB ESM / 14.7 KB d.ts).

NO touch to packages/tasks/src/trigger/. `@trigger.dev/sdk` peer-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Trigger.dev job runtime provider plugin enabling job dispatch, execution monitoring, and cancellation
  * Per-tenant configuration and credential isolation support

* **Documentation**
  * Added setup guide with environment variable configuration and operator integration examples

* **Tests**
  * Comprehensive test coverage for plugin conformance and operator hooks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->