### PR TITLE
feat(tasks): wire default @trigger.dev/sdk clientFactory for BYO

### DIFF
--- a/packages/tasks/package.json
+++ b/packages/tasks/package.json
@@ -29,6 +29,7 @@
     },
     "dependencies": {
         "@ever-works/agent": "workspace:*",
+        "@ever-works/job-runtime-trigger-plugin": "workspace:*",
         "@ever-works/plugin": "workspace:*",
         "@nestjs/cache-manager": "^3.1.0",
         "@nestjs/common": "^11.1.18",

--- a/packages/tasks/src/trigger/__tests__/trigger-tenant-client.factory.spec.ts
+++ b/packages/tasks/src/trigger/__tests__/trigger-tenant-client.factory.spec.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit tests for {@link createTenantTriggerClient} and
+ * {@link dispatchersFromTenantClient} — the default `clientFactory` +
+ * `dispatchersFromClient` implementations the apps/api `TriggerModule`
+ * passes into `@ever-works/job-runtime-trigger-plugin`'s `bindToTenant`.
+ *
+ * The Trigger.dev SDK v4 surface (`tasks.trigger`, `runs.cancel`,
+ * `runs.retrieve`, `auth.withAuth`) is mocked so the tests never touch
+ * the network. Assertions focus on:
+ *
+ *   - per-tenant `clientConfig` (accessToken + baseURL) reaches the SDK
+ *     verbatim on every `tasks.trigger` call;
+ *   - the default API URL kicks in when `credentials.apiUrl` is absent
+ *     AND the operator override flows through when present;
+ *   - two clients built from different credentials don't share state
+ *     (per-call construction, no module-global mutation);
+ *   - `dispatchersFromTenantClient` routes each call through the right
+ *     per-tenant client (not the singleton);
+ *   - the factory is offline-safe — no SDK call at construction time;
+ *   - SDK construction failures surface as named errors.
+ */
+
+const { tasksTriggerMock, runsCancelMock, runsRetrieveMock, withAuthMock } = vi.hoisted(() => ({
+    tasksTriggerMock: vi.fn(),
+    runsCancelMock: vi.fn(),
+    runsRetrieveMock: vi.fn(),
+    /**
+     * Default `auth.withAuth(config, fn)` implementation that just runs
+     * the callback. Individual tests can override to capture the config
+     * argument.
+     */
+    withAuthMock: vi.fn(async (_config: unknown, fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock('@trigger.dev/sdk/v3', () => ({
+    tasks: { trigger: tasksTriggerMock },
+    runs: { cancel: runsCancelMock, retrieve: runsRetrieveMock },
+    auth: { withAuth: withAuthMock },
+}));
+
+import {
+    createTenantTriggerClient,
+    dispatchersFromTenantClient,
+} from '../trigger-tenant-client.factory';
+import { DEFAULT_TRIGGER_API_URL } from '@ever-works/job-runtime-trigger-plugin';
+
+const tenantA = {
+    accessToken: 'tr_pat_a',
+    secretKey: 'tr_dev_a',
+    projectRef: 'proj_a',
+} as const;
+
+const tenantB = {
+    accessToken: 'tr_pat_b',
+    secretKey: 'tr_dev_b',
+    projectRef: 'proj_b',
+    apiUrl: 'https://trigger.tenant-b.internal',
+} as const;
+
+describe('createTenantTriggerClient', () => {
+    beforeEach(() => {
+        tasksTriggerMock.mockReset().mockResolvedValue({ id: 'run_default' });
+        runsCancelMock.mockReset().mockResolvedValue(undefined);
+        runsRetrieveMock.mockReset().mockResolvedValue({ id: 'r1', status: 'EXECUTING' });
+        withAuthMock.mockReset().mockImplementation((_c, fn) => fn());
+    });
+
+    it('is offline-safe — construction makes no SDK call', () => {
+        createTenantTriggerClient(tenantA);
+        expect(tasksTriggerMock).not.toHaveBeenCalled();
+        expect(runsCancelMock).not.toHaveBeenCalled();
+        expect(runsRetrieveMock).not.toHaveBeenCalled();
+        expect(withAuthMock).not.toHaveBeenCalled();
+    });
+
+    it('tasks.trigger forwards a per-tenant clientConfig with secretKey + DEFAULT_TRIGGER_API_URL', async () => {
+        tasksTriggerMock.mockResolvedValueOnce({ id: 'run_a1' });
+        const client = createTenantTriggerClient(tenantA);
+
+        const handle = await client.tasks.trigger('work-generation', { foo: 'bar' }, {
+            tags: ['a-tag'],
+        });
+
+        expect(handle).toEqual({ id: 'run_a1' });
+        expect(tasksTriggerMock).toHaveBeenCalledTimes(1);
+        const [taskId, payload, options, requestOptions] = tasksTriggerMock.mock.calls[0];
+        expect(taskId).toBe('work-generation');
+        expect(payload).toEqual({ foo: 'bar' });
+        expect(options).toEqual({ tags: ['a-tag'] });
+        expect(requestOptions).toEqual({
+            clientConfig: {
+                accessToken: tenantA.secretKey,
+                baseURL: DEFAULT_TRIGGER_API_URL,
+            },
+        });
+    });
+
+    it('credentials.apiUrl override flows through to clientConfig.baseURL', async () => {
+        const client = createTenantTriggerClient(tenantB);
+        await client.tasks.trigger('work-generation', {});
+
+        const [, , , requestOptions] = tasksTriggerMock.mock.calls[0];
+        expect(requestOptions).toEqual({
+            clientConfig: {
+                accessToken: tenantB.secretKey,
+                baseURL: tenantB.apiUrl,
+            },
+        });
+    });
+
+    it('runs.cancel routes through auth.withAuth with the tenant clientConfig', async () => {
+        const client = createTenantTriggerClient(tenantB);
+        await client.runs.cancel('run_xyz');
+
+        expect(withAuthMock).toHaveBeenCalledTimes(1);
+        const [config] = withAuthMock.mock.calls[0];
+        expect(config).toEqual({
+            accessToken: tenantB.secretKey,
+            baseURL: tenantB.apiUrl,
+        });
+        expect(runsCancelMock).toHaveBeenCalledWith('run_xyz');
+    });
+
+    it('runs.retrieve routes through auth.withAuth and returns the SDK run record', async () => {
+        runsRetrieveMock.mockResolvedValueOnce({ id: 'run_ret', status: 'COMPLETED' });
+        const client = createTenantTriggerClient(tenantA);
+        const record = await client.runs.retrieve('run_ret');
+
+        expect(record).toEqual({ id: 'run_ret', status: 'COMPLETED' });
+        expect(withAuthMock).toHaveBeenCalledTimes(1);
+        const [config] = withAuthMock.mock.calls[0];
+        expect(config).toEqual({
+            accessToken: tenantA.secretKey,
+            baseURL: DEFAULT_TRIGGER_API_URL,
+        });
+    });
+
+    it('two clients built from different credentials do not share clientConfig state', async () => {
+        const clientA = createTenantTriggerClient(tenantA);
+        const clientB = createTenantTriggerClient(tenantB);
+        await clientA.tasks.trigger('t', {});
+        await clientB.tasks.trigger('t', {});
+
+        const configA = tasksTriggerMock.mock.calls[0][3];
+        const configB = tasksTriggerMock.mock.calls[1][3];
+        expect(configA.clientConfig.accessToken).toBe(tenantA.secretKey);
+        expect(configA.clientConfig.baseURL).toBe(DEFAULT_TRIGGER_API_URL);
+        expect(configB.clientConfig.accessToken).toBe(tenantB.secretKey);
+        expect(configB.clientConfig.baseURL).toBe(tenantB.apiUrl);
+    });
+
+    it('twice-built clients on the same creds are functionally equivalent', async () => {
+        // The plugin's TenantCredentialCache memoises on (tenantId,
+        // credentialVersion), but the factory itself never has to —
+        // calling it twice must produce two clients that route through
+        // the same clientConfig values (object identity is allowed to
+        // differ).
+        const c1 = createTenantTriggerClient(tenantA);
+        const c2 = createTenantTriggerClient(tenantA);
+        expect(c1).not.toBe(c2);
+
+        await c1.tasks.trigger('t', {});
+        await c2.tasks.trigger('t', {});
+
+        expect(tasksTriggerMock.mock.calls[0][3]).toEqual(
+            tasksTriggerMock.mock.calls[1][3],
+        );
+    });
+});
+
+describe('dispatchersFromTenantClient', () => {
+    beforeEach(() => {
+        tasksTriggerMock.mockReset().mockResolvedValue({ id: 'run_dispatch' });
+        runsCancelMock.mockReset();
+        runsRetrieveMock.mockReset();
+        withAuthMock.mockReset().mockImplementation((_c, fn) => fn());
+    });
+
+    it('routes dispatchKbEmbedDocument through the supplied client, not the singleton', async () => {
+        // Build a fake client whose tasks.trigger is a vi.fn — proves
+        // the dispatcher uses THIS client, never falling back to the
+        // mocked SDK module.
+        const fakeTrigger = vi.fn().mockResolvedValue({ id: 'tenant-run' });
+        const fakeClient = {
+            tasks: { trigger: fakeTrigger },
+            runs: { cancel: vi.fn(), retrieve: vi.fn() },
+        };
+        const dispatchers = dispatchersFromTenantClient(fakeClient) as unknown as {
+            dispatchKbEmbedDocument: (p: unknown) => Promise<string | null>;
+        };
+
+        const runId = await dispatchers.dispatchKbEmbedDocument({
+            workId: 'work-1',
+            documentId: 'doc-1',
+        });
+
+        expect(runId).toBe('tenant-run');
+        expect(fakeTrigger).toHaveBeenCalledTimes(1);
+        expect(fakeTrigger).toHaveBeenCalledWith(
+            'kb-embed-document',
+            { workId: 'work-1', documentId: 'doc-1' },
+            expect.objectContaining({
+                tags: ['kb-embed-document', 'work:work-1', 'doc:doc-1'],
+                concurrencyKey: 'kb-embed:work-1',
+            }),
+        );
+        // No leakage to the module-global SDK mock.
+        expect(tasksTriggerMock).not.toHaveBeenCalled();
+    });
+
+    it('dispatchKbNormalizeMedia picks the right per-kind task id', async () => {
+        const fakeTrigger = vi.fn().mockResolvedValue({ id: 'r' });
+        const fakeClient = {
+            tasks: { trigger: fakeTrigger },
+            runs: { cancel: vi.fn(), retrieve: vi.fn() },
+        };
+        const dispatchers = dispatchersFromTenantClient(fakeClient) as unknown as {
+            dispatchKbNormalizeMedia: (p: unknown) => Promise<string | null>;
+        };
+
+        await dispatchers.dispatchKbNormalizeMedia({
+            mediaKind: 'video',
+            workId: 'w',
+            uploadId: 'u',
+        });
+        await dispatchers.dispatchKbNormalizeMedia({
+            mediaKind: 'audio',
+            workId: 'w',
+            uploadId: 'u',
+        });
+
+        expect(fakeTrigger.mock.calls[0][0]).toBe('kb-normalize-video');
+        expect(fakeTrigger.mock.calls[1][0]).toBe('kb-normalize-audio');
+    });
+
+    it('soft-error dispatchers return null when the SDK throws (matches singleton shape)', async () => {
+        const fakeTrigger = vi.fn().mockRejectedValue(new Error('SDK down'));
+        const fakeClient = {
+            tasks: { trigger: fakeTrigger },
+            runs: { cancel: vi.fn(), retrieve: vi.fn() },
+        };
+        const dispatchers = dispatchersFromTenantClient(fakeClient) as unknown as {
+            dispatchWorkGeneration: (p: unknown) => Promise<string | null>;
+        };
+
+        const out = await dispatchers.dispatchWorkGeneration({
+            workId: 'w',
+            mode: 'full',
+        });
+        expect(out).toBeNull();
+    });
+
+    it('dispatchKbReembedWork propagates SDK errors (no silent drop)', async () => {
+        const fakeTrigger = vi.fn().mockRejectedValue(new Error('SDK down'));
+        const fakeClient = {
+            tasks: { trigger: fakeTrigger },
+            runs: { cancel: vi.fn(), retrieve: vi.fn() },
+        };
+        const dispatchers = dispatchersFromTenantClient(fakeClient) as unknown as {
+            dispatchKbReembedWork: (p: unknown) => Promise<string>;
+        };
+
+        await expect(
+            dispatchers.dispatchKbReembedWork({
+                workId: 'w',
+                previousModel: 'old',
+                newModel: 'new',
+            }),
+        ).rejects.toThrow('SDK down');
+    });
+
+    it('two dispatcher maps for two clients do not cross-pollute', async () => {
+        const triggerA = vi.fn().mockResolvedValue({ id: 'a-run' });
+        const triggerB = vi.fn().mockResolvedValue({ id: 'b-run' });
+        const clientA = {
+            tasks: { trigger: triggerA },
+            runs: { cancel: vi.fn(), retrieve: vi.fn() },
+        };
+        const clientB = {
+            tasks: { trigger: triggerB },
+            runs: { cancel: vi.fn(), retrieve: vi.fn() },
+        };
+        const dA = dispatchersFromTenantClient(clientA) as unknown as {
+            dispatchKbEmbedDocument: (p: unknown) => Promise<string | null>;
+        };
+        const dB = dispatchersFromTenantClient(clientB) as unknown as {
+            dispatchKbEmbedDocument: (p: unknown) => Promise<string | null>;
+        };
+
+        await dA.dispatchKbEmbedDocument({ workId: 'a', documentId: 'a' });
+        await dB.dispatchKbEmbedDocument({ workId: 'b', documentId: 'b' });
+
+        expect(triggerA).toHaveBeenCalledTimes(1);
+        expect(triggerB).toHaveBeenCalledTimes(1);
+        expect(triggerA.mock.calls[0][1]).toEqual({ workId: 'a', documentId: 'a' });
+        expect(triggerB.mock.calls[0][1]).toEqual({ workId: 'b', documentId: 'b' });
+    });
+
+    it('the dispatchers map is frozen', () => {
+        const fakeClient = {
+            tasks: { trigger: vi.fn() },
+            runs: { cancel: vi.fn(), retrieve: vi.fn() },
+        };
+        const dispatchers = dispatchersFromTenantClient(fakeClient);
+        expect(Object.isFrozen(dispatchers)).toBe(true);
+    });
+});

--- a/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
+++ b/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import type {
     IJobRuntimeProvider,
     JobRunStatus,
@@ -11,7 +11,16 @@ import type {
     WorkerHostHandle,
     WorkerHostOptions,
 } from '@ever-works/plugin';
+import {
+    mapTriggerStatus as mapTriggerStatusLocal,
+    type TriggerClient,
+    type TriggerTenantCredentials,
+} from '@ever-works/job-runtime-trigger-plugin';
 import { TriggerService, triggerTenantStampStorage } from './trigger.service';
+import {
+    createTenantTriggerClient,
+    dispatchersFromTenantClient,
+} from './trigger-tenant-client.factory';
 
 /**
  * EW-742 P3.2 T22 (stamping) — the subset of dispatcher method names on
@@ -105,7 +114,38 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
     // -- IJobRuntimeProvider ----------------------------------------------
     readonly runtimeId: JobRuntimeId = 'trigger';
 
-    constructor(private readonly triggerService: TriggerService) {}
+    private readonly logger = new Logger(TriggerJobRuntimeProvider.name);
+
+    /**
+     * EW-742 P3.2 T22 — operator-supplied per-tenant `TriggerClient`
+     * factory. Defaults to the `@trigger.dev/sdk`-v4-backed
+     * {@link createTenantTriggerClient} which uses
+     * `tasks.trigger(..., { clientConfig })` + `auth.withAuth(...)` so
+     * concurrent multi-tenant calls don't cross-pollute. Overridable
+     * for tests + alternate operator wiring (e.g. self-hosted
+     * Trigger.dev with a custom client class).
+     */
+    private readonly clientFactory: (credentials: TriggerTenantCredentials) => TriggerClient;
+
+    /**
+     * Builds the per-tenant dispatchers map from a per-tenant
+     * `TriggerClient`. Defaults to {@link dispatchersFromTenantClient}
+     * (mirrors {@link TriggerService}'s dispatchers via the BYO
+     * client). Overridable per the same reasoning as
+     * {@link clientFactory}.
+     */
+    private readonly dispatchersFromClient: (client: TriggerClient) => JobRuntimeDispatchers;
+
+    constructor(
+        private readonly triggerService: TriggerService,
+        opts: {
+            clientFactory?: (credentials: TriggerTenantCredentials) => TriggerClient;
+            dispatchersFromClient?: (client: TriggerClient) => JobRuntimeDispatchers;
+        } = {},
+    ) {
+        this.clientFactory = opts.clientFactory ?? createTenantTriggerClient;
+        this.dispatchersFromClient = opts.dispatchersFromClient ?? dispatchersFromTenantClient;
+    }
 
     /**
      * The dispatchers surface IS the underlying {@link TriggerService}
@@ -243,6 +283,24 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
         }
 
         const base = this;
+
+        // EW-742 P3.2 T22 — BYO / override credential extraction.
+        //
+        // Snapshots that carry the full
+        // {@link TriggerTenantCredentials} bag (accessToken + secretKey
+        // + projectRef) route through a per-tenant Trigger.dev client
+        // built by {@link clientFactory}. The view's `dispatchers` then
+        // come from {@link dispatchersFromClient} so every
+        // `dispatchXxx` call hits the tenant's project, not the
+        // platform default. Inherit snapshots (empty bag, or only the
+        // legacy `projectAccessToken` key) skip this branch entirely
+        // and fall through to the singleton-Proxy stamping path —
+        // byte-identical to the pre-T22 wiring.
+        const tenantCredentials = this.extractTenantCredentials(snapshot);
+        const tenantClient: TriggerClient | null = tenantCredentials
+            ? this.safeBuildTenantClient(snapshot, tenantCredentials)
+            : null;
+
         // EW-742 P3.2 T22 (stamping) — per-tenant dispatcher Proxy.
         //
         // The bound view's `dispatchers` is a Proxy around the singleton
@@ -270,8 +328,15 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
             if (stampedDispatchersCache) {
                 return stampedDispatchersCache;
             }
-            const target = base.dispatchers as Record<string, unknown>;
-            stampedDispatchersCache = new Proxy(target, {
+            // BYO branch — wrap the BYO dispatchers in the SAME stamp
+            // Proxy so tenant tags / concurrencyKey still get prefixed
+            // at the binding layer (the BYO dispatchers themselves
+            // intentionally don't stamp — stamping at both layers
+            // would double-prefix).
+            const dispatchersSource: Record<string, unknown> = tenantClient
+                ? (base.dispatchersFromClient(tenantClient) as Record<string, unknown>)
+                : (base.dispatchers as Record<string, unknown>);
+            stampedDispatchersCache = new Proxy(dispatchersSource, {
                 get(t, prop, receiver) {
                     const value = Reflect.get(t, prop, receiver);
                     if (typeof value !== 'function') {
@@ -301,6 +366,7 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
         // carries the snapshot for downstream stamping.
         const view: IJobRuntimeProvider & {
             readonly tenantSnapshot: TenantCredentialSnapshot;
+            readonly tenantClient: TriggerClient | null;
         } = Object.freeze({
             // -- IPlugin metadata, copied verbatim ---------------------
             id: base.id,
@@ -317,12 +383,30 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
             registerSchedules(schedules: readonly ScheduleSpec[]): Promise<void> {
                 return base.registerSchedules(schedules);
             },
-            cancel(runId: string): Promise<boolean> {
-                return base.cancel(runId);
-            },
-            getRunStatus(runId: string): Promise<JobRunStatus> {
-                return base.getRunStatus(runId);
-            },
+            cancel: tenantClient
+                ? async (runId: string): Promise<boolean> => {
+                      // BYO — cancel against the tenant's Trigger.dev
+                      // project; a singleton cancel would either no-op
+                      // (run id not in the platform project) or, worse,
+                      // hit the wrong project.
+                      try {
+                          await tenantClient.runs.cancel(runId);
+                          return true;
+                      } catch {
+                          return false;
+                      }
+                  }
+                : (runId: string) => base.cancel(runId),
+            getRunStatus: tenantClient
+                ? async (runId: string): Promise<JobRunStatus> => {
+                      try {
+                          const run = await tenantClient.runs.retrieve(runId);
+                          return mapTriggerStatusLocal(run.status);
+                      } catch {
+                          return 'unknown';
+                      }
+                  }
+                : (runId: string) => base.getRunStatus(runId),
             isEnabled(): boolean {
                 return base.isEnabled();
             },
@@ -350,6 +434,11 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
             },
             // -- snapshot exposed for downstream stampers --------------
             tenantSnapshot: snapshot,
+            // -- BYO surface: exposed so callers / tests / introspection
+            //    can verify the BYO branch wired through. `null` for
+            //    inherit snapshots (or BYO snapshots where the factory
+            //    threw and we fell open to the singleton).
+            tenantClient,
         });
 
         // Cache-replace: evict any older version for this tenant so
@@ -361,5 +450,78 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
         }
         this.tenantViews.set(cacheKey, view);
         return view;
+    }
+
+    /**
+     * EW-742 P3.2 T22 — validate the snapshot's `credentials` bag
+     * against the {@link TriggerTenantCredentials} shape (mirrors the
+     * `extractTenantCredentials` helper on
+     * `@ever-works/job-runtime-trigger-plugin`'s
+     * {@link TriggerJobRuntimePlugin}). Returns the typed bundle on
+     * success; `null` (with a fail-open warn) when ANY required field
+     * is missing or non-string.
+     *
+     * Inherit-shaped snapshots (empty `credentials`, or only the
+     * legacy `projectAccessToken` key from earlier T21 wiring)
+     * intentionally return `null` WITHOUT a warn — they're the
+     * dominant path and noise here would drown actually-actionable
+     * BYO misconfigurations. The warn fires only when there's at
+     * least one Trigger.dev-shaped key but the bundle is incomplete.
+     */
+    private extractTenantCredentials(
+        snapshot: TenantCredentialSnapshot,
+    ): TriggerTenantCredentials | null {
+        const bag = snapshot.credentials as Record<string, unknown>;
+        const accessToken = typeof bag.accessToken === 'string' ? bag.accessToken : null;
+        const secretKey = typeof bag.secretKey === 'string' ? bag.secretKey : null;
+        const projectRef = typeof bag.projectRef === 'string' ? bag.projectRef : null;
+        const apiUrl = typeof bag.apiUrl === 'string' ? bag.apiUrl : undefined;
+
+        if (!accessToken && !secretKey && !projectRef) {
+            return null;
+        }
+
+        if (!accessToken || !secretKey || !projectRef) {
+            const missing = [
+                !accessToken && 'accessToken',
+                !secretKey && 'secretKey',
+                !projectRef && 'projectRef',
+            ]
+                .filter(Boolean)
+                .join(', ');
+            this.logger.warn(
+                `bindToTenant(tenantId=${snapshot.tenantId}, v=${snapshot.credentialVersion}): ` +
+                    `malformed BYO credentials — missing ${missing}. Falling back to platform default.`,
+            );
+            return null;
+        }
+
+        return apiUrl !== undefined
+            ? { accessToken, secretKey, projectRef, apiUrl }
+            : { accessToken, secretKey, projectRef };
+    }
+
+    /**
+     * Wrap the per-tenant `clientFactory` call in try/catch so a
+     * misbehaving operator factory (throws on construction, returns
+     * wrong shape) doesn't crash the whole bind. On failure we fall
+     * open to the platform default and warn — same shape as the
+     * missing-field path. Mirrors `safeBuildClient` on
+     * `TriggerJobRuntimePlugin`.
+     */
+    private safeBuildTenantClient(
+        snapshot: TenantCredentialSnapshot,
+        credentials: TriggerTenantCredentials,
+    ): TriggerClient | null {
+        try {
+            return this.clientFactory(credentials);
+        } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            this.logger.warn(
+                `bindToTenant(tenantId=${snapshot.tenantId}, v=${snapshot.credentialVersion}): ` +
+                    `clientFactory threw — ${reason}. Falling back to platform default.`,
+            );
+            return null;
+        }
     }
 }

--- a/packages/tasks/src/trigger/trigger-tenant-client.factory.ts
+++ b/packages/tasks/src/trigger/trigger-tenant-client.factory.ts
@@ -1,0 +1,398 @@
+/**
+ * EW-742 P3.2 T22 — default `clientFactory` + `dispatchersFromClient`
+ * implementations for the `@ever-works/job-runtime-trigger-plugin` BYO
+ * path.
+ *
+ * The plugin (PR #1548) ships library-only — `bindToTenant` accepts
+ * operator-supplied hooks that turn a tenant's credential bag into a
+ * per-tenant `@trigger.dev/sdk` client + dispatchers map. This module
+ * wires the production-default implementations of those two hooks
+ * against the `@trigger.dev/sdk` v4 surface that apps/api already
+ * depends on, so the BYO mode works end-to-end without each operator
+ * having to wire it themselves.
+ *
+ * # Why the SDK construction looks the way it does
+ *
+ * `@trigger.dev/sdk` v4 does not expose a per-instance `Client` class.
+ * The `tasks.trigger(...)` / `runs.cancel(...)` / `runs.retrieve(...)`
+ * functions are module-level and read the access token + base URL from
+ * an internal `apiClientManager` global registered via
+ * `configure({ accessToken, baseURL })`. Using `configure` here would
+ * cross-tenant pollute (it is a process-global mutation).
+ *
+ * Two per-call paths are available in v4 that avoid that pollution:
+ *
+ *   1. `tasks.trigger(id, payload, options, { clientConfig })` —
+ *      `trigger_internal` calls `apiClientManager.clientOrThrow(
+ *      requestOptions?.clientConfig)`, which constructs a fresh
+ *      `ApiClient(baseURL, accessToken, ...)` per call when the
+ *      `clientConfig` is supplied. This is race-free under concurrent
+ *      multi-tenant dispatch.
+ *
+ *   2. `withAuth({ accessToken, baseURL }, () => runs.cancel(...))`
+ *      — `runs.cancel` / `runs.retrieve` do NOT accept a
+ *      `clientConfig` requestOption, so they have to be wrapped in
+ *      `auth.withAuth(...)`. `withAuth` uses
+ *      `apiClientManager.runWithConfig`, which mutates the global
+ *      apiClientManager registration for the duration of the callback
+ *      (sync mutate + finally restore). This is correct for sequential
+ *      multi-tenant calls but DOES race under concurrent calls from
+ *      different tenants. For Ever Works' use the `runs.*` path is
+ *      cancel + status polling — both low-volume and not on the hot
+ *      enqueue path — so the practical risk is small. A follow-up
+ *      could lift the `runs.*` calls onto a per-tenant `ApiClient`
+ *      constructed via `@trigger.dev/core`'s `ApiClient` class for
+ *      strict race-freedom.
+ *
+ * # Tenant isolation invariants
+ *
+ *   - Construction is cheap + offline-safe: no network call happens
+ *     in `createTenantTriggerClient(creds)` — the returned object
+ *     holds closures over `creds` and only contacts Trigger.dev when
+ *     a dispatcher is invoked.
+ *   - Idempotency: calling `createTenantTriggerClient(creds)` twice
+ *     with the same credentials returns two functionally equivalent
+ *     objects (different identities — the plugin's
+ *     `TenantCredentialCache` dedups by `(tenantId, credentialVersion)`
+ *     so this matters only for the test path).
+ *   - The factory throws nothing synchronously beyond what
+ *     `@trigger.dev/sdk` itself throws when imported. The plugin's
+ *     `safeBuildClient` already catches throws and fails open with a
+ *     warn, but the defensive try/catch here surfaces a clearer
+ *     error message naming `createTenantTriggerClient` in the chain.
+ */
+
+import { auth, runs, tasks } from '@trigger.dev/sdk/v3';
+import {
+    DEFAULT_TRIGGER_API_URL,
+    type TriggerTenantCredentials
+} from '@ever-works/job-runtime-trigger-plugin';
+import type {
+    TriggerClient,
+    TriggerRunHandle,
+    TriggerRunRecord,
+    TriggerTaskOptions
+} from '@ever-works/job-runtime-trigger-plugin';
+import type { JobRuntimeDispatchers } from '@ever-works/plugin';
+import type {
+    WorkGenerationPayload,
+    WorkImportPayload,
+    TemplateCustomizationPayload,
+    WebhookDeliveryPayload,
+    KbMirrorDocumentPayload,
+    KbBackfillSkeletonPayload,
+    KbEmbedDocumentPayload,
+    KbOrgOverlayFanoutPayload,
+    KbNormalizeMediaPayload,
+    KbTranscribePayload,
+    KbReembedWorkPayload
+} from '@ever-works/agent/tasks';
+import type { NotificationChannelDeliveryPayload } from '@ever-works/agent/facades';
+
+/**
+ * Per-tenant task id constants. Kept in sync with the per-task module
+ * names under `packages/tasks/src/tasks/trigger/` so the BYO path uses
+ * the same task identifiers as the inherit path. A drift here would
+ * surface as "task not found" at dispatch time against the tenant's
+ * Trigger.dev project — operators bringing their own project must
+ * deploy the same task package the platform ships.
+ */
+const TASK_IDS = {
+    workGeneration: 'work-generation',
+    workImport: 'work-import',
+    templateCustomization: 'template-customization',
+    webhookDelivery: 'webhook-delivery',
+    kbMirrorDocument: 'kb-mirror-document',
+    kbBackfillSkeleton: 'kb-backfill-skeleton',
+    kbEmbedDocument: 'kb-embed-document',
+    kbOrgOverlayFanout: 'kb-org-overlay-fanout',
+    kbNormalizeVideo: 'kb-normalize-video',
+    kbNormalizeAudio: 'kb-normalize-audio',
+    kbTranscribe: 'kb-transcribe',
+    kbReembedWork: 'kb-reembed-work',
+    notificationChannelDelivery: 'notification-channel-delivery'
+} as const;
+
+/**
+ * Build a `TriggerClient` (the structural `{ tasks, runs }` interface
+ * the plugin expects) bound to one tenant's Trigger.dev credentials.
+ *
+ * The returned object's `tasks.trigger` invocations include
+ * `requestOptions.clientConfig` so the SDK constructs a fresh
+ * `ApiClient` per call without touching the module-global
+ * `apiClientManager` state. `runs.cancel` / `runs.retrieve` route
+ * through `auth.withAuth(...)` (the SDK doesn't expose a per-call
+ * `clientConfig` for them — see file header for the caveat).
+ *
+ * Construction is cheap + offline-safe — no network call happens
+ * until a dispatcher fires.
+ */
+export function createTenantTriggerClient(
+    credentials: TriggerTenantCredentials
+): TriggerClient {
+    let clientConfig: { accessToken: string; baseURL: string };
+    try {
+        clientConfig = Object.freeze({
+            accessToken: credentials.secretKey,
+            baseURL: credentials.apiUrl ?? DEFAULT_TRIGGER_API_URL
+        });
+    } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(
+            `createTenantTriggerClient: failed to assemble client config for ` +
+                `projectRef=${credentials.projectRef}: ${reason}`
+        );
+    }
+
+    return Object.freeze({
+        tasks: {
+            async trigger(
+                taskId: string,
+                payload: unknown,
+                options?: TriggerTaskOptions
+            ): Promise<TriggerRunHandle> {
+                const handle = await tasks.trigger(
+                    taskId,
+                    payload,
+                    options as never,
+                    { clientConfig }
+                );
+                // `tasks.trigger` returns `RunHandle<...>` shaped as
+                // `{ id, publicAccessToken, ... }` — structurally a
+                // `TriggerRunHandle` per the plugin's types.
+                return handle as unknown as TriggerRunHandle;
+            }
+        },
+        runs: {
+            async cancel(runId: string): Promise<unknown> {
+                return auth.withAuth(clientConfig, () => runs.cancel(runId));
+            },
+            async retrieve(runId: string): Promise<TriggerRunRecord> {
+                const run = await auth.withAuth(clientConfig, () =>
+                    runs.retrieve(runId)
+                );
+                return run as unknown as TriggerRunRecord;
+            }
+        }
+    });
+}
+
+/**
+ * Build the `JobRuntimeDispatchers` map for a per-tenant
+ * `TriggerClient`. Each dispatcher mirrors the corresponding
+ * `TriggerService.dispatchXxx` body's `tags` / `concurrencyKey` /
+ * `machine` choices so a BYO tenant gets the same Trigger.dev
+ * dashboard semantics as an inherit tenant — only the underlying
+ * client differs.
+ *
+ * Tenant stamping (`tenant:<id>` tag, `tenantId`-prefixed
+ * `concurrencyKey`) is NOT applied here — the plugin's per-tenant view
+ * carries the stamp at the binding layer (see
+ * `TriggerJobRuntimeProvider.bindToTenant`'s Proxy in
+ * `trigger-job-runtime.provider.ts`) and stamping at BOTH layers would
+ * double-prefix the tag. This dispatcher map is the structural BYO
+ * routing only; stamping stays the binding layer's job.
+ *
+ * Catches per-dispatcher SDK errors and returns `null` (matches the
+ * `TriggerService` shared-singleton behaviour — callers fall through
+ * to the in-process fallback for the soft-error paths, or surface the
+ * `null` to the workbench for the loud-error paths).
+ */
+export function dispatchersFromTenantClient(client: TriggerClient): JobRuntimeDispatchers {
+    /**
+     * Tiny adapter that runs a per-dispatcher closure and converts a
+     * Trigger.dev SDK throw into a soft `null` return (mirrors
+     * `TriggerService.dispatchXxx` shape). The `kb-reembed-work`
+     * dispatcher overrides this with a `propagate` shape because its
+     * contract forbids silent drops.
+     */
+    const softDispatch = async (
+        fn: () => Promise<TriggerRunHandle>
+    ): Promise<string | null> => {
+        try {
+            const handle = await fn();
+            return handle?.id ?? null;
+        } catch {
+            return null;
+        }
+    };
+
+    const dispatchers: JobRuntimeDispatchers & Record<string, unknown> = {
+        async dispatchWorkGeneration(payload: WorkGenerationPayload): Promise<string | null> {
+            return softDispatch(() =>
+                client.tasks.trigger(TASK_IDS.workGeneration, payload, {
+                    tags: ['work-generation', payload.mode, payload.workId]
+                })
+            );
+        },
+
+        async dispatchWorkImport(payload: WorkImportPayload): Promise<string | null> {
+            return softDispatch(() =>
+                client.tasks.trigger(TASK_IDS.workImport, payload, {
+                    tags: ['work-import', payload.sourceType, payload.workId]
+                })
+            );
+        },
+
+        async dispatchTemplateCustomization(
+            payload: TemplateCustomizationPayload
+        ): Promise<string | null> {
+            return softDispatch(() =>
+                client.tasks.trigger(TASK_IDS.templateCustomization, payload, {
+                    tags: ['template-customization', payload.customizationId]
+                })
+            );
+        },
+
+        async dispatchWebhookDelivery(payload: WebhookDeliveryPayload): Promise<string | null> {
+            return softDispatch(() =>
+                client.tasks.trigger(TASK_IDS.webhookDelivery, payload, {
+                    tags: [
+                        'webhook-delivery',
+                        `event:${payload.eventName}`,
+                        `subscription:${payload.subscriptionId}`
+                    ]
+                })
+            );
+        },
+
+        async dispatchKbMirrorDocument(payload: KbMirrorDocumentPayload): Promise<string | null> {
+            return softDispatch(() =>
+                client.tasks.trigger(TASK_IDS.kbMirrorDocument, payload, {
+                    tags: [
+                        'kb-mirror-document',
+                        `op:${payload.operation}`,
+                        `work:${payload.workId}`,
+                        `doc:${payload.documentId}`
+                    ],
+                    concurrencyKey: `kb-mirror:${payload.workId}`
+                })
+            );
+        },
+
+        async dispatchKbBackfillSkeleton(
+            payload: KbBackfillSkeletonPayload
+        ): Promise<string | null> {
+            // Fleet-wide — operator bootstrap that may legitimately cross
+            // tenant boundaries; on the BYO path the bootstrap STILL runs
+            // against the tenant's project (one tenant runs their own
+            // ops scripts against their own Trigger.dev project), so the
+            // dispatcher carries the same tags/concurrencyKey shape as
+            // the singleton.
+            return softDispatch(() =>
+                client.tasks.trigger(TASK_IDS.kbBackfillSkeleton, payload, {
+                    tags: [
+                        'kb-backfill-skeleton',
+                        `count:${payload.workIds?.length ?? 0}`
+                    ]
+                })
+            );
+        },
+
+        async dispatchKbEmbedDocument(
+            payload: KbEmbedDocumentPayload
+        ): Promise<string | null> {
+            return softDispatch(() =>
+                client.tasks.trigger(TASK_IDS.kbEmbedDocument, payload, {
+                    tags: [
+                        'kb-embed-document',
+                        `work:${payload.workId}`,
+                        `doc:${payload.documentId}`
+                    ],
+                    concurrencyKey: `kb-embed:${payload.workId}`
+                })
+            );
+        },
+
+        async dispatchKbOrgOverlayFanout(
+            payload: KbOrgOverlayFanoutPayload
+        ): Promise<string | null> {
+            return softDispatch(() =>
+                client.tasks.trigger(TASK_IDS.kbOrgOverlayFanout, payload, {
+                    tags: [
+                        'kb-org-overlay-fanout',
+                        `op:${payload.operation}`,
+                        `org:${payload.organizationId}`,
+                        `doc:${payload.documentId}`,
+                        `targets:${payload.workIds.length}`
+                    ],
+                    concurrencyKey: `kb-org-overlay:${payload.organizationId}`
+                })
+            );
+        },
+
+        async dispatchKbNormalizeMedia(
+            payload: KbNormalizeMediaPayload
+        ): Promise<string | null> {
+            const taskId =
+                payload.mediaKind === 'video'
+                    ? TASK_IDS.kbNormalizeVideo
+                    : TASK_IDS.kbNormalizeAudio;
+            return softDispatch(() =>
+                client.tasks.trigger(taskId, payload, {
+                    tags: [
+                        `kb-normalize-${payload.mediaKind}`,
+                        `work:${payload.workId}`,
+                        `upload:${payload.uploadId}`
+                    ],
+                    concurrencyKey: `kb-normalize:${payload.workId}`
+                })
+            );
+        },
+
+        async dispatchKbTranscribe(payload: KbTranscribePayload): Promise<string | null> {
+            return softDispatch(() =>
+                client.tasks.trigger(TASK_IDS.kbTranscribe, payload, {
+                    tags: [
+                        'kb-transcribe',
+                        `work:${payload.workId}`,
+                        `upload:${payload.uploadId}`
+                    ],
+                    concurrencyKey: `kb-transcribe:${payload.workId}`
+                })
+            );
+        },
+
+        /**
+         * EW-642 D7 contract — kb-reembed-work PROPAGATES errors
+         * (silent drop would leave Work pinned to stale embedding
+         * model). Bypasses `softDispatch` so the SDK throw escapes
+         * the dispatcher.
+         */
+        async dispatchKbReembedWork(payload: KbReembedWorkPayload): Promise<string> {
+            const handle = await client.tasks.trigger(TASK_IDS.kbReembedWork, payload, {
+                tags: [
+                    'kb-reembed-work',
+                    `work:${payload.workId}`,
+                    `from:${payload.previousModel}`,
+                    `to:${payload.newModel}`
+                ],
+                concurrencyKey: `kb-reembed:${payload.workId}`
+            });
+            if (!handle?.id) {
+                throw new Error(
+                    `dispatchKbReembedWork(work=${payload.workId}): SDK returned no run id`
+                );
+            }
+            return handle.id;
+        },
+
+        async dispatchNotificationChannelDelivery(
+            payload: NotificationChannelDeliveryPayload
+        ): Promise<string | null> {
+            const delay = payload.deferUntil ? new Date(payload.deferUntil) : undefined;
+            return softDispatch(() =>
+                client.tasks.trigger(TASK_IDS.notificationChannelDelivery, payload, {
+                    tags: [
+                        'notification-channel-delivery',
+                        `channel:${payload.channelId}`,
+                        ...(payload.eventType ? [`event:${payload.eventType}`] : [])
+                    ],
+                    ...(delay ? { delay } : {})
+                } as TriggerTaskOptions)
+            );
+        }
+    };
+
+    return Object.freeze(dispatchers) as JobRuntimeDispatchers;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3001,6 +3001,9 @@ importers:
       '@ever-works/agent':
         specifier: workspace:*
         version: link:../agent
+      '@ever-works/job-runtime-trigger-plugin':
+        specifier: workspace:*
+        version: link:../plugins/job-runtime-trigger
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../plugin


### PR DESCRIPTION
## Summary
- Wires production-default \`clientFactory\` + \`dispatchersFromClient\` for the per-tenant Trigger.dev BYO path shipped library-only in #1548.
- \`TriggerJobRuntimeProvider.bindToTenant\` now routes through a per-tenant \`@trigger.dev/sdk\` v4 client when the snapshot carries full \`accessToken\`+\`secretKey\`+\`projectRef\`; inherit-mode stays byte-identical.
- New \`createTenantTriggerClient\` / \`dispatchersFromTenantClient\` in \`packages/tasks/src/trigger/trigger-tenant-client.factory.ts\`. Uses per-call \`clientConfig\` for \`tasks.trigger\` (race-free) + \`auth.withAuth\` for \`runs.cancel\` / \`runs.retrieve\`. Zero network calls at construction; no \`configure()\` cross-tenant pollution.
- \`cancel\` / \`getRunStatus\` on the BYO view also route through the tenant client.

## Test plan
- [x] \`pnpm --filter @ever-works/trigger-tasks exec vitest run src/trigger/__tests__/\` — 84/84 (incl. 13 new factory cases)
- [x] \`pnpm --filter @ever-works/job-runtime-trigger-plugin test\` — 119/119
- [x] \`apps/api && pnpm type-check\` clean
- [x] \`pnpm --filter ever-works-api test\` — 2974/2974
- [ ] Manual: BYO tenant dispatches to their own Trigger.dev project (smoke against a real tenant secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Bring Your Own (BYO) Trigger.dev credentials, enabling tenants to use custom Trigger.dev configurations for task execution.
  * Implemented per-tenant task dispatcher routing with isolation of credentials and API endpoints.

* **Tests**
  * Added comprehensive unit test coverage for tenant-specific client factory and dispatcher routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->