### PR TITLE
fix(ci): tolerate npm's retired audit endpoint (unblocks all PR CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,16 @@ jobs:
           if [ "$code" -eq 0 ]; then
             exit 0
           fi
-          if printf '%s' "$output" | grep -qiE 'ERR_PNPM_AUDIT_BAD_RESPONSE|being retired|responded with 410|no_such_endpoint'; then
-            echo "::warning title=Dependency audit skipped::npm's audit endpoint is unavailable (HTTP 410 — legacy audit API retired). The high/critical audit gate is soft for this run and will re-arm automatically once a working endpoint is restored."
+          # Detect the endpoint outage by pnpm's OWN error CODE only — not by
+          # human-language phrases like "410"/"retired", which could legitimately
+          # appear inside a real CVE advisory description and wrongly soft-pass a
+          # run that has actual vulnerabilities. `ERR_PNPM_AUDIT_BAD_RESPONSE` is
+          # emitted only when the audit endpoint returns an unusable response; a
+          # genuine high/critical finding never prints this token, so it still
+          # hard-fails below. Any other non-endpoint error (e.g. a network blip)
+          # also hard-fails — the conservative default.
+          if printf '%s' "$output" | grep -qF 'ERR_PNPM_AUDIT_BAD_RESPONSE'; then
+            echo "::warning title=Dependency audit skipped::npm's audit endpoint is unavailable (ERR_PNPM_AUDIT_BAD_RESPONSE — legacy audit API retired, HTTP 410). The high/critical audit gate is soft for this run and re-arms automatically once a working endpoint is restored."
             exit 0
           fi
           echo "::error title=Dependency audit failed::pnpm audit reported HIGH/CRITICAL production vulnerabilities (or an unexpected error). See the output above."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,30 @@ jobs:
       # CI-enforced so a new transitive doesn't slip through unnoticed.
       # Moderate findings stay as Dependabot work (re-evaluate the threshold
       # if the backlog becomes too noisy).
+      # NOTE (2026-07): npm retired the legacy audit endpoints
+      # (`/-/npm/v1/security/audits` + `/quick`) — they now return HTTP 410,
+      # so `pnpm audit` fails with `ERR_PNPM_AUDIT_BAD_RESPONSE` regardless of
+      # whether any vulnerability exists. That is an endpoint outage, not a
+      # security finding, and it was red-lining every PR in the repo. Degrade
+      # gracefully: a genuine HIGH/CRITICAL finding still fails CI, but an
+      # endpoint-unavailable error only warns. Self-healing — the gate re-arms
+      # automatically once pnpm/npm expose a working (bulk) advisory endpoint.
       - name: Audit production dependencies (high+)
-        run: pnpm audit --prod --audit-level=high
+        shell: bash
+        run: |
+          set +e
+          output="$(pnpm audit --prod --audit-level=high 2>&1)"
+          code=$?
+          printf '%s\n' "$output"
+          if [ "$code" -eq 0 ]; then
+            exit 0
+          fi
+          if printf '%s' "$output" | grep -qiE 'ERR_PNPM_AUDIT_BAD_RESPONSE|being retired|responded with 410|no_such_endpoint'; then
+            echo "::warning title=Dependency audit skipped::npm's audit endpoint is unavailable (HTTP 410 — legacy audit API retired). The high/critical audit gate is soft for this run and will re-arm automatically once a working endpoint is restored."
+            exit 0
+          fi
+          echo "::error title=Dependency audit failed::pnpm audit reported HIGH/CRITICAL production vulnerabilities (or an unexpected error). See the output above."
+          exit "$code"
 
       - name: Check formatting
         run: pnpm format:check


### PR DESCRIPTION
## Problem — every PR's CI is red, repo-wide

Since ~2026-07-14, the `lint-and-test` job fails at step **"Audit production dependencies (high+)"**:

```
ERR_PNPM_AUDIT_BAD_RESPONSE  The audit endpoint (…/-/npm/v1/security/audits/quick)
responded with 410: "This endpoint is being retired. Use the bulk advisory endpoint instead."
```

**npm retired the legacy audit endpoints** (`/-/npm/v1/security/audits` and `/quick`) — they now return **HTTP 410** for everyone. `pnpm audit` still calls them, so `pnpm audit --prod` fails **regardless of whether any vulnerability exists**. This is an endpoint outage, not a security finding.

Because the audit step runs **before** format/build/test, those steps are **skipped** — so no PR's code is actually being validated in CI right now, and nothing can go green. (Confirmed: the same step *passed* on develop runs ~4 days ago and *fails* on every run since.)

## Fix

Make the H-15 high/critical production-audit gate **resilient**:

- A genuine **HIGH/CRITICAL** finding → still **fails** CI (gate preserved).
- An **endpoint-unavailable** error (`410` / `ERR_PNPM_AUDIT_BAD_RESPONSE`) → emits a `::warning` and **passes**.
- **Self-healing:** the moment pnpm/npm expose a working (bulk) advisory endpoint, `pnpm audit` exits 0 and the gate re-arms automatically — no follow-up revert needed.

## Verification (local)

Against the currently-410 endpoint:
- the step **soft-passes with a warning** (exit 0);
- a simulated real-vuln failure (nonzero exit *without* the endpoint signature) still **hard-fails** (exit 1).

YAML validated (`yaml.safe_load`, 12 steps parse).

## Tradeoff (called out)

While npm's endpoint is down, the prod-audit gate is **advisory rather than blocking** — this is unavoidable when the audit backend itself is unreachable, and it's strictly better than the current state (the whole pipeline red, nothing validated). Dependabot's high/critical alerts remain a second line of defense in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved production dependency security checks in automated builds.
  * Builds now continue when the package audit service is temporarily unavailable, while still failing for genuine high-severity vulnerabilities or unexpected audit errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->