### PR TITLE
feat(teams): team_resources — associate Works/Agents/Missions/Tasks with Teams

### DIFF
--- a/apps/api/src/migrations/1781600000000-CreateTeamResources.ts
+++ b/apps/api/src/migrations/1781600000000-CreateTeamResources.ts
@@ -1,0 +1,112 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Teams & Prebuilt Companies — Team ↔ resource association table.
+ *
+ * Spec: operator ask "some Works belong to some Teams" — generalized to
+ * Works / Tasks / Agents / Missions / Ideas.
+ * Entity: `packages/agent/src/entities/team-resource.entity.ts`.
+ *
+ * Creates:
+ *   - `team_resources` — Tier C polymorphic edge rows (`resourceType` ∈
+ *     work|task|agent|mission|idea, `resourceId` → the matching table).
+ *     UNIQUE on `(teamId, resourceType, resourceId)` so a resource can't be
+ *     attached to the same Team twice; a secondary `(resourceType,
+ *     resourceId)` index drives the reverse "which teams own this resource"
+ *     lookup. `ON DELETE CASCADE` from `teams` so a Team takes its
+ *     associations with it. Resource existence + tenancy is validated in
+ *     `TeamResourcesService` (no polymorphic FK possible).
+ *
+ * Scope FKs (`tenantId`/`organizationId`) follow the Tier C house
+ * convention: nullable, `ON DELETE SET NULL`.
+ *
+ * Forward-only + idempotent (`hasTable` guard) — same shape as
+ * `1781500000000-CreateTeamsTables`.
+ */
+export class CreateTeamResources1781600000000 implements MigrationInterface {
+    name = 'CreateTeamResources1781600000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('team_resources')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'team_resources',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'teamId', type: 'uuid' },
+                    { name: 'resourceType', type: 'varchar', length: '16' },
+                    { name: 'resourceId', type: 'uuid' },
+                    { name: 'addedById', type: 'uuid', isNullable: true },
+                    { name: 'tenantId', type: 'uuid', isNullable: true },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'CURRENT_TIMESTAMP' },
+                ],
+            }),
+            true,
+        );
+
+        await queryRunner.createIndex(
+            'team_resources',
+            new TableIndex({
+                name: 'uq_team_resources_team_resource',
+                columnNames: ['teamId', 'resourceType', 'resourceId'],
+                isUnique: true,
+            }),
+        );
+        // Reverse lookup: "which teams own this Work/Agent/…" — drives the
+        // GET /organizations/:orgId/resource-teams endpoint + resource-detail UI.
+        await queryRunner.createIndex(
+            'team_resources',
+            new TableIndex({
+                name: 'idx_team_resources_resource',
+                columnNames: ['resourceType', 'resourceId'],
+            }),
+        );
+
+        await queryRunner.createForeignKey(
+            'team_resources',
+            new TableForeignKey({
+                name: 'fk_team_resources_team',
+                columnNames: ['teamId'],
+                referencedTableName: 'teams',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'team_resources',
+            new TableForeignKey({
+                name: 'fk_team_resources_tenant',
+                columnNames: ['tenantId'],
+                referencedTableName: 'tenants',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+        await queryRunner.createForeignKey(
+            'team_resources',
+            new TableForeignKey({
+                name: 'fk_team_resources_organization',
+                columnNames: ['organizationId'],
+                referencedTableName: 'organizations',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('team_resources')) {
+            await queryRunner.dropTable('team_resources', true);
+        }
+    }
+}

--- a/apps/api/src/teams/dto/team.dto.ts
+++ b/apps/api/src/teams/dto/team.dto.ts
@@ -8,7 +8,8 @@ import {
     Matches,
     MaxLength,
 } from 'class-validator';
-import type { TeamMemberRole, TeamMemberType } from '@ever-works/agent/teams';
+import type { TeamMemberRole, TeamMemberType, TeamResourceType } from '@ever-works/agent/teams';
+import { TEAM_RESOURCE_TYPES } from '@ever-works/agent/teams';
 
 /**
  * Teams & Prebuilt Companies — request DTOs
@@ -106,4 +107,26 @@ export class RemoveTeamMemberQueryDto {
     @ApiProperty({ enum: ['agent', 'user'] })
     @IsIn(['agent', 'user'])
     memberType: TeamMemberType;
+}
+
+/** Attach a Work/Task/Agent/Mission/Idea to a Team. */
+export class AttachTeamResourceDto {
+    @ApiProperty({ enum: [...TEAM_RESOURCE_TYPES] })
+    @IsIn([...TEAM_RESOURCE_TYPES])
+    resourceType: TeamResourceType;
+
+    @ApiProperty({ description: 'Id of the resource to attach (per resourceType)' })
+    @IsUUID()
+    resourceId: string;
+}
+
+/** Reverse lookup query: which Teams own `(resourceType, resourceId)`. */
+export class ResourceTeamsQueryDto {
+    @ApiProperty({ enum: [...TEAM_RESOURCE_TYPES] })
+    @IsIn([...TEAM_RESOURCE_TYPES])
+    resourceType: TeamResourceType;
+
+    @ApiProperty({ description: 'Id of the resource to look up' })
+    @IsUUID()
+    resourceId: string;
 }

--- a/apps/api/src/teams/teams.controller.ts
+++ b/apps/api/src/teams/teams.controller.ts
@@ -14,9 +14,15 @@ import {
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import type { Team } from '@ever-works/agent/teams';
-import { OrgChartService, TeamsService } from '@ever-works/agent/teams';
-import type { OrgChartPayload, TeamMemberView } from '@ever-works/agent/teams';
+import type { Team, TeamResourceType } from '@ever-works/agent/teams';
+import { OrgChartService, TeamResourcesService, TeamsService } from '@ever-works/agent/teams';
+import type {
+    OrgChartPayload,
+    ResourceTeamRef,
+    TeamMemberView,
+    TeamResourceItem,
+    TeamResourcesGrouped,
+} from '@ever-works/agent/teams';
 import { AuthSessionGuard, CurrentUser } from '../auth';
 import { AuthenticatedUser } from '@src/auth/types/auth.types';
 import {
@@ -25,8 +31,10 @@ import {
 } from '../organizations/guards/organization-ownership.guard';
 import {
     AddTeamMemberDto,
+    AttachTeamResourceDto,
     CreateTeamDto,
     RemoveTeamMemberQueryDto,
+    ResourceTeamsQueryDto,
     UpdateTeamDto,
 } from './dto/team.dto';
 
@@ -69,6 +77,7 @@ export class TeamsController {
     constructor(
         private readonly teamsService: TeamsService,
         private readonly orgChart: OrgChartService,
+        private readonly teamResources: TeamResourcesService,
     ) {}
 
     @Get('teams')
@@ -180,6 +189,67 @@ export class TeamsController {
         @Query() query: RemoveTeamMemberQueryDto,
     ): Promise<void> {
         await this.teamsService.removeMember(orgId, teamId, query.memberType, memberId);
+    }
+
+    @Get('teams/:teamId/resources')
+    @ApiOperation({
+        summary: 'List resources attached to a team',
+        description: 'Attached Works/Tasks/Agents/Missions/Ideas, resolved + grouped by type.',
+    })
+    @ApiResponse({ status: 200, description: 'Team resources listed' })
+    async listResources(
+        @Param('orgId', ParseUUIDPipe) orgId: string,
+        @Param('teamId', ParseUUIDPipe) teamId: string,
+    ): Promise<TeamResourcesGrouped> {
+        return this.teamResources.listForTeam(orgId, teamId);
+    }
+
+    @Post('teams/:teamId/resources')
+    @OrgAdmin()
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Attach a resource (Work/Task/Agent/Mission/Idea) to a team',
+        description: 'The resource must belong to the same Organization (404-never-403 on mismatch).',
+    })
+    @ApiResponse({ status: 201, description: 'Resource attached' })
+    @ApiResponse({ status: 404, description: 'Team or resource not found in this Organization' })
+    @ApiResponse({ status: 409, description: 'Resource already attached to this team' })
+    async attachResource(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('orgId', ParseUUIDPipe) orgId: string,
+        @Param('teamId', ParseUUIDPipe) teamId: string,
+        @Body() dto: AttachTeamResourceDto,
+    ): Promise<TeamResourceItem> {
+        return this.teamResources.attach(auth.userId, orgId, teamId, dto);
+    }
+
+    @Delete('teams/:teamId/resources/:resourceType/:resourceId')
+    @OrgAdmin()
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: 'Detach a resource from a team' })
+    @ApiResponse({ status: 204, description: 'Resource detached' })
+    @ApiResponse({ status: 404, description: 'Resource is not attached to this team' })
+    async detachResource(
+        @Param('orgId', ParseUUIDPipe) orgId: string,
+        @Param('teamId', ParseUUIDPipe) teamId: string,
+        @Param('resourceType') resourceType: TeamResourceType,
+        @Param('resourceId', ParseUUIDPipe) resourceId: string,
+    ): Promise<void> {
+        await this.teamResources.detach(orgId, teamId, resourceType, resourceId);
+    }
+
+    @Get('resource-teams')
+    @ApiOperation({
+        summary: 'Reverse lookup: teams that own a given resource',
+        description: 'Which Teams in this Organization a Work/Task/Agent/Mission/Idea belongs to.',
+    })
+    @ApiResponse({ status: 200, description: 'Owning teams listed' })
+    async resourceTeams(
+        @Param('orgId', ParseUUIDPipe) orgId: string,
+        @Query() query: ResourceTeamsQueryDto,
+    ): Promise<ResourceTeamRef[]> {
+        return this.teamResources.listTeamsForResource(orgId, query.resourceType, query.resourceId);
     }
 
     @Get('org-chart')

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5053,7 +5053,24 @@
                 "removeMember": "Remove",
                 "roleLead": "Lead",
                 "roleMember": "Member",
-                "emptyRoster": "No members yet — add Agents or teammates to this team."
+                "emptyRoster": "No members yet — add Agents or teammates to this team.",
+                "resourcesTitle": "Resources",
+                "resourcesSubtitle": "Works, agents and more that belong to this team.",
+                "emptyResources": "No resources attached yet — attach Works or Agents this team owns.",
+                "addResourceCta": "Attach a resource",
+                "addResourceTypeLabel": "Type",
+                "addResourceSelectLabel": "Resource",
+                "addResourceSearchPlaceholder": "Search…",
+                "addResourceSubmit": "Attach",
+                "attaching": "Attaching…",
+                "removeResource": "Remove",
+                "resourceTypeWork": "Work",
+                "resourceTypeAgent": "Agent",
+                "resourceGroupWork": "Works",
+                "resourceGroupAgent": "Agents",
+                "resourceGroupMission": "Missions",
+                "resourceGroupIdea": "Ideas",
+                "resourceGroupTask": "Tasks"
             },
             "settings": {
                 "title": "Team Settings",
@@ -5075,7 +5092,9 @@
                 "updateFailed": "Could not update the team",
                 "deleteFailed": "Could not delete the team",
                 "memberAddFailed": "Could not add the member",
-                "memberRemoveFailed": "Could not remove the member"
+                "memberRemoveFailed": "Could not remove the member",
+                "resourceAttachFailed": "Could not attach the resource",
+                "resourceDetachFailed": "Could not remove the resource"
             }
         },
         "orgChartPage": {

--- a/apps/web/src/app/[locale]/(dashboard)/teams/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/teams/[id]/page.tsx
@@ -1,7 +1,9 @@
 import { notFound } from 'next/navigation';
-import { teamsAPI, type Team } from '@/lib/api/teams';
+import { teamsAPI, type Team, type TeamResourcesGrouped } from '@/lib/api/teams';
 import { agentsAPI, type Agent } from '@/lib/api/agents';
+import { getWorks } from '@/app/actions/dashboard/works';
 import { TeamDetailClient } from '@/components/teams/TeamDetailClient';
+import type { ResourceOption } from '@/components/teams/TeamResourcesSection';
 
 /**
  * Teams & Prebuilt Companies §4.2 — `/teams/[id]` overview. Active-org
@@ -16,13 +18,23 @@ export default async function TeamDetailPage({ params }: { params: Promise<{ id:
     if (orgs.length === 0) notFound();
     const org = orgs[0];
 
-    const [team, teams, agentsResp] = await Promise.all([
+    const emptyResources: TeamResourcesGrouped = {
+        work: [],
+        task: [],
+        agent: [],
+        mission: [],
+        idea: [],
+    };
+
+    const [team, teams, agentsResp, resources, worksResp] = await Promise.all([
         teamsAPI.get(org.id, id),
         teamsAPI.list(org.id).catch(() => [] as Team[]),
         agentsAPI.list({ limit: 100 }).catch(() => ({
             data: [] as Agent[],
             meta: { total: 0, limit: 100, offset: 0 },
         })),
+        teamsAPI.listResources(org.id, id).catch(() => emptyResources),
+        getWorks({ limit: 100, offset: 0 }).catch(() => ({ success: false, works: [], total: 0 })),
     ]);
     if (!team) notFound();
 
@@ -32,5 +44,20 @@ export default async function TeamDetailPage({ params }: { params: Promise<{ id:
         title: agent.title,
     }));
 
-    return <TeamDetailClient org={org} team={team} teams={teams} agents={agents} />;
+    const works: ResourceOption[] = (worksResp.works ?? []).map((work) => ({
+        id: work.id,
+        name: work.name,
+        subtitle: work.slug ?? null,
+    }));
+
+    return (
+        <TeamDetailClient
+            org={org}
+            team={team}
+            teams={teams}
+            agents={agents}
+            resources={resources}
+            works={works}
+        />
+    );
 }

--- a/apps/web/src/app/actions/dashboard/teams.ts
+++ b/apps/web/src/app/actions/dashboard/teams.ts
@@ -7,6 +7,7 @@ import {
     type CreateTeamInput,
     type TeamMemberRole,
     type TeamMemberType,
+    type TeamResourceType,
     type UpdateTeamInput,
 } from '@/lib/api/teams';
 import { getAuthFromCookie } from '@/lib/auth';
@@ -75,5 +76,27 @@ export async function removeTeamMemberAction(
 ) {
     await requireTeamsAuth();
     await teamsAPI.removeMember(orgId, teamId, memberType, memberId);
+    revalidateTeamSurfaces();
+}
+
+export async function attachTeamResourceAction(
+    orgId: string,
+    teamId: string,
+    input: { resourceType: TeamResourceType; resourceId: string },
+) {
+    await requireTeamsAuth();
+    const resource = await teamsAPI.attachResource(orgId, teamId, input);
+    revalidateTeamSurfaces();
+    return resource;
+}
+
+export async function detachTeamResourceAction(
+    orgId: string,
+    teamId: string,
+    resourceType: TeamResourceType,
+    resourceId: string,
+) {
+    await requireTeamsAuth();
+    await teamsAPI.detachResource(orgId, teamId, resourceType, resourceId);
     revalidateTeamSurfaces();
 }

--- a/apps/web/src/components/teams/TeamDetailClient.tsx
+++ b/apps/web/src/components/teams/TeamDetailClient.tsx
@@ -26,12 +26,17 @@ import { Button } from '@/components/ui/button';
 import { Link, useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { addTeamMemberAction, removeTeamMemberAction } from '@/app/actions/dashboard/teams';
+import {
+    TeamResourcesSection,
+    type ResourceOption,
+} from '@/components/teams/TeamResourcesSection';
 import type {
     Team,
     TeamDetail,
     TeamMemberRole,
     TeamMemberType,
     TeamMemberView,
+    TeamResourcesGrouped,
     TeamsOrganization,
 } from '@/lib/api/teams';
 
@@ -75,6 +80,10 @@ export interface TeamDetailClientProps {
     teams: Team[];
     /** Org Agents — add-member select + manager/member name resolution. */
     agents: TeamAgentOption[];
+    /** Resources (Works/Agents/…) attached to this team, grouped by type. */
+    resources: TeamResourcesGrouped;
+    /** Org Works available to attach in the Resources section. */
+    works: ResourceOption[];
 }
 
 /**
@@ -85,7 +94,14 @@ export interface TeamDetailClientProps {
  * actions then `router.refresh()` so the server payload stays the
  * single source of truth.
  */
-export function TeamDetailClient({ org, team, teams, agents }: TeamDetailClientProps) {
+export function TeamDetailClient({
+    org,
+    team,
+    teams,
+    agents,
+    resources,
+    works,
+}: TeamDetailClientProps) {
     const t = useTranslations('dashboard.teamsPage');
     const router = useRouter();
     const [memberType, setMemberType] = useState<TeamMemberType>('agent');
@@ -349,6 +365,19 @@ export function TeamDetailClient({ org, team, teams, agents }: TeamDetailClientP
                     </div>
                 </div>
             </section>
+
+            {/* Resources (Works/Agents/Missions/Ideas/Tasks that belong to this team) */}
+            <TeamResourcesSection
+                org={org}
+                teamId={team.id}
+                resources={resources}
+                works={works}
+                agents={agents.map((agent) => ({
+                    id: agent.id,
+                    name: agent.name,
+                    subtitle: agent.title,
+                }))}
+            />
 
             {/* Sub-teams */}
             {subTeams.length > 0 ? (

--- a/apps/web/src/components/teams/TeamResourcesSection.tsx
+++ b/apps/web/src/components/teams/TeamResourcesSection.tsx
@@ -1,0 +1,313 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Bot, Briefcase, Lightbulb, ListChecks, Target, type LucideIcon } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Link, useRouter } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import {
+    attachTeamResourceAction,
+    detachTeamResourceAction,
+} from '@/app/actions/dashboard/teams';
+import type {
+    TeamResourceItem,
+    TeamResourcesGrouped,
+    TeamResourceType,
+    TeamsOrganization,
+} from '@/lib/api/teams';
+
+const SELECT_CLASSES =
+    'w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-3 h-9 text-sm text-text dark:text-text-dark';
+
+/** The resource types the add-form can attach (searchable over org works/agents). */
+type AddableType = Extract<TeamResourceType, 'work' | 'agent'>;
+
+export interface ResourceOption {
+    id: string;
+    name: string;
+    /** Agent title / secondary label (optional). */
+    subtitle?: string | null;
+}
+
+export interface TeamResourcesSectionProps {
+    org: TeamsOrganization;
+    teamId: string;
+    resources: TeamResourcesGrouped;
+    /** Org Works available to attach. */
+    works: ResourceOption[];
+    /** Org Agents available to attach. */
+    agents: ResourceOption[];
+}
+
+const GROUP_ORDER: TeamResourceType[] = ['work', 'agent', 'mission', 'idea', 'task'];
+
+const GROUP_ICON: Record<TeamResourceType, LucideIcon> = {
+    work: Briefcase,
+    agent: Bot,
+    mission: Target,
+    idea: Lightbulb,
+    task: ListChecks
+};
+
+function resourceHref(type: TeamResourceType, id: string): string {
+    switch (type) {
+        case 'work':
+            return ROUTES.DASHBOARD_WORK(id);
+        case 'agent':
+            return ROUTES.DASHBOARD_AGENT(id);
+        case 'mission':
+            return ROUTES.DASHBOARD_MISSION(id);
+        case 'idea':
+            return ROUTES.DASHBOARD_IDEA(id);
+        case 'task':
+            return ROUTES.DASHBOARD_TASK(id);
+    }
+}
+
+/**
+ * Teams & Prebuilt Companies — Team detail "Resources" section. Lists the
+ * Works / Agents / Missions / Ideas / Tasks attached to this team (grouped,
+ * each linking to its detail page with a remove control) and an add form: a
+ * type toggle (Work | Agent) + a searchable select of the org's resources.
+ * Mutations run through the server actions then `router.refresh()` so the
+ * server payload stays the single source of truth.
+ */
+export function TeamResourcesSection({
+    org,
+    teamId,
+    resources,
+    works,
+    agents
+}: TeamResourcesSectionProps) {
+    const t = useTranslations('dashboard.teamsPage');
+    const router = useRouter();
+    const [addType, setAddType] = useState<AddableType>('work');
+    const [search, setSearch] = useState('');
+    const [selectedId, setSelectedId] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [removingId, setRemovingId] = useState<string | null>(null);
+
+    const allItems = useMemo(
+        () => GROUP_ORDER.flatMap((type) => resources[type]),
+        [resources],
+    );
+    const hasAny = allItems.length > 0;
+
+    // Ids already attached (per type) — filtered out of the add options.
+    const attachedByType = useMemo(() => {
+        const map: Record<AddableType, Set<string>> = { work: new Set(), agent: new Set() };
+        for (const item of resources.work) map.work.add(item.resourceId);
+        for (const item of resources.agent) map.agent.add(item.resourceId);
+        return map;
+    }, [resources]);
+
+    const options = useMemo(() => {
+        const source = addType === 'work' ? works : agents;
+        const attached = attachedByType[addType];
+        const q = search.trim().toLowerCase();
+        return source
+            .filter((option) => !attached.has(option.id))
+            .filter((option) =>
+                q
+                    ? option.name.toLowerCase().includes(q) ||
+                      (option.subtitle ?? '').toLowerCase().includes(q)
+                    : true,
+            );
+    }, [addType, works, agents, attachedByType, search]);
+
+    const handleTypeChange = (next: AddableType) => {
+        setAddType(next);
+        setSelectedId('');
+        setSearch('');
+    };
+
+    const handleAttach = async () => {
+        if (!selectedId || isSubmitting) return;
+        setIsSubmitting(true);
+        try {
+            await attachTeamResourceAction(org.id, teamId, {
+                resourceType: addType,
+                resourceId: selectedId
+            });
+            setSelectedId('');
+            setSearch('');
+            router.refresh();
+        } catch {
+            toast.error(t('errors.resourceAttachFailed'));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const handleRemove = async (item: TeamResourceItem) => {
+        if (removingId) return;
+        setRemovingId(item.id);
+        try {
+            await detachTeamResourceAction(org.id, teamId, item.resourceType, item.resourceId);
+            router.refresh();
+        } catch {
+            toast.error(t('errors.resourceDetachFailed'));
+        } finally {
+            setRemovingId(null);
+        }
+    };
+
+    const groupLabel = (type: TeamResourceType): string => {
+        switch (type) {
+            case 'work':
+                return t('detail.resourceGroupWork');
+            case 'agent':
+                return t('detail.resourceGroupAgent');
+            case 'mission':
+                return t('detail.resourceGroupMission');
+            case 'idea':
+                return t('detail.resourceGroupIdea');
+            case 'task':
+                return t('detail.resourceGroupTask');
+        }
+    };
+
+    return (
+        <section
+            data-testid="team-resources"
+            className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5 space-y-4"
+        >
+            <div>
+                <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                    {t('detail.resourcesTitle')}
+                </h2>
+                <p className="text-xs text-text-secondary dark:text-text-secondary-dark mt-0.5">
+                    {t('detail.resourcesSubtitle')}
+                </p>
+            </div>
+
+            {!hasAny ? (
+                <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                    {t('detail.emptyResources')}
+                </p>
+            ) : (
+                <div className="space-y-4">
+                    {GROUP_ORDER.filter((type) => resources[type].length > 0).map((type) => {
+                        const GroupIcon = GROUP_ICON[type];
+                        return (
+                            <div key={type}>
+                                <h3 className="text-xs font-medium uppercase tracking-wide text-text-secondary dark:text-text-secondary-dark mb-2">
+                                    {groupLabel(type)}
+                                </h3>
+                                <ul className="divide-y divide-border/40 dark:divide-border-dark/40">
+                                    {resources[type].map((item) => (
+                                        <li
+                                            key={item.id}
+                                            data-testid={`team-resource-${item.resourceId}`}
+                                            className="flex items-center gap-3 py-2.5"
+                                        >
+                                            <div className="shrink-0 w-7 h-7 rounded-md bg-surface-secondary dark:bg-surface-secondary-dark flex items-center justify-center">
+                                                <GroupIcon
+                                                    className="w-3.5 h-3.5 text-text-secondary dark:text-text-secondary-dark"
+                                                    strokeWidth={1.5}
+                                                    aria-hidden="true"
+                                                />
+                                            </div>
+                                            <div className="min-w-0 flex-1">
+                                                <Link
+                                                    href={resourceHref(item.resourceType, item.resourceId)}
+                                                    className="text-sm text-text dark:text-text-dark truncate hover:text-primary transition-colors block"
+                                                >
+                                                    {item.name ?? item.resourceId}
+                                                </Link>
+                                            </div>
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={() => handleRemove(item)}
+                                                loading={removingId === item.id}
+                                                disabled={removingId !== null}
+                                                className="text-xs text-danger hover:text-danger"
+                                                data-testid={`team-resource-remove-${item.resourceId}`}
+                                            >
+                                                {t('detail.removeResource')}
+                                            </Button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+
+            {/* Attach a resource */}
+            <div
+                data-testid="team-resource-add"
+                className="border-t border-border/40 dark:border-border-dark/40 pt-4"
+            >
+                <h3 className="text-xs font-medium text-text dark:text-text-dark mb-2">
+                    {t('detail.addResourceCta')}
+                </h3>
+                <div className="flex flex-col sm:flex-row gap-2 sm:items-end">
+                    <div className="sm:w-32">
+                        <label
+                            htmlFor="team-resource-type"
+                            className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1"
+                        >
+                            {t('detail.addResourceTypeLabel')}
+                        </label>
+                        <select
+                            id="team-resource-type"
+                            value={addType}
+                            onChange={(event) => handleTypeChange(event.target.value as AddableType)}
+                            className={SELECT_CLASSES}
+                        >
+                            <option value="work">{t('detail.resourceTypeWork')}</option>
+                            <option value="agent">{t('detail.resourceTypeAgent')}</option>
+                        </select>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                        <label
+                            htmlFor="team-resource-select"
+                            className="block text-xs text-text-secondary dark:text-text-secondary-dark mb-1"
+                        >
+                            {t('detail.addResourceSelectLabel')}
+                        </label>
+                        <input
+                            type="text"
+                            value={search}
+                            onChange={(event) => setSearch(event.target.value)}
+                            placeholder={t('detail.addResourceSearchPlaceholder')}
+                            className={`${SELECT_CLASSES} mb-2`}
+                            aria-label={t('detail.addResourceSearchPlaceholder')}
+                            data-testid="team-resource-search"
+                        />
+                        <select
+                            id="team-resource-select"
+                            value={selectedId}
+                            onChange={(event) => setSelectedId(event.target.value)}
+                            className={SELECT_CLASSES}
+                        >
+                            <option value="">{t('detail.addResourceSelectLabel')}</option>
+                            {options.map((option) => (
+                                <option key={option.id} value={option.id}>
+                                    {option.subtitle
+                                        ? `${option.name} — ${option.subtitle}`
+                                        : option.name}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                    <Button
+                        size="sm"
+                        onClick={handleAttach}
+                        disabled={!selectedId || isSubmitting}
+                        loading={isSubmitting}
+                        data-testid="team-resource-add-submit"
+                        className="shrink-0"
+                    >
+                        {isSubmitting ? t('detail.attaching') : t('detail.addResourceSubmit')}
+                    </Button>
+                </div>
+            </div>
+        </section>
+    );
+}

--- a/apps/web/src/lib/api/teams.ts
+++ b/apps/web/src/lib/api/teams.ts
@@ -39,6 +39,32 @@ export interface TeamDetail extends Team {
     childTeamIds: string[];
 }
 
+export type TeamResourceType = 'work' | 'task' | 'agent' | 'mission' | 'idea';
+
+export interface TeamResourceItem {
+    id: string;
+    resourceType: TeamResourceType;
+    resourceId: string;
+    name: string | null;
+    slug: string | null;
+    addedById: string | null;
+    createdAt: string;
+}
+
+export interface TeamResourcesGrouped {
+    work: TeamResourceItem[];
+    task: TeamResourceItem[];
+    agent: TeamResourceItem[];
+    mission: TeamResourceItem[];
+    idea: TeamResourceItem[];
+}
+
+export interface ResourceTeamRef {
+    teamId: string;
+    name: string;
+    slug: string;
+}
+
 export interface CreateTeamInput {
     name: string;
     slug?: string;
@@ -170,6 +196,59 @@ export const teamsAPI = {
             });
         } catch {
             return null;
+        }
+    },
+
+    async listResources(orgId: string, teamId: string): Promise<TeamResourcesGrouped> {
+        try {
+            return await serverFetch<TeamResourcesGrouped>(
+                `/organizations/${orgId}/teams/${teamId}/resources`,
+                { method: 'GET' },
+            );
+        } catch {
+            return { work: [], task: [], agent: [], mission: [], idea: [] };
+        }
+    },
+
+    async attachResource(
+        orgId: string,
+        teamId: string,
+        input: { resourceType: TeamResourceType; resourceId: string },
+    ): Promise<TeamResourceItem> {
+        return serverMutation<TeamResourceItem>({
+            endpoint: `/organizations/${orgId}/teams/${teamId}/resources`,
+            data: input,
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    async detachResource(
+        orgId: string,
+        teamId: string,
+        resourceType: TeamResourceType,
+        resourceId: string,
+    ): Promise<void> {
+        await serverMutation<void>({
+            endpoint: `/organizations/${orgId}/teams/${teamId}/resources/${resourceType}/${resourceId}`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
+
+    async resourceTeams(
+        orgId: string,
+        resourceType: TeamResourceType,
+        resourceId: string,
+    ): Promise<ResourceTeamRef[]> {
+        try {
+            return await serverFetch<ResourceTeamRef[]>(
+                `/organizations/${orgId}/resource-teams?resourceType=${resourceType}&resourceId=${resourceId}`,
+                { method: 'GET' },
+            );
+        } catch {
+            return [];
         }
     },
 };

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -97,6 +97,7 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     // Teams & Prebuilt Companies (teams-and-companies spec §2) ──
     'Team',
     'TeamMember',
+    'TeamResource',
     // ──────────────────────────
     'Template',
     'TemplateCustomization',

--- a/packages/agent/src/database/database.config.ts
+++ b/packages/agent/src/database/database.config.ts
@@ -59,6 +59,7 @@ import {
     AgentMembership,
     Team,
     TeamMember,
+    TeamResource,
     Skill,
     SkillBinding,
     Task,
@@ -189,6 +190,8 @@ export const ENTITIES = [
     // Teams & Prebuilt Companies (teams-and-companies spec §2)
     Team,
     TeamMember,
+    // Team ↔ resource association (Works/Agents/Missions/Ideas/Tasks belong to Teams)
+    TeamResource,
     Skill,
     SkillBinding,
     // Phase 11 — Tasks family

--- a/packages/agent/src/entities/__tests__/tier-c.tenants-orgs.spec.ts
+++ b/packages/agent/src/entities/__tests__/tier-c.tenants-orgs.spec.ts
@@ -17,6 +17,7 @@ import { TaskRelation } from '../task-relation.entity';
 import { TaskReviewer } from '../task-reviewer.entity';
 import { TaskWatcher } from '../task-watcher.entity';
 import { TeamMember } from '../team-member.entity';
+import { TeamResource } from '../team-resource.entity';
 import { UsageLedgerEntry } from '../usage-ledger-entry.entity';
 import { WebhookDelivery } from '../webhook-delivery.entity';
 import { WorkGenerationHistory } from '../work-generation-history.entity';
@@ -69,6 +70,7 @@ describe('Tier C entities — Phase 5a scope columns', () => {
         { name: 'AgentMembership', target: AgentMembership },
         { name: 'SkillBinding', target: SkillBinding },
         { name: 'TeamMember', target: TeamMember },
+        { name: 'TeamResource', target: TeamResource },
         { name: 'WorkMember', target: WorkMember },
         { name: 'WorkInvitation', target: WorkInvitation },
         { name: 'WorkGenerationHistory', target: WorkGenerationHistory },

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -102,3 +102,4 @@ export * from './tenant-credential-snapshot.entity';
 // Teams & Prebuilt Companies (docs/specs/features/teams-and-companies)
 export * from './team.entity';
 export * from './team-member.entity';
+export * from './team-resource.entity';

--- a/packages/agent/src/entities/team-resource.entity.ts
+++ b/packages/agent/src/entities/team-resource.entity.ts
@@ -1,0 +1,74 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { PortableDateColumn } from './_types';
+
+/**
+ * Teams & Prebuilt Companies — Team ↔ resource association
+ * (operator ask "some Works belong to some Teams").
+ *
+ * A polymorphic edge row: one Work / Task / Agent / Mission / Idea attached
+ * to one Team (mirrors the `TeamMember.memberType` and `TaskAssignee.actorType`
+ * patterns). A resource may sit in several Teams — the attachment is an edge,
+ * never a column on the resource, so nothing on the Work/Agent/… side changes.
+ *
+ * `resourceType` discriminates which table `resourceId` points at:
+ *   - `work`    → `works.id`
+ *   - `task`    → `tasks.id`
+ *   - `agent`   → `agents.id`
+ *   - `mission` → `missions.id`
+ *   - `idea`    → `work_proposals.id`
+ *
+ * There is deliberately NO `@ManyToOne` to any scope/resource entity — the
+ * polymorphic `resourceId` cannot be a single FK, and the scope columns
+ * follow the same raw-column discipline as the rest of the Tier C family
+ * (cycle-avoidance, see user.entity.ts EW-654 comment). Referential
+ * integrity for `teamId` is a real FK (ON DELETE CASCADE, migration);
+ * resource existence + tenancy is validated in `TeamResourcesService`
+ * (the EW-711 IDOR boundary).
+ */
+
+export type TeamResourceType = 'work' | 'task' | 'agent' | 'mission' | 'idea';
+
+/** Canonical list — shared by the DTO validators and the service guards. */
+export const TEAM_RESOURCE_TYPES: readonly TeamResourceType[] = [
+    'work',
+    'task',
+    'agent',
+    'mission',
+    'idea',
+];
+
+@Entity({ name: 'team_resources' })
+@Index('uq_team_resources_team_resource', ['teamId', 'resourceType', 'resourceId'], { unique: true })
+@Index('idx_team_resources_resource', ['resourceType', 'resourceId'])
+export class TeamResource {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** FK to `teams.id` (ON DELETE CASCADE by migration). Raw column. */
+    @Column({ type: 'uuid' })
+    teamId: string;
+
+    @Column({ type: 'varchar', length: 16 })
+    resourceType: TeamResourceType;
+
+    /** `works.id` / `tasks.id` / `agents.id` / `missions.id` /
+     *  `work_proposals.id` depending on `resourceType`; service-validated. */
+    @Column({ type: 'uuid' })
+    resourceId: string;
+
+    @Column({ type: 'uuid', nullable: true })
+    addedById?: string | null;
+
+    // Tier C denormalized scope FKs (EW-657) — set explicitly from the owning
+    // Team on insert (raw `/api/organizations/:orgId/...` routes run with
+    // EMPTY_SCOPE, so the ambient ScopeStampingSubscriber may not carry this
+    // org). No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    @PortableDateColumn()
+    createdAt: Date;
+}

--- a/packages/agent/src/teams/index.ts
+++ b/packages/agent/src/teams/index.ts
@@ -3,9 +3,12 @@
 // the entities so callers don't need deep imports from `../entities/*`.
 export * from './teams.service';
 export * from './org-chart.service';
+export * from './team-resources.service';
 export * from './teams.module';
 export * from './types';
 export { Team } from '../entities/team.entity';
 export type { TeamMetadata } from '../entities/team.entity';
 export { TeamMember } from '../entities/team-member.entity';
 export type { TeamMemberRole, TeamMemberType } from '../entities/team-member.entity';
+export { TeamResource, TEAM_RESOURCE_TYPES } from '../entities/team-resource.entity';
+export type { TeamResourceType } from '../entities/team-resource.entity';

--- a/packages/agent/src/teams/team-resources.service.ts
+++ b/packages/agent/src/teams/team-resources.service.ts
@@ -1,0 +1,328 @@
+import {
+    BadRequestException,
+    ConflictException,
+    Injectable,
+    NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { Agent } from '../entities/agent.entity';
+import { Mission } from '../entities/mission.entity';
+import { Organization } from '../entities/organization.entity';
+import { Task } from '../entities/task.entity';
+import { Team } from '../entities/team.entity';
+import {
+    TEAM_RESOURCE_TYPES,
+    TeamResource,
+    type TeamResourceType,
+} from '../entities/team-resource.entity';
+import { Work } from '../entities/work.entity';
+import { WorkProposal } from '../entities/work-proposal.entity';
+import {
+    AttachTeamResourceInput,
+    ResourceTeamRef,
+    TeamResourceItem,
+    TeamResourcesGrouped,
+} from './types';
+
+/** Minimal shape every resource repo exposes for the IDOR + display resolve. */
+interface ScopedResourceRow {
+    id: string;
+    tenantId?: string | null;
+    organizationId?: string | null;
+}
+
+/**
+ * Teams & Prebuilt Companies — Team ↔ resource association service
+ * (operator ask "some Works belong to some Teams", generalized to
+ * Works / Tasks / Agents / Missions / Ideas).
+ *
+ * Authorization happens BEFORE these methods run: every route is behind
+ * `OrganizationOwnershipGuard` (fail-closed tenant-ownership, 404 posture).
+ * This service re-validates the *object graph* — that both the Team AND the
+ * referenced resource actually belong to the same Organization/Tenant — so a
+ * legitimate caller cannot link a foreign Work/Agent/… by id (the EW-711
+ * IDOR class). 404-never-403 throughout: foreign and missing ids are
+ * indistinguishable to the caller.
+ */
+@Injectable()
+export class TeamResourcesService {
+    constructor(
+        @InjectRepository(TeamResource)
+        private readonly resources: Repository<TeamResource>,
+        @InjectRepository(Team)
+        private readonly teams: Repository<Team>,
+        @InjectRepository(Organization)
+        private readonly organizations: Repository<Organization>,
+        @InjectRepository(Work)
+        private readonly works: Repository<Work>,
+        @InjectRepository(Agent)
+        private readonly agents: Repository<Agent>,
+        @InjectRepository(Mission)
+        private readonly missions: Repository<Mission>,
+        @InjectRepository(WorkProposal)
+        private readonly ideas: Repository<WorkProposal>,
+        @InjectRepository(Task)
+        private readonly tasks: Repository<Task>,
+    ) {}
+
+    /**
+     * Attach a resource to a Team. Validates the Team is in the org AND the
+     * resource exists + belongs to the same tenant/org (IDOR guard). Scope
+     * columns are stamped from the Team (not the ALS subscriber — raw
+     * `/api/organizations/:orgId/...` routes run with EMPTY_SCOPE).
+     */
+    async attach(
+        userId: string,
+        orgId: string,
+        teamId: string,
+        input: AttachTeamResourceInput,
+    ): Promise<TeamResourceItem> {
+        const resourceType = this.normalizeResourceType(input.resourceType);
+        const team = await this.getTeamOrThrow(orgId, teamId);
+        const org = await this.organizations.findOne({ where: { id: orgId } });
+        if (!org) {
+            throw new NotFoundException(`Organization ${orgId} not found`);
+        }
+
+        const resource = await this.assertResourceInOrg(org, resourceType, input.resourceId);
+
+        const row = this.resources.create({
+            teamId: team.id,
+            resourceType,
+            resourceId: input.resourceId,
+            addedById: userId,
+            // Prefer the Team's stamped scope; fall back to the org (a Team is
+            // always org-stamped in v1, so these agree).
+            tenantId: team.tenantId ?? org.tenantId ?? null,
+            organizationId: team.organizationId ?? org.id,
+            createdAt: new Date(),
+        });
+
+        try {
+            const saved = await this.resources.save(row);
+            return this.toItem(saved, this.resolveRef(resourceType, resource));
+        } catch (error) {
+            if (this.isUniqueViolation(error)) {
+                throw new ConflictException('This resource is already attached to the team');
+            }
+            throw error;
+        }
+    }
+
+    /** Detach a resource from a Team (idempotent-ish: 404 when nothing matched). */
+    async detach(
+        orgId: string,
+        teamId: string,
+        resourceType: TeamResourceType,
+        resourceId: string,
+    ): Promise<void> {
+        const type = this.normalizeResourceType(resourceType);
+        await this.getTeamOrThrow(orgId, teamId);
+        const result = await this.resources.delete({ teamId, resourceType: type, resourceId });
+        if (!result.affected) {
+            throw new NotFoundException('Resource is not attached to this team');
+        }
+    }
+
+    /** List a Team's attached resources, resolved + grouped by type. */
+    async listForTeam(orgId: string, teamId: string): Promise<TeamResourcesGrouped> {
+        await this.getTeamOrThrow(orgId, teamId);
+        const rows = await this.resources.find({
+            where: { teamId },
+            order: { createdAt: 'ASC' },
+        });
+
+        const grouped: TeamResourcesGrouped = {
+            work: [],
+            task: [],
+            agent: [],
+            mission: [],
+            idea: [],
+        };
+        if (rows.length === 0) {
+            return grouped;
+        }
+
+        // Resolve display refs in one query per type present.
+        const refsByType = await this.resolveRefsForRows(rows);
+        for (const row of rows) {
+            const type = row.resourceType;
+            if (!this.isKnownType(type)) {
+                continue;
+            }
+            const ref = refsByType.get(type)?.get(row.resourceId) ?? { name: null, slug: null };
+            grouped[type].push(this.toItem(row, ref));
+        }
+        return grouped;
+    }
+
+    /**
+     * Reverse lookup: which Teams (in this org) own a given resource. Filters
+     * by `organizationId = orgId` so an attacker-supplied resourceId can only
+     * ever reveal Teams inside the org they already passed the guard for.
+     */
+    async listTeamsForResource(
+        orgId: string,
+        resourceType: TeamResourceType,
+        resourceId: string,
+    ): Promise<ResourceTeamRef[]> {
+        const type = this.normalizeResourceType(resourceType);
+        const rows = await this.resources.find({
+            where: { organizationId: orgId, resourceType: type, resourceId },
+        });
+        if (rows.length === 0) {
+            return [];
+        }
+        const teamRows = await this.teams.find({
+            where: { id: In(rows.map((r) => r.teamId)), organizationId: orgId },
+            order: { name: 'ASC' },
+        });
+        return teamRows.map((t) => ({ teamId: t.id, name: t.name, slug: t.slug }));
+    }
+
+    // ── Validation helpers ──
+
+    private async getTeamOrThrow(orgId: string, teamId: string): Promise<Team> {
+        const team = await this.teams.findOne({ where: { id: teamId, organizationId: orgId } });
+        if (!team) {
+            throw new NotFoundException(`Team ${teamId} not found`);
+        }
+        return team;
+    }
+
+    /**
+     * The referenced resource must belong to the same Tenant as the org, and
+     * (when it is org-stamped) the same Organization. Mirrors
+     * `TeamsService.assertAgentInOrg`: a resource with no `tenantId` cannot be
+     * proven to belong here, so it is rejected (pre-backfill rows are
+     * practically unreachable — the backfill runs on first-Org creation).
+     */
+    private async assertResourceInOrg(
+        org: Organization,
+        resourceType: TeamResourceType,
+        resourceId: string,
+    ): Promise<ScopedResourceRow> {
+        const repo = this.repoFor(resourceType);
+        const row = (await repo.findOne({ where: { id: resourceId } })) as ScopedResourceRow | null;
+        const notFound = new NotFoundException(`Resource ${resourceId} not found`);
+        // Exactly the TeamsService.assertAgentInOrg posture: the resource's
+        // tenant must match the org's, an org-stamped resource must match this
+        // org, and a resource with no tenant cannot be proven to belong here.
+        if (!row) {
+            throw notFound;
+        }
+        if (row.tenantId && row.tenantId !== org.tenantId) {
+            throw notFound;
+        }
+        if (row.organizationId && row.organizationId !== org.id) {
+            throw notFound;
+        }
+        if (!row.tenantId) {
+            throw notFound;
+        }
+        return row;
+    }
+
+    private normalizeResourceType(value: string): TeamResourceType {
+        if (!this.isKnownType(value)) {
+            throw new BadRequestException(
+                `resourceType must be one of: ${TEAM_RESOURCE_TYPES.join(', ')}`,
+            );
+        }
+        return value;
+    }
+
+    private isKnownType(value: string): value is TeamResourceType {
+        return (TEAM_RESOURCE_TYPES as readonly string[]).includes(value);
+    }
+
+    private repoFor(resourceType: TeamResourceType): Repository<ScopedResourceRow> {
+        switch (resourceType) {
+            case 'work':
+                return this.works as unknown as Repository<ScopedResourceRow>;
+            case 'agent':
+                return this.agents as unknown as Repository<ScopedResourceRow>;
+            case 'mission':
+                return this.missions as unknown as Repository<ScopedResourceRow>;
+            case 'idea':
+                return this.ideas as unknown as Repository<ScopedResourceRow>;
+            case 'task':
+                return this.tasks as unknown as Repository<ScopedResourceRow>;
+        }
+    }
+
+    // ── Display resolution ──
+
+    private async resolveRefsForRows(
+        rows: TeamResource[],
+    ): Promise<Map<TeamResourceType, Map<string, { name: string | null; slug: string | null }>>> {
+        const idsByType = new Map<TeamResourceType, string[]>();
+        for (const row of rows) {
+            if (!this.isKnownType(row.resourceType)) continue;
+            const list = idsByType.get(row.resourceType) ?? [];
+            list.push(row.resourceId);
+            idsByType.set(row.resourceType, list);
+        }
+
+        const out = new Map<
+            TeamResourceType,
+            Map<string, { name: string | null; slug: string | null }>
+        >();
+        for (const [type, ids] of idsByType) {
+            const repo = this.repoFor(type);
+            const found = await repo.find({ where: { id: In(ids) } });
+            const byId = new Map<string, { name: string | null; slug: string | null }>();
+            for (const entity of found) {
+                byId.set((entity as ScopedResourceRow).id, this.resolveRef(type, entity));
+            }
+            out.set(type, byId);
+        }
+        return out;
+    }
+
+    /** Per-type identity mapping (works/agents expose name+slug; missions/ideas/
+     *  tasks expose a title, and only some carry a slug). */
+    private resolveRef(
+        resourceType: TeamResourceType,
+        entity: unknown,
+    ): { name: string | null; slug: string | null } {
+        const e = entity as Record<string, unknown>;
+        const str = (v: unknown): string | null => (typeof v === 'string' ? v : null);
+        switch (resourceType) {
+            case 'work':
+            case 'agent':
+                return { name: str(e.name), slug: str(e.slug) };
+            case 'task':
+                return { name: str(e.title), slug: str(e.slug) };
+            case 'mission':
+                return { name: str(e.title), slug: null };
+            case 'idea':
+                return { name: str(e.title), slug: str(e.slugSuggestion) };
+        }
+    }
+
+    private toItem(
+        row: TeamResource,
+        ref: { name: string | null; slug: string | null },
+    ): TeamResourceItem {
+        return {
+            id: row.id,
+            resourceType: row.resourceType,
+            resourceId: row.resourceId,
+            name: ref.name,
+            slug: ref.slug,
+            addedById: row.addedById ?? null,
+            createdAt: row.createdAt,
+        };
+    }
+
+    /** Postgres 23505 / sqlite SQLITE_CONSTRAINT unique-violation detection. */
+    private isUniqueViolation(error: unknown): boolean {
+        const e = error as { code?: string; message?: string };
+        return (
+            e?.code === '23505' ||
+            (typeof e?.message === 'string' && e.message.includes('UNIQUE constraint failed'))
+        );
+    }
+}

--- a/packages/agent/src/teams/teams.module.ts
+++ b/packages/agent/src/teams/teams.module.ts
@@ -1,12 +1,18 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Agent } from '../entities/agent.entity';
+import { Mission } from '../entities/mission.entity';
 import { Organization } from '../entities/organization.entity';
+import { Task } from '../entities/task.entity';
 import { Team } from '../entities/team.entity';
 import { TeamMember } from '../entities/team-member.entity';
+import { TeamResource } from '../entities/team-resource.entity';
 import { Tenant } from '../entities/tenant.entity';
 import { User } from '../entities/user.entity';
+import { Work } from '../entities/work.entity';
+import { WorkProposal } from '../entities/work-proposal.entity';
 import { OrgChartService } from './org-chart.service';
+import { TeamResourcesService } from './team-resources.service';
 import { TeamsService } from './teams.service';
 
 /**
@@ -18,8 +24,22 @@ import { TeamsService } from './teams.service';
  * company-template importer can reuse them.
  */
 @Module({
-    imports: [TypeOrmModule.forFeature([Team, TeamMember, Agent, Organization, Tenant, User])],
-    providers: [TeamsService, OrgChartService],
-    exports: [TeamsService, OrgChartService],
+    imports: [
+        TypeOrmModule.forFeature([
+            Team,
+            TeamMember,
+            TeamResource,
+            Agent,
+            Organization,
+            Tenant,
+            User,
+            Work,
+            Mission,
+            WorkProposal,
+            Task,
+        ]),
+    ],
+    providers: [TeamsService, OrgChartService, TeamResourcesService],
+    exports: [TeamsService, OrgChartService, TeamResourcesService],
 })
 export class AgentTeamsModule {}

--- a/packages/agent/src/teams/types.ts
+++ b/packages/agent/src/teams/types.ts
@@ -1,4 +1,5 @@
 import type { TeamMemberRole, TeamMemberType } from '../entities/team-member.entity';
+import type { TeamResourceType } from '../entities/team-resource.entity';
 
 /**
  * Teams & Prebuilt Companies — service-layer input/output types
@@ -73,3 +74,41 @@ export interface OrgChartPayload {
 /** Service-enforced structural limits (spec §1.1). */
 export const TEAM_MAX_DEPTH = 10;
 export const TEAM_HIERARCHY_WALK_LIMIT = 50;
+
+// ── Team ↔ resource association ("some Works belong to some Teams") ──
+
+export interface AttachTeamResourceInput {
+    resourceType: TeamResourceType;
+    resourceId: string;
+}
+
+/** One resolved resource attached to a Team. */
+export interface TeamResourceItem {
+    /** The `team_resources` row id (used as the remove handle). */
+    id: string;
+    resourceType: TeamResourceType;
+    resourceId: string;
+    /** Resolved display name (work/agent name, or mission/idea/task title). */
+    name: string | null;
+    /** Resolved slug when the resource has one (works/agents/tasks/ideas). */
+    slug: string | null;
+    addedById: string | null;
+    createdAt: Date;
+}
+
+/** Attached resources grouped by type (`listForTeam`). Empty arrays, never
+ *  missing keys, so the web can render every section unconditionally. */
+export interface TeamResourcesGrouped {
+    work: TeamResourceItem[];
+    task: TeamResourceItem[];
+    agent: TeamResourceItem[];
+    mission: TeamResourceItem[];
+    idea: TeamResourceItem[];
+}
+
+/** A Team that owns a given resource (`listTeamsForResource`). */
+export interface ResourceTeamRef {
+    teamId: string;
+    name: string;
+    slug: string;
+}


### PR DESCRIPTION
**Stacked on #1647** (Teams) — base will re-target to `develop` once Teams merges.

Implements the operator ask *"some Works belong to some Teams"* generalized to all five resource types. New polymorphic `team_resources` edge (Tier C entity + migration `1781600000000`, full registration + tier-c lock test), `TeamResourcesService` (attach/detach/list with same-org/tenant IDOR guard), org-nested API (`POST/DELETE/GET /teams/:teamId/resources` + reverse `/organizations/:orgId/resource-teams`), and a **Resources** section on the Team detail page. Unblocks the deferred Memory Team-facet and dashboard team-scoping. Verified: agent build clean, **56 tier-c tests pass** (incl. the new entity), api+web tsc clean, hard-rule clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)