### PR TITLE
ci: gate DigitalOcean steps behind vars.DO_ENABLED (we no longer use DO)

### DIFF
--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -24,20 +24,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Save DigitalOcean kubeconfig with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 k8s-gauzy
 
       - name: Write PostgreSQL Certificate file
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           echo "$DB_CA_CERT" | base64 --decode > ${HOME}/ca-certificate.crt
         env:
           DB_CA_CERT: '${{ secrets.DATABASE_CA_CERT }}'
 
       - name: Generate TLS Secrets
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           rm -f ${HOME}/ingress.api.crt ${HOME}/ingress.api.key ${HOME}/ingress.webapp.crt ${HOME}/ingress.webapp.key
           echo ${{ secrets.INGRESS_API_CERT }} | base64 --decode > ${HOME}/ingress.api.crt
@@ -48,6 +52,7 @@ jobs:
           kubectl create secret tls appdev.ever.works-tls --save-config --dry-run=client --cert=${HOME}/ingress.webapp.crt --key=${HOME}/ingress.webapp.key -o yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
 
       - name: Apply k8s manifests changes in DigitalOcean k8s cluster (if any)
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           envsubst < $GITHUB_WORKSPACE/.deploy/k8s/k8s-manifest.dev.yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
         env:
@@ -185,6 +190,7 @@ jobs:
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-api-dev
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-web-dev

--- a/.github/workflows/deploy-do-mcp-dev.yml
+++ b/.github/workflows/deploy-do-mcp-dev.yml
@@ -24,14 +24,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Save DigitalOcean kubeconfig with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 k8s-gauzy
 
       - name: Generate TLS Secrets
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           rm -f ${HOME}/ingress.mcp.crt ${HOME}/ingress.mcp.key
           echo ${{ secrets.INGRESS_MCP_CERT }} | base64 --decode > ${HOME}/ingress.mcp.crt
@@ -39,6 +42,7 @@ jobs:
           kubectl create secret tls mcpdev.ever.works-tls --save-config --dry-run=client --cert=${HOME}/ingress.mcp.crt --key=${HOME}/ingress.mcp.key -o yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
 
       - name: Apply k8s manifests changes in DigitalOcean k8s cluster (if any)
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           envsubst < $GITHUB_WORKSPACE/.deploy/k8s/k8s-manifest.mcp.dev.yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
         env:
@@ -47,6 +51,7 @@ jobs:
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-mcp-dev
 

--- a/.github/workflows/deploy-do-mcp-prod.yml
+++ b/.github/workflows/deploy-do-mcp-prod.yml
@@ -24,14 +24,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Save DigitalOcean kubeconfig with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 k8s-gauzy
 
       - name: Generate TLS Secrets
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           rm -f ${HOME}/ingress.mcp.crt ${HOME}/ingress.mcp.key
           echo ${{ secrets.INGRESS_MCP_CERT }} | base64 --decode > ${HOME}/ingress.mcp.crt
@@ -39,6 +42,7 @@ jobs:
           kubectl create secret tls mcp.ever.works-tls --save-config --dry-run=client --cert=${HOME}/ingress.mcp.crt --key=${HOME}/ingress.mcp.key -o yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
 
       - name: Apply k8s manifests changes in DigitalOcean k8s cluster (if any)
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           envsubst < $GITHUB_WORKSPACE/.deploy/k8s/k8s-manifest.mcp.prod.yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
         env:
@@ -47,6 +51,7 @@ jobs:
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-mcp
 

--- a/.github/workflows/deploy-do-mcp-stage.yml
+++ b/.github/workflows/deploy-do-mcp-stage.yml
@@ -24,14 +24,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Save DigitalOcean kubeconfig with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 k8s-gauzy
 
       - name: Generate TLS Secrets
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           rm -f ${HOME}/ingress.mcp.crt ${HOME}/ingress.mcp.key
           echo ${{ secrets.INGRESS_MCP_CERT }} | base64 --decode > ${HOME}/ingress.mcp.crt
@@ -39,6 +42,7 @@ jobs:
           kubectl create secret tls mcpstage.ever.works-tls --save-config --dry-run=client --cert=${HOME}/ingress.mcp.crt --key=${HOME}/ingress.mcp.key -o yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
 
       - name: Apply k8s manifests changes in DigitalOcean k8s cluster (if any)
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           envsubst < $GITHUB_WORKSPACE/.deploy/k8s/k8s-manifest.mcp.stage.yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
         env:
@@ -47,6 +51,7 @@ jobs:
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-mcp-stage
 

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -24,20 +24,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Save DigitalOcean kubeconfig with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 k8s-gauzy
 
       - name: Write PostgreSQL Certificate file
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           echo "$DB_CA_CERT" | base64 --decode > ${HOME}/ca-certificate.crt
         env:
           DB_CA_CERT: '${{ secrets.DATABASE_CA_CERT }}'
 
       - name: Generate TLS Secrets
+        if: ${{ vars.DO_ENABLED == 'true' }}
         # M-13: pass secrets via `env:` and double-quote `"$VAR"` instead of
         # interpolating `${{ secrets.X }}` directly into the shell. Inline
         # interpolation expands client-side and a secret containing shell
@@ -58,6 +62,7 @@ jobs:
           INGRESS_WEBAPP_CERT_KEY: ${{ secrets.INGRESS_WEBAPP_CERT_KEY }}
 
       - name: Apply k8s manifests changes in DigitalOcean k8s cluster (if any)
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           envsubst < $GITHUB_WORKSPACE/.deploy/k8s/k8s-manifest.prod.yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
         env:
@@ -210,6 +215,7 @@ jobs:
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-api
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-web

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -24,20 +24,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Save DigitalOcean kubeconfig with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl kubernetes cluster kubeconfig save --expiry-seconds 600 k8s-gauzy
 
       - name: Write PostgreSQL Certificate file
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           echo "$DB_CA_CERT" | base64 --decode > ${HOME}/ca-certificate.crt
         env:
           DB_CA_CERT: '${{ secrets.DATABASE_CA_CERT }}'
 
       - name: Generate TLS Secrets
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           rm -f ${HOME}/ingress.api.crt ${HOME}/ingress.api.key ${HOME}/ingress.webapp.crt ${HOME}/ingress.webapp.key
           echo ${{ secrets.INGRESS_API_CERT }} | base64 --decode > ${HOME}/ingress.api.crt
@@ -48,6 +52,7 @@ jobs:
           kubectl create secret tls appstage.ever.works-tls --save-config --dry-run=client --cert=${HOME}/ingress.webapp.crt --key=${HOME}/ingress.webapp.key -o yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
 
       - name: Apply k8s manifests changes in DigitalOcean k8s cluster (if any)
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           envsubst < $GITHUB_WORKSPACE/.deploy/k8s/k8s-manifest.stage.yaml | kubectl --context do-sfo2-k8s-gauzy apply -f -
         env:
@@ -185,6 +190,7 @@ jobs:
       # we need this step because for now we just use :latest tag
       # note: for production we will use different strategy later
       - name: Restart Pods to pick up :latest tag version
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-api-stage
           kubectl --context do-sfo2-k8s-gauzy rollout restart deployment/ever-works-web-stage

--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -80,15 +80,18 @@ jobs:
       # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
 
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-works-api-dev:latest
 
@@ -183,14 +186,17 @@ jobs:
       # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-works-web-dev:latest
 

--- a/.github/workflows/docker-build-publish-mcp-dev.yml
+++ b/.github/workflows/docker-build-publish-mcp-dev.yml
@@ -66,16 +66,19 @@ jobs:
           docker push everco/ever-works-mcp-dev:latest
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         continue-on-error: true
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         continue-on-error: true
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         continue-on-error: true
         run: |
           docker push registry.digitalocean.com/ever/ever-works-mcp-dev:latest

--- a/.github/workflows/docker-build-publish-mcp-prod.yml
+++ b/.github/workflows/docker-build-publish-mcp-prod.yml
@@ -65,16 +65,19 @@ jobs:
           docker push everco/ever-works-mcp:latest
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         continue-on-error: true
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         continue-on-error: true
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         continue-on-error: true
         run: |
           docker push registry.digitalocean.com/ever/ever-works-mcp:latest

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -66,16 +66,19 @@ jobs:
           docker push everco/ever-works-mcp-stage:latest
 
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         continue-on-error: true
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         continue-on-error: true
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         continue-on-error: true
         run: |
           docker push registry.digitalocean.com/ever/ever-works-mcp-stage:latest

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -79,15 +79,18 @@ jobs:
       # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
 
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-works-api:latest
 
@@ -181,14 +184,17 @@ jobs:
       # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-works-web:latest
 

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -80,15 +80,18 @@ jobs:
       # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
 
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-works-api-stage:latest
 
@@ -183,14 +186,17 @@ jobs:
       # 2026-06-12 â€” expired DO token â†’ prod served the prior build). The
       # DockerHub/CW mirrors above stay best-effort by design.
       - name: Install doctl
+        if: ${{ vars.DO_ENABLED == 'true' }}
         uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
       - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: doctl registry login --expiry-seconds 3600
 
       - name: Push to DigitalOcean Registry
+        if: ${{ vars.DO_ENABLED == 'true' }}
         run: |
           docker push registry.digitalocean.com/ever/ever-works-web-stage:latest
 


### PR DESCRIPTION
## What

Gates every **DigitalOcean (DO)** CI action behind the org variable `vars.DO_ENABLED` so that all DO work is **skipped by default** (we no longer deploy to DO). No DO code is removed — each DO step just carries `if: ${{ vars.DO_ENABLED == 'true' }}` and can be re-enabled instantly by setting the org/repo variable `DO_ENABLED=true`.

This mirrors the standard already used in `ever-co/ever-gauzy`.

## How

Added `if: ${{ vars.DO_ENABLED == 'true' }}` as the **first key** of each DO-related step (before `uses:`/`run:`/`continue-on-error:`). **60 steps** gated across **12 workflows**, `+60 / -0` (additions only — nothing deleted).

### `deploy-do-*` (DO Kubernetes deploys)
Gated: `Install doctl`, `Save DigitalOcean kubeconfig`, `Write PostgreSQL Certificate file`, `Generate TLS Secrets`, `Apply k8s manifests … in DigitalOcean k8s cluster`, `Restart Pods` (every step runs against the `do-sfo2-k8s-gauzy` context). `Checkout` is left ungated, so a DO-disabled run is a clean no-op.

- `deploy-do-dev.yml` (+6), `deploy-do-prod.yml` (+6), `deploy-do-stage.yml` (+6)
- `deploy-do-mcp-dev.yml` (+5), `deploy-do-mcp-prod.yml` (+5), `deploy-do-mcp-stage.yml` (+5)

### `docker-build-publish-*` (image build + registry push)
Gated the three DO push-side steps per job: `Install doctl`, `Log in to DigitalOcean Container Registry`, `Push to DigitalOcean Registry`. GHCR / Docker Hub / CW steps are untouched.

- `docker-build-publish-dev.yml` (+6), `docker-build-publish-prod.yml` (+6), `docker-build-publish-stage.yml` (+6)
- `docker-build-publish-mcp-dev.yml` (+3), `docker-build-publish-mcp-prod.yml` (+3), `docker-build-publish-mcp-stage.yml` (+3)

**DO tags in `docker/build-push-action`:** every Build step uses `load: true` (not `push: true`), so buildx never pushes the `registry.digitalocean.com/...` tag — the DO push is done by a separate `docker push` step, which is what we gate. The DO tag is therefore left in place (it's a local-load no-op when DO is disabled), avoiding any empty-tag hack.

## Safety

- No DO code deleted — only `if:` gates added. Re-enable with `DO_ENABLED=true`.
- Verdaccio / GHCR / Docker Hub / CW steps untouched.

## Do NOT merge automatically
Opened for review.
