### PR TITLE
feat(vercel): OAuth Connect flow (env-gated; token fallback kept)

### DIFF
--- a/packages/plugins/vercel/src/__tests__/vercel.plugin.spec.ts
+++ b/packages/plugins/vercel/src/__tests__/vercel.plugin.spec.ts
@@ -1,13 +1,28 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { VercelPlugin } from '../vercel.plugin';
 import type { PluginContext } from '@ever-works/plugin';
+
+const okJsonResponse = (body: unknown): Response =>
+	({
+		ok: true,
+		status: 200,
+		json: () => Promise.resolve(body)
+	}) as unknown as Response;
 
 describe('VercelPlugin', () => {
 	let plugin: VercelPlugin;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// Ensure OAuth env is unset by default so the capability stays gated off.
+		vi.stubEnv('VERCEL_OAUTH_CLIENT_ID', '');
+		vi.stubEnv('VERCEL_OAUTH_CLIENT_SECRET', '');
+		vi.stubEnv('VERCEL_INTEGRATION_SLUG', '');
 		plugin = new VercelPlugin();
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
 	});
 
 	describe('metadata', () => {
@@ -37,6 +52,30 @@ describe('VercelPlugin', () => {
 		});
 	});
 
+	describe('OAuth capability gating', () => {
+		it('does NOT advertise oauth when the integration env vars are unset', () => {
+			expect(plugin.capabilities).toEqual(['deployment']);
+			expect(plugin.getManifest().capabilities).toEqual(['deployment']);
+		});
+
+		it('advertises oauth once client id + secret + slug are configured via env', () => {
+			vi.stubEnv('VERCEL_OAUTH_CLIENT_ID', 'cid');
+			vi.stubEnv('VERCEL_OAUTH_CLIENT_SECRET', 'csec');
+			vi.stubEnv('VERCEL_INTEGRATION_SLUG', 'ever-works');
+			const configured = new VercelPlugin();
+			expect(configured.capabilities).toEqual(['deployment', 'oauth']);
+			expect(configured.getManifest().capabilities).toEqual(['deployment', 'oauth']);
+		});
+
+		it('stays gated off when the slug is missing (URL cannot be built)', () => {
+			vi.stubEnv('VERCEL_OAUTH_CLIENT_ID', 'cid');
+			vi.stubEnv('VERCEL_OAUTH_CLIENT_SECRET', 'csec');
+			// slug intentionally left empty
+			const configured = new VercelPlugin();
+			expect(configured.capabilities).toEqual(['deployment']);
+		});
+	});
+
 	describe('settingsSchema', () => {
 		it('should have required apiToken field', () => {
 			expect(plugin.settingsSchema).toBeDefined();
@@ -52,9 +91,158 @@ describe('VercelPlugin', () => {
 			expect(apiTokenSchema['x-scope']).toBe('user');
 		});
 
-		it('should only require an api token in user settings', () => {
-			expect(Object.keys(plugin.settingsSchema.properties || {})).toEqual(['apiToken']);
-			expect(plugin.settingsSchema.required).toContain('apiToken');
+		it('keeps apiToken as the only required field and adds OAuth integration settings', () => {
+			expect(Object.keys(plugin.settingsSchema.properties || {})).toEqual([
+				'apiToken',
+				'clientId',
+				'clientSecret',
+				'integrationSlug'
+			]);
+			expect(plugin.settingsSchema.required).toEqual(['apiToken']);
+		});
+
+		it('binds the OAuth settings to their env vars (x-envVar)', () => {
+			const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+			expect(props.clientId['x-envVar']).toBe('VERCEL_OAUTH_CLIENT_ID');
+			expect(props.clientId['x-adminOnly']).toBe(true);
+			expect(props.clientSecret['x-envVar']).toBe('VERCEL_OAUTH_CLIENT_SECRET');
+			expect(props.clientSecret['x-secret']).toBe(true);
+			expect(props.integrationSlug['x-envVar']).toBe('VERCEL_INTEGRATION_SLUG');
+		});
+	});
+
+	describe('IOAuthPlugin — getAuthorizationUrl', () => {
+		it('throws when the integration slug is not configured', () => {
+			expect(() => plugin.getAuthorizationUrl('state', { clientId: 'cid' })).toThrow(
+				/VERCEL_INTEGRATION_SLUG/
+			);
+		});
+
+		it('throws when the client id is missing', () => {
+			vi.stubEnv('VERCEL_INTEGRATION_SLUG', 'ever-works');
+			expect(() => plugin.getAuthorizationUrl('state')).toThrow(/client ID not configured/i);
+		});
+
+		it('builds the classic integration install URL with state, scope, redirect_uri', () => {
+			vi.stubEnv('VERCEL_INTEGRATION_SLUG', 'ever-works');
+			const url = plugin.getAuthorizationUrl('xyz', {
+				clientId: 'cid',
+				redirectUri: 'https://app.ever.works/api/oauth/vercel/callback/plugins',
+				scopes: ['user', 'project']
+			});
+			expect(url.startsWith('https://vercel.com/integrations/ever-works/new?')).toBe(true);
+			const u = new URL(url);
+			expect(u.searchParams.get('client_id')).toBe('cid');
+			expect(u.searchParams.get('state')).toBe('xyz');
+			expect(u.searchParams.get('scope')).toBe('user project');
+			expect(u.searchParams.get('redirect_uri')).toBe(
+				'https://app.ever.works/api/oauth/vercel/callback/plugins'
+			);
+		});
+
+		it('falls back to the client id + slug env vars when config omits them', () => {
+			vi.stubEnv('VERCEL_OAUTH_CLIENT_ID', 'env-cid');
+			vi.stubEnv('VERCEL_INTEGRATION_SLUG', 'ever-works');
+			const url = plugin.getAuthorizationUrl('s');
+			const u = new URL(url);
+			expect(u.pathname).toBe('/integrations/ever-works/new');
+			expect(u.searchParams.get('client_id')).toBe('env-cid');
+			// default scopes applied when none supplied
+			expect((u.searchParams.get('scope') as string).length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('IOAuthPlugin — exchangeCodeForToken', () => {
+		const originalFetch = globalThis.fetch;
+		let fetchMock: ReturnType<typeof vi.fn>;
+
+		beforeEach(() => {
+			fetchMock = vi.fn();
+			globalThis.fetch = fetchMock as unknown as typeof fetch;
+		});
+
+		afterEach(() => {
+			globalThis.fetch = originalFetch;
+		});
+
+		it('throws when client id or secret is missing', async () => {
+			await expect(plugin.exchangeCodeForToken('code')).rejects.toThrow(/credentials not configured/i);
+			await expect(plugin.exchangeCodeForToken('code', { clientId: 'cid' })).rejects.toThrow(
+				/credentials not configured/i
+			);
+		});
+
+		it('posts form-encoded credentials to the Vercel token endpoint', async () => {
+			fetchMock.mockResolvedValueOnce(
+				okJsonResponse({ access_token: 'tok', token_type: 'Bearer', scope: 'user project' })
+			);
+			const t = await plugin.exchangeCodeForToken('code', {
+				clientId: 'cid',
+				clientSecret: 'csec',
+				redirectUri: 'https://r/cb'
+			});
+			expect(t).toEqual({ accessToken: 'tok', tokenType: 'Bearer', scope: 'user project' });
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe('https://api.vercel.com/v2/oauth/access_token');
+			expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+				'application/x-www-form-urlencoded'
+			);
+			const body = new URLSearchParams(init.body as string);
+			expect(body.get('client_id')).toBe('cid');
+			expect(body.get('client_secret')).toBe('csec');
+			expect(body.get('code')).toBe('code');
+			expect(body.get('redirect_uri')).toBe('https://r/cb');
+		});
+
+		it('defaults tokenType to "bearer" when the response omits it', async () => {
+			fetchMock.mockResolvedValueOnce(okJsonResponse({ access_token: 'tok' }));
+			const t = await plugin.exchangeCodeForToken('code', { clientId: 'cid', clientSecret: 'csec' });
+			expect(t.tokenType).toBe('bearer');
+		});
+
+		it('throws a sanitized error when Vercel returns an error payload', async () => {
+			fetchMock.mockResolvedValueOnce(
+				okJsonResponse({ error: 'invalid_grant', error_description: 'Code invalid' })
+			);
+			await expect(
+				plugin.exchangeCodeForToken('bad', { clientId: 'cid', clientSecret: 'csec' })
+			).rejects.toThrow(/Code invalid/);
+		});
+
+		it('throws when the HTTP response is not ok', async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: false,
+				status: 401,
+				json: () => Promise.resolve({})
+			} as unknown as Response);
+			await expect(
+				plugin.exchangeCodeForToken('bad', { clientId: 'cid', clientSecret: 'csec' })
+			).rejects.toThrow(/Vercel OAuth error/);
+		});
+	});
+
+	describe('IOAuthPlugin — getAuthenticatedUser', () => {
+		it('maps a resolved Vercel user to the OAuthUser shape', async () => {
+			const apiService = (plugin as any).apiService;
+			vi.spyOn(apiService, 'validateToken').mockResolvedValueOnce({
+				id: 'usr_1',
+				email: 'dev@ever.works',
+				name: 'Dev',
+				username: 'dever'
+			});
+			const user = await plugin.getAuthenticatedUser('tok');
+			expect(user).toEqual({
+				id: 'usr_1',
+				username: 'dever',
+				email: 'dev@ever.works',
+				name: 'Dev'
+			});
+		});
+
+		it('throws when the token resolves to no user (OAuth contract)', async () => {
+			const apiService = (plugin as any).apiService;
+			vi.spyOn(apiService, 'validateToken').mockResolvedValueOnce(null);
+			await expect(plugin.getAuthenticatedUser('bad')).rejects.toThrow(/Failed to resolve Vercel user/);
 		});
 	});
 

--- a/packages/plugins/vercel/src/types.ts
+++ b/packages/plugins/vercel/src/types.ts
@@ -2,10 +2,28 @@
  * Vercel plugin settings
  */
 export interface VercelSettings {
-	/** Vercel API token (user-scoped, required) */
+	/** Vercel API token (user-scoped, required) — manual token fallback */
 	apiToken?: string;
 	/** Default team scope for deployments */
 	defaultTeamScope?: string;
+	/**
+	 * Vercel OAuth Integration Client ID (admin/global).
+	 * Sourced from the `VERCEL_OAUTH_CLIENT_ID` env var. When set together with
+	 * `clientSecret` + `integrationSlug`, the plugin advertises the `oauth`
+	 * capability and the "Connect with Vercel" flow becomes available.
+	 */
+	clientId?: string;
+	/**
+	 * Vercel OAuth Integration Client Secret (admin/global, secret).
+	 * Sourced from the `VERCEL_OAUTH_CLIENT_SECRET` env var.
+	 */
+	clientSecret?: string;
+	/**
+	 * Vercel Integration URL slug (admin/global) used to build the install /
+	 * authorize URL (`https://vercel.com/integrations/<slug>/new`).
+	 * Sourced from the `VERCEL_INTEGRATION_SLUG` env var.
+	 */
+	integrationSlug?: string;
 }
 
 /**

--- a/packages/plugins/vercel/src/vercel.plugin.ts
+++ b/packages/plugins/vercel/src/vercel.plugin.ts
@@ -1,6 +1,7 @@
 import type {
 	IPlugin,
 	IDeploymentPlugin,
+	IOAuthPlugin,
 	PluginContext,
 	PluginCategory,
 	PluginManifest,
@@ -11,24 +12,66 @@ import type {
 	DeploymentProject,
 	DeploymentDomain,
 	AddDomainResult,
-	ConnectionValidationResult
+	ConnectionValidationResult,
+	OAuthConfig,
+	OAuthToken,
+	OAuthUser
 } from '@ever-works/plugin';
 import { VercelApiService } from './vercel-api.service.js';
 import type { VercelSettings } from './types.js';
+
+/**
+ * Environment variables that configure the Vercel OAuth ("Connect with Vercel")
+ * Integration. These are set by the platform administrator AFTER registering a
+ * Vercel OAuth Integration in the Vercel dashboard (which issues the
+ * client_id/client_secret + URL slug). Until all three are present the plugin
+ * keeps the manual API-token flow as the only path (see `isOAuthConfigured`).
+ */
+const ENV_OAUTH_CLIENT_ID = 'VERCEL_OAUTH_CLIENT_ID';
+const ENV_OAUTH_CLIENT_SECRET = 'VERCEL_OAUTH_CLIENT_SECRET';
+const ENV_INTEGRATION_SLUG = 'VERCEL_INTEGRATION_SLUG';
+
+/**
+ * Default OAuth scopes requested for the Vercel Integration. For classic
+ * Vercel integrations the effective scopes are defined in the Integration
+ * Console rather than the authorize URL, but they are still included for
+ * providers/flows that honor the `scope` query parameter and for parity with
+ * the GitHub plugin's scope handling.
+ * @see https://vercel.com/docs/integrations/create-integration/vercel-api-integrations#scopes
+ */
+const VERCEL_OAUTH_SCOPES: readonly string[] = ['user', 'team', 'project', 'deployment', 'domain'];
 
 /**
  * Vercel deployment plugin
  *
  * Provides deployment capabilities to Vercel.
  * Uses 'user-required' configuration mode - users MUST provide their own Vercel token.
+ *
+ * Also implements the OAuth ("Connect with Vercel") capability. The `oauth`
+ * capability is env-gated: it is only advertised once a Vercel OAuth
+ * Integration has been registered and its credentials wired via the
+ * `VERCEL_OAUTH_CLIENT_ID` / `VERCEL_OAUTH_CLIENT_SECRET` /
+ * `VERCEL_INTEGRATION_SLUG` env vars. Before that, the plugin falls back to the
+ * manual `apiToken` field so nothing breaks.
  */
-export class VercelPlugin implements IPlugin, IDeploymentPlugin {
+export class VercelPlugin implements IPlugin, IDeploymentPlugin, IOAuthPlugin {
 	readonly id = 'vercel';
 	readonly name = 'Vercel';
 	readonly version = '1.0.0';
 	readonly category: PluginCategory = 'deployment';
-	readonly capabilities: readonly string[] = ['deployment'];
 	readonly providerName = 'vercel';
+
+	/**
+	 * Capabilities are env-gated: the `oauth` capability is only advertised when
+	 * a Vercel OAuth Integration is configured (see `isOAuthConfigured`). When it
+	 * is not, only `deployment` is advertised and the UI keeps showing the manual
+	 * API-token field (the fallback). This is a getter (not a static field) so
+	 * the live signal is correct for the OAuth facade's `isOAuthPlugin()` gate
+	 * and other consumers that read the plugin instance directly.
+	 */
+	get capabilities(): readonly string[] {
+		return this.isOAuthConfigured() ? ['deployment', 'oauth'] : ['deployment'];
+	}
 
 	readonly settingsSchema: JsonSchema = {
 		type: 'object',
@@ -39,6 +82,32 @@ export class VercelPlugin implements IPlugin, IDeploymentPlugin {
 				description: 'Your personal Vercel API token. Get one from https://vercel.com/account/tokens',
 				'x-secret': true,
 				'x-scope': 'user'
+			},
+			clientId: {
+				type: 'string',
+				title: 'OAuth Client ID',
+				description: 'Vercel OAuth Integration Client ID (from the Vercel Integration Console)',
+				'x-envVar': ENV_OAUTH_CLIENT_ID,
+				'x-adminOnly': true,
+				'x-scope': 'global'
+			},
+			clientSecret: {
+				type: 'string',
+				title: 'OAuth Client Secret',
+				description: 'Vercel OAuth Integration Client Secret (from the Vercel Integration Console)',
+				'x-secret': true,
+				'x-envVar': ENV_OAUTH_CLIENT_SECRET,
+				'x-adminOnly': true,
+				'x-scope': 'user'
+			},
+			integrationSlug: {
+				type: 'string',
+				title: 'Integration URL slug',
+				description:
+					'Vercel Integration URL slug used to build the install/authorize URL (https://vercel.com/integrations/<slug>/new)',
+				'x-envVar': ENV_INTEGRATION_SLUG,
+				'x-adminOnly': true,
+				'x-scope': 'global'
 			}
 		},
 		required: ['apiToken']
@@ -130,7 +199,15 @@ export class VercelPlugin implements IPlugin, IDeploymentPlugin {
 		if (!valid) {
 			return { success: false, message: 'Vercel rejected the API token.' };
 		}
-		const user = await this.getAuthenticatedUser(token);
+		// `getAuthenticatedUser` throws if the identity lookup fails (OAuth
+		// contract); the token was just validated so this normally succeeds, but
+		// degrade to a generic success message rather than surfacing a throw.
+		let user: OAuthUser | null = null;
+		try {
+			user = await this.getAuthenticatedUser(token);
+		} catch {
+			user = null;
+		}
 		return {
 			success: true,
 			message: user?.username ? `Connected to Vercel as ${user.username}.` : 'Vercel connection verified.',
@@ -138,14 +215,134 @@ export class VercelPlugin implements IPlugin, IDeploymentPlugin {
 		};
 	}
 
-	async getAuthenticatedUser(token: string): Promise<{ username: string; email?: string } | null> {
+	/**
+	 * IOAuthPlugin + IDeploymentPlugin: resolve the identity behind a token.
+	 * Returns the richer `OAuthUser` shape (which is structurally assignable to
+	 * the deployment interface's `{ username; email? }`). Throws when the token
+	 * resolves to no user — the OAuth facade calls this straight after a token
+	 * exchange and dereferences `user.id`/`user.username`, so a null would break
+	 * it; a throw is surfaced as a clear connection error instead.
+	 */
+	async getAuthenticatedUser(token: string): Promise<OAuthUser> {
 		const user = await this.apiService.validateToken(token);
 		if (!user) {
-			return null;
+			throw new Error('Failed to resolve Vercel user for the provided token');
 		}
 		return {
+			id: user.id,
 			username: user.username || user.name || user.email,
-			email: user.email
+			email: user.email,
+			name: user.name
+		};
+	}
+
+	// IOAuthPlugin implementation ("Connect with Vercel")
+	//
+	// Uses Vercel's classic Integration OAuth flow: the user is sent to the
+	// integration's install/authorize URL, and the returned `code` is exchanged
+	// server-side for a long-lived access token.
+	// @see https://vercel.com/docs/integrations/create-integration/vercel-api-integrations#create-an-access-token
+
+	/**
+	 * Build the Vercel Integration install/authorize URL. For classic Vercel
+	 * integrations the entry point is `https://vercel.com/integrations/<slug>/new`;
+	 * Vercel echoes the `state` back to the configured Redirect URL together with
+	 * the `code`. `clientId`/`redirectUri`/`scopes` come from the generic OAuth
+	 * service config (env-resolved via the settings `x-envVar` bindings); the
+	 * integration slug is not part of the generic `OAuthConfig`, so it is read
+	 * from `VERCEL_INTEGRATION_SLUG` (its declared `x-envVar`).
+	 * @see https://vercel.com/docs/integrations/create-integration/vercel-api-integrations
+	 */
+	getAuthorizationUrl(state: string, config?: Partial<OAuthConfig>): string {
+		const slug = this.getIntegrationSlug();
+		if (!slug) {
+			throw new Error(`Vercel OAuth is not configured: set ${ENV_INTEGRATION_SLUG}`);
+		}
+
+		const clientId = config?.clientId || process.env[ENV_OAUTH_CLIENT_ID];
+		if (!clientId) {
+			throw new Error(`Vercel OAuth client ID not configured: set ${ENV_OAUTH_CLIENT_ID}`);
+		}
+
+		const redirectUri = config?.redirectUri;
+		const scopes = config?.scopes && config.scopes.length > 0 ? config.scopes : VERCEL_OAUTH_SCOPES;
+
+		const params = new URLSearchParams({
+			client_id: clientId,
+			state,
+			scope: scopes.join(' ')
+		});
+		// The Redirect URL is primarily configured in the Integration Console;
+		// passing it here keeps parity with providers that honor it and makes the
+		// intended callback explicit.
+		if (redirectUri) {
+			params.set('redirect_uri', redirectUri);
+		}
+
+		return `https://vercel.com/integrations/${encodeURIComponent(slug)}/new?${params.toString()}`;
+	}
+
+	/**
+	 * Exchange the authorization `code` for a long-lived access token via
+	 * `POST https://api.vercel.com/v2/oauth/access_token`. The body MUST be
+	 * `application/x-www-form-urlencoded` with `client_id`, `client_secret`,
+	 * `code`, and `redirect_uri`.
+	 * @see https://vercel.com/docs/integrations/create-integration/vercel-api-integrations#exchange-code-for-access-token
+	 */
+	async exchangeCodeForToken(code: string, config?: Partial<OAuthConfig>): Promise<OAuthToken> {
+		const clientId = config?.clientId || process.env[ENV_OAUTH_CLIENT_ID];
+		const clientSecret = config?.clientSecret || process.env[ENV_OAUTH_CLIENT_SECRET];
+		const redirectUri = config?.redirectUri;
+
+		if (!clientId || !clientSecret) {
+			throw new Error(
+				`Vercel OAuth credentials not configured: set ${ENV_OAUTH_CLIENT_ID} and ${ENV_OAUTH_CLIENT_SECRET}`
+			);
+		}
+
+		const body = new URLSearchParams({
+			client_id: clientId,
+			client_secret: clientSecret,
+			code
+		});
+		if (redirectUri) {
+			body.set('redirect_uri', redirectUri);
+		}
+
+		const response = await fetch('https://api.vercel.com/v2/oauth/access_token', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+				Accept: 'application/json'
+			},
+			body: body.toString()
+		});
+
+		const data = (await response.json().catch(() => ({}))) as {
+			access_token?: string;
+			token_type?: string;
+			scope?: string;
+			error?: string;
+			error_description?: string;
+		};
+
+		if (!response.ok || data.error || !data.access_token) {
+			// Security (log-injection): `error`/`error_description` are
+			// attacker-influenceable strings from the OAuth authorization server.
+			// Strip control characters and cap the length before surfacing them in
+			// a thrown (and likely logged) Error. Mirrors the GitHub plugin.
+			const detail = String(data.error_description || data.error || `HTTP ${response.status}`)
+				// eslint-disable-next-line no-control-regex
+				.replace(/[\x00-\x1f\x7f]+/g, ' ')
+				.trim()
+				.slice(0, 300);
+			throw new Error(`Vercel OAuth error: ${detail}`);
+		}
+
+		return {
+			accessToken: data.access_token,
+			tokenType: data.token_type || 'bearer',
+			scope: data.scope
 		};
 	}
 
@@ -281,7 +478,11 @@ export class VercelPlugin implements IPlugin, IDeploymentPlugin {
 				'1. Create a Vercel account at [vercel.com](https://vercel.com)',
 				'2. Generate an API token from [vercel.com/account/tokens](https://vercel.com/account/tokens)',
 				'3. Enter your token in the settings below',
-				'4. Save settings to verify the token before using it for deployments'
+				'4. Save settings to verify the token before using it for deployments',
+				'',
+				'## Connect with Vercel (OAuth)',
+				'',
+				'If the platform administrator has registered a Vercel OAuth Integration, you can connect your Vercel account with one click instead of pasting an API token. The manual API-token field above always remains available as a fallback.'
 			].join('\n'),
 			homepage: 'https://vercel.com/account/tokens',
 			uiHints: {
@@ -319,8 +520,42 @@ export class VercelPlugin implements IPlugin, IDeploymentPlugin {
 		const settings = await this.context.getSettings();
 		return {
 			apiToken: settings?.apiToken as string | undefined,
-			defaultTeamScope: settings?.defaultTeamScope as string | undefined
+			defaultTeamScope: settings?.defaultTeamScope as string | undefined,
+			clientId: settings?.clientId as string | undefined,
+			clientSecret: settings?.clientSecret as string | undefined,
+			integrationSlug: settings?.integrationSlug as string | undefined
 		};
+	}
+
+	/**
+	 * The integration slug used to build the install/authorize URL. Read from
+	 * the declared `VERCEL_INTEGRATION_SLUG` env var. `getAuthorizationUrl` is
+	 * synchronous (per the IOAuthPlugin contract) and the slug is not part of the
+	 * generic `OAuthConfig`, so it is resolved from the environment directly —
+	 * the same pattern other bundled plugins (aws-s3, cloudflare-dns) use for
+	 * env-sourced settings.
+	 */
+	private getIntegrationSlug(): string | undefined {
+		const slug = process.env[ENV_INTEGRATION_SLUG];
+		return slug && slug.trim().length > 0 ? slug.trim() : undefined;
+	}
+
+	/**
+	 * True only when the Vercel OAuth Integration is fully wired via env vars
+	 * (client id + secret + integration slug). Gates the `oauth` capability so it
+	 * is advertised only once the owner has registered the integration; before
+	 * that the plugin keeps the manual `apiToken` field as the working fallback.
+	 *
+	 * Env-based (not settings-based) because `capabilities` is a synchronous
+	 * getter with no async settings access, and env vars are the documented
+	 * activation mechanism.
+	 */
+	private isOAuthConfigured(): boolean {
+		return (
+			!!process.env[ENV_OAUTH_CLIENT_ID] &&
+			!!process.env[ENV_OAUTH_CLIENT_SECRET] &&
+			!!this.getIntegrationSlug()
+		);
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the **"Connect with Vercel" OAuth flow** on the Vercel plugin (`packages/plugins/vercel`), mirroring the GitHub plugin's `IOAuthPlugin` pattern. The flow is **fully implemented and unit-tested, but dormant** — it activates only after the owner registers a Vercel OAuth Integration and sets the env vars below. Nothing changes at runtime on merge.

- `VercelPlugin` now `implements IPlugin, IDeploymentPlugin, IOAuthPlugin`.
- Uses Vercel's **classic Integration OAuth flow**:
  - Authorize → `https://vercel.com/integrations/<slug>/new?client_id&state&scope[&redirect_uri]`
  - Token exchange → `POST https://api.vercel.com/v2/oauth/access_token` (form-encoded `client_id`/`client_secret`/`code`/`redirect_uri`), per [Vercel docs](https://vercel.com/docs/integrations/create-integration/vercel-api-integrations#create-an-access-token).
- New admin/global settings `clientId` / `clientSecret` / `integrationSlug` bound to env vars via `x-envVar` (mirrors GitHub's pattern).
- Manual `apiToken` field + setup readme **retained** as fallback (no-removal). `/v2/user` token validation unchanged.

## ⚙️ Owner action required to activate

Set these env vars on the API (after creating the Vercel OAuth Integration in the Vercel dashboard, which issues the client_id/secret + slug):

| Env var | Value |
| --- | --- |
| `VERCEL_OAUTH_CLIENT_ID` | Integration Client ID (Vercel Integration Console) |
| `VERCEL_OAUTH_CLIENT_SECRET` | Integration Client Secret |
| `VERCEL_INTEGRATION_SLUG` | Integration URL slug (used to build `vercel.com/integrations/<slug>/new`) |

**Redirect / callback URL** to configure on the Vercel Integration Console:

```
https://app.ever.works/api/oauth/vercel/callback/plugins
```

This is derived from the platform's generic plugin-OAuth callback route (`ROUTES.API_OAUTH_PLUGINS_CALLBACK = /api/oauth/:providerId/callback/plugins`, web route `apps/web/src/app/api/oauth/[providerId]/callback/plugins/route.ts`, which forwards to the generic API controller `GET /api/oauth/:providerId/callback/plugins`). Substitute the real host for other environments (e.g. `https://<dev-host>/api/oauth/vercel/callback/plugins`).

No secrets are hardcoded — credentials come only from the env vars above.

## Capability gating & the one architectural caveat

`capabilities` is an **env-gated getter**: it advertises `oauth` only when all three env vars are set, otherwise just `deployment` (so the manual token field stays the working path). This gate is consulted live by the OAuth facade (`isOAuthPlugin(registered.plugin)`) and plugin-operations paths.

**Caveat (documented, intentional):** the OAuth *router* resolves providers from a **static capability index built from the package manifest** (`PluginRegistryService.getByCapability`), and the class validator (`validateAgainstManifest`) makes any manifest capability that's absent from the live getter a **load-blocking error**. Because of that pairing, this PR deliberately leaves `packages/plugins/vercel/package.json` `everworks.plugin.capabilities` as `["deployment"]`:

- Keeping it `["deployment"]` is the load-safe choice (the env-gated getter being a *superset* is only a warning) and guarantees **zero runtime/UI change on merge** — the token field remains, nothing breaks.
- To surface the **"Connect with Vercel"** button and route the callback to this provider, the owner adds `"oauth"` to that manifest's `capabilities` **together with** setting the env vars. (Adding it without the env vars would trip the load-time validator, which is why it's a deliberate joint activation step rather than shipped on by default.)

The callback route itself is already **generic** — it handles `providerId=vercel` with no per-plugin registration once the capability is advertised.

## Validation

- `pnpm --filter @ever-works/contracts run build` → **success**
- `pnpm --filter @ever-works/plugin run build` → **success**
- `pnpm --filter @ever-works/vercel-plugin run type-check` (`tsc --noEmit`) → **exit 0**
- `pnpm --filter @ever-works/vercel-plugin run build` (tsc + tsup + DTS) → **exit 0**
- `pnpm --filter @ever-works/vercel-plugin run test` → **51 passed** (added OAuth capability-gating, authorize-URL, code-exchange, and user-mapping specs mirroring the GitHub OAuth spec)
- No eslint config exists for plugin packages (`tsc --noEmit` is the static gate); the Vercel plugin is dynamically loaded and not statically imported by the API, so the API type-check is unaffected by the `getAuthenticatedUser` signature change.

Do **not** merge/deploy — for review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
