### PR TITLE
feat(web): add Agents dropdown to Work header listing Work-scoped Agents

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1723,7 +1723,8 @@
                 "pausedToast": "تم إيقاف الوكيل مؤقتًا",
                 "activatedToast": "تم تفعيل الوكيل",
                 "statusUpdateFailed": "تعذر تحديث الحالة",
-                "newAgent": "وكيل جديد"
+                "newAgent": "وكيل جديد",
+                "moreAgents": "+{count} أخرى"
             },
             "failedToGenerateItems": "فشل في توليد العناصر. يرجى المحاولة مرة أخرى.",
             "generationCompleted": "اكتمل التوليد بنجاح",

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1713,6 +1713,18 @@
             "createButton": "إنشاء عمل"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "الوكلاء",
+                "heading": "وكلاء هذا العمل",
+                "emptyTitle": "لا يوجد وكلاء بعد",
+                "emptySubtitle": "أنشئ وكيلاً لأتمتة هذا العمل.",
+                "pause": "إيقاف الوكيل مؤقتًا",
+                "activate": "تفعيل الوكيل",
+                "pausedToast": "تم إيقاف الوكيل مؤقتًا",
+                "activatedToast": "تم تفعيل الوكيل",
+                "statusUpdateFailed": "تعذر تحديث الحالة",
+                "newAgent": "وكيل جديد"
+            },
             "failedToGenerateItems": "فشل في توليد العناصر. يرجى المحاولة مرة أخرى.",
             "generationCompleted": "اكتمل التوليد بنجاح",
             "generationCancelled": "تم إلغاء التوليد",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1713,6 +1713,18 @@
             "createButton": "Създай работа"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Агенти",
+                "heading": "Агенти за тази Работа",
+                "emptyTitle": "Все още няма Агенти",
+                "emptySubtitle": "Създайте Агент, за да автоматизирате тази Работа.",
+                "pause": "Пауза на Агента",
+                "activate": "Активиране на Агента",
+                "pausedToast": "Агентът е поставен на пауза",
+                "activatedToast": "Агентът е активиран",
+                "statusUpdateFailed": "Статусът не можа да бъде обновен",
+                "newAgent": "Нов Агент"
+            },
             "failedToGenerateItems": "Неуспешно генериране на елементи. Моля, опитайте отново.",
             "generationCompleted": "Генерирането завърши успешно",
             "generationCancelled": "Генерирането беше отменено",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1723,7 +1723,8 @@
                 "pausedToast": "Агентът е поставен на пауза",
                 "activatedToast": "Агентът е активиран",
                 "statusUpdateFailed": "Статусът не можа да бъде обновен",
-                "newAgent": "Нов Агент"
+                "newAgent": "Нов Агент",
+                "moreAgents": "+{count} още"
             },
             "failedToGenerateItems": "Неуспешно генериране на елементи. Моля, опитайте отново.",
             "generationCompleted": "Генерирането завърши успешно",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1723,7 +1723,8 @@
                 "pausedToast": "Agent pausiert",
                 "activatedToast": "Agent aktiviert",
                 "statusUpdateFailed": "Status konnte nicht aktualisiert werden",
-                "newAgent": "Neuer Agent"
+                "newAgent": "Neuer Agent",
+                "moreAgents": "+{count} weitere"
             },
             "failedToGenerateItems": "Fehler beim Generieren der Elemente. Bitte versuchen Sie es erneut.",
             "generationCompleted": "Generierung erfolgreich abgeschlossen",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1713,6 +1713,18 @@
             "createButton": "Werk erstellen"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Agenten",
+                "heading": "Agenten für diese Aufgabe",
+                "emptyTitle": "Noch keine Agenten",
+                "emptySubtitle": "Erstellen Sie einen Agenten, um diese Aufgabe zu automatisieren.",
+                "pause": "Agent pausieren",
+                "activate": "Agent aktivieren",
+                "pausedToast": "Agent pausiert",
+                "activatedToast": "Agent aktiviert",
+                "statusUpdateFailed": "Status konnte nicht aktualisiert werden",
+                "newAgent": "Neuer Agent"
+            },
             "failedToGenerateItems": "Fehler beim Generieren der Elemente. Bitte versuchen Sie es erneut.",
             "generationCompleted": "Generierung erfolgreich abgeschlossen",
             "generationCancelled": "Generierung wurde abgebrochen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1829,6 +1829,18 @@
             "createButton": "New Work"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Agents",
+                "heading": "Agents for this Work",
+                "emptyTitle": "No Agents yet",
+                "emptySubtitle": "Create one to automate this Work.",
+                "pause": "Pause Agent",
+                "activate": "Activate Agent",
+                "pausedToast": "Agent paused",
+                "activatedToast": "Agent activated",
+                "statusUpdateFailed": "Could not update status",
+                "newAgent": "New Agent"
+            },
             "failedToGenerateItems": "Failed to generate items. Please try again.",
             "generationCompleted": "Generation completed successfully",
             "generationCancelled": "Generation was cancelled",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1839,7 +1839,8 @@
                 "pausedToast": "Agent paused",
                 "activatedToast": "Agent activated",
                 "statusUpdateFailed": "Could not update status",
-                "newAgent": "New Agent"
+                "newAgent": "New Agent",
+                "moreAgents": "+{count} more"
             },
             "failedToGenerateItems": "Failed to generate items. Please try again.",
             "generationCompleted": "Generation completed successfully",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1723,7 +1723,8 @@
                 "pausedToast": "Agente pausado",
                 "activatedToast": "Agente activado",
                 "statusUpdateFailed": "No se pudo actualizar el estado",
-                "newAgent": "Nuevo Agente"
+                "newAgent": "Nuevo Agente",
+                "moreAgents": "+{count} más"
             },
             "failedToGenerateItems": "No se pudieron generar los elementos. Inténtalo de nuevo.",
             "generationCompleted": "Generación completada exitosamente",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1713,6 +1713,18 @@
             "createButton": "Crear trabajo"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Agentes",
+                "heading": "Agentes de este Trabajo",
+                "emptyTitle": "Aún no hay Agentes",
+                "emptySubtitle": "Crea un Agente para automatizar este Trabajo.",
+                "pause": "Pausar Agente",
+                "activate": "Activar Agente",
+                "pausedToast": "Agente pausado",
+                "activatedToast": "Agente activado",
+                "statusUpdateFailed": "No se pudo actualizar el estado",
+                "newAgent": "Nuevo Agente"
+            },
             "failedToGenerateItems": "No se pudieron generar los elementos. Inténtalo de nuevo.",
             "generationCompleted": "Generación completada exitosamente",
             "generationCancelled": "La generación fue cancelada",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1723,7 +1723,8 @@
                 "pausedToast": "Agent mis en pause",
                 "activatedToast": "Agent activé",
                 "statusUpdateFailed": "Impossible de mettre à jour le statut",
-                "newAgent": "Nouvel Agent"
+                "newAgent": "Nouvel Agent",
+                "moreAgents": "+{count} de plus"
             },
             "failedToGenerateItems": "Échec de la génération des éléments. Veuillez réessayer.",
             "generationCompleted": "Génération terminée avec succès",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1713,6 +1713,18 @@
             "createButton": "Créer un travail"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Agents",
+                "heading": "Agents de ce Work",
+                "emptyTitle": "Aucun Agent pour l'instant",
+                "emptySubtitle": "Créez un Agent pour automatiser ce Work.",
+                "pause": "Mettre l'Agent en pause",
+                "activate": "Activer l'Agent",
+                "pausedToast": "Agent mis en pause",
+                "activatedToast": "Agent activé",
+                "statusUpdateFailed": "Impossible de mettre à jour le statut",
+                "newAgent": "Nouvel Agent"
+            },
             "failedToGenerateItems": "Échec de la génération des éléments. Veuillez réessayer.",
             "generationCompleted": "Génération terminée avec succès",
             "generationCancelled": "Génération annulée",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1713,6 +1713,18 @@
             "createButton": "צור עבודה"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "סוכנים",
+                "heading": "סוכנים לעבודה זו",
+                "emptyTitle": "אין סוכנים עדיין",
+                "emptySubtitle": "צרו סוכן כדי להפוך עבודה זו לאוטומטית.",
+                "pause": "השהיית הסוכן",
+                "activate": "הפעלת הסוכן",
+                "pausedToast": "הסוכן הושהה",
+                "activatedToast": "הסוכן הופעל",
+                "statusUpdateFailed": "לא ניתן לעדכן את הסטטוס",
+                "newAgent": "סוכן חדש"
+            },
             "failedToGenerateItems": "נכשל ביצירת פריטים. נסה שוב.",
             "generationCompleted": "היצירה הושלמה בהצלחה",
             "generationCancelled": "היצירה בוטלה",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1723,7 +1723,8 @@
                 "pausedToast": "הסוכן הושהה",
                 "activatedToast": "הסוכן הופעל",
                 "statusUpdateFailed": "לא ניתן לעדכן את הסטטוס",
-                "newAgent": "סוכן חדש"
+                "newAgent": "סוכן חדש",
+                "moreAgents": "+{count} נוספים"
             },
             "failedToGenerateItems": "נכשל ביצירת פריטים. נסה שוב.",
             "generationCompleted": "היצירה הושלמה בהצלחה",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1602,6 +1602,18 @@
             "createButton": "कार्य बनाएँ"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "एजेंट",
+                "heading": "इस काम के एजेंट",
+                "emptyTitle": "अभी तक कोई एजेंट नहीं",
+                "emptySubtitle": "इस काम को स्वचालित करने के लिए एक एजेंट बनाएं।",
+                "pause": "एजेंट रोकें",
+                "activate": "एजेंट सक्रिय करें",
+                "pausedToast": "एजेंट रोका गया",
+                "activatedToast": "एजेंट सक्रिय किया गया",
+                "statusUpdateFailed": "स्थिति अपडेट नहीं हो सकी",
+                "newAgent": "नया एजेंट"
+            },
             "failedToGenerateItems": "आइटम उत्पन्न करने में विफल। कृपया पुनः प्रयास करें।",
             "generationCompleted": "उत्पत्ति सफलतापूर्वक पूर्ण हुई",
             "generationCancelled": "उत्पत्ति रद्द कर दी गई",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "एजेंट रोका गया",
                 "activatedToast": "एजेंट सक्रिय किया गया",
                 "statusUpdateFailed": "स्थिति अपडेट नहीं हो सकी",
-                "newAgent": "नया एजेंट"
+                "newAgent": "नया एजेंट",
+                "moreAgents": "+{count} और"
             },
             "failedToGenerateItems": "आइटम उत्पन्न करने में विफल। कृपया पुनः प्रयास करें।",
             "generationCompleted": "उत्पत्ति सफलतापूर्वक पूर्ण हुई",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1602,6 +1602,18 @@
             "createButton": "Buat Karya"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Agen",
+                "heading": "Agen untuk Karya ini",
+                "emptyTitle": "Belum ada Agen",
+                "emptySubtitle": "Buat Agen untuk mengotomatiskan Karya ini.",
+                "pause": "Jeda Agen",
+                "activate": "Aktifkan Agen",
+                "pausedToast": "Agen dijeda",
+                "activatedToast": "Agen diaktifkan",
+                "statusUpdateFailed": "Tidak dapat memperbarui status",
+                "newAgent": "Agen Baru"
+            },
             "failedToGenerateItems": "Gagal menghasilkan item. Silakan coba lagi.",
             "generationCompleted": "Generasi selesai dengan sukses",
             "generationCancelled": "Generasi dibatalkan",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "Agen dijeda",
                 "activatedToast": "Agen diaktifkan",
                 "statusUpdateFailed": "Tidak dapat memperbarui status",
-                "newAgent": "Agen Baru"
+                "newAgent": "Agen Baru",
+                "moreAgents": "+{count} lainnya"
             },
             "failedToGenerateItems": "Gagal menghasilkan item. Silakan coba lagi.",
             "generationCompleted": "Generasi selesai dengan sukses",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1602,6 +1602,18 @@
             "createButton": "Crea lavori"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Agenti",
+                "heading": "Agenti di questo Lavoro",
+                "emptyTitle": "Nessun Agente ancora",
+                "emptySubtitle": "Crea un Agente per automatizzare questo Lavoro.",
+                "pause": "Metti in pausa l'Agente",
+                "activate": "Attiva l'Agente",
+                "pausedToast": "Agente messo in pausa",
+                "activatedToast": "Agente attivato",
+                "statusUpdateFailed": "Impossibile aggiornare lo stato",
+                "newAgent": "Nuovo Agente"
+            },
             "failedToGenerateItems": "Impossibile generare gli elementi. Riprova.",
             "generationCompleted": "Generazione completata con successo",
             "generationCancelled": "Generazione annullata",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "Agente messo in pausa",
                 "activatedToast": "Agente attivato",
                 "statusUpdateFailed": "Impossibile aggiornare lo stato",
-                "newAgent": "Nuovo Agente"
+                "newAgent": "Nuovo Agente",
+                "moreAgents": "+{count} altri"
             },
             "failedToGenerateItems": "Impossibile generare gli elementi. Riprova.",
             "generationCompleted": "Generazione completata con successo",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1602,6 +1602,18 @@
             "createButton": "ワークを作成"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "エージェント",
+                "heading": "この作業のエージェント",
+                "emptyTitle": "まだエージェントがありません",
+                "emptySubtitle": "エージェントを作成してこの作業を自動化しましょう。",
+                "pause": "エージェントを一時停止",
+                "activate": "エージェントを有効化",
+                "pausedToast": "エージェントを一時停止しました",
+                "activatedToast": "エージェントを有効化しました",
+                "statusUpdateFailed": "ステータスを更新できませんでした",
+                "newAgent": "新しいエージェント"
+            },
             "failedToGenerateItems": "アイテムの生成に失敗しました。もう一度お試しください。",
             "generationCompleted": "生成が正常に完了しました",
             "generationCancelled": "生成がキャンセルされました",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "エージェントを一時停止しました",
                 "activatedToast": "エージェントを有効化しました",
                 "statusUpdateFailed": "ステータスを更新できませんでした",
-                "newAgent": "新しいエージェント"
+                "newAgent": "新しいエージェント",
+                "moreAgents": "他 {count} 件"
             },
             "failedToGenerateItems": "アイテムの生成に失敗しました。もう一度お試しください。",
             "generationCompleted": "生成が正常に完了しました",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "에이전트가 일시중지되었습니다",
                 "activatedToast": "에이전트가 활성화되었습니다",
                 "statusUpdateFailed": "상태를 업데이트할 수 없습니다",
-                "newAgent": "새 에이전트"
+                "newAgent": "새 에이전트",
+                "moreAgents": "+{count}개 더"
             },
             "failedToGenerateItems": "항목 생성에 실패했습니다. 다시 시도해 주세요.",
             "generationCompleted": "생성 완료",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1602,6 +1602,18 @@
             "createButton": "워크 생성"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "에이전트",
+                "heading": "이 작업의 에이전트",
+                "emptyTitle": "아직 에이전트가 없습니다",
+                "emptySubtitle": "에이전트를 만들어 이 작업을 자동화하세요.",
+                "pause": "에이전트 일시중지",
+                "activate": "에이전트 활성화",
+                "pausedToast": "에이전트가 일시중지되었습니다",
+                "activatedToast": "에이전트가 활성화되었습니다",
+                "statusUpdateFailed": "상태를 업데이트할 수 없습니다",
+                "newAgent": "새 에이전트"
+            },
             "failedToGenerateItems": "항목 생성에 실패했습니다. 다시 시도해 주세요.",
             "generationCompleted": "생성 완료",
             "generationCancelled": "생성이 취소되었습니다",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1602,6 +1602,18 @@
             "createButton": "Werk aanmaken"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Agenten",
+                "heading": "Agenten voor deze Work",
+                "emptyTitle": "Nog geen Agenten",
+                "emptySubtitle": "Maak een Agent om deze Work te automatiseren.",
+                "pause": "Agent pauzeren",
+                "activate": "Agent activeren",
+                "pausedToast": "Agent gepauzeerd",
+                "activatedToast": "Agent geactiveerd",
+                "statusUpdateFailed": "Status kon niet worden bijgewerkt",
+                "newAgent": "Nieuwe Agent"
+            },
             "failedToGenerateItems": "Kon items niet genereren. Probeer het opnieuw.",
             "generationCompleted": "Generatie succesvol voltooid",
             "generationCancelled": "Generatie is geannuleerd",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "Agent gepauzeerd",
                 "activatedToast": "Agent geactiveerd",
                 "statusUpdateFailed": "Status kon niet worden bijgewerkt",
-                "newAgent": "Nieuwe Agent"
+                "newAgent": "Nieuwe Agent",
+                "moreAgents": "+{count} meer"
             },
             "failedToGenerateItems": "Kon items niet genereren. Probeer het opnieuw.",
             "generationCompleted": "Generatie succesvol voltooid",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1602,6 +1602,18 @@
             "createButton": "Utwórz praca"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Agenci",
+                "heading": "Agenci tej Pracy",
+                "emptyTitle": "Brak Agentów",
+                "emptySubtitle": "Utwórz Agenta, aby zautomatyzować tę Pracę.",
+                "pause": "Wstrzymaj Agenta",
+                "activate": "Aktywuj Agenta",
+                "pausedToast": "Agent wstrzymany",
+                "activatedToast": "Agent aktywowany",
+                "statusUpdateFailed": "Nie udało się zaktualizować statusu",
+                "newAgent": "Nowy Agent"
+            },
             "failedToGenerateItems": "Nie udało się wygenerować elementów. Spróbuj ponownie.",
             "generationCompleted": "Wygenerowano pomyślnie",
             "generationCancelled": "Generowanie zostało anulowane",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "Agent wstrzymany",
                 "activatedToast": "Agent aktywowany",
                 "statusUpdateFailed": "Nie udało się zaktualizować statusu",
-                "newAgent": "Nowy Agent"
+                "newAgent": "Nowy Agent",
+                "moreAgents": "+{count} więcej"
             },
             "failedToGenerateItems": "Nie udało się wygenerować elementów. Spróbuj ponownie.",
             "generationCompleted": "Wygenerowano pomyślnie",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "Agente pausado",
                 "activatedToast": "Agente ativado",
                 "statusUpdateFailed": "Não foi possível atualizar o status",
-                "newAgent": "Novo Agente"
+                "newAgent": "Novo Agente",
+                "moreAgents": "+{count} mais"
             },
             "failedToGenerateItems": "Falha ao gerar itens. Tente novamente.",
             "generationCompleted": "Geração concluída com sucesso",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1602,6 +1602,18 @@
             "createButton": "Criar Trabalho"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Agentes",
+                "heading": "Agentes deste Trabalho",
+                "emptyTitle": "Nenhum Agente ainda",
+                "emptySubtitle": "Crie um Agente para automatizar este Trabalho.",
+                "pause": "Pausar Agente",
+                "activate": "Ativar Agente",
+                "pausedToast": "Agente pausado",
+                "activatedToast": "Agente ativado",
+                "statusUpdateFailed": "Não foi possível atualizar o status",
+                "newAgent": "Novo Agente"
+            },
             "failedToGenerateItems": "Falha ao gerar itens. Tente novamente.",
             "generationCompleted": "Geração concluída com sucesso",
             "generationCancelled": "Geração cancelada",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "Агент приостановлен",
                 "activatedToast": "Агент активирован",
                 "statusUpdateFailed": "Не удалось обновить статус",
-                "newAgent": "Новый агент"
+                "newAgent": "Новый агент",
+                "moreAgents": "+ещё {count}"
             },
             "failedToGenerateItems": "Не удалось сгенерировать элементы. Пожалуйста, попробуйте снова.",
             "generationCompleted": "Генерация успешно завершена",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1602,6 +1602,18 @@
             "createButton": "Создать работа"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Агенты",
+                "heading": "Агенты этой Работы",
+                "emptyTitle": "Пока нет агентов",
+                "emptySubtitle": "Создайте агента, чтобы автоматизировать эту Работу.",
+                "pause": "Приостановить агента",
+                "activate": "Активировать агента",
+                "pausedToast": "Агент приостановлен",
+                "activatedToast": "Агент активирован",
+                "statusUpdateFailed": "Не удалось обновить статус",
+                "newAgent": "Новый агент"
+            },
             "failedToGenerateItems": "Не удалось сгенерировать элементы. Пожалуйста, попробуйте снова.",
             "generationCompleted": "Генерация успешно завершена",
             "generationCancelled": "Генерация была отменена",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1602,6 +1602,18 @@
             "createButton": "สร้างงาน"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "เอเจนต์",
+                "heading": "เอเจนต์สำหรับงานนี้",
+                "emptyTitle": "ยังไม่มีเอเจนต์",
+                "emptySubtitle": "สร้างเอเจนต์เพื่อทำให้งานนี้เป็นอัตโนมัติ",
+                "pause": "หยุดเอเจนต์ชั่วคราว",
+                "activate": "เปิดใช้งานเอเจนต์",
+                "pausedToast": "หยุดเอเจนต์ชั่วคราวแล้ว",
+                "activatedToast": "เปิดใช้งานเอเจนต์แล้ว",
+                "statusUpdateFailed": "ไม่สามารถอัปเดตสถานะได้",
+                "newAgent": "เอเจนต์ใหม่"
+            },
             "failedToGenerateItems": "ไม่สามารถสร้างรายการได้ โปรดลองอีกครั้ง",
             "generationCompleted": "การสร้างเสร็จสิ้นเรียบร้อยแล้ว",
             "generationCancelled": "การสร้างถูกยกเลิก",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "หยุดเอเจนต์ชั่วคราวแล้ว",
                 "activatedToast": "เปิดใช้งานเอเจนต์แล้ว",
                 "statusUpdateFailed": "ไม่สามารถอัปเดตสถานะได้",
-                "newAgent": "เอเจนต์ใหม่"
+                "newAgent": "เอเจนต์ใหม่",
+                "moreAgents": "+อีก {count}"
             },
             "failedToGenerateItems": "ไม่สามารถสร้างรายการได้ โปรดลองอีกครั้ง",
             "generationCompleted": "การสร้างเสร็จสิ้นเรียบร้อยแล้ว",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1602,6 +1602,18 @@
             "createButton": "İş Oluştur"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Ajanlar",
+                "heading": "Bu İşin Ajanları",
+                "emptyTitle": "Henüz hiç Ajan yok",
+                "emptySubtitle": "Bu İşi otomatikleştirmek için bir Ajan oluşturun.",
+                "pause": "Ajanı duraklat",
+                "activate": "Ajanı etkinleştir",
+                "pausedToast": "Ajan duraklatıldı",
+                "activatedToast": "Ajan etkinleştirildi",
+                "statusUpdateFailed": "Durum güncellenemedi",
+                "newAgent": "Yeni Ajan"
+            },
             "failedToGenerateItems": "Öğeleri oluşturma başarısız oldu. Lütfen tekrar deneyin.",
             "generationCompleted": "Oluşturma başarıyla tamamlandı",
             "generationCancelled": "Oluşturma iptal edildi",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "Ajan duraklatıldı",
                 "activatedToast": "Ajan etkinleştirildi",
                 "statusUpdateFailed": "Durum güncellenemedi",
-                "newAgent": "Yeni Ajan"
+                "newAgent": "Yeni Ajan",
+                "moreAgents": "+{count} daha"
             },
             "failedToGenerateItems": "Öğeleri oluşturma başarısız oldu. Lütfen tekrar deneyin.",
             "generationCompleted": "Oluşturma başarıyla tamamlandı",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1602,6 +1602,18 @@
             "createButton": "Створити робота"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Агенти",
+                "heading": "Агенти цієї Роботи",
+                "emptyTitle": "Ще немає агентів",
+                "emptySubtitle": "Створіть агента, щоб автоматизувати цю Роботу.",
+                "pause": "Призупинити агента",
+                "activate": "Активувати агента",
+                "pausedToast": "Агента призупинено",
+                "activatedToast": "Агента активовано",
+                "statusUpdateFailed": "Не вдалося оновити статус",
+                "newAgent": "Новий Агент"
+            },
             "failedToGenerateItems": "Не вдалося згенерувати елементи. Спробуйте ще раз.",
             "generationCompleted": "Генерацію завершено успішно",
             "generationCancelled": "Генерацію скасовано",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "Агента призупинено",
                 "activatedToast": "Агента активовано",
                 "statusUpdateFailed": "Не вдалося оновити статус",
-                "newAgent": "Новий Агент"
+                "newAgent": "Новий Агент",
+                "moreAgents": "+ще {count}"
             },
             "failedToGenerateItems": "Не вдалося згенерувати елементи. Спробуйте ще раз.",
             "generationCompleted": "Генерацію завершено успішно",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1602,6 +1602,18 @@
             "createButton": "Tạo công việc"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "Agents",
+                "heading": "Agents của Công việc này",
+                "emptyTitle": "Chưa có Agent nào",
+                "emptySubtitle": "Tạo một Agent để tự động hóa Công việc này.",
+                "pause": "Tạm dừng Agent",
+                "activate": "Kích hoạt Agent",
+                "pausedToast": "Đã tạm dừng Agent",
+                "activatedToast": "Đã kích hoạt Agent",
+                "statusUpdateFailed": "Không thể cập nhật trạng thái",
+                "newAgent": "Agent mới"
+            },
             "failedToGenerateItems": "Không thể tạo các mục. Vui lòng thử lại.",
             "generationCompleted": "Tạo hoàn tất thành công",
             "generationCancelled": "Tạo đã bị hủy",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "Đã tạm dừng Agent",
                 "activatedToast": "Đã kích hoạt Agent",
                 "statusUpdateFailed": "Không thể cập nhật trạng thái",
-                "newAgent": "Agent mới"
+                "newAgent": "Agent mới",
+                "moreAgents": "+{count} khác"
             },
             "failedToGenerateItems": "Không thể tạo các mục. Vui lòng thử lại.",
             "generationCompleted": "Tạo hoàn tất thành công",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1602,6 +1602,18 @@
             "createButton": "创建作品"
         },
         "workDetail": {
+            "agentsDropdown": {
+                "trigger": "代理",
+                "heading": "此工作的代理",
+                "emptyTitle": "还没有代理",
+                "emptySubtitle": "创建一个代理来自动化此工作。",
+                "pause": "暂停代理",
+                "activate": "激活代理",
+                "pausedToast": "代理已暂停",
+                "activatedToast": "代理已激活",
+                "statusUpdateFailed": "无法更新状态",
+                "newAgent": "新代理"
+            },
             "failedToGenerateItems": "生成项目失败。请重试。",
             "generationCompleted": "生成成功完成",
             "generationCancelled": "生成已取消",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1612,7 +1612,8 @@
                 "pausedToast": "代理已暂停",
                 "activatedToast": "代理已激活",
                 "statusUpdateFailed": "无法更新状态",
-                "newAgent": "新代理"
+                "newAgent": "新代理",
+                "moreAgents": "还有 {count} 个"
             },
             "failedToGenerateItems": "生成项目失败。请重试。",
             "generationCompleted": "生成成功完成",

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/layout.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/layout.tsx
@@ -38,6 +38,7 @@ export default async function WorkLayout({ params, children }: LayoutParams) {
     let oauthConnection: GitProviderConnectionInfo | null = null;
     let config = null;
     let agents: Agent[] = [];
+    let agentsTotal = 0;
 
     try {
         const res = await workAPI.get(id);
@@ -57,6 +58,7 @@ export default async function WorkLayout({ params, children }: LayoutParams) {
             ]);
 
             agents = agentsRes?.data ?? [];
+            agentsTotal = agentsRes?.meta?.total ?? agents.length;
 
             oauthConnection = connectionRes;
 
@@ -80,6 +82,7 @@ export default async function WorkLayout({ params, children }: LayoutParams) {
             oauthConnection={oauthConnection}
             config={config}
             agents={agents}
+            agentsTotal={agentsTotal}
         >
             {children}
         </WorkLayoutClient>

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/layout.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Work, workAPI, gitProvidersAPI, GitProviderConnectionInfo } from '@/lib/api';
+import { agentsAPI, type Agent } from '@/lib/api/agents';
 import { notFound } from 'next/navigation';
 import { WorkLayoutClient } from '@/components/works/detail/WorkLayoutClient';
 import { getTranslations } from 'next-intl/server';
@@ -36,6 +37,7 @@ export default async function WorkLayout({ params, children }: LayoutParams) {
     let work: Work;
     let oauthConnection: GitProviderConnectionInfo | null = null;
     let config = null;
+    let agents: Agent[] = [];
 
     try {
         const res = await workAPI.get(id);
@@ -46,11 +48,15 @@ export default async function WorkLayout({ params, children }: LayoutParams) {
         config = work.configCache ?? null;
 
         if (work) {
-            // Fetch connection info and provider list in parallel
-            const [connectionRes, providersRes] = await Promise.all([
+            // Fetch connection info, provider list, and the Work-scoped
+            // Agents (header dropdown) in parallel
+            const [connectionRes, providersRes, agentsRes] = await Promise.all([
                 gitProvidersAPI.checkConnection(work.gitProvider).catch(() => null),
                 gitProvidersAPI.list().catch(() => null),
+                agentsAPI.list({ scope: 'work', workId: id, limit: 50 }).catch(() => null),
             ]);
+
+            agents = agentsRes?.data ?? [];
 
             oauthConnection = connectionRes;
 
@@ -69,7 +75,12 @@ export default async function WorkLayout({ params, children }: LayoutParams) {
     }
 
     return (
-        <WorkLayoutClient work={work} oauthConnection={oauthConnection} config={config}>
+        <WorkLayoutClient
+            work={work}
+            oauthConnection={oauthConnection}
+            config={config}
+            agents={agents}
+        >
             {children}
         </WorkLayoutClient>
     );

--- a/apps/web/src/components/works/detail/WorkAgentsDropdown.tsx
+++ b/apps/web/src/components/works/detail/WorkAgentsDropdown.tsx
@@ -30,7 +30,8 @@ import {
  * the Agent's status tone, tone-mapped status badge with the translated
  * `agentsPage.card.status*` labels) and expose a hover pause/resume
  * quick action mirroring the AgentSettingsClient semantics: pause is
- * offered for `active`, resume for `draft`/`paused`/`error`.
+ * offered for `active`, resume for `draft`/`paused`/`error`. All other
+ * copy lives under `dashboard.workDetail.agentsDropdown`.
  */
 
 const STATUS_BADGE_CLASS: Record<Agent['status'], string> = {
@@ -62,6 +63,7 @@ const STATUS_AVATAR_CLASS: Record<Agent['status'], string> = {
 
 export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents: Agent[] }) {
     const t = useTranslations('dashboard.agentsPage.card');
+    const tDropdown = useTranslations('dashboard.workDetail.agentsDropdown');
     const router = useRouter();
     const [pendingId, setPendingId] = useState<string | null>(null);
     const [, startTransition] = useTransition();
@@ -82,14 +84,16 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
             try {
                 if (action === 'pause') {
                     await pauseAgentAction(agent.id);
-                    toast.success('Agent paused');
+                    toast.success(tDropdown('pausedToast'));
                 } else {
                     await resumeAgentAction(agent.id);
-                    toast.success('Agent activated');
+                    toast.success(tDropdown('activatedToast'));
                 }
                 router.refresh();
             } catch (error) {
-                toast.error(error instanceof Error ? error.message : 'Could not update status');
+                toast.error(
+                    error instanceof Error ? error.message : tDropdown('statusUpdateFailed'),
+                );
             } finally {
                 setPendingId(null);
             }
@@ -101,10 +105,10 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
             <DropdownMenu>
                 <DropdownMenuTrigger
                     className="gap-1.5 rounded-lg border border-border dark:border-border-dark px-3 h-8 text-[12px] font-medium text-text-secondary dark:text-text-secondary-dark hover:border-border-hover dark:hover:border-border-hover-dark hover:text-text dark:hover:text-text-dark outline-none focus:outline-none focus-visible:border-border-hover dark:focus-visible:border-border-hover-dark transition-colors"
-                    aria-label="Agents for this Work"
+                    aria-label={tDropdown('heading')}
                 >
                     <Bot className="w-3.5 h-3.5" />
-                    Agents
+                    {tDropdown('trigger')}
                     {agents.length > 0 && (
                         <span className="rounded-full bg-black/5 px-1.5 text-[10px] tabular-nums dark:bg-white/8">
                             {agents.length}
@@ -114,7 +118,7 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-80">
                     <DropdownMenuLabel className="text-[11px] font-medium uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
-                        Agents for this Work
+                        {tDropdown('heading')}
                     </DropdownMenuLabel>
                     <div className="max-h-80 overflow-y-auto">
                         {agents.length === 0 ? (
@@ -123,10 +127,10 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
                                     <Bot className="h-4 w-4 text-concept-agents" />
                                 </div>
                                 <p className="text-sm text-text dark:text-text-dark">
-                                    No Agents yet
+                                    {tDropdown('emptyTitle')}
                                 </p>
                                 <p className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark">
-                                    Create one to automate this Work.
+                                    {tDropdown('emptySubtitle')}
                                 </p>
                             </div>
                         ) : (
@@ -179,10 +183,14 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
                                                 <button
                                                     type="button"
                                                     aria-label={
-                                                        canPause ? 'Pause Agent' : 'Activate Agent'
+                                                        canPause
+                                                            ? tDropdown('pause')
+                                                            : tDropdown('activate')
                                                     }
                                                     title={
-                                                        canPause ? 'Pause Agent' : 'Activate Agent'
+                                                        canPause
+                                                            ? tDropdown('pause')
+                                                            : tDropdown('activate')
                                                     }
                                                     disabled={isPending}
                                                     onClick={(e) => {
@@ -223,7 +231,7 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
                             <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-dashed border-border dark:border-border-dark">
                                 <Plus className="h-3.5 w-3.5" />
                             </span>
-                            New Agent
+                            {tDropdown('newAgent')}
                         </Link>
                     </DropdownMenuItem>
                 </DropdownMenuContent>

--- a/apps/web/src/components/works/detail/WorkAgentsDropdown.tsx
+++ b/apps/web/src/components/works/detail/WorkAgentsDropdown.tsx
@@ -26,8 +26,8 @@ import {
  * click away. The list is server-fetched by `works/[id]/layout.tsx`
  * and threaded down through WorkLayoutClient → WorkHeader.
  *
- * Rows reuse the AgentCard design language (initials avatar on the
- * concept-agents tint, tone-mapped status badge with the translated
+ * Rows reuse the AgentCard design language (bot avatar tile tinted by
+ * the Agent's status tone, tone-mapped status badge with the translated
  * `agentsPage.card.status*` labels) and expose a hover pause/resume
  * quick action mirroring the AgentSettingsClient semantics: pause is
  * offered for `active`, resume for `draft`/`paused`/`error`.
@@ -51,16 +51,14 @@ const STATUS_DOT_CLASS: Record<Agent['status'], string> = {
     archived: 'bg-text-muted/60',
 };
 
-function agentInitials(name: string): string {
-    return (
-        name
-            .split(/\s+/)
-            .map((p) => p.charAt(0))
-            .join('')
-            .slice(0, 2)
-            .toUpperCase() || 'A'
-    );
-}
+const STATUS_AVATAR_CLASS: Record<Agent['status'], string> = {
+    draft: 'bg-text-muted/10 border-text-muted/20 text-text-muted',
+    active: 'bg-success/10 border-success/20 text-success',
+    paused: 'bg-warning/10 border-warning/20 text-warning',
+    running: 'bg-info/10 border-info/20 text-info',
+    error: 'bg-danger/10 border-danger/20 text-danger',
+    archived: 'bg-text-muted/10 border-text-muted/20 text-text-muted',
+};
 
 export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents: Agent[] }) {
     const t = useTranslations('dashboard.agentsPage.card');
@@ -102,7 +100,7 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
         <span className="inline-flex">
             <DropdownMenu>
                 <DropdownMenuTrigger
-                    className="gap-1.5 rounded-lg border border-border dark:border-border-dark px-3 h-8 text-[12px] font-medium text-text-secondary dark:text-text-secondary-dark hover:border-primary/40 hover:text-primary dark:hover:text-primary transition-colors"
+                    className="gap-1.5 rounded-lg border border-border dark:border-border-dark px-3 h-8 text-[12px] font-medium text-text-secondary dark:text-text-secondary-dark hover:border-border-hover dark:hover:border-border-hover-dark hover:text-text dark:hover:text-text-dark outline-none focus:outline-none focus-visible:border-border-hover dark:focus-visible:border-border-hover-dark transition-colors"
                     aria-label="Agents for this Work"
                 >
                     <Bot className="w-3.5 h-3.5" />
@@ -145,10 +143,13 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
                                             href={ROUTES.DASHBOARD_AGENT(agent.id)}
                                             className="group/agent cursor-pointer items-center gap-2.5 py-2"
                                         >
-                                            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-concept-agents/10 border border-concept-agents/20">
-                                                <span className="text-[10px] font-semibold text-concept-agents">
-                                                    {agentInitials(agent.name)}
-                                                </span>
+                                            <span
+                                                className={cn(
+                                                    'flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border',
+                                                    STATUS_AVATAR_CLASS[agent.status],
+                                                )}
+                                            >
+                                                <Bot className="h-3.5 w-3.5" />
                                             </span>
                                             <span className="min-w-0 flex-1">
                                                 <span className="flex items-center gap-2">
@@ -157,13 +158,13 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
                                                     </span>
                                                     <span
                                                         className={cn(
-                                                            'inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+                                                            'inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-px text-[8px] font-medium uppercase tracking-wide',
                                                             STATUS_BADGE_CLASS[agent.status],
                                                         )}
                                                     >
                                                         <span
                                                             className={cn(
-                                                                'h-1.5 w-1.5 rounded-full',
+                                                                'h-1 w-1 rounded-full',
                                                                 STATUS_DOT_CLASS[agent.status],
                                                             )}
                                                         />

--- a/apps/web/src/components/works/detail/WorkAgentsDropdown.tsx
+++ b/apps/web/src/components/works/detail/WorkAgentsDropdown.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { Bot, ChevronDown, Plus } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
+import type { Agent } from '@/lib/api/agents';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+/**
+ * Work header "Agents" dropdown — the visibility counterpart of the
+ * header's "+ New Agent" affordance (FU-3). Agents created pinned to
+ * this Work (`scope: 'work'` + `workId`) surface here; each row links
+ * to the Agent detail page and the footer keeps the create flow one
+ * click away. The list is server-fetched by `works/[id]/layout.tsx`
+ * and threaded down through WorkLayoutClient → WorkHeader.
+ */
+
+const STATUS_DOT_CLASS: Record<Agent['status'], string> = {
+    draft: 'bg-text-muted/60',
+    active: 'bg-success',
+    paused: 'bg-warning',
+    running: 'bg-info',
+    error: 'bg-danger',
+    archived: 'bg-text-muted/60',
+};
+
+export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents: Agent[] }) {
+    return (
+        <span className="inline-flex">
+            <DropdownMenu>
+                <DropdownMenuTrigger
+                    className="gap-1.5 rounded-lg border border-border dark:border-border-dark px-3 h-8 text-[12px] font-medium text-text-secondary dark:text-text-secondary-dark hover:border-primary/40 hover:text-primary dark:hover:text-primary transition-colors"
+                    aria-label="Agents for this Work"
+                >
+                    <Bot className="w-3.5 h-3.5" />
+                    Agents
+                    {agents.length > 0 && (
+                        <span className="rounded-full bg-black/5 px-1.5 text-[10px] tabular-nums dark:bg-white/8">
+                            {agents.length}
+                        </span>
+                    )}
+                    <ChevronDown className="w-3 h-3 opacity-60" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-72">
+                    <DropdownMenuLabel className="text-xs font-medium text-text-muted dark:text-text-muted-dark">
+                        Agents for this Work
+                    </DropdownMenuLabel>
+                    {agents.length === 0 ? (
+                        <div className="px-2 py-2 text-xs text-text-muted dark:text-text-muted-dark">
+                            No Agents scoped to this Work yet.
+                        </div>
+                    ) : (
+                        agents.map((agent) => (
+                            <DropdownMenuItem key={agent.id} asChild>
+                                <Link
+                                    href={ROUTES.DASHBOARD_AGENT(agent.id)}
+                                    className="cursor-pointer gap-2"
+                                >
+                                    <span
+                                        className={cn(
+                                            'w-1.5 h-1.5 rounded-full shrink-0',
+                                            STATUS_DOT_CLASS[agent.status],
+                                        )}
+                                        title={agent.status}
+                                    />
+                                    <span className="min-w-0 flex-1">
+                                        <span className="block truncate text-sm text-text dark:text-text-dark">
+                                            {agent.name}
+                                        </span>
+                                        {agent.title && (
+                                            <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
+                                                {agent.title}
+                                            </span>
+                                        )}
+                                    </span>
+                                </Link>
+                            </DropdownMenuItem>
+                        ))
+                    )}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem asChild>
+                        <Link
+                            href={`/works/${workId}/agents/new`}
+                            className="cursor-pointer gap-2 text-sm text-text-secondary dark:text-text-secondary-dark"
+                        >
+                            <Plus className="w-3.5 h-3.5 shrink-0" />
+                            New Agent
+                        </Link>
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+        </span>
+    );
+}

--- a/apps/web/src/components/works/detail/WorkAgentsDropdown.tsx
+++ b/apps/web/src/components/works/detail/WorkAgentsDropdown.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { Bot, ChevronDown, Plus } from 'lucide-react';
-import { Link } from '@/i18n/navigation';
+import { useState, useTransition } from 'react';
+import { Bot, ChevronDown, Loader2, Pause, Play, Plus } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { Link, useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { cn } from '@/lib/utils/cn';
 import type { Agent } from '@/lib/api/agents';
+import { pauseAgentAction, resumeAgentAction } from '@/app/actions/agents';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -21,18 +25,79 @@ import {
  * to the Agent detail page and the footer keeps the create flow one
  * click away. The list is server-fetched by `works/[id]/layout.tsx`
  * and threaded down through WorkLayoutClient → WorkHeader.
+ *
+ * Rows reuse the AgentCard design language (initials avatar on the
+ * concept-agents tint, tone-mapped status badge with the translated
+ * `agentsPage.card.status*` labels) and expose a hover pause/resume
+ * quick action mirroring the AgentSettingsClient semantics: pause is
+ * offered for `active`, resume for `draft`/`paused`/`error`.
  */
+
+const STATUS_BADGE_CLASS: Record<Agent['status'], string> = {
+    draft: 'bg-text-muted/10 text-text-muted',
+    active: 'bg-success/10 text-success',
+    paused: 'bg-warning/10 text-warning',
+    running: 'bg-info/10 text-info',
+    error: 'bg-danger/10 text-danger',
+    archived: 'bg-text-muted/10 text-text-muted',
+};
 
 const STATUS_DOT_CLASS: Record<Agent['status'], string> = {
     draft: 'bg-text-muted/60',
     active: 'bg-success',
     paused: 'bg-warning',
-    running: 'bg-info',
+    running: 'bg-info animate-pulse',
     error: 'bg-danger',
     archived: 'bg-text-muted/60',
 };
 
+function agentInitials(name: string): string {
+    return (
+        name
+            .split(/\s+/)
+            .map((p) => p.charAt(0))
+            .join('')
+            .slice(0, 2)
+            .toUpperCase() || 'A'
+    );
+}
+
 export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents: Agent[] }) {
+    const t = useTranslations('dashboard.agentsPage.card');
+    const router = useRouter();
+    const [pendingId, setPendingId] = useState<string | null>(null);
+    const [, startTransition] = useTransition();
+
+    const statusLabel: Record<Agent['status'], string> = {
+        draft: t('statusDraft'),
+        active: t('statusActive'),
+        paused: t('statusPaused'),
+        running: t('statusRunning'),
+        error: t('statusError'),
+        archived: t('statusArchived'),
+    };
+
+    const toggleStatus = (agent: Agent) => {
+        const action = agent.status === 'active' ? 'pause' : 'resume';
+        setPendingId(agent.id);
+        startTransition(async () => {
+            try {
+                if (action === 'pause') {
+                    await pauseAgentAction(agent.id);
+                    toast.success('Agent paused');
+                } else {
+                    await resumeAgentAction(agent.id);
+                    toast.success('Agent activated');
+                }
+                router.refresh();
+            } catch (error) {
+                toast.error(error instanceof Error ? error.message : 'Could not update status');
+            } finally {
+                setPendingId(null);
+            }
+        });
+    };
+
     return (
         <span className="inline-flex">
             <DropdownMenu>
@@ -49,49 +114,114 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
                     )}
                     <ChevronDown className="w-3 h-3 opacity-60" />
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-72">
-                    <DropdownMenuLabel className="text-xs font-medium text-text-muted dark:text-text-muted-dark">
+                <DropdownMenuContent align="end" className="w-80">
+                    <DropdownMenuLabel className="text-[11px] font-medium uppercase tracking-wide text-text-muted dark:text-text-muted-dark">
                         Agents for this Work
                     </DropdownMenuLabel>
-                    {agents.length === 0 ? (
-                        <div className="px-2 py-2 text-xs text-text-muted dark:text-text-muted-dark">
-                            No Agents scoped to this Work yet.
-                        </div>
-                    ) : (
-                        agents.map((agent) => (
-                            <DropdownMenuItem key={agent.id} asChild>
-                                <Link
-                                    href={ROUTES.DASHBOARD_AGENT(agent.id)}
-                                    className="cursor-pointer gap-2"
-                                >
-                                    <span
-                                        className={cn(
-                                            'w-1.5 h-1.5 rounded-full shrink-0',
-                                            STATUS_DOT_CLASS[agent.status],
-                                        )}
-                                        title={agent.status}
-                                    />
-                                    <span className="min-w-0 flex-1">
-                                        <span className="block truncate text-sm text-text dark:text-text-dark">
-                                            {agent.name}
-                                        </span>
-                                        {agent.title && (
-                                            <span className="block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
-                                                {agent.title}
+                    <div className="max-h-80 overflow-y-auto">
+                        {agents.length === 0 ? (
+                            <div className="px-2 py-6 text-center">
+                                <div className="mx-auto mb-2 flex h-9 w-9 items-center justify-center rounded-lg bg-concept-agents/10 border border-concept-agents/20">
+                                    <Bot className="h-4 w-4 text-concept-agents" />
+                                </div>
+                                <p className="text-sm text-text dark:text-text-dark">
+                                    No Agents yet
+                                </p>
+                                <p className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark">
+                                    Create one to automate this Work.
+                                </p>
+                            </div>
+                        ) : (
+                            agents.map((agent) => {
+                                const canPause = agent.status === 'active';
+                                const canResume =
+                                    agent.status === 'draft' ||
+                                    agent.status === 'paused' ||
+                                    agent.status === 'error';
+                                const isPending = pendingId === agent.id;
+                                return (
+                                    <DropdownMenuItem key={agent.id} asChild>
+                                        <Link
+                                            href={ROUTES.DASHBOARD_AGENT(agent.id)}
+                                            className="group/agent cursor-pointer items-center gap-2.5 py-2"
+                                        >
+                                            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-concept-agents/10 border border-concept-agents/20">
+                                                <span className="text-[10px] font-semibold text-concept-agents">
+                                                    {agentInitials(agent.name)}
+                                                </span>
                                             </span>
-                                        )}
-                                    </span>
-                                </Link>
-                            </DropdownMenuItem>
-                        ))
-                    )}
+                                            <span className="min-w-0 flex-1">
+                                                <span className="flex items-center gap-2">
+                                                    <span className="truncate text-sm font-medium text-text dark:text-text-dark">
+                                                        {agent.name}
+                                                    </span>
+                                                    <span
+                                                        className={cn(
+                                                            'inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+                                                            STATUS_BADGE_CLASS[agent.status],
+                                                        )}
+                                                    >
+                                                        <span
+                                                            className={cn(
+                                                                'h-1.5 w-1.5 rounded-full',
+                                                                STATUS_DOT_CLASS[agent.status],
+                                                            )}
+                                                        />
+                                                        {statusLabel[agent.status]}
+                                                    </span>
+                                                </span>
+                                                <span className="mt-0.5 block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
+                                                    {agent.title ?? t('noTitle')}
+                                                </span>
+                                            </span>
+                                            {(canPause || canResume) && (
+                                                <button
+                                                    type="button"
+                                                    aria-label={
+                                                        canPause ? 'Pause Agent' : 'Activate Agent'
+                                                    }
+                                                    title={
+                                                        canPause ? 'Pause Agent' : 'Activate Agent'
+                                                    }
+                                                    disabled={isPending}
+                                                    onClick={(e) => {
+                                                        // Quick action — don't navigate the row
+                                                        // Link or let the menu swallow the click.
+                                                        e.preventDefault();
+                                                        e.stopPropagation();
+                                                        toggleStatus(agent);
+                                                    }}
+                                                    className={cn(
+                                                        'flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-transparent text-text-muted dark:text-text-muted-dark transition-all',
+                                                        'opacity-0 group-hover/agent:opacity-100 focus-visible:opacity-100',
+                                                        'hover:border-border dark:hover:border-border-dark hover:text-text dark:hover:text-text-dark hover:bg-surface-hover dark:hover:bg-surface-hover-dark',
+                                                        isPending && 'opacity-100',
+                                                    )}
+                                                >
+                                                    {isPending ? (
+                                                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                                    ) : canPause ? (
+                                                        <Pause className="h-3.5 w-3.5" />
+                                                    ) : (
+                                                        <Play className="h-3.5 w-3.5" />
+                                                    )}
+                                                </button>
+                                            )}
+                                        </Link>
+                                    </DropdownMenuItem>
+                                );
+                            })
+                        )}
+                    </div>
                     <DropdownMenuSeparator />
                     <DropdownMenuItem asChild>
                         <Link
                             href={`/works/${workId}/agents/new`}
-                            className="cursor-pointer gap-2 text-sm text-text-secondary dark:text-text-secondary-dark"
+                            className="cursor-pointer gap-2 text-sm font-medium text-text-secondary dark:text-text-secondary-dark"
                         >
-                            <Plus className="w-3.5 h-3.5 shrink-0" />
+                            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-dashed border-border dark:border-border-dark">
+                                <Plus className="h-3.5 w-3.5" />
+                            </span>
                             New Agent
                         </Link>
                     </DropdownMenuItem>

--- a/apps/web/src/components/works/detail/WorkAgentsDropdown.tsx
+++ b/apps/web/src/components/works/detail/WorkAgentsDropdown.tsx
@@ -61,12 +61,23 @@ const STATUS_AVATAR_CLASS: Record<Agent['status'], string> = {
     archived: 'bg-text-muted/10 border-text-muted/20 text-text-muted',
 };
 
-export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents: Agent[] }) {
+export function WorkAgentsDropdown({
+    workId,
+    agents,
+    total,
+}: {
+    workId: string;
+    agents: Agent[];
+    /** Upstream total — may exceed agents.length when the fetch was capped. */
+    total?: number;
+}) {
     const t = useTranslations('dashboard.agentsPage.card');
     const tDropdown = useTranslations('dashboard.workDetail.agentsDropdown');
     const router = useRouter();
     const [pendingId, setPendingId] = useState<string | null>(null);
     const [, startTransition] = useTransition();
+    const agentsTotal = Math.max(total ?? agents.length, agents.length);
+    const omittedCount = agentsTotal - agents.length;
 
     const statusLabel: Record<Agent['status'], string> = {
         draft: t('statusDraft'),
@@ -109,9 +120,9 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
                 >
                     <Bot className="w-3.5 h-3.5" />
                     {tDropdown('trigger')}
-                    {agents.length > 0 && (
+                    {agentsTotal > 0 && (
                         <span className="rounded-full bg-black/5 px-1.5 text-[10px] tabular-nums dark:bg-white/8">
-                            {agents.length}
+                            {agentsTotal}
                         </span>
                     )}
                     <ChevronDown className="w-3 h-3 opacity-60" />
@@ -141,85 +152,101 @@ export function WorkAgentsDropdown({ workId, agents }: { workId: string; agents:
                                     agent.status === 'paused' ||
                                     agent.status === 'error';
                                 const isPending = pendingId === agent.id;
+                                const hasQuickAction = canPause || canResume;
                                 return (
-                                    <DropdownMenuItem key={agent.id} asChild>
-                                        <Link
-                                            href={ROUTES.DASHBOARD_AGENT(agent.id)}
-                                            className="group/agent cursor-pointer items-center gap-2.5 py-2"
-                                        >
-                                            <span
+                                    // The quick action is a positioned SIBLING of the row
+                                    // Link (not a child) so the DOM never nests a button
+                                    // inside an anchor: the Link stays the menu item and
+                                    // navigates on click/Enter, while button clicks never
+                                    // reach the anchor or close the menu — no
+                                    // preventDefault/stopPropagation needed.
+                                    <div key={agent.id} className="group/agent relative">
+                                        <DropdownMenuItem asChild>
+                                            <Link
+                                                href={ROUTES.DASHBOARD_AGENT(agent.id)}
                                                 className={cn(
-                                                    'flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border',
-                                                    STATUS_AVATAR_CLASS[agent.status],
+                                                    'cursor-pointer items-center gap-2.5 py-2',
+                                                    hasQuickAction && 'pr-10',
                                                 )}
                                             >
-                                                <Bot className="h-3.5 w-3.5" />
-                                            </span>
-                                            <span className="min-w-0 flex-1">
-                                                <span className="flex items-center gap-2">
-                                                    <span className="truncate text-sm font-medium text-text dark:text-text-dark">
-                                                        {agent.name}
-                                                    </span>
-                                                    <span
-                                                        className={cn(
-                                                            'inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-px text-[8px] font-medium uppercase tracking-wide',
-                                                            STATUS_BADGE_CLASS[agent.status],
-                                                        )}
-                                                    >
-                                                        <span
-                                                            className={cn(
-                                                                'h-1 w-1 rounded-full',
-                                                                STATUS_DOT_CLASS[agent.status],
-                                                            )}
-                                                        />
-                                                        {statusLabel[agent.status]}
-                                                    </span>
-                                                </span>
-                                                <span className="mt-0.5 block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
-                                                    {agent.title ?? t('noTitle')}
-                                                </span>
-                                            </span>
-                                            {(canPause || canResume) && (
-                                                <button
-                                                    type="button"
-                                                    aria-label={
-                                                        canPause
-                                                            ? tDropdown('pause')
-                                                            : tDropdown('activate')
-                                                    }
-                                                    title={
-                                                        canPause
-                                                            ? tDropdown('pause')
-                                                            : tDropdown('activate')
-                                                    }
-                                                    disabled={isPending}
-                                                    onClick={(e) => {
-                                                        // Quick action — don't navigate the row
-                                                        // Link or let the menu swallow the click.
-                                                        e.preventDefault();
-                                                        e.stopPropagation();
-                                                        toggleStatus(agent);
-                                                    }}
+                                                <span
                                                     className={cn(
-                                                        'flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-transparent text-text-muted dark:text-text-muted-dark transition-all',
-                                                        'opacity-0 group-hover/agent:opacity-100 focus-visible:opacity-100',
-                                                        'hover:border-border dark:hover:border-border-dark hover:text-text dark:hover:text-text-dark hover:bg-surface-hover dark:hover:bg-surface-hover-dark',
-                                                        isPending && 'opacity-100',
+                                                        'flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border',
+                                                        STATUS_AVATAR_CLASS[agent.status],
                                                     )}
                                                 >
-                                                    {isPending ? (
-                                                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                                                    ) : canPause ? (
-                                                        <Pause className="h-3.5 w-3.5" />
-                                                    ) : (
-                                                        <Play className="h-3.5 w-3.5" />
-                                                    )}
-                                                </button>
-                                            )}
-                                        </Link>
-                                    </DropdownMenuItem>
+                                                    <Bot className="h-3.5 w-3.5" />
+                                                </span>
+                                                <span className="min-w-0 flex-1">
+                                                    <span className="flex items-center gap-2">
+                                                        <span className="truncate text-sm font-medium text-text dark:text-text-dark">
+                                                            {agent.name}
+                                                        </span>
+                                                        <span
+                                                            className={cn(
+                                                                'inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-px text-[8px] font-medium uppercase tracking-wide',
+                                                                STATUS_BADGE_CLASS[agent.status],
+                                                            )}
+                                                        >
+                                                            <span
+                                                                className={cn(
+                                                                    'h-1 w-1 rounded-full',
+                                                                    STATUS_DOT_CLASS[agent.status],
+                                                                )}
+                                                            />
+                                                            {statusLabel[agent.status]}
+                                                        </span>
+                                                    </span>
+                                                    <span className="mt-0.5 block truncate text-[11px] text-text-muted dark:text-text-muted-dark">
+                                                        {agent.title ?? t('noTitle')}
+                                                    </span>
+                                                </span>
+                                            </Link>
+                                        </DropdownMenuItem>
+                                        {hasQuickAction && (
+                                            <button
+                                                type="button"
+                                                aria-label={
+                                                    canPause
+                                                        ? tDropdown('pause')
+                                                        : tDropdown('activate')
+                                                }
+                                                title={
+                                                    canPause
+                                                        ? tDropdown('pause')
+                                                        : tDropdown('activate')
+                                                }
+                                                disabled={isPending}
+                                                onClick={() => toggleStatus(agent)}
+                                                className={cn(
+                                                    'absolute right-2 top-1/2 z-10 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-md border border-transparent text-text-muted dark:text-text-muted-dark transition-all',
+                                                    'opacity-0 group-hover/agent:opacity-100 focus-visible:opacity-100',
+                                                    'hover:border-border dark:hover:border-border-dark hover:text-text dark:hover:text-text-dark hover:bg-surface-hover dark:hover:bg-surface-hover-dark',
+                                                    isPending && 'opacity-100',
+                                                )}
+                                            >
+                                                {isPending ? (
+                                                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                                ) : canPause ? (
+                                                    <Pause className="h-3.5 w-3.5" />
+                                                ) : (
+                                                    <Play className="h-3.5 w-3.5" />
+                                                )}
+                                            </button>
+                                        )}
+                                    </div>
                                 );
                             })
+                        )}
+                        {omittedCount > 0 && (
+                            <DropdownMenuItem asChild>
+                                <Link
+                                    href={ROUTES.DASHBOARD_AGENTS}
+                                    className="cursor-pointer justify-center text-xs text-text-muted dark:text-text-muted-dark"
+                                >
+                                    {tDropdown('moreAgents', { count: omittedCount })}
+                                </Link>
+                            </DropdownMenuItem>
                         )}
                     </div>
                     <DropdownMenuSeparator />

--- a/apps/web/src/components/works/detail/WorkHeader.tsx
+++ b/apps/web/src/components/works/detail/WorkHeader.tsx
@@ -18,9 +18,11 @@ interface WorkHeaderProps {
     work: Work;
     /** Work-scoped Agents shown in the header dropdown. */
     agents?: Agent[];
+    /** Total Work-scoped Agents upstream — may exceed agents.length. */
+    agentsTotal?: number;
 }
 
-export function WorkHeader({ work, agents = [] }: WorkHeaderProps) {
+export function WorkHeader({ work, agents = [], agentsTotal }: WorkHeaderProps) {
     const t = useTranslations('dashboard.workDetail');
     const { repoLinks } = useWorkDetail();
     const { role } = useWorkPermissions();
@@ -156,7 +158,7 @@ export function WorkHeader({ work, agents = [] }: WorkHeaderProps) {
                     <div className="flex items-center gap-2 shrink-0">
                         {/* Agents scoped to this Work — list + "+ New Agent"
                             (the FU-3 on-ramp lives in the dropdown footer). */}
-                        <WorkAgentsDropdown workId={work.id} agents={agents} />
+                        <WorkAgentsDropdown workId={work.id} agents={agents} total={agentsTotal} />
 
                         {/* External link */}
                         {externalWebsiteUrl && (

--- a/apps/web/src/components/works/detail/WorkHeader.tsx
+++ b/apps/web/src/components/works/detail/WorkHeader.tsx
@@ -5,18 +5,22 @@ import { cn } from '@/lib/utils/cn';
 import { getGenerationStatusConfig } from '@/lib/utils/generation-status';
 import { useTranslations } from 'next-intl';
 import { WorkMemberRole, WorkScheduleStatus } from '@/lib/api/enums';
-import { Link as IconLink, Users, Cog, Github, Clock, AlertTriangle, Bot } from 'lucide-react';
+import { Link as IconLink, Users, Cog, Github, Clock, AlertTriangle } from 'lucide-react';
 import { useWorkDetail, useWorkPermissions } from './WorkDetailContext';
 import { buildPublicComparisonUrl } from '@/lib/utils/comparison';
 import { Link, usePathname } from '@/i18n/navigation';
 import { ShinyText } from '@/components/ui/ShinyText';
 import { AnimatedClock } from '@/components/ui/AnimatedClock';
+import { WorkAgentsDropdown } from './WorkAgentsDropdown';
+import type { Agent } from '@/lib/api/agents';
 
 interface WorkHeaderProps {
     work: Work;
+    /** Work-scoped Agents shown in the header dropdown. */
+    agents?: Agent[];
 }
 
-export function WorkHeader({ work }: WorkHeaderProps) {
+export function WorkHeader({ work, agents = [] }: WorkHeaderProps) {
     const t = useTranslations('dashboard.workDetail');
     const { repoLinks } = useWorkDetail();
     const { role } = useWorkPermissions();
@@ -150,15 +154,9 @@ export function WorkHeader({ work }: WorkHeaderProps) {
                     </div>
 
                     <div className="flex items-center gap-2 shrink-0">
-                        {/* FU-3 — direct on-ramp to a Work-scoped Agent. */}
-                        <Link
-                            href={`/works/${work.id}/agents/new`}
-                            className="inline-flex items-center gap-1.5 rounded-lg border border-border dark:border-border-dark px-3 h-8 text-[12px] font-medium text-text-secondary dark:text-text-secondary-dark hover:border-primary/40 hover:text-primary dark:hover:text-primary transition-colors"
-                            title="Create a new Work-scoped Agent"
-                        >
-                            <Bot className="w-3.5 h-3.5" />
-                            New Agent
-                        </Link>
+                        {/* Agents scoped to this Work — list + "+ New Agent"
+                            (the FU-3 on-ramp lives in the dropdown footer). */}
+                        <WorkAgentsDropdown workId={work.id} agents={agents} />
 
                         {/* External link */}
                         {externalWebsiteUrl && (

--- a/apps/web/src/components/works/detail/WorkLayoutClient.tsx
+++ b/apps/web/src/components/works/detail/WorkLayoutClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useRouter } from '@/i18n/navigation';
 import { GitProviderConnectionInfo, Work, WorkConfig } from '@/lib/api/types-only';
+import type { Agent } from '@/lib/api/agents';
 import { WorkHeader } from './WorkHeader';
 import { WorkTabs } from './WorkTabs';
 import { GenerateStatusType } from '@/lib/api/enums';
@@ -21,12 +22,15 @@ interface WorkLayoutClientProps {
     children: React.ReactNode;
     oauthConnection: GitProviderConnectionInfo | null;
     config: WorkConfig | null;
+    /** Work-scoped Agents for the header dropdown. */
+    agents?: Agent[];
 }
 
 export function WorkLayoutClient({
     work,
     oauthConnection,
     config,
+    agents = [],
     children,
 }: WorkLayoutClientProps) {
     const router = useRouter();
@@ -160,7 +164,7 @@ export function WorkLayoutClient({
             onWorkChange={setSyncedWork}
         >
             <div className="w-full">
-                <WorkHeader work={syncedWork} />
+                <WorkHeader work={syncedWork} agents={agents} />
                 <WorkTabs work={syncedWork} />
 
                 <div className="mt-6">{children}</div>

--- a/apps/web/src/components/works/detail/WorkLayoutClient.tsx
+++ b/apps/web/src/components/works/detail/WorkLayoutClient.tsx
@@ -24,6 +24,8 @@ interface WorkLayoutClientProps {
     config: WorkConfig | null;
     /** Work-scoped Agents for the header dropdown. */
     agents?: Agent[];
+    /** Total Work-scoped Agents upstream — may exceed agents.length. */
+    agentsTotal?: number;
 }
 
 export function WorkLayoutClient({
@@ -31,6 +33,7 @@ export function WorkLayoutClient({
     oauthConnection,
     config,
     agents = [],
+    agentsTotal,
     children,
 }: WorkLayoutClientProps) {
     const router = useRouter();
@@ -164,7 +167,7 @@ export function WorkLayoutClient({
             onWorkChange={setSyncedWork}
         >
             <div className="w-full">
-                <WorkHeader work={syncedWork} agents={agents} />
+                <WorkHeader work={syncedWork} agents={agents} agentsTotal={agentsTotal} />
                 <WorkTabs work={syncedWork} />
 
                 <div className="mt-6">{children}</div>


### PR DESCRIPTION

https://github.com/user-attachments/assets/1f4f6b71-c8c1-4932-b170-75b61ca16e01



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Agents dropdown in Work details, showing associated agents, empty-state messaging, and a shortcut to create a new agent.
  * Users can now pause or resume agents directly from the dropdown, with status updates reflected immediately.

* **Bug Fixes**
  * Added success and failure notifications for agent status changes.
  * Improved Work detail loading so agent information appears alongside existing workspace data.

* **Localization**
  * Added the new Agents dropdown text across multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->