### PR TITLE
fix(api): TenantJobRuntimeModule must import AuthModule (boot crash)

### DIFF
--- a/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
+++ b/apps/api/src/account/tenant-job-runtime/tenant-job-runtime.module.ts
@@ -17,6 +17,7 @@ import {
     TenantAwareRuntimeResolver,
     TenantCredentialCache,
 } from '@ever-works/agent/tasks';
+import { AuthModule } from '../../auth/auth.module';
 import { IsPlatformAdminGuard } from '../../auth/guards/platform-admin.guard';
 import { OperatorTenantRuntimeAllowlistController } from '../../operator/tenant-runtime-allowlist/operator-tenant-runtime-allowlist.controller';
 import { TenantJobRuntimeBootAuditService } from './tenant-job-runtime-boot-audit.service';
@@ -58,6 +59,12 @@ import { TenantJobRuntimeService } from './tenant-job-runtime.service';
 @Module({
     imports: [
         DatabaseModule,
+        // EW-752 P5.1 dev-bootstrap fix: OperatorTenantRuntimeAllowlistController
+        // uses IsPlatformAdminGuard which extends AuthSessionGuard. AuthSessionGuard
+        // injects `Symbol(AUTH_PROVIDER)` — provided by AuthModule. Without this
+        // import, `pnpm dev:api` crashes at module init with
+        // UnknownDependenciesException(AuthSessionGuard.AUTH_PROVIDER).
+        AuthModule,
         TypeOrmModule.forFeature([
             TenantJobRuntimeConfig,
             TenantJobRuntimeAudit,

--- a/packages/agent/src/entities/tenant-credential-snapshot.entity.ts
+++ b/packages/agent/src/entities/tenant-credential-snapshot.entity.ts
@@ -91,12 +91,13 @@ export class TenantCredentialSnapshot {
 
     /**
      * The credential bag as stored — **already encrypted** by the
-     * secret-store resolver layer. Stored as JSONB so future schema
-     * evolution doesn't need a type-altering migration. Whether
-     * decryption happens at write or read time is operator-side; this
-     * column just persists the bag verbatim.
+     * secret-store resolver layer. `simple-json` so the column maps to
+     * Postgres `jsonb` in prod and sqlite TEXT in local dev (the rest of
+     * the codebase uses the same convention). Whether decryption happens
+     * at write or read time is operator-side; this column just persists
+     * the bag verbatim.
      */
-    @Column({ type: 'jsonb' })
+    @Column({ type: 'simple-json' })
     credentialsEncrypted: Record<string, unknown>;
 
     /**


### PR DESCRIPTION
## Summary

\`pnpm dev:api\` (and any boot path that loads \`TenantJobRuntimeModule\`) crashes with:

\`\`\`
UnknownDependenciesException: Nest can't resolve dependencies of the
AuthSessionGuard (Reflector, ModuleRef, ?). Please make sure that
the argument Symbol(AUTH_PROVIDER) at index [2] is available in the
TenantJobRuntimeModule module.
\`\`\`

PR #1501 (EW-752 P5.1) added \`OperatorTenantRuntimeAllowlistController\` to this module behind \`@UseGuards(IsPlatformAdminGuard)\`. \`IsPlatformAdminGuard\` extends \`AuthSessionGuard\` which injects \`Symbol(AUTH_PROVIDER)\` — exported by \`AuthModule\`. The module never imported \`AuthModule\`, so the guard's DI graph couldn't resolve at module-init.

## Discovery

Third dev-bootstrap bug found this session while attempting Phase A Playwright e2e execution, after #1564 (TenantCredentialCache SWC-Number-DI) and #1567 (TenantCredentialSnapshot jsonb→simple-json). After this fix, API boots all the way to \`/api/health\` returning 200, and Phase A Playwright specs from #1560 actually run end-to-end (12/12 gracefully self-skipped on missing test-fixture env vars per the spec design).

## Test plan
- [x] Repro: pre-fix \`pnpm dev:api\` crashes with the named exception
- [x] Post-fix: API boots; \`/api/health\` → 200
- [x] Post-fix: \`npx playwright test webhooks-trigger-receiver-api.spec.ts --no-deps\` → 12/12 ran (all skipped on missing TEST_TENANT_ID + TEST_TRIGGER_WEBHOOK_SECRET — spec's designed self-skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform authentication dependency resolution to ensure proper guard initialization.
  * Enhanced database compatibility for encrypted credential storage across different environments.

* **Chores**
  * Internal infrastructure improvements for system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->