### PR TITLE
feat(tasks): self-hosted Trigger.dev deploys (flag-gated)

### DIFF
--- a/.github/workflows/release-trigger-prod.yml
+++ b/.github/workflows/release-trigger-prod.yml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   deploy:
+    # Legacy Trigger.dev CLOUD deploy. Skipped once we migrate to self-hosted
+    # (TRIGGER_SELFHOSTED=true -> release-trigger-selfhosted.yml handles it).
+    # Flip the flag back to re-enable this cloud path.
+    if: ${{ vars.TRIGGER_SELFHOSTED != 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod

--- a/.github/workflows/release-trigger-selfhosted.yml
+++ b/.github/workflows/release-trigger-selfhosted.yml
@@ -1,0 +1,110 @@
+name: Deploy to Self-hosted Trigger.dev
+
+# Deploys the packages/tasks bundle to our SELF-HOSTED Trigger.dev instance
+# (https://trigger.ever.co, org "Ever" / ever-2a3b) instead of Trigger.dev cloud.
+#
+# Additive + reversible: this whole workflow is gated behind the repo/org var
+# `TRIGGER_SELFHOSTED`. While that flag is unset/`false` this file is a no-op and
+# the legacy cloud deploys (release-trigger-{prod,stage}.yml) run as before. Flip
+# `TRIGGER_SELFHOSTED=true` to migrate onto self-hosted; flip it back to roll back.
+#
+# Auth: the self-hosted Personal Access Token lives in the repo Actions secret
+# `TRIGGER_SELFHOSTED_ACCESS_TOKEN`. The project ref is injected via env so the
+# shared trigger.config.ts targets the self-hosted project.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Trigger.dev environment to deploy to"
+        type: choice
+        options:
+          - prod
+          - staging
+        default: prod
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main, stage]
+    types:
+      - completed
+
+# M-12: minimum default permissions. Individual jobs can elevate where needed.
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    # Only run when the self-hosted migration flag is on AND the trigger is valid
+    # (a manual dispatch, or a CI run that actually succeeded).
+    if: >-
+      ${{ vars.TRIGGER_SELFHOSTED == 'true' &&
+          (github.event_name == 'workflow_dispatch' ||
+           github.event.workflow_run.conclusion == 'success') }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # For workflow_run, check out the exact commit CI validated.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Resolve target Trigger.dev environment
+        id: env
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TRIGGER_ENV="${{ github.event.inputs.environment }}"
+          else
+            # workflow_run: map the head branch to a Trigger.dev env.
+            case "${{ github.event.workflow_run.head_branch }}" in
+              main)  TRIGGER_ENV="prod" ;;
+              stage) TRIGGER_ENV="staging" ;;
+              *)     TRIGGER_ENV="" ;;
+            esac
+          fi
+          if [ -z "$TRIGGER_ENV" ]; then
+            echo "No self-hosted Trigger.dev env for this trigger; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Deploying to self-hosted Trigger.dev env: $TRIGGER_ENV"
+            echo "trigger_env=$TRIGGER_ENV" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install pnpm
+        if: steps.env.outputs.skip != 'true'
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3
+        with:
+          version: 10.33.3
+
+      - name: Use Node.js 22.x
+        if: steps.env.outputs.skip != 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22.x"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        if: steps.env.outputs.skip != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        if: steps.env.outputs.skip != 'true'
+        run: pnpm build --filter './packages/**'
+
+      - name: Prepare plugins for Trigger.dev
+        if: steps.env.outputs.skip != 'true'
+        working-directory: packages/tasks
+        run: pnpm prepare:plugins
+
+      - name: 🚀 Deploy Trigger.dev (self-hosted)
+        if: steps.env.outputs.skip != 'true'
+        working-directory: packages/tasks
+        env:
+          # Self-hosted PAT (repo Actions secret). Keep the cloud token
+          # (TRIGGER_ACCESS_TOKEN) untouched for the legacy cloud workflows.
+          TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_SELFHOSTED_ACCESS_TOKEN }}
+          # Public origin of our self-hosted instance (used by the CLI to deploy).
+          TRIGGER_API_URL: https://trigger.ever.co
+          # Pin the shared trigger.config.ts to the self-hosted project ref.
+          TRIGGER_PROJECT_REF: proj_ixrpwdtsfolfxlbkgkle
+        run: pnpm dlx trigger.dev@4.5.4 deploy --env ${{ steps.env.outputs.trigger_env }}

--- a/.github/workflows/release-trigger-selfhosted.yml
+++ b/.github/workflows/release-trigger-selfhosted.yml
@@ -41,22 +41,39 @@ jobs:
           (github.event_name == 'workflow_dispatch' ||
            github.event.workflow_run.conclusion == 'success') }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    # Record the deployment under the matching GitHub environment for governance
+    # parity with the legacy cloud workflows (prod/stage). These environments
+    # currently carry no protection rules, so this does not add an approval gate;
+    # it makes any future protection apply to the self-hosted path too.
+    environment: >-
+      ${{ (github.event.inputs.environment == 'staging' ||
+           github.event.workflow_run.head_branch == 'stage') && 'stage' || 'prod' }}
 
     steps:
       - uses: actions/checkout@v7
         with:
           # For workflow_run, check out the exact commit CI validated.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # Build/deploy only — no push back to the repo, so don't leave the
+          # GitHub token in the local git config.
+          persist-credentials: false
 
       - name: Resolve target Trigger.dev environment
         id: env
         shell: bash
+        # Map GitHub context into env vars first, then use the vars in the
+        # script — never interpolate ${{ github.event... }} straight into bash
+        # (a maliciously named branch/input could otherwise inject shell code).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_ENV: ${{ github.event.inputs.environment }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TRIGGER_ENV="${{ github.event.inputs.environment }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TRIGGER_ENV="$INPUT_ENV"
           else
             # workflow_run: map the head branch to a Trigger.dev env.
-            case "${{ github.event.workflow_run.head_branch }}" in
+            case "$HEAD_BRANCH" in
               main)  TRIGGER_ENV="prod" ;;
               stage) TRIGGER_ENV="staging" ;;
               *)     TRIGGER_ENV="" ;;
@@ -107,4 +124,4 @@ jobs:
           TRIGGER_API_URL: https://trigger.ever.co
           # Pin the shared trigger.config.ts to the self-hosted project ref.
           TRIGGER_PROJECT_REF: proj_ixrpwdtsfolfxlbkgkle
-        run: pnpm dlx trigger.dev@4.5.4 deploy --env ${{ steps.env.outputs.trigger_env }}
+        run: pnpm dlx trigger.dev@4.5.4 deploy --env "${{ steps.env.outputs.trigger_env }}"

--- a/.github/workflows/release-trigger-stage.yml
+++ b/.github/workflows/release-trigger-stage.yml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   deploy:
+    # Legacy Trigger.dev CLOUD deploy. Skipped once we migrate to self-hosted
+    # (TRIGGER_SELFHOSTED=true -> release-trigger-selfhosted.yml handles it).
+    # Flip the flag back to re-enable this cloud path.
+    if: ${{ vars.TRIGGER_SELFHOSTED != 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage

--- a/packages/tasks/trigger.config.ts
+++ b/packages/tasks/trigger.config.ts
@@ -6,7 +6,11 @@ import { collectPluginDependencies } from './src/build/collect-plugin-deps';
 const canRetry = process.env.TRIGGER_DEV_ENABLE_RETRIES === 'true';
 
 export default defineConfig({
-    project: 'proj_uevrbfmpvojzzazvhffy',
+    // Project ref is read from the environment so the same task bundle can be
+    // deployed to either the Trigger.dev CLOUD project or our self-hosted
+    // instance (trigger.ever.co, org "Ever"). Falls back to the original cloud
+    // project ref when TRIGGER_PROJECT_REF is unset (e.g. legacy cloud CI).
+    project: process.env.TRIGGER_PROJECT_REF || 'proj_uevrbfmpvojzzazvhffy',
     runtime: 'node-22',
     logLevel: 'log',
     // The max compute seconds a task is allowed to run. If the task run exceeds this duration, it will be stopped.


### PR DESCRIPTION
## What
Migrate the Trigger.dev integration off the cloud SaaS onto our in-cluster self-hosted instance (`https://trigger.ever.co`, org **Ever** / `ever-2a3b`, project `proj_ixrpwdtsfolfxlbkgkle`).

## Changes (additive + reversible, flag-gated)
- **`packages/tasks/trigger.config.ts`** — read `project` from `process.env.TRIGGER_PROJECT_REF`, falling back to the original cloud ref `proj_uevrbfmpvojzzazvhffy`. Same bundle deploys to either target.
- **`.github/workflows/release-trigger-selfhosted.yml`** (new) — gated behind `vars.TRIGGER_SELFHOSTED`. Deploys `packages/tasks` to `trigger.ever.co` (prod/staging) on ARC runners, via `workflow_dispatch` or the CI cascade. Auth via new repo secret `TRIGGER_SELFHOSTED_ACCESS_TOKEN` (self-hosted PAT).
- **`release-trigger-{prod,stage}.yml`** — legacy cloud deploy now gated `if: vars.TRIGGER_SELFHOSTED != 'true'`, so it's skipped while migrated and re-enabled by flipping the flag. Nothing deleted.

## Rollback
Set `TRIGGER_SELFHOSTED=false` (or unset) → cloud workflows resume, self-hosted workflow no-ops. Config falls back to the cloud project ref.

## Cascade
This is the `develop` entrypoint; will cascade `develop → stage → main` per the three-env rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-hosted deployment workflow for the Trigger.dev tasks bundle, runnable manually or on successful CI for main/stage.
  * Deployment environment (prod/staging) is resolved automatically, with dispatch inputs supported.
  * Updated Trigger.dev project configuration to use `TRIGGER_PROJECT_REF` from environment.

* **Bug Fixes**
  * Prevented legacy cloud deployment jobs from running when self-hosted deployment is enabled (production and stage).
  * Ensured safe fallback behavior for the project reference when the environment variable is not set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->