### PR TITLE
fix(api+e2e): unblock Phase A fixtures — wildcard matcher + TEST_USER tenant + secondary empty-bag

### DIFF
--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -147,23 +147,31 @@ export class AuthService {
         if (!raw) return false;
         const target = email.trim().toLowerCase();
         // Each entry is either an EXACT email (case-insensitive) or a
-        // PREFIX glob ending in `*` (e.g. `e2e-seed-primary-*@test.local`
-        // matches any address whose lower-cased form starts with
-        // `e2e-seed-primary-`). The glob is intentionally minimal — only
-        // a single trailing `*` is honoured, because the Playwright
-        // global-setup generates per-pid suffixes and the operator can't
-        // know the exact email in advance. No regex / shell-glob /
-        // mid-string wildcards: keeps the matching cheap and the auth
-        // path (production critical) easy to reason about.
+        // glob containing exactly ONE `*` wildcard:
+        //   - `prefix*`         → target starts with `prefix`
+        //   - `*suffix`         → target ends with `suffix`
+        //   - `prefix*suffix`   → target starts with `prefix` AND ends with `suffix`
+        // The Playwright global-setup generates per-pid suffixes (the
+        // operator can't know the exact email in advance), and useful
+        // patterns like `e2e-seed-primary-*@test.local` need to pin the
+        // domain — hence one mid-string `*`. Entries containing more
+        // than one `*` are rejected (no match) so the matching stays
+        // cheap and the auth path (production critical) easy to reason
+        // about. No full regex / shell-glob support.
         const entries = raw
             .split(',')
             .map((s) => s.trim().toLowerCase())
             .filter((s) => s.length > 0);
         const matched = entries.some((entry) => {
-            if (entry.endsWith('*')) {
-                return target.startsWith(entry.slice(0, -1));
+            if (!entry.includes('*')) {
+                return entry === target;
             }
-            return entry === target;
+            const parts = entry.split('*');
+            if (parts.length !== 2) {
+                return false;
+            }
+            const [prefix, suffix] = parts;
+            return target.startsWith(prefix) && target.endsWith(suffix);
         });
         if (!matched) return false;
         try {

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -2,10 +2,11 @@ import { test as setup, expect } from '@playwright/test';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { TEST_USER } from './helpers/test-user';
-import { registerViaAPI } from './helpers/auth';
+import { registerViaAPI, loginViaAPI } from './helpers/auth';
 import {
     createOrganization,
     newWebhookSecret,
+    putTriggerEmptyBagConfig,
     putTriggerWebhookConfig,
     registerSeedUser,
 } from './helpers/api-seed';
@@ -58,6 +59,22 @@ setup('authenticate', async ({ page, baseURL }) => {
                 secondaryUser,
                 'secondary',
             );
+            // EW-743 — the webhook spec's "tenant exists but
+            // webhookSecret bag absent → 401" case needs a config row
+            // with a resolvable secret ref whose bag does NOT carry
+            // `webhookSecret`. Without this PUT the secondary tenant
+            // has no config at all and the controller returns 404
+            // instead of the fail-closed 401. Best-effort: a degraded
+            // call here only loses the 401 case (the spec falls back
+            // to skipping when TENANT_ID_NO_SECRET is absent).
+            try {
+                await putTriggerEmptyBagConfig(apiBase, secondaryTenant);
+            } catch (err) {
+                console.warn(
+                    `[e2e global-setup] secondary empty-bag config skipped (${(err as Error).message}). ` +
+                        `Webhook spec's "no-secret" case will report a 404 vs 401 mismatch.`,
+                );
+            }
             tenantIdNoSecret = secondaryTenant.tenantId;
             secondaryUserMeta = {
                 email: secondaryUser.email,
@@ -96,11 +113,65 @@ setup('authenticate', async ({ page, baseURL }) => {
         );
     }
 
-    // 1. Register the user via API (fast)
+    // 1. Register the user via API (fast). Capture the access token so
+    //    we can also lazy-bootstrap a tenant for TEST_USER (step 1b) —
+    //    every browser-driven spec that depends on the `chromium`
+    //    project's storageState relies on this user, and several
+    //    (EW-743 Phase A admin allow-list + 3-mode picker; future
+    //    settings/job-runtime) require a tenant context to render at
+    //    all. Without the lazy-create, the provider picker doesn't
+    //    populate and the operator admin page falls through to the
+    //    not-found tree.
+    let testUserToken: string | undefined;
     try {
-        await registerViaAPI(baseURL!, TEST_USER);
+        const registered = await registerViaAPI(baseURL!, TEST_USER);
+        testUserToken = registered.access_token;
     } catch {
         // User may already exist from a previous run — try logging in instead
+        try {
+            const logged = await loginViaAPI(baseURL!, {
+                email: TEST_USER.email,
+                password: TEST_USER.password,
+            });
+            testUserToken = logged.access_token;
+        } catch {
+            // Both register + login failed (API down / throttled). Step 3's
+            // UI login flow will surface the real failure and `chromium`
+            // specs will fail loudly there instead of skipping silently.
+        }
+    }
+
+    // 1b. Lazy-bootstrap a tenant for TEST_USER if we got a token. The
+    //     dev-mode bootstrap-platform-admin path (EW-743 P? — see
+    //     `AuthService.grantPlatformAdminIfBootstrapped`) is what makes
+    //     the admin allow-list spec assert against a real admin user.
+    //     Best-effort: every artifact already required is written above,
+    //     so a degraded API only loses the tenant context for the few
+    //     specs that actually need it (they self-skip on lookup failure).
+    if (testUserToken) {
+        try {
+            const apiBaseInner = process.env.API_URL || apiBase;
+            const orgRes = await fetch(`${apiBaseInner}/api/organizations`, {
+                method: 'POST',
+                headers: {
+                    'content-type': 'application/json',
+                    authorization: `Bearer ${testUserToken}`,
+                },
+                body: JSON.stringify({
+                    name: `E2E TestUser Org ${process.pid}`,
+                    slug: `e2e-test-user-org-${process.pid}-${Date.now().toString(36)}`,
+                }),
+            });
+            if (!orgRes.ok) {
+                console.warn(
+                    `[e2e global-setup] TEST_USER organization lazy-create returned ${orgRes.status} — admin/3-mode specs may skip or fall through to the not-found tree.`,
+                );
+            }
+        } catch (err) {
+            console.warn(
+                `[e2e global-setup] TEST_USER organization lazy-create threw (${(err as Error).message}). Continuing — admin/3-mode specs may degrade.`,
+            );
+        }
     }
 
     // 2. Thorough warmup: hit /en/login AND /en so both routes are compiled

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -158,7 +158,6 @@ setup('authenticate', async ({ page, baseURL }) => {
         }
     }, ONBOARDING_KEY);
 
-    const apiBase = process.env.API_URL || 'http://localhost:3100';
     try {
         const loginRes = await fetch(`${apiBase}/api/auth/login`, {
             method: 'POST',

--- a/apps/web/e2e/helpers/api-seed.ts
+++ b/apps/web/e2e/helpers/api-seed.ts
@@ -133,3 +133,48 @@ export async function putTriggerWebhookConfig(
 export function newWebhookSecret(): string {
     return `whsec_e2e_${randomBytes(16).toString('hex')}`;
 }
+
+/**
+ * PUT a job-runtime config for a tenant with a credentials bag that
+ * deliberately does NOT carry a `webhookSecret` field. Used by the
+ * webhook receiver spec's "tenant exists but webhookSecret bag absent
+ * → 401" case (#1533/#1537/#1542 contract: the receiver must fail
+ * closed at signature when the bag is present but the field is
+ * missing, not 404).
+ *
+ * Without this seeded row the secondary tenant has NO config at all,
+ * so the controller treats the tenant as having no provider configured
+ * and returns 404 (different semantic path), which the spec correctly
+ * reports as a mismatch.
+ *
+ * The bag is `{}` — present but missing the field — so the secret-ref
+ * resolver returns an object that lacks `webhookSecret`, exactly the
+ * shape the fail-closed branch is meant to cover.
+ */
+export async function putTriggerEmptyBagConfig(
+    apiBase: string,
+    tenant: SeededTenant,
+): Promise<void> {
+    const bag = {};
+    const base64 = Buffer.from(JSON.stringify(bag), 'utf8').toString('base64');
+    const credentialsSecretRef = `inline:${base64}`;
+    const res = await fetch(`${apiBase}/api/account/job-runtime/config`, {
+        method: 'PUT',
+        headers: {
+            'content-type': 'application/json',
+            authorization: `Bearer ${tenant.user.accessToken}`,
+        },
+        body: JSON.stringify({
+            providerId: 'trigger',
+            mode: 'byo',
+            credentialsSecretRef,
+            enabled: true,
+        }),
+    });
+    if (!res.ok) {
+        const body = await res.text();
+        throw new Error(
+            `[api-seed] putEmptyBagConfig failed ${res.status}: ${body}`,
+        );
+    }
+}

--- a/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
+++ b/packages/tasks/src/trigger/trigger-job-runtime.provider.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import type {
     IJobRuntimeProvider,
     JobRunStatus,
@@ -138,13 +138,24 @@ export class TriggerJobRuntimeProvider implements IJobRuntimeProvider {
 
     constructor(
         private readonly triggerService: TriggerService,
-        opts: {
+        // NestJS DI is metadata-driven: `opts` is typed as an inline
+        // object literal, which SWC emits as `Object` in the design
+        // paramtypes. Without `@Optional()` the container tries (and
+        // fails) to resolve a provider for `Object` at API boot, even
+        // though the default value `= {}` makes the param logically
+        // optional. `@Optional()` tells the injector to pass `undefined`
+        // when no provider matches — the runtime then falls back to the
+        // default in the same way the unit tests (which pass nothing)
+        // already exercise.
+        @Optional()
+        opts?: {
             clientFactory?: (credentials: TriggerTenantCredentials) => TriggerClient;
             dispatchersFromClient?: (client: TriggerClient) => JobRuntimeDispatchers;
-        } = {},
+        },
     ) {
-        this.clientFactory = opts.clientFactory ?? createTenantTriggerClient;
-        this.dispatchersFromClient = opts.dispatchersFromClient ?? dispatchersFromTenantClient;
+        this.clientFactory = opts?.clientFactory ?? createTenantTriggerClient;
+        this.dispatchersFromClient =
+            opts?.dispatchersFromClient ?? dispatchersFromTenantClient;
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to #1584. Three coordinated post-boot fixes that take the EW-743 Phase A wrapper from **13/19/11** (pass/skip/fail) on the post-#1584 base to **14/19/10** by removing the seed/setup gaps the prior session shipped but never executed against a live stack.

The remaining 10 failures are **pre-existing UI bugs** documented in detail below (and in the Workspace runbook); they are *not* caused by EW-743 work and should ship as separate PRs by someone with eyes on the admin page DTO + the JobRuntimeSettings select widget choice.

## Changes

### 1. `apps/api/src/auth/services/auth.service.ts` — generalised matcher

`grantPlatformAdminIfBootstrapped` now recognises ONE wildcard anywhere in the entry:

| Pattern         | Matches                                  |
| --------------- | ---------------------------------------- |
| `prefix*`       | `target.startsWith(prefix)`              |
| `*suffix`       | `target.endsWith(suffix)`                |
| `prefix*suffix` | both                                     |
| `exact@email`   | case-insensitive exact match (unchanged) |

**Why:** the JSDoc and the existing unit tests at `auth.service.spec.ts:148/160/171` already documented the runbook-recommended pattern `e2e-seed-primary-*@test.local` (mid-string `*`), but the old `entry.endsWith('*')` matcher fell through to exact-match on those patterns and silently returned false. The Playwright global-setup never granted admin to seed users → the admin allow-list spec hit the not-found tree on every case. **Those 2 unit tests have been RED on `main` and nobody noticed** (CI's apps/api Jest worker doesn't appear to gate that file).

### 2. `apps/web/e2e/global-setup.ts` step 1b — TEST_USER tenant lazy-create

Capture the access token from `registerViaAPI(TEST_USER)` (was silently discarded) and POST `/api/organizations` so TEST_USER has a real tenant context. Without it, every browser-driven spec hitting a tenant-scoped page (admin allow-list, 3-mode picker, future settings/*) sees an empty provider picker or a tenant-required 403.

Best-effort: degraded org-create only loses tenant-context specs; auth artifacts + `seed.json` are written before this runs.

### 3. `apps/web/e2e/helpers/api-seed.ts` + global-setup step 0 — secondary empty-bag

New `putTriggerEmptyBagConfig()` helper + a call after the secondary tenant is registered. The webhook receiver spec's `"tenant exists but webhookSecret bag absent → 401"` case requires a config row whose decoded bag has no `webhookSecret` field; without that row the secondary tenant has NO config at all and the controller returns 404 (different semantic path: `"tenant has no provider configured"`) instead of the fail-closed 401.

## Verified locally (post-#1584 base)

```
pnpm --filter @ever-works/web test:e2e:phase-a --reporter=list --workers=1

  43 tests total
  ✓  14 passed  (12 webhook spec all-green; 1 admin unauth-404; setup)
  -  19 skipped (env-driven self-skips: TEST_TENANT_ID_B,
                 TEST_PER_TENANT_GATING_ENABLED, TEST_NON_ADMIN_STATE_PATH)
  ✗  10 failed pre-existing UI bugs (NOT EW-743):
        9 admin allow-list  ← profile-DTO defense-in-depth deadlock
        1 3-mode picker     ← native <select> vs custom <Select> mismatch
```

API log proves the bootstrap path now fires for all 3 e2e users:

```
[bootstrap] Granted isPlatformAdmin=true to e2e-seed-primary-…@test.local
[bootstrap] Granted isPlatformAdmin=true to e2e-seed-secondary-…@test.local
[bootstrap] Granted isPlatformAdmin=true to e2e-mqpjtpnf@test.local       ← TEST_USER
```

## Pre-existing blockers (need separate PRs)

### A. `/admin/...` defense-in-depth check is dead

Both `admin/tenants/[tenantId]/runtime-allowlist/page.tsx:39` and `admin/usage/page.tsx:36` do:

```ts
const profile = await authAPI.getProfile().catch(() => null);
if (!profile?.isPlatformAdmin) {
    notFound();
}
```

But `/api/auth/profile` is a whitelist projection (EW-722 Wave M #156 info-leak) that intentionally excludes `isPlatformAdmin` — the controller comment at `auth.service.ts:555-558` calls out `"the platform-admin flag … must never leave the server"`. Both `/auth/profile` and `/auth/profile/fresh` omit the field.

Net effect: **`profile.isPlatformAdmin` is always `undefined` → falsy → `notFound()` fires for every visitor, including actual platform admins**. The pages have not rendered for anyone since EW-722 landed.

Fix options (deferring to whoever owns the security review):
1. Add `isPlatformAdmin` to the profile DTO whitelist (boolean role flag, not the kind of operational state EW-722 targeted).
2. Add a dedicated `/api/auth/is-platform-admin` endpoint and have the pages call that.
3. Loosen the check to `profile.isPlatformAdmin === false` (only short-circuit when the field is *explicitly* false, so absent → trust the backend `IsPlatformAdminGuard` to gate via the catch).

### B. 3-mode picker spec uses native `<select>` but UI is a custom component

`tenant-job-runtime-trigger-3mode.spec.ts` does `page.locator('select').first()`, but `<JobRuntimeSettings>` uses `@/components/ui/select`'s custom `<Select>` (a shadcn-style div+button popover, not an HTML `<select>`). The spec needs a locator refactor (`data-testid` or `[role="combobox"]`); the component is correct.

## Test plan

- [x] `pnpm dev:api` boots, `/api/health` returns 200, no DI errors (PR #1584 fixes apply)
- [x] `pnpm dev:web` boots, `/` returns 307 to login
- [x] `apps/web/e2e/.auth/seed.json` written with both tenants
- [x] API log shows `[bootstrap] Granted` for all 3 e2e users (primary, secondary, TEST_USER)
- [x] Phase A wrapper: 14 passed (+1 vs baseline), 10 failed (-1 vs baseline)
- [x] All 8 `grantPlatformAdminIfBootstrapped` unit tests pass (including the 2 that were RED on main)

Cascade: develop → stage → main per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Admin email pattern matching now supports flexible wildcard configurations with a single `*` in any position (e.g., `*`@company.com``, `admin-*`@example.com``), while maintaining support for exact email matches. All matching is case-insensitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->