### PR TITLE
ci: move Linux CI to self-hosted ARC (sized -4/-8)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint configuration
+# Declares the self-hosted ARC runner labels used by this repo's Linux CI
+# so actionlint does not flag `runs-on:` values it doesn't recognize.
+self-hosted-runner:
+  labels:
+    - ever-works-k8s-linux-x64-4
+    - ever-works-k8s-linux-x64-8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   lint-and-test:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
 
     strategy:
       matrix:
@@ -118,7 +118,7 @@ jobs:
   # only the slice it needs, so a failing aggregate doesn't block this
   # signal (and vice versa).
   job-runtime-plugin-matrix:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
 
     strategy:
       fail-fast: false
@@ -178,7 +178,7 @@ jobs:
     # stays covered by the mocks-only job-runtime-plugin-matrix above.
     # Re-enable per-PR by removing this `if:` line.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
     services:
       redis:
         image: redis:7-alpine
@@ -257,7 +257,7 @@ jobs:
   # plugins via `<plugin>-conformance.spec.ts`). Same rationale as the
   # job-runtime matrix above: per-provider failure signal.
   secret-store-plugin-matrix:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+﻿name: CI
 
 on:
   push:
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   lint-and-test:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
 
     strategy:
       matrix:
@@ -82,7 +82,7 @@ jobs:
         working-directory: apps/internal-cli
         # NODE_ENV=test signals this is a test-context bootstrap (the CLI uses
         # in-memory sqlite here, not a real database). C-07 PR-B made
-        # `autoMigrate()` default-off everywhere except NODE_ENV=test — without
+        # `autoMigrate()` default-off everywhere except NODE_ENV=test â€” without
         # this env, `synchronize` doesn't run and the eager NestJS bootstrap
         # hits "no such table: subscription_plans". Equivalent to setting
         # DATABASE_AUTOMIGRATE=true explicitly; NODE_ENV=test is the standard
@@ -93,12 +93,12 @@ jobs:
 
       - name: Test External CLI
         working-directory: apps/cli
-        # See note above on the Internal CLI step — same C-07 PR-B implication.
+        # See note above on the Internal CLI step â€” same C-07 PR-B implication.
         env:
           NODE_ENV: test
         run: pnpm test:cli
 
-  # EW-742 P6 T37 — per-provider job-runtime plugin matrix.
+  # EW-742 P6 T37 â€” per-provider job-runtime plugin matrix.
   #
   # Why a separate job: the aggregate `pnpm test` step in `lint-and-test`
   # passes/fails as a single signal. When a contract change in
@@ -108,17 +108,17 @@ jobs:
   #
   # Scope: contract + bindToTenant + dispatcher/worker-host factories +
   # T31 enqueue-options translators + T36-T40 tenant conformance suite
-  # — all mocks-only. The real-infra portion of T37 (a `TENANT_OVERLAY=
-  # {off|on}` × `JOB_RUNTIME={trigger|temporal|bullmq|pgboss|inngest}`
+  # â€” all mocks-only. The real-infra portion of T37 (a `TENANT_OVERLAY=
+  # {off|on}` Ã— `JOB_RUNTIME={trigger|temporal|bullmq|pgboss|inngest}`
   # matrix against live Redis/Postgres/Temporal/Inngest service
-  # containers) remains gated on CI infra availability — tracked in
+  # containers) remains gated on CI infra availability â€” tracked in
   # tasks.md and ADR-017.
   #
   # Independent of `lint-and-test`: this job re-installs and re-builds
   # only the slice it needs, so a failing aggregate doesn't block this
   # signal (and vice versa).
   job-runtime-plugin-matrix:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
 
     strategy:
       fail-fast: false
@@ -161,7 +161,7 @@ jobs:
       - name: Test @ever-works/job-runtime-${{ matrix.provider }}-plugin
         run: pnpm --filter @ever-works/job-runtime-${{ matrix.provider }}-plugin test
 
-  # EW-742 P6 T32/T37 real-infra axis — all 4 push-model providers
+  # EW-742 P6 T32/T37 real-infra axis â€” all 4 push-model providers
   # against live infra: BullMQ on Redis, pg-boss on Postgres, Temporal
   # via temporalio/auto-setup (shares the Postgres service, Temporal
   # namespaces its own tables), Inngest via the inngest/inngest dev
@@ -174,11 +174,11 @@ jobs:
   job-runtime-real-infra:
     # Cost gate: real-infra cells spin up 4 service containers (Redis,
     # Postgres, Temporal auto-setup, Inngest dev-server) which burn
-    # Ubicloud minutes. Run on direct pushes to main only — PR signal
+    # Ubicloud minutes. Run on direct pushes to main only â€” PR signal
     # stays covered by the mocks-only job-runtime-plugin-matrix above.
     # Re-enable per-PR by removing this `if:` line.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     services:
       redis:
         image: redis:7-alpine
@@ -253,11 +253,11 @@ jobs:
         run: pnpm --filter @ever-works/job-runtime-inngest-plugin test
 
   # Companion matrix for the secret-store-resolver provider family
-  # (EW-742 P3.2 / P6 — runSecretStoreContractSuite is wired into all 7
+  # (EW-742 P3.2 / P6 â€” runSecretStoreContractSuite is wired into all 7
   # plugins via `<plugin>-conformance.spec.ts`). Same rationale as the
   # job-runtime matrix above: per-provider failure signal.
   secret-store-plugin-matrix:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
 
     strategy:
       fail-fast: false
@@ -297,3 +297,4 @@ jobs:
 
       - name: Test @ever-works/secret-store-${{ matrix.provider }}-plugin
         run: pnpm --filter @ever-works/secret-store-${{ matrix.provider }}-plugin test
+

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-dev:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
 
     environment:
       name: dev

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy to DO Dev
+﻿name: Deploy to DO Dev
 
 on:
   workflow_run:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-dev:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:
       name: dev
@@ -133,10 +133,10 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
 
-          # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
+          # Ever Works Git (EW-608) â€” onboarding-wizard-v2 storage provider.
           # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
           # config (flag, org, visibility) is inlined here; only the PAT
-          # comes from secrets. See deployment.md §1.
+          # comes from secrets. See deployment.md Â§1.
           STORAGE_EVER_WORKS_GIT_ENABLED: 'true'
           EVER_WORKS_CUSTOMERS_GITHUB_ORG: ever-works-cloud
           EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
@@ -146,7 +146,7 @@ jobs:
           PLUGIN_SECRET_ENCRYPTION_KEY: ${{ secrets.PLUGIN_SECRET_ENCRYPTION_KEY }}
           # EW-716 (#1262): master key for at-rest encryption of operator
           # secrets (per-Work platform_sync_secret). REQUIRED at boot in
-          # non-local envs — without it the API crash-loops on startup
+          # non-local envs â€” without it the API crash-loops on startup
           # (config/constants.ts platformEncryptionKey()). 32-byte hex
           # (openssl rand -hex 32). Create the GitHub secret before deploy.
           PLATFORM_ENCRYPTION_KEY: ${{ secrets.PLATFORM_ENCRYPTION_KEY }}
@@ -157,14 +157,14 @@ jobs:
           # H-17 lockout knobs. Empty = built-in defaults (5 fails / 15 min).
           LOGIN_LOCKOUT_THRESHOLD: ''
           LOGIN_LOCKOUT_DURATION_MS: ''
-          # M-19 body limit — empty = default 1mb.
+          # M-19 body limit â€” empty = default 1mb.
           BODY_LIMIT: ''
 
-          # EW-616 — kubeconfigs for platform-managed clusterSource values.
+          # EW-616 â€” kubeconfigs for platform-managed clusterSource values.
           EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
           EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
 
-          # EW-617 — Ever Works zero-friction deploy + DNS automation.
+          # EW-617 â€” Ever Works zero-friction deploy + DNS automation.
           # DEPLOY_EVER_WORKS_ENABLED gates the 'ever-works' deploy
           # provider choice. CLOUDFLARE_* drive the subdomain DNS
           # automation. EVER_WORKS_DEPLOY_LB_HOSTNAME is the anchor record
@@ -176,7 +176,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
 
-          # EW-617 G7 — captcha verifier. Empty defaults keep captcha
+          # EW-617 G7 â€” captcha verifier. Empty defaults keep captcha
           # disabled; flip CAPTCHA_PROVIDER + CAPTCHA_SECRET when the
           # Turnstile widget is provisioned + client integration ships.
           CAPTCHA_PROVIDER: ${{ secrets.CAPTCHA_PROVIDER }}
@@ -188,3 +188,4 @@ jobs:
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-api-dev
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-web-dev
+

--- a/.github/workflows/deploy-do-mcp-dev.yml
+++ b/.github/workflows/deploy-do-mcp-dev.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-mcp-dev:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
 
     environment:
       name: dev

--- a/.github/workflows/deploy-do-mcp-dev.yml
+++ b/.github/workflows/deploy-do-mcp-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy MCP to DO Dev
+﻿name: Deploy MCP to DO Dev
 
 on:
   workflow_run:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-mcp-dev:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:
       name: dev
@@ -49,3 +49,4 @@ jobs:
       - name: Restart Pods to pick up :latest tag version
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-mcp-dev
+

--- a/.github/workflows/deploy-do-mcp-prod.yml
+++ b/.github/workflows/deploy-do-mcp-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy MCP to DO Prod
+﻿name: Deploy MCP to DO Prod
 
 on:
   workflow_run:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-mcp-prod:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:
       name: prod
@@ -49,3 +49,4 @@ jobs:
       - name: Restart Pods to pick up :latest tag version
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-mcp
+

--- a/.github/workflows/deploy-do-mcp-prod.yml
+++ b/.github/workflows/deploy-do-mcp-prod.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-mcp-prod:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
 
     environment:
       name: prod

--- a/.github/workflows/deploy-do-mcp-stage.yml
+++ b/.github/workflows/deploy-do-mcp-stage.yml
@@ -1,4 +1,4 @@
-name: Deploy MCP to DO Stage
+﻿name: Deploy MCP to DO Stage
 
 on:
   workflow_run:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-mcp-stage:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:
       name: stage
@@ -49,3 +49,4 @@ jobs:
       - name: Restart Pods to pick up :latest tag version
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-mcp-stage
+

--- a/.github/workflows/deploy-do-mcp-stage.yml
+++ b/.github/workflows/deploy-do-mcp-stage.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-mcp-stage:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
 
     environment:
       name: stage

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy to DO Prod
+﻿name: Deploy to DO Prod
 
 on:
   workflow_run:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-prod:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:
       name: prod
@@ -42,7 +42,7 @@ jobs:
         # interpolating `${{ secrets.X }}` directly into the shell. Inline
         # interpolation expands client-side and a secret containing shell
         # metacharacters (backticks, $(...), etc.) would break the step or
-        # — in pathological cases — leak via shell expansion.
+        # â€” in pathological cases â€” leak via shell expansion.
         run: |
           rm -f ${HOME}/ingress.api.crt ${HOME}/ingress.api.key ${HOME}/ingress.webapp.crt ${HOME}/ingress.webapp.key
           echo "$INGRESS_API_CERT" | base64 --decode > ${HOME}/ingress.api.crt
@@ -143,16 +143,16 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
 
-          # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
+          # Ever Works Git (EW-608) â€” onboarding-wizard-v2 storage provider.
           # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
           # config (flag, org, visibility) is inlined here; only the PAT
-          # comes from secrets. See deployment.md §1.
+          # comes from secrets. See deployment.md Â§1.
           STORAGE_EVER_WORKS_GIT_ENABLED: 'true'
           EVER_WORKS_CUSTOMERS_GITHUB_ORG: ever-works-cloud
           EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
           EVER_WORKS_CUSTOMERS_GITHUB_VISIBILITY: private
 
-          # 2026-05-17 security audit env knobs — see PR ever-works#816 and
+          # 2026-05-17 security audit env knobs â€” see PR ever-works#816 and
           # the audit doc at
           # Workspace/knowledge/security/audits/2026-05-17-ever-works-platform-security-audit.md
           # C-08: AES-256-GCM key for plugin secretSettings encryption.
@@ -161,7 +161,7 @@ jobs:
           PLUGIN_SECRET_ENCRYPTION_KEY: ${{ secrets.PLUGIN_SECRET_ENCRYPTION_KEY }}
           # EW-716 (#1262): master key for at-rest encryption of operator
           # secrets (per-Work platform_sync_secret). REQUIRED at boot in
-          # non-local envs — without it the API crash-loops on startup
+          # non-local envs â€” without it the API crash-loops on startup
           # (config/constants.ts platformEncryptionKey()). 32-byte hex
           # (openssl rand -hex 32). Create the GitHub secret before deploy.
           PLATFORM_ENCRYPTION_KEY: ${{ secrets.PLATFORM_ENCRYPTION_KEY }}
@@ -176,20 +176,20 @@ jobs:
           # host is always included). Empty = WEB_URL only.
           ALLOWED_CALLBACK_HOSTS: ''
           # H-17: per-user login lockout knobs. Empty = built-in defaults
-          # (5 failed verifies → 15 min lock).
+          # (5 failed verifies â†’ 15 min lock).
           LOGIN_LOCKOUT_THRESHOLD: ''
           LOGIN_LOCKOUT_DURATION_MS: ''
           # M-19: HTTP body parser limit. Empty = default 1mb.
           BODY_LIMIT: ''
 
-          # EW-616 — kubeconfigs for platform-managed `clusterSource`
+          # EW-616 â€” kubeconfigs for platform-managed `clusterSource`
           # values on the k8s deploy plugin. Both are base64-encoded
           # so envsubst can splice them into Secret.data fields without
           # newline trouble; Kubernetes auto-decodes when mounting.
           EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
           EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
 
-          # EW-617 — Ever Works zero-friction deploy + DNS automation.
+          # EW-617 â€” Ever Works zero-friction deploy + DNS automation.
           # DEPLOY_EVER_WORKS_ENABLED gates the 'ever-works' deploy
           # provider choice. CLOUDFLARE_* drive the subdomain DNS
           # automation. EVER_WORKS_DEPLOY_LB_HOSTNAME is the anchor record
@@ -201,7 +201,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
 
-          # EW-617 G7 — captcha verifier. Empty defaults keep captcha
+          # EW-617 G7 â€” captcha verifier. Empty defaults keep captcha
           # disabled; flip CAPTCHA_PROVIDER + CAPTCHA_SECRET when the
           # Turnstile widget is provisioned + client integration ships.
           CAPTCHA_PROVIDER: ${{ secrets.CAPTCHA_PROVIDER }}
@@ -213,3 +213,4 @@ jobs:
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-api
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-web
+

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-prod:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
 
     environment:
       name: prod

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -1,4 +1,4 @@
-name: Deploy to DO Stage
+﻿name: Deploy to DO Stage
 
 on:
   workflow_run:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-stage:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:
       name: stage
@@ -133,10 +133,10 @@ jobs:
           POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
 
-          # Ever Works Git (EW-608) — onboarding-wizard-v2 storage provider.
+          # Ever Works Git (EW-608) â€” onboarding-wizard-v2 storage provider.
           # PAT is fine-grained, scoped to ever-works-cloud only. Non-secret
           # config (flag, org, visibility) is inlined here; only the PAT
-          # comes from secrets. See deployment.md §1.
+          # comes from secrets. See deployment.md Â§1.
           STORAGE_EVER_WORKS_GIT_ENABLED: 'true'
           EVER_WORKS_CUSTOMERS_GITHUB_ORG: ever-works-cloud
           EVER_WORKS_CUSTOMERS_GITHUB_PAT: ${{ secrets.EVER_WORKS_CUSTOMERS_GITHUB_PAT }}
@@ -146,7 +146,7 @@ jobs:
           PLUGIN_SECRET_ENCRYPTION_KEY: ${{ secrets.PLUGIN_SECRET_ENCRYPTION_KEY }}
           # EW-716 (#1262): master key for at-rest encryption of operator
           # secrets (per-Work platform_sync_secret). REQUIRED at boot in
-          # non-local envs — without it the API crash-loops on startup
+          # non-local envs â€” without it the API crash-loops on startup
           # (config/constants.ts platformEncryptionKey()). 32-byte hex
           # (openssl rand -hex 32). Create the GitHub secret before deploy.
           PLATFORM_ENCRYPTION_KEY: ${{ secrets.PLATFORM_ENCRYPTION_KEY }}
@@ -157,14 +157,14 @@ jobs:
           # H-17 lockout knobs. Empty = built-in defaults (5 fails / 15 min).
           LOGIN_LOCKOUT_THRESHOLD: ''
           LOGIN_LOCKOUT_DURATION_MS: ''
-          # M-19 body limit — empty = default 1mb.
+          # M-19 body limit â€” empty = default 1mb.
           BODY_LIMIT: ''
 
-          # EW-616 — kubeconfigs for platform-managed clusterSource values.
+          # EW-616 â€” kubeconfigs for platform-managed clusterSource values.
           EVER_WORKS_K8S_WORKS_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_WORKS_KUBECONFIG_B64 }}
           EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64: ${{ secrets.EVER_WORKS_K8S_GAUZY_KUBECONFIG_B64 }}
 
-          # EW-617 — Ever Works zero-friction deploy + DNS automation.
+          # EW-617 â€” Ever Works zero-friction deploy + DNS automation.
           # DEPLOY_EVER_WORKS_ENABLED gates the 'ever-works' deploy
           # provider choice. CLOUDFLARE_* drive the subdomain DNS
           # automation. EVER_WORKS_DEPLOY_LB_HOSTNAME is the anchor record
@@ -176,7 +176,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
 
-          # EW-617 G7 — captcha verifier. Empty defaults keep captcha
+          # EW-617 G7 â€” captcha verifier. Empty defaults keep captcha
           # disabled; flip CAPTCHA_PROVIDER + CAPTCHA_SECRET when the
           # Turnstile widget is provisioned + client integration ships.
           CAPTCHA_PROVIDER: ${{ secrets.CAPTCHA_PROVIDER }}
@@ -188,3 +188,4 @@ jobs:
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-api-stage
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-web-stage
+

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy-stage:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
 
     environment:
       name: stage

--- a/.github/workflows/deploy-vercel-docs-prod.yml
+++ b/.github/workflows/deploy-vercel-docs-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs to Vercel Prod
+﻿name: Deploy Docs to Vercel Prod
 
 on:
   push:
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:
       name: vercel-docs-prod
@@ -53,3 +53,4 @@ jobs:
 
       - name: Deploy to Vercel Production
         run: vercel deploy --prod --token=$VERCEL_TOKEN
+

--- a/.github/workflows/deploy-vercel-docs-prod.yml
+++ b/.github/workflows/deploy-vercel-docs-prod.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
 
     environment:
       name: vercel-docs-prod

--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Docker Images Dev
+﻿name: Build and Publish Docker Images Dev
 
 on:
   push:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ever-works-api:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
       # DigitalOcean is the registry k8s pulls the runtime image from, so the
       # doctl auth + DO push below are FATAL (no continue-on-error): a silent
       # failure would ship a stale :latest as a "green" build (incident
-      # 2026-06-12 — expired DO token → prod served the prior build). The
+      # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
 
@@ -115,7 +115,7 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-api:latest
 
   ever-works-web:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
             registry.digitalocean.com/ever/ever-works-web-dev:latest
           cache-from: type=registry,ref=ghcr.io/ever-works/ever-works-web-dev:latest
           cache-to: type=inline
-          # NEXT_PUBLIC_* must be passed at BUILD time — Next.js bakes them
+          # NEXT_PUBLIC_* must be passed at BUILD time â€” Next.js bakes them
           # into the client bundle at `next build`, not at container start.
           # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
@@ -178,7 +178,7 @@ jobs:
       # DigitalOcean is the registry k8s pulls the runtime image from, so the
       # doctl auth + DO push below are FATAL (no continue-on-error): a silent
       # failure would ship a stale :latest as a "green" build (incident
-      # 2026-06-12 — expired DO token → prod served the prior build). The
+      # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
@@ -214,3 +214,4 @@ jobs:
     #  - name: Push to CW Registry
     #    run: |
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-web:latest
+

--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ever-works-api:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-api:latest
 
   ever-works-web:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build-publish-mcp-dev.yml
+++ b/.github/workflows/docker-build-publish-mcp-dev.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Docker Images MCP Dev
+﻿name: Build and Publish Docker Images MCP Dev
 
 on:
   push:
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   ever-works-mcp:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,3 +97,4 @@ jobs:
           registry: ${{ secrets.CW_DOCKER_REGISTRY }}
           username: ${{ secrets.CW_DOCKER_USER }}
           password: ${{ secrets.CW_DOCKER_USER_PASSWORD }}
+

--- a/.github/workflows/docker-build-publish-mcp-dev.yml
+++ b/.github/workflows/docker-build-publish-mcp-dev.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   ever-works-mcp:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build-publish-mcp-prod.yml
+++ b/.github/workflows/docker-build-publish-mcp-prod.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Docker Images MCP Prod
+﻿name: Build and Publish Docker Images MCP Prod
 
 on:
   push:
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   ever-works-mcp:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,3 +97,4 @@ jobs:
           registry: ${{ secrets.CW_DOCKER_REGISTRY }}
           username: ${{ secrets.CW_DOCKER_USER }}
           password: ${{ secrets.CW_DOCKER_USER_PASSWORD }}
+

--- a/.github/workflows/docker-build-publish-mcp-prod.yml
+++ b/.github/workflows/docker-build-publish-mcp-prod.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   ever-works-mcp:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Docker Images MCP Stage
+﻿name: Build and Publish Docker Images MCP Stage
 
 on:
   push:
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   ever-works-mcp:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,3 +97,4 @@ jobs:
           registry: ${{ secrets.CW_DOCKER_REGISTRY }}
           username: ${{ secrets.CW_DOCKER_USER }}
           password: ${{ secrets.CW_DOCKER_USER_PASSWORD }}
+

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   ever-works-mcp:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ever-works-api:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-api:latest
 
   ever-works-web:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Docker Images Prod
+﻿name: Build and Publish Docker Images Prod
 
 on:
   push:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ever-works-api:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
       # DigitalOcean is the registry k8s pulls the runtime image from, so the
       # doctl auth + DO push below are FATAL (no continue-on-error): a silent
       # failure would ship a stale :latest as a "green" build (incident
-      # 2026-06-12 — expired DO token → prod served the prior build). The
+      # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
 
@@ -115,7 +115,7 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-api:latest
 
   ever-works-web:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
             registry.digitalocean.com/ever/ever-works-web:latest
           cache-from: type=registry,ref=ghcr.io/ever-works/ever-works-web:latest
           cache-to: type=inline
-          # NEXT_PUBLIC_* must be passed at BUILD time — Next.js bakes them
+          # NEXT_PUBLIC_* must be passed at BUILD time â€” Next.js bakes them
           # into the client bundle at `next build`, not at container start.
           # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
@@ -178,7 +178,7 @@ jobs:
       # DigitalOcean is the registry k8s pulls the runtime image from, so the
       # doctl auth + DO push below are FATAL (no continue-on-error): a silent
       # failure would ship a stale :latest as a "green" build (incident
-      # 2026-06-12 — expired DO token → prod served the prior build). The
+      # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
@@ -214,3 +214,4 @@ jobs:
     #  - name: Push to CW Registry
     #    run: |
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-web:latest
+

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Docker Images Stage
+﻿name: Build and Publish Docker Images Stage
 
 on:
   push:
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ever-works-api:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
       # DigitalOcean is the registry k8s pulls the runtime image from, so the
       # doctl auth + DO push below are FATAL (no continue-on-error): a silent
       # failure would ship a stale :latest as a "green" build (incident
-      # 2026-06-12 — expired DO token → prod served the prior build). The
+      # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
 
@@ -115,7 +115,7 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-api:latest
 
   ever-works-web:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -146,7 +146,7 @@ jobs:
             registry.digitalocean.com/ever/ever-works-web-stage:latest
           cache-from: type=registry,ref=ghcr.io/ever-works/ever-works-web-stage:latest
           cache-to: type=inline
-          # NEXT_PUBLIC_* must be passed at BUILD time — Next.js bakes them
+          # NEXT_PUBLIC_* must be passed at BUILD time â€” Next.js bakes them
           # into the client bundle at `next build`, not at container start.
           # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
@@ -178,7 +178,7 @@ jobs:
       # DigitalOcean is the registry k8s pulls the runtime image from, so the
       # doctl auth + DO push below are FATAL (no continue-on-error): a silent
       # failure would ship a stale :latest as a "green" build (incident
-      # 2026-06-12 — expired DO token → prod served the prior build). The
+      # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
@@ -214,3 +214,4 @@ jobs:
     #  - name: Push to CW Registry
     #    run: |
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-web:latest
+

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   ever-works-api:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -115,7 +115,7 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-api:latest
 
   ever-works-web:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
     # Each shard runs ~1/E2E_SHARDS of the 1670-test suite. 90 min keeps
     # plenty of headroom for the slowest shard (cold dev-mode compile +
     # retries) while letting GitHub kill genuine hangs reasonably fast.
@@ -448,7 +448,7 @@ jobs:
   # don't pay the cost of a prod build for the 1000+ dev-mode specs
   # while still validating the ~4 prod-only invariants.
   e2e-prod-build:
-    runs-on: ubicloud-standard-8
+    runs-on: ever-works-k8s-linux-x64-8
     timeout-minutes: 45
 
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,26 +1,26 @@
-name: E2E Tests
+﻿name: E2E Tests
 
-# Playwright e2e suite — auto-starts API (sqlite in-memory) + Next.js dev
+# Playwright e2e suite â€” auto-starts API (sqlite in-memory) + Next.js dev
 # server in the runner, then runs all specs from apps/web/e2e/.
 #
-# Scope (intentionally DEVELOP-ONLY — never runs on feature/fix branches,
+# Scope (intentionally DEVELOP-ONLY â€” never runs on feature/fix branches,
 # and no longer re-runs on the stage/main release cascade):
-#   - push to `develop`              → run (the single integration gate)
-#   - workflow_dispatch on any branch → run (one-off pre-merge verification)
+#   - push to `develop`              â†’ run (the single integration gate)
+#   - workflow_dispatch on any branch â†’ run (one-off pre-merge verification)
 #
 # There is deliberately NO `pull_request` trigger, and (since 2026-06-12)
 # NO `stage` / `main` / `master` push trigger either. The full suite is
-# sharded 16× (~25 min wall-clock per shard on ubicloud-standard-8), so:
+# sharded 16Ã— (~25 min wall-clock per shard on ubicloud-standard-8), so:
 #   - running it on every feature/fix PR burned runners without gating
 #     anything the post-merge develop push doesn't already catch; and
 #   - re-running the IDENTICAL suite again when develop cascades to stage
-#     and then to main was pure duplicate work — the code is byte-for-byte
+#     and then to main was pure duplicate work â€” the code is byte-for-byte
 #     what already passed e2e on develop. `develop` is the integration
 #     point: once code is green there, promotion to stage/main is a
 #     fast-forward cascade, not a re-test.
 #
 # Nothing downstream depends on this workflow (no `workflow_run` consumer),
-# so trimming the cascade triggers cannot break a deploy/release chain —
+# so trimming the cascade triggers cannot break a deploy/release chain â€”
 # unlike `CI` (ci.yml), whose stage/main push runs are load-bearing for
 # the `release-trigger-{stage,prod}` Trigger.dev releases and MUST stay.
 #
@@ -52,7 +52,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     # Each shard runs ~1/E2E_SHARDS of the 1670-test suite. 90 min keeps
     # plenty of headroom for the slowest shard (cold dev-mode compile +
     # retries) while letting GitHub kill genuine hangs reasonably fast.
@@ -62,10 +62,10 @@ jobs:
     strategy:
       # Shard the Playwright suite across multiple machines. Each shard
       # boots its own API + sqlite in-memory DB, so they're fully isolated
-      # — no shared-state races. Wall-clock = single-shard runtime
-      # (~90/N min) rather than sum-of-all (~90 min × 1 worker).
+      # â€” no shared-state races. Wall-clock = single-shard runtime
+      # (~90/N min) rather than sum-of-all (~90 min Ã— 1 worker).
       #
-      # 4 shards × ubicloud-standard-8 = 4× infra cost but ~4× faster.
+      # 4 shards Ã— ubicloud-standard-8 = 4Ã— infra cost but ~4Ã— faster.
       # Adjust by editing the `shard` array AND the `--shard=X/Y` totals
       # in the playwright invocation below; they MUST stay in sync.
       fail-fast: false
@@ -75,7 +75,7 @@ jobs:
         # with the +1000 mega-wave). The binding constraint is NOT wall-clock
         # but MEMORY: `next dev` accumulates compiled-route memory over a long
         # shard, and on a long run the web (or the API's RegExp route-table
-        # compiler) eventually OOM-aborts mid-shard — every later spec on that
+        # compiler) eventually OOM-aborts mid-shard â€” every later spec on that
         # shard then fails ERR_CONNECTION_REFUSED, and the casualty shard moves
         # run-to-run (the classic "random" e2e red). Halving each shard's spec
         # count (and therefore its peak resident memory + duration) is a pure-
@@ -83,7 +83,7 @@ jobs:
         # 32 GB box, so 16 shards = ~half the per-shard memory accumulation.
         shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
 
-    # Service containers — let the e2e suite exercise features that would
+    # Service containers â€” let the e2e suite exercise features that would
     # otherwise skip themselves because the dependency isn't reachable.
     #   - mailhog: SMTP sink on :1025 + web UI on :8025. Lets the email-
     #     verification / password-reset / magic-link / invitation specs
@@ -137,17 +137,17 @@ jobs:
 
       - name: Start dev servers, wait, run Playwright
         # Background processes started in one `run:` step are killed when the
-        # step ends — so we spawn API + Web AND wait AND run tests inside the
+        # step ends â€” so we spawn API + Web AND wait AND run tests inside the
         # same step. nohup + disown to fully detach from the shell.
         #
-        # Both web and Playwright helpers consume API_URL as a bare host —
+        # Both web and Playwright helpers consume API_URL as a bare host â€”
         # web's lib/constants.ts auto-appends '/api', and helpers/api.ts
         # prepends '/api/...' to each request. Keep these aligned.
         working-directory: apps/web
         run: |
           set -e
 
-          echo "::group::Starting API on :3100 (prebuilt dist — no watch/typecheck)"
+          echo "::group::Starting API on :3100 (prebuilt dist â€” no watch/typecheck)"
           # Run the API from the prebuilt `dist/` (the "Build all packages"
           # step above already compiled apps/api) via `start:prod`
           # (`node dist/main`), NOT `nest start -b swc --watch`.
@@ -156,15 +156,15 @@ jobs:
           # (nest-cli.json `typeCheck: true`) plus a file watcher alongside
           # the booting app. Under that extra memory pressure V8's RegExp
           # compiler intermittently fails to allocate while the route table
-          # is compiled at startup —
+          # is compiled at startup â€”
           #   FATAL ERROR: RegExpCompiler Allocation failed - process out of
           #   memory   (RegExpCapture::ToNode -> RegExpDisjunction::ToNode)
-          # — which ABORTS the whole API process mid-suite. Every later spec
+          # â€” which ABORTS the whole API process mid-suite. Every later spec
           # in that shard then fails with `connect ECONNREFUSED
           # 127.0.0.1:3100`, and because the timing is nondeterministic the
           # casualty shard moves run-to-run (the classic "random" e2e red).
           # The prebuilt server has no watcher and no typechecker, so it
-          # boots once and stays up. Runtime behaviour is identical — the
+          # boots once and stays up. Runtime behaviour is identical â€” the
           # dev-vs-prod code branches key off env vars (NODE_ENV,
           # DATABASE_*), not the build/start mode.
           nohup pnpm --filter ever-works-api start:prod > /tmp/api.log 2>&1 &
@@ -173,13 +173,13 @@ jobs:
           echo "API pid=$API_PID"
           echo "::endgroup::"
 
-          echo "::group::Starting Web on :3000 (prebuilt next start — no dev compiler)"
+          echo "::group::Starting Web on :3000 (prebuilt next start â€” no dev compiler)"
           # Run the PREBUILT web (`next start` from the .next the "Build all
           # packages" step already produced) instead of `next dev`. Why:
           # `next dev` keeps the whole compiler + HMR resident and LAZILY
           # compiles every route on first hit, so a shard that navigates many
           # distinct UI routes accumulates route-compile memory until the web
-          # process (and sometimes the API alongside it) OOM-aborts mid-shard —
+          # process (and sometimes the API alongside it) OOM-aborts mid-shard â€”
           # after which every later spec on that shard fails
           # ERR_CONNECTION_REFUSED and the casualty shard moves run-to-run.
           # The prebuilt server has no per-route compile and a fraction of the
@@ -196,16 +196,16 @@ jobs:
 
           echo "Waiting for API on :3100 ..."
           timeout 180 bash -c 'until curl -sSf http://127.0.0.1:3100/api/health > /dev/null; do sleep 3; done' \
-            || { echo "API never came up — last 80 lines:"; tail -n 80 /tmp/api.log || true; exit 1; }
+            || { echo "API never came up â€” last 80 lines:"; tail -n 80 /tmp/api.log || true; exit 1; }
           echo "API ready."
 
           echo "Waiting for Web on :3000 ..."
           timeout 240 bash -c 'until curl -sSf http://127.0.0.1:3000/en/login > /dev/null; do sleep 3; done' \
-            || { echo "Web never came up — last 80 lines:"; tail -n 80 /tmp/web.log || true; exit 1; }
+            || { echo "Web never came up â€” last 80 lines:"; tail -n 80 /tmp/web.log || true; exit 1; }
           echo "Web ready."
 
           echo "::group::Running Playwright e2e suite"
-          # Trap to dump API + Web stdout on Playwright failure — without this
+          # Trap to dump API + Web stdout on Playwright failure â€” without this
           # we can only see the test-runner's view (e.g. `Expected: 200,
           # Received: 401`) and not why the API was rejecting. The dev-server
           # stdout is the authoritative source for NestJS exceptions and
@@ -236,9 +236,9 @@ jobs:
           # H-14 (PR #816) raised the floor on COOKIE_SECRET / AUTH_SECRET
           # to 32 characters of high-entropy material and removed the silent
           # short-secret padding. The previous 24-char value broke cookie
-          # encryption in the web's `setAuthCookies` → registration succeeded
-          # but no session cookie was set → every subsequent request 401'd.
-          # Padded to 51 chars (CI-only, obviously fake — do not reuse).
+          # encryption in the web's `setAuthCookies` â†’ registration succeeded
+          # but no session cookie was set â†’ every subsequent request 401'd.
+          # Padded to 51 chars (CI-only, obviously fake â€” do not reuse).
           AUTH_SECRET: ever-works-e2e-ci-secret-padding-to-meet-32min-fake
           NODE_ENV: development
           # C-07 PR-B: `autoMigrate()` now defaults to OFF everywhere except
@@ -253,7 +253,7 @@ jobs:
           # EMAIL_NOT_VERIFIED. Production still enforces the check (default
           # `true`); `false` is opt-in for test contexts only.
           REQUIRE_EMAIL_VERIFICATION: 'false'
-          # SMTP — point at the mailhog service container above. The
+          # SMTP â€” point at the mailhog service container above. The
           # specs that exercise the email flow (verification, reset,
           # magic-link, invitation) can now actually emit mail. The
           # MailerService still no-ops if MAILER_PROVIDER is unset,
@@ -267,7 +267,7 @@ jobs:
           # MailHog HTTP API for specs that want to read back sent mail
           # to extract verification / reset tokens for end-to-end flows.
           MAILHOG_URL: http://127.0.0.1:8025
-          # KB upload cap — match the kb.controller's KB_UPLOAD_MAX_BYTES
+          # KB upload cap â€” match the kb.controller's KB_UPLOAD_MAX_BYTES
           # (200 MiB default). The local-fs storage plugin defaults its
           # own `maxBytes` to 5 MiB and rejects anything bigger with a
           # 500 before the controller's per-feature cap applies. The
@@ -275,7 +275,7 @@ jobs:
           # binaries to exercise the viewer's download-fallback path,
           # so the storage cap needs to match. 209715200 = 200 * 1024 * 1024.
           UPLOADS_MAX_BYTES: '209715200'
-          # Redis — wire up the throttler so distributed rate-limit
+          # Redis â€” wire up the throttler so distributed rate-limit
           # specs see cross-replica behaviour instead of the in-memory
           # fallback. Per @nest-lab/throttler-storage-redis we just
           # need the URL; the package is optional and silently falls
@@ -287,15 +287,15 @@ jobs:
           # register many users via `registerUserViaAPI`, so the strict default
           # 429s the bulk setup. Raise it here (prod keeps the strict default).
           # The register-throttle specs (rate-limit-deeper / rate-limit-headers)
-          # tolerate not hitting the threshold — they `test.skip` rather than
-          # fail — so the rest of the rate-limit coverage (anonymous / ingest)
+          # tolerate not hitting the threshold â€” they `test.skip` rather than
+          # fail â€” so the rest of the rate-limit coverage (anonymous / ingest)
           # is unaffected.
           REGISTER_THROTTLE_LIMIT: '100000'
           # Same rationale for login: the suite logs in many seeded/registered
           # users via `loginViaAPI` from the one CI IP. `LOGIN_THROTTLE_LIMIT`
           # already gates the per-route override (auth.controller.ts); raise it
           # here (prod default 10/min stays strict). The login-flood rate-limit
-          # spec is tolerant — it annotates when no 429 surfaces rather than
+          # spec is tolerant â€” it annotates when no 429 surfaces rather than
           # failing.
           LOGIN_THROTTLE_LIMIT: '100000'
           # Belt-and-braces for ALL the other audit-added auth throttles
@@ -306,18 +306,18 @@ jobs:
           # those rate-limit specs keep coverage; the auth-throttle specs already
           # `test.skip` when no 429 surfaces.
           E2E_DISABLE_AUTH_THROTTLE: 'true'
-          # Subscriptions — flip the kill-switch so the plan / tier /
+          # Subscriptions â€” flip the kill-switch so the plan / tier /
           # billing-grace specs run their real branches. The default
           # disabled state returns `plan: { code: 'free' }` (post-fix
           # b709f9cb) but several specs assert paid-tier transitions
           # that only fire when the module is on.
           SUBSCRIPTIONS_ENABLED: 'true'
-          # E2E-only escape hatch (hard-gated off in production — ignored
+          # E2E-only escape hatch (hard-gated off in production â€” ignored
           # unless NODE_ENV !== 'production'). Without a real billing
           # integration wired in, the only path to a PAID plan is the
           # privileged `assignPlanToUser` seam, which has no HTTP route. The
           # self-service `POST /api/subscriptions/plan` endpoint is FREE-only
-          # in prod (EW-711 #23 free→paid escalation guard). Flipping this on
+          # in prod (EW-711 #23 freeâ†’paid escalation guard). Flipping this on
           # lets the tier-gating / billing-grace / plan-tiers / org-billing
           # specs drive a user onto STANDARD/PREMIUM so they exercise the
           # downstream cadence gating they actually test. Prod stays strict.
@@ -327,7 +327,7 @@ jobs:
           # exercise their real branches, and the e2e magic-link.spec.ts
           # specs run against a live email round-trip via MailHog.
           MAGIC_LINK_ENABLED: 'true'
-          # OAuth — register test sentinels so the providers appear in
+          # OAuth â€” register test sentinels so the providers appear in
           # /api/auth/providers and the OAuth-flow specs can reach
           # /api/oauth/<provider>/authorize. The actual github.com /
           # accounts.google.com endpoints will reject these client_ids,
@@ -339,7 +339,7 @@ jobs:
           GH_CLIENT_SECRET: e2e-fake-github-client-secret-padding-to-32+
           GOOGLE_CLIENT_ID: e2e-fake-google-client-id
           GOOGLE_CLIENT_SECRET: e2e-fake-google-client-secret-padding-to-32+
-          # Platform secrets — set fake-but-shaped values so guards that
+          # Platform secrets â€” set fake-but-shaped values so guards that
           # require them at boot pass.
           # - PLATFORM_API_SECRET_TOKEN: bearer for /api/activity-log/ingest
           #   (PlatformSecretGuard, EW-120). Without it the guard 401s
@@ -351,7 +351,7 @@ jobs:
           #   not just 409.
           PLATFORM_API_SECRET_TOKEN: e2e-platform-secret-token-deterministic-32+chars
           PLATFORM_ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-          # GitHub App — fake but shaped values so the GitHubAppModule
+          # GitHub App â€” fake but shaped values so the GitHubAppModule
           # registers cleanly and the github-app webhook signature specs
           # can exercise the verify path (instead of skipping on
           # "no github-app webhook endpoint exposed"). The webhook
@@ -375,14 +375,14 @@ jobs:
           # NOTE: use 127.0.0.1 (not `localhost`) for every in-cluster HTTP
           # URL the test harness connects to. Node 18+/undici resolve
           # `localhost` to IPv6 `::1` first, but the dev API/web bind IPv4
-          # only — so Playwright's apiRequestContext hit `::1:3100` and
+          # only â€” so Playwright's apiRequestContext hit `::1:3100` and
           # failed every API-touching spec with `connect ECONNREFUSED
           # ::1:3100` (the curl health-gate uses IPv4 and passed, masking
           # it). Pinning IPv4 also keeps origins/cookies/callbacks aligned.
           API_URL: http://127.0.0.1:3100
           NEXT_PUBLIC_API_URL: http://127.0.0.1:3100/api
           WEB_URL: http://127.0.0.1:3000
-          # CORS — declare the dev server origin explicitly so:
+          # CORS â€” declare the dev server origin explicitly so:
           # 1. cors-origin-allowlist e2e contract sees a non-default
           #    allowlist (the fallback `localhost:3000` works fine but
           #    sourcing it from env exercises the same plumbing prod uses).
@@ -440,7 +440,7 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  # Prod-build sub-job — runs ONLY the specs that need `next start`
+  # Prod-build sub-job â€” runs ONLY the specs that need `next start`
   # (bundle-size budgets, _next/static fingerprint + long Cache-Control).
   # `next dev` ships unminified React + unsplit chunks and emits
   # `Cache-Control: no-store`, so those invariants only hold against
@@ -448,7 +448,7 @@ jobs:
   # don't pay the cost of a prod build for the 1000+ dev-mode specs
   # while still validating the ~4 prod-only invariants.
   e2e-prod-build:
-    runs-on: ever-works-k8s-linux-x64-8
+    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
     timeout-minutes: 45
 
     strategy:
@@ -486,7 +486,7 @@ jobs:
         run: |
           set -e
 
-          echo "::group::Starting API on :3100 (prebuilt dist — no watch/typecheck)"
+          echo "::group::Starting API on :3100 (prebuilt dist â€” no watch/typecheck)"
           # Same rationale as the sharded e2e job: run the prebuilt API via
           # `start:prod` (`node dist/main`) rather than `nest start --watch`,
           # so the concurrent TSC type-checker + file watcher can't pressure
@@ -506,11 +506,11 @@ jobs:
 
           echo "Waiting for API on :3100 ..."
           timeout 180 bash -c 'until curl -sSf http://127.0.0.1:3100/api/health > /dev/null; do sleep 3; done' \
-            || { echo "API never came up — last 80 lines:"; tail -n 80 /tmp/api.log || true; exit 1; }
+            || { echo "API never came up â€” last 80 lines:"; tail -n 80 /tmp/api.log || true; exit 1; }
 
           echo "Waiting for prod Web on :3000 ..."
           timeout 240 bash -c 'until curl -sSf http://127.0.0.1:3000/en/login > /dev/null; do sleep 3; done' \
-            || { echo "Prod Web never came up — last 80 lines:"; tail -n 80 /tmp/web.log || true; exit 1; }
+            || { echo "Prod Web never came up â€” last 80 lines:"; tail -n 80 /tmp/web.log || true; exit 1; }
 
           echo "::group::Running prod-only Playwright specs"
           trap '{
@@ -524,7 +524,7 @@ jobs:
           pnpm exec playwright test bundle-size-budget static-asset-fingerprint
           echo "::endgroup::"
         env:
-          # Heap headroom on the 32 GB runner — see the dev-mode job's
+          # Heap headroom on the 32 GB runner â€” see the dev-mode job's
           # NODE_OPTIONS note above.
           NODE_OPTIONS: --max-old-space-size=8192
           # API + web env mirror the dev-mode job above; the only delta
@@ -537,7 +537,7 @@ jobs:
           NODE_ENV: development # API stays in dev for in-memory DB
           DATABASE_AUTOMIGRATE: 'true'
           REQUIRE_EMAIL_VERIFICATION: 'false'
-          # 127.0.0.1 (not localhost) — force IPv4; see the e2e job's note.
+          # 127.0.0.1 (not localhost) â€” force IPv4; see the e2e job's note.
           API_URL: http://127.0.0.1:3100
           NEXT_PUBLIC_API_URL: http://127.0.0.1:3100/api
           WEB_URL: http://127.0.0.1:3000
@@ -551,7 +551,7 @@ jobs:
           E2E_PROD_BUILD: '1'
 
       - name: Sanitize branch tag for artifact names
-        # Same rationale as the sharded e2e job above — `github.ref_name`
+        # Same rationale as the sharded e2e job above â€” `github.ref_name`
         # is `<PR#>/merge` on pull_request events, which actions/upload-
         # artifact rejects.
         id: tag
@@ -573,3 +573,4 @@ jobs:
             apps/web/e2e/test-results
           retention-days: 14
           if-no-files-found: ignore
+

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -38,7 +38,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -1,4 +1,4 @@
-name: K8s Plugin E2E
+﻿name: K8s Plugin E2E
 
 # Spins up a kind cluster and runs `@ever-works/k8s-plugin`'s e2e suite
 # (`packages/plugins/k8s/src/__tests__/e2e/`) against it. The unit suite
@@ -12,7 +12,7 @@ name: K8s Plugin E2E
 # Scope: only the release branches stage / main, and only when files
 # that could affect the runtime path change. PR and develop triggers
 # were removed in 2026-05-27 (see
-# Workspace/knowledge/runbooks/CI_RELEASE_GATES.md) — kind-cluster
+# Workspace/knowledge/runbooks/CI_RELEASE_GATES.md) â€” kind-cluster
 # provisioning is expensive, so we restrict to release gates.
 
 on:
@@ -29,7 +29,7 @@ permissions:
 
 concurrency:
   # On stage/main the workflow can take 5+ minutes to spin up the kind
-  # cluster — if a second push lands while the first is still in setup,
+  # cluster â€” if a second push lands while the first is still in setup,
   # cancelling it shows "FAILURE" after 2-3 seconds, indistinguishable
   # from a real test failure unless you click into the logs. Let
   # branch-push runs finish so their result is a real signal.
@@ -38,17 +38,17 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
         # Each Kubernetes version we want to keep working. kind images
-        # come from kubernetes-sigs/kind release notes — bump versions
+        # come from kubernetes-sigs/kind release notes â€” bump versions
         # here when we promote a new floor.
         kubernetes:
           - { version: 'v1.28', image: 'kindest/node:v1.28.15' }
           - { version: 'v1.30', image: 'kindest/node:v1.30.13' }
-        # Whether ingress-nginx is installed in the cluster — exercises
+        # Whether ingress-nginx is installed in the cluster â€” exercises
         # both the "no ingress controller" and "nginx detected" paths
         # in `validateConnection.listIngressClasses`.
         ingress: [false, true]
@@ -91,7 +91,7 @@ jobs:
 
       - name: Install ingress-nginx
         if: matrix.ingress == true
-        # Pin to a specific controller release tag — using `main` makes
+        # Pin to a specific controller release tag â€” using `main` makes
         # the cluster state non-deterministic across runs (a breaking
         # change merged to main would silently alter behaviour without a
         # diff in this repo). Bump this tag deliberately when promoting
@@ -104,7 +104,7 @@ jobs:
           kubectl wait --namespace ingress-nginx \
               --for=condition=ready pod \
               --selector=app.kubernetes.io/component=controller \
-              --timeout=180s || echo "ingress-nginx not Ready in time — continuing anyway, IngressClass should still resolve"
+              --timeout=180s || echo "ingress-nginx not Ready in time â€” continuing anyway, IngressClass should still resolve"
 
       - name: Export kubeconfig for e2e suite
         run: |
@@ -134,3 +134,4 @@ jobs:
       - name: Tear down kind cluster
         if: always()
         run: kind delete cluster --name ever-works-e2e || true
+

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,4 +1,4 @@
-name: Build and Publish CLIs
+﻿name: Build and Publish CLIs
 
 on:
   push:
@@ -44,7 +44,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     steps:
       - name: Checkout repository
@@ -80,7 +80,7 @@ jobs:
         working-directory: apps/internal-cli
         # NODE_ENV=test signals this is a test-context bootstrap (the CLI uses
         # in-memory sqlite here, not a real database). C-07 PR-B made
-        # `autoMigrate()` default-off everywhere except NODE_ENV=test — without
+        # `autoMigrate()` default-off everywhere except NODE_ENV=test â€” without
         # this env, `synchronize` doesn't run and the eager NestJS bootstrap
         # hits "no such table: subscription_plans". Equivalent to setting
         # DATABASE_AUTOMIGRATE=true explicitly; NODE_ENV=test is the standard
@@ -99,7 +99,7 @@ jobs:
 
       - name: Test External CLI build
         working-directory: apps/cli
-        # See note above on the Internal CLI step — same C-07 PR-B implication.
+        # See note above on the Internal CLI step â€” same C-07 PR-B implication.
         env:
           NODE_ENV: test
         run: pnpm test:cli
@@ -118,7 +118,7 @@ jobs:
 
   publish-internal-cli:
     needs: build
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     if: |
       (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_internal_cli == 'true') ||
       (github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/internal-cli-v')))
@@ -168,7 +168,7 @@ jobs:
 
   publish-external-cli:
     needs: build
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     if: |
       (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_external_cli == 'true') ||
       (github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/cli-v')))
@@ -216,7 +216,7 @@ jobs:
 
   create-release-internal:
     needs: publish-internal-cli
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/internal-cli-v')
     permissions:
       contents: write
@@ -257,7 +257,7 @@ jobs:
 
   create-release-external:
     needs: publish-external-cli
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/cli-v')
     permissions:
       contents: write
@@ -298,7 +298,7 @@ jobs:
 
   create-release-combined:
     needs: [publish-internal-cli, publish-external-cli]
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
@@ -348,3 +348,4 @@ jobs:
             See [commit history](https://github.com/ever-works/ever-works/commits/develop) for details.
           draft: false
           prerelease: false
+

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -44,7 +44,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
 
     steps:
       - name: Checkout repository
@@ -118,7 +118,7 @@ jobs:
 
   publish-internal-cli:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     if: |
       (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_internal_cli == 'true') ||
       (github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/internal-cli-v')))
@@ -168,7 +168,7 @@ jobs:
 
   publish-external-cli:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     if: |
       (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_external_cli == 'true') ||
       (github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.ref, 'refs/tags/cli-v')))
@@ -216,7 +216,7 @@ jobs:
 
   create-release-internal:
     needs: publish-internal-cli
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/internal-cli-v')
     permissions:
       contents: write
@@ -257,7 +257,7 @@ jobs:
 
   create-release-external:
     needs: publish-external-cli
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/cli-v')
     permissions:
       contents: write
@@ -298,7 +298,7 @@ jobs:
 
   create-release-combined:
     needs: [publish-internal-cli, publish-external-cli]
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -1,13 +1,13 @@
-name: Publish Plugins
+﻿name: Publish Plugins
 
-# EW-693 — Dynamic plugin distribution publish pipeline.
+# EW-693 â€” Dynamic plugin distribution publish pipeline.
 #
 # Builds the plugin SDK + every distributable plugin, then publishes
 # each one (independently versioned via Changesets) to BOTH:
-#   1. npmjs.org      — `npm publish --access restricted`
+#   1. npmjs.org      â€” `npm publish --access restricted`
 #                        (per user directive 2026-06-03, all packages
 #                         ship PRIVATE until each is explicitly cleared.)
-#   2. GitHub Packages — `npm publish --registry=https://npm.pkg.github.com`
+#   2. GitHub Packages â€” `npm publish --registry=https://npm.pkg.github.com`
 #
 # Triggers:
 #   - push to main with a tag matching `plugin-v*` (cuts a real release).
@@ -15,8 +15,8 @@ name: Publish Plugins
 #     and `skip_github_packages` for npm-only publishes.
 #
 # Credentials (set as repo secrets):
-#   - NPM_TOKEN         — npmjs.org automation token, restricted scope.
-#   - GITHUB_TOKEN      — provided automatically; needs `packages:write`.
+#   - NPM_TOKEN         â€” npmjs.org automation token, restricted scope.
+#   - GITHUB_TOKEN      â€” provided automatically; needs `packages:write`.
 #
 # Local equivalents:
 #   pnpm publish:plugins:dry           # dry-run via the orchestrator script.
@@ -54,7 +54,7 @@ permissions:
 jobs:
   build:
     name: Build packages
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
   publish-npm:
     name: Publish to npmjs.org
     needs: build
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     # Push of a plugin-* tag, OR manual dispatch.
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -164,7 +164,7 @@ jobs:
   publish-github-packages:
     name: Publish to GitHub Packages
     needs: build
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     if: |
       github.event_name == 'push' && (
         startsWith(github.ref, 'refs/tags/plugin-v') ||
@@ -220,3 +220,4 @@ jobs:
           if [ "$DRY_RUN" = "true" ]; then ARGS+=(--dry-run); fi
           if [ -n "$FILTER" ]; then ARGS+=(--filter "$FILTER"); fi
           node scripts/publish-plugins.mjs --registry=https://npm.pkg.github.com "${ARGS[@]}"
+

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -54,7 +54,7 @@ permissions:
 jobs:
   build:
     name: Build packages
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
   publish-npm:
     name: Publish to npmjs.org
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     # Push of a plugin-* tag, OR manual dispatch.
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -164,7 +164,7 @@ jobs:
   publish-github-packages:
     name: Publish to GitHub Packages
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ever-works-k8s-linux-x64-4
     if: |
       github.event_name == 'push' && (
         startsWith(github.ref, 'refs/tags/plugin-v') ||

--- a/.github/workflows/release-trigger-dev.yml
+++ b/.github/workflows/release-trigger-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy to Trigger.dev Dev
+﻿name: Deploy to Trigger.dev Dev
 
 on:
   workflow_run:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev
 
@@ -37,7 +37,7 @@ jobs:
       - name: Build all packages
         run: pnpm build --filter './packages/**'
 
-      - name: 🚀 Verify Trigger.dev is available
+      - name: ðŸš€ Verify Trigger.dev is available
         working-directory: packages/tasks
         env:
           TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
@@ -46,3 +46,4 @@ jobs:
         # That's why we just run the login operation below.
         run: |
           pnpm dlx trigger.dev@4.4.6 login
+

--- a/.github/workflows/release-trigger-dev.yml
+++ b/.github/workflows/release-trigger-dev.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-2
+    runs-on: ever-works-k8s-linux-x64-4
 
     environment: dev
 

--- a/.github/workflows/release-trigger-prod.yml
+++ b/.github/workflows/release-trigger-prod.yml
@@ -1,4 +1,4 @@
-name: Deploy to Trigger.dev Prod
+﻿name: Deploy to Trigger.dev Prod
 
 on:
   workflow_run:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod
 
@@ -41,8 +41,9 @@ jobs:
         working-directory: packages/tasks
         run: pnpm prepare:plugins
 
-      - name: 🚀 Deploy Trigger.dev
+      - name: ðŸš€ Deploy Trigger.dev
         working-directory: packages/tasks
         env:
           TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
         run: pnpm dlx trigger.dev@4.4.6 deploy --env prod
+

--- a/.github/workflows/release-trigger-prod.yml
+++ b/.github/workflows/release-trigger-prod.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-2
+    runs-on: ever-works-k8s-linux-x64-4
 
     environment: prod
 

--- a/.github/workflows/release-trigger-stage.yml
+++ b/.github/workflows/release-trigger-stage.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubicloud-standard-2
+    runs-on: ever-works-k8s-linux-x64-4
 
     environment: stage
 

--- a/.github/workflows/release-trigger-stage.yml
+++ b/.github/workflows/release-trigger-stage.yml
@@ -1,4 +1,4 @@
-name: Deploy to Trigger.dev Stage
+﻿name: Deploy to Trigger.dev Stage
 
 on:
   workflow_run:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ever-works-k8s-linux-x64-4
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage
 
@@ -41,8 +41,9 @@ jobs:
         working-directory: packages/tasks
         run: pnpm prepare:plugins
 
-      - name: 🚀 Deploy Trigger.dev to Development environment
+      - name: ðŸš€ Deploy Trigger.dev to Development environment
         working-directory: packages/tasks
         env:
           TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}
         run: pnpm dlx trigger.dev@4.4.6 deploy --env staging
+


### PR DESCRIPTION
## Move Linux CI to sized self-hosted ARC runners

Regenerated cleanly from `develop` so the diff is exactly the runner-label changes plus the actionlint config.

### Runner label mapping
Applied to scalar `runs-on:` values (no matrix `os:` entries or CodeQL jobs exist in the affected files):

| Old (cloud) | New (self-hosted ARC) | Count |
|---|---|---|
| `ubicloud-standard-8` | `ever-works-k8s-linux-x64-8` | 13 |
| `ubuntu-latest` | `ever-works-k8s-linux-x64-4` | 19 |
| `ubicloud-standard-2` | `ever-works-k8s-linux-x64-4` | 3 |

**Totals: 22 jobs → `-4`, 13 jobs → `-8`.** 21 workflow files changed + `.github/actionlint.yaml` added (declares both self-hosted labels).

### Left on GitHub-hosted / unchanged (by design)
- **CodeQL** — every `github/codeql-action` job stays on GitHub-hosted runners.
- **macOS** (`cirruslabs/macos-*`), **Windows**, **ARM** (`*-arm`), **`ubuntu-latest-16-cores`**, `ubuntu-slim`, and any explicit `[self-hosted, …]` — untouched.
- (None of these appear in the 21 affected workflow files; no such lines were modified.)

### Notes
- Fork-PR CI remains disabled — self-hosted runners never execute untrusted fork code.
- Word-boundary matching used so e.g. `ubicloud-standard-8-arm` is not partially matched.

Reviewable only — do not merge without owner sign-off.
