### PR TITLE
cascade: stage -> main (self-hosted Trigger.dev deploy + CI hygiene)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/apps/*"
+      - "/packages/*"
+      - "/packages/plugins/*"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "monthly"
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]
+      npm-major:
+        applies-to: version-updates
+        update-types: ["major"]
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   lint-and-test:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     strategy:
       matrix:
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -38,7 +38,7 @@ jobs:
           version: 10.33.3
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -118,7 +118,7 @@ jobs:
   # only the slice it needs, so a failing aggregate doesn't block this
   # signal (and vice versa).
   job-runtime-plugin-matrix:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     strategy:
       fail-fast: false
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -142,7 +142,7 @@ jobs:
           version: 10.33.3
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -178,7 +178,7 @@ jobs:
     # stays covered by the mocks-only job-runtime-plugin-matrix above.
     # Re-enable per-PR by removing this `if:` line.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     services:
       redis:
         image: redis:7-alpine
@@ -211,7 +211,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -221,7 +221,7 @@ jobs:
           version: 10.33.3
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           cache: 'pnpm'
@@ -257,7 +257,7 @@ jobs:
   # plugins via `<plugin>-conformance.spec.ts`). Same rationale as the
   # job-runtime matrix above: per-provider failure signal.
   secret-store-plugin-matrix:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     strategy:
       fail-fast: false
@@ -274,7 +274,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -284,7 +284,7 @@ jobs:
           version: 10.33.3
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'

--- a/.github/workflows/deploy-do-dev.yml
+++ b/.github/workflows/deploy-do-dev.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install doctl
         if: ${{ vars.DO_ENABLED == 'true' }}

--- a/.github/workflows/deploy-do-mcp-dev.yml
+++ b/.github/workflows/deploy-do-mcp-dev.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install doctl
         if: ${{ vars.DO_ENABLED == 'true' }}

--- a/.github/workflows/deploy-do-mcp-prod.yml
+++ b/.github/workflows/deploy-do-mcp-prod.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install doctl
         if: ${{ vars.DO_ENABLED == 'true' }}

--- a/.github/workflows/deploy-do-mcp-stage.yml
+++ b/.github/workflows/deploy-do-mcp-stage.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install doctl
         if: ${{ vars.DO_ENABLED == 'true' }}

--- a/.github/workflows/deploy-do-prod.yml
+++ b/.github/workflows/deploy-do-prod.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install doctl
         if: ${{ vars.DO_ENABLED == 'true' }}

--- a/.github/workflows/deploy-do-stage.yml
+++ b/.github/workflows/deploy-do-stage.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install doctl
         if: ${{ vars.DO_ENABLED == 'true' }}

--- a/.github/workflows/deploy-vercel-docs-prod.yml
+++ b/.github/workflows/deploy-vercel-docs-prod.yml
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
 

--- a/.github/workflows/docker-build-publish-dev.yml
+++ b/.github/workflows/docker-build-publish-dev.yml
@@ -16,10 +16,10 @@ permissions:
 
 jobs:
   ever-works-api:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
@@ -119,10 +119,10 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-api:latest
 
   ever-works-web:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3

--- a/.github/workflows/docker-build-publish-mcp-dev.yml
+++ b/.github/workflows/docker-build-publish-mcp-dev.yml
@@ -19,10 +19,10 @@ permissions:
 
 jobs:
   ever-works-mcp:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3

--- a/.github/workflows/docker-build-publish-mcp-prod.yml
+++ b/.github/workflows/docker-build-publish-mcp-prod.yml
@@ -19,10 +19,10 @@ permissions:
 
 jobs:
   ever-works-mcp:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3

--- a/.github/workflows/docker-build-publish-mcp-stage.yml
+++ b/.github/workflows/docker-build-publish-mcp-stage.yml
@@ -19,10 +19,10 @@ permissions:
 
 jobs:
   ever-works-mcp:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3

--- a/.github/workflows/docker-build-publish-prod.yml
+++ b/.github/workflows/docker-build-publish-prod.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
@@ -121,7 +121,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3

--- a/.github/workflows/docker-build-publish-stage.yml
+++ b/.github/workflows/docker-build-publish-stage.yml
@@ -16,10 +16,10 @@ permissions:
 
 jobs:
   ever-works-api:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
@@ -119,10 +119,10 @@ jobs:
     #      docker push ${{ secrets.CW_DOCKER_REGISTRY }}/ever-co/ever-works-api:latest
 
   ever-works-web:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3

--- a/.github/workflows/harvest-secrets-to-openbao.yml
+++ b/.github/workflows/harvest-secrets-to-openbao.yml
@@ -19,7 +19,7 @@ jobs:
       OIDC_AUDIENCE: openbao-github-oidc
     steps:
       - name: Harvest to OpenBao (OIDC login -> prove isolation -> write)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ALL_SECRETS: ${{ toJSON(secrets) }}
           ALL_VARS: ${{ toJSON(vars) }}

--- a/.github/workflows/k8s-build.yml
+++ b/.github/workflows/k8s-build.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   build:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,9 +36,9 @@ jobs:
             context: .
             pkg: apps/docs/package.json
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -60,7 +60,7 @@ jobs:
           VERSION=$(grep -m1 '"version"' "${{ matrix.pkg }}" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
           echo "version=${VERSION:-0.0.0}" >> "$GITHUB_OUTPUT"
           echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -67,7 +67,7 @@ jobs:
           version: 10.33.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
           version: 10.33.3
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           cache: "pnpm"
@@ -105,13 +105,13 @@ jobs:
         run: pnpm test:cli
 
       - name: Upload Internal CLI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: internal-cli-dist
           path: apps/internal-cli/dist/
 
       - name: Upload External CLI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: external-cli-dist
           path: apps/cli/dist/
@@ -125,16 +125,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           registry-url: "https://registry.npmjs.org"
 
       - name: Download Internal CLI artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: internal-cli-dist
           path: apps/internal-cli/dist/
@@ -175,16 +175,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           registry-url: "https://registry.npmjs.org"
 
       - name: Download External CLI artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: external-cli-dist
           path: apps/cli/dist/
@@ -222,9 +222,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Node.js for version extraction
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
       - name: Extract internal CLI version
@@ -263,9 +263,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Node.js for version extraction
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
       - name: Extract external CLI version
@@ -304,9 +304,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Node.js for version extraction
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
       - name: Extract versions

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
           version: 10.33.3
 
       - name: Setup Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           cache: 'pnpm'
@@ -97,7 +97,7 @@ jobs:
           "
 
       - name: Upload built packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: plugins-dist
           path: |
@@ -119,7 +119,7 @@ jobs:
       ))
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -129,7 +129,7 @@ jobs:
           version: 10.33.3
 
       - name: Setup Node.js (npmjs.org auth)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
@@ -139,7 +139,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Restore built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: plugins-dist
           path: .
@@ -177,7 +177,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -187,7 +187,7 @@ jobs:
           version: 10.33.3
 
       - name: Setup Node.js (GitHub Packages auth)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22.x
           registry-url: 'https://npm.pkg.github.com'
@@ -198,7 +198,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Restore built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: plugins-dist
           path: .

--- a/.github/workflows/release-trigger-dev.yml
+++ b/.github/workflows/release-trigger-dev.yml
@@ -18,7 +18,7 @@ jobs:
     environment: dev
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3
@@ -26,7 +26,7 @@ jobs:
           version: 10.33.3
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.x"
           cache: "pnpm"

--- a/.github/workflows/release-trigger-prod.yml
+++ b/.github/workflows/release-trigger-prod.yml
@@ -18,7 +18,7 @@ jobs:
     environment: prod
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3
@@ -26,7 +26,7 @@ jobs:
           version: 10.33.3
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.x"
           cache: "pnpm"

--- a/.github/workflows/release-trigger-prod.yml
+++ b/.github/workflows/release-trigger-prod.yml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   deploy:
+    # Legacy Trigger.dev CLOUD deploy. Skipped once we migrate to self-hosted
+    # (TRIGGER_SELFHOSTED=true -> release-trigger-selfhosted.yml handles it).
+    # Flip the flag back to re-enable this cloud path.
+    if: ${{ vars.TRIGGER_SELFHOSTED != 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: prod

--- a/.github/workflows/release-trigger-selfhosted.yml
+++ b/.github/workflows/release-trigger-selfhosted.yml
@@ -1,0 +1,110 @@
+name: Deploy to Self-hosted Trigger.dev
+
+# Deploys the packages/tasks bundle to our SELF-HOSTED Trigger.dev instance
+# (https://trigger.ever.co, org "Ever" / ever-2a3b) instead of Trigger.dev cloud.
+#
+# Additive + reversible: this whole workflow is gated behind the repo/org var
+# `TRIGGER_SELFHOSTED`. While that flag is unset/`false` this file is a no-op and
+# the legacy cloud deploys (release-trigger-{prod,stage}.yml) run as before. Flip
+# `TRIGGER_SELFHOSTED=true` to migrate onto self-hosted; flip it back to roll back.
+#
+# Auth: the self-hosted Personal Access Token lives in the repo Actions secret
+# `TRIGGER_SELFHOSTED_ACCESS_TOKEN`. The project ref is injected via env so the
+# shared trigger.config.ts targets the self-hosted project.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Trigger.dev environment to deploy to"
+        type: choice
+        options:
+          - prod
+          - staging
+        default: prod
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main, stage]
+    types:
+      - completed
+
+# M-12: minimum default permissions. Individual jobs can elevate where needed.
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    # Only run when the self-hosted migration flag is on AND the trigger is valid
+    # (a manual dispatch, or a CI run that actually succeeded).
+    if: >-
+      ${{ vars.TRIGGER_SELFHOSTED == 'true' &&
+          (github.event_name == 'workflow_dispatch' ||
+           github.event.workflow_run.conclusion == 'success') }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # For workflow_run, check out the exact commit CI validated.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Resolve target Trigger.dev environment
+        id: env
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TRIGGER_ENV="${{ github.event.inputs.environment }}"
+          else
+            # workflow_run: map the head branch to a Trigger.dev env.
+            case "${{ github.event.workflow_run.head_branch }}" in
+              main)  TRIGGER_ENV="prod" ;;
+              stage) TRIGGER_ENV="staging" ;;
+              *)     TRIGGER_ENV="" ;;
+            esac
+          fi
+          if [ -z "$TRIGGER_ENV" ]; then
+            echo "No self-hosted Trigger.dev env for this trigger; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Deploying to self-hosted Trigger.dev env: $TRIGGER_ENV"
+            echo "trigger_env=$TRIGGER_ENV" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install pnpm
+        if: steps.env.outputs.skip != 'true'
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3
+        with:
+          version: 10.33.3
+
+      - name: Use Node.js 22.x
+        if: steps.env.outputs.skip != 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: "22.x"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        if: steps.env.outputs.skip != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build all packages
+        if: steps.env.outputs.skip != 'true'
+        run: pnpm build --filter './packages/**'
+
+      - name: Prepare plugins for Trigger.dev
+        if: steps.env.outputs.skip != 'true'
+        working-directory: packages/tasks
+        run: pnpm prepare:plugins
+
+      - name: 🚀 Deploy Trigger.dev (self-hosted)
+        if: steps.env.outputs.skip != 'true'
+        working-directory: packages/tasks
+        env:
+          # Self-hosted PAT (repo Actions secret). Keep the cloud token
+          # (TRIGGER_ACCESS_TOKEN) untouched for the legacy cloud workflows.
+          TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_SELFHOSTED_ACCESS_TOKEN }}
+          # Public origin of our self-hosted instance (used by the CLI to deploy).
+          TRIGGER_API_URL: https://trigger.ever.co
+          # Pin the shared trigger.config.ts to the self-hosted project ref.
+          TRIGGER_PROJECT_REF: proj_ixrpwdtsfolfxlbkgkle
+        run: pnpm dlx trigger.dev@4.5.4 deploy --env ${{ steps.env.outputs.trigger_env }}

--- a/.github/workflows/release-trigger-selfhosted.yml
+++ b/.github/workflows/release-trigger-selfhosted.yml
@@ -41,22 +41,39 @@ jobs:
           (github.event_name == 'workflow_dispatch' ||
            github.event.workflow_run.conclusion == 'success') }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    # Record the deployment under the matching GitHub environment for governance
+    # parity with the legacy cloud workflows (prod/stage). These environments
+    # currently carry no protection rules, so this does not add an approval gate;
+    # it makes any future protection apply to the self-hosted path too.
+    environment: >-
+      ${{ (github.event.inputs.environment == 'staging' ||
+           github.event.workflow_run.head_branch == 'stage') && 'stage' || 'prod' }}
 
     steps:
       - uses: actions/checkout@v7
         with:
           # For workflow_run, check out the exact commit CI validated.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # Build/deploy only — no push back to the repo, so don't leave the
+          # GitHub token in the local git config.
+          persist-credentials: false
 
       - name: Resolve target Trigger.dev environment
         id: env
         shell: bash
+        # Map GitHub context into env vars first, then use the vars in the
+        # script — never interpolate ${{ github.event... }} straight into bash
+        # (a maliciously named branch/input could otherwise inject shell code).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_ENV: ${{ github.event.inputs.environment }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TRIGGER_ENV="${{ github.event.inputs.environment }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TRIGGER_ENV="$INPUT_ENV"
           else
             # workflow_run: map the head branch to a Trigger.dev env.
-            case "${{ github.event.workflow_run.head_branch }}" in
+            case "$HEAD_BRANCH" in
               main)  TRIGGER_ENV="prod" ;;
               stage) TRIGGER_ENV="staging" ;;
               *)     TRIGGER_ENV="" ;;
@@ -107,4 +124,4 @@ jobs:
           TRIGGER_API_URL: https://trigger.ever.co
           # Pin the shared trigger.config.ts to the self-hosted project ref.
           TRIGGER_PROJECT_REF: proj_ixrpwdtsfolfxlbkgkle
-        run: pnpm dlx trigger.dev@4.5.4 deploy --env ${{ steps.env.outputs.trigger_env }}
+        run: pnpm dlx trigger.dev@4.5.4 deploy --env "${{ steps.env.outputs.trigger_env }}"

--- a/.github/workflows/release-trigger-stage.yml
+++ b/.github/workflows/release-trigger-stage.yml
@@ -13,6 +13,10 @@ permissions:
 
 jobs:
   deploy:
+    # Legacy Trigger.dev CLOUD deploy. Skipped once we migrate to self-hosted
+    # (TRIGGER_SELFHOSTED=true -> release-trigger-selfhosted.yml handles it).
+    # Flip the flag back to re-enable this cloud path.
+    if: ${{ vars.TRIGGER_SELFHOSTED != 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: stage

--- a/.github/workflows/release-trigger-stage.yml
+++ b/.github/workflows/release-trigger-stage.yml
@@ -18,7 +18,7 @@ jobs:
     environment: stage
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d  # v3
@@ -26,7 +26,7 @@ jobs:
           version: 10.33.3
 
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22.x"
           cache: "pnpm"

--- a/packages/tasks/trigger.config.ts
+++ b/packages/tasks/trigger.config.ts
@@ -6,7 +6,11 @@ import { collectPluginDependencies } from './src/build/collect-plugin-deps';
 const canRetry = process.env.TRIGGER_DEV_ENABLE_RETRIES === 'true';
 
 export default defineConfig({
-    project: 'proj_uevrbfmpvojzzazvhffy',
+    // Project ref is read from the environment so the same task bundle can be
+    // deployed to either the Trigger.dev CLOUD project or our self-hosted
+    // instance (trigger.ever.co, org "Ever"). Falls back to the original cloud
+    // project ref when TRIGGER_PROJECT_REF is unset (e.g. legacy cloud CI).
+    project: process.env.TRIGGER_PROJECT_REF || 'proj_uevrbfmpvojzzazvhffy',
     runtime: 'node-22',
     logLevel: 'log',
     // The max compute seconds a task is allowed to run. If the task run exceeds this duration, it will be stopped.


### PR DESCRIPTION
Whole-branch cascade stage -> main / production (no cherry-pick). Carries the flag-gated self-hosted Trigger.dev deploy workflow + CI-hygiene. On main CI success, the self-hosted deploy runs (gated on vars.TRIGGER_SELFHOSTED) and publishes tasks to trigger.ever.co.

🤖 Generated with [Claude Code](https://claude.com/claude-code)