### PR TITLE
release: stage → main (job-runtime /api fix, provider icons, CI audit fix)

### DIFF
--- a/apps/web/src/components/settings/JobRuntimeSettings.tsx
+++ b/apps/web/src/components/settings/JobRuntimeSettings.tsx
@@ -13,6 +13,7 @@ import {
     JOB_RUNTIME_PROVIDER_MODE_BANNERS,
     PROVIDERS_WITHOUT_CREDENTIALS,
 } from './job-runtime-schemas';
+import { providerIconMap } from './job-runtime-provider-icons';
 import {
     Dialog,
     DialogClose,
@@ -113,6 +114,11 @@ export function JobRuntimeSettings({
         () => availableProviders.map((value) => ({ value, label: PROVIDER_LABELS[value] })),
         [availableProviders],
     );
+
+    // EW-742 — brand-mark badges for the picker, keyed by provider id and fed
+    // to the Select via `iconMap`; each <option> opts in with `data-icon`.
+    // Static (provider set is fixed), so build once.
+    const providerIcons = useMemo(() => providerIconMap(18), []);
 
     // Form-local state mirrors the editable shape of the upsert payload.
     // We initialise providerId with a sane default when the row is the
@@ -329,9 +335,10 @@ export function JobRuntimeSettings({
                         }
                         disabled={noProvidersAvailable}
                         data-testid="job-runtime-provider-picker"
+                        iconMap={providerIcons}
                     >
                         {providerOptions.map((opt) => (
-                            <option key={opt.value} value={opt.value}>
+                            <option key={opt.value} value={opt.value} data-icon={opt.value}>
                                 {opt.label}
                             </option>
                         ))}

--- a/apps/web/src/components/settings/job-runtime-provider-icons.tsx
+++ b/apps/web/src/components/settings/job-runtime-provider-icons.tsx
@@ -1,0 +1,165 @@
+import * as React from 'react';
+import type { TenantJobRuntimeProviderId } from '@/lib/api/tenant-job-runtime';
+
+/**
+ * EW-742 — small brand-mark badges for the job-runtime provider picker.
+ *
+ * Each provider renders as a rounded square in its signature colour with a
+ * simple white glyph, so the picker shows an icon to the LEFT of the
+ * provider name (Trigger.dev, Temporal, …). These are lightweight, inlined,
+ * theme-agnostic SVGs — a mid-tone brand colour with a white glyph reads
+ * correctly in both light and dark mode without per-theme variants. They are
+ * stylised marks (not the vendors' official trademarked logos) and can be
+ * swapped for official SVGs later without touching call sites.
+ *
+ * Rendered via the generic `Select`'s `iconMap` prop (keyed by provider id),
+ * mirroring the existing `data-dot` chip mechanism.
+ */
+
+interface GlyphProps {
+    /** Rendered pixel size (width === height). */
+    size?: number;
+    className?: string;
+    title?: string;
+}
+
+// Shared badge wrapper: a rounded square filled with `color`, `children` is
+// the white glyph drawn on top (coordinates in a 20×20 viewBox).
+function Badge({
+    color,
+    size = 18,
+    className,
+    title,
+    children,
+}: GlyphProps & { color: string; children: React.ReactNode }) {
+    return (
+        <svg
+            width={size}
+            height={size}
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className={className}
+            role="img"
+            aria-hidden={title ? undefined : true}
+            aria-label={title}
+        >
+            {title ? <title>{title}</title> : null}
+            <rect x="0" y="0" width="20" height="20" rx="5" fill={color} />
+            {children}
+        </svg>
+    );
+}
+
+// Trigger.dev — signature charcoal/lime; glyph is a "play/trigger" triangle.
+function TriggerIcon({ size, className, title }: GlyphProps) {
+    return (
+        <Badge color="#16171D" size={size} className={className} title={title ?? 'Trigger.dev'}>
+            <path d="M8 6.2 L14 10 L8 13.8 Z" fill="#C6F24E" />
+        </Badge>
+    );
+}
+
+// Temporal — brand blue; glyph is a clock (temporal = time).
+function TemporalIcon({ size, className, title }: GlyphProps) {
+    return (
+        <Badge color="#1F6BFF" size={size} className={className} title={title ?? 'Temporal'}>
+            <circle cx="10" cy="10" r="4.4" stroke="#FFFFFF" strokeWidth="1.5" />
+            <path
+                d="M10 7.4 V10 L12 11.2"
+                stroke="#FFFFFF"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </Badge>
+    );
+}
+
+// BullMQ — red; "B" monogram.
+function BullmqIcon({ size, className, title }: GlyphProps) {
+    return (
+        <Badge color="#E11D48" size={size} className={className} title={title ?? 'BullMQ'}>
+            <text
+                x="10"
+                y="10"
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize="11"
+                fontWeight="700"
+                fontFamily="ui-sans-serif, system-ui, sans-serif"
+                fill="#FFFFFF"
+            >
+                B
+            </text>
+        </Badge>
+    );
+}
+
+// pg-boss — Postgres blue; "pg" wordmark.
+function PgbossIcon({ size, className, title }: GlyphProps) {
+    return (
+        <Badge color="#31648C" size={size} className={className} title={title ?? 'pg-boss'}>
+            <text
+                x="10"
+                y="10.5"
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize="9"
+                fontWeight="700"
+                fontFamily="ui-sans-serif, system-ui, sans-serif"
+                fill="#FFFFFF"
+            >
+                pg
+            </text>
+        </Badge>
+    );
+}
+
+// Inngest — violet; waveform bars (functions / events).
+function InngestIcon({ size, className, title }: GlyphProps) {
+    return (
+        <Badge color="#6D28D9" size={size} className={className} title={title ?? 'Inngest'}>
+            <g fill="#FFFFFF">
+                <rect x="5.5" y="9" width="1.8" height="5" rx="0.9" />
+                <rect x="9.1" y="6" width="1.8" height="8" rx="0.9" />
+                <rect x="12.7" y="10.5" width="1.8" height="3.5" rx="0.9" />
+            </g>
+        </Badge>
+    );
+}
+
+const ICON_BY_PROVIDER: Record<
+    TenantJobRuntimeProviderId,
+    (props: GlyphProps) => React.ReactElement
+> = {
+    trigger: TriggerIcon,
+    temporal: TemporalIcon,
+    bullmq: BullmqIcon,
+    pgboss: PgbossIcon,
+    inngest: InngestIcon,
+};
+
+export interface ProviderBrandIconProps extends GlyphProps {
+    providerId: TenantJobRuntimeProviderId;
+}
+
+/** Brand-mark badge for a single job-runtime provider. */
+export function ProviderBrandIcon({ providerId, ...props }: ProviderBrandIconProps) {
+    const Icon = ICON_BY_PROVIDER[providerId];
+    if (!Icon) return null;
+    return <Icon {...props} />;
+}
+
+/**
+ * Prebuilt `iconMap` for the `Select` component: provider id → brand badge.
+ * Consumed by the provider picker in `JobRuntimeSettings`.
+ */
+export function providerIconMap(size = 18): Record<string, React.ReactNode> {
+    return Object.fromEntries(
+        (Object.keys(ICON_BY_PROVIDER) as TenantJobRuntimeProviderId[]).map((id) => [
+            id,
+            <ProviderBrandIcon key={id} providerId={id} size={size} />,
+        ]),
+    );
+}

--- a/apps/web/src/components/settings/job-runtime-provider-icons.unit.spec.tsx
+++ b/apps/web/src/components/settings/job-runtime-provider-icons.unit.spec.tsx
@@ -1,0 +1,62 @@
+// EW-742 — unit spec for the job-runtime provider brand-mark icons.
+// Renders each icon to static markup (no DOM needed) and pins the badge
+// shape (an <svg> with a brand colour + an accessible label per provider),
+// plus the `providerIconMap` / unknown-provider contract.
+
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { TenantJobRuntimeProviderId } from '@/lib/api/tenant-job-runtime';
+import { ProviderBrandIcon, providerIconMap } from './job-runtime-provider-icons';
+
+const CASES: { id: TenantJobRuntimeProviderId; label: string; color: string }[] = [
+    { id: 'trigger', label: 'Trigger.dev', color: '#16171D' },
+    { id: 'temporal', label: 'Temporal', color: '#1F6BFF' },
+    { id: 'bullmq', label: 'BullMQ', color: '#E11D48' },
+    { id: 'pgboss', label: 'pg-boss', color: '#31648C' },
+    { id: 'inngest', label: 'Inngest', color: '#6D28D9' },
+];
+
+describe('ProviderBrandIcon', () => {
+    it.each(CASES)(
+        'renders an svg badge for $id with its brand colour + label',
+        ({ id, label, color }) => {
+            const html = renderToStaticMarkup(<ProviderBrandIcon providerId={id} size={18} />);
+            expect(html).toContain('<svg');
+            expect(html).toContain(`aria-label="${label}"`);
+            expect(html.toLowerCase()).toContain(color.toLowerCase());
+            expect(html).toContain('width="18"');
+            expect(html).toContain('height="18"');
+        },
+    );
+
+    it('honours the requested size', () => {
+        const html = renderToStaticMarkup(<ProviderBrandIcon providerId="trigger" size={24} />);
+        expect(html).toContain('width="24"');
+        expect(html).toContain('height="24"');
+    });
+
+    it('renders nothing for an unknown provider id', () => {
+        const html = renderToStaticMarkup(
+            <ProviderBrandIcon providerId={'nope' as TenantJobRuntimeProviderId} />,
+        );
+        expect(html).toBe('');
+    });
+});
+
+describe('providerIconMap', () => {
+    it('returns an entry for every known provider id', () => {
+        const map = providerIconMap();
+        expect(Object.keys(map).sort()).toEqual(
+            ['bullmq', 'inngest', 'pgboss', 'temporal', 'trigger'].sort(),
+        );
+    });
+
+    it('each entry renders to an svg badge', () => {
+        const map = providerIconMap(16);
+        for (const node of Object.values(map)) {
+            const html = renderToStaticMarkup(<>{node}</>);
+            expect(html).toContain('<svg');
+            expect(html).toContain('width="16"');
+        }
+    });
+});

--- a/apps/web/src/components/ui/select.icon.unit.spec.tsx
+++ b/apps/web/src/components/ui/select.icon.unit.spec.tsx
@@ -1,0 +1,72 @@
+// EW-742 — unit spec for the Select `iconMap` / `data-icon` feature.
+// Uses vitest + jsdom + @testing-library/react. Confirms a leading icon
+// renders in the trigger (selected) and in each open row, that it is
+// backward-compatible (no icon without data-icon/iconMap), and that labels
+// still render.
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { Select } from './select';
+
+afterEach(cleanup);
+
+const iconMap = {
+    alpha: <svg data-testid="ic-alpha" />,
+    beta: <svg data-testid="ic-beta" />,
+};
+
+function renderSelect(value: string) {
+    return render(
+        <Select value={value} iconMap={iconMap}>
+            <option value="alpha" data-icon="alpha">
+                Alpha
+            </option>
+            <option value="beta" data-icon="beta">
+                Beta
+            </option>
+        </Select>,
+    );
+}
+
+describe('Select iconMap / data-icon', () => {
+    it('renders the selected option icon in the (closed) trigger', () => {
+        renderSelect('alpha');
+        expect(screen.getAllByTestId('ic-alpha').length).toBeGreaterThan(0);
+        // Beta is not selected and the list is closed → its icon is absent.
+        expect(screen.queryByTestId('ic-beta')).toBeNull();
+    });
+
+    it('renders each option icon once the dropdown is open', () => {
+        renderSelect('alpha');
+        fireEvent.click(screen.getByRole('button'));
+        expect(screen.getAllByTestId('ic-alpha').length).toBeGreaterThan(0);
+        expect(screen.getAllByTestId('ic-beta').length).toBeGreaterThan(0);
+        // Labels still render alongside the icons (in the trigger AND the open
+        // row for the selected value, so there can be more than one match).
+        expect(screen.getAllByText('Alpha').length).toBeGreaterThan(0);
+        expect(screen.getAllByText('Beta').length).toBeGreaterThan(0);
+    });
+
+    it('is backward-compatible: no icon markup when data-icon / iconMap are absent', () => {
+        render(
+            <Select value="x">
+                <option value="x">Xray</option>
+                <option value="y">Yankee</option>
+            </Select>,
+        );
+        expect(screen.queryByTestId('ic-alpha')).toBeNull();
+        expect(screen.getByText('Xray')).toBeTruthy();
+    });
+
+    it('renders no leading icon when an option omits data-icon even if iconMap is set', () => {
+        render(
+            <Select value="a" iconMap={iconMap}>
+                <option value="a">Plain</option>
+            </Select>,
+        );
+        // "a" is not a key with a matching data-icon, so neither test icon shows.
+        expect(screen.queryByTestId('ic-alpha')).toBeNull();
+        expect(screen.queryByTestId('ic-beta')).toBeNull();
+        expect(screen.getByText('Plain')).toBeTruthy();
+    });
+});

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -19,6 +19,10 @@ interface OptionData {
     /** Tailwind bg-* class rendered as a small colored dot before the label.
      *  Set via `data-dot` on the `<option>` (e.g. status color chips). */
     dotClass?: string;
+    /** Key into the Select's `iconMap`, rendered as a leading icon before the
+     *  label (in both the trigger and each row). Set via `data-icon` on the
+     *  `<option>` (e.g. provider brand marks). */
+    iconKey?: string;
 }
 
 interface GroupData {
@@ -49,6 +53,14 @@ export interface SelectProps {
      * Mirrors the same prop on native shadcn primitives.
      */
     'data-testid'?: string;
+    /**
+     * Optional leading icons, keyed by an option's `data-icon` value. When an
+     * option declares `data-icon="foo"` and `iconMap.foo` is provided, that
+     * node renders before the label in both the trigger and the dropdown row.
+     * Keeps the Select generic — callers own the actual icon nodes (e.g.
+     * provider brand marks).
+     */
+    iconMap?: Record<string, React.ReactNode>;
 }
 
 // ---- helpers ------------------------------------------------------ //
@@ -61,12 +73,14 @@ function parseItems(children: React.ReactNode): FlatItem[] {
         if (child.type === 'option') {
             const p = child.props as React.OptionHTMLAttributes<HTMLOptionElement>;
             const dot = (p as Record<string, unknown>)['data-dot'];
+            const icon = (p as Record<string, unknown>)['data-icon'];
             items.push({
                 type: 'option',
                 value: String(p.value ?? ''),
                 label: nodeText(p.children),
                 disabled: !!p.disabled,
                 ...(typeof dot === 'string' && dot ? { dotClass: dot } : {}),
+                ...(typeof icon === 'string' && icon ? { iconKey: icon } : {}),
             });
         } else if (child.type === 'optgroup') {
             const p = child.props as React.OptgroupHTMLAttributes<HTMLOptGroupElement>;
@@ -74,11 +88,13 @@ function parseItems(children: React.ReactNode): FlatItem[] {
             React.Children.forEach(p.children as React.ReactNode, (opt) => {
                 if (!React.isValidElement(opt) || opt.type !== 'option') return;
                 const op = opt.props as React.OptionHTMLAttributes<HTMLOptionElement>;
+                const opIcon = (op as Record<string, unknown>)['data-icon'];
                 opts.push({
                     type: 'option',
                     value: String(op.value ?? ''),
                     label: nodeText(op.children),
                     disabled: !!op.disabled,
+                    ...(typeof opIcon === 'string' && opIcon ? { iconKey: opIcon } : {}),
                 });
             });
             items.push({ type: 'group', label: String(p.label ?? ''), options: opts });
@@ -116,6 +132,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
             id,
             name,
             'data-testid': dataTestId,
+            iconMap,
         },
         ref,
     ) => {
@@ -233,6 +250,11 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                     )}
                 >
                     <span className="flex min-w-0 items-center gap-1.5">
+                        {selected?.iconKey && iconMap?.[selected.iconKey] ? (
+                            <span aria-hidden="true" className="flex shrink-0 items-center">
+                                {iconMap[selected.iconKey]}
+                            </span>
+                        ) : null}
                         {selected?.dotClass && (
                             <span
                                 aria-hidden="true"
@@ -289,6 +311,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                                         selected={item.value === value}
                                         size={size}
                                         onPick={pick}
+                                        iconMap={iconMap}
                                     />
                                 ) : (
                                     <div key={`group-${item.label}-${idx}`}>
@@ -304,6 +327,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                                                 size={size}
                                                 onPick={pick}
                                                 indent
+                                                iconMap={iconMap}
                                             />
                                         ))}
                                     </div>
@@ -326,12 +350,14 @@ function OptionRow({
     size,
     onPick,
     indent,
+    iconMap,
 }: {
     opt: OptionData;
     selected: boolean;
     size: 'xs' | 'sm' | 'default';
     onPick: (opt: OptionData) => void;
     indent?: boolean;
+    iconMap?: Record<string, React.ReactNode>;
 }) {
     const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
         if (opt.disabled) {
@@ -395,6 +421,11 @@ function OptionRow({
                     'opacity-50 cursor-not-allowed pointer-events-none text-text-muted dark:text-text-muted-dark',
             )}
         >
+            {opt.iconKey && iconMap?.[opt.iconKey] ? (
+                <span aria-hidden="true" className="flex shrink-0 items-center">
+                    {iconMap[opt.iconKey]}
+                </span>
+            ) : null}
             {opt.dotClass && (
                 <span
                     aria-hidden="true"

--- a/apps/web/src/lib/api/email-addresses.ts
+++ b/apps/web/src/lib/api/email-addresses.ts
@@ -57,15 +57,13 @@ export interface EmailMessageDetail extends EmailMessageListItem {
 export const emailAddressesAPI = {
     list: async (direction?: EmailAddressDirection) => {
         const query = direction ? `?direction=${direction}` : '';
-        const data = await serverFetch<{ addresses: EmailAddress[] }>(
-            `/api/email/addresses${query}`,
-        );
+        const data = await serverFetch<{ addresses: EmailAddress[] }>(`/email/addresses${query}`);
         return data.addresses;
     },
     create: async (input: CreateEmailAddressDto) => {
         const data = await serverMutation<{ address: EmailAddress }>({
             method: 'POST',
-            endpoint: '/api/email/addresses',
+            endpoint: '/email/addresses',
             data: input,
             wrapInData: false,
         });
@@ -74,7 +72,7 @@ export const emailAddressesAPI = {
     update: async (id: string, input: Partial<CreateEmailAddressDto> & { disabled?: boolean }) => {
         const data = await serverMutation<{ address: EmailAddress }>({
             method: 'PATCH',
-            endpoint: `/api/email/addresses/${id}`,
+            endpoint: `/email/addresses/${id}`,
             data: input,
             wrapInData: false,
         });
@@ -83,7 +81,7 @@ export const emailAddressesAPI = {
     remove: async (id: string) => {
         await serverMutation<void>({
             method: 'DELETE',
-            endpoint: `/api/email/addresses/${id}`,
+            endpoint: `/email/addresses/${id}`,
             data: {},
             wrapInData: false,
         });
@@ -91,7 +89,7 @@ export const emailAddressesAPI = {
     triggerVerification: async (id: string) => {
         const data = await serverMutation<{ messageRef: string }>({
             method: 'POST',
-            endpoint: `/api/email/addresses/${id}/verify`,
+            endpoint: `/email/addresses/${id}/verify`,
             data: {},
             wrapInData: false,
         });
@@ -99,14 +97,12 @@ export const emailAddressesAPI = {
     },
     listMessagesForAgent: async (agentId: string, limit = 50, offset = 0) => {
         const data = await serverFetch<{ messages: EmailMessageListItem[] }>(
-            `/api/email/messages?agentId=${agentId}&limit=${limit}&offset=${offset}`,
+            `/email/messages?agentId=${agentId}&limit=${limit}&offset=${offset}`,
         );
         return data.messages;
     },
     getMessage: async (id: string) => {
-        const data = await serverFetch<{ message: EmailMessageDetail }>(
-            `/api/email/messages/${id}`,
-        );
+        const data = await serverFetch<{ message: EmailMessageDetail }>(`/email/messages/${id}`);
         return data.message;
     },
     sendMessage: async (input: {
@@ -122,7 +118,7 @@ export const emailAddressesAPI = {
             result: { providerMessageId: string; accepted: string[]; rejected: unknown[] };
         }>({
             method: 'POST',
-            endpoint: '/api/email/messages',
+            endpoint: '/email/messages',
             data: input,
             wrapInData: false,
         });

--- a/apps/web/src/lib/api/email-addresses.unit.spec.ts
+++ b/apps/web/src/lib/api/email-addresses.unit.spec.ts
@@ -1,0 +1,135 @@
+// EW-650 / EW-679 — regression spec for the email-addresses API wrapper.
+// Guards the endpoint URL shape against the `/api/api/...` double-prefix
+// bug: `serverFetch` / `serverMutation` prepend `API_URL` (normalised to
+// end in `/api`), so endpoints must NOT start with `/api`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+async function importApi() {
+    return import('./email-addresses');
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverMutationMock.mockReset();
+    serverFetchMock.mockResolvedValue({ addresses: [], messages: [], message: {} });
+    serverMutationMock.mockResolvedValue({ address: {}, messageRef: 'r', result: {} });
+});
+afterEach(() => vi.resetModules());
+
+describe('emailAddressesAPI — endpoint URL shape (no /api double-prefix)', () => {
+    it('list GETs /email/addresses (with optional direction query)', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.list();
+        expect(serverFetchMock).toHaveBeenCalledWith('/email/addresses');
+        await emailAddressesAPI.list('inbound');
+        expect(serverFetchMock).toHaveBeenCalledWith('/email/addresses?direction=inbound');
+    });
+
+    it('create POSTs /email/addresses', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.create({
+            address: 'a@b.co',
+            direction: 'both',
+            pluginId: 'p',
+            providerSettings: {},
+        });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'POST', endpoint: '/email/addresses' }),
+        );
+    });
+
+    it('update PATCHes /email/addresses/:id', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.update('e-1', { defaultForReplies: true });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'PATCH', endpoint: '/email/addresses/e-1' }),
+        );
+    });
+
+    it('remove DELETEs /email/addresses/:id', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.remove('e-1');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'DELETE', endpoint: '/email/addresses/e-1' }),
+        );
+    });
+
+    it('triggerVerification POSTs /email/addresses/:id/verify', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.triggerVerification('e-1');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/email/addresses/e-1/verify' }),
+        );
+    });
+
+    it('listMessagesForAgent GETs /email/messages with query params', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.listMessagesForAgent('ag-1', 50, 0);
+        expect(serverFetchMock).toHaveBeenCalledWith(
+            '/email/messages?agentId=ag-1&limit=50&offset=0',
+        );
+    });
+
+    it('getMessage GETs /email/messages/:id', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.getMessage('m-1');
+        expect(serverFetchMock).toHaveBeenCalledWith('/email/messages/m-1');
+    });
+
+    it('sendMessage POSTs /email/messages', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await emailAddressesAPI.sendMessage({
+            agentId: 'ag-1',
+            to: ['x@y.co'],
+            subject: 's',
+            bodyText: 'b',
+        });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'POST', endpoint: '/email/messages' }),
+        );
+    });
+
+    it('NONE of the methods ever passes an endpoint starting with /api', async () => {
+        const { emailAddressesAPI } = await importApi();
+        await Promise.all([
+            emailAddressesAPI.list('outbound'),
+            emailAddressesAPI.create({
+                address: 'a@b.co',
+                direction: 'both',
+                pluginId: 'p',
+                providerSettings: {},
+            }),
+            emailAddressesAPI.update('id', {}),
+            emailAddressesAPI.remove('id'),
+            emailAddressesAPI.triggerVerification('id'),
+            emailAddressesAPI.listMessagesForAgent('ag', 10, 5),
+            emailAddressesAPI.getMessage('m'),
+            emailAddressesAPI.sendMessage({
+                agentId: 'a',
+                to: ['x@y.co'],
+                subject: 's',
+                bodyText: 'b',
+            }),
+        ]);
+
+        const fetchEndpoints = serverFetchMock.mock.calls.map((c) => c[0] as string);
+        const mutationEndpoints = serverMutationMock.mock.calls.map(
+            (c) => (c[0] as { endpoint: string }).endpoint,
+        );
+        for (const endpoint of [...fetchEndpoints, ...mutationEndpoints]) {
+            expect(endpoint.startsWith('/api')).toBe(false);
+            expect(endpoint).not.toContain('/api/');
+        }
+    });
+});

--- a/apps/web/src/lib/api/notification-channels.ts
+++ b/apps/web/src/lib/api/notification-channels.ts
@@ -26,14 +26,14 @@ export interface CreateChannelDto {
 export const notificationChannelsAPI = {
     list: async () => {
         const data = await serverFetch<{ channels: NotificationChannel[] }>(
-            '/api/notification-channels',
+            '/notification-channels',
         );
         return data.channels;
     },
     create: async (input: CreateChannelDto) => {
         const data = await serverMutation<{ channel: NotificationChannel }>({
             method: 'POST',
-            endpoint: '/api/notification-channels',
+            endpoint: '/notification-channels',
             data: input,
             wrapInData: false,
         });
@@ -42,7 +42,7 @@ export const notificationChannelsAPI = {
     update: async (id: string, input: Partial<CreateChannelDto> & { disabled?: boolean }) => {
         const data = await serverMutation<{ channel: NotificationChannel }>({
             method: 'PATCH',
-            endpoint: `/api/notification-channels/${id}`,
+            endpoint: `/notification-channels/${id}`,
             data: input,
             wrapInData: false,
         });
@@ -51,7 +51,7 @@ export const notificationChannelsAPI = {
     remove: async (id: string) => {
         await serverMutation<void>({
             method: 'DELETE',
-            endpoint: `/api/notification-channels/${id}`,
+            endpoint: `/notification-channels/${id}`,
             data: {},
             wrapInData: false,
         });
@@ -59,7 +59,7 @@ export const notificationChannelsAPI = {
     sendTest: async (id: string) => {
         return serverMutation<{ status: string; error?: string; providerMessageId?: string }>({
             method: 'POST',
-            endpoint: `/api/notification-channels/${id}/test`,
+            endpoint: `/notification-channels/${id}/test`,
             data: {},
             wrapInData: false,
         });

--- a/apps/web/src/lib/api/notification-channels.unit.spec.ts
+++ b/apps/web/src/lib/api/notification-channels.unit.spec.ts
@@ -1,0 +1,88 @@
+// EW-663 / EW-679 — regression spec for the notification-channels API
+// wrapper. Guards the endpoint URL shape against the `/api/api/...`
+// double-prefix bug: `serverFetch` / `serverMutation` prepend `API_URL`
+// (normalised to end in `/api`), so endpoints must NOT start with `/api`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+async function importApi() {
+    return import('./notification-channels');
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverMutationMock.mockReset();
+    serverFetchMock.mockResolvedValue({ channels: [] });
+    serverMutationMock.mockResolvedValue({ channel: {} });
+});
+afterEach(() => vi.resetModules());
+
+describe('notificationChannelsAPI — endpoint URL shape (no /api double-prefix)', () => {
+    it('list GETs /notification-channels', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await notificationChannelsAPI.list();
+        expect(serverFetchMock).toHaveBeenCalledWith('/notification-channels');
+    });
+
+    it('create POSTs /notification-channels', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await notificationChannelsAPI.create({ pluginId: 'p', name: 'n', targetConfig: {} });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'POST', endpoint: '/notification-channels' }),
+        );
+    });
+
+    it('update PATCHes /notification-channels/:id', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await notificationChannelsAPI.update('ch-1', { name: 'n2' });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'PATCH', endpoint: '/notification-channels/ch-1' }),
+        );
+    });
+
+    it('remove DELETEs /notification-channels/:id', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await notificationChannelsAPI.remove('ch-1');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ method: 'DELETE', endpoint: '/notification-channels/ch-1' }),
+        );
+    });
+
+    it('sendTest POSTs /notification-channels/:id/test', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await notificationChannelsAPI.sendTest('ch-1');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/notification-channels/ch-1/test' }),
+        );
+    });
+
+    it('NONE of the methods ever passes an endpoint starting with /api', async () => {
+        const { notificationChannelsAPI } = await importApi();
+        await Promise.all([
+            notificationChannelsAPI.list(),
+            notificationChannelsAPI.create({ pluginId: 'p', name: 'n', targetConfig: {} }),
+            notificationChannelsAPI.update('id', { name: 'n' }),
+            notificationChannelsAPI.remove('id'),
+            notificationChannelsAPI.sendTest('id'),
+        ]);
+
+        const fetchEndpoints = serverFetchMock.mock.calls.map((c) => c[0] as string);
+        const mutationEndpoints = serverMutationMock.mock.calls.map(
+            (c) => (c[0] as { endpoint: string }).endpoint,
+        );
+        for (const endpoint of [...fetchEndpoints, ...mutationEndpoints]) {
+            expect(endpoint.startsWith('/api')).toBe(false);
+            expect(endpoint).not.toContain('/api/');
+        }
+    });
+});

--- a/apps/web/src/lib/api/notification-preferences.ts
+++ b/apps/web/src/lib/api/notification-preferences.ts
@@ -39,17 +39,17 @@ export interface PreferencesView {
 export const notificationPreferencesAPI = {
     listEventTypes: async () => {
         const data = await serverFetch<{ eventTypes: NotificationEventType[] }>(
-            '/api/notifications/event-types',
+            '/notifications/event-types',
         );
         return data.eventTypes;
     },
     getPreferences: async () => {
-        return serverFetch<PreferencesView>('/api/notifications/preferences');
+        return serverFetch<PreferencesView>('/notifications/preferences');
     },
     setEventSubscription: async (eventKey: string, channelIds: string[]) => {
         return serverMutation<{ subscription: NotificationSubscription }>({
             method: 'PUT',
-            endpoint: `/api/notifications/preferences/event/${encodeURIComponent(eventKey)}`,
+            endpoint: `/notifications/preferences/event/${encodeURIComponent(eventKey)}`,
             data: { channelIds },
             wrapInData: false,
         });
@@ -61,7 +61,7 @@ export const notificationPreferencesAPI = {
     }) => {
         return serverMutation<{ preference: NotificationPreference }>({
             method: 'PUT',
-            endpoint: '/api/notifications/preferences/quiet-hours',
+            endpoint: '/notifications/preferences/quiet-hours',
             data: input,
             wrapInData: false,
         });
@@ -69,7 +69,7 @@ export const notificationPreferencesAPI = {
     muteCategory: async (category: string, mutedUntil: string | null) => {
         return serverMutation<{ mute: { category: string; mutedUntil: string | null } }>({
             method: 'POST',
-            endpoint: '/api/notifications/preferences/mute',
+            endpoint: '/notifications/preferences/mute',
             data: { category, mutedUntil },
             wrapInData: false,
         });
@@ -77,7 +77,7 @@ export const notificationPreferencesAPI = {
     unmuteCategory: async (category: string) => {
         await serverMutation<void>({
             method: 'DELETE',
-            endpoint: `/api/notifications/preferences/mute/${encodeURIComponent(category)}`,
+            endpoint: `/notifications/preferences/mute/${encodeURIComponent(category)}`,
             data: {},
             wrapInData: false,
         });

--- a/apps/web/src/lib/api/notification-preferences.unit.spec.ts
+++ b/apps/web/src/lib/api/notification-preferences.unit.spec.ts
@@ -1,0 +1,109 @@
+// EW-664 / EW-679 — regression spec for the notification-preferences API
+// wrapper. Pins the endpoint URL shape so the `/api/api/...` double-prefix
+// bug can never come back: `serverFetch` / `serverMutation` prepend
+// `API_URL` (normalised to end in `/api`), so every endpoint here MUST be
+// relative to `/api` — it must NOT start with `/api`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+async function importApi() {
+    return import('./notification-preferences');
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverMutationMock.mockReset();
+    serverFetchMock.mockResolvedValue({ eventTypes: [] });
+    serverMutationMock.mockResolvedValue({});
+});
+afterEach(() => vi.resetModules());
+
+describe('notificationPreferencesAPI — endpoint URL shape (no /api double-prefix)', () => {
+    it('listEventTypes GETs /notifications/event-types', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.listEventTypes();
+        expect(serverFetchMock).toHaveBeenCalledWith('/notifications/event-types');
+    });
+
+    it('getPreferences GETs /notifications/preferences', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.getPreferences();
+        expect(serverFetchMock).toHaveBeenCalledWith('/notifications/preferences');
+    });
+
+    it('setEventSubscription PUTs /notifications/preferences/event/:key', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.setEventSubscription('work.completed', ['c1']);
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                method: 'PUT',
+                endpoint: '/notifications/preferences/event/work.completed',
+                data: { channelIds: ['c1'] },
+                wrapInData: false,
+            }),
+        );
+    });
+
+    it('setQuietHours PUTs /notifications/preferences/quiet-hours', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.setQuietHours({
+            quietHoursStart: null,
+            quietHoursEnd: null,
+            timezone: null,
+        });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/notifications/preferences/quiet-hours' }),
+        );
+    });
+
+    it('muteCategory POSTs /notifications/preferences/mute', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.muteCategory('billing', null);
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/notifications/preferences/mute' }),
+        );
+    });
+
+    it('unmuteCategory DELETEs /notifications/preferences/mute/:category', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await notificationPreferencesAPI.unmuteCategory('billing');
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({ endpoint: '/notifications/preferences/mute/billing' }),
+        );
+    });
+
+    it('NONE of the methods ever passes an endpoint starting with /api', async () => {
+        const { notificationPreferencesAPI } = await importApi();
+        await Promise.all([
+            notificationPreferencesAPI.listEventTypes(),
+            notificationPreferencesAPI.getPreferences(),
+            notificationPreferencesAPI.setEventSubscription('e', ['c']),
+            notificationPreferencesAPI.setQuietHours({
+                quietHoursStart: null,
+                quietHoursEnd: null,
+                timezone: null,
+            }),
+            notificationPreferencesAPI.muteCategory('c', null),
+            notificationPreferencesAPI.unmuteCategory('c'),
+        ]);
+
+        const fetchEndpoints = serverFetchMock.mock.calls.map((c) => c[0] as string);
+        const mutationEndpoints = serverMutationMock.mock.calls.map(
+            (c) => (c[0] as { endpoint: string }).endpoint,
+        );
+        for (const endpoint of [...fetchEndpoints, ...mutationEndpoints]) {
+            expect(endpoint.startsWith('/api')).toBe(false);
+            expect(endpoint).not.toContain('/api/');
+        }
+    });
+});

--- a/apps/web/src/lib/api/operator-tenant-runtime-allowlist.unit.spec.ts
+++ b/apps/web/src/lib/api/operator-tenant-runtime-allowlist.unit.spec.ts
@@ -2,7 +2,7 @@
 // operator-scoped per-tenant runtime allow-list API wrapper.
 //
 // Targets: apps/web/src/lib/api/operator-tenant-runtime-allowlist.ts
-//   - URL construction (`/api/operator/tenants/:tenantId/runtime-allowlist`)
+//   - URL construction (`/operator/tenants/:tenantId/runtime-allowlist`)
 //   - .list() uses serverFetch (GET)
 //   - .replace() uses serverMutation with PUT + { providerIds } body + wrapInData: false
 //   - .deleteEntry() uses serverMutation with DELETE + /:providerId suffix
@@ -11,6 +11,12 @@
 //
 // Before: 0 spec lines covering this module. After: ~15 cases pinning the
 // URL shape and the request envelope for all three verbs.
+//
+// NOTE: these assertions were stale — they expected a leading `/api`, but
+// commit 52e590a4 already dropped it from `base()` (serverFetch prepends
+// API_URL, which ends in `/api`, so `/api/...` would double to `/api/api/`).
+// The spec was not updated in that commit and had been failing since.
+// Realigned here to the shipped `/operator/...` paths.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -46,9 +52,7 @@ describe('operatorTenantRuntimeAllowlistAPI.list', () => {
         const { operatorTenantRuntimeAllowlistAPI } = await importApi();
         await operatorTenantRuntimeAllowlistAPI.list('t-abc');
         expect(serverFetchMock).toHaveBeenCalledTimes(1);
-        expect(serverFetchMock).toHaveBeenCalledWith(
-            '/api/operator/tenants/t-abc/runtime-allowlist',
-        );
+        expect(serverFetchMock).toHaveBeenCalledWith('/operator/tenants/t-abc/runtime-allowlist');
     });
 
     it('returns the parsed response verbatim (no client-side reshaping)', async () => {
@@ -83,7 +87,7 @@ describe('operatorTenantRuntimeAllowlistAPI.replace', () => {
         await operatorTenantRuntimeAllowlistAPI.replace('t-7', ['trigger', 'bullmq']);
         expect(serverMutationMock).toHaveBeenCalledTimes(1);
         expect(serverMutationMock).toHaveBeenCalledWith({
-            endpoint: '/api/operator/tenants/t-7/runtime-allowlist',
+            endpoint: '/operator/tenants/t-7/runtime-allowlist',
             data: { providerIds: ['trigger', 'bullmq'] },
             method: 'PUT',
             wrapInData: false,
@@ -131,7 +135,7 @@ describe('operatorTenantRuntimeAllowlistAPI.deleteEntry', () => {
         await operatorTenantRuntimeAllowlistAPI.deleteEntry('t-7', 'trigger');
         expect(serverMutationMock).toHaveBeenCalledTimes(1);
         expect(serverMutationMock).toHaveBeenCalledWith({
-            endpoint: '/api/operator/tenants/t-7/runtime-allowlist/trigger',
+            endpoint: '/operator/tenants/t-7/runtime-allowlist/trigger',
             data: {},
             method: 'DELETE',
             wrapInData: false,
@@ -163,9 +167,7 @@ describe('convenience aliases', () => {
     it('getTenantRuntimeAllowlist delegates to .list(tenantId)', async () => {
         const { getTenantRuntimeAllowlist } = await importApi();
         await getTenantRuntimeAllowlist('t-99');
-        expect(serverFetchMock).toHaveBeenCalledWith(
-            '/api/operator/tenants/t-99/runtime-allowlist',
-        );
+        expect(serverFetchMock).toHaveBeenCalledWith('/operator/tenants/t-99/runtime-allowlist');
     });
 
     it('replaceTenantRuntimeAllowlist delegates to .replace(tenantId, providerIds)', async () => {
@@ -173,7 +175,7 @@ describe('convenience aliases', () => {
         await replaceTenantRuntimeAllowlist('t-99', ['trigger']);
         expect(serverMutationMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                endpoint: '/api/operator/tenants/t-99/runtime-allowlist',
+                endpoint: '/operator/tenants/t-99/runtime-allowlist',
                 method: 'PUT',
                 data: { providerIds: ['trigger'] },
             }),
@@ -185,7 +187,7 @@ describe('convenience aliases', () => {
         await deleteTenantRuntimeAllowlistEntry('t-99', 'inngest');
         expect(serverMutationMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                endpoint: '/api/operator/tenants/t-99/runtime-allowlist/inngest',
+                endpoint: '/operator/tenants/t-99/runtime-allowlist/inngest',
                 method: 'DELETE',
             }),
         );

--- a/apps/web/src/lib/api/tenant-job-runtime.ts
+++ b/apps/web/src/lib/api/tenant-job-runtime.ts
@@ -54,7 +54,12 @@ export interface TenantJobRuntimeAvailableProvidersResponse {
     providers: TenantJobRuntimeProviderId[];
 }
 
-const BASE = '/api/account/job-runtime';
+// NOTE: no leading `/api` here — `serverFetch`/`serverMutation` prepend
+// `API_URL`, which `lib/constants.ts` normalises to already end in `/api`.
+// Including `/api` here would compose to `/api/api/account/job-runtime/...`
+// → the Nest app 404s with "Cannot GET /api/api/...". Matches every other
+// helper in this folder (see the 52e590a4 operator-allowlist fix).
+const BASE = '/account/job-runtime';
 
 export const tenantJobRuntimeAPI = {
     getConfig: async () => {

--- a/apps/web/src/lib/api/tenant-job-runtime.unit.spec.ts
+++ b/apps/web/src/lib/api/tenant-job-runtime.unit.spec.ts
@@ -1,0 +1,191 @@
+// EW-742 — regression spec for the tenant job-runtime overlay API wrapper.
+//
+// Targets: apps/web/src/lib/api/tenant-job-runtime.ts
+//
+// Primary purpose: pin the endpoint URL shape so the `/api/api/...`
+// double-prefix bug can never come back. `serverFetch` / `serverMutation`
+// prepend `API_URL` (normalised to end in `/api` by lib/constants.ts), so
+// every endpoint passed here MUST be relative to `/api` — i.e. it must NOT
+// start with `/api`. A regression here rendered the Job Runtime settings
+// page unusable ("Cannot GET /api/api/account/job-runtime/config").
+//
+// Also covers the request envelope (method + wrapInData:false + body) for
+// each of the six verbs and the convenience aliases.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock, serverMutationMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+    serverMutationMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+    serverMutation: serverMutationMock,
+}));
+
+const configResponse = {
+    tenantId: 't-1',
+    providerId: null,
+    mode: 'inherit',
+    hasCredentials: false,
+    credentialsSecretRefRedacted: null,
+    credentialVersion: null,
+    enabled: true,
+    createdBy: null,
+    createdAt: null,
+    updatedAt: null,
+};
+
+async function importApi() {
+    return import('./tenant-job-runtime');
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverMutationMock.mockReset();
+    serverFetchMock.mockResolvedValue(configResponse);
+    serverMutationMock.mockResolvedValue(configResponse);
+});
+afterEach(() => vi.resetModules());
+
+describe('tenantJobRuntimeAPI — endpoint URL shape (no /api double-prefix)', () => {
+    it('getConfig hits /account/job-runtime/config WITHOUT a leading /api', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.getConfig();
+        expect(serverFetchMock).toHaveBeenCalledTimes(1);
+        expect(serverFetchMock).toHaveBeenCalledWith('/account/job-runtime/config');
+    });
+
+    it('getAvailableProviders hits /account/job-runtime/available-providers', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.getAvailableProviders();
+        expect(serverFetchMock).toHaveBeenCalledWith('/account/job-runtime/available-providers');
+    });
+
+    it('upsertConfig PUTs to /account/job-runtime/config with the raw payload', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        const payload = { providerId: 'trigger', mode: 'byo' } as const;
+        await tenantJobRuntimeAPI.upsertConfig(payload);
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/account/job-runtime/config',
+            data: payload,
+            method: 'PUT',
+            wrapInData: false,
+        });
+    });
+
+    it('rotate POSTs to /account/job-runtime/rotate', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.rotate();
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/account/job-runtime/rotate',
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    });
+
+    it('forceInvalidate POSTs to /account/job-runtime/force-invalidate', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.forceInvalidate();
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/account/job-runtime/force-invalidate',
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    });
+
+    it('revertToInherit DELETEs /account/job-runtime/config', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        await tenantJobRuntimeAPI.revertToInherit();
+        expect(serverMutationMock).toHaveBeenCalledWith({
+            endpoint: '/account/job-runtime/config',
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    });
+
+    it('NONE of the six verbs ever passes an endpoint starting with /api', async () => {
+        const { tenantJobRuntimeAPI } = await importApi();
+        // Independent calls — fire concurrently (we only assert the set of
+        // endpoints hit, not their order).
+        await Promise.all([
+            tenantJobRuntimeAPI.getConfig(),
+            tenantJobRuntimeAPI.getAvailableProviders(),
+            tenantJobRuntimeAPI.upsertConfig({ providerId: 'trigger', mode: 'byo' }),
+            tenantJobRuntimeAPI.rotate(),
+            tenantJobRuntimeAPI.forceInvalidate(),
+            tenantJobRuntimeAPI.revertToInherit(),
+        ]);
+
+        const fetchEndpoints = serverFetchMock.mock.calls.map((c) => c[0] as string);
+        const mutationEndpoints = serverMutationMock.mock.calls.map(
+            (c) => (c[0] as { endpoint: string }).endpoint,
+        );
+        for (const endpoint of [...fetchEndpoints, ...mutationEndpoints]) {
+            expect(endpoint.startsWith('/api')).toBe(false);
+            expect(endpoint).not.toContain('/api/');
+        }
+    });
+});
+
+describe('tenantJobRuntimeAPI — convenience aliases delegate to the namespaced object', () => {
+    it('getJobRuntimeConfig delegates to getConfig', async () => {
+        const { getJobRuntimeConfig } = await importApi();
+        await getJobRuntimeConfig();
+        expect(serverFetchMock).toHaveBeenCalledWith('/account/job-runtime/config');
+    });
+
+    it('getAvailableJobRuntimeProviders delegates to getAvailableProviders', async () => {
+        const { getAvailableJobRuntimeProviders } = await importApi();
+        await getAvailableJobRuntimeProviders();
+        expect(serverFetchMock).toHaveBeenCalledWith('/account/job-runtime/available-providers');
+    });
+
+    it('upsertJobRuntimeConfig delegates to upsertConfig', async () => {
+        const { upsertJobRuntimeConfig } = await importApi();
+        await upsertJobRuntimeConfig({ providerId: 'bullmq', mode: 'override' });
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: '/account/job-runtime/config',
+                method: 'PUT',
+            }),
+        );
+    });
+
+    it('rotateJobRuntimeConfig delegates to rotate', async () => {
+        const { rotateJobRuntimeConfig } = await importApi();
+        await rotateJobRuntimeConfig();
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: '/account/job-runtime/rotate',
+                method: 'POST',
+            }),
+        );
+    });
+
+    it('forceInvalidateJobRuntimeConfig delegates to forceInvalidate', async () => {
+        const { forceInvalidateJobRuntimeConfig } = await importApi();
+        await forceInvalidateJobRuntimeConfig();
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: '/account/job-runtime/force-invalidate',
+                method: 'POST',
+            }),
+        );
+    });
+
+    it('deleteJobRuntimeConfig delegates to revertToInherit', async () => {
+        const { deleteJobRuntimeConfig } = await importApi();
+        await deleteJobRuntimeConfig();
+        expect(serverMutationMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: '/account/job-runtime/config',
+                method: 'DELETE',
+            }),
+        );
+    });
+});


### PR DESCRIPTION
Final cascade to production (main).

Carries the job-runtime work now on stage:
- #1628 — fix `/api/api/` double-prefix (job-runtime + notification/email API clients) — **fixes the reported Settings → Job Runtime 404**
- #1633 — provider brand icons in the picker
- #1632 — resilient `pnpm audit` CI step

Standard release cascade develop → stage → main. CI note: self-hosted CI runners are offline repo-wide; validated locally (vitest, tsc, eslint) + CodeRabbit + Greptile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)