### PR TITLE
feat(api): Trigger.dev webhook receiver with per-tenant HMAC verify

### DIFF
--- a/apps/api/src/webhooks/__tests__/trigger-webhook.controller.spec.ts
+++ b/apps/api/src/webhooks/__tests__/trigger-webhook.controller.spec.ts
@@ -1,0 +1,210 @@
+import { BadRequestException, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { createHmac, timingSafeEqual } from 'crypto';
+
+// Stub the @Public decorator and entity imports so loading the
+// controller doesn't pull the full auth → agent/database chain.
+// Mirrors the strategy in composio-triggers.controller.spec.ts and
+// the existing webhook-secret.service.spec.ts.
+jest.mock('../../auth/decorators/public.decorator', () => ({ Public: () => () => undefined }));
+jest.mock('@ever-works/agent/entities', () => ({ TenantJobRuntimeConfig: class {} }));
+jest.mock('@ever-works/agent/tasks', () => ({
+    SECRET_STORE_RESOLVER: Symbol.for('SECRET_STORE_RESOLVER_TEST'),
+}));
+
+// eslint-disable-next-line import/first
+import { TriggerWebhookController } from '../trigger-webhook.controller';
+// eslint-disable-next-line import/first
+import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+// eslint-disable-next-line import/first
+import type { SecretStoreResolver } from '@ever-works/agent/tasks';
+// eslint-disable-next-line import/first
+import type { Repository } from 'typeorm';
+
+const TENANT_ID = '00000000-0000-0000-0000-000000000001';
+const SECRET = 'super-secret-webhook-key';
+const POINTER = 'inline:dGVzdA==';
+
+function signBody(body: string, secret: string): string {
+    const hex = createHmac('sha256', secret).update(body, 'utf8').digest('hex');
+    return `sha256=${hex}`;
+}
+
+function buildOverlayRow(overrides: Partial<TenantJobRuntimeConfig> = {}): TenantJobRuntimeConfig {
+    return {
+        tenantId: TENANT_ID,
+        providerId: 'trigger',
+        credentialsSecretRef: POINTER,
+        credentialVersion: 1,
+        mode: 'byo',
+        enabled: true,
+        createdBy: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...overrides,
+    } as TenantJobRuntimeConfig;
+}
+
+describe('TriggerWebhookController', () => {
+    let tenantRepo: jest.Mocked<Pick<Repository<TenantJobRuntimeConfig>, 'findOne'>>;
+    let secretStore: jest.Mocked<SecretStoreResolver>;
+    let controller: TriggerWebhookController;
+    let logSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        tenantRepo = { findOne: jest.fn() };
+        secretStore = { resolve: jest.fn() } as jest.Mocked<SecretStoreResolver>;
+        controller = new TriggerWebhookController(
+            tenantRepo as unknown as Repository<TenantJobRuntimeConfig>,
+            secretStore,
+        );
+        logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    });
+
+    afterEach(() => {
+        logSpy.mockRestore();
+        jest.resetAllMocks();
+    });
+
+    it('accepts a valid HMAC signature and logs the event metadata', async () => {
+        const body = JSON.stringify({ id: 'evt_abc123', type: 'run.succeeded', data: { foo: 1 } });
+        const signature = signBody(body, SECRET);
+        tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+        secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+        const result = await controller.receive(
+            TENANT_ID,
+            { rawBody: body },
+            { 'x-trigger-signature': signature },
+        );
+
+        expect(result).toEqual({ ok: true });
+        expect(tenantRepo.findOne).toHaveBeenCalledWith({ where: { tenantId: TENANT_ID } });
+        expect(secretStore.resolve).toHaveBeenCalledWith(POINTER);
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        const logged = String(logSpy.mock.calls[0][0]);
+        expect(logged).toContain(TENANT_ID);
+        expect(logged).toContain('evt_abc123');
+        expect(logged).toContain('run.succeeded');
+    });
+
+    it('rejects a request with no X-Trigger-Signature header (400)', async () => {
+        await expect(
+            controller.receive(TENANT_ID, { rawBody: '{}' }, {}),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(tenantRepo.findOne).not.toHaveBeenCalled();
+        expect(secretStore.resolve).not.toHaveBeenCalled();
+    });
+
+    it('rejects a request with a bogus signature (401)', async () => {
+        const body = JSON.stringify({ id: 'evt_x', type: 'run.failed' });
+        tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+        secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+        await expect(
+            controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': 'sha256=deadbeef' + '0'.repeat(56) },
+            ),
+        ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('returns 404 when the tenant has no overlay row', async () => {
+        const body = '{}';
+        tenantRepo.findOne.mockResolvedValue(null);
+
+        await expect(
+            controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            ),
+        ).rejects.toBeInstanceOf(NotFoundException);
+        expect(secretStore.resolve).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when tenant exists but credentials.webhookSecret is absent', async () => {
+        const body = '{}';
+        tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+        secretStore.resolve.mockResolvedValue({ apiKey: 'something-else' });
+
+        await expect(
+            controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            ),
+        ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('returns 401 when the tenant overlay row has no credentialsSecretRef (inherit mode)', async () => {
+        const body = '{}';
+        tenantRepo.findOne.mockResolvedValue(
+            buildOverlayRow({ credentialsSecretRef: null, mode: 'inherit' }),
+        );
+
+        await expect(
+            controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            ),
+        ).rejects.toBeInstanceOf(UnauthorizedException);
+        expect(secretStore.resolve).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the raw body is present but not valid JSON', async () => {
+        const body = 'not-a-json-object{{{';
+        tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+        secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+        await expect(
+            controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            ),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('returns 400 when the request has no captured rawBody', async () => {
+        await expect(
+            controller.receive(
+                TENANT_ID,
+                {}, // no rawBody — pre-signature-check guard
+                { 'x-trigger-signature': 'sha256=' + '0'.repeat(64) },
+            ),
+        ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects a signature without the `sha256=` scheme prefix (401)', async () => {
+        const body = '{}';
+        tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+        secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+        const raw = createHmac('sha256', SECRET).update(body).digest('hex');
+
+        await expect(
+            controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                // omit the `sha256=` prefix
+                { 'x-trigger-signature': raw },
+            ),
+        ).rejects.toBeInstanceOf(UnauthorizedException);
+    });
+
+    it('uses constant-time compare on equal-length buffers (timingSafeEqual invariant)', () => {
+        // Sanity: assert the Node.js primitive the controller relies on
+        // doesn't short-circuit on a 1-byte difference at the prefix.
+        // Both Buffers must be the same length or `timingSafeEqual`
+        // throws — which is exactly why the controller bails on
+        // length-mismatch BEFORE invoking it.
+        const a = Buffer.from('a'.repeat(64), 'utf8');
+        const b = Buffer.from('a'.repeat(63) + 'b', 'utf8');
+        expect(a.length).toBe(b.length);
+        expect(timingSafeEqual(a, b)).toBe(false);
+
+        const shorter = Buffer.from('a'.repeat(63), 'utf8');
+        expect(() => timingSafeEqual(a, shorter)).toThrow();
+    });
+});

--- a/apps/api/src/webhooks/trigger-webhook.controller.ts
+++ b/apps/api/src/webhooks/trigger-webhook.controller.ts
@@ -1,0 +1,225 @@
+import {
+    BadRequestException,
+    Controller,
+    Headers,
+    HttpCode,
+    HttpStatus,
+    Inject,
+    Logger,
+    NotFoundException,
+    Param,
+    ParseUUIDPipe,
+    Post,
+    Req,
+    UnauthorizedException,
+} from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { InjectRepository } from '@nestjs/typeorm';
+import { createHmac, timingSafeEqual } from 'crypto';
+import { Repository } from 'typeorm';
+import { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+import { SECRET_STORE_RESOLVER, type SecretStoreResolver } from '@ever-works/agent/tasks';
+import { Public } from '../auth/decorators/public.decorator';
+
+/**
+ * EW-743 — Trigger.dev webhook receiver.
+ *
+ * Inbound deliveries from a tenant's Trigger.dev project land at
+ * `POST /api/webhooks/trigger/:tenantId`. The receiver:
+ *
+ *   1. Loads the tenant's `TenantJobRuntimeConfig` overlay row (EW-742
+ *      P1) — 404 if no row exists.
+ *   2. Resolves `credentialsSecretRef` via the bundled
+ *      {@link SecretStoreResolver} and reads `credentials.webhookSecret`
+ *      — 401 if the bag is missing the field (fail-closed; no
+ *      auto-pass).
+ *   3. HMAC-SHA256 verifies the raw request body against the per-tenant
+ *      secret using `crypto.timingSafeEqual` on equal-length buffers
+ *      so the compare doesn't short-circuit on partial matches.
+ *   4. Parses the body as JSON for typed access AFTER signature check
+ *      and logs `{ tenantId, eventId, eventType }`.
+ *
+ * Today's scope is receiver-only: a valid signature returns 200 and
+ * logs. Downstream fan-out (turning Trigger.dev run-finished events
+ * into platform events) is a follow-up PR — T25 in the EW-743 plan
+ * is blocked on Trigger.dev's REST API not supporting programmatic
+ * project creation, so operators will provision per-tenant projects
+ * + populate `credentials.webhookSecret` manually for now.
+ *
+ * # Header convention
+ *
+ * `X-Trigger-Signature: sha256=<hex>` — chosen as a sensible default
+ * matching the GitHub / Composio convention. Trigger.dev's actual
+ * webhook signature header is not pinned in their public v4 docs
+ * (https://trigger.dev/docs/v4-upgrade); once operators wire the
+ * upstream signing config, this name may need to track whatever
+ * Trigger.dev settles on. See TODO below.
+ *
+ * Replay protection (timestamp window) is deliberately OPTIONAL on
+ * this PR — Trigger.dev's payload schema is not pinned either, so we
+ * can't reliably read a `X-Trigger-Timestamp` header today. Leaving
+ * the hook in place via a TODO so the operator runbook can switch it
+ * on without a refactor.
+ */
+@ApiTags('Webhooks')
+@Controller('api/webhooks/trigger')
+export class TriggerWebhookController {
+    private readonly logger = new Logger(TriggerWebhookController.name);
+
+    // Per the class header — keep the constant addressable so a future
+    // PR can flip the header name once the upstream contract pins.
+    //
+    // TODO(EW-743 follow-up): replace with Trigger.dev's documented
+    // webhook signature header once they publish it. Mirror the
+    // composio-triggers receiver's `webhook-signature` convention if
+    // they adopt the Standard Webhooks spec.
+    private static readonly SIGNATURE_HEADER = 'x-trigger-signature';
+    private static readonly SIGNATURE_PREFIX = 'sha256=';
+
+    constructor(
+        @InjectRepository(TenantJobRuntimeConfig)
+        private readonly tenantRuntimeRepo: Repository<TenantJobRuntimeConfig>,
+        @Inject(SECRET_STORE_RESOLVER)
+        private readonly secretStore: SecretStoreResolver,
+    ) {}
+
+    @Public()
+    @Post(':tenantId')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Trigger.dev webhook receiver',
+        description:
+            'Receives signed webhook deliveries from a tenant-scoped Trigger.dev project. Verifies HMAC-SHA256 against the per-tenant secret stored under `TenantJobRuntimeConfig.credentials.webhookSecret`. Returns 200 on accept; 401 on bad / missing signature; 404 on unknown tenant; 400 on missing header / malformed body. Downstream event fan-out lands in a follow-up PR.',
+    })
+    @ApiParam({ name: 'tenantId', description: 'Tenant id (UUID)' })
+    @ApiResponse({ status: 200, description: 'Accepted' })
+    @ApiResponse({ status: 400, description: 'Missing signature header or malformed JSON body' })
+    @ApiResponse({ status: 401, description: 'Invalid signature or no webhook secret configured' })
+    @ApiResponse({ status: 404, description: 'Unknown tenant' })
+    async receive(
+        @Param('tenantId', new ParseUUIDPipe()) tenantId: string,
+        @Req() req: { rawBody?: string },
+        @Headers() headers: Record<string, string>,
+    ): Promise<{ ok: true }> {
+        const signatureHeader = headers[TriggerWebhookController.SIGNATURE_HEADER];
+        if (!signatureHeader || typeof signatureHeader !== 'string') {
+            throw new BadRequestException(
+                `Missing ${TriggerWebhookController.SIGNATURE_HEADER} header`,
+            );
+        }
+        if (!req.rawBody) {
+            throw new BadRequestException('Missing raw webhook payload');
+        }
+
+        // 404 BEFORE any other check so unknown-tenant probes don't get
+        // a signature-malformed reply that would leak existence.
+        const row = await this.tenantRuntimeRepo.findOne({ where: { tenantId } });
+        if (!row) {
+            throw new NotFoundException();
+        }
+
+        const webhookSecret = await this.loadWebhookSecret(row);
+        if (!webhookSecret) {
+            // Fail-closed: a tenant overlay row exists but the secret
+            // bag has no `webhookSecret` field. Don't auto-pass — that
+            // would let any caller deliver to a half-provisioned tenant.
+            throw new UnauthorizedException();
+        }
+
+        if (!this.verifySignature(signatureHeader, req.rawBody, webhookSecret)) {
+            throw new UnauthorizedException();
+        }
+
+        // Parse AFTER signature check — pre-parse would let an attacker
+        // burn JSON.parse cycles on unauthenticated payloads.
+        let payload: TriggerWebhookPayload;
+        try {
+            payload = JSON.parse(req.rawBody) as TriggerWebhookPayload;
+        } catch {
+            throw new BadRequestException('Webhook body is not valid JSON');
+        }
+
+        // TODO(EW-743 follow-up): once Trigger.dev's payload schema is
+        // pinned, read `X-Trigger-Timestamp` and reject signatures more
+        // than 5 minutes old (replay protection). Skipped today because
+        // the upstream header name is not documented.
+
+        this.logger.log(
+            `Trigger.dev webhook received: tenantId=${tenantId} eventId=${
+                payload?.id ?? '?'
+            } eventType=${payload?.type ?? '?'}`,
+        );
+
+        // Downstream fan-out is a follow-up PR — see class header.
+        return { ok: true };
+    }
+
+    /**
+     * Constant-time HMAC compare. The supplied header is expected as
+     * `sha256=<hex>`; we strip the scheme prefix, decode to a Buffer,
+     * and compare against the freshly-computed HMAC. Length-mismatch
+     * exits BEFORE `timingSafeEqual` because that function throws on
+     * unequal buffer lengths (which is itself a side-channel signal,
+     * but worse: it crashes the request). Returning `false` on length
+     * mismatch is the documented Node.js pattern.
+     */
+    private verifySignature(headerValue: string, rawBody: string, secret: string): boolean {
+        if (!headerValue.startsWith(TriggerWebhookController.SIGNATURE_PREFIX)) {
+            return false;
+        }
+        const providedHex = headerValue.slice(TriggerWebhookController.SIGNATURE_PREFIX.length);
+        if (!/^[0-9a-f]+$/i.test(providedHex)) {
+            return false;
+        }
+        const expectedHex = createHmac('sha256', secret).update(rawBody, 'utf8').digest('hex');
+        if (providedHex.length !== expectedHex.length) {
+            return false;
+        }
+        const providedBuf = Buffer.from(providedHex, 'hex');
+        const expectedBuf = Buffer.from(expectedHex, 'hex');
+        // Both buffers are the same length by construction (hex → bytes
+        // halves the length deterministically), but double-check before
+        // the constant-time compare to satisfy the API contract.
+        if (providedBuf.length !== expectedBuf.length) {
+            return false;
+        }
+        return timingSafeEqual(providedBuf, expectedBuf);
+    }
+
+    /**
+     * Resolve the tenant's `credentials.webhookSecret` via the bound
+     * {@link SecretStoreResolver}. Returns `null` when:
+     *   - the overlay row has no `credentialsSecretRef` (mode=inherit);
+     *   - the resolver fails to decode the pointer (unknown scheme,
+     *     bad payload, etc.) — the resolver contract returns `null`
+     *     rather than throwing;
+     *   - the resolved bag has no `webhookSecret` field or the field
+     *     isn't a non-empty string.
+     */
+    private async loadWebhookSecret(row: TenantJobRuntimeConfig): Promise<string | null> {
+        if (!row.credentialsSecretRef) {
+            return null;
+        }
+        const bag = await this.secretStore.resolve(row.credentialsSecretRef);
+        if (!bag) {
+            return null;
+        }
+        const secret = bag['webhookSecret'];
+        if (typeof secret !== 'string' || secret.length === 0) {
+            return null;
+        }
+        return secret;
+    }
+}
+
+/**
+ * Minimal shape we need from a Trigger.dev webhook payload for logging.
+ * Kept intentionally tiny — the official Trigger.dev event schema isn't
+ * pinned in their public v4 docs, so we treat the body as opaque
+ * beyond the two fields we surface in logs.
+ */
+interface TriggerWebhookPayload {
+    id?: string;
+    type?: string;
+    [key: string]: unknown;
+}

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -1,5 +1,7 @@
 import { Module, OnModuleInit } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { DatabaseModule } from '@ever-works/agent/database';
+import { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
 // Security (EW-711 #14): WorkModule provides/exports WorkOwnershipService so
 // WebhooksService can authorize a supplied workId before binding a
 // subscription to that Work's event stream.
@@ -8,6 +10,10 @@ import {
     WebhookSubscriptionDeliveryService,
     WorkModule,
 } from '@ever-works/agent/services';
+import {
+    InProcessSecretStoreResolver,
+    SECRET_STORE_RESOLVER,
+} from '@ever-works/agent/tasks';
 import { TriggerModule as TasksTriggerModule } from '@ever-works/trigger-tasks';
 import { AuthModule } from '../auth/auth.module';
 import { WebhooksController } from './webhooks.controller';
@@ -16,6 +22,7 @@ import { WebhookSecretService } from './webhook-secret.service';
 import { WebhookEventDispatcherService } from './webhook-event-dispatcher.service';
 import { WebhooksDeliveriesService } from './webhooks-deliveries.service';
 import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
+import { TriggerWebhookController } from './trigger-webhook.controller';
 
 /**
  * `/api/webhooks` surface — subscriptions CRUD, delivery test-fire,
@@ -42,8 +49,13 @@ import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job
         // EW-742 P3.2 T22 — RuntimeBindingStamperService for the
         // WebhookEventDispatcherService enqueue-site stamping.
         TenantJobRuntimeModule,
+        // EW-743 — the Trigger.dev webhook receiver injects the tenant
+        // overlay repo directly to resolve the per-tenant
+        // `credentials.webhookSecret`. `TenantJobRuntimeModule` does
+        // not export the bare repository, so register it locally.
+        TypeOrmModule.forFeature([TenantJobRuntimeConfig]),
     ],
-    controllers: [WebhooksController],
+    controllers: [WebhooksController, TriggerWebhookController],
     providers: [
         WebhooksService,
         WebhookSecretService,
@@ -51,6 +63,13 @@ import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job
         WebhookSubscriptionDeliveryService,
         WebhookEventDispatcherService,
         WebhooksDeliveriesService,
+        // EW-743 — SecretStoreResolver binding for the Trigger.dev
+        // webhook receiver. `TenantJobRuntimeModule` also binds this
+        // for its own use but does not export the token, so the same
+        // default implementation is provided locally. Production
+        // deployments override this binding at the module level for
+        // their secret-store scheme (Vault, k8s, etc.).
+        { provide: SECRET_STORE_RESOLVER, useClass: InProcessSecretStoreResolver },
     ],
     exports: [
         WebhooksService,


### PR DESCRIPTION
## Summary

Adds `POST /api/webhooks/trigger/:tenantId` — a `@Public()` receiver that HMAC-SHA256-verifies inbound Trigger.dev deliveries against the per-tenant secret stored under `TenantJobRuntimeConfig.credentials.webhookSecret` (resolved via the bundled `SecretStoreResolver`).

- Receiver-only on this PR. Valid signature → structured log + 200.
- Compare uses `crypto.timingSafeEqual` on equal-length buffers; bails on length mismatch BEFORE the compare to avoid the Node-documented throw.
- 200 / 400 missing-header-or-bad-JSON / 401 bad-sig-or-no-secret / 404 unknown-tenant.
- Header `X-Trigger-Signature: sha256=<hex>` as the speculative default (TODO to track upstream).
- Replay protection (`X-Trigger-Timestamp`) deferred — Trigger.dev's v4 schema isn't pinned.

Unblocks T25 per-tenant project routing on the receiver side; the upstream Trigger.dev REST API still doesn't support programmatic project creation, so operators provision per-tenant projects + populate the secret manually for now.

## Test plan
- [x] 10 new unit cases (valid HMAC, missing header, bad sig, unknown tenant, no secret bag, inherit mode, malformed JSON, no rawBody, missing `sha256=` prefix, `timingSafeEqual` invariant) — green
- [x] `pnpm type-check` in `apps/api` — clean
- [x] No regression in existing webhook suites (46/46 green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)