### PR TITLE
test(trigger-internal): unblock specs after EW-742 P3.2 T22 drift

### DIFF
--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -144,6 +144,14 @@ describe('TriggerInternalController', () => {
             tasksService,
             taskChatService,
             undefined, // notificationChannelFacade
+            // EW-742 P3.2 T22 — three new constructor args added by PRs
+            // bbc24309 / 5e4e2483 / 41906b71 to expose the worker-host
+            // tenant-resolver dependencies through the remote-proxy
+            // controller. None of the test cases below exercise these
+            // paths, so passing `undefined` is sufficient.
+            undefined, // credentialVersionService
+            undefined, // organizationRepository
+            undefined, // webhookSubscriptionRepository
             undefined, // workProposalsApiService (Optional trailing)
         );
         c.onModuleInit();

--- a/apps/api/src/trigger/trigger-internal.module.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.module.spec.ts
@@ -45,6 +45,19 @@ jest.mock('@ever-works/agent/agents', () => ({
 jest.mock('@ever-works/agent/tasks-domain', () => ({
     TasksDomainModule: class TasksDomainModule {},
 }));
+// EW-742 P3.2 T22 — trigger-internal.module imports TenantJobRuntimeModule
+// + OrganizationsModule (added by bbc24309 / 5e4e2483 / 41906b71). Loading
+// those modules pulls in real `@ever-works/agent/entities` + `@ever-works/agent/tasks`
+// barrels which transitively type-check the agent `utils/metrics.util.ts`
+// under the api tsconfig and report TS2365 errors there. Stub the modules
+// here so the trigger-internal-module wiring contract can be asserted in
+// isolation without the deep agent type-check chain.
+jest.mock('../account/tenant-job-runtime/tenant-job-runtime.module', () => ({
+    TenantJobRuntimeModule: class TenantJobRuntimeModule {},
+}));
+jest.mock('../organizations/organizations.module', () => ({
+    OrganizationsModule: class OrganizationsModule {},
+}));
 jest.mock('./trigger-internal.controller', () => ({
     TriggerInternalController: class TriggerInternalController {},
 }));


### PR DESCRIPTION
## Why

`apps/api/src/trigger/trigger-internal.*.spec.ts` have been red on `develop` since the EW-742 P3.2 T22 commits added new constructor params + module imports without updating the specs.

## What was failing

- **controller spec** — TS2554 \"Expected 31-32 arguments, but got 29\". 3 new required ctor args (`credentialVersionService`, `organizationRepository`, `webhookSubscriptionRepository`) landed before the optional `workProposalsApiService`.
- **module spec** — TS2365 in `packages/agent/src/utils/metrics.util.ts`. The new `TenantJobRuntimeModule` + `OrganizationsModule` imports transitively pull `@ever-works/agent/{entities,tasks}` into the api ts-jest scope, dragging metrics.util.ts into the type-check.

## Fix

- Pass `undefined` for the 3 new ctor args in the controller spec — no existing test exercises those paths.
- Add `jest.mock()` stubs for `TenantJobRuntimeModule` + `OrganizationsModule` in the module spec, mirroring the existing barrel-stub pattern.

## After

`pnpm test --testPathPattern='trigger-internal'` → **2 suites, 16/16 tests, ~33s** (was 0 tests, 2 suites failed to load).

## Out of scope

`metrics.util.ts` strict-typing failure is a separate develop-wide problem affecting ~22 other suites; left for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to improve test isolation and coverage for internal components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->