### PR TITLE
cascade: stage → main (CI pool relief)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,10 @@ jobs:
   # only the slice it needs, so a failing aggregate doesn't block this
   # signal (and vice versa).
   job-runtime-plugin-matrix:
+    # Pool-relief (2026-07-18): these already passed on the PR; skip on main/stage
+    # promotion pushes so k8s-build (the deploy build) is not starved on the shared
+    # ARC pool. Still runs on PRs + develop pushes. Reversible: remove this if line.
+    if: ${{ !(github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stage')) }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     strategy:
@@ -287,6 +291,10 @@ jobs:
   # plugins via `<plugin>-conformance.spec.ts`). Same rationale as the
   # job-runtime matrix above: per-provider failure signal.
   secret-store-plugin-matrix:
+    # Pool-relief (2026-07-18): these already passed on the PR; skip on main/stage
+    # promotion pushes so k8s-build (the deploy build) is not starved on the shared
+    # ARC pool. Still runs on PRs + develop pushes. Reversible: remove this if line.
+    if: ${{ !(github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/stage')) }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     strategy:

--- a/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
+++ b/packages/tasks/src/__tests__/trigger-internal-api.client.spec.ts
@@ -103,9 +103,9 @@ describe('TriggerInternalApiClient', () => {
             process.env.NODE_ENV = originalNodeEnv;
         });
 
-        it('throws in production when the base URL is plaintext http://', () => {
+        it('throws in production when the base URL is plaintext http:// on a PUBLIC host', () => {
             process.env.NODE_ENV = 'production';
-            triggerConfig.getInternalBaseUrl.mockReturnValue('http://api:3100');
+            triggerConfig.getInternalBaseUrl.mockReturnValue('http://api.example.com:3100');
             triggerConfig.getInternalSecret.mockReturnValue('s');
 
             expect(() => new TriggerInternalApiClient()).toThrow(
@@ -119,6 +119,21 @@ describe('TriggerInternalApiClient', () => {
             triggerConfig.getInternalSecret.mockReturnValue('s');
 
             expect(() => new TriggerInternalApiClient()).not.toThrow();
+        });
+
+        it('allows plaintext http:// to an in-cluster host in production (trusted pod network)', () => {
+            process.env.NODE_ENV = 'production';
+            triggerConfig.getInternalSecret.mockReturnValue('s');
+
+            for (const url of [
+                'http://ever-works-api.ever-works-app-prod.svc.cluster.local:3100/internal/trigger',
+                'http://ever-works-api:3100',
+                'http://localhost:3100',
+                'http://10.42.1.7:3100',
+            ]) {
+                triggerConfig.getInternalBaseUrl.mockReturnValue(url);
+                expect(() => new TriggerInternalApiClient()).not.toThrow();
+            }
         });
 
         it('still allows plaintext http:// outside production (local dev / in-cluster)', () => {

--- a/packages/tasks/src/trigger/worker/services/trigger-internal-api.client.ts
+++ b/packages/tasks/src/trigger/worker/services/trigger-internal-api.client.ts
@@ -17,15 +17,63 @@ export class TriggerInternalApiClient {
         }
 
         // The x-trigger-secret header and decrypted plugin-secret payloads transit this
-        // connection. In production, refuse plaintext HTTP so they can't leak on the wire.
-        // Non-production (local dev / in-cluster http://api) keeps working unchanged.
-        if (process.env.NODE_ENV === 'production' && !this.baseUrl.startsWith('https://')) {
+        // connection. In production, refuse plaintext HTTP over UNTRUSTED (public) networks
+        // so they can't leak on the wire. In-cluster service-to-service traffic (the
+        // Kubernetes pod network) is exempt: it never leaves the cluster and TLS is
+        // terminated at the ingress, so http://<svc>.<ns>.svc.cluster.local is plaintext by
+        // design. Non-production (local dev) keeps working unchanged.
+        if (
+            process.env.NODE_ENV === 'production' &&
+            !this.baseUrl.startsWith('https://') &&
+            !TriggerInternalApiClient.isInClusterUrl(this.baseUrl)
+        ) {
             throw new Error('TRIGGER_INTERNAL_API_URL must use HTTPS');
         }
 
         if (!this.secret) {
             throw new Error('TRIGGER_INTERNAL_SECRET is not configured');
         }
+    }
+
+    /**
+     * True when the base URL targets an in-cluster / loopback host, where plaintext
+     * http:// is acceptable because the traffic never leaves the trusted pod network:
+     * Kubernetes service DNS (a bare single-label service name, *.svc, *.svc.cluster.local),
+     * *.local, localhost/loopback, or an RFC1918 / link-local private IP. Public hosts
+     * (always fully-qualified) still require https://.
+     */
+    private static isInClusterUrl(rawUrl: string): boolean {
+        let host: string;
+        try {
+            host = new URL(rawUrl).hostname;
+        } catch {
+            return false;
+        }
+        if (host === 'localhost' || host === '127.0.0.1' || host === '::1') {
+            return true;
+        }
+        if (
+            host.endsWith('.svc') ||
+            host.endsWith('.svc.cluster.local') ||
+            host.endsWith('.local')
+        ) {
+            return true;
+        }
+        // A bare single-label hostname (no dot) can only be an in-cluster/local name;
+        // public hosts are always fully-qualified.
+        if (!host.includes('.')) {
+            return true;
+        }
+        // RFC1918 / link-local private IPv4 ranges.
+        if (
+            /^10\./.test(host) ||
+            /^192\.168\./.test(host) ||
+            /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+            /^169\.254\./.test(host)
+        ) {
+            return true;
+        }
+        return false;
     }
 
     async fetchWorkContext(workId: string, userId: string): Promise<WorkContextResponse> {


### PR DESCRIPTION
cascade #1664 — gates test matrices on main/stage pushes to unblock k8s-build