### PR TITLE
fix(e2e+tasks): unblock Phase A boot — dedupe apiBase + @Optional() on TriggerJobRuntimeProvider opts

### DIFF
--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -158,7 +158,6 @@ setup('authenticate', async ({ page, baseURL }) => {
         }
     }, ONBOARDING_KEY);
 
-    const apiBase = process.env.API_URL || 'http://localhost:3100';
     try {
         const loginRes = await fetch(`${apiBase}/api/auth/login`, {
             method: 'POST',

--- a/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
+++ b/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import type {
     IJobRuntimeProvider,
     JobRunStatus,
@@ -138,13 +138,24 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
 
     constructor(
         private readonly triggerService: TriggerService,
-        opts: {
+        // NestJS DI is metadata-driven: `opts` is typed as an inline
+        // object literal, which SWC emits as `Object` in the design
+        // paramtypes. Without `@Optional()` the container tries (and
+        // fails) to resolve a provider for `Object` at API boot, even
+        // though the default value `= {}` makes the param logically
+        // optional. `@Optional()` tells the injector to pass `undefined`
+        // when no provider matches — the runtime then falls back to the
+        // default in the same way the unit tests (which pass nothing)
+        // already exercise.
+        @Optional()
+        opts?: {
             clientFactory?: (credentials: TriggerTenantCredentials) => TriggerClient;
             dispatchersFromClient?: (client: TriggerClient) => JobRuntimeDispatchers;
-        } = {},
+        },
     ) {
-        this.clientFactory = opts.clientFactory ?? createTenantTriggerClient;
-        this.dispatchersFromClient = opts.dispatchersFromClient ?? dispatchersFromTenantClient;
+        this.clientFactory = opts?.clientFactory ?? createTenantTriggerClient;
+        this.dispatchersFromClient =
+            opts?.dispatchersFromClient ?? dispatchersFromTenantClient;
     }
 
     /**


### PR DESCRIPTION
## Summary

Two boot blockers discovered while executing the EW-743 Phase A handoff runbook against a freshly booted local stack on `origin/main`. Together they unblock the prior session's "infrastructure shipped, never verified" claim:

- **`apps/web/e2e/global-setup.ts`** — duplicate `const apiBase` (lines 39 + 161, both at function-body scope) was a SyntaxError. PR #1572 added the seed-block declaration at line 39 but didn't remove the legacy onboarding-dismiss declaration at line 161. The setup project failed to load → every Phase A spec self-skipped because `.auth/user.json` never got written.
- **`packages/tasks/src/trigger/trigger-job-runtime.provider.ts`** — PR #1551 (commit `4f687cce`) added an optional `opts: { clientFactory?, dispatchersFromClient? } = {}` second constructor arg. SWC emits `Object` as the design paramtype for inline object literals, so NestJS's DI container tries to resolve a provider for `Object` at API boot and fails. `pnpm dev:api` died at `NestApplication.create()` with `UnknownDependenciesException` before binding port 3100. Fix: `@Optional()` on the param (same pattern as the existing `@Optional()` uses elsewhere).

Both bugs slipped past CI because:
- Phase A specs are local-only by design (need a live API + Web + browser).
- The 84 trigger-tasks unit tests + 119 plugin tests instantiate the provider with `new` directly, bypassing the DI container.

## Verified locally

With both fixes applied + workspace built:

```
pnpm --filter @ever-works/web test:e2e:phase-a --reporter=list --workers=1
…
13 passed (12 webhook spec + 1 admin unauth-404 + setup project), 19 skipped (env-driven, expected), 11 failed (storage-state semantic gap — see below)
```

The 11 remaining failures are all *post-boot* — the chain now runs end-to-end against real fixtures. They fall into three buckets that need follow-up PRs (not in scope for this boot-blocker fix):

1. **9 admin allow-list + 1 3-mode picker fails** — the `chromium` project's storageState authenticates as `TEST_USER`, but only the SEED PRIMARY user has `isPlatformAdmin=true` + a tenant (via the EW-743 #1575/#1578 bootstrap path). The fix is to either (a) refactor `global-setup.ts` step 5 to save storageState for the seed primary user instead of TEST_USER, or (b) bootstrap a tenant + admin grant for TEST_USER too.
2. **1 webhook spec fail** ("tenant exists but webhookSecret bag absent → 401" — got 404) — the secondary tenant has no job-runtime config row at all, so the controller 404s instead of failing closed at signature. Fix: have `global-setup.ts` step 0 also PUT an empty-bag config row for secondary tenant.

These are documented in the follow-up section of the Workspace runbook.

## Test plan

- [x] `pnpm dev:api` boots and `/api/health` returns 200 in ~75s
- [x] `pnpm dev:web` boots and `/` responds 307 (redirect to login)
- [x] `pnpm --filter @ever-works/web test:e2e:phase-a` setup project completes (`.auth/seed.json` written, both tenants registered)
- [x] 84 trigger-tasks unit tests + 119 plugin tests still green (unchanged ctor signature semantics; `@Optional()` is DI-only sugar)
- [x] No changes to production hot path — both edits are zero-runtime-cost (duplicate decl removed; `@Optional()` decorator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced system initialization stability through improved dependency configuration
  * Improved test infrastructure for onboarding flow handling and validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->