### PR TITLE
fix(agent): pin StepMetrics[] so reduce sums stay number-typed

### DIFF
--- a/packages/agent/src/utils/metrics.util.ts
+++ b/packages/agent/src/utils/metrics.util.ts
@@ -95,13 +95,17 @@ export function extractPipelineUsageMetrics(
     const extendedMetrics = metrics as PipelineMetricsWithTokenUsage;
     const explicitTotalTokens = extendedMetrics.tokenUsage?.total?.totalTokens;
     const explicitTotalCost = extendedMetrics.totalCost;
-    const stepMetrics = Object.values(metrics.steps ?? {});
+    // `metrics.steps ?? {}` widens to `Record<string, StepMetrics> | {}`, which
+    // makes `Object.values` infer `unknown[]` and poisons the reduce accumulators
+    // below with `unknown`. Pin the element type so each `step` stays a
+    // `StepMetrics` and the `sum + …` arithmetic stays `number + number`.
+    const stepMetrics: StepMetrics[] = Object.values(metrics.steps ?? {});
 
-    const totalTokensFromSteps = stepMetrics.reduce(
+    const totalTokensFromSteps = stepMetrics.reduce<number>(
         (sum, step) => sum + readStepMetricNumber(step, 'totalTokens'),
         0,
     );
-    const totalCost = stepMetrics.reduce(
+    const totalCost = stepMetrics.reduce<number>(
         (sum, step) => sum + readStepMetricNumber(step, 'totalCost'),
         0,
     );


### PR DESCRIPTION
## Summary

\`extractPipelineUsageMetrics\` in \`packages/agent/src/utils/metrics.util.ts\` emitted five TS2365/TS2322 errors after \`metrics.steps ?? {}\` widened the empty-object fallback into the array element type, leaving \`Object.values\` inferred as \`unknown[]\`. The \`unknown\` poisoned both reduce accumulators and the zero-check comparisons.

## Fix

Pin \`const stepMetrics: StepMetrics[]\` and annotate \`.reduce<number>(...)\`. No runtime behaviour change, no signature change, no \`as any\`.

## Why this matters

\`apps/api\` ts-jest resolves \`@ever-works/agent/{entities,tasks}\` to source, so type errors in \`metrics.util.ts\` leak into downstream specs (per PR #1530 task-2 diagnosis).

## Test plan
- [x] \`packages/agent\` \`pnpm test\` — 312 suites / 6096 tests passing
- [x] \`metrics.util.ts\` lines 101/105/116/117/118 no longer in type-check output
- [x] \`apps/api\` \`pnpm test\` — unchanged baseline maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type safety and code robustness in metrics processing to prevent potential data inconsistencies during computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->