### PR TITLE
feat(trigger-plugin): per-tenant BYO Trigger.dev credentials (3 modes)

### DIFF
--- a/packages/plugins/job-runtime-trigger/package.json
+++ b/packages/plugins/job-runtime-trigger/package.json
@@ -47,7 +47,58 @@
 			"distribution": "core",
 			"builtIn": true,
 			"visibility": "operator",
-			"envVars": ["TRIGGER_SECRET_KEY", "TRIGGER_PROJECT_REF"]
+			"envVars": ["TRIGGER_SECRET_KEY", "TRIGGER_PROJECT_REF", "TRIGGER_API_URL"],
+			"settingsSchema": {
+				"type": "object",
+				"properties": {
+					"mode": {
+						"type": "string",
+						"enum": ["inherit", "byo", "override"],
+						"default": "inherit",
+						"title": "Tenant Mode",
+						"description": "Tenant overlay mode. `inherit` uses the platform default; `byo` / `override` use the tenant credentials below."
+					},
+					"accessToken": {
+						"type": "string",
+						"title": "Trigger.dev Personal Access Token (PAT)",
+						"description": "Tenant-supplied management PAT (tr_pat_*). Required when mode is `byo` or `override`.",
+						"x-secret": true,
+						"x-scope": "tenant"
+					},
+					"secretKey": {
+						"type": "string",
+						"title": "Trigger.dev Secret Key",
+						"description": "Project-scoped server secret (tr_dev_* or tr_prod_*). Used by the SDK to authenticate tasks.trigger calls. Required when mode is `byo` or `override`; in `inherit` mode the operator default (TRIGGER_SECRET_KEY) is used.",
+						"x-secret": true,
+						"x-scope": "tenant",
+						"x-envVar": "TRIGGER_SECRET_KEY"
+					},
+					"projectRef": {
+						"type": "string",
+						"title": "Trigger.dev Project Ref",
+						"description": "Trigger.dev project reference (e.g. proj_abc123). Required when mode is `byo` or `override`.",
+						"x-scope": "tenant",
+						"x-envVar": "TRIGGER_PROJECT_REF"
+					},
+					"apiUrl": {
+						"type": "string",
+						"title": "Trigger.dev API URL",
+						"description": "Override for self-hosted Trigger.dev (default https://api.trigger.dev).",
+						"default": "https://api.trigger.dev",
+						"x-scope": "tenant",
+						"x-envVar": "TRIGGER_API_URL"
+					}
+				},
+				"allOf": [
+					{
+						"if": {
+							"properties": { "mode": { "enum": ["byo", "override"] } },
+							"required": ["mode"]
+						},
+						"then": { "required": ["accessToken", "secretKey", "projectRef"] }
+					}
+				]
+			}
 		}
 	}
 }

--- a/packages/plugins/job-runtime-trigger/src/__tests__/trigger-byo-credentials.spec.ts
+++ b/packages/plugins/job-runtime-trigger/src/__tests__/trigger-byo-credentials.spec.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { JobRuntimeDispatchers, TenantCredentialSnapshot } from '@ever-works/plugin';
+import {
+	DEFAULT_TRIGGER_API_URL,
+	TriggerJobRuntimePlugin,
+	type TriggerTenantCredentials
+} from '../trigger-job-runtime.plugin.js';
+import type {
+	TriggerClient,
+	TriggerRunHandle,
+	TriggerRunRecord,
+	TriggerTaskOptions
+} from '../trigger-types.js';
+
+/**
+ * EW-742 P3.2 T22 — BYO / override Trigger.dev credentials test plan.
+ *
+ * Sibling of `trigger-plugin-operator-hooks.spec.ts` (which covers the
+ * inherit / operator-wired path) and `trigger-tenant-conformance.spec.ts`
+ * (which exercises the cross-provider P6 contract). This file pins the
+ * BYO-specific contract added by EW-742 P3.2:
+ *
+ *   1. No snapshot is not a real call path (TS type forbids it), but
+ *      "snapshot with no credentials" stays on the inherit fast path:
+ *      tenantClient `null`, no warn, view's dispatchers identical to
+ *      the platform default.
+ *   2. Partial credentials (one of accessToken/secretKey/projectRef
+ *      missing) fail-open + warn naming the missing field.
+ *   3. Full credentials + a wired `clientFactory` build a per-tenant
+ *      `TriggerClient` and route the view's dispatchers through it.
+ *   4. Missing `clientFactory` even with full creds is fail-open + warn.
+ *   5. `apiUrl` override flows through to the factory verbatim.
+ *   6. Idempotency on (tenantId, credentialVersion).
+ *   7. Cache invalidation on credentialVersion bump.
+ *   8. Cross-tenant binding isolation (per-provider — full cross-
+ *      provider isolation already lives in #1531).
+ */
+
+interface TriggerCall {
+	readonly taskId: string;
+	readonly payload: unknown;
+	readonly options?: TriggerTaskOptions;
+}
+
+/**
+ * Lightweight stand-in for a per-tenant Trigger.dev SDK client. Each
+ * instance carries an `id` tag so tests can assert which client a
+ * dispatch was routed to (proves per-tenant isolation at the binding
+ * layer).
+ */
+class FakeTenantClient implements TriggerClient {
+	constructor(readonly id: string) {}
+	readonly triggerCalls: TriggerCall[] = [];
+
+	readonly tasks = {
+		trigger: async (
+			taskId: string,
+			payload: unknown,
+			options?: TriggerTaskOptions
+		): Promise<TriggerRunHandle> => {
+			this.triggerCalls.push({ taskId, payload, options });
+			return { id: `${this.id}:run` };
+		}
+	};
+
+	readonly runs = {
+		cancel: async (_runId: string): Promise<unknown> => undefined,
+		retrieve: async (runId: string): Promise<TriggerRunRecord> => ({
+			id: runId,
+			status: 'EXECUTING'
+		})
+	};
+}
+
+const snapshot = (
+	overrides: Partial<TenantCredentialSnapshot> = {}
+): TenantCredentialSnapshot => ({
+	tenantId: '00000000-0000-0000-0000-00000000aaaa',
+	providerId: 'trigger',
+	credentialVersion: 1,
+	credentials: {
+		accessToken: 'tr_pat_aaaa',
+		secretKey: 'tr_dev_aaaa',
+		projectRef: 'proj_aaaa'
+	},
+	...overrides
+});
+
+describe('TriggerJobRuntimePlugin — BYO credentials (EW-742 P3.2 T22)', () => {
+	describe('1. inherit fast path', () => {
+		it('returns a view whose dispatchers equal the platform default when credentials bag is empty', () => {
+			const warn = vi.fn();
+			const platformDispatchers: JobRuntimeDispatchers = Object.freeze({
+				dispatchKbEmbedDocument: () => Promise.resolve('platform-default')
+			});
+			const plugin = new TriggerJobRuntimePlugin({ logger: { warn } }).useDispatchers(
+				platformDispatchers
+			);
+			const view = plugin.bindToTenant(snapshot({ credentials: {} }));
+			expect(view.tenantClient).toBeNull();
+			expect(view.tenantProjectAccessToken).toBeNull();
+			expect(view.dispatchers).toBe(plugin.dispatchers);
+			// Empty bag — pure inherit case, no warn noise.
+			expect(warn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('2. malformed credentials fail-open with named warn', () => {
+		it.each([
+			['accessToken', { secretKey: 'k', projectRef: 'r' }],
+			['secretKey', { accessToken: 't', projectRef: 'r' }],
+			['projectRef', { accessToken: 't', secretKey: 'k' }]
+		])('missing %s → warn names it, view falls back to platform default', (missing, bag) => {
+			const warn = vi.fn();
+			const clientFactory = vi.fn();
+			const plugin = new TriggerJobRuntimePlugin({
+				logger: { warn },
+				clientFactory
+			});
+			const view = plugin.bindToTenant(snapshot({ credentials: bag }));
+			expect(view.tenantClient).toBeNull();
+			expect(view.dispatchers).toBe(plugin.dispatchers);
+			expect(clientFactory).not.toHaveBeenCalled();
+			expect(warn).toHaveBeenCalledTimes(1);
+			const message = warn.mock.calls[0][0] as string;
+			expect(message).toContain('malformed BYO credentials');
+			expect(message).toContain(missing);
+		});
+	});
+
+	describe('3. full credentials + clientFactory → per-tenant routing', () => {
+		it('builds a per-tenant client and routes dispatchers through it', async () => {
+			const tenantClient = new FakeTenantClient('tenant-a');
+			const clientFactory = vi.fn((_creds: TriggerTenantCredentials) => tenantClient);
+			const plugin = new TriggerJobRuntimePlugin({
+				clientFactory,
+				dispatchersFromClient: (c) => ({
+					dispatchKbEmbedDocument: async (payload: unknown) => {
+						const handle = await c.tasks.trigger('kb-embed-document', payload);
+						return handle.id;
+					}
+				})
+			});
+
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.tenantClient).toBe(tenantClient);
+			expect(view.tenantProjectAccessToken).toBe('tr_pat_aaaa');
+			// Sanity — view's dispatchers are NOT the platform default.
+			expect(view.dispatchers).not.toBe(plugin.dispatchers);
+
+			const d = view.dispatchers as unknown as {
+				dispatchKbEmbedDocument: (p: unknown) => Promise<string | null>;
+			};
+			await expect(d.dispatchKbEmbedDocument({ workId: 'w1' })).resolves.toBe('tenant-a:run');
+			expect(tenantClient.triggerCalls).toEqual([
+				{ taskId: 'kb-embed-document', payload: { workId: 'w1' }, options: undefined }
+			]);
+			// Factory got the validated, typed credentials bundle.
+			expect(clientFactory).toHaveBeenCalledTimes(1);
+			expect(clientFactory.mock.calls[0][0]).toEqual({
+				accessToken: 'tr_pat_aaaa',
+				secretKey: 'tr_dev_aaaa',
+				projectRef: 'proj_aaaa'
+			});
+		});
+	});
+
+	describe('4. full credentials without clientFactory → fail-open', () => {
+		it('no clientFactory wired → tenantClient null, dispatchers are platform default', () => {
+			const platformDispatchers: JobRuntimeDispatchers = Object.freeze({
+				dispatchKbEmbedDocument: () => Promise.resolve('platform-default')
+			});
+			const plugin = new TriggerJobRuntimePlugin().useDispatchers(platformDispatchers);
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.tenantClient).toBeNull();
+			expect(view.tenantProjectAccessToken).toBe('tr_pat_aaaa');
+			expect(view.dispatchers).toBe(plugin.dispatchers);
+		});
+	});
+
+	describe('5. apiUrl override flows through to clientFactory', () => {
+		it('credentials.apiUrl is passed to clientFactory verbatim', () => {
+			const clientFactory = vi.fn((_c: TriggerTenantCredentials) => new FakeTenantClient('x'));
+			const plugin = new TriggerJobRuntimePlugin({ clientFactory });
+			plugin.bindToTenant(
+				snapshot({
+					credentials: {
+						accessToken: 'tr_pat_x',
+						secretKey: 'tr_dev_x',
+						projectRef: 'proj_x',
+						apiUrl: 'https://trigger.tenant-x.internal'
+					}
+				})
+			);
+			expect(clientFactory).toHaveBeenCalledTimes(1);
+			expect(clientFactory.mock.calls[0][0]).toEqual({
+				accessToken: 'tr_pat_x',
+				secretKey: 'tr_dev_x',
+				projectRef: 'proj_x',
+				apiUrl: 'https://trigger.tenant-x.internal'
+			});
+		});
+
+		it('no apiUrl in credentials → clientFactory receives no `apiUrl` (operator picks default)', () => {
+			const clientFactory = vi.fn((_c: TriggerTenantCredentials) => new FakeTenantClient('x'));
+			const plugin = new TriggerJobRuntimePlugin({ clientFactory });
+			plugin.bindToTenant(snapshot());
+			expect(clientFactory.mock.calls[0][0]).not.toHaveProperty('apiUrl');
+			// DEFAULT_TRIGGER_API_URL stays exported for operators that
+			// want to apply the default themselves.
+			expect(DEFAULT_TRIGGER_API_URL).toBe('https://api.trigger.dev');
+		});
+	});
+
+	describe('6. idempotency on (tenantId, credentialVersion)', () => {
+		it('two bind calls with the same snapshot return the SAME view (cached)', () => {
+			const clientFactory = vi.fn(() => new FakeTenantClient('tenant-a'));
+			const plugin = new TriggerJobRuntimePlugin({ clientFactory });
+			const v1 = plugin.bindToTenant(snapshot());
+			const v2 = plugin.bindToTenant(snapshot());
+			expect(v2).toBe(v1);
+			// Factory invoked exactly once — proves memoisation, not just
+			// reference equality after a fresh build.
+			expect(clientFactory).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('7. credentialVersion bump invalidates cache', () => {
+		it('bumping credentialVersion returns a FRESH view + a FRESH client', () => {
+			let counter = 0;
+			const clientFactory = vi.fn(() => new FakeTenantClient(`tenant-a-v${++counter}`));
+			const plugin = new TriggerJobRuntimePlugin({ clientFactory });
+			const v1 = plugin.bindToTenant(snapshot({ credentialVersion: 1 }));
+			const v2 = plugin.bindToTenant(snapshot({ credentialVersion: 2 }));
+			expect(v2).not.toBe(v1);
+			expect(v1.tenantClient).not.toBe(v2.tenantClient);
+			expect((v1.tenantClient as FakeTenantClient).id).toBe('tenant-a-v1');
+			expect((v2.tenantClient as FakeTenantClient).id).toBe('tenant-a-v2');
+		});
+	});
+
+	describe('8. cross-tenant binding isolation', () => {
+		it("tenant A's dispatch does NOT route through tenant B's client", async () => {
+			const clientByTenant = new Map<string, FakeTenantClient>();
+			const clientFactory = (creds: TriggerTenantCredentials): TriggerClient => {
+				const client = new FakeTenantClient(creds.projectRef);
+				clientByTenant.set(creds.projectRef, client);
+				return client;
+			};
+			const plugin = new TriggerJobRuntimePlugin({
+				clientFactory,
+				dispatchersFromClient: (c) => ({
+					dispatchKbEmbedDocument: async (payload: unknown) => {
+						const handle = await c.tasks.trigger('kb-embed-document', payload);
+						return handle.id;
+					}
+				})
+			});
+
+			const viewA = plugin.bindToTenant(
+				snapshot({
+					tenantId: '00000000-0000-0000-0000-0000000000aa',
+					credentials: {
+						accessToken: 'tr_pat_a',
+						secretKey: 'tr_dev_a',
+						projectRef: 'proj_a'
+					}
+				})
+			);
+			const viewB = plugin.bindToTenant(
+				snapshot({
+					tenantId: '00000000-0000-0000-0000-0000000000bb',
+					credentials: {
+						accessToken: 'tr_pat_b',
+						secretKey: 'tr_dev_b',
+						projectRef: 'proj_b'
+					}
+				})
+			);
+
+			const dA = viewA.dispatchers as unknown as {
+				dispatchKbEmbedDocument: (p: unknown) => Promise<string | null>;
+			};
+			const dB = viewB.dispatchers as unknown as {
+				dispatchKbEmbedDocument: (p: unknown) => Promise<string | null>;
+			};
+
+			await dA.dispatchKbEmbedDocument({ workId: 'a-work' });
+			await dB.dispatchKbEmbedDocument({ workId: 'b-work' });
+
+			expect(clientByTenant.get('proj_a')!.triggerCalls).toHaveLength(1);
+			expect(clientByTenant.get('proj_a')!.triggerCalls[0].payload).toEqual({
+				workId: 'a-work'
+			});
+			expect(clientByTenant.get('proj_b')!.triggerCalls).toHaveLength(1);
+			expect(clientByTenant.get('proj_b')!.triggerCalls[0].payload).toEqual({
+				workId: 'b-work'
+			});
+			// And the two views themselves are distinct.
+			expect(viewA).not.toBe(viewB);
+			expect(viewA.tenantClient).not.toBe(viewB.tenantClient);
+		});
+	});
+
+	describe('bonus: clientFactory error is caught', () => {
+		it('clientFactory throwing → warn + view falls back to platform default', () => {
+			const warn = vi.fn();
+			const plugin = new TriggerJobRuntimePlugin({
+				logger: { warn },
+				clientFactory: () => {
+					throw new Error('boom');
+				}
+			});
+			const view = plugin.bindToTenant(snapshot());
+			expect(view.tenantClient).toBeNull();
+			expect(view.dispatchers).toBe(plugin.dispatchers);
+			expect(warn).toHaveBeenCalledTimes(1);
+			expect(warn.mock.calls[0][0]).toContain('clientFactory threw');
+			expect(warn.mock.calls[0][0]).toContain('boom');
+		});
+	});
+});

--- a/packages/plugins/job-runtime-trigger/src/index.ts
+++ b/packages/plugins/job-runtime-trigger/src/index.ts
@@ -1,11 +1,13 @@
 export {
 	TriggerJobRuntimePlugin,
 	TriggerDispatcherNotConfiguredError,
-	mapTriggerStatus
+	mapTriggerStatus,
+	DEFAULT_TRIGGER_API_URL
 } from './trigger-job-runtime.plugin.js';
 export type {
 	TriggerTenantBindingView,
-	TriggerJobRuntimePluginOptions
+	TriggerJobRuntimePluginOptions,
+	TriggerTenantCredentials
 } from './trigger-job-runtime.plugin.js';
 export { TriggerDispatcherFactory } from './trigger-dispatcher-factory.js';
 export {

--- a/packages/plugins/job-runtime-trigger/src/trigger-job-runtime.plugin.ts
+++ b/packages/plugins/job-runtime-trigger/src/trigger-job-runtime.plugin.ts
@@ -14,6 +14,35 @@ import type {
 import type { TriggerClient } from './trigger-types.js';
 
 /**
+ * Default Trigger.dev SaaS API endpoint. Kept in sync with the schema
+ * default on {@link TriggerJobRuntimePlugin.settingsSchema}.`apiUrl`
+ * — change BOTH if the SaaS endpoint moves.
+ */
+export const DEFAULT_TRIGGER_API_URL = 'https://api.trigger.dev';
+
+/**
+ * Tenant-supplied Trigger.dev credentials, as they live inside
+ * {@link TenantCredentialSnapshot.credentials} for `byo` / `override`
+ * modes. The shape is data-only (jsonb at rest, no migration); the
+ * validator at `bindToTenant` enforces presence of the three required
+ * fields.
+ */
+export interface TriggerTenantCredentials {
+	/** Trigger.dev Personal Access Token (`tr_pat_*`). */
+	readonly accessToken: string;
+	/** Project-scoped secret (`tr_dev_*` / `tr_prod_*`). */
+	readonly secretKey: string;
+	/** Trigger.dev project ref (`proj_*`). */
+	readonly projectRef: string;
+	/**
+	 * Optional API endpoint override — defaults to
+	 * {@link DEFAULT_TRIGGER_API_URL}. Operators of self-hosted
+	 * Trigger.dev point this at their own deployment.
+	 */
+	readonly apiUrl?: string;
+}
+
+/**
  * EW-686 P2 — Trigger.dev `IJobRuntimeProvider` plugin (canonical
  * pluggable form).
  *
@@ -64,11 +93,33 @@ export interface TriggerTenantBindingView extends IJobRuntimeProvider {
 	readonly tenantSnapshot: TenantCredentialSnapshot;
 	/** Per-tenant Trigger.dev project access token (for the operator-built per-tenant client). */
 	readonly tenantProjectAccessToken: string | null;
+	/**
+	 * Per-tenant Trigger.dev SDK client when the snapshot carried a full
+	 * {@link TriggerTenantCredentials} bag AND the plugin was constructed
+	 * with a `clientFactory`. `null` for `inherit` mode (no credentials
+	 * present), malformed credentials, or when the operator didn't wire a
+	 * `clientFactory` — callers must then dispatch through the platform-
+	 * default `client` instead.
+	 */
+	readonly tenantClient: TriggerClient | null;
 }
 
 export interface TriggerJobRuntimePluginOptions {
-	/** Per-tenant dispatcher builder — see plugin header. */
-	readonly dispatchersBuilder?: (snapshot: TenantCredentialSnapshot) => JobRuntimeDispatchers;
+	/**
+	 * Per-tenant dispatcher builder — operator escape hatch when they
+	 * want to swap MORE than just the SDK client (e.g. per-tenant queues,
+	 * per-tenant tag prefixes). When present, this takes precedence over
+	 * the `clientFactory` auto-wiring below.
+	 *
+	 * Receives the bound `TriggerClient` (if `clientFactory` resolved
+	 * one) so the builder can reuse it instead of constructing yet
+	 * another client. Falls through to the platform default
+	 * `dispatchers` if the builder returns `undefined`.
+	 */
+	readonly dispatchersBuilder?: (
+		snapshot: TenantCredentialSnapshot,
+		tenantClient: TriggerClient | null
+	) => JobRuntimeDispatchers | undefined;
 	/**
 	 * Optional default Trigger.dev client used by the plugin's own
 	 * `cancel` / `getRunStatus` (so callers don't need to reach into
@@ -81,6 +132,40 @@ export interface TriggerJobRuntimePluginOptions {
 	 * shape as the Inngest plugin which has no SDK-side equivalents.
 	 */
 	readonly client?: TriggerClient;
+	/**
+	 * EW-742 P3.2 T22 — operator-supplied factory that turns a tenant's
+	 * credential bag into a per-tenant `TriggerClient`. Invoked by
+	 * `bindToTenant` when the snapshot carries a full
+	 * {@link TriggerTenantCredentials} payload (BYO / override modes).
+	 *
+	 * Operator implementation typically constructs a fresh Trigger.dev
+	 * SDK client against `credentials.apiUrl ?? DEFAULT_TRIGGER_API_URL`
+	 * with `credentials.accessToken` for management calls and
+	 * `credentials.secretKey` for the task dispatch path — same SDK
+	 * surface (`{ tasks, runs }`) the platform-default `client` exposes.
+	 *
+	 * When omitted, BYO / override snapshots fall through to the
+	 * platform-default behaviour and the plugin logs a warn — operators
+	 * who want true BYO MUST wire this hook (the plugin can't take a
+	 * hard dependency on `@trigger.dev/sdk` itself; see `trigger-types.ts`).
+	 */
+	readonly clientFactory?: (credentials: TriggerTenantCredentials) => TriggerClient;
+	/**
+	 * Optional per-credential-bundle dispatcher builder. Same role as
+	 * {@link dispatchersBuilder} but receives the per-tenant
+	 * `TriggerClient` directly — operators who only need to swap the
+	 * SDK client (not the dispatcher shape) wire `clientFactory` +
+	 * `dispatchersFromClient` instead of the more general
+	 * `dispatchersBuilder`.
+	 */
+	readonly dispatchersFromClient?: (client: TriggerClient) => JobRuntimeDispatchers;
+	/**
+	 * Optional logger sink for warnings about missing / malformed tenant
+	 * credentials. Defaults to `console.warn` so the plugin works without
+	 * a NestJS logger context, but operators inside the API typically
+	 * inject `Logger.warn.bind(new Logger('TriggerJobRuntimePlugin'))`.
+	 */
+	readonly logger?: { warn(message: string): void };
 }
 
 export class TriggerJobRuntimePlugin implements IJobRuntimeProvider {
@@ -97,29 +182,87 @@ export class TriggerJobRuntimePlugin implements IJobRuntimeProvider {
 	];
 	readonly runtimeId: JobRuntimeId = 'trigger';
 
+	/**
+	 * Tenant-overlay settings schema (EW-742). Three modes:
+	 *
+	 *   - `inherit`  — use the platform's shared Trigger.dev project +
+	 *                  credentials (operator-supplied via env / global
+	 *                  plugin settings). The `accessToken` /
+	 *                  `secretKey` / `projectRef` fields are ignored.
+	 *                  Default for every tenant.
+	 *   - `byo`      — tenant brings their own Trigger.dev SaaS account.
+	 *                  All three credential fields below are REQUIRED.
+	 *   - `override` — same shape as `byo`; semantically "I am replacing
+	 *                  the platform default with my own". Validation is
+	 *                  identical.
+	 *
+	 * Credential fields are stamped `x-scope: 'tenant'` so the
+	 * tenant-overlay settings UI surfaces them per-tenant rather than
+	 * globally, and `x-secret: true` so they never appear in plaintext
+	 * read-back endpoints (the platform stores them via the encrypted
+	 * secrets envelope per `settings-system.md` §5).
+	 *
+	 * `apiUrl` default (`https://api.trigger.dev`) is encoded in the
+	 * schema AND in `DEFAULT_TRIGGER_API_URL` below — keep both in sync
+	 * if either changes.
+	 */
 	readonly settingsSchema: JsonSchema = {
 		type: 'object',
 		properties: {
-			projectRef: {
+			mode: {
 				type: 'string',
-				title: 'Trigger.dev Project Ref',
-				description: 'Trigger.dev project reference (e.g. proj_abc123).',
-				'x-envVar': 'TRIGGER_PROJECT_REF'
+				enum: ['inherit', 'byo', 'override'],
+				default: 'inherit',
+				title: 'Tenant Mode',
+				description:
+					'Tenant overlay mode. `inherit` uses the platform default; `byo` / `override` use the tenant credentials below.'
+			},
+			accessToken: {
+				type: 'string',
+				title: 'Trigger.dev Personal Access Token (PAT)',
+				description:
+					'Tenant-supplied management PAT (tr_pat_*). Required when mode is `byo` or `override`.',
+				'x-secret': true,
+				'x-scope': 'tenant'
 			},
 			secretKey: {
 				type: 'string',
 				title: 'Trigger.dev Secret Key',
-				description: 'Server-side prod secret (tr_prod_*). Used by the SDK to authenticate tasks.trigger calls.',
+				description:
+					'Project-scoped server secret (tr_dev_* or tr_prod_*). Used by the SDK to authenticate tasks.trigger calls. Required when mode is `byo` or `override`; in `inherit` mode the operator default (TRIGGER_SECRET_KEY) is used.',
 				'x-secret': true,
+				'x-scope': 'tenant',
 				'x-envVar': 'TRIGGER_SECRET_KEY'
+			},
+			projectRef: {
+				type: 'string',
+				title: 'Trigger.dev Project Ref',
+				description:
+					'Trigger.dev project reference (e.g. proj_abc123). Required when mode is `byo` or `override`.',
+				'x-scope': 'tenant',
+				'x-envVar': 'TRIGGER_PROJECT_REF'
 			},
 			apiUrl: {
 				type: 'string',
 				title: 'Trigger.dev API URL',
-				description: 'Override for self-hosted Trigger.dev (default https://api.trigger.dev).',
+				description:
+					'Override for self-hosted Trigger.dev (default https://api.trigger.dev).',
+				default: 'https://api.trigger.dev',
+				'x-scope': 'tenant',
 				'x-envVar': 'TRIGGER_API_URL'
 			}
-		}
+		},
+		allOf: [
+			{
+				// When mode is `byo` or `override`, all three credential fields are
+				// REQUIRED. JSON Schema `if/then` keyed off the `mode` discriminator.
+				if: {
+					properties: { mode: { enum: ['byo', 'override'] } },
+					required: ['mode']
+				},
+				then: { required: ['accessToken', 'secretKey', 'projectRef'] }
+			}
+		]
 	};
 
 	private readonly stubDispatchers: JobRuntimeDispatchers = new Proxy(
@@ -227,6 +370,43 @@ export class TriggerJobRuntimePlugin implements IJobRuntimeProvider {
 		return { stop: async () => undefined };
 	}
 
+	/**
+	 * EW-742 P3.2 T22 — per-tenant Trigger.dev binding (BYO / override
+	 * support).
+	 *
+	 * Three observable behaviours based on the snapshot's credential bag:
+	 *
+	 *   1. **Inherit semantic** (no `credentials` keys recognised) —
+	 *      returns a frozen view of THIS provider with the snapshot
+	 *      captured. The view's `dispatchers` delegate to the
+	 *      platform-default `dispatchersImpl`; `tenantClient` is `null`;
+	 *      `tenantProjectAccessToken` is `null`. Byte-identical to the
+	 *      pre-T22 path for any tenant that hasn't opted into BYO.
+	 *
+	 *   2. **BYO / override happy-path** (`accessToken` + `secretKey` +
+	 *      `projectRef` all present AND a `clientFactory` is wired) —
+	 *      builds a per-tenant `TriggerClient` via
+	 *      {@link TriggerJobRuntimePluginOptions.clientFactory}, surfaces
+	 *      it on `tenantClient`, and routes the view's `dispatchers`
+	 *      through it (via `dispatchersFromClient` if provided,
+	 *      `dispatchersBuilder` if provided, else the platform default).
+	 *      The platform-default `dispatchersImpl` is NEVER mutated —
+	 *      `inherit` mode for other tenants stays byte-identical.
+	 *
+	 *   3. **Malformed credentials / no factory** — logs a warn naming
+	 *      the missing field (or "no clientFactory wired") and returns
+	 *      the inherit-shaped view as a fail-open. Operators see the
+	 *      warn in stdout; in-flight runs keep working against the
+	 *      platform default rather than failing the dispatch loudly at
+	 *      bind time (network at bind-time is fragile — the first
+	 *      dispatch through wrong credentials is the right place for
+	 *      loud failure).
+	 *
+	 * Memoisation: cached by `(tenantId, credentialVersion)`; bumping
+	 * the version evicts and replaces the previous entry. Cache stays
+	 * bounded by tenant count per the {@link IJobRuntimeProvider}
+	 * contract idempotency guarantee.
+	 */
 	bindToTenant(snapshot: TenantCredentialSnapshot): TriggerTenantBindingView {
 		const cacheKey = `${snapshot.tenantId}:${snapshot.credentialVersion}`;
 		const cached = this.tenantViews.get(cacheKey);
@@ -235,14 +415,47 @@ export class TriggerJobRuntimePlugin implements IJobRuntimeProvider {
 		}
 
 		const base = this;
-		const tenantProjectAccessToken =
-			typeof snapshot.credentials.projectAccessToken === 'string'
-				? snapshot.credentials.projectAccessToken
+
+		// EW-742 P3.2 T22 — resolve per-tenant Trigger.dev SDK client.
+		// `extractTenantCredentials` validates the bag shape; missing
+		// fields → null + a fail-open warn. `clientFactory` produces the
+		// actual `{ tasks, runs }` client; without it, we still surface
+		// the validated credentials on `tenantProjectAccessToken` so
+		// operators can build a client downstream.
+		const tenantCredentials = this.extractTenantCredentials(snapshot);
+		const tenantClient: TriggerClient | null =
+			tenantCredentials && this.opts.clientFactory
+				? this.safeBuildClient(snapshot, tenantCredentials)
 				: null;
 
-		const dispatchersForView: JobRuntimeDispatchers = this.opts.dispatchersBuilder
-			? Object.freeze({ ...this.opts.dispatchersBuilder(snapshot) })
-			: base.dispatchersImpl;
+		// The PAT we surface for the operator-built per-tenant client.
+		// Back-compat: snapshots that used the historical
+		// `projectAccessToken` key keep working — the conformance suite
+		// at `__tests__/trigger-tenant-conformance.spec.ts` exercises
+		// that path.
+		const tenantProjectAccessToken =
+			tenantCredentials?.accessToken ??
+			(typeof snapshot.credentials.projectAccessToken === 'string'
+				? snapshot.credentials.projectAccessToken
+				: null);
+
+		// Dispatcher selection precedence:
+		//   1. operator's full `dispatchersBuilder(snapshot, tenantClient)`
+		//      (most flexible — can swap queues, tags, etc.);
+		//   2. `dispatchersFromClient(tenantClient)` when a per-tenant
+		//      client was constructed;
+		//   3. platform-default `dispatchersImpl` (inherit semantic).
+		let dispatchersForView: JobRuntimeDispatchers = base.dispatchersImpl;
+		if (this.opts.dispatchersBuilder) {
+			const built = this.opts.dispatchersBuilder(snapshot, tenantClient);
+			if (built) {
+				dispatchersForView = Object.freeze({ ...built });
+			}
+		} else if (tenantClient && this.opts.dispatchersFromClient) {
+			dispatchersForView = Object.freeze({
+				...this.opts.dispatchersFromClient(tenantClient)
+			});
+		}
 
 		const view: TriggerTenantBindingView = Object.freeze({
 			id: base.id,
@@ -273,7 +486,8 @@ export class TriggerJobRuntimePlugin implements IJobRuntimeProvider {
 				return base.bindToTenant(other);
 			},
 			tenantSnapshot: snapshot,
-			tenantProjectAccessToken
+			tenantProjectAccessToken,
+			tenantClient
 		});
 
 		for (const key of this.tenantViews.keys()) {
@@ -283,6 +497,92 @@ export class TriggerJobRuntimePlugin implements IJobRuntimeProvider {
 		}
 		this.tenantViews.set(cacheKey, view);
 		return view;
+	}
+
+	/**
+	 * Validate the snapshot's `credentials` bag against the
+	 * {@link TriggerTenantCredentials} shape. Returns the typed bundle
+	 * on success; `null` (with a fail-open warn) when ANY required field
+	 * is missing or non-string.
+	 *
+	 * Inherit-shaped snapshots (empty `credentials`, or only the legacy
+	 * `projectAccessToken` key from earlier T21 wiring) intentionally
+	 * return `null` WITHOUT a warn — they're the dominant path and noise
+	 * here would drown the actually-actionable BYO misconfigurations.
+	 * The warn fires only when there's at least one Trigger.dev-shaped
+	 * key but the bundle is incomplete.
+	 */
+	private extractTenantCredentials(
+		snapshot: TenantCredentialSnapshot
+	): TriggerTenantCredentials | null {
+		const bag = snapshot.credentials;
+		const accessToken = typeof bag.accessToken === 'string' ? bag.accessToken : null;
+		const secretKey = typeof bag.secretKey === 'string' ? bag.secretKey : null;
+		const projectRef = typeof bag.projectRef === 'string' ? bag.projectRef : null;
+		const apiUrl = typeof bag.apiUrl === 'string' ? bag.apiUrl : undefined;
+
+		// Pure inherit case — no Trigger.dev-shaped keys at all. Silent.
+		if (!accessToken && !secretKey && !projectRef) {
+			return null;
+		}
+
+		// Partial bag — at least one field present but not all three.
+		// This is operator misconfiguration: warn loudly so it's visible,
+		// then fail-open to the platform default.
+		if (!accessToken || !secretKey || !projectRef) {
+			const missing = [
+				!accessToken && 'accessToken',
+				!secretKey && 'secretKey',
+				!projectRef && 'projectRef'
+			]
+				.filter(Boolean)
+				.join(', ');
+			this.warn(
+				`bindToTenant(tenantId=${snapshot.tenantId}, v=${snapshot.credentialVersion}): ` +
+					`malformed BYO credentials — missing ${missing}. Falling back to platform default.`
+			);
+			return null;
+		}
+
+		return apiUrl !== undefined
+			? { accessToken, secretKey, projectRef, apiUrl }
+			: { accessToken, secretKey, projectRef };
+	}
+
+	/**
+	 * Wrap the `clientFactory` call in a try/catch so a misbehaving
+	 * operator factory (throws on construction, returns wrong shape)
+	 * doesn't crash the whole bind. On failure we fall open to the
+	 * platform default and warn — same shape as the missing-field path.
+	 */
+	private safeBuildClient(
+		snapshot: TenantCredentialSnapshot,
+		credentials: TriggerTenantCredentials
+	): TriggerClient | null {
+		try {
+			return this.opts.clientFactory!(credentials);
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+			this.warn(
+				`bindToTenant(tenantId=${snapshot.tenantId}, v=${snapshot.credentialVersion}): ` +
+					`clientFactory threw — ${reason}. Falling back to platform default.`
+			);
+			return null;
+		}
+	}
+
+	/**
+	 * Route warns through the operator-supplied logger when present,
+	 * otherwise `console.warn`. Kept private so the rest of the file
+	 * doesn't have to know about the optionality.
+	 */
+	private warn(message: string): void {
+		const target =
+			this.opts.logger ??
+			({
+				warn: (m: string) => console.warn(`[@ever-works/job-runtime-trigger-plugin] ${m}`)
+			} as const);
+		target.warn(message);
 	}
 }
 


### PR DESCRIPTION
## Summary
- Three-mode \`settingsSchema\` (\`inherit\` | \`byo\` | \`override\`) with \`mode\` discriminator + JSON-Schema \`if/then\` requiring the credential trio in BYO/override.
- New \`clientFactory(credentials) => TriggerClient\` + \`dispatchersFromClient(client)\` plugin options for clean per-tenant SDK-client routing without forcing a \`@trigger.dev/sdk\` peer dep on the plugin package itself.
- \`bindToTenant\` validates the snapshot's credential bag, builds a per-tenant client, routes the view's dispatchers through it; malformed credentials warn (naming the missing field) and fall open to the platform default — first dispatch is where loud failure belongs, not bind time.
- Memoisation contract unchanged (EW-742 P3.1 T21 \`TenantCredentialCache\` semantic preserved); per-tenant view surfaces \`tenantClient\` for downstream introspection.

## Test plan
- [x] \`pnpm --filter @ever-works/job-runtime-trigger-plugin test\` — 119/119 (107 baseline + 12 new BYO cases)
- [x] \`pnpm --filter @ever-works/plugin test\` — 260/260 (tenant conformance suite still green)
- [x] \`packages/agent\` tenant-aware/credential-cache/tenant-credential tests — 29/29
- [x] Type-check clean on plugin AND \`apps/api\`

## Deferred
- Wiring the default \`clientFactory\` (\`@trigger.dev/sdk\`-backed) into \`apps/api\`'s real bootstrap — this PR is library-only.
- Operator-UI changes to render the new \`mode\` field per tenant (depends on the EW-742 P5 tenant-job-runtime controller PR #1350).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-tenant Trigger.dev credential configuration with three modes: inherit, bring-your-own (BYO), and override.
  * Enhanced validation and fail-open error handling for credential issues.

* **Tests**
  * Added comprehensive test suite covering BYO credential scenarios, caching behavior, and cross-tenant isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->