### PR TITLE
docs: genericize Neon brand references (Neon retired → CNPG)

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
@@ -156,7 +156,7 @@ describe('DeployController', () => {
                 isCreator: true,
             });
             workRuntimeEnvService.getDatabaseUrl.mockResolvedValue(
-                'postgresql://neondb_owner:supersecret@ep-x-pooler.us-east-1.aws.neon.tech/neondb?sslmode=require',
+                'postgresql://dbowner:supersecret@ep-x-pooler.us-east-1.aws.example.com/appdb?sslmode=require',
             );
 
             const res: any = await controller.getRuntimeEnv(
@@ -166,7 +166,7 @@ describe('DeployController', () => {
 
             expect(ownershipService.ensureCanEdit).toHaveBeenCalledWith('work-1', 'user-1');
             expect(res.databaseUrl.configured).toBe(true);
-            expect(res.databaseUrl.masked).toContain('neondb_owner:***@');
+            expect(res.databaseUrl.masked).toContain('dbowner:***@');
             expect(res.databaseUrl.masked).not.toContain('supersecret');
             expect(res.managed).toEqual(expect.arrayContaining(['AUTH_SECRET', 'COOKIE_SECRET']));
         });
@@ -192,20 +192,20 @@ describe('DeployController', () => {
                 isCreator: true,
             });
             workRuntimeEnvService.getDatabaseUrl.mockResolvedValue(
-                'postgresql://u:p@host.neon.tech/db',
+                'postgresql://u:p@host.example.com/db',
             );
 
             const res: any = await controller.setRuntimeEnv(
                 { userId: 'user-1' } as never,
                 'work-1',
                 {
-                    databaseUrl: 'postgresql://u:p@host.neon.tech/db',
+                    databaseUrl: 'postgresql://u:p@host.example.com/db',
                 },
             );
 
             expect(workRuntimeEnvService.setDatabaseUrl).toHaveBeenCalledWith(
                 'work-1',
-                'postgresql://u:p@host.neon.tech/db',
+                'postgresql://u:p@host.example.com/db',
             );
             expect(res.status).toBe('success');
             expect(res.databaseUrl.configured).toBe(true);

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -1122,7 +1122,7 @@ export class DeployService {
     /**
      * Provision the per-Work application runtime env that a k8s-deployed
      * directory site needs to boot in production. Vercel supplied these from
-     * project env + the Neon integration; k8s has no such source, so without
+     * project env + the external Postgres integration; k8s has no such source, so without
      * this the deployed site 500s (`[auth] AUTH_SECRET must be set in
      * production`). Pushed as GitHub secrets; `deploy_k8s.yaml` materializes
      * them into a `${slug}-runtime-env` k8s Secret the Deployment mounts via
@@ -1130,7 +1130,7 @@ export class DeployService {
      *
      * `AUTH_SECRET`/`COOKIE_SECRET` are generated once and persisted (stable
      * across redeploys — rotating would drop every live session). `DATABASE_URL`
-     * is the per-Work Postgres (e.g. reused Neon) connection string when
+     * is the per-Work Postgres (e.g. reused external Postgres) connection string when
      * configured. `NEXT_PUBLIC_APP_URL`/`COOKIE_DOMAIN` are derived from the
      * ingress host inside the manifest, not here.
      */

--- a/apps/api/src/plugins-capabilities/deploy/dto/runtime-env.dto.ts
+++ b/apps/api/src/plugins-capabilities/deploy/dto/runtime-env.dto.ts
@@ -6,14 +6,14 @@ import { IsNotEmpty, IsString, Matches } from 'class-validator';
  *
  * Sets the per-Work `DATABASE_URL` — the one piece of deploy runtime env that
  * is NOT auto-generated (unlike `AUTH_SECRET` / `COOKIE_SECRET`, which the deploy
- * feature mints and rotates itself). On Vercel this was injected by the Neon
+ * feature mints and rotates itself). On Vercel this was injected by a managed-Postgres
  * Marketplace integration; on k8s the operator/owner supplies it here so it can
  * be seen and edited from the platform rather than set out-of-band.
  */
 export class SetRuntimeEnvDto {
     @ApiProperty({
         description: 'Postgres connection string used as the Work site DATABASE_URL',
-        example: 'postgresql://user:password@host.neon.tech/dbname?sslmode=require',
+        example: 'postgresql://user:password@your-db-host:5432/dbname?sslmode=require',
     })
     @IsString()
     @IsNotEmpty()

--- a/apps/web/src/components/works/detail/deploy/RuntimeEnvManagement.tsx
+++ b/apps/web/src/components/works/detail/deploy/RuntimeEnvManagement.tsx
@@ -17,7 +17,7 @@ interface RuntimeEnvManagementProps {
  * Per-Work runtime environment surface (Deploy tab).
  *
  * Shows + edits the one piece of deploy runtime env that is user-managed —
- * `DATABASE_URL` (e.g. the site's Postgres/Neon connection) — via the
+ * `DATABASE_URL` (e.g. the site's Postgres connection) — via the
  * `/deploy/works/:id/runtime-env` API. The value is shown **masked** (host/db
  * only, never the password) and applied on the next deploy. The auto-managed
  * secrets (AUTH_SECRET/COOKIE_SECRET) are listed read-only as "managed by

--- a/docs/devops/kubernetes.md
+++ b/docs/devops/kubernetes.md
@@ -372,7 +372,7 @@ When running multiple API replicas:
 
 ## Best Practices
 
-1. **Use managed databases** -- Run PostgreSQL as a managed service (RDS, Cloud SQL, Neon) rather than as a pod.
+1. **Use managed databases** -- Run PostgreSQL as a managed service (RDS, Cloud SQL, or in-cluster CloudNativePG / CNPG) rather than as a pod.
 
 2. **Separate secrets from config** -- Use Kubernetes Secrets for credentials, ConfigMaps for non-sensitive configuration.
 

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -430,11 +430,11 @@ export class Work {
     // AES-256-GCM-encrypted per-Work runtime env injected into a k8s-deployed
     // site's container (deploy_k8s renders a `${slug}-runtime-env` Secret that
     // deployment.yaml mounts via envFrom). Vercel supplied these from project
-    // env + the Neon integration; k8s has no such source, so the deploy
+    // env + the external Postgres integration; k8s has no such source, so the deploy
     // feature provisions them (EW: k8s runtime-env). `AUTH_SECRET`/
     // `COOKIE_SECRET` are generated once and persisted so they stay stable
     // across redeploys (rotating would invalidate live sessions); the database
-    // URL is the per-Work Postgres connection string (e.g. the reused Neon DB).
+    // URL is the per-Work Postgres connection string (e.g. the reused external Postgres DB).
     // All NULL until the first k8s deploy / explicit set.
     @Column({ type: 'text', nullable: true })
     deployAuthSecretEncrypted?: string | null;

--- a/packages/agent/src/services/work-runtime-env.service.ts
+++ b/packages/agent/src/services/work-runtime-env.service.ts
@@ -17,7 +17,7 @@ const SECRET_LENGTH_BYTES = 32;
  * them so `deploy_k8s.yaml` materializes a `${slug}-runtime-env` Secret the
  * Deployment mounts via `envFrom`.
  *
- * **Why this exists**: Vercel injected these from project env + the Neon
+ * **Why this exists**: Vercel injected these from project env + the external Postgres
  * Marketplace integration. The k8s deploy path had no equivalent, so a
  * freshly-built site 500'd at first render (`[auth] AUTH_SECRET must be set in
  * production`). This service is the platform-side source of truth.
@@ -25,7 +25,7 @@ const SECRET_LENGTH_BYTES = 32;
  * **Persistence + stability**: `AUTH_SECRET` / `COOKIE_SECRET` are generated
  * once and persisted (AES-256-GCM, `PLATFORM_ENCRYPTION_KEY`) so they stay
  * stable across redeploys — rotating either would silently invalidate every
- * live session/cookie. `DATABASE_URL` is set explicitly (e.g. the reused Neon
+ * live session/cookie. `DATABASE_URL` is set explicitly (e.g. the reused external Postgres
  * connection string) rather than generated. This mirrors `WebhookSecretService`
  * / `PlatformSyncSecretService` exactly, including the race-safe conditional
  * UPDATE (`set*IfNull`) so concurrent deploys converge on one value.


### PR DESCRIPTION
Inert cosmetic Neon mentions (historical comments, a Swagger example, a managed-DB doc list, test fixtures) — none were active Neon usage. Genericized: comments → "external Postgres"; k8s doc adds CloudNativePG (CNPG); Swagger example → generic host; test fixtures → example.com. i18n translations left for a later pass.