### PR TITLE
feat(website-templates): agent-customizable web + web-minimal; kind-aware default

### DIFF
--- a/docs/features/website-templates.md
+++ b/docs/features/website-templates.md
@@ -80,7 +80,9 @@ Templates the Works platform supports:
   faceted filters, no directory data model.
 - **Rebrand from one file:** all copy lives in `apps/web/lib/site.config.ts`.
 - **Status:** ✅ Available; registered as `WebsiteTemplateId = 'web'`. Select it
-  for a **Landing Page**, **Blog**, or general **Website** Work.
+  for a **Landing Page**, **Blog**, or general **Website** Work. Agent-customizable
+  via a plain-CSS `apps/web/src/styles/theme.css` surface (design-token overrides +
+  `[data-component]` hooks).
 
 ### 4. `web-minimal` — web-minimal-template (Astro, general-purpose minimal)
 
@@ -93,6 +95,7 @@ Templates the Works platform supports:
   by default; the same marketing section set as `web`, built statically.
 - **Rebrand from one file:** all copy lives in `apps/web/src/config/site.ts`.
 - **Status:** ✅ Available; registered as `WebsiteTemplateId = 'web-minimal'`.
+  Agent-customizable via a plain-CSS `apps/web/src/styles/theme.css` surface.
 
 ## Roadmap
 

--- a/packages/agent/src/generators/website-generator/config/website-template.config.ts
+++ b/packages/agent/src/generators/website-generator/config/website-template.config.ts
@@ -56,9 +56,9 @@ const WEB_WEBSITE_TEMPLATE: WebsiteTemplateConfig = {
     branch: 'main',
     syncBranches: ['main', 'stage', 'develop'],
     betaBranch: null,
-    // Clean marketing/landing starter; no agent-customization prompt yet, so
-    // forks are edited manually (see template-catalog/customization-prompts/).
-    customizable: false,
+    // Agent UI-customizable via a plain-CSS theme.css surface (see
+    // template-catalog/customization-prompts/web-template.prompt.ts).
+    customizable: true,
 };
 
 const WEB_MINIMAL_WEBSITE_TEMPLATE: WebsiteTemplateConfig = {
@@ -71,7 +71,9 @@ const WEB_MINIMAL_WEBSITE_TEMPLATE: WebsiteTemplateConfig = {
     branch: 'main',
     syncBranches: ['main', 'stage', 'develop'],
     betaBranch: null,
-    customizable: false,
+    // Agent UI-customizable via a plain-CSS theme.css surface (see
+    // template-catalog/customization-prompts/web-minimal-template.prompt.ts).
+    customizable: true,
 };
 
 export const DEFAULT_WEBSITE_TEMPLATE_ID: WebsiteTemplateId = 'classic';
@@ -82,6 +84,25 @@ export const WEBSITE_TEMPLATES: WebsiteTemplateConfig[] = [
     WEB_WEBSITE_TEMPLATE,
     WEB_MINIMAL_WEBSITE_TEMPLATE,
 ];
+
+// Default website template per Work kind — applied ONLY when a Work has no
+// explicit websiteTemplateId AND no saved user preference (see
+// WebsiteTemplateResolverService.resolveForWork). General-purpose (non-directory)
+// kinds map to the general `web` template; every other kind (directory,
+// awesome-repo, the 'default' seed value, or anything unknown) falls through to
+// the system default (classic), so existing behaviour is unchanged. The
+// `web-minimal` (Astro) variant stays opt-in, like `minimal` is for directories.
+const KIND_DEFAULT_WEBSITE_TEMPLATE: Record<string, WebsiteTemplateId> = {
+    website: 'web',
+    'landing-page': 'web',
+    landing: 'web',
+    blog: 'web'
+};
+
+export function getWebsiteTemplateIdForWorkKind(kind?: string | null): WebsiteTemplateId | null {
+    if (!kind) return null;
+    return KIND_DEFAULT_WEBSITE_TEMPLATE[kind.trim().toLowerCase()] ?? null;
+}
 
 export function listWebsiteTemplates(): WebsiteTemplateConfig[] {
     return [...WEBSITE_TEMPLATES];

--- a/packages/agent/src/generators/website-generator/website-template-resolver.service.ts
+++ b/packages/agent/src/generators/website-generator/website-template-resolver.service.ts
@@ -5,6 +5,7 @@ import {
     findWebsiteTemplateConfig,
     getDefaultWebsiteTemplateId,
     getWebsiteTemplateConfig as getStaticWebsiteTemplateConfig,
+    getWebsiteTemplateIdForWorkKind,
     type WebsiteTemplateConfig,
 } from './config/website-template.config';
 import type { Work } from '@src/entities/work.entity';
@@ -104,7 +105,7 @@ export class WebsiteTemplateResolverService {
     }
 
     async resolveForWork(
-        work: Pick<Work, 'userId'> & { websiteTemplateId?: string | null },
+        work: Pick<Work, 'userId'> & { websiteTemplateId?: string | null; kind?: string | null },
     ): Promise<WebsiteTemplateConfig> {
         if (work.websiteTemplateId) {
             return this.resolve(work.websiteTemplateId);
@@ -125,6 +126,19 @@ export class WebsiteTemplateResolverService {
             );
             if (preferredTemplate) {
                 return preferredTemplate;
+            }
+        }
+
+        // No explicit template and no saved preference: pick a sensible default
+        // from the Work's kind. General-purpose kinds (website/landing-page/blog)
+        // map to the general `web` template; directory/awesome/'default'/unknown
+        // kinds return null here and fall through to the system default
+        // (classic) below — so existing behaviour is preserved.
+        const kindTemplateId = getWebsiteTemplateIdForWorkKind(work.kind);
+        if (kindTemplateId) {
+            const kindTemplate = findWebsiteTemplateConfig(kindTemplateId);
+            if (kindTemplate) {
+                return kindTemplate;
             }
         }
 

--- a/packages/agent/src/template-catalog/customization-prompts/index.ts
+++ b/packages/agent/src/template-catalog/customization-prompts/index.ts
@@ -1,7 +1,11 @@
 import { MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT } from './minimal-template.prompt';
+import { WEB_TEMPLATE_CUSTOMIZATION_PROMPT } from './web-template.prompt';
+import { WEB_MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT } from './web-minimal-template.prompt';
 
 const CUSTOMIZATION_PROMPTS: Record<string, string> = {
     minimal: MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT,
+    web: WEB_TEMPLATE_CUSTOMIZATION_PROMPT,
+    'web-minimal': WEB_MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT,
 };
 
 export function getCustomizationPromptForBaseTemplate(
@@ -14,4 +18,8 @@ export function hasCustomizationPromptForBaseTemplate(id: string | null | undefi
     return getCustomizationPromptForBaseTemplate(id) !== null;
 }
 
-export { MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT };
+export {
+    MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT,
+    WEB_TEMPLATE_CUSTOMIZATION_PROMPT,
+    WEB_MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT,
+};

--- a/packages/agent/src/template-catalog/customization-prompts/web-minimal-template.prompt.ts
+++ b/packages/agent/src/template-catalog/customization-prompts/web-minimal-template.prompt.ts
@@ -1,0 +1,47 @@
+// Base prompt applied to every agent run (claude-code, codex, opencode, gemini,
+// ...) that customizes a fork of web-minimal-template (the general-purpose Astro
+// marketing/landing template). It pins the agent to a single compile-safe
+// styling surface: apps/web/src/styles/theme.css. The user's request is appended
+// at runtime. The orchestrator enforces the surface independently of this prompt
+// — see template-customization.service.ts (only theme.css is committed; other
+// edits are discarded; a theme.css with Tailwind directives is rejected).
+
+export const WEB_MINIMAL_TEMPLATE_CUSTOMIZATION_PROMPT = `You are customizing a fork of web-minimal-template — a general-purpose Astro marketing/landing website (static output, Tailwind CSS v4, in a pnpm + Turborepo monorepo). Treat the user's request as a visual design brief, not a feature request.
+
+# The only file you edit: apps/web/src/styles/theme.css
+
+Do ALL of your work in apps/web/src/styles/theme.css. It is plain CSS, imported after the framework styles (apps/web/src/styles/global.css), so anything you put there wins. This is the only file that ships — the orchestrator commits theme.css and discards every other change, so editing any other file is wasted effort and will be thrown away.
+
+theme.css is processed by Tailwind. To keep the site compiling, it MUST stay plain CSS:
+- Allowed: standard CSS only — custom-property overrides, selectors, @media, @supports, @font-face, @keyframes, @import url(...) for web fonts.
+- Forbidden: @apply, @tailwind, @theme, @source, @reference, @plugin, @config, @utility, @variant, @custom-variant. A file containing any of these is rejected and your whole run is discarded.
+
+Do not edit global.css, *.astro, *.ts, packages/**, config, or deployment files. They either break the build or are discarded.
+
+# How to restyle: design tokens + component hooks
+
+1. Override design tokens. global.css defines these Tailwind theme custom properties; redefine any of them in theme.css under :root (light) and :root.dark (dark — the template toggles the .dark class on <html>):
+   --color-background, --color-foreground, --color-card, --color-muted, --color-muted-foreground, --color-border, --color-primary, --color-primary-foreground, --color-accent, --font-sans, --radius-lg, --radius-xl, --radius-2xl.
+   Every utility (bg-primary, text-muted-foreground, border-border, rounded-xl, ...) resolves to these variables, so overriding a token re-tints the whole site coherently.
+
+2. Style component hooks. Sections and components expose stable [data-component] / [data-part] attributes. Target them with plain CSS:
+   - Chrome: [data-component="site-header"], [data-component="site-footer"]
+   - Hero: [data-component="hero"] ([data-part="badge"], [data-part="title"], [data-part="subtitle"], [data-part="actions"])
+   - Sections: [data-component="logo-cloud"], [data-component="features"], [data-component="how-it-works"], [data-component="testimonials"], [data-component="pricing"], [data-component="faq"], [data-component="cta"]
+   - Cards: [data-component="feature-card"] ([data-part="icon"], [data-part="title"], [data-part="description"]), [data-component="pricing-card"] (the featured plan carries [data-featured]), [data-component="testimonial-card"], [data-component="step"], [data-component="faq-item"]
+   - Pages: [data-component="blog-list"], [data-component="blog-post"], [data-component="contact-form"], [data-component="not-found"]
+
+# Coverage — design the whole site, not just the homepage
+
+Your tokens and rules render across every route: home (hero, logo cloud, features, how-it-works, testimonials, pricing, FAQ, CTA), About, Pricing, Contact, the blog index and post pages, and 404. Make it one coherent system: typography scale, spacing rhythm, page width, cards, buttons, links, badges, focus states.
+
+# Requirements
+
+1. Cover both light and dark mode.
+2. Keep contrast at WCAG AA or better in both themes.
+3. Stay responsive: nav, hero, cards, grids, and long headings must not overlap or overflow on mobile or desktop.
+4. If the request is vague, make conservative, cohesive choices and stop. Avoid decorative excess.
+5. No commits or PRs — the orchestrator commits and pushes.
+
+The user's customization request follows below.
+`;

--- a/packages/agent/src/template-catalog/customization-prompts/web-template.prompt.ts
+++ b/packages/agent/src/template-catalog/customization-prompts/web-template.prompt.ts
@@ -1,0 +1,47 @@
+// Base prompt applied to every agent run (claude-code, codex, opencode, gemini,
+// ...) that customizes a fork of web-template (the general-purpose Next.js
+// marketing/landing template). It pins the agent to a single compile-safe
+// styling surface: apps/web/src/styles/theme.css. The user's request is appended
+// at runtime. The orchestrator enforces the surface independently of this prompt
+// — see template-customization.service.ts (only theme.css is committed; other
+// edits are discarded; a theme.css with Tailwind directives is rejected).
+
+export const WEB_TEMPLATE_CUSTOMIZATION_PROMPT = `You are customizing a fork of web-template — a general-purpose Next.js marketing/landing website (App Router, React 19, Tailwind CSS v4, in a pnpm + Turborepo monorepo). Treat the user's request as a visual design brief, not a feature request.
+
+# The only file you edit: apps/web/src/styles/theme.css
+
+Do ALL of your work in apps/web/src/styles/theme.css. It is plain CSS, imported after the framework styles (apps/web/app/globals.css), so anything you put there wins. This is the only file that ships — the orchestrator commits theme.css and discards every other change, so editing any other file is wasted effort and will be thrown away.
+
+theme.css is processed by Tailwind. To keep the site compiling, it MUST stay plain CSS:
+- Allowed: standard CSS only — custom-property overrides, selectors, @media, @supports, @font-face, @keyframes, @import url(...) for web fonts.
+- Forbidden: @apply, @tailwind, @theme, @source, @reference, @plugin, @config, @utility, @variant, @custom-variant. A file containing any of these is rejected and your whole run is discarded.
+
+Do not edit globals.css, *.tsx, *.ts, packages/**, config, or deployment files. They either break the build or are discarded.
+
+# How to restyle: design tokens + component hooks
+
+1. Override design tokens. globals.css defines these Tailwind theme custom properties; redefine any of them in theme.css under :root (light) and :root.dark (dark — the template toggles the .dark class on <html>):
+   --color-background, --color-foreground, --color-card, --color-muted, --color-muted-foreground, --color-border, --color-primary, --color-primary-foreground, --color-accent, --font-sans, --radius-lg, --radius-xl, --radius-2xl.
+   Every utility (bg-primary, text-muted-foreground, border-border, rounded-xl, ...) resolves to these variables, so overriding a token re-tints the whole site coherently.
+
+2. Style component hooks. Sections and components expose stable [data-component] / [data-part] attributes. Target them with plain CSS:
+   - Chrome: [data-component="site-header"], [data-component="site-footer"]
+   - Hero: [data-component="hero"] ([data-part="badge"], [data-part="title"], [data-part="subtitle"], [data-part="actions"])
+   - Sections: [data-component="logo-cloud"], [data-component="features"], [data-component="how-it-works"], [data-component="testimonials"], [data-component="pricing"], [data-component="faq"], [data-component="cta"]
+   - Cards: [data-component="feature-card"] ([data-part="icon"], [data-part="title"], [data-part="description"]), [data-component="pricing-card"] (the featured plan carries [data-featured]), [data-component="testimonial-card"], [data-component="step"], [data-component="faq-item"]
+   - Pages: [data-component="blog-list"], [data-component="blog-post"], [data-component="contact-form"], [data-component="not-found"]
+
+# Coverage — design the whole site, not just the homepage
+
+Your tokens and rules render across every route: home (hero, logo cloud, features, how-it-works, testimonials, pricing, FAQ, CTA), About, Pricing, Contact, the blog index and post pages, and 404. Make it one coherent system: typography scale, spacing rhythm, page width, cards, buttons, links, badges, focus states.
+
+# Requirements
+
+1. Cover both light and dark mode.
+2. Keep contrast at WCAG AA or better in both themes.
+3. Stay responsive: nav, hero, cards, grids, and long headings must not overlap or overflow on mobile or desktop.
+4. If the request is vague, make conservative, cohesive choices and stop. Avoid decorative excess.
+5. No commits or PRs — the orchestrator commits and pushes.
+
+The user's customization request follows below.
+`;

--- a/packages/agent/src/template-catalog/template-customization.service.ts
+++ b/packages/agent/src/template-catalog/template-customization.service.ts
@@ -834,13 +834,27 @@ export class TemplateCustomizationService {
     }
 
     private async assertThemeCssWired(workspaceDir: string): Promise<void> {
-        const layoutPath = path.join(workspaceDir, 'apps/web/src/layouts/BaseLayout.astro');
-        const layout = await fs.readFile(layoutPath, 'utf8').catch(() => null);
-        if (layout === null || !layout.includes('styles/theme.css')) {
-            throw new Error(
-                'Fork is not migrated for customization: apps/web/src/layouts/BaseLayout.astro does not import styles/theme.css, so styling edits would not load. Sync this template from its base before customizing.',
-            );
+        // Framework-specific layout files that may import the theme.css override
+        // surface (CUSTOMIZATION_ALLOWED_PATHS). A customizable fork must load
+        // apps/web/src/styles/theme.css from one of these so agent styling edits
+        // actually take effect — Astro via BaseLayout.astro, Next.js via the App
+        // Router root layout.
+        const layoutCandidates = [
+            'apps/web/src/layouts/BaseLayout.astro', // Astro (web-minimal, directory-web-minimal)
+            'apps/web/app/layout.tsx', // Next.js App Router (web)
+            'apps/web/src/app/layout.tsx', // Next.js App Router with a src/ dir
+        ];
+        for (const rel of layoutCandidates) {
+            const layout = await fs.readFile(path.join(workspaceDir, rel), 'utf8').catch(() => null);
+            if (layout && layout.includes('theme.css')) {
+                return;
+            }
         }
+        throw new Error(
+            `Fork is not migrated for customization: none of [${layoutCandidates.join(', ')}] ` +
+                'imports apps/web/src/styles/theme.css, so styling edits would not load. ' +
+                'Sync this template from its base before customizing.',
+        );
     }
 
     private async assertThemeCssCompiles(

--- a/packages/agent/src/template-catalog/utils/framework-inference.ts
+++ b/packages/agent/src/template-catalog/utils/framework-inference.ts
@@ -1,6 +1,20 @@
+// Known Ever Works base template repos → their web framework. Explicit map so
+// names that don't contain "next"/"astro" (e.g. `web-template`, the directory
+// templates) still resolve correctly. Falls back to substring heuristics for
+// custom/unknown repos.
+const KNOWN_FRAMEWORKS: Record<string, string> = {
+    'directory-web-template': 'Next.js',
+    'directory-web-minimal-template': 'Astro',
+    'web-template': 'Next.js',
+    'web-minimal-template': 'Astro',
+};
+
 export function inferFrameworkFromRepository(repo: string): string | null {
     const normalized = repo.toLowerCase();
+    if (KNOWN_FRAMEWORKS[normalized]) return KNOWN_FRAMEWORKS[normalized];
     if (normalized.includes('astro')) return 'Astro';
+    if (normalized.includes('minimal')) return 'Astro';
     if (normalized.includes('next')) return 'Next.js';
+    if (normalized.includes('web')) return 'Next.js';
     return null;
 }


### PR DESCRIPTION
Follow-up to #1676. Makes the two general-purpose website templates agent-customizable and adds a backward-compatible kind→template default.

**Customization** (both templates now editable by the AI via a plain-CSS `apps/web/src/styles/theme.css` surface):
- `customizable: true` + registered prompts (`web-template.prompt.ts`, `web-minimal-template.prompt.ts`).
- `assertThemeCssWired` generalized to accept the Next.js App Router layout (not only Astro's `BaseLayout.astro`).
- `inferFrameworkFromRepository` fixed for the new/dir repo names.
- The template repos ([web-template](https://github.com/ever-works/web-template), [web-minimal-template](https://github.com/ever-works/web-minimal-template)) ship the matching `theme.css` + `[data-component]` hooks (Docker-build validated).

**Kind-aware default**: `resolveForWork` maps general-purpose kinds (website/landing-page/blog) → `web` when no explicit template/preference. Backward-compatible: directory/awesome/`default`/unknown → classic (unchanged). Note: `work.kind` isn't persisted from the creation chips yet — that wiring is a separate follow-up, so this is currently the correct-but-dormant foundation for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Website templates can now be customized through a dedicated CSS theme surface, including design tokens and component styling hooks.
  * Web and minimal web templates are automatically selected for applicable work types when no explicit preference is set.
  * Added customization guidance covering light/dark modes, responsive design, and accessibility requirements.

* **Bug Fixes**
  * Improved compatibility when validating theme integration across supported website frameworks and layouts.
  * Enhanced recognition of web and minimal template frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->