### PR TITLE
ci(job-runtime): real-infra smoke for BullMQ + pg-boss (EW-742 T37 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,61 @@ jobs:
       - name: Test @ever-works/job-runtime-${{ matrix.provider }}-plugin
         run: pnpm --filter @ever-works/job-runtime-${{ matrix.provider }}-plugin test
 
+  # EW-742 P6 T32/T37 real-infra axis — BullMQ + pg-boss against
+  # live Redis + Postgres service containers. Temporal + Inngest skipped
+  # for now (heavier containerisation: Temporal needs auto-setup image,
+  # Inngest needs the dev-server CLI). Real-infra cells run as a SEPARATE
+  # job from the mocks-only matrix so an infra hiccup doesn't mask the
+  # mocks-only failure signal.
+  job-runtime-real-infra:
+    runs-on: ubicloud-standard-8
+    services:
+      redis:
+        image: redis:7-alpine
+        ports: ['6379:6379']
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports: ['5432:5432']
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3
+        with:
+          version: 10.33.3
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @ever-works/plugin (contract + conformance subpath)
+        run: pnpm --filter @ever-works/plugin build
+
+      - name: BullMQ real-infra
+        env:
+          EW_TEST_REAL_REDIS_URL: redis://localhost:6379
+        run: pnpm --filter @ever-works/job-runtime-bullmq-plugin test
+
+      - name: pg-boss real-infra
+        env:
+          EW_TEST_REAL_PGBOSS_URL: postgres://test:test@localhost:5432/test
+        run: pnpm --filter @ever-works/job-runtime-pgboss-plugin test
+
   # Companion matrix for the secret-store-resolver provider family
   # (EW-742 P3.2 / P6 — runSecretStoreContractSuite is wired into all 7
   # plugins via `<plugin>-conformance.spec.ts`). Same rationale as the

--- a/packages/plugins/job-runtime-bullmq/package.json
+++ b/packages/plugins/job-runtime-bullmq/package.json
@@ -34,6 +34,8 @@
 	"devDependencies": {
 		"@ever-works/plugin": "workspace:*",
 		"@types/node": "^22.0.0",
+		"bullmq": "^5.66.0",
+		"ioredis": "^5.10.1",
 		"tsup": "^8.4.0",
 		"typescript": "^5.7.3",
 		"vitest": "^4.1.0"

--- a/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-real-infra.spec.ts
+++ b/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-real-infra.spec.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * EW-742 P6 T32/T37 — REAL-INFRA integration spec for the BullMQ plugin.
+ *
+ * Mocks-free: this suite connects to a live Redis instance and exercises
+ * the full enqueue → worker handler loop through the real `bullmq` and
+ * `ioredis` libraries. The mocks-only `bullmq-*-isolation.spec.ts`
+ * covers the structural contract; this spec catches wire-level
+ * regressions (option translation, key-prefix isolation, dedup semantics,
+ * cancel-before-process races) that mocks can mask.
+ *
+ * # Gating
+ *
+ * The entire suite skips when `EW_TEST_REAL_REDIS_URL` is unset. This
+ * means `pnpm test` works in two modes:
+ *
+ *   - operator dev box (no Redis): every case shows as `skipped`
+ *   - CI `job-runtime-real-infra` job (Redis service container):
+ *     `EW_TEST_REAL_REDIS_URL=redis://localhost:6379` is exported and
+ *     the suite runs for real.
+ *
+ * # Concurrency safety
+ *
+ * Every test creates queues whose names embed a fresh `randomUUID()` so
+ * parallel CI shards / repeated reruns / vitest's own worker pool never
+ * collide on a shared Redis key. Tear-down `close()` is best-effort; a
+ * leak only costs Redis memory for the TTL of the keys, not test
+ * correctness.
+ */
+
+const REDIS_URL = process.env['EW_TEST_REAL_REDIS_URL'];
+const realInfra = REDIS_URL ? describe : describe.skip;
+
+import { BullMqDispatcherFactory } from '../bullmq-dispatcher-factory.js';
+import { BullMqWorkerHostFactory } from '../bullmq-worker-host-factory.js';
+import type { BullMqDeps, BullMqJobView } from '../bullmq-types.js';
+
+interface RealConnection {
+	quit(): Promise<unknown>;
+	keys(pattern: string): Promise<string[]>;
+	del(...keys: string[]): Promise<number>;
+}
+
+interface BullMqLibrary {
+	Queue: BullMqDeps['Queue'];
+	Worker: BullMqDeps['Worker'];
+}
+
+/**
+ * Lazy-load the real bullmq/ioredis only when the suite is actually
+ * going to run. Both are devDeps gated behind `EW_TEST_REAL_REDIS_URL`,
+ * so when an operator runs `pnpm test` without Redis we never try to
+ * import them.
+ */
+async function loadRealBullMq(): Promise<{ bullmq: BullMqLibrary; redis: RealConnection }> {
+	const bullmqMod = (await import('bullmq')) as unknown as BullMqLibrary;
+	const ioredisMod = (await import('ioredis')) as { default: new (url: string, opts?: unknown) => RealConnection };
+	const Redis = ioredisMod.default;
+	const redis = new Redis(REDIS_URL!, { maxRetriesPerRequest: null });
+	return { bullmq: { Queue: bullmqMod.Queue, Worker: bullmqMod.Worker }, redis };
+}
+
+realInfra('BullMQ real-infra (EW-742 P6 T32/T37)', () => {
+	let bullmq: BullMqLibrary;
+	let redis: RealConnection;
+	const cleanup: Array<() => Promise<unknown>> = [];
+	const prefixesUsed = new Set<string>();
+
+	beforeAll(async () => {
+		const loaded = await loadRealBullMq();
+		bullmq = loaded.bullmq;
+		redis = loaded.redis;
+	}, 30_000);
+
+	afterEach(async () => {
+		// Tear down per-test queues + workers in reverse-LIFO order.
+		while (cleanup.length > 0) {
+			const fn = cleanup.pop();
+			if (fn) await fn().catch(() => undefined);
+		}
+		// Best-effort scrub of any per-tenant prefixes we created so a
+		// flaky run can't leak keys into the next test's assertions.
+		for (const prefix of prefixesUsed) {
+			try {
+				const keys = await redis.keys(`${prefix}:*`);
+				if (keys.length > 0) await redis.del(...keys);
+			} catch {
+				// Ignore — Redis cleanup is best-effort.
+			}
+		}
+		prefixesUsed.clear();
+	});
+
+	function makeDeps(): BullMqDeps {
+		return { Queue: bullmq.Queue, Worker: bullmq.Worker };
+	}
+
+	function trackPrefix(prefix: string): string {
+		prefixesUsed.add(prefix);
+		return prefix;
+	}
+
+	it('single-tenant enqueue + worker handler processes the job end-to-end', async () => {
+		const queueName = `ew-it-single-${randomUUID()}`;
+		const prefix = trackPrefix(`ew-real-${randomUUID().slice(0, 8)}`);
+
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		cleanup.push(() => factory.close());
+		const dispatcher = factory.forQueue(queueName);
+
+		const workerHost = new BullMqWorkerHostFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		const received: Array<{ name: string; data: unknown }> = [];
+		let resolveProcessed: () => void;
+		const processed = new Promise<void>((r) => (resolveProcessed = r));
+		workerHost.register(queueName, async (job) => {
+			received.push({ name: job.name, data: job.data });
+			resolveProcessed();
+		});
+		const handle = await workerHost.start();
+		cleanup.push(() => handle.stop());
+
+		const jobId = await dispatcher.dispatch(queueName, { hello: 'world' });
+		expect(jobId).toBeTruthy();
+		await processed;
+		expect(received).toHaveLength(1);
+		expect(received[0]?.data).toEqual({ hello: 'world' });
+	}, 30_000);
+
+	it('two tenants on the same queue name route by JobsOptions.tenantId without cross-leak', async () => {
+		const queueName = `ew-it-tenant-${randomUUID()}`;
+		const prefix = trackPrefix(`ew-real-${randomUUID().slice(0, 8)}`);
+
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		cleanup.push(() => factory.close());
+		const dispatcher = factory.forQueue(queueName);
+
+		const workerHost = new BullMqWorkerHostFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		const seen: Array<{ tenantId: unknown; payload: unknown }> = [];
+		let pending = 2;
+		let resolveAll: () => void;
+		const allDone = new Promise<void>((r) => (resolveAll = r));
+
+		workerHost.register(queueName, async (job: BullMqJobView) => {
+			// T31 stamping carrier: tenantId lives on opts.tenantId (mirrors
+			// the carrier the dispatcher writes via mapEnqueueOptions).
+			const opts = (job as unknown as { opts?: { tenantId?: unknown } }).opts;
+			seen.push({ tenantId: opts?.tenantId, payload: job.data });
+			if (--pending === 0) resolveAll();
+		});
+		const handle = await workerHost.start();
+		cleanup.push(() => handle.stop());
+
+		const idA = await dispatcher.enqueue(
+			queueName,
+			{ which: 'A' },
+			{ tenantId: 'tenant-a', idempotencyKey: `a-${randomUUID()}` }
+		);
+		const idB = await dispatcher.enqueue(
+			queueName,
+			{ which: 'B' },
+			{ tenantId: 'tenant-b', idempotencyKey: `b-${randomUUID()}` }
+		);
+		expect(idA).toBeTruthy();
+		expect(idB).toBeTruthy();
+
+		await allDone;
+		expect(seen).toHaveLength(2);
+		const a = seen.find((s) => (s.payload as { which?: string }).which === 'A');
+		const b = seen.find((s) => (s.payload as { which?: string }).which === 'B');
+		expect(a?.tenantId).toBe('tenant-a');
+		expect(b?.tenantId).toBe('tenant-b');
+	}, 30_000);
+
+	it('per-tenant queue-prefix isolation lands jobs in distinct Redis keys', async () => {
+		const queueName = `ew-it-prefix-${randomUUID()}`;
+		const prefixA = trackPrefix(`ew-tenant-a-${randomUUID().slice(0, 8)}`);
+		const prefixB = trackPrefix(`ew-tenant-b-${randomUUID().slice(0, 8)}`);
+
+		const factoryA = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix: prefixA });
+		const factoryB = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix: prefixB });
+		cleanup.push(() => factoryA.close());
+		cleanup.push(() => factoryB.close());
+
+		// Enqueue with NO worker attached so the keys persist for inspection.
+		await factoryA.forQueue(queueName).dispatch(queueName, { tenant: 'a' });
+		await factoryB.forQueue(queueName).dispatch(queueName, { tenant: 'b' });
+
+		const keysA = await redis.keys(`${prefixA}:*`);
+		const keysB = await redis.keys(`${prefixB}:*`);
+		expect(keysA.length).toBeGreaterThan(0);
+		expect(keysB.length).toBeGreaterThan(0);
+		// Cross-leak guard: tenant A keys never carry tenant B's prefix and vice versa.
+		expect(keysA.every((k) => k.startsWith(`${prefixA}:`))).toBe(true);
+		expect(keysB.every((k) => k.startsWith(`${prefixB}:`))).toBe(true);
+		expect(keysA.some((k) => k.startsWith(`${prefixB}:`))).toBe(false);
+	}, 30_000);
+
+	it('idempotencyKey dedup: second enqueue with same key returns same id or null', async () => {
+		const queueName = `ew-it-idem-${randomUUID()}`;
+		const prefix = trackPrefix(`ew-real-${randomUUID().slice(0, 8)}`);
+		const idemKey = `idem-${randomUUID()}`;
+
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		cleanup.push(() => factory.close());
+		const dispatcher = factory.forQueue(queueName);
+
+		const first = await dispatcher.enqueue(queueName, { n: 1 }, { idempotencyKey: idemKey });
+		const second = await dispatcher.enqueue(queueName, { n: 2 }, { idempotencyKey: idemKey });
+
+		expect(first).toBeTruthy();
+		// BullMQ's dedup semantic: same `jobId` returns the original
+		// job's id (older bullmq) or null (newer bullmq).
+		expect([first, null]).toContain(second);
+	}, 30_000);
+
+	it('cancel before processing: removed job is never handed to the worker', async () => {
+		const queueName = `ew-it-cancel-${randomUUID()}`;
+		const prefix = trackPrefix(`ew-real-${randomUUID().slice(0, 8)}`);
+
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		cleanup.push(() => factory.close());
+		const dispatcher = factory.forQueue(queueName);
+
+		// Enqueue with a far-future delay so cancel wins the race.
+		const jobId = await dispatcher.dispatch(queueName, { cancelMe: true }, { delay: 60_000 });
+		expect(jobId).toBeTruthy();
+
+		const cancelled = await factory.cancel(jobId!);
+		expect(cancelled).toBe(true);
+
+		// Now start a worker; give it ~1.5s to confirm nothing arrives.
+		const workerHost = new BullMqWorkerHostFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		let received = 0;
+		workerHost.register(queueName, async () => {
+			received++;
+		});
+		const handle = await workerHost.start();
+		cleanup.push(() => handle.stop());
+
+		await new Promise((r) => setTimeout(r, 1500));
+		expect(received).toBe(0);
+	}, 30_000);
+
+	it('T31 end-to-end: factory.enqueue stamps opts; worker reads job.opts.tenantId + tags', async () => {
+		const queueName = `ew-it-t31-${randomUUID()}`;
+		const prefix = trackPrefix(`ew-real-${randomUUID().slice(0, 8)}`);
+		const tenantId = `tenant-${randomUUID().slice(0, 8)}`;
+
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		cleanup.push(() => factory.close());
+		const dispatcher = factory.forQueue(queueName);
+
+		const workerHost = new BullMqWorkerHostFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		let observed: { tenantId?: unknown; tags?: unknown } | null = null;
+		let resolveDone: () => void;
+		const done = new Promise<void>((r) => (resolveDone = r));
+		workerHost.register(queueName, async (job) => {
+			const opts = (job as unknown as { opts?: { tenantId?: unknown; tags?: unknown } }).opts;
+			observed = { tenantId: opts?.tenantId, tags: opts?.tags };
+			resolveDone();
+		});
+		const handle = await workerHost.start();
+		cleanup.push(() => handle.stop());
+
+		const id = await dispatcher.enqueue(
+			queueName,
+			{ workId: 'w-1' },
+			{ tenantId, idempotencyKey: `idem-${randomUUID()}`, tags: ['kb', 'embed'] }
+		);
+		expect(id).toBeTruthy();
+		await done;
+		expect(observed).not.toBeNull();
+		expect(observed!.tenantId).toBe(tenantId);
+		expect(observed!.tags).toEqual(['kb', 'embed']);
+	}, 30_000);
+});

--- a/packages/plugins/job-runtime-pgboss/package.json
+++ b/packages/plugins/job-runtime-pgboss/package.json
@@ -22,6 +22,8 @@
 	"devDependencies": {
 		"@ever-works/plugin": "workspace:*",
 		"@types/node": "^22.0.0",
+		"pg": "^8.13.0",
+		"pg-boss": "^10.1.5",
 		"tsup": "^8.4.0",
 		"typescript": "^5.7.3",
 		"vitest": "^4.1.0"

--- a/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-real-infra.spec.ts
+++ b/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-real-infra.spec.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * EW-742 P6 T32/T37 — REAL-INFRA integration spec for the pg-boss plugin.
+ *
+ * Mocks-free: connects to a live Postgres and runs the full
+ * `boss.send()` → `boss.work()` loop through the real `pg-boss` library.
+ * Companion to `pgboss-tenant-isolation.spec.ts` (mocks-only) — together
+ * they cover both the structural contract and wire-level behaviour
+ * (singletonKey dedup, expireInSeconds enforcement, schema-per-tenant
+ * isolation, batched workers).
+ *
+ * # Gating
+ *
+ * Skips entirely when `EW_TEST_REAL_PGBOSS_URL` is unset, so
+ * `pnpm test` works for operators without a local Postgres. CI exports
+ * the URL inside the `job-runtime-real-infra` job, where Postgres runs
+ * as a service container.
+ *
+ * # Concurrency safety
+ *
+ * Each test creates a fresh schema name with `randomUUID()` so parallel
+ * vitest workers + repeated CI reruns don't trample each other inside
+ * the same Postgres database. Schemas are dropped on cleanup so a long
+ * CI lifetime doesn't accumulate dead `tenant_*` schemas.
+ */
+
+const PG_URL = process.env['EW_TEST_REAL_PGBOSS_URL'];
+const realInfra = PG_URL ? describe : describe.skip;
+
+import { PgBossDispatcherFactory } from '../pgboss-dispatcher-factory.js';
+import { PgBossWorkerHostFactory } from '../pgboss-worker-host-factory.js';
+import type { PgBossInstance, PgBossJobView } from '../pgboss-types.js';
+
+interface PgBossCtor {
+	new (opts: Record<string, unknown>): PgBossInstance;
+}
+
+/** Lazy import — only loaded when the gate is open. */
+async function loadRealPgBoss(): Promise<PgBossCtor> {
+	const mod = (await import('pg-boss')) as unknown as { default: PgBossCtor };
+	return mod.default;
+}
+
+/** Best-effort cleanup of the per-test schema so CI Postgres stays tidy. */
+async function dropSchema(schema: string): Promise<void> {
+	try {
+		const { Client } = (await import('pg')) as unknown as {
+			Client: new (cfg: { connectionString: string }) => {
+				connect(): Promise<void>;
+				query(sql: string): Promise<unknown>;
+				end(): Promise<void>;
+			};
+		};
+		const client = new Client({ connectionString: PG_URL! });
+		await client.connect();
+		await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+		await client.end();
+	} catch {
+		// pg might not be installed (it's a pg-boss transitive); ignore.
+	}
+}
+
+realInfra('pg-boss real-infra (EW-742 P6 T32/T37)', () => {
+	let PgBoss: PgBossCtor;
+	const cleanup: Array<() => Promise<unknown>> = [];
+	const schemasUsed = new Set<string>();
+
+	beforeAll(async () => {
+		PgBoss = await loadRealPgBoss();
+	}, 30_000);
+
+	afterEach(async () => {
+		while (cleanup.length > 0) {
+			const fn = cleanup.pop();
+			if (fn) await fn().catch(() => undefined);
+		}
+		for (const schema of schemasUsed) {
+			await dropSchema(schema);
+		}
+		schemasUsed.clear();
+	});
+
+	function freshSchema(label: string): string {
+		const schema = `ew_${label}_${randomUUID().replace(/-/g, '_')}`;
+		schemasUsed.add(schema);
+		return schema;
+	}
+
+	async function startBoss(schema: string): Promise<PgBossInstance> {
+		const boss = new PgBoss({ connectionString: PG_URL!, schema });
+		await boss.start();
+		cleanup.push(() => boss.stop({ graceful: true, timeout: 5000 } as Record<string, unknown>));
+		return boss;
+	}
+
+	it('single-tenant send + work handler processes the job end-to-end', async () => {
+		const schema = freshSchema('single');
+		const boss = await startBoss(schema);
+		const queueName = `q-single-${randomUUID().slice(0, 8)}`;
+
+		const factory = new PgBossDispatcherFactory({ boss });
+		const workerHost = new PgBossWorkerHostFactory({ boss });
+		const seen: unknown[] = [];
+		let resolveDone: () => void;
+		const done = new Promise<void>((r) => (resolveDone = r));
+		workerHost.register(queueName, { teamSize: 1 }, async (jobOrBatch) => {
+			const job = Array.isArray(jobOrBatch) ? jobOrBatch[0]! : (jobOrBatch as PgBossJobView);
+			seen.push(job.data);
+			resolveDone();
+		});
+		await workerHost.start();
+
+		const id = await factory.send(queueName, { hello: 'world' });
+		expect(id).toBeTruthy();
+		await done;
+		expect(seen).toEqual([{ hello: 'world' }]);
+	}, 30_000);
+
+	it('two-tenant isolation via _ew.tenantId payload namespace', async () => {
+		const schema = freshSchema('tenants');
+		const boss = await startBoss(schema);
+		const queueName = `q-tenants-${randomUUID().slice(0, 8)}`;
+
+		const factory = new PgBossDispatcherFactory({ boss });
+		const workerHost = new PgBossWorkerHostFactory({ boss });
+		const seen: Array<{ tenantId: unknown; payload: unknown }> = [];
+		let pending = 2;
+		let resolveAll: () => void;
+		const allDone = new Promise<void>((r) => (resolveAll = r));
+		workerHost.register(queueName, { teamSize: 2 }, async (jobOrBatch) => {
+			const jobs = Array.isArray(jobOrBatch) ? jobOrBatch : [jobOrBatch as PgBossJobView];
+			for (const j of jobs) {
+				const ew = (j.data as { _ew?: { tenantId?: unknown } })._ew;
+				seen.push({ tenantId: ew?.tenantId, payload: j.data });
+				if (--pending === 0) resolveAll();
+			}
+		});
+		await workerHost.start();
+
+		await factory.enqueue(queueName, { which: 'A' }, { tenantId: 'tenant-a' });
+		await factory.enqueue(queueName, { which: 'B' }, { tenantId: 'tenant-b' });
+
+		await allDone;
+		const a = seen.find((s) => (s.payload as { which?: string }).which === 'A');
+		const b = seen.find((s) => (s.payload as { which?: string }).which === 'B');
+		expect(a?.tenantId).toBe('tenant-a');
+		expect(b?.tenantId).toBe('tenant-b');
+	}, 30_000);
+
+	it('per-tenant schema isolation: two PgBoss instances on distinct schemas', async () => {
+		const schemaA = freshSchema('tenant_a');
+		const schemaB = freshSchema('tenant_b');
+		const bossA = await startBoss(schemaA);
+		const bossB = await startBoss(schemaB);
+		const queueName = `q-iso-${randomUUID().slice(0, 8)}`;
+
+		const factoryA = new PgBossDispatcherFactory({ boss: bossA });
+		const factoryB = new PgBossDispatcherFactory({ boss: bossB });
+
+		// Only attach worker on bossA to confirm bossB's job never bleeds across.
+		const workerHost = new PgBossWorkerHostFactory({ boss: bossA });
+		const seenA: unknown[] = [];
+		let resolveA: () => void;
+		const aGot = new Promise<void>((r) => (resolveA = r));
+		workerHost.register(queueName, { teamSize: 1 }, async (jobOrBatch) => {
+			const job = Array.isArray(jobOrBatch) ? jobOrBatch[0]! : (jobOrBatch as PgBossJobView);
+			seenA.push(job.data);
+			resolveA();
+		});
+		await workerHost.start();
+
+		const idA = await factoryA.send(queueName, { from: 'A' });
+		const idB = await factoryB.send(queueName, { from: 'B' });
+		expect(idA).toBeTruthy();
+		expect(idB).toBeTruthy();
+
+		await aGot;
+		// 800ms grace to confirm bossA's worker never picks up B's job.
+		await new Promise((r) => setTimeout(r, 800));
+		expect(seenA).toHaveLength(1);
+		expect(seenA[0]).toEqual({ from: 'A' });
+
+		// Cleanup the second boss explicitly (startBoss pushes it onto cleanup queue).
+		void factoryB;
+	}, 45_000);
+
+	it('singletonKey idempotency: second send with same key returns null', async () => {
+		const schema = freshSchema('idem');
+		const boss = await startBoss(schema);
+		const queueName = `q-idem-${randomUUID().slice(0, 8)}`;
+		const idemKey = `idem-${randomUUID()}`;
+
+		const factory = new PgBossDispatcherFactory({ boss });
+		const first = await factory.enqueue(queueName, { n: 1 }, { idempotencyKey: idemKey });
+		const second = await factory.enqueue(queueName, { n: 2 }, { idempotencyKey: idemKey });
+
+		expect(first).toBeTruthy();
+		// pg-boss's documented dedup semantic: second call returns null
+		// while the singletonKey row is still in-flight.
+		expect(second).toBeNull();
+	}, 30_000);
+
+	it('cancel before processing: removed job is never handed to the worker', async () => {
+		const schema = freshSchema('cancel');
+		const boss = await startBoss(schema);
+		const queueName = `q-cancel-${randomUUID().slice(0, 8)}`;
+
+		const factory = new PgBossDispatcherFactory({ boss });
+		// startAfter in the far future so cancel wins.
+		const id = await factory.send(queueName, { cancelMe: true }, { startAfter: 60 });
+		expect(id).toBeTruthy();
+		const cancelled = await factory.cancel(id!);
+		expect(cancelled).toBe(true);
+
+		const workerHost = new PgBossWorkerHostFactory({ boss });
+		let received = 0;
+		workerHost.register(queueName, { teamSize: 1 }, async () => {
+			received++;
+		});
+		await workerHost.start();
+
+		await new Promise((r) => setTimeout(r, 1500));
+		expect(received).toBe(0);
+	}, 30_000);
+
+	it('batched workers (teamSize > 1) handle multi-tenant jobs in parallel correctly', async () => {
+		const schema = freshSchema('batch');
+		const boss = await startBoss(schema);
+		const queueName = `q-batch-${randomUUID().slice(0, 8)}`;
+
+		const factory = new PgBossDispatcherFactory({ boss });
+		const workerHost = new PgBossWorkerHostFactory({ boss });
+		const seen: Array<{ tenantId: unknown; payload: unknown }> = [];
+		const expected = 6;
+		let pending = expected;
+		let resolveAll: () => void;
+		const allDone = new Promise<void>((r) => (resolveAll = r));
+		workerHost.register(queueName, { teamSize: 4, batchSize: 2 }, async (jobOrBatch) => {
+			const jobs = Array.isArray(jobOrBatch) ? jobOrBatch : [jobOrBatch as PgBossJobView];
+			for (const j of jobs) {
+				const ew = (j.data as { _ew?: { tenantId?: unknown } })._ew;
+				seen.push({ tenantId: ew?.tenantId, payload: j.data });
+				if (--pending === 0) resolveAll();
+			}
+		});
+		await workerHost.start();
+
+		const tenants = ['tenant-a', 'tenant-b', 'tenant-c'];
+		for (let i = 0; i < expected; i++) {
+			const t = tenants[i % tenants.length]!;
+			await factory.enqueue(queueName, { n: i }, { tenantId: t });
+		}
+
+		await allDone;
+		expect(seen).toHaveLength(expected);
+		// Each delivered job's stamped tenantId matches the dispatcher's choice
+		// (i.e. the worker never invents or swaps a tenant).
+		for (const entry of seen) {
+			expect(tenants).toContain(entry.tenantId);
+		}
+	}, 45_000);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(088a339e3579cdac4e2e02b02d6b8844)
+        version: 2.3.4(544273b70af2d25f909948f205d87822)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.0)(rxjs@7.8.2)
@@ -1823,6 +1823,12 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
+      bullmq:
+        specifier: ^5.66.0
+        version: 5.79.0
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
@@ -1859,6 +1865,12 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
+      pg:
+        specifier: ^8.13.0
+        version: 8.18.0
+      pg-boss:
+        specifier: ^10.1.5
+        version: 10.4.2
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
@@ -6186,6 +6198,36 @@ packages:
   '@mozilla/readability@0.6.0':
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
@@ -11216,6 +11258,15 @@ packages:
     resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
     engines: {node: '>=0.2.0'}
 
+  bullmq@5.79.0:
+    resolution: {integrity: sha512-sg+kYGn7PIDI/AAkSWINPNz0vMp745YaBYMyo3AtcfXk5iCvjEPU+XMbU3yf7rSf1KsU+OfU+GH8FhxUa+WDNA==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      redis: '>=5.0.0'
+    peerDependenciesMeta:
+      redis:
+        optional: true
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -11821,6 +11872,10 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
 
   cron@4.4.0:
     resolution: {integrity: sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==}
@@ -15717,6 +15772,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
+    hasBin: true
+
+  msgpackr@2.0.2:
+    resolution: {integrity: sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==}
+
   msw@2.12.10:
     resolution: {integrity: sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==}
     engines: {node: '>=18'}
@@ -15901,6 +15963,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -16480,6 +16546,10 @@ packages:
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  pg-boss@10.4.2:
+    resolution: {integrity: sha512-AttEWOtSzn53av8OnCMWEanwRBvjkZCE1y5nLrZnwvkkMnlZ5XpWDpZ7sKI/BYjvi2OVieMX37arD2ACgJ750w==}
+    engines: {node: '>=20'}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -18139,6 +18209,10 @@ packages:
 
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
+
+  serialize-error@8.1.0:
+    resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
+    engines: {node: '>=10'}
 
   serialize-javascript@7.0.5:
     resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
@@ -21553,7 +21627,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.8.1
+      semver: 7.8.4
 
   '@changesets/assemble-release-plan@6.0.10':
     dependencies:
@@ -21562,7 +21636,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.8.1
+      semver: 7.8.4
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -21619,7 +21693,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.8.1
+      semver: 7.8.4
 
   '@changesets/get-release-plan@4.0.16':
     dependencies:
@@ -24649,6 +24723,24 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    optional: true
+
   '@mswjs/interceptors@0.41.3':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -24849,7 +24941,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(088a339e3579cdac4e2e02b02d6b8844)':
+  '@nestjs-modules/mailer@2.3.4(544273b70af2d25f909948f205d87822)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -24863,6 +24955,7 @@ snapshots:
       '@types/ejs': 3.1.5
       '@types/mjml': 4.7.4
       '@types/pug': 2.0.10
+      bullmq: 5.79.0
       ejs: 5.0.1
       handlebars: 4.7.9
       liquidjs: 10.27.0
@@ -30298,6 +30391,17 @@ snapshots:
 
   buffers@0.1.1: {}
 
+  bullmq@5.79.0:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.10.1
+      msgpackr: 2.0.2
+      node-abort-controller: 3.1.1
+      semver: 7.8.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -30942,6 +31046,10 @@ snapshots:
   create-require@1.1.1: {}
 
   crelt@1.0.6: {}
+
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
 
   cron@4.4.0:
     dependencies:
@@ -32844,7 +32952,7 @@ snapshots:
       minimatch: 10.2.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.8.1
+      semver: 7.8.4
       tapable: 2.3.2
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
@@ -32861,7 +32969,7 @@ snapshots:
       minimatch: 10.2.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.8.1
+      semver: 7.8.4
       tapable: 2.3.2
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))
@@ -36250,6 +36358,22 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.4:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
+    optional: true
+
+  msgpackr@2.0.2:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
+
   msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@20.19.33)
@@ -36504,6 +36628,11 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-gyp-build@4.8.4: {}
 
@@ -37154,6 +37283,14 @@ snapshots:
   pend@1.2.0: {}
 
   perfect-debounce@1.0.0: {}
+
+  pg-boss@10.4.2:
+    dependencies:
+      cron-parser: 4.9.0
+      pg: 8.18.0
+      serialize-error: 8.1.0
+    transitivePeerDependencies:
+      - pg-native
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -39256,6 +39393,10 @@ snapshots:
       - supports-color
 
   seq-queue@0.0.5: {}
+
+  serialize-error@8.1.0:
+    dependencies:
+      type-fest: 0.20.2
 
   serialize-javascript@7.0.5: {}
 


### PR DESCRIPTION
## Summary

EW-742 T37 follow-up — completes the real-infra axis of the per-provider CI matrix for two of the four push-model providers.

- New CI job `job-runtime-real-infra` runs alongside the existing `job-runtime-plugin-matrix` (4×4 mocks) and `secret-store-plugin-matrix` (7×7 mocks). Brings up Redis 7-alpine + Postgres 16-alpine via `services:` blocks.
- New spec `packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-real-infra.spec.ts` (6 cases) — enqueue → poll → drain against real BullMQ; gated by `EW_TEST_REAL_REDIS_URL`.
- New spec `packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-real-infra.spec.ts` (6 cases) — same shape against real pg-boss; gated by `EW_TEST_REAL_PGBOSS_URL`.
- Adds `bullmq` + `ioredis` (BullMQ devDeps) and `pg-boss` + `pg` (pg-boss devDeps).

Why a smoke spec and not a contract-suite port: the 11-invariant contract suite + per-tenant binding suite (T36–T40) already runs mock-only. The gap was confirming the real SDKs match the mock behavior. Each spec uses random queue names (`ew-it-<uuid>`) for BullMQ and per-test schemas (`ew_<uuid>`) for pg-boss; `afterEach` cleans up so cells stay independent.

Temporal + Inngest real-infra deferred — Temporal auto-setup image needs longer health-check windows and Inngest needs the dev-server CLI; both are separate runner setups worth their own PR.

## Test plan

- [x] `pnpm --filter @ever-works/job-runtime-bullmq-plugin test` → 117 passed + 6 skipped (skip = env not set, expected locally)
- [x] `pnpm --filter @ever-works/job-runtime-pgboss-plugin test` → 114 passed + 6 skipped
- [x] `pnpm install --frozen-lockfile` clean
- [ ] CI `job-runtime-real-infra` job goes green end-to-end with the service containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added real-infrastructure integration tests for BullMQ and pg-boss job runtime providers.
  * Tests validate tenant isolation, job idempotency, cancellation behavior, and batch processing against live Redis and Postgres containers.

* **Chores**
  * Updated CI workflow to execute job runtime tests in dedicated pipeline.
  * Added development dependencies for job runtime integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->