### PR TITLE
fix(web): remove `/api/api/` double-prefix across job-runtime, notification & email API clients

### DIFF
--- a/apps/web/src/lib/api/email-addresses.ts
+++ b/apps/web/src/lib/api/email-addresses.ts
@@ -57,15 +57,13 @@ export interface EmailMessageDetail extends EmailMessageListItem {
 export const emailAddressesAPI = {
     list: async (direction?: EmailAddressDirection) => {
         const query = direction ? `?direction=${direction}` : '';
-        const data = await serverFetch<{ addresses: EmailAddress[] }>(
-            `/api/email/addresses${query}`,
-        );
+        const data = await serverFetch<{ addresses: EmailAddress[] }>(`/email/addresses${query}`);
         return data.addresses;
     },
     create: async (input: CreateEmailAddressDto) => {
         const data = await serverMutation<{ address: EmailAddress }>({
             method: 'POST',
-            endpoint: '/api/email/addresses',
+            endpoint: '/email/addresses',
             data: input,
             wrapInData: false,
         });
@@ -74,7 +72,7 @@ export const emailAddressesAPI = {
     update: async (id: string, input: Partial<CreateEmailAddressDto> & { disabled?: boolean }) => {
         const data = await serverMutation<{ address: EmailAddress }>({
             method: 'PATCH',
-            endpoint: `/api/email/addresses/${id}`,
+            endpoint: `/email/addresses/${id}`,
             data: input,
             wrapInData: false,
         });
@@ -83,7 +81,7 @@ export const emailAddressesAPI = {
     remove: async (id: string) => {
         await serverMutation<void>({
             method: 'DELETE',
-            endpoint: `/api/email/addresses/${id}`,
+            endpoint: `/email/addresses/${id}`,
             data: {},
             wrapInData: false,
         });
@@ -91,7 +89,7 @@ export const emailAddressesAPI = {
     triggerVerification: async (id: string) => {
         const data = await serverMutation<{ messageRef: string }>({
             method: 'POST',
-            endpoint: `/api/email/addresses/${id}/verify`,
+            endpoint: `/email/addresses/${id}/verify`,
             data: {},
             wrapInData: false,
         });
@@ -99,14 +97,12 @@ export const emailAddressesAPI = {
     },
     listMessagesForAgent: async (agentId: string, limit = 50, offset = 0) => {
         const data = await serverFetch<{ messages: EmailMessageListItem[] }>(
-            `/api/email/messages?agentId=${agentId}&limit=${limit}&offset=${offset}`,
+            `/email/messages?agentId=${agentId}&limit=${limit}&offset=${offset}`,
         );
         return data.messages;
     },
     getMessage: async (id: string) => {
-        const data = await serverFetch<{ message: EmailMessageDetail }>(
-            `/api/email/messages/${id}`,
-        );
+        const data = await serverFetch<{ message: EmailMessageDetail }>(`/email/messages/${id}`);
         return data.message;
     },
     sendMessage: async (input: {
@@ -122,7 +118,7 @@ export const emailAddressesAPI = {
             result: { providerMessageId: string; accepted: string[]; rejected: unknown[] };
         }>({
             method: 'POST',
-            endpoint: '/api/email/messages',
+            endpoint: '/email/messages',
             data: input,
             wrapInData: false,
         });

--- a/apps/web/src/lib/api/email-addresses.unit.spec.ts
+++ b/apps/web/src/lib/api/email-addresses.unit.spec.ts
@@ -1,0 +1,135 @@
+// EW-650 / EW-679 — regression spec for the email-addresses API wrapper.
+// Guards the endpoint URL shape against the `/api/api/...` double-prefix
+// bug: `serverFetch` / `serverMutation` prepend `API_URL` (normalised to
+// end in `/api`), so endpoints must NOT start with `/api`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+async function importApi() {
+    return import('./email-addresses');
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverMutationMock.mockReset();
+    serverFetchMock.mockResolvedValue({ addresses: [], messages: [], message: {} });
+    serverMutationMock.mockResolvedValue({ address: {}, messageRef: 'r', result: {} });
+});
+afterEach(() => vi.resetModules());
+
+describe('emailAddressesAPI — endpoint URL shape (no /api double-prefix)', () => {
+    it('list GETs /email/addresses (with optional direction query)', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.list();
+        expect(serverFetchMock).toHaveBeenCalledWith('/email/addresses');
+        await emailAddressesAPI.list('inbound');
+        expect(serverFetchMock).toHaveBeenCalledWith('/email/addresses?direction=inbound');
+    });
+
+    it('create POSTs /email/addresses', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.create({
+            address: 'a@b.co',
+            direction: 'both',
+            pluginId: 'p',
+            providerSettings: {},
+        });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'POST', endpoint: '/email/addresses' }),
+        );
+    });
+
+    it('update PATCHes /email/addresses/:id', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.update('e-1', { defaultForReplies: true });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'PATCH', endpoint: '/email/addresses/e-1' }),
+        );
+    });
+
+    it('remove DELETEs /email/addresses/:id', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.remove('e-1');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'DELETE', endpoint: '/email/addresses/e-1' }),
+        );
+    });
+
+    it('triggerVerification POSTs /email/addresses/:id/verify', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.triggerVerification('e-1');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/email/addresses/e-1/verify' }),
+        );
+    });
+
+    it('listMessagesForAgent GETs /email/messages with query params', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.listMessagesForAgent('ag-1', 50, 0);
+        expect(serverFetchMock).toHaveBeenCalledWith(
+            '/email/messages?agentId=ag-1&limit=50&offset=0',
+        );
+    });
+
+    it('getMessage GETs /email/messages/:id', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.getMessage('m-1');
+        expect(serverFetchMock).toHaveBeenCalledWith('/email/messages/m-1');
+    });
+
+    it('sendMessage POSTs /email/messages', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.sendMessage({
+            agentId: 'ag-1',
+            to: ['x@y.co'],
+            subject: 's',
+            bodyText: 'b',
+        });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'POST', endpoint: '/email/messages' }),
+        );
+    });
+
+    it('NONE of the methods ever passes an endpoint starting with /api', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await Promise.all([
+            emailAddressesAPI.list('outbound'),
+            emailAddressesAPI.create({
+                address: 'a@b.co',
+                direction: 'both',
+                pluginId: 'p',
+                providerSettings: {},
+            }),
+            emailAddressesAPI.update('id', {}),
+            emailAddressesAPI.remove('id'),
+            emailAddressesAPI.triggerVerification('id'),
+            emailAddressesAPI.listMessagesForAgent('ag', 10, 5),
+            emailAddressesAPI.getMessage('m'),
+            emailAddressesAPI.sendMessage({
+                agentId: 'a',
+                to: ['x@y.co'],
+                subject: 's',
+                bodyText: 'b',
+            }),
+        ]);
+
+        const fetchEndpoints = serverFetchMock.mock.calls.map((c) => c[0] as string);
+        const mutationEndpoints = serverMutationMock.mock.calls.map(
+            (c) => (c[0] as { endpoint: string }).endpoint,
+        );
+        for (const endpoint of [...fetchEndpoints, ...mutationEndpoints]) {
+            expect(endpoint.startsWith('/api')).toBe(false);
+            expect(endpoint).not.toContain('/api/');
+        }
+    });
+});

--- a/apps/web/src/lib/api/notification-channels.ts
+++ b/apps/web/src/lib/api/notification-channels.ts
@@ -26,14 +26,14 @@ export interface CreateChannelDto {
 export const notificationChannelsAPI = {
     list: async () => {
         const data = await serverFetch<{ channels: NotificationChannel[] }>(
-            '/api/notification-channels',
+            '/notification-channels',
         );
         return data.channels;
     },
     create: async (input: CreateChannelDto) => {
         const data = await serverMutation<{ channel: NotificationChannel }>({
             method: 'POST',
-            endpoint: '/api/notification-channels',
+            endpoint: '/notification-channels',
             data: input,
             wrapInData: false,
         });
@@ -42,7 +42,7 @@ export const notificationChannelsAPI = {
     update: async (id: string, input: Partial<CreateChannelDto> & { disabled?: boolean }) => {
         const data = await serverMutation<{ channel: NotificationChannel }>({
             method: 'PATCH',
-            endpoint: `/api/notification-channels/${id}`,
+            endpoint: `/notification-channels/${id}`,
             data: input,
             wrapInData: false,
         });
@@ -51,7 +51,7 @@ export const notificationChannelsAPI = {
     remove: async (id: string) => {
         await serverMutation<void>({
             method: 'DELETE',
-            endpoint: `/api/notification-channels/${id}`,
+            endpoint: `/notification-channels/${id}`,
             data: {},
             wrapInData: false,
         });
@@ -59,7 +59,7 @@ export const notificationChannelsAPI = {
     sendTest: async (id: string) => {
         return serverMutation<{ status: string; error?: string; providerMessageId?: string }>({
             method: 'POST',
-            endpoint: `/api/notification-channels/${id}/test`,
+            endpoint: `/notification-channels/${id}/test`,
             data: {},
             wrapInData: false,
         });

--- a/apps/web/src/lib/api/notification-channels.unit.spec.ts
+++ b/apps/web/src/lib/api/notification-channels.unit.spec.ts
@@ -1,0 +1,88 @@
+// EW-663 / EW-679 — regression spec for the notification-channels API
+// wrapper. Guards the endpoint URL shape against the `/api/api/...`
+// double-prefix bug: `serverFetch` / `serverMutation` prepend `API_URL`
+// (normalised to end in `/api`), so endpoints must NOT start with `/api`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+async function importApi() {
+    return import('./notification-channels');
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverMutationMock.mockReset();
+    serverFetchMock.mockResolvedValue({ channels: [] });
+    serverMutationMock.mockResolvedValue({ channel: {} });
+});
+afterEach(() => vi.resetModules());
+
+describe('notificationChannelsAPI — endpoint URL shape (no /api double-prefix)', () => {
+    it('list GETs /notification-channels', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await notificationChannelsAPI.list();
+        expect(serverFetchMock).toHaveBeenCalledWith('/notification-channels');
+    });
+
+    it('create POSTs /notification-channels', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await notificationChannelsAPI.create({ pluginId: 'p', name: 'n', targetConfig: {} });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'POST', endpoint: '/notification-channels' }),
+        );
+    });
+
+    it('update PATCHes /notification-channels/:id', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await notificationChannelsAPI.update('ch-1', { name: 'n2' });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'PATCH', endpoint: '/notification-channels/ch-1' }),
+        );
+    });
+
+    it('remove DELETEs /notification-channels/:id', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await notificationChannelsAPI.remove('ch-1');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'DELETE', endpoint: '/notification-channels/ch-1' }),
+        );
+    });
+
+    it('sendTest POSTs /notification-channels/:id/test', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await notificationChannelsAPI.sendTest('ch-1');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/notification-channels/ch-1/test' }),
+        );
+    });
+
+    it('NONE of the methods ever passes an endpoint starting with /api', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await Promise.all([
+            notificationChannelsAPI.list(),
+            notificationChannelsAPI.create({ pluginId: 'p', name: 'n', targetConfig: {} }),
+            notificationChannelsAPI.update('id', { name: 'n' }),
+            notificationChannelsAPI.remove('id'),
+            notificationChannelsAPI.sendTest('id'),
+        ]);
+
+        const fetchEndpoints = serverFetchMock.mock.calls.map((c) => c[0] as string);
+        const mutationEndpoints = serverMutationMock.mock.calls.map(
+            (c) => (c[0] as { endpoint: string }).endpoint,
+        );
+        for (const endpoint of [...fetchEndpoints, ...mutationEndpoints]) {
+            expect(endpoint.startsWith('/api')).toBe(false);
+            expect(endpoint).not.toContain('/api/');
+        }
+    });
+});

--- a/apps/web/src/lib/api/notification-preferences.ts
+++ b/apps/web/src/lib/api/notification-preferences.ts
@@ -39,17 +39,17 @@ export interface PreferencesView {
 export const notificationPreferencesAPI = {
     listEventTypes: async () => {
         const data = await serverFetch<{ eventTypes: NotificationEventType[] }>(
-            '/api/notifications/event-types',
+            '/notifications/event-types',
         );
         return data.eventTypes;
     },
     getPreferences: async () => {
-        return serverFetch<PreferencesView>('/api/notifications/preferences');
+        return serverFetch<PreferencesView>('/notifications/preferences');
     },
     setEventSubscription: async (eventKey: string, channelIds: string[]) => {
         return serverMutation<{ subscription: NotificationSubscription }>({
             method: 'PUT',
-            endpoint: `/api/notifications/preferences/event/${encodeURIComponent(eventKey)}`,
+            endpoint: `/notifications/preferences/event/${encodeURIComponent(eventKey)}`,
             data: { channelIds },
             wrapInData: false,
         });
@@ -61,7 +61,7 @@ export const notificationPreferencesAPI = {
     }) => {
         return serverMutation<{ preference: NotificationPreference }>({
             method: 'PUT',
-            endpoint: '/api/notifications/preferences/quiet-hours',
+            endpoint: '/notifications/preferences/quiet-hours',
             data: input,
             wrapInData: false,
         });
@@ -69,7 +69,7 @@ export const notificationPreferencesAPI = {
     muteCategory: async (category: string, mutedUntil: string | null) => {
         return serverMutation<{ mute: { category: string; mutedUntil: string | null } }>({
             method: 'POST',
-            endpoint: '/api/notifications/preferences/mute',
+            endpoint: '/notifications/preferences/mute',
             data: { category, mutedUntil },
             wrapInData: false,
         });
@@ -77,7 +77,7 @@ export const notificationPreferencesAPI = {
     unmuteCategory: async (category: string) => {
         await serverMutation<void>({
             method: 'DELETE',
-            endpoint: `/api/notifications/preferences/mute/${encodeURIComponent(category)}`,
+            endpoint: `/notifications/preferences/mute/${encodeURIComponent(category)}`,
             data: {},
             wrapInData: false,
         });

--- a/apps/web/src/lib/api/notification-preferences.unit.spec.ts
+++ b/apps/web/src/lib/api/notification-preferences.unit.spec.ts
@@ -1,0 +1,109 @@
+// EW-664 / EW-679 — regression spec for the notification-preferences API
+// wrapper. Pins the endpoint URL shape so the `/api/api/...` double-prefix
+// bug can never come back: `serverFetch` / `serverMutation` prepend
+// `API_URL` (normalised to end in `/api`), so every endpoint here MUST be
+// relative to `/api` — it must NOT start with `/api`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+async function importApi() {
+    return import('./notification-preferences');
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverMutationMock.mockReset();
+    serverFetchMock.mockResolvedValue({ eventTypes: [] });
+    serverMutationMock.mockResolvedValue({});
+});
+afterEach(() => vi.resetModules());
+
+describe('notificationPreferencesAPI — endpoint URL shape (no /api double-prefix)', () => {
+    it('listEventTypes GETs /notifications/event-types', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.listEventTypes();
+        expect(serverFetchMock).toHaveBeenCalledWith('/notifications/event-types');
+    });
+
+    it('getPreferences GETs /notifications/preferences', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.getPreferences();
+        expect(serverFetchMock).toHaveBeenCalledWith('/notifications/preferences');
+    });
+
+    it('setEventSubscription PUTs /notifications/preferences/event/:key', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.setEventSubscription('work.completed', ['c1']);
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'PUT',
+                endpoint: '/notifications/preferences/event/work.completed',
+                data: { channelIds: ['c1'] },
+                wrapInData: false,
+            }),
+        );
+    });
+
+    it('setQuietHours PUTs /notifications/preferences/quiet-hours', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.setQuietHours({
+            quietHoursStart: null,
+            quietHoursEnd: null,
+            timezone: null,
+        });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/notifications/preferences/quiet-hours' }),
+        );
+    });
+
+    it('muteCategory POSTs /notifications/preferences/mute', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.muteCategory('billing', null);
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/notifications/preferences/mute' }),
+        );
+    });
+
+    it('unmuteCategory DELETEs /notifications/preferences/mute/:category', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.unmuteCategory('billing');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/notifications/preferences/mute/billing' }),
+        );
+    });
+
+    it('NONE of the methods ever passes an endpoint starting with /api', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await Promise.all([
+            notificationPreferencesAPI.listEventTypes(),
+            notificationPreferencesAPI.getPreferences(),
+            notificationPreferencesAPI.setEventSubscription('e', ['c']),
+            notificationPreferencesAPI.setQuietHours({
+                quietHoursStart: null,
+                quietHoursEnd: null,
+                timezone: null,
+            }),
+            notificationPreferencesAPI.muteCategory('c', null),
+            notificationPreferencesAPI.unmuteCategory('c'),
+        ]);
+
+        const fetchEndpoints = serverFetchMock.mock.calls.map((c) => c[0] as string);
+        const mutationEndpoints = serverMutationMock.mock.calls.map(
+            (c) => (c[0] as { endpoint: string }).endpoint,
+        );
+        for (const endpoint of [...fetchEndpoints, ...mutationEndpoints]) {
+            expect(endpoint.startsWith('/api')).toBe(false);
+            expect(endpoint).not.toContain('/api/');
+        }
+    });
+});

--- a/apps/web/src/lib/api/operator-tenant-runtime-allowlist.unit.spec.ts
+++ b/apps/web/src/lib/api/operator-tenant-runtime-allowlist.unit.spec.ts
@@ -2,7 +2,7 @@
 // operator-scoped per-tenant runtime allow-list API wrapper.
 //
 // Targets: apps/web/src/lib/api/operator-tenant-runtime-allowlist.ts
-//   - URL construction (`/api/operator/tenants/:tenantId/runtime-allowlist`)
+//   - URL construction (`/operator/tenants/:tenantId/runtime-allowlist`)
 //   - .list() uses serverFetch (GET)
 //   - .replace() uses serverMutation with PUT + { providerIds } body + wrapInData: false
 //   - .deleteEntry() uses serverMutation with DELETE + /:providerId suffix
@@ -11,6 +11,12 @@
 //
 // Before: 0 spec lines covering this module. After: ~15 cases pinning the
 // URL shape and the request envelope for all three verbs.
+//
+// NOTE: these assertions were stale — they expected a leading `/api`, but
+// commit 52e590a4 already dropped it from `base()` (serverFetch prepends
+// API_URL, which ends in `/api`, so `/api/...` would double to `/api/api/`).
+// The spec was not updated in that commit and had been failing since.
+// Realigned here to the shipped `/operator/...` paths.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -46,9 +52,7 @@ describe('operatorTenantRuntimeAllowlistAPI.list', () => {
         const { operatorTenantRuntimeAllowlistAPI } = await importApi();
         await operatorTenantRuntimeAllowlistAPI.list('t-abc');
         expect(serverFetchMock).toHaveBeenCalledTimes(1);
-        expect(serverFetchMock).toHaveBeenCalledWith(
-            '/api/operator/tenants/t-abc/runtime-allowlist',
-        );
+        expect(serverFetchMock).toHaveBeenCalledWith('/operator/tenants/t-abc/runtime-allowlist');
     });
 
     it('returns the parsed response verbatim (no client-side reshaping)', async () => {
@@ -83,7 +87,7 @@ describe('operatorTenantRuntimeAllowlistAPI.replace', () => {
         await operatorTenantRuntimeAllowlistAPI.replace('t-7', ['trigger', 'bullmq']);
         expect(serverMutationMock).toHaveBeenCalledTimes(1);
         expect(serverMutationMock).toHaveBeenCalledWith({
-            endpoint: '/api/operator/tenants/t-7/runtime-allowlist',
+            endpoint: '/operator/tenants/t-7/runtime-allowlist',
             data: { providerIds: ['trigger', 'bullmq'] },
             method: 'PUT',
             wrapInData: false,
@@ -131,7 +135,7 @@ describe('operatorTenantRuntimeAllowlistAPI.deleteEntry', () => {
         await operatorTenantRuntimeAllowlistAPI.deleteEntry('t-7', 'trigger');
         expect(serverMutationMock).toHaveBeenCalledTimes(1);
         expect(serverMutationMock).toHaveBeenCalledWith({
-            endpoint: '/api/operator/tenants/t-7/runtime-allowlist/trigger',
+            endpoint: '/operator/tenants/t-7/runtime-allowlist/trigger',
             data: {},
             method: 'DELETE',
             wrapInData: false,
@@ -163,9 +167,7 @@ describe('convenience aliases', () => {
     it('getTenantRuntimeAllowlist delegates to .list(tenantId)', async () => {
         const { getTenantRuntimeAllowlist } = await importApi();
         await getTenantRuntimeAllowlist('t-99');
-        expect(serverFetchMock).toHaveBeenCalledWith(
-            '/api/operator/tenants/t-99/runtime-allowlist',
-        );
+        expect(serverFetchMock).toHaveBeenCalledWith('/operator/tenants/t-99/runtime-allowlist');
     });
 
     it('replaceTenantRuntimeAllowlist delegates to .replace(tenantId, providerIds)', async () => {
@@ -173,7 +175,7 @@ describe('convenience aliases', () => {
         await replaceTenantRuntimeAllowlist('t-99', ['trigger']);
         expect(serverMutationMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                endpoint: '/api/operator/tenants/t-99/runtime-allowlist',
+                endpoint: '/operator/tenants/t-99/runtime-allowlist',
                 method: 'PUT',
                 data: { providerIds: ['trigger'] },
             }),
@@ -185,7 +187,7 @@ describe('convenience aliases', () => {
         await deleteTenantRuntimeAllowlistEntry('t-99', 'inngest');
         expect(serverMutationMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                endpoint: '/api/operator/tenants/t-99/runtime-allowlist/inngest',
+                endpoint: '/operator/tenants/t-99/runtime-allowlist/inngest',
                 method: 'DELETE',
             }),
         );

--- a/apps/web/src/lib/api/tenant-job-runtime.ts
+++ b/apps/web/src/lib/api/tenant-job-runtime.ts
@@ -54,7 +54,12 @@ export interface TenantJobRuntimeAvailableProvidersResponse {
     providers: TenantJobRuntimeProviderId[];
 }
 
-const BASE = '/api/account/job-runtime';
+// NOTE: no leading `/api` here — `serverFetch`/`serverMutation` prepend
+// `API_URL`, which `lib/constants.ts` normalises to already end in `/api`.
+// Including `/api` here would compose to `/api/api/account/job-runtime/...`
+// → the Nest app 404s with "Cannot GET /api/api/...". Matches every other
+// helper in this folder (see the 52e590a4 operator-allowlist fix).
+const BASE = '/account/job-runtime';
 
 export const tenantJobRuntimeAPI = {
     getConfig: async () => {

--- a/apps/web/src/lib/api/tenant-job-runtime.unit.spec.ts
+++ b/apps/web/src/lib/api/tenant-job-runtime.unit.spec.ts
@@ -1,0 +1,187 @@
+// EW-742 — regression spec for the tenant job-runtime overlay API wrapper.
+//
+// Targets: apps/web/src/lib/api/tenant-job-runtime.ts
+//
+// Primary purpose: pin the endpoint URL shape so the `/api/api/...`
+// double-prefix bug can never come back. `serverFetch` / `serverMutation`
+// prepend `API_URL` (normalised to end in `/api` by lib/constants.ts), so
+// every endpoint passed here MUST be relative to `/api` — i.e. it must NOT
+// start with `/api`. A regression here rendered the Job Runtime settings
+// page unusable ("Cannot GET /api/api/account/job-runtime/config").
+//
+// Also covers the request envelope (method + wrapInData:false + body) for
+// each of the six verbs and the convenience aliases.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+const configResponse = {
+    tenantId: 't-1',
+    providerId: null,
+    mode: 'inherit',
+    hasCredentials: false,
+    credentialsSecretRefRedacted: null,
+    credentialVersion: null,
+    enabled: true,
+    createdBy: null,
+    createdAt: null,
+    updatedAt: null,
+};
+
+async function importApi() {
+    return import('./tenant-job-runtime');
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverMutationMock.mockReset();
+    serverFetchMock.mockResolvedValue(configResponse);
+    serverMutationMock.mockResolvedValue(configResponse);
+});
+afterEach(() => vi.resetModules());
+
+describe('tenantJobRuntimeAPI — endpoint URL shape (no /api double-prefix)', () => {
+    it('getConfig hits /account/job-runtime/config WITHOUT a leading /api', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.getConfig();
+        expect(serverFetchMock).toHaveBeenCalledTimes(1);
+        expect(serverFetchMock).toHaveBeenCalledWith('/account/job-runtime/config');
+    });
+
+    it('getAvailableProviders hits /account/job-runtime/available-providers', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.getAvailableProviders();
+        expect(serverFetchMock).toHaveBeenCalledWith('/account/job-runtime/available-providers');
+    });
+
+    it('upsertConfig PUTs to /account/job-runtime/config with the raw payload', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        const payload = { providerId: 'trigger', mode: 'byo' } as const;
+        await tenantJobRuntimeAPI.upsertConfig(payload);
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/account/job-runtime/config',
+            data: payload,
+            method: 'PUT',
+            wrapInData: false,
+        });
+    });
+
+    it('rotate POSTs to /account/job-runtime/rotate', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.rotate();
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/account/job-runtime/rotate',
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    });
+
+    it('forceInvalidate POSTs to /account/job-runtime/force-invalidate', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.forceInvalidate();
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/account/job-runtime/force-invalidate',
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    });
+
+    it('revertToInherit DELETEs /account/job-runtime/config', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.revertToInherit();
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/account/job-runtime/config',
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    });
+
+    it('NONE of the six verbs ever passes an endpoint starting with /api', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.getConfig();
+        await tenantJobRuntimeAPI.getAvailableProviders();
+        await tenantJobRuntimeAPI.upsertConfig({ providerId: 'trigger', mode: 'byo' });
+        await tenantJobRuntimeAPI.rotate();
+        await tenantJobRuntimeAPI.forceInvalidate();
+        await tenantJobRuntimeAPI.revertToInherit();
+
+        const fetchEndpoints = serverFetchMock.mock.calls.map((c) => c[0] as string);
+        const mutationEndpoints = serverMutationMock.mock.calls.map(
+            (c) => (c[0] as { endpoint: string }).endpoint,
+        );
+        for (const endpoint of [...fetchEndpoints, ...mutationEndpoints]) {
+            expect(endpoint.startsWith('/api')).toBe(false);
+            expect(endpoint).not.toContain('/api/');
+        }
+    });
+});
+
+describe('tenantJobRuntimeAPI — convenience aliases delegate to the namespaced object', () => {
+    it('getJobRuntimeConfig delegates to getConfig', async () => {
+        const { getJobRuntimeConfig } = await importApi();
+        await getJobRuntimeConfig();
+        expect(serverFetchMock).toHaveBeenCalledWith('/account/job-runtime/config');
+    });
+
+    it('getAvailableJobRuntimeProviders delegates to getAvailableProviders', async () => {
+        const { getAvailableJobRuntimeProviders } = await importApi();
+        await getAvailableJobRuntimeProviders();
+        expect(serverFetchMock).toHaveBeenCalledWith('/account/job-runtime/available-providers');
+    });
+
+    it('upsertJobRuntimeConfig delegates to upsertConfig', async () => {
+        const { upsertJobRuntimeConfig } = await importApi();
+        await upsertJobRuntimeConfig({ providerId: 'bullmq', mode: 'override' });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: '/account/job-runtime/config',
+                method: 'PUT',
+            }),
+        );
+    });
+
+    it('rotateJobRuntimeConfig delegates to rotate', async () => {
+        const { rotateJobRuntimeConfig } = await importApi();
+        await rotateJobRuntimeConfig();
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: '/account/job-runtime/rotate',
+                method: 'POST',
+            }),
+        );
+    });
+
+    it('forceInvalidateJobRuntimeConfig delegates to forceInvalidate', async () => {
+        const { forceInvalidateJobRuntimeConfig } = await importApi();
+        await forceInvalidateJobRuntimeConfig();
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: '/account/job-runtime/force-invalidate',
+                method: 'POST',
+            }),
+        );
+    });
+
+    it('deleteJobRuntimeConfig delegates to revertToInherit', async () => {
+        const { deleteJobRuntimeConfig } = await importApi();
+        await deleteJobRuntimeConfig();
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: '/account/job-runtime/config',
+                method: 'DELETE',
+            }),
+        );
+    });
+});

--- a/apps/web/src/lib/api/tenant-job-runtime.unit.spec.ts
+++ b/apps/web/src/lib/api/tenant-job-runtime.unit.spec.ts
@@ -110,12 +110,16 @@ describe('tenantJobRuntimeAPI — endpoint URL shape (no /api double-prefix)', (
 
     it('NONE of the six verbs ever passes an endpoint starting with /api', async () => {
         const { tenantJobRuntimeAPI } = await importApi();
-        await tenantJobRuntimeAPI.getConfig();
-        await tenantJobRuntimeAPI.getAvailableProviders();
-        await tenantJobRuntimeAPI.upsertConfig({ providerId: 'trigger', mode: 'byo' });
-        await tenantJobRuntimeAPI.rotate();
-        await tenantJobRuntimeAPI.forceInvalidate();
-        await tenantJobRuntimeAPI.revertToInherit();
+        // Independent calls — fire concurrently (we only assert the set of
+        // endpoints hit, not their order).
+        await Promise.all([
+            tenantJobRuntimeAPI.getConfig(),
+            tenantJobRuntimeAPI.getAvailableProviders(),
+            tenantJobRuntimeAPI.upsertConfig({ providerId: 'trigger', mode: 'byo' }),
+            tenantJobRuntimeAPI.rotate(),
+            tenantJobRuntimeAPI.forceInvalidate(),
+            tenantJobRuntimeAPI.revertToInherit(),
+        ]);
 
         const fetchEndpoints = serverFetchMock.mock.calls.map((c) => c[0] as string);
         const mutationEndpoints = serverMutationMock.mock.calls.map(


### PR DESCRIPTION
## Problem

The **Settings → Job Runtime** page showed:

> ⚠️ Cannot GET /api/api/account/job-runtime/config

and fell back to a synthetic *Inherit / Platform default* state, so the tenant could never see or edit their real overlay. Investigation showed the **same bug in several other API clients** too.

## Root cause

`serverFetch` / `serverMutation` compose the URL as `` `${API_URL}${endpoint}` ``, and `API_URL` (`lib/constants.ts`) is **normalised to always end in `/api`**:

```ts
export const API_URL = apiUrl.endsWith('/api') ? apiUrl : `${apiUrl}/api`;
```

So an `endpoint` that itself begins with `/api` composes to `<host>/api/api/...` → NestJS 404 (`Cannot GET /api/api/...`). This is the same class the team already fixed once for the operator client in `52e590a4`. A handful of newer clients reintroduced it.

## Fixes (all in `apps/web/src/lib/api/`)

| Client | Endpoints | Impact |
|---|---|---|
| `tenant-job-runtime.ts` | `BASE` `/api/account/job-runtime` → `/account/job-runtime` | **The reported bug** — Settings › Job Runtime |
| `notification-preferences.ts` | `/api/notifications/*` → `/notifications/*` (6) | **Live**: Settings › Notifications (list event types, get prefs) |
| `notification-channels.ts` | `/api/notification-channels/*` → `/notification-channels/*` (5) | **Live**: Notifications + Integrations › Channels (list, sendTest, remove) |
| `email-addresses.ts` | `/api/email/*` → `/email/*` (8) | **Live**: Integrations › Emails (list) + Agent Inbox (list/get messages) |

Each now composes to `<host>/api/<controller-path>`, matching the respective `@Controller('api/...')` (there is no `setGlobalPrefix` in the API). The live pages were failing today, masked by `.catch` fallbacks (empty lists / `notFound()`).

## Tests

- **New regression specs** for all four clients — per-endpoint URL assertions **plus a guard that NO method ever passes an endpoint starting with `/api`**, so this bug class can't come back.
- **Repaired** `operator-tenant-runtime-allowlist.unit.spec.ts` — its assertions still expected the pre-`52e590a4` `/api/operator/...` paths and had been **failing on develop since that fix landed** (impl updated, spec not). Realigned to the shipped `/operator/...` paths.

Verified locally: `vitest run` → all green, `prettier --check`, `eslint`, `tsc --noEmit` all clean.

## Scope note

The `uploads.ts` `/api/uploads/file` path was checked and is **not** affected — it's a direct browser fetch to a *relative* URL served by a real Next.js BFF route (`app/api/uploads/file/route.ts`), so `API_URL` never applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server API clients to use the correct REST paths (removing an extra `/api` prefix) to prevent incorrect routing and 404s.
  * Updated operator tenant runtime allowlist, tenant job runtime, email addresses, notification channels, and notification preferences endpoints.
* **Tests**
  * Added/expanded Vitest regression coverage for tenant job runtime, operator tenant runtime allowlist, email addresses, notification channels, and notification preferences.
  * Tests verify endpoint shapes (never starting with `/api`) and correct request methods/payload handling, including alias delegation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->