### PR TITLE
feat(deploy): managed Ever Works deploy (Path A+B) + shared-cluster namespace security

### DIFF
--- a/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.spec.ts
@@ -5,7 +5,10 @@ import {
     ClusterSource,
     isAdminOnlyOrg,
     isEverWorksSharedOrg,
+    isReservedDeployNamespace,
+    isSharedClusterSource,
     normalizeClusterSource,
+    RESERVED_DEPLOY_NAMESPACES,
     resolveKubeconfigForClusterSource,
     validateClusterSourceForOwner,
 } from './cluster-source-matrix';
@@ -233,6 +236,60 @@ describe('cluster-source-matrix — deploy matrix (renamed: k8s-works internal, 
         it("only the admin-only k8s-works description mentions the 'ever-works' org requirement", () => {
             expect(CLUSTER_SOURCE_DESCRIPTIONS['k8s-works']).toMatch(/ever-works/i);
             expect(CLUSTER_SOURCE_DESCRIPTIONS['k8s-works-shared']).not.toMatch(/admin/i);
+        });
+    });
+
+    // EW (owner item #3b) — server-side namespace enforcement helpers.
+    describe('isReservedDeployNamespace', () => {
+        it.each([
+            'ever-works',
+            'kube-system',
+            'kube-public',
+            'kube-node-lease',
+            'default',
+            'argocd',
+            'cert-manager',
+            'ingress-nginx',
+            'monitoring',
+        ])('rejects the reserved namespace %s', (ns) =>
+            expect(isReservedDeployNamespace(ns)).toBe(true),
+        );
+
+        it('is case- and whitespace-insensitive', () => {
+            expect(isReservedDeployNamespace('  KUBE-System ')).toBe(true);
+            expect(isReservedDeployNamespace('Ever-Works')).toBe(true);
+        });
+
+        it('rejects any kube-* namespace (whole system family), not just the named ones', () => {
+            expect(isReservedDeployNamespace('kube-flannel')).toBe(true);
+            expect(isReservedDeployNamespace('kube-anything')).toBe(true);
+        });
+
+        it.each(['acme', 'my-team', 'ever-works-tenants-user-1', 'tenant-42'])(
+            'allows the ordinary tenant namespace %s',
+            (ns) => expect(isReservedDeployNamespace(ns)).toBe(false),
+        );
+
+        it('treats empty/blank input as not reserved (caller decides)', () => {
+            expect(isReservedDeployNamespace('')).toBe(false);
+            expect(isReservedDeployNamespace('   ')).toBe(false);
+        });
+
+        it('exposes the reserved set for reuse', () => {
+            expect(RESERVED_DEPLOY_NAMESPACES.has('ever-works')).toBe(true);
+            expect(RESERVED_DEPLOY_NAMESPACES.has('acme')).toBe(false);
+        });
+    });
+
+    describe('isSharedClusterSource', () => {
+        it('is true only for the shared customer cluster', () => {
+            expect(isSharedClusterSource('k8s-works-shared')).toBe(true);
+            expect(isSharedClusterSource('k8s-works')).toBe(false);
+            expect(isSharedClusterSource('custom-kubeconfig')).toBe(false);
+        });
+
+        it('normalises the legacy k8s-gauzy alias (→ internal, not shared)', () => {
+            expect(isSharedClusterSource('k8s-gauzy' as ClusterSource)).toBe(false);
         });
     });
 });

--- a/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.ts
+++ b/apps/api/src/plugins-capabilities/deploy/cluster-source-matrix.ts
@@ -253,3 +253,58 @@ export function resolveKubeconfigForClusterSource(
     }
     return userKubeconfig;
 }
+
+/**
+ * Namespaces a tenant deploy may NEVER target on a platform-managed cluster.
+ *
+ * EW — server-side namespace enforcement (Task 7 / owner item #3b). The k8s
+ * `namespace` field is free-text and, before this guard, had no server-side
+ * check — a shared-cluster deploy could target the platform's own
+ * `ever-works` namespace, a Kubernetes system namespace, or another tenant's
+ * space. This is the authoritative blocklist consulted by
+ * `DeployService.resolveDeployNamespace`.
+ *
+ * Any `kube-*` namespace is additionally rejected (see `isReservedDeployNamespace`)
+ * so the whole reserved `kube-system` / `kube-public` / `kube-node-lease`
+ * family is covered even if a new one is introduced upstream.
+ */
+export const RESERVED_DEPLOY_NAMESPACES: ReadonlySet<string> = new Set([
+    'ever-works',
+    'kube-system',
+    'kube-public',
+    'kube-node-lease',
+    'default',
+    'argocd',
+    'cert-manager',
+    'ingress-nginx',
+    'monitoring',
+]);
+
+/**
+ * True when `namespace` is a platform-reserved namespace that no tenant deploy
+ * may target. Matches the explicit `RESERVED_DEPLOY_NAMESPACES` set plus any
+ * `kube-*` namespace. Case- and whitespace-insensitive. An empty/blank input
+ * is NOT reserved (the caller decides how to treat "no namespace supplied").
+ */
+export function isReservedDeployNamespace(namespace: string): boolean {
+    const ns = namespace.trim().toLowerCase();
+    if (!ns) return false;
+    if (RESERVED_DEPLOY_NAMESPACES.has(ns)) return true;
+    // Cover the entire Kubernetes system-namespace family (`kube-system`,
+    // `kube-public`, `kube-node-lease`, and any future `kube-*`).
+    return ns.startsWith('kube-');
+}
+
+/**
+ * True for cluster sources that are a platform-owned SHARED cluster, where a
+ * user-supplied namespace must be ignored in favour of a deterministic
+ * per-tenant namespace (cross-tenant isolation). Today that is exactly
+ * `k8s-works-shared`; the `includes('shared')` guard keeps a future shared
+ * source (e.g. a regional `k8s-works-shared-eu`) covered without a code change.
+ * The internal admin cluster (`k8s-works`) and the user's own cluster
+ * (`custom-kubeconfig`) are NOT shared.
+ */
+export function isSharedClusterSource(clusterSource: ClusterSource): boolean {
+    const source = normalizeClusterSource(clusterSource) ?? clusterSource;
+    return source === 'k8s-works-shared' || source.includes('shared');
+}

--- a/apps/api/src/plugins-capabilities/deploy/deploy.module.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.module.ts
@@ -5,7 +5,11 @@ import { WebsiteGeneratorModule } from '@ever-works/agent/generators';
 import { WorkModule } from '@ever-works/agent/services';
 import { AuthModule } from '../../auth/auth.module';
 import { ActivityLogModule } from '@ever-works/agent/activity-log';
-import { EverWorksDnsService, SubdomainAllocator } from '@ever-works/agent/ever-works-providers';
+import {
+    EverWorksDnsService,
+    EverWorksK8sDeployProvider,
+    SubdomainAllocator,
+} from '@ever-works/agent/ever-works-providers';
 import { DeployController } from './deploy.controller';
 import { DeployService } from './deploy.service';
 import { DeploymentVerifierService } from './tasks/deployment-verifier.service';
@@ -25,6 +29,11 @@ import { ManagedSubdomainService } from './managed-subdomain.service';
         DeployService,
         DeploymentVerifierService,
         EverWorksDnsService,
+        // Task 10 / Path A — dedicated managed-deploy provider, registered so
+        // it is part of the deploy module's DI graph (it was registered
+        // nowhere). The facade resolves `deployProvider === 'ever-works'`
+        // credentials through it (reading `EVER_WORKS_DEPLOY_*`).
+        EverWorksK8sDeployProvider,
         SubdomainAllocator,
         ManagedSubdomainService,
     ],

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.spec.ts
@@ -1414,4 +1414,165 @@ describe('DeployService — plugin-driven dispatch + secrets', () => {
             expect(keys).not.toContain('K8S_EXTRA_HOSTS');
         });
     });
+
+    /**
+     * EW (owner item #3b) — authoritative, server-side namespace enforcement.
+     *
+     * The k8s `namespace` field is free-text; before this the deploy path had
+     * NO server-side check, so a shared-cluster deploy could target
+     * `ever-works` / `kube-system` / another tenant. `resolveDeployNamespace`
+     * OVERRIDES the namespace with a deterministic per-tenant one on shared /
+     * managed clusters and REJECTS any reserved namespace on every source.
+     */
+    describe('server-side namespace enforcement (owner item #3b)', () => {
+        // Reflect the namespace the orchestrator injected into the K8S_NAMESPACE
+        // secret so we can assert on what the workflow will actually receive.
+        const nsSecrets = jest
+            .fn()
+            .mockImplementation(async (settings: Record<string, unknown>) => ({
+                K8S_NAMESPACE:
+                    typeof settings.namespace === 'string' ? settings.namespace : 'ever-works',
+            }));
+
+        const k8sPlugin = () => ({
+            id: 'k8s',
+            getWorkflowFilenames: () => ['deploy_k8s.yaml'],
+            getDeploymentSecrets: nsSecrets,
+        });
+
+        const originalEnv = process.env;
+        beforeEach(() => {
+            nsSecrets.mockClear();
+            process.env = { ...originalEnv };
+            delete process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
+            delete process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG;
+            delete process.env.EVER_WORKS_DEPLOY_NAMESPACE;
+        });
+        afterEach(() => {
+            process.env = originalEnv;
+        });
+
+        it('shared cluster (k8s-works-shared) OVERRIDES a user namespace with a per-tenant one', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'shared-yaml';
+            const { service, githubPlugin } = buildService({
+                plugin: k8sPlugin(),
+                deployProvider: 'k8s',
+                websiteOwner: 'acme',
+                // A hostile user tries to target the platform's own namespace.
+                settings: { clusterSource: 'k8s-works-shared', namespace: 'kube-system' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            const settingsArg = nsSecrets.mock.calls[0][0];
+            expect(settingsArg.namespace).toBe('ever-works-tenants-user-1');
+            const byKey = Object.fromEntries(
+                captureCalls(githubPlugin).secrets.map((s: any) => [s.key, s.value]),
+            );
+            // The user's `kube-system` never reaches the pushed secret.
+            expect(byKey.K8S_NAMESPACE).toBe('ever-works-tenants-user-1');
+        });
+
+        it('honours EVER_WORKS_DEPLOY_NAMESPACE as the per-tenant base', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'shared-yaml';
+            process.env.EVER_WORKS_DEPLOY_NAMESPACE = 'tenants';
+            const { service } = buildService({
+                plugin: k8sPlugin(),
+                deployProvider: 'k8s',
+                websiteOwner: 'acme',
+                settings: { clusterSource: 'k8s-works-shared' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            expect(nsSecrets.mock.calls[0][0].namespace).toBe('tenants-user-1');
+        });
+
+        it('the managed ever-works provider always gets a per-tenant namespace', async () => {
+            const { service } = buildService({
+                plugin: k8sPlugin(),
+                deployProvider: 'ever-works',
+                websiteOwner: 'acme',
+                token: 'platform-managed-kubeconfig',
+                settings: { namespace: 'ever-works' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            expect(nsSecrets.mock.calls[0][0].namespace).toBe('ever-works-tenants-user-1');
+        });
+
+        it('rejects a reserved namespace on custom-kubeconfig (blocklist applies to every source)', async () => {
+            const { service } = buildService({
+                plugin: k8sPlugin(),
+                deployProvider: 'k8s',
+                websiteOwner: 'acme',
+                token: 'user-pasted-yaml',
+                settings: { clusterSource: 'custom-kubeconfig', namespace: 'ever-works' },
+            });
+
+            await expect(service.deploy('work-1', 'user-1', {})).rejects.toThrow(/reserved/i);
+        });
+
+        it('rejects a kube-* namespace on the admin internal cluster (k8s-works)', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_KUBECONFIG = 'internal-yaml';
+            const { service } = buildService({
+                plugin: k8sPlugin(),
+                deployProvider: 'k8s',
+                websiteOwner: 'ever-works',
+                isPlatformAdmin: true,
+                settings: { clusterSource: 'k8s-works', namespace: 'kube-flannel' },
+            });
+
+            await expect(service.deploy('work-1', 'user-1', {})).rejects.toThrow(/reserved/i);
+        });
+
+        it('passes a valid custom-kubeconfig namespace through unchanged', async () => {
+            const { service } = buildService({
+                plugin: k8sPlugin(),
+                deployProvider: 'k8s',
+                websiteOwner: 'acme',
+                token: 'user-pasted-yaml',
+                settings: { clusterSource: 'custom-kubeconfig', namespace: 'my-team' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            expect(nsSecrets.mock.calls[0][0].namespace).toBe('my-team');
+        });
+
+        it('leaves the namespace untouched (plugin default) when none is supplied on a user cluster', async () => {
+            const { service } = buildService({
+                plugin: k8sPlugin(),
+                deployProvider: 'k8s',
+                websiteOwner: 'acme',
+                token: 'user-pasted-yaml',
+                settings: { clusterSource: 'custom-kubeconfig' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            // No override injected → plugin falls back to its own default.
+            expect(nsSecrets.mock.calls[0][0].namespace).toBeUndefined();
+        });
+
+        it('does not touch the namespace for non-k8s providers (Vercel)', async () => {
+            const { service } = buildService({
+                deployProvider: 'vercel',
+                plugin: {
+                    id: 'vercel',
+                    getWorkflowFilenames: () => ['deploy_vercel.yaml'],
+                    getDeploymentSecrets: nsSecrets,
+                },
+                token: 'vercel-token',
+                settings: { namespace: 'kube-system' },
+            });
+
+            await service.deploy('work-1', 'user-1', {});
+
+            // Vercel has no namespace concept — the reserved value is ignored,
+            // not rejected, and no per-tenant override is applied.
+            expect(nsSecrets.mock.calls[0][0].namespace).toBe('kube-system');
+        });
+    });
 });

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -29,7 +29,11 @@ import {
     WorkRuntimeEnvService,
     ZeroFrictionFunnelService,
 } from '@ever-works/agent/services';
-import { EverWorksDnsService, SubdomainAllocator } from '@ever-works/agent/ever-works-providers';
+import {
+    EverWorksDnsService,
+    SubdomainAllocator,
+    buildEverWorksTenantNamespace,
+} from '@ever-works/agent/ever-works-providers';
 import { ZERO_FRICTION_FUNNEL_EVENTS } from '@ever-works/contracts/telemetry';
 import {
     WebsiteUpdateService,
@@ -41,6 +45,8 @@ import type { IDeploymentPlugin } from '@ever-works/plugin';
 import type { BatchDeployItemDto, BatchDeployItemResultDto } from './dto/batch-deploy.dto';
 import {
     ClusterSource,
+    isReservedDeployNamespace,
+    isSharedClusterSource,
     normalizeClusterSource,
     resolveKubeconfigForClusterSource,
     validateClusterSourceForOwner,
@@ -236,7 +242,24 @@ export class DeployService {
         // the user's directory is reachable at that subdomain without any
         // manual DNS. If env vars are missing the DNS service no-ops; the
         // k8s plugin's default LB hostname remains the fallback.
-        const deploySettings = await this.applyManagedSubdomain(work, settings);
+        let deploySettings = await this.applyManagedSubdomain(work, settings);
+
+        // EW (owner item #3b) — authoritative, server-side namespace policy.
+        // The k8s `namespace` field is free-text with no client-side guarantee;
+        // enforce the per-tenant override (shared clusters) + reserved-namespace
+        // blocklist HERE, before the plugin's `getDeploymentSecrets` turns it
+        // into the pushed `K8S_NAMESPACE`. A user-supplied `ever-works` /
+        // `kube-system` / other-tenant namespace can never reach the cluster.
+        const enforcedNamespace = this.resolveDeployNamespace(
+            work.deployProvider,
+            plugin?.id,
+            work,
+            settings ?? {},
+        );
+        if (enforcedNamespace !== undefined) {
+            deploySettings = { ...(deploySettings ?? {}), namespace: enforcedNamespace };
+        }
+
         await this.setRequiredSecrets(ctx, effectiveDeployToken, work, plugin, deploySettings);
         await this.setKubernetesGhcrPullSecret(ctx, work, userId, plugin);
         await this.setOptionalSecrets(ctx, options.teamScope, gitToken);
@@ -447,6 +470,20 @@ export class DeployService {
             return userToken;
         }
 
+        // Task 10 — the managed `ever-works` provider deploys to a
+        // platform-OWNED cluster using a platform-HELD kubeconfig that the
+        // deploy facade already resolved from `EVER_WORKS_DEPLOY_*` (dedicated,
+        // Path A) or `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` (shared, Path B).
+        // The user-cluster deploy matrix (`validateClusterSourceForOwner`)
+        // exists to stop a USER's own cluster from receiving a shared-org PAT —
+        // it does not apply here, and applying it would wrongly reject managed
+        // deploys whose website repo lives in the `ever-works-cloud` storage
+        // org (rule 2). Pass the platform kubeconfig straight through; strip
+        // the sentinel so it can never leak into `K8S_TOKEN`.
+        if (deployProvider === EVER_WORKS_DEPLOY_PROVIDER_ID) {
+            return userToken === PLATFORM_MANAGED_KUBECONFIG_SENTINEL ? '' : userToken;
+        }
+
         // EW-616: the deploy facade returns a sentinel string when the
         // user picked a platform-managed cluster without pasting a
         // kubeconfig. Treat it as "no kubeconfig" for the validator and
@@ -477,6 +514,68 @@ export class DeployService {
             this.logger.error(`Cluster-source resolution failed for ${websiteOwner}: ${message}`);
             throw new InternalServerErrorException(message);
         }
+    }
+
+    /**
+     * EW (owner item #3b) — authoritative per-tenant namespace resolution for
+     * the k8s deploy path. Mirrors `resolveDeployToken`: a no-op pass-through
+     * (returns `undefined`) for non-k8s providers, so Vercel and friends are
+     * untouched.
+     *
+     * Policy (see `cluster-source-matrix`):
+     *  - **Shared, platform-owned clusters** (`k8s-works-shared`, any shared
+     *    source) AND the managed `ever-works` provider: OVERRIDE whatever the
+     *    user typed with a deterministic per-tenant namespace
+     *    (`{base}-{ownerUserId}`). The namespace field is never user-editable
+     *    to a foreign/system namespace on a cluster shared with other tenants.
+     *  - **All other k8s sources** (`custom-kubeconfig` = user's own cluster,
+     *    `k8s-works` = admin internal): the user's namespace passes through,
+     *    but a platform-reserved namespace (`ever-works`, `kube-system`, …,
+     *    any `kube-*`) is rejected with a clear 400. An empty namespace returns
+     *    `undefined` so the k8s plugin keeps its existing default.
+     *
+     * Returns the namespace to force onto `deploySettings.namespace`, or
+     * `undefined` to leave the plugin's own resolution in place.
+     */
+    private resolveDeployNamespace(
+        deployProvider: string | undefined,
+        pluginId: string | undefined,
+        work: Work,
+        settings: Record<string, unknown>,
+    ): string | undefined {
+        if (!this.isKubernetesDeploy(deployProvider, pluginId)) {
+            return undefined;
+        }
+
+        const clusterSource = coerceClusterSource(settings.clusterSource);
+        const isManagedShared =
+            deployProvider === EVER_WORKS_DEPLOY_PROVIDER_ID ||
+            isSharedClusterSource(clusterSource);
+
+        if (isManagedShared) {
+            // Cross-tenant isolation: ignore user input entirely and derive a
+            // deterministic per-tenant namespace from the Work owner.
+            const owner = work.user as User | undefined;
+            const tenantId = owner?.id || work.id;
+            const base = process.env.EVER_WORKS_DEPLOY_NAMESPACE?.trim() || 'ever-works-tenants';
+            return buildEverWorksTenantNamespace(tenantId, base);
+        }
+
+        // custom-kubeconfig (user's own cluster) / k8s-works (admin internal):
+        // honour the user's namespace, but never a platform-reserved one.
+        const requested = typeof settings.namespace === 'string' ? settings.namespace.trim() : '';
+        if (!requested) {
+            return undefined;
+        }
+        if (isReservedDeployNamespace(requested)) {
+            const message =
+                `Namespace '${requested}' is reserved and cannot be used as a deploy target. ` +
+                `Choose a different namespace (reserved: ever-works, default, kube-*, argocd, ` +
+                `cert-manager, ingress-nginx, monitoring).`;
+            this.logger.warn(`Deploy namespace rejected for work ${work.id}: ${message}`);
+            throw new BadRequestException(message);
+        }
+        return requested;
     }
 
     private async createRepoContext(

--- a/packages/agent/src/ever-works-providers/ever-works-k8s-deploy.provider.ts
+++ b/packages/agent/src/ever-works-providers/ever-works-k8s-deploy.provider.ts
@@ -56,10 +56,7 @@ export class EverWorksK8sDeployProvider {
      */
     getNamespaceForUser(userId: string, override?: string): string {
         const base = override ?? config.everWorks.deploy.getNamespace();
-        const sanitisedUserId = sanitiseDnsLabel(userId);
-        const candidate = `${base}-${sanitisedUserId}`;
-        // K8s namespace names must be ≤ 63 chars (RFC 1123).
-        return candidate.length > 63 ? candidate.slice(0, 63).replace(/-+$/, '') : candidate;
+        return buildEverWorksTenantNamespace(userId, base);
     }
 
     /**
@@ -97,12 +94,43 @@ export class EverWorksK8sDeployProvider {
             throw new EverWorksDeployDisabledError();
         }
 
-        const inlineKubeconfig = env?.kubeconfig ?? config.everWorks.deploy.getKubeconfig();
-        const pathKubeconfig = env?.kubeconfigPath ?? config.everWorks.deploy.getKubeconfigPath();
+        const kubeconfig = await this.resolveKubeconfig({
+            kubeconfig: env?.kubeconfig,
+            kubeconfigPath: env?.kubeconfigPath,
+            readFile: options.readFile,
+        });
+
+        return {
+            kubeconfig,
+            namespace: this.getNamespaceForUser(options.work.userId, env?.namespace),
+            ingressHost: this.resolveIngressHost(options.work, env?.ingressHostTemplate),
+            ingressClass: env?.ingressClass ?? config.everWorks.deploy.getIngressClass(),
+            tlsIssuer: env?.tlsIssuer ?? config.everWorks.deploy.getTlsIssuer(),
+            registry: (env?.registry ?? config.everWorks.deploy.getRegistry()) || undefined,
+        };
+    }
+
+    /**
+     * Resolve just the platform-held kubeconfig for the dedicated Ever Works
+     * deploy cluster (Path A). Reads `EVER_WORKS_DEPLOY_KUBECONFIG` inline, or
+     * `EVER_WORKS_DEPLOY_KUBECONFIG_PATH` from disk, matching `buildConfig`.
+     * Throws `EverWorksDeployMisconfiguredError` when neither is set or the
+     * file read fails. Exposed so the deploy facade can source the `K8S_TOKEN`
+     * for a `deployProvider === 'ever-works'` deploy without also templating
+     * an ingress host it doesn't need at credential-resolution time.
+     */
+    async resolveKubeconfig(source?: {
+        readonly kubeconfig?: string;
+        readonly kubeconfigPath?: string;
+        readonly readFile?: EverWorksKubeconfigReader;
+    }): Promise<string> {
+        const inlineKubeconfig = source?.kubeconfig ?? config.everWorks.deploy.getKubeconfig();
+        const pathKubeconfig =
+            source?.kubeconfigPath ?? config.everWorks.deploy.getKubeconfigPath();
 
         let kubeconfig = inlineKubeconfig;
         if (!kubeconfig && pathKubeconfig) {
-            const reader = options.readFile ?? ((path: string) => fs.readFile(path, 'utf-8'));
+            const reader = source?.readFile ?? ((path: string) => fs.readFile(path, 'utf-8'));
             try {
                 kubeconfig = await reader(pathKubeconfig);
             } catch (cause) {
@@ -118,18 +146,27 @@ export class EverWorksK8sDeployProvider {
             );
         }
 
-        return {
-            kubeconfig,
-            namespace: this.getNamespaceForUser(options.work.userId, env?.namespace),
-            ingressHost: this.resolveIngressHost(options.work, env?.ingressHostTemplate),
-            ingressClass: env?.ingressClass ?? config.everWorks.deploy.getIngressClass(),
-            tlsIssuer: env?.tlsIssuer ?? config.everWorks.deploy.getTlsIssuer(),
-            registry: (env?.registry ?? config.everWorks.deploy.getRegistry()) || undefined,
-        };
+        return kubeconfig;
     }
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Deterministic per-tenant Kubernetes namespace for a user: `{base}-{userId}`,
+ * DNS-label-sanitised and capped at the RFC-1123 63-char limit.
+ *
+ * Exported as the single source of truth for the per-tenant namespace scheme
+ * so the authoritative server-side enforcement in the API deploy service
+ * (`DeployService.resolveDeployNamespace`) and this provider's
+ * `getNamespaceForUser` can never drift apart.
+ */
+export function buildEverWorksTenantNamespace(userId: string, base: string): string {
+    const sanitisedUserId = sanitiseDnsLabel(userId);
+    const candidate = `${base}-${sanitisedUserId}`;
+    // K8s namespace names must be ≤ 63 chars (RFC 1123).
+    return candidate.length > 63 ? candidate.slice(0, 63).replace(/-+$/, '') : candidate;
+}
 
 function sanitiseDnsLabel(input: string): string {
     return input

--- a/packages/agent/src/ever-works-providers/index.ts
+++ b/packages/agent/src/ever-works-providers/index.ts
@@ -7,6 +7,7 @@ export * from './types';
 export { EverWorksGitProvider, type EverWorksGitHttpFetch } from './ever-works-git.provider';
 export {
     EverWorksK8sDeployProvider,
+    buildEverWorksTenantNamespace,
     type EverWorksKubeconfigReader,
 } from './ever-works-k8s-deploy.provider';
 export {

--- a/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/deploy.facade.spec.ts
@@ -516,4 +516,117 @@ describe('DeployFacadeService', () => {
             expect(failing).toHaveBeenCalled();
         });
     });
+
+    /**
+     * Task 10 — the managed `ever-works` deploy provider sources its kubeconfig
+     * from platform env, NOT from the user's k8s settings. The infra owner
+     * decides Path A vs Path B purely by which env var they provision:
+     *   - Path A: `EVER_WORKS_DEPLOY_*` (dedicated cluster, via the provider).
+     *   - Path B: `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` (shared cluster).
+     * When neither is set, resolution gracefully keeps the existing
+     * sentinel/user-kubeconfig behaviour (never crashes).
+     */
+    describe('Task 10 — managed ever-works kubeconfig resolution (Path A + Path B)', () => {
+        const ORIGINAL_SHARED = process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
+        afterEach(() => {
+            if (ORIGINAL_SHARED === undefined) {
+                delete process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
+            } else {
+                process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = ORIGINAL_SHARED;
+            }
+        });
+
+        const build = (args: {
+            everWorks: { isEnabled: () => boolean; resolveKubeconfig?: jest.Mock };
+            settings?: Record<string, { value?: unknown }>;
+        }) => {
+            const plugin = {
+                id: 'k8s',
+                name: 'Kubernetes',
+                providerName: 'kubernetes',
+                capabilities: ['deployment'],
+            };
+            const registered = {
+                plugin,
+                manifest: {
+                    id: 'k8s',
+                    name: 'Kubernetes',
+                    category: 'deployment',
+                    capabilities: ['deployment'],
+                    description: '',
+                    icon: { type: 'lucide', value: 'Container' },
+                },
+                state: 'loaded',
+            };
+            const registry = {
+                get: jest.fn((id: string) => (id === 'k8s' ? registered : undefined)),
+                getByCapability: jest.fn(() => [registered]),
+            };
+            const settingsService = {
+                getResolvedSettings: jest.fn().mockResolvedValue(args.settings ?? {}),
+                getSettings: jest.fn().mockResolvedValue({}),
+            };
+            const workRepository = {
+                findById: jest
+                    .fn()
+                    .mockResolvedValue({ id: 'work-1', deployProvider: 'ever-works' }),
+                update: jest.fn(),
+            };
+            const domainRepository = { findByWork: jest.fn().mockResolvedValue([]) };
+            const service = new DeployFacadeService(
+                registry as any,
+                settingsService as any,
+                workRepository as any,
+                {} as any,
+                domainRepository as any,
+                undefined,
+                args.everWorks as any,
+            );
+            return { service };
+        };
+
+        it('Path A — uses the dedicated cluster kubeconfig from EverWorksK8sDeployProvider when enabled', async () => {
+            const resolveKubeconfig = jest.fn().mockResolvedValue('dedicated-kubeconfig');
+            const { service } = build({ everWorks: { isEnabled: () => true, resolveKubeconfig } });
+
+            const resolved = await service.getPluginAndTokenAndSettings({
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            expect(resolveKubeconfig).toHaveBeenCalledTimes(1);
+            expect(resolved.plugin.id).toBe('k8s');
+            expect(resolved.token).toBe('dedicated-kubeconfig');
+        });
+
+        it('Path B — falls back to EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG when the dedicated provider is disabled', async () => {
+            process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG = 'shared-cluster-kubeconfig';
+            const resolveKubeconfig = jest.fn();
+            const { service } = build({ everWorks: { isEnabled: () => false, resolveKubeconfig } });
+
+            const resolved = await service.getPluginAndTokenAndSettings({
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            // Dedicated provider is disabled → never consulted for a kubeconfig.
+            expect(resolveKubeconfig).not.toHaveBeenCalled();
+            expect(resolved.token).toBe('shared-cluster-kubeconfig');
+        });
+
+        it('gracefully keeps the platform-managed sentinel when neither managed cluster is configured', async () => {
+            delete process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG;
+            const { service } = build({
+                everWorks: { isEnabled: () => false },
+                settings: { clusterSource: { value: 'k8s-works' } },
+            });
+
+            const resolved = await service.getPluginAndTokenAndSettings({
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+
+            expect(resolved.token).toBe(PLATFORM_MANAGED_KUBECONFIG_SENTINEL);
+        });
+    });
 });

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import type {
     IDeploymentPlugin,
     IDeployFacade,
@@ -17,6 +17,7 @@ import { WorkPluginRepository } from '../plugins/repositories/work-plugin.reposi
 import { WorkRepository } from '../database/repositories/work.repository';
 import { GitFacadeService } from './git.facade';
 import { WorkCustomDomainRepository } from '../database/repositories/work-custom-domain.repository';
+import { EverWorksK8sDeployProvider } from '../ever-works-providers';
 import { FacadeError, NoProviderError, ProviderNotFoundError } from './base.facade';
 import type { Work } from '../entities/work.entity';
 import type { User } from '../entities/user.entity';
@@ -101,6 +102,13 @@ export class DeployFacadeService implements IDeployFacade {
         private readonly gitFacade: GitFacadeService,
         private readonly domainRepository: WorkCustomDomainRepository,
         private readonly workPluginRepository?: WorkPluginRepository,
+        // Task 10 / Path A — the dedicated managed-deploy provider. Optional so
+        // the many hand-constructed test fixtures (and any injector that hasn't
+        // registered it) keep working; when absent we self-instantiate the
+        // stateless provider, which reads `EVER_WORKS_DEPLOY_*` from env at call
+        // time. Registered as a real Nest provider in the work + deploy modules.
+        @Optional()
+        private readonly everWorksDeployProvider: EverWorksK8sDeployProvider = new EverWorksK8sDeployProvider(),
     ) {}
 
     resolveProviderId(providerId: string): string {
@@ -862,11 +870,25 @@ export class DeployFacadeService implements IDeployFacade {
         }
 
         // Get token from plugin settings (user-required mode)
-        const token = await this.getTokenFromSettings(
+        let token = await this.getTokenFromSettings(
             pluginProviderId,
             options.userId,
             options.workId,
         );
+
+        // Task 10 (Path A + Path B) — for the managed `ever-works` provider,
+        // source the deploy kubeconfig from the platform env (dedicated tenant
+        // cluster, or the shared customer cluster) instead of the user's k8s
+        // settings. When neither env is provisioned this returns null and we
+        // keep the existing sentinel/user-kubeconfig behaviour so nothing
+        // regresses and a downstream layer surfaces the clear "not available
+        // yet" error rather than crashing.
+        if (providerId === EVER_WORKS_DEPLOY_PROVIDER_ID) {
+            const managedKubeconfig = await this.resolveEverWorksManagedKubeconfig();
+            if (managedKubeconfig) {
+                token = managedKubeconfig;
+            }
+        }
 
         if (!token) {
             const providerName =
@@ -879,6 +901,46 @@ export class DeployFacadeService implements IDeployFacade {
             token,
             work,
         };
+    }
+
+    /**
+     * Task 10 — resolve the platform-held kubeconfig for a managed
+     * `ever-works` deploy. The owner chose BOTH managed backends; which one is
+     * live is decided purely by which env var the infra owner provisioned:
+     *
+     *   - **Path A (dedicated tenant cluster):**
+     *     `EVER_WORKS_DEPLOY_KUBECONFIG` / `EVER_WORKS_DEPLOY_KUBECONFIG_PATH`
+     *     — resolved via `EverWorksK8sDeployProvider` (preferred when enabled).
+     *   - **Path B (shared customer cluster):**
+     *     `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG` — read directly here as a
+     *     fallback when the dedicated cluster is not configured.
+     *
+     * Returns `null` when neither is configured so the caller keeps the
+     * existing behaviour; this method never throws so a not-yet-provisioned
+     * managed cluster cannot crash the deploy resolution.
+     */
+    private async resolveEverWorksManagedKubeconfig(): Promise<string | null> {
+        // Path A — dedicated cluster (env-gated via DEPLOY_EVER_WORKS_ENABLED +
+        // a configured kubeconfig).
+        if (this.everWorksDeployProvider?.isEnabled()) {
+            try {
+                return await this.everWorksDeployProvider.resolveKubeconfig();
+            } catch (error) {
+                this.logger.warn(
+                    `Ever Works dedicated deploy kubeconfig is enabled but could not be resolved: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
+
+        // Path B — shared customer cluster.
+        const shared = process.env.EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG?.trim();
+        if (shared) {
+            return shared;
+        }
+
+        return null;
     }
 
     /**

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -48,6 +48,7 @@ import {
     EVER_WORKS_DEPLOY_QUOTA_COUNTER,
     EverWorksDeployQuotaService,
     EverWorksGitProvider,
+    EverWorksK8sDeployProvider,
     EverWorksDnsService,
     type EverWorksDeployQuotaCounter,
 } from '@src/ever-works-providers';
@@ -114,6 +115,13 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         // PAT, so users picking "Ever Works Git" don't need to bring their
         // own GitHub. Consumed by `WorkLifecycleService.createWork`.
         EverWorksGitProvider,
+        // Task 10 / Path A — the dedicated managed-deploy provider. It builds
+        // the per-Work k8s deploy config (kubeconfig + per-tenant namespace +
+        // ingress) from `EVER_WORKS_DEPLOY_*` env for `deployProvider ===
+        // 'ever-works'`. It exists + is unit-tested but was registered nowhere;
+        // register it here so consumers (e.g. `WorkLifecycleService`) can inject
+        // it and it participates in the DI graph.
+        EverWorksK8sDeployProvider,
         EverWorksDnsService,
         {
             // The Ever Works Deploy quota service is repo-agnostic — it

--- a/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
+++ b/packages/plugins/k8s/src/__tests__/k8s.plugin.spec.ts
@@ -154,6 +154,18 @@ describe('KubernetesPlugin metadata', () => {
 		});
 	});
 
+	it('hides the namespace field for platform-managed sources (server enforces per-tenant namespace)', () => {
+		// Owner item #3b — defense-in-depth for the authoritative server-side
+		// namespace enforcement: on shared/managed clusters the namespace is
+		// assigned per tenant, so the free-text field is hidden and only shown
+		// for a user's own cluster (custom-kubeconfig).
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.namespace?.['x-showIf']).toEqual({
+			field: 'clusterSource',
+			value: 'custom-kubeconfig'
+		});
+	});
+
 	it('registry sub-form is a oneOf with three branches (github default)', () => {
 		const reg = plugin.settingsSchema.properties?.registry as { oneOf?: unknown[]; default?: { kind: string } };
 		expect(reg.oneOf).toHaveLength(3);

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -193,7 +193,21 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 			namespace: {
 				type: 'string',
 				title: 'Namespace',
-				default: DEFAULT_NAMESPACE
+				// `DEFAULT_NAMESPACE` (`ever-works`) is kept for back-compat with
+				// pre-existing custom-kubeconfig Works that rely on it on their OWN
+				// cluster. It is intentionally NOT surfaced/used for shared or
+				// managed sources: the server (`DeployService.resolveDeployNamespace`)
+				// OVERRIDES it with a deterministic per-tenant namespace on shared
+				// clusters and REJECTS reserved namespaces on every source, so this
+				// default can never reach a platform-owned namespace.
+				default: DEFAULT_NAMESPACE,
+				description:
+					"Only used when 'Target cluster' is 'custom-kubeconfig' (your own cluster). On platform-managed clusters the namespace is assigned automatically per tenant and this field is ignored.",
+				// Defense-in-depth for the server-side namespace enforcement:
+				// hide/lock the field for platform-managed sources so a shared- or
+				// internal-cluster tenant cannot even attempt to type a foreign or
+				// system namespace. The server remains authoritative regardless.
+				'x-showIf': { field: 'clusterSource', value: 'custom-kubeconfig' }
 			},
 			registry: REGISTRY_SCHEMA,
 			ingressClass: {


### PR DESCRIPTION
Deploy-side changes (owner items #1 + #3b). Validated locally: contracts+plugin build 0; agent + k8s-plugin + api type-check 0; Jest 128 (deploy.service+matrix) + 37 (facade+provider) + 71 (controller), Vitest 41 (k8s.plugin) all pass; eslint/prettier clean on changed files.

**#3b — namespace security (server-authoritative):** new `resolveDeployNamespace` — reserved-namespace blocklist on every source (`ever-works`, `kube-*`, `argocd`, …→ 400), and a deterministic per-tenant namespace (`{base}-{userId}`) forced on shared/managed sources so a customer can't target a platform/system namespace. Client field hidden for managed sources (`x-showIf`).

**#1 — managed "Ever Works" deploy, both paths:** registers the previously-unwired `EverWorksK8sDeployProvider`; **Path A** reads `EVER_WORKS_DEPLOY_KUBECONFIG` (gated by `DEPLOY_EVER_WORKS_ENABLED`), **Path B** falls back to `EVER_WORKS_K8S_WORKS_SHARED_KUBECONFIG`; owner picks by which env is provisioned; graceful (never crashes) when neither is set. Code reads env only — sets nothing.

Additive; no removals. Needs the API image rebuilt + env provisioned to activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)