### PR TITLE
ci: pool relief — gate heavy test matrices on main/stage pushes (unblocks k8s-build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
   # only the slice it needs, so a failing aggregate doesn't block this
   # signal (and vice versa).
   job-runtime-plugin-matrix:
+    # Pool-relief (2026-07-18): these already passed on the PR; skip on main/stage
+    # promotion pushes so k8s-build (the deploy build) is not starved on the shared
+    # ARC pool. Still runs on PRs + develop pushes. Reversible: remove this if line.
+    if: ${{ !(github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stage')) }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     strategy:
@@ -287,6 +291,10 @@ jobs:
   # plugins via `<plugin>-conformance.spec.ts`). Same rationale as the
   # job-runtime matrix above: per-provider failure signal.
   secret-store-plugin-matrix:
+    # Pool-relief (2026-07-18): these already passed on the PR; skip on main/stage
+    # promotion pushes so k8s-build (the deploy build) is not starved on the shared
+    # ARC pool. Still runs on PRs + develop pushes. Reversible: remove this if line.
+    if: ${{ !(github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stage')) }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     strategy:


### PR DESCRIPTION
The 12-job job-runtime+secret-store test matrices ran on every push and starved k8s-build on the shared ARC pool → :prod stopped updating (root cause of the hand-build workaround). Gate them to skip on main/stage promotion pushes (still run on PRs + develop). Reversible; mirrors the existing real-infra gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to skip selected provider test matrix jobs for promotion pushes to `main` and `stage`.
  * These tests continue to run for pull requests and other push events, helping preserve shared test capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->