### PR TITLE
Fix/agent

### DIFF
--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -27,6 +27,7 @@ jest.mock('@ever-works/agent/agents', () => ({
     AgentExportService: class {},
     AgentScheduleDispatcherService: class {},
     AgentRunRepository: class {},
+    AgentRunLogRepository: class {},
     SkillBindingRepository: class {},
     PluginUsageRepository: class {},
 }));
@@ -41,6 +42,13 @@ jest.mock('@ever-works/agent/activity-log', () => ({
         AGENT_RUN_TRIGGERED: 'agent_run_triggered',
         AGENT_RUN_CANCELLED: 'agent_run_cancelled',
         AGENT_TASK_ASSIGNED: 'agent_task_assigned',
+        AGENT_CREATED: 'agent_created',
+        AGENT_PAUSED: 'agent_paused',
+        AGENT_RESUMED: 'agent_resumed',
+        AGENT_ARCHIVED: 'agent_archived',
+        AGENT_EXPORTED: 'agent_exported',
+        AGENT_IMPORTED: 'agent_imported',
+        AGENT_BUDGET_EXCEEDED: 'agent_budget_exceeded',
     },
     ActivityStatus: { COMPLETED: 'completed' },
 }));
@@ -63,6 +71,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
     let exportService: any;
     let dispatcher: any;
     let agentRuns: any;
+    let agentRunLogs: any;
     let skillBindings: any;
     let pluginUsage: any;
     let tasks: any;
@@ -98,11 +107,16 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             createQueued: jest.fn(),
             findInFlightForTaskAgent: jest.fn().mockResolvedValue(null),
             markFailed: jest.fn().mockResolvedValue(undefined),
+            findByIdAndUser: jest.fn().mockResolvedValue(null),
         };
+        agentRunLogs = { findByRun: jest.fn().mockResolvedValue([]) };
         skillBindings = { resolveActive: jest.fn().mockResolvedValue([]) };
         pluginUsage = { getTotalSpendCentsForOwner: jest.fn().mockResolvedValue(0) };
         tasks = { getOne: jest.fn().mockResolvedValue({ id: taskId }) };
-        activityLog = { log: jest.fn().mockResolvedValue(undefined) };
+        activityLog = {
+            log: jest.fn().mockResolvedValue(undefined),
+            findAgentEvents: jest.fn().mockResolvedValue({ activities: [], total: 0 }),
+        };
         heartbeatTrigger = { enqueue: jest.fn() };
         taskExecuteDispatcher = { enqueue: jest.fn().mockResolvedValue({ runId }) };
 
@@ -112,6 +126,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             exportService,
             dispatcher,
             agentRuns,
+            agentRunLogs,
             skillBindings,
             pluginUsage,
             tasks,
@@ -142,6 +157,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
                 exportService,
                 dispatcher,
                 agentRuns,
+                agentRunLogs,
                 skillBindings,
                 pluginUsage,
                 tasks,
@@ -202,6 +218,149 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             expect(result.data[0]).toMatchObject({ status: 'completed' });
             expect(agentRuns.findByAgentAndUser).toHaveBeenCalledWith(agentId, 'u1', 25, 0);
             expect(agentRuns.countByAgentAndUser).toHaveBeenCalledWith(agentId, 'u1');
+        });
+    });
+
+    describe('GET /:id/runs/:runId', () => {
+        const runRow = {
+            id: runId,
+            agentId,
+            status: 'failed',
+            triggerKind: 'task',
+            startedAt: new Date('2026-01-01T00:00:00Z'),
+            finishedAt: new Date('2026-01-01T00:00:05Z'),
+            durationMs: 5_000,
+            summary: 'partial note',
+            errorMessage: 'provider timeout',
+            taskId,
+            chatMessageId: null,
+            memorySessionId: 'sess-1',
+            createdAt: new Date('2026-01-01T00:00:00Z'),
+        };
+
+        it('returns full run detail + ordered step logs', async () => {
+            agentRuns.findByIdAndUser.mockResolvedValueOnce(runRow);
+            agentRunLogs.findByRun.mockResolvedValueOnce([
+                {
+                    id: 'log-1',
+                    level: 'INFO',
+                    step: 'provider-call',
+                    message: 'dispatched',
+                    metadata: { totalTokens: 42 },
+                    createdAt: new Date('2026-01-01T00:00:01Z'),
+                },
+            ]);
+            const result = await controller.getRun(auth, agentId, runId);
+            expect(result).toMatchObject({
+                id: runId,
+                status: 'failed',
+                summary: 'partial note',
+                errorMessage: 'provider timeout',
+                memorySessionId: 'sess-1',
+            });
+            expect(result.logs).toHaveLength(1);
+            expect(result.logs[0]).toMatchObject({
+                level: 'INFO',
+                step: 'provider-call',
+                metadata: { totalTokens: 42 },
+            });
+            expect(agentRuns.findByIdAndUser).toHaveBeenCalledWith(runId, 'u1');
+            expect(agentRunLogs.findByRun).toHaveBeenCalledWith(runId, 500);
+        });
+
+        it('throws 404 when the run does not exist for this user', async () => {
+            agentRuns.findByIdAndUser.mockResolvedValueOnce(null);
+            await expect(controller.getRun(auth, agentId, runId)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+
+        it('throws 404 when the run belongs to a different agent (no cross-agent read)', async () => {
+            agentRuns.findByIdAndUser.mockResolvedValueOnce({
+                ...runRow,
+                agentId: '00000000-0000-0000-0000-0000000000ff',
+            });
+            await expect(controller.getRun(auth, agentId, runId)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(agentRunLogs.findByRun).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('POST /:id/pause + /:id/resume', () => {
+        it('pause logs AGENT_PAUSED with the agent as resource', async () => {
+            service.pause = jest.fn().mockResolvedValue({ id: agentId, status: 'paused' });
+            const result = await controller.pause(auth, agentId);
+            expect(result.status).toBe('paused');
+            expect(activityLog.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    actionType: 'agent_paused',
+                    userId: 'u1',
+                    details: expect.objectContaining({ resourceId: agentId }),
+                }),
+            );
+        });
+
+        it('resume logs AGENT_RESUMED', async () => {
+            service.resume = jest.fn().mockResolvedValue({ id: agentId, status: 'active' });
+            const result = await controller.resume(auth, agentId);
+            expect(result.status).toBe('active');
+            expect(activityLog.log).toHaveBeenCalledWith(
+                expect.objectContaining({ actionType: 'agent_resumed' }),
+            );
+        });
+
+        it('does not log when the transition throws', async () => {
+            service.pause = jest.fn().mockRejectedValue(new ConflictException('raced'));
+            await expect(controller.pause(auth, agentId)).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+            expect(activityLog.log).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('GET /:id/events', () => {
+        it('returns paginated lifecycle events scoped to this agent', async () => {
+            activityLog.findAgentEvents.mockResolvedValueOnce({
+                activities: [
+                    {
+                        id: 'evt-1',
+                        actionType: 'agent_paused',
+                        details: { status: 'paused', resourceId: agentId },
+                        createdAt: new Date('2026-01-02T00:00:00Z'),
+                    },
+                ],
+                total: 1,
+            });
+            const result = await controller.listEvents(auth, agentId, { limit: 25, offset: 0 });
+            expect(result.meta).toEqual({ total: 1, limit: 25, offset: 0 });
+            expect(result.data[0]).toMatchObject({ id: 'evt-1', actionType: 'agent_paused' });
+            expect(activityLog.findAgentEvents).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u1',
+                    agentId,
+                    actionTypes: expect.arrayContaining(['agent_paused', 'agent_resumed']),
+                }),
+            );
+        });
+
+        it('returns an empty page when ActivityLogService is unbound', async () => {
+            controller = new AgentsController(
+                service,
+                files,
+                exportService,
+                dispatcher,
+                agentRuns,
+                agentRunLogs,
+                skillBindings,
+                pluginUsage,
+                tasks,
+                undefined,
+                heartbeatTrigger,
+                taskExecuteDispatcher,
+            );
+            const result = await controller.listEvents(auth, agentId, {});
+            expect(result).toEqual({ data: [], meta: { total: 0, limit: 25, offset: 0 } });
         });
     });
 
@@ -316,6 +475,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
                 exportService,
                 dispatcher,
                 agentRuns,
+                agentRunLogs,
                 skillBindings,
                 pluginUsage,
                 tasks,

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -23,6 +23,7 @@ import { Throttle } from '@nestjs/throttler';
 import {
     AgentFileService,
     AGENT_FILE_NAMES,
+    AgentRunLogRepository,
     AgentRunRepository,
     AgentScheduleDispatcherService,
     AGENT_HEARTBEAT_TRIGGER,
@@ -84,6 +85,22 @@ import {
  * Cross-user reads return 404 (architecture/security §9 — no
  * existence leak via 403).
  */
+/**
+ * Activity-log action types surfaced as "lifecycle events" in the
+ * per-Agent activity feed (GET :id/events). Rows are matched by
+ * `details.resourceId = agentId`, so adding a type here is enough to
+ * surface any future tryLog() emitter.
+ */
+const AGENT_LIFECYCLE_EVENT_TYPES: ActivityActionType[] = [
+    ActivityActionType.AGENT_CREATED,
+    ActivityActionType.AGENT_PAUSED,
+    ActivityActionType.AGENT_RESUMED,
+    ActivityActionType.AGENT_ARCHIVED,
+    ActivityActionType.AGENT_EXPORTED,
+    ActivityActionType.AGENT_IMPORTED,
+    ActivityActionType.AGENT_BUDGET_EXCEEDED,
+];
+
 @ApiTags('agents')
 @Controller('api/agents')
 export class AgentsController {
@@ -99,6 +116,7 @@ export class AgentsController {
         // layer because the surface stays read-mostly + tightly scoped.
         private readonly dispatcher: AgentScheduleDispatcherService,
         private readonly agentRuns: AgentRunRepository,
+        private readonly agentRunLogs: AgentRunLogRepository,
         private readonly skillBindings: SkillBindingRepository,
         private readonly pluginUsage: PluginUsageRepository,
         private readonly tasks: TasksService,
@@ -229,7 +247,17 @@ export class AgentsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<AgentDto> {
-        return this.service.pause(auth.userId, id);
+        const dto = await this.service.pause(auth.userId, id);
+        // agents/spec.md — status transitions MUST leave an activity
+        // trail; surfaced in the /agents/[id]/activity feed via
+        // GET :id/events.
+        void this.tryLog({
+            userId: auth.userId,
+            agentId: id,
+            actionType: ActivityActionType.AGENT_PAUSED,
+            details: { status: dto.status },
+        });
+        return dto;
     }
 
     @Post(':id/resume')
@@ -240,7 +268,14 @@ export class AgentsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
     ): Promise<AgentDto> {
-        return this.service.resume(auth.userId, id);
+        const dto = await this.service.resume(auth.userId, id);
+        void this.tryLog({
+            userId: auth.userId,
+            agentId: id,
+            actionType: ActivityActionType.AGENT_RESUMED,
+            details: { status: dto.status },
+        });
+        return dto;
     }
 
     // ── Phase 4 — Agent file storage (5 canonical MD files + agent.yml) ─
@@ -436,6 +471,114 @@ export class AgentsController {
                 errorMessage: r.errorMessage ?? null,
                 taskId: r.taskId ?? null,
                 createdAt: r.createdAt.toISOString(),
+            })),
+            meta: { total, limit, offset },
+        };
+    }
+
+    @Get(':id/runs/:runId')
+    @ApiOperation({
+        summary: 'Full detail for one AgentRun, including its structured step logs.',
+    })
+    @HttpCode(HttpStatus.OK)
+    async getRun(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Param('runId', ParseUUIDPipe) runId: string,
+    ): Promise<{
+        id: string;
+        status: string;
+        triggerKind: string;
+        startedAt: string | null;
+        finishedAt: string | null;
+        durationMs: number | null;
+        summary: string | null;
+        errorMessage: string | null;
+        taskId: string | null;
+        chatMessageId: string | null;
+        memorySessionId: string | null;
+        createdAt: string;
+        logs: Array<{
+            id: string;
+            level: 'INFO' | 'WARN' | 'ERROR';
+            step: string;
+            message: string;
+            metadata: Record<string, unknown> | null;
+            createdAt: string;
+        }>;
+    }> {
+        await this.service.getOne(auth.userId, id);
+        // Security: user-scoped lookup + agentId match — cross-user or
+        // cross-agent runIds 404 (architecture/security §9, no-existence-leak).
+        const run = await this.agentRuns.findByIdAndUser(runId, auth.userId);
+        if (!run || run.agentId !== id) {
+            throw new NotFoundException(`AgentRun ${runId} not found.`);
+        }
+        const logs = await this.agentRunLogs.findByRun(runId, 500);
+        return {
+            id: run.id,
+            status: run.status,
+            triggerKind: run.triggerKind,
+            startedAt: run.startedAt?.toISOString() ?? null,
+            finishedAt: run.finishedAt?.toISOString() ?? null,
+            durationMs: run.durationMs ?? null,
+            summary: run.summary ?? null,
+            errorMessage: run.errorMessage ?? null,
+            taskId: run.taskId ?? null,
+            chatMessageId: run.chatMessageId ?? null,
+            memorySessionId: run.memorySessionId ?? null,
+            createdAt: run.createdAt.toISOString(),
+            logs: logs.map((l) => ({
+                id: l.id,
+                level: l.level,
+                step: l.step,
+                message: l.message,
+                metadata: l.metadata ?? null,
+                createdAt: l.createdAt.toISOString(),
+            })),
+        };
+    }
+
+    @Get(':id/events')
+    @ApiOperation({
+        summary:
+            'Paginated Agent lifecycle events (paused / resumed / created / archived / …) from the activity log.',
+    })
+    @HttpCode(HttpStatus.OK)
+    async listEvents(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Query() query: ListAgentRunsQueryDto,
+    ): Promise<{
+        data: Array<{
+            id: string;
+            actionType: string;
+            details: Record<string, unknown> | null;
+            createdAt: string;
+        }>;
+        meta: { total: number; limit: number; offset: number };
+    }> {
+        await this.service.getOne(auth.userId, id);
+        const limit = query.limit ?? 25;
+        const offset = query.offset ?? 0;
+        // ActivityLogService is @Optional — when unbound the feed simply
+        // has no lifecycle rows (mirrors tryLog's best-effort posture).
+        if (!this.activityLog) {
+            return { data: [], meta: { total: 0, limit, offset } };
+        }
+        const { activities, total } = await this.activityLog.findAgentEvents({
+            userId: auth.userId,
+            agentId: id,
+            actionTypes: AGENT_LIFECYCLE_EVENT_TYPES,
+            limit,
+            offset,
+        });
+        return {
+            data: activities.map((a) => ({
+                id: a.id,
+                actionType: a.actionType,
+                details: a.details ?? null,
+                createdAt: a.createdAt.toISOString(),
             })),
             meta: { total, limit, offset },
         };

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -65,6 +65,12 @@ import {
 // `PluginUsageRepository`.
 import { SkillsModule as AgentSkillsModule } from '@ever-works/agent/skills';
 import { DatabaseModule } from '@ever-works/agent/database';
+// ActivityLogService is injected @Optional() into AgentsController for
+// the lifecycle trail (AGENT_PAUSED / AGENT_RESUMED / run-triggered /
+// run-cancelled / task-assigned) and the GET :id/events feed. Without
+// this import the optional injection silently resolved to `undefined`
+// and every tryLog() was a no-op — same wiring as works/plugins/auth.
+import { ActivityLogModule } from '@ever-works/agent/activity-log';
 import { AuthModule } from '../auth/auth.module';
 import { AgentsController } from './agents.controller';
 import { AgentTemplatesController } from './agent-templates.controller';
@@ -110,6 +116,7 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
         TasksDomainModule,
         FacadesModule,
         AuthModule,
+        ActivityLogModule,
         // Notifications v2 (EW-670) — EmailModule provides EmailService,
         // consumed by the AGENT_EMAIL_FACADE binding below.
         EmailModule,

--- a/apps/web/src/app/[locale]/(dashboard)/agents/[id]/activity/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/[id]/activity/page.tsx
@@ -17,9 +17,16 @@ export default async function AgentActivityPage({ params }: { params: Params }) 
     const agent = await agentsAPI.get(id);
     if (!agent) notFound();
 
-    const initial = await agentsAPI
-        .listRuns(id, { limit: 25, offset: 0 })
-        .catch(() => ({ data: [], meta: { total: 0, limit: 25, offset: 0 } }));
+    // Lifecycle events (paused / resumed / …) are few per Agent — one
+    // 100-row page covers the interleaved timeline across run pages.
+    const [initial, initialEvents] = await Promise.all([
+        agentsAPI
+            .listRuns(id, { limit: 25, offset: 0 })
+            .catch(() => ({ data: [], meta: { total: 0, limit: 25, offset: 0 } })),
+        agentsAPI
+            .listEvents(id, { limit: 100, offset: 0 })
+            .catch(() => ({ data: [], meta: { total: 0, limit: 100, offset: 0 } })),
+    ]);
 
-    return <AgentActivityClient agentId={id} initial={initial} />;
+    return <AgentActivityClient agentId={id} initial={initial} initialEvents={initialEvents.data} />;
 }

--- a/apps/web/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation';
-import { Bot, CalendarClock, Clock, HeartPulse, Moon, Sparkles, TriangleAlert } from 'lucide-react';
+import { Bot, CalendarClock, Clock, HeartPulse, Moon, TriangleAlert } from 'lucide-react';
 import { agentsAPI, type Agent } from '@/lib/api/agents';
 import { AgentAttachmentsPanel } from '@/components/agents/AgentAttachmentsPanel';
 import { ShowDateTime } from '@/components/ui/show-datetime';
@@ -166,8 +166,7 @@ export default async function AgentDashboardPage({ params }: { params: Promise<{
 
             {/* Capabilities */}
             <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
-                <div className="flex items-center gap-2 mb-3">
-                    <Sparkles className="w-4 h-4 text-concept-agents" />
+                <div className="mb-3">
                     <h2 className="text-sm font-medium text-text dark:text-text-dark">
                         Capabilities
                     </h2>

--- a/apps/web/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/[id]/page.tsx
@@ -1,14 +1,66 @@
-import { agentsAPI } from '@/lib/api/agents';
 import { notFound } from 'next/navigation';
+import { Bot, CalendarClock, Clock, HeartPulse, Moon, Sparkles, TriangleAlert } from 'lucide-react';
+import { agentsAPI, type Agent } from '@/lib/api/agents';
 import { AgentAttachmentsPanel } from '@/components/agents/AgentAttachmentsPanel';
+import { ShowDateTime } from '@/components/ui/show-datetime';
 
 /**
  * Agents/Skills/Tasks PR #1017 — Phase 5. Dashboard tab is the
- * default landing surface for `/agents/[id]`. v1 is a placeholder
- * — real summary tiles (status, last run, due next, current
- * budget consumption) land in a later sub-tick once the run /
- * heartbeat dispatcher ships in Phase 6.
+ * default landing surface for `/agents/[id]`. Surfaces an overview
+ * hero (avatar + status), quick stat tiles (heartbeat, idle
+ * behavior, last / next run), capabilities, and attachments.
  */
+
+const STATUS_TONE: Record<Agent['status'], string> = {
+    draft: 'bg-text-muted/10 text-text-muted',
+    active: 'bg-success/10 text-success',
+    paused: 'bg-warning/10 text-warning',
+    running: 'bg-info/10 text-info',
+    error: 'bg-danger/10 text-danger',
+    archived: 'bg-text-muted/10 text-text-muted',
+};
+
+const IDLE_LABEL: Record<Agent['idleBehavior'], string> = {
+    propose: 'Propose work',
+    sleep: 'Sleep',
+    'self-improve': 'Self improve',
+};
+
+function initialsOf(name: string): string {
+    return (
+        name
+            .split(/\s+/)
+            .map((p) => p.charAt(0))
+            .join('')
+            .slice(0, 2)
+            .toUpperCase() || 'A'
+    );
+}
+
+function StatTile({
+    icon: Icon,
+    label,
+    children,
+    accent,
+}: {
+    icon: typeof Clock;
+    label: string;
+    children: React.ReactNode;
+    accent?: string;
+}) {
+    return (
+        <div className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-4">
+            <div className="flex items-center gap-2 text-text-muted dark:text-text-muted-dark">
+                <Icon className={`w-3.5 h-3.5 ${accent ?? ''}`} />
+                <span className="text-[11px] uppercase tracking-wide">{label}</span>
+            </div>
+            <div className="mt-2 text-sm font-medium text-text dark:text-text-dark truncate">
+                {children}
+            </div>
+        </div>
+    );
+}
+
 export default async function AgentDashboardPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
     const agent = await agentsAPI.get(id);
@@ -18,39 +70,119 @@ export default async function AgentDashboardPage({ params }: { params: Promise<{
     // on a stale env doesn't 500 the whole page.
     const attachments = await agentsAPI.listAttachments(id).catch(() => []);
 
+    const runFailing = agent.errorCount > 0;
+
     return (
         <div className="p-6 space-y-4 max-w-screen-2xl mx-auto">
+            {/* Overview hero */}
             <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
-                <h2 className="text-sm font-medium text-text dark:text-text-dark mb-3">Summary</h2>
-                <dl className="grid grid-cols-2 @lg/main:grid-cols-4 gap-4 text-xs">
-                    <div>
-                        <dt className="text-text-muted">Scope</dt>
-                        <dd className="text-text dark:text-text-dark capitalize">{agent.scope}</dd>
+                <div className="flex items-start gap-4">
+                    <div className="shrink-0 w-14 h-14 rounded-xl bg-concept-agents/10 border border-concept-agents/20 flex items-center justify-center">
+                        {agent.avatarMode === 'initials' ? (
+                            <span className="text-base font-semibold text-concept-agents">
+                                {initialsOf(agent.name)}
+                            </span>
+                        ) : (
+                            <Bot className="w-6 h-6 text-concept-agents" />
+                        )}
                     </div>
-                    <div>
-                        <dt className="text-text-muted">Status</dt>
-                        <dd className="text-text dark:text-text-dark capitalize">{agent.status}</dd>
+                    <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <h2 className="text-lg font-semibold text-text dark:text-text-dark truncate">
+                                {agent.name}
+                            </h2>
+                            <span
+                                className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${STATUS_TONE[agent.status]}`}
+                            >
+                                <span className="w-1.5 h-1.5 rounded-full bg-current" />
+                                {agent.status}
+                            </span>
+                        </div>
+                        <p className="mt-0.5 text-sm text-text-muted dark:text-text-muted-dark truncate">
+                            {agent.title ?? 'No title set'}
+                        </p>
+                        <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px]">
+                            <span className="rounded-md bg-surface-secondary dark:bg-surface-secondary-dark px-2 py-1 capitalize text-text-secondary dark:text-text-secondary-dark">
+                                {agent.scope} scope
+                            </span>
+                            <span className="rounded-md bg-surface-secondary dark:bg-surface-secondary-dark px-2 py-1 font-mono text-text-secondary dark:text-text-secondary-dark">
+                                {agent.modelId ?? 'default model'}
+                            </span>
+                            <span className="rounded-md bg-surface-secondary dark:bg-surface-secondary-dark px-2 py-1 font-mono text-text-muted dark:text-text-muted-dark">
+                                {agent.slug}
+                            </span>
+                        </div>
                     </div>
-                    <div>
-                        <dt className="text-text-muted">Heartbeat</dt>
-                        <dd className="text-text dark:text-text-dark">
-                            {agent.heartbeatCadence ?? '—'}
-                        </dd>
-                    </div>
-                    <div>
-                        <dt className="text-text-muted">Last run</dt>
-                        <dd className="text-text dark:text-text-dark">{agent.lastRunAt ?? '—'}</dd>
-                    </div>
-                </dl>
+                </div>
             </section>
+
+            {/* Quick stats */}
+            <div className="grid grid-cols-2 @lg/main:grid-cols-4 gap-3">
+                <StatTile icon={HeartPulse} label="Heartbeat" accent="text-danger">
+                    {agent.heartbeatCadence ?? 'Manual'}
+                </StatTile>
+                <StatTile icon={Moon} label="Idle behavior">
+                    {IDLE_LABEL[agent.idleBehavior]}
+                </StatTile>
+                <StatTile icon={Clock} label="Last run">
+                    {agent.lastRunAt ? <ShowDateTime value={agent.lastRunAt} /> : '—'}
+                </StatTile>
+                <StatTile icon={CalendarClock} label="Next heartbeat">
+                    {agent.nextHeartbeatAt ? <ShowDateTime value={agent.nextHeartbeatAt} /> : '—'}
+                </StatTile>
+            </div>
+
+            {/* Health strip */}
+            <section
+                className={`flex items-center gap-3 rounded-xl border p-4 ${
+                    runFailing
+                        ? 'border-danger/30 bg-danger/5'
+                        : 'border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark'
+                }`}
+            >
+                <div
+                    className={`shrink-0 w-9 h-9 rounded-lg flex items-center justify-center ${
+                        runFailing
+                            ? 'bg-danger/10 border border-danger/20'
+                            : 'bg-success/10 border border-success/20'
+                    }`}
+                >
+                    <TriangleAlert
+                        className={`w-4 h-4 ${runFailing ? 'text-danger' : 'text-success'}`}
+                    />
+                </div>
+                <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium text-text dark:text-text-dark">
+                        {runFailing ? 'Recent runs are failing' : 'Healthy'}
+                    </div>
+                    <div className="text-xs text-text-muted dark:text-text-muted-dark">
+                        {agent.errorCount} error{agent.errorCount === 1 ? '' : 's'} · pauses after{' '}
+                        {agent.pauseAfterFailures} consecutive failure
+                        {agent.pauseAfterFailures === 1 ? '' : 's'}
+                        {agent.lastRunStatus ? ` · last run ${agent.lastRunStatus}` : ''}
+                    </div>
+                </div>
+            </section>
+
+            {/* Capabilities */}
             <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">
-                <h2 className="text-sm font-medium text-text dark:text-text-dark mb-3">
-                    Capabilities
-                </h2>
-                <p className="text-sm text-text-secondary dark:text-text-secondary-dark">
-                    {agent.capabilities ?? 'No capabilities set yet.'}
-                </p>
+                <div className="flex items-center gap-2 mb-3">
+                    <Sparkles className="w-4 h-4 text-concept-agents" />
+                    <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                        Capabilities
+                    </h2>
+                </div>
+                {agent.capabilities ? (
+                    <p className="text-sm leading-relaxed text-text-secondary dark:text-text-secondary-dark whitespace-pre-wrap">
+                        {agent.capabilities}
+                    </p>
+                ) : (
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark italic">
+                        No capabilities set yet.
+                    </p>
+                )}
             </section>
+
             <AgentAttachmentsPanel agentId={id} initial={attachments} />
         </div>
     );

--- a/apps/web/src/app/actions/agents.ts
+++ b/apps/web/src/app/actions/agents.ts
@@ -146,6 +146,19 @@ export async function listAgentRunsAction(
     return agentsAPI.listRuns(id, opts);
 }
 
+export async function listAgentEventsAction(
+    id: string,
+    opts: { limit?: number; offset?: number } = {},
+) {
+    await ensureAuth();
+    return agentsAPI.listEvents(id, opts);
+}
+
+export async function getAgentRunDetailAction(id: string, runId: string) {
+    await ensureAuth();
+    return agentsAPI.getRun(id, runId);
+}
+
 export async function listAgentSkillsAction(id: string) {
     await ensureAuth();
     return agentsAPI.listSkills(id);

--- a/apps/web/src/app/api/uploads/[userId]/[filename]/route.ts
+++ b/apps/web/src/app/api/uploads/[userId]/[filename]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+type RouteContext = { params: Promise<{ userId: string; filename: string }> };
+
+/**
+ * Serve proxy for previously-uploaded files.
+ *
+ * Upload responses (and the attachment list endpoints) reference files
+ * by the API-routed URL `/api/uploads/<userId>/<sha256>.<ext>` — but the
+ * NestJS serve endpoint of the same path is owner-gated behind a Bearer
+ * token the browser doesn't hold (auth lives in an HTTP-only cookie).
+ * This route makes those URLs directly openable from an <a> tag: auth
+ * cookie → Authorization Bearer, then the upstream file is streamed
+ * back with its Content-Type and security headers intact.
+ *
+ * Mirrors the sibling upload proxies (`../route.ts`, `../file/route.ts`)
+ * for the auth + query-allowlist conventions.
+ */
+export async function GET(request: NextRequest, { params }: RouteContext) {
+    const { userId, filename } = await params;
+    const token = await getAuthAccessCookie();
+    // Security: reject unauthenticated requests at the BFF layer instead
+    // of proxying them upstream without credentials.
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const headers = new Headers();
+    headers.set('Authorization', `Bearer ${token}`);
+
+    // Security: allowlist only the documented query parameter (workId —
+    // round-tripped for per-Work storage backends) and encode the path
+    // segments to prevent URL injection via crafted IDs.
+    const upstreamUrl = new URL(
+        `${API_URL}/uploads/${encodeURIComponent(userId)}/${encodeURIComponent(filename)}`,
+    );
+    const workId = request.nextUrl.searchParams.get('workId');
+    if (workId) upstreamUrl.searchParams.set('workId', workId);
+
+    const upstream = await fetch(upstreamUrl.toString(), {
+        headers,
+        cache: 'no-store',
+    });
+
+    if (!upstream.ok) {
+        const text = await upstream.text().catch(() => '');
+        return new Response(text, {
+            status: upstream.status,
+            headers: {
+                'Content-Type': upstream.headers.get('content-type') ?? 'application/json',
+                'Cache-Control': 'no-store',
+            },
+        });
+    }
+
+    // Stream the file body through, preserving the upstream's content
+    // negotiation + the defense-in-depth headers the API sets against
+    // inline rendering of attacker-uploaded active content.
+    const passthrough = new Headers();
+    for (const name of [
+        'content-type',
+        'content-length',
+        'content-disposition',
+        'content-security-policy',
+        'x-content-type-options',
+        'cache-control',
+    ]) {
+        const value = upstream.headers.get(name);
+        if (value) passthrough.set(name, value);
+    }
+    return new Response(upstream.body, { status: upstream.status, headers: passthrough });
+}

--- a/apps/web/src/components/agents/AgentActivityClient.tsx
+++ b/apps/web/src/components/agents/AgentActivityClient.tsx
@@ -1,9 +1,24 @@
 'use client';
 
-import { useState, useTransition } from 'react';
-import { cancelAgentRunAction, listAgentRunsAction } from '@/app/actions/agents';
+import { Fragment, useMemo, useState, useTransition } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import {
+    CheckCircle2,
+    ChevronDown,
+    ChevronRight,
+    Clock,
+    Loader2,
+    OctagonMinus,
+    XCircle,
+} from 'lucide-react';
+import {
+    cancelAgentRunAction,
+    getAgentRunDetailAction,
+    listAgentEventsAction,
+    listAgentRunsAction,
+} from '@/app/actions/agents';
 import { cn } from '@/lib/utils/cn';
-import { Button } from '@/components/ui/button';
+import { useMounted } from '@/lib/hooks/use-mounted';
 
 interface AgentRunRow {
     id: string;
@@ -18,31 +33,216 @@ interface AgentRunRow {
     createdAt: string;
 }
 
+interface AgentRunLogRow {
+    id: string;
+    level: 'INFO' | 'WARN' | 'ERROR';
+    step: string;
+    message: string;
+    metadata: Record<string, unknown> | null;
+    createdAt: string;
+}
+
+interface AgentRunDetail extends AgentRunRow {
+    chatMessageId: string | null;
+    memorySessionId: string | null;
+    logs: AgentRunLogRow[];
+}
+
+interface AgentEventRow {
+    id: string;
+    actionType: string;
+    details: Record<string, unknown> | null;
+    createdAt: string;
+}
+
 interface Props {
     agentId: string;
     initial: { data: AgentRunRow[]; meta: { total: number; limit: number; offset: number } };
+    initialEvents?: AgentEventRow[];
 }
 
-const STATUS_STYLES: Record<string, string> = {
-    queued: 'bg-slate-100 text-slate-700 dark:bg-slate-700/40 dark:text-slate-300',
-    running: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 animate-pulse',
-    completed: 'bg-success/15 text-success',
-    failed: 'bg-danger/15 text-danger',
-    cancelled: 'bg-slate-200 text-slate-600 dark:bg-slate-700/60 dark:text-slate-400',
+type FeedItem = { kind: 'run'; run: AgentRunRow } | { kind: 'event'; event: AgentEventRow };
+
+// Mirrors ActivityStatusBadge on /activity so both feeds read the same.
+const RUN_STATUS_CONFIG: Record<
+    string,
+    { icon: typeof Clock; color: string; bg: string; spin?: boolean }
+> = {
+    queued: {
+        icon: Clock,
+        color: 'text-text-muted dark:text-text-muted-dark',
+        bg: 'bg-surface-secondary dark:bg-surface-secondary-dark',
+    },
+    running: {
+        icon: Loader2,
+        color: 'text-blue-600 dark:text-blue-400',
+        bg: 'bg-blue-50 dark:bg-blue-900/20',
+        spin: true,
+    },
+    completed: {
+        icon: CheckCircle2,
+        color: 'text-green-600 dark:text-green-400',
+        bg: 'bg-green-50 dark:bg-green-900/20',
+    },
+    failed: {
+        icon: XCircle,
+        color: 'text-red-600 dark:text-red-400',
+        bg: 'bg-red-50 dark:bg-red-900/20',
+    },
+    cancelled: {
+        icon: OctagonMinus,
+        color: 'text-amber-700 dark:text-amber-300',
+        bg: 'bg-amber-50 dark:bg-amber-900/20',
+    },
 };
 
-export function AgentActivityClient({ agentId, initial }: Props) {
+function RunStatusBadge({ status }: { status: string }) {
+    const config = RUN_STATUS_CONFIG[status] ?? RUN_STATUS_CONFIG.queued;
+    const Icon = config.icon;
+    return (
+        <span
+            className={`inline-flex whitespace-nowrap items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${config.color} ${config.bg}`}
+        >
+            <Icon className={`w-3 h-3 ${config.spin ? 'animate-spin' : ''}`} />
+            {status}
+        </span>
+    );
+}
+
+// Mirrors ActivityTypeBadge colors on /activity.
+const TRIGGER_KIND_COLORS: Record<string, string> = {
+    heartbeat: 'bg-purple-50 text-purple-700 dark:bg-purple-900/20 dark:text-purple-300',
+    manual: 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300',
+    task: 'bg-teal-50 text-teal-700 dark:bg-teal-900/20 dark:text-teal-300',
+    chat: 'bg-cyan-50 text-cyan-700 dark:bg-cyan-900/20 dark:text-cyan-300',
+    event: 'bg-gray-50 text-gray-700 dark:bg-gray-900/20 dark:text-gray-300',
+};
+
+const EVENT_PRESENTATION: Record<string, { label: string; className: string }> = {
+    agent_created: {
+        label: 'created',
+        className: 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300',
+    },
+    agent_paused: {
+        label: 'paused',
+        className: 'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300',
+    },
+    agent_resumed: {
+        label: 'resumed',
+        className: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300',
+    },
+    agent_archived: {
+        label: 'archived',
+        className: 'bg-gray-50 text-gray-700 dark:bg-gray-900/20 dark:text-gray-300',
+    },
+    agent_exported: {
+        label: 'exported',
+        className: 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-300',
+    },
+    agent_imported: {
+        label: 'imported',
+        className: 'bg-indigo-50 text-indigo-700 dark:bg-indigo-900/20 dark:text-indigo-300',
+    },
+    agent_budget_exceeded: {
+        label: 'budget exceeded',
+        className: 'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300',
+    },
+};
+
+const DEFAULT_TYPE_COLOR = 'bg-gray-50 text-gray-700 dark:bg-gray-900/20 dark:text-gray-300';
+
+const eventPresentation = (actionType: string) =>
+    EVENT_PRESENTATION[actionType] ?? {
+        label: actionType.replace(/^agent_/, '').replace(/_/g, ' '),
+        className: DEFAULT_TYPE_COLOR,
+    };
+
+function TypePill({ label, className }: { label: string; className: string }) {
+    return (
+        <span
+            className={`inline-flex whitespace-nowrap px-2 py-0.5 rounded-full text-xs font-medium capitalize ${className}`}
+        >
+            {label}
+        </span>
+    );
+}
+
+const LOG_LEVEL_STYLES: Record<AgentRunLogRow['level'], string> = {
+    INFO: 'bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted dark:text-text-muted-dark',
+    WARN: 'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300',
+    ERROR: 'bg-red-50 text-red-700 dark:bg-red-900/20 dark:text-red-300',
+};
+
+const formatDuration = (ms: number | null): string => {
+    if (ms == null) return '—';
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(1)}s`;
+};
+
+/**
+ * Hydration-safe timestamp, mirroring ActivityTimestamp on /activity:
+ * renders an empty <time> until mounted, then the locale-formatted
+ * value (`stacked` = date over time, `relative` = "5 minutes ago").
+ */
+function Timestamp({
+    value,
+    variant = 'absolute',
+    className,
+}: {
+    value: string | null;
+    variant?: 'absolute' | 'relative' | 'stacked';
+    className?: string;
+}) {
+    const mounted = useMounted();
+    if (!value) return <span className={className}>—</span>;
+    if (!mounted) return <time dateTime={value} className={className} />;
+
+    const date = new Date(value);
+    const absolute = date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+
+    return (
+        <time
+            dateTime={value}
+            title={variant === 'relative' ? absolute : undefined}
+            className={className}
+        >
+            {variant === 'relative' ? (
+                formatDistanceToNow(date, { addSuffix: true })
+            ) : variant === 'stacked' ? (
+                <span className="inline-flex flex-col leading-4 whitespace-nowrap">
+                    <span>{date.toLocaleDateString()}</span>
+                    <span>{date.toLocaleTimeString()}</span>
+                </span>
+            ) : (
+                absolute
+            )}
+        </time>
+    );
+}
+
+const TH_CLASS =
+    'px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary dark:text-text-secondary-dark';
+
+export function AgentActivityClient({ agentId, initial, initialEvents = [] }: Props) {
     const [rows, setRows] = useState<AgentRunRow[]>(initial.data);
     const [meta, setMeta] = useState(initial.meta);
+    const [events, setEvents] = useState<AgentEventRow[]>(initialEvents);
     const [pending, startTransition] = useTransition();
     const [cancellingId, setCancellingId] = useState<string | null>(null);
+    const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+    // runId → detail; null = fetch failed (rendered as retryable error state).
+    const [details, setDetails] = useState<Record<string, AgentRunDetail | null>>({});
 
     const refresh = (offset: number) => {
         startTransition(() => {
             void (async () => {
-                const next = await listAgentRunsAction(agentId, { limit: meta.limit, offset });
+                const [next, nextEvents] = await Promise.all([
+                    listAgentRunsAction(agentId, { limit: meta.limit, offset }),
+                    listAgentEventsAction(agentId, { limit: 100 }).catch(() => null),
+                ]);
                 setRows(next.data);
                 setMeta(next.meta);
+                if (nextEvents) setEvents(nextEvents.data);
             })();
         });
     };
@@ -61,11 +261,74 @@ export function AgentActivityClient({ agentId, initial }: Props) {
         });
     };
 
-    const formatDuration = (ms: number | null): string => {
-        if (ms == null) return '—';
-        if (ms < 1000) return `${ms}ms`;
-        return `${(ms / 1000).toFixed(1)}s`;
+    const loadDetail = async (runId: string) => {
+        try {
+            const detail = await getAgentRunDetailAction(agentId, runId);
+            setDetails((prev) => ({ ...prev, [runId]: detail as AgentRunDetail }));
+        } catch {
+            setDetails((prev) => ({ ...prev, [runId]: null }));
+        }
     };
+
+    const toggle = (runId: string) => {
+        if (!expandedIds.has(runId) && details[runId] === undefined) void loadDetail(runId);
+        setExpandedIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(runId)) {
+                next.delete(runId);
+            } else {
+                next.add(runId);
+            }
+            return next;
+        });
+    };
+
+    const retryDetail = (runId: string) => {
+        setDetails((prev) => {
+            const next = { ...prev };
+            delete next[runId];
+            return next;
+        });
+        void loadDetail(runId);
+    };
+
+    const handleRowKeyDown = (e: React.KeyboardEvent, runId: string) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggle(runId);
+        }
+    };
+
+    // Interleave lifecycle events into the run pagination: events are
+    // fetched once (they're rare) and clipped to the time window covered
+    // by the current page of runs, with the first/last page absorbing
+    // everything newer/older respectively. ISO timestamps sort
+    // lexicographically, so plain string comparison is safe here.
+    const feed = useMemo<FeedItem[]>(() => {
+        const isFirst = meta.offset === 0;
+        const isLast = meta.offset + meta.limit >= meta.total;
+        let visible: AgentEventRow[];
+        if (rows.length === 0) {
+            visible = isFirst ? events : [];
+        } else {
+            const newest = rows[0].createdAt;
+            const oldest = rows[rows.length - 1].createdAt;
+            visible = events.filter(
+                (e) => (isFirst || e.createdAt <= newest) && (isLast || e.createdAt >= oldest),
+            );
+        }
+        return [
+            ...rows.map<FeedItem>((run) => ({ kind: 'run', run })),
+            ...visible.map<FeedItem>((event) => ({ kind: 'event', event })),
+        ].sort((a, b) => {
+            const ta = a.kind === 'run' ? a.run.createdAt : a.event.createdAt;
+            const tb = b.kind === 'run' ? b.run.createdAt : b.event.createdAt;
+            return tb.localeCompare(ta);
+        });
+    }, [rows, events, meta]);
+
+    const page = Math.floor(meta.offset / meta.limit) + 1;
+    const totalPages = Math.max(1, Math.ceil(meta.total / meta.limit));
 
     return (
         <div className="p-6 max-w-screen-2xl mx-auto space-y-4">
@@ -75,77 +338,427 @@ export function AgentActivityClient({ agentId, initial }: Props) {
                     {meta.total} run{meta.total === 1 ? '' : 's'} total
                 </p>
             </header>
-            <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark divide-y divide-border/40 dark:divide-border-dark/40">
-                {rows.length === 0 ? (
-                    <div className="p-6 text-center text-xs text-text-muted dark:text-text-muted-dark">
-                        No runs yet. The Agent will record activity here once the dispatcher fires
-                        its first heartbeat.
+
+            <div className="relative overflow-hidden rounded-lg border border-border dark:border-border-dark">
+                {pending && feed.length > 0 && (
+                    <div className="pointer-events-none absolute right-3 top-3 z-10 inline-flex items-center gap-1.5 rounded-full border border-border dark:border-border-dark bg-card/95 dark:bg-card-primary-dark/95 px-2.5 py-1 text-xs text-text-muted dark:text-text-muted-dark shadow-sm backdrop-blur-sm">
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        Loading…
                     </div>
-                ) : (
-                    rows.map((r) => (
-                        <article key={r.id} className="p-4 flex items-start gap-3">
-                            <span
-                                className={cn(
-                                    'shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium',
-                                    STATUS_STYLES[r.status] ??
-                                        'bg-slate-100 text-slate-700 dark:bg-slate-700/40 dark:text-slate-300',
-                                )}
-                            >
-                                {r.status}
-                            </span>
-                            <span className="shrink-0 rounded-md border border-border/40 dark:border-border-dark/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
-                                {r.triggerKind}
-                            </span>
-                            <div className="min-w-0 flex-1">
-                                <div className="text-sm text-text dark:text-text-dark truncate">
-                                    {r.summary ?? r.errorMessage ?? '(no summary)'}
-                                </div>
-                                <div className="mt-0.5 flex items-center gap-3 text-[11px] text-text-muted dark:text-text-muted-dark">
-                                    <time dateTime={r.createdAt}>
-                                        {new Date(r.createdAt).toLocaleString()}
-                                    </time>
-                                    <span>· {formatDuration(r.durationMs)}</span>
-                                    {r.taskId ? <span>· task {r.taskId.slice(0, 8)}</span> : null}
-                                </div>
-                            </div>
-                            {(r.status === 'queued' || r.status === 'running') && (
-                                <Button
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => cancel(r.id)}
-                                    disabled={pending && cancellingId === r.id}
-                                >
-                                    {pending && cancellingId === r.id ? '…' : 'Cancel'}
-                                </Button>
-                            )}
-                        </article>
-                    ))
                 )}
-            </section>
-            <footer className="flex items-center justify-between text-xs text-text-muted dark:text-text-muted-dark">
-                <span>
-                    Showing {rows.length === 0 ? 0 : meta.offset + 1}–{meta.offset + rows.length} of{' '}
-                    {meta.total}
-                </span>
-                <div className="flex items-center gap-2">
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled={meta.offset === 0 || pending}
-                        onClick={() => refresh(Math.max(0, meta.offset - meta.limit))}
-                    >
-                        Previous
-                    </Button>
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled={meta.offset + meta.limit >= meta.total || pending}
-                        onClick={() => refresh(meta.offset + meta.limit)}
-                    >
-                        Next
-                    </Button>
+                <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-border dark:divide-border-dark">
+                        <thead className="bg-muted/50 dark:bg-muted/20">
+                            <tr>
+                                <th scope="col" className="w-8 px-3 py-3">
+                                    <span className="sr-only">Expand</span>
+                                </th>
+                                <th scope="col" className={TH_CLASS}>
+                                    Date / Time
+                                </th>
+                                <th scope="col" className={TH_CLASS}>
+                                    Type
+                                </th>
+                                <th scope="col" className={TH_CLASS}>
+                                    Summary
+                                </th>
+                                <th scope="col" className={`whitespace-nowrap ${TH_CLASS}`}>
+                                    Duration
+                                </th>
+                                <th scope="col" className={`w-[9rem] whitespace-nowrap ${TH_CLASS}`}>
+                                    Status
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-border dark:divide-border-dark">
+                            {feed.length === 0 && (
+                                <tr className="bg-card dark:bg-transparent">
+                                    <td
+                                        colSpan={6}
+                                        className="px-4 py-10 text-center text-xs text-text-muted dark:text-text-muted-dark"
+                                    >
+                                        No activity yet. The Agent will record runs and status
+                                        changes here once the dispatcher fires its first heartbeat.
+                                    </td>
+                                </tr>
+                            )}
+                            {feed.map((item) => {
+                                if (item.kind === 'event') {
+                                    const e = item.event;
+                                    const p = eventPresentation(e.actionType);
+                                    return (
+                                        <tr key={`evt-${e.id}`} className="bg-card dark:bg-transparent">
+                                            <td className="px-3 py-3" />
+                                            <td className="px-4 py-3 text-xs text-text-muted dark:text-text-muted-dark whitespace-nowrap">
+                                                <Timestamp value={e.createdAt} variant="stacked" />
+                                            </td>
+                                            <td className="px-4 py-3">
+                                                <TypePill label={p.label} className={p.className} />
+                                            </td>
+                                            <td className="px-4 py-3 text-xs text-text dark:text-text-dark" colSpan={2}>
+                                                Agent {p.label}{' '}
+                                                <Timestamp
+                                                    value={e.createdAt}
+                                                    variant="relative"
+                                                    className="text-text-muted dark:text-text-muted-dark"
+                                                />
+                                            </td>
+                                            <td className="w-[9rem] whitespace-nowrap px-4 py-3 text-xs text-text-muted dark:text-text-muted-dark">
+                                                —
+                                            </td>
+                                        </tr>
+                                    );
+                                }
+
+                                const r = item.run;
+                                const isExpanded = expandedIds.has(r.id);
+                                const detail = details[r.id];
+                                return (
+                                    <Fragment key={r.id}>
+                                        <tr
+                                            className="bg-card dark:bg-transparent hover:bg-muted/30 dark:hover:bg-muted/10 transition-colors cursor-pointer"
+                                            onClick={() => toggle(r.id)}
+                                            onKeyDown={(e) => handleRowKeyDown(e, r.id)}
+                                            tabIndex={0}
+                                            role="button"
+                                            aria-expanded={isExpanded}
+                                        >
+                                            <td className="px-3 py-3 text-center">
+                                                {isExpanded ? (
+                                                    <ChevronDown
+                                                        className="w-4 h-4 text-text-muted dark:text-text-muted-dark"
+                                                        aria-hidden="true"
+                                                    />
+                                                ) : (
+                                                    <ChevronRight
+                                                        className="w-4 h-4 text-text-muted dark:text-text-muted-dark"
+                                                        aria-hidden="true"
+                                                    />
+                                                )}
+                                            </td>
+                                            <td className="px-4 py-3 text-xs text-text-muted dark:text-text-muted-dark whitespace-nowrap">
+                                                <Timestamp value={r.createdAt} variant="stacked" />
+                                            </td>
+                                            <td className="px-4 py-3">
+                                                <TypePill
+                                                    label={r.triggerKind}
+                                                    className={
+                                                        TRIGGER_KIND_COLORS[r.triggerKind] ??
+                                                        DEFAULT_TYPE_COLOR
+                                                    }
+                                                />
+                                            </td>
+                                            <td className="px-4 py-3 text-xs text-text dark:text-text-dark max-w-md">
+                                                <div className="flex items-start justify-between gap-3">
+                                                    <div className="min-w-0 flex-1">
+                                                        <div className="line-clamp-2 break-words">
+                                                            {r.summary ??
+                                                                r.errorMessage ??
+                                                                '(no summary)'}
+                                                        </div>
+                                                        {r.errorMessage && r.summary ? (
+                                                            <div className="mt-0.5 line-clamp-1 break-words text-red-600 dark:text-red-400">
+                                                                {r.errorMessage}
+                                                            </div>
+                                                        ) : null}
+                                                    </div>
+                                                    {(r.status === 'queued' ||
+                                                        r.status === 'running') && (
+                                                        <button
+                                                            type="button"
+                                                            onClick={(e) => {
+                                                                e.stopPropagation();
+                                                                cancel(r.id);
+                                                            }}
+                                                            disabled={
+                                                                pending && cancellingId === r.id
+                                                            }
+                                                            className="shrink-0 px-2.5 py-1 text-xs rounded-md border border-border dark:border-border-dark text-text dark:text-text-dark disabled:opacity-40 hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors"
+                                                        >
+                                                            {pending && cancellingId === r.id
+                                                                ? '…'
+                                                                : 'Cancel'}
+                                                        </button>
+                                                    )}
+                                                </div>
+                                            </td>
+                                            <td className="px-4 py-3 text-xs text-text-muted dark:text-text-muted-dark whitespace-nowrap tabular-nums">
+                                                {formatDuration(r.durationMs)}
+                                            </td>
+                                            <td className="w-[9rem] whitespace-nowrap px-4 py-3 align-top">
+                                                <RunStatusBadge status={r.status} />
+                                            </td>
+                                        </tr>
+                                        <tr className={isExpanded ? 'bg-muted/20 dark:bg-muted/10' : ''}>
+                                            <td colSpan={6} style={{ padding: 0 }}>
+                                                <div
+                                                    style={{
+                                                        display: 'grid',
+                                                        gridTemplateRows: isExpanded
+                                                            ? '1fr'
+                                                            : '0fr',
+                                                        transition:
+                                                            'grid-template-rows 300ms ease',
+                                                    }}
+                                                >
+                                                    <div className="overflow-hidden">
+                                                        <div className="px-6 py-4 space-y-3">
+                                                            {detail === undefined ? (
+                                                                <p className="inline-flex items-center gap-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                                                                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                                                    Loading run details…
+                                                                </p>
+                                                            ) : detail === null ? (
+                                                                <p className="text-xs text-red-600 dark:text-red-400">
+                                                                    Could not load run details.{' '}
+                                                                    <button
+                                                                        type="button"
+                                                                        className="underline cursor-pointer"
+                                                                        onClick={(e) => {
+                                                                            e.stopPropagation();
+                                                                            retryDetail(r.id);
+                                                                        }}
+                                                                    >
+                                                                        Retry
+                                                                    </button>
+                                                                </p>
+                                                            ) : (
+                                                                <>
+                                                                    <div className="rounded-md border border-border dark:border-border-dark bg-card dark:bg-card-primary-dark/30 p-3">
+                                                                        <p className="text-xs mb-3 font-semibold uppercase tracking-wide text-text-secondary dark:text-text-secondary-dark">
+                                                                            Run
+                                                                        </p>
+                                                                        <dl className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs sm:grid-cols-4">
+                                                                            <div>
+                                                                                <dt className="text-text-muted dark:text-text-muted-dark">
+                                                                                    Created
+                                                                                </dt>
+                                                                                <dd className="text-text dark:text-text-dark">
+                                                                                    <Timestamp
+                                                                                        value={
+                                                                                            detail.createdAt
+                                                                                        }
+                                                                                    />
+                                                                                </dd>
+                                                                            </div>
+                                                                            <div>
+                                                                                <dt className="text-text-muted dark:text-text-muted-dark">
+                                                                                    Started
+                                                                                </dt>
+                                                                                <dd className="text-text dark:text-text-dark">
+                                                                                    <Timestamp
+                                                                                        value={
+                                                                                            detail.startedAt
+                                                                                        }
+                                                                                    />
+                                                                                </dd>
+                                                                            </div>
+                                                                            <div>
+                                                                                <dt className="text-text-muted dark:text-text-muted-dark">
+                                                                                    Finished
+                                                                                </dt>
+                                                                                <dd className="text-text dark:text-text-dark">
+                                                                                    <Timestamp
+                                                                                        value={
+                                                                                            detail.finishedAt
+                                                                                        }
+                                                                                    />
+                                                                                </dd>
+                                                                            </div>
+                                                                            <div>
+                                                                                <dt className="text-text-muted dark:text-text-muted-dark">
+                                                                                    Duration
+                                                                                </dt>
+                                                                                <dd className="text-text dark:text-text-dark tabular-nums">
+                                                                                    {formatDuration(
+                                                                                        detail.durationMs,
+                                                                                    )}
+                                                                                </dd>
+                                                                            </div>
+                                                                            {detail.taskId ? (
+                                                                                <div>
+                                                                                    <dt className="text-text-muted dark:text-text-muted-dark">
+                                                                                        Task
+                                                                                    </dt>
+                                                                                    <dd className="text-text dark:text-text-dark break-all font-mono text-[11px]">
+                                                                                        {
+                                                                                            detail.taskId
+                                                                                        }
+                                                                                    </dd>
+                                                                                </div>
+                                                                            ) : null}
+                                                                            {detail.chatMessageId ? (
+                                                                                <div>
+                                                                                    <dt className="text-text-muted dark:text-text-muted-dark">
+                                                                                        Chat message
+                                                                                    </dt>
+                                                                                    <dd className="text-text dark:text-text-dark break-all font-mono text-[11px]">
+                                                                                        {
+                                                                                            detail.chatMessageId
+                                                                                        }
+                                                                                    </dd>
+                                                                                </div>
+                                                                            ) : null}
+                                                                            {detail.memorySessionId ? (
+                                                                                <div>
+                                                                                    <dt className="text-text-muted dark:text-text-muted-dark">
+                                                                                        Memory
+                                                                                        session
+                                                                                    </dt>
+                                                                                    <dd className="text-text dark:text-text-dark break-all font-mono text-[11px]">
+                                                                                        {
+                                                                                            detail.memorySessionId
+                                                                                        }
+                                                                                    </dd>
+                                                                                </div>
+                                                                            ) : null}
+                                                                        </dl>
+                                                                    </div>
+                                                                    {detail.summary ? (
+                                                                        <section className="space-y-2">
+                                                                            <h5 className="text-xs font-semibold uppercase tracking-wide text-text-secondary dark:text-text-secondary-dark">
+                                                                                Summary
+                                                                            </h5>
+                                                                            <p className="text-xs text-text dark:text-text-dark whitespace-pre-wrap">
+                                                                                {detail.summary}
+                                                                            </p>
+                                                                        </section>
+                                                                    ) : null}
+                                                                    {detail.errorMessage ? (
+                                                                        <section className="space-y-2">
+                                                                            <h5 className="text-xs font-semibold uppercase tracking-wide text-red-600 dark:text-red-400">
+                                                                                Error
+                                                                            </h5>
+                                                                            <p className="text-xs text-red-600 dark:text-red-400 whitespace-pre-wrap break-all">
+                                                                                {
+                                                                                    detail.errorMessage
+                                                                                }
+                                                                            </p>
+                                                                        </section>
+                                                                    ) : null}
+                                                                    <section className="space-y-2">
+                                                                        <h5 className="text-xs font-semibold uppercase tracking-wide text-text-secondary dark:text-text-secondary-dark">
+                                                                            Steps (
+                                                                            {detail.logs.length})
+                                                                        </h5>
+                                                                        {detail.logs.length ===
+                                                                        0 ? (
+                                                                            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                                                                No step logs were
+                                                                                recorded for this
+                                                                                run.
+                                                                            </p>
+                                                                        ) : (
+                                                                            <ol className="divide-y divide-border dark:divide-border-dark rounded-md border border-border dark:border-border-dark overflow-hidden">
+                                                                                {detail.logs.map(
+                                                                                    (log) => (
+                                                                                        <li
+                                                                                            key={
+                                                                                                log.id
+                                                                                            }
+                                                                                            className="flex items-start gap-2 bg-card dark:bg-transparent px-3 py-2 text-xs"
+                                                                                        >
+                                                                                            <span
+                                                                                                className={cn(
+                                                                                                    'shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium',
+                                                                                                    LOG_LEVEL_STYLES[
+                                                                                                        log
+                                                                                                            .level
+                                                                                                    ],
+                                                                                                )}
+                                                                                            >
+                                                                                                {
+                                                                                                    log.level
+                                                                                                }
+                                                                                            </span>
+                                                                                            <span className="shrink-0 rounded-md border border-border dark:border-border-dark px-1.5 py-0.5 text-[10px] font-mono text-text-muted dark:text-text-muted-dark">
+                                                                                                {
+                                                                                                    log.step
+                                                                                                }
+                                                                                            </span>
+                                                                                            <div className="min-w-0 flex-1">
+                                                                                                <p className="text-text dark:text-text-dark whitespace-pre-wrap break-words">
+                                                                                                    {
+                                                                                                        log.message
+                                                                                                    }
+                                                                                                </p>
+                                                                                                {log.metadata &&
+                                                                                                Object.keys(
+                                                                                                    log.metadata,
+                                                                                                )
+                                                                                                    .length >
+                                                                                                    0 ? (
+                                                                                                    <details className="mt-1">
+                                                                                                        <summary className="cursor-pointer text-[10px] text-text-muted dark:text-text-muted-dark">
+                                                                                                            metadata
+                                                                                                        </summary>
+                                                                                                        <pre className="mt-1 overflow-x-auto rounded-md border border-border dark:border-border-dark bg-surface-secondary dark:bg-surface-secondary-dark p-2.5 text-[11px] font-mono text-text-secondary dark:text-text-secondary-dark">
+                                                                                                            {JSON.stringify(
+                                                                                                                log.metadata,
+                                                                                                                null,
+                                                                                                                2,
+                                                                                                            )}
+                                                                                                        </pre>
+                                                                                                    </details>
+                                                                                                ) : null}
+                                                                                            </div>
+                                                                                            <Timestamp
+                                                                                                value={
+                                                                                                    log.createdAt
+                                                                                                }
+                                                                                                variant="relative"
+                                                                                                className="shrink-0 text-[10px] text-text-muted dark:text-text-muted-dark"
+                                                                                            />
+                                                                                        </li>
+                                                                                    ),
+                                                                                )}
+                                                                            </ol>
+                                                                        )}
+                                                                    </section>
+                                                                </>
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </Fragment>
+                                );
+                            })}
+                        </tbody>
+                    </table>
                 </div>
-            </footer>
+            </div>
+
+            {totalPages > 1 && (
+                <div className="flex items-center justify-between">
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                        Showing {rows.length === 0 ? 0 : meta.offset + 1} to{' '}
+                        {meta.offset + rows.length} of {meta.total} runs
+                    </p>
+                    <div className="flex items-center gap-3">
+                        <span className="text-sm text-text-muted dark:text-text-muted-dark">
+                            Page {page} of {totalPages}
+                        </span>
+                        <div className="flex gap-1.5">
+                            <button
+                                onClick={() => refresh(Math.max(0, meta.offset - meta.limit))}
+                                disabled={meta.offset === 0 || pending}
+                                className="px-2.5 py-1 text-xs rounded-md border border-border dark:border-border-dark disabled:opacity-40 hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors"
+                            >
+                                Previous
+                            </button>
+                            <button
+                                onClick={() => refresh(meta.offset + meta.limit)}
+                                disabled={meta.offset + meta.limit >= meta.total || pending}
+                                className="px-2.5 py-1 text-xs rounded-md border border-border dark:border-border-dark disabled:opacity-40 hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark transition-colors"
+                            >
+                                Next
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/apps/web/src/components/agents/AgentSettingsClient.tsx
+++ b/apps/web/src/components/agents/AgentSettingsClient.tsx
@@ -1,9 +1,13 @@
 'use client';
 
 import { useState, useTransition } from 'react';
-import { Archive, Pause, Play, Save } from 'lucide-react';
+import { Archive, Cpu, IdCard, Pause, Play, Save, ShieldCheck } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Select } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import { useRouter } from '@/i18n/navigation';
 import {
     archiveAgentAction,
@@ -111,16 +115,24 @@ export function AgentSettingsClient({ agent: initialAgent }: AgentSettingsClient
 
     return (
         <div className="p-6 max-w-screen-2xl mx-auto space-y-4">
-            <section className="rounded-lg border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 space-y-4">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <div>
-                        <h2 className="text-sm font-medium text-text dark:text-text-dark">
-                            Identity
-                        </h2>
-                        <p className="text-xs text-text-muted font-mono">{agent.slug}</p>
+            {/* Identity */}
+            <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 space-y-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="flex items-start gap-3">
+                        <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                            <IdCard className="w-4 h-4 text-primary" />
+                        </div>
+                        <div>
+                            <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                                Identity
+                            </h2>
+                            <p className="text-xs text-text-muted dark:text-text-muted-dark font-mono">
+                                {agent.slug}
+                            </p>
+                        </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
-                        <span className="rounded-sm border border-border/60 px-2 py-1 text-xs capitalize text-text-secondary dark:border-border-dark/60 dark:text-text-secondary-dark">
+                        <span className="rounded-full border border-border/60 px-2.5 py-1 text-xs capitalize text-text-secondary dark:border-border-dark/60 dark:text-text-secondary-dark">
                             {agent.status}
                         </span>
                         {canPause ? (
@@ -129,8 +141,9 @@ export function AgentSettingsClient({ agent: initialAgent }: AgentSettingsClient
                                 size="sm"
                                 onClick={() => changeStatus('pause')}
                                 loading={isChangingStatus}
+                                className="gap-1.5 px-2.5 py-1 text-xs"
                             >
-                                <Pause className="h-4 w-4" />
+                                <Pause className="h-3.5 w-3.5" />
                                 Pause
                             </Button>
                         ) : null}
@@ -140,8 +153,9 @@ export function AgentSettingsClient({ agent: initialAgent }: AgentSettingsClient
                                 size="sm"
                                 onClick={() => changeStatus('resume')}
                                 loading={isChangingStatus}
+                                className="gap-1.5 px-2.5 py-1 text-xs"
                             >
-                                <Play className="h-4 w-4" />
+                                <Play className="h-3.5 w-3.5" />
                                 {agent.status === 'draft' ? 'Activate' : 'Resume'}
                             </Button>
                         ) : null}
@@ -150,139 +164,155 @@ export function AgentSettingsClient({ agent: initialAgent }: AgentSettingsClient
                             size="sm"
                             onClick={() => changeStatus('archive')}
                             loading={isChangingStatus}
+                            className="gap-1.5 px-2.5 py-1 text-xs"
                         >
-                            <Archive className="h-4 w-4" />
+                            <Archive className="h-3.5 w-3.5" />
                             Archive
                         </Button>
                     </div>
                 </div>
 
                 <div className="grid gap-4 md:grid-cols-2">
-                    <label className="space-y-1 text-xs text-text-muted">
-                        <span>Name</span>
-                        <input
-                            value={name}
-                            onChange={(event) => setName(event.target.value)}
-                            className="w-full rounded-sm border border-border/70 bg-background px-3 py-2 text-sm text-text outline-none focus:border-button-primary dark:border-border-dark/70 dark:bg-background-dark dark:text-text-dark"
-                        />
-                    </label>
-                    <label className="space-y-1 text-xs text-text-muted">
-                        <span>Title</span>
-                        <input
-                            value={title}
-                            onChange={(event) => setTitle(event.target.value)}
-                            className="w-full rounded-sm border border-border/70 bg-background px-3 py-2 text-sm text-text outline-none focus:border-button-primary dark:border-border-dark/70 dark:bg-background-dark dark:text-text-dark"
-                        />
-                    </label>
-                </div>
-                <label className="space-y-1 text-xs text-text-muted">
-                    <span>Capabilities</span>
-                    <textarea
-                        value={capabilities}
-                        onChange={(event) => setCapabilities(event.target.value)}
-                        rows={4}
-                        className="w-full rounded-sm border border-border/70 bg-background px-3 py-2 text-sm text-text outline-none focus:border-button-primary dark:border-border-dark/70 dark:bg-background-dark dark:text-text-dark"
+                    <Input
+                        label="Name"
+                        variant="form"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
                     />
-                </label>
+                    <Input
+                        label="Title"
+                        variant="form"
+                        value={title}
+                        onChange={(event) => setTitle(event.target.value)}
+                    />
+                </div>
+                <Textarea
+                    label="Capabilities"
+                    variant="form"
+                    rows={4}
+                    value={capabilities}
+                    onChange={(event) => setCapabilities(event.target.value)}
+                />
             </section>
 
-            <section className="rounded-lg border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 space-y-4">
-                <h2 className="text-sm font-medium text-text dark:text-text-dark">Runtime</h2>
+            {/* Runtime */}
+            <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 space-y-4">
+                <div className="flex items-start gap-3">
+                    <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                        <Cpu className="w-4 h-4 text-primary" />
+                    </div>
+                    <div>
+                        <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                            Runtime
+                        </h2>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            Model, cadence, and idle behavior for this Agent.
+                        </p>
+                    </div>
+                </div>
                 <div className="grid gap-4 md:grid-cols-2">
-                    <label className="space-y-1 text-xs text-text-muted">
-                        <span>AI provider id</span>
-                        <input
-                            value={aiProviderId}
-                            onChange={(event) => setAiProviderId(event.target.value)}
-                            placeholder="Account default"
-                            className="w-full rounded-sm border border-border/70 bg-background px-3 py-2 text-sm text-text outline-none focus:border-button-primary dark:border-border-dark/70 dark:bg-background-dark dark:text-text-dark"
-                        />
-                    </label>
-                    <label className="space-y-1 text-xs text-text-muted">
-                        <span>Model id</span>
-                        <input
-                            value={modelId}
-                            onChange={(event) => setModelId(event.target.value)}
-                            placeholder="Provider default"
-                            className="w-full rounded-sm border border-border/70 bg-background px-3 py-2 text-sm text-text outline-none focus:border-button-primary dark:border-border-dark/70 dark:bg-background-dark dark:text-text-dark"
-                        />
-                    </label>
-                    <label className="space-y-1 text-xs text-text-muted">
-                        <span>Heartbeat cadence</span>
-                        <input
-                            value={heartbeatCadence}
-                            onChange={(event) => setHeartbeatCadence(event.target.value)}
-                            placeholder="manual or cron expression"
-                            className="w-full rounded-sm border border-border/70 bg-background px-3 py-2 text-sm text-text outline-none focus:border-button-primary dark:border-border-dark/70 dark:bg-background-dark dark:text-text-dark"
-                        />
-                    </label>
-                    <label className="space-y-1 text-xs text-text-muted">
-                        <span>Idle behavior</span>
-                        <select
+                    <Input
+                        label="AI provider id"
+                        variant="form"
+                        value={aiProviderId}
+                        onChange={(event) => setAiProviderId(event.target.value)}
+                        placeholder="Account default"
+                    />
+                    <Input
+                        label="Model id"
+                        variant="form"
+                        value={modelId}
+                        onChange={(event) => setModelId(event.target.value)}
+                        placeholder="Provider default"
+                    />
+                    <Input
+                        label="Heartbeat cadence"
+                        variant="form"
+                        value={heartbeatCadence}
+                        onChange={(event) => setHeartbeatCadence(event.target.value)}
+                        placeholder="manual or cron expression"
+                    />
+                    <div>
+                        <label className="block text-xs font-medium text-text dark:text-text-dark mb-2">
+                            Idle behavior
+                        </label>
+                        <Select
                             value={idleBehavior}
-                            onChange={(event) =>
-                                setIdleBehavior(event.target.value as AgentIdleBehavior)
+                            onValueChange={(value) =>
+                                setIdleBehavior(value as AgentIdleBehavior)
                             }
-                            className="w-full rounded-sm border border-border/70 bg-background px-3 py-2 text-sm text-text outline-none focus:border-button-primary dark:border-border-dark/70 dark:bg-background-dark dark:text-text-dark"
                         >
                             {idleBehaviorOptions.map((option) => (
                                 <option key={option.value} value={option.value}>
                                     {option.label}
                                 </option>
                             ))}
-                        </select>
-                    </label>
-                    <label className="space-y-1 text-xs text-text-muted">
-                        <span>Skill context tokens</span>
-                        <input
-                            type="number"
-                            min={500}
-                            max={20000}
-                            value={maxSkillContextTokens}
-                            onChange={(event) => setMaxSkillContextTokens(event.target.value)}
-                            className="w-full rounded-sm border border-border/70 bg-background px-3 py-2 text-sm text-text outline-none focus:border-button-primary dark:border-border-dark/70 dark:bg-background-dark dark:text-text-dark"
-                        />
-                    </label>
-                    <label className="space-y-1 text-xs text-text-muted">
-                        <span>Pause after failures</span>
-                        <input
-                            type="number"
-                            min={1}
-                            max={20}
-                            value={pauseAfterFailures}
-                            onChange={(event) => setPauseAfterFailures(event.target.value)}
-                            className="w-full rounded-sm border border-border/70 bg-background px-3 py-2 text-sm text-text outline-none focus:border-button-primary dark:border-border-dark/70 dark:bg-background-dark dark:text-text-dark"
-                        />
-                    </label>
+                        </Select>
+                    </div>
+                    <Input
+                        label="Skill context tokens"
+                        variant="form"
+                        type="number"
+                        min={500}
+                        max={20000}
+                        value={maxSkillContextTokens}
+                        onChange={(event) => setMaxSkillContextTokens(event.target.value)}
+                    />
+                    <Input
+                        label="Pause after failures"
+                        variant="form"
+                        type="number"
+                        min={1}
+                        max={20}
+                        value={pauseAfterFailures}
+                        onChange={(event) => setPauseAfterFailures(event.target.value)}
+                    />
                 </div>
             </section>
 
-            <section className="rounded-lg border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 space-y-4">
-                <h2 className="text-sm font-medium text-text dark:text-text-dark">Permissions</h2>
+            {/* Permissions */}
+            <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 space-y-4">
+                <div className="flex items-start gap-3">
+                    <div className="shrink-0 w-9 h-9 rounded-lg bg-primary/10 border border-primary/20 flex items-center justify-center">
+                        <ShieldCheck className="w-4 h-4 text-primary" />
+                    </div>
+                    <div>
+                        <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                            Permissions
+                        </h2>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            Control what this Agent is allowed to do on its own.
+                        </p>
+                    </div>
+                </div>
                 <div className="grid gap-3 md:grid-cols-2">
                     {permissionLabels.map((permission) => (
-                        <label
+                        <div
                             key={permission.key}
-                            className="flex items-center justify-between gap-3 rounded-sm border border-border/50 px-3 py-2 text-sm text-text-secondary dark:border-border-dark/50 dark:text-text-secondary-dark"
+                            className="flex items-center justify-between gap-3 rounded-lg border border-border/50 px-3 py-2.5 text-sm text-text-secondary dark:border-border-dark/50 dark:text-text-secondary-dark"
                         >
                             <span>{permission.label}</span>
-                            <input
-                                type="checkbox"
+                            <Switch
+                                className="mt-0"
                                 checked={permissions[permission.key]}
-                                onChange={(event) =>
+                                onChange={(checked) =>
                                     setPermissions((current) => ({
                                         ...current,
-                                        [permission.key]: event.target.checked,
+                                        [permission.key]: checked,
                                     }))
                                 }
-                                className="h-4 w-4"
                             />
-                        </label>
+                        </div>
                     ))}
                 </div>
                 <div className="flex justify-end">
-                    <Button onClick={save} loading={isSaving}>
-                        <Save className="h-4 w-4" />
+                    <Button
+                        onClick={save}
+                        loading={isSaving}
+                        size="sm"
+                        className="gap-1.5 px-2.5 py-1 text-xs"
+                    >
+                        <Save className="h-3.5 w-3.5" />
                         Save settings
                     </Button>
                 </div>

--- a/apps/web/src/components/common/EntityAttachmentsSection.tsx
+++ b/apps/web/src/components/common/EntityAttachmentsSection.tsx
@@ -5,10 +5,10 @@ import {
     File as FileIcon,
     FileArchive,
     FileAudio,
-    FileImage,
     FileSpreadsheet,
     FileText,
     FileVideo,
+    Image as ImageIcon,
     Trash2,
     Upload,
 } from 'lucide-react';
@@ -55,27 +55,78 @@ interface UploadedFileMeta {
  * `uploadId` (no filename/mime), so they fall back to the generic icon; a
  * fresh upload has both mime + url, so images get a real thumbnail.
  */
-function fileKind(
-    filename: string,
-    contentType?: string,
-): { icon: typeof FileIcon; tint: string; isImage: boolean } {
+interface FileKind {
+    icon: typeof FileIcon;
+    /** Icon/label text tint. */
+    tint: string;
+    /** Tinted background for the Drive-style preview area. */
+    previewBg: string;
+    /** Short label shown on the preview tile (e.g. PDF, MP4). */
+    label: string;
+    isImage: boolean;
+}
+
+function fileKind(filename: string, contentType?: string): FileKind {
     const ct = (contentType ?? '').toLowerCase();
     const ext = filename.includes('.') ? (filename.split('.').pop() ?? '').toLowerCase() : '';
     const inExt = (list: string[]) => list.includes(ext);
+    const label = (fallback: string) => (ext ? ext.toUpperCase() : fallback);
 
     if (ct.startsWith('image/') || inExt(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif']))
-        return { icon: FileImage, tint: 'text-info', isImage: true };
+        return {
+            icon: ImageIcon,
+            tint: 'text-info',
+            previewBg: 'bg-info/10',
+            label: label('IMG'),
+            isImage: true,
+        };
     if (ct === 'application/pdf' || ext === 'pdf')
-        return { icon: FileText, tint: 'text-danger', isImage: false };
+        return {
+            icon: FileText,
+            tint: 'text-danger',
+            previewBg: 'bg-danger/10',
+            label: 'PDF',
+            isImage: false,
+        };
     if (ct.startsWith('video/') || inExt(['mp4', 'mov', 'webm', 'mkv', 'avi']))
-        return { icon: FileVideo, tint: 'text-primary', isImage: false };
+        return {
+            icon: FileVideo,
+            tint: 'text-primary',
+            previewBg: 'bg-primary/10',
+            label: label('VIDEO'),
+            isImage: false,
+        };
     if (ct.startsWith('audio/') || inExt(['mp3', 'wav', 'ogg', 'flac', 'm4a']))
-        return { icon: FileAudio, tint: 'text-warning', isImage: false };
+        return {
+            icon: FileAudio,
+            tint: 'text-warning',
+            previewBg: 'bg-warning/10',
+            label: label('AUDIO'),
+            isImage: false,
+        };
     if (inExt(['zip', 'tar', 'gz', 'rar', '7z']))
-        return { icon: FileArchive, tint: 'text-text-muted', isImage: false };
+        return {
+            icon: FileArchive,
+            tint: 'text-text-muted',
+            previewBg: 'bg-surface-secondary dark:bg-surface-secondary-dark',
+            label: label('ZIP'),
+            isImage: false,
+        };
     if (inExt(['csv', 'xls', 'xlsx', 'ods']))
-        return { icon: FileSpreadsheet, tint: 'text-success', isImage: false };
-    return { icon: FileIcon, tint: 'text-text-muted', isImage: false };
+        return {
+            icon: FileSpreadsheet,
+            tint: 'text-success',
+            previewBg: 'bg-success/10',
+            label: label('SHEET'),
+            isImage: false,
+        };
+    return {
+        icon: FileIcon,
+        tint: 'text-text-muted',
+        previewBg: 'bg-surface-secondary dark:bg-surface-secondary-dark',
+        label: label('FILE'),
+        isImage: false,
+    };
 }
 
 export interface EntityAttachmentRow {
@@ -254,64 +305,97 @@ export function EntityAttachmentsSection<TRow extends EntityAttachmentRow>({
             )}
 
             {rows.length > 0 && (
-                <ul className="mt-4 space-y-2" data-testid={testId ? `${testId}-list` : undefined}>
+                <ul
+                    className="mt-4 grid grid-cols-2 sm:grid-cols-3 @2xl/main:grid-cols-4 gap-3"
+                    data-testid={testId ? `${testId}-list` : undefined}
+                >
                     {rows.map((r) => {
                         const m = meta[r.id] ?? null;
                         const filename = m?.filename ?? r.uploadId;
                         const size = m ? formatSize(m.sizeBytes) : null;
                         const kind = fileKind(filename, m?.contentType);
                         const KindIcon = kind.icon;
-                        const thumbUrl = kind.isImage ? m?.url : undefined;
+                        // Only in-session uploads carry a URL, so only those are openable.
+                        const openUrl = m?.url;
+                        // A type-aware icon tile — images get the image icon, PDFs the
+                        // PDF icon, etc. (Drive-style, reliable — no broken thumbnails.)
+                        const PreviewInner = (
+                            <div className="flex flex-col items-center justify-center gap-1.5">
+                                <KindIcon className={cn('w-8 h-8', kind.tint)} aria-hidden="true" />
+                                <span
+                                    className={cn(
+                                        'text-[10px] font-semibold tracking-wide',
+                                        kind.tint,
+                                    )}
+                                >
+                                    {kind.label}
+                                </span>
+                            </div>
+                        );
                         return (
                             <li
                                 key={r.id}
-                                className="flex items-center gap-3 rounded-md border border-border/40 dark:border-border-dark/40 p-2.5"
+                                className="group relative rounded-lg border border-border/50 dark:border-border-dark/50 bg-card dark:bg-card-primary-dark overflow-hidden hover:border-border dark:hover:border-border-dark hover:shadow-sm transition-all"
                             >
-                                <div className="shrink-0 w-10 h-10 rounded-md border border-border/40 dark:border-border-dark/40 bg-surface-secondary dark:bg-surface-secondary-dark overflow-hidden flex items-center justify-center">
-                                    {thumbUrl ? (
-                                        // eslint-disable-next-line @next/next/no-img-element -- user-uploaded URL isn't a configured next/image domain; a plain thumbnail is sufficient here.
-                                        <img
-                                            src={thumbUrl}
-                                            alt={filename}
-                                            className="w-full h-full object-cover"
-                                        />
-                                    ) : (
-                                        <KindIcon
-                                            className={cn('w-4 h-4', kind.tint)}
-                                            aria-hidden="true"
-                                        />
-                                    )}
-                                </div>
-                                <div className="min-w-0 flex-1">
-                                    {/* Download wiring pending — the upload
-                                        URL needs the user id, which we don't
-                                        carry on this row. Surface filename as
-                                        plain text + a tooltip until a
-                                        uploadId-only resolver lands (same
-                                        constraint TaskAttachmentsSection
-                                        documents). */}
-                                    <span
-                                        className="text-sm text-text dark:text-text-dark truncate block"
-                                        title="Download wiring pending"
+                                {/* Preview tile — Drive-style. Clickable when we
+                                    have a URL (in-session uploads); otherwise a
+                                    static thumbnail/type tile. */}
+                                {openUrl ? (
+                                    <a
+                                        href={openUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        title={`Open ${filename}`}
+                                        className={cn(
+                                            'flex aspect-4/3 items-center justify-center overflow-hidden',
+                                            kind.previewBg,
+                                        )}
                                     >
-                                        {filename}
-                                    </span>
-                                    <div className="text-[11px] text-text-muted dark:text-text-muted-dark">
-                                        {size ?? r.uploadId.slice(0, 12) + '…'} · attached{' '}
-                                        {new Date(r.createdAt).toLocaleString()}
+                                        {PreviewInner}
+                                    </a>
+                                ) : (
+                                    <div
+                                        className={cn(
+                                            'flex aspect-4/3 items-center justify-center overflow-hidden',
+                                            kind.previewBg,
+                                        )}
+                                    >
+                                        {PreviewInner}
+                                    </div>
+                                )}
+
+                                {/* Footer — filename + meta */}
+                                <div className="flex items-center gap-2 p-2.5 border-t border-border/40 dark:border-border-dark/40">
+                                    <KindIcon
+                                        className={cn('w-3.5 h-3.5 shrink-0', kind.tint)}
+                                        aria-hidden="true"
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                        <span
+                                            className="block truncate text-xs font-medium text-text dark:text-text-dark"
+                                            title={filename}
+                                        >
+                                            {filename}
+                                        </span>
+                                        <span className="block truncate text-[10px] text-text-muted dark:text-text-muted-dark">
+                                            {size ? `${size} · ` : ''}
+                                            {new Date(r.createdAt).toLocaleDateString()}
+                                        </span>
                                     </div>
                                 </div>
-                                <Button
-                                    variant="ghost"
-                                    size="sm"
+
+                                {/* Detach — reveals on hover, Drive-style */}
+                                <button
+                                    type="button"
                                     onClick={() => handleRemove(r.id)}
                                     disabled={pending}
-                                    className="text-danger hover:text-danger gap-1.5"
                                     title="Detach"
+                                    aria-label={`Detach ${filename}`}
                                     data-testid={testId ? `${testId}-detach-${r.id}` : undefined}
+                                    className="absolute top-1.5 right-1.5 grid h-7 w-7 place-items-center rounded-md bg-card/90 dark:bg-card-primary-dark/90 text-text-muted opacity-0 shadow-sm backdrop-blur transition-opacity hover:text-danger group-hover:opacity-100 focus-visible:opacity-100 disabled:cursor-not-allowed disabled:opacity-50"
                                 >
                                     <Trash2 className="w-3.5 h-3.5" />
-                                </Button>
+                                </button>
                             </li>
                         );
                     })}

--- a/apps/web/src/components/common/EntityAttachmentsSection.tsx
+++ b/apps/web/src/components/common/EntityAttachmentsSection.tsx
@@ -1,7 +1,17 @@
 'use client';
 
 import { useRef, useState, useTransition } from 'react';
-import { Paperclip, Trash2, Upload } from 'lucide-react';
+import {
+    File as FileIcon,
+    FileArchive,
+    FileAudio,
+    FileImage,
+    FileSpreadsheet,
+    FileText,
+    FileVideo,
+    Trash2,
+    Upload,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils/cn';
 import { uploadFile, UploadError } from '@/lib/api/uploads';
@@ -35,6 +45,37 @@ interface UploadedFileMeta {
     filename: string;
     sizeBytes: number;
     contentType: string;
+    /** API-served URL, present for in-session uploads — enables image previews. */
+    url?: string;
+}
+
+/**
+ * Maps a file to a preview affordance: an icon + accent tint, and whether
+ * it can render an inline image thumbnail. Server-loaded rows only carry a
+ * `uploadId` (no filename/mime), so they fall back to the generic icon; a
+ * fresh upload has both mime + url, so images get a real thumbnail.
+ */
+function fileKind(
+    filename: string,
+    contentType?: string,
+): { icon: typeof FileIcon; tint: string; isImage: boolean } {
+    const ct = (contentType ?? '').toLowerCase();
+    const ext = filename.includes('.') ? (filename.split('.').pop() ?? '').toLowerCase() : '';
+    const inExt = (list: string[]) => list.includes(ext);
+
+    if (ct.startsWith('image/') || inExt(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif']))
+        return { icon: FileImage, tint: 'text-info', isImage: true };
+    if (ct === 'application/pdf' || ext === 'pdf')
+        return { icon: FileText, tint: 'text-danger', isImage: false };
+    if (ct.startsWith('video/') || inExt(['mp4', 'mov', 'webm', 'mkv', 'avi']))
+        return { icon: FileVideo, tint: 'text-primary', isImage: false };
+    if (ct.startsWith('audio/') || inExt(['mp3', 'wav', 'ogg', 'flac', 'm4a']))
+        return { icon: FileAudio, tint: 'text-warning', isImage: false };
+    if (inExt(['zip', 'tar', 'gz', 'rar', '7z']))
+        return { icon: FileArchive, tint: 'text-text-muted', isImage: false };
+    if (inExt(['csv', 'xls', 'xlsx', 'ods']))
+        return { icon: FileSpreadsheet, tint: 'text-success', isImage: false };
+    return { icon: FileIcon, tint: 'text-text-muted', isImage: false };
 }
 
 export interface EntityAttachmentRow {
@@ -96,6 +137,7 @@ export function EntityAttachmentsSection<TRow extends EntityAttachmentRow>({
                                 filename: file.name,
                                 sizeBytes: file.size,
                                 contentType: file.type,
+                                url: res.url,
                             },
                         }));
                     } catch (err) {
@@ -217,12 +259,29 @@ export function EntityAttachmentsSection<TRow extends EntityAttachmentRow>({
                         const m = meta[r.id] ?? null;
                         const filename = m?.filename ?? r.uploadId;
                         const size = m ? formatSize(m.sizeBytes) : null;
+                        const kind = fileKind(filename, m?.contentType);
+                        const KindIcon = kind.icon;
+                        const thumbUrl = kind.isImage ? m?.url : undefined;
                         return (
                             <li
                                 key={r.id}
                                 className="flex items-center gap-3 rounded-md border border-border/40 dark:border-border-dark/40 p-2.5"
                             >
-                                <Paperclip className="w-4 h-4 text-text-muted dark:text-text-muted-dark shrink-0" />
+                                <div className="shrink-0 w-10 h-10 rounded-md border border-border/40 dark:border-border-dark/40 bg-surface-secondary dark:bg-surface-secondary-dark overflow-hidden flex items-center justify-center">
+                                    {thumbUrl ? (
+                                        // eslint-disable-next-line @next/next/no-img-element -- user-uploaded URL isn't a configured next/image domain; a plain thumbnail is sufficient here.
+                                        <img
+                                            src={thumbUrl}
+                                            alt={filename}
+                                            className="w-full h-full object-cover"
+                                        />
+                                    ) : (
+                                        <KindIcon
+                                            className={cn('w-4 h-4', kind.tint)}
+                                            aria-hidden="true"
+                                        />
+                                    )}
+                                </div>
                                 <div className="min-w-0 flex-1">
                                     {/* Download wiring pending — the upload
                                         URL needs the user id, which we don't

--- a/apps/web/src/components/common/EntityAttachmentsSection.tsx
+++ b/apps/web/src/components/common/EntityAttachmentsSection.tsx
@@ -51,9 +51,9 @@ interface UploadedFileMeta {
 
 /**
  * Maps a file to a preview affordance: an icon + accent tint, and whether
- * it can render an inline image thumbnail. Server-loaded rows only carry a
- * `uploadId` (no filename/mime), so they fall back to the generic icon; a
- * fresh upload has both mime + url, so images get a real thumbnail.
+ * it can render an inline image thumbnail. Server-loaded rows may carry
+ * joined upload metadata (filename/mime) on the row itself; rows without
+ * either source fall back to the generic icon.
  */
 interface FileKind {
     icon: typeof FileIcon;
@@ -133,6 +133,14 @@ export interface EntityAttachmentRow {
     readonly id: string;
     readonly uploadId: string;
     readonly createdAt: string;
+    // Optional joined upload metadata. When the entity's list endpoint
+    // enriches rows server-side (agents do), refreshed pages keep the
+    // type-aware icon/label/size instead of the generic-file fallback.
+    readonly filename?: string | null;
+    readonly mimeType?: string | null;
+    readonly sizeBytes?: number | null;
+    /** API-routed serve URL — makes the tile openable after a refresh. */
+    readonly url?: string | null;
 }
 
 export interface EntityAttachmentsSectionProps<TRow extends EntityAttachmentRow> {
@@ -310,13 +318,17 @@ export function EntityAttachmentsSection<TRow extends EntityAttachmentRow>({
                     data-testid={testId ? `${testId}-list` : undefined}
                 >
                     {rows.map((r) => {
+                        // In-session upload meta wins (it has the URL); fall
+                        // back to the server-joined row metadata on refresh.
                         const m = meta[r.id] ?? null;
-                        const filename = m?.filename ?? r.uploadId;
-                        const size = m ? formatSize(m.sizeBytes) : null;
-                        const kind = fileKind(filename, m?.contentType);
+                        const filename = m?.filename ?? r.filename ?? r.uploadId;
+                        const sizeBytes = m?.sizeBytes ?? r.sizeBytes ?? null;
+                        const size = sizeBytes == null ? null : formatSize(sizeBytes);
+                        const kind = fileKind(filename, m?.contentType ?? r.mimeType ?? undefined);
                         const KindIcon = kind.icon;
-                        // Only in-session uploads carry a URL, so only those are openable.
-                        const openUrl = m?.url;
+                        // In-session uploads carry the URL in local meta;
+                        // server-listed rows carry it on the row itself.
+                        const openUrl = m?.url ?? r.url ?? undefined;
                         // A type-aware icon tile — images get the image icon, PDFs the
                         // PDF icon, etc. (Drive-style, reliable — no broken thumbnails.)
                         const PreviewInner = (
@@ -338,8 +350,8 @@ export function EntityAttachmentsSection<TRow extends EntityAttachmentRow>({
                                 className="group relative rounded-lg border border-border/50 dark:border-border-dark/50 bg-card dark:bg-card-primary-dark overflow-hidden hover:border-border dark:hover:border-border-dark hover:shadow-sm transition-all"
                             >
                                 {/* Preview tile — Drive-style. Clickable when we
-                                    have a URL (in-session uploads); otherwise a
-                                    static thumbnail/type tile. */}
+                                    have a URL (in-session or server-provided);
+                                    otherwise a static thumbnail/type tile. */}
                                 {openUrl ? (
                                     <a
                                         href={openUrl}

--- a/apps/web/src/components/common/EntityAttachmentsSection.tsx
+++ b/apps/web/src/components/common/EntityAttachmentsSection.tsx
@@ -173,6 +173,9 @@ export function EntityAttachmentsSection<TRow extends EntityAttachmentRow>({
 }: EntityAttachmentsSectionProps<TRow>) {
     const [rows, setRows] = useState<TRow[]>([...initial]);
     const [meta, setMeta] = useState<Record<string, UploadedFileMeta>>({});
+    // Attachment ids whose <img> failed to load — those tiles fall back
+    // to the type icon instead of showing a broken-image glyph.
+    const [brokenThumbs, setBrokenThumbs] = useState<Record<string, true>>({});
     const [pending, startTransition] = useTransition();
     const [dragOver, setDragOver] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -329,21 +332,39 @@ export function EntityAttachmentsSection<TRow extends EntityAttachmentRow>({
                         // In-session uploads carry the URL in local meta;
                         // server-listed rows carry it on the row itself.
                         const openUrl = m?.url ?? r.url ?? undefined;
-                        // A type-aware icon tile — images get the image icon, PDFs the
-                        // PDF icon, etc. (Drive-style, reliable — no broken thumbnails.)
-                        const PreviewInner = (
-                            <div className="flex flex-col items-center justify-center gap-1.5">
-                                <KindIcon className={cn('w-8 h-8', kind.tint)} aria-hidden="true" />
-                                <span
-                                    className={cn(
-                                        'text-[10px] font-semibold tracking-wide',
-                                        kind.tint,
-                                    )}
-                                >
-                                    {kind.label}
-                                </span>
-                            </div>
-                        );
+                        // Images render a real thumbnail (served same-origin via
+                        // the auth proxy); everything else — and any image that
+                        // fails to load — gets the type-aware icon tile. Plain
+                        // <img>, not next/image: the optimizer fetches server-side
+                        // without the viewer's session cookie, which the
+                        // owner-gated serve proxy rejects with a 401.
+                        const PreviewInner =
+                            kind.isImage && openUrl && !brokenThumbs[r.id] ? (
+                                <img
+                                    src={openUrl}
+                                    alt={filename}
+                                    loading="lazy"
+                                    className="h-full w-full object-cover"
+                                    onError={() =>
+                                        setBrokenThumbs((prev) => ({ ...prev, [r.id]: true }))
+                                    }
+                                />
+                            ) : (
+                                <div className="flex flex-col items-center justify-center gap-1.5">
+                                    <KindIcon
+                                        className={cn('w-8 h-8', kind.tint)}
+                                        aria-hidden="true"
+                                    />
+                                    <span
+                                        className={cn(
+                                            'text-[10px] font-semibold tracking-wide',
+                                            kind.tint,
+                                        )}
+                                    >
+                                        {kind.label}
+                                    </span>
+                                </div>
+                            );
                         return (
                             <li
                                 key={r.id}

--- a/apps/web/src/lib/api/agents.ts
+++ b/apps/web/src/lib/api/agents.ts
@@ -345,8 +345,8 @@ export const agentsAPI = {
         meta: { total: number; limit: number; offset: number };
     }> {
         const params = new URLSearchParams();
-        if (opts.limit) params.set('limit', String(opts.limit));
-        if (opts.offset) params.set('offset', String(opts.offset));
+        if (opts.limit != null) params.set('limit', String(opts.limit));
+        if (opts.offset != null) params.set('offset', String(opts.offset));
         const qs = params.toString();
         return serverFetch(`/agents/${id}/runs${qs ? `?${qs}` : ''}`, { method: 'GET' });
     },
@@ -366,8 +366,8 @@ export const agentsAPI = {
         meta: { total: number; limit: number; offset: number };
     }> {
         const params = new URLSearchParams();
-        if (opts.limit) params.set('limit', String(opts.limit));
-        if (opts.offset) params.set('offset', String(opts.offset));
+        if (opts.limit != null) params.set('limit', String(opts.limit));
+        if (opts.offset != null) params.set('offset', String(opts.offset));
         const qs = params.toString();
         return serverFetch(`/agents/${id}/events${qs ? `?${qs}` : ''}`, { method: 'GET' });
     },

--- a/apps/web/src/lib/api/agents.ts
+++ b/apps/web/src/lib/api/agents.ts
@@ -479,4 +479,13 @@ export interface AgentAttachmentRow {
     readonly agentId: string;
     readonly uploadId: string;
     readonly createdAt: string;
+    // Joined `user_uploads` metadata — present on list responses (the
+    // API enriches rows server-side) so attachment tiles can render
+    // type-aware icons after a refresh; absent on add responses, where
+    // the client already knows the file it just uploaded.
+    readonly filename?: string | null;
+    readonly mimeType?: string | null;
+    readonly sizeBytes?: number | null;
+    /** API-routed serve URL (`/api/uploads/<userId>/<hash>.<ext>`). */
+    readonly url?: string | null;
 }

--- a/apps/web/src/lib/api/agents.ts
+++ b/apps/web/src/lib/api/agents.ts
@@ -351,6 +351,57 @@ export const agentsAPI = {
         return serverFetch(`/agents/${id}/runs${qs ? `?${qs}` : ''}`, { method: 'GET' });
     },
 
+    // Lifecycle events (paused / resumed / created / …) for the
+    // activity feed — interleaved with runs client-side.
+    async listEvents(
+        id: string,
+        opts: { limit?: number; offset?: number } = {},
+    ): Promise<{
+        data: Array<{
+            id: string;
+            actionType: string;
+            details: Record<string, unknown> | null;
+            createdAt: string;
+        }>;
+        meta: { total: number; limit: number; offset: number };
+    }> {
+        const params = new URLSearchParams();
+        if (opts.limit) params.set('limit', String(opts.limit));
+        if (opts.offset) params.set('offset', String(opts.offset));
+        const qs = params.toString();
+        return serverFetch(`/agents/${id}/events${qs ? `?${qs}` : ''}`, { method: 'GET' });
+    },
+
+    // FU-4 follow-up — full run detail incl. the structured step logs
+    // written to `agent_run_logs` during the run (previously write-only).
+    async getRun(
+        id: string,
+        runId: string,
+    ): Promise<{
+        id: string;
+        status: string;
+        triggerKind: string;
+        startedAt: string | null;
+        finishedAt: string | null;
+        durationMs: number | null;
+        summary: string | null;
+        errorMessage: string | null;
+        taskId: string | null;
+        chatMessageId: string | null;
+        memorySessionId: string | null;
+        createdAt: string;
+        logs: Array<{
+            id: string;
+            level: 'INFO' | 'WARN' | 'ERROR';
+            step: string;
+            message: string;
+            metadata: Record<string, unknown> | null;
+            createdAt: string;
+        }>;
+    }> {
+        return serverFetch(`/agents/${id}/runs/${runId}`, { method: 'GET' });
+    },
+
     async listSkills(id: string): Promise<{
         data: Array<{
             bindingId: string;

--- a/packages/agent/src/activity-log/activity-log.service.ts
+++ b/packages/agent/src/activity-log/activity-log.service.ts
@@ -340,6 +340,21 @@ export class ActivityLogService {
         return this.repository.findByWork(options);
     }
 
+    /**
+     * Per-Agent lifecycle events (paused / resumed / …) for the Agent
+     * activity feed. User-scoped; matches rows stamped with
+     * `details.resourceId = agentId` by the agents controller.
+     */
+    async findAgentEvents(options: {
+        userId: string;
+        agentId: string;
+        actionTypes: ActivityActionType[];
+        limit?: number;
+        offset?: number;
+    }): Promise<{ activities: ActivityLog[]; total: number }> {
+        return this.repository.findAgentEvents(options);
+    }
+
     async countRunning(userId: string): Promise<number> {
         return this.repository.countByStatus(userId, 'in_progress' as ActivityStatus);
     }

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -19,7 +19,7 @@ import {
 } from '../entities/agent.entity';
 import { AgentAttachment } from '../entities/agent-attachment.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { Work } from '../entities/work.entity';
 import { Mission } from '../entities/mission.entity';
 import { WorkProposal } from '../entities/work-proposal.entity';
@@ -68,6 +68,25 @@ export interface CreateAgentInput {
     // name + a synthesized email (`<slug>@agents.ever.works`).
     committerName?: string | null;
     committerEmail?: string | null;
+}
+
+/**
+ * `AgentAttachment` edge enriched with the owning user's `user_uploads`
+ * metadata (when the uploads repo is wired and the row still exists).
+ * Returned by {@link AgentsService.listAttachments} so the web tiles
+ * can render type-aware icons/labels after a page refresh.
+ */
+export interface AgentAttachmentListRow extends AgentAttachment {
+    filename?: string | null;
+    mimeType?: string | null;
+    sizeBytes?: number | null;
+    /**
+     * API-routed serve URL (`/api/uploads/<userId>/<hash>.<ext>`), same
+     * shape `UploadsService.saveFile` returns at upload time — lets the
+     * web tiles stay openable after a refresh. Null when the stored
+     * object key can't provide the served filename.
+     */
+    url?: string | null;
 }
 
 export interface UpdateAgentInput {
@@ -446,12 +465,51 @@ export class AgentsService {
 
     /**
      * List the Upload edges attached to an Agent. Same shape as the
-     * Mission / Idea attachment surfaces.
+     * Mission / Idea attachment surfaces, plus joined `user_uploads`
+     * metadata (filename / mimeType / size) when available — without
+     * it the web attachment tiles can only render a generic file icon
+     * after a page refresh (the client-side filename/MIME cache only
+     * covers in-session uploads).
      */
-    async listAttachments(userId: string, id: string): Promise<AgentAttachment[]> {
+    async listAttachments(userId: string, id: string): Promise<AgentAttachmentListRow[]> {
         await this.requireOwned(userId, id);
         if (!this.agentAttachments) return [];
-        return this.agentAttachments.findByAgentId(id);
+        const rows = await this.agentAttachments.findByAgentId(id);
+        if (rows.length === 0 || !this.uploadsRepo) return rows;
+        // `user_uploads` is deduped per (userId, sha256); addAttachment
+        // already enforces the upload is owned by the caller, so the
+        // owner-scoped lookup resolves every attachable upload.
+        const uploads = await this.uploadsRepo.find({
+            where: { userId, sha256: In(rows.map((r) => r.uploadId)) },
+        });
+        const bySha = new Map(uploads.map((u) => [u.sha256, u]));
+        return rows.map((r) => {
+            const u = bySha.get(r.uploadId);
+            if (!u) return r;
+            // The storage key ends with the served filename
+            // (`<sha256>.<ext>` — see UploadsService.saveFile), which is
+            // what the owner-gated serve route keys on. Slice it off at
+            // the hash (rather than splitting on `/`) so per-Work keys
+            // like `dr:<workId>:<name>` resolve too, then rebuild the
+            // same API-routed URL saveFile returned at upload time,
+            // including the `?workId=` round-trip for those backends.
+            const nameAt = u.storagePath.lastIndexOf(u.sha256);
+            const servedName = nameAt >= 0 ? u.storagePath.slice(nameAt) : '';
+            let url: string | null = null;
+            if (servedName) {
+                url = u.workId
+                    ? `/api/uploads/${encodeURIComponent(userId)}/${servedName}?workId=${encodeURIComponent(u.workId)}`
+                    : `/api/uploads/${encodeURIComponent(userId)}/${servedName}`;
+            }
+            return {
+                ...r,
+                filename: u.originalFilename ?? null,
+                mimeType: u.mimeType ?? null,
+                // bigint columns come back as strings from the pg driver.
+                sizeBytes: u.fileSize == null ? null : Number(u.fileSize),
+                url,
+            };
+        });
     }
 
     /** Attach an uploaded file to an Agent. Idempotent. */

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -45,6 +45,7 @@ export {
 // budget rollup). Mirrors the same pattern as `AgentFileService` etc.
 export { AgentRepository } from '../database/repositories/agent.repository';
 export { AgentRunRepository } from '../database/repositories/agent-run.repository';
+export { AgentRunLogRepository } from '../database/repositories/agent-run-log.repository';
 export { SkillBindingRepository } from '../database/repositories/skill-binding.repository';
 export { PluginUsageRepository } from '../database/repositories/plugin-usage.repository';
 // FU-14 — re-export WorkRepository for the AGENT_GIT_FACADE binding

--- a/packages/agent/src/database/repositories/activity-log.repository.ts
+++ b/packages/agent/src/database/repositories/activity-log.repository.ts
@@ -129,14 +129,22 @@ export class ActivityLogRepository {
         if (options.actionTypes.length === 0) return { activities: [], total: 0 };
         const limit = Math.min(options.limit ?? 25, 100);
         const offset = options.offset ?? 0;
+        // The id lands inside the LIKE pattern, where `%` / `_` are
+        // wildcards — escape them (and the escape char itself) so the
+        // needle only ever matches the literal id. The controller path
+        // guarantees a UUID, but this is a public repository method and
+        // an unvalidated id must not be able to widen the match. The
+        // explicit ESCAPE keeps the behaviour portable: sqlite's LIKE
+        // has no default escape character.
+        const escapedAgentId = options.agentId.replace(/[\\%_]/g, '\\$&');
         const [activities, total] = await this.repository
             .createQueryBuilder('activity')
             .where('activity.userId = :userId', { userId: options.userId })
             .andWhere('activity.actionType IN (:...actionTypes)', {
                 actionTypes: options.actionTypes,
             })
-            .andWhere('activity.details LIKE :needle', {
-                needle: `%"resourceId":"${options.agentId}"%`,
+            .andWhere("activity.details LIKE :needle ESCAPE '\\'", {
+                needle: `%"resourceId":"${escapedAgentId}"%`,
             })
             .orderBy('activity.createdAt', 'DESC')
             .take(limit)

--- a/packages/agent/src/database/repositories/activity-log.repository.ts
+++ b/packages/agent/src/database/repositories/activity-log.repository.ts
@@ -109,6 +109,42 @@ export class ActivityLogRepository {
         return { activities, total };
     }
 
+    /**
+     * Per-Agent lifecycle events (AGENT_PAUSED / AGENT_RESUMED / …) for
+     * the /agents/[id]/activity feed. The activity log has no dedicated
+     * `agentId` column — agent writers (AgentsController.tryLog) stamp
+     * `details.resourceId` instead — so this matches on the serialized
+     * `"resourceId":"<agentId>"` JSON fragment. `details` is a
+     * `simple-json` (text) column, which makes LIKE portable across
+     * postgres/sqlite; the userId + actionType predicates keep the
+     * scanned set small.
+     */
+    async findAgentEvents(options: {
+        userId: string;
+        agentId: string;
+        actionTypes: ActivityActionType[];
+        limit?: number;
+        offset?: number;
+    }): Promise<{ activities: ActivityLog[]; total: number }> {
+        if (options.actionTypes.length === 0) return { activities: [], total: 0 };
+        const limit = Math.min(options.limit ?? 25, 100);
+        const offset = options.offset ?? 0;
+        const [activities, total] = await this.repository
+            .createQueryBuilder('activity')
+            .where('activity.userId = :userId', { userId: options.userId })
+            .andWhere('activity.actionType IN (:...actionTypes)', {
+                actionTypes: options.actionTypes,
+            })
+            .andWhere('activity.details LIKE :needle', {
+                needle: `%"resourceId":"${options.agentId}"%`,
+            })
+            .orderBy('activity.createdAt', 'DESC')
+            .take(limit)
+            .skip(offset)
+            .getManyAndCount();
+        return { activities, total };
+    }
+
     async findLatestByUserWorkActionStatus(params: {
         userId: string;
         workId: string;


### PR DESCRIPTION

<img width="1361" height="757" alt="FireShot Capture 076 - Content Curator - Ever Works -  localhost" src="https://github.com/user-attachments/assets/66175a29-a472-40ad-8896-2c9fa92c042b" />
<img width="1365" height="1473" alt="FireShot Capture 078 - Content Curator - Ever Works -  localhost" src="https://github.com/user-attachments/assets/17e6c0eb-0ef9-4730-9c18-ba73a10485c2" />
<img width="1365" height="1594" alt="FireShot Capture 074 - Content Curator - Ever Works -  localhost" src="https://github.com/user-attachments/assets/2f24850e-06e0-4ecb-8914-28d3385a5dc9" />


# feat(agents): expose run details + lifecycle events, fix activity logging, Fix agent UI

## Summary

This PR rounds out the agent runtime surface end-to-end across the API, the `@ever-works/agent` package, and the web app. It has three threads:

1. **Observability gap** — every agent run has been writing structured step logs to `agent_run_logs`, but nothing ever read them back; the table was effectively write-only. Likewise, agent lifecycle transitions (pause/resume) left no activity trail at all, and — due to a module-wiring bug — *no* agent activity logging was actually happening in production. This PR exposes run details and lifecycle events through new endpoints and fixes the logging.
2. **Activity feed redesign** — the per-agent activity page is rebuilt in the same table design language as the global `/activity` page, with expandable run detail rows and inline lifecycle events.
3. **UI modernization** — the agent dashboard, settings tab, and shared attachments section are reworked to match the design system used by sibling pages.

14 commits, 13 files, **+1601 / −251**.

---

## API changes (`apps/api`)

### 🐛 Fix: agent activity logging was silently a no-op

`AgentsController` injects `ActivityLogService` via `@Optional()`, but `AgentsModule` never imported `ActivityLogModule`. The optional injection therefore resolved to `undefined` and **every** `tryLog()` call — run-triggered, run-cancelled, task-assigned — was silently dropped. Nothing crashed, so this went unnoticed.

Fixed by importing `ActivityLogModule` in `agents.module.ts`, the same wiring already used by the works, plugins, and auth modules.

### ✨ New endpoint: `GET /api/agents/:id/runs/:runId`

Full detail for a single `AgentRun`, including fields the list endpoint omits (`chatMessageId`, `memorySessionId`) **plus its structured step logs** from `agent_run_logs` (up to 500, ordered):

    {
      "id": "…", "status": "SUCCEEDED", "triggerKind": "SCHEDULE",
      "startedAt": "…", "finishedAt": "…", "durationMs": 4200,
      "summary": "…", "errorMessage": null,
      "taskId": null, "chatMessageId": null, "memorySessionId": "…",
      "createdAt": "…",
      "logs": [
        { "id": "…", "level": "INFO", "step": "plan", "message": "…", "metadata": { }, "createdAt": "…" }
      ]
    }

**Security**: the run is looked up user-scoped (`findByIdAndUser`) *and* checked against the `:id` path param, so cross-user **and** cross-agent runIds both return 404 — no existence leak (architecture/security §9).

### ✨ New endpoint: `GET /api/agents/:id/events`

Paginated agent lifecycle events for the activity feed, read from the activity log:

- Covered action types: `AGENT_CREATED`, `AGENT_PAUSED`, `AGENT_RESUMED`, `AGENT_ARCHIVED`, `AGENT_EXPORTED`, `AGENT_IMPORTED`, `AGENT_BUDGET_EXCEEDED` (a single controller-level list — adding a type there is enough to surface any future emitter).
- Returns `{ data: [{ id, actionType, details, createdAt }], meta: { total, limit, offset } }`.
- When `ActivityLogService` is unbound (it stays `@Optional()`), the endpoint degrades to an empty page rather than 500ing — mirroring `tryLog()`'s best-effort posture.

### ✨ Pause/resume now leave an activity trail

`POST :id/pause` and `POST :id/resume` emit `AGENT_PAUSED` / `AGENT_RESUMED` activity rows **after** a successful status transition (a failed transition logs nothing), as the agents spec always required. These rows are what the new `:id/events` endpoint and the web activity feed surface.

---

## Agent package changes (`packages/agent`)

- **`ActivityLogRepository.findAgentEvents(...)`** — new per-agent lifecycle query. The activity log has no `agentId` column (agent writers stamp `details.resourceId` instead), so the query matches the serialized `"resourceId":"<agentId>"` fragment with a `LIKE` on the `simple-json` (text) `details` column — portable across postgres/sqlite — with `userId` + `actionType IN (...)` predicates keeping the scanned set small. Limit is clamped to 100.
- **`ActivityLogService.findAgentEvents(...)`** — thin delegation so the API controller reads through the service, consistent with the existing surface.
- **`packages/agent/src/agents/index.ts`** — re-exports `AgentRunLogRepository` so the API controller can inject it without a deep import.

---

## Web changes (`apps/web`)

### Activity feed redesign (`AgentActivityClient.tsx`, +~780 lines)

Replaces the compact run list with the `/activity` table design language:

- Columns: expander / stacked date-time / type pill / summary / duration / status.
- **Expandable detail rows** — clicking a run fetches `getRun` and shows run timestamps, the full summary, the error message, and the per-step `agent_run_logs` rows with level badges and metadata.
- Pause/resume **lifecycle events render inline** as non-expandable rows, clipped to the current page's time window so the interleaved timeline stays consistent across run pages.
- Failed runs now show their `errorMessage` alongside the summary instead of being hidden by it.
- Matching status + type badge palettes, corner loading chip, and "Page X of Y" pagination.

### Data plumbing

- `agentsAPI.getRun()` and `agentsAPI.listEvents()` server-side fetchers, mirroring the `listRuns` pagination shape.
- `getAgentRunDetailAction` + `listAgentEventsAction` server actions so the client-side feed can reach them (`agentsAPI` is server-only).
- The activity page fetches one parallel 100-row events page alongside runs; fetch failures degrade to an empty list like the runs fetch.

### Dashboard modernization (`/agents/[id]`)

Overview hero (avatar + colored status), quick stat tiles (heartbeat, idle behavior, last/next run), and a health strip.

### Attachments (`EntityAttachmentsSection.tsx`, shared)

Drive-style responsive card grid with type-aware icons (image, PDF, video, audio, sheet, archive, generic), image thumbnails for in-session uploads, hover-to-detach, and click-to-open.

### Settings

Aligned with the shared design system: shared `Input`/`Textarea`/`Select`/`Switch` components replace raw elements; rounded-xl cards with icon-badge section headers to match sibling agent tabs; compact status and save buttons.

---

## Tests

8 new cases in `agents.controller.runtime.spec.ts` (+162 lines):

- Run detail happy path with ordered step logs.
- 404 on unknown runId and on a cross-agent runId (valid run, wrong `:id`).
- Pause logs `AGENT_PAUSED` with the agent as resource; resume logs `AGENT_RESUMED`.
- No activity row when the pause/resume transition throws.
- Events pagination scoped to the requested agent.
- Empty events page when `ActivityLogService` is unbound.

## Breaking changes

None — additive endpoints, additive package exports, and web-only UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent activity feed with lifecycle events and paginated, expandable run details (including step logs).
  * Expanded the agent dashboard with a richer overview, health/status indicators, and enhanced capabilities/tiles.
  * Improved attachment previews with MIME/extension-aware tiles and richer server-provided metadata.
  * Added an API endpoint to securely proxy uploaded content by filename.
* **Bug Fixes**
  * Improved pause/resume activity logging with best-effort entries and safer failure handling.
  * Ensured run detail access returns 404 for missing or mismatched agent/run combinations.
  * Kept the activity feed functional when event data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->