### PR TITLE
feat(web): brand icons in the job-runtime provider picker

### DIFF
--- a/apps/web/src/components/settings/JobRuntimeSettings.tsx
+++ b/apps/web/src/components/settings/JobRuntimeSettings.tsx
@@ -13,6 +13,7 @@ import {
     JOB_RUNTIME_PROVIDER_MODE_BANNERS,
     PROVIDERS_WITHOUT_CREDENTIALS,
 } from './job-runtime-schemas';
+import { ProviderBrandIcon, providerIconMap } from './job-runtime-provider-icons';
 import {
     Dialog,
     DialogClose,
@@ -113,6 +114,11 @@ export function JobRuntimeSettings({
         () => availableProviders.map((value) => ({ value, label: PROVIDER_LABELS[value] })),
         [availableProviders],
     );
+
+    // EW-742 — brand-mark badges for the picker, keyed by provider id and fed
+    // to the Select via `iconMap`; each <option> opts in with `data-icon`.
+    // Static (provider set is fixed), so build once.
+    const providerIcons = useMemo(() => providerIconMap(18), []);
 
     // Form-local state mirrors the editable shape of the upsert payload.
     // We initialise providerId with a sane default when the row is the
@@ -329,9 +335,10 @@ export function JobRuntimeSettings({
                         }
                         disabled={noProvidersAvailable}
                         data-testid="job-runtime-provider-picker"
+                        iconMap={providerIcons}
                     >
                         {providerOptions.map((opt) => (
-                            <option key={opt.value} value={opt.value}>
+                            <option key={opt.value} value={opt.value} data-icon={opt.value}>
                                 {opt.label}
                             </option>
                         ))}

--- a/apps/web/src/components/settings/JobRuntimeSettings.tsx
+++ b/apps/web/src/components/settings/JobRuntimeSettings.tsx
@@ -13,7 +13,7 @@ import {
     JOB_RUNTIME_PROVIDER_MODE_BANNERS,
     PROVIDERS_WITHOUT_CREDENTIALS,
 } from './job-runtime-schemas';
-import { ProviderBrandIcon, providerIconMap } from './job-runtime-provider-icons';
+import { providerIconMap } from './job-runtime-provider-icons';
 import {
     Dialog,
     DialogClose,

--- a/apps/web/src/components/settings/job-runtime-provider-icons.tsx
+++ b/apps/web/src/components/settings/job-runtime-provider-icons.tsx
@@ -1,0 +1,165 @@
+import * as React from 'react';
+import type { TenantJobRuntimeProviderId } from '@/lib/api/tenant-job-runtime';
+
+/**
+ * EW-742 — small brand-mark badges for the job-runtime provider picker.
+ *
+ * Each provider renders as a rounded square in its signature colour with a
+ * simple white glyph, so the picker shows an icon to the LEFT of the
+ * provider name (Trigger.dev, Temporal, …). These are lightweight, inlined,
+ * theme-agnostic SVGs — a mid-tone brand colour with a white glyph reads
+ * correctly in both light and dark mode without per-theme variants. They are
+ * stylised marks (not the vendors' official trademarked logos) and can be
+ * swapped for official SVGs later without touching call sites.
+ *
+ * Rendered via the generic `Select`'s `iconMap` prop (keyed by provider id),
+ * mirroring the existing `data-dot` chip mechanism.
+ */
+
+interface GlyphProps {
+    /** Rendered pixel size (width === height). */
+    size?: number;
+    className?: string;
+    title?: string;
+}
+
+// Shared badge wrapper: a rounded square filled with `color`, `children` is
+// the white glyph drawn on top (coordinates in a 20×20 viewBox).
+function Badge({
+    color,
+    size = 18,
+    className,
+    title,
+    children,
+}: GlyphProps & { color: string; children: React.ReactNode }) {
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className={className}
+            role="img"
+            aria-hidden={title ? undefined : true}
+            aria-label={title}
+        >
+            {title ? <title>{title}</title> : null}
+            <rect x="0" y="0" width="20" height="20" rx="5" fill={color} />
+            {children}
+        </svg>
+    );
+}
+
+// Trigger.dev — signature charcoal/lime; glyph is a "play/trigger" triangle.
+function TriggerIcon({ size, className, title }: GlyphProps) {
+    return (
+        <Badge color="#16171D" size={size} className={className} title={title ?? 'Trigger.dev'}>
+            <path d="M8 6.2 L14 10 L8 13.8 Z" fill="#C6F24E" />
+        </Badge>
+    );
+}
+
+// Temporal — brand blue; glyph is a clock (temporal = time).
+function TemporalIcon({ size, className, title }: GlyphProps) {
+    return (
+        <Badge color="#1F6BFF" size={size} className={className} title={title ?? 'Temporal'}>
+            <circle cx="10" cy="10" r="4.4" stroke="#FFFFFF" strokeWidth="1.5" />
+            <path
+                d="M10 7.4 V10 L12 11.2"
+                stroke="#FFFFFF"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </Badge>
+    );
+}
+
+// BullMQ — red; "B" monogram.
+function BullmqIcon({ size, className, title }: GlyphProps) {
+    return (
+        <Badge color="#E11D48" size={size} className={className} title={title ?? 'BullMQ'}>
+            <text
+                x="10"
+                y="10"
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize="11"
+                fontWeight="700"
+                fontFamily="ui-sans-serif, system-ui, sans-serif"
+                fill="#FFFFFF"
+            >
+                B
+            </text>
+        </Badge>
+    );
+}
+
+// pg-boss — Postgres blue; "pg" wordmark.
+function PgbossIcon({ size, className, title }: GlyphProps) {
+    return (
+        <Badge color="#31648C" size={size} className={className} title={title ?? 'pg-boss'}>
+            <text
+                x="10"
+                y="10.5"
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize="9"
+                fontWeight="700"
+                fontFamily="ui-sans-serif, system-ui, sans-serif"
+                fill="#FFFFFF"
+            >
+                pg
+            </text>
+        </Badge>
+    );
+}
+
+// Inngest — violet; waveform bars (functions / events).
+function InngestIcon({ size, className, title }: GlyphProps) {
+    return (
+        <Badge color="#6D28D9" size={size} className={className} title={title ?? 'Inngest'}>
+            <g fill="#FFFFFF">
+                <rect x="5.5" y="9" width="1.8" height="5" rx="0.9" />
+                <rect x="9.1" y="6" width="1.8" height="8" rx="0.9" />
+                <rect x="12.7" y="10.5" width="1.8" height="3.5" rx="0.9" />
+            </g>
+        </Badge>
+    );
+}
+
+const ICON_BY_PROVIDER: Record<
+    TenantJobRuntimeProviderId,
+    (props: GlyphProps) => React.ReactElement
+> = {
+    trigger: TriggerIcon,
+    temporal: TemporalIcon,
+    bullmq: BullmqIcon,
+    pgboss: PgbossIcon,
+    inngest: InngestIcon,
+};
+
+export interface ProviderBrandIconProps extends GlyphProps {
+    providerId: TenantJobRuntimeProviderId;
+}
+
+/** Brand-mark badge for a single job-runtime provider. */
+export function ProviderBrandIcon({ providerId, ...props }: ProviderBrandIconProps) {
+    const Icon = ICON_BY_PROVIDER[providerId];
+    if (!Icon) return null;
+    return <Icon {...props} />;
+}
+
+/**
+ * Prebuilt `iconMap` for the `Select` component: provider id → brand badge.
+ * Consumed by the provider picker in `JobRuntimeSettings`.
+ */
+export function providerIconMap(size = 18): Record<string, React.ReactNode> {
+    return Object.fromEntries(
+        (Object.keys(ICON_BY_PROVIDER) as TenantJobRuntimeProviderId[]).map((id) => [
+            id,
+            <ProviderBrandIcon key={id} providerId={id} size={size} />,
+        ]),
+    );
+}

--- a/apps/web/src/components/settings/job-runtime-provider-icons.unit.spec.tsx
+++ b/apps/web/src/components/settings/job-runtime-provider-icons.unit.spec.tsx
@@ -1,0 +1,62 @@
+// EW-742 — unit spec for the job-runtime provider brand-mark icons.
+// Renders each icon to static markup (no DOM needed) and pins the badge
+// shape (an <svg> with a brand colour + an accessible label per provider),
+// plus the `providerIconMap` / unknown-provider contract.
+
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { TenantJobRuntimeProviderId } from '@/lib/api/tenant-job-runtime';
+import { ProviderBrandIcon, providerIconMap } from './job-runtime-provider-icons';
+
+const CASES: { id: TenantJobRuntimeProviderId; label: string; color: string }[] = [
+    { id: 'trigger', label: 'Trigger.dev', color: '#16171D' },
+    { id: 'temporal', label: 'Temporal', color: '#1F6BFF' },
+    { id: 'bullmq', label: 'BullMQ', color: '#E11D48' },
+    { id: 'pgboss', label: 'pg-boss', color: '#31648C' },
+    { id: 'inngest', label: 'Inngest', color: '#6D28D9' },
+];
+
+describe('ProviderBrandIcon', () => {
+    it.each(CASES)(
+        'renders an svg badge for $id with its brand colour + label',
+        ({ id, label, color }) => {
+            const html = renderToStaticMarkup(<ProviderBrandIcon providerId={id} size={18} />);
+            expect(html).toContain('<svg');
+            expect(html).toContain(`aria-label="${label}"`);
+            expect(html.toLowerCase()).toContain(color.toLowerCase());
+            expect(html).toContain('width="18"');
+            expect(html).toContain('height="18"');
+        },
+    );
+
+    it('honours the requested size', () => {
+        const html = renderToStaticMarkup(<ProviderBrandIcon providerId="trigger" size={24} />);
+        expect(html).toContain('width="24"');
+        expect(html).toContain('height="24"');
+    });
+
+    it('renders nothing for an unknown provider id', () => {
+        const html = renderToStaticMarkup(
+            <ProviderBrandIcon providerId={'nope' as TenantJobRuntimeProviderId} />,
+        );
+        expect(html).toBe('');
+    });
+});
+
+describe('providerIconMap', () => {
+    it('returns an entry for every known provider id', () => {
+        const map = providerIconMap();
+        expect(Object.keys(map).sort()).toEqual(
+            ['bullmq', 'inngest', 'pgboss', 'temporal', 'trigger'].sort(),
+        );
+    });
+
+    it('each entry renders to an svg badge', () => {
+        const map = providerIconMap(16);
+        for (const node of Object.values(map)) {
+            const html = renderToStaticMarkup(<>{node}</>);
+            expect(html).toContain('<svg');
+            expect(html).toContain('width="16"');
+        }
+    });
+});

--- a/apps/web/src/components/ui/select.icon.unit.spec.tsx
+++ b/apps/web/src/components/ui/select.icon.unit.spec.tsx
@@ -1,0 +1,72 @@
+// EW-742 — unit spec for the Select `iconMap` / `data-icon` feature.
+// Uses vitest + jsdom + @testing-library/react. Confirms a leading icon
+// renders in the trigger (selected) and in each open row, that it is
+// backward-compatible (no icon without data-icon/iconMap), and that labels
+// still render.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { Select } from './select';
+
+afterEach(cleanup);
+
+const iconMap = {
+    alpha: <svg data-testid="ic-alpha" />,
+    beta: <svg data-testid="ic-beta" />,
+};
+
+function renderSelect(value: string) {
+    return render(
+        <Select value={value} iconMap={iconMap}>
+            <option value="alpha" data-icon="alpha">
+                Alpha
+            </option>
+            <option value="beta" data-icon="beta">
+                Beta
+            </option>
+        </Select>,
+    );
+}
+
+describe('Select iconMap / data-icon', () => {
+    it('renders the selected option icon in the (closed) trigger', () => {
+        renderSelect('alpha');
+        expect(screen.getAllByTestId('ic-alpha').length).toBeGreaterThan(0);
+        // Beta is not selected and the list is closed → its icon is absent.
+        expect(screen.queryByTestId('ic-beta')).toBeNull();
+    });
+
+    it('renders each option icon once the dropdown is open', () => {
+        renderSelect('alpha');
+        fireEvent.click(screen.getByRole('button'));
+        expect(screen.getAllByTestId('ic-alpha').length).toBeGreaterThan(0);
+        expect(screen.getAllByTestId('ic-beta').length).toBeGreaterThan(0);
+        // Labels still render alongside the icons (in the trigger AND the open
+        // row for the selected value, so there can be more than one match).
+        expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('Beta').length).toBeGreaterThan(0);
+    });
+
+    it('is backward-compatible: no icon markup when data-icon / iconMap are absent', () => {
+        render(
+            <Select value="x">
+                <option value="x">Xray</option>
+                <option value="y">Yankee</option>
+            </Select>,
+        );
+        expect(screen.queryByTestId('ic-alpha')).toBeNull();
+        expect(screen.getByText('Xray')).toBeTruthy();
+    });
+
+    it('renders no leading icon when an option omits data-icon even if iconMap is set', () => {
+        render(
+            <Select value="a" iconMap={iconMap}>
+                <option value="a">Plain</option>
+            </Select>,
+        );
+        // "a" is not a key with a matching data-icon, so neither test icon shows.
+        expect(screen.queryByTestId('ic-alpha')).toBeNull();
+        expect(screen.queryByTestId('ic-beta')).toBeNull();
+        expect(screen.getByText('Plain')).toBeTruthy();
+    });
+});

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -19,6 +19,10 @@ interface OptionData {
     /** Tailwind bg-* class rendered as a small colored dot before the label.
      *  Set via `data-dot` on the `<option>` (e.g. status color chips). */
     dotClass?: string;
+    /** Key into the Select's `iconMap`, rendered as a leading icon before the
+     *  label (in both the trigger and each row). Set via `data-icon` on the
+     *  `<option>` (e.g. provider brand marks). */
+    iconKey?: string;
 }
 
 interface GroupData {
@@ -49,6 +53,14 @@ export interface SelectProps {
      * Mirrors the same prop on native shadcn primitives.
      */
     'data-testid'?: string;
+    /**
+     * Optional leading icons, keyed by an option's `data-icon` value. When an
+     * option declares `data-icon="foo"` and `iconMap.foo` is provided, that
+     * node renders before the label in both the trigger and the dropdown row.
+     * Keeps the Select generic — callers own the actual icon nodes (e.g.
+     * provider brand marks).
+     */
+    iconMap?: Record<string, React.ReactNode>;
 }
 
 // ---- helpers ------------------------------------------------------ //
@@ -61,12 +73,14 @@ function parseItems(children: React.ReactNode): FlatItem[] {
         if (child.type === 'option') {
             const p = child.props as React.OptionHTMLAttributes<HTMLOptionElement>;
             const dot = (p as Record<string, unknown>)['data-dot'];
+            const icon = (p as Record<string, unknown>)['data-icon'];
             items.push({
                 type: 'option',
                 value: String(p.value ?? ''),
                 label: nodeText(p.children),
                 disabled: !!p.disabled,
                 ...(typeof dot === 'string' && dot ? { dotClass: dot } : {}),
+                ...(typeof icon === 'string' && icon ? { iconKey: icon } : {}),
             });
         } else if (child.type === 'optgroup') {
             const p = child.props as React.OptgroupHTMLAttributes<HTMLOptGroupElement>;
@@ -74,11 +88,13 @@ function parseItems(children: React.ReactNode): FlatItem[] {
             React.Children.forEach(p.children as React.ReactNode, (opt) => {
                 if (!React.isValidElement(opt) || opt.type !== 'option') return;
                 const op = opt.props as React.OptionHTMLAttributes<HTMLOptionElement>;
+                const opIcon = (op as Record<string, unknown>)['data-icon'];
                 opts.push({
                     type: 'option',
                     value: String(op.value ?? ''),
                     label: nodeText(op.children),
                     disabled: !!op.disabled,
+                    ...(typeof opIcon === 'string' && opIcon ? { iconKey: opIcon } : {}),
                 });
             });
             items.push({ type: 'group', label: String(p.label ?? ''), options: opts });
@@ -116,6 +132,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
             id,
             name,
             'data-testid': dataTestId,
+            iconMap,
         },
         ref,
     ) => {
@@ -233,6 +250,11 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                     )}
                 >
                     <span className="flex min-w-0 items-center gap-1.5">
+                        {selected?.iconKey && iconMap?.[selected.iconKey] ? (
+                            <span aria-hidden="true" className="flex shrink-0 items-center">
+                                {iconMap[selected.iconKey]}
+                            </span>
+                        ) : null}
                         {selected?.dotClass && (
                             <span
                                 aria-hidden="true"
@@ -289,6 +311,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                                         selected={item.value === value}
                                         size={size}
                                         onPick={pick}
+                                        iconMap={iconMap}
                                     />
                                 ) : (
                                     <div key={`group-${item.label}-${idx}`}>
@@ -304,6 +327,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                                                 size={size}
                                                 onPick={pick}
                                                 indent
+                                                iconMap={iconMap}
                                             />
                                         ))}
                                     </div>
@@ -326,12 +350,14 @@ function OptionRow({
     size,
     onPick,
     indent,
+    iconMap,
 }: {
     opt: OptionData;
     selected: boolean;
     size: 'xs' | 'sm' | 'default';
     onPick: (opt: OptionData) => void;
     indent?: boolean;
+    iconMap?: Record<string, React.ReactNode>;
 }) {
     const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (opt.disabled) {
@@ -395,6 +421,11 @@ function OptionRow({
                     'opacity-50 cursor-not-allowed pointer-events-none text-text-muted dark:text-text-muted-dark',
             )}
         >
+            {opt.iconKey && iconMap?.[opt.iconKey] ? (
+                <span aria-hidden="true" className="flex shrink-0 items-center">
+                    {iconMap[opt.iconKey]}
+                </span>
+            ) : null}
             {opt.dotClass && (
                 <span
                     aria-hidden="true"


### PR DESCRIPTION
## What

Adds a small **brand-mark badge to the left of each provider name** in the **Settings → Job Runtime** provider picker — in both the closed trigger and the open dropdown rows.

Providers: Trigger.dev, Temporal, BullMQ, pg-boss, Inngest.

## How

- **`job-runtime-provider-icons.tsx`** (new) — inlined, theme-agnostic SVG badges (a signature brand colour + a simple white glyph each). Exposes `ProviderBrandIcon` and a prebuilt `providerIconMap()`.
- **`Select`** (generalised) — new optional `iconMap` prop + per-`<option>` `data-icon` attribute, mirroring the existing `data-dot` chip mechanism. **Fully backward-compatible**: options without `data-icon` render exactly as before, so no other `Select` call site is affected.
- **`JobRuntimeSettings`** — passes `iconMap={providerIcons}` and `data-icon={value}` on each provider option. Picker `data-testid`, option values, and labels are unchanged (existing e2e selectors keep working).

## Note on the marks

These are **stylised** brand marks (a coloured badge + glyph), **not** the vendors' official trademarked logos. They read as per-provider brand icons and give a cohesive look; they can be swapped for official vendor SVGs later without touching any call site.

## Tests

- `job-runtime-provider-icons.unit.spec.tsx` — badge shape / colour / accessible label per provider, custom size, unknown-id → renders nothing, `providerIconMap` contract.
- `select.icon.unit.spec.tsx` — icon renders in the trigger (selected) and in open rows; backward-compat (no icon without `data-icon`/`iconMap`); labels still render.

Verified locally: `vitest` 13/13, `prettier --check`, `eslint`, `tsc --noEmit` all clean.

## Relationship to the fix PRs

Independent of #1628 (job-runtime API fix) and #1632 (CI fix) — different files, no overlap. Can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added branded provider icons to job runtime provider selection.
  * Provider icons now show in both the currently selected value and the dropdown list.
  * Enhanced the Select component to support leading icons for options (including grouped optgroups).

* **Tests**
  * Added unit tests for provider brand icon rendering (color, size, accessibility) and handling of unknown providers.
  * Added unit tests confirming Select icon behavior, including graceful fallback when icon configuration is not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->