### PR TITLE
chore(cascade): develop → stage (Fix/UX search-filter + tar 7.5.16)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -599,6 +599,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "بحث",
+                "searchPlaceholder": "العنوان أو الوصف",
+                "status": "الحالة",
+                "anyStatus": "أي حالة",
+                "apply": "تطبيق",
+                "reset": "إعادة تعيين"
             }
         },
         "agentsPage": {
@@ -690,7 +698,19 @@
                     "status": "الحالة",
                     "priority": "الأولوية",
                     "label": "العلامة",
-                    "all": "الكل"
+                    "all": "الكل",
+                    "search": "بحث",
+                    "searchPlaceholder": "العنوان أو الوصف أو الرمز",
+                    "anyStatus": "أي حالة",
+                    "anyPriority": "أي أولوية",
+                    "labelPlaceholder": "تسمية",
+                    "apply": "تطبيق",
+                    "reset": "إعادة تعيين"
+                },
+                "pagination": {
+                    "showing": "عرض {from}-{to} من {total}",
+                    "previous": "السابق",
+                    "next": "التالي"
                 }
             },
             "newDialog": {
@@ -977,7 +997,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "بحث",
+                "searchPlaceholder": "العنوان أو الوصف",
+                "status": "الحالة",
+                "anyStatus": "أي حالة",
+                "apply": "تطبيق",
+                "reset": "إعادة تعيين"
+            }
         },
         "discover": {
             "title": "اكتشف",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -599,6 +599,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Търсене",
+                "searchPlaceholder": "Заглавие или описание",
+                "status": "Статус",
+                "anyStatus": "Всякакъв статус",
+                "apply": "Приложи",
+                "reset": "Нулирай"
             }
         },
         "agentsPage": {
@@ -690,7 +698,19 @@
                     "status": "Статус",
                     "priority": "Приоритет",
                     "label": "Етикет",
-                    "all": "Всички"
+                    "all": "Всички",
+                    "search": "Търсене",
+                    "searchPlaceholder": "Заглавие, идентификатор или описание",
+                    "anyStatus": "Всякакъв статус",
+                    "anyPriority": "Всякакъв приоритет",
+                    "labelPlaceholder": "етикет",
+                    "apply": "Приложи",
+                    "reset": "Нулирай"
+                },
+                "pagination": {
+                    "showing": "Показване на {from}-{to} от {total}",
+                    "previous": "Предишна",
+                    "next": "Следваща"
                 }
             },
             "newDialog": {
@@ -977,7 +997,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Търсене",
+                "searchPlaceholder": "Заглавие или описание",
+                "status": "Статус",
+                "anyStatus": "Всякакъв статус",
+                "apply": "Приложи",
+                "reset": "Нулирай"
+            }
         },
         "discover": {
             "title": "Открийте",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -599,6 +599,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Suche",
+                "searchPlaceholder": "Titel oder Beschreibung",
+                "status": "Status",
+                "anyStatus": "Beliebiger Status",
+                "apply": "Übernehmen",
+                "reset": "Zurücksetzen"
             }
         },
         "agentsPage": {
@@ -690,7 +698,19 @@
                     "status": "Status",
                     "priority": "Priorität",
                     "label": "Label",
-                    "all": "Alle"
+                    "all": "Alle",
+                    "search": "Suche",
+                    "searchPlaceholder": "Titel, Slug oder Beschreibung",
+                    "anyStatus": "Beliebiger Status",
+                    "anyPriority": "Beliebige Priorität",
+                    "labelPlaceholder": "Bezeichnung",
+                    "apply": "Übernehmen",
+                    "reset": "Zurücksetzen"
+                },
+                "pagination": {
+                    "showing": "{from}–{to} von {total} angezeigt",
+                    "previous": "Zurück",
+                    "next": "Weiter"
                 }
             },
             "newDialog": {
@@ -977,7 +997,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Suche",
+                "searchPlaceholder": "Titel oder Beschreibung",
+                "status": "Status",
+                "anyStatus": "Beliebiger Status",
+                "apply": "Übernehmen",
+                "reset": "Zurücksetzen"
+            }
         },
         "discover": {
             "title": "Entdecken",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -599,6 +599,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "anyStatus": "Any status",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status"
             }
         },
         "agentsPage": {
@@ -690,7 +698,19 @@
                     "status": "Status",
                     "priority": "Priority",
                     "label": "Label",
-                    "all": "All"
+                    "all": "All",
+                    "search": "Search",
+                    "searchPlaceholder": "Title, slug, or description",
+                    "anyStatus": "Any status",
+                    "anyPriority": "Any priority",
+                    "labelPlaceholder": "label",
+                    "apply": "Apply",
+                    "reset": "Reset"
+                },
+                "pagination": {
+                    "showing": "Showing {from}-{to} of {total}",
+                    "previous": "Previous",
+                    "next": "Next"
                 }
             },
             "newDialog": {
@@ -977,7 +997,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Search",
+                "searchPlaceholder": "Title or description",
+                "apply": "Apply",
+                "reset": "Reset",
+                "status": "Status",
+                "anyStatus": "Any status"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -599,6 +599,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Buscar",
+                "searchPlaceholder": "Título o descripción",
+                "status": "Estado",
+                "anyStatus": "Cualquier estado",
+                "apply": "Aplicar",
+                "reset": "Restablecer"
             }
         },
         "agentsPage": {
@@ -690,7 +698,19 @@
                     "status": "Estado",
                     "priority": "Prioridad",
                     "label": "Etiqueta",
-                    "all": "Todas"
+                    "all": "Todas",
+                    "search": "Buscar",
+                    "searchPlaceholder": "Título, slug o descripción",
+                    "anyStatus": "Cualquier estado",
+                    "anyPriority": "Cualquier prioridad",
+                    "labelPlaceholder": "etiqueta",
+                    "apply": "Aplicar",
+                    "reset": "Restablecer"
+                },
+                "pagination": {
+                    "showing": "Mostrando {from}-{to} de {total}",
+                    "previous": "Anterior",
+                    "next": "Siguiente"
                 }
             },
             "newDialog": {
@@ -977,7 +997,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Buscar",
+                "searchPlaceholder": "Título o descripción",
+                "status": "Estado",
+                "anyStatus": "Cualquier estado",
+                "apply": "Aplicar",
+                "reset": "Restablecer"
+            }
         },
         "discover": {
             "title": "Descubrir",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -599,6 +599,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Rechercher",
+                "searchPlaceholder": "Titre ou description",
+                "status": "Statut",
+                "anyStatus": "Tout statut",
+                "apply": "Appliquer",
+                "reset": "Réinitialiser"
             }
         },
         "agentsPage": {
@@ -690,7 +698,19 @@
                     "status": "Statut",
                     "priority": "Priorité",
                     "label": "Étiquette",
-                    "all": "Tous"
+                    "all": "Tous",
+                    "search": "Rechercher",
+                    "searchPlaceholder": "Titre, slug ou description",
+                    "anyStatus": "Tout statut",
+                    "anyPriority": "Toute priorité",
+                    "labelPlaceholder": "étiquette",
+                    "apply": "Appliquer",
+                    "reset": "Réinitialiser"
+                },
+                "pagination": {
+                    "showing": "Affichage de {from}-{to} sur {total}",
+                    "previous": "Précédent",
+                    "next": "Suivant"
                 }
             },
             "newDialog": {
@@ -977,7 +997,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Rechercher",
+                "searchPlaceholder": "Titre ou description",
+                "status": "Statut",
+                "anyStatus": "Tout statut",
+                "apply": "Appliquer",
+                "reset": "Réinitialiser"
+            }
         },
         "discover": {
             "title": "Découvrir",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -599,6 +599,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "חיפוש",
+                "searchPlaceholder": "כותרת או תיאור",
+                "status": "סטטוס",
+                "anyStatus": "כל סטטוס",
+                "apply": "החל",
+                "reset": "אפס"
             }
         },
         "agentsPage": {
@@ -690,7 +698,19 @@
                     "status": "מצב",
                     "priority": "עדיפות",
                     "label": "תווית",
-                    "all": "הכל"
+                    "all": "הכל",
+                    "search": "חיפוש",
+                    "searchPlaceholder": "כותרת, מזהה או תיאור",
+                    "anyStatus": "כל סטטוס",
+                    "anyPriority": "כל עדיפות",
+                    "labelPlaceholder": "תווית",
+                    "apply": "החל",
+                    "reset": "אפס"
+                },
+                "pagination": {
+                    "showing": "מציג {from}-{to} מתוך {total}",
+                    "previous": "הקודם",
+                    "next": "הבא"
                 }
             },
             "newDialog": {
@@ -977,7 +997,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "חיפוש",
+                "searchPlaceholder": "כותרת או תיאור",
+                "status": "סטטוס",
+                "anyStatus": "כל סטטוס",
+                "apply": "החל",
+                "reset": "אפס"
+            }
         },
         "discover": {
             "title": "גלה",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "खोजें",
+                "searchPlaceholder": "शीर्षक या विवरण",
+                "status": "स्थिति",
+                "anyStatus": "कोई भी स्थिति",
+                "apply": "लागू करें",
+                "reset": "रीसेट करें"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "स्थिति",
                     "priority": "प्राथमिकता",
                     "label": "लेबल",
-                    "all": "सभी"
+                    "all": "सभी",
+                    "search": "खोजें",
+                    "searchPlaceholder": "शीर्षक, स्लग या विवरण",
+                    "anyStatus": "कोई भी स्थिति",
+                    "anyPriority": "कोई भी प्राथमिकता",
+                    "labelPlaceholder": "लेबल",
+                    "apply": "लागू करें",
+                    "reset": "रीसेट करें"
+                },
+                "pagination": {
+                    "showing": "{from}-{to} / {total} दिखाए जा रहे हैं",
+                    "previous": "पिछला",
+                    "next": "अगला"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "खोजें",
+                "searchPlaceholder": "शीर्षक या विवरण",
+                "status": "स्थिति",
+                "anyStatus": "कोई भी स्थिति",
+                "apply": "लागू करें",
+                "reset": "रीसेट करें"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "खोजें",
+                "searchPlaceholder": "शीर्षक या विवरण",
+                "status": "स्थिति",
+                "anyStatus": "कोई भी स्थिति",
+                "apply": "लागू करें",
+                "reset": "रीसेट करें"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Cari",
+                "searchPlaceholder": "Judul atau deskripsi",
+                "status": "Status",
+                "anyStatus": "Semua status",
+                "apply": "Terapkan",
+                "reset": "Reset"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "Status",
                     "priority": "Prioritas",
                     "label": "Label",
-                    "all": "Semua"
+                    "all": "Semua",
+                    "search": "Cari",
+                    "searchPlaceholder": "Judul, slug, atau deskripsi",
+                    "anyStatus": "Semua status",
+                    "anyPriority": "Semua prioritas",
+                    "labelPlaceholder": "label",
+                    "apply": "Terapkan",
+                    "reset": "Reset"
+                },
+                "pagination": {
+                    "showing": "Menampilkan {from}-{to} dari {total}",
+                    "previous": "Sebelumnya",
+                    "next": "Berikutnya"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Cari",
+                "searchPlaceholder": "Judul atau deskripsi",
+                "status": "Status",
+                "anyStatus": "Semua status",
+                "apply": "Terapkan",
+                "reset": "Reset"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Cari",
+                "searchPlaceholder": "Judul atau deskripsi",
+                "status": "Status",
+                "anyStatus": "Semua status",
+                "apply": "Terapkan",
+                "reset": "Reset"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Cerca",
+                "searchPlaceholder": "Titolo o descrizione",
+                "status": "Stato",
+                "anyStatus": "Qualsiasi stato",
+                "apply": "Applica",
+                "reset": "Reimposta"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "Stato",
                     "priority": "Priorità",
                     "label": "Etichetta",
-                    "all": "Tutti"
+                    "all": "Tutti",
+                    "search": "Cerca",
+                    "searchPlaceholder": "Titolo, slug o descrizione",
+                    "anyStatus": "Qualsiasi stato",
+                    "anyPriority": "Qualsiasi priorità",
+                    "labelPlaceholder": "etichetta",
+                    "apply": "Applica",
+                    "reset": "Reimposta"
+                },
+                "pagination": {
+                    "showing": "Visualizzazione di {from}-{to} su {total}",
+                    "previous": "Precedente",
+                    "next": "Successivo"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Cerca",
+                "searchPlaceholder": "Titolo o descrizione",
+                "status": "Stato",
+                "anyStatus": "Qualsiasi stato",
+                "apply": "Applica",
+                "reset": "Reimposta"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Cerca",
+                "searchPlaceholder": "Titolo o descrizione",
+                "status": "Stato",
+                "anyStatus": "Qualsiasi stato",
+                "apply": "Applica",
+                "reset": "Reimposta"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "検索",
+                "searchPlaceholder": "タイトルまたは説明",
+                "status": "ステータス",
+                "anyStatus": "すべてのステータス",
+                "apply": "適用",
+                "reset": "リセット"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "ステータス",
                     "priority": "優先度",
                     "label": "ラベル",
-                    "all": "すべて"
+                    "all": "すべて",
+                    "search": "検索",
+                    "searchPlaceholder": "タイトル、スラッグ、または説明",
+                    "anyStatus": "すべてのステータス",
+                    "anyPriority": "すべての優先度",
+                    "labelPlaceholder": "ラベル",
+                    "apply": "適用",
+                    "reset": "リセット"
+                },
+                "pagination": {
+                    "showing": "{from}〜{to} / {total}件を表示",
+                    "previous": "前へ",
+                    "next": "次へ"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "検索",
+                "searchPlaceholder": "タイトルまたは説明",
+                "status": "ステータス",
+                "anyStatus": "すべてのステータス",
+                "apply": "適用",
+                "reset": "リセット"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "検索",
+                "searchPlaceholder": "タイトルまたは説明",
+                "status": "ステータス",
+                "anyStatus": "すべてのステータス",
+                "apply": "適用",
+                "reset": "リセット"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "검색",
+                "searchPlaceholder": "제목 또는 설명",
+                "status": "상태",
+                "anyStatus": "모든 상태",
+                "apply": "적용",
+                "reset": "초기화"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "상태",
                     "priority": "우선순위",
                     "label": "레이블",
-                    "all": "전체"
+                    "all": "전체",
+                    "search": "검색",
+                    "searchPlaceholder": "제목, 슬러그 또는 설명",
+                    "anyStatus": "모든 상태",
+                    "anyPriority": "모든 우선순위",
+                    "labelPlaceholder": "레이블",
+                    "apply": "적용",
+                    "reset": "초기화"
+                },
+                "pagination": {
+                    "showing": "{total}개 중 {from}-{to} 표시",
+                    "previous": "이전",
+                    "next": "다음"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "검색",
+                "searchPlaceholder": "제목 또는 설명",
+                "status": "상태",
+                "anyStatus": "모든 상태",
+                "apply": "적용",
+                "reset": "초기화"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "검색",
+                "searchPlaceholder": "제목 또는 설명",
+                "status": "상태",
+                "anyStatus": "모든 상태",
+                "apply": "적용",
+                "reset": "초기화"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Zoeken",
+                "searchPlaceholder": "Titel of beschrijving",
+                "status": "Status",
+                "anyStatus": "Elke status",
+                "apply": "Toepassen",
+                "reset": "Herstellen"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "Status",
                     "priority": "Prioriteit",
                     "label": "Label",
-                    "all": "Alle"
+                    "all": "Alle",
+                    "search": "Zoeken",
+                    "searchPlaceholder": "Titel, slug of beschrijving",
+                    "anyStatus": "Elke status",
+                    "anyPriority": "Elke prioriteit",
+                    "labelPlaceholder": "label",
+                    "apply": "Toepassen",
+                    "reset": "Herstellen"
+                },
+                "pagination": {
+                    "showing": "{from}-{to} van {total} weergegeven",
+                    "previous": "Vorige",
+                    "next": "Volgende"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Zoeken",
+                "searchPlaceholder": "Titel of beschrijving",
+                "status": "Status",
+                "anyStatus": "Elke status",
+                "apply": "Toepassen",
+                "reset": "Herstellen"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Zoeken",
+                "searchPlaceholder": "Titel of beschrijving",
+                "status": "Status",
+                "anyStatus": "Elke status",
+                "apply": "Toepassen",
+                "reset": "Herstellen"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Szukaj",
+                "searchPlaceholder": "Tytuł lub opis",
+                "status": "Status",
+                "anyStatus": "Dowolny status",
+                "apply": "Zastosuj",
+                "reset": "Resetuj"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "Status",
                     "priority": "Priorytet",
                     "label": "Etykieta",
-                    "all": "Wszystkie"
+                    "all": "Wszystkie",
+                    "search": "Szukaj",
+                    "searchPlaceholder": "Tytuł, slug lub opis",
+                    "anyStatus": "Dowolny status",
+                    "anyPriority": "Dowolny priorytet",
+                    "labelPlaceholder": "etykieta",
+                    "apply": "Zastosuj",
+                    "reset": "Resetuj"
+                },
+                "pagination": {
+                    "showing": "Wyświetlanie {from}-{to} z {total}",
+                    "previous": "Poprzednia",
+                    "next": "Następna"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Szukaj",
+                "searchPlaceholder": "Tytuł lub opis",
+                "status": "Status",
+                "anyStatus": "Dowolny status",
+                "apply": "Zastosuj",
+                "reset": "Resetuj"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Szukaj",
+                "searchPlaceholder": "Tytuł lub opis",
+                "status": "Status",
+                "anyStatus": "Dowolny status",
+                "apply": "Zastosuj",
+                "reset": "Resetuj"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Buscar",
+                "searchPlaceholder": "Título ou descrição",
+                "status": "Status",
+                "anyStatus": "Qualquer status",
+                "apply": "Aplicar",
+                "reset": "Redefinir"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "Status",
                     "priority": "Prioridade",
                     "label": "Etiqueta",
-                    "all": "Todas"
+                    "all": "Todas",
+                    "search": "Buscar",
+                    "searchPlaceholder": "Título, slug ou descrição",
+                    "anyStatus": "Qualquer status",
+                    "anyPriority": "Qualquer prioridade",
+                    "labelPlaceholder": "rótulo",
+                    "apply": "Aplicar",
+                    "reset": "Redefinir"
+                },
+                "pagination": {
+                    "showing": "Exibindo {from}-{to} de {total}",
+                    "previous": "Anterior",
+                    "next": "Próximo"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Buscar",
+                "searchPlaceholder": "Título ou descrição",
+                "status": "Status",
+                "anyStatus": "Qualquer status",
+                "apply": "Aplicar",
+                "reset": "Redefinir"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Buscar",
+                "searchPlaceholder": "Título ou descrição",
+                "status": "Status",
+                "anyStatus": "Qualquer status",
+                "apply": "Aplicar",
+                "reset": "Redefinir"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Поиск",
+                "searchPlaceholder": "Заголовок или описание",
+                "status": "Статус",
+                "anyStatus": "Любой статус",
+                "apply": "Применить",
+                "reset": "Сбросить"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "Статус",
                     "priority": "Приоритет",
                     "label": "Метка",
-                    "all": "Все"
+                    "all": "Все",
+                    "search": "Поиск",
+                    "searchPlaceholder": "Заголовок, slug или описание",
+                    "anyStatus": "Любой статус",
+                    "anyPriority": "Любой приоритет",
+                    "labelPlaceholder": "метка",
+                    "apply": "Применить",
+                    "reset": "Сбросить"
+                },
+                "pagination": {
+                    "showing": "Показано {from}–{to} из {total}",
+                    "previous": "Назад",
+                    "next": "Вперёд"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Поиск",
+                "searchPlaceholder": "Заголовок или описание",
+                "status": "Статус",
+                "anyStatus": "Любой статус",
+                "apply": "Применить",
+                "reset": "Сбросить"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Поиск",
+                "searchPlaceholder": "Заголовок или описание",
+                "status": "Статус",
+                "anyStatus": "Любой статус",
+                "apply": "Применить",
+                "reset": "Сбросить"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "ค้นหา",
+                "searchPlaceholder": "ชื่อหรือคำอธิบาย",
+                "status": "สถานะ",
+                "anyStatus": "สถานะใดก็ได้",
+                "apply": "นำไปใช้",
+                "reset": "รีเซ็ต"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "สถานะ",
                     "priority": "ความสำคัญ",
                     "label": "ป้ายกำกับ",
-                    "all": "ทั้งหมด"
+                    "all": "ทั้งหมด",
+                    "search": "ค้นหา",
+                    "searchPlaceholder": "ชื่อ สลัก หรือคำอธิบาย",
+                    "anyStatus": "สถานะใดก็ได้",
+                    "anyPriority": "ลำดับความสำคัญใดก็ได้",
+                    "labelPlaceholder": "ป้ายกำกับ",
+                    "apply": "นำไปใช้",
+                    "reset": "รีเซ็ต"
+                },
+                "pagination": {
+                    "showing": "แสดง {from}-{to} จาก {total}",
+                    "previous": "ก่อนหน้า",
+                    "next": "ถัดไป"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "ค้นหา",
+                "searchPlaceholder": "ชื่อหรือคำอธิบาย",
+                "status": "สถานะ",
+                "anyStatus": "สถานะใดก็ได้",
+                "apply": "นำไปใช้",
+                "reset": "รีเซ็ต"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "ค้นหา",
+                "searchPlaceholder": "ชื่อหรือคำอธิบาย",
+                "status": "สถานะ",
+                "anyStatus": "สถานะใดก็ได้",
+                "apply": "นำไปใช้",
+                "reset": "รีเซ็ต"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Ara",
+                "searchPlaceholder": "Başlık veya açıklama",
+                "status": "Durum",
+                "anyStatus": "Herhangi bir durum",
+                "apply": "Uygula",
+                "reset": "Sıfırla"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "Durum",
                     "priority": "Öncelik",
                     "label": "Etiket",
-                    "all": "Tümü"
+                    "all": "Tümü",
+                    "search": "Ara",
+                    "searchPlaceholder": "Başlık, slug veya açıklama",
+                    "anyStatus": "Herhangi bir durum",
+                    "anyPriority": "Herhangi bir öncelik",
+                    "labelPlaceholder": "etiket",
+                    "apply": "Uygula",
+                    "reset": "Sıfırla"
+                },
+                "pagination": {
+                    "showing": "{total} içinden {from}-{to} gösteriliyor",
+                    "previous": "Önceki",
+                    "next": "Sonraki"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Ara",
+                "searchPlaceholder": "Başlık veya açıklama",
+                "status": "Durum",
+                "anyStatus": "Herhangi bir durum",
+                "apply": "Uygula",
+                "reset": "Sıfırla"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Ara",
+                "searchPlaceholder": "Başlık veya açıklama",
+                "status": "Durum",
+                "anyStatus": "Herhangi bir durum",
+                "apply": "Uygula",
+                "reset": "Sıfırla"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Пошук",
+                "searchPlaceholder": "Заголовок або опис",
+                "status": "Статус",
+                "anyStatus": "Будь-який статус",
+                "apply": "Застосувати",
+                "reset": "Скинути"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "Статус",
                     "priority": "Пріоритет",
                     "label": "Мітка",
-                    "all": "Усі"
+                    "all": "Усі",
+                    "search": "Пошук",
+                    "searchPlaceholder": "Заголовок, slug або опис",
+                    "anyStatus": "Будь-який статус",
+                    "anyPriority": "Будь-який пріоритет",
+                    "labelPlaceholder": "мітка",
+                    "apply": "Застосувати",
+                    "reset": "Скинути"
+                },
+                "pagination": {
+                    "showing": "Показано {from}–{to} з {total}",
+                    "previous": "Назад",
+                    "next": "Вперед"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Пошук",
+                "searchPlaceholder": "Заголовок або опис",
+                "status": "Статус",
+                "anyStatus": "Будь-який статус",
+                "apply": "Застосувати",
+                "reset": "Скинути"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Пошук",
+                "searchPlaceholder": "Заголовок або опис",
+                "status": "Статус",
+                "anyStatus": "Будь-який статус",
+                "apply": "Застосувати",
+                "reset": "Скинути"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "Tìm kiếm",
+                "searchPlaceholder": "Tiêu đề hoặc mô tả",
+                "status": "Trạng thái",
+                "anyStatus": "Bất kỳ trạng thái",
+                "apply": "Áp dụng",
+                "reset": "Đặt lại"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "Trạng thái",
                     "priority": "Ưu tiên",
                     "label": "Nhãn",
-                    "all": "Tất cả"
+                    "all": "Tất cả",
+                    "search": "Tìm kiếm",
+                    "searchPlaceholder": "Tiêu đề, slug hoặc mô tả",
+                    "anyStatus": "Bất kỳ trạng thái",
+                    "anyPriority": "Bất kỳ ưu tiên",
+                    "labelPlaceholder": "nhãn",
+                    "apply": "Áp dụng",
+                    "reset": "Đặt lại"
+                },
+                "pagination": {
+                    "showing": "Hiển thị {from}-{to} trong {total}",
+                    "previous": "Trước",
+                    "next": "Tiếp theo"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Tìm kiếm",
+                "searchPlaceholder": "Tiêu đề hoặc mô tả",
+                "status": "Trạng thái",
+                "anyStatus": "Bất kỳ trạng thái",
+                "apply": "Áp dụng",
+                "reset": "Đặt lại"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "Tìm kiếm",
+                "searchPlaceholder": "Tiêu đề hoặc mô tả",
+                "status": "Trạng thái",
+                "anyStatus": "Bất kỳ trạng thái",
+                "apply": "Áp dụng",
+                "reset": "Đặt lại"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -568,6 +568,14 @@
                 "capUnlimited": "Unlimited",
                 "capPrefix": "Outstanding cap:",
                 "clonedFromPrefix": "Cloned from another Mission"
+            },
+            "filterBar": {
+                "search": "搜索",
+                "searchPlaceholder": "标题或描述",
+                "status": "状态",
+                "anyStatus": "任意状态",
+                "apply": "应用",
+                "reset": "重置"
             }
         },
         "agentsPage": {
@@ -632,7 +640,19 @@
                     "status": "状态",
                     "priority": "优先级",
                     "label": "标签",
-                    "all": "全部"
+                    "all": "全部",
+                    "search": "搜索",
+                    "searchPlaceholder": "标题、标识符或描述",
+                    "anyStatus": "任意状态",
+                    "anyPriority": "任意优先级",
+                    "labelPlaceholder": "标签",
+                    "apply": "应用",
+                    "reset": "重置"
+                },
+                "pagination": {
+                    "showing": "显示第 {from}-{to} 条，共 {total} 条",
+                    "previous": "上一页",
+                    "next": "下一页"
                 }
             },
             "newDialog": {
@@ -872,7 +892,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "搜索",
+                "searchPlaceholder": "标题或描述",
+                "status": "状态",
+                "anyStatus": "任意状态",
+                "apply": "应用",
+                "reset": "重置"
+            }
         },
         "discover": {
             "title": "Discover",
@@ -4563,7 +4591,15 @@
                 "title": "No Ideas match these filters.",
                 "subtitle": "Toggle accepted / dismissed, or add one with the field above."
             },
-            "viewAll": "View all ({n}) →"
+            "viewAll": "View all ({n}) →",
+            "filterBar": {
+                "search": "搜索",
+                "searchPlaceholder": "标题或描述",
+                "status": "状态",
+                "anyStatus": "任意状态",
+                "apply": "应用",
+                "reset": "重置"
+            }
         },
         "discover": {
             "title": "Discover",

--- a/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
-import { ListChecks, Plus } from 'lucide-react';
+import { ListChecks, Plus, Search } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ROUTES } from '@/lib/constants';
 import { tasksAPI, type TaskPriority, type TaskStatus } from '@/lib/api/tasks';
+import { TasksFilterSelects } from '@/components/tasks/TasksFilterSelects';
 import { TasksList } from '@/components/tasks/TasksList';
 import { PageHeader } from '@/components/common/PageHeader';
 import { Link } from '@/i18n/navigation';
@@ -105,66 +106,40 @@ export default async function TasksPage({ searchParams }: { searchParams: TasksS
             <form className="mb-4 flex flex-col gap-2 @lg/main:flex-row @lg/main:items-end">
                 <label className="flex-1 min-w-0">
                     <span className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1">
-                        Search
+                        {t('list.filter.search')}
                     </span>
-                    <input
-                        name="search"
-                        defaultValue={query.search ?? ''}
-                        placeholder="Title, slug, or description"
-                        className="w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-3 h-9 text-sm text-text dark:text-text-dark"
-                    />
+                    <div className="relative">
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-muted dark:text-text-muted-dark pointer-events-none" />
+                        <input
+                            name="search"
+                            defaultValue={query.search ?? ''}
+                            placeholder={t('list.filter.searchPlaceholder')}
+                            className="w-full rounded-lg border border-card-border dark:border-white/9 bg-card dark:bg-card-primary-dark pl-9 pr-4 py-2 h-9 text-xs text-text dark:text-text-dark placeholder-text-muted dark:placeholder-text-muted-dark hover:border-border-secondary dark:hover:border-border-secondary-dark focus:border-primary dark:focus:border-white/9 focus:ring-2 focus:ring-primary-800/20 transition-colors outline-none"
+                        />
+                    </div>
                 </label>
-                <label className="min-w-40">
-                    <span className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1">
-                        Status
-                    </span>
-                    <select
-                        name="status"
-                        defaultValue={query.status ?? ''}
-                        className="w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-3 h-9 text-sm text-text dark:text-text-dark"
-                    >
-                        <option value="">Any status</option>
-                        {TASK_STATUSES.map((s) => (
-                            <option key={s} value={s}>
-                                {s.replace('_', ' ')}
-                            </option>
-                        ))}
-                    </select>
-                </label>
+                <TasksFilterSelects
+                    key={`${query.status ?? ''}-${query.priority ?? ''}`}
+                    defaultStatus={query.status}
+                    defaultPriority={query.priority}
+                />
                 <label className="min-w-36">
                     <span className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1">
-                        Priority
-                    </span>
-                    <select
-                        name="priority"
-                        defaultValue={query.priority ?? ''}
-                        className="w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-3 h-9 text-sm text-text dark:text-text-dark"
-                    >
-                        <option value="">Any priority</option>
-                        {TASK_PRIORITIES.map((p) => (
-                            <option key={p} value={p}>
-                                {p.toUpperCase()}
-                            </option>
-                        ))}
-                    </select>
-                </label>
-                <label className="min-w-36">
-                    <span className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1">
-                        Label
+                        {t('list.filter.label')}
                     </span>
                     <input
                         name="label"
                         defaultValue={query.label ?? ''}
-                        placeholder="label"
-                        className="w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-3 h-9 text-sm text-text dark:text-text-dark"
+                        placeholder={t('list.filter.labelPlaceholder')}
+                        className="w-full rounded-lg border border-card-border dark:border-white/9 bg-card dark:bg-card-primary-dark px-4 py-2 h-9 text-xs text-text dark:text-text-dark placeholder-text-muted dark:placeholder-text-muted-dark hover:border-border-secondary dark:hover:border-border-secondary-dark focus:border-primary dark:focus:border-white/9 focus:ring-2 focus:ring-primary-800/20 transition-colors outline-none"
                     />
                 </label>
                 <div className="flex items-center gap-2">
                     <Button type="submit" size="sm">
-                        Apply
+                        {t('list.filter.apply')}
                     </Button>
                     <Button href={ROUTES.DASHBOARD_TASKS} size="sm" variant="ghost">
-                        Reset
+                        {t('list.filter.reset')}
                     </Button>
                 </div>
             </form>
@@ -172,9 +147,14 @@ export default async function TasksPage({ searchParams }: { searchParams: TasksS
             {result.meta.total > result.meta.limit && (
                 <nav className="mt-5 flex items-center justify-between gap-3 text-xs text-text-muted dark:text-text-muted-dark">
                     <span>
-                        Showing {result.meta.offset + 1}-
-                        {Math.min(result.meta.offset + result.data.length, result.meta.total)} of{' '}
-                        {result.meta.total}
+                        {t('list.pagination.showing', {
+                            from: result.meta.offset + 1,
+                            to: Math.min(
+                                result.meta.offset + result.data.length,
+                                result.meta.total,
+                            ),
+                            total: result.meta.total,
+                        })}
                     </span>
                     <div className="flex items-center gap-2">
                         {result.meta.offset > 0 && (
@@ -182,7 +162,7 @@ export default async function TasksPage({ searchParams }: { searchParams: TasksS
                                 href={buildTasksHref({ ...baseHrefInput, offset: prevOffset })}
                                 className="rounded-md border border-border/60 dark:border-border-dark/60 px-3 py-1.5 text-text dark:text-text-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark"
                             >
-                                Previous
+                                {t('list.pagination.previous')}
                             </Link>
                         )}
                         {nextOffset < result.meta.total && (
@@ -190,7 +170,7 @@ export default async function TasksPage({ searchParams }: { searchParams: TasksS
                                 href={buildTasksHref({ ...baseHrefInput, offset: nextOffset })}
                                 className="rounded-md border border-border/60 dark:border-border-dark/60 px-3 py-1.5 text-text dark:text-text-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark"
                             >
-                                Next
+                                {t('list.pagination.next')}
                             </Link>
                         )}
                     </div>

--- a/apps/web/src/components/ideas/IdeasPageClient.tsx
+++ b/apps/web/src/components/ideas/IdeasPageClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useState, useTransition } from 'react';
-import { Lightbulb, Settings as SettingsIcon } from 'lucide-react';
+import { useState, useTransition, useEffect } from 'react';
+import { Lightbulb, Settings as SettingsIcon, Search } from 'lucide-react';
+import { Select } from '@/components/ui/select';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { buildIdeaAction } from '@/app/actions/dashboard/work-proposals';
@@ -97,6 +98,10 @@ export function IdeasPageClient({
     const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
     const [isCreating, startCreating] = useTransition();
     const [isBuilding, startBuilding] = useTransition();
+    let [statusFilter, setStatusFilter] = useState<string>(filters?.status ?? 'actionable');
+    useEffect(() => {
+        setStatusFilter(filters?.status ?? 'actionable');
+    }, [filters?.status]);
 
     const startFromPrompt = useStartFromPrompt();
 
@@ -249,44 +254,41 @@ export function IdeasPageClient({
             <form className="mb-5 flex flex-col gap-2 @lg/main:flex-row @lg/main:items-end">
                 <label className="flex-1 min-w-0">
                     <span className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1">
-                        Search
+                        {t('filterBar.search')}
                     </span>
-                    <input
-                        name="search"
-                        defaultValue={filters?.search ?? ''}
-                        placeholder="Title or description"
-                        maxLength={500}
-                        className="w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-3 h-9 text-sm text-text dark:text-text-dark"
-                    />
+                    <div className="relative">
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-muted dark:text-text-muted-dark pointer-events-none" />
+                        <input
+                            name="search"
+                            defaultValue={filters?.search ?? ''}
+                            placeholder={t('filterBar.searchPlaceholder')}
+                            maxLength={500}
+                            className="w-full rounded-lg border border-card-border dark:border-white/9 bg-card dark:bg-card-primary-dark pl-9 pr-4 py-2 h-9 text-xs text-text dark:text-text-dark placeholder-text-muted dark:placeholder-text-muted-dark hover:border-border-secondary dark:hover:border-border-secondary-dark focus:border-primary dark:focus:border-white/9 focus:ring-2 focus:ring-primary-800/20 transition-colors outline-none"
+                        />
+                    </div>
                 </label>
-                <label className="min-w-44">
+                <div className="min-w-44">
                     <span className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1">
-                        Status
+                        {t('filterBar.status')}
                     </span>
-                    <select
-                        name="status"
-                        defaultValue={filters?.status ?? 'actionable'}
-                        className="w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-3 h-9 text-sm text-text dark:text-text-dark"
-                    >
+                    <input type="hidden" name="status" value={statusFilter} />
+                    <Select value={statusFilter} onValueChange={setStatusFilter} size="xs">
                         {STATUS_FILTER_ORDER.map((status) => (
                             <option key={status} value={status}>
                                 {status === 'actionable' ? 'Actionable' : t(`filters.${status}`)}
                             </option>
                         ))}
-                    </select>
-                </label>
+                    </Select>
+                </div>
                 <div className="flex items-center gap-2">
-                    <button
-                        type="submit"
-                        className="inline-flex h-9 items-center justify-center rounded-md bg-button-primary dark:bg-button-primary-dark px-3 text-sm font-medium text-button-primary-foreground dark:text-button-primary-foreground-dark hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark"
-                    >
-                        Apply
-                    </button>
+                    <Button type="submit" size="sm">
+                        {t('filterBar.apply')}
+                    </Button>
                     <Link
                         href={ROUTES.DASHBOARD_IDEAS}
                         className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-medium text-text dark:text-text-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark"
                     >
-                        Reset
+                        {t('filterBar.reset')}
                     </Link>
                 </div>
             </form>

--- a/apps/web/src/components/missions/MissionsList.tsx
+++ b/apps/web/src/components/missions/MissionsList.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useState, useTransition } from 'react';
-import { Target } from 'lucide-react';
+import { useState, useTransition, useEffect } from 'react';
+import { Target, Search } from 'lucide-react';
+import { Select } from '@/components/ui/select';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
 import { Link } from '@/i18n/navigation';
 import {
     PromptComposer,
@@ -68,6 +70,10 @@ export function MissionsList({
     const [draft, setDraft] = useState('');
     const [attachments, setAttachments] = useState<ReadonlyArray<ComposerAttachment>>([]);
     const [submitting, startSubmit] = useTransition();
+    let [statusFilter, setStatusFilter] = useState(filters?.status ?? '');
+    useEffect(() => {
+        setStatusFilter(filters?.status ?? '');
+    }, [filters?.status]);
     const startFromPrompt = useStartFromPrompt();
 
     const submit = () => {
@@ -139,46 +145,45 @@ export function MissionsList({
             <form className="mb-5 flex flex-col gap-2 @lg/main:flex-row @lg/main:items-end">
                 <label className="flex-1 min-w-0">
                     <span className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1">
-                        Search
+                        {t('filterBar.search')}
                     </span>
-                    <input
-                        name="search"
-                        defaultValue={filters?.search ?? ''}
-                        placeholder="Title or description"
-                        maxLength={500}
-                        className="w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-3 h-9 text-sm text-text dark:text-text-dark"
-                    />
+                    <div className="relative">
+                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-muted dark:text-text-muted-dark pointer-events-none" />
+                        <input
+                            name="search"
+                            defaultValue={filters?.search ?? ''}
+                            placeholder={t('filterBar.searchPlaceholder')}
+                            maxLength={500}
+                            className="w-full rounded-lg border border-card-border dark:border-white/9 bg-card dark:bg-card-primary-dark pl-9 pr-4 py-2 h-9 text-xs text-text dark:text-text-dark placeholder-text-muted dark:placeholder-text-muted-dark hover:border-border-secondary dark:hover:border-border-secondary-dark focus:border-primary dark:focus:border-white/9 focus:ring-2 focus:ring-primary-800/20 transition-colors outline-none"
+                        />
+                    </div>
                 </label>
-                <label className="min-w-40">
+                <div className="min-w-40">
                     <span className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1">
-                        Status
+                        {t('filterBar.status')}
                     </span>
-                    <select
-                        name="status"
-                        defaultValue={filters?.status ?? ''}
-                        className="w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-3 h-9 text-sm text-text dark:text-text-dark"
+                    <input type="hidden" name="status" value={statusFilter} />
+                    <Select
+                        value={statusFilter}
+                        onValueChange={setStatusFilter}
+                        placeholder={t('filterBar.anyStatus')}
+                        size="xs"
                     >
-                        <option value="">Any status</option>
+                        <option value="">{t('filterBar.anyStatus')}</option>
                         {MISSION_STATUSES.map((status) => (
                             <option key={status} value={status}>
                                 {status}
                             </option>
                         ))}
-                    </select>
-                </label>
+                    </Select>
+                </div>
                 <div className="flex items-center gap-2">
-                    <button
-                        type="submit"
-                        className="inline-flex h-9 items-center justify-center rounded-md bg-button-primary dark:bg-button-primary-dark px-3 text-sm font-medium text-button-primary-foreground dark:text-button-primary-foreground-dark hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark"
-                    >
-                        Apply
-                    </button>
-                    <Link
-                        href={ROUTES.DASHBOARD_MISSIONS}
-                        className="inline-flex h-9 items-center justify-center rounded-md px-3 text-sm font-medium text-text dark:text-text-dark hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark"
-                    >
-                        Reset
-                    </Link>
+                    <Button type="submit" size="sm">
+                        {t('filterBar.apply')}
+                    </Button>
+                    <Button href={ROUTES.DASHBOARD_MISSIONS} size="sm" variant="ghost">
+                        {t('filterBar.reset')}
+                    </Button>
                 </div>
             </form>
 

--- a/apps/web/src/components/tasks/TasksFilterSelects.tsx
+++ b/apps/web/src/components/tasks/TasksFilterSelects.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Select } from '@/components/ui/select';
+
+const TASK_STATUSES = [
+    'backlog',
+    'todo',
+    'in_progress',
+    'in_review',
+    'blocked',
+    'done',
+    'cancelled',
+] as const;
+
+const TASK_PRIORITIES = ['p0', 'p1', 'p2', 'p3', 'p4'] as const;
+
+interface TasksFilterSelectsProps {
+    defaultStatus?: string;
+    defaultPriority?: string;
+}
+
+export function TasksFilterSelects({
+    defaultStatus = '',
+    defaultPriority = '',
+}: TasksFilterSelectsProps) {
+    const t = useTranslations('dashboard.tasksPage');
+    let [status, setStatus] = useState(defaultStatus);
+    let [priority, setPriority] = useState(defaultPriority);
+
+    return (
+        <>
+            {/* Hidden inputs carry values through native form submission */}
+            <input type="hidden" name="status" value={status} />
+            <input type="hidden" name="priority" value={priority} />
+
+            <div className="min-w-40">
+                <span className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1">
+                    {t('list.filter.status')}
+                </span>
+                <Select
+                    value={status}
+                    onValueChange={setStatus}
+                    placeholder={t('list.filter.anyStatus')}
+                    size="xs"
+                >
+                    <option value="">{t('list.filter.anyStatus')}</option>
+                    {TASK_STATUSES.map((s) => (
+                        <option key={s} value={s}>
+                            {t(`status.${s}`)}
+                        </option>
+                    ))}
+                </Select>
+            </div>
+
+            <div className="min-w-36">
+                <span className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1">
+                    {t('list.filter.priority')}
+                </span>
+                <Select
+                    value={priority}
+                    onValueChange={setPriority}
+                    placeholder={t('list.filter.anyPriority')}
+                    size="xs"
+                >
+                    <option value="">{t('list.filter.anyPriority')}</option>
+                    {TASK_PRIORITIES.map((p) => (
+                        <option key={p} value={p}>
+                            {p.toUpperCase()}
+                        </option>
+                    ))}
+                </Select>
+            </div>
+        </>
+    );
+}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -33,8 +33,8 @@ export interface SelectProps {
     onValueChange?: (value: string) => void;
     onChange?: React.ChangeEventHandler<HTMLSelectElement>;
     disabled?: boolean;
-    /** 'sm' = h-8 text-xs  |  'default' = h-9 text-sm */
-    size?: 'sm' | 'default';
+    /** 'xs' = h-8 text-xs  |  'sm' = h-8 text-xs  |  'default' = h-9 text-sm */
+    size?: 'xs' | 'sm' | 'default';
     className?: string;
     children?: React.ReactNode;
     placeholder?: string;
@@ -214,7 +214,8 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                     aria-haspopup="listbox"
                     aria-expanded={open}
                     className={cn(
-                        'w-full flex items-center justify-between rounded-lg border text-sm',
+                        'w-full flex items-center justify-between rounded-lg border',
+                        size === 'xs' ? 'text-xs' : 'text-sm',
                         'transition-colors outline-none text-left cursor-pointer',
                         'bg-card dark:bg-card-primary-dark',
                         'border-border dark:border-border-secondary-dark',
@@ -223,7 +224,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                         'disabled:cursor-not-allowed disabled:opacity-50',
                         open &&
                             'border-border-secondary dark:border-white/20 ring-1 ring-primary/20 dark:ring-white/10',
-                        size === 'default' ? 'h-9 px-3 py-2' : 'h-8 px-2 text-sm',
+                        size === 'default' ? 'h-9 px-3 py-2' : 'h-8 px-2',
                     )}
                 >
                     <span
@@ -315,7 +316,7 @@ function OptionRow({
 }: {
     opt: OptionData;
     selected: boolean;
-    size: 'sm' | 'default';
+    size: 'xs' | 'sm' | 'default';
     onPick: (opt: OptionData) => void;
     indent?: boolean;
 }) {
@@ -370,7 +371,9 @@ function OptionRow({
                 'flex items-center gap-2 cursor-pointer select-none transition-colors',
                 size === 'default'
                     ? 'px-3 py-2 text-sm mx-1 rounded-sm my-px'
-                    : 'px-2 py-1.5 mx-1 rounded-sm my-px text-sm',
+                    : size === 'xs'
+                      ? 'px-2 py-1 mx-1 rounded-sm my-px text-xs'
+                      : 'px-2 py-1.5 mx-1 rounded-sm my-px text-sm',
                 indent && 'pl-6',
                 selected
                     ? 'bg-surface-secondary dark:bg-white/6 font-medium text-text dark:text-text-dark'

--- a/packages/plugins/codex/package.json
+++ b/packages/plugins/codex/package.json
@@ -37,7 +37,7 @@
 		"@ever-works/plugin": "workspace:*"
 	},
 	"dependencies": {
-		"tar": "^7.4.3"
+		"tar": "^7.5.16"
 	},
 	"devDependencies": {
 		"@ever-works/plugin": "workspace:*",

--- a/packages/plugins/opencode/package.json
+++ b/packages/plugins/opencode/package.json
@@ -37,7 +37,7 @@
 	},
 	"dependencies": {
 		"extract-zip": "^2.0.1",
-		"tar": "^7.4.3"
+		"tar": "^7.5.16"
 	},
 	"devDependencies": {
 		"@ever-works/plugin": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1494,7 +1494,7 @@ importers:
   packages/plugins/codex:
     dependencies:
       tar:
-        specifier: '>=7.5.16'
+        specifier: ^7.5.16
         version: 7.5.16
     devDependencies:
       '@ever-works/plugin':
@@ -2325,7 +2325,7 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       tar:
-        specifier: '>=7.5.16'
+        specifier: ^7.5.16
         version: 7.5.16
     devDependencies:
       '@ever-works/plugin':


### PR DESCRIPTION
Standard develop → stage cascade.

## What's new since the previous cascade

| PR | Subject |
| --- | --- |
| #1353 | fix(web): replace inconsistent search/filter inputs on tasks, ideas, missions (extracts TasksFilterSelects, switches all three pages to the custom Select, adds filterBar + pagination i18n keys for 20 locales) |
| #1326 | chore(deps): bump tar from 7.5.13 to 7.5.16 (dependabot) |

Both PRs originally CONFLICTING/DIRTY. Resolution work landed in session 1518:
- #1326: reset to develop, re-applied the two package.json bumps, regenerated pnpm-lock.yaml.
- #1353: reset to develop, cherry-picked 26 non-dep files, 3-way merged 21 i18n message files (kept develop's EW-742 admin allow-list + 3-mode picker keys alongside PR's filterBar additions), hand-merged select.tsx to keep both PR's new 'xs' size variant AND develop's data-testid + data-value attributes from #1589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)