### PR TITLE
feat: accurate ever-works agent/skill bundle (Claude Code + Codex)

### DIFF
--- a/.agents/skills/ever-works/SKILL.md
+++ b/.agents/skills/ever-works/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ever-works
+description: >-
+  Repo-specific guide to the Ever Works monorepo (ever-works/ever-works) — its
+  pnpm + Turborepo layout, the per-workspace test runners (Jest vs Vitest vs
+  Playwright), file-naming and import-alias conventions, the commit/branch
+  model, and the real build/lint/type-check commands. Use this whenever working
+  anywhere in this repository so changes match the codebase's actual conventions
+  and pass CI.
+---
+
+# Ever Works monorepo
+
+**Ever Works** is an open-source, AI-powered work/content builder platform — an
+open agentic runtime that researches, ships, and maintains content-rich websites
+and Git repositories.
+
+**Read the repo's own instructions first.** `AGENTS.md` (repo root) routes agents
+to `CLAUDE.md` (repo root), which is the **canonical, authoritative** rule set.
+This skill is a concise summary of those files plus conventions verified from the
+code. If anything here ever diverges from `CLAUDE.md`, **`CLAUDE.md` wins** — do
+not treat this skill as a replacement for it.
+
+## Monorepo layout (Turborepo + pnpm workspaces)
+
+Workspaces are `apps/*`, `packages/*`, and `packages/plugins/*`; Turborepo orders
+builds via `^build`.
+
+- `apps/api` — NestJS 11 REST API (SWC compiler, TypeORM, JWT + OAuth). Dev port 3100.
+- `apps/web` — Next.js 16 App Router (React 19, Tailwind CSS 4, next-intl). Dev port 3000.
+- `apps/cli` — public CLI (esbuild + commander); `apps/internal-cli` — internal NestJS CLI (nest-commander).
+- `apps/admin` — admin interface; `apps/mcp` — Model Context Protocol server; `apps/docs` — Docusaurus 3 site (renders the root `docs/`).
+- `packages/plugin` — plugin-system contracts & utilities (ESM, tsup); `packages/contracts` — shared TypeScript types (ESM, tsup).
+- `packages/agent` — `@ever-works/agent`, the core AI agent logic (NestJS + SWC), 21 sub-module exports; consumed by the API.
+- `packages/plugins/*` — 39 provider plugins (ai-provider, ai-gateway, search, content-extractor, screenshot, git-provider, deployment, pipeline, …). Each is ESM, built with tsup, tested with Vitest.
+- `packages/tasks` — Trigger.dev background jobs; `packages/monitoring` — Sentry + PostHog; `packages/cli-shared` — shared CLI utilities.
+- `docs/` — markdown docs content; `.specify/` — GitHub Spec Kit (feature specs live under `docs/specs/features/`).
+
+## Commands (pnpm only — never npm/yarn; Node >= 22)
+
+```bash
+pnpm install
+pnpm dev:web            # Next.js app on :3000 (next dev --turbopack)
+pnpm dev:api            # NestJS API on :3100
+pnpm build              # Turborepo build (excludes apps/docs)
+pnpm build:web          # single target; also build:api, build:plugins, build:packages
+pnpm type-check         # tsc --noEmit across all workspaces
+pnpm lint               # ESLint (flat config, eslint.config.mjs — ESLint 9)
+pnpm format             # Prettier (format:check to verify only)
+pnpm test               # All unit tests (turbo fans out to each workspace's runner)
+pnpm test:e2e           # Web Playwright e2e
+```
+
+Package manager is pinned: `pnpm@10.33.3`. Run `pnpm install` after adding deps.
+
+## Testing (three runners — use the one the package uses)
+
+Ever Works uses Jest **and** Vitest, split by build tooling (see the repo's own
+`docs/testing/overview.md`), plus Playwright for web e2e:
+
+- **Jest** — `packages/agent` (~26 suites / ~719 tests, `packages/agent/jest.config.js`) and `apps/api` (`apps/api/jest.config.js`). These are the SWC/NestJS packages. Test files are `*.spec.ts`.
+  - `cd packages/agent && pnpm test` · `pnpm test:cov` · `npx jest --testPathPattern='generators'`
+  - `cd apps/api && pnpm test`
+- **Vitest** — `packages/plugin`, every `packages/plugins/*`, and `apps/web` unit tests. Test files are `*.spec.ts`.
+  - `cd packages/plugins/openai && pnpm test` · `npx vitest run src/openai.spec.ts`
+  - `cd apps/web && pnpm test` (web unit)
+- **Playwright** — `apps/web` end-to-end. Specs in `apps/web/e2e/*.spec.ts`, config `apps/web/playwright.config.ts`.
+  - `cd apps/web && pnpm test:e2e` (or `pnpm test:e2e` from the repo root)
+- Root `pnpm test` runs `turbo run test`, delegating to each workspace's own runner.
+
+## File & symbol naming
+
+Follow the "Code Style → Naming" section of `CLAUDE.md` as authoritative. Verified
+across the tree, the working rules are:
+
+- **kebab-case** for all non-component TypeScript files: NestJS `*.service.ts`, `*.controller.ts`, `*.module.ts`, `*.dto.ts`, entities, guards, and shared/agent modules (e.g. `tenant-job-runtime.service.ts`, `account-import.service.ts`); web hooks are `use-*.ts` (e.g. `use-local-storage.ts`); `lib/` and utility files are kebab-case too.
+- **PascalCase** for React component files under `apps/web/src/components/**` and `apps/docs/src/theme/**` (e.g. `ActivityTable.tsx`, `AgentActivityClient.tsx`). This is the dominant convention for components (~340 files).
+- **lowercase reserved names** for Next.js App Router files — `page.tsx`, `layout.tsx`, `loading.tsx`, `route.ts`, etc. (framework-required).
+- **Symbols:** PascalCase for classes / interfaces / types, camelCase for functions / variables, UPPER_SNAKE_CASE for constants.
+- A few legacy files deviate (a camelCase hook, a kebab-case component). When unsure, match the sibling files in the directory you are editing and defer to `CLAUDE.md`.
+
+## Imports & path aliases
+
+- `@/*` → `apps/web/src/*` (web). e.g. `import { APP_NAME } from '@/lib/constants'`.
+- `@src/*` → `apps/api/src/*` (api).
+- `@ever-works/*` → workspace packages. e.g. `import { BasePlugin } from '@ever-works/plugin'`; plugins also import sub-paths such as `@ever-works/plugin/abstract` and `@ever-works/plugin/ai`.
+- Use relative imports within the same feature folder. There is **no** import-renaming convention (`import { X as Y }`) — do not introduce one.
+
+## Code style
+
+- **Prettier** formats the repo. The root `package.json` config (tabs, print width 120, single quotes, semicolons, no trailing commas) takes precedence over the per-package `.prettierrc` (spaces, width 100). Run `pnpm format`; don't hand-fight it.
+- **TypeScript strict**, ESLint 9 flat config (`eslint.config.mjs`).
+
+## Commits & branches
+
+- **Conventional Commits**, enforced by commitlint (`@commitlint/config-conventional`, run via husky): `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:` (plus the standard `build`, `ci`, `perf`, `style`, `revert`). Scopes are welcome, e.g. `feat(api): …`.
+- **Branches:** `develop` (default / integration) → `stage` → `main` (production). Promote changes **forward through the cascade** — open a PR from `develop` → `stage`, then `stage` → `main`; the repo uses dedicated `cascade/*` branches for these promotions. Merge the whole branch forward rather than cherry-picking individual commits.
+
+## Deployment (do not run ad-hoc deploy commands)
+
+Apps ship as containers (`node:22-alpine`) to Kubernetes via GitOps. The API
+self-applies pending TypeORM migrations on boot (`migrationsRun`, gated by the
+`RUN_MIGRATIONS` env). Trigger.dev tasks deploy via `pnpm deploy:trigger`. Do not
+invent or run other deploy / `kubectl` commands from this repository.
+
+## Gotchas
+
+- **Web build uses Webpack, not Turbopack.** `apps/web` builds with `next build --webpack` (dev uses `--turbopack`). Keep the `--webpack` flag on the build script.
+- **Build shared packages before type-checking / testing.** `@ever-works/contracts` and `@ever-works/plugin` must be built (`pnpm build` / `pnpm build:plugins`) before `apps/web` type-check or agent tests can resolve them. The agent Jest config also maps those packages to source via `moduleNameMapper` — if test imports fail, build first.
+- **TypeORM migrations ship with entity changes.** Any entity/schema change needs a migration in the **same PR** (`apps/api/src/migrations/`). See `docs/specs/architecture/database-migrations.md`.
+- **DTS build failure with conditional spreads.** `...cond && { key: value }` yields `string | false` and breaks declaration emit — use explicit `if` blocks to add properties conditionally.
+- **No stray docs in the repo root.** Working/plan/summary/tracker markdown goes under `docs/internal/` (or `docs/specs/<feature>/`), never the root — see `AGENTS.md` / `CLAUDE.md`.
+
+## UI & design patterns
+
+Canonical CTA rules (light vs dark mode) and KPI / stat-card rules live in
+[`references/ui-patterns.md`](references/ui-patterns.md). Follow them for
+`apps/web` UI work.
+
+## Authoritative source
+
+`AGENTS.md` → `CLAUDE.md` (repo root) are the source of truth; `AUGMENT.md` and
+`.github/copilot-instructions.md` add tool-specific notes. Prefer updating
+`CLAUDE.md` over duplicating rules here.

--- a/.agents/skills/ever-works/agents/openai.yaml
+++ b/.agents/skills/ever-works/agents/openai.yaml
@@ -1,0 +1,7 @@
+name: ever-works
+description: >-
+  Repo-specific guide to the Ever Works monorepo — layout, per-workspace test
+  frameworks (Jest / Vitest / Playwright), file-naming and import-alias
+  conventions, the commit/branch model, and build/lint/type-check commands. Use
+  when working anywhere in ever-works/ever-works.
+allow_implicit_invocation: true

--- a/.agents/skills/ever-works/references/ui-patterns.md
+++ b/.agents/skills/ever-works/references/ui-patterns.md
@@ -1,0 +1,30 @@
+# Ever Works — UI & design patterns
+
+Canonical design guidance across the Ever Works web surfaces — the platform (`ever-works/ever-works` → `apps/web`) and the open-source `directory-web-template` (and every customer site forked from it). These are the rules; per-repo CSS is just the local expression.
+
+## Primary CTA — light vs dark mode
+- **Light mode:** solid theme-primary fill (brand colour), white text.
+- **Dark mode:** white background, near-black text (`dark:bg-white dark:text-gray-900`) — NOT the brand colour inverted.
+
+```tsx
+<button className="bg-primary text-white dark:bg-white dark:text-gray-900">
+  Get started
+</button>
+```
+Why: the brand colour at full saturation on a near-black canvas reads as a coloured rectangle rather than a clear action target. White-on-dark gives the CTA the same visual weight as the light-mode pattern without competing with content. Applies to primary CTAs (template hero "Get started", category "Browse all", item "Visit"; the platform's onboarding CTAs). Secondary/icon/link buttons follow normal theme rules.
+
+## Stats / KPI cards — monochrome
+KPI tiles use ONE neutral icon-and-value colour (default text on card background). Do NOT colour the value/icon by "good vs bad" status (red/amber/green).
+
+```tsx
+// ✅ monochrome KPI
+<KPICard label="Active users" value={1284} />
+// ❌ don't colour the value by health
+<KPICard label="Failed runs" value={42} className="text-red-600" />
+// ✅ status colour belongs on the row badge of the underlying table
+<StatusBadge state="failing" />
+```
+Why: a KPI grid with mixed red/amber/green reads as an alert dashboard, not a summary — each tile competes for attention. Reserve colour for row-level status in the table the KPI summarises; keep the KPI grid calm.
+
+## Applying patterns in code
+Prefer composing tokens (e.g. a `primaryCta` variant on a shared `Button`) over per-page inline classes — keeps each pattern auditable in one place per repo. Components live in `apps/web/src/components/` (platform) and `src/components/` (template). Design changes are additive by default — a new pattern must not silently drop existing surfaces.

--- a/.claude/identity.json
+++ b/.claude/identity.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.0.0",
+  "technicalLevel": "advanced",
+  "domains": ["typescript", "nestjs", "nextjs", "turborepo"],
+  "verbosity": "concise"
+}

--- a/.claude/skills/ever-works/SKILL.md
+++ b/.claude/skills/ever-works/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ever-works
+description: >-
+  Repo-specific guide to the Ever Works monorepo (ever-works/ever-works) — its
+  pnpm + Turborepo layout, the per-workspace test runners (Jest vs Vitest vs
+  Playwright), file-naming and import-alias conventions, the commit/branch
+  model, and the real build/lint/type-check commands. Use this whenever working
+  anywhere in this repository so changes match the codebase's actual conventions
+  and pass CI.
+---
+
+# Ever Works monorepo
+
+**Ever Works** is an open-source, AI-powered work/content builder platform — an
+open agentic runtime that researches, ships, and maintains content-rich websites
+and Git repositories.
+
+**Read the repo's own instructions first.** `AGENTS.md` (repo root) routes agents
+to `CLAUDE.md` (repo root), which is the **canonical, authoritative** rule set.
+This skill is a concise summary of those files plus conventions verified from the
+code. If anything here ever diverges from `CLAUDE.md`, **`CLAUDE.md` wins** — do
+not treat this skill as a replacement for it.
+
+## Monorepo layout (Turborepo + pnpm workspaces)
+
+Workspaces are `apps/*`, `packages/*`, and `packages/plugins/*`; Turborepo orders
+builds via `^build`.
+
+- `apps/api` — NestJS 11 REST API (SWC compiler, TypeORM, JWT + OAuth). Dev port 3100.
+- `apps/web` — Next.js 16 App Router (React 19, Tailwind CSS 4, next-intl). Dev port 3000.
+- `apps/cli` — public CLI (esbuild + commander); `apps/internal-cli` — internal NestJS CLI (nest-commander).
+- `apps/admin` — admin interface; `apps/mcp` — Model Context Protocol server; `apps/docs` — Docusaurus 3 site (renders the root `docs/`).
+- `packages/plugin` — plugin-system contracts & utilities (ESM, tsup); `packages/contracts` — shared TypeScript types (ESM, tsup).
+- `packages/agent` — `@ever-works/agent`, the core AI agent logic (NestJS + SWC), 21 sub-module exports; consumed by the API.
+- `packages/plugins/*` — 39 provider plugins (ai-provider, ai-gateway, search, content-extractor, screenshot, git-provider, deployment, pipeline, …). Each is ESM, built with tsup, tested with Vitest.
+- `packages/tasks` — Trigger.dev background jobs; `packages/monitoring` — Sentry + PostHog; `packages/cli-shared` — shared CLI utilities.
+- `docs/` — markdown docs content; `.specify/` — GitHub Spec Kit (feature specs live under `docs/specs/features/`).
+
+## Commands (pnpm only — never npm/yarn; Node >= 22)
+
+```bash
+pnpm install
+pnpm dev:web            # Next.js app on :3000 (next dev --turbopack)
+pnpm dev:api            # NestJS API on :3100
+pnpm build              # Turborepo build (excludes apps/docs)
+pnpm build:web          # single target; also build:api, build:plugins, build:packages
+pnpm type-check         # tsc --noEmit across all workspaces
+pnpm lint               # ESLint (flat config, eslint.config.mjs — ESLint 9)
+pnpm format             # Prettier (format:check to verify only)
+pnpm test               # All unit tests (turbo fans out to each workspace's runner)
+pnpm test:e2e           # Web Playwright e2e
+```
+
+Package manager is pinned: `pnpm@10.33.3`. Run `pnpm install` after adding deps.
+
+## Testing (three runners — use the one the package uses)
+
+Ever Works uses Jest **and** Vitest, split by build tooling (see the repo's own
+`docs/testing/overview.md`), plus Playwright for web e2e:
+
+- **Jest** — `packages/agent` (~26 suites / ~719 tests, `packages/agent/jest.config.js`) and `apps/api` (`apps/api/jest.config.js`). These are the SWC/NestJS packages. Test files are `*.spec.ts`.
+  - `cd packages/agent && pnpm test` · `pnpm test:cov` · `npx jest --testPathPattern='generators'`
+  - `cd apps/api && pnpm test`
+- **Vitest** — `packages/plugin`, every `packages/plugins/*`, and `apps/web` unit tests. Test files are `*.spec.ts`.
+  - `cd packages/plugins/openai && pnpm test` · `npx vitest run src/openai.spec.ts`
+  - `cd apps/web && pnpm test` (web unit)
+- **Playwright** — `apps/web` end-to-end. Specs in `apps/web/e2e/*.spec.ts`, config `apps/web/playwright.config.ts`.
+  - `cd apps/web && pnpm test:e2e` (or `pnpm test:e2e` from the repo root)
+- Root `pnpm test` runs `turbo run test`, delegating to each workspace's own runner.
+
+## File & symbol naming
+
+Follow the "Code Style → Naming" section of `CLAUDE.md` as authoritative. Verified
+across the tree, the working rules are:
+
+- **kebab-case** for all non-component TypeScript files: NestJS `*.service.ts`, `*.controller.ts`, `*.module.ts`, `*.dto.ts`, entities, guards, and shared/agent modules (e.g. `tenant-job-runtime.service.ts`, `account-import.service.ts`); web hooks are `use-*.ts` (e.g. `use-local-storage.ts`); `lib/` and utility files are kebab-case too.
+- **PascalCase** for React component files under `apps/web/src/components/**` and `apps/docs/src/theme/**` (e.g. `ActivityTable.tsx`, `AgentActivityClient.tsx`). This is the dominant convention for components (~340 files).
+- **lowercase reserved names** for Next.js App Router files — `page.tsx`, `layout.tsx`, `loading.tsx`, `route.ts`, etc. (framework-required).
+- **Symbols:** PascalCase for classes / interfaces / types, camelCase for functions / variables, UPPER_SNAKE_CASE for constants.
+- A few legacy files deviate (a camelCase hook, a kebab-case component). When unsure, match the sibling files in the directory you are editing and defer to `CLAUDE.md`.
+
+## Imports & path aliases
+
+- `@/*` → `apps/web/src/*` (web). e.g. `import { APP_NAME } from '@/lib/constants'`.
+- `@src/*` → `apps/api/src/*` (api).
+- `@ever-works/*` → workspace packages. e.g. `import { BasePlugin } from '@ever-works/plugin'`; plugins also import sub-paths such as `@ever-works/plugin/abstract` and `@ever-works/plugin/ai`.
+- Use relative imports within the same feature folder. There is **no** import-renaming convention (`import { X as Y }`) — do not introduce one.
+
+## Code style
+
+- **Prettier** formats the repo. The root `package.json` config (tabs, print width 120, single quotes, semicolons, no trailing commas) takes precedence over the per-package `.prettierrc` (spaces, width 100). Run `pnpm format`; don't hand-fight it.
+- **TypeScript strict**, ESLint 9 flat config (`eslint.config.mjs`).
+
+## Commits & branches
+
+- **Conventional Commits**, enforced by commitlint (`@commitlint/config-conventional`, run via husky): `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:` (plus the standard `build`, `ci`, `perf`, `style`, `revert`). Scopes are welcome, e.g. `feat(api): …`.
+- **Branches:** `develop` (default / integration) → `stage` → `main` (production). Promote changes **forward through the cascade** — open a PR from `develop` → `stage`, then `stage` → `main`; the repo uses dedicated `cascade/*` branches for these promotions. Merge the whole branch forward rather than cherry-picking individual commits.
+
+## Deployment (do not run ad-hoc deploy commands)
+
+Apps ship as containers (`node:22-alpine`) to Kubernetes via GitOps. The API
+self-applies pending TypeORM migrations on boot (`migrationsRun`, gated by the
+`RUN_MIGRATIONS` env). Trigger.dev tasks deploy via `pnpm deploy:trigger`. Do not
+invent or run other deploy / `kubectl` commands from this repository.
+
+## Gotchas
+
+- **Web build uses Webpack, not Turbopack.** `apps/web` builds with `next build --webpack` (dev uses `--turbopack`). Keep the `--webpack` flag on the build script.
+- **Build shared packages before type-checking / testing.** `@ever-works/contracts` and `@ever-works/plugin` must be built (`pnpm build` / `pnpm build:plugins`) before `apps/web` type-check or agent tests can resolve them. The agent Jest config also maps those packages to source via `moduleNameMapper` — if test imports fail, build first.
+- **TypeORM migrations ship with entity changes.** Any entity/schema change needs a migration in the **same PR** (`apps/api/src/migrations/`). See `docs/specs/architecture/database-migrations.md`.
+- **DTS build failure with conditional spreads.** `...cond && { key: value }` yields `string | false` and breaks declaration emit — use explicit `if` blocks to add properties conditionally.
+- **No stray docs in the repo root.** Working/plan/summary/tracker markdown goes under `docs/internal/` (or `docs/specs/<feature>/`), never the root — see `AGENTS.md` / `CLAUDE.md`.
+
+## UI & design patterns
+
+Canonical CTA rules (light vs dark mode) and KPI / stat-card rules live in
+[`references/ui-patterns.md`](references/ui-patterns.md). Follow them for
+`apps/web` UI work.
+
+## Authoritative source
+
+`AGENTS.md` → `CLAUDE.md` (repo root) are the source of truth; `AUGMENT.md` and
+`.github/copilot-instructions.md` add tool-specific notes. Prefer updating
+`CLAUDE.md` over duplicating rules here.

--- a/.claude/skills/ever-works/references/ui-patterns.md
+++ b/.claude/skills/ever-works/references/ui-patterns.md
@@ -1,0 +1,30 @@
+# Ever Works — UI & design patterns
+
+Canonical design guidance across the Ever Works web surfaces — the platform (`ever-works/ever-works` → `apps/web`) and the open-source `directory-web-template` (and every customer site forked from it). These are the rules; per-repo CSS is just the local expression.
+
+## Primary CTA — light vs dark mode
+- **Light mode:** solid theme-primary fill (brand colour), white text.
+- **Dark mode:** white background, near-black text (`dark:bg-white dark:text-gray-900`) — NOT the brand colour inverted.
+
+```tsx
+<button className="bg-primary text-white dark:bg-white dark:text-gray-900">
+  Get started
+</button>
+```
+Why: the brand colour at full saturation on a near-black canvas reads as a coloured rectangle rather than a clear action target. White-on-dark gives the CTA the same visual weight as the light-mode pattern without competing with content. Applies to primary CTAs (template hero "Get started", category "Browse all", item "Visit"; the platform's onboarding CTAs). Secondary/icon/link buttons follow normal theme rules.
+
+## Stats / KPI cards — monochrome
+KPI tiles use ONE neutral icon-and-value colour (default text on card background). Do NOT colour the value/icon by "good vs bad" status (red/amber/green).
+
+```tsx
+// ✅ monochrome KPI
+<KPICard label="Active users" value={1284} />
+// ❌ don't colour the value by health
+<KPICard label="Failed runs" value={42} className="text-red-600" />
+// ✅ status colour belongs on the row badge of the underlying table
+<StatusBadge state="failing" />
+```
+Why: a KPI grid with mixed red/amber/green reads as an alert dashboard, not a summary — each tile competes for attention. Reserve colour for row-level status in the table the KPI summarises; keep the KPI grid calm.
+
+## Applying patterns in code
+Prefer composing tokens (e.g. a `primaryCta` variant on a shared `Button`) over per-page inline classes — keeps each pattern auditable in one place per repo. Components live in `apps/web/src/components/` (platform) and `src/components/` (template). Design changes are additive by default — a new pattern must not silently drop existing surfaces.

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,11 @@
+# Codex guide — ever-works
+
+Codex follows the same rules as every other agent in this repository.
+
+1. Read the authoritative instructions first: **`AGENTS.md`** and **`CLAUDE.md`** at the repository root.
+2. Load the repo skill at **`.agents/skills/ever-works/SKILL.md`** — a concise, verified summary of the monorepo layout, the test frameworks (Jest vs Vitest vs Playwright), naming/alias conventions, commands, and gotchas.
+3. Use **pnpm** only (Node >= 22). Verify work with `pnpm type-check`, `pnpm lint`, and `pnpm test` (root `pnpm test` fans out to each workspace's own runner).
+4. Read-only exploration is safe; get review before writes. Do **not** run ad-hoc deploy / `kubectl` commands from this repo (deployment is GitOps-driven).
+
+Read-only role presets for multi-agent work live in `.codex/agents/`
+(`explorer`, `reviewer`, `docs-researcher`).

--- a/.codex/agents/docs-researcher.toml
+++ b/.codex/agents/docs-researcher.toml
@@ -1,0 +1,11 @@
+name = "docs-researcher"
+description = "Read-only documentation researcher for the ever-works monorepo: verifies APIs and conventions against the repo's own docs. Never edits files."
+sandbox_mode = "read-only"
+approval_policy = "never"
+instructions = """
+You are a read-only documentation researcher for the ever-works monorepo.
+Answer questions and verify API usage against the repo's own sources: CLAUDE.md,
+AGENTS.md, docs/ (including docs/testing/overview.md and docs/specs/), and each
+package's README. Prefer the repo's documented behaviour over assumptions, and
+cite the file you relied on. Do not modify files.
+"""

--- a/.codex/agents/explorer.toml
+++ b/.codex/agents/explorer.toml
@@ -1,0 +1,12 @@
+name = "explorer"
+description = "Read-only code explorer for the ever-works monorepo: maps structure, traces call paths, and locates code. Never edits files."
+sandbox_mode = "read-only"
+approval_policy = "never"
+instructions = """
+You are a read-only explorer for the ever-works monorepo (pnpm + Turborepo).
+Map structure, trace execution paths across apps/* and packages/*, and locate
+the code relevant to a task. Report findings with concrete file paths and line
+references. Do not modify files, run builds, or execute deploy commands.
+Ground every claim in the code; defer to CLAUDE.md and
+.agents/skills/ever-works/SKILL.md for conventions.
+"""

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,15 @@
+name = "reviewer"
+description = "Read-only reviewer for the ever-works monorepo, focused on correctness, security, and adherence to repo conventions. Never edits files."
+sandbox_mode = "read-only"
+approval_policy = "never"
+instructions = """
+You are a read-only reviewer for the ever-works monorepo. Review diffs for
+correctness bugs, security issues, and adherence to the repo's conventions:
+kebab-case .ts files / PascalCase .tsx components, the @/, @src/, and
+@ever-works/* import aliases, Conventional Commits, and the correct test runner
+per workspace (Jest for packages/agent and apps/api; Vitest for packages/plugin,
+packages/plugins/*, and apps/web unit tests; Playwright for apps/web e2e). Flag
+missing TypeORM migrations for entity changes. Report issues with file paths and
+line references; do not modify files. Defer to CLAUDE.md and
+.agents/skills/ever-works/SKILL.md.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,31 @@
+# Codex configuration for the ever-works monorepo.
+#
+# Authoritative project rules live in AGENTS.md -> CLAUDE.md at the repo root,
+# and a verified summary is in .agents/skills/ever-works/SKILL.md. Read those
+# before making changes.
+
+# Conservative defaults: explore freely, ask before writing.
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+
+# --- MCP servers ---
+# No MCP servers are enabled by default, so this config carries zero
+# supply-chain surface. If you add one, PIN it to an explicit, vetted version.
+# NEVER use `npx -y` without a version, and never `@latest` — an unpinned
+# server silently pulls new, unreviewed code on every run.
+#
+# Example (commented out — uncomment and pin to a version you have vetted):
+#
+# [mcp_servers.playwright]
+# command = "npx"
+# args = ["@playwright/mcp@0.0.41"]   # exact version only — no -y, no @latest
+#
+# For the GitHub MCP server, prefer the official image pinned by tag or digest:
+#
+# [mcp_servers.github]
+# command = "docker"
+# args = [
+#   "run", "-i", "--rm",
+#   "-e", "GITHUB_PERSONAL_ACCESS_TOKEN",
+#   "ghcr.io/github/github-mcp-server:v0.6.0",   # pin the tag (or use @sha256:...)
+# ]


### PR DESCRIPTION
## Summary

Supersedes the closed auto-generated bundle #1646 with a **repo-verified** one. #1646 was closed because its generated skill was factually wrong about this repo and shipped defects. This PR produces the same *kind* of bundle, but every convention claim is checked against the code on `develop`, and the files are review-clean. **All files are new / additive.**

## What #1646 got wrong (and this fixes)

- **Inert SKILL.md** — it was wrapped in an outer ```` ```markdown ```` fence, so the whole skill rendered as a code block. Here the file starts with YAML frontmatter (`---`); the only fenced block in the body is one real `bash` snippet.
- **Factually wrong content** — #1646 claimed camelCase filenames, "does not use a specific framework", relative-only imports, Vitest-only testing, and invented `/new-feature-spec` `/update-i18n` `/new-feature` slash commands. All corrected and verified below.
- **Supply-chain risk** — its `.codex/config.toml` ran 5 MCP servers unpinned via `npx -y`. Here **no MCP servers run**; the only example is commented out and explicitly version-pinned.

## Files included (and why)

| Path | Why |
|---|---|
| `.agents/skills/ever-works/SKILL.md` | Flagship skill — a concise, verified summary of the monorepo. This is the **tracked canonical copy** (the repo already vendors skills under `.agents/skills/`). |
| `.claude/skills/ever-works/SKILL.md` | Identical Claude Code copy. `.claude/` is git-ignored (`.gitignore` line 62), so this mirrors the `.agents/` copy for tools that read `.claude/` locally — matching the repo's existing autoskills `.agents/skills` ↔ `.claude/skills` mirroring. |
| `.agents/skills/ever-works/agents/openai.yaml` | Minimal Codex skill metadata (`name` / `description` / `allow_implicit_invocation`). No existing `agents/openai.yaml` exists in the repo to copy, so it's kept minimal and well-formed. |
| `.claude/identity.json` | Small, accurate identity baseline (technicalLevel, domains, verbosity). |
| `.codex/config.toml` | Codex baseline with conservative defaults and **no active MCP servers** (zero supply-chain surface). |
| `.codex/AGENTS.md` | Short Codex guide that points at the skill and the repo's real `AGENTS.md` → `CLAUDE.md`. |
| `.codex/agents/{explorer,reviewer,docs-researcher}.toml` | Read-only role presets (`sandbox_mode = "read-only"`). |
| `.{claude,agents}/skills/ever-works/references/ui-patterns.md` | Curated CTA (light/dark) + KPI/stat-card design rules, referenced from both SKILL bodies. |

## Deliberately skipped (present in #1646)

- **`.claude/ecc-tools.json`** — a third-party ECC install/upgrade/uninstall manifest. Not ours to hand-maintain.
- **`.claude/homunculus/instincts/*`** — tied to an external continuous-learning skill; optional/niche. The bundle is kept to genuinely-useful, self-maintainable files.

## Convention claims — verifiable evidence (all on `develop`)

- **Package manager / runtime:** `pnpm@10.33.3`, `engines.node ">=22"` — `package.json`.
- **Path aliases:** `@/*` → `apps/web/src/*` (`apps/web/tsconfig.json` → `"@/*": ["./src/*"]`; used in `apps/web/src/i18n/routing.ts` as `from '@/lib/constants'`), `@src/*` → `apps/api/src/*` (`apps/api/tsconfig.json` → `"@src/*": ["./src/*"]`), `@ever-works/*` → workspace packages (`packages/plugin/README.md`); summarized in `CLAUDE.md` → Path Aliases.
- **Test frameworks (Jest + Vitest + Playwright):** `docs/testing/overview.md` (Jest for `packages/agent` ~26 suites/~719 tests + `apps/api`; Vitest for `packages/plugin` + `packages/plugins/*`). Verified in `apps/api/package.json` and `packages/agent/package.json` (`jest --maxWorkers=2`, jest ^29), `packages/plugin/package.json` (`vitest run`), and `apps/web/package.json` (`test: vitest run`, `test:e2e: playwright test`, e2e specs under `apps/web/e2e/*.spec.ts`, `apps/web/playwright.config.ts`).
- **File naming:** kebab-case `.ts` — e.g. `apps/api/src/account/account.controller.ts`, `apps/web/src/lib/hooks/use-local-storage.ts`, `packages/agent/src/account-transfer/account-import.service.ts`. React `.tsx` components predominantly PascalCase — e.g. `apps/web/src/components/activity-log/ActivityTable.tsx` (341 PascalCase vs 48 kebab component files). App Router files lowercase (`page.tsx`, `layout.tsx`). Symbol rules per `CLAUDE.md` → Naming.
- **Commits:** Conventional Commits enforced by commitlint — `package.json` devDeps `@commitlint/cli` + `@commitlint/config-conventional` (^19.8.1), `husky` ^9.1.7; `CLAUDE.md` → Commits.
- **Branches:** `develop` (default) → `stage` → `main` all exist; the repo promotes via `cascade-*-develop-to-stage` / `cascade-*-stage-to-main` branches.
- **Web build gotcha:** `apps/web/package.json` → `build: next build --webpack` (dev uses `--turbopack`).

## Review-clean checklist

- [x] SKILL.md starts with frontmatter `---`, not a code fence.
- [x] No `@latest` / unpinned `npx -y` MCP packages anywhere (`.codex/config.toml` has no active servers).
- [x] All YAML / TOML / JSON parse (validated).
- [x] No invented commands — every command is taken from `package.json`.

Please review before merging. This PR deploys nothing and touches no application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
