### PR TITLE
ci(verdaccio): route dev+stage build through internal Verdaccio VIP (not prod)

### DIFF
--- a/.deploy/docker/api/Dockerfile
+++ b/.deploy/docker/api/Dockerfile
@@ -26,6 +26,20 @@ WORKDIR /app
 
 COPY --from=pruner /app/pkg-jsons/ .
 RUN echo "shamefully-hoist=true" > .npmrc
+
+# Package registry selection (backward-compatible, fork-safe):
+# When the VERDACCIO_REGISTRY build-arg is set, install deps through our internal
+# Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
+# hashes, so `pnpm install --frozen-lockfile` still verifies). When empty — a fork,
+# or any build that does not pass it (e.g. prod) — this is a no-op and pnpm uses the
+# public npm registry, exactly as before. The pnpm-lock rewrite is best-effort
+# (non-fatal) so a URL/path mismatch degrades to public downloads, never a hard fail.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+    fi
+
 RUN pnpm install --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .

--- a/.deploy/docker/mcp/Dockerfile
+++ b/.deploy/docker/mcp/Dockerfile
@@ -17,6 +17,20 @@ WORKDIR /app
 COPY --from=pruner /app/out/json/ .
 COPY --from=pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN echo "shamefully-hoist=true" > .npmrc
+
+# Package registry selection (backward-compatible, fork-safe):
+# When the VERDACCIO_REGISTRY build-arg is set, install deps through our internal
+# Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
+# hashes, so `pnpm install --frozen-lockfile` still verifies). When empty — a fork,
+# or any build that does not pass it (e.g. prod) — this is a no-op and pnpm uses the
+# public npm registry, exactly as before. The pnpm-lock rewrite is best-effort
+# (non-fatal) so a URL/path mismatch degrades to public downloads, never a hard fail.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+    fi
+
 RUN pnpm install --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
@@ -45,6 +59,14 @@ WORKDIR /app
 COPY --from=api-pruner /app/out/json/ .
 COPY --from=api-pruner /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
 RUN echo "shamefully-hoist=true" > .npmrc
+
+# Package registry selection (backward-compatible, fork-safe) — see installer stage above.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+    fi
+
 RUN pnpm install --frozen-lockfile
 COPY --from=api-pruner /app/out/full/ .
 RUN pnpm exec turbo build --filter=ever-works-api...

--- a/.deploy/docker/web/Dockerfile
+++ b/.deploy/docker/web/Dockerfile
@@ -61,6 +61,21 @@ RUN apk add --no-cache pixman-dev cairo-dev pango-dev jpeg-dev giflib-dev
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/.gitignore .gitignore
 
+# Package registry selection (backward-compatible, fork-safe):
+# When the VERDACCIO_REGISTRY build-arg is set, install deps through our internal
+# Verdaccio cache (an anonymous, read-only proxy of npm — identical integrity
+# hashes, so `pnpm install --frozen-lockfile` still verifies). We write the setting
+# to the workspace-root .npmrc (/app), which pnpm reads when installing under
+# apps/web. When empty — a fork, or any build that does not pass it (e.g. prod) —
+# this is a no-op and pnpm uses the public npm registry, exactly as before. The
+# pnpm-lock rewrite is best-effort (non-fatal) so a URL/path mismatch degrades to
+# public downloads, never a hard fail.
+ARG VERDACCIO_REGISTRY=""
+RUN if [ -n "$VERDACCIO_REGISTRY" ]; then \
+        echo "registry=${VERDACCIO_REGISTRY}" >> .npmrc && \
+        { sed -i "s|https://registry.npmjs.org|${VERDACCIO_REGISTRY%/}|g; s|https://registry.yarnpkg.com|${VERDACCIO_REGISTRY%/}|g" pnpm-lock.yaml 2>/dev/null || true; }; \
+    fi
+
 # Install deps
 RUN cd apps/web && pnpm install --frozen-lockfile
 

--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -51,6 +51,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=development
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             BUILD_VERSION=${{ steps.meta.outputs.version }}
             GIT_SHA=${{ github.sha }}
             GIT_REF=${{ github.ref_name }}
@@ -151,6 +152,7 @@ jobs:
           # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
             NODE_ENV=development
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
             NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
             NEXT_PUBLIC_BUILD_VERSION=${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-build-publish-mcp-dev.yml
+++ b/.github/workflows/docker-build-publish-mcp-dev.yml
@@ -47,6 +47,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=development
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
 
       - name: Docker images list
         run: |

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -47,6 +47,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
 
       - name: Docker images list
         run: |

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -51,6 +51,7 @@ jobs:
           cache-to: type=inline
           build-args: |
             NODE_ENV=development
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             BUILD_VERSION=${{ steps.meta.outputs.version }}
             GIT_SHA=${{ github.sha }}
             GIT_REF=${{ github.ref_name }}
@@ -151,6 +152,7 @@ jobs:
           # Reuses the existing POSTHOG_* secrets (same phc_* key, same host).
           build-args: |
             NODE_ENV=production
+            VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}
             NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
             NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
             NEXT_PUBLIC_BUILD_VERSION=${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## What

Route the **dev + stage** in-cluster Docker image builds (`api`, `web`, `mcp`) to install npm/pnpm dependencies through our **internal Verdaccio cache** (VIP) instead of hitting public npm on every build.

Each dep-install stage now reads a new `VERDACCIO_REGISTRY` build-arg. When set, it writes `registry=<url>` to `.npmrc` (which pnpm honors for `pnpm install --frozen-lockfile`) and best-effort rewrites any registry URLs in `pnpm-lock.yaml`. The workflows pass it from the org/repo variable `${{ vars.VERDACCIO_REGISTRY }}`.

## Files

**Dockerfiles** (dep-install stages — `pnpm install --frozen-lockfile`):
- `.deploy/docker/api/Dockerfile` — `installer` stage
- `.deploy/docker/web/Dockerfile` — `installer` stage (registry written to workspace-root `/app/.npmrc`, read by the `cd apps/web && pnpm install`)
- `.deploy/docker/mcp/Dockerfile` — both `installer` **and** `specgen` stages

**Workflows** (add `VERDACCIO_REGISTRY=${{ vars.VERDACCIO_REGISTRY }}` build-arg, right after `NODE_ENV`):
- `docker-build-publish-dev.yml` (api + web)
- `docker-build-publish-stage.yml` (api + web)
- `docker-build-publish-mcp-dev.yml`
- `docker-build-publish-mcp-stage.yml`

## Backward-compatible & fork-safe

- **Empty `VERDACCIO_REGISTRY` → no-op.** The `ARG VERDACCIO_REGISTRY=""` default means any build that does not pass the arg (a fork, a plain `docker build`, **or prod**) behaves exactly as before, using public npm. The VIP IP is never hardcoded — it comes solely from `${{ vars.VERDACCIO_REGISTRY }}`, which is empty on forks.
- **`--frozen-lockfile` still verifies.** Verdaccio is a read-only proxy of npm with identical integrity hashes, so lockfile verification is unaffected.
- **The `pnpm-lock.yaml` rewrite is non-fatal** (`|| true`) — a URL/path mismatch degrades to public downloads rather than breaking the build.

## Prod is untouched (owner rule)

Only the **dev** and **stage** workflows pass the build-arg. `docker-build-publish-prod.yml` and `docker-build-publish-mcp-prod.yml` are **not** modified. `k8s-build.yml` is intentionally left alone because it produces prod (`main`/`master`) tags in the same matrix file — routing its build-arg would touch prod. The shared Dockerfile edits are safe for those workflows precisely because they never pass `VERDACCIO_REGISTRY` (→ public npm).

Note: only ARC self-hosted runners can reach the internal VIP; all four targeted workflows already run on `${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}` (ARC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)