### PR TITLE
test(api): integration tests for Trigger.dev webhook receiver + router + subscribers

### DIFF
--- a/apps/api/src/webhooks/__tests__/trigger-webhook-controller-deep.itest.spec.ts
+++ b/apps/api/src/webhooks/__tests__/trigger-webhook-controller-deep.itest.spec.ts
@@ -1,0 +1,469 @@
+/**
+ * EW-1516 — integration tests #2: deeper controller-edge coverage.
+ *
+ * Extends the existing 12 controller spec cases with edge-case
+ * variants the per-controller spec does not pin: signature prefix
+ * casing, hex casing, oversized bodies, tenant route-vs-envelope
+ * mismatch propagation through the controller, etc.
+ *
+ * Mirrors the strategy in trigger-webhook.controller.spec.ts — direct
+ * instantiation with mocked repo + secret store + router. Does NOT
+ * stand up a Nest HTTP server.
+ */
+
+import { BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
+import { createHmac } from 'crypto';
+
+// Stub external workspace imports as the unit spec does.
+jest.mock('../../auth/decorators/public.decorator', () => ({ Public: () => () => undefined }));
+jest.mock('@ever-works/agent/entities', () => ({ TenantJobRuntimeConfig: class {} }));
+jest.mock('@ever-works/agent/tasks', () => ({
+    SECRET_STORE_RESOLVER: Symbol.for('SECRET_STORE_RESOLVER_TEST_DEEP'),
+}));
+
+// eslint-disable-next-line import/first
+import { TriggerWebhookController } from '../trigger-webhook.controller';
+// eslint-disable-next-line import/first
+import { TriggerWebhookEventRouterService } from '../trigger-webhook-event-router.service';
+// eslint-disable-next-line import/first
+import type { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+// eslint-disable-next-line import/first
+import type { SecretStoreResolver } from '@ever-works/agent/tasks';
+// eslint-disable-next-line import/first
+import type { Repository } from 'typeorm';
+
+const TENANT_ID = '00000000-0000-0000-0000-000000000aaa';
+const OTHER_TENANT = '00000000-0000-0000-0000-000000000bbb';
+const SECRET = 'super-secret-webhook-key';
+const POINTER = 'inline:dGVzdA==';
+
+function signBody(body: string, secret: string): string {
+    const hex = createHmac('sha256', secret).update(body, 'utf8').digest('hex');
+    return `sha256=${hex}`;
+}
+
+function buildOverlayRow(
+    overrides: Partial<TenantJobRuntimeConfig> = {},
+): TenantJobRuntimeConfig {
+    return {
+        tenantId: TENANT_ID,
+        providerId: 'trigger',
+        credentialsSecretRef: POINTER,
+        credentialVersion: 1,
+        mode: 'byo',
+        enabled: true,
+        createdBy: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...overrides,
+    } as TenantJobRuntimeConfig;
+}
+
+describe('TriggerWebhookController — deep edge-case coverage', () => {
+    let tenantRepo: jest.Mocked<Pick<Repository<TenantJobRuntimeConfig>, 'findOne'>>;
+    let secretStore: jest.Mocked<SecretStoreResolver>;
+    let eventRouter: jest.Mocked<Pick<TriggerWebhookEventRouterService, 'route'>>;
+    let controller: TriggerWebhookController;
+    let logSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        tenantRepo = { findOne: jest.fn() };
+        secretStore = { resolve: jest.fn() } as jest.Mocked<SecretStoreResolver>;
+        eventRouter = { route: jest.fn().mockReturnValue(true) };
+        controller = new TriggerWebhookController(
+            tenantRepo as unknown as Repository<TenantJobRuntimeConfig>,
+            secretStore,
+            eventRouter as unknown as TriggerWebhookEventRouterService,
+        );
+        logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    });
+
+    afterEach(() => {
+        logSpy.mockRestore();
+        jest.resetAllMocks();
+    });
+
+    describe('signature header parsing', () => {
+        // Pin the exact accepted casing: receiver code uses
+        // `sha256=` (lowercase prefix) and lowercase hex output from
+        // createHmac. These tests fence what counts as a valid header.
+
+        it('rejects uppercase scheme prefix `SHA256=` (401)', async () => {
+            const body = '{}';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+            const hex = createHmac('sha256', SECRET).update(body).digest('hex');
+
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: body },
+                    { 'x-trigger-signature': `SHA256=${hex}` },
+                ),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+            expect(eventRouter.route).not.toHaveBeenCalled();
+        });
+
+        it('accepts uppercase hex AFTER `sha256=` prefix', async () => {
+            // The hex regex used in verifySignature is /^[0-9a-f]+$/i —
+            // it accepts uppercase A-F. Buffer.from('AB', 'hex') and
+            // Buffer.from('ab', 'hex') yield the same bytes, so the
+            // timingSafeEqual succeeds.
+            const body = '{}';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+            const hex = createHmac('sha256', SECRET).update(body).digest('hex');
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': `sha256=${hex.toUpperCase()}` },
+            );
+
+            expect(result).toEqual({ ok: true });
+            expect(eventRouter.route).toHaveBeenCalledTimes(1);
+        });
+
+        it('rejects signature with non-hex characters in the digest (401)', async () => {
+            const body = '{}';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: body },
+                    { 'x-trigger-signature': 'sha256=zz' + '0'.repeat(62) },
+                ),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+
+        it('rejects signature with odd hex length (401)', async () => {
+            // 63 hex chars — half-byte that Buffer.from would silently
+            // truncate; controller bails on length-mismatch before
+            // hitting timingSafeEqual.
+            const body = '{}';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: body },
+                    { 'x-trigger-signature': 'sha256=' + 'a'.repeat(63) },
+                ),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+
+        it('rejects signature with too-long hex (>64 chars) (401)', async () => {
+            const body = '{}';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: body },
+                    { 'x-trigger-signature': 'sha256=' + 'a'.repeat(128) },
+                ),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+
+        it('rejects empty hex after the `sha256=` prefix (401)', async () => {
+            const body = '{}';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: body },
+                    { 'x-trigger-signature': 'sha256=' },
+                ),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+
+        it('rejects signature header that is just whitespace (400 or 401)', async () => {
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+            // Empty-string header is treated as missing → 400, not 401.
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: '{}' },
+                    { 'x-trigger-signature': '' },
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+    });
+
+    describe('body content variations', () => {
+        it('accepts an empty JSON object body when correctly signed', async () => {
+            const body = '{}';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            );
+
+            expect(result).toEqual({ ok: true });
+            // Router will reject the malformed envelope but the controller
+            // does not care — it forwarded the parsed body.
+            expect(eventRouter.route).toHaveBeenCalledTimes(1);
+        });
+
+        it('accepts a large valid body (~256 KB) with correct signature', async () => {
+            // Document: there is no inline body-size limit in the
+            // controller. Operators rely on the upstream NestJS body
+            // parser's `limit` setting; here we pin that the controller
+            // itself does not reject reasonable payloads.
+            const big = JSON.stringify({
+                event_type: 'alert.run.succeeded',
+                tenant_id: TENANT_ID,
+                created_at: '2026-06-22T00:00:00.000Z',
+                payload: { run: { id: 'run_big', logs: 'x'.repeat(256 * 1024) } },
+            });
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: big },
+                { 'x-trigger-signature': signBody(big, SECRET) },
+            );
+
+            expect(result).toEqual({ ok: true });
+            expect(eventRouter.route).toHaveBeenCalledTimes(1);
+        });
+
+        it('rejects body containing trailing garbage as not-valid-JSON (400)', async () => {
+            const body = '{"event_type":"alert.run.failed"} garbage';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: body },
+                    { 'x-trigger-signature': signBody(body, SECRET) },
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            // Router never seen — parse failed after signature check.
+            expect(eventRouter.route).not.toHaveBeenCalled();
+        });
+
+        it('accepts JSON array as body (parses + forwards; router drops)', async () => {
+            // JSON arrays parse successfully; the router's envelope guard
+            // rejects them. Controller behaviour: 200 (don't redeliver).
+            const body = '[1,2,3]';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+            eventRouter.route.mockReturnValue(false);
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            );
+
+            expect(result).toEqual({ ok: true });
+            expect(eventRouter.route).toHaveBeenCalledWith(TENANT_ID, [1, 2, 3]);
+        });
+
+        it('accepts JSON `null` body (200; router drops)', async () => {
+            const body = 'null';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+            eventRouter.route.mockReturnValue(false);
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            );
+
+            expect(result).toEqual({ ok: true });
+            expect(eventRouter.route).toHaveBeenCalledWith(TENANT_ID, null);
+        });
+    });
+
+    describe('tenant route-vs-envelope handling', () => {
+        it('forwards body tenant_id mismatch to router (route value wins downstream)', async () => {
+            // The controller does NOT short-circuit on mismatch — the
+            // router decides what to do with the body. This test pins
+            // the controller's hand-off, not the router's behaviour
+            // (that is tested in the router spec).
+            const body = JSON.stringify({
+                event_type: 'alert.run.failed',
+                tenant_id: OTHER_TENANT,
+                created_at: '2026-06-22T00:00:00.000Z',
+                payload: { run: { id: 'run_z' } },
+            });
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            );
+
+            expect(result).toEqual({ ok: true });
+            // Route arg = TENANT_ID (route-param), body still carries
+            // OTHER_TENANT — router handles divergence.
+            const [routeTenant, parsedBody] = eventRouter.route.mock.calls[0];
+            expect(routeTenant).toBe(TENANT_ID);
+            expect((parsedBody as { tenant_id: string }).tenant_id).toBe(OTHER_TENANT);
+        });
+
+        it('forwards empty payload object (200; router will drop)', async () => {
+            const body = JSON.stringify({
+                event_type: 'alert.run.failed',
+                tenant_id: TENANT_ID,
+                created_at: '2026-06-22T00:00:00.000Z',
+                payload: {},
+            });
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+            eventRouter.route.mockReturnValue(true);
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            );
+
+            expect(result).toEqual({ ok: true });
+            expect(eventRouter.route).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('replay-protection placeholder', () => {
+        it('X-Trigger-Timestamp header is accepted (ignored today; reserved per #1533 TODO)', async () => {
+            // The current receiver does NOT consult an X-Trigger-Timestamp
+            // header (per the TODO in trigger-webhook.controller.ts).
+            // Pin that the header's presence does NOT break the flow —
+            // when replay protection lands, this test should be flipped
+            // to assert the rejection behaviour.
+            const body = '{}';
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                {
+                    'x-trigger-signature': signBody(body, SECRET),
+                    'x-trigger-timestamp': '2026-06-22T00:00:00.000Z',
+                },
+            );
+
+            expect(result).toEqual({ ok: true });
+            expect(eventRouter.route).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('secret store integration', () => {
+        it('does not call router when secret resolver returns null (401)', async () => {
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue(null as never);
+
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: '{}' },
+                    { 'x-trigger-signature': signBody('{}', SECRET) },
+                ),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+            expect(eventRouter.route).not.toHaveBeenCalled();
+        });
+
+        it('returns 401 when webhookSecret is empty string (fail-closed)', async () => {
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: '' });
+
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: '{}' },
+                    { 'x-trigger-signature': signBody('{}', SECRET) },
+                ),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+
+        it('returns 401 when webhookSecret is not a string (e.g. accidental object)', async () => {
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            // A misconfigured secret store could legitimately return a
+            // non-string under the same key — must fail closed.
+            secretStore.resolve.mockResolvedValue({
+                webhookSecret: { nested: 'oops' } as unknown as string,
+            });
+
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: '{}' },
+                    { 'x-trigger-signature': signBody('{}', SECRET) },
+                ),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+    });
+
+    describe('idempotency at the controller layer', () => {
+        it('replay storm: 10 identical deliveries all 200 + each forwards to router', async () => {
+            const body = JSON.stringify({
+                event_type: 'alert.run.succeeded',
+                tenant_id: TENANT_ID,
+                created_at: '2026-06-22T00:00:00.000Z',
+                payload: { run: { id: 'run_idem' } },
+            });
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+            const sig = signBody(body, SECRET);
+
+            for (let i = 0; i < 10; i++) {
+                const result = await controller.receive(
+                    TENANT_ID,
+                    { rawBody: body },
+                    { 'x-trigger-signature': sig },
+                );
+                expect(result).toEqual({ ok: true });
+            }
+
+            // Controller is intentionally stateless: every valid
+            // delivery hits the router. De-dup is a subscriber concern.
+            expect(eventRouter.route).toHaveBeenCalledTimes(10);
+        });
+
+        it('throws synchronously when router itself throws — operator-visible error path', async () => {
+            // Pinning the current behaviour: the controller does NOT
+            // wrap router.route() in a try/catch. The router's contract
+            // is "never throw"; if it does, the failure should surface
+            // as a 500 so operators see it (route causes redelivery,
+            // which is fine since the body was valid).
+            const body = JSON.stringify({
+                event_type: 'alert.run.succeeded',
+                tenant_id: TENANT_ID,
+                created_at: '2026-06-22T00:00:00.000Z',
+                payload: { run: { id: 'run_throw' } },
+            });
+            tenantRepo.findOne.mockResolvedValue(buildOverlayRow());
+            secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+            eventRouter.route.mockImplementation(() => {
+                throw new Error('router bug');
+            });
+
+            await expect(
+                controller.receive(
+                    TENANT_ID,
+                    { rawBody: body },
+                    { 'x-trigger-signature': signBody(body, SECRET) },
+                ),
+            ).rejects.toThrow('router bug');
+        });
+    });
+});

--- a/apps/api/src/webhooks/__tests__/trigger-webhook-end-to-end.itest.spec.ts
+++ b/apps/api/src/webhooks/__tests__/trigger-webhook-end-to-end.itest.spec.ts
@@ -1,0 +1,656 @@
+/**
+ * EW-1516 — integration tests #1: full controller → router → subscribers chain.
+ *
+ * Wires the receiver, router, and BOTH subscribers in a single
+ * @nestjs/testing module. Mocks the tenant overlay repo + secret
+ * store + WorkGenerationHistoryRepository + SentryService. Uses a
+ * REAL EventEmitter2 instance so subscriber @OnEvent bindings fire
+ * end-to-end after a controller call returns 200.
+ *
+ * Tests cover:
+ *  - Happy path per supported event type (5 events).
+ *  - Idempotency: same delivery twice → row terminal-stable.
+ *  - Cross-tenant safety at the controller layer.
+ *  - Replay storm: 10 valid deliveries in flight.
+ *  - Malformed envelope → 200 ack, router drops, no subscriber fires.
+ *  - Invalid signature → 401, NO router call, NO subscriber call.
+ *  - Unknown tenant → 404, NO router call, NO subscriber call.
+ */
+
+// Stub external workspace imports so Jest doesn't pull the auth /
+// agent transitive chain. Mirrors the per-spec patterns used by the
+// existing controller + subscriber unit tests.
+jest.mock('../../auth/decorators/public.decorator', () => ({ Public: () => () => undefined }));
+jest.mock('@ever-works/agent/entities', () => ({ TenantJobRuntimeConfig: class {} }));
+jest.mock('@ever-works/agent/tasks', () => ({
+    SECRET_STORE_RESOLVER: Symbol.for('SECRET_STORE_RESOLVER_TEST_E2E'),
+}));
+jest.mock('@ever-works/agent/database', () => ({
+    WorkGenerationHistoryRepository: class {},
+}));
+
+import { Logger } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { createHmac } from 'crypto';
+
+// eslint-disable-next-line import/first
+import { TenantJobRuntimeConfig } from '@ever-works/agent/entities';
+// eslint-disable-next-line import/first
+import { SECRET_STORE_RESOLVER } from '@ever-works/agent/tasks';
+// eslint-disable-next-line import/first
+import type { SecretStoreResolver } from '@ever-works/agent/tasks';
+// eslint-disable-next-line import/first
+import { WorkGenerationHistoryRepository } from '@ever-works/agent/database';
+// eslint-disable-next-line import/first
+import { SentryService } from '@ever-works/monitoring';
+// eslint-disable-next-line import/first
+import { GenerateStatusType } from '@ever-works/contracts/api';
+// eslint-disable-next-line import/first
+import { TriggerWebhookController } from '../trigger-webhook.controller';
+// eslint-disable-next-line import/first
+import { TriggerWebhookEventRouterService } from '../trigger-webhook-event-router.service';
+// eslint-disable-next-line import/first
+import { TriggerRunStatusSubscriber } from '../subscribers/trigger-run-status.subscriber';
+// eslint-disable-next-line import/first
+import { TriggerRunFailureSentryBreadcrumbSubscriber } from '../subscribers/trigger-run-failure-sentry-breadcrumb.subscriber';
+// eslint-disable-next-line import/first
+import { TRIGGER_WEBHOOK_EVENTS } from '../trigger-webhook-events';
+
+const TENANT_ID = '00000000-0000-0000-0000-000000000111';
+const OTHER_TENANT = '00000000-0000-0000-0000-000000000222';
+const SECRET = 'super-secret-webhook-key-e2e';
+const POINTER = 'inline:dGVzdA==';
+
+type TenantRow = { tenantId: string; credentialsSecretRef: string | null };
+
+function signBody(body: string, secret: string): string {
+    const hex = createHmac('sha256', secret).update(body, 'utf8').digest('hex');
+    return `sha256=${hex}`;
+}
+
+function envelope(opts: {
+    eventType: string;
+    runId?: string;
+    deploymentId?: string;
+    errorMessage?: string;
+    tenantId?: string;
+    createdAt?: string;
+}): string {
+    const payload: Record<string, unknown> = {};
+    if (opts.runId) {
+        const run: Record<string, unknown> = { id: opts.runId };
+        if (opts.errorMessage) run.error = { message: opts.errorMessage };
+        payload.run = run;
+    }
+    if (opts.deploymentId) {
+        const dep: Record<string, unknown> = { id: opts.deploymentId };
+        if (opts.errorMessage) dep.error = { message: opts.errorMessage };
+        payload.deployment = dep;
+    }
+    return JSON.stringify({
+        event_type: opts.eventType,
+        tenant_id: opts.tenantId ?? TENANT_ID,
+        created_at: opts.createdAt ?? '2026-06-22T08:00:00.000Z',
+        payload,
+    });
+}
+
+async function settle(): Promise<void> {
+    // EventEmitter2 fires async @OnEvent handlers on the microtask queue;
+    // flush before assertions that observe persistence writes.
+    await new Promise((r) => setImmediate(r));
+}
+
+describe('Trigger.dev webhook — controller → router → subscribers (end-to-end)', () => {
+    let module: TestingModule;
+    let controller: TriggerWebhookController;
+    let tenantRepo: { findOne: jest.Mock<Promise<TenantRow | null>, [unknown]> };
+    let secretStore: jest.Mocked<SecretStoreResolver>;
+    let history: jest.Mocked<
+        Pick<WorkGenerationHistoryRepository, 'findByTriggerRunId' | 'updateEntry'>
+    >;
+    let sentry: jest.Mocked<Pick<SentryService, 'error'>>;
+    let logSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+        tenantRepo = { findOne: jest.fn() };
+        secretStore = { resolve: jest.fn() } as jest.Mocked<SecretStoreResolver>;
+        history = {
+            findByTriggerRunId: jest.fn(),
+            updateEntry: jest.fn(),
+        };
+        sentry = { error: jest.fn() };
+
+        module = await Test.createTestingModule({
+            imports: [EventEmitterModule.forRoot()],
+            controllers: [TriggerWebhookController],
+            providers: [
+                TriggerWebhookEventRouterService,
+                TriggerRunStatusSubscriber,
+                TriggerRunFailureSentryBreadcrumbSubscriber,
+                { provide: getRepositoryToken(TenantJobRuntimeConfig), useValue: tenantRepo },
+                { provide: SECRET_STORE_RESOLVER, useValue: secretStore },
+                { provide: WorkGenerationHistoryRepository, useValue: history },
+                { provide: SentryService, useValue: sentry },
+            ],
+        }).compile();
+
+        await module.init();
+        controller = module.get(TriggerWebhookController);
+
+        logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+        warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+        debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+        errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    });
+
+    afterEach(async () => {
+        logSpy.mockRestore();
+        warnSpy.mockRestore();
+        debugSpy.mockRestore();
+        errorSpy.mockRestore();
+        await module.close();
+        jest.resetAllMocks();
+    });
+
+    function arrangeKnownTenant(): void {
+        tenantRepo.findOne.mockResolvedValue({
+            tenantId: TENANT_ID,
+            credentialsSecretRef: POINTER,
+        });
+        secretStore.resolve.mockResolvedValue({ webhookSecret: SECRET });
+    }
+
+    async function deliver(
+        eventType: string,
+        opts: {
+            runId?: string;
+            deploymentId?: string;
+            errorMessage?: string;
+            tenantId?: string;
+            createdAt?: string;
+            secret?: string;
+            tamper?: boolean;
+        } = {},
+    ): Promise<unknown> {
+        const body = envelope({
+            eventType,
+            runId: opts.runId,
+            deploymentId: opts.deploymentId,
+            errorMessage: opts.errorMessage,
+            tenantId: opts.tenantId,
+            createdAt: opts.createdAt,
+        });
+        const sig = opts.tamper
+            ? 'sha256=' + '0'.repeat(64)
+            : signBody(body, opts.secret ?? SECRET);
+        return controller.receive(
+            TENANT_ID,
+            { rawBody: body },
+            { 'x-trigger-signature': sig },
+        );
+    }
+
+    describe('happy path per event type (5 events)', () => {
+        it('alert.run.succeeded → 200 + persistence flips row to GENERATED + NO Sentry call', async () => {
+            arrangeKnownTenant();
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-s',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-s' } as never);
+
+            const result = await deliver('alert.run.succeeded', { runId: 'run_s' });
+            await settle();
+
+            expect(result).toEqual({ ok: true });
+            expect(history.findByTriggerRunId).toHaveBeenCalledWith('run_s');
+            expect(history.updateEntry).toHaveBeenCalledWith(
+                'hist-s',
+                expect.objectContaining({ status: GenerateStatusType.GENERATED }),
+            );
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+
+        it('alert.run.failed → 200 + persistence flips to ERROR + Sentry called with runId+errorMessage', async () => {
+            arrangeKnownTenant();
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-f',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-f' } as never);
+
+            const result = await deliver('alert.run.failed', {
+                runId: 'run_f',
+                errorMessage: 'task crashed',
+            });
+            await settle();
+
+            expect(result).toEqual({ ok: true });
+            expect(history.updateEntry).toHaveBeenCalledWith(
+                'hist-f',
+                expect.objectContaining({
+                    status: GenerateStatusType.ERROR,
+                    errorMessage: 'task crashed',
+                }),
+            );
+            expect(sentry.error).toHaveBeenCalledTimes(1);
+            const [msg, attrs] = sentry.error.mock.calls[0];
+            expect(String(msg)).toContain('trigger.run.failed');
+            expect(attrs).toMatchObject({
+                tenantId: TENANT_ID,
+                runId: 'run_f',
+                errorMessage: 'task crashed',
+            });
+        });
+
+        it('alert.run.cancelled → 200 + persistence flips to CANCELLED + NO Sentry call', async () => {
+            arrangeKnownTenant();
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-c',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-c' } as never);
+
+            const result = await deliver('alert.run.cancelled', { runId: 'run_c' });
+            await settle();
+
+            expect(result).toEqual({ ok: true });
+            expect(history.updateEntry).toHaveBeenCalledWith(
+                'hist-c',
+                expect.objectContaining({ status: GenerateStatusType.CANCELLED }),
+            );
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+
+        it('alert.deployment.success → 200 + NO persistence write + NO Sentry call', async () => {
+            arrangeKnownTenant();
+
+            const result = await deliver('alert.deployment.success', {
+                deploymentId: 'dep_ok',
+            });
+            await settle();
+
+            expect(result).toEqual({ ok: true });
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(history.updateEntry).not.toHaveBeenCalled();
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+
+        it('alert.deployment.failed → 200 + NO persistence write + Sentry called with deploymentId', async () => {
+            arrangeKnownTenant();
+
+            const result = await deliver('alert.deployment.failed', {
+                deploymentId: 'dep_bad',
+                errorMessage: 'image pull failed',
+            });
+            await settle();
+
+            expect(result).toEqual({ ok: true });
+            expect(history.updateEntry).not.toHaveBeenCalled();
+            expect(sentry.error).toHaveBeenCalledTimes(1);
+            const [msg, attrs] = sentry.error.mock.calls[0];
+            expect(String(msg)).toContain('trigger.deployment.failed');
+            expect(attrs).toMatchObject({
+                tenantId: TENANT_ID,
+                deploymentId: 'dep_bad',
+                errorMessage: 'image pull failed',
+            });
+        });
+
+        it('controller logs the received event metadata on accept', async () => {
+            arrangeKnownTenant();
+
+            // The controller logs `payload?.id` and `payload?.type`
+            // (the receiver's TriggerWebhookPayload interface — top-
+            // level id/type fields). The envelope() helper builds the
+            // router-shape body (`event_type` + `tenant_id` + payload),
+            // so we hand-roll a body here with the receiver-side
+            // fields PLUS the router-shape fields so both layers log
+            // something useful.
+            const body = JSON.stringify({
+                id: 'evt_log',
+                type: 'run.succeeded',
+                event_type: 'alert.run.succeeded',
+                tenant_id: TENANT_ID,
+                created_at: '2026-06-22T00:00:00.000Z',
+                payload: { run: { id: 'run_log' } },
+            });
+            await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            );
+
+            // Controller log line: includes tenantId + the top-level
+            // id/type fields it surfaces from the receiver-side payload.
+            const logLines = logSpy.mock.calls.map((c) => String(c[0] ?? ''));
+            expect(logLines.some((l) => l.includes(TENANT_ID))).toBe(true);
+            expect(logLines.some((l) => l.includes('evt_log'))).toBe(true);
+            expect(logLines.some((l) => l.includes('run.succeeded'))).toBe(true);
+        });
+    });
+
+    describe('idempotency — at-least-once delivery semantics', () => {
+        it('same RUN_SUCCEEDED delivered twice → row terminal-stable, ONE update + ONE no-op', async () => {
+            arrangeKnownTenant();
+            // Delivery #1: row still GENERATING, gets flipped.
+            history.findByTriggerRunId.mockResolvedValueOnce({
+                id: 'hist-idem',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValueOnce({ id: 'hist-idem' } as never);
+            // Delivery #2: row now GENERATED (matches what we wrote).
+            history.findByTriggerRunId.mockResolvedValueOnce({
+                id: 'hist-idem',
+                status: GenerateStatusType.GENERATED,
+            } as never);
+
+            await deliver('alert.run.succeeded', { runId: 'run_idem' });
+            await settle();
+            await deliver('alert.run.succeeded', { runId: 'run_idem' });
+            await settle();
+
+            // Persistence: one write (the second short-circuits).
+            expect(history.updateEntry).toHaveBeenCalledTimes(1);
+        });
+
+        it('same RUN_FAILED delivered twice → Sentry called TWICE (subscriber is intentionally stateless)', async () => {
+            // Documented in trigger-run-failure-sentry-breadcrumb.subscriber.ts
+            // class header: "Idempotent: a duplicate delivery produces a
+            // duplicate log line. That's fine — operators correlate by
+            // runId and de-dup mentally". This test pins that contract.
+            arrangeKnownTenant();
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-2x',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-2x' } as never);
+
+            await deliver('alert.run.failed', { runId: 'run_2x', errorMessage: 'e' });
+            await settle();
+            await deliver('alert.run.failed', { runId: 'run_2x', errorMessage: 'e' });
+            await settle();
+
+            expect(sentry.error).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('cross-tenant safety', () => {
+        it('event for tenant A in body → persistence still looks up by triggerRunId (route value wins)', async () => {
+            // The body declares OTHER_TENANT but the route param is
+            // TENANT_ID — the router emits with TENANT_ID, and the
+            // persistence subscriber's lookup key is the triggerRunId
+            // (cross-tenant safety relies on runId uniqueness).
+            arrangeKnownTenant();
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-x',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-x' } as never);
+
+            await deliver('alert.run.failed', {
+                runId: 'run_x',
+                tenantId: OTHER_TENANT,
+            });
+            await settle();
+
+            // Sentry attr should carry the ROUTE tenantId, NOT the body's.
+            const [, attrs] = sentry.error.mock.calls[0];
+            expect(attrs).toMatchObject({ tenantId: TENANT_ID });
+            // Router logged the mismatch.
+            expect(
+                warnSpy.mock.calls.some((c) =>
+                    String(c[0] ?? '').includes('tenantId mismatch'),
+                ),
+            ).toBe(true);
+        });
+
+        it('persistence subscriber NEVER sees the body tenant_id', async () => {
+            arrangeKnownTenant();
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-x2',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-x2' } as never);
+
+            await deliver('alert.run.succeeded', {
+                runId: 'run_x2',
+                tenantId: OTHER_TENANT,
+            });
+            await settle();
+
+            // The subscriber's only input is `triggerRunId`. It doesn't
+            // call any tenant-scoped repo method — verifying it received
+            // a runId-only call pins the cross-tenant boundary.
+            expect(history.findByTriggerRunId).toHaveBeenCalledWith('run_x2');
+        });
+    });
+
+    describe('replay storm', () => {
+        it('10 valid distinct deliveries in flight → each persists + no throws', async () => {
+            arrangeKnownTenant();
+            // Round-robin different runIds — each one has its own
+            // history row in GENERATING state.
+            history.findByTriggerRunId.mockImplementation(async (runId: string) => ({
+                id: `hist-${runId}`,
+                status: GenerateStatusType.GENERATING,
+            }) as never);
+            history.updateEntry.mockImplementation(
+                async (id: string) => ({ id }) as never,
+            );
+
+            const deliveries = Array.from({ length: 10 }, (_, i) =>
+                deliver('alert.run.succeeded', { runId: `run_${i}` }),
+            );
+
+            await expect(Promise.all(deliveries)).resolves.toBeDefined();
+            await settle();
+
+            // Each delivery is independent; persistence sees 10 lookups
+            // + 10 updates (no de-dup since runIds differ).
+            expect(history.findByTriggerRunId).toHaveBeenCalledTimes(10);
+            expect(history.updateEntry).toHaveBeenCalledTimes(10);
+        });
+
+        it('10 IDENTICAL deliveries in flight → 1 write + 9 no-op short-circuits', async () => {
+            arrangeKnownTenant();
+            // First call sees GENERATING; subsequent calls (after the
+            // mock's mutation below) see GENERATED. We simulate the
+            // persisted state-machine view by flipping the mock's
+            // return value once the first write resolves.
+            let observedStatus = GenerateStatusType.GENERATING;
+            history.findByTriggerRunId.mockImplementation(async () => ({
+                id: 'hist-storm',
+                status: observedStatus,
+            }) as never);
+            history.updateEntry.mockImplementation(async () => {
+                observedStatus = GenerateStatusType.GENERATED;
+                return { id: 'hist-storm' } as never;
+            });
+
+            // Sequential to make the state-flip deterministic — a true
+            // race would land >1 write, which is acceptable per the
+            // class header's "Idempotent at the SQL layer" note but
+            // unrelated to what this test is pinning.
+            for (let i = 0; i < 10; i++) {
+                await deliver('alert.run.succeeded', { runId: 'run_storm' });
+                await settle();
+            }
+
+            expect(history.updateEntry).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('malformed envelope', () => {
+        it('missing event_type → 200 ack, router drops, NO subscriber fires', async () => {
+            arrangeKnownTenant();
+            const body = JSON.stringify({
+                tenant_id: TENANT_ID,
+                created_at: '2026-06-22T00:00:00.000Z',
+                payload: { run: { id: 'run_x' } },
+            });
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            );
+            await settle();
+
+            expect(result).toEqual({ ok: true });
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(sentry.error).not.toHaveBeenCalled();
+            expect(
+                warnSpy.mock.calls.some((c) =>
+                    String(c[0] ?? '').includes('malformed envelope'),
+                ),
+            ).toBe(true);
+        });
+
+        it('missing payload → 200 ack, router drops, NO subscriber fires', async () => {
+            arrangeKnownTenant();
+            const body = JSON.stringify({
+                event_type: 'alert.run.failed',
+                tenant_id: TENANT_ID,
+                created_at: '2026-06-22T00:00:00.000Z',
+            });
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            );
+            await settle();
+
+            expect(result).toEqual({ ok: true });
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+
+        it('missing tenant_id → 200 ack, router drops, NO subscriber fires', async () => {
+            arrangeKnownTenant();
+            const body = JSON.stringify({
+                event_type: 'alert.run.failed',
+                created_at: '2026-06-22T00:00:00.000Z',
+                payload: { run: { id: 'run_y' } },
+            });
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            );
+            await settle();
+
+            expect(result).toEqual({ ok: true });
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+
+        it('unmapped event_type → 200 ack, router debug-drops, NO subscriber fires', async () => {
+            arrangeKnownTenant();
+            const body = JSON.stringify({
+                event_type: 'alert.future.unknown',
+                tenant_id: TENANT_ID,
+                created_at: '2026-06-22T00:00:00.000Z',
+                payload: { run: { id: 'run_unmapped' } },
+            });
+
+            const result = await controller.receive(
+                TENANT_ID,
+                { rawBody: body },
+                { 'x-trigger-signature': signBody(body, SECRET) },
+            );
+            await settle();
+
+            expect(result).toEqual({ ok: true });
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('invalid signature', () => {
+        it('tampered HMAC → 401 + NO router call + NO subscriber call', async () => {
+            arrangeKnownTenant();
+
+            await expect(
+                deliver('alert.run.failed', { runId: 'run_z', tamper: true }),
+            ).rejects.toThrow();
+            await settle();
+
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(sentry.error).not.toHaveBeenCalled();
+            // Router itself should not have been invoked — but since
+            // the router is constructed by Nest, we assert it via its
+            // emit side-effect (Sentry + history both untouched).
+        });
+
+        it('signature signed with wrong secret → 401 + NO subscriber fires', async () => {
+            arrangeKnownTenant();
+
+            await expect(
+                deliver('alert.run.succeeded', {
+                    runId: 'run_wrong',
+                    secret: 'wrong-secret',
+                }),
+            ).rejects.toThrow();
+            await settle();
+
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+
+        it('missing signature header → 400 + NO repo lookup + NO subscriber fires', async () => {
+            tenantRepo.findOne.mockResolvedValue({
+                tenantId: TENANT_ID,
+                credentialsSecretRef: POINTER,
+            });
+
+            await expect(
+                controller.receive(TENANT_ID, { rawBody: '{}' }, {}),
+            ).rejects.toThrow();
+            await settle();
+
+            expect(tenantRepo.findOne).not.toHaveBeenCalled();
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('unknown tenant', () => {
+        it('tenant repo returns null → 404 + NO secret resolve + NO subscriber fires', async () => {
+            tenantRepo.findOne.mockResolvedValue(null);
+
+            await expect(
+                deliver('alert.run.failed', { runId: 'run_404' }),
+            ).rejects.toThrow();
+            await settle();
+
+            expect(secretStore.resolve).not.toHaveBeenCalled();
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+
+        it('tenant exists but no webhookSecret in bag → 401 + NO subscriber fires', async () => {
+            tenantRepo.findOne.mockResolvedValue({
+                tenantId: TENANT_ID,
+                credentialsSecretRef: POINTER,
+            });
+            secretStore.resolve.mockResolvedValue({ apiKey: 'something-else' });
+
+            await expect(
+                deliver('alert.run.failed', { runId: 'run_no_secret' }),
+            ).rejects.toThrow();
+            await settle();
+
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/api/src/webhooks/__tests__/trigger-webhook-subscribers-deep.itest.spec.ts
+++ b/apps/api/src/webhooks/__tests__/trigger-webhook-subscribers-deep.itest.spec.ts
@@ -1,0 +1,554 @@
+/**
+ * EW-1516 — integration tests #3: deeper subscriber coverage.
+ *
+ * Combines the persistence subscriber (TriggerRunStatusSubscriber) and
+ * the Sentry breadcrumb subscriber in a SINGLE @nestjs/testing module
+ * sharing one EventEmitter2 instance. Events are emitted directly on
+ * the bus to test subscriber behaviour without the controller +
+ * router layers in between.
+ *
+ * Complements (does NOT replace) the per-subscriber unit specs in
+ * apps/api/src/webhooks/subscribers/__tests__/.
+ */
+
+// Stub external workspace packages so Jest doesn't have to resolve
+// their transitive `@src/...` imports — mirrors the existing
+// trigger-run-status.subscriber.spec.ts pattern.
+jest.mock('@ever-works/agent/database', () => ({
+    WorkGenerationHistoryRepository: class {},
+}));
+
+import { Logger } from '@nestjs/common';
+import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkGenerationHistoryRepository } from '@ever-works/agent/database';
+import { SentryService } from '@ever-works/monitoring';
+import { GenerateStatusType } from '@ever-works/contracts/api';
+import { TriggerRunStatusSubscriber } from '../subscribers/trigger-run-status.subscriber';
+import { TriggerRunFailureSentryBreadcrumbSubscriber } from '../subscribers/trigger-run-failure-sentry-breadcrumb.subscriber';
+import {
+    TRIGGER_WEBHOOK_EVENTS,
+    TriggerWebhookInternalEventName,
+    TriggerWebhookInternalEventPayload,
+} from '../trigger-webhook-events';
+
+const TENANT_ID = '00000000-0000-0000-0000-0000000000aa';
+const OTHER_TENANT = '00000000-0000-0000-0000-0000000000bb';
+
+function envelope(
+    internalEventName: TriggerWebhookInternalEventName,
+    payloadOverrides: Record<string, unknown> = {},
+    tenantId: string = TENANT_ID,
+): TriggerWebhookInternalEventPayload {
+    return {
+        tenantId,
+        upstreamEventType: internalEventName.replace('trigger.', 'alert.'),
+        internalEventName,
+        createdAt: '2026-06-22T08:00:00.000Z',
+        payload:
+            internalEventName === TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED ||
+            internalEventName === TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_SUCCEEDED
+                ? { deployment: { id: 'dep_xyz' }, ...payloadOverrides }
+                : {
+                      run: { id: 'run_abc', error: { message: 'oom' } },
+                      ...payloadOverrides,
+                  },
+    };
+}
+
+function makeHistoryMock(): jest.Mocked<
+    Pick<WorkGenerationHistoryRepository, 'findByTriggerRunId' | 'updateEntry'>
+> {
+    return {
+        findByTriggerRunId: jest.fn(),
+        updateEntry: jest.fn(),
+    };
+}
+
+async function settle(): Promise<void> {
+    // EventEmitter2 fires handlers synchronously, but async handlers
+    // (TriggerRunStatusSubscriber.handle is async) need a microtask
+    // flush before assertions see their writes.
+    await new Promise((r) => setImmediate(r));
+}
+
+describe('Trigger.dev subscribers — deep integration', () => {
+    let module: TestingModule;
+    let emitter: EventEmitter2;
+    let history: ReturnType<typeof makeHistoryMock>;
+    let sentry: jest.Mocked<Pick<SentryService, 'error'>>;
+    let logSpy: jest.SpyInstance;
+    let debugSpy: jest.SpyInstance;
+    let errorSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+
+    async function buildModule(opts: { withSentry: boolean } = { withSentry: true }) {
+        history = makeHistoryMock();
+        sentry = { error: jest.fn() };
+
+        const providers: any[] = [
+            TriggerRunStatusSubscriber,
+            TriggerRunFailureSentryBreadcrumbSubscriber,
+            { provide: WorkGenerationHistoryRepository, useValue: history },
+        ];
+        if (opts.withSentry) {
+            providers.push({ provide: SentryService, useValue: sentry });
+        }
+
+        module = await Test.createTestingModule({
+            imports: [EventEmitterModule.forRoot()],
+            providers,
+        }).compile();
+
+        await module.init();
+        emitter = module.get(EventEmitter2);
+    }
+
+    beforeEach(async () => {
+        await buildModule({ withSentry: true });
+        logSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+        debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+        errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+        warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    });
+
+    afterEach(async () => {
+        logSpy.mockRestore();
+        debugSpy.mockRestore();
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+        await module.close();
+        jest.resetAllMocks();
+    });
+
+    describe('persistence — terminal state machine', () => {
+        it.each([
+            {
+                event: TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED,
+                terminal: GenerateStatusType.GENERATED,
+            },
+            {
+                event: TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                terminal: GenerateStatusType.ERROR,
+            },
+            {
+                event: TRIGGER_WEBHOOK_EVENTS.RUN_CANCELLED,
+                terminal: GenerateStatusType.CANCELLED,
+            },
+        ])(
+            'GENERATING → $terminal on $event',
+            async ({ event, terminal }) => {
+                history.findByTriggerRunId.mockResolvedValue({
+                    id: 'hist-1',
+                    status: GenerateStatusType.GENERATING,
+                } as never);
+                history.updateEntry.mockResolvedValue({ id: 'hist-1' } as never);
+
+                emitter.emit(event, envelope(event));
+                await settle();
+
+                expect(history.updateEntry).toHaveBeenCalledTimes(1);
+                const [id, updates] = history.updateEntry.mock.calls[0];
+                expect(id).toBe('hist-1');
+                expect(updates.status).toBe(terminal);
+                expect(updates.finishedAt).toBeInstanceOf(Date);
+            },
+        );
+
+        it('finishedAt uses event.createdAt (not Date.now)', async () => {
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-1',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-1' } as never);
+
+            const evt = envelope(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED);
+            emitter.emit(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED, evt);
+            await settle();
+
+            const finishedAt = history.updateEntry.mock.calls[0][1].finishedAt as Date;
+            expect(finishedAt.toISOString()).toBe(evt.createdAt);
+        });
+
+        it('out-of-order delivery: cancelled arrives after row already GENERATED → no-op short-circuit', async () => {
+            // Row was already flipped to GENERATED by an earlier success
+            // delivery; the late cancelled delivery must NOT clobber the
+            // terminal state.
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-1',
+                status: GenerateStatusType.GENERATED,
+            } as never);
+
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_CANCELLED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_CANCELLED),
+            );
+            await settle();
+
+            expect(history.updateEntry).not.toHaveBeenCalled();
+            expect(debugSpy).toHaveBeenCalled();
+            expect(
+                debugSpy.mock.calls.some((c) =>
+                    String(c[0] ?? '').includes('already terminal'),
+                ),
+            ).toBe(true);
+        });
+
+        it.each([
+            GenerateStatusType.GENERATED,
+            GenerateStatusType.ERROR,
+            GenerateStatusType.CANCELLED,
+        ])(
+            'row already terminal (%s) → short-circuit, no update, no throw',
+            async (priorStatus) => {
+                history.findByTriggerRunId.mockResolvedValue({
+                    id: 'hist-1',
+                    status: priorStatus,
+                } as never);
+
+                emitter.emit(
+                    TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED,
+                    envelope(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED),
+                );
+                await settle();
+
+                expect(history.updateEntry).not.toHaveBeenCalled();
+            },
+        );
+
+        it('row not found → debug log + drop, no throw, no update', async () => {
+            history.findByTriggerRunId.mockResolvedValue(null);
+
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED),
+            );
+            await settle();
+
+            expect(history.updateEntry).not.toHaveBeenCalled();
+            expect(
+                debugSpy.mock.calls.some((c) =>
+                    String(c[0] ?? '').includes('no work_generation_history'),
+                ),
+            ).toBe(true);
+        });
+
+        it('repo.findByTriggerRunId throws → caught + logged, does not propagate', async () => {
+            history.findByTriggerRunId.mockRejectedValue(new Error('db down'));
+
+            // emit is synchronous from EventEmitter2; the throw would
+            // surface inside the subscriber's try/catch.
+            expect(() =>
+                emitter.emit(
+                    TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                    envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED),
+                ),
+            ).not.toThrow();
+            await settle();
+
+            expect(
+                errorSpy.mock.calls.some((c) => String(c[0] ?? '').includes('db down')),
+            ).toBe(true);
+        });
+
+        it('repo.updateEntry throws → caught + logged, does not propagate', async () => {
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-1',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockRejectedValue(new Error('unique constraint'));
+
+            expect(() =>
+                emitter.emit(
+                    TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED,
+                    envelope(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED),
+                ),
+            ).not.toThrow();
+            await settle();
+
+            expect(
+                errorSpy.mock.calls.some((c) =>
+                    String(c[0] ?? '').includes('unique constraint'),
+                ),
+            ).toBe(true);
+        });
+
+        it('errorMessage persisted on RUN_FAILED when payload.run.error.message present', async () => {
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-1',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-1' } as never);
+
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED, {
+                    run: { id: 'run_abc', error: { message: 'OOM killed' } },
+                }),
+            );
+            await settle();
+
+            expect(history.updateEntry).toHaveBeenCalledWith(
+                'hist-1',
+                expect.objectContaining({
+                    status: GenerateStatusType.ERROR,
+                    errorMessage: 'OOM killed',
+                }),
+            );
+        });
+
+        it('errorMessage NOT included on RUN_SUCCEEDED even if payload carries one', async () => {
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-1',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-1' } as never);
+
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED, {
+                    run: { id: 'run_abc', error: { message: 'leftover' } },
+                }),
+            );
+            await settle();
+
+            const updates = history.updateEntry.mock.calls[0][1];
+            expect(updates).not.toHaveProperty('errorMessage');
+        });
+
+        it('long errorMessage truncated to 2048 chars + ellipsis', async () => {
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-1',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-1' } as never);
+
+            const huge = 'x'.repeat(3000);
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED, {
+                    run: { id: 'run_abc', error: { message: huge } },
+                }),
+            );
+            await settle();
+
+            const msg = history.updateEntry.mock.calls[0][1].errorMessage as string;
+            expect(msg.length).toBe(2049); // 2048 + ellipsis (1 char)
+            expect(msg.endsWith('…')).toBe(true);
+        });
+
+        it('deployment.* events do NOT trigger persistence handler', async () => {
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_SUCCEEDED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_SUCCEEDED),
+            );
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED),
+            );
+            await settle();
+
+            expect(history.findByTriggerRunId).not.toHaveBeenCalled();
+            expect(history.updateEntry).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Sentry — failure channel', () => {
+        it('RUN_FAILED → SentryService.error called with runId + errorMessage', async () => {
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED),
+            );
+            await settle();
+
+            expect(sentry.error).toHaveBeenCalledTimes(1);
+            const [msg, attrs] = sentry.error.mock.calls[0];
+            expect(String(msg)).toContain('trigger.run.failed');
+            expect(attrs).toMatchObject({
+                tenantId: TENANT_ID,
+                runId: 'run_abc',
+                errorMessage: 'oom',
+            });
+        });
+
+        it('DEPLOYMENT_FAILED → SentryService.error called with deploymentId', async () => {
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_FAILED),
+            );
+            await settle();
+
+            expect(sentry.error).toHaveBeenCalledTimes(1);
+            const [msg, attrs] = sentry.error.mock.calls[0];
+            expect(String(msg)).toContain('trigger.deployment.failed');
+            expect(attrs).toMatchObject({
+                tenantId: TENANT_ID,
+                deploymentId: 'dep_xyz',
+            });
+        });
+
+        it.each([
+            TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED,
+            TRIGGER_WEBHOOK_EVENTS.RUN_CANCELLED,
+            TRIGGER_WEBHOOK_EVENTS.DEPLOYMENT_SUCCEEDED,
+        ])('non-failure %s does NOT call Sentry', async (eventName) => {
+            // Persistence subscriber may consume some of these; rebuild
+            // a row so the find call doesn't crash.
+            history.findByTriggerRunId.mockResolvedValue(null);
+
+            emitter.emit(eventName, envelope(eventName as TriggerWebhookInternalEventName));
+            await settle();
+
+            expect(sentry.error).not.toHaveBeenCalled();
+        });
+
+        it('Sentry service absent → falls back to Logger.warn with same fields', async () => {
+            await module.close();
+            await buildModule({ withSentry: false });
+            // Re-attach the warn spy on the fresh module's loggers.
+            warnSpy.mockRestore();
+            warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED),
+            );
+            await settle();
+
+            expect(
+                warnSpy.mock.calls.some((c) => {
+                    const line = String(c[0] ?? '');
+                    return (
+                        line.includes('trigger.run.failed') &&
+                        line.includes('SentryService not bound')
+                    );
+                }),
+            ).toBe(true);
+        });
+
+        it('Sentry throws → caught + logged, does not propagate, persistence still runs', async () => {
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-1',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-1' } as never);
+            sentry.error.mockImplementation(() => {
+                throw new Error('sentry transport hosed');
+            });
+
+            expect(() =>
+                emitter.emit(
+                    TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                    envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED),
+                ),
+            ).not.toThrow();
+            await settle();
+
+            // Persistence still wrote.
+            expect(history.updateEntry).toHaveBeenCalledTimes(1);
+            // Sentry path logged its caught error.
+            expect(
+                errorSpy.mock.calls.some((c) =>
+                    String(c[0] ?? '').includes('sentry transport hosed'),
+                ),
+            ).toBe(true);
+        });
+
+        it('payload missing run.id → Sentry still called, just without runId attr', async () => {
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED, {
+                    run: { error: { message: 'boom' } },
+                }),
+            );
+            await settle();
+
+            expect(sentry.error).toHaveBeenCalledTimes(1);
+            const [, attrs] = sentry.error.mock.calls[0];
+            expect(attrs).not.toHaveProperty('runId');
+            expect(attrs).toMatchObject({ errorMessage: 'boom' });
+        });
+
+        it('Sentry attrs include createdAt + upstreamEventType + internalEventName', async () => {
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED),
+            );
+            await settle();
+
+            const [, attrs] = sentry.error.mock.calls[0];
+            expect(attrs).toMatchObject({
+                upstreamEventType: 'alert.run.failed',
+                internalEventName: TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                createdAt: '2026-06-22T08:00:00.000Z',
+            });
+        });
+    });
+
+    describe('subscriber independence', () => {
+        it('persistence throws → Sentry subscriber still fires for RUN_FAILED', async () => {
+            history.findByTriggerRunId.mockRejectedValue(new Error('db'));
+
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED),
+            );
+            await settle();
+
+            // Persistence subscriber swallowed its error (logged).
+            expect(
+                errorSpy.mock.calls.some((c) => String(c[0] ?? '').includes('db')),
+            ).toBe(true);
+            // Sentry still got called — independent subscriber.
+            expect(sentry.error).toHaveBeenCalledTimes(1);
+        });
+
+        it('Sentry throws → persistence subscriber still flips terminal state', async () => {
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-1',
+                status: GenerateStatusType.GENERATING,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-1' } as never);
+            sentry.error.mockImplementation(() => {
+                throw new Error('sentry');
+            });
+
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_FAILED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_FAILED),
+            );
+            await settle();
+
+            expect(history.updateEntry).toHaveBeenCalledWith(
+                'hist-1',
+                expect.objectContaining({ status: GenerateStatusType.ERROR }),
+            );
+        });
+
+        it('cross-tenant isolation: row for tenant A is not updated by event for tenant B', async () => {
+            // The persistence subscriber looks up by triggerRunId only,
+            // so cross-tenant safety relies on triggerRunId uniqueness.
+            // This test pins that behaviour: an event for OTHER_TENANT
+            // that resolves a row with a DIFFERENT tenantId still
+            // proceeds (current behaviour); document it explicitly so a
+            // future contributor sees the constraint.
+            history.findByTriggerRunId.mockResolvedValue({
+                id: 'hist-A',
+                status: GenerateStatusType.GENERATING,
+                tenantId: TENANT_ID,
+            } as never);
+            history.updateEntry.mockResolvedValue({ id: 'hist-A' } as never);
+
+            emitter.emit(
+                TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED,
+                envelope(TRIGGER_WEBHOOK_EVENTS.RUN_SUCCEEDED, {}, OTHER_TENANT),
+            );
+            await settle();
+
+            // Subscriber proceeded with the lookup; pinning current
+            // behaviour. If a future change adds a tenant check the
+            // assertion below should be flipped to `not.toHaveBeenCalled`.
+            expect(history.findByTriggerRunId).toHaveBeenCalledWith('run_abc');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- **68** new integration cases across 3 specs covering the Trigger.dev webhook receiver (#1533), event router (#1537), and subscribers (#1542).
- Combines controller + router + both subscribers in a \`@nestjs/testing\` module with real \`EventEmitter2\`, mocked tenant repo, mocked \`WorkGenerationHistoryRepository\`, mocked \`SentryService\`.
- No live Trigger.dev SDK calls; HMACs computed with \`crypto.createHmac\`.

## Test plan
- [x] \`cd apps/api && pnpm test --testPathPattern='trigger-webhook'\` → 95 passing, 5 suites
- [x] \`cd apps/api && pnpm test\` → 2842 passing (pre-existing unrelated \`plugins-capabilities/*\` failures untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded webhook integration test coverage for signature validation, payload handling, idempotency, error scenarios, and subscriber behavior across the webhook event processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->