### PR TITLE
chore(web): add `pnpm test:e2e:phase-a` convenience script

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,8 @@
         "test:e2e": "playwright test",
         "test:e2e:ui": "playwright test --ui",
         "test:e2e:headed": "playwright test --headed",
-        "test:e2e:debug": "playwright test --debug"
+        "test:e2e:debug": "playwright test --debug",
+        "test:e2e:phase-a": "playwright test webhooks-trigger-receiver-api admin-tenant-runtime-allowlist tenant-job-runtime-trigger-3mode"
     },
     "dependencies": {
         "@ai-sdk/openai-compatible": "^2.0.41",


### PR DESCRIPTION
## Summary

Tiny ergonomic follow-up to the EW-743 Phase A batch (#1572, #1575, #1578). Wraps the 3 spec file basenames into a single \`pnpm test:e2e:phase-a\` so operators / agents don't have to remember them.

## What lands

\`apps/web/package.json\` — one new script:

\`\`\`json
\"test:e2e:phase-a\": \"playwright test webhooks-trigger-receiver-api admin-tenant-runtime-allowlist tenant-job-runtime-trigger-3mode\"
\`\`\`

Now the documented invocation in [\`EVER_WORKS_E2E_PHASE_A_LOCAL.md\`](https://github.com/ever-works/workspace/blob/develop/knowledge/runbooks/EVER_WORKS_E2E_PHASE_A_LOCAL.md) becomes:

\`\`\`bash
pnpm --filter @ever-works/web test:e2e:phase-a
\`\`\`

…with the implied prerequisites (\`pnpm dev:api\` + \`pnpm dev:web\` + \`EVER_WORKS_BOOTSTRAP_PLATFORM_ADMIN_EMAILS='e2e-seed-primary-*@test.local'\`) covered in the runbook TL;DR.

## Test plan

- [ ] CI passes (no behavioural change — script addition only)
- [ ] Manual: \`pnpm --filter @ever-works/web test:e2e:phase-a --list\` enumerates exactly the 3 spec files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated E2E testing scripts with enhanced phase-based test execution and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->