### PR TITLE
chore: cascade stage → main (platform-admin bootstrap)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -20,6 +20,14 @@ PLATFORM_ENCRYPTION_KEY=
 # CORS Origins (comma-separated)
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
 
+# Dev-mode platform-admin bootstrap (comma-separated emails). When a user
+# registers (POST /api/auth/register) whose email matches an entry here
+# (case-insensitive), they receive isPlatformAdmin=true at create time.
+# Leave UNSET in production — used only by local dev / e2e suites that
+# need an admin storage-state against a fresh DB. See AuthService
+# `grantPlatformAdminIfBootstrapped`.
+# EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS=
+
 # =============================================================================
 # AUTH RUNTIME CONFIGURATION
 # =============================================================================

--- a/apps/api/src/auth/controllers/auth.controller.ts
+++ b/apps/api/src/auth/controllers/auth.controller.ts
@@ -128,6 +128,17 @@ export class AuthController {
             toHeaders(req.headers || {}),
         );
 
+        // EW-743 Phase A — dev-mode platform-admin bootstrap. When
+        // EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS lists this email,
+        // elevate the freshly-created user so e2e specs gated by
+        // `IsPlatformAdminGuard` can run without an out-of-band DB
+        // write. Production never sets the env var; the helper never
+        // throws so a misconfigured env never breaks registration.
+        await this.authService.grantPlatformAdminIfBootstrapped(
+            response.user.id,
+            registerDto.email,
+        );
+
         try {
             await this.authService.sendVerificationEmail(
                 response.user.id,

--- a/apps/api/src/auth/services/auth.service.spec.ts
+++ b/apps/api/src/auth/services/auth.service.spec.ts
@@ -100,6 +100,52 @@ describe('AuthService', () => {
         });
     });
 
+    describe('grantPlatformAdminIfBootstrapped', () => {
+        const ORIGINAL = process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS;
+        afterEach(() => {
+            if (ORIGINAL === undefined) delete process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS;
+            else process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS = ORIGINAL;
+        });
+
+        it('returns false and does NOT call update when the env var is unset', async () => {
+            delete process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS;
+            const granted = await service.grantPlatformAdminIfBootstrapped('u1', 'a@b.co');
+            expect(granted).toBe(false);
+            expect(userRepo.update).not.toHaveBeenCalled();
+        });
+
+        it('returns false when the email is not in the bootstrap list', async () => {
+            process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS = 'admin@b.co';
+            const granted = await service.grantPlatformAdminIfBootstrapped('u1', 'a@b.co');
+            expect(granted).toBe(false);
+            expect(userRepo.update).not.toHaveBeenCalled();
+        });
+
+        it('grants admin + returns true when the email matches (case-insensitive)', async () => {
+            process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS = 'Admin@B.Co';
+            userRepo.update.mockResolvedValue(undefined as any);
+            const granted = await service.grantPlatformAdminIfBootstrapped('u1', 'admin@b.co');
+            expect(granted).toBe(true);
+            expect(userRepo.update).toHaveBeenCalledWith('u1', { isPlatformAdmin: true });
+        });
+
+        it('handles a comma-separated list with whitespace and matches any entry', async () => {
+            process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS =
+                ' first@b.co , second@b.co ,third@b.co';
+            userRepo.update.mockResolvedValue(undefined as any);
+            const granted = await service.grantPlatformAdminIfBootstrapped('u2', 'second@b.co');
+            expect(granted).toBe(true);
+            expect(userRepo.update).toHaveBeenCalledWith('u2', { isPlatformAdmin: true });
+        });
+
+        it('returns false (does NOT throw) when userRepository.update rejects', async () => {
+            process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS = 'a@b.co';
+            userRepo.update.mockRejectedValueOnce(new Error('db down'));
+            const granted = await service.grantPlatformAdminIfBootstrapped('u1', 'a@b.co');
+            expect(granted).toBe(false);
+        });
+    });
+
     describe('validateSocialUser', () => {
         const socialUser = (overrides: Record<string, unknown> = {}) => ({
             email: 'sa@b.co',

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -115,6 +115,55 @@ export class AuthService {
         }
     }
 
+    /**
+     * Dev-mode hook for granting `isPlatformAdmin = true` to users whose
+     * email is listed in `EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS`
+     * (comma-separated; case-insensitive match on the trimmed email).
+     *
+     * Why this exists:
+     *
+     *   - The platform has no GUI for elevating a user to platform-admin
+     *     today; the column was added via migration
+     *     `1778871104492-AddUserPlatformAdminAndBudgetAlertEmail` and
+     *     populated via direct DB writes. That works in production but
+     *     blocks every spec / local-dev workflow that needs an authed
+     *     admin against a fresh sqlite DB.
+     *   - EW-743 Phase A e2e specs (`admin-tenant-runtime-allowlist`,
+     *     etc.) need a platform-admin storage-state to assert the
+     *     `IsPlatformAdminGuard` path. The `:memory:` sqlite default
+     *     means external tools can't UPDATE the DB after registration.
+     *   - This narrow hook closes that loop without adding a new
+     *     endpoint or controller surface. Production deployments never
+     *     set the env var, so the behaviour is dev-only by config.
+     *
+     * Failure handling: this method NEVER throws. A degraded
+     * `userRepository.update` only loses the elevation — the rest of the
+     * register flow proceeds — and the caller logs at warn. Throwing
+     * here would block legitimate registrations on operator
+     * misconfiguration of the env var, which is the wrong trade-off.
+     */
+    async grantPlatformAdminIfBootstrapped(userId: string, email: string): Promise<boolean> {
+        const raw = process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS;
+        if (!raw) return false;
+        const allowed = raw
+            .split(',')
+            .map((s) => s.trim().toLowerCase())
+            .filter((s) => s.length > 0);
+        if (!allowed.includes(email.trim().toLowerCase())) return false;
+        try {
+            await this.userRepository.update(userId, { isPlatformAdmin: true });
+            this.logger.log(
+                `[bootstrap] Granted isPlatformAdmin=true to ${email} (user ${userId}) via EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS.`,
+            );
+            return true;
+        } catch (err) {
+            this.logger.warn(
+                `[bootstrap] Failed to grant isPlatformAdmin to ${email}: ${(err as Error).message}`,
+            );
+            return false;
+        }
+    }
+
     async validateSocialUser(socialUser: SocialAuthUser) {
         const isTrustedEmail = socialUser.emailVerified !== false;
         let user = await this.userRepository.findByEmailForSocialAuth(socialUser.email);


### PR DESCRIPTION
Routine cascade. Includes #1575 + the earlier seed-bake batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)