### PR TITLE
ci: gate deploy-do-* jobs at job level behind DO_ENABLED

### DIFF
--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   deploy-dev:
+    # DO is retired (registry 403); we don't deploy to DigitalOcean now. Gate the
+    # whole job at job level (not just per-step) so it SKIPS without consuming an ARC
+    # runner. Kept (no-removal) — set the DO_ENABLED repo/org var to 'true' to re-enable.
+    if: ${{ vars.DO_ENABLED == 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:

--- a/.github/workflows/deploy-do-mcp-dev.yml
+++ b/.github/workflows/deploy-do-mcp-dev.yml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   deploy-mcp-dev:
+    # DO is retired (registry 403); we don't deploy to DigitalOcean now. Gate the
+    # whole job at job level (not just per-step) so it SKIPS without consuming an ARC
+    # runner. Kept (no-removal) — set the DO_ENABLED repo/org var to 'true' to re-enable.
+    if: ${{ vars.DO_ENABLED == 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:

--- a/.github/workflows/deploy-do-mcp-prod.yml
+++ b/.github/workflows/deploy-do-mcp-prod.yml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   deploy-mcp-prod:
+    # DO is retired (registry 403); we don't deploy to DigitalOcean now. Gate the
+    # whole job at job level (not just per-step) so it SKIPS without consuming an ARC
+    # runner. Kept (no-removal) — set the DO_ENABLED repo/org var to 'true' to re-enable.
+    if: ${{ vars.DO_ENABLED == 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:

--- a/.github/workflows/deploy-do-mcp-stage.yml
+++ b/.github/workflows/deploy-do-mcp-stage.yml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   deploy-mcp-stage:
+    # DO is retired (registry 403); we don't deploy to DigitalOcean now. Gate the
+    # whole job at job level (not just per-step) so it SKIPS without consuming an ARC
+    # runner. Kept (no-removal) — set the DO_ENABLED repo/org var to 'true' to re-enable.
+    if: ${{ vars.DO_ENABLED == 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   deploy-prod:
+    # DO is retired (registry 403); we don't deploy to DigitalOcean now. Gate the
+    # whole job at job level (not just per-step) so it SKIPS without consuming an ARC
+    # runner. Kept (no-removal) — set the DO_ENABLED repo/org var to 'true' to re-enable.
+    if: ${{ vars.DO_ENABLED == 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   deploy-stage:
+    # DO is retired (registry 403); we don't deploy to DigitalOcean now. Gate the
+    # whole job at job level (not just per-step) so it SKIPS without consuming an ARC
+    # runner. Kept (no-removal) — set the DO_ENABLED repo/org var to 'true' to re-enable.
+    if: ${{ vars.DO_ENABLED == 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment:


### PR DESCRIPTION
The 6 `deploy-do-*` jobs were DO_ENABLED-gated per-step, so each still grabbed an ARC runner on every `workflow_run` then no-op'd — pressure on the shared runner pool. Hoist the gate to **job level** so they skip without a runner. Kept for re-enable via `DO_ENABLED=true` (no-removal). `docker-build-publish-*` intentionally untouched (they also publish to GHCR/Docker Hub).