### PR TITLE
ci: build ever-works-docs (docs.ever.works) in k8s-build

### DIFF
--- a/.github/workflows/k8s-build.yml
+++ b/.github/workflows/k8s-build.yml
@@ -28,6 +28,13 @@ jobs:
             dockerfile: .deploy/docker/mcp/Dockerfile
             context: .
             pkg: apps/mcp/package.json
+          # docs.ever.works (Docusaurus). Was served from a stale ever-works-docs
+          # image that no active workflow rebuilt; build it here so it gets fresh
+          # :prod + sha-<sha> tags (docs-ever-works-prod ArgoCD app tracks :prod by digest).
+          - image: ever-works-docs
+            dockerfile: .deploy/docker/docs/Dockerfile
+            context: .
+            pkg: apps/docs/package.json
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
docs.ever.works served from a stale `ever-works-docs` image that no active workflow rebuilt. Add `apps/docs` (Docusaurus) to the k8s-build matrix using the existing `.deploy/docker/docs/Dockerfile` → fresh `:prod`+`sha-*`; the `docs-ever-works-prod` app already tracks `:prod` by digest. Rollback digest if needed: `sha256:642b16587b23…`.