### PR TITLE
ci: gate job-runtime-real-infra to direct main pushes only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,17 @@ jobs:
   # namespaces its own tables), Inngest via the inngest/inngest dev
   # server. Real-infra cells run as a SEPARATE job from the mocks-only
   # matrix so an infra hiccup doesn't mask the mocks-only failure signal.
+  # Cost gate: this job is restricted to direct pushes to main (see the
+  # job-level `if:` below) because the four service containers burn
+  # Ubicloud minutes; per-PR signal stays covered by the mocks-only
+  # job-runtime-plugin-matrix above.
   job-runtime-real-infra:
+    # Cost gate: real-infra cells spin up 4 service containers (Redis,
+    # Postgres, Temporal auto-setup, Inngest dev-server) which burn
+    # Ubicloud minutes. Run on direct pushes to main only — PR signal
+    # stays covered by the mocks-only job-runtime-plugin-matrix above.
+    # Re-enable per-PR by removing this `if:` line.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubicloud-standard-8
     services:
       redis:


### PR DESCRIPTION
## Summary
- `job-runtime-real-infra` spins up 4 service containers (Redis, Postgres, Temporal auto-setup, Inngest dev-server) on Ubicloud, burning minutes on every PR.
- Per-PR signal is already covered by the mocks-only `job-runtime-plugin-matrix`; real-infra only needs to fire post-merge.
- Adds a job-level `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` plus comment block explaining the cost gate and how to revert.

## Test plan
- [ ] Confirm CI on this PR does **not** run `job-runtime-real-infra` (mocks-only matrix still runs).
- [ ] After merge to `main`, confirm `job-runtime-real-infra` fires on the direct push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to optimize infrastructure test execution by restricting a resource-intensive integration test job to run only on direct pushes to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->