### PR TITLE
feat(auth): support prefix-glob in EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -20,13 +20,16 @@ PLATFORM_ENCRYPTION_KEY=
 # CORS Origins (comma-separated)
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
 
-# Dev-mode platform-admin bootstrap (comma-separated emails). When a user
-# registers (POST /api/auth/register) whose email matches an entry here
-# (case-insensitive), they receive isPlatformAdmin=true at create time.
-# Leave UNSET in production — used only by local dev / e2e suites that
-# need an admin storage-state against a fresh DB. See AuthService
+# Dev-mode platform-admin bootstrap (comma-separated emails). When a
+# user registers (POST /api/auth/register) whose email matches an entry
+# here (case-insensitive), they receive isPlatformAdmin=true at create
+# time. Each entry is either an EXACT email or a PREFIX-glob ending in
+# `*` (e.g. `e2e-seed-primary-*@test.local`). Only a single trailing
+# `*` is honoured — no regex / mid-string wildcards. Leave UNSET in
+# production — used only by local dev / e2e suites that need an admin
+# storage-state against a fresh DB. See AuthService
 # `grantPlatformAdminIfBootstrapped`.
-# EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS=
+# EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS=e2e-seed-primary-*@test.local
 
 # =============================================================================
 # AUTH RUNTIME CONFIGURATION

--- a/apps/api/src/auth/services/auth.service.spec.ts
+++ b/apps/api/src/auth/services/auth.service.spec.ts
@@ -144,6 +144,46 @@ describe('AuthService', () => {
             const granted = await service.grantPlatformAdminIfBootstrapped('u1', 'a@b.co');
             expect(granted).toBe(false);
         });
+
+        it('matches a prefix glob entry ending in *', async () => {
+            process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS =
+                'e2e-seed-primary-*@test.local';
+            userRepo.update.mockResolvedValue(undefined as any);
+            const granted = await service.grantPlatformAdminIfBootstrapped(
+                'u3',
+                'e2e-seed-primary-12345-abcd@test.local',
+            );
+            expect(granted).toBe(true);
+            expect(userRepo.update).toHaveBeenCalledWith('u3', { isPlatformAdmin: true });
+        });
+
+        it('prefix glob does NOT match addresses outside the prefix', async () => {
+            process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS =
+                'e2e-seed-primary-*@test.local';
+            const granted = await service.grantPlatformAdminIfBootstrapped(
+                'u4',
+                'e2e-seed-secondary-12345@test.local',
+            );
+            expect(granted).toBe(false);
+            expect(userRepo.update).not.toHaveBeenCalled();
+        });
+
+        it('mixes prefix-glob and exact entries; any matching entry grants', async () => {
+            process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS =
+                'exact@b.co, e2e-seed-*@test.local';
+            userRepo.update.mockResolvedValue(undefined as any);
+            const grantedExact = await service.grantPlatformAdminIfBootstrapped(
+                'u5',
+                'exact@b.co',
+            );
+            const grantedGlob = await service.grantPlatformAdminIfBootstrapped(
+                'u6',
+                'e2e-seed-secondary-xyz@test.local',
+            );
+            expect(grantedExact).toBe(true);
+            expect(grantedGlob).toBe(true);
+            expect(userRepo.update).toHaveBeenCalledTimes(2);
+        });
     });
 
     describe('validateSocialUser', () => {

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -145,11 +145,27 @@ export class AuthService {
     async grantPlatformAdminIfBootstrapped(userId: string, email: string): Promise<boolean> {
         const raw = process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS;
         if (!raw) return false;
-        const allowed = raw
+        const target = email.trim().toLowerCase();
+        // Each entry is either an EXACT email (case-insensitive) or a
+        // PREFIX glob ending in `*` (e.g. `e2e-seed-primary-*@test.local`
+        // matches any address whose lower-cased form starts with
+        // `e2e-seed-primary-`). The glob is intentionally minimal — only
+        // a single trailing `*` is honoured, because the Playwright
+        // global-setup generates per-pid suffixes and the operator can't
+        // know the exact email in advance. No regex / shell-glob /
+        // mid-string wildcards: keeps the matching cheap and the auth
+        // path (production critical) easy to reason about.
+        const entries = raw
             .split(',')
             .map((s) => s.trim().toLowerCase())
             .filter((s) => s.length > 0);
-        if (!allowed.includes(email.trim().toLowerCase())) return false;
+        const matched = entries.some((entry) => {
+            if (entry.endsWith('*')) {
+                return target.startsWith(entry.slice(0, -1));
+            }
+            return entry === target;
+        });
+        if (!matched) return false;
         try {
             await this.userRepository.update(userId, { isPlatformAdmin: true });
             this.logger.log(


### PR DESCRIPTION
## Summary

Follow-up to #1575. Adds a single trailing-\`*\` glob to the bootstrap email matching so the operator can pre-set the env var **before** API boot, even though \`apps/web/e2e/helpers/api-seed.ts\` generates per-pid email suffixes the operator can't predict.

## What lands

- **\`AuthService.grantPlatformAdminIfBootstrapped\`** — each entry now matches either EXACTLY (case-insensitive, as before) OR as a prefix-glob when ending in \`*\`. No regex. No shell-glob (\`?\`, \`[...]\`, \`**\`). No mid-string wildcards. Production-critical auth path → keep matching minimal.
- **3 new unit tests** (now 8 total in this block) cover prefix match, prefix non-match, and mixed exact + glob lists.
- **\`apps/api/.env.example\`** updated with an example value showing the glob form.

## Operator workflow after this

\`\`\`bash
export EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS='e2e-seed-primary-*@test.local'
pnpm dev:api && pnpm dev:web
pnpm --filter @ever-works/web exec playwright test
\`\`\`

Every fresh API boot, the seed-primary user (whatever per-pid email) is auto-elevated to platform-admin → allow-list spec executes against real fixtures without intervention.

## Security posture

- Default behaviour unchanged (env var unset = no grants).
- Prefix is strictly left-anchored \`startsWith\` after stripping the trailing \`*\` — no overlap with adjacent claims.
- A leaked env var listing \`*@anything\` would be a mass-grant — trivial to spot in code review.
- INFO log per grant preserves audit trail.

## Test plan

- [ ] CI: type-check + 8 unit cases in auth.service.spec.ts pass
- [ ] Manual: register a matching prefix → DB \`is_platform_admin = 1\`
- [ ] Manual: register a non-matching email with matching prefix list → \`is_platform_admin\` stays 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Platform admin email bootstrapping now supports prefix glob patterns (e.g., `admin-*`) alongside exact email matches for enhanced flexibility.

* **Tests**
  * Added test coverage for glob pattern matching and mixed email/pattern allowlist scenarios.

* **Documentation**
  * Clarified environment variable usage and matching behavior with updated example configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->