### PR TITLE
feat(api): trigger-webhook subscribers (#1537 phase 3)

### DIFF
--- a/apps/api/src/webhooks/subscribers/__tests__/trigger-run-failure-sentry-breadcrumb.subscriber.spec.ts
+++ b/apps/api/src/webhooks/subscribers/__tests__/trigger-run-failure-sentry-breadcrumb.subscriber.spec.ts
@@ -1,0 +1,188 @@
+import { Logger } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
+import { SentryService } from '@ever-works/monitoring';
+import { TriggerRunFailureSentryBreadcrumbSubscriber } from '../trigger-run-failure-sentry-breadcrumb.subscriber';
+import {
+    TRIGGER_WEBHOOK_EVENTS,
+    TriggerWebhookInternalEventName,
+    TriggerWebhookInternalEventPayload,
+} from '../../trigger-webhook-events';
+
+const TENANT_ID = '00000000-0000-0000-0000-000000000001';
+
+function envelope(
+    internalEventName: TriggerWebhookInternalEventName,
+    payloadOverrides: Record<string, unknown> = {},
+): TriggerWebhookInternalEventPayload {
+    return {
+        tenantId: TENANT_ID,
+        upstreamEventType: internalEventName.replace('trigger.', 'alert.'),
+        internalEventName,
+        createdAt: '2026-06-21T12:00:00.000Z',
+        payload:
+            internalEventName === TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED
+                ? {
+                      deployment: { id: 'dep_xyz' },
+                      ...payloadOverrides,
+                  }
+                : {
+                      run: { id: 'run_abc', error: { message: 'oom' } },
+                      ...payloadOverrides,
+                  },
+    };
+}
+
+describe('TriggerRunFailureSentryBreadcrumbSubscriber', () => {
+    let module: TestingModule;
+    let subscriber: TriggerRunFailureSentryBreadcrumbSubscriber;
+    let sentry: jest.Mocked<SentryService>;
+    let emitter: EventEmitter2;
+    let warnSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+        const sentryMock: jest.Mocked<Partial<SentryService>> = {
+            error: jest.fn(),
+        };
+
+        module = await Test.createTestingModule({
+            imports: [EventEmitterModule.forRoot()],
+            providers: [
+                TriggerRunFailureSentryBreadcrumbSubscriber,
+                { provide: SentryService, useValue: sentryMock },
+            ],
+        }).compile();
+
+        await module.init();
+
+        subscriber = module.get(TriggerRunFailureSentryBreadcrumbSubscriber);
+        sentry = module.get(SentryService) as jest.Mocked<SentryService>;
+        emitter = module.get(EventEmitter2);
+
+        warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+        errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    });
+
+    afterEach(async () => {
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+        await module.close();
+        jest.resetAllMocks();
+    });
+
+    it('logs to Sentry with runId + tenantId on trigger.run.failed', () => {
+        subscriber.onRunFailed(envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED));
+
+        expect(sentry.error).toHaveBeenCalledTimes(1);
+        const [msg, attrs] = sentry.error.mock.calls[0];
+        expect(String(msg)).toContain('trigger.run.failed');
+        expect(String(msg)).toContain(TENANT_ID);
+        expect(attrs).toMatchObject({
+            tenantId: TENANT_ID,
+            runId: 'run_abc',
+            errorMessage: 'oom',
+            internalEventName: TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+            upstreamEventType: 'alert.run.failed',
+        });
+    });
+
+    it('logs to Sentry with deploymentId + tenantId on trigger.deployment.failed', () => {
+        subscriber.onDeploymentFailed(envelope(TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED));
+
+        expect(sentry.error).toHaveBeenCalledTimes(1);
+        const [msg, attrs] = sentry.error.mock.calls[0];
+        expect(String(msg)).toContain('trigger.deployment.failed');
+        expect(attrs).toMatchObject({
+            tenantId: TENANT_ID,
+            deploymentId: 'dep_xyz',
+            internalEventName: TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED,
+        });
+    });
+
+    it('is idempotent — two identical deliveries produce two identical Sentry calls', () => {
+        const evt = envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED);
+        subscriber.onRunFailed(evt);
+        subscriber.onRunFailed(evt);
+        expect(sentry.error).toHaveBeenCalledTimes(2);
+        expect(sentry.error.mock.calls[0]).toEqual(sentry.error.mock.calls[1]);
+    });
+
+    it('drops payload missing run.id gracefully (no runId attr; Sentry still called)', () => {
+        subscriber.onRunFailed(
+            envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED, { run: { error: { message: 'oom' } } }),
+        );
+
+        expect(sentry.error).toHaveBeenCalledTimes(1);
+        const [, attrs] = sentry.error.mock.calls[0];
+        expect(attrs).not.toHaveProperty('runId');
+        expect(attrs).toMatchObject({ tenantId: TENANT_ID, errorMessage: 'oom' });
+    });
+
+    it('falls back to Logger.warn when SentryService is not bound', async () => {
+        await module.close();
+
+        // Re-build the module without binding SentryService — the
+        // @Optional() decorator on the subscriber means it constructs
+        // with `undefined` and routes the line through Nest Logger.
+        module = await Test.createTestingModule({
+            imports: [EventEmitterModule.forRoot()],
+            providers: [TriggerRunFailureSentryBreadcrumbSubscriber],
+        }).compile();
+        await module.init();
+        subscriber = module.get(TriggerRunFailureSentryBreadcrumbSubscriber);
+
+        subscriber.onRunFailed(envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED));
+
+        expect(warnSpy).toHaveBeenCalled();
+        const line = String(warnSpy.mock.calls[0][0]);
+        expect(line).toContain('trigger.run.failed');
+        expect(line).toContain(TENANT_ID);
+        expect(line).toContain('run_abc');
+        expect(line).toContain('SentryService not bound');
+    });
+
+    it('catches + logs when SentryService.error throws — does not propagate', () => {
+        sentry.error.mockImplementation(() => {
+            throw new Error('sentry transport down');
+        });
+
+        expect(() =>
+            subscriber.onRunFailed(envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED)),
+        ).not.toThrow();
+        expect(errorSpy).toHaveBeenCalled();
+        expect(String(errorSpy.mock.calls[0][0])).toContain('sentry transport down');
+    });
+
+    it('does NOT react to run.succeeded / run.cancelled (only failures)', async () => {
+        emitter.emit(
+            TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED,
+            envelope(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED),
+        );
+        emitter.emit(
+            TRIGGER_WEBHOOK_EVENTS.RUN_CANCELLED,
+            envelope(TRIGGER_WEBHOOK_EVENTS.RUN_CANCELLED),
+        );
+        emitter.emit(
+            TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_SUCCEEDED,
+            envelope(TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_SUCCEEDED),
+        );
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(sentry.error).not.toHaveBeenCalled();
+    });
+
+    it('wires both @OnEvent failure listeners end-to-end via EventEmitter2', async () => {
+        emitter.emit(
+            TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+            envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED),
+        );
+        emitter.emit(
+            TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED,
+            envelope(TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED),
+        );
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(sentry.error).toHaveBeenCalledTimes(2);
+    });
+});

--- a/apps/api/src/webhooks/subscribers/__tests__/trigger-run-status.subscriber.spec.ts
+++ b/apps/api/src/webhooks/subscribers/__tests__/trigger-run-status.subscriber.spec.ts
@@ -1,0 +1,197 @@
+// Match the project-wide test convention (e.g. budget-alert.handler.spec.ts):
+// stub external workspace packages so Jest doesn't have to resolve their
+// transitive `@src/...` imports that target the API tsconfig path mapping.
+jest.mock('@ever-works/agent/database', () => ({
+    WorkGenerationHistoryRepository: class {},
+}));
+
+import { Logger } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import type { WorkGenerationHistoryRepository } from '@ever-works/agent/database';
+import { GenerateStatusType } from '@ever-works/contracts/api';
+import { TriggerRunStatusSubscriber } from '../trigger-run-status.subscriber';
+import {
+    TRIGGER_WEBHOOK_EVENTS,
+    TriggerWebhookInternalEventName,
+    TriggerWebhookInternalEventPayload,
+} from '../../trigger-webhook-events';
+
+const TENANT_ID = '00000000-0000-0000-0000-000000000001';
+
+function envelope(
+    internalEventName: TriggerWebhookInternalEventName,
+    payloadOverrides: Record<string, unknown> = {},
+): TriggerWebhookInternalEventPayload {
+    return {
+        tenantId: TENANT_ID,
+        upstreamEventType: internalEventName.replace('trigger.', 'alert.'),
+        internalEventName,
+        createdAt: '2026-06-21T12:00:00.000Z',
+        payload: {
+            run: { id: 'run_abc', status: 'COMPLETED' },
+            ...payloadOverrides,
+        },
+    };
+}
+
+function makeHistoryMock(): jest.Mocked<
+    Pick<WorkGenerationHistoryRepository, 'findByTriggerRunId' | 'updateEntry'>
+> {
+    return {
+        findByTriggerRunId: jest.fn(),
+        updateEntry: jest.fn(),
+    };
+}
+
+describe('TriggerRunStatusSubscriber', () => {
+    let subscriber: TriggerRunStatusSubscriber;
+    let history: ReturnType<typeof makeHistoryMock>;
+    let logSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        history = makeHistoryMock();
+        subscriber = new TriggerRunStatusSubscriber(history as unknown as WorkGenerationHistoryRepository);
+
+        logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+        debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+        errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    });
+
+    afterEach(() => {
+        logSpy.mockRestore();
+        debugSpy.mockRestore();
+        errorSpy.mockRestore();
+        jest.resetAllMocks();
+    });
+
+    describe('happy path', () => {
+        it.each([
+            {
+                handler: 'onRunSucceeded' as const,
+                name: TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED,
+                terminal: GenerateStatusType.GENERATED,
+            },
+            {
+                handler: 'onRunFailed' as const,
+                name: TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                terminal: GenerateStatusType.ERROR,
+            },
+            {
+                handler: 'onRunCancelled' as const,
+                name: TRIGGER_WEBHOOK_EVENTS.RUN_CANCELLED,
+                terminal: GenerateStatusType.CANCELLED,
+            },
+        ])(
+            'flips history row to "$terminal" via $handler',
+            async ({ handler, name, terminal }) => {
+                history.findByTriggerRunId.mockResolvedValue({
+                    id: 'hist-1',
+                    status: GenerateStatusType.GENERATING,
+                } as never);
+                history.updateEntry.mockResolvedValue({ id: 'hist-1' } as never);
+
+                await subscriber[handler](envelope(name));
+
+                expect(history.findByTriggerRunId).toHaveBeenCalledWith('run_abc');
+                expect(history.updateEntry).toHaveBeenCalledTimes(1);
+                const [id, updates] = history.updateEntry.mock.calls[0];
+                expect(id).toBe('hist-1');
+                expect(updates.status).toBe(terminal);
+                expect(updates.finishedAt).toBeInstanceOf(Date);
+            },
+        );
+    });
+
+    it('persists errorMessage from payload.run.error.message on RUN_FAILED', async () => {
+        history.findByTriggerRunId.mockResolvedValue({
+            id: 'hist-1',
+            status: GenerateStatusType.GENERATING,
+        } as never);
+        history.updateEntry.mockResolvedValue({ id: 'hist-1' } as never);
+
+        await subscriber.onRunFailed(
+            envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED, {
+                run: { id: 'run_abc', error: { message: 'task crashed: ENOMEM' } },
+            }),
+        );
+
+        expect(history.updateEntry).toHaveBeenCalledWith(
+            'hist-1',
+            expect.objectContaining({
+                status: GenerateStatusType.ERROR,
+                errorMessage: 'task crashed: ENOMEM',
+            }),
+        );
+    });
+
+    it('is idempotent — same delivery twice yields one terminal write + one no-op', async () => {
+        // First delivery: row is GENERATING, gets flipped.
+        history.findByTriggerRunId.mockResolvedValueOnce({
+            id: 'hist-1',
+            status: GenerateStatusType.GENERATING,
+        } as never);
+        history.updateEntry.mockResolvedValueOnce({ id: 'hist-1' } as never);
+        // Second delivery: row is already GENERATED.
+        history.findByTriggerRunId.mockResolvedValueOnce({
+            id: 'hist-1',
+            status: GenerateStatusType.GENERATED,
+        } as never);
+
+        await subscriber.onRunSucceeded(envelope(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED));
+        await subscriber.onRunSucceeded(envelope(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED));
+
+        // updateEntry called only on the first delivery — terminal
+        // short-circuit catches the second.
+        expect(history.updateEntry).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs + drops when no history row matches the triggerRunId', async () => {
+        history.findByTriggerRunId.mockResolvedValue(null);
+
+        await subscriber.onRunSucceeded(envelope(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED));
+
+        expect(history.updateEntry).not.toHaveBeenCalled();
+        expect(debugSpy).toHaveBeenCalled();
+        expect(String(debugSpy.mock.calls.at(-1)?.[0] ?? '')).toContain('no work_generation_history');
+    });
+
+    it('drops payload missing run.id without throwing', async () => {
+        await expect(
+            subscriber.onRunFailed(
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED, { run: { status: 'FAILED' } }),
+            ),
+        ).resolves.toBeUndefined();
+
+        expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+        expect(history.updateEntry).not.toHaveBeenCalled();
+        expect(debugSpy).toHaveBeenCalled();
+        expect(String(debugSpy.mock.calls.at(-1)?.[0] ?? '')).toContain('missing payload.run.id');
+    });
+
+    it('catches + logs when the repository throws — does not propagate', async () => {
+        history.findByTriggerRunId.mockRejectedValue(new Error('db connection lost'));
+
+        await expect(
+            subscriber.onRunFailed(envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED)),
+        ).resolves.toBeUndefined();
+
+        expect(errorSpy).toHaveBeenCalled();
+        expect(String(errorSpy.mock.calls[0][0])).toContain('db connection lost');
+    });
+
+    it('does not have handlers for deployment.* events', () => {
+        // Channel-purity check: the subscriber must expose only the
+        // three run.* handlers. If a future contributor wires a
+        // deployment.* handler here by mistake, this assertion catches
+        // it.
+        const proto = TriggerRunStatusSubscriber.prototype;
+        const ownMethods = Object.getOwnPropertyNames(proto).filter(
+            (n) => n !== 'constructor' && typeof (proto as any)[n] === 'function',
+        );
+        expect(ownMethods.sort()).toEqual(
+            ['handle', 'onRunCancelled', 'onRunFailed', 'onRunSucceeded'].sort(),
+        );
+    });
+});

--- a/apps/api/src/webhooks/subscribers/trigger-run-failure-sentry-breadcrumb.subscriber.ts
+++ b/apps/api/src/webhooks/subscribers/trigger-run-failure-sentry-breadcrumb.subscriber.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { SentryService } from '@ever-works/monitoring';
+import {
+    TRIGGER_WEBHOOK_EVENTS,
+    TriggerWebhookInternalEventPayload,
+} from '../trigger-webhook-events';
+
+/**
+ * EW-743 Phase 3 — bounded observability fanout for Trigger.dev
+ * `trigger.run.failed` and `trigger.deployment.failed`.
+ *
+ * Surfaces each failed Trigger.dev event as a structured Sentry log
+ * line (via the platform's `SentryService` from `@ever-works/monitoring`)
+ * tagged with `runId`, `tenantId`, and the upstream event type, so
+ * operators can grep / filter Sentry to discover Trigger.dev runs that
+ * never recovered. No exception is captured — webhook failures are
+ * EXPECTED workload events, not platform errors. Adding them to
+ * Sentry's exceptions stream would dilute the signal-to-noise of the
+ * project's real error count.
+ *
+ * # Constraints
+ *
+ *  - `SentryService` is provided by the `@Global()` `MonitoringModule`
+ *    that the API root wires at startup. It is marked `@Optional()`
+ *    here so unit tests can construct the subscriber without standing
+ *    up the entire monitoring graph, and so a deploy that disables
+ *    monitoring (offline / dev) does not refuse to construct the
+ *    WebhooksModule.
+ *  - When `SentryService` is absent we log the same line via the
+ *    Nest `Logger` instead, so operators don't lose the observability
+ *    signal in dev / test environments.
+ *  - Never throws (router contract). All bodies are wrapped in
+ *    try/catch.
+ *  - Idempotent: a duplicate delivery produces a duplicate log line.
+ *    That's fine — operators correlate by `runId` and de-dup mentally,
+ *    and Sentry's own ingest pipeline rate-limits.
+ *
+ * # Why not addBreadcrumb()?
+ *
+ * Breadcrumbs are scoped to the active Sentry Hub, which on the
+ * NestJS request-pipeline is the incoming HTTP request. A breadcrumb
+ * added inside an EventEmitter2 handler that fires AFTER the trigger
+ * webhook controller has returned would attach to a different scope
+ * (or no scope at all). A structured `sentryService.error(...)` log
+ * goes to the standalone logs surface and does not depend on hub
+ * scoping. See the SentryService class header.
+ */
+@Injectable()
+export class TriggerRunFailureSentryBreadcrumbSubscriber {
+    private readonly logger = new Logger(TriggerRunFailureSentryBreadcrumbSubscriber.name);
+
+    constructor(@Optional() private readonly sentry?: SentryService) {}
+
+    @OnEvent(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED)
+    onRunFailed(event: TriggerWebhookInternalEventPayload): void {
+        this.emit('trigger.run.failed', event, {
+            runId: extractRunId(event.payload),
+            errorMessage: extractErrorMessage(event.payload),
+        });
+    }
+
+    @OnEvent(TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED)
+    onDeploymentFailed(event: TriggerWebhookInternalEventPayload): void {
+        this.emit('trigger.deployment.failed', event, {
+            deploymentId: extractDeploymentId(event.payload),
+            errorMessage: extractErrorMessage(event.payload),
+        });
+    }
+
+    private emit(
+        label: string,
+        event: TriggerWebhookInternalEventPayload,
+        attrs: Readonly<Record<string, string | null>>,
+    ): void {
+        try {
+            const sanitizedAttrs: Record<string, string> = {
+                upstreamEventType: event.upstreamEventType,
+                internalEventName: event.internalEventName,
+                tenantId: event.tenantId,
+                createdAt: event.createdAt,
+            };
+            for (const [key, value] of Object.entries(attrs)) {
+                if (value) {
+                    sanitizedAttrs[key] = value;
+                }
+            }
+
+            const message = `${label} (tenantId=${event.tenantId})`;
+
+            if (this.sentry) {
+                this.sentry.error(message, sanitizedAttrs);
+            } else {
+                // No SentryService bound (offline dev / test). Keep the
+                // signal — same fields, just routed through Nest Logger.
+                this.logger.warn(
+                    `${message} ${JSON.stringify(sanitizedAttrs)} ` +
+                        `(SentryService not bound; operators see this in Nest logs only)`,
+                );
+            }
+        } catch (err) {
+            // MUST NOT throw — router contract.
+            this.logger.error(
+                `Sentry breadcrumb subscriber failed for ${label}: ` +
+                    `${(err as Error).message ?? String(err)}`,
+                (err as Error).stack,
+            );
+        }
+    }
+}
+
+function extractRunId(payload: Readonly<Record<string, unknown>>): string | null {
+    const run = (payload as { run?: unknown }).run;
+    if (!run || typeof run !== 'object') return null;
+    const id = (run as { id?: unknown }).id;
+    return typeof id === 'string' && id.length > 0 ? id : null;
+}
+
+function extractDeploymentId(payload: Readonly<Record<string, unknown>>): string | null {
+    const deployment = (payload as { deployment?: unknown }).deployment;
+    if (!deployment || typeof deployment !== 'object') return null;
+    const id = (deployment as { id?: unknown }).id;
+    return typeof id === 'string' && id.length > 0 ? id : null;
+}
+
+function extractErrorMessage(payload: Readonly<Record<string, unknown>>): string | null {
+    const run = (payload as { run?: unknown }).run;
+    if (run && typeof run === 'object') {
+        const error = (run as { error?: unknown }).error;
+        if (error && typeof error === 'object') {
+            const message = (error as { message?: unknown }).message;
+            if (typeof message === 'string' && message.length > 0) {
+                return message.length > 512 ? `${message.slice(0, 512)}…` : message;
+            }
+        }
+    }
+    const deployment = (payload as { deployment?: unknown }).deployment;
+    if (deployment && typeof deployment === 'object') {
+        const error = (deployment as { error?: unknown }).error;
+        if (error && typeof error === 'object') {
+            const message = (error as { message?: unknown }).message;
+            if (typeof message === 'string' && message.length > 0) {
+                return message.length > 512 ? `${message.slice(0, 512)}…` : message;
+            }
+        }
+    }
+    return null;
+}

--- a/apps/api/src/webhooks/subscribers/trigger-run-status.subscriber.ts
+++ b/apps/api/src/webhooks/subscribers/trigger-run-status.subscriber.ts
@@ -1,0 +1,189 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { WorkGenerationHistoryRepository } from '@ever-works/agent/database';
+import { GenerateStatusType } from '@ever-works/contracts/api';
+import {
+    TRIGGER_WEBHOOK_EVENTS,
+    TriggerWebhookInternalEventName,
+    TriggerWebhookInternalEventPayload,
+} from '../trigger-webhook-events';
+
+/**
+ * EW-743 Phase 3 — listens to `trigger.run.{succeeded,failed,cancelled}`
+ * and flips the matching `work_generation_history` row's status to a
+ * terminal value (`generated` / `error` / `cancelled`).
+ *
+ * Match key: `triggerRunId` extracted from the Trigger.dev webhook
+ * payload (`payload.run.id`). We do NOT create a new row when no match
+ * exists — the upstream dispatcher (`WorkGenerationService`) is the
+ * authoritative producer of history rows; this subscriber only reacts.
+ *
+ * # Why WorkGenerationHistory (and not AgentRun / TemplateCustomization / WebhookDelivery)
+ *
+ * `work_generation_history` has the cleanest fit:
+ *   - It's the dominant `triggerRunId`-bearing entity (every work
+ *     generation gets a row).
+ *   - Its status enum (`GENERATING|GENERATED|ERROR|CANCELLED`) maps
+ *     1:1 to the three terminal Trigger.dev run states.
+ *   - Its repository is already wired into the global `DatabaseModule`
+ *     and is therefore DI-available in `WebhooksModule` without any
+ *     module-graph surgery.
+ *
+ * `AgentRun` also has `triggerRunId` + a similar terminal-status enum,
+ * but its repository is feature-module-scoped (not exported from
+ * `DatabaseModule`), so wiring it here would force a feature-module
+ * import cascade outside this PR's scope. A follow-up subscriber for
+ * `AgentRun` can land independently.
+ *
+ * # Constraints
+ *
+ *  - Idempotent: re-applying a terminal status is a no-op at the SQL
+ *    layer (`UPDATE ... SET status = 'generated' WHERE id = ?` against
+ *    an already-`generated` row writes the same value), so duplicate
+ *    deliveries (Trigger.dev is at-least-once) are safe by construction.
+ *    We additionally short-circuit early when the persisted status is
+ *    already terminal to avoid pointless UPDATEs + finishedAt clobber.
+ *  - Never throws: per the router's contract, a thrown subscriber would
+ *    poison EventEmitter2 and bring down sibling subscribers (Sentry
+ *    breadcrumb subscriber, future notification subscriber, ...). All
+ *    handler bodies are wrapped in try/catch and failures are logged.
+ *  - Missing record: if no row has the runId, log at debug + drop. This
+ *    is expected for runs originated outside the platform (Trigger.dev
+ *    `dev` runs, manual `triggers.run.dev`, stale alerts after a tenant
+ *    re-provision) and should NOT page operators.
+ */
+@Injectable()
+export class TriggerRunStatusSubscriber {
+    private readonly logger = new Logger(TriggerRunStatusSubscriber.name);
+
+    constructor(private readonly history: WorkGenerationHistoryRepository) {}
+
+    @OnEvent(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED)
+    async onRunSucceeded(event: TriggerWebhookInternalEventPayload): Promise<void> {
+        await this.handle(event, GenerateStatusType.GENERATED);
+    }
+
+    @OnEvent(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED)
+    async onRunFailed(event: TriggerWebhookInternalEventPayload): Promise<void> {
+        await this.handle(event, GenerateStatusType.ERROR);
+    }
+
+    @OnEvent(TRIGGER_WEBHOOK_EVENTS.RUN_CANCELLED)
+    async onRunCancelled(event: TriggerWebhookInternalEventPayload): Promise<void> {
+        await this.handle(event, GenerateStatusType.CANCELLED);
+    }
+
+    private async handle(
+        event: TriggerWebhookInternalEventPayload,
+        terminalStatus: GenerateStatusType,
+    ): Promise<void> {
+        try {
+            const runId = extractRunId(event.payload);
+            if (!runId) {
+                this.logger.debug(
+                    `${event.internalEventName as TriggerWebhookInternalEventName} ` +
+                        `dropped: missing payload.run.id (tenantId=${event.tenantId})`,
+                );
+                return;
+            }
+
+            const record = await this.history.findByTriggerRunId(runId);
+            if (!record) {
+                // Expected for runs originated outside the platform —
+                // see class header. Debug, not warn.
+                this.logger.debug(
+                    `${event.internalEventName} dropped: no work_generation_history row ` +
+                        `for triggerRunId=${runId} (tenantId=${event.tenantId})`,
+                );
+                return;
+            }
+
+            // Idempotency short-circuit: terminal statuses are final.
+            // Without this, a retry delivery would rewrite finishedAt to
+            // the second-delivery's `now`, drifting the persisted
+            // duration. Comparing the persisted status against the
+            // event's target also covers the "router fires the wrong
+            // terminal status for this row" case (extremely unlikely
+            // but defensible).
+            if (isTerminal(record.status)) {
+                this.logger.debug(
+                    `${event.internalEventName} ignored: row ${record.id} already ` +
+                        `terminal (status=${record.status})`,
+                );
+                return;
+            }
+
+            const errorMessage = extractErrorMessage(event.payload);
+            await this.history.updateEntry(record.id, {
+                status: terminalStatus,
+                finishedAt: new Date(event.createdAt) || new Date(),
+                ...(terminalStatus === GenerateStatusType.ERROR && errorMessage
+                    ? { errorMessage }
+                    : {}),
+            });
+
+            this.logger.log(
+                `${event.internalEventName}: work_generation_history ${record.id} → ${terminalStatus} ` +
+                    `(triggerRunId=${runId}, tenantId=${event.tenantId})`,
+            );
+        } catch (err) {
+            // MUST NOT throw — router contract. Log + swallow.
+            this.logger.error(
+                `${event.internalEventName ?? 'trigger.run.?'} handler failed: ` +
+                    `${(err as Error).message ?? String(err)}`,
+                (err as Error).stack,
+            );
+        }
+    }
+}
+
+function isTerminal(status: GenerateStatusType): boolean {
+    return (
+        status === GenerateStatusType.GENERATED ||
+        status === GenerateStatusType.ERROR ||
+        status === GenerateStatusType.CANCELLED
+    );
+}
+
+/**
+ * Trigger.dev v4 `alert.run.*` payload shape (per
+ * https://trigger.dev/docs/troubleshooting-alerts#alert-webhooks):
+ *
+ *   { run: { id: "run_abc", status: "COMPLETED", ... }, ... }
+ *
+ * We don't import a typed schema for two reasons:
+ *   1. Trigger.dev's webhook contract is documented but not exported
+ *      as a TS type from `@trigger.dev/sdk` (the alert types live
+ *      on their SaaS-side workers).
+ *   2. The router intentionally passes the payload through opaquely
+ *      so future schema growth doesn't require a router redeploy.
+ *
+ * Hence: defensive accessor with explicit type checks.
+ */
+function extractRunId(payload: Readonly<Record<string, unknown>>): string | null {
+    const run = (payload as { run?: unknown }).run;
+    if (!run || typeof run !== 'object') return null;
+    const id = (run as { id?: unknown }).id;
+    return typeof id === 'string' && id.length > 0 ? id : null;
+}
+
+/**
+ * Best-effort error extraction from the alert.run.failed payload. The
+ * Trigger.dev schema is `{ run: { error: { message: string, ... } } }`
+ * for failed runs; `null` for any other shape so the column update
+ * stays optional rather than persisting "undefined".
+ */
+function extractErrorMessage(payload: Readonly<Record<string, unknown>>): string | null {
+    const run = (payload as { run?: unknown }).run;
+    if (!run || typeof run !== 'object') return null;
+    const error = (run as { error?: unknown }).error;
+    if (!error || typeof error !== 'object') return null;
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string' && message.length > 0) {
+        // Truncate aggressively — `errorMessage` is `text` but we don't
+        // want to dump a 100 KB stack into the DB just because Trigger
+        // forwarded one.
+        return message.length > 2048 ? `${message.slice(0, 2048)}…` : message;
+    }
+    return null;
+}

--- a/apps/api/src/webhooks/webhooks.module.ts
+++ b/apps/api/src/webhooks/webhooks.module.ts
@@ -24,6 +24,8 @@ import { WebhooksDeliveriesService } from './webhooks-deliveries.service';
 import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
 import { TriggerWebhookController } from './trigger-webhook.controller';
 import { TriggerWebhookEventRouterService } from './trigger-webhook-event-router.service';
+import { TriggerRunStatusSubscriber } from './subscribers/trigger-run-status.subscriber';
+import { TriggerRunFailureSentryBreadcrumbSubscriber } from './subscribers/trigger-run-failure-sentry-breadcrumb.subscriber';
 
 /**
  * `/api/webhooks` surface — subscriptions CRUD, delivery test-fire,
@@ -77,6 +79,15 @@ import { TriggerWebhookEventRouterService } from './trigger-webhook-event-router
         // via @OnEvent on the constants from
         // ./trigger-webhook-events.
         TriggerWebhookEventRouterService,
+        // EW-743 Phase 3 — Trigger.dev internal-event subscribers.
+        // Each subscribes via @OnEvent('trigger.*') and consumes the
+        // router's envelope. They are deliberately NOT exported — no
+        // one outside this module calls them directly; they live as
+        // EventEmitter2 listeners. Adding more subscribers in the
+        // future means: drop the @Injectable file under
+        // ./subscribers, append it here, and add a spec.
+        TriggerRunStatusSubscriber,
+        TriggerRunFailureSentryBreadcrumbSubscriber,
     ],
     exports: [
         WebhooksService,

--- a/packages/agent/src/database/repositories/work-generation-history.repository.ts
+++ b/packages/agent/src/database/repositories/work-generation-history.repository.ts
@@ -179,6 +179,23 @@ export class WorkGenerationHistoryRepository {
         return this.repository.findOne({ where: { id } });
     }
 
+    /**
+     * EW-743 Phase 3 — lookup a history record by the Trigger.dev run id
+     * stamped on it at enqueue time. Used by the trigger-webhook
+     * subscriber to flip a record's status when Trigger.dev fires
+     * `alert.run.{succeeded,failed,cancelled}`.
+     *
+     * Returns `null` (not throw) when no record matches: webhooks can
+     * fire for runs that were never recorded in `work_generation_history`
+     * (e.g. one-off Trigger.dev runs from `dev` projects, runs created
+     * before the column was populated, runs from other tenants reaching
+     * a misconfigured endpoint). Callers MUST handle null as "drop".
+     */
+    async findByTriggerRunId(triggerRunId: string): Promise<WorkGenerationHistory | null> {
+        if (!triggerRunId) return null;
+        return this.repository.findOne({ where: { triggerRunId } });
+    }
+
     async findLatestInProgressByWork(workId: string): Promise<WorkGenerationHistory | null> {
         return this.repository.findOne({
             where: {


### PR DESCRIPTION
## Summary
- Adds 2 real \`@OnEvent\` subscribers to the Trigger.dev webhook router shipped in #1537
- \`TriggerRunStatusSubscriber\` flips \`work_generation_history\` rows by \`triggerRunId\` match on \`run.{succeeded,failed,cancelled}\` (no migration — existing column)
- \`TriggerRunFailureSentryBreadcrumbSubscriber\` routes \`run.failed\` + \`deployment.failed\` to Sentry with \`runId\` / \`tenantId\` / error attrs; falls back to Nest \`Logger\` when SentryService isn't bound (offline/test).

## Why these two
- **Persistence** is the most actionable: closes the loop on records stuck in \`generating\` after Trigger.dev completed the run.
- **Sentry breadcrumb** gives bounded + cheap operator visibility into Trigger.dev failures without polluting the exceptions stream.

## Decisions
- Wrote to existing \`WorkGenerationHistory.status\` (no migration).
- Used \`SentryService.error\` rather than \`addBreadcrumb\` because EventEmitter2 handlers run outside the request hub.
- Both subscribers wrap handler bodies in try/catch + log to honour the router contract (never throw → no poisoning of other subscribers).
- Idempotency: persistence short-circuits when the row is already terminal; Sentry side is naturally idempotent.

## Tests
- 17 new (9 + 8): happy paths per terminal status, idempotency, missing record, payload missing run.id, repo throws, channel purity, Sentry-absent fallback.
- Full \`apps/api\` suite: 2974/2974 passing.
- \`type-check\` clean.

## Deferred
- \`AgentRun\` subscriber (repo not exported from \`DatabaseModule\` — feature-module cascade out of scope).
- Operator-notification subscriber for deployments (no facade exists today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced monitoring of trigger run failures with structured error tracking
  * Automatic status synchronization for trigger run outcomes (succeeded, failed, cancelled)

* **Improvements**
  * Added resilient webhook event processing with comprehensive error handling and graceful fallbacks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->