### PR TITLE
chore: cascade stage → main (e2e seed-bake + others)

### DIFF
--- a/apps/web/e2e/admin-tenant-runtime-allowlist.spec.ts
+++ b/apps/web/e2e/admin-tenant-runtime-allowlist.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { loadSeed } from './helpers/seed';
 
 /**
  * EW-742 P5.1 (#1516) — Operator admin UI for the per-tenant runtime
@@ -51,9 +52,17 @@ import { test, expect, type Page } from '@playwright/test';
  *   - a11y: keyboard navigation through the checkbox grid
  */
 
+// EW-743 Phase A — fall back to the seed file written by global-setup
+// when TEST_TENANT_ID is not explicitly exported. The seed tenant is a
+// REGULAR user (not platform-admin), so the page-renders / checkbox-grid
+// cases assert the not-found tree by design until a dev-mode platform
+// admin grant ships — every check tolerates that via `expect(...).not.toHaveURL(/\/login/)`
+// + explicit "h1 absent" assertions.
+const seed = loadSeed();
 const LOCALE = 'en';
-const TENANT_ID = process.env.TEST_TENANT_ID ?? '';
-const TENANT_ID_B = process.env.TEST_TENANT_ID_B ?? '';
+const TENANT_ID = process.env.TEST_TENANT_ID || seed?.tenantId || '';
+const TENANT_ID_B =
+    process.env.TEST_TENANT_ID_B || seed?.tenantIdNoSecret || '';
 const GATING_ENV = process.env.TEST_PER_TENANT_GATING_ENABLED;
 
 const pagePath = (tenantId: string) =>

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -3,6 +3,13 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { TEST_USER } from './helpers/test-user';
 import { registerViaAPI } from './helpers/auth';
+import {
+    createOrganization,
+    newWebhookSecret,
+    putTriggerWebhookConfig,
+    registerSeedUser,
+} from './helpers/api-seed';
+import { writeSeed, SEED_PATH } from './helpers/seed';
 
 const authFile = 'e2e/.auth/user.json';
 const credentialsFile = 'e2e/.auth/test-user.json';
@@ -18,6 +25,76 @@ setup('authenticate', async ({ page, baseURL }) => {
     // dashboard routes (10-25s EACH on a cold runner), so the whole setup
     // needs a very generous budget.
     setup.setTimeout(600_000);
+
+    // 0. EW-743 Phase A — seed two tenants against the live API so the
+    //    webhook receiver spec runs against real fixtures instead of
+    //    skipping every case. The first tenant carries a resolvable
+    //    `webhookSecret` bag (covers the 11 "happy path" cases); the
+    //    second tenant has NO job-runtime config (covers the 12th case:
+    //    "tenant exists but webhookSecret bag absent → 401"). Best-effort:
+    //    on any failure we log and continue — every spec self-skips when
+    //    its required env/seed is missing, so a degraded API never blocks
+    //    the rest of the suite. The seed file is the single source of
+    //    truth specs read via `loadSeed()`.
+    const apiBase = process.env.API_URL || 'http://localhost:3100';
+    try {
+        const primaryUser = await registerSeedUser(apiBase, 'primary');
+        const primaryTenant = await createOrganization(
+            apiBase,
+            primaryUser,
+            'primary',
+        );
+        const webhookSecret = newWebhookSecret();
+        await putTriggerWebhookConfig(apiBase, primaryTenant, webhookSecret);
+
+        let tenantIdNoSecret: string | undefined;
+        let secondaryUserMeta:
+            | { email: string; password: string; username: string }
+            | undefined;
+        try {
+            const secondaryUser = await registerSeedUser(apiBase, 'secondary');
+            const secondaryTenant = await createOrganization(
+                apiBase,
+                secondaryUser,
+                'secondary',
+            );
+            tenantIdNoSecret = secondaryTenant.tenantId;
+            secondaryUserMeta = {
+                email: secondaryUser.email,
+                password: secondaryUser.password,
+                username: secondaryUser.username,
+            };
+        } catch (err) {
+            console.warn(
+                `[e2e global-setup] secondary tenant seed skipped (${(err as Error).message}). ` +
+                    `Webhook spec's "no-secret" case will skip itself.`,
+            );
+        }
+
+        writeSeed({
+            apiBase,
+            tenantId: primaryTenant.tenantId,
+            webhookSecret,
+            tenantIdNoSecret,
+            primaryUser: {
+                email: primaryUser.email,
+                password: primaryUser.password,
+                username: primaryUser.username,
+            },
+            secondaryUser: secondaryUserMeta,
+            generatedAt: new Date().toISOString(),
+        });
+        console.log(
+            `[e2e global-setup] seeded tenants: primary=${primaryTenant.tenantId}` +
+                (tenantIdNoSecret ? `, no-secret=${tenantIdNoSecret}` : '') +
+                ` → ${SEED_PATH}`,
+        );
+    } catch (err) {
+        console.warn(
+            `[e2e global-setup] tenant seed failed (${(err as Error).message}). ` +
+                `Webhook + allow-list specs will self-skip. Verify API is up at ${apiBase}.`,
+        );
+    }
 
     // 1. Register the user via API (fast)
     try {

--- a/apps/web/e2e/helpers/api-seed.ts
+++ b/apps/web/e2e/helpers/api-seed.ts
@@ -1,0 +1,135 @@
+import { randomBytes } from 'node:crypto';
+
+/**
+ * API-side helpers used by `global-setup.ts` to seed two tenants
+ * against a live local API:
+ *
+ *   - Tenant A (`primary`)   — has a job-runtime config row with a
+ *                              resolvable `credentialsSecretRef` carrying
+ *                              `{webhookSecret}` (used by 11 of the 12
+ *                              webhook spec cases).
+ *   - Tenant B (`secondary`) — has NO job-runtime config (used by the
+ *                              "tenant exists but webhookSecret bag
+ *                              absent" case to land the spec at 12/12).
+ *
+ * The seed chain is:
+ *   POST /api/auth/register        → access_token
+ *   POST /api/organizations        → tenantId
+ *   PUT  /api/account/job-runtime/config  (only for tenant A)
+ *
+ * The PUT payload uses the documented `inline:<base64>` secret-ref
+ * scheme that the in-process secret-store resolver decodes — keeps the
+ * ref ≤128 chars (the column cap).
+ */
+
+export interface SeededUser {
+    username: string;
+    email: string;
+    password: string;
+    accessToken: string;
+}
+
+export interface SeededTenant {
+    user: SeededUser;
+    tenantId: string;
+    slug: string;
+}
+
+const PASSWORD = 'E2eSeed1234!secure';
+
+function uniqueSuffix(): string {
+    // Worker pid + 4 random bytes — collision-free across parallel
+    // setup runs and across multiple invocations on the same machine.
+    return `${process.pid}-${randomBytes(4).toString('hex')}`;
+}
+
+export async function registerSeedUser(
+    apiBase: string,
+    label: 'primary' | 'secondary',
+): Promise<SeededUser> {
+    const suffix = uniqueSuffix();
+    const username = `e2e-seed-${label}-${suffix}`;
+    const email = `e2e-seed-${label}-${suffix}@test.local`;
+    const res = await fetch(`${apiBase}/api/auth/register`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ username, email, password: PASSWORD }),
+    });
+    if (!res.ok) {
+        const body = await res.text();
+        throw new Error(
+            `[api-seed] register(${label}) failed ${res.status}: ${body}`,
+        );
+    }
+    const json = (await res.json()) as { access_token: string };
+    return { username, email, password: PASSWORD, accessToken: json.access_token };
+}
+
+export async function createOrganization(
+    apiBase: string,
+    user: SeededUser,
+    label: 'primary' | 'secondary',
+): Promise<SeededTenant> {
+    const suffix = uniqueSuffix();
+    const slug = `e2e-org-${label}-${suffix}`;
+    const name = `E2E Org ${label} ${suffix}`;
+    const res = await fetch(`${apiBase}/api/organizations`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            authorization: `Bearer ${user.accessToken}`,
+        },
+        body: JSON.stringify({ name, slug }),
+    });
+    if (!res.ok) {
+        const body = await res.text();
+        throw new Error(
+            `[api-seed] createOrg(${label}) failed ${res.status}: ${body}`,
+        );
+    }
+    const json = (await res.json()) as { tenantId: string };
+    if (!json.tenantId) {
+        throw new Error(
+            `[api-seed] createOrg(${label}) response missing tenantId: ${JSON.stringify(json)}`,
+        );
+    }
+    return { user, tenantId: json.tenantId, slug };
+}
+
+export async function putTriggerWebhookConfig(
+    apiBase: string,
+    tenant: SeededTenant,
+    webhookSecret: string,
+): Promise<void> {
+    const bag = { webhookSecret };
+    const base64 = Buffer.from(JSON.stringify(bag), 'utf8').toString('base64');
+    const credentialsSecretRef = `inline:${base64}`;
+    if (credentialsSecretRef.length > 128) {
+        throw new Error(
+            `[api-seed] credentialsSecretRef too long (${credentialsSecretRef.length} > 128). Shorten the bag.`,
+        );
+    }
+    const res = await fetch(`${apiBase}/api/account/job-runtime/config`, {
+        method: 'PUT',
+        headers: {
+            'content-type': 'application/json',
+            authorization: `Bearer ${tenant.user.accessToken}`,
+        },
+        body: JSON.stringify({
+            providerId: 'trigger',
+            mode: 'byo',
+            credentialsSecretRef,
+            enabled: true,
+        }),
+    });
+    if (!res.ok) {
+        const body = await res.text();
+        throw new Error(
+            `[api-seed] putConfig failed ${res.status}: ${body}`,
+        );
+    }
+}
+
+export function newWebhookSecret(): string {
+    return `whsec_e2e_${randomBytes(16).toString('hex')}`;
+}

--- a/apps/web/e2e/helpers/seed.ts
+++ b/apps/web/e2e/helpers/seed.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+/**
+ * E2E seed metadata written by `global-setup.ts` and read by specs that
+ * need a real seeded tenant (TENANT_ID + webhook secret + optional
+ * no-secret tenant). Specs read this through `loadSeed()` so they
+ * inherit the seeded state without per-spec API choreography.
+ *
+ * The shape is duplicated as plain fields for direct JSON consumption;
+ * env vars override the seed file when explicitly exported.
+ */
+export interface E2ESeed {
+    apiBase: string;
+    tenantId: string;
+    webhookSecret: string;
+    tenantIdNoSecret?: string;
+    primaryUser: { email: string; password: string; username: string };
+    secondaryUser?: { email: string; password: string; username: string };
+    generatedAt: string;
+}
+
+export const SEED_PATH = 'e2e/.auth/seed.json';
+
+export function writeSeed(seed: E2ESeed, path: string = SEED_PATH): void {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(seed, null, 2), 'utf8');
+}
+
+/**
+ * Load seed metadata for a spec. Returns null when the file is absent —
+ * specs use this to skip with a clear message rather than throw.
+ *
+ * Env vars take precedence over the file's defaults so a CI shard can
+ * override TEST_TENANT_ID / TEST_TRIGGER_WEBHOOK_SECRET without
+ * regenerating the file.
+ */
+export function loadSeed(path: string = SEED_PATH): E2ESeed | null {
+    let raw: string;
+    try {
+        raw = readFileSync(path, 'utf8');
+    } catch {
+        return null;
+    }
+    let parsed: E2ESeed;
+    try {
+        parsed = JSON.parse(raw) as E2ESeed;
+    } catch {
+        return null;
+    }
+    return {
+        apiBase: process.env.PLAYWRIGHT_API_BASE_URL ?? parsed.apiBase,
+        tenantId: process.env.TEST_TENANT_ID || parsed.tenantId,
+        webhookSecret:
+            process.env.TEST_TRIGGER_WEBHOOK_SECRET || parsed.webhookSecret,
+        tenantIdNoSecret:
+            process.env.TEST_TENANT_ID_NO_SECRET || parsed.tenantIdNoSecret,
+        primaryUser: parsed.primaryUser,
+        secondaryUser: parsed.secondaryUser,
+        generatedAt: parsed.generatedAt,
+    };
+}

--- a/apps/web/e2e/webhooks-trigger-receiver-api.spec.ts
+++ b/apps/web/e2e/webhooks-trigger-receiver-api.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type APIRequestContext } from '@playwright/test';
 import { createHmac, randomUUID } from 'crypto';
+import { loadSeed } from './helpers/seed';
 
 /**
  * EW-743 (#1533 + #1537 + #1542) — Trigger.dev webhook receiver at
@@ -47,10 +48,20 @@ import { createHmac, randomUUID } from 'crypto';
  *   - 10 concurrent valid POSTs → all 200
  */
 
-const API_BASE = process.env.PLAYWRIGHT_API_BASE_URL ?? 'http://localhost:3100';
-const TENANT_ID = process.env.TEST_TENANT_ID ?? '';
-const WEBHOOK_SECRET = process.env.TEST_TRIGGER_WEBHOOK_SECRET ?? '';
-const TENANT_ID_NO_SECRET = process.env.TEST_TENANT_ID_NO_SECRET ?? '';
+// EW-743 Phase A — env vars take precedence (CI sharding / manual
+// override), otherwise fall back to the seed file written by the
+// `global-setup.ts` setup project. When BOTH are absent every case
+// self-skips with a clear message.
+const seed = loadSeed();
+const API_BASE =
+    process.env.PLAYWRIGHT_API_BASE_URL ??
+    seed?.apiBase ??
+    'http://localhost:3100';
+const TENANT_ID = process.env.TEST_TENANT_ID || seed?.tenantId || '';
+const WEBHOOK_SECRET =
+    process.env.TEST_TRIGGER_WEBHOOK_SECRET || seed?.webhookSecret || '';
+const TENANT_ID_NO_SECRET =
+    process.env.TEST_TENANT_ID_NO_SECRET || seed?.tenantIdNoSecret || '';
 
 const url = (tenantId: string) =>
 	`${API_BASE}/api/webhooks/trigger/${tenantId}`;


### PR DESCRIPTION
Routine stage → main cascade. Includes #1572 (Phase A e2e seed routine baked into global-setup.ts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)