### PR TITLE
cascade: develop → stage (onboarding /onboarding page, EW-617 G4)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -55,7 +55,10 @@ const CSP = [
     "media-src 'self' https:",
     "font-src 'self' data:",
     "style-src 'self' 'unsafe-inline'",
-    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us.i.posthog.com https://eu.i.posthog.com",
+    "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us.i.posthog.com https://eu.i.posthog.com https://challenges.cloudflare.com",
+    // EW-617 — Cloudflare Turnstile widget script + challenge iframe. Keep in
+    // lock-step with proxy.ts's buildCsp() (its byte-twin).
+    "frame-src 'self' https://challenges.cloudflare.com",
     // dotlottie-web fetches its WASM blob from jsdelivr (primary) or unpkg
     // (backup). Both are essential for the on-page Lottie animations that
     // boot on /login and /register; without them the E2E suite trips on

--- a/apps/web/src/app/[locale]/onboarding/anonymous-bootstrap.tsx
+++ b/apps/web/src/app/[locale]/onboarding/anonymous-bootstrap.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState, useTransition } from 'react';
+import { useRouter, Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { useTurnstile } from '@/components/onboarding/use-turnstile';
+import { startAnonymousOnboarding } from '@/app/actions/onboarding/anonymous';
+
+type Phase = 'starting' | 'error';
+
+// Cross-mount guard key. If a mint "succeeds" but the session doesn't take and
+// we land back here, we must NOT auto-remint (that loops until the 5/hour/IP
+// throttle) — show the manual fallback instead.
+const SESSION_GUARD = 'ew_anon_onboarding_attempted';
+
+function readHashParam(hash: string, key: string): string | null {
+    if (!hash) return null;
+    try {
+        return new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash).get(key);
+    } catch {
+        return null;
+    }
+}
+
+export function AnonymousOnboardingBootstrap() {
+    const router = useRouter();
+    const { getToken, ready } = useTurnstile();
+    const [, startTransition] = useTransition();
+    const [phase, setPhase] = useState<Phase>('starting');
+    const [message, setMessage] = useState<string | null>(null);
+    // Guard against React StrictMode's dev double-mount (and any remount)
+    // firing two mints and burning the throttle. Mirrors the magic-link
+    // redeem client's `redeemedTokens` ref.
+    const startedRef = useRef(false);
+    // If Turnstile never becomes ready (CSP-blocked / ad-blocked), attempt anyway
+    // after a grace period so the user isn't stuck on a spinner — the server 400s
+    // (captcha) and we fall through to the sign-up affordance.
+    const [forceAttempt, setForceAttempt] = useState(false);
+
+    // Kick off the mint inside a transition so the setStates land after the
+    // await boundary, not synchronously within the effect (react-hooks/
+    // set-state-in-effect). Same shape as the magic-link redeem client.
+    const attempt = useCallback(() => {
+        startTransition(async () => {
+            let alreadyTried = false;
+            try {
+                alreadyTried = sessionStorage.getItem(SESSION_GUARD) === '1';
+                sessionStorage.setItem(SESSION_GUARD, '1');
+            } catch {
+                /* private mode — the ref guard still prevents same-mount reruns */
+            }
+            if (alreadyTried) {
+                setPhase('error');
+                setMessage('We couldn’t start a guest session. Please sign up to continue.');
+                return;
+            }
+
+            setPhase('starting');
+            setMessage(null);
+            const corrId =
+                typeof window !== 'undefined'
+                    ? readHashParam(window.location.hash, 'corrId')
+                    : null;
+            const captchaToken = await getToken(); // '' when Turnstile unavailable
+            const result = await startAnonymousOnboarding({
+                captchaToken: captchaToken || undefined,
+                correlationId: corrId || undefined,
+            });
+            if (result.success) {
+                // Cookie is set. Re-render THIS url (hash preserved — refresh()
+                // never touches the URL) so the server page takes the authed
+                // branch and mounts the wizard, which reads #prompt from the hash.
+                router.refresh();
+                return;
+            }
+            setPhase('error');
+            setMessage(result.error ?? 'Something went wrong.');
+        });
+    }, [getToken, router, startTransition]);
+
+    useEffect(() => {
+        const t = setTimeout(() => setForceAttempt(true), 8000);
+        return () => clearTimeout(t);
+    }, []);
+
+    useEffect(() => {
+        if (startedRef.current) return;
+        if (!ready && !forceAttempt) return;
+        startedRef.current = true;
+        attempt();
+    }, [ready, forceAttempt, attempt]);
+
+    const retry = useCallback(() => {
+        try {
+            sessionStorage.removeItem(SESSION_GUARD);
+        } catch {
+            /* private mode */
+        }
+        attempt();
+    }, [attempt]);
+
+    if (phase === 'error') {
+        return (
+            <main className="min-h-screen grid place-items-center bg-surface dark:bg-surface-dark px-6">
+                <div className="max-w-md text-center space-y-4">
+                    <h1 className="text-lg font-semibold text-text dark:text-text-dark">
+                        Let’s get you started
+                    </h1>
+                    <p className="text-sm text-text/60 dark:text-text-dark/60">{message}</p>
+                    <div className="flex items-center justify-center gap-3">
+                        <button
+                            type="button"
+                            onClick={retry}
+                            className="px-4 py-2 rounded-md text-sm bg-text text-white dark:bg-white dark:text-black"
+                        >
+                            Try again
+                        </button>
+                        <Link
+                            href={ROUTES.AUTH_REGISTER}
+                            className="px-4 py-2 rounded-md text-sm border border-border dark:border-border-dark text-text dark:text-text-dark"
+                        >
+                            Sign up
+                        </Link>
+                    </div>
+                </div>
+            </main>
+        );
+    }
+
+    return (
+        <main className="min-h-screen grid place-items-center bg-surface dark:bg-surface-dark">
+            <div className="flex flex-col items-center gap-4" role="status" aria-live="polite">
+                <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-text dark:border-border-dark dark:border-t-white" />
+                <p className="text-sm text-text/60 dark:text-text-dark/60">Setting up your workspace…</p>
+            </div>
+        </main>
+    );
+}

--- a/apps/web/src/app/[locale]/onboarding/onboarding-page-client.tsx
+++ b/apps/web/src/app/[locale]/onboarding/onboarding-page-client.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useRouter } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { EverWorksOnboardingWizard } from '@/components/onboarding/EverWorksOnboardingWizard';
+import type { OnboardingCatalogResponse, OnboardingStateResponse } from '@ever-works/contracts/api';
+import type { UserPlugin } from '@/lib/api/plugins';
+import type { OAuthConnectionInfo } from '@/lib/api/plugins-capabilities/oauth';
+import type { GitProviderConnectionInfo } from '@/lib/api/plugins-capabilities/git-providers';
+import type { PluginDeviceAuthStatus } from '@/lib/api/plugins-capabilities/device-auth';
+
+interface Props {
+    initialState: OnboardingStateResponse;
+    catalog: OnboardingCatalogResponse;
+    plugins: ReadonlyArray<UserPlugin>;
+    initialConnections: Record<string, OAuthConnectionInfo | GitProviderConnectionInfo | null>;
+    initialDeviceAuthStatuses: Record<string, PluginDeviceAuthStatus | null>;
+}
+
+export function OnboardingPageClient(props: Props) {
+    const router = useRouter();
+    // Force open regardless of works count / prior dismissal. This standalone
+    // page is an explicit "start onboarding" surface, so open === true — that is
+    // the fix for the logged-in-WITH-works case (the owner's 404), with NO edit
+    // to the dashboard auto-open logic.
+    const [open, setOpen] = useState(true);
+
+    const handleClose = useCallback(() => {
+        setOpen(false);
+        // Nothing sits behind the modal here — route into the app. Anonymous
+        // users hold a valid session, so the dashboard renders for them too.
+        router.push(ROUTES.DASHBOARD);
+    }, [router]);
+
+    // The wizard reads #prompt/#corrId from window.location.hash on mount,
+    // sanitizes, setPrompt, jumps to the create-work step, then strips the hash
+    // — no extra wiring needed here.
+    return (
+        <main className="min-h-screen bg-surface dark:bg-surface-dark">
+            <EverWorksOnboardingWizard
+                open={open}
+                initialState={props.initialState}
+                catalog={props.catalog}
+                plugins={props.plugins}
+                initialConnections={props.initialConnections}
+                initialDeviceAuthStatuses={props.initialDeviceAuthStatuses}
+                onClose={handleClose}
+            />
+        </main>
+    );
+}

--- a/apps/web/src/app/[locale]/onboarding/page.tsx
+++ b/apps/web/src/app/[locale]/onboarding/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from 'next';
+import { getAuthFromCookie } from '@/lib/auth';
+import { pluginsAPI } from '@/lib/api/plugins';
+import { onboardingAPI } from '@/lib/api/onboarding';
+import { ONBOARDING_DEFAULT_STATE } from '@ever-works/contracts/api';
+import type { OnboardingCatalogResponse, OnboardingStateResponse } from '@ever-works/contracts/api';
+import type { OAuthConnectionInfo } from '@/lib/api/plugins-capabilities/oauth';
+import type { GitProviderConnectionInfo } from '@/lib/api/plugins-capabilities/git-providers';
+import type { PluginDeviceAuthStatus } from '@/lib/api/plugins-capabilities/device-auth';
+import type { UserPlugin } from '@/lib/api/plugins';
+import { OnboardingPageClient } from './onboarding-page-client';
+import { AnonymousOnboardingBootstrap } from './anonymous-bootstrap';
+
+// EW-617 zero-friction landing target. PUBLIC route: fresh marketing-site
+// visitors arrive at `/onboarding#prompt=…&corrId=…` with no session. For them
+// we mint an anonymous session client-side (Turnstile → server action → cookie)
+// then re-render down the authed branch. For logged-in users we mount the same
+// wizard the dashboard mounts as a dialog — here forced open on a standalone
+// page. Never statically rendered: depends on the auth cookie.
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+    title: 'Get started',
+    robots: { index: false, follow: false }, // never index the funnel URL
+};
+
+const FALLBACK_CATALOG: OnboardingCatalogResponse = { ai: [], storage: [], deploy: [], plugins: [] };
+const FALLBACK_STATE: OnboardingStateResponse = {
+    completedAt: null,
+    dismissedAt: null,
+    state: ONBOARDING_DEFAULT_STATE,
+};
+
+export default async function OnboardingPage() {
+    const user = await getAuthFromCookie();
+
+    // No valid session → anonymous bootstrap (client-side mint → refresh).
+    if (!user) {
+        return <AnonymousOnboardingBootstrap />;
+    }
+
+    // Authed (logged-in OR already-anonymous). Fetch wizard props exactly as
+    // (dashboard)/layout.tsx does; every call degrades to a safe fallback, so an
+    // empty/anon catalog still lands the user on the create-work step.
+    const [pluginsResponse, onboardingState, onboardingCatalog] = await Promise.all([
+        pluginsAPI.list().catch(() => ({ plugins: [] as UserPlugin[], total: 0 })),
+        onboardingAPI.getState().catch(() => FALLBACK_STATE),
+        onboardingAPI.getCatalog().catch(() => FALLBACK_CATALOG),
+    ]);
+
+    const plugins = pluginsResponse.plugins
+        .filter((p) => p.uiHints?.includeInOnboarding)
+        .sort((a, b) => (a.uiHints?.onboardingPriority ?? 99) - (b.uiHints?.onboardingPriority ?? 99));
+
+    const initialConnections = Object.fromEntries(
+        plugins.map(
+            (p) => [p.pluginId, null] as [string, OAuthConnectionInfo | GitProviderConnectionInfo | null],
+        ),
+    );
+    const initialDeviceAuthStatuses = Object.fromEntries(
+        plugins.map((p) => [p.pluginId, null] as [string, PluginDeviceAuthStatus | null]),
+    );
+
+    return (
+        <OnboardingPageClient
+            initialState={onboardingState}
+            catalog={onboardingCatalog}
+            plugins={plugins}
+            initialConnections={initialConnections}
+            initialDeviceAuthStatuses={initialDeviceAuthStatuses}
+        />
+    );
+}

--- a/apps/web/src/app/actions/onboarding/anonymous.ts
+++ b/apps/web/src/app/actions/onboarding/anonymous.ts
@@ -1,0 +1,59 @@
+'use server';
+
+import { authAPI } from '@/lib/api';
+import { setAuthAccessCookie } from '@/lib/auth/cookies';
+import { ApiResponseError } from '@/lib/api/server-api';
+
+// The API's CreateAnonymousDto.correlationId is @IsUUID('4'); with
+// forbidNonWhitelisted a non-UUID value 400s the whole mint. Only forward valid.
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// Not exported: a `'use server'` module may only export async functions, so
+// this result shape stays module-private (the client consumes it structurally).
+interface StartAnonymousResult {
+    success: boolean;
+    error?: string;
+    reason?: 'throttled' | 'captcha' | 'error';
+    userId?: string;
+}
+
+export async function startAnonymousOnboarding(input: {
+    captchaToken?: string;
+    correlationId?: string;
+}): Promise<StartAnonymousResult> {
+    const correlationId =
+        input.correlationId && UUID_V4.test(input.correlationId) ? input.correlationId : undefined;
+
+    try {
+        const res = await authAPI.createAnonymous({
+            captchaToken: input.captchaToken || undefined,
+            correlationId,
+        });
+        // Persist the opaque anon token as the SAME encrypted httpOnly cookie the
+        // login flow sets, so every downstream RSC fetch / server action is authed.
+        await setAuthAccessCookie(res.access_token);
+        return { success: true, userId: res.user.id };
+    } catch (error) {
+        if (error instanceof ApiResponseError) {
+            if (error.statusCode === 429) {
+                return {
+                    success: false,
+                    reason: 'throttled',
+                    error: 'Too many attempts — please try again shortly.',
+                };
+            }
+            if (error.statusCode === 400) {
+                return {
+                    success: false,
+                    reason: 'captcha',
+                    error: 'We couldn’t verify your browser. Please sign up to continue.',
+                };
+            }
+        }
+        return {
+            success: false,
+            reason: 'error',
+            error: 'Could not start a guest session. Please sign up to continue.',
+        };
+    }
+}

--- a/apps/web/src/lib/api/auth.ts
+++ b/apps/web/src/lib/api/auth.ts
@@ -55,6 +55,14 @@ export interface RedeemMagicLinkDto {
     token: string;
 }
 
+// EW-617 G2 — zero-friction anonymous session. Mints a temporary (email-less)
+// user so onboarding can run before sign-up. Captcha-gated in production; the
+// browser supplies a fresh Turnstile token. `correlationId` must be a UUID v4.
+export interface CreateAnonymousDto {
+    captchaToken?: string;
+    correlationId?: string;
+}
+
 // Response Types
 export interface AuthResponse {
     access_token: string;
@@ -262,6 +270,16 @@ export const authAPI = {
     redeemMagicLink: async (data: RedeemMagicLinkDto) => {
         return serverMutation<AuthResponse>({
             endpoint: '/auth/magic-link/redeem',
+            data,
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+    // EW-617 G2 — mint a temporary anonymous session. API_URL already ends in
+    // `/api`, so this resolves to POST https://api.ever.works/api/auth/anonymous.
+    createAnonymous: async (data: CreateAnonymousDto) => {
+        return serverMutation<AuthResponse>({
+            endpoint: '/auth/anonymous',
             data,
             method: 'POST',
             wrapInData: false,

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -164,6 +164,11 @@ export const ROUTES = {
     // be in PUBLIC_ROUTES — otherwise the proxy auth gate bounces it to
     // /login and clears the cookie before the redeem can run.
     AUTH_MAGIC_LINK: '/login/magic-link',
+    // EW-617 zero-friction onboarding. Public landing target for the marketing
+    // site's prompt hand-off (`/onboarding#prompt=…&corrId=…`). Reached
+    // UNAUTHENTICATED by fresh visitors — the page mints an anonymous session
+    // client-side, so it MUST be in PUBLIC_ROUTES (mirrors AUTH_MAGIC_LINK).
+    ONBOARDING: '/onboarding',
 
     // API routes
     API_AUTH_VERIFY_EMAIL: '/api/auth/verify-email',
@@ -197,6 +202,9 @@ export const PUBLIC_ROUTES = [
     // client-side redeem can set the session cookie (mirrors the other
     // token-landing pages above).
     ROUTES.AUTH_MAGIC_LINK,
+    // EW-617 zero-friction onboarding landing page — public so anonymous
+    // visitors from the marketing site can mint a guest session client-side.
+    ROUTES.ONBOARDING,
     '/about',
     '/contact',
     '/privacy',

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -87,7 +87,10 @@ function buildCsp(): string {
         "media-src 'self' https:",
         "font-src 'self' data:",
         "style-src 'self' 'unsafe-inline'",
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us.i.posthog.com https://eu.i.posthog.com",
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us.i.posthog.com https://eu.i.posthog.com https://challenges.cloudflare.com",
+        // EW-617 — Cloudflare Turnstile widget script + challenge iframe. Keep
+        // in lock-step with next.config.ts's CSP array (its byte-twin).
+        "frame-src 'self' https://challenges.cloudflare.com",
         `connect-src 'self' ${apiHost} https://*.posthog.com https://us.i.posthog.com https://eu.i.posthog.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://api.openai.com https://cdn.jsdelivr.net https://unpkg.com ${extraConnect.join(' ')}`.trim(),
         "worker-src 'self' blob:",
     ].join('; ');


### PR DESCRIPTION
Cascade of the `/onboarding` zero-friction landing page fix (#1640) develop → stage. Only new content vs stage is that fix (develop carried no other unreleased work). Local type-check + lint + `next build` green; touched files are byte-identical across develop/stage/main so no conflicts.