### PR TITLE
fix(onboarding,templates): UI + content polish (owner feedback)

### DIFF
--- a/apps/web/e2e/flow-onboarding-catalog-choices.spec.ts
+++ b/apps/web/e2e/flow-onboarding-catalog-choices.spec.ts
@@ -815,10 +815,10 @@ test.describe('Onboarding wizard UI — a BYOK AI choice inserts a config step i
                 ).toHaveCount(0);
             }
 
-            // The "Create your first work" final step is always present, and the
+            // The "Create your first Work" final step is always present, and the
             // total rendered SideNav step buttons equal the server-derived count.
             await expect(
-                wizard.getByRole('button', { name: 'Create your first work' }),
+                wizard.getByRole('button', { name: 'Create your first Work' }),
             ).toBeVisible({
                 timeout: 10_000,
             });

--- a/apps/web/e2e/flow-onboarding-wizard.spec.ts
+++ b/apps/web/e2e/flow-onboarding-wizard.spec.ts
@@ -467,7 +467,7 @@ test.describe('Onboarding wizard — dismiss + complete lifecycle', () => {
             timeout: 10_000,
         });
         await expect(
-            page.getByRole('button', { name: 'Create your first work' }).first(),
+            page.getByRole('button', { name: 'Create your first Work' }).first(),
         ).toBeVisible({
             timeout: 10_000,
         });

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -263,7 +263,8 @@
             "savedSuccess": "تم حفظ الإعدادات.",
             "noSettings": "لا يتطلب هذا الملحق تكويناً.",
             "getTokenPrompt": "أنشئ رمزاً أولاً، ثم الصقه أدناه واحفظه للتحقق من الاتصال.",
-            "loadingStatus": "جاري تحميل حالة الاتصال..."
+            "loadingStatus": "جاري تحميل حالة الاتصال...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "قم بتوصيل مفتاحك الخاص لفتح التكوين الكامل.",
@@ -4437,7 +4438,9 @@
                 "defaultSelected": "تم تحديد الافتراضي",
                 "makeDefault": "اجعله افتراضيًا",
                 "fork": "شُتّت",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "تعديل",
                 "archive": "أرشفة",
                 "customizeAgain": "تخصيص مرة أخرى",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Настройките са запазени.",
             "noSettings": "Не е нужна конфигурация за този плъгин.",
             "getTokenPrompt": "Първо създайте токен, след това го поставете по-долу и запазете, за да проверите връзката.",
-            "loadingStatus": "Зареждане на състоянието на връзката..."
+            "loadingStatus": "Зареждане на състоянието на връзката...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Свържете своя ключ, за да отключите пълната конфигурация.",
@@ -4437,7 +4438,9 @@
                 "defaultSelected": "Избрано по подразбиране",
                 "makeDefault": "Направи по подразбиране",
                 "fork": "Форк",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Редактиране",
                 "archive": "Архивиране",
                 "customizeAgain": "Персонализирайте отново",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Einstellungen gespeichert.",
             "noSettings": "Keine Konfiguration für dieses Plugin erforderlich.",
             "getTokenPrompt": "Erstellen Sie zuerst ein Token, fügen Sie es unten ein und speichern Sie, um die Verbindung zu überprüfen.",
-            "loadingStatus": "Verbindungsstatus wird geladen…"
+            "loadingStatus": "Verbindungsstatus wird geladen…",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Verbinden Sie Ihren eigenen Schlüssel, um die volle Konfiguration freizuschalten.",
@@ -4437,7 +4438,9 @@
                 "defaultSelected": "Standard ausgewählt",
                 "makeDefault": "Als Standard festlegen",
                 "fork": "Forken",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Bearbeiten",
                 "archive": "Archivieren",
                 "customizeAgain": "Anpassen",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Settings saved.",
             "noSettings": "No configuration required for this plugin.",
             "getTokenPrompt": "Create a token first, then paste it below and save to verify the connection.",
-            "loadingStatus": "Loading connection status..."
+            "loadingStatus": "Loading connection status...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Connect your own key to unlock the full configuration.",
@@ -4738,7 +4739,9 @@
                 "defaultSelected": "Default selected",
                 "makeDefault": "Make default",
                 "fork": "Fork",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Edit",
                 "archive": "Archive",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Configuración guardada.",
             "noSettings": "No se requiere configuración para este plugin.",
             "getTokenPrompt": "Crea un token primero, luego pégalo a continuación y guárdalo para verificar la conexión.",
-            "loadingStatus": "Cargando estado de conexión..."
+            "loadingStatus": "Cargando estado de conexión...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Conecta tu propia clave para desbloquear la configuración completa.",
@@ -4437,7 +4438,9 @@
                 "defaultSelected": "Predeterminado seleccionado",
                 "makeDefault": "Establecer como predeterminado",
                 "fork": "Ramificar",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Editar",
                 "archive": "Archivar",
                 "customizeAgain": "Personalizar de nuevo",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Paramètres enregistrés.",
             "noSettings": "Aucune configuration requise pour ce plugin.",
             "getTokenPrompt": "Créez d'abord un jeton, puis collez-le ci-dessous et enregistrez pour vérifier la connexion.",
-            "loadingStatus": "Chargement du statut de connexion..."
+            "loadingStatus": "Chargement du statut de connexion...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Connectez votre propre clé pour débloquer la configuration complète.",
@@ -4437,7 +4438,9 @@
                 "defaultSelected": "Par défaut sélectionné",
                 "makeDefault": "Définir comme par défaut",
                 "fork": "Fourcher",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Modifier",
                 "archive": "Archiver",
                 "customizeAgain": "Personnaliser à nouveau",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -263,7 +263,8 @@
             "savedSuccess": "ההגדרות נשמרו.",
             "noSettings": "אין צורך בהגדרה עבור תוסף זה.",
             "getTokenPrompt": "צרו אסימון קודם, הדביקו אותו למטה ושמרו כדי לאמת את החיבור.",
-            "loadingStatus": "טוען סטטוס חיבור..."
+            "loadingStatus": "טוען סטטוס חיבור...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "חברו את המפתח שלכם כדי לפתוח את ההגדרה המלאה.",
@@ -4437,7 +4438,9 @@
                 "defaultSelected": "ברירת מחדל נבחרה",
                 "makeDefault": "הפוך לברירת מחדל",
                 "fork": "פיצול",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "עריכה",
                 "archive": "ארכיון",
                 "customizeAgain": "התאמה אישית שוב",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -263,7 +263,8 @@
             "savedSuccess": "सेटिंग्स सहेजी गईं।",
             "noSettings": "इस प्लगइन के लिए कोई कॉन्फ़िगरेशन आवश्यक नहीं।",
             "getTokenPrompt": "पहले एक टोकन बनाएं, फिर इसे नीचे पेस्ट करें और कनेक्शन सत्यापित करने के लिए सहेजें।",
-            "loadingStatus": "कनेक्शन स्थिति लोड हो रही है..."
+            "loadingStatus": "कनेक्शन स्थिति लोड हो रही है...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "पूर्ण कॉन्फ़िगरेशन अनलॉक करने के लिए अपना कुंजी कनेक्ट करें।",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "डिफ़ॉल्ट चयनित",
                 "makeDefault": "डिफ़ॉल्ट बनाएं",
                 "fork": "फ़ॉर्क",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "संपादित करें",
                 "archive": "आर्काइव",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Pengaturan disimpan.",
             "noSettings": "Tidak ada konfigurasi yang diperlukan untuk plugin ini.",
             "getTokenPrompt": "Buat token terlebih dahulu, lalu tempelkan di bawah ini dan simpan untuk memverifikasi koneksi.",
-            "loadingStatus": "Memuat status koneksi..."
+            "loadingStatus": "Memuat status koneksi...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Hubungkan kunci Anda sendiri untuk membuka konfigurasi lengkap.",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "Default dipilih",
                 "makeDefault": "Jadikan default",
                 "fork": "Fork",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Edit",
                 "archive": "Arsipkan",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Impostazioni salvate.",
             "noSettings": "Nessuna configurazione richiesta per questo plugin.",
             "getTokenPrompt": "Crea prima un token, poi incollalo qui sotto e salva per verificare la connessione.",
-            "loadingStatus": "Caricamento stato connessione..."
+            "loadingStatus": "Caricamento stato connessione...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Connetti la tua chiave per sbloccare la configurazione completa.",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "Predefinito selezionato",
                 "makeDefault": "Imposta come predefinito",
                 "fork": "Fork",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Modifica",
                 "archive": "Archivia",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -263,7 +263,8 @@
             "savedSuccess": "設定を保存しました。",
             "noSettings": "このプラグインには設定不要です。",
             "getTokenPrompt": "まずトークンを作成し、以下に貼り付けて保存して接続を検証してください。",
-            "loadingStatus": "接続状態を読み込み中..."
+            "loadingStatus": "接続状態を読み込み中...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "独自のキーを接続して完全な設定をアンロックします。",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "デフォルトが選択されました",
                 "makeDefault": "デフォルトに設定",
                 "fork": "フォーク",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "編集",
                 "archive": "アーカイブ",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -263,7 +263,8 @@
             "savedSuccess": "설정이 저장되었습니다.",
             "noSettings": "이 플러그인에 대한 구성 불필요.",
             "getTokenPrompt": "먼저 토큰을 생성한 후 아래에 붙여넣고 저장하여 연결을 확인하세요.",
-            "loadingStatus": "연결 상태 로딩 중..."
+            "loadingStatus": "연결 상태 로딩 중...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "자신의 키를 연결하여 전체 구성을 해제하세요.",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "기본값 선택됨",
                 "makeDefault": "기본값으로 설정",
                 "fork": "포크",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "편집",
                 "archive": "보관",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Instellingen opgeslagen.",
             "noSettings": "Geen configuratie vereist voor deze plugin.",
             "getTokenPrompt": "Maak eerst een token aan, plak het hieronder en sla op om de verbinding te verifiëren.",
-            "loadingStatus": "Verbindingsstatus laden..."
+            "loadingStatus": "Verbindingsstatus laden...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Verbind je eigen sleutel om de volledige configuratie te ontgrendelen.",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "Standaard geselecteerd",
                 "makeDefault": "Maak standaard",
                 "fork": "Fork",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Bewerken",
                 "archive": "Archiveren",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Ustawienia zapisane.",
             "noSettings": "Ten plugin nie wymaga konfiguracji.",
             "getTokenPrompt": "Najpierw utwórz token, następnie wklej go poniżej i zapisz, aby zweryfikować połączenie.",
-            "loadingStatus": "Ładowanie statusu połączenia..."
+            "loadingStatus": "Ładowanie statusu połączenia...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Połącz swój własny klucz, aby odblokować pełną konfigurację.",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "Domyślny wybrany",
                 "makeDefault": "Ustaw jako domyślny",
                 "fork": "Rozgałęź",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Edytuj",
                 "archive": "Archiwizuj",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Configurações salvas.",
             "noSettings": "Nenhuma configuração necessária para este plugin.",
             "getTokenPrompt": "Crie um token primeiro, depois cole-o abaixo e salve para verificar a conexão.",
-            "loadingStatus": "Carregando status da conexão..."
+            "loadingStatus": "Carregando status da conexão...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Conecte sua própria chave para desbloquear a configuração completa.",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "Padrão selecionado",
                 "makeDefault": "Tornar padrão",
                 "fork": "Fork",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Editar",
                 "archive": "Arquivar",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Настройки сохранены.",
             "noSettings": "Для этого плагина не требуется настройка.",
             "getTokenPrompt": "Сначала создайте токен, затем вставьте его ниже и сохраните, чтобы проверить соединение.",
-            "loadingStatus": "Загрузка статуса соединения..."
+            "loadingStatus": "Загрузка статуса соединения...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Подключите свой ключ, чтобы разблокировать полную конфигурацию.",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "Выбрано значение по умолчанию",
                 "makeDefault": "Сделать значением по умолчанию",
                 "fork": "Форкнуть",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Редактировать",
                 "archive": "Архивировать",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -263,7 +263,8 @@
             "savedSuccess": "บันทึกการตั้งค่าแล้ว",
             "noSettings": "ไม่ต้องตั้งค่าสำหรับปลั๊กอินนี้",
             "getTokenPrompt": "สร้างโทเค็นก่อน จากนั้นวางด้านล่างและบันทึกเพื่อยืนยันการเชื่อมต่อ",
-            "loadingStatus": "กำลังโหลดสถานะการเชื่อมต่อ..."
+            "loadingStatus": "กำลังโหลดสถานะการเชื่อมต่อ...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "เชื่อมต่อคีย์ของคุณเองเพื่อปลดล็อกการตั้งค่าเต็มรูปแบบ",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "เลือกค่าเริ่มต้นแล้ว",
                 "makeDefault": "ตั้งเป็นค่าเริ่มต้น",
                 "fork": "ฟอร์ก",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "แก้ไข",
                 "archive": "จัดเก็บถาวร",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Ayarlar kaydedildi.",
             "noSettings": "Bu eklenti için yapılandırma gerekmez.",
             "getTokenPrompt": "Önce bir belirteç oluşturun, ardından aşağıya yapıştırın ve bağlantıyı doğrulamak için kaydedin.",
-            "loadingStatus": "Bağlantı durumu yükleniyor..."
+            "loadingStatus": "Bağlantı durumu yükleniyor...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Tam yapılandırmayı açmak için kendi anahtarınızı bağlayın.",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "Varsayılan seçildi",
                 "makeDefault": "Varsayılan yap",
                 "fork": "Çatalla",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Düzenle",
                 "archive": "Arşivle",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Налаштування збережено.",
             "noSettings": "Для цього плагіна не потрібне налаштування.",
             "getTokenPrompt": "Спочатку створіть токен, потім вставте його нижче та збережіть, щоб перевірити з'єднання.",
-            "loadingStatus": "Завантаження статусу з'єднання..."
+            "loadingStatus": "Завантаження статусу з'єднання...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Підключіть свій ключ, щоб розблокувати повне налаштування.",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "Вибрано за замовчуванням",
                 "makeDefault": "Встановити за замовчуванням",
                 "fork": "Форк",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Редагувати",
                 "archive": "Архівувати",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -263,7 +263,8 @@
             "savedSuccess": "Cài đặt đã được lưu.",
             "noSettings": "Không yêu cầu cấu hình cho plugin này.",
             "getTokenPrompt": "Tạo một token trước, sau đó dán nó bên dưới và lưu để xác minh kết nối.",
-            "loadingStatus": "Đang tải trạng thái kết nối..."
+            "loadingStatus": "Đang tải trạng thái kết nối...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "Kết nối khóa của riêng bạn để mở khóa cấu hình đầy đủ.",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "Mặc định được chọn",
                 "makeDefault": "Đặt làm mặc định",
                 "fork": "Fork",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "Chỉnh sửa",
                 "archive": "Lưu trữ",
                 "customizeAgain": "Customize again",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -263,7 +263,8 @@
             "savedSuccess": "设置已保存。",
             "noSettings": "此插件无需配置。",
             "getTokenPrompt": "首先创建令牌，然后粘贴到下方并保存以验证连接。",
-            "loadingStatus": "正在加载连接状态..."
+            "loadingStatus": "正在加载连接状态...",
+            "setupGuide": "Setup guide"
         },
         "plugins": {
             "byokDescription": "连接您自己的密钥以解锁完整配置。",
@@ -4240,7 +4241,9 @@
                 "defaultSelected": "已选默认",
                 "makeDefault": "设为默认",
                 "fork": "分派",
-                "useTemplate": "Use this Template",
+                "useTemplate": "Use",
+                "useTemplateFull": "Use this Template",
+                "moreActions": "More actions",
                 "edit": "编辑",
                 "archive": "归档",
                 "customizeAgain": "Customize again",

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -300,7 +300,7 @@ function SideNav({
                     Get started with Ever Works
                 </h2>
                 <p className="text-[11px] leading-relaxed mt-1 text-text-muted dark:text-text-muted-dark">
-                    A guided 9-step walkthrough. You can change any choice later from Settings.
+                    A guided multi-step walkthrough. You can change any choice later from Settings.
                 </p>
             </div>
             <nav className="flex-1 px-3 pb-2 space-y-0.5 overflow-y-auto">
@@ -382,7 +382,13 @@ function StepBody({
 }) {
     switch (step.kind) {
         case 'welcome':
-            return <WelcomeStep />;
+            return (
+                <WelcomeStep
+                    upcomingSteps={flow.steps
+                        .filter((s) => s.kind !== 'welcome')
+                        .map(labelForStep)}
+                />
+            );
         case 'ai-choice':
             return (
                 <ChoiceStep
@@ -414,7 +420,7 @@ function StepBody({
             return (
                 <ChoiceStep
                     title="Your storage"
-                    description="Where do you want your work repos to live?"
+                    description="Where do you want your Work repos to live?"
                     cards={catalog.storage}
                     selected={flow.state.storage.choice}
                     icons={STORAGE_ICONS}
@@ -428,7 +434,7 @@ function StepBody({
             return (
                 <ConfigStep
                     title="Connect your GitHub"
-                    description="Sign in with GitHub so we can create your work repos."
+                    description="Sign in with GitHub so we can create your Work repos."
                     plugin={plugin}
                     connection={connections['github'] ?? null}
                     isStatusLoading={isStatusLoading}
@@ -439,7 +445,7 @@ function StepBody({
             return (
                 <ChoiceStep
                     title="Your deployment"
-                    description="Where do you want your works to be deployed?"
+                    description="Where do you want your Works to be deployed?"
                     cards={catalog.deploy}
                     selected={flow.state.deploy.choice}
                     columns={3}
@@ -474,6 +480,7 @@ function StepBody({
                 <CreateWorkStep
                     onLeave={() => flow.finish()}
                     prompt={flow.state.prompt}
+                    onPromptChange={flow.setPrompt}
                     onQuickCreate={
                         flow.state.prompt
                             ? async (prompt) => {
@@ -616,7 +623,7 @@ function labelForStep(step: WizardStep): string {
         case 'plugins-catalog':
             return 'Plugins & Integrations';
         case 'create-work':
-            return 'Create your first work';
+            return 'Create your first Work';
         default:
             return step.kind;
     }

--- a/apps/web/src/components/onboarding/OnboardingPluginStep.tsx
+++ b/apps/web/src/components/onboarding/OnboardingPluginStep.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from 'react';
 import { useTranslations } from 'next-intl';
-import { Save, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react';
+import { Save, CheckCircle2, AlertCircle, Loader2, BookOpen } from 'lucide-react';
 import type { UserPlugin } from '@/lib/api/plugins';
 import type { OAuthConnectionInfo } from '@/lib/api/plugins-capabilities/oauth';
 import type { GitProviderConnectionInfo } from '@/lib/api/plugins-capabilities/git-providers';
@@ -10,6 +10,7 @@ import type { PluginDeviceAuthStatus } from '@/lib/api/plugins-capabilities/devi
 import { updatePluginSettings } from '@/app/actions/plugins';
 import { PluginOAuthConnection } from '@/components/settings/PluginOAuthConnection';
 import { PluginOnboardingWizard } from '@/components/settings/PluginOnboardingWizard';
+import { PluginReadme } from '@/components/plugins/PluginReadme';
 import { PluginSettingsFormFields } from '@/components/plugins/PluginSettingsFormFields';
 import { Button } from '@/components/ui/button';
 import { usePluginSettings } from '@/lib/hooks/use-plugin-settings';
@@ -194,6 +195,23 @@ function FieldBasedPluginStep({
                     </span>
                 )}
             </div>
+
+            {/* EW-617 (owner #2 fallback) — surface the plugin's existing
+                readme setup steps inline beneath the token field. Opt-in via
+                `uiHints.showReadmeInOnboarding` so only documented plugins
+                (e.g. Vercel) show it. Additive; the external "Get token" link
+                above still ships. */}
+            {plugin.uiHints?.showReadmeInOnboarding && plugin.readme ? (
+                <details className="rounded-xl border border-border dark:border-border-dark bg-surface dark:bg-surface-dark">
+                    <summary className="flex cursor-pointer list-none items-center gap-2 px-4 py-3 text-sm font-medium text-text dark:text-text-dark">
+                        <BookOpen className="h-4 w-4 text-text-muted dark:text-text-muted-dark" />
+                        {t('setupGuide')}
+                    </summary>
+                    <div className="border-t border-border dark:border-border-dark px-4 py-3">
+                        <PluginReadme content={plugin.readme} />
+                    </div>
+                </details>
+            ) : null}
         </div>
     );
 }

--- a/apps/web/src/components/onboarding/steps/CreateWorkStep.tsx
+++ b/apps/web/src/components/onboarding/steps/CreateWorkStep.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { ArrowRight, FolderPlus, Sparkles } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
@@ -10,7 +10,7 @@ export interface CreateWorkStepProps {
     /**
      * EW-617 G4: when a prompt is present (from the landing page `?prompt=…`
      * handoff, or typed into the wizard), this step swaps the
-     * "Create your first work" link for a one-click "Generate now" button.
+     * "Create your first Work" link for a one-click "Generate now" button.
      * The button calls `onQuickCreate(prompt)` and shows progress; the
      * parent owns the API call so this component stays I/O-free.
      */
@@ -19,6 +19,13 @@ export interface CreateWorkStepProps {
         readonly workSlug?: string;
         readonly generationHistoryId?: string;
     } | void>;
+    /**
+     * Called as the user edits the prompt textarea so the parent can persist
+     * the edited value into the wizard state (`flow.setPrompt`). Keeps the
+     * generated Work in sync with what the user actually sees before hitting
+     * "Generate now".
+     */
+    readonly onPromptChange?: (value: string) => void;
 }
 
 /**
@@ -32,18 +39,32 @@ export interface CreateWorkStepProps {
  * The wizard closes once the action fires; the parent emits the
  * `onboarding_completed` telemetry event and marks the server flag.
  */
-export function CreateWorkStep({ onLeave, prompt, onQuickCreate }: CreateWorkStepProps) {
+export function CreateWorkStep({
+    onLeave,
+    prompt,
+    onQuickCreate,
+    onPromptChange,
+}: CreateWorkStepProps) {
     const trimmedPrompt = prompt?.trim() ?? '';
-    const hasPrompt = trimmedPrompt.length > 0 && Boolean(onQuickCreate);
+    // Latch the "generate" mode on first render. Once the step is entered via
+    // the prompt hand-off it stays in generate mode for the component's
+    // lifetime, so clearing the textarea disables the button rather than
+    // collapsing the whole step back to the legacy "create" link.
+    const hasPromptRef = useRef(trimmedPrompt.length > 0 && Boolean(onQuickCreate));
+    const hasPrompt = hasPromptRef.current;
+    const [editablePrompt, setEditablePrompt] = useState(trimmedPrompt);
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
+    const canSubmit = editablePrompt.trim().length > 0;
+
     const handleQuickCreate = async () => {
-        if (!onQuickCreate || submitting) return;
+        const value = editablePrompt.trim();
+        if (!onQuickCreate || submitting || !value) return;
         setSubmitting(true);
         setError(null);
         try {
-            await onQuickCreate(trimmedPrompt);
+            await onQuickCreate(value);
             onLeave();
         } catch (cause) {
             const message = cause instanceof Error ? cause.message : String(cause);
@@ -51,6 +72,11 @@ export function CreateWorkStep({ onLeave, prompt, onQuickCreate }: CreateWorkSte
         } finally {
             setSubmitting(false);
         }
+    };
+
+    const handlePromptChange = (value: string) => {
+        setEditablePrompt(value);
+        onPromptChange?.(value);
     };
 
     return (
@@ -65,17 +91,31 @@ export function CreateWorkStep({ onLeave, prompt, onQuickCreate }: CreateWorkSte
                 </div>
                 <div>
                     <h3 className="text-lg font-semibold text-text dark:text-text-dark">
-                        {hasPrompt ? 'Ready to generate' : 'Create your first work'}
+                        {hasPrompt ? 'Ready to generate' : 'Create your first Work'}
                     </h3>
                     <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
                         {hasPrompt
-                            ? 'We saved your wizard choices. One click and we’ll generate the directory from your prompt — repos, items, and deploy all in one go.'
-                            : "You're all set. Hit the button below to start building — your choices above are saved and any new work will pick them up."}
+                            ? 'We saved your wizard choices. Review or tweak the prompt below, then generate — repos, items, and deploy all in one go.'
+                            : "You're all set. Hit the button below to start building — your choices above are saved and any new Work will pick them up."}
                     </p>
                     {hasPrompt ? (
-                        <p className="mt-3 rounded-md border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/30 px-3 py-2 text-sm text-text dark:text-text-dark">
-                            <span className="font-medium">Prompt:</span> {trimmedPrompt}
-                        </p>
+                        <div className="mt-3">
+                            <label
+                                htmlFor="onboarding-prompt-input"
+                                className="block text-sm font-medium text-text dark:text-text-dark mb-1.5"
+                            >
+                                Prompt
+                            </label>
+                            <textarea
+                                id="onboarding-prompt-input"
+                                data-testid="onboarding-prompt-input"
+                                value={editablePrompt}
+                                onChange={(event) => handlePromptChange(event.target.value)}
+                                rows={4}
+                                maxLength={5000}
+                                className="w-full resize-y rounded-lg border border-card-border bg-white px-4 py-3 text-sm text-text outline-none transition-colors duration-200 placeholder-text-muted hover:border-border-secondary focus:border-primary focus:ring-2 focus:ring-primary/20 dark:border-white/9 dark:bg-card-primary-dark dark:text-text-dark dark:placeholder-text-muted-dark dark:hover:border-border-secondary-dark dark:focus:border-white/9"
+                            />
+                        </div>
                     ) : null}
                 </div>
             </div>
@@ -85,7 +125,7 @@ export function CreateWorkStep({ onLeave, prompt, onQuickCreate }: CreateWorkSte
                         <button
                             type="button"
                             onClick={handleQuickCreate}
-                            disabled={submitting}
+                            disabled={submitting || !canSubmit}
                             data-testid="onboarding-generate-now"
                             className="inline-flex items-center gap-2 rounded-lg bg-black dark:bg-button-primary-dark px-4 py-2.5 text-sm font-medium text-white dark:text-black transition-colors hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark disabled:cursor-not-allowed disabled:opacity-60"
                         >
@@ -108,7 +148,7 @@ export function CreateWorkStep({ onLeave, prompt, onQuickCreate }: CreateWorkSte
                         onClick={onLeave}
                         className="inline-flex items-center gap-2 rounded-lg bg-black dark:bg-button-primary-dark px-4 py-2.5 text-sm font-medium text-white dark:text-black transition-colors hover:bg-button-primary-hover dark:hover:bg-button-primary-hover-dark"
                     >
-                        Create your first work
+                        Create your first Work
                         <ArrowRight className="w-4 h-4" />
                     </Link>
                 )}

--- a/apps/web/src/components/onboarding/steps/PluginsCatalogStep.tsx
+++ b/apps/web/src/components/onboarding/steps/PluginsCatalogStep.tsx
@@ -47,7 +47,7 @@ export function PluginsCatalogStep({ cards, pluginsById, onExpand }: PluginsCata
                     No additional integrations available right now.
                 </div>
             ) : (
-                <div className="space-y-2 max-h-[420px] overflow-y-auto pr-1">
+                <div className="space-y-2">
                     {cards.map((card) => {
                         const plugin = pluginsById[card.pluginId];
                         const expanded = openId === card.pluginId;

--- a/apps/web/src/components/onboarding/steps/WelcomeStep.tsx
+++ b/apps/web/src/components/onboarding/steps/WelcomeStep.tsx
@@ -1,26 +1,40 @@
 'use client';
 
-import { BookOpen, Shield, Sparkles, Zap } from 'lucide-react';
+import { Boxes, GitBranch, Rocket } from 'lucide-react';
+
+export interface WelcomeStepProps {
+    /**
+     * Labels of the remaining wizard steps (Welcome excluded), passed from the
+     * parent so the "what's next" overview always mirrors the dynamic flow
+     * (6 base steps, up to 9 with BYOK config steps). Derived from
+     * `computeStepList` via the same `labelForStep` the SideNav uses, so the
+     * numbering here matches the sidebar.
+     */
+    readonly upcomingSteps?: ReadonlyArray<string>;
+}
 
 /**
- * Welcome step — explains Ever Works and the next 8 wizard steps in one
- * paragraph. No choices on this screen; just a "Next" call to action.
+ * Welcome step — introduces Ever Works and previews the next steps on one
+ * screen. No choices here; just a "Next" call to action.
  */
-export function WelcomeStep() {
+export function WelcomeStep({ upcomingSteps = [] }: WelcomeStepProps) {
     return (
         <div className="space-y-6 max-w-2xl">
             <div className="flex items-start gap-4">
                 <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-surface-secondary dark:bg-white/5">
-                    <BookOpen className="w-5 h-5 text-text-secondary dark:text-text-secondary-dark" />
+                    <Boxes className="w-5 h-5 text-text-secondary dark:text-text-secondary-dark" />
                 </div>
                 <div>
                     <h3 className="text-lg font-semibold text-text dark:text-text-dark">
                         Welcome to Ever Works
                     </h3>
                     <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
-                        Build AI-powered directories without leaving your browser. We&apos;ll walk
-                        you through three quick choices (AI, Storage, Deployment) before you create
-                        your first work.
+                        Ever Works is an open agentic runtime for building content-rich web apps and
+                        Git repositories, then publishing them as live sites. Spin up directories,
+                        websites, landing pages, blogs and awesome-lists — or go further with
+                        Missions, Agents, Tasks and Companies — all AI-generated, Git-backed and
+                        one-click deployed. This short setup captures a few defaults (AI, Storage,
+                        Deployment); you can change any of them later from Settings.
                     </p>
                 </div>
             </div>
@@ -28,22 +42,22 @@ export function WelcomeStep() {
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                 {[
                     {
-                        Icon: Sparkles,
-                        title: 'AI-generated content',
+                        Icon: Boxes,
+                        title: 'Build almost anything',
                         description:
-                            'Items, descriptions, tags and categories generated for you, ready to edit.',
+                            'Directories, websites, landing pages, blogs and awesome-lists — plus Missions, Agents, Tasks and Companies.',
                     },
                     {
-                        Icon: Zap,
+                        Icon: GitBranch,
+                        title: 'AI-generated & Git-backed',
+                        description:
+                            'Content, items, tags and categories are generated for you and versioned in a real Git repository.',
+                    },
+                    {
+                        Icon: Rocket,
                         title: 'One-click deployment',
                         description:
-                            'Pick where to host — Ever Works manages the cluster or use your own.',
-                    },
-                    {
-                        Icon: Shield,
-                        title: 'Your storage, your rules',
-                        description:
-                            'Push to a managed Ever Works org or to your own GitHub account.',
+                            'Publish to a managed Ever Works cluster or bring your own — every project ships as a live site.',
                     },
                 ].map((feature) => (
                     <div
@@ -60,6 +74,27 @@ export function WelcomeStep() {
                     </div>
                 ))}
             </div>
+
+            {upcomingSteps.length > 0 ? (
+                <div className="rounded-xl border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/30 p-5">
+                    <p className="text-sm font-semibold text-text dark:text-text-dark">
+                        Here&apos;s what&apos;s next
+                    </p>
+                    <ol className="mt-3 space-y-2">
+                        {upcomingSteps.map((label, index) => (
+                            <li
+                                key={`${index}-${label}`}
+                                className="flex items-center gap-3 text-sm text-text-secondary dark:text-text-secondary-dark"
+                            >
+                                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-border dark:border-border-dark text-[11px] font-semibold text-text-muted dark:text-text-muted-dark">
+                                    {index + 1}
+                                </span>
+                                {label}
+                            </li>
+                        ))}
+                    </ol>
+                </div>
+            ) : null}
         </div>
     );
 }

--- a/apps/web/src/components/templates/TemplatesCatalog.tsx
+++ b/apps/web/src/components/templates/TemplatesCatalog.tsx
@@ -25,6 +25,7 @@ import {
     Target,
     Globe,
     FolderClosed,
+    MoreVertical,
 } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import type {
@@ -36,6 +37,12 @@ import type {
     TemplateKind,
 } from '@/lib/api/templates';
 import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
@@ -377,6 +384,8 @@ function TemplateCard({
                                     href={`/new?type=mission&template=${encodeURIComponent(
                                         template.id,
                                     )}`}
+                                    title={t('card.useTemplateFull')}
+                                    aria-label={t('card.useTemplateFull')}
                                 >
                                     <Sparkles className="h-3.5 w-3.5" />
                                     {t('card.useTemplate')}
@@ -445,16 +454,40 @@ function TemplateCard({
                                 </Button>
                             </>
                         )}
-                        <Button
-                            variant={isDefault ? 'secondary' : 'primary'}
-                            size="sm"
-                            loading={loading}
-                            disabled={isDefault || loading}
-                            onClick={() => onSetDefault(template.id)}
-                            className="whitespace-nowrap text-xs"
-                        >
-                            {isDefault ? t('card.defaultSelected') : t('card.makeDefault')}
-                        </Button>
+                        {/* Owner feedback 2026-07-17 (#9) — the primary
+                            "Make default" action moved into a ⋮ kebab so the
+                            card action row fits on one line. Reuses the shared
+                            DropdownMenu (asChild + ghost Button, matching
+                            ItemActions); leaves room for future per-template
+                            actions in the same menu. The `w-fit` wrapper pins
+                            the menu root's `w-full` to the trigger width so it
+                            doesn't stretch this shrink-to-fit row. */}
+                        <div className="w-fit shrink-0">
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        aria-label={t('card.moreActions')}
+                                        title={t('card.moreActions')}
+                                        className="text-xs"
+                                    >
+                                        <MoreVertical className="h-3.5 w-3.5" />
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="end">
+                                    <DropdownMenuItem
+                                        onClick={() => onSetDefault(template.id)}
+                                        disabled={isDefault || loading}
+                                    >
+                                        <Star className="mr-2 h-3.5 w-3.5" />
+                                        {isDefault
+                                            ? t('card.defaultSelected')
+                                            : t('card.makeDefault')}
+                                    </DropdownMenuItem>
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/packages/plugin/src/contracts/plugin-manifest.types.ts
+++ b/packages/plugin/src/contracts/plugin-manifest.types.ts
@@ -201,6 +201,13 @@ export interface PluginUiHints {
 	completionFields?: string[];
 	/** User-friendly step description shown in the onboarding wizard (separate from the plugin description). */
 	onboardingDescription?: string;
+	/**
+	 * Render this plugin's `readme` (markdown setup guide) inline in the
+	 * first-time onboarding config step, beneath the settings fields. Opt-in
+	 * per plugin so we surface setup steps (e.g. "Get a Vercel token") without
+	 * dumping every plugin's readme into the wizard.
+	 */
+	showReadmeInOnboarding?: boolean;
 	/** Exposes a plugin-managed device auth flow, such as a backend-started CLI device-code session. */
 	deviceAuth?: {
 		/** Settings field that selects the auth mode when device auth is available. */

--- a/packages/plugins/vercel/src/vercel.plugin.ts
+++ b/packages/plugins/vercel/src/vercel.plugin.ts
@@ -294,7 +294,8 @@ export class VercelPlugin implements IPlugin, IDeploymentPlugin {
 				includeInOnboarding: true,
 				onboardingPriority: 4,
 				completionFields: ['apiToken'],
-				onboardingDescription: 'Add a Vercel token to publish your works as live websites.'
+				onboardingDescription: 'Add a Vercel token to publish your works as live websites.',
+				showReadmeInOnboarding: true
 			},
 			icon: {
 				type: 'lucide',


### PR DESCRIPTION
Batch of owner-reported onboarding wizard + Templates page fixes. All validated locally (apps/web type-check exit 0, eslint clean, all 21 message locales parse).

- **#4** Plugins step: removed the nested `max-h-[420px] overflow-y-auto` so the list fills the dialog and only scrolls on real overflow.
- **#5** "work" → "Work" across the v2 wizard (8 literals + both e2e specs) + the final step's prompt is now an editable `<textarea>` (gated, edits persist via `flow.setPrompt`).
- **#7** Welcome copy rewritten to the full product breadth (directories, sites, landing pages, blogs, awesome-lists + Missions/Agents/Tasks/Companies) + a numbered "what's next" overview.
- **#8** Sidebar "9-step" → "multi-step" (the count is dynamic).
- **#9** Templates card: "Use this Template" → "Use" (full phrase kept as title/aria-label) + "Make default" moved into a `⋮` kebab menu.
- **#2 (fallback)** Vercel setup instructions surfaced inline in the Configure-Vercel step (opt-in manifest flag; token field + link untouched). *Note: the manifest field change in `packages/plugins/vercel` needs the API image too — will ride the next API deploy.*

Additive only; no removals. Cascades develop → stage → main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding now shows a dynamic overview of upcoming steps.
  * Prompts can be edited before generating a new Work.
  * Supported integrations can display an inline setup guide during onboarding.
  * Template cards now offer a streamlined actions menu, including setting a default template.
* **Improvements**
  * Updated onboarding wording and navigation labels for clarity.
  * Improved accessibility for template actions.
  * Refreshed localized text across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->