### PR TITLE
release: cascade PR-A/B/C/D develop→stage (EW-685 T4 + EW-742 P1/P5.1/T37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,61 @@ jobs:
       - name: Test @ever-works/job-runtime-${{ matrix.provider }}-plugin
         run: pnpm --filter @ever-works/job-runtime-${{ matrix.provider }}-plugin test
 
+  # EW-742 P6 T32/T37 real-infra axis — BullMQ + pg-boss against
+  # live Redis + Postgres service containers. Temporal + Inngest skipped
+  # for now (heavier containerisation: Temporal needs auto-setup image,
+  # Inngest needs the dev-server CLI). Real-infra cells run as a SEPARATE
+  # job from the mocks-only matrix so an infra hiccup doesn't mask the
+  # mocks-only failure signal.
+  job-runtime-real-infra:
+    runs-on: ubicloud-standard-8
+    services:
+      redis:
+        image: redis:7-alpine
+        ports: ['6379:6379']
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports: ['5432:5432']
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3
+        with:
+          version: 10.33.3
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build @ever-works/plugin (contract + conformance subpath)
+        run: pnpm --filter @ever-works/plugin build
+
+      - name: BullMQ real-infra
+        env:
+          EW_TEST_REAL_REDIS_URL: redis://localhost:6379
+        run: pnpm --filter @ever-works/job-runtime-bullmq-plugin test
+
+      - name: pg-boss real-infra
+        env:
+          EW_TEST_REAL_PGBOSS_URL: postgres://test:test@localhost:5432/test
+        run: pnpm --filter @ever-works/job-runtime-pgboss-plugin test
+
   # Companion matrix for the secret-store-resolver provider family
   # (EW-742 P3.2 / P6 — runSecretStoreContractSuite is wired into all 7
   # plugins via `<plugin>-conformance.spec.ts`). Same rationale as the

--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from '@ever-works/agent/database';
 import {
+    TenantCredentialSnapshot,
     TenantJobRuntimeAudit,
     TenantJobRuntimeConfig,
     TenantRuntimeProviderAllowlist,
@@ -65,6 +66,12 @@ import { TenantJobRuntimeService } from './tenant-job-runtime.service';
             // so the service can inject both the legacy audit repo and the
             // new allow-list repo without duplicating the DI graph.
             TenantRuntimeProviderAllowlist,
+            // EW-742 P1 T11 follow-up — per-version credential snapshot
+            // history. `CredentialVersionService` injects this repo to
+            // satisfy the graceful-drain contract (ADR-017 §3 Q4): an
+            // in-flight run pinned at v=N must still resolve its bag
+            // after the tenant rotates to N+1.
+            TenantCredentialSnapshot,
         ]),
     ],
     providers: [

--- a/apps/api/src/migrations/1781300000000-AddTenantCredentialSnapshot.ts
+++ b/apps/api/src/migrations/1781300000000-AddTenantCredentialSnapshot.ts
@@ -1,0 +1,130 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * EW-742 P1 T11 follow-up — creates the `tenant_credential_snapshot`
+ * table that backs the per-version credential history for the tenant
+ * overlay. Required by the graceful-drain semantic from
+ * [ADR-017 §3 Q4](../../../../../docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md#3-credential-rotation--graceful-drain-locked-q4-do-not-reopen):
+ * `CredentialVersionService.resolveSnapshot(tenantId, N)` MUST keep
+ * returning the version-N bag even after the tenant rotates to N+1, so
+ * an in-flight run pinned at N can still bind to its original credentials.
+ *
+ * Spec: [`docs/specs/features/tenant-job-runtime-overlay/spec.md` FR-5](../../../../../docs/specs/features/tenant-job-runtime-overlay/spec.md)
+ * Plan: [`plan.md` §3](../../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md#3-data-model)
+ * Entity: `packages/agent/src/entities/tenant-credential-snapshot.entity.ts`
+ *
+ * **Schema:**
+ *   - Synthetic PK `id` (`uuid`) so future audit / run-history rows can
+ *     FK to a specific snapshot row.
+ *   - UNIQUE index on `(tenantId, providerId, credentialVersion)` —
+ *     the natural key. Re-inserting the same tuple is the caller's
+ *     idempotency signal (the service swallows the conflict).
+ *   - Secondary index on `tenantId` for the "list every snapshot for
+ *     this tenant" lookup (drain reconciliation + operator dashboards).
+ *   - `credentialsEncrypted` as `jsonb` — the bag is opaque to the DB
+ *     and already-encrypted by the secret-store resolver layer. JSONB
+ *     keeps future shape evolution migration-free.
+ *   - `capturedAt` defaults to `CURRENT_TIMESTAMP`; rows are immutable
+ *     (no `updatedAt`).
+ *   - FK `tenantId` → `tenants.id` with `ON DELETE CASCADE` so removing
+ *     a tenant takes the per-tenant snapshot history with it. Mirrors
+ *     the same cascade choice used by `tenant_job_runtime_config` and
+ *     `tenant_runtime_provider_allowlist`.
+ *
+ * Forward-only + idempotent (`hasTable` guard) — same shape as
+ * `1780900000000-AddTenantJobRuntimeConfig` and
+ * `1781100000000-AddTenantRuntimeProviderAllowlist`.
+ */
+export class AddTenantCredentialSnapshot1781300000000 implements MigrationInterface {
+    name = 'AddTenantCredentialSnapshot1781300000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('tenant_credential_snapshot')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'tenant_credential_snapshot',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    {
+                        name: 'tenantId',
+                        type: 'uuid',
+                    },
+                    {
+                        name: 'providerId',
+                        type: 'varchar',
+                        length: '64',
+                    },
+                    {
+                        name: 'credentialVersion',
+                        type: 'integer',
+                    },
+                    {
+                        name: 'credentialsEncrypted',
+                        type: 'jsonb',
+                    },
+                    {
+                        name: 'capturedAt',
+                        type: 'timestamp',
+                        default: 'CURRENT_TIMESTAMP',
+                    },
+                ],
+            }),
+            true,
+        );
+
+        // Secondary index for the "list every snapshot for tenant X"
+        // lookup (drain reconciliation + operator dashboards). The
+        // composite UNIQUE index below also covers tenant-scoped
+        // lookups when providerId is also constrained, but a
+        // tenant-only sweep (delete on tenant offboard, ops audit)
+        // benefits from a dedicated single-column index.
+        await queryRunner.createIndex(
+            'tenant_credential_snapshot',
+            new TableIndex({
+                name: 'idx_tenant_credential_snapshot_tenant',
+                columnNames: ['tenantId'],
+            }),
+        );
+
+        // Natural key uniqueness — the service translates a PK-conflict
+        // on this index into a no-op (idempotent captureSnapshot).
+        await queryRunner.createIndex(
+            'tenant_credential_snapshot',
+            new TableIndex({
+                name: 'uq_tenant_credential_snapshot_tenant_provider_version',
+                columnNames: ['tenantId', 'providerId', 'credentialVersion'],
+                isUnique: true,
+            }),
+        );
+
+        // Remove the snapshot history when the owning tenant is purged.
+        // Same cascade choice as `tenant_job_runtime_config` +
+        // `tenant_runtime_provider_allowlist` — the snapshot bag is
+        // meaningless without the tenant it belonged to.
+        await queryRunner.createForeignKey(
+            'tenant_credential_snapshot',
+            new TableForeignKey({
+                name: 'fk_tenant_credential_snapshot_tenant',
+                columnNames: ['tenantId'],
+                referencedTableName: 'tenants',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('tenant_credential_snapshot')) {
+            await queryRunner.dropTable('tenant_credential_snapshot', true);
+        }
+    }
+}

--- a/apps/api/src/works/__tests__/tenant-job-runtime-config.repository.spec.ts
+++ b/apps/api/src/works/__tests__/tenant-job-runtime-config.repository.spec.ts
@@ -1,5 +1,9 @@
 import { CredentialVersionService } from '@ever-works/agent/tasks';
-import { TenantJobRuntimeConfig, TenantJobRuntimeAudit } from '@ever-works/agent/entities';
+import {
+    TenantCredentialSnapshot,
+    TenantJobRuntimeConfig,
+    TenantJobRuntimeAudit,
+} from '@ever-works/agent/entities';
 
 /**
  * EW-742 P1 (T13) — coverage for the per-tenant overlay storage tier:
@@ -100,14 +104,35 @@ describe('TenantJobRuntimeConfig storage tier (EW-742 P1)', () => {
 
     describe('CredentialVersionService.bumpVersion', () => {
         let repo: RepoMock;
+        let snapshotRepo: RepoMock;
         let service: CredentialVersionService;
 
         beforeEach(() => {
             repo = makeRepo();
+            // EW-742 P1 T11 follow-up — the service now also injects the
+            // snapshot history repo. These tests don't exercise the
+            // history path (covered by `credential-version-history.service.spec.ts`
+            // in `packages/agent`), so the mock just returns null from
+            // findOne and a no-op QB on insert.
+            snapshotRepo = makeRepo();
+            (snapshotRepo as any).createQueryBuilder = jest.fn(() => ({
+                insert: () => ({
+                    into: () => ({
+                        values: () => ({
+                            orIgnore: () => ({
+                                execute: jest.fn().mockResolvedValue(undefined),
+                            }),
+                        }),
+                    }),
+                }),
+            }));
             // CredentialVersionService takes the typed TypeORM Repository
             // via @InjectRepository; the test mock satisfies the duck-typed
             // surface (increment + findOne) the service actually calls.
-            service = new CredentialVersionService(repo as unknown as never);
+            service = new CredentialVersionService(
+                repo as unknown as never,
+                snapshotRepo as unknown as never,
+            );
         });
 
         it('increments monotonically and returns the new version', async () => {
@@ -175,18 +200,29 @@ describe('TenantJobRuntimeConfig storage tier (EW-742 P1)', () => {
             expect(snap).toBe(row);
         });
 
-        it('resolveSnapshot returns null when the requested version is stale (P1 limitation)', async () => {
-            // Documented limitation — without a history table, a request
-            // for an older version cannot be satisfied. Worker host treats
-            // the null as CREDENTIAL_DRAINED. Tracked as a P1 follow-up.
+        it('resolveSnapshot returns null when the requested version is stale and history has no row', async () => {
+            // T11 follow-up — the service now consults `tenant_credential_snapshot`
+            // for `version != current`. When the history table doesn't have
+            // the requested version either (snapshot pruning, or the bump
+            // landed before capture), the worker host still treats the
+            // null as CREDENTIAL_DRAINED.
             repo.findOne.mockResolvedValueOnce({
                 tenantId: 'tenant-a',
+                providerId: 'trigger',
                 credentialVersion: 7,
             } as TenantJobRuntimeConfig);
+            snapshotRepo.findOne.mockResolvedValueOnce(null);
 
             const snap = await service.resolveSnapshot('tenant-a', 3);
 
             expect(snap).toBeNull();
+            expect(snapshotRepo.findOne).toHaveBeenCalledWith({
+                where: {
+                    tenantId: 'tenant-a',
+                    providerId: 'trigger',
+                    credentialVersion: 3,
+                },
+            });
         });
 
         it('resolveSnapshot returns null when no overlay row exists', async () => {

--- a/apps/api/src/works/works.module.ts
+++ b/apps/api/src/works/works.module.ts
@@ -1,4 +1,4 @@
-import { Module, Logger } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { DistributedTaskLockService } from '@ever-works/agent/cache';
 import { KnowledgeBaseModule, WorkModule } from '@ever-works/agent/services';
 import { DatabaseModule } from '@ever-works/agent/database';
@@ -12,20 +12,6 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
 import { ItemsGeneratorModule } from '@ever-works/agent/items-generator';
 import { ActivityFeedModule } from './activity-feed/activity-feed.module';
 import { OrganizationsModule } from '../organizations/organizations.module';
-import {
-    KB_NORMALIZE_MEDIA_DISPATCHER,
-    KB_REEMBED_WORK_DISPATCHER,
-    KB_TRANSCRIBE_DISPATCHER,
-    RuntimeBindingStamperService,
-    type KbNormalizeMediaDispatcher,
-    type KbNormalizeMediaPayload,
-    type KbReembedWorkDispatcher,
-    type KbReembedWorkPayload,
-    type KbTranscribeDispatcher,
-    type KbTranscribePayload,
-} from '@ever-works/agent/tasks';
-import { WorkRepository } from '@ever-works/agent/database';
-import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
 
 // Controllers
 import { WorksController } from './works.controller';
@@ -61,9 +47,6 @@ import { WorkScheduleDispatcherCronService } from './tasks/work-schedule-dispatc
         // tenant-ownership guard OrgKbController uses to authorize its
         // raw `/api/organizations/:orgId/...` routes.
         OrganizationsModule,
-        // EW-742 P3.2 T22 — RuntimeBindingStamperService for the
-        // KB_REEMBED_WORK_DISPATCHER factory's enqueue-site stamping.
-        TenantJobRuntimeModule,
     ],
     providers: [
         CacheEntryRepository,
@@ -85,125 +68,29 @@ import { WorkScheduleDispatcherCronService } from './tasks/work-schedule-dispatc
         // silently injected `undefined` and every upload returned 503.
         // See the docstring on `KbStorageModule` for the DI walk.
         //
-        // EW-643 Phase 3 slice 2c — bind the two KB media-pipeline
-        // dispatcher tokens (`KB_NORMALIZE_MEDIA_DISPATCHER` +
-        // `KB_TRANSCRIBE_DISPATCHER`) so `KnowledgeBaseService` (which
-        // injects them `@Optional()`) actually receives a live
-        // dispatcher in this deployment. We use a `useFactory` that
-        // dynamically imports `@trigger.dev/sdk` and the matching
-        // task module, calls `tasks.trigger(<id>, payload)`, and
-        // returns the Trigger.dev run id — mirroring the
-        // `agentTaskExecuteTriggerAdapter` style used by the
-        // platform's `TasksModule` (apps/api/src/tasks/tasks.module.ts).
+        // EW-685 T4 full cutover — the three KB dispatcher tokens
+        // (`KB_NORMALIZE_MEDIA_DISPATCHER`, `KB_TRANSCRIBE_DISPATCHER`,
+        // `KB_REEMBED_WORK_DISPATCHER`) that used to live here as
+        // custom Trigger.dev SDK adapters are now bound through the
+        // EW-685 binding factory in
+        // `packages/tasks/src/trigger/trigger.module.ts` — every
+        // `*_DISPATCHER` symbol resolves uniformly through the
+        // `JOB_RUNTIME_PROVIDER_REGISTRY`, so a future
+        // `EVER_WORKS_JOB_RUNTIME` flip (BullMQ / pg-boss / Temporal)
+        // swaps these three the same way it swaps the other eight.
         //
-        // The dynamic import keeps `@trigger.dev/sdk` out of the
-        // import graph at module-load time, so unit tests that
-        // construct `WorksModule` without Trigger.dev configured do
-        // not crash on a missing peer. Each adapter swallows its
-        // dispatch errors + returns `null`, matching the existing
-        // `KbNormalizeMediaDispatcher` / `KbTranscribeDispatcher`
-        // contracts (a `null` is a soft failure the slice-5
-        // reconciliation job catches).
-        {
-            provide: KB_NORMALIZE_MEDIA_DISPATCHER,
-            useFactory: (): KbNormalizeMediaDispatcher => {
-                const logger = new Logger('KbNormalizeMediaDispatcher');
-                return {
-                    async dispatchKbNormalizeMedia(
-                        payload: KbNormalizeMediaPayload,
-                    ): Promise<string | null> {
-                        try {
-                            const { tasks } = await import('@trigger.dev/sdk');
-                            const taskId =
-                                payload.mediaKind === 'video'
-                                    ? 'kb-normalize-video'
-                                    : 'kb-normalize-audio';
-                            const handle = await tasks.trigger(taskId, payload);
-                            return handle.id;
-                        } catch (error) {
-                            logger.warn(
-                                `Failed to dispatch kb-normalize-${payload.mediaKind} for upload ${payload.uploadId}: ${(error as Error).message}`,
-                            );
-                            return null;
-                        }
-                    },
-                };
-            },
-        },
-        {
-            provide: KB_TRANSCRIBE_DISPATCHER,
-            useFactory: (): KbTranscribeDispatcher => {
-                const logger = new Logger('KbTranscribeDispatcher');
-                return {
-                    async dispatchKbTranscribe(
-                        payload: KbTranscribePayload,
-                    ): Promise<string | null> {
-                        try {
-                            const { tasks } = await import('@trigger.dev/sdk');
-                            const handle = await tasks.trigger('kb-transcribe', payload);
-                            return handle.id;
-                        } catch (error) {
-                            logger.warn(
-                                `Failed to dispatch kb-transcribe for upload ${payload.uploadId}: ${(error as Error).message}`,
-                            );
-                            return null;
-                        }
-                    },
-                };
-            },
-        },
-        // EW-642 D7 — bind the `kb-reembed-work` dispatcher. Same
-        // dynamic-import shape as the two KB media dispatchers above,
-        // but unlike them this dispatcher does NOT swallow errors and
-        // return `null` — a re-embed sweep that silently fails to
-        // dispatch would leave a Work permanently on the old embedding
-        // model with no signal to the operator. Errors propagate so
-        // the caller (typically the pgvector settings-change hook, see
-        // TODO in `packages/plugins/pgvector/src/pgvector.plugin.ts`)
-        // can surface them as a workbench banner.
-        {
-            provide: KB_REEMBED_WORK_DISPATCHER,
-            // EW-742 P3.2 T22 — stamp `(providerId, credentialVersion)`
-            // onto the payload before forwarding to Trigger.dev. The
-            // pgvector plugin call site has no tenant context (it's a
-            // vendor-agnostic vector store), so the stamping happens
-            // here in the host adapter where the WorkRepository +
-            // stamper are reachable. Fail-open per FR-5.
-            inject: [WorkRepository, RuntimeBindingStamperService],
-            useFactory: (
-                workRepository: WorkRepository,
-                stamper: RuntimeBindingStamperService,
-            ): KbReembedWorkDispatcher => {
-                const factoryLogger = new Logger('KbReembedWorkDispatcher');
-                return {
-                    async dispatchKbReembedWork(payload: KbReembedWorkPayload): Promise<string> {
-                        let providerId = payload.providerId ?? null;
-                        let credentialVersion = payload.credentialVersion ?? null;
-                        if (providerId === null && credentialVersion === null) {
-                            try {
-                                const work = await workRepository.findById(payload.workId);
-                                const binding = await stamper.stamp(work?.tenantId ?? null);
-                                providerId = binding.providerId;
-                                credentialVersion = binding.credentialVersion;
-                            } catch (err) {
-                                factoryLogger.debug(
-                                    `dispatchKbReembedWork: stamper lookup failed for work=${payload.workId} ` +
-                                        `(${(err as Error).message}); falling back to instance default.`,
-                                );
-                            }
-                        }
-                        const stamped: KbReembedWorkPayload = {
-                            ...payload,
-                            providerId,
-                            credentialVersion,
-                        };
-                        const { tasks } = await import('@trigger.dev/sdk');
-                        const handle = await tasks.trigger('kb-reembed-work', stamped);
-                        return handle.id;
-                    },
-                };
-            },
-        },
+        // The previous KB_REEMBED adapter ran an enqueue-site stamping
+        // pass (`RuntimeBindingStamperService.stamp(work.tenantId)`)
+        // because the pgvector plugin call site has no tenant context;
+        // the worker task's `TenantRuntimeBindingResolverService
+        // .resolveForWork` already re-resolves the tenant from
+        // `payload.workId`, so dropping the enqueue-side stamping only
+        // downgrades graceful-drain detection (ADR-017 §3) for this
+        // dispatcher from "fail loudly when rotated past this version"
+        // to "run against current credentials" — and the re-embed task
+        // is idempotent on `embedding_model` so an operator can
+        // re-fire the model flip from the pgvector settings UI to
+        // pick up fresh creds if drain ever bit them.
     ],
     controllers: [
         WorksController,

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1674,6 +1674,28 @@
             "columnCost": "Cost",
             "loadFailed": "Could not load admin usage. You may not have platform-admin access."
         },
+        "adminTenantRuntimeAllowlist": {
+            "title": "Tenant runtime allow-list",
+            "subtitle": "Operator-scoped per-tenant overlay on the job-runtime provider allow-list. Empty means the tenant inherits the global allow-list. Changes take effect on the next dispatcher resolution and are audited.",
+            "gatingDisabledBanner": "Per-tenant gating is disabled. The list below is preserved but ignored until EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING=true.",
+            "emptyInheritBanner": "Tenant inherits the global allow-list (no per-tenant restriction).",
+            "restrictedBanner": "Tenant restricted to: {providers}.",
+            "pickerLabel": "Allowed providers",
+            "pickerHelper": "Select every job-runtime provider this tenant is allowed to choose. Save replaces the whole list atomically. Clear empties the overlay so the tenant falls back to the global allow-list.",
+            "savedListLabel": "Currently saved",
+            "actions": {
+                "save": "Save allow-list",
+                "clear": "Clear (inherit global)",
+                "removeProvider": "Remove {provider}"
+            },
+            "messages": {
+                "saveSuccess": "Tenant runtime allow-list saved",
+                "saveError": "Failed to save tenant runtime allow-list",
+                "deleteSuccess": "Provider removed from tenant allow-list",
+                "deleteError": "Failed to remove provider from tenant allow-list",
+                "noProviders": "No providers in the per-tenant allow-list."
+            }
+        },
         "budgets": {
             "overviewTitle": "Spend in {period}",
             "overviewProgressLabel": "{percent}% of {cap} cap",

--- a/apps/web/src/app/[locale]/(dashboard)/admin/tenants/[tenantId]/runtime-allowlist/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/admin/tenants/[tenantId]/runtime-allowlist/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+import { authAPI } from '@/lib/api';
+import { operatorTenantRuntimeAllowlistAPI } from '@/lib/api/operator-tenant-runtime-allowlist';
+import { TenantRuntimeAllowlistManager } from '@/components/admin/TenantRuntimeAllowlistManager';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+    title: 'Tenant runtime allow-list',
+};
+
+interface PageProps {
+    params: Promise<{ tenantId: string }>;
+}
+
+/**
+ * EW-742 P5.1 (T35a UI follow-up) — operator admin page for the
+ * per-tenant runtime provider allow-list.
+ *
+ * Lives at `/[locale]/admin/tenants/:tenantId/runtime-allowlist`.
+ * The backend's `IsPlatformAdminGuard` (on
+ * `OperatorTenantRuntimeAllowlistController`) is the authoritative
+ * gate; this page also performs a defense-in-depth `isPlatformAdmin`
+ * check on the profile and 404s for non-admins so the route does not
+ * leak its existence via a distinctive error message — mirrors the
+ * `/admin/usage` page (EW-602).
+ */
+export default async function TenantRuntimeAllowlistAdminPage({ params }: PageProps) {
+    const t = await getTranslations('dashboard.adminTenantRuntimeAllowlist');
+    const { tenantId } = await params;
+
+    // Security: defense-in-depth — verify the caller holds the platform-admin
+    // flag before issuing the admin API call. The backend's `IsPlatformAdminGuard`
+    // is the authoritative check; this is a redundant frontend layer so that a
+    // future misconfiguration of the backend guard does not silently expose data.
+    const profile = await authAPI.getProfile().catch(() => null);
+    if (!profile?.isPlatformAdmin) {
+        notFound();
+    }
+
+    let initial;
+    try {
+        initial = await operatorTenantRuntimeAllowlistAPI.list(tenantId);
+    } catch {
+        // Treat any fetch failure (403 from a backend-side guard
+        // mismatch, 404 from an unknown tenant, etc.) as "not allowed"
+        // so the route stays invisible. The page is operator-only and
+        // the error detail is not useful to non-operators.
+        notFound();
+    }
+
+    return (
+        <div className="space-y-6">
+            <header>
+                <h1 className="text-2xl font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h1>
+                <p className="mt-1 text-sm text-text-secondary dark:text-text-secondary-dark">
+                    {t('subtitle')}
+                </p>
+                <p className="mt-2 font-mono text-xs text-text-muted dark:text-text-muted-dark break-all">
+                    {tenantId}
+                </p>
+            </header>
+
+            <TenantRuntimeAllowlistManager tenantId={tenantId} initial={initial} />
+        </div>
+    );
+}

--- a/apps/web/src/app/actions/admin/tenant-runtime-allowlist.ts
+++ b/apps/web/src/app/actions/admin/tenant-runtime-allowlist.ts
@@ -1,0 +1,94 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { ROUTES } from '@/lib/constants';
+import { getAuthFromCookie } from '@/lib/auth';
+import { ApiResponseError } from '@/lib/api/server-api';
+import { authAPI } from '@/lib/api';
+import {
+    operatorTenantRuntimeAllowlistAPI,
+    type TenantRuntimeAllowlistResponse,
+} from '@/lib/api/operator-tenant-runtime-allowlist';
+import type { TenantJobRuntimeProviderId } from '@/lib/api/tenant-job-runtime';
+
+/**
+ * EW-742 P5.1 (T35a UI follow-up) — Server Actions wrapping the
+ * operator-scoped per-tenant runtime allow-list REST API. Returns a
+ * discriminated `{ success, data?, error? }` shape so the client form
+ * can surface either a toast or an inline error without re-throwing
+ * across the RSC boundary.
+ *
+ * Each action re-verifies the session AND the platform-admin flag at
+ * the Server Action boundary. The API tier's `IsPlatformAdminGuard` is
+ * the authoritative check; this is defense-in-depth so a future
+ * misconfiguration of the backend guard does not silently expose the
+ * mutations via direct action invocation. Mirrors the layered guard
+ * pattern in `app/[locale]/(dashboard)/admin/usage/page.tsx`.
+ */
+
+const ADMIN_PAGE_PATTERN =
+    '/[locale]/(dashboard)/admin/tenants/[tenantId]/runtime-allowlist';
+
+async function ensurePlatformAdmin() {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+    // Defense-in-depth: verify the platform-admin flag is set on the
+    // fresh profile, not just on the cached cookie claims. The API
+    // guard remains the authoritative check.
+    const profile = await authAPI.getProfile().catch(() => null);
+    if (!profile?.isPlatformAdmin) {
+        // Match the page-level posture: pretend the route does not
+        // exist rather than leak its existence via a 403.
+        redirect('/');
+    }
+    return profile;
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+    if (error instanceof ApiResponseError && error.message) return error.message;
+    if (error instanceof Error && error.message) return error.message;
+    return fallback;
+}
+
+export type TenantRuntimeAllowlistActionResult =
+    | { success: true; data: TenantRuntimeAllowlistResponse; error: null }
+    | { success: false; data: null; error: string };
+
+export async function replaceTenantRuntimeAllowlistAction(
+    tenantId: string,
+    providerIds: TenantJobRuntimeProviderId[],
+): Promise<TenantRuntimeAllowlistActionResult> {
+    await ensurePlatformAdmin();
+    try {
+        const data = await operatorTenantRuntimeAllowlistAPI.replace(tenantId, providerIds);
+        revalidatePath(ADMIN_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to save tenant runtime allow-list'),
+        };
+    }
+}
+
+export async function deleteTenantRuntimeAllowlistEntryAction(
+    tenantId: string,
+    providerId: TenantJobRuntimeProviderId,
+): Promise<TenantRuntimeAllowlistActionResult> {
+    await ensurePlatformAdmin();
+    try {
+        const data = await operatorTenantRuntimeAllowlistAPI.deleteEntry(tenantId, providerId);
+        revalidatePath(ADMIN_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to remove tenant runtime allow-list entry'),
+        };
+    }
+}

--- a/apps/web/src/components/admin/TenantRuntimeAllowlistManager.tsx
+++ b/apps/web/src/components/admin/TenantRuntimeAllowlistManager.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { AlertTriangle, Save, Eraser, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import type { TenantJobRuntimeProviderId } from '@/lib/api/tenant-job-runtime';
+import type { TenantRuntimeAllowlistResponse } from '@/lib/api/operator-tenant-runtime-allowlist';
+import {
+    deleteTenantRuntimeAllowlistEntryAction,
+    replaceTenantRuntimeAllowlistAction,
+} from '@/app/actions/admin/tenant-runtime-allowlist';
+
+interface TenantRuntimeAllowlistManagerProps {
+    readonly tenantId: string;
+    readonly initial: TenantRuntimeAllowlistResponse;
+}
+
+/**
+ * EW-742 P5.1 (T35a UI follow-up) — operator client component for
+ * editing a tenant's per-runtime-provider allow-list.
+ *
+ * Visual structure:
+ *   1. Status banner (`perTenantGatingEnabled` + saved-list summary)
+ *   2. Picker of the 5 known providers as checkboxes
+ *   3. Inline list of currently-saved providers with an `×` per-row
+ *      delete shortcut + Save / Clear actions
+ *
+ * The picker tracks a draft selection; "Save" replaces the whole list
+ * atomically via the operator PUT endpoint (single transaction on the
+ * API side), "Clear" replaces with an empty array (tenant inherits the
+ * global list), and per-row `×` removes a single provider via DELETE.
+ *
+ * Mirrors the visual language of `JobRuntimeSettings` (the tenant
+ * self-service view) — same Button / Checkbox / AlertTriangle
+ * primitives, same `space-y-*` rhythm — so an operator who has used
+ * the tenant page recognises the operator page immediately.
+ */
+const KNOWN_PROVIDERS: readonly TenantJobRuntimeProviderId[] = [
+    'trigger',
+    'temporal',
+    'bullmq',
+    'pgboss',
+    'inngest',
+] as const;
+
+const PROVIDER_LABELS: Record<TenantJobRuntimeProviderId, string> = {
+    trigger: 'Trigger.dev',
+    temporal: 'Temporal',
+    bullmq: 'BullMQ',
+    pgboss: 'pg-boss',
+    inngest: 'Inngest',
+};
+
+export function TenantRuntimeAllowlistManager({
+    tenantId,
+    initial,
+}: TenantRuntimeAllowlistManagerProps) {
+    const t = useTranslations('dashboard.adminTenantRuntimeAllowlist');
+    const [saved, setSaved] = useState<TenantRuntimeAllowlistResponse>(initial);
+    const [draft, setDraft] = useState<Set<TenantJobRuntimeProviderId>>(
+        () => new Set(initial.providerIds),
+    );
+    const [isPending, startTransition] = useTransition();
+
+    // Local change tracking — used to disable the Save button when the
+    // operator has not actually changed anything (avoids round-trips
+    // that would no-op on the API side but still emit an audit row).
+    const isDirty = useMemo(() => {
+        if (draft.size !== saved.providerIds.length) return true;
+        for (const id of saved.providerIds) {
+            if (!draft.has(id)) return true;
+        }
+        return false;
+    }, [draft, saved.providerIds]);
+
+    function toggle(providerId: TenantJobRuntimeProviderId, checked: boolean) {
+        setDraft((prev) => {
+            const next = new Set(prev);
+            if (checked) {
+                next.add(providerId);
+            } else {
+                next.delete(providerId);
+            }
+            return next;
+        });
+    }
+
+    function handleSave() {
+        // Preserve the user-friendly KNOWN_PROVIDERS order so the API
+        // receives a deterministic sequence; the server stores rows in
+        // insertion order and the operator UI lists them the same way.
+        const ordered: TenantJobRuntimeProviderId[] = KNOWN_PROVIDERS.filter((id) => draft.has(id));
+        startTransition(async () => {
+            const result = await replaceTenantRuntimeAllowlistAction(tenantId, ordered);
+            if (result.success) {
+                setSaved(result.data);
+                setDraft(new Set(result.data.providerIds));
+                toast.success(t('messages.saveSuccess'));
+            } else {
+                toast.error(result.error || t('messages.saveError'));
+            }
+        });
+    }
+
+    function handleClear() {
+        startTransition(async () => {
+            const result = await replaceTenantRuntimeAllowlistAction(tenantId, []);
+            if (result.success) {
+                setSaved(result.data);
+                setDraft(new Set());
+                toast.success(t('messages.saveSuccess'));
+            } else {
+                toast.error(result.error || t('messages.saveError'));
+            }
+        });
+    }
+
+    function handleDeleteRow(providerId: TenantJobRuntimeProviderId) {
+        startTransition(async () => {
+            const result = await deleteTenantRuntimeAllowlistEntryAction(tenantId, providerId);
+            if (result.success) {
+                setSaved(result.data);
+                setDraft(new Set(result.data.providerIds));
+                toast.success(t('messages.deleteSuccess'));
+            } else {
+                toast.error(result.error || t('messages.deleteError'));
+            }
+        });
+    }
+
+    // Status-banner copy depends on two orthogonal axes — gating
+    // on/off + saved-list empty/populated — so resolve it once here
+    // rather than scattering ternaries through JSX.
+    const gatingDisabled = !saved.perTenantGatingEnabled;
+    const savedList = saved.providerIds
+        .map((id) => PROVIDER_LABELS[id] ?? id)
+        .join(', ');
+
+    return (
+        <div className="space-y-8">
+            {gatingDisabled ? (
+                <div className="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg">
+                    <AlertTriangle className="w-5 h-5 text-warning flex-shrink-0 mt-0.5" />
+                    <p className="text-sm text-text dark:text-text-dark">
+                        {t('gatingDisabledBanner')}
+                    </p>
+                </div>
+            ) : saved.providerIds.length === 0 ? (
+                <div className="flex items-start gap-2 p-3 bg-surface-secondary/40 dark:bg-surface-secondary-dark/40 border border-border dark:border-border-dark rounded-lg">
+                    <p className="text-sm text-text dark:text-text-dark">
+                        {t('emptyInheritBanner')}
+                    </p>
+                </div>
+            ) : (
+                <div className="flex items-start gap-2 p-3 bg-surface-secondary/40 dark:bg-surface-secondary-dark/40 border border-border dark:border-border-dark rounded-lg">
+                    <p className="text-sm text-text dark:text-text-dark">
+                        {t('restrictedBanner', { providers: savedList })}
+                    </p>
+                </div>
+            )}
+
+            <section className="space-y-4 p-4 rounded-lg border border-border dark:border-border-dark">
+                <div>
+                    <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                        {t('pickerLabel')}
+                    </h2>
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark mt-1">
+                        {t('pickerHelper')}
+                    </p>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                    {KNOWN_PROVIDERS.map((providerId) => (
+                        <Checkbox
+                            key={providerId}
+                            id={`runtime-allowlist-${providerId}`}
+                            label={PROVIDER_LABELS[providerId]}
+                            checked={draft.has(providerId)}
+                            onChange={(e) => toggle(providerId, e.target.checked)}
+                            disabled={isPending}
+                        />
+                    ))}
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2 pt-2">
+                    <Button onClick={handleSave} loading={isPending} disabled={!isDirty}>
+                        <Save className="w-4 h-4" />
+                        {t('actions.save')}
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        onClick={handleClear}
+                        disabled={isPending || saved.providerIds.length === 0}
+                    >
+                        <Eraser className="w-4 h-4" />
+                        {t('actions.clear')}
+                    </Button>
+                </div>
+            </section>
+
+            <section className="space-y-3">
+                <h2 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('savedListLabel')}
+                </h2>
+                {saved.providerIds.length === 0 ? (
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                        {t('messages.noProviders')}
+                    </p>
+                ) : (
+                    <ul className="flex flex-wrap gap-2">
+                        {saved.providerIds.map((providerId) => (
+                            <li
+                                key={providerId}
+                                className="inline-flex items-center gap-1.5 rounded-full border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40 pl-3 pr-1.5 py-1 text-xs text-text dark:text-text-dark"
+                            >
+                                <span>{PROVIDER_LABELS[providerId] ?? providerId}</span>
+                                <button
+                                    type="button"
+                                    onClick={() => handleDeleteRow(providerId)}
+                                    disabled={isPending}
+                                    aria-label={t('actions.removeProvider', {
+                                        provider: PROVIDER_LABELS[providerId] ?? providerId,
+                                    })}
+                                    className="inline-flex items-center justify-center w-5 h-5 rounded-full hover:bg-danger/10 hover:text-danger disabled:opacity-50 transition-colors"
+                                >
+                                    <X className="w-3 h-3" />
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </section>
+        </div>
+    );
+}

--- a/apps/web/src/lib/api/operator-tenant-runtime-allowlist.ts
+++ b/apps/web/src/lib/api/operator-tenant-runtime-allowlist.ts
@@ -1,0 +1,79 @@
+import 'server-only';
+import { serverFetch, serverMutation } from './server-api';
+import type { TenantJobRuntimeProviderId } from './tenant-job-runtime';
+
+/**
+ * EW-742 P5.1 (T35a UI follow-up) — web client for the operator-scoped
+ * per-tenant runtime provider allow-list REST API (mounted at
+ * `/api/operator/tenants/:tenantId/runtime-allowlist` on the platform
+ * API — see `apps/api/src/operator/tenant-runtime-allowlist/operator-tenant-runtime-allowlist.controller.ts`).
+ *
+ * Auth: gated by `IsPlatformAdminGuard` on the controller. This wrapper
+ * is server-only (`'server-only'`); the caller's JWT cookie is attached
+ * by `serverFetch` / `serverMutation`. There is no client-side fallback.
+ *
+ * Shape mirrors `lib/api/tenant-job-runtime.ts` (the tenant
+ * self-service surface for the same overlay), but every endpoint here
+ * is path-scoped to a specific `tenantId` because the caller is an
+ * instance operator acting on ANOTHER tenant's row.
+ */
+
+export interface TenantRuntimeAllowlistResponse {
+    /** Echoed back so the caller can correlate response with request. */
+    tenantId: string;
+    /**
+     * Per-tenant allow-list rows. Empty means "tenant inherits the
+     * global allow-list" (when gating is on) or "no per-tenant
+     * restriction" (when gating is off — list is preserved but ignored).
+     */
+    providerIds: TenantJobRuntimeProviderId[];
+    /**
+     * Whether per-tenant gating is currently ON. Driven by env
+     * `EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING`. Echoed so the
+     * operator can tell at a glance whether the rows actually take
+     * effect right now.
+     */
+    perTenantGatingEnabled: boolean;
+}
+
+const base = (tenantId: string) => `/api/operator/tenants/${tenantId}/runtime-allowlist`;
+
+export const operatorTenantRuntimeAllowlistAPI = {
+    list: async (tenantId: string) => {
+        return serverFetch<TenantRuntimeAllowlistResponse>(base(tenantId));
+    },
+
+    replace: async (tenantId: string, providerIds: TenantJobRuntimeProviderId[]) => {
+        return serverMutation<TenantRuntimeAllowlistResponse>({
+            endpoint: base(tenantId),
+            data: { providerIds },
+            method: 'PUT',
+            wrapInData: false,
+        });
+    },
+
+    deleteEntry: async (tenantId: string, providerId: TenantJobRuntimeProviderId) => {
+        return serverMutation<TenantRuntimeAllowlistResponse>({
+            endpoint: `${base(tenantId)}/${providerId}`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
+};
+
+/**
+ * Convenience aliases mirroring the function shape called out in the
+ * implementing prompt, so call sites that don't want to thread the
+ * namespaced object can import these directly.
+ */
+export const getTenantRuntimeAllowlist = (tenantId: string) =>
+    operatorTenantRuntimeAllowlistAPI.list(tenantId);
+export const replaceTenantRuntimeAllowlist = (
+    tenantId: string,
+    providerIds: TenantJobRuntimeProviderId[],
+) => operatorTenantRuntimeAllowlistAPI.replace(tenantId, providerIds);
+export const deleteTenantRuntimeAllowlistEntry = (
+    tenantId: string,
+    providerId: TenantJobRuntimeProviderId,
+) => operatorTenantRuntimeAllowlistAPI.deleteEntry(tenantId, providerId);

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -99,8 +99,10 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'Tenant',
     'TenantEmailAddress',
     // Tenant-scoped job-runtime overlay (EW-742 P1 / EW-745) ──
+    'TenantCredentialSnapshot',
     'TenantJobRuntimeAudit',
     'TenantJobRuntimeConfig',
+    'TenantRuntimeProviderAllowlist',
     // ──────────────────────────────────────────────────────────
     'UsageLedgerEntry',
     'User',

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -91,6 +91,8 @@ import {
     TenantJobRuntimeAudit,
     // Per-tenant runtime provider allow-list overlay (EW-752 P5.1)
     TenantRuntimeProviderAllowlist,
+    // Per-version credential snapshot history (EW-742 P1 T11 follow-up)
+    TenantCredentialSnapshot,
 } from '../entities';
 import {
     PluginEntity,
@@ -233,6 +235,11 @@ export const ENTITIES = [
     TenantJobRuntimeAudit,
     // Per-tenant runtime provider allow-list overlay (EW-752 P5.1)
     TenantRuntimeProviderAllowlist,
+    // Per-version credential snapshot history (EW-742 P1 T11 follow-up) —
+    // backs CredentialVersionService.resolveSnapshot for v < current so
+    // in-flight runs can bind to their captured credentials after a
+    // rotation (ADR-017 §3 Q4).
+    TenantCredentialSnapshot,
 ];
 
 /**

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -95,3 +95,6 @@ export * from './tenant-job-runtime-config.entity';
 export * from './tenant-job-runtime-audit.entity';
 // EW-752 P5.1 — per-tenant runtime provider allow-list overlay (T35a + T35b)
 export * from './tenant-runtime-provider-allowlist.entity';
+// EW-742 P1 T11 follow-up — per-version credential snapshot history
+// (graceful drain per ADR-017 §3 Q4)
+export * from './tenant-credential-snapshot.entity';

--- a/packages/agent/src/entities/tenant-credential-snapshot.entity.ts
+++ b/packages/agent/src/entities/tenant-credential-snapshot.entity.ts
@@ -1,0 +1,108 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * EW-742 P1 T11 follow-up — per-version credential snapshot history for
+ * the tenant overlay. Backs the graceful-drain semantic from
+ * [ADR-017 §3 Q4](../../../../docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md#3-credential-rotation--graceful-drain-locked-q4-do-not-reopen):
+ * an in-flight run enqueued at `credentialVersion = N` keeps its captured
+ * credential bag for the run's full lifetime, even after the operator
+ * rotates the tenant to `N+1`. Without this table the resolver loses the
+ * old bag the moment a rotation lands and the run binds to whatever's
+ * current — which is precisely the drain bug Q4 forbids.
+ *
+ * # Why a separate table (not a JSONB column on tenant_job_runtime_config)
+ *
+ *   - `tenant_job_runtime_config` is a single row per tenant; storing
+ *     history inline would force unbounded JSONB growth and lose the
+ *     per-version uniqueness guarantee at the DB layer.
+ *   - A dedicated table lets us index `(tenantId, providerId,
+ *     credentialVersion)` and FK other rows (future audit linkage) to the
+ *     specific snapshot the run actually used.
+ *   - Snapshot pruning (drop snapshots older than the oldest in-flight
+ *     run) becomes a single `DELETE FROM tenant_credential_snapshot WHERE
+ *     credentialVersion < $cutoff` query.
+ *
+ * # Cardinality + uniqueness
+ *
+ *   - PK is a synthetic `uuid` so other tables can FK to a specific
+ *     snapshot row (future audit / run-history linkage). The natural key
+ *     `(tenantId, providerId, credentialVersion)` is enforced as a
+ *     UNIQUE INDEX at the migration layer — re-inserting the same tuple
+ *     is the caller's signal that the snapshot already exists, and the
+ *     service translates the PK-conflict into a no-op (idempotency).
+ *   - `providerId` is `varchar(64)` to match the convention used by
+ *     `tenant_job_runtime_config.providerId` so adding a new provider
+ *     never needs a type-altering migration.
+ *
+ * # Encryption
+ *
+ *   - `credentialsEncrypted` is **already encrypted** by the time it
+ *     reaches this entity. The secret-store resolver layer (P3.2 / EW-748)
+ *     owns the at-rest envelope under `PLUGIN_SECRET_ENCRYPTION_KEY` (see
+ *     [`settings-system.md` §5](../../../../docs/specs/architecture/settings-system.md));
+ *     this column is a transparent passthrough.
+ *   - JSONB (not BYTEA) so future schema evolution of the bag's shape
+ *     never needs a type-altering migration. The bag's interior keys are
+ *     opaque to TypeORM and the service — `Record<string, unknown>`.
+ *
+ * No `@ManyToOne` relations declared — see `user.entity.ts` EW-654
+ * comment for the import-cycle rationale shared across every
+ * tenant-scoped entity. The FK to `tenants(id)` (ON DELETE CASCADE) and
+ * the UNIQUE index on `(tenantId, providerId, credentialVersion)` are
+ * enforced at the DB layer by the migration
+ * `1781300000000-AddTenantCredentialSnapshot`.
+ */
+@Entity({ name: 'tenant_credential_snapshot' })
+export class TenantCredentialSnapshot {
+    /**
+     * Synthetic PK so other tables can FK to a specific snapshot row
+     * (future audit linkage). The natural key
+     * `(tenantId, providerId, credentialVersion)` is the unique index
+     * created by the migration.
+     */
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /**
+     * FK to `tenants.id`. Indexed because the most common lookup is
+     * "give me every snapshot for tenant X" (drain reconciliation +
+     * operator dashboards). The composite UNIQUE index also covers
+     * `(tenantId, providerId, credentialVersion)` lookups.
+     */
+    @Column({ type: 'uuid' })
+    @Index('idx_tenant_credential_snapshot_tenant')
+    tenantId: string;
+
+    /**
+     * Matches `IJobRuntimeProvider.runtimeId` (one of `'trigger' |
+     * 'temporal' | 'bullmq' | 'pgboss' | 'inngest'` today). `varchar(64)`
+     * keeps it consistent with `tenant_job_runtime_config.providerId`.
+     */
+    @Column({ type: 'varchar', length: 64 })
+    providerId: string;
+
+    /**
+     * The monotonic per-tenant version this snapshot captures. Together
+     * with `(tenantId, providerId)` forms the natural key enforced by
+     * the migration's UNIQUE index.
+     */
+    @Column({ type: 'integer' })
+    credentialVersion: number;
+
+    /**
+     * The credential bag as stored — **already encrypted** by the
+     * secret-store resolver layer. Stored as JSONB so future schema
+     * evolution doesn't need a type-altering migration. Whether
+     * decryption happens at write or read time is operator-side; this
+     * column just persists the bag verbatim.
+     */
+    @Column({ type: 'jsonb' })
+    credentialsEncrypted: Record<string, unknown>;
+
+    /**
+     * Wall-clock capture time. Set automatically by TypeORM on insert;
+     * never updated (snapshots are immutable history rows).
+     */
+    @CreateDateColumn()
+    capturedAt: Date;
+}

--- a/packages/agent/src/tasks/__tests__/credential-version-history.service.spec.ts
+++ b/packages/agent/src/tasks/__tests__/credential-version-history.service.spec.ts
@@ -1,0 +1,352 @@
+import { CredentialVersionService } from '../credential-version.service';
+import type { TenantCredentialSnapshot } from '../../entities/tenant-credential-snapshot.entity';
+import type { TenantJobRuntimeConfig } from '../../entities/tenant-job-runtime-config.entity';
+
+/**
+ * EW-742 P1 T11 follow-up — coverage for the snapshot-history side of
+ * `CredentialVersionService`. The base service contract (bumpVersion +
+ * resolveSnapshot for `version == current`) is already covered by
+ * `apps/api/src/works/__tests__/tenant-job-runtime-config.repository.spec.ts`;
+ * this file pins the **history** behaviours that the original P1 stopgap
+ * deferred:
+ *
+ *   1. `captureSnapshot` inserts a row through the snapshot repository.
+ *   2. `captureSnapshot` is idempotent on the natural key — re-inserting
+ *      the same `(tenantId, providerId, credentialVersion)` triple is a
+ *      no-op (the migration's UNIQUE index + `orIgnore()` swallow the
+ *      conflict; defensive try/catch swallows it on drivers that ignore
+ *      the directive).
+ *   3. `resolveSnapshot(tenantId, current)` returns the live overlay row
+ *      directly (no history-table read at all).
+ *   4. `resolveSnapshot(tenantId, current - 1)` synthesises a config-shaped
+ *      row from the historical bag.
+ *   5. `resolveSnapshot(tenantId, unknown-version)` returns null when no
+ *      history row exists either.
+ *   6. `bumpVersion` extension — when the caller passes credentials, the
+ *      post-bump snapshot is captured AND `current()` advances.
+ *
+ * Repository mocks mirror the pattern from
+ * `packages/agent/src/database/repositories/*.repository.spec.ts` —
+ * shallow duck-typed objects with `jest.fn()` per method, satisfying
+ * only the surface the service touches.
+ */
+
+type RepoMock = {
+    create: jest.Mock;
+    save: jest.Mock;
+    findOne: jest.Mock;
+    find: jest.Mock;
+    update: jest.Mock;
+    increment: jest.Mock;
+    createQueryBuilder: jest.Mock;
+};
+
+function makeRepo(): RepoMock {
+    return {
+        create: jest.fn((data) => data),
+        save: jest.fn(async (row) => row),
+        findOne: jest.fn(),
+        find: jest.fn(),
+        update: jest.fn(),
+        increment: jest.fn(),
+        createQueryBuilder: jest.fn(),
+    };
+}
+
+/**
+ * Build a fake `createQueryBuilder` chain that mirrors the shape
+ * `CredentialVersionService.captureSnapshot` uses:
+ *
+ *   .createQueryBuilder().insert().into(...).values(...).orIgnore().execute()
+ *
+ * The terminal `execute` is the only step that actually does work; the
+ * intermediate links just return the next builder. `executeImpl` controls
+ * what `execute()` resolves to (or throws) — defaults to a resolved
+ * `undefined`, the no-op success case.
+ *
+ * Tests inspect `valuesMock` (returned alongside the chain) to assert
+ * the payload the service passed in.
+ */
+function makeInsertChain(executeImpl: () => Promise<unknown>) {
+    const execute = jest.fn(executeImpl);
+    const orIgnore = jest.fn(() => ({ execute }));
+    const values = jest.fn(() => ({ orIgnore }));
+    const into = jest.fn(() => ({ values }));
+    const insert = jest.fn(() => ({ into }));
+    return {
+        chain: { insert },
+        values,
+        orIgnore,
+        execute,
+        insert,
+        into,
+    };
+}
+
+describe('CredentialVersionService — snapshot history (EW-742 P1 T11 follow-up)', () => {
+    let configRepo: RepoMock;
+    let snapshotRepo: RepoMock;
+    let service: CredentialVersionService;
+
+    beforeEach(() => {
+        configRepo = makeRepo();
+        snapshotRepo = makeRepo();
+        service = new CredentialVersionService(
+            configRepo as unknown as never,
+            snapshotRepo as unknown as never,
+        );
+    });
+
+    describe('captureSnapshot', () => {
+        it('inserts a row into the snapshot history table', async () => {
+            const insertChain = makeInsertChain(async () => undefined);
+            snapshotRepo.createQueryBuilder.mockReturnValueOnce(insertChain.chain);
+
+            await service.captureSnapshot('tenant-a', 'trigger', 5, {
+                token: 'enc:abc',
+            });
+
+            expect(snapshotRepo.createQueryBuilder).toHaveBeenCalledTimes(1);
+            expect(insertChain.values).toHaveBeenCalledWith({
+                tenantId: 'tenant-a',
+                providerId: 'trigger',
+                credentialVersion: 5,
+                credentialsEncrypted: { token: 'enc:abc' },
+            });
+            expect(insertChain.orIgnore).toHaveBeenCalledTimes(1);
+            expect(insertChain.execute).toHaveBeenCalledTimes(1);
+        });
+
+        it('is idempotent on the natural key when the driver swallows via orIgnore (no throw)', async () => {
+            // Postgres path: `ON CONFLICT DO NOTHING` makes execute() resolve
+            // cleanly even on a duplicate insert. Two back-to-back captures
+            // of the same triple must both succeed without surfacing.
+            const first = makeInsertChain(async () => undefined);
+            const second = makeInsertChain(async () => undefined);
+            snapshotRepo.createQueryBuilder
+                .mockReturnValueOnce(first.chain)
+                .mockReturnValueOnce(second.chain);
+
+            await service.captureSnapshot('tenant-a', 'trigger', 5, { token: 'enc:abc' });
+            await service.captureSnapshot('tenant-a', 'trigger', 5, { token: 'enc:abc' });
+
+            expect(snapshotRepo.createQueryBuilder).toHaveBeenCalledTimes(2);
+            expect(first.execute).toHaveBeenCalledTimes(1);
+            expect(second.execute).toHaveBeenCalledTimes(1);
+        });
+
+        it('is idempotent on the natural key when the driver throws a unique-violation', async () => {
+            // Defensive path — some drivers / TypeORM versions surface
+            // the conflict as a thrown error even with `.orIgnore()`. The
+            // service must detect the unique-violation signature and
+            // treat it as a no-op (still no throw to the caller).
+            const insertChain = makeInsertChain(async () => {
+                throw new Error('duplicate key value violates unique constraint "uq_…"');
+            });
+            snapshotRepo.createQueryBuilder.mockReturnValueOnce(insertChain.chain);
+
+            await expect(
+                service.captureSnapshot('tenant-a', 'trigger', 5, { token: 'enc:abc' }),
+            ).resolves.toBeUndefined();
+        });
+
+        it('propagates non-unique-violation errors', async () => {
+            // A connection drop or schema error MUST NOT be silently
+            // swallowed — that would mask real outages behind the
+            // idempotency story.
+            const insertChain = makeInsertChain(async () => {
+                throw new Error('connection terminated');
+            });
+            snapshotRepo.createQueryBuilder.mockReturnValueOnce(insertChain.chain);
+
+            await expect(
+                service.captureSnapshot('tenant-a', 'trigger', 5, { token: 'enc:abc' }),
+            ).rejects.toThrow(/connection terminated/);
+        });
+    });
+
+    describe('resolveSnapshot', () => {
+        it('returns the current overlay row when version === current (no history read)', async () => {
+            const row = {
+                tenantId: 'tenant-a',
+                providerId: 'trigger',
+                credentialsSecretRef: 'vault:cur',
+                credentialVersion: 5,
+                mode: 'byo',
+                enabled: true,
+                createdBy: null,
+                createdAt: new Date('2026-01-01T00:00:00Z'),
+                updatedAt: new Date('2026-01-02T00:00:00Z'),
+            } as TenantJobRuntimeConfig;
+            configRepo.findOne.mockResolvedValueOnce(row);
+
+            const snap = await service.resolveSnapshot('tenant-a', 5);
+
+            expect(snap).toBe(row);
+            // Fast path — history table is never consulted when the
+            // requested version is the current one.
+            expect(snapshotRepo.findOne).not.toHaveBeenCalled();
+        });
+
+        it('synthesises a config row from the snapshot when version === current - 1', async () => {
+            const currentRow = {
+                tenantId: 'tenant-a',
+                providerId: 'trigger',
+                credentialsSecretRef: 'vault:cur',
+                credentialVersion: 6,
+                mode: 'byo',
+                enabled: true,
+                createdBy: 'user-1',
+                createdAt: new Date('2026-01-01T00:00:00Z'),
+                updatedAt: new Date('2026-01-02T00:00:00Z'),
+            } as TenantJobRuntimeConfig;
+            const historyRow = {
+                id: 'snap-uuid',
+                tenantId: 'tenant-a',
+                providerId: 'trigger',
+                credentialVersion: 5,
+                credentialsEncrypted: { token: 'enc:prev' },
+                capturedAt: new Date('2026-01-01T12:00:00Z'),
+            } as TenantCredentialSnapshot;
+
+            configRepo.findOne.mockResolvedValueOnce(currentRow);
+            snapshotRepo.findOne.mockResolvedValueOnce(historyRow);
+
+            const snap = await service.resolveSnapshot('tenant-a', 5);
+
+            expect(snap).not.toBeNull();
+            // Tenant-level metadata inherited from the current row.
+            expect(snap?.mode).toBe('byo');
+            expect(snap?.enabled).toBe(true);
+            expect(snap?.createdBy).toBe('user-1');
+            // Version-pinned fields restored from history.
+            expect(snap?.credentialVersion).toBe(5);
+            expect(snap?.providerId).toBe('trigger');
+            // The historical bag is re-issued as an `inline:` pointer so
+            // the existing secret-store resolver chain dereferences it
+            // through its existing path. Decoding the base64 round-trips
+            // back to the original bag.
+            expect(snap?.credentialsSecretRef).toMatch(/^inline:/);
+            const encoded = snap!.credentialsSecretRef!.slice('inline:'.length);
+            const decoded = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'));
+            expect(decoded).toEqual({ token: 'enc:prev' });
+            // History lookup scoped by the natural key.
+            expect(snapshotRepo.findOne).toHaveBeenCalledWith({
+                where: {
+                    tenantId: 'tenant-a',
+                    providerId: 'trigger',
+                    credentialVersion: 5,
+                },
+            });
+        });
+
+        it('returns null for an unknown historical version (drained)', async () => {
+            const currentRow = {
+                tenantId: 'tenant-a',
+                providerId: 'trigger',
+                credentialVersion: 6,
+                mode: 'byo',
+                enabled: true,
+            } as TenantJobRuntimeConfig;
+            configRepo.findOne.mockResolvedValueOnce(currentRow);
+            snapshotRepo.findOne.mockResolvedValueOnce(null);
+
+            const snap = await service.resolveSnapshot('tenant-a', 99);
+
+            expect(snap).toBeNull();
+        });
+
+        it('returns null when the tenant has no overlay row at all', async () => {
+            configRepo.findOne.mockResolvedValueOnce(null);
+
+            const snap = await service.resolveSnapshot('tenant-missing', 1);
+
+            expect(snap).toBeNull();
+            // No tenant overlay → no point asking history.
+            expect(snapshotRepo.findOne).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('bumpVersion (extended)', () => {
+        it('captures the new version snapshot AND advances current()', async () => {
+            // Stage 1 — bumpVersion with credentials.
+            configRepo.increment.mockResolvedValueOnce({ affected: 1 } as never);
+            configRepo.findOne.mockResolvedValueOnce({
+                tenantId: 'tenant-a',
+                providerId: 'trigger',
+                credentialVersion: 3,
+            } as TenantJobRuntimeConfig);
+            const insertChain = makeInsertChain(async () => undefined);
+            snapshotRepo.createQueryBuilder.mockReturnValueOnce(insertChain.chain);
+
+            const newVersion = await service.bumpVersion('tenant-a', 'trigger', {
+                token: 'enc:new',
+            });
+
+            expect(newVersion).toBe(3);
+            // The new bag was captured under the new version.
+            expect(insertChain.values).toHaveBeenCalledWith({
+                tenantId: 'tenant-a',
+                providerId: 'trigger',
+                credentialVersion: 3,
+                credentialsEncrypted: { token: 'enc:new' },
+            });
+
+            // Stage 2 — getCurrentVersion reflects the bump.
+            configRepo.findOne.mockResolvedValueOnce({
+                tenantId: 'tenant-a',
+                credentialVersion: 3,
+            } as TenantJobRuntimeConfig);
+            expect(await service.getCurrentVersion('tenant-a')).toBe(3);
+        });
+
+        it('falls back to the row providerId when caller omits it but supplies credentials', async () => {
+            configRepo.increment.mockResolvedValueOnce({ affected: 1 } as never);
+            configRepo.findOne.mockResolvedValueOnce({
+                tenantId: 'tenant-a',
+                providerId: 'temporal',
+                credentialVersion: 4,
+            } as TenantJobRuntimeConfig);
+            const insertChain = makeInsertChain(async () => undefined);
+            snapshotRepo.createQueryBuilder.mockReturnValueOnce(insertChain.chain);
+
+            await service.bumpVersion('tenant-a', undefined, { token: 'enc:y' });
+
+            expect(insertChain.values).toHaveBeenCalledWith({
+                tenantId: 'tenant-a',
+                providerId: 'temporal',
+                credentialVersion: 4,
+                credentialsEncrypted: { token: 'enc:y' },
+            });
+        });
+
+        it('skips snapshot capture when no credentials are supplied (legacy 1-arg call)', async () => {
+            // The legacy bumpVersion(tenantId) signature stays a pure
+            // version pointer rotation — call sites that don't have the
+            // bag in hand (force-invalidate, the audit-only path) MUST
+            // NOT trigger a half-empty snapshot row.
+            configRepo.increment.mockResolvedValueOnce({ affected: 1 } as never);
+            configRepo.findOne.mockResolvedValueOnce({
+                tenantId: 'tenant-a',
+                providerId: 'trigger',
+                credentialVersion: 7,
+            } as TenantJobRuntimeConfig);
+
+            const newVersion = await service.bumpVersion('tenant-a');
+
+            expect(newVersion).toBe(7);
+            expect(snapshotRepo.createQueryBuilder).not.toHaveBeenCalled();
+        });
+
+        it('returns null and skips snapshot capture when no overlay row exists', async () => {
+            configRepo.increment.mockResolvedValueOnce({ affected: 0 } as never);
+
+            const result = await service.bumpVersion('tenant-missing', 'trigger', {
+                token: 'enc:x',
+            });
+
+            expect(result).toBeNull();
+            expect(snapshotRepo.createQueryBuilder).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/agent/src/tasks/__tests__/job-runtime.providers.spec.ts
+++ b/packages/agent/src/tasks/__tests__/job-runtime.providers.spec.ts
@@ -208,11 +208,12 @@ describe('job-runtime.providers (EW-685 P0 T4 binding factory)', () => {
             }
         });
 
-        it('symbols filter binds only the requested subset (EW-685 T4 partial cutover)', () => {
-            // The TriggerModule cutover passes 8 of the 11 symbols because
-            // the remaining 3 (KB_NORMALIZE_MEDIA / KB_TRANSCRIBE /
-            // KB_REEMBED_WORK) are bound in works.module.ts under custom
-            // Trigger.dev SDK adapters with their own soft-error contracts.
+        it('symbols filter binds only the requested subset (pull-model provider partial bind)', () => {
+            // EW-685 T4 full cutover landed in trigger.module.ts with no
+            // `symbols:` filter (all 11 bind through the registry). The
+            // `symbols:` option remains for tests and for future modules
+            // that want to bind a strict subset (e.g. a pull-model worker
+            // host that only owns a subset of the dispatcher surface).
             // The factory must honour the subset and return EXACTLY those
             // providers — no fewer, no more.
             const subset: readonly symbol[] = [

--- a/packages/agent/src/tasks/_tasks-symbols.ts
+++ b/packages/agent/src/tasks/_tasks-symbols.ts
@@ -40,8 +40,9 @@ export const TASKS_BARREL_RUNTIME_SYMBOLS: ReadonlyArray<string> = [
     'InProcessSecretStoreResolver',
     // EW-685 P0 T4 — DI token for the in-memory job-runtime provider
     // registry consumed by the binding factory `buildJobRuntimeProviders()`.
-    // Declared but not wired into any NestJS module yet; see
-    // `job-runtime.providers.ts` header "Critical constraint" for rationale.
+    // Wired into `packages/tasks/src/trigger/trigger.module.ts` per the
+    // EW-685 T4 full cutover (all 11 *_DISPATCHER symbols resolve
+    // through the registry, no per-dispatcher special-casing).
     'JOB_RUNTIME_PROVIDER_REGISTRY',
     'KB_BACKFILL_SKELETON_DISPATCHER',
     'KB_EMBED_DOCUMENT_DISPATCHER',
@@ -50,6 +51,11 @@ export const TASKS_BARREL_RUNTIME_SYMBOLS: ReadonlyArray<string> = [
     'KB_ORG_OVERLAY_FANOUT_DISPATCHER',
     'KB_REEMBED_WORK_DISPATCHER',
     'KB_TRANSCRIBE_DISPATCHER',
+    // EW-685 P0 T4 — binding factory that wires every `*_DISPATCHER` symbol
+    // onto the active job-runtime provider's `dispatchers` view via the
+    // `JOB_RUNTIME_PROVIDER_REGISTRY`. Wired into TriggerModule per the
+    // EW-685 T4 full cutover.
+    'buildJobRuntimeProviders',
     // EW-742 P3.1 / T22 — enqueue-site `credentialVersion` capture helper.
     // Dispatchers `await stamper.stamp(tenantId)` and write the result into
     // the run record so the worker host can later resolve THAT snapshot

--- a/packages/agent/src/tasks/credential-version.service.ts
+++ b/packages/agent/src/tasks/credential-version.service.ts
@@ -1,12 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { TenantCredentialSnapshot } from '../entities/tenant-credential-snapshot.entity';
 import { TenantJobRuntimeConfig } from '../entities/tenant-job-runtime-config.entity';
 
 /**
- * EW-742 P1 (T11) — issues + resolves the monotonic per-tenant
- * `credentialVersion` that powers the graceful-drain semantics from
- * [ADR-017 §3](../../../../docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md#3-credential-rotation--graceful-drain-locked-q4-do-not-reopen)
+ * EW-742 P1 (T11) + T11 follow-up — issues and resolves the monotonic
+ * per-tenant `credentialVersion` that powers the graceful-drain semantics
+ * from [ADR-017 §3](../../../../docs/specs/decisions/017-tenant-scoped-job-runtime-overlay.md#3-credential-rotation--graceful-drain-locked-q4-do-not-reopen)
  * (Q4) and [`spec.md` FR-5](../../../../docs/specs/features/tenant-job-runtime-overlay/spec.md):
  *
  *   - every enqueue captures the current `(tenantId, credentialVersion)`
@@ -15,13 +16,23 @@ import { TenantJobRuntimeConfig } from '../entities/tenant-job-runtime-config.en
  *     full lifetime, even if the tenant rotates mid-run;
  *   - new enqueues see the new version on next dispatch.
  *
- * Singleton-scoped service (no per-request state). Sits in
- * `packages/agent/src/tasks/` next to the dispatcher symbols it will
- * collaborate with in EW-742 P3 (T22 — credential version capture at
- * every enqueue) so the import is local to the tasks layer rather than
- * crossing into the agent's facade tier.
+ * # Snapshot history (T11 follow-up)
  *
- * The companion resolver (P3 / T20) will live alongside this service.
+ * The graceful-drain contract is only honoured if a request for
+ * `version = N` keeps returning the version-N credentials AFTER the
+ * tenant rotates to `N+1`. The original P1 stopgap returned `null` for
+ * `version != current` because the snapshot history table did not yet
+ * exist; this service now reads from `tenant_credential_snapshot` (entity
+ * `TenantCredentialSnapshot`) for the historical path. `captureSnapshot`
+ * is the write side — callers (the rotation flow inside
+ * `TenantJobRuntimeService` and the bumpVersion helper) MUST invoke it
+ * with the NEW credential bag immediately after the version is advanced
+ * so the next rotation has a row to drain back to.
+ *
+ * Singleton-scoped service (no per-request state). Sits in
+ * `packages/agent/src/tasks/` next to the dispatcher symbols it
+ * collaborates with so the import is local to the tasks layer rather
+ * than crossing into the agent's facade tier.
  */
 @Injectable()
 export class CredentialVersionService {
@@ -30,6 +41,8 @@ export class CredentialVersionService {
     constructor(
         @InjectRepository(TenantJobRuntimeConfig)
         private readonly repository: Repository<TenantJobRuntimeConfig>,
+        @InjectRepository(TenantCredentialSnapshot)
+        private readonly snapshotRepo: Repository<TenantCredentialSnapshot>,
     ) {}
 
     /**
@@ -43,8 +56,26 @@ export class CredentialVersionService {
      * `UPDATE ... SET "credentialVersion" = "credentialVersion" + 1`
      * round-trip — no read-modify-write race window. The subsequent
      * `findOne` reads the post-update value committed by the UPDATE.
+     *
+     * # Snapshot capture (T11 follow-up)
+     *
+     * When the caller supplies `providerId` + `newCredentials`, the
+     * post-bump version is persisted to the snapshot history table in
+     * the same call. This is what makes the **next** rotation's drain
+     * work: the moment v=N+2 lands, v=N+1's credentials are still
+     * resolvable from `tenant_credential_snapshot`. Callers that already
+     * have the credentials bag in hand (the rotation flow inside
+     * `TenantJobRuntimeService`) SHOULD pass them; callers that don't
+     * (e.g. the legacy single-arg path used by tests / the
+     * force-invalidate endpoint that only rotates the version pointer)
+     * can omit them and call `captureSnapshot` separately when the bag
+     * is later resolved.
      */
-    async bumpVersion(tenantId: string): Promise<number | null> {
+    async bumpVersion(
+        tenantId: string,
+        providerId?: string,
+        newCredentials?: Record<string, unknown>,
+    ): Promise<number | null> {
         const result = await this.repository.increment({ tenantId }, 'credentialVersion', 1);
         if (!result.affected) {
             return null;
@@ -54,6 +85,29 @@ export class CredentialVersionService {
         this.logger.debug(
             `Bumped credentialVersion for tenant ${tenantId} → ${newVersion ?? 'unknown'}`,
         );
+
+        // Capture the new snapshot in the same call when the caller has
+        // already supplied the credentials. Falling back to the row's
+        // `providerId` if the caller omitted it (rotations always target
+        // the row's current provider — `mode` switches go through a
+        // different flow that bumps separately).
+        if (newVersion !== null && newCredentials) {
+            const effectiveProviderId = providerId ?? row?.providerId;
+            if (effectiveProviderId) {
+                await this.captureSnapshot(
+                    tenantId,
+                    effectiveProviderId,
+                    newVersion,
+                    newCredentials,
+                );
+            } else {
+                this.logger.warn(
+                    `bumpVersion for tenant ${tenantId} v${newVersion}: caller supplied ` +
+                        `credentials but no providerId and the row lacks one. Snapshot skipped.`,
+                );
+            }
+        }
+
         return newVersion;
     }
 
@@ -72,27 +126,99 @@ export class CredentialVersionService {
     }
 
     /**
+     * Persist a `(tenantId, providerId, credentialVersion)` snapshot to
+     * the history table. Idempotent on the natural key — re-calling with
+     * the same tuple is a no-op (the migration's UNIQUE index turns the
+     * second INSERT into a `ConflictException`; we swallow it because
+     * "the snapshot already exists" is exactly what the caller wants).
+     *
+     * `credentialsEncrypted` is stored verbatim — encryption is the
+     * secret-store resolver layer's responsibility (P3.2 / EW-748). This
+     * column never touches plaintext; the bag passed in MUST already be
+     * the at-rest encrypted form (or in the inline:/dev case, the bag
+     * the operator wants persisted as-is).
+     */
+    async captureSnapshot(
+        tenantId: string,
+        providerId: string,
+        credentialVersion: number,
+        credentialsEncrypted: Record<string, unknown>,
+    ): Promise<void> {
+        try {
+            // Use `insert` (not `save`) so we get a clean PK-conflict on
+            // re-insert rather than an UPDATE — the natural key is the
+            // unique index `(tenantId, providerId, credentialVersion)`
+            // and snapshots are immutable. We translate the conflict
+            // into a no-op below.
+            //
+            // `orIgnore: true` would also work on Postgres (TypeORM emits
+            // `ON CONFLICT DO NOTHING`), and it avoids paying the cost
+            // of the secondary lookup. Use it when supported; fall back
+            // to catch-and-swallow on drivers that don't (better-sqlite3
+            // and older TypeORM versions still understand the boolean).
+            await this.snapshotRepo
+                .createQueryBuilder()
+                .insert()
+                .into(TenantCredentialSnapshot)
+                .values({
+                    tenantId,
+                    providerId,
+                    credentialVersion,
+                    credentialsEncrypted,
+                })
+                .orIgnore()
+                .execute();
+            this.logger.debug(
+                `Captured credential snapshot for tenant=${tenantId} provider=${providerId} ` +
+                    `v=${credentialVersion}`,
+            );
+        } catch (err) {
+            // Defensive: if `.orIgnore()` somehow doesn't suppress the
+            // unique-constraint violation (driver-specific behaviour),
+            // detect-and-swallow on the natural-key conflict so the
+            // method stays idempotent.
+            const message = err instanceof Error ? err.message : String(err);
+            const isUniqueViolation =
+                /duplicate key|unique constraint|UNIQUE constraint/i.test(message);
+            if (!isUniqueViolation) {
+                throw err;
+            }
+            this.logger.debug(
+                `captureSnapshot idempotent no-op for tenant=${tenantId} provider=${providerId} ` +
+                    `v=${credentialVersion} (snapshot already exists)`,
+            );
+        }
+    }
+
+    /**
      * Resolves the credential snapshot for a specific `(tenantId,
-     * version)` tuple. Used by the worker host (P4) when handling an
-     * in-flight run whose enqueue captured `version` — the snapshot MUST
-     * still be the credential set that was active at enqueue time, even
-     * if the tenant has rotated since.
+     * version)` tuple. Used by the worker host when handling an in-flight
+     * run whose enqueue captured `version` — the snapshot MUST still be
+     * the credential set that was active at enqueue time, even if the
+     * tenant has rotated since.
      *
-     * **P1 limitation:** this service does NOT yet persist historical
-     * credential snapshots; it returns the CURRENT row only when the
-     * requested `version` matches the row's current `credentialVersion`,
-     * and `null` otherwise. The full graceful-drain Q4 contract requires
-     * a `tenant_job_runtime_config_history` table that mirrors each
-     * version's `credentialsSecretRef` — that follow-up is tracked as a
-     * P1 sub-story; until it lands the worker host must treat a missing
-     * snapshot as "credentials rotated past this run" and either retry
-     * with the current credentials (if the run is idempotent) or fail
-     * with `CREDENTIAL_DRAINED` and let the user re-enqueue. See
-     * [`plan.md` §10 P3 — Dispatcher routing](../../../../docs/specs/features/tenant-job-runtime-overlay/plan.md#p3--dispatcher-routing-tenant-aware-resolver--credential-version-capture)
-     * for the matching P3 work item.
+     * # Resolution paths
      *
-     * TODO(EW-742 P1.1): introduce `tenant_job_runtime_config_history`
-     * and rewrite this method to query it for `version < currentVersion`.
+     *   - `version === current`: return the current overlay row directly.
+     *     The bag isn't needed because the live secret-store resolver
+     *     still has the current `credentialsSecretRef` to dereference.
+     *   - `version !== current` (historical): look up
+     *     `tenant_credential_snapshot` by
+     *     `(tenantId, providerId, credentialVersion)`. If found,
+     *     synthesise a {@link TenantJobRuntimeConfig}-shaped object that
+     *     carries the historical version while inheriting the tenant's
+     *     current `mode`/`enabled` (those are tenant-level metadata, not
+     *     version-pinned). The historical `credentialsEncrypted` bag is
+     *     re-issued as an `inline:` `credentialsSecretRef` so the
+     *     existing secret-store resolver chain can dereference it
+     *     without a custom snapshot scheme — the in-process resolver
+     *     already supports `inline:<base64-json>`.
+     *   - `version !== current` AND no snapshot row: return `null`. The
+     *     worker host treats this as `CREDENTIAL_DRAINED` (the rotation
+     *     advanced past anything we've captured); call sites already
+     *     handle null per
+     *     `packages/tasks/src/trigger/worker/services/tenant-runtime-binding-resolver.service.ts`.
+     *   - Tenant has no overlay row at all: return `null` (same as P1).
      */
     async resolveSnapshot(
         tenantId: string,
@@ -102,13 +228,62 @@ export class CredentialVersionService {
         if (!row) {
             return null;
         }
-        if (row.credentialVersion !== version) {
+        if (row.credentialVersion === version) {
+            return row;
+        }
+
+        // Historical path — read from the snapshot history table. Scope
+        // by `providerId` too so a tenant that switched providers at
+        // some point can't accidentally resolve a snapshot from the
+        // wrong runtime (the natural key is the same triple the migration
+        // indexes uniquely).
+        const snapshot = await this.snapshotRepo.findOne({
+            where: {
+                tenantId,
+                providerId: row.providerId,
+                credentialVersion: version,
+            },
+        });
+        if (!snapshot) {
             this.logger.warn(
                 `resolveSnapshot miss for tenant ${tenantId}: requested v${version}, ` +
-                    `current v${row.credentialVersion}. P1 returns null (no history table yet).`,
+                    `current v${row.credentialVersion} and no history row found. ` +
+                    `Worker host will treat as drained.`,
             );
             return null;
         }
-        return row;
+
+        // Synthesise a TenantJobRuntimeConfig-shaped object using the
+        // current row's tenant-level metadata (mode/enabled — these
+        // describe the tenant's overlay state, not the credentials) and
+        // the snapshot's per-version fields. The encrypted bag is re-
+        // issued as `inline:<base64-json>` so the existing secret-store
+        // resolver chain dereferences it through the same path it uses
+        // for dev / test inline credentials. Operators running a real
+        // secret store still hit this synthesised inline pointer; the
+        // bag itself never round-trips through their store on the
+        // historical path (it's already the resolved form by virtue of
+        // having been captured at enqueue time).
+        const inlinePointer = `inline:${Buffer.from(
+            JSON.stringify(snapshot.credentialsEncrypted),
+        ).toString('base64')}`;
+
+        const synthesised: TenantJobRuntimeConfig = {
+            tenantId,
+            providerId: snapshot.providerId,
+            credentialsSecretRef: inlinePointer,
+            credentialVersion: snapshot.credentialVersion,
+            mode: row.mode,
+            enabled: row.enabled,
+            createdBy: row.createdBy,
+            createdAt: row.createdAt,
+            updatedAt: snapshot.capturedAt,
+        };
+
+        this.logger.debug(
+            `resolveSnapshot served historical v${version} for tenant ${tenantId} ` +
+                `(current is v${row.credentialVersion})`,
+        );
+        return synthesised;
     }
 }

--- a/packages/agent/src/tasks/job-runtime.providers.ts
+++ b/packages/agent/src/tasks/job-runtime.providers.ts
@@ -26,29 +26,16 @@ import { WORK_IMPORT_DISPATCHER } from './work-import-dispatcher';
  * semantic when no provider is registered (the call site's in-process
  * dev fallback still kicks in on `null`).
  *
- * ## Critical constraint — declared but NOT wired in this PR
+ * ## EW-685 T4 full cutover — fully wired
  *
- * Today the `*_DISPATCHER` symbols are bound directly to `TriggerService`
- * inside `packages/tasks/src/trigger/trigger.module.ts` (via
- * `{ provide: <SYMBOL>, useExisting: TriggerService }`). **Those bindings
- * stay untouched.** This file exports `buildJobRuntimeProviders()` and
- * the in-memory `JOB_RUNTIME_PROVIDER_REGISTRY` registry, but no NestJS
- * module imports the result yet — the factory is a callable seam that:
- *
- *   - tests can exercise end-to-end (see `__tests__/job-runtime.providers.spec.ts`);
- *   - the EW-742 P3 / EW-747 tenant-aware resolver can extend
- *     (`getActive(tenantId?)`) without churning call sites;
- *   - a follow-up PR can wire into `TasksModule` to flip the cutover
- *     once the team is comfortable.
- *
- * ## TODO (follow-up cutover PR)
- *
- * Wire `buildJobRuntimeProviders()` into `TasksModule` (or the equivalent
- * provider-bootstrap module) + remove the direct `useExisting:
- * TriggerService` bindings in `packages/tasks/src/trigger/trigger.module.ts`
- * to complete the cutover. Today the factory is callable from tests + the
- * future tenant-aware resolver (EW-742 P3 / EW-747) but doesn't replace
- * the existing direct bindings yet.
+ * Every `*_DISPATCHER` symbol in `@ever-works/agent/tasks` is now bound
+ * through this factory in `packages/tasks/src/trigger/trigger.module.ts`
+ * (no `symbols:` filter — all 11 dispatchers flow through the registry).
+ * The previous 8-vs-3 split (with `KB_NORMALIZE_MEDIA_DISPATCHER` /
+ * `KB_TRANSCRIBE_DISPATCHER` / `KB_REEMBED_WORK_DISPATCHER` still bound
+ * as custom adapters in `apps/api/src/works/works.module.ts`) was
+ * retired when matching `TriggerService.dispatchXxx` methods landed —
+ * see the trio of impls on `TriggerService`.
  *
  * @see {@link IJobRuntimeProvider}
  * @see {@link JOB_RUNTIME_PROVIDER_REGISTRY}
@@ -60,12 +47,12 @@ import { WORK_IMPORT_DISPATCHER } from './work-import-dispatcher';
  * package uses (`Symbol.for(...)` would registry-share across worker
  * processes and silently collide on dynamic plugin reloads).
  *
- * The registry token is what a follow-up `TasksModule` wiring will inject
- * into the factory functions returned by {@link buildJobRuntimeProviders}.
- * Centralising the lookup behind a token (rather than a module-level
- * singleton) keeps the EW-742 P3 tenant-aware resolver swap surgical —
- * the resolver replaces the registry implementation, factory call sites
- * stay identical.
+ * The registry token is what {@link buildJobRuntimeProviders}'s factory
+ * functions inject — wired in `packages/tasks/src/trigger/trigger.module.ts`
+ * post-EW-685 T4 full cutover. Centralising the lookup behind a token
+ * (rather than a module-level singleton) keeps the EW-742 P3
+ * tenant-aware resolver swap surgical — the resolver replaces the
+ * registry implementation, factory call sites stay identical.
  */
 export const JOB_RUNTIME_PROVIDER_REGISTRY = Symbol('JOB_RUNTIME_PROVIDER_REGISTRY');
 
@@ -178,29 +165,24 @@ const DISPATCHER_SYMBOLS: readonly symbol[] = [
  *
  * @param opts Optional `symbols` filter — when supplied, only those
  *   tokens are bound (the rest stay wherever the operator's module
- *   tree binds them today). Used by the EW-685 T4 partial cutover in
- *   `packages/tasks/src/trigger/trigger.module.ts` to swap the 8
- *   TriggerService-owned dispatchers onto the registry while leaving
- *   `KB_NORMALIZE_MEDIA_DISPATCHER` / `KB_TRANSCRIBE_DISPATCHER` /
- *   `KB_REEMBED_WORK_DISPATCHER` in `apps/api/src/works/works.module.ts`
- *   under their existing soft-error custom adapters (each calls
- *   `@trigger.dev/sdk` directly + returns `null` on dispatch failure
- *   — a contract the binding-factory path doesn't yet model).
- *   Default is the full set (all 11 — used by tests + by a future
- *   PR that consolidates the 3 stragglers into TriggerService).
+ *   tree binds them today). The EW-685 T4 full cutover in
+ *   `packages/tasks/src/trigger/trigger.module.ts` now passes no
+ *   filter (all 11 dispatchers flow through the registry) — the
+ *   `symbols:` option is retained for tests and for future modules
+ *   that want to bind a subset (e.g. a pull-model worker host that
+ *   only owns a strict subset of the dispatcher surface).
  *
  * @returns A frozen NestJS `Provider[]` ready to be spread into a
- *   module's `providers` array. EW-685 T4 cutover landed in
- *   `trigger.module.ts` with the 8-symbol subset; the 3 remaining
- *   bindings are pending consolidation per the JSDoc on the `symbols`
- *   option above.
+ *   module's `providers` array. EW-685 T4 full cutover landed in
+ *   `trigger.module.ts`; every `*_DISPATCHER` symbol resolves through
+ *   the registry without per-dispatcher special-casing.
  */
 export interface BuildJobRuntimeProvidersOptions {
     /**
-     * Subset of `DISPATCHER_SYMBOLS` to bind. When omitted, all 11 are
-     * bound (default — used by the conformance spec + by a future
-     * PR that consolidates the 3 currently-custom-adapter symbols
-     * under TriggerService).
+     * Subset of `DISPATCHER_SYMBOLS` to bind. When omitted, all 11
+     * are bound (the default `trigger.module.ts` path post-EW-685 T4
+     * full cutover). Used by tests and by future modules that want
+     * to bind a strict subset.
      */
     readonly symbols?: readonly symbol[];
 }

--- a/packages/plugins/job-runtime-bullmq/package.json
+++ b/packages/plugins/job-runtime-bullmq/package.json
@@ -34,6 +34,8 @@
 	"devDependencies": {
 		"@ever-works/plugin": "workspace:*",
 		"@types/node": "^22.0.0",
+		"bullmq": "^5.66.0",
+		"ioredis": "^5.10.1",
 		"tsup": "^8.4.0",
 		"typescript": "^5.7.3",
 		"vitest": "^4.1.0"

--- a/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-real-infra.spec.ts
+++ b/packages/plugins/job-runtime-bullmq/src/__tests__/bullmq-real-infra.spec.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * EW-742 P6 T32/T37 — REAL-INFRA integration spec for the BullMQ plugin.
+ *
+ * Mocks-free: this suite connects to a live Redis instance and exercises
+ * the full enqueue → worker handler loop through the real `bullmq` and
+ * `ioredis` libraries. The mocks-only `bullmq-*-isolation.spec.ts`
+ * covers the structural contract; this spec catches wire-level
+ * regressions (option translation, key-prefix isolation, dedup semantics,
+ * cancel-before-process races) that mocks can mask.
+ *
+ * # Gating
+ *
+ * The entire suite skips when `EW_TEST_REAL_REDIS_URL` is unset. This
+ * means `pnpm test` works in two modes:
+ *
+ *   - operator dev box (no Redis): every case shows as `skipped`
+ *   - CI `job-runtime-real-infra` job (Redis service container):
+ *     `EW_TEST_REAL_REDIS_URL=redis://localhost:6379` is exported and
+ *     the suite runs for real.
+ *
+ * # Concurrency safety
+ *
+ * Every test creates queues whose names embed a fresh `randomUUID()` so
+ * parallel CI shards / repeated reruns / vitest's own worker pool never
+ * collide on a shared Redis key. Tear-down `close()` is best-effort; a
+ * leak only costs Redis memory for the TTL of the keys, not test
+ * correctness.
+ */
+
+const REDIS_URL = process.env['EW_TEST_REAL_REDIS_URL'];
+const realInfra = REDIS_URL ? describe : describe.skip;
+
+import { BullMqDispatcherFactory } from '../bullmq-dispatcher-factory.js';
+import { BullMqWorkerHostFactory } from '../bullmq-worker-host-factory.js';
+import type { BullMqDeps, BullMqJobView } from '../bullmq-types.js';
+
+interface RealConnection {
+	quit(): Promise<unknown>;
+	keys(pattern: string): Promise<string[]>;
+	del(...keys: string[]): Promise<number>;
+}
+
+interface BullMqLibrary {
+	Queue: BullMqDeps['Queue'];
+	Worker: BullMqDeps['Worker'];
+}
+
+/**
+ * Lazy-load the real bullmq/ioredis only when the suite is actually
+ * going to run. Both are devDeps gated behind `EW_TEST_REAL_REDIS_URL`,
+ * so when an operator runs `pnpm test` without Redis we never try to
+ * import them.
+ */
+async function loadRealBullMq(): Promise<{ bullmq: BullMqLibrary; redis: RealConnection }> {
+	const bullmqMod = (await import('bullmq')) as unknown as BullMqLibrary;
+	const ioredisMod = (await import('ioredis')) as { default: new (url: string, opts?: unknown) => RealConnection };
+	const Redis = ioredisMod.default;
+	const redis = new Redis(REDIS_URL!, { maxRetriesPerRequest: null });
+	return { bullmq: { Queue: bullmqMod.Queue, Worker: bullmqMod.Worker }, redis };
+}
+
+realInfra('BullMQ real-infra (EW-742 P6 T32/T37)', () => {
+	let bullmq: BullMqLibrary;
+	let redis: RealConnection;
+	const cleanup: Array<() => Promise<unknown>> = [];
+	const prefixesUsed = new Set<string>();
+
+	beforeAll(async () => {
+		const loaded = await loadRealBullMq();
+		bullmq = loaded.bullmq;
+		redis = loaded.redis;
+	}, 30_000);
+
+	afterEach(async () => {
+		// Tear down per-test queues + workers in reverse-LIFO order.
+		while (cleanup.length > 0) {
+			const fn = cleanup.pop();
+			if (fn) await fn().catch(() => undefined);
+		}
+		// Best-effort scrub of any per-tenant prefixes we created so a
+		// flaky run can't leak keys into the next test's assertions.
+		for (const prefix of prefixesUsed) {
+			try {
+				const keys = await redis.keys(`${prefix}:*`);
+				if (keys.length > 0) await redis.del(...keys);
+			} catch {
+				// Ignore — Redis cleanup is best-effort.
+			}
+		}
+		prefixesUsed.clear();
+	});
+
+	function makeDeps(): BullMqDeps {
+		return { Queue: bullmq.Queue, Worker: bullmq.Worker };
+	}
+
+	function trackPrefix(prefix: string): string {
+		prefixesUsed.add(prefix);
+		return prefix;
+	}
+
+	it('single-tenant enqueue + worker handler processes the job end-to-end', async () => {
+		const queueName = `ew-it-single-${randomUUID()}`;
+		const prefix = trackPrefix(`ew-real-${randomUUID().slice(0, 8)}`);
+
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		cleanup.push(() => factory.close());
+		const dispatcher = factory.forQueue(queueName);
+
+		const workerHost = new BullMqWorkerHostFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		const received: Array<{ name: string; data: unknown }> = [];
+		let resolveProcessed: () => void;
+		const processed = new Promise<void>((r) => (resolveProcessed = r));
+		workerHost.register(queueName, async (job) => {
+			received.push({ name: job.name, data: job.data });
+			resolveProcessed();
+		});
+		const handle = await workerHost.start();
+		cleanup.push(() => handle.stop());
+
+		const jobId = await dispatcher.dispatch(queueName, { hello: 'world' });
+		expect(jobId).toBeTruthy();
+		await processed;
+		expect(received).toHaveLength(1);
+		expect(received[0]?.data).toEqual({ hello: 'world' });
+	}, 30_000);
+
+	it('two tenants on the same queue name route by JobsOptions.tenantId without cross-leak', async () => {
+		const queueName = `ew-it-tenant-${randomUUID()}`;
+		const prefix = trackPrefix(`ew-real-${randomUUID().slice(0, 8)}`);
+
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		cleanup.push(() => factory.close());
+		const dispatcher = factory.forQueue(queueName);
+
+		const workerHost = new BullMqWorkerHostFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		const seen: Array<{ tenantId: unknown; payload: unknown }> = [];
+		let pending = 2;
+		let resolveAll: () => void;
+		const allDone = new Promise<void>((r) => (resolveAll = r));
+
+		workerHost.register(queueName, async (job: BullMqJobView) => {
+			// T31 stamping carrier: tenantId lives on opts.tenantId (mirrors
+			// the carrier the dispatcher writes via mapEnqueueOptions).
+			const opts = (job as unknown as { opts?: { tenantId?: unknown } }).opts;
+			seen.push({ tenantId: opts?.tenantId, payload: job.data });
+			if (--pending === 0) resolveAll();
+		});
+		const handle = await workerHost.start();
+		cleanup.push(() => handle.stop());
+
+		const idA = await dispatcher.enqueue(
+			queueName,
+			{ which: 'A' },
+			{ tenantId: 'tenant-a', idempotencyKey: `a-${randomUUID()}` }
+		);
+		const idB = await dispatcher.enqueue(
+			queueName,
+			{ which: 'B' },
+			{ tenantId: 'tenant-b', idempotencyKey: `b-${randomUUID()}` }
+		);
+		expect(idA).toBeTruthy();
+		expect(idB).toBeTruthy();
+
+		await allDone;
+		expect(seen).toHaveLength(2);
+		const a = seen.find((s) => (s.payload as { which?: string }).which === 'A');
+		const b = seen.find((s) => (s.payload as { which?: string }).which === 'B');
+		expect(a?.tenantId).toBe('tenant-a');
+		expect(b?.tenantId).toBe('tenant-b');
+	}, 30_000);
+
+	it('per-tenant queue-prefix isolation lands jobs in distinct Redis keys', async () => {
+		const queueName = `ew-it-prefix-${randomUUID()}`;
+		const prefixA = trackPrefix(`ew-tenant-a-${randomUUID().slice(0, 8)}`);
+		const prefixB = trackPrefix(`ew-tenant-b-${randomUUID().slice(0, 8)}`);
+
+		const factoryA = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix: prefixA });
+		const factoryB = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix: prefixB });
+		cleanup.push(() => factoryA.close());
+		cleanup.push(() => factoryB.close());
+
+		// Enqueue with NO worker attached so the keys persist for inspection.
+		await factoryA.forQueue(queueName).dispatch(queueName, { tenant: 'a' });
+		await factoryB.forQueue(queueName).dispatch(queueName, { tenant: 'b' });
+
+		const keysA = await redis.keys(`${prefixA}:*`);
+		const keysB = await redis.keys(`${prefixB}:*`);
+		expect(keysA.length).toBeGreaterThan(0);
+		expect(keysB.length).toBeGreaterThan(0);
+		// Cross-leak guard: tenant A keys never carry tenant B's prefix and vice versa.
+		expect(keysA.every((k) => k.startsWith(`${prefixA}:`))).toBe(true);
+		expect(keysB.every((k) => k.startsWith(`${prefixB}:`))).toBe(true);
+		expect(keysA.some((k) => k.startsWith(`${prefixB}:`))).toBe(false);
+	}, 30_000);
+
+	it('idempotencyKey dedup: second enqueue with same key returns same id or null', async () => {
+		const queueName = `ew-it-idem-${randomUUID()}`;
+		const prefix = trackPrefix(`ew-real-${randomUUID().slice(0, 8)}`);
+		const idemKey = `idem-${randomUUID()}`;
+
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		cleanup.push(() => factory.close());
+		const dispatcher = factory.forQueue(queueName);
+
+		const first = await dispatcher.enqueue(queueName, { n: 1 }, { idempotencyKey: idemKey });
+		const second = await dispatcher.enqueue(queueName, { n: 2 }, { idempotencyKey: idemKey });
+
+		expect(first).toBeTruthy();
+		// BullMQ's dedup semantic: same `jobId` returns the original
+		// job's id (older bullmq) or null (newer bullmq).
+		expect([first, null]).toContain(second);
+	}, 30_000);
+
+	it('cancel before processing: removed job is never handed to the worker', async () => {
+		const queueName = `ew-it-cancel-${randomUUID()}`;
+		const prefix = trackPrefix(`ew-real-${randomUUID().slice(0, 8)}`);
+
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		cleanup.push(() => factory.close());
+		const dispatcher = factory.forQueue(queueName);
+
+		// Enqueue with a far-future delay so cancel wins the race.
+		const jobId = await dispatcher.dispatch(queueName, { cancelMe: true }, { delay: 60_000 });
+		expect(jobId).toBeTruthy();
+
+		const cancelled = await factory.cancel(jobId!);
+		expect(cancelled).toBe(true);
+
+		// Now start a worker; give it ~1.5s to confirm nothing arrives.
+		const workerHost = new BullMqWorkerHostFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		let received = 0;
+		workerHost.register(queueName, async () => {
+			received++;
+		});
+		const handle = await workerHost.start();
+		cleanup.push(() => handle.stop());
+
+		await new Promise((r) => setTimeout(r, 1500));
+		expect(received).toBe(0);
+	}, 30_000);
+
+	it('T31 end-to-end: factory.enqueue stamps opts; worker reads job.opts.tenantId + tags', async () => {
+		const queueName = `ew-it-t31-${randomUUID()}`;
+		const prefix = trackPrefix(`ew-real-${randomUUID().slice(0, 8)}`);
+		const tenantId = `tenant-${randomUUID().slice(0, 8)}`;
+
+		const factory = new BullMqDispatcherFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		cleanup.push(() => factory.close());
+		const dispatcher = factory.forQueue(queueName);
+
+		const workerHost = new BullMqWorkerHostFactory(makeDeps(), { connection: REDIS_URL!, prefix });
+		let observed: { tenantId?: unknown; tags?: unknown } | null = null;
+		let resolveDone: () => void;
+		const done = new Promise<void>((r) => (resolveDone = r));
+		workerHost.register(queueName, async (job) => {
+			const opts = (job as unknown as { opts?: { tenantId?: unknown; tags?: unknown } }).opts;
+			observed = { tenantId: opts?.tenantId, tags: opts?.tags };
+			resolveDone();
+		});
+		const handle = await workerHost.start();
+		cleanup.push(() => handle.stop());
+
+		const id = await dispatcher.enqueue(
+			queueName,
+			{ workId: 'w-1' },
+			{ tenantId, idempotencyKey: `idem-${randomUUID()}`, tags: ['kb', 'embed'] }
+		);
+		expect(id).toBeTruthy();
+		await done;
+		expect(observed).not.toBeNull();
+		expect(observed!.tenantId).toBe(tenantId);
+		expect(observed!.tags).toEqual(['kb', 'embed']);
+	}, 30_000);
+});

--- a/packages/plugins/job-runtime-pgboss/package.json
+++ b/packages/plugins/job-runtime-pgboss/package.json
@@ -22,6 +22,8 @@
 	"devDependencies": {
 		"@ever-works/plugin": "workspace:*",
 		"@types/node": "^22.0.0",
+		"pg": "^8.13.0",
+		"pg-boss": "^10.1.5",
 		"tsup": "^8.4.0",
 		"typescript": "^5.7.3",
 		"vitest": "^4.1.0"

--- a/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-real-infra.spec.ts
+++ b/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-real-infra.spec.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * EW-742 P6 T32/T37 — REAL-INFRA integration spec for the pg-boss plugin.
+ *
+ * Mocks-free: connects to a live Postgres and runs the full
+ * `boss.send()` → `boss.work()` loop through the real `pg-boss` library.
+ * Companion to `pgboss-tenant-isolation.spec.ts` (mocks-only) — together
+ * they cover both the structural contract and wire-level behaviour
+ * (singletonKey dedup, expireInSeconds enforcement, schema-per-tenant
+ * isolation, batched workers).
+ *
+ * # Gating
+ *
+ * Skips entirely when `EW_TEST_REAL_PGBOSS_URL` is unset, so
+ * `pnpm test` works for operators without a local Postgres. CI exports
+ * the URL inside the `job-runtime-real-infra` job, where Postgres runs
+ * as a service container.
+ *
+ * # Concurrency safety
+ *
+ * Each test creates a fresh schema name with `randomUUID()` so parallel
+ * vitest workers + repeated CI reruns don't trample each other inside
+ * the same Postgres database. Schemas are dropped on cleanup so a long
+ * CI lifetime doesn't accumulate dead `tenant_*` schemas.
+ */
+
+const PG_URL = process.env['EW_TEST_REAL_PGBOSS_URL'];
+const realInfra = PG_URL ? describe : describe.skip;
+
+import { PgBossDispatcherFactory } from '../pgboss-dispatcher-factory.js';
+import { PgBossWorkerHostFactory } from '../pgboss-worker-host-factory.js';
+import type { PgBossInstance, PgBossJobView } from '../pgboss-types.js';
+
+interface PgBossCtor {
+	new (opts: Record<string, unknown>): PgBossInstance;
+}
+
+/** Lazy import — only loaded when the gate is open. */
+async function loadRealPgBoss(): Promise<PgBossCtor> {
+	const mod = (await import('pg-boss')) as unknown as { default: PgBossCtor };
+	return mod.default;
+}
+
+/** Best-effort cleanup of the per-test schema so CI Postgres stays tidy. */
+async function dropSchema(schema: string): Promise<void> {
+	try {
+		const { Client } = (await import('pg')) as unknown as {
+			Client: new (cfg: { connectionString: string }) => {
+				connect(): Promise<void>;
+				query(sql: string): Promise<unknown>;
+				end(): Promise<void>;
+			};
+		};
+		const client = new Client({ connectionString: PG_URL! });
+		await client.connect();
+		await client.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+		await client.end();
+	} catch {
+		// pg might not be installed (it's a pg-boss transitive); ignore.
+	}
+}
+
+realInfra('pg-boss real-infra (EW-742 P6 T32/T37)', () => {
+	let PgBoss: PgBossCtor;
+	const cleanup: Array<() => Promise<unknown>> = [];
+	const schemasUsed = new Set<string>();
+
+	beforeAll(async () => {
+		PgBoss = await loadRealPgBoss();
+	}, 30_000);
+
+	afterEach(async () => {
+		while (cleanup.length > 0) {
+			const fn = cleanup.pop();
+			if (fn) await fn().catch(() => undefined);
+		}
+		for (const schema of schemasUsed) {
+			await dropSchema(schema);
+		}
+		schemasUsed.clear();
+	});
+
+	function freshSchema(label: string): string {
+		const schema = `ew_${label}_${randomUUID().replace(/-/g, '_')}`;
+		schemasUsed.add(schema);
+		return schema;
+	}
+
+	async function startBoss(schema: string): Promise<PgBossInstance> {
+		const boss = new PgBoss({ connectionString: PG_URL!, schema });
+		await boss.start();
+		cleanup.push(() => boss.stop({ graceful: true, timeout: 5000 } as Record<string, unknown>));
+		return boss;
+	}
+
+	it('single-tenant send + work handler processes the job end-to-end', async () => {
+		const schema = freshSchema('single');
+		const boss = await startBoss(schema);
+		const queueName = `q-single-${randomUUID().slice(0, 8)}`;
+
+		const factory = new PgBossDispatcherFactory({ boss });
+		const workerHost = new PgBossWorkerHostFactory({ boss });
+		const seen: unknown[] = [];
+		let resolveDone: () => void;
+		const done = new Promise<void>((r) => (resolveDone = r));
+		workerHost.register(queueName, { teamSize: 1 }, async (jobOrBatch) => {
+			const job = Array.isArray(jobOrBatch) ? jobOrBatch[0]! : (jobOrBatch as PgBossJobView);
+			seen.push(job.data);
+			resolveDone();
+		});
+		await workerHost.start();
+
+		const id = await factory.send(queueName, { hello: 'world' });
+		expect(id).toBeTruthy();
+		await done;
+		expect(seen).toEqual([{ hello: 'world' }]);
+	}, 30_000);
+
+	it('two-tenant isolation via _ew.tenantId payload namespace', async () => {
+		const schema = freshSchema('tenants');
+		const boss = await startBoss(schema);
+		const queueName = `q-tenants-${randomUUID().slice(0, 8)}`;
+
+		const factory = new PgBossDispatcherFactory({ boss });
+		const workerHost = new PgBossWorkerHostFactory({ boss });
+		const seen: Array<{ tenantId: unknown; payload: unknown }> = [];
+		let pending = 2;
+		let resolveAll: () => void;
+		const allDone = new Promise<void>((r) => (resolveAll = r));
+		workerHost.register(queueName, { teamSize: 2 }, async (jobOrBatch) => {
+			const jobs = Array.isArray(jobOrBatch) ? jobOrBatch : [jobOrBatch as PgBossJobView];
+			for (const j of jobs) {
+				const ew = (j.data as { _ew?: { tenantId?: unknown } })._ew;
+				seen.push({ tenantId: ew?.tenantId, payload: j.data });
+				if (--pending === 0) resolveAll();
+			}
+		});
+		await workerHost.start();
+
+		await factory.enqueue(queueName, { which: 'A' }, { tenantId: 'tenant-a' });
+		await factory.enqueue(queueName, { which: 'B' }, { tenantId: 'tenant-b' });
+
+		await allDone;
+		const a = seen.find((s) => (s.payload as { which?: string }).which === 'A');
+		const b = seen.find((s) => (s.payload as { which?: string }).which === 'B');
+		expect(a?.tenantId).toBe('tenant-a');
+		expect(b?.tenantId).toBe('tenant-b');
+	}, 30_000);
+
+	it('per-tenant schema isolation: two PgBoss instances on distinct schemas', async () => {
+		const schemaA = freshSchema('tenant_a');
+		const schemaB = freshSchema('tenant_b');
+		const bossA = await startBoss(schemaA);
+		const bossB = await startBoss(schemaB);
+		const queueName = `q-iso-${randomUUID().slice(0, 8)}`;
+
+		const factoryA = new PgBossDispatcherFactory({ boss: bossA });
+		const factoryB = new PgBossDispatcherFactory({ boss: bossB });
+
+		// Only attach worker on bossA to confirm bossB's job never bleeds across.
+		const workerHost = new PgBossWorkerHostFactory({ boss: bossA });
+		const seenA: unknown[] = [];
+		let resolveA: () => void;
+		const aGot = new Promise<void>((r) => (resolveA = r));
+		workerHost.register(queueName, { teamSize: 1 }, async (jobOrBatch) => {
+			const job = Array.isArray(jobOrBatch) ? jobOrBatch[0]! : (jobOrBatch as PgBossJobView);
+			seenA.push(job.data);
+			resolveA();
+		});
+		await workerHost.start();
+
+		const idA = await factoryA.send(queueName, { from: 'A' });
+		const idB = await factoryB.send(queueName, { from: 'B' });
+		expect(idA).toBeTruthy();
+		expect(idB).toBeTruthy();
+
+		await aGot;
+		// 800ms grace to confirm bossA's worker never picks up B's job.
+		await new Promise((r) => setTimeout(r, 800));
+		expect(seenA).toHaveLength(1);
+		expect(seenA[0]).toEqual({ from: 'A' });
+
+		// Cleanup the second boss explicitly (startBoss pushes it onto cleanup queue).
+		void factoryB;
+	}, 45_000);
+
+	it('singletonKey idempotency: second send with same key returns null', async () => {
+		const schema = freshSchema('idem');
+		const boss = await startBoss(schema);
+		const queueName = `q-idem-${randomUUID().slice(0, 8)}`;
+		const idemKey = `idem-${randomUUID()}`;
+
+		const factory = new PgBossDispatcherFactory({ boss });
+		const first = await factory.enqueue(queueName, { n: 1 }, { idempotencyKey: idemKey });
+		const second = await factory.enqueue(queueName, { n: 2 }, { idempotencyKey: idemKey });
+
+		expect(first).toBeTruthy();
+		// pg-boss's documented dedup semantic: second call returns null
+		// while the singletonKey row is still in-flight.
+		expect(second).toBeNull();
+	}, 30_000);
+
+	it('cancel before processing: removed job is never handed to the worker', async () => {
+		const schema = freshSchema('cancel');
+		const boss = await startBoss(schema);
+		const queueName = `q-cancel-${randomUUID().slice(0, 8)}`;
+
+		const factory = new PgBossDispatcherFactory({ boss });
+		// startAfter in the far future so cancel wins.
+		const id = await factory.send(queueName, { cancelMe: true }, { startAfter: 60 });
+		expect(id).toBeTruthy();
+		const cancelled = await factory.cancel(id!);
+		expect(cancelled).toBe(true);
+
+		const workerHost = new PgBossWorkerHostFactory({ boss });
+		let received = 0;
+		workerHost.register(queueName, { teamSize: 1 }, async () => {
+			received++;
+		});
+		await workerHost.start();
+
+		await new Promise((r) => setTimeout(r, 1500));
+		expect(received).toBe(0);
+	}, 30_000);
+
+	it('batched workers (teamSize > 1) handle multi-tenant jobs in parallel correctly', async () => {
+		const schema = freshSchema('batch');
+		const boss = await startBoss(schema);
+		const queueName = `q-batch-${randomUUID().slice(0, 8)}`;
+
+		const factory = new PgBossDispatcherFactory({ boss });
+		const workerHost = new PgBossWorkerHostFactory({ boss });
+		const seen: Array<{ tenantId: unknown; payload: unknown }> = [];
+		const expected = 6;
+		let pending = expected;
+		let resolveAll: () => void;
+		const allDone = new Promise<void>((r) => (resolveAll = r));
+		workerHost.register(queueName, { teamSize: 4, batchSize: 2 }, async (jobOrBatch) => {
+			const jobs = Array.isArray(jobOrBatch) ? jobOrBatch : [jobOrBatch as PgBossJobView];
+			for (const j of jobs) {
+				const ew = (j.data as { _ew?: { tenantId?: unknown } })._ew;
+				seen.push({ tenantId: ew?.tenantId, payload: j.data });
+				if (--pending === 0) resolveAll();
+			}
+		});
+		await workerHost.start();
+
+		const tenants = ['tenant-a', 'tenant-b', 'tenant-c'];
+		for (let i = 0; i < expected; i++) {
+			const t = tenants[i % tenants.length]!;
+			await factory.enqueue(queueName, { n: i }, { tenantId: t });
+		}
+
+		await allDone;
+		expect(seen).toHaveLength(expected);
+		// Each delivered job's stamped tenantId matches the dispatcher's choice
+		// (i.e. the worker never invents or swaps a tenant).
+		for (const entry of seen) {
+			expect(tenants).toContain(entry.tenantId);
+		}
+	}, 45_000);
+});

--- a/packages/tasks/src/trigger/trigger.module.ts
+++ b/packages/tasks/src/trigger/trigger.module.ts
@@ -10,38 +10,19 @@ import {
     KB_BACKFILL_SKELETON_DISPATCHER,
     KB_EMBED_DOCUMENT_DISPATCHER,
     KB_ORG_OVERLAY_FANOUT_DISPATCHER,
+    KB_NORMALIZE_MEDIA_DISPATCHER,
+    KB_TRANSCRIBE_DISPATCHER,
+    KB_REEMBED_WORK_DISPATCHER,
     JOB_RUNTIME_PROVIDER_REGISTRY,
     InMemoryJobRuntimeProviderRegistry,
     buildJobRuntimeProviders,
+    type JobRuntimeProviderRegistry,
 } from '@ever-works/agent/tasks';
 import {
     NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
     type NotificationChannelDeliveryDispatcher,
     type NotificationChannelDeliveryPayload,
 } from '@ever-works/agent/facades';
-
-/**
- * EW-685 T4 cutover — the 8 dispatcher symbols TriggerModule owns. The
- * remaining 3 (`KB_NORMALIZE_MEDIA_DISPATCHER`, `KB_TRANSCRIBE_DISPATCHER`,
- * `KB_REEMBED_WORK_DISPATCHER`) are bound separately in
- * `apps/api/src/works/works.module.ts` under custom Trigger.dev SDK
- * adapters with soft-error contracts (each call returns `null` on
- * dispatch failure → the slice-5 reconciliation cron catches the drift).
- * Consolidating those 3 onto TriggerService.dispatchers — and thus
- * routing them through this same factory — is a follow-up PR; the partial
- * cutover here proves the architecture without touching the
- * soft-error path.
- */
-const TRIGGER_OWNED_DISPATCHER_SYMBOLS = [
-    WORK_GENERATION_DISPATCHER,
-    WORK_IMPORT_DISPATCHER,
-    TEMPLATE_CUSTOMIZATION_DISPATCHER,
-    WEBHOOK_DELIVERY_DISPATCHER,
-    KB_MIRROR_DOCUMENT_DISPATCHER,
-    KB_BACKFILL_SKELETON_DISPATCHER,
-    KB_EMBED_DOCUMENT_DISPATCHER,
-    KB_ORG_OVERLAY_FANOUT_DISPATCHER,
-] as const;
 
 @Global()
 @Module({
@@ -77,30 +58,70 @@ const TRIGGER_OWNED_DISPATCHER_SYMBOLS = [
             },
             inject: [TriggerJobRuntimeProvider],
         },
-        // EW-685 T4 cutover — the 8 dispatcher symbols TriggerModule owns,
-        // now bound via the registry. See TRIGGER_OWNED_DISPATCHER_SYMBOLS
-        // header for the deferred 3.
-        ...buildJobRuntimeProviders({ symbols: TRIGGER_OWNED_DISPATCHER_SYMBOLS }),
+        // EW-685 T4 full cutover — every `*_DISPATCHER` symbol now
+        // flows through the registry. `buildJobRuntimeProviders()`
+        // with no `symbols:` filter binds all 11 tokens from the
+        // `@ever-works/agent/tasks` barrel. The previous 3-symbol
+        // carve-out (KB_NORMALIZE_MEDIA / KB_TRANSCRIBE /
+        // KB_REEMBED_WORK) was retired once their custom Trigger.dev
+        // SDK adapters in `apps/api/src/works/works.module.ts` were
+        // replaced by matching `TriggerService.dispatchXxx` methods —
+        // see the trio of `dispatchKbNormalizeMedia` /
+        // `dispatchKbTranscribe` / `dispatchKbReembedWork` impls on
+        // `TriggerService`. From this PR forward, an
+        // `EVER_WORKS_JOB_RUNTIME=bullmq` flip swaps all 11 the same
+        // way (no per-dispatcher special-casing).
+        ...buildJobRuntimeProviders(),
         // Notifications v2 (EW-663) — the facade's delivery dispatcher
-        // contract is `enqueue(payload) → { runId }`, so a thin adapter
-        // bridges to TriggerService.dispatchNotificationChannelDelivery
-        // (which returns the run id, or null when Trigger is disabled →
-        // the facade falls back to in-process delivery).
-        //
-        // NOT routed through the binding factory because its method
-        // shape (`enqueue` returning `{ runId }`) differs from the
-        // `JobRuntimeDispatchers` `dispatchXxx → string | null` shape
-        // every other `*_DISPATCHER` symbol exposes. Migrating it
-        // onto the registry would require either widening the contract
-        // or adding a wrapper layer — neither is in scope here.
+        // contract is `enqueue(payload) → { runId }`, which differs
+        // from the `JobRuntimeDispatchers` `dispatchXxx → string | null`
+        // method shape every other `*_DISPATCHER` symbol exposes. Per
+        // EW-685 T4 full cutover (Path 2 — picked over moving the
+        // symbol onto the registry's 11-symbol list because that would
+        // churn the facade consumer and cross the `@ever-works/agent/
+        // facades` ↔ `@ever-works/agent/tasks` symbol boundary): the
+        // binding stays a custom adapter, but it now resolves the
+        // active provider via the registry instead of the underlying
+        // `TriggerService` instance. The active provider's
+        // `dispatchers.dispatchNotificationChannelDelivery(payload)`
+        // returns a `string | null` run id (null when the runtime is
+        // disabled / no provider registered / the dispatch threw); the
+        // adapter wraps that into the `{ runId }` envelope the facade
+        // expects. When the operator flips
+        // `EVER_WORKS_JOB_RUNTIME=bullmq`, this adapter automatically
+        // routes through the BullMQ provider's dispatchers map — same
+        // single-source-of-truth as the other 11.
         {
             provide: NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
-            useFactory: (trigger: TriggerService): NotificationChannelDeliveryDispatcher => ({
+            useFactory: (
+                registry: JobRuntimeProviderRegistry,
+            ): NotificationChannelDeliveryDispatcher => ({
                 async enqueue(payload: NotificationChannelDeliveryPayload) {
-                    return { runId: await trigger.dispatchNotificationChannelDelivery(payload) };
+                    const provider = registry.getActive();
+                    if (!provider) {
+                        return { runId: null };
+                    }
+                    // The active provider's dispatchers bag is the
+                    // intentionally-untyped `JobRuntimeDispatchers`
+                    // shape (see IJobRuntimeProvider JSDoc); cast to
+                    // the concrete dispatcher to call through. The
+                    // `?.()` guard returns `null` if the runtime
+                    // doesn't implement notification delivery (future
+                    // pull-model providers can opt out).
+                    const dispatch = (
+                        provider.dispatchers as {
+                            dispatchNotificationChannelDelivery?: (
+                                p: NotificationChannelDeliveryPayload,
+                            ) => Promise<string | null>;
+                        }
+                    ).dispatchNotificationChannelDelivery?.bind(provider.dispatchers);
+                    if (!dispatch) {
+                        return { runId: null };
+                    }
+                    return { runId: await dispatch(payload) };
                 },
             }),
-            inject: [TriggerService],
+            inject: [JOB_RUNTIME_PROVIDER_REGISTRY],
         },
     ],
     exports: [
@@ -117,6 +138,11 @@ const TRIGGER_OWNED_DISPATCHER_SYMBOLS = [
         KB_BACKFILL_SKELETON_DISPATCHER,
         KB_EMBED_DOCUMENT_DISPATCHER,
         KB_ORG_OVERLAY_FANOUT_DISPATCHER,
+        // EW-685 T4 full cutover — the 3 KB tokens previously bound
+        // in apps/api/src/works/works.module.ts now ship through here.
+        KB_NORMALIZE_MEDIA_DISPATCHER,
+        KB_TRANSCRIBE_DISPATCHER,
+        KB_REEMBED_WORK_DISPATCHER,
         NOTIFICATION_CHANNEL_DELIVERY_DISPATCHER,
     ],
 })

--- a/packages/tasks/src/trigger/trigger.service.ts
+++ b/packages/tasks/src/trigger/trigger.service.ts
@@ -22,6 +22,8 @@ import {
     KbNormalizeMediaDispatcher,
     KbTranscribePayload,
     KbTranscribeDispatcher,
+    KbReembedWorkPayload,
+    KbReembedWorkDispatcher,
 } from '@ever-works/agent/tasks';
 import type {
     JobRunStatus,
@@ -42,6 +44,7 @@ import { kbOrgOverlayFanoutTask } from '../tasks/trigger/kb-org-overlay-fanout.t
 import { kbNormalizeVideoTask } from '../tasks/trigger/kb-normalize-video.task';
 import { kbNormalizeAudioTask } from '../tasks/trigger/kb-normalize-audio.task';
 import { kbTranscribeTask } from '../tasks/trigger/kb-transcribe.task';
+import { kbReembedWorkTask } from '../tasks/trigger/kb-reembed-work.task';
 import { notificationChannelDeliveryTask } from '../tasks/trigger/notification-channel-delivery.task';
 import type { NotificationChannelDeliveryPayload } from '@ever-works/agent/facades';
 
@@ -57,7 +60,8 @@ export class TriggerService
         KbEmbedDocumentDispatcher,
         KbOrgOverlayFanoutDispatcher,
         KbNormalizeMediaDispatcher,
-        KbTranscribeDispatcher
+        KbTranscribeDispatcher,
+        KbReembedWorkDispatcher
 {
     private readonly logger = new Logger(TriggerService.name);
     private configured = false;
@@ -96,8 +100,8 @@ export class TriggerService
      * every `*Dispatcher` interface exported from `@ever-works/agent/tasks`
      * (WorkGeneration, WorkImport, TemplateCustomization, WebhookDelivery,
      * KbMirrorDocument, KbBackfillSkeleton, KbEmbedDocument,
-     * KbOrgOverlayFanout, KbNormalizeMedia, KbTranscribe + notification
-     * channel delivery). The cast through `unknown` is required because
+     * KbOrgOverlayFanout, KbNormalizeMedia, KbTranscribe, KbReembedWork
+     * + notification channel delivery). The cast through `unknown` is required because
      * the contract's {@link JobRuntimeDispatchers} type is intentionally
      * the opaque `Readonly<Record<string, unknown>>` shape — see the
      * JSDoc on `JobRuntimeDispatchers` in the contract file for the
@@ -655,5 +659,64 @@ export class TriggerService
             this.logger.error('Failed to dispatch kb-transcribe task', error as Error);
             return null;
         }
+    }
+
+    /**
+     * EW-642 D7 / EW-685 T4 cutover — enqueue an on-demand re-embed sweep
+     * for one Work. Producer is the pgvector plugin's settings-change
+     * hook (see `packages/plugins/pgvector/src/pgvector.plugin.ts`); the
+     * worker task body (`kb-reembed-work.task.ts`) calls
+     * `KnowledgeBaseReembedService.reembedWork(payload)` to do the
+     * actual chunk-level re-embed.
+     *
+     * **No soft-error swallow.** Unlike the other KB dispatchers
+     * (`dispatchKbNormalizeMedia` / `dispatchKbTranscribe`) which return
+     * `null` on dispatch failure so the slice-5 reconciliation cron
+     * catches the drift, this dispatcher PROPAGATES errors per the
+     * {@link KbReembedWorkDispatcher} contract — a silent drop on the
+     * re-embed path leaves a Work pinned to a stale embedding model
+     * with no operator signal, which the pgvector plugin's settings-
+     * change handler explicitly forbids. The pgvector handler catches
+     * the error itself, names the failed Work in its rejection
+     * message, and lets the workbench banner surface the failure.
+     *
+     * Tenant-binding stamping note: the previous custom adapter in
+     * `apps/api/src/works/works.module.ts` looked up
+     * `(providerId, credentialVersion)` from
+     * {@link RuntimeBindingStamperService} at the enqueue site because
+     * the pgvector plugin call site has no tenant context. Routing
+     * through `TriggerService` drops that enqueue-side stamping; the
+     * worker task's `TenantRuntimeBindingResolverService.resolveForWork`
+     * still resolves the tenant from `payload.workId` via
+     * `WorkRepository.findById`, so a missing
+     * `(providerId, credentialVersion)` pair on the inbound payload
+     * resolves to `'no-binding'` and the worker falls back to the
+     * instance default — byte-identical to the pre-T22 path. The
+     * graceful-drain detection (ADR-017 §3) downgrades from "fail
+     * loudly on rotation past this run's version" to "run against
+     * current credentials"; the re-embed task is idempotent on
+     * `embedding_model` (skips coordinates already on `newModel`) so
+     * the operator can re-flip the model from the settings UI to
+     * pick up fresh credentials.
+     */
+    async dispatchKbReembedWork(payload: KbReembedWorkPayload): Promise<string> {
+        if (!this.ensureConfigured()) {
+            throw new Error(
+                'kb-reembed-work dispatch attempted while Trigger.dev is disabled — ' +
+                    'a silent drop would leave the Work pinned to the old embedding model.',
+            );
+        }
+
+        const handle = await kbReembedWorkTask.trigger(payload, {
+            tags: [
+                'kb-reembed-work',
+                `work:${payload.workId}`,
+                `from:${payload.previousModel}`,
+                `to:${payload.newModel}`,
+            ],
+            machine: this.machine() as any,
+            concurrencyKey: `kb-reembed:${payload.workId}`,
+        });
+        return handle.id;
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(088a339e3579cdac4e2e02b02d6b8844)
+        version: 2.3.4(544273b70af2d25f909948f205d87822)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.16.0)(rxjs@7.8.2)
@@ -1823,6 +1823,12 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
+      bullmq:
+        specifier: ^5.66.0
+        version: 5.79.0
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
@@ -1859,6 +1865,12 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
+      pg:
+        specifier: ^8.13.0
+        version: 8.18.0
+      pg-boss:
+        specifier: ^10.1.5
+        version: 10.4.2
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
@@ -6186,6 +6198,36 @@ packages:
   '@mozilla/readability@0.6.0':
     resolution: {integrity: sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==}
     engines: {node: '>=14.0.0'}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
@@ -11216,6 +11258,15 @@ packages:
     resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
     engines: {node: '>=0.2.0'}
 
+  bullmq@5.79.0:
+    resolution: {integrity: sha512-sg+kYGn7PIDI/AAkSWINPNz0vMp745YaBYMyo3AtcfXk5iCvjEPU+XMbU3yf7rSf1KsU+OfU+GH8FhxUa+WDNA==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      redis: '>=5.0.0'
+    peerDependenciesMeta:
+      redis:
+        optional: true
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -11821,6 +11872,10 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
 
   cron@4.4.0:
     resolution: {integrity: sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==}
@@ -15717,6 +15772,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
+    hasBin: true
+
+  msgpackr@2.0.2:
+    resolution: {integrity: sha512-c5hYOXFbP79Slh6Dzd2wzk+jnV7mX1UxfMYtilnY1NmalXPqG8DGb5cYCMBrW4AsH3zekBBZd4QrKz9NhtvYLQ==}
+
   msw@2.12.10:
     resolution: {integrity: sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==}
     engines: {node: '>=18'}
@@ -15901,6 +15963,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -16480,6 +16546,10 @@ packages:
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  pg-boss@10.4.2:
+    resolution: {integrity: sha512-AttEWOtSzn53av8OnCMWEanwRBvjkZCE1y5nLrZnwvkkMnlZ5XpWDpZ7sKI/BYjvi2OVieMX37arD2ACgJ750w==}
+    engines: {node: '>=20'}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -18139,6 +18209,10 @@ packages:
 
   seq-queue@0.0.5:
     resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
+
+  serialize-error@8.1.0:
+    resolution: {integrity: sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==}
+    engines: {node: '>=10'}
 
   serialize-javascript@7.0.5:
     resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
@@ -21553,7 +21627,7 @@ snapshots:
       outdent: 0.5.0
       prettier: 2.8.8
       resolve-from: 5.0.0
-      semver: 7.8.1
+      semver: 7.8.4
 
   '@changesets/assemble-release-plan@6.0.10':
     dependencies:
@@ -21562,7 +21636,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
-      semver: 7.8.1
+      semver: 7.8.4
 
   '@changesets/changelog-git@0.2.1':
     dependencies:
@@ -21619,7 +21693,7 @@ snapshots:
       '@changesets/types': 6.1.0
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
-      semver: 7.8.1
+      semver: 7.8.4
 
   '@changesets/get-release-plan@4.0.16':
     dependencies:
@@ -24649,6 +24723,24 @@ snapshots:
 
   '@mozilla/readability@0.6.0': {}
 
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    optional: true
+
   '@mswjs/interceptors@0.41.3':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -24849,7 +24941,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(088a339e3579cdac4e2e02b02d6b8844)':
+  '@nestjs-modules/mailer@2.3.4(544273b70af2d25f909948f205d87822)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -24863,6 +24955,7 @@ snapshots:
       '@types/ejs': 3.1.5
       '@types/mjml': 4.7.4
       '@types/pug': 2.0.10
+      bullmq: 5.79.0
       ejs: 5.0.1
       handlebars: 4.7.9
       liquidjs: 10.27.0
@@ -30298,6 +30391,17 @@ snapshots:
 
   buffers@0.1.1: {}
 
+  bullmq@5.79.0:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.10.1
+      msgpackr: 2.0.2
+      node-abort-controller: 3.1.1
+      semver: 7.8.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -30942,6 +31046,10 @@ snapshots:
   create-require@1.1.1: {}
 
   crelt@1.0.6: {}
+
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
 
   cron@4.4.0:
     dependencies:
@@ -32844,7 +32952,7 @@ snapshots:
       minimatch: 10.2.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.8.1
+      semver: 7.8.4
       tapable: 2.3.2
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
@@ -32861,7 +32969,7 @@ snapshots:
       minimatch: 10.2.5
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
-      semver: 7.8.1
+      semver: 7.8.4
       tapable: 2.3.2
       typescript: 5.9.3
       webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))
@@ -36250,6 +36358,22 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.4:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
+    optional: true
+
+  msgpackr@2.0.2:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
+
   msw@2.12.10(@types/node@20.19.33)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 5.1.21(@types/node@20.19.33)
@@ -36504,6 +36628,11 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-gyp-build@4.8.4: {}
 
@@ -37154,6 +37283,14 @@ snapshots:
   pend@1.2.0: {}
 
   perfect-debounce@1.0.0: {}
+
+  pg-boss@10.4.2:
+    dependencies:
+      cron-parser: 4.9.0
+      pg: 8.18.0
+      serialize-error: 8.1.0
+    transitivePeerDependencies:
+      - pg-native
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -39256,6 +39393,10 @@ snapshots:
       - supports-color
 
   seq-queue@0.0.5: {}
+
+  serialize-error@8.1.0:
+    dependencies:
+      type-fest: 0.20.2
 
   serialize-javascript@7.0.5: {}
 


### PR DESCRIPTION
## Summary

Bundles four develop PRs into a single stage cascade:

- #1513 — full EW-685 T4 registry cutover (all 11 dispatchers + NOTIFICATION via registry)
- #1514 — CredentialVersionService snapshot history table (EW-742 P1 T11 follow-up)
- #1515 — CI real-infra smoke tests for BullMQ + pg-boss (EW-742 T37)
- #1516 — operator UI for per-tenant runtime allow-list (EW-742 P5.1)

## Test plan

- [x] All 4 source PRs merged to develop with green CI
- [ ] Stage CI green
- [ ] Cascade stage→main after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)