### PR TITLE
fix(web): center collapsed sidebar icon and icon-style logo

### DIFF
--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -165,7 +165,7 @@ export function DashboardSidebar({
                         <div
                             className={cn(
                                 'flex items-center',
-                                isCollapsed ? 'justify-center' : 'pr-6',
+                                isCollapsed ? 'justify-center ml-2' : 'pr-6',
                             )}
                         >
                             <WorkspaceSwitcher config={config} isCollapsed={isCollapsed} />

--- a/apps/web/src/components/logos/index.tsx
+++ b/apps/web/src/components/logos/index.tsx
@@ -32,7 +32,7 @@ export function LogoEverWorkImage({
 }: LogoEverWorkProps) {
     const siteConfig = getSiteConfig(configProps);
     return (
-        <span className={cn('relative flex items-center', className)}>
+        <span className={cn('relative flex items-center justify-center', className)}>
             <Image
                 src={siteConfig.logo.light}
                 alt={siteConfig.name}


### PR DESCRIPTION
Nudge the collapsed WorkspaceSwitcher icon to the column center and center the logo image within its slot so an icon-style logo no longer hugs the left edge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment and spacing in the dashboard sidebar when collapsed.
  * Centered the workspace switcher and logo presentation more consistently within their containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->