### PR TITLE
feat(deploy): rework k8s cluster-source model (rename + admin gate + k8s default)

### DIFF
--- a/apps/api/src/migrations/1781400000000-RenameK8sClusterSource.ts
+++ b/apps/api/src/migrations/1781400000000-RenameK8sClusterSource.ts
@@ -1,0 +1,90 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Rename the k8s plugin's `clusterSource` values, atomically, across every
+ * scope tier where they may be stored.
+ *
+ * The cluster-source model was renamed so the value names match the physical
+ * clusters:
+ *   - old `k8s-gauzy` (Ever Works INTERNAL cluster)  → `k8s-works`
+ *   - old `k8s-works` (Ever Works SHARED customer cluster) → `k8s-works-shared`
+ *
+ * This is a **value collision**: the string `k8s-works` meant "shared" before
+ * and means "internal" after. The rename therefore MUST be resolved once, in
+ * the data, before any post-rename code reads a stored value — otherwise a
+ * stored `k8s-works` is ambiguous. TypeORM runs pending migrations atomically
+ * on API boot (`migrationsRun`, `migrationsTransactionMode: 'all'`) before the
+ * app serves traffic, so this migration is that one-shot rewrite. After it
+ * runs, a stored `k8s-works` unambiguously means the internal cluster and the
+ * deploy layer only has to defensively normalise the (non-colliding) legacy
+ * `k8s-gauzy` alias.
+ *
+ * `clusterSource` is a non-secret field, so it lives in plaintext inside the
+ * `settings` column (TypeORM `simple-json` → Postgres `text`) of the three
+ * plugin-settings tables — `plugins` (global), `user_plugins`, `work_plugins`.
+ * A `global`-scoped field can be saved at any tier and the deploy path resolves
+ * the full cascade, so all three tables are rewritten. The encrypted
+ * `secretSettings`/`kubeconfig` column is never touched.
+ *
+ * ORDERING IS LOAD-BEARING: within each table we remap `k8s-works` →
+ * `k8s-works-shared` FIRST, then `k8s-gauzy` → `k8s-works`. Reversing the order
+ * would move the freshly-renamed `k8s-gauzy` rows a second time (into
+ * `k8s-works-shared`), corrupting the internal-cluster selections.
+ *
+ * Postgres-only: `settings` is `text`, so the value must be read/written via a
+ * `::jsonb` cast (dev/CI use SQLite + `synchronize`, where this never runs).
+ */
+export class RenameK8sClusterSource1781400000000 implements MigrationInterface {
+    name = 'RenameK8sClusterSource1781400000000';
+
+    /** Tables that carry a k8s `clusterSource` in their `settings` JSON text. */
+    private static readonly TABLES = ['plugins', 'user_plugins', 'work_plugins'] as const;
+
+    private async remap(
+        queryRunner: QueryRunner,
+        table: string,
+        fromValue: string,
+        toValue: string,
+    ): Promise<void> {
+        // `to_jsonb($1::text)` writes a proper JSON string; cast the whole
+        // object back to `::text` because the column is `text`, not `jsonb`.
+        // The predicate skips NULL/empty/`{}`/other-plugin rows and rows whose
+        // clusterSource doesn't match, so this is a no-op for everything else.
+        await queryRunner.query(
+            `UPDATE "${table}"
+             SET "settings" = jsonb_set("settings"::jsonb, '{clusterSource}', to_jsonb($1::text))::text
+             WHERE "pluginId" = 'k8s'
+               AND "settings" IS NOT NULL
+               AND "settings" <> ''
+               AND ("settings"::jsonb ->> 'clusterSource') = $2`,
+            [toValue, fromValue],
+        );
+    }
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (queryRunner.connection.options.type !== 'postgres') {
+            return;
+        }
+        for (const table of RenameK8sClusterSource1781400000000.TABLES) {
+            // Order matters — see the class doc. Shared first, then internal.
+            await this.remap(queryRunner, table, 'k8s-works', 'k8s-works-shared');
+            await this.remap(queryRunner, table, 'k8s-gauzy', 'k8s-works');
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (queryRunner.connection.options.type !== 'postgres') {
+            return;
+        }
+        // Best-effort inverse, in reverse order. `k8s-works` → `k8s-gauzy`
+        // FIRST (undoing the gauzy→works step), then `k8s-works-shared` →
+        // `k8s-works` (undoing the works→shared step). Any `k8s-works-shared`
+        // rows created directly after the rename (new customer selections)
+        // will be rolled back to the pre-rename `k8s-works` spelling — the
+        // reason a revert is only "best effort" for a value-collision rename.
+        for (const table of RenameK8sClusterSource1781400000000.TABLES) {
+            await this.remap(queryRunner, table, 'k8s-works', 'k8s-gauzy');
+            await this.remap(queryRunner, table, 'k8s-works-shared', 'k8s-works');
+        }
+    }
+}

--- a/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.spec.ts
@@ -1,12 +1,16 @@
 import {
     allowedClusterSourcesFor,
+    CLUSTER_SOURCE_DESCRIPTIONS,
+    CLUSTER_SOURCE_LABELS,
+    ClusterSource,
     isAdminOnlyOrg,
     isEverWorksSharedOrg,
+    normalizeClusterSource,
     resolveKubeconfigForClusterSource,
     validateClusterSourceForOwner,
 } from './cluster-source-matrix';
 
-describe('cluster-source-matrix — EW-616 deploy matrix', () => {
+describe('cluster-source-matrix — deploy matrix (renamed: k8s-works internal, k8s-works-shared shared)', () => {
     describe('isEverWorksSharedOrg', () => {
         it.each(['ever-works', 'EVER-WORKS', 'Ever-Works', '  ever-works  ', 'ever-works-cloud'])(
             'returns true for %s',
@@ -18,7 +22,7 @@ describe('cluster-source-matrix — EW-616 deploy matrix', () => {
     });
 
     describe('isAdminOnlyOrg', () => {
-        it('matches only the legacy ever-works org', () => {
+        it('matches only the ever-works org', () => {
             expect(isAdminOnlyOrg('ever-works')).toBe(true);
             expect(isAdminOnlyOrg('EVER-WORKS')).toBe(true);
             expect(isAdminOnlyOrg('ever-works-cloud')).toBe(false);
@@ -26,118 +30,209 @@ describe('cluster-source-matrix — EW-616 deploy matrix', () => {
         });
     });
 
-    describe('allowedClusterSourcesFor — drives the UI dropdown', () => {
-        it('ever-works org → [k8s-works, k8s-gauzy] (admin path)', () => {
-            expect(allowedClusterSourcesFor('ever-works')).toEqual(['k8s-works', 'k8s-gauzy']);
+    describe('normalizeClusterSource — canonicalises + remaps the legacy alias', () => {
+        it.each(['k8s-works', 'k8s-works-shared', 'custom-kubeconfig'] as const)(
+            'passes through the current value %s',
+            (value) => expect(normalizeClusterSource(value)).toBe(value),
+        );
+        it('remaps the legacy k8s-gauzy → k8s-works (internal cluster)', () => {
+            expect(normalizeClusterSource('k8s-gauzy')).toBe('k8s-works');
         });
-
-        it('ever-works-cloud org → [k8s-works] only', () => {
-            expect(allowedClusterSourcesFor('ever-works-cloud')).toEqual(['k8s-works']);
+        it('does NOT remap k8s-works (post-rename it is unambiguously the internal cluster)', () => {
+            // Guards the migration/coerce contract: a runtime `k8s-works` must
+            // stay `k8s-works`, never be re-interpreted as the old shared value.
+            expect(normalizeClusterSource('k8s-works')).toBe('k8s-works');
         });
-
-        it('customer-owned org → [custom-kubeconfig, k8s-works]', () => {
-            expect(allowedClusterSourcesFor('acme')).toEqual(['custom-kubeconfig', 'k8s-works']);
+        it('returns undefined for anything unrecognised', () => {
+            expect(normalizeClusterSource('nonsense')).toBeUndefined();
+            expect(normalizeClusterSource('')).toBeUndefined();
         });
     });
 
-    describe('validateClusterSourceForOwner — the 9 matrix cells', () => {
-        const ok = null;
+    describe('allowedClusterSourcesFor — drives the admin-aware UI dropdown', () => {
+        it('admin, no Work context → [k8s-works, k8s-works-shared, custom-kubeconfig]', () => {
+            expect(allowedClusterSourcesFor(true)).toEqual([
+                'k8s-works',
+                'k8s-works-shared',
+                'custom-kubeconfig',
+            ]);
+        });
+        it('non-admin, no Work context → [k8s-works-shared, custom-kubeconfig] (never k8s-works)', () => {
+            expect(allowedClusterSourcesFor(false)).toEqual([
+                'k8s-works-shared',
+                'custom-kubeconfig',
+            ]);
+        });
+        it('admin + ever-works org → [k8s-works, k8s-works-shared] (custom excluded — shared org)', () => {
+            expect(allowedClusterSourcesFor(true, 'ever-works')).toEqual([
+                'k8s-works',
+                'k8s-works-shared',
+            ]);
+        });
+        it('admin + ever-works-cloud → [k8s-works-shared] (k8s-works needs ever-works org; custom excluded)', () => {
+            expect(allowedClusterSourcesFor(true, 'ever-works-cloud')).toEqual([
+                'k8s-works-shared',
+            ]);
+        });
+        it('admin + customer org → [k8s-works-shared, custom-kubeconfig] (k8s-works needs ever-works org)', () => {
+            expect(allowedClusterSourcesFor(true, 'acme')).toEqual([
+                'k8s-works-shared',
+                'custom-kubeconfig',
+            ]);
+        });
+        it('non-admin + customer org → [k8s-works-shared, custom-kubeconfig]', () => {
+            expect(allowedClusterSourcesFor(false, 'acme')).toEqual([
+                'k8s-works-shared',
+                'custom-kubeconfig',
+            ]);
+        });
+        it('non-admin + ever-works org → [k8s-works-shared] only (never k8s-works, custom excluded)', () => {
+            expect(allowedClusterSourcesFor(false, 'ever-works')).toEqual(['k8s-works-shared']);
+        });
+    });
 
-        // Row 1: ever-works (admin path) — k8s-works ✓, k8s-gauzy ✓, custom ✗
-        it('ever-works + k8s-works ✓', () => {
-            expect(validateClusterSourceForOwner('ever-works', 'k8s-works')).toBe(ok);
+    describe('validateClusterSourceForOwner — admin-gated k8s-works + org rules', () => {
+        const ok = null;
+        const admin = { isPlatformAdmin: true };
+        const nonAdmin = { isPlatformAdmin: false };
+
+        // k8s-works (internal cluster) requires BOTH isPlatformAdmin AND ever-works org.
+        it('ever-works + k8s-works ✓ for an admin', () => {
+            expect(validateClusterSourceForOwner('ever-works', 'k8s-works', admin)).toBe(ok);
         });
-        it('ever-works + k8s-gauzy ✓ (admin path)', () => {
-            expect(validateClusterSourceForOwner('ever-works', 'k8s-gauzy')).toBe(ok);
+        it('ever-works + k8s-works ✗ for a non-admin (K8S_WORKS_NOT_ALLOWED — not admin)', () => {
+            const result = validateClusterSourceForOwner('ever-works', 'k8s-works', nonAdmin);
+            expect(result?.code).toBe('K8S_WORKS_NOT_ALLOWED');
+            expect(result?.message).toMatch(/restricted to platform admins/i);
         });
-        it('ever-works + custom-kubeconfig ✗ (cell C — cross-tenant PAT exposure)', () => {
-            const result = validateClusterSourceForOwner('ever-works', 'custom-kubeconfig');
+        it('ever-works-cloud + k8s-works ✗ even for an admin (K8S_WORKS_NOT_ALLOWED — wrong org)', () => {
+            const result = validateClusterSourceForOwner('ever-works-cloud', 'k8s-works', admin);
+            expect(result?.code).toBe('K8S_WORKS_NOT_ALLOWED');
+            expect(result?.message).toContain('ever-works');
+        });
+        it('customer-owned + k8s-works ✗ even for an admin (K8S_WORKS_NOT_ALLOWED — wrong org)', () => {
+            const result = validateClusterSourceForOwner('acme', 'k8s-works', admin);
+            expect(result?.code).toBe('K8S_WORKS_NOT_ALLOWED');
+            expect(result?.message).toContain('acme');
+        });
+        it('fails closed when options are omitted (defaults isPlatformAdmin=false)', () => {
+            expect(validateClusterSourceForOwner('ever-works', 'k8s-works')?.code).toBe(
+                'K8S_WORKS_NOT_ALLOWED',
+            );
+        });
+
+        // k8s-works-shared (shared customer cluster) — always allowed, any owner/admin.
+        it.each(['ever-works', 'ever-works-cloud', 'acme'])(
+            '%s + k8s-works-shared ✓ (the default, no gate)',
+            (owner) => {
+                expect(validateClusterSourceForOwner(owner, 'k8s-works-shared', admin)).toBe(ok);
+                expect(validateClusterSourceForOwner(owner, 'k8s-works-shared', nonAdmin)).toBe(ok);
+            },
+        );
+
+        // custom-kubeconfig vs shared org (cross-tenant PAT) — unchanged from EW-616.
+        it('ever-works + custom-kubeconfig ✗ (cross-tenant PAT exposure)', () => {
+            const result = validateClusterSourceForOwner('ever-works', 'custom-kubeconfig', admin);
             expect(result?.code).toBe('CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG');
             expect(result?.message).toContain('ever-works');
         });
-
-        // Row 2: ever-works-cloud (shared customer org) — only k8s-works
-        it('ever-works-cloud + k8s-works ✓ (the default for new customers)', () => {
-            expect(validateClusterSourceForOwner('ever-works-cloud', 'k8s-works')).toBe(ok);
-        });
-        it('ever-works-cloud + k8s-gauzy ✗ (admin-only cluster)', () => {
-            const result = validateClusterSourceForOwner('ever-works-cloud', 'k8s-gauzy');
-            expect(result?.code).toBe('K8S_GAUZY_NOT_ALLOWED');
-        });
-        it('ever-works-cloud + custom-kubeconfig ✗ (cell C)', () => {
-            const result = validateClusterSourceForOwner('ever-works-cloud', 'custom-kubeconfig');
+        it('ever-works-cloud + custom-kubeconfig ✗ (cross-tenant PAT exposure)', () => {
+            const result = validateClusterSourceForOwner(
+                'ever-works-cloud',
+                'custom-kubeconfig',
+                nonAdmin,
+            );
             expect(result?.code).toBe('CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG');
         });
-
-        // Row 3: customer-owned org — k8s-works ✓, k8s-gauzy ✗, custom ✓
-        it('customer-owned + k8s-works ✓ (customer image on platform cluster)', () => {
-            expect(validateClusterSourceForOwner('acme', 'k8s-works')).toBe(ok);
+        it('customer-owned + custom-kubeconfig ✓ (BYOC default)', () => {
+            expect(validateClusterSourceForOwner('acme', 'custom-kubeconfig', nonAdmin)).toBe(ok);
         });
-        it('customer-owned + k8s-gauzy ✗ (admin-only cluster)', () => {
-            const result = validateClusterSourceForOwner('acme', 'k8s-gauzy');
-            expect(result?.code).toBe('K8S_GAUZY_NOT_ALLOWED');
-            expect(result?.message).toContain('acme');
-        });
-        it('customer-owned + custom-kubeconfig ✓ (the BYOC default)', () => {
-            expect(validateClusterSourceForOwner('acme', 'custom-kubeconfig')).toBe(ok);
-        });
-
-        it('custom-kubeconfig + missing kubeconfig ✗ (operator error)', () => {
+        it('custom-kubeconfig + missing kubeconfig ✗ (CUSTOM_KUBECONFIG_MISSING_KUBECONFIG)', () => {
             const result = validateClusterSourceForOwner('acme', 'custom-kubeconfig', {
                 hasKubeconfig: false,
             });
             expect(result?.code).toBe('CUSTOM_KUBECONFIG_MISSING_KUBECONFIG');
         });
-
-        it('case insensitive: EVER-WORKS-CLOUD + custom-kubeconfig is rejected like ever-works-cloud', () => {
+        it('case insensitive: EVER-WORKS-CLOUD + custom-kubeconfig rejected like ever-works-cloud', () => {
             const result = validateClusterSourceForOwner('EVER-WORKS-CLOUD', 'custom-kubeconfig');
             expect(result?.code).toBe('CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG');
+        });
+
+        // Legacy alias defense-in-depth: an un-migrated k8s-gauzy normalises to
+        // k8s-works and is gated the same way.
+        it('legacy k8s-gauzy is gated as k8s-works (non-admin → K8S_WORKS_NOT_ALLOWED)', () => {
+            const result = validateClusterSourceForOwner(
+                'ever-works',
+                'k8s-gauzy' as ClusterSource,
+                nonAdmin,
+            );
+            expect(result?.code).toBe('K8S_WORKS_NOT_ALLOWED');
+        });
+        it('legacy k8s-gauzy + admin + ever-works ✓ (same as k8s-works)', () => {
+            expect(
+                validateClusterSourceForOwner('ever-works', 'k8s-gauzy' as ClusterSource, admin),
+            ).toBe(ok);
         });
     });
 
     describe('resolveKubeconfigForClusterSource — env-var substitution', () => {
-        it('k8s-works → reads EVER_WORKS_K8S_WORKS_KUBECONFIG', () => {
-            const env = { EVER_WORKS_K8S_WORKS_KUBECONFIG: 'apiVersion: v1\nkind: Config\n' };
-            expect(resolveKubeconfigForClusterSource('k8s-works', 'user-kubeconfig', env)).toBe(
-                'apiVersion: v1\nkind: Config\n',
+        it('k8s-works → reads EVER_WORKS_K8S_WORKS_KUBECONFIG (internal cluster)', () => {
+            const env = { EVER_WORKS_K8S_WORKS_KUBECONFIG: 'internal-yaml' };
+            expect(resolveKubeconfigForClusterSource('k8s-works', 'user-yaml', env)).toBe(
+                'internal-yaml',
             );
         });
-
-        it('k8s-works → throws when env var is missing', () => {
+        it('k8s-works → throws when its env var is missing', () => {
             expect(() => resolveKubeconfigForClusterSource('k8s-works', '', {})).toThrow(
                 /EVER_WORKS_K8S_WORKS_KUBECONFIG is not configured/,
             );
         });
-
-        it('k8s-works → throws when env var is empty/whitespace', () => {
+        it('k8s-works → throws when its env var is whitespace', () => {
             expect(() =>
                 resolveKubeconfigForClusterSource('k8s-works', '', {
                     EVER_WORKS_K8S_WORKS_KUBECONFIG: '   ',
                 }),
             ).toThrow();
         });
-
-        it('k8s-gauzy → reads EVER_WORKS_K8S_GAUZY_KUBECONFIG', () => {
-            const env = { EVER_WORKS_K8S_GAUZY_KUBECONFIG: 'gauzy-kubeconfig' };
-            expect(resolveKubeconfigForClusterSource('k8s-gauzy', 'user-kubeconfig', env)).toBe(
-                'gauzy-kubeconfig',
+        it('k8s-works-shared → reads EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG', () => {
+            const env = { EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG: 'shared-yaml' };
+            expect(resolveKubeconfigForClusterSource('k8s-works-shared', 'user-yaml', env)).toBe(
+                'shared-yaml',
             );
         });
-
-        it('k8s-gauzy → throws when env var is missing', () => {
-            expect(() => resolveKubeconfigForClusterSource('k8s-gauzy', '', {})).toThrow(
-                /EVER_WORKS_K8S_GAUZY_KUBECONFIG is not configured/,
+        it('k8s-works-shared → throws a clear "not available yet" error when unprovisioned', () => {
+            expect(() => resolveKubeconfigForClusterSource('k8s-works-shared', '', {})).toThrow(
+                /not available yet/i,
             );
         });
-
+        it('legacy k8s-gauzy → normalises to k8s-works env var', () => {
+            const env = { EVER_WORKS_K8S_WORKS_KUBECONFIG: 'internal-yaml' };
+            expect(
+                resolveKubeconfigForClusterSource('k8s-gauzy' as ClusterSource, 'user-yaml', env),
+            ).toBe('internal-yaml');
+        });
         it('custom-kubeconfig → passes through the user kubeconfig (env vars ignored)', () => {
             const env = {
-                EVER_WORKS_K8S_WORKS_KUBECONFIG: 'platform-yaml',
-                EVER_WORKS_K8S_GAUZY_KUBECONFIG: 'gauzy-yaml',
+                EVER_WORKS_K8S_WORKS_KUBECONFIG: 'internal-yaml',
+                EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG: 'shared-yaml',
             };
             expect(resolveKubeconfigForClusterSource('custom-kubeconfig', 'user-yaml', env)).toBe(
                 'user-yaml',
             );
+        });
+    });
+
+    describe('option metadata completeness', () => {
+        it('every ClusterSource has a label and a description', () => {
+            const sources: ClusterSource[] = ['k8s-works', 'k8s-works-shared', 'custom-kubeconfig'];
+            for (const source of sources) {
+                expect(CLUSTER_SOURCE_LABELS[source]).toBeTruthy();
+                expect(CLUSTER_SOURCE_DESCRIPTIONS[source]).toBeTruthy();
+            }
+        });
+        it("only the admin-only k8s-works description mentions the 'ever-works' org requirement", () => {
+            expect(CLUSTER_SOURCE_DESCRIPTIONS['k8s-works']).toMatch(/ever-works/i);
+            expect(CLUSTER_SOURCE_DESCRIPTIONS['k8s-works-shared']).not.toMatch(/admin/i);
         });
     });
 });

--- a/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.ts
+++ b/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.ts
@@ -1,41 +1,69 @@
 /**
- * EW-616 deploy matrix enforcement.
+ * Deploy-target resolution matrix for the per-Work Kubernetes deploy path.
  *
- * Two independent dimensions:
+ * Three inputs decide where a Work may be published:
  *
- *  - **Website repo owner** (and therefore the GHCR namespace the
- *    image lives in): `ever-works`, `ever-works-cloud`, or
- *    customer-owned.
- *  - **Cluster source**: `k8s-works`, `k8s-gauzy`, `custom-kubeconfig`.
+ *  - **isPlatformAdmin** — whether the deploying user is a platform admin
+ *    (`User.isPlatformAdmin`).
+ *  - **Website repo owner** (and therefore the GHCR namespace the image
+ *    lives in): `ever-works`, `ever-works-cloud`, or customer-owned.
+ *  - **Cluster source**: `k8s-works`, `k8s-works-shared`, `custom-kubeconfig`.
  *
- * Two rules combine to produce the supported set:
+ * Renamed from EW-616 (old `k8s-gauzy` → `k8s-works` internal, old
+ * `k8s-works` → `k8s-works-shared` shared). See `normalizeClusterSource`
+ * for the back-compat alias and the one-shot data migration
+ * `*-RenameK8sClusterSource.ts` for the stored-value rewrite.
  *
- *  1. `k8s-gauzy` is admin-only — restricted to Works whose website
- *     repo is in the `ever-works` GitHub org. This is the internal
- *     platform cluster; real customers must not be allowed to deploy
- *     onto it.
+ * Rules that combine to produce the supported set:
  *
- *  2. `custom-kubeconfig` cannot be combined with an Ever Works-shared
- *     GHCR namespace (`ever-works` or `ever-works-cloud`). The cluster
- *     would receive an org-scoped classic PAT as an `imagePullSecret`,
- *     and `kubectl get secret -o yaml` on the customer's cluster could
- *     recover it and use it to read every GHCR image in that shared
- *     org. To use your own cluster, you must also bring your own GitHub
- *     org so the credential only grants access to your own resources.
+ *  1. `k8s-works` (the Ever Works INTERNAL cluster) is admin-only. It
+ *     requires BOTH `isPlatformAdmin` AND a website repo in the `ever-works`
+ *     GitHub org. Real customers must never be able to deploy onto it, and a
+ *     non-admin must never be able to select it (even via the API/CLI).
  *
- * The resulting 5 supported combinations:
+ *  2. `custom-kubeconfig` cannot be combined with an Ever Works-shared GHCR
+ *     namespace (`ever-works` or `ever-works-cloud`). The cluster would
+ *     receive an org-scoped classic PAT as an `imagePullSecret`, and
+ *     `kubectl get secret -o yaml` on the customer's cluster could recover it
+ *     and read every GHCR image in that shared org. To use your own cluster
+ *     you must also bring your own GitHub org.
  *
- * | Website owner            | k8s-works | k8s-gauzy        | custom-kubeconfig |
- * | ------------------------ | --------- | ---------------- | ----------------- |
- * | `ever-works`             | OK        | OK (admin path)  | rejected (rule 2) |
- * | `ever-works-cloud`       | OK        | rejected (rule 1)| rejected (rule 2) |
- * | customer-owned           | OK        | rejected (rule 1)| OK                |
+ *  3. `k8s-works-shared` (the Ever Works SHARED customer cluster) is the
+ *     default and is allowed for every owner. Its cluster may not be
+ *     provisioned yet — `resolveKubeconfigForClusterSource` fails with a
+ *     clear "not yet available" error rather than crashing.
+ *
+ * The resulting supported combinations (admin gate applies only to `k8s-works`):
+ *
+ * | Website owner      | k8s-works                | k8s-works-shared | custom-kubeconfig |
+ * | ------------------ | ------------------------ | ---------------- | ----------------- |
+ * | `ever-works`       | OK (admin only)          | OK               | rejected (rule 2) |
+ * | `ever-works-cloud` | rejected (rule 1)        | OK (default)     | rejected (rule 2) |
+ * | customer-owned     | rejected (rule 1)        | OK (default)     | OK                |
  *
  * The full background is in the EW-615/EW-616 tickets and the
  * `EVER_WORKS_K8S_DEPLOY_TROUBLESHOOTING.md` runbook.
  */
 
-export type ClusterSource = 'k8s-works' | 'k8s-gauzy' | 'custom-kubeconfig';
+export type ClusterSource = 'k8s-works' | 'k8s-works-shared' | 'custom-kubeconfig';
+
+/**
+ * Pre-rename value that may still appear in un-migrated rows or in-flight
+ * requests during a rolling deploy. `k8s-gauzy` was the internal cluster and
+ * maps to the renamed `k8s-works`.
+ *
+ * NOTE: the OTHER pre-rename value, the string `k8s-works`, is deliberately
+ * NOT remapped here — after the rename it unambiguously means the internal
+ * cluster. Genuine old-shared `k8s-works` rows are rewritten to
+ * `k8s-works-shared` once, atomically, by the data migration; treating a
+ * runtime `k8s-works` as "old shared" would silently break every admin
+ * selection.
+ */
+export type LegacyClusterSource = 'k8s-gauzy';
+
+const LEGACY_CLUSTER_SOURCE_ALIASES: Readonly<Record<LegacyClusterSource, ClusterSource>> = {
+    'k8s-gauzy': 'k8s-works',
+};
 
 const EVER_WORKS_SHARED_ORGS = new Set(['ever-works', 'ever-works-cloud']);
 
@@ -48,54 +76,115 @@ export function isAdminOnlyOrg(websiteOwner: string): boolean {
 }
 
 /**
- * Allowed cluster sources for a given website-repo owner, in the order
- * they should appear in the UI dropdown. The first entry is the
- * recommended default. The UI's `x-widget: k8s-cluster-source` reads
- * this to drive the conditional dropdown.
+ * Normalise a stored/incoming cluster-source string to a canonical
+ * `ClusterSource`, remapping the unambiguous legacy `k8s-gauzy` alias.
+ * Returns `undefined` for anything unrecognised so callers can fall back to
+ * their own default (`custom-kubeconfig` for the deploy path).
  */
-export function allowedClusterSourcesFor(websiteOwner: string): readonly ClusterSource[] {
-    if (isAdminOnlyOrg(websiteOwner)) {
-        return ['k8s-works', 'k8s-gauzy'];
+export function normalizeClusterSource(value: string): ClusterSource | undefined {
+    if (value === 'k8s-works' || value === 'k8s-works-shared' || value === 'custom-kubeconfig') {
+        return value;
     }
-    if (isEverWorksSharedOrg(websiteOwner)) {
-        return ['k8s-works'];
+    if (value === 'k8s-gauzy') {
+        return LEGACY_CLUSTER_SOURCE_ALIASES['k8s-gauzy'];
     }
-    return ['custom-kubeconfig', 'k8s-works'];
+    return undefined;
 }
+
+/**
+ * Allowed cluster sources for the caller, in the order they should appear in
+ * the UI dropdown (first entry = recommended default). Drives the
+ * `k8s-cluster-source` widget via `GET /api/deploy/cluster-sources`.
+ *
+ * `websiteOwner` is optional: the user-global plugin-settings page has no Work
+ * context, so it filters on `isPlatformAdmin` alone. When a Work owner IS
+ * known (a Work-scoped call), the same org rules the deploy gate enforces are
+ * applied so the dropdown never offers a combination the deploy would reject.
+ */
+export function allowedClusterSourcesFor(
+    isPlatformAdmin: boolean,
+    websiteOwner?: string,
+): readonly ClusterSource[] {
+    const out: ClusterSource[] = [];
+    // Internal cluster: platform admins only. When a specific Work owner is
+    // known, additionally require the `ever-works` org (mirrors rule 1).
+    if (isPlatformAdmin && (websiteOwner === undefined || isAdminOnlyOrg(websiteOwner))) {
+        out.push('k8s-works');
+    }
+    // Shared customer cluster: the default, always offered.
+    out.push('k8s-works-shared');
+    // Custom kubeconfig: hidden for Ever Works-shared orgs (rule 2). Offered
+    // when the owner is unknown (user-global settings page) or customer-owned.
+    if (websiteOwner === undefined || !isEverWorksSharedOrg(websiteOwner)) {
+        out.push('custom-kubeconfig');
+    }
+    return out;
+}
+
+/**
+ * Human labels for the cluster-source dropdown. The raw enum values are opaque
+ * (`k8s-works-shared`, …); the `k8s-cluster-source` widget renders these
+ * instead. Kept next to the enum so a new value can't be added without a label.
+ */
+export const CLUSTER_SOURCE_LABELS: Readonly<Record<ClusterSource, string>> = {
+    'k8s-works-shared': 'Ever Works shared customer cluster',
+    'k8s-works': 'Ever Works internal cluster (admin only)',
+    'custom-kubeconfig': 'Custom — paste your own kubeconfig',
+};
+
+/**
+ * Per-option help text. Mirrors the owner-provided settings-page copy; the
+ * `k8s-works` line is only ever sent to platform admins (a non-admin's allowed
+ * list never includes `k8s-works`, so its description never reaches them).
+ */
+export const CLUSTER_SOURCE_DESCRIPTIONS: Readonly<Record<ClusterSource, string>> = {
+    'k8s-works-shared': 'Ever Works shared customer cluster.',
+    'k8s-works':
+        "Ever Works internal cluster (admin-only, requires the website repo to live in the 'ever-works' GitHub org).",
+    'custom-kubeconfig': 'Paste your own kubeconfig below.',
+};
 
 export interface ClusterSourceValidationFailure {
     readonly code:
-        | 'K8S_GAUZY_NOT_ALLOWED'
+        | 'K8S_WORKS_NOT_ALLOWED'
         | 'CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG'
         | 'CUSTOM_KUBECONFIG_MISSING_KUBECONFIG';
     readonly message: string;
 }
 
 /**
- * Validate a (websiteOwner, clusterSource) pair against the deploy
- * matrix. Returns a failure record when the pair is rejected,
- * `null` otherwise. The caller decides how to surface the failure
- * (HTTP exception in the controller, logger.error in batch flows, etc).
+ * Validate a (websiteOwner, clusterSource) pair against the deploy matrix.
+ * Returns a failure record when the pair is rejected, `null` otherwise. The
+ * caller decides how to surface the failure (HTTP exception in the controller,
+ * logger.error in batch flows, etc).
  *
- * Pure / side-effect-free so it can be unit-tested without DI.
+ * Fails closed: `isPlatformAdmin` defaults to `false` and `hasKubeconfig`
+ * defaults to `true` when the options are omitted. Pure / side-effect-free so
+ * it can be unit-tested without DI.
  */
 export function validateClusterSourceForOwner(
     websiteOwner: string,
     clusterSource: ClusterSource,
-    options: { hasKubeconfig: boolean } = { hasKubeconfig: true },
+    options: { hasKubeconfig?: boolean; isPlatformAdmin?: boolean } = {},
 ): ClusterSourceValidationFailure | null {
-    if (clusterSource === 'k8s-gauzy' && !isAdminOnlyOrg(websiteOwner)) {
-        return {
-            code: 'K8S_GAUZY_NOT_ALLOWED',
-            message:
-                `'k8s-gauzy' is the Ever Works internal platform cluster ` +
-                `and is restricted to Works in the 'ever-works' GitHub org. ` +
-                `The website repo for this Work is in '${websiteOwner}'. ` +
-                `Pick 'k8s-works' instead, or move the Work to the 'ever-works' org.`,
-        };
+    const source = normalizeClusterSource(clusterSource) ?? clusterSource;
+    const isPlatformAdmin = options.isPlatformAdmin ?? false;
+    const hasKubeconfig = options.hasKubeconfig ?? true;
+
+    // Rule 1: `k8s-works` (internal cluster). BOTH gates required — platform
+    // admin AND `ever-works` org. Fails closed.
+    if (source === 'k8s-works' && (!isPlatformAdmin || !isAdminOnlyOrg(websiteOwner))) {
+        const message = !isPlatformAdmin
+            ? `'k8s-works' is the Ever Works internal cluster and is restricted to platform admins. ` +
+              `Pick 'k8s-works-shared' (the shared customer cluster) instead.`
+            : `'k8s-works' is the Ever Works internal cluster and requires the website repo to live in ` +
+              `the 'ever-works' GitHub org. The website repo for this Work is in '${websiteOwner}'. ` +
+              `Pick 'k8s-works-shared' instead, or move the Work to the 'ever-works' org.`;
+        return { code: 'K8S_WORKS_NOT_ALLOWED', message };
     }
 
-    if (clusterSource === 'custom-kubeconfig' && isEverWorksSharedOrg(websiteOwner)) {
+    // Rule 2: `custom-kubeconfig` vs Ever Works-shared org (cross-tenant PAT).
+    if (source === 'custom-kubeconfig' && isEverWorksSharedOrg(websiteOwner)) {
         return {
             code: 'CUSTOM_KUBECONFIG_NOT_ALLOWED_FOR_SHARED_ORG',
             message:
@@ -103,11 +192,11 @@ export function validateClusterSourceForOwner(
                 `The cluster's imagePullSecret would contain an org-scoped PAT that grants read access ` +
                 `to every GHCR image in '${websiteOwner}' (cross-tenant exposure). ` +
                 `To use your own cluster, move this Work to your own GitHub org first, ` +
-                `or pick 'k8s-works' as the target cluster.`,
+                `or pick 'k8s-works-shared' as the target cluster.`,
         };
     }
 
-    if (clusterSource === 'custom-kubeconfig' && !options.hasKubeconfig) {
+    if (source === 'custom-kubeconfig' && !hasKubeconfig) {
         return {
             code: 'CUSTOM_KUBECONFIG_MISSING_KUBECONFIG',
             message:
@@ -120,22 +209,27 @@ export function validateClusterSourceForOwner(
 }
 
 /**
- * Resolve the kubeconfig YAML to push as the workflow's `K8S_TOKEN`
- * secret. For platform-managed cluster sources, this reads the right
- * env var; for `custom-kubeconfig`, it returns the user-pasted token.
+ * Resolve the kubeconfig YAML to push as the workflow's `K8S_TOKEN` secret.
+ * For platform-managed cluster sources this reads the right env var; for
+ * `custom-kubeconfig` it returns the user-pasted token. Legacy `k8s-gauzy` is
+ * normalised to `k8s-works` first.
  *
- * Throws when a platform-managed source is requested but the platform
- * has not provisioned the corresponding env var (operator bug).
+ *  - `k8s-works`         → `EVER_WORKS_K8S_WORKS_KUBECONFIG` (internal cluster)
+ *  - `k8s-works-shared`  → `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` (shared
+ *                          customer cluster — may not be provisioned yet)
  *
- * The env-var lookup is injected so unit tests can avoid touching
- * `process.env` directly.
+ * Throws when a platform-managed source is requested but the platform has not
+ * provisioned the corresponding env var. The env-var lookup is injected so
+ * unit tests can avoid touching `process.env` directly.
  */
 export function resolveKubeconfigForClusterSource(
     clusterSource: ClusterSource,
     userKubeconfig: string,
     env: NodeJS.ProcessEnv = process.env,
 ): string {
-    if (clusterSource === 'k8s-works') {
+    const source = normalizeClusterSource(clusterSource) ?? clusterSource;
+
+    if (source === 'k8s-works') {
         const value = env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
         if (!value || !value.trim()) {
             throw new Error(
@@ -144,11 +238,15 @@ export function resolveKubeconfigForClusterSource(
         }
         return value;
     }
-    if (clusterSource === 'k8s-gauzy') {
-        const value = env.EVER_WORKS_K8S_GAUZY_KUBECONFIG;
+    if (source === 'k8s-works-shared') {
+        const value = env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
         if (!value || !value.trim()) {
+            // The shared customer cluster may not be provisioned yet. Surface a
+            // clear, user-actionable message instead of a raw env-var error.
             throw new Error(
-                "Cluster source is 'k8s-gauzy' but EVER_WORKS_K8S_GAUZY_KUBECONFIG is not configured on the platform.",
+                "The Ever Works shared customer cluster ('k8s-works-shared') is not available yet: " +
+                    'EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG is not configured on the platform. ' +
+                    'Choose another target cluster, or try again once the shared cluster is provisioned.',
             );
         }
         return value;

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
@@ -81,6 +81,7 @@ describe('DeployController', () => {
     let activityLogService: { log: jest.Mock };
     let workRuntimeEnvService: { getDatabaseUrl: jest.Mock; setDatabaseUrl: jest.Mock };
     let managedSubdomainService: { getState: jest.Mock; update: jest.Mock };
+    let userRepository: { findById: jest.Mock };
     let controller: DeployController;
 
     const buildWork = (overrides: Record<string, unknown> = {}) => ({
@@ -137,6 +138,10 @@ describe('DeployController', () => {
             update: jest.fn(),
         };
 
+        userRepository = {
+            findById: jest.fn().mockResolvedValue({ id: 'caller-1', isPlatformAdmin: false }),
+        };
+
         controller = new DeployController(
             deployService as unknown as DeployService,
             deployFacade as unknown as DeployFacadeService,
@@ -146,7 +151,45 @@ describe('DeployController', () => {
             activityLogService as unknown as ActivityLogService,
             workRuntimeEnvService as never,
             managedSubdomainService as never,
+            userRepository as never,
         );
+    });
+
+    describe('getClusterSources (admin-aware k8s clusterSource list)', () => {
+        it('omits the admin-only k8s-works option for a non-admin caller', async () => {
+            userRepository.findById.mockResolvedValue({ id: 'caller-1', isPlatformAdmin: false });
+
+            const res: any = await controller.getClusterSources(auth);
+
+            expect(res.status).toBe('success');
+            expect(res.isPlatformAdmin).toBe(false);
+            const values = res.clusterSources.map((c: any) => c.value);
+            expect(values).toEqual(['k8s-works-shared', 'custom-kubeconfig']);
+            expect(values).not.toContain('k8s-works');
+            // Every returned option carries a human label.
+            for (const option of res.clusterSources) {
+                expect(option.label).toBeTruthy();
+            }
+        });
+
+        it('includes k8s-works for a platform-admin caller', async () => {
+            userRepository.findById.mockResolvedValue({ id: 'caller-1', isPlatformAdmin: true });
+
+            const res: any = await controller.getClusterSources(auth);
+
+            expect(res.isPlatformAdmin).toBe(true);
+            const values = res.clusterSources.map((c: any) => c.value);
+            expect(values).toEqual(['k8s-works', 'k8s-works-shared', 'custom-kubeconfig']);
+        });
+
+        it('fails closed to non-admin when the user row cannot be loaded', async () => {
+            userRepository.findById.mockResolvedValue(null);
+
+            const res: any = await controller.getClusterSources(auth);
+
+            expect(res.isPlatformAdmin).toBe(false);
+            expect(res.clusterSources.map((c: any) => c.value)).not.toContain('k8s-works');
+        });
     });
 
     describe('runtime-env (per-Work DATABASE_URL)', () => {

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
@@ -162,7 +162,8 @@ describe('DeployController', () => {
             const res: any = await controller.getClusterSources(auth);
 
             expect(res.status).toBe('success');
-            expect(res.isPlatformAdmin).toBe(false);
+            // The admin flag itself must NOT be returned to the client.
+            expect(res).not.toHaveProperty('isPlatformAdmin');
             const values = res.clusterSources.map((c: any) => c.value);
             expect(values).toEqual(['k8s-works-shared', 'custom-kubeconfig']);
             expect(values).not.toContain('k8s-works');
@@ -177,7 +178,7 @@ describe('DeployController', () => {
 
             const res: any = await controller.getClusterSources(auth);
 
-            expect(res.isPlatformAdmin).toBe(true);
+            expect(res).not.toHaveProperty('isPlatformAdmin');
             const values = res.clusterSources.map((c: any) => c.value);
             expect(values).toEqual(['k8s-works', 'k8s-works-shared', 'custom-kubeconfig']);
         });
@@ -187,7 +188,6 @@ describe('DeployController', () => {
 
             const res: any = await controller.getClusterSources(auth);
 
-            expect(res.isPlatformAdmin).toBe(false);
             expect(res.clusterSources.map((c: any) => c.value)).not.toContain('k8s-works');
         });
     });

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -184,10 +184,14 @@ export class DeployController {
         const isPlatformAdmin = Boolean(user?.isPlatformAdmin);
         // No Work context on the user-global plugin-settings page, so filter on
         // admin status alone. The per-Work org rules stay enforced at deploy time.
+        //
+        // Note: `isPlatformAdmin` is used only to compute the list and is
+        // deliberately NOT returned — the flag is stripped from the client
+        // elsewhere for the same reason, and the presence/absence of `k8s-works`
+        // in the list is all the widget needs.
         const values = allowedClusterSourcesFor(isPlatformAdmin);
         return {
             status: 'success',
-            isPlatformAdmin,
             clusterSources: values.map((value) => ({
                 value,
                 label: CLUSTER_SOURCE_LABELS[value],

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -15,8 +15,13 @@ import { AuthSessionGuard, CurrentUser } from '../../auth';
 import { AuthenticatedUser } from '../../auth/types/auth.types';
 import { DeployFacadeService } from '@ever-works/agent/facades';
 import { WorkOwnershipService, WorkRuntimeEnvService } from '@ever-works/agent/services';
-import { WorkDeploymentRepository } from '@ever-works/agent/database';
+import { UserRepository, WorkDeploymentRepository } from '@ever-works/agent/database';
 import { DeployService } from './deploy.service';
+import {
+    allowedClusterSourcesFor,
+    CLUSTER_SOURCE_DESCRIPTIONS,
+    CLUSTER_SOURCE_LABELS,
+} from './cluster-source-matrix';
 import { DeploymentVerifierService } from './tasks/deployment-verifier.service';
 import { ActivityLogService } from '@ever-works/agent/activity-log';
 import {
@@ -77,6 +82,7 @@ export class DeployController {
         private readonly activityLogService: ActivityLogService,
         private readonly workRuntimeEnvService: WorkRuntimeEnvService,
         private readonly managedSubdomainService: ManagedSubdomainService,
+        private readonly userRepository: UserRepository,
     ) {}
 
     private getProviderName(deployProvider: string | undefined): string {
@@ -151,6 +157,42 @@ export class DeployController {
             message: configured
                 ? `Provider '${providerId}' is configured.`
                 : `Provider '${providerId}' is available but not configured.`,
+        };
+    }
+
+    /**
+     * List the k8s `clusterSource` options the current user is allowed to pick.
+     *
+     * The client is never told `isPlatformAdmin` (it is stripped from the
+     * profile response), so the admin-aware dropdown cannot be built on the
+     * client. This endpoint computes the allowed list server-side — the admin-
+     * only `k8s-works` option is omitted for non-admins — and the
+     * `k8s-cluster-source` widget renders exactly what it returns. This is
+     * cosmetic; the authoritative gate is `validateClusterSourceForOwner` at
+     * deploy time, so a non-admin still cannot deploy to `k8s-works` via the
+     * API/CLI even if they craft the request by hand.
+     */
+    @Get('/cluster-sources')
+    @ApiOperation({
+        summary: 'List allowed k8s cluster sources',
+        description:
+            'Returns the Kubernetes clusterSource options the current user may select, filtered by platform-admin status server-side.',
+    })
+    @ApiResponse({ status: 200, description: 'Allowed cluster sources' })
+    async getClusterSources(@CurrentUser() auth: AuthenticatedUser) {
+        const user = await this.userRepository.findById(auth.userId);
+        const isPlatformAdmin = Boolean(user?.isPlatformAdmin);
+        // No Work context on the user-global plugin-settings page, so filter on
+        // admin status alone. The per-Work org rules stay enforced at deploy time.
+        const values = allowedClusterSourcesFor(isPlatformAdmin);
+        return {
+            status: 'success',
+            isPlatformAdmin,
+            clusterSources: values.map((value) => ({
+                value,
+                label: CLUSTER_SOURCE_LABELS[value],
+                description: CLUSTER_SOURCE_DESCRIPTIONS[value],
+            })),
         };
     }
 

--- a/apps/api/src/plugins-capabilities/deploy/deploy.e2e.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.e2e.spec.ts
@@ -77,22 +77,28 @@ describe.skip('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + 
         env?: NodeJS.ProcessEnv;
         /** Token that `DeployFacade.getPluginAndTokenAndSettings` would
          *  return for this Work. Defaults to whatever's in
-         *  `userSettings.kubeconfig`, or the EW-616 sentinel when the
-         *  user picked a platform-managed source without a saved
+         *  `userSettings.kubeconfig`, or the platform-managed sentinel when
+         *  the user picked a platform-managed source without a saved
          *  kubeconfig. */
         facadeToken?: string;
+        /** Whether the Work owner is a platform admin — gates `k8s-works`. */
+        isPlatformAdmin?: boolean;
     }) => {
         // The real k8s plugin — its coerceSettings + getDeploymentSecrets
         // are exercised through DeployService.setRequiredSecrets.
         const k8sPlugin = new KubernetesPlugin();
 
         // Decide what token the (mocked) facade would have produced for
-        // this combination, matching the real facade's logic.
+        // this combination, matching the real facade's logic (platform-managed
+        // cluster sources — `k8s-works` / `k8s-works-shared`, or the legacy
+        // `k8s-gauzy` alias — yield the sentinel when no kubeconfig is saved).
         const kubeconfig = opts.userSettings.kubeconfig as string | undefined;
         const clusterSource = opts.userSettings.clusterSource as string | undefined;
         const facadeToken =
             opts.facadeToken ??
-            (clusterSource === 'k8s-works' || clusterSource === 'k8s-gauzy'
+            (clusterSource === 'k8s-works' ||
+            clusterSource === 'k8s-works-shared' ||
+            clusterSource === 'k8s-gauzy'
                 ? kubeconfig || SENTINEL
                 : kubeconfig || '');
 
@@ -119,7 +125,11 @@ describe.skip('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + 
             slug: 'my-site',
             deployProvider: 'k8s',
             gitProvider: 'github',
-            user: { id: 'user-1', username: 'evereq' },
+            user: {
+                id: 'user-1',
+                username: 'evereq',
+                isPlatformAdmin: opts.isPlatformAdmin ?? false,
+            },
             getRepoOwner: () => opts.websiteOwner,
             getDataRepo: () => `${opts.websiteOwner}/data`,
             getWebsiteRepo: () => `${opts.websiteOwner}-site`,
@@ -186,6 +196,7 @@ describe.skip('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + 
 
         const prevEnv = { ...process.env };
         delete process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
+        delete process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
         delete process.env.EVER_WORKS_K8S_GAUZY_KUBECONFIG;
         Object.assign(process.env, opts.env ?? {});
 
@@ -220,21 +231,22 @@ describe.skip('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + 
 
     afterEach(() => {
         delete process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
+        delete process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
         delete process.env.EVER_WORKS_K8S_GAUZY_KUBECONFIG;
     });
 
-    it('ever-works-cloud Work + clusterSource=k8s-works (sentinel from facade) → env kubeconfig pushed as K8S_TOKEN, sentinel never leaks', async () => {
+    it('ever-works-cloud Work + clusterSource=k8s-works-shared (sentinel from facade) → env kubeconfig pushed as K8S_TOKEN, sentinel never leaks', async () => {
         const { service, capturedSecrets, restoreEnv } = buildHarness({
             websiteOwner: 'ever-works-cloud',
-            userSettings: { clusterSource: 'k8s-works' /* no kubeconfig */ },
-            env: { EVER_WORKS_K8S_WORKS_KUBECONFIG: 'platform-cluster-yaml' },
+            userSettings: { clusterSource: 'k8s-works-shared' /* no kubeconfig */ },
+            env: { EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG: 'shared-cluster-yaml' },
         });
 
         try {
             await service.deploy('work-1', 'user-1', {});
             const secrets = capturedSecrets();
             const k8sToken = secrets.find((s: any) => s.key === 'K8S_TOKEN');
-            expect(k8sToken?.value).toBe('platform-cluster-yaml');
+            expect(k8sToken?.value).toBe('shared-cluster-yaml');
             for (const s of secrets) {
                 expect(s.value).not.toBe(SENTINEL);
             }
@@ -243,11 +255,12 @@ describe.skip('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + 
         }
     });
 
-    it('ever-works Work + clusterSource=k8s-gauzy → admin path uses EVER_WORKS_K8S_GAUZY_KUBECONFIG', async () => {
+    it('ever-works Work + admin + clusterSource=k8s-works → internal path uses EVER_WORKS_K8S_WORKS_KUBECONFIG', async () => {
         const { service, capturedSecrets, restoreEnv } = buildHarness({
             websiteOwner: 'ever-works',
-            userSettings: { clusterSource: 'k8s-gauzy' },
-            env: { EVER_WORKS_K8S_GAUZY_KUBECONFIG: 'internal-cluster-yaml' },
+            isPlatformAdmin: true,
+            userSettings: { clusterSource: 'k8s-works' },
+            env: { EVER_WORKS_K8S_WORKS_KUBECONFIG: 'internal-cluster-yaml' },
         });
         try {
             await service.deploy('work-1', 'user-1', {});
@@ -275,26 +288,29 @@ describe.skip('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + 
         }
     });
 
-    it('customer-owned Work + clusterSource=k8s-gauzy → 400 BadRequest (admin-only cluster)', async () => {
+    it('non-admin picking clusterSource=k8s-works → 400 BadRequest (admin-only cluster)', async () => {
         const { service, restoreEnv } = buildHarness({
-            websiteOwner: 'acme',
-            userSettings: { clusterSource: 'k8s-gauzy' },
+            websiteOwner: 'ever-works',
+            isPlatformAdmin: false,
+            userSettings: { clusterSource: 'k8s-works' },
+            env: { EVER_WORKS_K8S_WORKS_KUBECONFIG: 'internal-cluster-yaml' },
         });
         try {
             await expect(service.deploy('work-1', 'user-1', {})).rejects.toBeInstanceOf(
                 BadRequestException,
             );
             await expect(service.deploy('work-1', 'user-1', {})).rejects.toThrow(
-                /'k8s-gauzy' is the Ever Works internal platform cluster/,
+                /restricted to platform admins/i,
             );
         } finally {
             restoreEnv();
         }
     });
 
-    it('clusterSource=k8s-works but platform env var missing → 500 InternalServerError', async () => {
+    it('admin picking k8s-works but platform env var missing → 500 InternalServerError', async () => {
         const { service, restoreEnv } = buildHarness({
-            websiteOwner: 'ever-works-cloud',
+            websiteOwner: 'ever-works',
+            isPlatformAdmin: true,
             userSettings: { clusterSource: 'k8s-works' },
             // intentionally no env
         });
@@ -326,9 +342,10 @@ describe.skip('EW-616 deploy pipeline — real KubernetesPlugin + real matrix + 
 
     it('real KubernetesPlugin contributes K8S_CLUSTER_SOURCE reflecting user choice', async () => {
         const { service, capturedSecrets, restoreEnv } = buildHarness({
-            websiteOwner: 'ever-works-cloud',
+            websiteOwner: 'ever-works',
+            isPlatformAdmin: true,
             userSettings: { clusterSource: 'k8s-works' },
-            env: { EVER_WORKS_K8S_WORKS_KUBECONFIG: 'platform-yaml' },
+            env: { EVER_WORKS_K8S_WORKS_KUBECONFIG: 'internal-yaml' },
         });
         try {
             await service.deploy('work-1', 'user-1', {});

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -68,6 +68,8 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         githubPluginOverrides?: Record<string, unknown>;
         /** Work's public `website` URL — drives the per-Work k8s Ingress host. */
         website?: string;
+        /** Whether the Work owner is a platform admin — gates `k8s-works`. */
+        isPlatformAdmin?: boolean;
     }) => {
         const websiteOwner = overrides.websiteOwner ?? 'acme';
         const work = {
@@ -78,7 +80,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             gitProvider: 'github',
             websiteTemplateId: 'directory-web-template',
             activitySyncMode: overrides.activitySyncMode ?? 'push',
-            user: { id: 'user-1' },
+            user: { id: 'user-1', isPlatformAdmin: overrides.isPlatformAdmin ?? false },
             getRepoOwner: () => websiteOwner,
             getDataRepo: () => `${websiteOwner}/data`,
             getWebsiteRepo: () => `${websiteOwner}-site`,
@@ -1058,6 +1060,7 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
         beforeEach(() => {
             process.env = { ...originalEnv };
             delete process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
+            delete process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
             delete process.env.EVER_WORKS_K8S_GAUZY_KUBECONFIG;
         });
 
@@ -1080,12 +1083,12 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             expect(k8sToken?.value).toBe('user-pasted-yaml');
         });
 
-        it('k8s-works + ever-works-cloud → substitutes EVER_WORKS_K8S_WORKS_KUBECONFIG as K8S_TOKEN', async () => {
-            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'platform-yaml';
+        it('k8s-works-shared + ever-works-cloud → substitutes EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG as K8S_TOKEN', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'shared-yaml';
             const { service, githubPlugin } = buildService({
                 plugin: k8sPlugin,
                 token: 'user-pasted-yaml-should-be-ignored',
-                settings: { clusterSource: 'k8s-works' },
+                settings: { clusterSource: 'k8s-works-shared' },
                 websiteOwner: 'ever-works-cloud',
             });
 
@@ -1093,22 +1096,67 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
 
             const { secrets } = captureCalls(githubPlugin);
             const k8sToken = secrets.find((s: any) => s.key === 'K8S_TOKEN');
-            expect(k8sToken?.value).toBe('platform-yaml');
+            expect(k8sToken?.value).toBe('shared-yaml');
         });
 
-        it('k8s-gauzy + ever-works → substitutes EVER_WORKS_K8S_GAUZY_KUBECONFIG (admin path)', async () => {
-            process.env.EVER_WORKS_K8S_GAUZY_KUBECONFIG = 'gauzy-yaml';
+        it('k8s-works + admin + ever-works → substitutes EVER_WORKS_K8S_WORKS_KUBECONFIG (internal/admin path)', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-yaml';
             const { service, githubPlugin } = buildService({
                 plugin: k8sPlugin,
                 token: 'user-yaml-ignored',
-                settings: { clusterSource: 'k8s-gauzy' },
+                settings: { clusterSource: 'k8s-works' },
                 websiteOwner: 'ever-works',
+                isPlatformAdmin: true,
             });
 
             await service.deploy('work-1', 'user-1', {});
 
             const { secrets } = captureCalls(githubPlugin);
-            expect(secrets.find((s: any) => s.key === 'K8S_TOKEN')?.value).toBe('gauzy-yaml');
+            expect(secrets.find((s: any) => s.key === 'K8S_TOKEN')?.value).toBe('internal-yaml');
+        });
+
+        it('legacy k8s-gauzy + admin + ever-works → still resolves via EVER_WORKS_K8S_WORKS_KUBECONFIG', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-yaml';
+            const { service, githubPlugin } = buildService({
+                plugin: k8sPlugin,
+                token: 'user-yaml-ignored',
+                settings: { clusterSource: 'k8s-gauzy' },
+                websiteOwner: 'ever-works',
+                isPlatformAdmin: true,
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const { secrets } = captureCalls(githubPlugin);
+            expect(secrets.find((s: any) => s.key === 'K8S_TOKEN')?.value).toBe('internal-yaml');
+        });
+
+        it('rejects a non-admin picking k8s-works with a BadRequest (admin-only cluster)', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-yaml';
+            const { service } = buildService({
+                plugin: k8sPlugin,
+                settings: { clusterSource: 'k8s-works' },
+                websiteOwner: 'ever-works',
+                isPlatformAdmin: false,
+            });
+
+            await expect(service.deploy('work-1', 'user-1', {})).rejects.toThrow(
+                /restricted to platform admins/i,
+            );
+        });
+
+        it('rejects an admin picking k8s-works for a non-ever-works Work (wrong org)', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-yaml';
+            const { service } = buildService({
+                plugin: k8sPlugin,
+                settings: { clusterSource: 'k8s-works' },
+                websiteOwner: 'acme',
+                isPlatformAdmin: true,
+            });
+
+            await expect(service.deploy('work-1', 'user-1', {})).rejects.toThrow(
+                /requires the website repo to live in the 'ever-works' GitHub org/,
+            );
         });
 
         it('rejects ever-works-cloud + custom-kubeconfig with a BadRequest (cell C)', async () => {
@@ -1123,24 +1171,32 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             );
         });
 
-        it('rejects customer-owned + k8s-gauzy with a BadRequest (admin-only)', async () => {
+        it('surfaces a clear "not available yet" error for k8s-works-shared before its cluster is provisioned', async () => {
+            // EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG intentionally absent.
             const { service } = buildService({
                 plugin: k8sPlugin,
-                settings: { clusterSource: 'k8s-gauzy' },
+                settings: { clusterSource: 'k8s-works-shared' },
                 websiteOwner: 'acme',
             });
 
+            const InternalServerErrorException =
+                require('@nestjs/common').InternalServerErrorException;
+            await expect(service.deploy('work-1', 'user-1', {})).rejects.toBeInstanceOf(
+                InternalServerErrorException,
+            );
             await expect(service.deploy('work-1', 'user-1', {})).rejects.toThrow(
-                /'k8s-gauzy' is the Ever Works internal platform cluster/,
+                /not available yet/i,
             );
         });
 
         it('rejects k8s-works with InternalServerError when EVER_WORKS_K8S_WORKS_KUBECONFIG is not provisioned (operator gap, not user error)', async () => {
-            // env var intentionally absent
+            // env var intentionally absent; admin + ever-works passes validation
+            // so the flow reaches the (failing) env-var resolution.
             const { service } = buildService({
                 plugin: k8sPlugin,
                 settings: { clusterSource: 'k8s-works' },
-                websiteOwner: 'ever-works-cloud',
+                websiteOwner: 'ever-works',
+                isPlatformAdmin: true,
             });
 
             const InternalServerErrorException =
@@ -1164,7 +1220,8 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
                 plugin: k8sPlugin,
                 token: sentinel,
                 settings: { clusterSource: 'k8s-works' },
-                websiteOwner: 'ever-works-cloud',
+                websiteOwner: 'ever-works',
+                isPlatformAdmin: true,
             });
 
             await service.deploy('work-1', 'user-1', {});
@@ -1186,9 +1243,11 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
                     getWorkflowFilenames: () => ['deploy_vercel.yaml'],
                     getDeploymentSecrets: jest.fn().mockResolvedValue({}),
                 },
-                // these would trip the k8s matrix but vercel must not care
-                settings: { clusterSource: 'k8s-gauzy' },
+                // a non-admin picking k8s-works WOULD trip the k8s matrix, but
+                // vercel is not k8s so the matrix must not be consulted at all.
+                settings: { clusterSource: 'k8s-works' },
                 websiteOwner: 'ever-works-cloud',
+                isPlatformAdmin: false,
                 token: 'vercel-deploy-token',
             });
 

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -41,24 +41,25 @@ import type { IDeploymentPlugin } from '@ever-works/plugin';
 import type { BatchDeployItemDto, BatchDeployItemResultDto } from './dto/batch-deploy.dto';
 import {
     ClusterSource,
+    normalizeClusterSource,
     resolveKubeconfigForClusterSource,
     validateClusterSourceForOwner,
 } from './cluster-source-matrix';
-
-const VALID_CLUSTER_SOURCES: readonly ClusterSource[] = [
-    'k8s-works',
-    'k8s-gauzy',
-    'custom-kubeconfig',
-];
 
 const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
 const EVER_WORKS_DEPLOY_PROVIDER_ID = 'ever-works';
 
 function coerceClusterSource(value: unknown): ClusterSource {
-    if (typeof value === 'string' && (VALID_CLUSTER_SOURCES as readonly string[]).includes(value)) {
-        return value as ClusterSource;
+    if (typeof value === 'string') {
+        // `normalizeClusterSource` accepts the current values and remaps the
+        // unambiguous legacy `k8s-gauzy` alias → `k8s-works`. It deliberately
+        // does NOT remap `k8s-works` → `k8s-works-shared` (that stored-value
+        // rewrite is done once, atomically, by the RenameK8sClusterSource
+        // migration); doing it here would silently break admin selections.
+        const normalized = normalizeClusterSource(value);
+        if (normalized) return normalized;
     }
-    // Back-compat: Works that pre-date the EW-616 dropdown have no
+    // Back-compat: Works that pre-date the cluster-source dropdown have no
     // `clusterSource` set in their plugin settings. Treat them as
     // `custom-kubeconfig` so they keep working as long as their
     // website repo is not in an Ever Works-shared org.
@@ -205,7 +206,8 @@ export class DeployService {
         const websiteRepo = work.getWebsiteRepo();
 
         // EW-616: enforce the deploy matrix for k8s deploys.
-        // - `k8s-gauzy` is admin-only (ever-works org).
+        // - `k8s-works` (internal cluster) is admin-only: requires BOTH
+        //   `user.isPlatformAdmin` AND a website repo in the `ever-works` org.
         // - Ever Works-shared GHCR + customer-provided cluster is rejected
         //   to avoid cross-tenant credential exposure.
         // The resolved kubeconfig replaces the user-pasted one for
@@ -216,6 +218,7 @@ export class DeployService {
             websiteOwner,
             settings ?? {},
             token,
+            Boolean(user.isPlatformAdmin),
         );
 
         const ctx = await this.createRepoContext(websiteOwner, websiteRepo, gitToken);
@@ -438,6 +441,7 @@ export class DeployService {
         websiteOwner: string,
         settings: Record<string, unknown>,
         userToken: string,
+        isPlatformAdmin: boolean,
     ): string {
         if (!this.isKubernetesDeploy(deployProvider, pluginId)) {
             return userToken;
@@ -453,6 +457,7 @@ export class DeployService {
         const clusterSource = coerceClusterSource(settings.clusterSource);
         const failure = validateClusterSourceForOwner(websiteOwner, clusterSource, {
             hasKubeconfig: Boolean(realUserToken && realUserToken.trim()),
+            isPlatformAdmin,
         });
         if (failure) {
             this.logger.warn(`Deploy-matrix violation [${failure.code}]: ${failure.message}`);
@@ -464,7 +469,7 @@ export class DeployService {
         } catch (error: any) {
             // The only failure path here is a missing platform-managed
             // env var (`EVER_WORKS_K8S_WORKS_KUBECONFIG` /
-            // `EVER_WORKS_K8S_GAUZY_KUBECONFIG`). The user picked a
+            // `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG`). The user picked a
             // valid option — this is a platform-provisioning gap, so
             // surface it as 5xx, not 4xx, so on-call can distinguish it
             // from genuine user-input errors.

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/page.tsx
@@ -31,6 +31,7 @@ interface NewWorkPageProps {
     searchParams: Promise<{ proposal?: string; mode?: string; prompt?: string; kind?: string }>;
 }
 
+const KUBERNETES_DEPLOY_PROVIDER_ID = 'k8s';
 const VALID_CREATION_MODES: CreationMode[] = ['ai', 'manual', 'import'];
 const VALID_WORK_KINDS = ['website', 'landing-page', 'blog', 'directory', 'awesome-repo'] as const;
 type InitialWorkKind = (typeof VALID_WORK_KINDS)[number];
@@ -95,8 +96,17 @@ export default async function NewWorkPage({ searchParams }: NewWorkPageProps) {
         if (deployProvidersResult.providers) {
             deployProviders = deployProvidersResult.providers;
             const firstConfigured = deployProviders.find((p) => p.enabled && p.configured);
+            // When nothing is configured, default to Kubernetes (the shared
+            // customer cluster) rather than Vercel — k8s needs no external
+            // account, so it's the deterministic zero-config fallback. Vercel
+            // remains available and becomes the default the moment its token is
+            // connected (it is `configured`, so `firstConfigured` wins).
+            const enabledK8s = deployProviders.find(
+                (p) => p.enabled && p.id === KUBERNETES_DEPLOY_PROVIDER_ID,
+            );
             const firstEnabled = deployProviders.find((p) => p.enabled);
-            defaultDeployProviderId = firstConfigured?.id || firstEnabled?.id || null;
+            defaultDeployProviderId =
+                firstConfigured?.id || enabledK8s?.id || firstEnabled?.id || null;
         }
     } catch (error) {
         console.error('Failed to fetch deploy providers:', error);

--- a/apps/web/src/app/actions/plugins.ts
+++ b/apps/web/src/app/actions/plugins.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { pluginsAPI } from '@/lib/api/plugins';
+import { deployAPI, type ClusterSourceOption } from '@/lib/api/plugins-capabilities/deploy';
 import {
     deviceAuthAPI,
     type PluginDeviceAuthStatus,
@@ -172,6 +173,24 @@ export async function fetchModels(pluginId: string): Promise<ActionResult<any[]>
         return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to fetch models',
+        };
+    }
+}
+
+/**
+ * List the Kubernetes `clusterSource` options the current user may pick.
+ * Admin-filtered server-side (the admin-only `k8s-works` option is omitted for
+ * non-admins), so the client never learns the admin flag.
+ */
+export async function fetchClusterSources(): Promise<ActionResult<ClusterSourceOption[]>> {
+    try {
+        const result = await deployAPI.getClusterSources();
+        return { success: true, data: result.clusterSources ?? [] };
+    } catch (error) {
+        console.error('Failed to fetch cluster sources:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to fetch cluster sources',
         };
     }
 }

--- a/apps/web/src/components/plugins/form/K8sClusterSourceSelect.tsx
+++ b/apps/web/src/components/plugins/form/K8sClusterSourceSelect.tsx
@@ -25,29 +25,21 @@ const FALLBACK_OPTIONS: readonly ClusterSourceOption[] = [
     { value: 'custom-kubeconfig', label: 'Custom — paste your own kubeconfig' },
 ];
 
-// Module-level cache + de-dupe so every field instance and re-render reuses one
-// round-trip (mirrors PluginModelSelect's caching).
-let clusterSourceCache: ClusterSourceOption[] | null = null;
-let inFlightRequest: Promise<ClusterSourceOption[]> | null = null;
-
+// The allowed list is PER-USER (a platform admin sees `k8s-works`; nobody else
+// does), so — unlike PluginModelSelect's provider-scoped model list — it must
+// NOT be memoised at module scope. Caching across users (or seeding SSR/initial
+// render from a module value) could leak one user's list to the next. We fetch
+// fresh on each mount, client-side only.
 async function loadClusterSources(): Promise<ClusterSourceOption[]> {
-    if (clusterSourceCache) return clusterSourceCache;
-    if (inFlightRequest) return inFlightRequest;
-
-    inFlightRequest = fetchClusterSources()
-        .then((response) => {
-            if (response.success && Array.isArray(response.data) && response.data.length > 0) {
-                clusterSourceCache = response.data;
-                return response.data;
-            }
-            return [...FALLBACK_OPTIONS];
-        })
-        .catch(() => [...FALLBACK_OPTIONS])
-        .finally(() => {
-            inFlightRequest = null;
-        });
-
-    return inFlightRequest;
+    try {
+        const response = await fetchClusterSources();
+        if (response.success && Array.isArray(response.data) && response.data.length > 0) {
+            return response.data;
+        }
+    } catch {
+        // fall through to the fail-closed fallback below
+    }
+    return [...FALLBACK_OPTIONS];
 }
 
 interface K8sClusterSourceSelectProps {
@@ -62,7 +54,9 @@ export function K8sClusterSourceSelect({
     onChange,
     defaultValue,
 }: K8sClusterSourceSelectProps) {
-    const [options, setOptions] = useState<ClusterSourceOption[] | null>(clusterSourceCache);
+    // Start empty (null) so SSR and the first client render never seed from a
+    // module-level value; the client-side effect fetches the per-user list.
+    const [options, setOptions] = useState<ClusterSourceOption[] | null>(null);
 
     useEffect(() => {
         let cancelled = false;

--- a/apps/web/src/components/plugins/form/K8sClusterSourceSelect.tsx
+++ b/apps/web/src/components/plugins/form/K8sClusterSourceSelect.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Select } from '@/components/ui/select';
+import { fetchClusterSources } from '@/app/actions/plugins';
+import type { ClusterSourceOption } from '@/lib/api/plugins-capabilities/deploy';
+
+/**
+ * Admin-aware dropdown for the k8s plugin's `clusterSource` setting.
+ *
+ * The client is never told whether the user is a platform admin (the flag is
+ * stripped from the profile response for security), so the allowed options are
+ * computed server-side and fetched from `GET /api/deploy/cluster-sources` via
+ * the `fetchClusterSources` server action. A non-admin's list never contains
+ * the internal `k8s-works` option.
+ *
+ * Fail-closed: if the endpoint can't be reached, fall back to the non-admin-
+ * safe subset (never surfacing `k8s-works`). The authoritative gate is the
+ * server-side deploy matrix, so hiding here is purely cosmetic.
+ */
+
+// Non-admin-safe fallback — deliberately omits the admin-only `k8s-works`.
+const FALLBACK_OPTIONS: readonly ClusterSourceOption[] = [
+    { value: 'k8s-works-shared', label: 'Ever Works shared customer cluster' },
+    { value: 'custom-kubeconfig', label: 'Custom — paste your own kubeconfig' },
+];
+
+// Module-level cache + de-dupe so every field instance and re-render reuses one
+// round-trip (mirrors PluginModelSelect's caching).
+let clusterSourceCache: ClusterSourceOption[] | null = null;
+let inFlightRequest: Promise<ClusterSourceOption[]> | null = null;
+
+async function loadClusterSources(): Promise<ClusterSourceOption[]> {
+    if (clusterSourceCache) return clusterSourceCache;
+    if (inFlightRequest) return inFlightRequest;
+
+    inFlightRequest = fetchClusterSources()
+        .then((response) => {
+            if (response.success && Array.isArray(response.data) && response.data.length > 0) {
+                clusterSourceCache = response.data;
+                return response.data;
+            }
+            return [...FALLBACK_OPTIONS];
+        })
+        .catch(() => [...FALLBACK_OPTIONS])
+        .finally(() => {
+            inFlightRequest = null;
+        });
+
+    return inFlightRequest;
+}
+
+interface K8sClusterSourceSelectProps {
+    value: string;
+    onChange: (value: string) => void;
+    /** Schema default, used when no value is set yet. */
+    defaultValue?: string;
+}
+
+export function K8sClusterSourceSelect({
+    value,
+    onChange,
+    defaultValue,
+}: K8sClusterSourceSelectProps) {
+    const [options, setOptions] = useState<ClusterSourceOption[] | null>(clusterSourceCache);
+
+    useEffect(() => {
+        let cancelled = false;
+        void loadClusterSources().then((opts) => {
+            if (!cancelled) setOptions(opts);
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const loading = options === null;
+    const resolved = options ?? [...FALLBACK_OPTIONS];
+    const current = String(value ?? defaultValue ?? '') || resolved[0]?.value || '';
+
+    // If the persisted value isn't among the allowed options (e.g. a legacy or
+    // now-hidden value), still surface it as an extra row rather than silently
+    // switching the user's selection out from under them.
+    const hasCurrent = resolved.some((option) => option.value === current);
+    const selected = resolved.find((option) => option.value === current);
+
+    return (
+        <div className="space-y-1.5">
+            <Select
+                value={current}
+                onValueChange={(v) => onChange(v)}
+                disabled={loading}
+                data-testid="k8s-cluster-source-select"
+            >
+                {!hasCurrent && current && <option value={current}>{current}</option>}
+                {resolved.map((option) => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
+            </Select>
+            {selected?.description && (
+                <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                    {selected.description}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/components/plugins/form/PluginSettingsField.tsx
+++ b/apps/web/src/components/plugins/form/PluginSettingsField.tsx
@@ -14,6 +14,7 @@ import { PluginSettingsObjectField } from './PluginSettingsObjectField';
 import { PluginSettingsArrayField } from './PluginSettingsArrayField';
 import { GithubPackagesOAuthButton } from './GithubPackagesOAuthButton';
 import { GithubOwnerWidget, GithubRepoWidget } from './GithubRepoWidgets';
+import { K8sClusterSourceSelect } from './K8sClusterSourceSelect';
 import { isType, getPrimaryType } from './utils';
 
 interface PluginSettingsFieldProps {
@@ -186,6 +187,22 @@ export function PluginSettingsField({
                         );
                     })}
                 </Select>
+            );
+        }
+
+        // k8s cluster-source select — MUST be handled before the generic enum
+        // branch below (the field carries both `enum` and this `widget`, and
+        // the enum branch would otherwise match first and render the raw,
+        // unfiltered options). The widget fetches the admin-filtered option
+        // list from the server so the admin-only `k8s-works` value never
+        // reaches a non-admin's dropdown.
+        if (schema.widget === 'k8s-cluster-source') {
+            return (
+                <K8sClusterSourceSelect
+                    value={String(value ?? schema.default ?? '')}
+                    defaultValue={schema.default != null ? String(schema.default) : undefined}
+                    onChange={(v) => onChange(v)}
+                />
             );
         }
 

--- a/apps/web/src/lib/api/plugins-capabilities/deploy.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/deploy.ts
@@ -132,10 +132,32 @@ export interface SubdomainState {
 
 export type SubdomainResponseDto = APIResponse<SubdomainState>;
 
+/**
+ * One selectable Kubernetes `clusterSource` option, as returned by
+ * `GET /api/deploy/cluster-sources`. `label`/`description` are human copy;
+ * the admin-only `k8s-works` option is omitted server-side for non-admins.
+ */
+export interface ClusterSourceOption {
+    value: string;
+    label: string;
+    description?: string;
+}
+
+export type ClusterSourcesResponseDto = APIResponse<{
+    isPlatformAdmin: boolean;
+    clusterSources: ClusterSourceOption[];
+}>;
+
 export const deployAPI = {
     // Get available deployment providers
     getProviders: async () => {
         return serverFetch<DeployProvidersResponseDto>('/deploy/providers');
+    },
+
+    // List the k8s clusterSource options the current user may select
+    // (admin-filtered server-side).
+    getClusterSources: async () => {
+        return serverFetch<ClusterSourcesResponseDto>('/deploy/cluster-sources');
     },
 
     // Check if a provider is configured for the current user

--- a/apps/web/src/lib/api/plugins-capabilities/deploy.ts
+++ b/apps/web/src/lib/api/plugins-capabilities/deploy.ts
@@ -144,7 +144,6 @@ export interface ClusterSourceOption {
 }
 
 export type ClusterSourcesResponseDto = APIResponse<{
-    isPlatformAdmin: boolean;
     clusterSources: ClusterSourceOption[];
 }>;
 

--- a/docs/features/k8s-deployment.md
+++ b/docs/features/k8s-deployment.md
@@ -35,17 +35,17 @@ Use the Kubernetes provider when you need to host on your own infrastructure —
 2. Find the **Kubernetes** card and click **Configure**.
 3. Fill in the form:
 
-| Field                    | Required | Notes                                                                                                                                                                                    |
-| ------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Target cluster**       | yes      | Where to deploy — see [Target cluster](#target-cluster) below. Defaults to `k8s-works-shared`, the Ever Works shared customer cluster.                                                   |
+| Field                    | Required                     | Notes                                                                                                                                                                                          |
+| ------------------------ | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Target cluster**       | yes                          | Where to deploy — see [Target cluster](#target-cluster) below. Defaults to `k8s-works-shared`, the Ever Works shared customer cluster.                                                         |
 | **kubeconfig**           | only for `custom-kubeconfig` | Paste the contents of your `~/.kube/config` (or a service-account-scoped equivalent). Stored encrypted, never returned by the API. Only needed when **Target cluster** is `custom-kubeconfig`. |
-| **Context**              | no       | Defaults to the kubeconfig's `current-context`. Set this if you want to target a non-default context without editing the file.                                                           |
-| **Namespace**            | no       | Defaults to `ever-works`. The namespace must already exist or your kubeconfig must have permission to create it.                                                                         |
-| **Registry**             | no       | Defaults to **GitHub Container Registry** using your connected GitHub account. Switch to **Docker Hub** or **Generic** to use a different registry. See [Registries](#registries) below. |
-| **Ingress class**        | no       | Populated from your cluster's `IngressClass` resources. Leave blank to use the cluster default.                                                                                          |
-| **Default ingress host** | no       | Used when a work has no custom domain configured.                                                                                                                                        |
-| **TLS issuer**           | no       | Name of a cert-manager `ClusterIssuer`. Adds the necessary annotations on the Ingress.                                                                                                   |
-| **Replicas**             | no       | Defaults to `1`. Min 1, max 10 in v1.                                                                                                                                                    |
+| **Context**              | no                           | Defaults to the kubeconfig's `current-context`. Set this if you want to target a non-default context without editing the file.                                                                 |
+| **Namespace**            | no                           | Defaults to `ever-works`. The namespace must already exist or your kubeconfig must have permission to create it.                                                                               |
+| **Registry**             | no                           | Defaults to **GitHub Container Registry** using your connected GitHub account. Switch to **Docker Hub** or **Generic** to use a different registry. See [Registries](#registries) below.       |
+| **Ingress class**        | no                           | Populated from your cluster's `IngressClass` resources. Leave blank to use the cluster default.                                                                                                |
+| **Default ingress host** | no                           | Used when a work has no custom domain configured.                                                                                                                                              |
+| **TLS issuer**           | no                           | Name of a cert-manager `ClusterIssuer`. Adds the necessary annotations on the Ingress.                                                                                                         |
+| **Replicas**             | no                           | Defaults to `1`. Min 1, max 10 in v1.                                                                                                                                                          |
 
 4. Click **Save & verify**. For `custom-kubeconfig`, the platform validates the kubeconfig against the cluster API and reports back the cluster name, server URL, Kubernetes server version, and the list of ingress controllers it detected. For the platform-managed clusters there is nothing to validate against your session — the platform owns those credentials.
 
@@ -53,11 +53,11 @@ Use the Kubernetes provider when you need to host on your own infrastructure —
 
 The **Target cluster** setting decides where your work is published:
 
-| Option              | What it is                                                                                                                                                            | Who can pick it                                                                                     |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `k8s-works-shared`  | The **Ever Works shared customer cluster** — the default. No cluster credentials to manage; the platform runs it for you.                                            | Everyone (the customer default).                                                                    |
-| `k8s-works`         | The **Ever Works internal cluster**. Admin-only, and the work's website repo must live in the `ever-works` GitHub org.                                               | **Platform admins only** — this option is hidden from everyone else, and the deploy API rejects it. |
-| `custom-kubeconfig` | **Bring your own cluster** — paste your own kubeconfig (see the field table above). Not available when the website repo is in an Ever Works-shared GitHub org.        | Anyone whose website repo is in their own GitHub org.                                                |
+| Option              | What it is                                                                                                                                                     | Who can pick it                                                                                     |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `k8s-works-shared`  | The **Ever Works shared customer cluster** — the default. No cluster credentials to manage; the platform runs it for you.                                      | Everyone (the customer default).                                                                    |
+| `k8s-works`         | The **Ever Works internal cluster**. Admin-only, and the work's website repo must live in the `ever-works` GitHub org.                                         | **Platform admins only** — this option is hidden from everyone else, and the deploy API rejects it. |
+| `custom-kubeconfig` | **Bring your own cluster** — paste your own kubeconfig (see the field table above). Not available when the website repo is in an Ever Works-shared GitHub org. | Anyone whose website repo is in their own GitHub org.                                               |
 
 Notes:
 

--- a/docs/features/k8s-deployment.md
+++ b/docs/features/k8s-deployment.md
@@ -37,7 +37,8 @@ Use the Kubernetes provider when you need to host on your own infrastructure —
 
 | Field                    | Required | Notes                                                                                                                                                                                    |
 | ------------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **kubeconfig**           | yes      | Paste the contents of your `~/.kube/config` (or a service-account-scoped equivalent). Stored encrypted, never returned by the API.                                                       |
+| **Target cluster**       | yes      | Where to deploy — see [Target cluster](#target-cluster) below. Defaults to `k8s-works-shared`, the Ever Works shared customer cluster.                                                   |
+| **kubeconfig**           | only for `custom-kubeconfig` | Paste the contents of your `~/.kube/config` (or a service-account-scoped equivalent). Stored encrypted, never returned by the API. Only needed when **Target cluster** is `custom-kubeconfig`. |
 | **Context**              | no       | Defaults to the kubeconfig's `current-context`. Set this if you want to target a non-default context without editing the file.                                                           |
 | **Namespace**            | no       | Defaults to `ever-works`. The namespace must already exist or your kubeconfig must have permission to create it.                                                                         |
 | **Registry**             | no       | Defaults to **GitHub Container Registry** using your connected GitHub account. Switch to **Docker Hub** or **Generic** to use a different registry. See [Registries](#registries) below. |
@@ -46,7 +47,24 @@ Use the Kubernetes provider when you need to host on your own infrastructure —
 | **TLS issuer**           | no       | Name of a cert-manager `ClusterIssuer`. Adds the necessary annotations on the Ingress.                                                                                                   |
 | **Replicas**             | no       | Defaults to `1`. Min 1, max 10 in v1.                                                                                                                                                    |
 
-4. Click **Save & verify**. The platform validates the kubeconfig against the cluster API and reports back the cluster name, server URL, Kubernetes server version, and the list of ingress controllers it detected.
+4. Click **Save & verify**. For `custom-kubeconfig`, the platform validates the kubeconfig against the cluster API and reports back the cluster name, server URL, Kubernetes server version, and the list of ingress controllers it detected. For the platform-managed clusters there is nothing to validate against your session — the platform owns those credentials.
+
+## Target cluster
+
+The **Target cluster** setting decides where your work is published:
+
+| Option              | What it is                                                                                                                                                            | Who can pick it                                                                                     |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `k8s-works-shared`  | The **Ever Works shared customer cluster** — the default. No cluster credentials to manage; the platform runs it for you.                                            | Everyone (the customer default).                                                                    |
+| `k8s-works`         | The **Ever Works internal cluster**. Admin-only, and the work's website repo must live in the `ever-works` GitHub org.                                               | **Platform admins only** — this option is hidden from everyone else, and the deploy API rejects it. |
+| `custom-kubeconfig` | **Bring your own cluster** — paste your own kubeconfig (see the field table above). Not available when the website repo is in an Ever Works-shared GitHub org.        | Anyone whose website repo is in their own GitHub org.                                                |
+
+Notes:
+
+- The dropdown only shows the options you're allowed to pick, and the server enforces the same rules at deploy time — a non-admin can never deploy to `k8s-works`, even via the API or CLI.
+- `k8s-works-shared` is a separate cluster from the internal one and may still be getting provisioned. If it isn't available yet, a deploy to it fails with a clear "not yet available" message rather than silently going elsewhere — pick `custom-kubeconfig` in the meantime, or try again later.
+- Existing works that were configured before this rename keep deploying to the same tier automatically (their stored value is migrated once, on the platform's next startup).
+- Kubernetes is the **default deployment provider** when you haven't connected Vercel — it needs no external account. Connect Vercel and it becomes the default the moment its token is saved.
 
 ## Registries
 

--- a/docs/features/k8s-deployment.md
+++ b/docs/features/k8s-deployment.md
@@ -62,7 +62,7 @@ The **Target cluster** setting decides where your work is published:
 Notes:
 
 - The dropdown only shows the options you're allowed to pick, and the server enforces the same rules at deploy time — a non-admin can never deploy to `k8s-works`, even via the API or CLI.
-- `k8s-works-shared` is a separate cluster from the internal one and may still be getting provisioned. If it isn't available yet, a deploy to it fails with a clear "not yet available" message rather than silently going elsewhere — pick `custom-kubeconfig` in the meantime, or try again later.
+- `k8s-works-shared` is a separate cluster from the internal one and may still be getting provisioned. If it isn't available yet, a deploy to it fails with a clear "not yet available" message rather than silently going elsewhere. If your website repo is in your own GitHub org you can switch to `custom-kubeconfig` in the meantime; if it's in an Ever Works-shared org (where `custom-kubeconfig` isn't allowed), wait until the shared cluster is provisioned.
 - Existing works that were configured before this rename keep deploying to the same tier automatically (their stored value is migrated once, on the platform's next startup).
 - Kubernetes is the **default deployment provider** when you haven't connected Vercel — it needs no external account. Connect Vercel and it becomes the default the moment its token is saved.
 

--- a/docs/specs/features/k8s-cluster-source-matrix/plan.md
+++ b/docs/specs/features/k8s-cluster-source-matrix/plan.md
@@ -5,8 +5,15 @@
 
 **Feature ID**: `k8s-cluster-source-matrix`
 **Spec**: `./spec.md`
-**Status**: `Done`
+**Status**: `Done` (superseded in part by the cluster-source rename — see [`spec.md` §0](./spec.md#0-revision--cluster-source-rename--admin-gating))
 **Last updated**: 2026-05-14
+
+> **Revision note:** the values were later renamed (`k8s-gauzy` → `k8s-works`
+> internal, `k8s-works` → `k8s-works-shared` shared), `k8s-works` was gated to
+> platform admins in the `ever-works` org, a `GET /api/deploy/cluster-sources`
+> endpoint + `k8s-cluster-source` widget were added for the admin-aware dropdown,
+> a one-shot `RenameK8sClusterSource` data migration was added, and Kubernetes
+> became the default provider when Vercel is unconnected. See [`spec.md` §0](./spec.md#0-revision--cluster-source-rename--admin-gating).
 
 ---
 

--- a/docs/specs/features/k8s-cluster-source-matrix/spec.md
+++ b/docs/specs/features/k8s-cluster-source-matrix/spec.md
@@ -68,6 +68,17 @@ Vercel) is the default; Vercel becomes the default the moment its token is saved
 
 ---
 
+> ⛔ **Sections 1–7 below are the ORIGINAL EW-616 specification (shipped May
+> 2026), preserved for history.** They still use the pre-rename value names
+> (`k8s-gauzy`, the old meaning of `k8s-works`), the old env-var mapping
+> (`EVER_WORKS_K8S_GAUZY_KUBECONFIG`), and the org-only (non-admin-gated) matrix.
+> **§0 above is authoritative** — wherever it differs from a scenario or
+> requirement below (value names, env vars, the admin gate, the default
+> provider, the UI endpoint/widget), §0 wins. Read the sections below as the
+> record of what EW-616 originally did, not as the current contract.
+
+---
+
 ## 1. Overview
 
 Before EW-616, the k8s deploy plugin had a single way to configure a cluster: paste a `kubeconfig` YAML. That conflated three different operational paths into one form field:

--- a/docs/specs/features/k8s-cluster-source-matrix/spec.md
+++ b/docs/specs/features/k8s-cluster-source-matrix/spec.md
@@ -29,11 +29,11 @@
 
 **Renamed values** (the name now matches the physical cluster):
 
-| Old value     | New value          | Cluster                                   | Kubeconfig env var                        |
-| ------------- | ------------------ | ----------------------------------------- | ----------------------------------------- |
-| `k8s-gauzy`   | `k8s-works`        | Ever Works **internal** cluster (admin)   | `EVER_WORKS_K8S_WORKS_KUBECONFIG`         |
-| `k8s-works`   | `k8s-works-shared` | Ever Works **shared customer** cluster    | `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG`  |
-| `custom-kubeconfig` | `custom-kubeconfig` | Bring-your-own                      | user-pasted                               |
+| Old value           | New value           | Cluster                                 | Kubeconfig env var                       |
+| ------------------- | ------------------- | --------------------------------------- | ---------------------------------------- |
+| `k8s-gauzy`         | `k8s-works`         | Ever Works **internal** cluster (admin) | `EVER_WORKS_K8S_WORKS_KUBECONFIG`        |
+| `k8s-works`         | `k8s-works-shared`  | Ever Works **shared customer** cluster  | `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` |
+| `custom-kubeconfig` | `custom-kubeconfig` | Bring-your-own                          | user-pasted                              |
 
 Because the string `k8s-works` meant "shared" before and means "internal" after,
 the migration MUST run before any post-rename code reads a stored value; the
@@ -45,13 +45,13 @@ non-colliding legacy `k8s-gauzy` alias (never `k8s-works`).
 must not see `k8s-works` in the settings dropdown and must not be able to deploy
 to it via the API/CLI. The updated matrix (`allowed` = may pick):
 
-| isPlatformAdmin | Website owner      | k8s-works | k8s-works-shared | custom-kubeconfig |
-| --------------- | ------------------ | --------- | ---------------- | ----------------- |
-| yes             | `ever-works`       | ✅        | ✅               | ❌ (shared org)   |
-| yes             | `ever-works-cloud` | ❌ (org)  | ✅               | ❌ (shared org)   |
-| yes             | customer-owned     | ❌ (org)  | ✅               | ✅                |
-| no              | `ever-works`       | ❌ (admin)| ✅               | ❌ (shared org)   |
-| no              | customer-owned     | ❌ (admin)| ✅               | ✅                |
+| isPlatformAdmin | Website owner      | k8s-works  | k8s-works-shared | custom-kubeconfig |
+| --------------- | ------------------ | ---------- | ---------------- | ----------------- |
+| yes             | `ever-works`       | ✅         | ✅               | ❌ (shared org)   |
+| yes             | `ever-works-cloud` | ❌ (org)   | ✅               | ❌ (shared org)   |
+| yes             | customer-owned     | ❌ (org)   | ✅               | ✅                |
+| no              | `ever-works`       | ❌ (admin) | ✅               | ❌ (shared org)   |
+| no              | customer-owned     | ❌ (admin) | ✅               | ✅                |
 
 **UI enforcement.** `isPlatformAdmin` is deliberately stripped from the client
 profile, so the dropdown cannot be filtered client-side. `GET /api/deploy/cluster-sources`

--- a/docs/specs/features/k8s-cluster-source-matrix/spec.md
+++ b/docs/specs/features/k8s-cluster-source-matrix/spec.md
@@ -20,6 +20,54 @@
 
 ---
 
+## 0. Revision — cluster-source rename + admin gating
+
+> The sections below describe the **original EW-616** behaviour. This revision
+> renames the values and tightens the gate; where they conflict, this section
+> wins. A one-shot data migration (`*-RenameK8sClusterSource`) rewrites stored
+> values atomically on API startup.
+
+**Renamed values** (the name now matches the physical cluster):
+
+| Old value     | New value          | Cluster                                   | Kubeconfig env var                        |
+| ------------- | ------------------ | ----------------------------------------- | ----------------------------------------- |
+| `k8s-gauzy`   | `k8s-works`        | Ever Works **internal** cluster (admin)   | `EVER_WORKS_K8S_WORKS_KUBECONFIG`         |
+| `k8s-works`   | `k8s-works-shared` | Ever Works **shared customer** cluster    | `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG`  |
+| `custom-kubeconfig` | `custom-kubeconfig` | Bring-your-own                      | user-pasted                               |
+
+Because the string `k8s-works` meant "shared" before and means "internal" after,
+the migration MUST run before any post-rename code reads a stored value; the
+runtime `coerceClusterSource`/`normalizeClusterSource` only remaps the
+non-colliding legacy `k8s-gauzy` alias (never `k8s-works`).
+
+**Admin gating.** `k8s-works` (internal cluster) now requires **BOTH**
+`User.isPlatformAdmin` **AND** a website repo in the `ever-works` org. Non-admins
+must not see `k8s-works` in the settings dropdown and must not be able to deploy
+to it via the API/CLI. The updated matrix (`allowed` = may pick):
+
+| isPlatformAdmin | Website owner      | k8s-works | k8s-works-shared | custom-kubeconfig |
+| --------------- | ------------------ | --------- | ---------------- | ----------------- |
+| yes             | `ever-works`       | ✅        | ✅               | ❌ (shared org)   |
+| yes             | `ever-works-cloud` | ❌ (org)  | ✅               | ❌ (shared org)   |
+| yes             | customer-owned     | ❌ (org)  | ✅               | ✅                |
+| no              | `ever-works`       | ❌ (admin)| ✅               | ❌ (shared org)   |
+| no              | customer-owned     | ❌ (admin)| ✅               | ✅                |
+
+**UI enforcement.** `isPlatformAdmin` is deliberately stripped from the client
+profile, so the dropdown cannot be filtered client-side. `GET /api/deploy/cluster-sources`
+computes the allowed list server-side (via `allowedClusterSourcesFor(isPlatformAdmin, websiteOwner?)`)
+and the `k8s-cluster-source` widget renders exactly that. Server-side
+`validateClusterSourceForOwner` is the authoritative gate regardless of the UI.
+
+**Graceful "not yet available".** `k8s-works-shared`'s cluster may not be
+provisioned; when `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` is unset the deploy
+fails with a clear "not available yet" message (500) rather than crashing.
+
+**Default provider.** When no deploy provider is connected, Kubernetes (not
+Vercel) is the default; Vercel becomes the default the moment its token is saved.
+
+---
+
 ## 1. Overview
 
 Before EW-616, the k8s deploy plugin had a single way to configure a cluster: paste a `kubeconfig` YAML. That conflated three different operational paths into one form field:

--- a/docs/specs/features/k8s-cluster-source-matrix/tasks.md
+++ b/docs/specs/features/k8s-cluster-source-matrix/tasks.md
@@ -2,8 +2,14 @@
 
 > Backlog of discrete, completable units of work that implement [`./plan.md`](./plan.md).
 
-**Status**: `Done`
+**Status**: `Done` (plus a later cluster-source rename — see [`spec.md` §0](./spec.md#0-revision--cluster-source-rename--admin-gating))
 **Last updated**: 2026-05-14
+
+> **Revision note:** a follow-up renamed the cluster-source values, admin-gated
+> `k8s-works`, added the `GET /api/deploy/cluster-sources` endpoint +
+> `k8s-cluster-source` widget, added the `RenameK8sClusterSource` migration, and
+> made k8s the default provider when Vercel is unconnected. See
+> [`spec.md` §0](./spec.md#0-revision--cluster-source-rename--admin-gating).
 
 ---
 

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -206,7 +206,18 @@ describe('DeployFacadeService', () => {
             ).resolves.toBe(true);
         });
 
-        it('returns the sentinel for k8s + clusterSource=k8s-gauzy when no kubeconfig is saved', async () => {
+        it('returns the sentinel for k8s + clusterSource=k8s-works-shared when no kubeconfig is saved', async () => {
+            const { service } = createService({
+                deployProvider: 'k8s',
+                settings: { clusterSource: { value: 'k8s-works-shared' } },
+            });
+
+            await expect(
+                service.getDeployToken({ userId: 'user-1', workId: 'work-1' }),
+            ).resolves.toBe(PLATFORM_MANAGED_KUBECONFIG_SENTINEL);
+        });
+
+        it('returns the sentinel for the legacy k8s-gauzy alias (rolling-deploy defense-in-depth)', async () => {
             const { service } = createService({
                 deployProvider: 'k8s',
                 settings: { clusterSource: { value: 'k8s-gauzy' } },

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -950,16 +950,21 @@ export class DeployFacadeService implements IDeployFacade {
             });
 
             // EW-616: for the k8s plugin, when the user picked a
-            // platform-managed cluster (`k8s-works` / `k8s-gauzy`) the
-            // pasted kubeconfig is intentionally empty —
-            // `DeployService.resolveDeployToken()` substitutes the
-            // platform's kubeconfig from `EVER_WORKS_K8S_*_KUBECONFIG`
-            // env vars at deploy time. Return a non-empty sentinel here
-            // so the facade considers the work "configured" and lets the
-            // deploy proceed; the sentinel is discarded downstream.
+            // platform-managed cluster (`k8s-works` / `k8s-works-shared`, or
+            // the legacy `k8s-gauzy` alias) the pasted kubeconfig is
+            // intentionally empty — `DeployService.resolveDeployToken()`
+            // substitutes the platform's kubeconfig from
+            // `EVER_WORKS_K8S_*_KUBECONFIG` env vars at deploy time. Return a
+            // non-empty sentinel here so the facade considers the work
+            // "configured" and lets the deploy proceed; the sentinel is
+            // discarded downstream.
             if (pluginId === 'k8s') {
                 const clusterSource = settings.clusterSource?.value as string | undefined;
-                if (clusterSource === 'k8s-works' || clusterSource === 'k8s-gauzy') {
+                if (
+                    clusterSource === 'k8s-works' ||
+                    clusterSource === 'k8s-works-shared' ||
+                    clusterSource === 'k8s-gauzy'
+                ) {
                     return (
                         (settings.kubeconfig?.value as string) ||
                         PLATFORM_MANAGED_KUBECONFIG_SENTINEL
@@ -985,7 +990,7 @@ export class DeployFacadeService implements IDeployFacade {
 
 /**
  * Sentinel value returned by `getTokenFromSettings` for k8s deploys
- * targeting a platform-managed cluster (`k8s-works` / `k8s-gauzy`).
+ * targeting a platform-managed cluster (`k8s-works` / `k8s-works-shared`).
  * The deploy facade only checks that a token is non-empty before
  * deciding the work is "configured", so any unique string works.
  * `DeployService.resolveDeployToken()` discards this sentinel and

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -125,10 +125,21 @@ describe('KubernetesPlugin metadata', () => {
 		expect(allOf?.[0].then?.required).toEqual(['kubeconfig']);
 	});
 
-	it('exposes the cluster-source dropdown enum (EW-616)', () => {
+	it('exposes the cluster-source dropdown enum + admin-aware widget', () => {
 		const cs = plugin.settingsSchema.properties?.clusterSource as Record<string, unknown>;
-		expect(cs?.enum).toEqual(['k8s-works', 'k8s-gauzy', 'custom-kubeconfig']);
+		// `k8s-works-shared` (shared customer cluster) is listed first as the
+		// customer default; `k8s-works` (internal cluster) is admin-only.
+		expect(cs?.enum).toEqual(['k8s-works-shared', 'k8s-works', 'custom-kubeconfig']);
 		expect(cs?.default).toBe('custom-kubeconfig');
+		// The dropdown is rendered by the admin-aware `k8s-cluster-source` widget,
+		// which hides `k8s-works` from non-admins.
+		expect(cs?.['x-widget']).toBe('k8s-cluster-source');
+		// The static description must NOT mention the admin-only `k8s-works` as a
+		// selectable option (note: `k8s-works-shared` legitimately contains that
+		// substring, so match the quoted option token / "internal cluster" copy).
+		expect(String(cs?.description)).not.toContain("'k8s-works'");
+		expect(String(cs?.description)).not.toMatch(/internal cluster/i);
+		expect(String(cs?.description)).toContain('k8s-works-shared');
 	});
 
 	it('hides kubeconfig + kubeContext when clusterSource is platform-managed (EW-616 UI)', () => {
@@ -182,15 +193,15 @@ describe('KubernetesPlugin.validateConnection', () => {
 		expect(r.message).toMatch(/paste a kubeconfig/i);
 	});
 
-	it('skips kubeconfig validation for platform-managed cluster sources (EW-616)', async () => {
-		const works = await plugin.validateConnection({ clusterSource: 'k8s-works' });
-		expect(works.success).toBe(true);
-		expect(works.message).toMatch(/platform-managed cluster 'k8s-works'/);
-		expect((works.details as { clusterSource?: string })?.clusterSource).toBe('k8s-works');
+	it('skips kubeconfig validation for platform-managed cluster sources', async () => {
+		const shared = await plugin.validateConnection({ clusterSource: 'k8s-works-shared' });
+		expect(shared.success).toBe(true);
+		expect(shared.message).toMatch(/platform-managed cluster 'k8s-works-shared'/);
+		expect((shared.details as { clusterSource?: string })?.clusterSource).toBe('k8s-works-shared');
 
-		const gauzy = await plugin.validateConnection({ clusterSource: 'k8s-gauzy' });
-		expect(gauzy.success).toBe(true);
-		expect(gauzy.message).toMatch(/platform-managed cluster 'k8s-gauzy'/);
+		const internal = await plugin.validateConnection({ clusterSource: 'k8s-works' });
+		expect(internal.success).toBe(true);
+		expect(internal.message).toMatch(/platform-managed cluster 'k8s-works'/);
 	});
 
 	it('returns rich cluster details on success', async () => {
@@ -239,15 +250,17 @@ describe('KubernetesPlugin.getDeploymentSecrets', () => {
 		expect(out.K8S_NAMESPACE).toBe('ever-works');
 	});
 
-	it('emits K8S_CLUSTER_SOURCE (defaulting to custom-kubeconfig for back-compat) (EW-616)', async () => {
+	it('emits K8S_CLUSTER_SOURCE (defaulting to custom-kubeconfig for back-compat)', async () => {
 		expect((await plugin.getDeploymentSecrets({})).K8S_CLUSTER_SOURCE).toBe('custom-kubeconfig');
+		expect((await plugin.getDeploymentSecrets({ clusterSource: 'k8s-works-shared' })).K8S_CLUSTER_SOURCE).toBe(
+			'k8s-works-shared'
+		);
 		expect((await plugin.getDeploymentSecrets({ clusterSource: 'k8s-works' })).K8S_CLUSTER_SOURCE).toBe(
 			'k8s-works'
 		);
-		expect((await plugin.getDeploymentSecrets({ clusterSource: 'k8s-gauzy' })).K8S_CLUSTER_SOURCE).toBe(
-			'k8s-gauzy'
-		);
-		// Garbage values fall through to the back-compat default.
+		// Garbage values (and the retired legacy `k8s-gauzy` spelling) fall
+		// through to the back-compat default — the plugin only knows the
+		// current values; the API-side migration rewrites stored legacy values.
 		expect((await plugin.getDeploymentSecrets({ clusterSource: 'nope' })).K8S_CLUSTER_SOURCE).toBe(
 			'custom-kubeconfig'
 		);

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -44,7 +44,7 @@ import type {
 	ResolvedImageVisibility
 } from './types.js';
 
-const VALID_CLUSTER_SOURCES: readonly ClusterSource[] = ['k8s-works', 'k8s-gauzy', 'custom-kubeconfig'];
+const VALID_CLUSTER_SOURCES: readonly ClusterSource[] = ['k8s-works-shared', 'k8s-works', 'custom-kubeconfig'];
 
 function isClusterSource(value: unknown): value is ClusterSource {
 	return typeof value === 'string' && (VALID_CLUSTER_SOURCES as readonly string[]).includes(value);
@@ -148,11 +148,27 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		properties: {
 			clusterSource: {
 				type: 'string',
-				enum: ['k8s-works', 'k8s-gauzy', 'custom-kubeconfig'],
+				// `k8s-works-shared` (shared customer cluster) is listed first as the
+				// customer default. `k8s-works` (internal cluster) is admin-only and is
+				// hidden from non-admins by the `k8s-cluster-source` widget + the
+				// server-side deploy gate; it stays in the enum so platform admins can
+				// still persist it (schema validation must accept it). `default` stays
+				// `custom-kubeconfig` so pre-existing Works with a pasted kubeconfig and
+				// no explicit clusterSource keep deploying exactly as before.
+				enum: ['k8s-works-shared', 'k8s-works', 'custom-kubeconfig'],
 				default: 'custom-kubeconfig',
 				title: 'Target cluster',
+				// Non-admin-safe copy (no mention of the admin-only `k8s-works`). The
+				// `k8s-cluster-source` widget renders the full admin copy for platform
+				// admins. Keep these two in sync with the owner-provided wording.
 				description:
-					"Where to deploy. 'k8s-works' = Ever Works shared customer cluster. 'k8s-gauzy' = Ever Works internal cluster (admin-only, requires the website repo to live in the 'ever-works' GitHub org). 'custom-kubeconfig' = paste your own kubeconfig below. Allowed values depend on the GitHub org that owns the website repo."
+					"Where to deploy. 'k8s-works-shared' = Ever Works shared customer cluster. 'custom-kubeconfig' = paste your own kubeconfig below. Allowed values depend on the GitHub org that owns the website repo.",
+				// EW: admin-aware dropdown. The widget fetches the caller's allowed
+				// cluster sources from `GET /api/deploy/cluster-sources` (filtered by
+				// `isPlatformAdmin` server-side, since the client is never told the
+				// admin flag) and renders human labels. Falls back to the raw `enum`
+				// in renderers that don't know the widget.
+				'x-widget': 'k8s-cluster-source'
 			},
 			kubeconfig: {
 				type: 'string',

--- a/packages/plugins/k8s/src/kubeconfig.parser.ts
+++ b/packages/plugins/k8s/src/kubeconfig.parser.ts
@@ -1,4 +1,7 @@
-import yaml from 'js-yaml';
+// js-yaml v5 is ESM-only and dropped its default export, so `import yaml from
+// 'js-yaml'` resolves to `undefined` (→ "Cannot read properties of undefined
+// (reading 'load')"). Use a namespace import to pick up the named `load` export.
+import * as yaml from 'js-yaml';
 import { createHash } from 'node:crypto';
 import { K8sPluginError } from './errors.js';
 

--- a/packages/plugins/k8s/src/types.ts
+++ b/packages/plugins/k8s/src/types.ts
@@ -48,29 +48,39 @@ export type ResolvedImageVisibility = 'public' | 'private';
 /**
  * Where the kubeconfig used to talk to the target cluster comes from.
  *
- * - `'k8s-works'`        — Ever Works shared customer cluster. The
- *                          platform substitutes
- *                          `process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG`
- *                          for the `K8S_TOKEN` GitHub Actions secret at
- *                          deploy time. The `kubeconfig` field below is
- *                          ignored.
- * - `'k8s-gauzy'`        — Ever Works internal platform cluster. Same
- *                          shape as `'k8s-works'` but uses
- *                          `process.env.EVER_WORKS_K8S_GAUZY_KUBECONFIG`.
- *                          Only allowed when the Work's website repo is
- *                          in the `ever-works` org (admin/internal
- *                          path).
- * - `'custom-kubeconfig'`— Customer pastes their own kubeconfig in the
- *                          `kubeconfig` field below. Only allowed when
- *                          the Work's website repo is NOT in an Ever
- *                          Works-shared org (the cell C exclusion).
+ * - `'k8s-works'`         — Ever Works *internal* cluster. Admin-only:
+ *                           allowed only for platform admins whose Work's
+ *                           website repo is in the `ever-works` GitHub org.
+ *                           The platform substitutes
+ *                           `process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG`
+ *                           for the `K8S_TOKEN` GitHub Actions secret at
+ *                           deploy time. The `kubeconfig` field below is
+ *                           ignored.
+ * - `'k8s-works-shared'`  — Ever Works *shared customer* cluster — the
+ *                           default target for regular customers. Same
+ *                           shape as `'k8s-works'` but uses
+ *                           `process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG`.
+ *                           That cluster may not be provisioned yet; when the
+ *                           env var is absent the deploy layer surfaces a clear
+ *                           "not yet available" error rather than crashing.
+ * - `'custom-kubeconfig'` — Customer pastes their own kubeconfig in the
+ *                           `kubeconfig` field below. Only allowed when
+ *                           the Work's website repo is NOT in an Ever
+ *                           Works-shared org (the cross-tenant-PAT exclusion).
  *
- * Validation of the (website-repo-owner, clusterSource) combination
- * happens in `DeployService.deploy()`. See the EW-615/EW-616 tickets
+ * Legacy note: this used to be `'k8s-works' | 'k8s-gauzy' | 'custom-kubeconfig'`
+ * where `'k8s-works'` meant the shared cluster and `'k8s-gauzy'` the internal
+ * one. They were renamed — old `k8s-gauzy` → `k8s-works` (internal), old
+ * `k8s-works` → `k8s-works-shared` (shared). A one-shot data migration rewrites
+ * stored values atomically, and the deploy layer still resolves the legacy
+ * `k8s-gauzy` alias defensively.
+ *
+ * Validation of the (website-repo-owner, isPlatformAdmin, clusterSource)
+ * combination happens in `DeployService.deploy()`. See the EW-615/EW-616 tickets
  * and `Workspace/knowledge/runbooks/EVER_WORKS_K8S_DEPLOY_TROUBLESHOOTING.md`
  * for the full supported-matrix table.
  */
-export type ClusterSource = 'k8s-works' | 'k8s-gauzy' | 'custom-kubeconfig';
+export type ClusterSource = 'k8s-works' | 'k8s-works-shared' | 'custom-kubeconfig';
 
 /**
  * Plugin settings as stored in `plugin_settings`.


### PR DESCRIPTION
## What & why

Reworks the per-Work **deploy-target resolution** for the Kubernetes deploy provider and fixes the stale cluster list on `app.ever.works/settings/plugins/deployment`. These are **end-user** deployment settings (where a customer publishes their generated Work), not Ever's own infra.

The value names now match the physical clusters, `k8s-works` is locked to platform admins, and Kubernetes becomes the default provider when Vercel isn't connected.

## The rename (value collision — handled by an atomic migration)

| Old value | New value | Cluster | Kubeconfig env var |
| --- | --- | --- | --- |
| `k8s-gauzy` | **`k8s-works`** | Ever Works **internal** cluster (admin-only) | `EVER_WORKS_K8S_WORKS_KUBECONFIG` |
| `k8s-works` | **`k8s-works-shared`** | Ever Works **shared customer** cluster (default) | `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` |
| `custom-kubeconfig` | `custom-kubeconfig` | Bring-your-own | user-pasted |

The string `k8s-works` meant *shared* before and means *internal* after — a genuine value collision. It's resolved **once, atomically**, by a one-shot TypeORM migration that rewrites stored values across `plugins` / `user_plugins` / `work_plugins` on API boot (single transaction, before any post-rename read). Runtime `coerce`/`normalize` therefore only remaps the **non-colliding** legacy `k8s-gauzy` alias — never `k8s-works`.

> ⚠️ **Deviation from the brief (deliberate correctness fix):** the task's step 4 asked runtime `coerceClusterSource` to remap `k8s-works → k8s-works-shared`. That would silently downgrade every admin's saved selection on read, since `k8s-works` is now a valid new value. The migration owns that remap instead; runtime coercion only touches `k8s-gauzy`.

## Security gate (authoritative, server-side)

`k8s-works` (internal cluster) requires **BOTH** `User.isPlatformAdmin` **AND** a website repo owned by the `ever-works` org. Enforced in `validateClusterSourceForOwner` (fails closed) and wired through `resolveDeployToken` (which now loads `work.user.isPlatformAdmin`). The `custom-kubeconfig`-vs-shared-org cross-tenant-PAT rule is preserved. A non-admin cannot deploy to `k8s-works` via API/CLI even by crafting the request.

| isPlatformAdmin | Website owner | k8s-works | k8s-works-shared | custom-kubeconfig |
| --- | --- | --- | --- | --- |
| yes | `ever-works` | ✅ | ✅ | ❌ shared org |
| yes | `ever-works-cloud` | ❌ org | ✅ | ❌ shared org |
| yes | customer-owned | ❌ org | ✅ | ✅ |
| no | `ever-works` | ❌ admin | ✅ | ❌ shared org |
| no | customer-owned | ❌ admin | ✅ | ✅ |

## Admin-aware UI (server-driven, since the client can't see the flag)

`isPlatformAdmin` is deliberately stripped from the client profile response, so the prompt's "minimal fallback" (filter the enum client-side) is **impossible**. Instead: new `GET /api/deploy/cluster-sources` returns the already-filtered `{value,label,description}[]` (computed via `allowedClusterSourcesFor(isPlatformAdmin, websiteOwner?)`), and a new `k8s-cluster-source` widget renders exactly that (placed before the enum branch in `PluginSettingsField`, fail-closed to the non-admin subset on error). **UI hiding is cosmetic; the server gate is the real boundary.**

## Other behaviour

- **`k8s-works-shared`** reads `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG`; its cluster may not be provisioned yet, so an unset env var yields a clear *"not available yet"* 500 rather than a crash or a silent wrong target.
- **Default provider:** k8s when no provider is connected (`new/page.tsx`); Vercel wins the moment its token is saved (`configured`).
- **No-removal honored:** the DigitalOcean self-deploy workflows/manifests (`.github/workflows/deploy-do-*`, `.deploy/k8s/*`) are untouched — their `k8s-gauzy`/`k8s-works` strings are a separate self-deploy pipeline.

## Infra (already provisioned — not touched here)

`EVER_WORKS_K8S_WORKS_KUBECONFIG` already points at the live internal cluster (`https://192.168.1.210:6443`). `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` is not set yet (shared cluster not built) and is tolerated gracefully.

## Decisions confirmed with the owner

- **Shared cluster** resolves via a **dedicated new env var** (keeps the existing `ever-works` per-user-namespace provider untouched; reconciliation is a follow-up).
- **Single PR** to `develop`, then cascade `develop → stage → main`.
- Admin `k8s-works` requires **both** `isPlatformAdmin` and `ever-works` org (the brief's assumption).

## Tests & verification

- Typecheck green: `@ever-works/k8s-plugin`, `@ever-works/agent`, `ever-works-api`, `ever-works-web`.
- `cluster-source-matrix.spec` (47), `deploy.service.spec` (54), `deploy.facade.spec` (19), `deploy.controller.spec` (+3 admin-filter cases), k8s plugin schema/sentinel specs updated. API deploy module: **267 passed / 9 skipped**.
- One pre-existing k8s `validateToken` failure is **red on `develop`** already (kubeconfig-parse fixture), unrelated to this change.
- Ran a 4-lens adversarial review (auth-bypass · migration correctness · collision/back-compat · logic) with per-finding verification: **0 confirmed findings**.

## Follow-ups (out of scope)

- Reconcile `k8s-works-shared` with the existing `EverWorksK8sDeployProvider` / `EVER_WORKS_DEPLOY_KUBECONFIG` per-user-namespace mechanism.
- Provision `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` when the shared cluster is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-aware Kubernetes “Target cluster” dropdown with internal, shared, and custom-kubeconfig options.
  * The UI now loads allowed options from the server and shows the selected option’s description when available.
  * Kubernetes can now be the default deployment provider when no other provider is configured.

* **Bug Fixes**
  * Legacy Kubernetes cluster selections are automatically remapped to the updated naming.
  * Improved behavior and messaging when the shared managed cluster isn’t available yet, plus tighter access control.

* **Documentation**
  * Updated Kubernetes deployment guidance for required fields, kubeconfig rules, and availability/migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->