### PR TITLE
chore: cascade develop → stage (general-purpose website templates)

### DIFF
--- a/docs/ai-agents/website-generation.md
+++ b/docs/ai-agents/website-generation.md
@@ -46,7 +46,7 @@ A second template, [`directory-web-minimal-template`](https://github.com/ever-wo
 `WEBSITE_TEMPLATE_MINIMAL_REPO=directory-web-minimal-template` and chosen
 per-Work via the website-template selector.
 
-For the full template catalogue (including the planned generic
+For the full template catalogue (including the general-purpose
 `web-template` and `web-minimal-template`), see
 [**Website Templates**](../features/website-templates.md).
 

--- a/docs/features/website-templates.md
+++ b/docs/features/website-templates.md
@@ -25,7 +25,7 @@ Each entry is a `WebsiteTemplateConfig`:
 
 ```ts
 interface WebsiteTemplateConfig {
-	id: WebsiteTemplateId; // e.g. 'classic', 'minimal'
+	id: WebsiteTemplateId; // e.g. 'classic', 'minimal', 'web', 'web-minimal'
 	name: string; // display name
 	description: string;
 	owner: string; // GitHub org/user
@@ -68,33 +68,37 @@ Templates the Works platform supports:
   `directory-web-minimal-template` to register it in
   [`website-template.config.ts`](https://github.com/ever-works/ever-works/blob/main/packages/agent/src/generators/website-generator/config/website-template.config.ts).
 
-### 3. `web-template` — generic Next.js (planned)
+### 3. `web` — web-template (Next.js, general-purpose)
 
-- **Repo:** `ever-works/web-template` _(planned, not yet published)_
-- **Stack:** Next.js (same shape as `classic`)
-- **For:** AI-generated **general-purpose websites** that aren't directories
-  — landing pages, marketing sites, content-heavy sites — with a similar
-  rich feature set to `directory-web-template` minus the
-  directory-specific affordances (no item lists, no faceted filters by
-  default).
-- **Status:** 🗓️ Planned. Once published it will register as
-  `WebsiteTemplateId = 'web'` (or similar) and ship a default branch +
-  beta-branch contract identical to the `classic` template.
+- **Repo:** [ever-works/web-template](https://github.com/ever-works/web-template)
+- **Stack:** Next.js (App Router, React 19, Tailwind CSS v4) — same monorepo /
+  `@ever-works/web` build contract as `classic`.
+- **For:** AI-generated **general-purpose websites** that aren't directories —
+  landing pages, marketing sites, content-heavy sites. Ships a full landing
+  page (hero, features, how-it-works, testimonials, pricing, FAQ, CTA) plus
+  About / Pricing / Contact pages and a Markdown blog — no item lists, no
+  faceted filters, no directory data model.
+- **Rebrand from one file:** all copy lives in `apps/web/lib/site.config.ts`.
+- **Status:** ✅ Available; registered as `WebsiteTemplateId = 'web'`. Select it
+  for a **Landing Page**, **Blog**, or general **Website** Work.
 
-### 4. `web-minimal-template` — generic Astro minimal (planned)
+### 4. `web-minimal` — web-minimal-template (Astro, general-purpose minimal)
 
-- **Repo:** `ever-works/web-minimal-template` _(planned, not yet published)_
-- **Stack:** Astro (same shape as `directory-web-minimal-template`)
+- **Repo:** [ever-works/web-minimal-template](https://github.com/ever-works/web-minimal-template)
+- **Stack:** Astro 6 (static output) + Tailwind CSS v4, TypeScript — same
+  static / nginx-on-:3000 build contract as `directory-web-minimal-template`.
 - **For:** AI-generated **general-purpose websites** with the same
-  performance / static-output / plugin-driven philosophy as the minimal
-  directory template — minus the directory-specific affordances.
-- **Status:** 🗓️ Planned.
+  performance / static-output philosophy as the minimal directory template —
+  minus the directory-specific affordances (no item/category routes). Zero JS
+  by default; the same marketing section set as `web`, built statically.
+- **Rebrand from one file:** all copy lives in `apps/web/src/config/site.ts`.
+- **Status:** ✅ Available; registered as `WebsiteTemplateId = 'web-minimal'`.
 
 ## Roadmap
 
-The four base templates above cover the matrix of (directory vs general)
-× (full-featured Next.js vs minimal Astro). Beyond that, the platform is
-designed to host **many more** templates — each new template is a
+The four base templates above are all published and cover the matrix of
+(directory vs general) × (full-featured Next.js vs minimal Astro). Beyond
+that, the platform is designed to host **many more** templates — each new template is a
 single-row addition to `WEBSITE_TEMPLATES` plus a published GitHub repo.
 Anyone can author and contribute one; the only contract is that the repo's
 branch layout matches `WebsiteTemplateConfig` (i.e. `main` and a sensible

--- a/packages/agent/src/generators/website-generator/config/website-template.config.ts
+++ b/packages/agent/src/generators/website-generator/config/website-template.config.ts
@@ -45,11 +45,42 @@ const MINIMAL_WEBSITE_TEMPLATE: WebsiteTemplateConfig = {
     customizable: true,
 };
 
+const WEB_WEBSITE_TEMPLATE: WebsiteTemplateConfig = {
+    id: 'web',
+    name: 'Website',
+    description:
+        'A general-purpose website template (Next.js) for marketing, landing, and content pages — not a directory.',
+    owner: 'ever-works',
+    // See docs/features/website-templates.md for the full template catalogue.
+    repo: 'web-template',
+    branch: 'main',
+    syncBranches: ['main', 'stage', 'develop'],
+    betaBranch: null,
+    // Clean marketing/landing starter; no agent-customization prompt yet, so
+    // forks are edited manually (see template-catalog/customization-prompts/).
+    customizable: false,
+};
+
+const WEB_MINIMAL_WEBSITE_TEMPLATE: WebsiteTemplateConfig = {
+    id: 'web-minimal',
+    name: 'Website (Minimal)',
+    description:
+        'A minimal general-purpose website template (Astro, static) for marketing, landing, and content pages — not a directory.',
+    owner: 'ever-works',
+    repo: 'web-minimal-template',
+    branch: 'main',
+    syncBranches: ['main', 'stage', 'develop'],
+    betaBranch: null,
+    customizable: false,
+};
+
 export const DEFAULT_WEBSITE_TEMPLATE_ID: WebsiteTemplateId = 'classic';
 
 export const WEBSITE_TEMPLATES: WebsiteTemplateConfig[] = [
     CLASSIC_WEBSITE_TEMPLATE,
     MINIMAL_WEBSITE_TEMPLATE,
+    WEB_WEBSITE_TEMPLATE,
+    WEB_MINIMAL_WEBSITE_TEMPLATE,
 ];
 
 export function listWebsiteTemplates(): WebsiteTemplateConfig[] {


### PR DESCRIPTION
Cascade of the general-purpose `web` + `web-minimal` website template wiring (#1676) from develop to stage. Additive: 2 template registrations + docs. 🤖 Generated with [Claude Code](https://claude.com/claude-code)