### PR TITLE
feat(web): operator UI for Trigger.dev 3-mode picker (inherit/byo/override)

### DIFF
--- a/apps/web/e2e/tenant-job-runtime.spec.ts
+++ b/apps/web/e2e/tenant-job-runtime.spec.ts
@@ -136,4 +136,147 @@ test.describe('Tenant job-runtime overlay — schema-driven credentials form', (
 		const secretCount = await secretInputs.count();
 		expect(secretCount, 'at least one secret credential field should render as password').toBeGreaterThan(0);
 	});
+
+	/**
+	 * EW-743 — Trigger.dev now exposes per-tenant BYO credentials
+	 * gated by the existing mode discriminator (PR #1548). The form
+	 * must:
+	 *   - Render the mode picker with all 3 options (inherit / byo / override)
+	 *   - Hide the credential trio in `inherit` and show it in `byo` / `override`
+	 *   - Preserve credential values when toggling byo→inherit→byo
+	 *     (non-destructive mode flip)
+	 *   - Show a per-mode helper banner whose copy differs per mode
+	 */
+	test.describe('Trigger.dev 3-mode picker (EW-743)', () => {
+		test('mode picker exposes all 3 options (inherit, byo, override)', async ({
+			page
+		}) => {
+			await page.goto(PAGE, { waitUntil: 'domcontentloaded' });
+			await page.waitForTimeout(1_500);
+
+			const providerSelect = page.locator('select').first();
+			const providerOptions = await providerSelect
+				.locator('option')
+				.evaluateAll((opts) => opts.map((o) => (o as HTMLOptionElement).value));
+			test.skip(
+				!providerOptions.includes('trigger'),
+				'trigger provider not in operator allow-list for this env'
+			);
+			await providerSelect.selectOption('trigger');
+
+			const modeSelect = page.locator('select').nth(1);
+			const modeOptions = await modeSelect
+				.locator('option')
+				.evaluateAll((opts) => opts.map((o) => (o as HTMLOptionElement).value));
+			expect(modeOptions).toEqual(expect.arrayContaining(['inherit', 'byo', 'override']));
+		});
+
+		test('switching trigger from inherit→byo reveals the credential fields', async ({
+			page
+		}) => {
+			await page.goto(PAGE, { waitUntil: 'domcontentloaded' });
+			await page.waitForTimeout(1_500);
+
+			const providerSelect = page.locator('select').first();
+			const providerOptions = await providerSelect
+				.locator('option')
+				.evaluateAll((opts) => opts.map((o) => (o as HTMLOptionElement).value));
+			test.skip(
+				!providerOptions.includes('trigger'),
+				'trigger provider not in operator allow-list for this env'
+			);
+			await providerSelect.selectOption('trigger');
+
+			const modeSelect = page.locator('select').nth(1);
+
+			// inherit: no credentials form, but per-mode banner is visible
+			await modeSelect.selectOption('inherit');
+			await page.waitForTimeout(500);
+			await expect(
+				page.locator('[data-testid="job-runtime-mode-banner-trigger-inherit"]')
+			).toBeVisible({ timeout: 5_000 });
+			await expect(
+				page.locator('[data-testid="job-runtime-credentials-form"]')
+			).toHaveCount(0);
+
+			// byo: credentials form appears + at least the access token + secret key fields
+			await modeSelect.selectOption('byo');
+			await page.waitForTimeout(500);
+			await expect(
+				page.locator('[data-testid="job-runtime-credentials-form"]')
+			).toBeVisible({ timeout: 5_000 });
+			const passwordCount = await page.locator('input[type="password"]').count();
+			expect(passwordCount, 'byo trigger should render at least PAT + secretKey as password').toBeGreaterThanOrEqual(2);
+		});
+
+		test('byo→inherit→byo preserves credential values (non-destructive mode flip)', async ({
+			page
+		}) => {
+			await page.goto(PAGE, { waitUntil: 'domcontentloaded' });
+			await page.waitForTimeout(1_500);
+
+			const providerSelect = page.locator('select').first();
+			const providerOptions = await providerSelect
+				.locator('option')
+				.evaluateAll((opts) => opts.map((o) => (o as HTMLOptionElement).value));
+			test.skip(
+				!providerOptions.includes('trigger'),
+				'trigger provider not in operator allow-list for this env'
+			);
+			await providerSelect.selectOption('trigger');
+
+			const modeSelect = page.locator('select').nth(1);
+			await modeSelect.selectOption('byo');
+			await page.waitForTimeout(500);
+
+			// Fill the first password field (Trigger.dev PAT) with a marker
+			const SENTINEL = 'tr_pat_e2e_state_preservation_check';
+			const firstPassword = page.locator('input[type="password"]').first();
+			await firstPassword.fill(SENTINEL);
+			await expect(firstPassword).toHaveValue(SENTINEL);
+
+			// Flip to inherit — credentials block disappears
+			await modeSelect.selectOption('inherit');
+			await page.waitForTimeout(500);
+			await expect(
+				page.locator('[data-testid="job-runtime-credentials-form"]')
+			).toHaveCount(0);
+
+			// Flip back to byo — value should still be there (parent preserved it)
+			await modeSelect.selectOption('byo');
+			await page.waitForTimeout(500);
+			const firstPasswordAfter = page.locator('input[type="password"]').first();
+			await expect(firstPasswordAfter).toHaveValue(SENTINEL);
+		});
+
+		test('per-mode banner copy differs between inherit, byo, and override', async ({
+			page
+		}) => {
+			await page.goto(PAGE, { waitUntil: 'domcontentloaded' });
+			await page.waitForTimeout(1_500);
+
+			const providerSelect = page.locator('select').first();
+			const providerOptions = await providerSelect
+				.locator('option')
+				.evaluateAll((opts) => opts.map((o) => (o as HTMLOptionElement).value));
+			test.skip(
+				!providerOptions.includes('trigger'),
+				'trigger provider not in operator allow-list for this env'
+			);
+			await providerSelect.selectOption('trigger');
+			const modeSelect = page.locator('select').nth(1);
+
+			const banners: Record<string, string> = {};
+			for (const m of ['inherit', 'byo', 'override'] as const) {
+				await modeSelect.selectOption(m);
+				await page.waitForTimeout(400);
+				const banner = page.locator(`[data-testid="job-runtime-mode-banner-trigger-${m}"]`);
+				await expect(banner).toBeVisible({ timeout: 5_000 });
+				banners[m] = (await banner.innerText()).trim();
+				expect(banners[m].length).toBeGreaterThan(10);
+			}
+
+			expect(new Set(Object.values(banners)).size).toBe(3);
+		});
+	});
 });

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1612,6 +1612,23 @@
                     "jsonPlaceholder": "{\n    \"token\": \"...\"\n}",
                     "jsonHelper": "Per-provider schema-driven forms land in a follow-up sub-story. For now, paste the JSON shape from providers.md as a free-form reference."
                 },
+                "trigger": {
+                    "banner": {
+                        "inherit": "Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+                        "byo": "Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.",
+                        "override": "Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+                    },
+                    "fields": {
+                        "accessTokenLabel": "Personal Access Token (PAT)",
+                        "accessTokenHelper": "Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.",
+                        "secretKeyLabel": "Project Secret Key",
+                        "secretKeyHelper": "Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.",
+                        "projectRefLabel": "Project Ref",
+                        "projectRefHelper": "Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.",
+                        "apiUrlLabel": "API URL (self-hosted only)",
+                        "apiUrlHelper": "Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev."
+                    }
+                },
                 "actions": {
                     "save": "Save",
                     "rotate": "Rotate credential",

--- a/apps/web/src/components/settings/JobRuntimeCredentialsForm.tsx
+++ b/apps/web/src/components/settings/JobRuntimeCredentialsForm.tsx
@@ -1,14 +1,20 @@
 'use client';
 
 import { useState } from 'react';
-import { Eye, EyeOff, Lock, AlertCircle } from 'lucide-react';
+import { Eye, EyeOff, Lock, AlertCircle, Info } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Button } from '@/components/ui/button';
-import type { TenantJobRuntimeProviderId } from '@/lib/api/tenant-job-runtime';
+import type {
+	TenantJobRuntimeMode,
+	TenantJobRuntimeProviderId
+} from '@/lib/api/tenant-job-runtime';
 import {
 	JOB_RUNTIME_CREDENTIAL_SCHEMAS,
+	JOB_RUNTIME_PROVIDER_MODE_BANNERS,
 	PROVIDERS_WITHOUT_CREDENTIALS,
+	isFieldRequired,
+	isFieldVisibleForMode,
 	type JobRuntimeCredentialField
 } from './job-runtime-schemas';
 
@@ -35,6 +41,18 @@ import {
 interface JobRuntimeCredentialsFormProps {
 	/** Selected provider; drives which fields render. */
 	readonly providerId: TenantJobRuntimeProviderId;
+	/**
+	 * Current tenant overlay mode. Drives the per-mode helper banner
+	 * and mode-discriminated field visibility / requiredness (EW-743:
+	 * Trigger.dev's accessToken / secretKey / projectRef are only
+	 * required when mode is `byo` or `override`).
+	 *
+	 * IMPORTANT: when mode flips from byo→inherit we INTENTIONALLY
+	 * preserve `values` in parent state so the operator can flip back
+	 * without re-pasting credentials. The parent decides when to clear
+	 * (on successful save, or on explicit revert-to-inherit).
+	 */
+	readonly mode: TenantJobRuntimeMode;
 	/** Current field values, owned by the parent. */
 	readonly values: Readonly<Record<string, string>>;
 	readonly onChange: (next: Readonly<Record<string, string>>) => void;
@@ -47,14 +65,17 @@ interface JobRuntimeCredentialsFormProps {
 
 export function JobRuntimeCredentialsForm({
 	providerId,
+	mode,
 	values,
 	onChange,
 	compact = false
 }: JobRuntimeCredentialsFormProps) {
-	const fields = JOB_RUNTIME_CREDENTIAL_SCHEMAS[providerId] ?? [];
-	const hasSchema = fields.length > 0;
+	const allFields = JOB_RUNTIME_CREDENTIAL_SCHEMAS[providerId] ?? [];
+	const hasSchema = allFields.length > 0;
 	const isNoCredentialsProvider = PROVIDERS_WITHOUT_CREDENTIALS.has(providerId);
 	const [revealed, setRevealed] = useState<Record<string, boolean>>({});
+
+	const banner = JOB_RUNTIME_PROVIDER_MODE_BANNERS[providerId]?.[mode];
 
 	if (isNoCredentialsProvider) {
 		return (
@@ -63,9 +84,8 @@ export function JobRuntimeCredentialsForm({
 				<div className="text-sm text-text dark:text-text-dark space-y-1">
 					<p className="font-medium">No tenant-supplied credentials</p>
 					<p className="text-text-muted dark:text-text-muted-dark text-xs">
-						Trigger.dev provider switching is handled operator-side. Per-tenant
-						Trigger.dev projects are configured via the worker self-registration flow —
-						see the tenant runbook for details.
+						This provider is operator-only — per-tenant credentials are not
+						accepted.
 					</p>
 				</div>
 			</div>
@@ -94,12 +114,27 @@ export function JobRuntimeCredentialsForm({
 	const toggleReveal = (name: string) =>
 		setRevealed((prev) => ({ ...prev, [name]: !prev[name] }));
 
+	// Filter to fields that are visible in the current mode. Hidden
+	// fields keep their values in `values` (parent state) so toggling
+	// modes is non-destructive (NN: state-preservation on mode flip).
+	const visibleFields = allFields.filter((f) => isFieldVisibleForMode(f, mode));
+
 	return (
-		<div className="space-y-4">
-			{fields.map((field) => (
+		<div className="space-y-4" data-testid="job-runtime-credentials-form">
+			{banner && (
+				<div
+					className="flex items-start gap-2 p-3 bg-info/10 border border-info/20 rounded-lg"
+					data-testid={`job-runtime-mode-banner-${providerId}-${mode}`}
+				>
+					<Info className="w-4 h-4 text-info flex-shrink-0 mt-0.5" aria-hidden />
+					<p className="text-xs text-text dark:text-text-dark">{banner}</p>
+				</div>
+			)}
+			{visibleFields.map((field) => (
 				<CredentialField
 					key={field.name}
 					field={field}
+					required={isFieldRequired(field, mode)}
 					value={values[field.name] ?? ''}
 					revealed={revealed[field.name] ?? false}
 					onToggleReveal={() => toggleReveal(field.name)}
@@ -113,6 +148,8 @@ export function JobRuntimeCredentialsForm({
 
 interface CredentialFieldProps {
 	readonly field: JobRuntimeCredentialField;
+	/** Mode-resolved requiredness (parent computes via `isFieldRequired`). */
+	readonly required: boolean;
 	readonly value: string;
 	readonly revealed: boolean;
 	readonly onToggleReveal: () => void;
@@ -122,6 +159,7 @@ interface CredentialFieldProps {
 
 function CredentialField({
 	field,
+	required,
 	value,
 	revealed,
 	onToggleReveal,
@@ -133,7 +171,7 @@ function CredentialField({
 			<label className="flex items-center gap-1.5 text-sm font-medium text-text dark:text-text-dark">
 				{field.secret && <Lock className="w-3.5 h-3.5 text-text-muted" aria-hidden />}
 				<span>{field.label}</span>
-				{field.required && (
+				{required && (
 					<span className="text-danger" aria-label="required">
 						*
 					</span>
@@ -201,16 +239,21 @@ function CredentialField({
 
 /**
  * Client-side validation: returns the names of fields that are
- * required-but-empty for the given provider. Parent uses this to
- * disable Save + show a per-field error.
+ * required-but-empty for the given provider in the given mode. Parent
+ * uses this to disable Save + show a per-field error.
+ *
+ * EW-743 — mode parameter is required so mode-discriminated
+ * requiredness (e.g. Trigger.dev's `accessToken` only required in
+ * `byo` / `override`) resolves correctly.
  */
 export function validateCredentialFields(
 	providerId: TenantJobRuntimeProviderId,
+	mode: TenantJobRuntimeMode,
 	values: Readonly<Record<string, string>>
 ): readonly string[] {
 	if (PROVIDERS_WITHOUT_CREDENTIALS.has(providerId)) return [];
 	const fields = JOB_RUNTIME_CREDENTIAL_SCHEMAS[providerId] ?? [];
 	return fields
-		.filter((f) => f.required && !values[f.name]?.trim())
+		.filter((f) => isFieldRequired(f, mode) && !values[f.name]?.trim())
 		.map((f) => f.name);
 }

--- a/apps/web/src/components/settings/JobRuntimeSettings.tsx
+++ b/apps/web/src/components/settings/JobRuntimeSettings.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
-import { AlertTriangle, RotateCw, ShieldOff, Undo2, Save } from 'lucide-react';
+import { AlertTriangle, Info, RotateCw, ShieldOff, Undo2, Save } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
@@ -12,7 +12,10 @@ import {
     JobRuntimeCredentialsForm,
     validateCredentialFields,
 } from './JobRuntimeCredentialsForm';
-import { PROVIDERS_WITHOUT_CREDENTIALS } from './job-runtime-schemas';
+import {
+    JOB_RUNTIME_PROVIDER_MODE_BANNERS,
+    PROVIDERS_WITHOUT_CREDENTIALS,
+} from './job-runtime-schemas';
 import {
     Dialog,
     DialogClose,
@@ -144,9 +147,9 @@ export function JobRuntimeSettings({
     const missingRequiredFields = useMemo(
         () =>
             needsCredentials && providerHasCredentials
-                ? validateCredentialFields(providerId, credentialValues)
+                ? validateCredentialFields(providerId, mode, credentialValues)
                 : [],
-        [needsCredentials, providerHasCredentials, providerId, credentialValues],
+        [needsCredentials, providerHasCredentials, providerId, mode, credentialValues],
     );
 
     const applyConfig = (next: TenantJobRuntimeConfigResponse) => {
@@ -371,6 +374,30 @@ export function JobRuntimeSettings({
                     <Switch checked={enabled} onChange={setEnabled} />
                 </div>
 
+                {/*
+                  EW-743 — when mode is `inherit` we suppress the credentials
+                  block entirely, but the provider may still have a per-mode
+                  banner worth showing (e.g. Trigger.dev's "Using the
+                  platform's shared project" copy). Render it above so the
+                  operator sees what `inherit` means for the picked provider.
+                */}
+                {!needsCredentials &&
+                    providerHasCredentials &&
+                    JOB_RUNTIME_PROVIDER_MODE_BANNERS[providerId]?.[mode] && (
+                        <div
+                            className="flex items-start gap-2 p-3 bg-info/10 border border-info/20 rounded-lg"
+                            data-testid={`job-runtime-mode-banner-${providerId}-${mode}`}
+                        >
+                            <Info
+                                className="w-4 h-4 text-info flex-shrink-0 mt-0.5"
+                                aria-hidden
+                            />
+                            <p className="text-xs text-text dark:text-text-dark">
+                                {JOB_RUNTIME_PROVIDER_MODE_BANNERS[providerId]?.[mode]}
+                            </p>
+                        </div>
+                    )}
+
                 {needsCredentials && (
                     <div className="space-y-4 p-4 rounded-lg border border-border dark:border-border-dark">
                         <h3 className="text-sm font-semibold text-text dark:text-text-dark">
@@ -392,11 +419,18 @@ export function JobRuntimeSettings({
                           EW-742 P2.2 T17 — per-provider schema-driven form
                           replaces the opaque credentialsJson textarea. Reset
                           state on provider change via `key={providerId}`.
+                          EW-743 — pass `mode` so mode-discriminated fields
+                          (Trigger.dev's accessToken / secretKey / projectRef)
+                          render with mode-aware requiredness + per-mode banner.
+                          Values are intentionally NOT cleared on mode flip —
+                          parent owns lifecycle and only clears on successful
+                          save or explicit revert.
                         */}
                         <div className="pt-2 border-t border-border/40 dark:border-border-dark/40">
                             <JobRuntimeCredentialsForm
                                 key={providerId}
                                 providerId={providerId}
+                                mode={mode}
                                 values={credentialValues}
                                 onChange={setCredentialValues}
                             />

--- a/apps/web/src/components/settings/job-runtime-schemas.ts
+++ b/apps/web/src/components/settings/job-runtime-schemas.ts
@@ -3,10 +3,9 @@
  * schema-driven tenant credentials form.
  *
  * These mirror each plugin package's `settingsSchema` (BullMQ /
- * pg-boss / Temporal / Inngest — Trigger.dev intentionally has no
- * tenant-supplied credentials, so its entry is empty). We hard-code
- * the field list in the web app rather than fetching the plugin's
- * schema at runtime because:
+ * pg-boss / Temporal / Inngest / Trigger.dev). We hard-code the field
+ * list in the web app rather than fetching the plugin's schema at
+ * runtime because:
  *
  *   1. The web app doesn't import `@ever-works/job-runtime-*-plugin`
  *      packages — that would pull bullmq/pg-boss/@temporalio/inngest
@@ -16,20 +15,37 @@
  *      and the operator-wiring docs (providers.md) document the
  *      credential bag shape verbatim.
  *
+ * EW-743 (PR #1548) — Trigger.dev gained per-tenant BYO credentials
+ * gated by the existing tenant overlay `mode` discriminator
+ * (`inherit` | `byo` | `override`). Required-when-mode-in-[byo,
+ * override] is expressed via the `requiredWhen` predicate on each
+ * field; `inherit` falls back to the operator-default project.
+ *
  * Each field declares:
  *   - `name`: the key in the credentials JSON object posted to the
  *     server (matches the plugin's settingsSchema.properties.<name>)
  *   - `label`: human-readable label
  *   - `description`: helper text shown under the field
  *   - `secret`: render as masked password input (true) or plain text (false)
- *   - `required`: client-side validation on save
+ *   - `required`: client-side validation on save (always-required;
+ *     mode-conditional requiredness uses `requiredWhen` instead)
+ *   - `requiredWhen`: discriminator-driven requiredness — currently
+ *     only `mode` is supported (set of mode values that make the
+ *     field required). Fields without `required` and without a
+ *     matching `requiredWhen` entry are optional. Trigger.dev's
+ *     `accessToken` / `secretKey` / `projectRef` use
+ *     `requiredWhen: { mode: ['byo', 'override'] }` to mirror the
+ *     plugin's JSON-Schema `if/then` rule.
  *   - `envVar`: documentation hint shown next to the field for
  *     operators who prefer the env-var fallback
  *   - `placeholder`: input placeholder
  *   - `multiline`: render as <textarea> (true) — used for PEM-encoded
  *     mTLS cert/key pairs
  */
-import type { TenantJobRuntimeProviderId } from '@/lib/api/tenant-job-runtime';
+import type {
+	TenantJobRuntimeMode,
+	TenantJobRuntimeProviderId
+} from '@/lib/api/tenant-job-runtime';
 
 export interface JobRuntimeCredentialField {
 	readonly name: string;
@@ -37,13 +53,58 @@ export interface JobRuntimeCredentialField {
 	readonly description: string;
 	readonly secret: boolean;
 	readonly required: boolean;
+	readonly requiredWhen?: { readonly mode: readonly TenantJobRuntimeMode[] };
 	readonly envVar?: string;
 	readonly placeholder?: string;
 	readonly multiline?: boolean;
 }
 
 export const JOB_RUNTIME_CREDENTIAL_SCHEMAS: Record<TenantJobRuntimeProviderId, readonly JobRuntimeCredentialField[]> = {
-	trigger: [],
+	trigger: [
+		{
+			name: 'accessToken',
+			label: 'Personal Access Token (PAT)',
+			description:
+				'Trigger.dev management PAT (tr_pat_…) from your Trigger.dev account. Required for BYO / Override; unused in Inherit mode.',
+			secret: true,
+			required: false,
+			requiredWhen: { mode: ['byo', 'override'] },
+			envVar: 'TRIGGER_ACCESS_TOKEN',
+			placeholder: 'tr_pat_…'
+		},
+		{
+			name: 'secretKey',
+			label: 'Project Secret Key',
+			description:
+				'Project-scoped server secret (tr_dev_… or tr_prod_…) used by the SDK to authenticate tasks.trigger calls. Required for BYO / Override.',
+			secret: true,
+			required: false,
+			requiredWhen: { mode: ['byo', 'override'] },
+			envVar: 'TRIGGER_SECRET_KEY',
+			placeholder: 'tr_prod_…'
+		},
+		{
+			name: 'projectRef',
+			label: 'Project Ref',
+			description:
+				'Trigger.dev project reference (e.g. proj_abc123). Required for BYO / Override.',
+			secret: false,
+			required: false,
+			requiredWhen: { mode: ['byo', 'override'] },
+			envVar: 'TRIGGER_PROJECT_REF',
+			placeholder: 'proj_…'
+		},
+		{
+			name: 'apiUrl',
+			label: 'API URL (self-hosted only)',
+			description:
+				'Override the Trigger.dev API endpoint for a self-hosted instance. Leave blank to use https://api.trigger.dev.',
+			secret: false,
+			required: false,
+			envVar: 'TRIGGER_API_URL',
+			placeholder: 'https://api.trigger.dev'
+		}
+	],
 	bullmq: [
 		{
 			name: 'redisUrl',
@@ -147,9 +208,71 @@ export const JOB_RUNTIME_CREDENTIAL_SCHEMAS: Record<TenantJobRuntimeProviderId, 
 };
 
 /**
- * Trigger.dev doesn't expose tenant-overlay credentials through the
- * tenant form — operators must point per-tenant Trigger.dev project
- * access tokens at the platform via operator-side config (per
- * `providers.md` § Trigger.dev "BYO project switching" deferral).
+ * Providers that never expose tenant-overlay credentials through the
+ * tenant form. As of EW-743 (PR #1548), Trigger.dev is no longer in
+ * this set — tenants can supply per-project credentials in `byo` /
+ * `override` mode. Reserved for future provider plugins that remain
+ * operator-only.
  */
-export const PROVIDERS_WITHOUT_CREDENTIALS: ReadonlySet<TenantJobRuntimeProviderId> = new Set(['trigger']);
+export const PROVIDERS_WITHOUT_CREDENTIALS: ReadonlySet<TenantJobRuntimeProviderId> = new Set<TenantJobRuntimeProviderId>();
+
+/**
+ * EW-743 — per-provider, per-mode helper banner shown above the
+ * credentials block. Currently only Trigger.dev varies copy by mode
+ * (inherit suppresses the credential trio entirely; byo and override
+ * use the same credential shape but communicate different operator
+ * intent). Other providers can opt in by adding an entry here.
+ */
+export const JOB_RUNTIME_PROVIDER_MODE_BANNERS: Partial<
+	Record<
+		TenantJobRuntimeProviderId,
+		Readonly<Record<TenantJobRuntimeMode, string>>
+	>
+> = {
+	trigger: {
+		inherit:
+			"Using the platform's shared Trigger.dev project. No tenant credentials are required — jobs dispatch through the operator-default project.",
+		byo: 'Bring your own Trigger.dev account + project. Paste the PAT, project secret key, and project ref from your Trigger.dev dashboard.',
+		override:
+			"Override the platform default with your own Trigger.dev project. Same credential shape as BYO — choose this when you're explicitly opting out of the platform default rather than supplementing it."
+	}
+};
+
+/**
+ * Resolve the effective `required` flag for a field given the current
+ * tenant overlay mode. Honors `requiredWhen.mode` (mode-discriminated
+ * requiredness — see PR #1548 `if/then` rule on Trigger.dev) and
+ * falls back to the field's static `required` flag.
+ */
+export function isFieldRequired(
+	field: JobRuntimeCredentialField,
+	mode: TenantJobRuntimeMode
+): boolean {
+	if (field.requiredWhen?.mode) {
+		return field.requiredWhen.mode.includes(mode);
+	}
+	return field.required;
+}
+
+/**
+ * Resolve whether a field should be visible at all for the given mode.
+ * Today a field is hidden only when it has a `requiredWhen.mode`
+ * predicate AND the current mode is NOT in the predicate set (i.e. the
+ * field is purely a mode-conditional credential — e.g. Trigger.dev's
+ * accessToken in inherit mode). Always-optional fields like
+ * Trigger.dev's `apiUrl` remain visible regardless of mode so operators
+ * can opt into self-host overrides.
+ *
+ * Note: callers may additionally suppress the entire credentials block
+ * (e.g. on `inherit` mode), so this only matters when the block is
+ * being rendered.
+ */
+export function isFieldVisibleForMode(
+	field: JobRuntimeCredentialField,
+	mode: TenantJobRuntimeMode
+): boolean {
+	if (field.requiredWhen?.mode) {
+		return field.requiredWhen.mode.includes(mode);
+	}
+	return true;
+}


### PR DESCRIPTION
## Summary
- Trigger.dev is now a credentialed provider in the tenant job-runtime settings form, gated by the existing 3-mode picker (\`inherit\` / \`byo\` / \`override\`) shipped in PR #1548.
- New \`requiredWhen\` predicate on credential fields models JSON-Schema-style \`if/then\` discriminator requiredness in the UI.
- Per-mode helper banners (Trigger.dev-only today, opt-in for others) communicate operator intent without a second mode picker.
- Mode flips are non-destructive — credential values survive byo↔inherit round-trips.

## Decisions
- Reused the existing parent-level mode \`Select\` in \`JobRuntimeSettings.tsx\` (from #1347) — did NOT introduce a duplicate per-provider mode picker. Plugin's \`mode\` enum maps 1:1 onto the tenant overlay mode.
- Banner content hard-coded in \`job-runtime-schemas.ts\` to match how every other label is hard-coded today; parallel i18n keys added to \`en.json\` so a follow-up can switch over without another schema change.
- \`PROVIDERS_WITHOUT_CREDENTIALS\` is now empty — kept the constant for future operator-only providers.

## Test plan
- [x] \`pnpm type-check\` clean
- [x] e2e went 4 → 8 cases (the new 4 self-skip when \`trigger\` isn't in the operator allow-list)
- [ ] Manual smoke at \`/en/settings/job-runtime\` once cascaded — cycle inherit→byo→override + confirm field/banner correctness
- [ ] Confirm non-trigger provider rendering unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)