### PR TITLE
test: coverage-driven gap fill for EW-742/EW-743 tenant overlay surface

### DIFF
--- a/apps/api/src/account/tenant-job-runtime/dto/upsert-tenant-job-runtime.dto.spec.ts
+++ b/apps/api/src/account/tenant-job-runtime/dto/upsert-tenant-job-runtime.dto.spec.ts
@@ -1,0 +1,246 @@
+// EW-742 / EW-746 — coverage-driven unit spec for the
+// `PUT /api/account/job-runtime/config` request DTO.
+//
+// Targets: apps/api/src/account/tenant-job-runtime/dto/upsert-tenant-job-runtime.dto.ts
+//   - providerId enum gate (TENANT_JOB_RUNTIME_PROVIDER_IDS)
+//   - mode enum gate (TENANT_JOB_RUNTIME_MODES)
+//   - credentialsSecretRef required-when-mode!=inherit invariant (ValidateIf branch)
+//   - credentialsSecretRef MaxLength(128) ceiling
+//   - enabled optional boolean (@IsOptional / @IsBoolean path)
+//   - Static enum tuples shipped at the expected width (regression guard
+//     against accidentally dropping a provider id from the floor-level
+//     allow-list)
+//
+// Before: 0 spec lines covering this DTO. After: ~22 cases pinning every
+// validator branch + the enum-tuple invariants the controller relies on.
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import {
+    TENANT_JOB_RUNTIME_MODES,
+    TENANT_JOB_RUNTIME_PROVIDER_IDS,
+    UpsertTenantJobRuntimeConfigDto,
+    type TenantJobRuntimeMode,
+    type TenantJobRuntimeProviderId,
+} from './upsert-tenant-job-runtime.dto';
+
+function makeDto(over: Partial<Record<string, unknown>> = {}) {
+    return plainToInstance(UpsertTenantJobRuntimeConfigDto, {
+        providerId: 'trigger',
+        mode: 'byo',
+        credentialsSecretRef: 'tenant-job-runtime:abc:trigger:v1',
+        enabled: true,
+        ...over,
+    });
+}
+
+async function errorsFor(over: Partial<Record<string, unknown>> = {}) {
+    return validate(makeDto(over));
+}
+
+describe('TENANT_JOB_RUNTIME_PROVIDER_IDS — floor-level enum (EW-685 contract)', () => {
+    it('ships exactly five provider ids in stable order (regression guard)', () => {
+        expect(TENANT_JOB_RUNTIME_PROVIDER_IDS).toEqual([
+            'trigger',
+            'temporal',
+            'bullmq',
+            'pgboss',
+            'inngest',
+        ]);
+    });
+
+    it('every id is non-empty and unique', () => {
+        const set = new Set(TENANT_JOB_RUNTIME_PROVIDER_IDS);
+        expect(set.size).toBe(TENANT_JOB_RUNTIME_PROVIDER_IDS.length);
+        expect([...set].every((id) => id.length > 0)).toBe(true);
+    });
+});
+
+describe('TENANT_JOB_RUNTIME_MODES — ADR-017 §1 enum', () => {
+    it('ships exactly three modes: inherit | byo | override', () => {
+        expect(TENANT_JOB_RUNTIME_MODES).toEqual(['inherit', 'byo', 'override']);
+    });
+});
+
+describe('UpsertTenantJobRuntimeConfigDto — happy paths', () => {
+    it('accepts a well-formed BYO payload with provider + mode + secret ref', async () => {
+        const errors = await errorsFor();
+        expect(errors).toHaveLength(0);
+    });
+
+    it.each(TENANT_JOB_RUNTIME_PROVIDER_IDS)(
+        'accepts providerId=%s (every EW-685 provider stays in the floor allow-list)',
+        async (providerId) => {
+            const errors = await errorsFor({ providerId });
+            expect(errors.find((e) => e.property === 'providerId')).toBeUndefined();
+        },
+    );
+
+    it('accepts mode=byo and mode=override with a credentialsSecretRef', async () => {
+        for (const mode of ['byo', 'override'] as TenantJobRuntimeMode[]) {
+            const errors = await errorsFor({ mode });
+            expect(errors).toHaveLength(0);
+        }
+    });
+
+    it('accepts mode=inherit WITHOUT a credentialsSecretRef (ValidateIf skips IsString)', async () => {
+        const errors = await errorsFor({ mode: 'inherit', credentialsSecretRef: undefined });
+        expect(errors).toHaveLength(0);
+    });
+
+    it('accepts mode=inherit WITH a credentialsSecretRef present (DTO-level pass-through; service layer enforces "forbidden when inherit")', async () => {
+        // ValidateIf runs IsString/MaxLength only when mode != inherit, so
+        // a present-but-allowed-by-DTO string in inherit mode does NOT
+        // emit a validator error here. The forbidden-when-inherit rule is
+        // enforced at the service layer with a precise message.
+        const errors = await errorsFor({
+            mode: 'inherit',
+            credentialsSecretRef: 'should-be-rejected-by-service-not-dto',
+        });
+        expect(errors).toHaveLength(0);
+    });
+
+    it('accepts omitted `enabled` (treated as default-true at the service layer)', async () => {
+        const errors = await errorsFor({ enabled: undefined });
+        expect(errors.find((e) => e.property === 'enabled')).toBeUndefined();
+    });
+
+    it('accepts enabled=false (soft-disable without dropping the row)', async () => {
+        const errors = await errorsFor({ enabled: false });
+        expect(errors).toHaveLength(0);
+    });
+});
+
+describe('UpsertTenantJobRuntimeConfigDto — providerId enum gate', () => {
+    it('rejects an unknown providerId (floor-level allow-list)', async () => {
+        const errors = await errorsFor({ providerId: 'gearman' });
+        const err = errors.find((e) => e.property === 'providerId');
+        expect(err).toBeDefined();
+        expect(err?.constraints).toHaveProperty('isIn');
+    });
+
+    it('rejects a numeric providerId (IsString gate)', async () => {
+        const errors = await errorsFor({ providerId: 42 });
+        const err = errors.find((e) => e.property === 'providerId');
+        expect(err).toBeDefined();
+    });
+
+    it('rejects an empty-string providerId', async () => {
+        const errors = await errorsFor({ providerId: '' });
+        const err = errors.find((e) => e.property === 'providerId');
+        expect(err).toBeDefined();
+        expect(err?.constraints).toHaveProperty('isIn');
+    });
+});
+
+describe('UpsertTenantJobRuntimeConfigDto — mode enum gate', () => {
+    it.each(['unknown', 'INHERIT', 'BYO', 'Override'])(
+        'rejects mode=%s (case-sensitive enum)',
+        async (mode) => {
+            const errors = await errorsFor({ mode });
+            const err = errors.find((e) => e.property === 'mode');
+            expect(err).toBeDefined();
+            expect(err?.constraints).toHaveProperty('isIn');
+        },
+    );
+
+    it('rejects a missing mode entirely', async () => {
+        const errors = await errorsFor({ mode: undefined });
+        const err = errors.find((e) => e.property === 'mode');
+        expect(err).toBeDefined();
+    });
+});
+
+describe('UpsertTenantJobRuntimeConfigDto — credentialsSecretRef required-when-mode!=inherit', () => {
+    it('rejects missing credentialsSecretRef when mode=byo', async () => {
+        const errors = await errorsFor({ mode: 'byo', credentialsSecretRef: undefined });
+        const err = errors.find((e) => e.property === 'credentialsSecretRef');
+        expect(err).toBeDefined();
+        // ValidateIf flips IsString back on → undefined triggers isString.
+        expect(err?.constraints).toHaveProperty('isString');
+    });
+
+    it('rejects missing credentialsSecretRef when mode=override', async () => {
+        const errors = await errorsFor({ mode: 'override', credentialsSecretRef: undefined });
+        const err = errors.find((e) => e.property === 'credentialsSecretRef');
+        expect(err).toBeDefined();
+        expect(err?.constraints).toHaveProperty('isString');
+    });
+
+    it('rejects null credentialsSecretRef when mode=byo (no @IsOptional escape hatch)', async () => {
+        const errors = await errorsFor({ mode: 'byo', credentialsSecretRef: null });
+        const err = errors.find((e) => e.property === 'credentialsSecretRef');
+        expect(err).toBeDefined();
+    });
+
+    it('rejects non-string credentialsSecretRef when mode=byo', async () => {
+        const errors = await errorsFor({ mode: 'byo', credentialsSecretRef: 12345 });
+        const err = errors.find((e) => e.property === 'credentialsSecretRef');
+        expect(err).toBeDefined();
+        expect(err?.constraints).toHaveProperty('isString');
+    });
+
+    it('rejects credentialsSecretRef longer than 128 chars (MaxLength ceiling)', async () => {
+        const tooLong = 'x'.repeat(129);
+        const errors = await errorsFor({ credentialsSecretRef: tooLong });
+        const err = errors.find((e) => e.property === 'credentialsSecretRef');
+        expect(err).toBeDefined();
+        expect(err?.constraints).toHaveProperty('maxLength');
+    });
+
+    it('accepts credentialsSecretRef at exactly the 128-char boundary', async () => {
+        const exactly = 'x'.repeat(128);
+        const errors = await errorsFor({ credentialsSecretRef: exactly });
+        expect(errors.find((e) => e.property === 'credentialsSecretRef')).toBeUndefined();
+    });
+});
+
+describe('UpsertTenantJobRuntimeConfigDto — enabled', () => {
+    it('rejects non-boolean enabled (IsBoolean gate)', async () => {
+        const errors = await errorsFor({ enabled: 'yes' });
+        const err = errors.find((e) => e.property === 'enabled');
+        expect(err).toBeDefined();
+        expect(err?.constraints).toHaveProperty('isBoolean');
+    });
+
+    it('accepts enabled=true and enabled=false', async () => {
+        for (const v of [true, false]) {
+            const errors = await errorsFor({ enabled: v });
+            expect(errors.find((e) => e.property === 'enabled')).toBeUndefined();
+        }
+    });
+
+    it('treats omitted enabled as valid (IsOptional)', async () => {
+        const dto = plainToInstance(UpsertTenantJobRuntimeConfigDto, {
+            providerId: 'trigger',
+            mode: 'inherit',
+        });
+        const errors = await validate(dto);
+        expect(errors.find((e) => e.property === 'enabled')).toBeUndefined();
+    });
+});
+
+describe('UpsertTenantJobRuntimeConfigDto — type exports stay aligned with the enum tuples', () => {
+    it('TenantJobRuntimeProviderId values match TENANT_JOB_RUNTIME_PROVIDER_IDS at runtime', () => {
+        // Round-trip: every literal in the tuple is assignable to the
+        // exported union type (compile-time) AND echoed back in the array
+        // (runtime). Guards against the tuple drifting from the type.
+        const literals: TenantJobRuntimeProviderId[] = [
+            'trigger',
+            'temporal',
+            'bullmq',
+            'pgboss',
+            'inngest',
+        ];
+        for (const id of literals) {
+            expect(TENANT_JOB_RUNTIME_PROVIDER_IDS).toContain(id);
+        }
+    });
+
+    it('TenantJobRuntimeMode values match TENANT_JOB_RUNTIME_MODES at runtime', () => {
+        const literals: TenantJobRuntimeMode[] = ['inherit', 'byo', 'override'];
+        for (const m of literals) {
+            expect(TENANT_JOB_RUNTIME_MODES).toContain(m);
+        }
+    });
+});

--- a/apps/web/src/app/actions/admin/tenant-runtime-allowlist.unit.spec.ts
+++ b/apps/web/src/app/actions/admin/tenant-runtime-allowlist.unit.spec.ts
@@ -1,0 +1,249 @@
+// EW-742 P5.1 (T35a UI follow-up) — coverage-driven unit spec for the two
+// operator-scoped Server Actions wrapping the per-tenant runtime allow-list
+// REST API.
+//
+// Targets: apps/web/src/app/actions/admin/tenant-runtime-allowlist.ts
+//   - ensurePlatformAdmin() gating: missing session → redirect to login;
+//     non-admin profile → redirect to "/" (route-doesn't-exist posture);
+//     getProfile() rejection caught → still treated as non-admin.
+//   - replaceTenantRuntimeAllowlistAction: happy path returns
+//     { success, data, error: null }, calls operatorTenantRuntimeAllowlistAPI.replace
+//     with ordered providerIds, revalidates the admin page route, surfaces
+//     ApiResponseError.message / generic Error.message / fallback copy.
+//   - deleteTenantRuntimeAllowlistEntryAction: same shape, calls deleteEntry
+//     with (tenantId, providerId), error mapping mirrors replace.
+//
+// Before: 0 spec lines covering this module. After: ~14 cases pinning the
+// auth gate + both action paths + the three error-mapping branches.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { redirectMock, revalidatePathMock, getAuthFromCookieMock, getProfileMock, replaceMock, deleteEntryMock } =
+    vi.hoisted(() => ({
+        redirectMock: vi.fn((_path: string) => {
+            throw new Error('__REDIRECT__');
+        }),
+        revalidatePathMock: vi.fn(),
+        getAuthFromCookieMock: vi.fn(),
+        getProfileMock: vi.fn(),
+        replaceMock: vi.fn(),
+        deleteEntryMock: vi.fn(),
+    }));
+
+vi.mock('next/cache', () => ({
+    revalidatePath: revalidatePathMock,
+}));
+
+vi.mock('next/navigation', () => ({
+    redirect: redirectMock,
+}));
+
+vi.mock('@/lib/auth', () => ({
+    getAuthFromCookie: getAuthFromCookieMock,
+}));
+
+vi.mock('@/lib/api', () => ({
+    authAPI: {
+        getProfile: getProfileMock,
+    },
+}));
+
+vi.mock('@/lib/api/operator-tenant-runtime-allowlist', () => ({
+    operatorTenantRuntimeAllowlistAPI: {
+        replace: replaceMock,
+        deleteEntry: deleteEntryMock,
+    },
+}));
+
+import { ApiResponseError } from '@/lib/api/server-api';
+
+const adminProfile = { isPlatformAdmin: true, id: 'op-1' };
+const okResponse = {
+    tenantId: 't-1',
+    providerIds: ['trigger', 'bullmq'],
+    perTenantGatingEnabled: true,
+};
+
+async function importActions() {
+    return import('./tenant-runtime-allowlist');
+}
+
+describe('replaceTenantRuntimeAllowlistAction', () => {
+    beforeEach(() => {
+        redirectMock.mockClear();
+        revalidatePathMock.mockClear();
+        getAuthFromCookieMock.mockReset();
+        getProfileMock.mockReset();
+        replaceMock.mockReset();
+        deleteEntryMock.mockReset();
+
+        getAuthFromCookieMock.mockResolvedValue({ id: 'op-1' });
+        getProfileMock.mockResolvedValue(adminProfile);
+        replaceMock.mockResolvedValue(okResponse);
+    });
+
+    afterEach(() => vi.resetModules());
+
+    it('returns { success: true, data, error: null } when the API call resolves', async () => {
+        const { replaceTenantRuntimeAllowlistAction } = await importActions();
+        const result = await replaceTenantRuntimeAllowlistAction('t-1', ['trigger', 'bullmq']);
+        expect(result).toEqual({ success: true, data: okResponse, error: null });
+    });
+
+    it('forwards the tenantId and providerIds in the original order to operatorTenantRuntimeAllowlistAPI.replace', async () => {
+        const { replaceTenantRuntimeAllowlistAction } = await importActions();
+        const ids: ('trigger' | 'bullmq' | 'pgboss')[] = ['pgboss', 'trigger', 'bullmq'];
+        await replaceTenantRuntimeAllowlistAction('t-99', ids);
+        expect(replaceMock).toHaveBeenCalledTimes(1);
+        expect(replaceMock).toHaveBeenCalledWith('t-99', ids);
+    });
+
+    it('revalidates the admin allow-list page route after a successful save', async () => {
+        const { replaceTenantRuntimeAllowlistAction } = await importActions();
+        await replaceTenantRuntimeAllowlistAction('t-1', []);
+        expect(revalidatePathMock).toHaveBeenCalledTimes(1);
+        const [pattern, kind] = revalidatePathMock.mock.calls[0]!;
+        expect(pattern).toContain('/admin/tenants/');
+        expect(pattern).toContain('/runtime-allowlist');
+        expect(kind).toBe('page');
+    });
+
+    it('redirects to the login route when getAuthFromCookie returns null (unauthenticated)', async () => {
+        getAuthFromCookieMock.mockResolvedValue(null);
+        const { replaceTenantRuntimeAllowlistAction } = await importActions();
+        await expect(replaceTenantRuntimeAllowlistAction('t-1', [])).rejects.toThrow('__REDIRECT__');
+        expect(redirectMock).toHaveBeenCalledTimes(1);
+        const target = redirectMock.mock.calls[0]![0] as string;
+        expect(target.toLowerCase()).toContain('login');
+        expect(replaceMock).not.toHaveBeenCalled();
+    });
+
+    it('redirects to "/" when the fresh profile is not a platform admin (route-not-found posture)', async () => {
+        getProfileMock.mockResolvedValue({ isPlatformAdmin: false, id: 'op-1' });
+        const { replaceTenantRuntimeAllowlistAction } = await importActions();
+        await expect(replaceTenantRuntimeAllowlistAction('t-1', [])).rejects.toThrow('__REDIRECT__');
+        expect(redirectMock).toHaveBeenCalledWith('/');
+        expect(replaceMock).not.toHaveBeenCalled();
+    });
+
+    it('treats a rejected getProfile() as non-admin (.catch(() => null) path)', async () => {
+        getProfileMock.mockRejectedValue(new Error('upstream down'));
+        const { replaceTenantRuntimeAllowlistAction } = await importActions();
+        await expect(replaceTenantRuntimeAllowlistAction('t-1', [])).rejects.toThrow('__REDIRECT__');
+        expect(redirectMock).toHaveBeenCalledWith('/');
+        expect(replaceMock).not.toHaveBeenCalled();
+    });
+
+    it('maps an ApiResponseError to { success: false, error: error.message } and skips revalidation', async () => {
+        replaceMock.mockRejectedValue(
+            new ApiResponseError('Allow-list capped at 5 providers', 400, 'TOO_MANY'),
+        );
+        const { replaceTenantRuntimeAllowlistAction } = await importActions();
+        const result = await replaceTenantRuntimeAllowlistAction('t-1', []);
+        expect(result.success).toBe(false);
+        if (result.success === false) {
+            expect(result.error).toBe('Allow-list capped at 5 providers');
+            expect(result.data).toBeNull();
+        }
+        expect(revalidatePathMock).not.toHaveBeenCalled();
+    });
+
+    it('maps a generic Error.message when not an ApiResponseError', async () => {
+        replaceMock.mockRejectedValue(new Error('network: ECONNREFUSED'));
+        const { replaceTenantRuntimeAllowlistAction } = await importActions();
+        const result = await replaceTenantRuntimeAllowlistAction('t-1', []);
+        expect(result.success).toBe(false);
+        if (result.success === false) {
+            expect(result.error).toBe('network: ECONNREFUSED');
+        }
+    });
+
+    it('falls back to a default error message when the rejection has no .message', async () => {
+        replaceMock.mockRejectedValue('opaque rejection value');
+        const { replaceTenantRuntimeAllowlistAction } = await importActions();
+        const result = await replaceTenantRuntimeAllowlistAction('t-1', []);
+        expect(result.success).toBe(false);
+        if (result.success === false) {
+            expect(result.error).toMatch(/failed/i);
+            expect(result.error).toMatch(/allow-?list/i);
+        }
+    });
+
+    it('treats an empty providerIds array as a clear-all (still calls replace + revalidates)', async () => {
+        const { replaceTenantRuntimeAllowlistAction } = await importActions();
+        await replaceTenantRuntimeAllowlistAction('t-1', []);
+        expect(replaceMock).toHaveBeenCalledWith('t-1', []);
+        expect(revalidatePathMock).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('deleteTenantRuntimeAllowlistEntryAction', () => {
+    beforeEach(() => {
+        redirectMock.mockClear();
+        revalidatePathMock.mockClear();
+        getAuthFromCookieMock.mockReset();
+        getProfileMock.mockReset();
+        replaceMock.mockReset();
+        deleteEntryMock.mockReset();
+
+        getAuthFromCookieMock.mockResolvedValue({ id: 'op-1' });
+        getProfileMock.mockResolvedValue(adminProfile);
+        deleteEntryMock.mockResolvedValue(okResponse);
+    });
+
+    afterEach(() => vi.resetModules());
+
+    it('returns { success: true, data, error: null } when the API call resolves', async () => {
+        const { deleteTenantRuntimeAllowlistEntryAction } = await importActions();
+        const result = await deleteTenantRuntimeAllowlistEntryAction('t-1', 'trigger');
+        expect(result).toEqual({ success: true, data: okResponse, error: null });
+    });
+
+    it('forwards (tenantId, providerId) to operatorTenantRuntimeAllowlistAPI.deleteEntry', async () => {
+        const { deleteTenantRuntimeAllowlistEntryAction } = await importActions();
+        await deleteTenantRuntimeAllowlistEntryAction('t-77', 'pgboss');
+        expect(deleteEntryMock).toHaveBeenCalledTimes(1);
+        expect(deleteEntryMock).toHaveBeenCalledWith('t-77', 'pgboss');
+    });
+
+    it('revalidates the admin allow-list page route after a successful delete', async () => {
+        const { deleteTenantRuntimeAllowlistEntryAction } = await importActions();
+        await deleteTenantRuntimeAllowlistEntryAction('t-1', 'inngest');
+        expect(revalidatePathMock).toHaveBeenCalledTimes(1);
+        expect(revalidatePathMock.mock.calls[0]![1]).toBe('page');
+    });
+
+    it('still enforces the platform-admin gate on delete (non-admin profile redirects to "/")', async () => {
+        getProfileMock.mockResolvedValue({ isPlatformAdmin: false, id: 'op-1' });
+        const { deleteTenantRuntimeAllowlistEntryAction } = await importActions();
+        await expect(deleteTenantRuntimeAllowlistEntryAction('t-1', 'trigger')).rejects.toThrow(
+            '__REDIRECT__',
+        );
+        expect(redirectMock).toHaveBeenCalledWith('/');
+        expect(deleteEntryMock).not.toHaveBeenCalled();
+    });
+
+    it('maps ApiResponseError.message into the error field on rejection', async () => {
+        deleteEntryMock.mockRejectedValue(
+            new ApiResponseError("Can't remove the last allow-listed provider", 409, 'LAST_ONE'),
+        );
+        const { deleteTenantRuntimeAllowlistEntryAction } = await importActions();
+        const result = await deleteTenantRuntimeAllowlistEntryAction('t-1', 'trigger');
+        expect(result.success).toBe(false);
+        if (result.success === false) {
+            expect(result.error).toContain('last allow-listed');
+        }
+        expect(revalidatePathMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a default error copy when the rejection lacks a message', async () => {
+        deleteEntryMock.mockRejectedValue(undefined);
+        const { deleteTenantRuntimeAllowlistEntryAction } = await importActions();
+        const result = await deleteTenantRuntimeAllowlistEntryAction('t-1', 'trigger');
+        expect(result.success).toBe(false);
+        if (result.success === false) {
+            expect(result.error).toMatch(/failed/i);
+            expect(result.error).toMatch(/remove/i);
+        }
+    });
+});

--- a/apps/web/src/components/settings/job-runtime-schemas.unit.spec.ts
+++ b/apps/web/src/components/settings/job-runtime-schemas.unit.spec.ts
@@ -1,0 +1,324 @@
+// EW-742 P2.2 T17 / EW-743 — coverage-driven unit spec for the credential
+// field schema metadata + the two mode-discriminator helpers
+// (`isFieldRequired`, `isFieldVisibleForMode`).
+//
+// Targets: apps/web/src/components/settings/job-runtime-schemas.ts
+//   - JOB_RUNTIME_CREDENTIAL_SCHEMAS shape integrity (per-provider field
+//     lists, secret/required flags, requiredWhen.mode predicates,
+//     placeholders, envVar hints, multiline cert fields).
+//   - PROVIDERS_WITHOUT_CREDENTIALS — confirms Trigger.dev is NOT in the
+//     set post EW-743 (regression guard).
+//   - JOB_RUNTIME_PROVIDER_MODE_BANNERS — Trigger.dev mode banner copy
+//     per inherit/byo/override.
+//   - isFieldRequired — discriminator-driven requiredness vs static
+//     `required` fallback for `requiredWhen.mode` branch.
+//   - isFieldVisibleForMode — visibility predicate; always-optional
+//     fields stay visible regardless of mode.
+//
+// Before: 0 spec lines covering this module (no sibling spec). After:
+// ~25 cases exercising every branch in the two pure helpers + the
+// schema-shape invariants the form depends on.
+//
+// Convention: matches the project-wide `src/**/*.unit.spec.{ts,tsx}`
+// glob (vitest + jsdom). Pure-function module — no React Testing Library
+// or i18n mocks needed.
+
+import { describe, expect, it } from 'vitest';
+import {
+    JOB_RUNTIME_CREDENTIAL_SCHEMAS,
+    JOB_RUNTIME_PROVIDER_MODE_BANNERS,
+    PROVIDERS_WITHOUT_CREDENTIALS,
+    isFieldRequired,
+    isFieldVisibleForMode,
+    type JobRuntimeCredentialField,
+} from './job-runtime-schemas';
+import type {
+    TenantJobRuntimeMode,
+    TenantJobRuntimeProviderId,
+} from '@/lib/api/tenant-job-runtime';
+
+const ALL_PROVIDERS: readonly TenantJobRuntimeProviderId[] = [
+    'trigger',
+    'bullmq',
+    'pgboss',
+    'temporal',
+    'inngest',
+];
+const ALL_MODES: readonly TenantJobRuntimeMode[] = ['inherit', 'byo', 'override'];
+
+function field(over: Partial<JobRuntimeCredentialField> = {}): JobRuntimeCredentialField {
+    return {
+        name: over.name ?? 'sample',
+        label: over.label ?? 'Sample',
+        description: over.description ?? 'desc',
+        secret: over.secret ?? false,
+        required: over.required ?? false,
+        ...(over.requiredWhen !== undefined ? { requiredWhen: over.requiredWhen } : {}),
+        ...(over.envVar !== undefined ? { envVar: over.envVar } : {}),
+        ...(over.placeholder !== undefined ? { placeholder: over.placeholder } : {}),
+        ...(over.multiline !== undefined ? { multiline: over.multiline } : {}),
+    };
+}
+
+describe('JOB_RUNTIME_CREDENTIAL_SCHEMAS — provider coverage', () => {
+    it.each(ALL_PROVIDERS)(
+        'declares an entry for provider %s with at least one field',
+        (provider) => {
+            const fields = JOB_RUNTIME_CREDENTIAL_SCHEMAS[provider];
+            expect(Array.isArray(fields)).toBe(true);
+            expect(fields.length).toBeGreaterThan(0);
+        },
+    );
+
+    it('declares schemas for exactly the five EW-685 contract providers (no orphan keys)', () => {
+        const keys = Object.keys(JOB_RUNTIME_CREDENTIAL_SCHEMAS).sort();
+        expect(keys).toEqual([...ALL_PROVIDERS].sort());
+    });
+
+    it('every field name is non-empty and unique within its provider', () => {
+        for (const provider of ALL_PROVIDERS) {
+            const names = JOB_RUNTIME_CREDENTIAL_SCHEMAS[provider].map((f) => f.name);
+            expect(names.every((n) => n.length > 0)).toBe(true);
+            expect(new Set(names).size).toBe(names.length);
+        }
+    });
+
+    it('every field has a label + description (form renderer relies on non-empty strings)', () => {
+        for (const provider of ALL_PROVIDERS) {
+            for (const f of JOB_RUNTIME_CREDENTIAL_SCHEMAS[provider]) {
+                expect(f.label.length).toBeGreaterThan(0);
+                expect(f.description.length).toBeGreaterThan(0);
+            }
+        }
+    });
+
+    it('secret fields never declare a `multiline` widget unless they are TLS material', () => {
+        // Sanity guard: any multiline+secret field today is exclusively
+        // PEM cert/key material — keep the assertion narrow so future
+        // multiline secrets must be added intentionally.
+        for (const provider of ALL_PROVIDERS) {
+            for (const f of JOB_RUNTIME_CREDENTIAL_SCHEMAS[provider]) {
+                if (f.multiline && f.secret) {
+                    expect(f.name).toMatch(/^tls/);
+                }
+            }
+        }
+    });
+});
+
+describe('JOB_RUNTIME_CREDENTIAL_SCHEMAS — trigger (EW-743 BYO contract)', () => {
+    const trigger = JOB_RUNTIME_CREDENTIAL_SCHEMAS.trigger;
+
+    it('exposes the four EW-743 fields in stable order', () => {
+        expect(trigger.map((f) => f.name)).toEqual([
+            'accessToken',
+            'secretKey',
+            'projectRef',
+            'apiUrl',
+        ]);
+    });
+
+    it('accessToken / secretKey / projectRef use requiredWhen=[byo,override] to mirror the plugin if/then', () => {
+        for (const name of ['accessToken', 'secretKey', 'projectRef']) {
+            const f = trigger.find((x) => x.name === name)!;
+            expect(f.required).toBe(false);
+            expect(f.requiredWhen?.mode).toEqual(['byo', 'override']);
+        }
+    });
+
+    it('apiUrl is always-optional (no requiredWhen) so self-host overrides stay visible', () => {
+        const apiUrl = trigger.find((f) => f.name === 'apiUrl')!;
+        expect(apiUrl.requiredWhen).toBeUndefined();
+        expect(apiUrl.required).toBe(false);
+        expect(apiUrl.secret).toBe(false);
+    });
+
+    it('accessToken + secretKey are masked (secret=true); projectRef + apiUrl are not', () => {
+        const byName = Object.fromEntries(trigger.map((f) => [f.name, f]));
+        expect(byName.accessToken.secret).toBe(true);
+        expect(byName.secretKey.secret).toBe(true);
+        expect(byName.projectRef.secret).toBe(false);
+        expect(byName.apiUrl.secret).toBe(false);
+    });
+
+    it('exposes envVar hints for every Trigger.dev field (operator fallback path)', () => {
+        for (const f of trigger) {
+            expect(f.envVar).toMatch(/^TRIGGER_/);
+        }
+    });
+});
+
+describe('JOB_RUNTIME_CREDENTIAL_SCHEMAS — temporal mTLS surface', () => {
+    const temporal = JOB_RUNTIME_CREDENTIAL_SCHEMAS.temporal;
+
+    it('exposes namespace + address + tlsCert + tlsKey', () => {
+        expect(temporal.map((f) => f.name)).toEqual([
+            'namespace',
+            'address',
+            'tlsCert',
+            'tlsKey',
+        ]);
+    });
+
+    it('renders PEM material as multiline secrets (paste-the-whole-block UX)', () => {
+        const tlsCert = temporal.find((f) => f.name === 'tlsCert')!;
+        const tlsKey = temporal.find((f) => f.name === 'tlsKey')!;
+        expect(tlsCert.multiline).toBe(true);
+        expect(tlsCert.secret).toBe(true);
+        expect(tlsKey.multiline).toBe(true);
+        expect(tlsKey.secret).toBe(true);
+    });
+
+    it('namespace is hard-required (always-required, no requiredWhen)', () => {
+        const namespace = temporal.find((f) => f.name === 'namespace')!;
+        expect(namespace.required).toBe(true);
+        expect(namespace.requiredWhen).toBeUndefined();
+    });
+});
+
+describe('JOB_RUNTIME_CREDENTIAL_SCHEMAS — bullmq / pgboss / inngest', () => {
+    it('bullmq.redisUrl is the only hard-required field, with a redis:// placeholder', () => {
+        const fs = JOB_RUNTIME_CREDENTIAL_SCHEMAS.bullmq;
+        const redisUrl = fs.find((f) => f.name === 'redisUrl')!;
+        expect(redisUrl.required).toBe(true);
+        expect(redisUrl.secret).toBe(true);
+        expect(redisUrl.placeholder).toContain('redis://');
+        const others = fs.filter((f) => f.name !== 'redisUrl');
+        expect(others.every((f) => f.required === false)).toBe(true);
+    });
+
+    it('pgboss.connectionString is required + secret; schema is optional + non-secret', () => {
+        const fs = JOB_RUNTIME_CREDENTIAL_SCHEMAS.pgboss;
+        const conn = fs.find((f) => f.name === 'connectionString')!;
+        const schema = fs.find((f) => f.name === 'schema')!;
+        expect(conn.required).toBe(true);
+        expect(conn.secret).toBe(true);
+        expect(schema.required).toBe(false);
+        expect(schema.secret).toBe(false);
+    });
+
+    it('inngest exposes eventKey + signingKey, both hard-required secrets', () => {
+        const fs = JOB_RUNTIME_CREDENTIAL_SCHEMAS.inngest;
+        expect(fs.map((f) => f.name)).toEqual(['eventKey', 'signingKey']);
+        expect(fs.every((f) => f.required === true && f.secret === true)).toBe(true);
+    });
+});
+
+describe('PROVIDERS_WITHOUT_CREDENTIALS', () => {
+    it('is empty post EW-743 — Trigger.dev no longer suppresses the tenant credentials form', () => {
+        expect(PROVIDERS_WITHOUT_CREDENTIALS.size).toBe(0);
+        expect(PROVIDERS_WITHOUT_CREDENTIALS.has('trigger')).toBe(false);
+    });
+
+    it.each(ALL_PROVIDERS)('does not include %s (every shipped provider exposes credentials)', (p) => {
+        expect(PROVIDERS_WITHOUT_CREDENTIALS.has(p)).toBe(false);
+    });
+});
+
+describe('JOB_RUNTIME_PROVIDER_MODE_BANNERS', () => {
+    it('declares a trigger entry with all three mode keys (no missing copy)', () => {
+        const banner = JOB_RUNTIME_PROVIDER_MODE_BANNERS.trigger;
+        expect(banner).toBeDefined();
+        expect(Object.keys(banner!).sort()).toEqual([...ALL_MODES].sort());
+    });
+
+    it('trigger.inherit copy mentions the shared platform project (operator default)', () => {
+        const banner = JOB_RUNTIME_PROVIDER_MODE_BANNERS.trigger!;
+        expect(banner.inherit.toLowerCase()).toContain('shared');
+    });
+
+    it('trigger.byo copy mentions PAT + secret + project ref (operator wiring hint)', () => {
+        const banner = JOB_RUNTIME_PROVIDER_MODE_BANNERS.trigger!;
+        expect(banner.byo.toLowerCase()).toContain('pat');
+    });
+
+    it('other providers do not declare a mode-banner entry (opt-in only)', () => {
+        for (const p of ALL_PROVIDERS) {
+            if (p === 'trigger') continue;
+            expect(JOB_RUNTIME_PROVIDER_MODE_BANNERS[p]).toBeUndefined();
+        }
+    });
+});
+
+describe('isFieldRequired', () => {
+    it('returns the discriminator-included match when requiredWhen.mode is set', () => {
+        const f = field({ requiredWhen: { mode: ['byo', 'override'] } });
+        expect(isFieldRequired(f, 'byo')).toBe(true);
+        expect(isFieldRequired(f, 'override')).toBe(true);
+    });
+
+    it('returns false when current mode is outside the requiredWhen.mode set', () => {
+        const f = field({ requiredWhen: { mode: ['byo', 'override'] } });
+        expect(isFieldRequired(f, 'inherit')).toBe(false);
+    });
+
+    it('falls back to the static required=true when requiredWhen is absent', () => {
+        const f = field({ required: true });
+        for (const m of ALL_MODES) expect(isFieldRequired(f, m)).toBe(true);
+    });
+
+    it('falls back to the static required=false when requiredWhen is absent', () => {
+        const f = field({ required: false });
+        for (const m of ALL_MODES) expect(isFieldRequired(f, m)).toBe(false);
+    });
+
+    it('requiredWhen takes precedence over the static `required` flag', () => {
+        // Even if `required: true` is declared, the discriminator wins —
+        // this guards against accidentally double-marking a field.
+        const f = field({ required: true, requiredWhen: { mode: ['byo'] } });
+        expect(isFieldRequired(f, 'inherit')).toBe(false);
+        expect(isFieldRequired(f, 'override')).toBe(false);
+        expect(isFieldRequired(f, 'byo')).toBe(true);
+    });
+
+    it('handles a single-mode requiredWhen list (only one mode triggers it)', () => {
+        const f = field({ requiredWhen: { mode: ['override'] } });
+        expect(isFieldRequired(f, 'override')).toBe(true);
+        expect(isFieldRequired(f, 'byo')).toBe(false);
+        expect(isFieldRequired(f, 'inherit')).toBe(false);
+    });
+
+    it('treats an empty requiredWhen.mode array as "never required" (degenerate but safe)', () => {
+        const f = field({ requiredWhen: { mode: [] }, required: true });
+        for (const m of ALL_MODES) expect(isFieldRequired(f, m)).toBe(false);
+    });
+});
+
+describe('isFieldVisibleForMode', () => {
+    it('returns true for the discriminator-included mode (the field IS the mode-conditional credential)', () => {
+        const f = field({ requiredWhen: { mode: ['byo', 'override'] } });
+        expect(isFieldVisibleForMode(f, 'byo')).toBe(true);
+        expect(isFieldVisibleForMode(f, 'override')).toBe(true);
+    });
+
+    it('hides a requiredWhen field when current mode is outside the set (inherit-mode credential suppression)', () => {
+        const f = field({ requiredWhen: { mode: ['byo', 'override'] } });
+        expect(isFieldVisibleForMode(f, 'inherit')).toBe(false);
+    });
+
+    it('always-optional fields stay visible regardless of mode (apiUrl-style override)', () => {
+        const f = field();
+        for (const m of ALL_MODES) expect(isFieldVisibleForMode(f, m)).toBe(true);
+    });
+
+    it('always-required fields stay visible regardless of mode', () => {
+        const f = field({ required: true });
+        for (const m of ALL_MODES) expect(isFieldVisibleForMode(f, m)).toBe(true);
+    });
+
+    it('Trigger.dev accessToken is hidden in inherit and visible in byo/override (live schema integration)', () => {
+        const accessToken = JOB_RUNTIME_CREDENTIAL_SCHEMAS.trigger.find(
+            (f) => f.name === 'accessToken',
+        )!;
+        expect(isFieldVisibleForMode(accessToken, 'inherit')).toBe(false);
+        expect(isFieldVisibleForMode(accessToken, 'byo')).toBe(true);
+        expect(isFieldVisibleForMode(accessToken, 'override')).toBe(true);
+    });
+
+    it('Trigger.dev apiUrl is visible in every mode (always-optional override field)', () => {
+        const apiUrl = JOB_RUNTIME_CREDENTIAL_SCHEMAS.trigger.find(
+            (f) => f.name === 'apiUrl',
+        )!;
+        for (const m of ALL_MODES) expect(isFieldVisibleForMode(apiUrl, m)).toBe(true);
+    });
+});

--- a/apps/web/src/lib/api/operator-tenant-runtime-allowlist.unit.spec.ts
+++ b/apps/web/src/lib/api/operator-tenant-runtime-allowlist.unit.spec.ts
@@ -1,0 +1,189 @@
+// EW-742 P5.1 (T35a UI follow-up) — coverage-driven unit spec for the
+// operator-scoped per-tenant runtime allow-list API wrapper.
+//
+// Targets: apps/web/src/lib/api/operator-tenant-runtime-allowlist.ts
+//   - URL construction (`/api/operator/tenants/:tenantId/runtime-allowlist`)
+//   - .list() uses serverFetch (GET)
+//   - .replace() uses serverMutation with PUT + { providerIds } body + wrapInData: false
+//   - .deleteEntry() uses serverMutation with DELETE + /:providerId suffix
+//   - Convenience aliases (getTenantRuntimeAllowlist / replaceTenantRuntimeAllowlist /
+//     deleteTenantRuntimeAllowlistEntry) delegate to the namespaced object
+//
+// Before: 0 spec lines covering this module. After: ~15 cases pinning the
+// URL shape and the request envelope for all three verbs.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+const okResponse = {
+    tenantId: 't-1',
+    providerIds: ['trigger', 'bullmq'] as const,
+    perTenantGatingEnabled: true,
+};
+
+async function importApi() {
+    return import('./operator-tenant-runtime-allowlist');
+}
+
+describe('operatorTenantRuntimeAllowlistAPI.list', () => {
+    beforeEach(() => {
+        serverFetchMock.mockReset();
+        serverMutationMock.mockReset();
+        serverFetchMock.mockResolvedValue(okResponse);
+    });
+    afterEach(() => vi.resetModules());
+
+    it('calls serverFetch with the operator-scoped per-tenant URL', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        await operatorTenantRuntimeAllowlistAPI.list('t-abc');
+        expect(serverFetchMock).toHaveBeenCalledTimes(1);
+        expect(serverFetchMock).toHaveBeenCalledWith('/api/operator/tenants/t-abc/runtime-allowlist');
+    });
+
+    it('returns the parsed response verbatim (no client-side reshaping)', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        const out = await operatorTenantRuntimeAllowlistAPI.list('t-1');
+        expect(out).toBe(okResponse);
+    });
+
+    it('does not touch serverMutation on a read path', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        await operatorTenantRuntimeAllowlistAPI.list('t-1');
+        expect(serverMutationMock).not.toHaveBeenCalled();
+    });
+
+    it('propagates rejections from serverFetch unchanged (caller maps the error)', async () => {
+        serverFetchMock.mockRejectedValue(new Error('upstream 503'));
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        await expect(operatorTenantRuntimeAllowlistAPI.list('t-1')).rejects.toThrow('upstream 503');
+    });
+});
+
+describe('operatorTenantRuntimeAllowlistAPI.replace', () => {
+    beforeEach(() => {
+        serverFetchMock.mockReset();
+        serverMutationMock.mockReset();
+        serverMutationMock.mockResolvedValue(okResponse);
+    });
+    afterEach(() => vi.resetModules());
+
+    it('PUTs to the per-tenant allow-list URL with a { providerIds } body', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        await operatorTenantRuntimeAllowlistAPI.replace('t-7', ['trigger', 'bullmq']);
+        expect(serverMutationMock).toHaveBeenCalledTimes(1);
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/api/operator/tenants/t-7/runtime-allowlist',
+            data: { providerIds: ['trigger', 'bullmq'] },
+            method: 'PUT',
+            wrapInData: false,
+        });
+    });
+
+    it('passes wrapInData: false so the body is the literal payload, not { data: {...} }', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        await operatorTenantRuntimeAllowlistAPI.replace('t-1', []);
+        const arg = serverMutationMock.mock.calls[0]![0];
+        expect(arg.wrapInData).toBe(false);
+    });
+
+    it('preserves the providerIds order verbatim (controller relies on caller-supplied order)', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        await operatorTenantRuntimeAllowlistAPI.replace('t-1', ['inngest', 'pgboss', 'temporal']);
+        const body = serverMutationMock.mock.calls[0]![0].data;
+        expect(body.providerIds).toEqual(['inngest', 'pgboss', 'temporal']);
+    });
+
+    it('allows an empty providerIds list (clear-all case)', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        await operatorTenantRuntimeAllowlistAPI.replace('t-1', []);
+        const body = serverMutationMock.mock.calls[0]![0].data;
+        expect(body.providerIds).toEqual([]);
+    });
+
+    it('returns the parsed mutation response (caller forwards data to UI)', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        const out = await operatorTenantRuntimeAllowlistAPI.replace('t-1', []);
+        expect(out).toBe(okResponse);
+    });
+});
+
+describe('operatorTenantRuntimeAllowlistAPI.deleteEntry', () => {
+    beforeEach(() => {
+        serverFetchMock.mockReset();
+        serverMutationMock.mockReset();
+        serverMutationMock.mockResolvedValue(okResponse);
+    });
+    afterEach(() => vi.resetModules());
+
+    it('DELETEs to /:providerId under the per-tenant URL', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        await operatorTenantRuntimeAllowlistAPI.deleteEntry('t-7', 'trigger');
+        expect(serverMutationMock).toHaveBeenCalledTimes(1);
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/api/operator/tenants/t-7/runtime-allowlist/trigger',
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    });
+
+    it('sends an empty {} body (REST DELETE semantics) — caller cannot smuggle extra fields', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        await operatorTenantRuntimeAllowlistAPI.deleteEntry('t-1', 'bullmq');
+        expect(serverMutationMock.mock.calls[0]![0].data).toEqual({});
+    });
+
+    it('returns the parsed mutation response (caller updates the UI saved-list view)', async () => {
+        const { operatorTenantRuntimeAllowlistAPI } = await importApi();
+        const out = await operatorTenantRuntimeAllowlistAPI.deleteEntry('t-1', 'pgboss');
+        expect(out).toBe(okResponse);
+    });
+});
+
+describe('convenience aliases', () => {
+    beforeEach(() => {
+        serverFetchMock.mockReset();
+        serverMutationMock.mockReset();
+        serverFetchMock.mockResolvedValue(okResponse);
+        serverMutationMock.mockResolvedValue(okResponse);
+    });
+    afterEach(() => vi.resetModules());
+
+    it('getTenantRuntimeAllowlist delegates to .list(tenantId)', async () => {
+        const { getTenantRuntimeAllowlist } = await importApi();
+        await getTenantRuntimeAllowlist('t-99');
+        expect(serverFetchMock).toHaveBeenCalledWith('/api/operator/tenants/t-99/runtime-allowlist');
+    });
+
+    it('replaceTenantRuntimeAllowlist delegates to .replace(tenantId, providerIds)', async () => {
+        const { replaceTenantRuntimeAllowlist } = await importApi();
+        await replaceTenantRuntimeAllowlist('t-99', ['trigger']);
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: '/api/operator/tenants/t-99/runtime-allowlist',
+                method: 'PUT',
+                data: { providerIds: ['trigger'] },
+            }),
+        );
+    });
+
+    it('deleteTenantRuntimeAllowlistEntry delegates to .deleteEntry(tenantId, providerId)', async () => {
+        const { deleteTenantRuntimeAllowlistEntry } = await importApi();
+        await deleteTenantRuntimeAllowlistEntry('t-99', 'inngest');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: '/api/operator/tenants/t-99/runtime-allowlist/inngest',
+                method: 'DELETE',
+            }),
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- **107** new tests across 4 source files that shipped fully unspec'd in EW-742 / EW-743:
  - \`job-runtime-schemas.ts\` (43) — per-provider credential field metadata + \`isFieldRequired\` / \`isFieldVisibleForMode\` mode discriminators
  - \`tenant-runtime-allowlist.ts\` Server Actions (16) — platform-admin gate, revalidation, three error-mapping branches
  - \`operator-tenant-runtime-allowlist.ts\` API client (15) — URL shape + PUT/DELETE envelopes
  - \`upsert-tenant-job-runtime.dto.ts\` (33) — every class-validator branch + enum-tuple shape
- Tests only; no production code touched. Each targeted file goes from 0 spec lines to full-branch coverage.

## Test plan
- [x] \`npx vitest run\` on new web specs → 74/74 pass
- [x] \`npx jest upsert-tenant-job-runtime.dto.spec\` → 33/33 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)