### PR TITLE
fix(agent): TenantCredentialSnapshot column simple-json instead of jsonb (sqlite boot)

### DIFF
--- a/packages/agent/src/entities/tenant-credential-snapshot.entity.ts
+++ b/packages/agent/src/entities/tenant-credential-snapshot.entity.ts
@@ -91,12 +91,13 @@ export class TenantCredentialSnapshot {
 
     /**
      * The credential bag as stored — **already encrypted** by the
-     * secret-store resolver layer. Stored as JSONB so future schema
-     * evolution doesn't need a type-altering migration. Whether
-     * decryption happens at write or read time is operator-side; this
-     * column just persists the bag verbatim.
+     * secret-store resolver layer. `simple-json` so the column maps to
+     * Postgres `jsonb` in prod and sqlite TEXT in local dev (the rest of
+     * the codebase uses the same convention). Whether decryption happens
+     * at write or read time is operator-side; this column just persists
+     * the bag verbatim.
      */
-    @Column({ type: 'jsonb' })
+    @Column({ type: 'simple-json' })
     credentialsEncrypted: Record<string, unknown>;
 
     /**


### PR DESCRIPTION
## Summary

\`DATABASE_TYPE=sqlite\` (the \`.env.example\` default + the CI e2e mode) fails to boot with:

\`\`\`
DataTypeNotSupportedError: Data type "jsonb" in
"TenantCredentialSnapshot.credentialsEncrypted" is not supported by
"better-sqlite3" database.
\`\`\`

PR #1514 added the snapshot entity with \`@Column({ type: 'jsonb' })\` — Postgres-specific. Every other opaque-bag column in \`packages/agent/src/entities/\` already uses \`'simple-json'\` (cross-dialect: Postgres jsonb / sqlite TEXT). 15+ entities follow that convention — only the snapshot one drifted.

## Discovery

Found while attempting Phase A Playwright e2e execution against a local stack. With this fix and #1564 (TenantCredentialCache DI), API boot proceeds further before hitting the next blocker (AuthSessionGuard \`AUTH_PROVIDER\` inject in TenantJobRuntimeModule).

## Test plan
- [x] \`pnpm --filter @ever-works/agent build\` clean
- [x] Repro: pre-fix API crashes with the named exception
- [x] Post-fix: API boot proceeds past entity validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal data storage configuration to improve cross-environment compatibility while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->