### PR TITLE
feat(vercel): activate OAuth capability (creds provisioned)

### DIFF
--- a/packages/plugins/vercel/package.json
+++ b/packages/plugins/vercel/package.json
@@ -48,7 +48,8 @@
 			"version": "1.0.0",
 			"category": "deployment",
 			"capabilities": [
-				"deployment"
+				"deployment",
+				"oauth"
 			],
 			"description": "Deploy works to Vercel",
 			"author": {


### PR DESCRIPTION
Adds 'oauth' to the Vercel plugin manifest capabilities. Env (VERCEL_OAUTH_CLIENT_ID/SECRET/INTEGRATION_SLUG) provisioned in ever-works-app prod+dev secrets, so the env-gated getter returns 'oauth' and the manifest is consistent → 'Connect with Vercel' activates. Token fallback unchanged.