### PR TITLE
chore(ci): gate legacy Vercel docs deploy behind VERCEL_ENABLED

### DIFF
--- a/.github/workflows/deploy-vercel-docs-prod.yml
+++ b/.github/workflows/deploy-vercel-docs-prod.yml
@@ -25,6 +25,11 @@ concurrency:
 
 jobs:
   deploy:
+    # Vercel is decommissioned; docs.ever.works is served from ever-k8s
+    # (ghcr.io/ever-works/ever-works-docs via the docs-ever-works-prod ArgoCD app).
+    # Gate (don't delete) this legacy Vercel deploy: it stays bypassed unless the
+    # owner re-enables it by setting the VERCEL_ENABLED repo/org var to 'true'.
+    if: ${{ vars.VERCEL_ENABLED == 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:


### PR DESCRIPTION
**Vercel is decommissioned.** `docs.ever.works` is already served from ever-k8s (`ghcr.io/ever-works/ever-works-docs` via the `docs-ever-works-prod` ArgoCD app), so `deploy-vercel-docs-prod.yml` is redundant — yet it still fired on every push to `main`, grabbing an ARC runner and attempting a dead Vercel deploy.

Per the owner **no-removal rule**, this gates rather than deletes: the `deploy` job is bypassed unless `vars.VERCEL_ENABLED == 'true'`. Fully reversible by setting that var.

Matches the existing `DO_ENABLED` gating idiom used across the DO workflows.