### PR TITLE
feat(skills,templates): wire Skills catalog + seed Work Templates

### DIFF
--- a/packages/agent/src/template-catalog/template-catalog.service.ts
+++ b/packages/agent/src/template-catalog/template-catalog.service.ts
@@ -26,6 +26,8 @@ import {
     listMissionTemplates,
     type MissionTemplateConfig,
 } from '@src/missions/mission-template.config';
+// Work Templates catalog source — powers the "Work Templates" tab.
+import { listWorkTemplates, type WorkTemplateConfig } from '@src/works/work-template.config';
 import { randomUUID } from 'node:crypto';
 import type { TemplateKind, TemplateSourceType } from '@src/entities/template.entity';
 import { config } from '@src/config';
@@ -128,6 +130,9 @@ export class TemplateCatalogService implements OnModuleInit {
             ),
             ...listMissionTemplates().map((template) =>
                 this.toBuiltInMissionTemplateRecord(template),
+            ),
+            ...listWorkTemplates().map((template) =>
+                this.toBuiltInWorkTemplateRecord(template),
             ),
         ];
 
@@ -805,6 +810,33 @@ export class TemplateCatalogService implements OnModuleInit {
             name: template.name,
             description: template.description,
             framework: null,
+            repositoryOwner: template.owner,
+            repositoryName: template.repo,
+            repositoryUrl: `https://github.com/${template.owner}/${template.repo}`,
+            branch: template.branch,
+            syncBranches: template.syncBranches,
+            betaBranch: template.betaBranch,
+            isActive: true,
+            metadata: {},
+        };
+    }
+
+    /**
+     * Built-in Work Template record. Same upsert shape as the website /
+     * mission variants; `kind: 'work'` routes it onto the "Work
+     * Templates" tab (kind-filtered catalog reader). Unlike the website
+     * variant — which infers `framework` from the repo name — a Work
+     * Template states its framework explicitly in config, so we pass it
+     * straight through (falling back to null when unset).
+     */
+    private toBuiltInWorkTemplateRecord(template: WorkTemplateConfig) {
+        return {
+            id: template.id,
+            kind: 'work' as const,
+            sourceType: 'built_in' as const,
+            name: template.name,
+            description: template.description,
+            framework: template.framework ?? null,
             repositoryOwner: template.owner,
             repositoryName: template.repo,
             repositoryUrl: `https://github.com/${template.owner}/${template.repo}`,

--- a/packages/agent/src/works/work-template.config.spec.ts
+++ b/packages/agent/src/works/work-template.config.spec.ts
@@ -1,0 +1,61 @@
+import {
+    WORK_TEMPLATES,
+    findWorkTemplateConfig,
+    listWorkTemplates,
+} from './work-template.config';
+
+/**
+ * Pins the built-in Work Templates catalog. These rows power the
+ * "Work Templates" tab on the Templates page (seeded via
+ * TemplateCatalogService.toBuiltInWorkTemplateRecord). Changing an
+ * id / repo here changes what users can fork, so keep the assertions
+ * strict.
+ */
+describe('work-template.config', () => {
+    it('seeds exactly the two curated Work Templates', () => {
+        const templates = listWorkTemplates();
+        expect(templates.map((t) => t.id)).toEqual([
+            'starter-directory',
+            'starter-directory-minimal',
+        ]);
+    });
+
+    it('points each template at a real ever-works repo with a stated framework', () => {
+        expect(findWorkTemplateConfig('starter-directory')).toMatchObject({
+            name: 'Starter Directory',
+            owner: 'ever-works',
+            repo: 'directory-web-template',
+            framework: 'Next.js',
+            branch: 'main',
+            syncBranches: ['main'],
+        });
+        expect(findWorkTemplateConfig('starter-directory-minimal')).toMatchObject({
+            name: 'Starter Directory (Minimal)',
+            owner: 'ever-works',
+            repo: 'directory-web-minimal-template',
+            framework: 'Astro',
+            branch: 'main',
+            syncBranches: ['main'],
+        });
+    });
+
+    it('returns null for an unknown template id', () => {
+        expect(findWorkTemplateConfig('does-not-exist')).toBeNull();
+        expect(findWorkTemplateConfig(undefined)).toBeNull();
+        expect(findWorkTemplateConfig(null)).toBeNull();
+    });
+
+    it('listWorkTemplates returns a fresh copy (callers cannot mutate the source)', () => {
+        const first = listWorkTemplates();
+        first.push({
+            id: 'tampered',
+            name: 'Tampered',
+            description: '',
+            owner: 'x',
+            repo: 'y',
+            branch: 'main',
+            syncBranches: ['main'],
+        });
+        expect(listWorkTemplates()).toHaveLength(WORK_TEMPLATES.length);
+    });
+});

--- a/packages/agent/src/works/work-template.config.ts
+++ b/packages/agent/src/works/work-template.config.ts
@@ -1,0 +1,74 @@
+/**
+ * Curated Work Templates catalog.
+ *
+ * Work Templates are the pre-baked starters behind the "Work
+ * Templates" tab on the Templates page: an id + display name +
+ * description pointing at a real GitHub boilerplate repo the user can
+ * fork into their own Work. The list here is the built-in catalog the
+ * `TemplateCatalogService` seeds on boot; users can add custom Work
+ * Template repos via the same Add Custom Template flow as website and
+ * mission templates.
+ *
+ * Shape mirrors `WebsiteTemplateConfig` / `MissionTemplateConfig`
+ * (owner / repo / branch + id / name / description) so the catalog
+ * seed path can treat every kind uniformly. Unlike those two, a Work
+ * Template carries an explicit `framework` so the catalog card can
+ * label it deterministically (the website seed infers framework from
+ * the repo name; Work Templates state it outright).
+ */
+export type WorkTemplateId = string;
+
+export interface WorkTemplateConfig {
+    id: WorkTemplateId;
+    name: string;
+    description: string;
+    owner: string;
+    repo: string;
+    branch: string;
+    syncBranches: string[];
+    betaBranch?: string | null;
+    // Human-facing framework label surfaced on the catalog card. Stated
+    // explicitly (rather than inferred) so e.g. the Astro starter is not
+    // mislabelled by repo-name heuristics.
+    framework?: string | null;
+}
+
+const STARTER_DIRECTORY_WORK_TEMPLATE: WorkTemplateConfig = {
+    id: 'starter-directory',
+    name: 'Starter Directory',
+    description:
+        'A Next.js directory boilerplate — a batteries-included starting point for spinning up a new directory Work.',
+    owner: 'ever-works',
+    repo: 'directory-web-template',
+    branch: 'main',
+    syncBranches: ['main'],
+    betaBranch: null,
+    framework: 'Next.js',
+};
+
+const STARTER_DIRECTORY_MINIMAL_WORK_TEMPLATE: WorkTemplateConfig = {
+    id: 'starter-directory-minimal',
+    name: 'Starter Directory (Minimal)',
+    description:
+        'A minimal Astro directory boilerplate — a lightweight starting point for a fast, content-first directory Work.',
+    owner: 'ever-works',
+    repo: 'directory-web-minimal-template',
+    branch: 'main',
+    syncBranches: ['main'],
+    betaBranch: null,
+    framework: 'Astro',
+};
+
+export const WORK_TEMPLATES: WorkTemplateConfig[] = [
+    STARTER_DIRECTORY_WORK_TEMPLATE,
+    STARTER_DIRECTORY_MINIMAL_WORK_TEMPLATE,
+];
+
+export function listWorkTemplates(): WorkTemplateConfig[] {
+    return [...WORK_TEMPLATES];
+}
+
+export function findWorkTemplateConfig(templateId?: string | null): WorkTemplateConfig | null {
+    if (!templateId) return null;
+    return WORK_TEMPLATES.find((template) => template.id === templateId) ?? null;
+}

--- a/packages/plugins/everworks-skills/package.json
+++ b/packages/plugins/everworks-skills/package.json
@@ -47,6 +47,7 @@
 			"capabilities": [
 				"skills-provider"
 			],
+			"autoEnable": true,
 			"defaultForCapabilities": [
 				"skills-provider"
 			],

--- a/packages/plugins/everworks-skills/src/everworks-skills.plugin.spec.ts
+++ b/packages/plugins/everworks-skills/src/everworks-skills.plugin.spec.ts
@@ -1,14 +1,35 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EverWorksSkillsPlugin } from './everworks-skills.plugin.js';
+
+function textResponse(body: string, status = 200): Response {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		text: async () => body
+	} as Response;
+}
 
 describe('EverWorksSkillsPlugin (builtin fallback catalog)', () => {
 	let plugin: EverWorksSkillsPlugin;
 
 	beforeEach(async () => {
+		// Force the builtin fallback path by making every live fetch fail.
+		// This keeps the fallback assertions below deterministic regardless
+		// of whether the test runner has network access.
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => {
+				throw new Error('network disabled in test');
+			})
+		);
 		plugin = new EverWorksSkillsPlugin();
 		await plugin.onLoad({
 			logger: { log: () => undefined, warn: () => undefined, error: () => undefined }
 		} as any);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
 	});
 
 	it('exposes the skills-provider capability', () => {
@@ -63,5 +84,98 @@ describe('EverWorksSkillsPlugin (builtin fallback catalog)', () => {
 
 	it('isAvailable returns true (no required credentials)', () => {
 		expect(plugin.isAvailable()).toBe(true);
+	});
+
+	it('falls back to the builtin catalog when the manifest is malformed', async () => {
+		// 200 OK but not a skills array -> loader throws -> builtin fallback.
+		vi.stubGlobal('fetch', vi.fn(async () => textResponse(JSON.stringify({ nope: true }))));
+		const fresh = new EverWorksSkillsPlugin();
+		await fresh.onLoad({
+			logger: { log: () => undefined, warn: () => undefined, error: () => undefined }
+		} as any);
+		const result = await fresh.listEntries({ limit: 50, offset: 0 });
+		expect(result.entries.map((e) => e.slug)).toEqual(
+			expect.arrayContaining(['cron-defaults', 'secret-handling', 'commit-message-style'])
+		);
+	});
+});
+
+describe('EverWorksSkillsPlugin (live ever-works/skills catalog)', () => {
+	const MANIFEST = JSON.stringify({
+		version: 1,
+		skills: [
+			{
+				slug: 'skill-creator',
+				name: 'Skill Creator',
+				summary: 'Create and improve Agent Skills.',
+				skillPath: 'skills/skill-creator/SKILL.md',
+				tags: ['meta', 'authoring'],
+				version: '2.1.0',
+				license: 'Apache-2.0',
+				sourceUrl: 'https://github.com/ever-works/skills/tree/main/skills/skill-creator'
+			}
+		]
+	});
+
+	const SKILL_MD = `---
+name: skill-creator
+description: Frontmatter-level description of the skill.
+allowedTools: ["Read", "Write"]
+---
+
+# Skill Creator
+
+A skill for creating new skills, defaulting cron to UTC.`;
+
+	let plugin: EverWorksSkillsPlugin;
+
+	beforeEach(async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (input: unknown) => {
+				const url = String(input);
+				if (url.endsWith('/manifest.json')) return textResponse(MANIFEST);
+				if (url.endsWith('/SKILL.md')) return textResponse(SKILL_MD);
+				throw new Error(`unexpected url ${url}`);
+			})
+		);
+		plugin = new EverWorksSkillsPlugin();
+		await plugin.onLoad({
+			logger: { log: () => undefined, warn: () => undefined, error: () => undefined }
+		} as any);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('maps a manifest row + SKILL.md frontmatter into a SkillCatalogEntry', async () => {
+		const entry = await plugin.getEntry('skill-creator');
+		expect(entry).not.toBeNull();
+		expect(entry).toMatchObject({
+			slug: 'skill-creator',
+			// title prefers the curated manifest name.
+			title: 'Skill Creator',
+			// description prefers the curated manifest summary.
+			description: 'Create and improve Agent Skills.',
+			// version prefers the manifest row version.
+			version: '2.1.0',
+			// tags come from the curated manifest row.
+			tags: ['meta', 'authoring'],
+			sourceUrl: 'https://github.com/ever-works/skills/tree/main/skills/skill-creator'
+		});
+		// frontmatter is the parsed SKILL.md frontmatter (not the manifest).
+		expect(entry?.frontmatter.name).toBe('skill-creator');
+		expect(entry?.frontmatter.description).toBe('Frontmatter-level description of the skill.');
+		expect(entry?.frontmatter.allowedTools).toEqual(['Read', 'Write']);
+		// body is the markdown WITHOUT the frontmatter block.
+		expect(entry?.body.startsWith('# Skill Creator')).toBe(true);
+		expect(entry?.body).not.toContain('---');
+	});
+
+	it('lists the live catalog entries', async () => {
+		const result = await plugin.listEntries({ limit: 50, offset: 0 });
+		expect(result.total).toBe(1);
+		expect(result.entries[0].slug).toBe('skill-creator');
 	});
 });

--- a/packages/plugins/everworks-skills/src/everworks-skills.plugin.ts
+++ b/packages/plugins/everworks-skills/src/everworks-skills.plugin.ts
@@ -8,24 +8,49 @@ import type {
 	SkillCatalogEntry,
 	SkillCatalogListOptions,
 	SkillCatalogListResult,
-	SkillCatalogUpdate
+	SkillCatalogUpdate,
+	SkillFrontmatter
 } from '@ever-works/plugin';
 
 import matter from 'gray-matter';
 
+const RAW_CONTENT_BASE = 'https://raw.githubusercontent.com';
+const DEFAULT_CATALOG_REPO = 'ever-works/skills';
+const DEFAULT_CATALOG_BRANCH = 'main';
+const CATALOG_FETCH_TIMEOUT_MS = 10_000;
+// Guard rails so a malformed admin setting can't build a surprising URL.
+const REPO_PATTERN = /^[\w.-]+\/[\w.-]+$/;
+const BRANCH_PATTERN = /^[\w./-]+$/;
+
+/**
+ * One row of the `ever-works/skills` `manifest.json` (ADR-014). All
+ * fields are treated as optional/untrusted at parse time — the loader
+ * validates `slug` + `skillPath` before building a catalog entry.
+ */
+interface SkillsManifestRow {
+	slug?: string;
+	name?: string;
+	summary?: string;
+	skillPath?: string;
+	path?: string;
+	tags?: string[];
+	version?: string;
+	license?: string;
+	sourceUrl?: string;
+}
+
 /**
  * Ever Works Skills — first-party `skills-provider` plugin (ADR-012).
  *
- * Sources its catalog from the [`ever-works/skills`](https://github.com/ever-works/skills)
- * GitHub repo (per ADR-014). v1 ships with a small built-in fallback
- * catalog so the plugin works out of the box even before the
- * upstream repo is created — the platform self-recovers when the
- * repo appears.
- *
- * Future iteration: replace the built-in fallback with a real
- * git-clone + cache loader that pulls `.md` files from the repo's
- * `catalog/` subtree, parses frontmatter via `gray-matter`, and
- * caches in memory with a configurable TTL.
+ * Sources its catalog from the public [`ever-works/skills`](https://github.com/ever-works/skills)
+ * GitHub repo (per ADR-014). The loader fetches `manifest.json` from
+ * the configured repo/branch over a plain HTTPS GET (the repo is
+ * public — no auth), then fetches each row's `SKILL.md`, parses its
+ * frontmatter via `gray-matter`, and caches the union in memory with
+ * a configurable TTL. If the repo is unreachable (or the manifest is
+ * malformed) the loader falls back to the small `BUILTIN_CATALOG`
+ * below so the plugin always returns SOMETHING — the platform
+ * self-recovers when the repo becomes reachable again.
  */
 const BUILTIN_CATALOG: SkillCatalogEntry[] = [
 	{
@@ -112,7 +137,7 @@ export class EverWorksSkillsPlugin implements IPlugin, ISkillsProviderPlugin {
 
 	async onLoad(context: PluginContext): Promise<void> {
 		this.context = context;
-		context.logger.log('Ever Works Skills provider loaded (v1: builtin fallback catalog).');
+		context.logger.log('Ever Works Skills provider loaded (catalog: ever-works/skills, builtin fallback).');
 	}
 
 	async onUnload(): Promise<void> {
@@ -160,15 +185,145 @@ export class EverWorksSkillsPlugin implements IPlugin, ISkillsProviderPlugin {
 			return this.cache.entries;
 		}
 
-		// TODO: Replace builtin fallback with a real git clone + cache
-		// of `ever-works/skills` per ADR-014. When the upstream repo
-		// is reachable, parse every `*.md` file via `gray-matter` into
-		// a SkillCatalogEntry. Fall back to the builtin if the clone
-		// fails so the plugin always returns SOMETHING.
-		this.cache = { entries: BUILTIN_CATALOG.slice(), fetchedAt: now };
-		void matter; // silence unused import warning until the loader wires up
-		return this.cache.entries;
+		const repo = resolveRepo(settings?.catalogRepo);
+		const branch = resolveBranch(settings?.catalogBranch);
+
+		try {
+			const entries = await this.fetchCatalog(repo, branch);
+			if (entries.length === 0) {
+				throw new Error('catalog manifest yielded no entries');
+			}
+			this.cache = { entries, fetchedAt: now };
+			return entries;
+		} catch (err) {
+			// Fall back to the builtin catalog on ANY failure (network,
+			// non-200, malformed manifest/frontmatter) so the plugin
+			// always returns SOMETHING. Cache the fallback so a sustained
+			// outage doesn't re-hit the upstream on every request; the
+			// TTL governs when we retry the live fetch.
+			this.context?.logger.warn(
+				`Ever Works Skills: catalog fetch from ${repo}@${branch} failed; using builtin fallback. ` +
+					`${err instanceof Error ? err.message : String(err)}`
+			);
+			this.cache = { entries: BUILTIN_CATALOG.slice(), fetchedAt: now };
+			return this.cache.entries;
+		}
 	}
+
+	private async fetchCatalog(repo: string, branch: string): Promise<SkillCatalogEntry[]> {
+		const manifestUrl = `${RAW_CONTENT_BASE}/${repo}/${branch}/manifest.json`;
+		const manifestText = await fetchText(manifestUrl);
+		const rows = extractManifestRows(JSON.parse(manifestText));
+
+		// Fetch every SKILL.md in parallel; a single failure rejects the
+		// batch and trips the builtin fallback in loadAll().
+		return Promise.all(rows.map((row) => this.fetchEntry(repo, branch, row)));
+	}
+
+	private async fetchEntry(
+		repo: string,
+		branch: string,
+		row: SkillsManifestRow
+	): Promise<SkillCatalogEntry> {
+		const slug = typeof row.slug === 'string' ? row.slug.trim() : '';
+		const skillPath = typeof row.skillPath === 'string' ? row.skillPath.trim() : '';
+		if (!slug || !skillPath) {
+			throw new Error(`invalid manifest row (missing slug/skillPath): ${JSON.stringify(row)}`);
+		}
+
+		const skillUrl = `${RAW_CONTENT_BASE}/${repo}/${branch}/${skillPath.replace(/^\/+/, '')}`;
+		const markdown = await fetchText(skillUrl);
+		const parsed = matter(markdown);
+		const frontmatter = normalizeFrontmatter(parsed.data, slug, row);
+
+		return {
+			slug,
+			title: firstNonEmpty(row.name, frontmatter.name, slug),
+			description: firstNonEmpty(row.summary, frontmatter.description, ''),
+			frontmatter,
+			body: parsed.content.trim(),
+			version: firstNonEmpty(row.version, asString(parsed.data.version), '1.0.0'),
+			tags: normalizeTags(row.tags, frontmatter.tags),
+			...(typeof row.sourceUrl === 'string' && row.sourceUrl ? { sourceUrl: row.sourceUrl } : {})
+		};
+	}
+}
+
+/**
+ * Fetch a URL as text with a hard timeout. Rejects on any transport
+ * error or non-2xx response so callers can uniformly fall back.
+ */
+async function fetchText(url: string): Promise<string> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), CATALOG_FETCH_TIMEOUT_MS);
+	try {
+		const res = await fetch(url, {
+			signal: controller.signal,
+			headers: { Accept: 'text/plain, application/json, */*' }
+		});
+		if (!res.ok) {
+			throw new Error(`GET ${url} -> HTTP ${res.status}`);
+		}
+		return await res.text();
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/** Accept either a bare array or the `{ skills: [...] }` envelope. */
+function extractManifestRows(parsed: unknown): SkillsManifestRow[] {
+	if (Array.isArray(parsed)) {
+		return parsed as SkillsManifestRow[];
+	}
+	if (parsed && typeof parsed === 'object' && Array.isArray((parsed as { skills?: unknown }).skills)) {
+		return (parsed as { skills: SkillsManifestRow[] }).skills;
+	}
+	throw new Error('manifest.json does not contain a skills array');
+}
+
+/**
+ * Build a `SkillFrontmatter` from the parsed SKILL.md frontmatter,
+ * preserving any extra keys (`allowedTools`, etc.) while guaranteeing
+ * the required `name`/`description` strings.
+ */
+function normalizeFrontmatter(
+	data: Record<string, unknown>,
+	slug: string,
+	row: SkillsManifestRow
+): SkillFrontmatter {
+	const name = firstNonEmpty(asString(data.name), row.name, slug);
+	const description = firstNonEmpty(asString(data.description), row.summary, '');
+	return { ...data, name, description };
+}
+
+/** Prefer the curated manifest tags; fall back to frontmatter tags. */
+function normalizeTags(rowTags: unknown, frontmatterTags: unknown): string[] {
+	const source = Array.isArray(rowTags) ? rowTags : Array.isArray(frontmatterTags) ? frontmatterTags : [];
+	return source.filter((t): t is string => typeof t === 'string');
+}
+
+function resolveRepo(value: unknown): string {
+	const repo = asString(value);
+	return repo && REPO_PATTERN.test(repo) ? repo : DEFAULT_CATALOG_REPO;
+}
+
+function resolveBranch(value: unknown): string {
+	const branch = asString(value);
+	return branch && BRANCH_PATTERN.test(branch) ? branch : DEFAULT_CATALOG_BRANCH;
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === 'string' ? value : undefined;
+}
+
+/** First argument that is a non-empty (trimmed) string. */
+function firstNonEmpty(...values: Array<string | undefined>): string {
+	for (const value of values) {
+		if (typeof value === 'string' && value.trim()) {
+			return value;
+		}
+	}
+	return '';
 }
 
 function filterCatalog(entries: SkillCatalogEntry[], options: SkillCatalogListOptions): SkillCatalogEntry[] {


### PR DESCRIPTION
API-side changes so the new catalogs surface in-app. Validated locally (contracts+plugin build, agent + everworks-skills + api type-check all exit 0; everworks-skills vitest 12/12, work-template spec 4/4; eslint clean on changed files).

- **Skills catalog loader** — `everworks-skills` plugin now fetches the public `ever-works/skills` repo (`manifest.json` → per-skill `SKILL.md`, gray-matter parsed), with the `BUILTIN_CATALOG` kept as a try/catch fallback (10s timeout, cached). Added `"autoEnable": true` so the provider is on by default → the 10 seeded skills appear in the Skills "Available" tab.
- **Work Templates** — new `listWorkTemplates()` config (`starter-directory` → `directory-web-template` (Next.js); `starter-directory-minimal` → `directory-web-minimal-template` (Astro)) + `toBuiltInWorkTemplateRecord()` wired into `seedBuiltInTemplates()`, so the Work Templates tab is no longer empty.

Needs the API image rebuilt to take effect (bundling with the deploy-side changes). Additive; no removals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in Work Templates, including Starter Directory and Minimal variants.
  * Added support for loading the skills catalog from the configured GitHub source.
  * Skills now include metadata from manifests and skill documentation, including descriptions, versions, and tags.
  * Enabled automatic activation for the EverWorks Skills plugin.

* **Bug Fixes**
  * Added a reliable built-in fallback when the remote skills catalog is unavailable, invalid, or malformed.
  * Added request timeouts and validation for remote catalog locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->