### PR TITLE
test(EW-742 P5.1): integration tests for operator per-tenant allow-list (58 cases)

### DIFF
--- a/apps/api/src/account/tenant-job-runtime/__tests__/operator-tenant-runtime-allowlist.controller.itest.spec.ts
+++ b/apps/api/src/account/tenant-job-runtime/__tests__/operator-tenant-runtime-allowlist.controller.itest.spec.ts
@@ -1,0 +1,606 @@
+// EW-742 P5.1 (T35a) — INTEGRATION-level spec for the operator-scoped
+// per-tenant runtime allow-list controller. Drives the controller →
+// service → in-memory-repo path through `@nestjs/testing` so the route
+// handler, DTO routing, audit emission and cross-tenant isolation are
+// exercised end-to-end at the boundary the OpenAPI surface promises —
+// without spinning the full NestJS HTTP listener or a real Postgres
+// instance.
+//
+// Scope (vs. the existing service-level spec at
+// `tenant-job-runtime-allowlist.service.spec.ts`):
+//   - GET / PUT / DELETE wire-level behaviour through the controller
+//   - Response shape conformance (tenantId echo, gating flag echo)
+//   - Cross-tenant write isolation (operator action on tenant A leaves
+//     tenant B's overlay untouched)
+//   - Audit-row emission per mutation, including `tenantId` correctness
+//   - Unknown-providerId path semantic on DELETE (404 NotFoundException,
+//     no audit row written)
+//   - PUT clears + re-populates atomically
+//   - Idempotent DELETE returns 404 + no audit row
+//
+// The `IsPlatformAdminGuard` is exercised in its own spec
+// (`apps/api/src/auth/guards/platform-admin.guard.spec.ts`); this file
+// instantiates the controller directly so it does NOT need to thread a
+// real guard through the NestJS DI graph.
+
+jest.mock('@ever-works/agent/entities', () => ({
+    TenantJobRuntimeConfig: class TenantJobRuntimeConfig {},
+    TenantJobRuntimeAudit: class TenantJobRuntimeAudit {},
+    TenantRuntimeProviderAllowlist: class TenantRuntimeProviderAllowlist {},
+}));
+
+jest.mock('@ever-works/agent/tasks', () => ({
+    CredentialVersionService: class CredentialVersionService {},
+}));
+
+// The controller imports `AuthSessionGuard` from `../../auth` (barrel
+// re-export of the entire auth module — auth.service, controllers,
+// DTOs, etc.). Loading that chain pulls in `@ever-works/agent/database`
+// which transitively imports `@src/config` via `database.config.ts` —
+// jest's `moduleNameMapper` for `@src/...` only resolves files inside
+// `apps/api/src/`, not files inside `packages/agent/`. We never
+// exercise the real guard in this integration spec (its own dedicated
+// spec at `apps/api/src/auth/guards/platform-admin.guard.spec.ts`
+// covers that surface), so stubbing the barrel keeps the import graph
+// shallow.
+jest.mock('../../../auth', () => ({
+    AuthSessionGuard: class AuthSessionGuard {
+        canActivate() {
+            return true;
+        }
+    },
+}));
+jest.mock('../../../auth/guards/platform-admin.guard', () => ({
+    IsPlatformAdminGuard: class IsPlatformAdminGuard {
+        canActivate() {
+            return true;
+        }
+    },
+}));
+jest.mock('../../../auth/decorators/user.decorator', () => ({
+    CurrentUser: () => () => undefined,
+}));
+
+import { randomUUID } from 'node:crypto';
+import { NotFoundException } from '@nestjs/common';
+import type { CredentialVersionService } from '@ever-works/agent/tasks';
+import type { TenantRuntimeProviderAllowlist as TenantRuntimeProviderAllowlistEntity } from '@ever-works/agent/entities';
+import type { AuthenticatedUser } from '../../../auth/types/auth.types';
+import { OperatorTenantRuntimeAllowlistController } from '../../../operator/tenant-runtime-allowlist/operator-tenant-runtime-allowlist.controller';
+import { TenantJobRuntimeService } from '../tenant-job-runtime.service';
+
+type AllowlistRow = TenantRuntimeProviderAllowlistEntity & { createdAt: Date };
+
+const PER_TENANT_GATING_ENV = 'EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING';
+const GLOBAL_ALLOWLIST_ENV = 'EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS';
+
+function buildAuth(overrides: Partial<AuthenticatedUser> = {}): AuthenticatedUser {
+    return {
+        userId: 'operator-user-1',
+        email: 'op@example.test',
+        username: 'op',
+        provider: 'local',
+        emailVerified: true,
+        isActive: true,
+        avatar: null,
+        iat: 0,
+        iss: '',
+        aud: '',
+        ...overrides,
+    } as AuthenticatedUser;
+}
+
+describe('OperatorTenantRuntimeAllowlistController — integration (EW-742 P5.1 T35a)', () => {
+    let controller: OperatorTenantRuntimeAllowlistController;
+    let service: TenantJobRuntimeService;
+    let auditRepo: { create: jest.Mock; save: jest.Mock };
+    let allowlistRepo: {
+        find: jest.Mock;
+        delete: jest.Mock;
+        create: jest.Mock;
+        save: jest.Mock;
+    };
+    let dataSource: { transaction: jest.Mock };
+
+    // Shared in-memory store backing the allow-list repo. Reset per test.
+    let store: AllowlistRow[];
+
+    const originalGating = process.env[PER_TENANT_GATING_ENV];
+    const originalGlobal = process.env[GLOBAL_ALLOWLIST_ENV];
+
+    beforeEach(() => {
+        store = [];
+
+        const configRepo = {
+            findOne: jest.fn(),
+            create: jest.fn((row) => row),
+            save: jest.fn((row) => row),
+        };
+        auditRepo = {
+            create: jest.fn((row) => row),
+            save: jest.fn(async (row) => row),
+        };
+        allowlistRepo = {
+            find: jest.fn(async ({ where }: { where: { tenantId: string } }) =>
+                store
+                    .filter((r) => r.tenantId === where.tenantId)
+                    .slice()
+                    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
+            ),
+            delete: jest.fn(async (criteria: Partial<AllowlistRow>) => {
+                const before = store.length;
+                store = store.filter((r) => {
+                    if (criteria.tenantId && r.tenantId !== criteria.tenantId) return true;
+                    if (criteria.providerId && r.providerId !== criteria.providerId) return true;
+                    return false;
+                });
+                return { affected: before - store.length };
+            }),
+            create: jest.fn((row: Partial<AllowlistRow>) => ({
+                createdAt: new Date(),
+                createdBy: row.createdBy ?? null,
+                ...row,
+            })),
+            save: jest.fn(async (rows: AllowlistRow | AllowlistRow[]) => {
+                const arr = Array.isArray(rows) ? rows : [rows];
+                for (const r of arr) store.push(r);
+                return arr;
+            }),
+        };
+        dataSource = {
+            transaction: jest.fn(async (cb: (manager: unknown) => Promise<void>) => {
+                const manager = { getRepository: () => allowlistRepo };
+                return cb(manager);
+            }),
+        };
+        const credentialVersionService = {
+            bumpVersion: jest.fn(),
+        } as unknown as jest.Mocked<Pick<CredentialVersionService, 'bumpVersion'>>;
+
+        service = new TenantJobRuntimeService(
+            configRepo as any,
+            auditRepo as any,
+            credentialVersionService as unknown as CredentialVersionService,
+            allowlistRepo as any,
+            dataSource as any,
+        );
+        controller = new OperatorTenantRuntimeAllowlistController(service);
+    });
+
+    afterEach(() => {
+        if (originalGating === undefined) {
+            delete process.env[PER_TENANT_GATING_ENV];
+        } else {
+            process.env[PER_TENANT_GATING_ENV] = originalGating;
+        }
+        if (originalGlobal === undefined) {
+            delete process.env[GLOBAL_ALLOWLIST_ENV];
+        } else {
+            process.env[GLOBAL_ALLOWLIST_ENV] = originalGlobal;
+        }
+    });
+
+    // ─── GET /api/operator/tenants/:tenantId/runtime-allowlist ──────────
+
+    describe('GET — list per-tenant allow-list rows', () => {
+        it('returns an empty list + the gating flag for a tenant with no overlay rows', async () => {
+            delete process.env[PER_TENANT_GATING_ENV];
+            const tenantId = randomUUID();
+
+            const result = await controller.list(tenantId);
+
+            expect(result).toEqual({
+                tenantId,
+                providerIds: [],
+                perTenantGatingEnabled: false,
+            });
+            expect(allowlistRepo.find).toHaveBeenCalledWith({
+                where: { tenantId },
+                order: { createdAt: 'ASC' },
+            });
+        });
+
+        it('returns providerIds in insertion order when the tenant has 3 rows', async () => {
+            const tenantId = randomUUID();
+            store.push(
+                {
+                    tenantId,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId,
+                    providerId: 'temporal',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId,
+                    providerId: 'bullmq',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:03.000Z'),
+                } as AllowlistRow,
+            );
+
+            const result = await controller.list(tenantId);
+
+            expect(result.providerIds).toEqual(['trigger', 'temporal', 'bullmq']);
+            expect(result.tenantId).toBe(tenantId);
+        });
+
+        it('echoes perTenantGatingEnabled=true when the env flag is on', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'true';
+            const result = await controller.list(randomUUID());
+            expect(result.perTenantGatingEnabled).toBe(true);
+        });
+
+        it('echoes perTenantGatingEnabled=false when the env flag is off', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'false';
+            const result = await controller.list(randomUUID());
+            expect(result.perTenantGatingEnabled).toBe(false);
+        });
+
+        it('does NOT leak rows from a different tenant', async () => {
+            const tenantA = randomUUID();
+            const tenantB = randomUUID();
+            store.push(
+                {
+                    tenantId: tenantA,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId: tenantB,
+                    providerId: 'temporal',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                } as AllowlistRow,
+            );
+
+            const a = await controller.list(tenantA);
+            const b = await controller.list(tenantB);
+
+            expect(a.providerIds).toEqual(['trigger']);
+            expect(b.providerIds).toEqual(['temporal']);
+        });
+
+        it('silently drops a legacy row whose providerId is no longer in the static enum', async () => {
+            const tenantId = randomUUID();
+            store.push(
+                {
+                    tenantId,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId,
+                    providerId: 'retired-provider' as any,
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                } as AllowlistRow,
+            );
+
+            const result = await controller.list(tenantId);
+
+            // The retired provider id is silently filtered — matches the
+            // resolver's "global is the upper bound" semantic.
+            expect(result.providerIds).toEqual(['trigger']);
+        });
+    });
+
+    // ─── PUT /api/operator/tenants/:tenantId/runtime-allowlist ──────────
+
+    describe('PUT — replace per-tenant allow-list atomically', () => {
+        it('persists the supplied providerIds in order + echoes them back', async () => {
+            const tenantId = randomUUID();
+            const auth = buildAuth();
+
+            const result = await controller.replace(
+                tenantId,
+                { providerIds: ['trigger', 'temporal'] } as any,
+                auth,
+            );
+
+            expect(result.tenantId).toBe(tenantId);
+            expect(result.providerIds).toEqual(['trigger', 'temporal']);
+            expect(store.map((r) => r.providerId)).toEqual(['trigger', 'temporal']);
+            // Single atomic transaction — DataSource.transaction called once.
+            expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+        });
+
+        it('records who replaced the list via the actorUserId on the audit row', async () => {
+            const tenantId = randomUUID();
+            const auth = buildAuth({ userId: 'op-bob' });
+
+            await controller.replace(tenantId, { providerIds: ['trigger'] } as any, auth);
+
+            const payload = auditRepo.create.mock.calls[0][0];
+            expect(payload.action).toBe('operator_allowlist_change');
+            expect(payload.actorUserId).toBe('op-bob');
+            expect(payload.tenantId).toBe(tenantId);
+            expect(payload.before).toEqual({ providerIds: [] });
+            expect(payload.after).toEqual({ providerIds: ['trigger'] });
+        });
+
+        it('an empty providerIds array clears the per-tenant overlay (tenant falls back to inherit)', async () => {
+            const tenantId = randomUUID();
+            store.push(
+                {
+                    tenantId,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId,
+                    providerId: 'bullmq',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                } as AllowlistRow,
+            );
+
+            const result = await controller.replace(
+                tenantId,
+                { providerIds: [] } as any,
+                buildAuth(),
+            );
+
+            expect(result.providerIds).toEqual([]);
+            expect(store.filter((r) => r.tenantId === tenantId)).toHaveLength(0);
+
+            const payload = auditRepo.create.mock.calls[0][0];
+            expect(payload.before).toEqual({ providerIds: ['trigger', 'bullmq'] });
+            expect(payload.after).toEqual({ providerIds: [] });
+        });
+
+        it('atomically replaces an existing row set (delete-then-insert in one txn)', async () => {
+            const tenantId = randomUUID();
+            store.push(
+                {
+                    tenantId,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId,
+                    providerId: 'temporal',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                } as AllowlistRow,
+            );
+
+            const result = await controller.replace(
+                tenantId,
+                { providerIds: ['bullmq', 'pgboss', 'inngest'] } as any,
+                buildAuth(),
+            );
+
+            expect(result.providerIds).toEqual(['bullmq', 'pgboss', 'inngest']);
+            // The two prior rows were removed; the three new rows replaced them.
+            expect(store.filter((r) => r.tenantId === tenantId).map((r) => r.providerId)).toEqual([
+                'bullmq',
+                'pgboss',
+                'inngest',
+            ]);
+            // Still a single transaction (not delete-commit + insert-commit).
+            expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+        });
+
+        it('cross-tenant safety — a replace on tenant A does NOT touch tenant B rows', async () => {
+            const tenantA = randomUUID();
+            const tenantB = randomUUID();
+            store.push(
+                {
+                    tenantId: tenantA,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId: tenantB,
+                    providerId: 'temporal',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId: tenantB,
+                    providerId: 'bullmq',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:03.000Z'),
+                } as AllowlistRow,
+            );
+
+            await controller.replace(
+                tenantA,
+                { providerIds: ['inngest', 'pgboss'] } as any,
+                buildAuth(),
+            );
+
+            // Tenant A flipped to the new set.
+            expect(
+                store.filter((r) => r.tenantId === tenantA).map((r) => r.providerId),
+            ).toEqual(['inngest', 'pgboss']);
+            // Tenant B unchanged — same 2 rows, in the same order.
+            expect(
+                store.filter((r) => r.tenantId === tenantB).map((r) => r.providerId),
+            ).toEqual(['temporal', 'bullmq']);
+            // Audit row tagged with tenant A, not tenant B.
+            const payload = auditRepo.create.mock.calls[0][0];
+            expect(payload.tenantId).toBe(tenantA);
+        });
+
+        it('passes the actor userId through to the per-row `createdBy` column', async () => {
+            const tenantId = randomUUID();
+            await controller.replace(
+                tenantId,
+                { providerIds: ['trigger'] } as any,
+                buildAuth({ userId: 'op-alice' }),
+            );
+
+            const row = store.find((r) => r.tenantId === tenantId);
+            expect(row?.createdBy).toBe('op-alice');
+        });
+
+        it('writes the audit row AFTER the transaction commits (single audit row per mutation)', async () => {
+            const tenantId = randomUUID();
+            await controller.replace(
+                tenantId,
+                { providerIds: ['trigger', 'temporal'] } as any,
+                buildAuth(),
+            );
+            expect(auditRepo.create).toHaveBeenCalledTimes(1);
+            expect(auditRepo.save).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // ─── DELETE /api/operator/tenants/:tenantId/runtime-allowlist/:providerId
+
+    describe('DELETE — remove a single per-tenant entry', () => {
+        it('removes the row + returns the remaining list', async () => {
+            const tenantId = randomUUID();
+            store.push(
+                {
+                    tenantId,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId,
+                    providerId: 'temporal',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                } as AllowlistRow,
+            );
+
+            const result = await controller.removeEntry(tenantId, 'trigger', buildAuth());
+
+            expect(result.providerIds).toEqual(['temporal']);
+            expect(store.map((r) => r.providerId)).toEqual(['temporal']);
+        });
+
+        it('emits an operator_allowlist_change audit row recording before/after', async () => {
+            const tenantId = randomUUID();
+            store.push(
+                {
+                    tenantId,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId,
+                    providerId: 'temporal',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                } as AllowlistRow,
+            );
+
+            await controller.removeEntry(tenantId, 'temporal', buildAuth({ userId: 'op-eve' }));
+
+            const payload = auditRepo.create.mock.calls[0][0];
+            expect(payload.action).toBe('operator_allowlist_change');
+            expect(payload.tenantId).toBe(tenantId);
+            expect(payload.actorUserId).toBe('op-eve');
+            expect(payload.before).toEqual({ providerIds: ['trigger', 'temporal'] });
+            expect(payload.after).toEqual({ providerIds: ['trigger'] });
+        });
+
+        it('404s when the providerId is not in the per-tenant overlay (no audit row)', async () => {
+            const tenantId = randomUUID();
+            await expect(
+                controller.removeEntry(tenantId, 'trigger', buildAuth()),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(auditRepo.create).not.toHaveBeenCalled();
+            expect(auditRepo.save).not.toHaveBeenCalled();
+        });
+
+        it('404s when the providerId is not a known runtime id (defensive layer)', async () => {
+            const tenantId = randomUUID();
+            // Path-param value is rejected at the controller before any
+            // service call (and definitely before any DELETE against the
+            // store). Matches the DTO's `IsIn` posture on PUT.
+            await expect(
+                controller.removeEntry(tenantId, 'not-a-real-runtime', buildAuth()),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(allowlistRepo.delete).not.toHaveBeenCalled();
+        });
+
+        it('does NOT touch another tenant when deleting the same providerId for tenant A', async () => {
+            const tenantA = randomUUID();
+            const tenantB = randomUUID();
+            store.push(
+                {
+                    tenantId: tenantA,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                } as AllowlistRow,
+                {
+                    tenantId: tenantB,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                } as AllowlistRow,
+            );
+
+            await controller.removeEntry(tenantA, 'trigger', buildAuth());
+
+            expect(store.filter((r) => r.tenantId === tenantA)).toHaveLength(0);
+            expect(store.filter((r) => r.tenantId === tenantB)).toHaveLength(1);
+        });
+
+        it('echoes the gating flag on the post-delete response', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'true';
+            const tenantId = randomUUID();
+            store.push(
+                {
+                    tenantId,
+                    providerId: 'trigger',
+                    createdBy: null,
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                } as AllowlistRow,
+            );
+
+            const result = await controller.removeEntry(tenantId, 'trigger', buildAuth());
+
+            expect(result.perTenantGatingEnabled).toBe(true);
+            expect(result.providerIds).toEqual([]);
+        });
+    });
+
+    // ─── End-to-end happy path: PUT then GET then DELETE ────────────────
+
+    describe('end-to-end operator flow', () => {
+        it('PUT → GET reflects the new state; DELETE → GET reflects the row removal', async () => {
+            const tenantId = randomUUID();
+            const auth = buildAuth();
+
+            // Initially empty.
+            expect((await controller.list(tenantId)).providerIds).toEqual([]);
+
+            // Replace with 3 providers.
+            await controller.replace(
+                tenantId,
+                { providerIds: ['trigger', 'temporal', 'bullmq'] } as any,
+                auth,
+            );
+            const afterPut = await controller.list(tenantId);
+            expect(afterPut.providerIds).toEqual(['trigger', 'temporal', 'bullmq']);
+
+            // Remove the middle one.
+            await controller.removeEntry(tenantId, 'temporal', auth);
+            const afterDelete = await controller.list(tenantId);
+            expect(afterDelete.providerIds).toEqual(['trigger', 'bullmq']);
+
+            // Two audit rows total: one for PUT, one for DELETE. The GET
+            // calls do NOT emit audit rows.
+            expect(auditRepo.create).toHaveBeenCalledTimes(2);
+            expect(auditRepo.create.mock.calls.every((c) => c[0].tenantId === tenantId)).toBe(true);
+        });
+    });
+});

--- a/apps/api/src/account/tenant-job-runtime/__tests__/tenant-job-runtime-allowlist-resolver.itest.spec.ts
+++ b/apps/api/src/account/tenant-job-runtime/__tests__/tenant-job-runtime-allowlist-resolver.itest.spec.ts
@@ -1,0 +1,311 @@
+// EW-742 P5.1 (T35a) — INTEGRATION-level spec for the
+// `getAvailableProvidersForTenant` 4-way resolver. Drives every branch
+// in plan.md §10 P5.1 — flag OFF, flag ON + empty per-tenant, flag ON +
+// subset, flag ON + superset (with silent drop) — plus edge cases
+// around an empty global allow-list and identity-of-set ordering.
+// Complements the existing service-level allow-list spec by
+// concentrating on the resolver intersection logic + its env coupling.
+
+jest.mock('@ever-works/agent/entities', () => ({
+    TenantJobRuntimeConfig: class TenantJobRuntimeConfig {},
+    TenantJobRuntimeAudit: class TenantJobRuntimeAudit {},
+    TenantRuntimeProviderAllowlist: class TenantRuntimeProviderAllowlist {},
+}));
+
+jest.mock('@ever-works/agent/tasks', () => ({
+    CredentialVersionService: class CredentialVersionService {},
+}));
+
+import { randomUUID } from 'node:crypto';
+import type { CredentialVersionService } from '@ever-works/agent/tasks';
+import type { TenantRuntimeProviderAllowlist as TenantRuntimeProviderAllowlistEntity } from '@ever-works/agent/entities';
+import { TenantJobRuntimeService } from '../tenant-job-runtime.service';
+
+type AllowlistRow = TenantRuntimeProviderAllowlistEntity & { createdAt: Date };
+
+const PER_TENANT_GATING_ENV = 'EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING';
+const GLOBAL_ALLOWLIST_ENV = 'EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS';
+
+function buildAllowlistRow(overrides: Partial<AllowlistRow> = {}): AllowlistRow {
+    return {
+        tenantId: 'tenant-1',
+        providerId: 'trigger',
+        createdBy: null,
+        createdAt: new Date('2026-06-18T00:00:00.000Z'),
+        ...overrides,
+    } as AllowlistRow;
+}
+
+describe('TenantJobRuntimeService.getAvailableProvidersForTenant — resolver intersection (integration, EW-742 P5.1 T35a)', () => {
+    let service: TenantJobRuntimeService;
+    let allowlistRepo: { find: jest.Mock };
+    let store: AllowlistRow[];
+
+    const originalGating = process.env[PER_TENANT_GATING_ENV];
+    const originalGlobal = process.env[GLOBAL_ALLOWLIST_ENV];
+
+    beforeEach(() => {
+        store = [];
+        const configRepo = { findOne: jest.fn(), create: jest.fn(), save: jest.fn() };
+        const auditRepo = { create: jest.fn((r) => r), save: jest.fn(async (r) => r) };
+        allowlistRepo = {
+            find: jest.fn(async ({ where }: { where: { tenantId: string } }) =>
+                store
+                    .filter((r) => r.tenantId === where.tenantId)
+                    .slice()
+                    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
+            ),
+        } as any;
+        const dataSource = { transaction: jest.fn() };
+        const credentialVersionService = {
+            bumpVersion: jest.fn(),
+        } as unknown as CredentialVersionService;
+
+        service = new TenantJobRuntimeService(
+            configRepo as any,
+            auditRepo as any,
+            credentialVersionService,
+            allowlistRepo as any,
+            dataSource as any,
+        );
+    });
+
+    afterEach(() => {
+        if (originalGating === undefined) {
+            delete process.env[PER_TENANT_GATING_ENV];
+        } else {
+            process.env[PER_TENANT_GATING_ENV] = originalGating;
+        }
+        if (originalGlobal === undefined) {
+            delete process.env[GLOBAL_ALLOWLIST_ENV];
+        } else {
+            process.env[GLOBAL_ALLOWLIST_ENV] = originalGlobal;
+        }
+    });
+
+    // ─── State 1: gating flag OFF ──────────────────────────────────────
+
+    describe('flag OFF', () => {
+        it('returns the global list even when per-tenant rows would narrow it', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'false';
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq';
+            const tenantId = randomUUID();
+            store.push(buildAllowlistRow({ tenantId, providerId: 'trigger' }));
+
+            const result = await service.getAvailableProvidersForTenant(tenantId);
+
+            expect(result).toEqual(['trigger', 'temporal', 'bullmq']);
+            // When the flag is OFF, the resolver short-circuits before
+            // hitting the per-tenant repo — a hot read path optimization.
+            expect(allowlistRepo.find).not.toHaveBeenCalled();
+        });
+
+        it('falls back to the bundled providers when the env var is unset (and ignores per-tenant)', async () => {
+            delete process.env[PER_TENANT_GATING_ENV];
+            delete process.env[GLOBAL_ALLOWLIST_ENV];
+            const tenantId = randomUUID();
+            store.push(buildAllowlistRow({ tenantId, providerId: 'trigger' }));
+
+            const result = await service.getAvailableProvidersForTenant(tenantId);
+
+            // All 5 bundled providers, no narrowing.
+            expect(result).toEqual(['trigger', 'temporal', 'bullmq', 'pgboss', 'inngest']);
+        });
+    });
+
+    // ─── State 2: flag ON + empty per-tenant ───────────────────────────
+
+    describe('flag ON, tenant has no per-tenant rows (inherit default)', () => {
+        it('returns the global list verbatim', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'true';
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq';
+
+            const result = await service.getAvailableProvidersForTenant(randomUUID());
+
+            expect(result).toEqual(['trigger', 'temporal', 'bullmq']);
+            // The resolver DID hit the per-tenant repo (proves it reached
+            // the gated branch), but found no rows.
+            expect(allowlistRepo.find).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // ─── State 3: flag ON + per-tenant ⊆ global ────────────────────────
+
+    describe('flag ON, per-tenant is a strict subset of global', () => {
+        it('returns the intersection in GLOBAL order (not per-tenant insertion order)', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'true';
+            // Global declared as: trigger → temporal → bullmq → pgboss
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq,pgboss';
+            const tenantId = randomUUID();
+            // Per-tenant in REVERSE order: pgboss → trigger
+            store.push(
+                buildAllowlistRow({
+                    tenantId,
+                    providerId: 'pgboss',
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                }),
+                buildAllowlistRow({
+                    tenantId,
+                    providerId: 'trigger',
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                }),
+            );
+
+            const result = await service.getAvailableProvidersForTenant(tenantId);
+
+            // Global order wins.
+            expect(result).toEqual(['trigger', 'pgboss']);
+        });
+
+        it('returns a single-element intersection when per-tenant has 1 row', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'true';
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq';
+            const tenantId = randomUUID();
+            store.push(buildAllowlistRow({ tenantId, providerId: 'temporal' }));
+
+            const result = await service.getAvailableProvidersForTenant(tenantId);
+            expect(result).toEqual(['temporal']);
+        });
+    });
+
+    // ─── State 4: flag ON + per-tenant ⊄ global (silent drop) ──────────
+
+    describe('flag ON, per-tenant contains an entry NOT in global (global is upper bound)', () => {
+        it('silently drops the out-of-global entry', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'true';
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger';
+            const tenantId = randomUUID();
+            store.push(
+                buildAllowlistRow({
+                    tenantId,
+                    providerId: 'trigger',
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                }),
+                buildAllowlistRow({
+                    tenantId,
+                    providerId: 'temporal',
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                }),
+            );
+
+            const result = await service.getAvailableProvidersForTenant(tenantId);
+            // temporal silently dropped.
+            expect(result).toEqual(['trigger']);
+        });
+
+        it('returns [] when every per-tenant entry is outside the global list', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'true';
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger';
+            const tenantId = randomUUID();
+            store.push(
+                buildAllowlistRow({
+                    tenantId,
+                    providerId: 'temporal',
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                }),
+                buildAllowlistRow({
+                    tenantId,
+                    providerId: 'bullmq',
+                    createdAt: new Date('2026-06-18T00:00:02.000Z'),
+                }),
+            );
+
+            const result = await service.getAvailableProvidersForTenant(tenantId);
+            // Operator shrunk the global to 'trigger' but the tenant
+            // overlay still references retired providers — they're
+            // dropped and the tenant ends up with NOTHING. Operators
+            // either re-populate the overlay or accept the empty state.
+            expect(result).toEqual([]);
+        });
+    });
+
+    // ─── State 5: operator typo / unknown ids ──────────────────────────
+
+    describe('operator declares only unknown providerIds (typo / removed runtime)', () => {
+        // The config layer fails OPEN here on purpose — if the operator
+        // submitted only unknown ids (typo, retired provider) we fall
+        // back to the bundled defaults so a single env-var slip doesn't
+        // strand every tenant. The resolver inherits that behaviour
+        // because it reads through `config.tenantJobRuntime.getAllowedProviders`.
+        it('falls back to the full bundled list when every operator id is unknown (flag OFF)', async () => {
+            delete process.env[PER_TENANT_GATING_ENV];
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'not-a-real-runtime,another-typo';
+            const tenantId = randomUUID();
+            store.push(buildAllowlistRow({ tenantId, providerId: 'trigger' }));
+
+            const result = await service.getAvailableProvidersForTenant(tenantId);
+
+            // Bundled fallback wins — flag OFF returns the unfiltered
+            // bundled list and the per-tenant overlay is ignored.
+            expect(result).toEqual(['trigger', 'temporal', 'bullmq', 'pgboss', 'inngest']);
+        });
+
+        it('intersects the bundled fallback with per-tenant rows when flag is ON', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'true';
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'not-a-real-runtime';
+            const tenantId = randomUUID();
+            store.push(
+                buildAllowlistRow({
+                    tenantId,
+                    providerId: 'temporal',
+                    createdAt: new Date('2026-06-18T00:00:01.000Z'),
+                }),
+            );
+
+            const result = await service.getAvailableProvidersForTenant(tenantId);
+
+            // Bundled fallback (5 providers) ∩ per-tenant (temporal) →
+            // [temporal]. Proves the resolver still applies the
+            // per-tenant narrowing even when the operator env var was
+            // effectively a no-op.
+            expect(result).toEqual(['temporal']);
+        });
+    });
+
+    // ─── Cross-tenant isolation in resolver path ───────────────────────
+
+    describe('cross-tenant isolation', () => {
+        it('resolver for tenant A does not see tenant B per-tenant rows', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'true';
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq';
+            const tenantA = randomUUID();
+            const tenantB = randomUUID();
+            store.push(
+                buildAllowlistRow({ tenantId: tenantA, providerId: 'trigger' }),
+                buildAllowlistRow({ tenantId: tenantB, providerId: 'bullmq' }),
+            );
+
+            const a = await service.getAvailableProvidersForTenant(tenantA);
+            const b = await service.getAvailableProvidersForTenant(tenantB);
+
+            expect(a).toEqual(['trigger']);
+            expect(b).toEqual(['bullmq']);
+        });
+    });
+
+    // ─── Identity / preservation properties ────────────────────────────
+
+    describe('preservation properties', () => {
+        it('returns a NEW array (no mutation of the underlying global list)', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'false';
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal';
+            const first = await service.getAvailableProvidersForTenant(randomUUID());
+            const second = await service.getAvailableProvidersForTenant(randomUUID());
+            // Independent array references — mutation of the first must
+            // not leak into the second call.
+            (first as string[]).push('mutated');
+            expect(second).toEqual(['trigger', 'temporal']);
+        });
+
+        it('reading the same tenant twice in a row is stable (read-after-read)', async () => {
+            process.env[PER_TENANT_GATING_ENV] = 'true';
+            process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq';
+            const tenantId = randomUUID();
+            store.push(buildAllowlistRow({ tenantId, providerId: 'temporal' }));
+
+            const a = await service.getAvailableProvidersForTenant(tenantId);
+            const b = await service.getAvailableProvidersForTenant(tenantId);
+            expect(a).toEqual(b);
+        });
+    });
+});

--- a/apps/api/src/account/tenant-job-runtime/__tests__/tenant-job-runtime-boot-audit.service.itest.spec.ts
+++ b/apps/api/src/account/tenant-job-runtime/__tests__/tenant-job-runtime-boot-audit.service.itest.spec.ts
@@ -1,0 +1,263 @@
+// EW-742 P5.1 (T35b) — INTEGRATION-level spec for the boot-time
+// `operator_allowlist_boot` audit writer. Drives multiple
+// `captureBootSnapshot()` invocations and `onApplicationBootstrap()`
+// against a shared in-memory audit store so the dedupe-by-hash contract
+// + config-flip detection + bootstrap failure swallow are exercised
+// against the same surface they hit in production. Complements the
+// existing unit spec at `tenant-job-runtime-boot-audit.service.spec.ts`.
+//
+// NEW cases (vs. the existing spec):
+//   - 5 simulated pod restarts on the same config → ONE persisted boot
+//     row (dedupe semantic)
+//   - Operator flips `EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING` →
+//     fresh row is appended despite the same allow-list
+//   - Operator shrinks `EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS` →
+//     fresh row is appended
+//   - Hash determinism: same effective providers in DIFFERENT operator
+//     order produce the same hash (canonical-sort dedupe)
+//   - `onApplicationBootstrap` calls captureBootSnapshot via the public
+//     surface (proves the bootstrap hook is wired)
+//   - `appendAuditRow` failure → bootstrap swallows + logs (not throws)
+//   - First-write contract — single payload shape spot-check
+//   - `findLatestBootAudit` failure → bootstrap still swallows
+
+jest.mock('@ever-works/agent/entities', () => ({
+    TenantJobRuntimeConfig: class TenantJobRuntimeConfig {},
+    TenantJobRuntimeAudit: class TenantJobRuntimeAudit {},
+    TenantRuntimeProviderAllowlist: class TenantRuntimeProviderAllowlist {},
+}));
+
+jest.mock('@ever-works/agent/tasks', () => ({
+    CredentialVersionService: class CredentialVersionService {},
+}));
+
+import type { TenantJobRuntimeAudit } from '@ever-works/agent/entities';
+import { TenantJobRuntimeBootAuditService } from '../tenant-job-runtime-boot-audit.service';
+import type { TenantJobRuntimeService } from '../tenant-job-runtime.service';
+
+const PER_TENANT_GATING_ENV = 'EVER_WORKS_TENANT_RUNTIME_PER_TENANT_GATING';
+const GLOBAL_ALLOWLIST_ENV = 'EVER_WORKS_TENANT_RUNTIME_ALLOWED_PROVIDERS';
+
+/**
+ * Build a `TenantJobRuntimeService` test double whose `findLatestBootAudit`
+ * + `appendAuditRow` operate against a shared in-memory list. Mirrors the
+ * real service contract used by the boot writer.
+ */
+function buildBootServiceWithStore() {
+    const store: Array<Pick<TenantJobRuntimeAudit, 'action' | 'after' | 'occurredAt'>> = [];
+
+    const findLatestBootAudit = jest.fn(async () => {
+        const matches = store
+            .filter((r) => r.action === 'operator_allowlist_boot')
+            .slice()
+            .sort(
+                (a, b) =>
+                    (b.occurredAt?.getTime() ?? 0) - (a.occurredAt?.getTime() ?? 0),
+            );
+        return matches[0] ?? null;
+    });
+
+    const appendAuditRow = jest.fn(
+        async (payload: {
+            tenantId: string | null;
+            actorUserId: string | null;
+            action: string;
+            before: Record<string, unknown> | null;
+            after: Record<string, unknown> | null;
+            credentialVersion: number | null;
+        }) => {
+            store.push({
+                action: payload.action,
+                after: payload.after as Record<string, unknown> | null,
+                occurredAt: new Date(),
+            } as any);
+        },
+    );
+
+    const serviceMock = { findLatestBootAudit, appendAuditRow } as unknown as jest.Mocked<
+        Pick<TenantJobRuntimeService, 'findLatestBootAudit' | 'appendAuditRow'>
+    >;
+
+    return {
+        service: serviceMock,
+        store,
+    };
+}
+
+describe('TenantJobRuntimeBootAuditService — boot audit dedupe (integration, EW-742 P5.1 T35b)', () => {
+    const originalGating = process.env[PER_TENANT_GATING_ENV];
+    const originalGlobal = process.env[GLOBAL_ALLOWLIST_ENV];
+
+    afterEach(() => {
+        if (originalGating === undefined) {
+            delete process.env[PER_TENANT_GATING_ENV];
+        } else {
+            process.env[PER_TENANT_GATING_ENV] = originalGating;
+        }
+        if (originalGlobal === undefined) {
+            delete process.env[GLOBAL_ALLOWLIST_ENV];
+        } else {
+            process.env[GLOBAL_ALLOWLIST_ENV] = originalGlobal;
+        }
+    });
+
+    it('writes exactly ONE boot row when 5 pods restart against the same config (dedupe)', async () => {
+        process.env[PER_TENANT_GATING_ENV] = 'false';
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq';
+        const { service, store } = buildBootServiceWithStore();
+        const boot = new TenantJobRuntimeBootAuditService(service as any);
+
+        const results = [];
+        for (let i = 0; i < 5; i++) {
+            results.push(await boot.captureBootSnapshot());
+        }
+
+        // First call writes; remaining 4 dedupe by hash.
+        expect(results.map((r) => r.wrote)).toEqual([true, false, false, false, false]);
+        expect(store).toHaveLength(1);
+        expect(service.appendAuditRow).toHaveBeenCalledTimes(1);
+        // Every call returns the same hash (deterministic).
+        const hashes = new Set(results.map((r) => r.hash));
+        expect(hashes.size).toBe(1);
+    });
+
+    it('appends a NEW row after the operator flips perTenantGating ON', async () => {
+        process.env[PER_TENANT_GATING_ENV] = 'false';
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal';
+        const { service, store } = buildBootServiceWithStore();
+        const boot = new TenantJobRuntimeBootAuditService(service as any);
+
+        const first = await boot.captureBootSnapshot();
+        expect(first.wrote).toBe(true);
+
+        // Operator flips the flag and restarts a pod — fresh row written.
+        process.env[PER_TENANT_GATING_ENV] = 'true';
+        const second = await boot.captureBootSnapshot();
+        expect(second.wrote).toBe(true);
+        expect(second.hash).not.toBe(first.hash);
+        expect(store).toHaveLength(2);
+    });
+
+    it('appends a NEW row after the operator shrinks the global allow-list', async () => {
+        process.env[PER_TENANT_GATING_ENV] = 'false';
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq';
+        const { service, store } = buildBootServiceWithStore();
+        const boot = new TenantJobRuntimeBootAuditService(service as any);
+
+        await boot.captureBootSnapshot();
+
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger';
+        const after = await boot.captureBootSnapshot();
+
+        expect(after.wrote).toBe(true);
+        expect(store).toHaveLength(2);
+    });
+
+    it('hash is deterministic across operator-declared ordering (canonical sort)', async () => {
+        process.env[PER_TENANT_GATING_ENV] = 'false';
+
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq';
+        const aPair = buildBootServiceWithStore();
+        const aBoot = new TenantJobRuntimeBootAuditService(aPair.service as any);
+        const a = await aBoot.captureBootSnapshot();
+
+        // Same providers in DIFFERENT order — should hash the same.
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'bullmq,trigger,temporal';
+        const bPair = buildBootServiceWithStore();
+        const bBoot = new TenantJobRuntimeBootAuditService(bPair.service as any);
+        const b = await bBoot.captureBootSnapshot();
+
+        expect(a.hash).toBe(b.hash);
+    });
+
+    it('emits a different hash when the underlying provider SET differs (not just order)', async () => {
+        process.env[PER_TENANT_GATING_ENV] = 'false';
+
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal';
+        const aPair = buildBootServiceWithStore();
+        const aBoot = new TenantJobRuntimeBootAuditService(aPair.service as any);
+        const a = await aBoot.captureBootSnapshot();
+
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq';
+        const bPair = buildBootServiceWithStore();
+        const bBoot = new TenantJobRuntimeBootAuditService(bPair.service as any);
+        const b = await bBoot.captureBootSnapshot();
+
+        expect(a.hash).not.toBe(b.hash);
+    });
+
+    it('persists action=operator_allowlist_boot with tenantId=null + canonical after payload', async () => {
+        process.env[PER_TENANT_GATING_ENV] = 'true';
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal';
+        const { service } = buildBootServiceWithStore();
+        const boot = new TenantJobRuntimeBootAuditService(service as any);
+
+        await boot.captureBootSnapshot();
+
+        const payload = service.appendAuditRow.mock.calls[0][0];
+        expect(payload.tenantId).toBeNull();
+        expect(payload.actorUserId).toBeNull();
+        expect(payload.action).toBe('operator_allowlist_boot');
+        expect(payload.before).toBeNull();
+        expect(payload.after).toMatchObject({
+            allowedProviders: ['trigger', 'temporal'],
+            perTenantGatingEnabled: true,
+            hash: expect.any(String),
+        });
+        expect(payload.credentialVersion).toBeNull();
+    });
+
+    it('onApplicationBootstrap delegates to captureBootSnapshot (wires the lifecycle hook)', async () => {
+        process.env[PER_TENANT_GATING_ENV] = 'false';
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger';
+        const { service, store } = buildBootServiceWithStore();
+        const boot = new TenantJobRuntimeBootAuditService(service as any);
+
+        await boot.onApplicationBootstrap();
+        expect(store).toHaveLength(1);
+    });
+
+    it('swallows + logs when the audit insert (appendAuditRow) fails — does NOT throw', async () => {
+        process.env[PER_TENANT_GATING_ENV] = 'false';
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger';
+        const service = {
+            findLatestBootAudit: jest.fn().mockResolvedValue(null),
+            appendAuditRow: jest.fn().mockRejectedValue(new Error('audit insert failed')),
+        };
+        const boot = new TenantJobRuntimeBootAuditService(service as any);
+
+        await expect(boot.onApplicationBootstrap()).resolves.toBeUndefined();
+        expect(service.appendAuditRow).toHaveBeenCalledTimes(1);
+    });
+
+    it('swallows + logs when findLatestBootAudit throws (DB transient)', async () => {
+        const service = {
+            findLatestBootAudit: jest.fn().mockRejectedValue(new Error('DB down')),
+            appendAuditRow: jest.fn(),
+        };
+        const boot = new TenantJobRuntimeBootAuditService(service as any);
+
+        await expect(boot.onApplicationBootstrap()).resolves.toBeUndefined();
+        // Never reached the insert because the read threw.
+        expect(service.appendAuditRow).not.toHaveBeenCalled();
+    });
+
+    it('dedupe is order-invariant — pod restart in DIFFERENT operator order still dedupes', async () => {
+        process.env[PER_TENANT_GATING_ENV] = 'false';
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'trigger,temporal,bullmq';
+        const { service, store } = buildBootServiceWithStore();
+        const boot = new TenantJobRuntimeBootAuditService(service as any);
+
+        const first = await boot.captureBootSnapshot();
+        expect(first.wrote).toBe(true);
+
+        // Operator reorders the env without changing the effective set.
+        // Should be treated as the same config → dedupe.
+        process.env[GLOBAL_ALLOWLIST_ENV] = 'bullmq,temporal,trigger';
+        const second = await boot.captureBootSnapshot();
+
+        expect(second.wrote).toBe(false);
+        expect(second.hash).toBe(first.hash);
+        expect(store).toHaveLength(1);
+    });
+});

--- a/apps/web/src/components/admin/__tests__/TenantRuntimeAllowlistManager.unit.spec.tsx
+++ b/apps/web/src/components/admin/__tests__/TenantRuntimeAllowlistManager.unit.spec.tsx
@@ -1,0 +1,415 @@
+// EW-742 P5.1 (T35a UI follow-up) — INTEGRATION-level spec for the
+// operator client component that edits a tenant's per-runtime-provider
+// allow-list. Uses vitest + jsdom + @testing-library/react against the
+// real component with mocked Server Actions, so the picker → save →
+// delete → status-banner wiring is exercised end-to-end at the UI
+// boundary without spinning the Next.js server.
+//
+// File extension: `.unit.spec.tsx` matches the project-wide vitest
+// `include` glob (`src/**/*.unit.spec.{ts,tsx}`). Playwright e2e
+// suites under `e2e/*.spec.ts` use a different runner and are
+// excluded by file extension.
+//
+// Scope:
+//   - Initial render (empty + pre-populated)
+//   - Toggle providers in the picker + click Save → server action call
+//     shape (tenantId, ordered providerIds)
+//   - Per-row delete chip → DELETE server action call shape
+//   - Clear button → empty array PUT
+//   - Status banner reflects all 3 saved states (gating off, gating on
+//     + empty saved, gating on + populated saved)
+//   - Save button disabled when draft matches saved (no-op guard)
+//   - Save button reflects the loading state via the existing
+//     `useTransition` hook
+//   - Error from the server action is surfaced via the `toast.error`
+//     side-effect (the component does not render an inline error
+//     banner — that's the existing pattern across the dashboard)
+//   - Successful save updates the saved-list view atomically
+//
+// All next-intl keys pass through verbatim via the standard i18n mock,
+// matching the convention in `apps/web/src/components/dashboard/*.unit.spec.tsx`.
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, vars?: Record<string, unknown>) =>
+        vars ? `${key}:${JSON.stringify(vars)}` : key,
+}));
+
+// `@/components/ui/button` imports `Link` from `@/i18n/navigation`,
+// which transitively pulls in `next/navigation` via `next-intl`. jsdom
+// can't resolve the bare `next/navigation` specifier (Node ESM strict
+// mode), so we stub the navigation module to a no-op anchor — the
+// allow-list manager only uses Buttons as `<button>` elements (no
+// `href` prop), so a permissive stub is sufficient.
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ push: vi.fn() }),
+    Link: ({
+        href,
+        children,
+        ...rest
+    }: {
+        href: string;
+        children: React.ReactNode;
+    } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+        <a href={href} {...rest}>
+            {children}
+        </a>
+    ),
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+    toast: {
+        success: (...args: any[]) => toastSuccess(...args),
+        error: (...args: any[]) => toastError(...args),
+    },
+}));
+
+const replaceActionMock = vi.fn();
+const deleteEntryActionMock = vi.fn();
+vi.mock('@/app/actions/admin/tenant-runtime-allowlist', () => ({
+    replaceTenantRuntimeAllowlistAction: (...args: unknown[]) => replaceActionMock(...args),
+    deleteTenantRuntimeAllowlistEntryAction: (...args: unknown[]) =>
+        deleteEntryActionMock(...args),
+}));
+
+import { TenantRuntimeAllowlistManager } from '../TenantRuntimeAllowlistManager';
+import type { TenantRuntimeAllowlistResponse } from '@/lib/api/operator-tenant-runtime-allowlist';
+import type { TenantJobRuntimeProviderId } from '@/lib/api/tenant-job-runtime';
+
+const TENANT_ID = '7f3c1a2e-4d5b-4c6a-9e8f-0b1c2d3e4f5a';
+
+function buildInitial(
+    overrides: Partial<TenantRuntimeAllowlistResponse> = {},
+): TenantRuntimeAllowlistResponse {
+    return {
+        tenantId: TENANT_ID,
+        providerIds: [],
+        perTenantGatingEnabled: true,
+        ...overrides,
+    };
+}
+
+// Look up a picker checkbox by its `runtime-allowlist-${providerId}` id
+// (set by the component). Using the id avoids the ambiguity that
+// `getByText(label)` produces when a provider label appears in BOTH
+// the picker AND the saved-list pill below it.
+const LABEL_TO_PROVIDER: Record<string, TenantJobRuntimeProviderId> = {
+    'Trigger.dev': 'trigger',
+    Temporal: 'temporal',
+    BullMQ: 'bullmq',
+    'pg-boss': 'pgboss',
+    Inngest: 'inngest',
+};
+
+function findCheckbox(label: string): HTMLInputElement {
+    const providerId = LABEL_TO_PROVIDER[label];
+    if (!providerId) throw new Error(`Unknown provider label "${label}"`);
+    const input = document.getElementById(
+        `runtime-allowlist-${providerId}`,
+    ) as HTMLInputElement | null;
+    if (!input) throw new Error(`Checkbox for "${label}" (id=runtime-allowlist-${providerId}) not found`);
+    return input;
+}
+
+beforeEach(() => {
+    replaceActionMock.mockReset();
+    deleteEntryActionMock.mockReset();
+    toastSuccess.mockReset();
+    toastError.mockReset();
+});
+
+describe('TenantRuntimeAllowlistManager — operator UI component (EW-742 P5.1 T35a)', () => {
+    // ─── Initial render ─────────────────────────────────────────────────
+
+    it('renders all 5 providers as unchecked checkboxes when the allow-list is empty', () => {
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: [] })}
+            />,
+        );
+
+        for (const label of ['Trigger.dev', 'Temporal', 'BullMQ', 'pg-boss', 'Inngest']) {
+            expect(screen.getByText(label)).toBeTruthy();
+            expect(findCheckbox(label).checked).toBe(false);
+        }
+    });
+
+    it('pre-populated allow-list pre-checks the matching providers', () => {
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: ['trigger', 'temporal'] })}
+            />,
+        );
+        expect(findCheckbox('Trigger.dev').checked).toBe(true);
+        expect(findCheckbox('Temporal').checked).toBe(true);
+        expect(findCheckbox('BullMQ').checked).toBe(false);
+        expect(findCheckbox('pg-boss').checked).toBe(false);
+        expect(findCheckbox('Inngest').checked).toBe(false);
+    });
+
+    // ─── Status banner ──────────────────────────────────────────────────
+
+    it('shows the "gating disabled" banner when perTenantGatingEnabled = false', () => {
+        const { container } = render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({
+                    perTenantGatingEnabled: false,
+                    providerIds: ['trigger'],
+                })}
+            />,
+        );
+        expect(container.textContent).toContain('gatingDisabledBanner');
+        // The restricted/empty-inherit banners must NOT also render.
+        expect(container.textContent).not.toContain('restrictedBanner');
+        expect(container.textContent).not.toContain('emptyInheritBanner');
+    });
+
+    it('shows the "inherit / empty" banner when gating is ON + the saved list is empty', () => {
+        const { container } = render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({
+                    perTenantGatingEnabled: true,
+                    providerIds: [],
+                })}
+            />,
+        );
+        expect(container.textContent).toContain('emptyInheritBanner');
+        expect(container.textContent).not.toContain('gatingDisabledBanner');
+    });
+
+    it('shows the "restricted" banner with the saved provider names when gating is ON + populated', () => {
+        const { container } = render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({
+                    perTenantGatingEnabled: true,
+                    providerIds: ['trigger', 'bullmq'],
+                })}
+            />,
+        );
+        // The mocked i18n key is rendered with the interpolation JSON
+        // payload so we can assert both the key wiring and the provider
+        // names that were threaded in.
+        expect(container.textContent).toContain('restrictedBanner');
+        expect(container.textContent).toContain('Trigger.dev');
+        expect(container.textContent).toContain('BullMQ');
+    });
+
+    // ─── Save (replace whole list) ──────────────────────────────────────
+
+    it('Save button is disabled when the draft matches the saved list (no-op guard)', () => {
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: ['trigger'] })}
+            />,
+        );
+        const save = screen.getByText('actions.save').closest('button') as HTMLButtonElement;
+        expect(save.disabled).toBe(true);
+    });
+
+    it('toggling a checkbox enables Save', () => {
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: ['trigger'] })}
+            />,
+        );
+        const save = screen.getByText('actions.save').closest('button') as HTMLButtonElement;
+        expect(save.disabled).toBe(true);
+
+        fireEvent.click(findCheckbox('Temporal'));
+        expect(save.disabled).toBe(false);
+    });
+
+    it('Save invokes the server action with (tenantId, [ordered providerIds])', async () => {
+        replaceActionMock.mockResolvedValue({
+            success: true,
+            data: buildInitial({ providerIds: ['trigger', 'bullmq'] }),
+            error: null,
+        });
+
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: [] })}
+            />,
+        );
+
+        fireEvent.click(findCheckbox('BullMQ'));
+        fireEvent.click(findCheckbox('Trigger.dev'));
+        fireEvent.click(screen.getByText('actions.save'));
+
+        await waitFor(() => expect(replaceActionMock).toHaveBeenCalledTimes(1));
+        const [tenantArg, providerIdsArg] = replaceActionMock.mock.calls[0];
+        expect(tenantArg).toBe(TENANT_ID);
+        // The component preserves the canonical KNOWN_PROVIDERS order
+        // (trigger, temporal, bullmq, pgboss, inngest) regardless of
+        // click order — Trigger.dev was clicked SECOND but lands FIRST.
+        expect(providerIdsArg).toEqual<TenantJobRuntimeProviderId[]>(['trigger', 'bullmq']);
+        await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+    });
+
+    it('successful Save updates the saved-list pill view to the new providers', async () => {
+        replaceActionMock.mockResolvedValue({
+            success: true,
+            data: buildInitial({ providerIds: ['trigger'] }),
+            error: null,
+        });
+
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: [] })}
+            />,
+        );
+
+        fireEvent.click(findCheckbox('Trigger.dev'));
+        fireEvent.click(screen.getByText('actions.save'));
+
+        // After save resolves, the saved-list label + a Trigger.dev pill
+        // should be rendered.
+        await waitFor(() => expect(screen.getAllByText('Trigger.dev').length).toBeGreaterThan(1));
+    });
+
+    it('Save error surfaces via toast.error with the action error message', async () => {
+        replaceActionMock.mockResolvedValue({
+            success: false,
+            data: null,
+            error: 'server exploded',
+        });
+
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: [] })}
+            />,
+        );
+
+        fireEvent.click(findCheckbox('Temporal'));
+        fireEvent.click(screen.getByText('actions.save'));
+
+        await waitFor(() => expect(toastError).toHaveBeenCalledWith('server exploded'));
+        expect(toastSuccess).not.toHaveBeenCalled();
+    });
+
+    // ─── Clear (replace with []) ────────────────────────────────────────
+
+    it('Clear button is disabled when the saved list is already empty', () => {
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: [] })}
+            />,
+        );
+        const clear = screen.getByText('actions.clear').closest('button') as HTMLButtonElement;
+        expect(clear.disabled).toBe(true);
+    });
+
+    it('Clear invokes the server action with an empty providerIds array', async () => {
+        replaceActionMock.mockResolvedValue({
+            success: true,
+            data: buildInitial({ providerIds: [] }),
+            error: null,
+        });
+
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: ['trigger', 'temporal'] })}
+            />,
+        );
+
+        fireEvent.click(screen.getByText('actions.clear'));
+
+        await waitFor(() => expect(replaceActionMock).toHaveBeenCalledTimes(1));
+        const [tenantArg, providerIdsArg] = replaceActionMock.mock.calls[0];
+        expect(tenantArg).toBe(TENANT_ID);
+        expect(providerIdsArg).toEqual([]);
+    });
+
+    // ─── Delete chip (remove single provider) ───────────────────────────
+
+    it('Delete chip invokes the delete server action with (tenantId, providerId)', async () => {
+        deleteEntryActionMock.mockResolvedValue({
+            success: true,
+            data: buildInitial({ providerIds: ['temporal'] }),
+            error: null,
+        });
+
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: ['trigger', 'temporal'] })}
+            />,
+        );
+
+        const removeTrigger = screen.getByLabelText(
+            /actions.removeProvider:\{"provider":"Trigger\.dev"\}/,
+        );
+        fireEvent.click(removeTrigger);
+
+        await waitFor(() => expect(deleteEntryActionMock).toHaveBeenCalledTimes(1));
+        const [tenantArg, providerIdArg] = deleteEntryActionMock.mock.calls[0];
+        expect(tenantArg).toBe(TENANT_ID);
+        expect(providerIdArg).toBe('trigger');
+        await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+    });
+
+    it('Delete error surfaces via toast.error with the action error message', async () => {
+        deleteEntryActionMock.mockResolvedValue({
+            success: false,
+            data: null,
+            error: 'delete blocked',
+        });
+
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: ['trigger'] })}
+            />,
+        );
+
+        const removeTrigger = screen.getByLabelText(
+            /actions.removeProvider:\{"provider":"Trigger\.dev"\}/,
+        );
+        fireEvent.click(removeTrigger);
+
+        await waitFor(() => expect(toastError).toHaveBeenCalledWith('delete blocked'));
+    });
+
+    // ─── Saved-list view ────────────────────────────────────────────────
+
+    it('saved-list shows the empty-state copy when no providers are saved', () => {
+        const { container } = render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: [] })}
+            />,
+        );
+        expect(container.textContent).toContain('messages.noProviders');
+    });
+
+    it('saved-list renders one pill per saved provider with the human label', () => {
+        render(
+            <TenantRuntimeAllowlistManager
+                tenantId={TENANT_ID}
+                initial={buildInitial({ providerIds: ['trigger', 'bullmq', 'inngest'] })}
+            />,
+        );
+        // Each saved provider has its own delete-chip aria-label, which
+        // is the cleanest way to count pills without grabbing the picker
+        // checkboxes too.
+        expect(screen.getByLabelText(/removeProvider.*Trigger\.dev/)).toBeTruthy();
+        expect(screen.getByLabelText(/removeProvider.*BullMQ/)).toBeTruthy();
+        expect(screen.getByLabelText(/removeProvider.*Inngest/)).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary
- **42** new backend Jest integration tests covering the operator-scoped CRUD controller, the boot-audit dedupe writer, and the 4-way tenant-overlay resolver — all wired through \`TenantJobRuntimeService\` with in-memory repo stubs (no live Postgres).
- **16** new vitest + jsdom component tests for \`TenantRuntimeAllowlistManager\`, mocking server actions as \`vi.fn()\` to verify picker → save → delete wiring, three-state status banner, no-op-save guard, and toast.error surfacing.

## Test plan
- [x] \`cd apps/api && pnpm jest --testPathPattern='tenant-job-runtime|allowlist|boot-audit|operator'\` → 7 suites / 96 tests pass
- [x] \`cd apps/web && pnpm vitest run\` → 91 files / 795 tests pass (16 new)
- [x] \`cd apps/web && pnpm type-check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the tenant runtime allowlist management feature, including unit and integration tests for allowlist operations, audit logging, and cross-tenant isolation enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->