### PR TITLE
chore: cascade develop → stage (prefix-glob bootstrap)

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -20,13 +20,16 @@ PLATFORM_ENCRYPTION_KEY=
 # CORS Origins (comma-separated)
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
 
-# Dev-mode platform-admin bootstrap (comma-separated emails). When a user
-# registers (POST /api/auth/register) whose email matches an entry here
-# (case-insensitive), they receive isPlatformAdmin=true at create time.
-# Leave UNSET in production — used only by local dev / e2e suites that
-# need an admin storage-state against a fresh DB. See AuthService
+# Dev-mode platform-admin bootstrap (comma-separated emails). When a
+# user registers (POST /api/auth/register) whose email matches an entry
+# here (case-insensitive), they receive isPlatformAdmin=true at create
+# time. Each entry is either an EXACT email or a PREFIX-glob ending in
+# `*` (e.g. `e2e-seed-primary-*@test.local`). Only a single trailing
+# `*` is honoured — no regex / mid-string wildcards. Leave UNSET in
+# production — used only by local dev / e2e suites that need an admin
+# storage-state against a fresh DB. See AuthService
 # `grantPlatformAdminIfBootstrapped`.
-# EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS=
+# EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS=e2e-seed-primary-*@test.local
 
 # =============================================================================
 # AUTH RUNTIME CONFIGURATION

--- a/apps/api/src/auth/services/auth.service.spec.ts
+++ b/apps/api/src/auth/services/auth.service.spec.ts
@@ -144,6 +144,46 @@ describe('AuthService', () => {
             const granted = await service.grantPlatformAdminIfBootstrapped('u1', 'a@b.co');
             expect(granted).toBe(false);
         });
+
+        it('matches a prefix glob entry ending in *', async () => {
+            process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS =
+                'e2e-seed-primary-*@test.local';
+            userRepo.update.mockResolvedValue(undefined as any);
+            const granted = await service.grantPlatformAdminIfBootstrapped(
+                'u3',
+                'e2e-seed-primary-12345-abcd@test.local',
+            );
+            expect(granted).toBe(true);
+            expect(userRepo.update).toHaveBeenCalledWith('u3', { isPlatformAdmin: true });
+        });
+
+        it('prefix glob does NOT match addresses outside the prefix', async () => {
+            process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS =
+                'e2e-seed-primary-*@test.local';
+            const granted = await service.grantPlatformAdminIfBootstrapped(
+                'u4',
+                'e2e-seed-secondary-12345@test.local',
+            );
+            expect(granted).toBe(false);
+            expect(userRepo.update).not.toHaveBeenCalled();
+        });
+
+        it('mixes prefix-glob and exact entries; any matching entry grants', async () => {
+            process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS =
+                'exact@b.co, e2e-seed-*@test.local';
+            userRepo.update.mockResolvedValue(undefined as any);
+            const grantedExact = await service.grantPlatformAdminIfBootstrapped(
+                'u5',
+                'exact@b.co',
+            );
+            const grantedGlob = await service.grantPlatformAdminIfBootstrapped(
+                'u6',
+                'e2e-seed-secondary-xyz@test.local',
+            );
+            expect(grantedExact).toBe(true);
+            expect(grantedGlob).toBe(true);
+            expect(userRepo.update).toHaveBeenCalledTimes(2);
+        });
     });
 
     describe('validateSocialUser', () => {

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -145,11 +145,27 @@ export class AuthService {
     async grantPlatformAdminIfBootstrapped(userId: string, email: string): Promise<boolean> {
         const raw = process.env.EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS;
         if (!raw) return false;
-        const allowed = raw
+        const target = email.trim().toLowerCase();
+        // Each entry is either an EXACT email (case-insensitive) or a
+        // PREFIX glob ending in `*` (e.g. `e2e-seed-primary-*@test.local`
+        // matches any address whose lower-cased form starts with
+        // `e2e-seed-primary-`). The glob is intentionally minimal — only
+        // a single trailing `*` is honoured, because the Playwright
+        // global-setup generates per-pid suffixes and the operator can't
+        // know the exact email in advance. No regex / shell-glob /
+        // mid-string wildcards: keeps the matching cheap and the auth
+        // path (production critical) easy to reason about.
+        const entries = raw
             .split(',')
             .map((s) => s.trim().toLowerCase())
             .filter((s) => s.length > 0);
-        if (!allowed.includes(email.trim().toLowerCase())) return false;
+        const matched = entries.some((entry) => {
+            if (entry.endsWith('*')) {
+                return target.startsWith(entry.slice(0, -1));
+            }
+            return entry === target;
+        });
+        if (!matched) return false;
         try {
             await this.userRepository.update(userId, { isPlatformAdmin: true });
             this.logger.log(


### PR DESCRIPTION
Routine cascade. Includes #1578 (prefix-glob support in EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)