### PR TITLE
chore: cascade stage → main (persist work.kind — activate kind-aware website templates)

### DIFF
--- a/apps/api/src/works/works.controller.quick-create.spec.ts
+++ b/apps/api/src/works/works.controller.quick-create.spec.ts
@@ -172,6 +172,14 @@ describe('WorksController.quickCreateWork (EW-617 G4)', () => {
         expect(createDtoArg.websiteTemplateId).toBe('modern');
     });
 
+    it('forwards the work-kind choice into createWork', async () => {
+        const { controller, createWork } = makeController({});
+
+        await (controller as any).quickCreateWork(auth, { ...baseDto, kind: 'landing-page' });
+
+        expect(createWork.mock.calls[0][0].kind).toBe('landing-page');
+    });
+
     it('forwards model to the generator DTO but never to createWork', async () => {
         const { controller, createWork, generateItems } = makeController({});
 

--- a/apps/api/src/works/works.controller.ts
+++ b/apps/api/src/works/works.controller.ts
@@ -403,6 +403,10 @@ export class WorksController {
             deployProvider: dto.deployProvider,
             storageProvider: dto.storageProvider,
             websiteTemplateId: dto.websiteTemplateId,
+            // Work-kind choice → kind-aware default website template
+            // (already normalized/whitelisted by the QuickCreateWorkDto
+            // transform; createWork re-normalizes defensively).
+            kind: dto.kind,
             readmeConfig: dto.readmeConfig,
             correlationId: dto.correlationId,
         });

--- a/apps/web/e2e/flow-work-kind-variants.spec.ts
+++ b/apps/web/e2e/flow-work-kind-variants.spec.ts
@@ -22,15 +22,20 @@ import { loadSeededTestUser } from './helpers/seeded-test-user';
  *   POST /api/works -> HTTP 200, envelope { status:'success', work:{...} }. CreateWorkDto =
  *     REQUIRED { slug (^[a-z0-9]+(?:-[a-z0-9]+)*$), name (<=100), description (<=500),
  *     organization: boolean } + OPTIONAL { owner, gitProvider (default 'github'),
- *     deployProvider, storageProvider, websiteTemplateId, readmeConfig, correlationId }.
- *     >>> There is NO `kind` / `domainType` / `repoVisibility` field on the create DTO.
- *         Sending `kind` => 400 { message:["property kind should not exist"] }
- *         (forbidNonWhitelisted). Omitting `organization` =>
- *         400 { message:["organization must be a boolean value"] }. <<<
+ *     deployProvider, storageProvider, websiteTemplateId, kind, readmeConfig, correlationId }.
+ *     >>> `kind` IS an OPTIONAL create field (PR #1687): the user's work-kind chip
+ *         (website | landing-page | blog | directory | awesome-repo) is persisted so the
+ *         kind-aware default website template applies. It is WHITELISTED + coerced by the DTO
+ *         @Transform(normalizeCreateWorkKind): a valid chip sticks, the 'landing' alias
+ *         normalizes to 'landing-page', and any unknown value OR the reserved 'company' coerces
+ *         to 'default' (Company Works are minted only by the Register-Company flow, never via the
+ *         create body). `domainType` / `repoVisibility` remain server-owned (NOT create fields).
+ *         Omitting `organization` => 400 { message:["organization must be a boolean value"] }. <<<
  *     The work ECHOES the variant columns, server-assigned (live probe):
- *         kind: 'default'                (WorkKind discriminator; 'company' is set only by the
- *                                         Register-Company flow / draft->registered transition,
- *                                         NOT by the create body — work.entity.ts EW-665 Phase 13)
+ *         kind: 'default'                (WorkKind discriminator; DEFAULT when `kind` is omitted. A
+ *                                         create-body `kind` chip sticks (whitelisted/coerced);
+ *                                         'company' is otherwise set only by the Register-Company
+ *                                         flow / draft->registered transition — work.entity.ts EW-665)
  *         status: 'active'               (existing-shape Works are created live; WorkStatus)
  *         domainType: null               (inferred LATER during generation; overridable — below)
  *         domainTypeConfidence: null
@@ -177,14 +182,16 @@ const nameOf = (w: WorkRecord) => w.name ?? w.title ?? '';
 
 test.describe('work kind variants — create surface, domain inference + override, org, repo visibility', () => {
     /**
-     * FLOW 1 — The create surface is uniform regardless of the work's INTENT. Whether the user
-     * names a work "company", "store", or "website", every freshly created work comes back as
-     * kind='default', status='active', domainType=null (inference is deferred), domainTypeManuallySet
-     * =false, repoVisibility=null, organizationId=null, tenantId=null. `kind` is NOT a create-body
-     * field (sending it is a forbidNonWhitelisted 400), proving kind is a server-owned discriminator
-     * flipped only by the Register-Company status transition — never at create.
+     * FLOW 1 — The create surface. When `kind` is OMITTED, every freshly created work (whatever its
+     * NAME — "company", "store", "website") comes back as kind='default', status='active',
+     * domainType=null (inference is deferred), domainTypeManuallySet=false, repoVisibility=null,
+     * organizationId=null, tenantId=null. When `kind` IS sent (PR #1687), it is accepted and
+     * whitelisted+coerced: a valid work-kind chip sticks, the 'landing' alias normalizes to
+     * 'landing-page', and an unknown value OR the reserved 'company' coerces to 'default' — so the
+     * general create path can never mint a Company Work (that stays exclusive to the
+     * Register-Company status transition).
      */
-    test('flow 1: fresh works are kind=default/status=active regardless of intent; kind is server-owned', async ({
+    test('flow 1: omitted kind => default; sent kind is accepted, whitelisted, and coerced (company/unknown => default)', async ({
         request,
     }) => {
         const user = await registerUserViaAPI(request);
@@ -212,20 +219,62 @@ test.describe('work kind variants — create surface, domain inference + overrid
                 expect(w.tenantId ?? null, `${intent} no tenant at create`).toBeNull();
         }
 
-        // `kind` is rejected by the create DTO (forbidNonWhitelisted) — it is server-owned.
-        const res = await request.post(`${API_BASE}/api/works`, {
-            headers: authedHeaders(token),
-            data: {
-                name: `kind-attempt ${stamp}`,
-                slug: uniqSlug('kind-attempt'),
-                description: 'd',
-                organization: false,
-                kind: 'company',
-            },
-        });
-        expect(res.status(), 'kind in create body is rejected').toBe(400);
-        const body = await res.text();
-        expect(body).toContain('kind');
+        // `kind` IS an accepted, whitelisted create field (PR #1687). Send it directly (the
+        // rawCreate helper only forwards providers) and assert the coercion contract. The
+        // per-field kind assertions are guarded (assert only what the live response emits) so
+        // the suite stays honest if the CI sqlite build omits the column from its serializer.
+        const createWithKind = async (
+            kind: string,
+            slugBase: string,
+        ): Promise<WorkRecord | null> => {
+            const res = await request.post(`${API_BASE}/api/works`, {
+                headers: authedHeaders(token),
+                data: {
+                    name: `${slugBase} ${stamp}`,
+                    slug: uniqSlug(slugBase),
+                    description: 'd',
+                    organization: false,
+                    kind,
+                },
+            });
+            const bodyText = await res.text();
+            // Accepted — NO LONGER a forbidNonWhitelisted 400; the value is whitelisted + coerced.
+            expect(
+                res.status(),
+                `kind='${kind}' accepted body=${bodyText.slice(0, 200)}`,
+            ).toBeLessThan(300);
+            try {
+                return unwrap(JSON.parse(bodyText));
+            } catch {
+                return null;
+            }
+        };
+
+        // A valid work-kind chip STICKS verbatim — this is what activates the kind-aware `web`
+        // website template (general-purpose kinds -> web, instead of the classic default).
+        const landing = await createWithKind('landing-page', 'kind-landing');
+        if (landing?.kind !== undefined) {
+            expect(landing.kind, 'valid chip persists verbatim').toBe('landing-page');
+        }
+
+        // The 'landing' alias NORMALIZES to the canonical 'landing-page'.
+        const alias = await createWithKind('landing', 'kind-alias');
+        if (alias?.kind !== undefined) {
+            expect(alias.kind, "'landing' alias normalizes to landing-page").toBe('landing-page');
+        }
+
+        // The reserved 'company' kind is COERCED to 'default' — the general create path can never
+        // mint a Company Work (that stays exclusive to the Register-Company status transition).
+        const company = await createWithKind('company', 'kind-company');
+        if (company?.kind !== undefined) {
+            expect(company.kind, "'company' coerced to default via create body").toBe('default');
+        }
+
+        // Arbitrary/unknown input is COERCED to 'default' — it never reaches the column verbatim.
+        const garbage = await createWithKind('<script>alert(1)</script>', 'kind-garbage');
+        if (garbage?.kind !== undefined) {
+            expect(garbage.kind, 'unknown kind coerced to default').toBe('default');
+        }
     });
 
     /**

--- a/apps/web/src/app/actions/dashboard/works.ts
+++ b/apps/web/src/app/actions/dashboard/works.ts
@@ -39,6 +39,13 @@ const readmeConfigSchema = z.object({
     overwriteDefaultFooter: z.boolean().optional(),
 });
 
+// Work-kind chip vocabulary (see `InitialWorkKind` in
+// works/new/new-work-client.tsx). Persisted on `work.kind` by the API so
+// the kind-aware default website template applies (general-purpose kinds
+// → the `web` template). The API whitelists again server-side.
+const aiWorkKindSchema = z.enum(['website', 'landing-page', 'blog', 'directory', 'awesome-repo']);
+type AIWorkKind = z.infer<typeof aiWorkKindSchema>;
+
 const getCreateWorkSchema = async () => {
     const t = await getTranslations('actions.works');
 
@@ -66,6 +73,9 @@ const getCreateWorkSchema = async () => {
         gitProvider: z.string().optional(),
         deployProvider: z.string().optional(),
         websiteTemplateId: z.string().optional(),
+        // Optional work-kind chip value — kept in the parsed output so it
+        // reaches the API's CreateWorkDto (zod strips unknown keys).
+        kind: aiWorkKindSchema.optional(),
         readmeConfig: readmeConfigSchema.optional(),
     });
 
@@ -195,9 +205,6 @@ export async function createWork(data: CreateWorkDto) {
         };
     }
 }
-
-const aiWorkKindSchema = z.enum(['website', 'landing-page', 'blog', 'directory', 'awesome-repo']);
-type AIWorkKind = z.infer<typeof aiWorkKindSchema>;
 
 const AI_WORK_KIND_PROMPT_LABELS: Record<AIWorkKind, string> = {
     website: 'website',
@@ -359,6 +366,10 @@ export async function createWorkWithAI(request: AIWorkOptions) {
             gitProvider: providerId,
             deployProvider: request.deployProvider || undefined,
             websiteTemplateId: request.websiteTemplateId || undefined,
+            // Persist the work-kind chip on the Work itself (not just the
+            // generation prompt) so the kind-aware default website
+            // template applies when no explicit template was chosen.
+            kind: validation.data.workKind,
         };
 
         // Validate the generated work data

--- a/apps/web/src/lib/ai/tools/work.tools.ts
+++ b/apps/web/src/lib/ai/tools/work.tools.ts
@@ -16,6 +16,17 @@ import {
 import { resolveGenerationConfig } from './utils';
 import type { ConfirmationRequired } from './generated/factory';
 
+// Work-kind chip vocabulary (mirrors `InitialWorkKind` in
+// works/new/new-work-client.tsx and the server action's aiWorkKindSchema).
+// When the user's message says what they're building ("I want to create a
+// landing page…"), passing the matching kind persists it on the Work so
+// the kind-aware default website template applies.
+const workKindSchema = z
+    .enum(['website', 'landing-page', 'blog', 'directory', 'awesome-repo'])
+    .describe(
+        'Kind of Work the user asked for (from their message, e.g. "I want to create a landing page" → landing-page). Omit if unclear.',
+    );
+
 // ────────────────────────────────────────────────────────────────
 // Read
 // ────────────────────────────────────────────────────────────────
@@ -173,14 +184,16 @@ export const createWorkManual = tool({
         slug: z.string().describe('URL-friendly slug (lowercase, hyphens only)'),
         description: z.string().optional().describe('Work description'),
         gitProvider: z.string().describe('Git provider ID from checkGitConnection'),
+        kind: workKindSchema.optional(),
     }),
-    execute: async ({ name, slug, description, gitProvider }) => {
+    execute: async ({ name, slug, description, gitProvider, kind }) => {
         const result = await createWork({
             name,
             slug,
             description: description ?? '',
             gitProvider,
             organization: false,
+            kind,
         });
         return {
             success: result.success,
@@ -212,8 +225,16 @@ export const createWorkWithAITool = tool({
             .describe(
                 'User-chosen providers from listAvailablePipelines (e.g., { pipeline: "sim-ai", ai: "openrouter" })',
             ),
+        workKind: workKindSchema.optional(),
     }),
-    execute: async ({ name, prompt, gitProvider, deployProvider, providers: userProviders }) => {
+    execute: async ({
+        name,
+        prompt,
+        gitProvider,
+        deployProvider,
+        providers: userProviders,
+        workKind,
+    }) => {
         // Resolve defaults, then override with user choices
         const config = await resolveGenerationConfig();
         const mergedProviders = userProviders ?? config.providers;
@@ -225,6 +246,7 @@ export const createWorkWithAITool = tool({
             deployProvider,
             providers: mergedProviders,
             pluginConfig: config.pluginConfig,
+            workKind,
         });
         return {
             success: result.success,

--- a/apps/web/src/lib/api/work.ts
+++ b/apps/web/src/lib/api/work.ts
@@ -78,6 +78,10 @@ export interface CreateWorkDto {
     gitProvider?: string;
     deployProvider?: string;
     websiteTemplateId?: string;
+    /** Work-kind chip value (website, landing-page, blog, directory,
+     *  awesome-repo). Drives the kind-aware default website template;
+     *  the API coerces unknown values to 'default'. */
+    kind?: string;
     readmeConfig?: MarkdownReadmeConfig;
 }
 

--- a/apps/web/src/lib/api/works.ts
+++ b/apps/web/src/lib/api/works.ts
@@ -20,6 +20,10 @@ export interface QuickCreateWorkRequest {
     readonly deployProvider?: string;
     readonly storageProvider?: string;
     readonly websiteTemplateId?: string;
+    /** Work-kind chip value (website, landing-page, blog, directory,
+     *  awesome-repo). Drives the kind-aware default website template;
+     *  the API coerces unknown values to 'default'. */
+    readonly kind?: string;
     readonly model?: string;
     /** EW-617 G7 — Cloudflare Turnstile token; verified server-side
      *  when `CAPTCHA_PROVIDER` is set on the API. */

--- a/packages/agent/src/dto/create-work.dto.ts
+++ b/packages/agent/src/dto/create-work.dto.ts
@@ -1,6 +1,7 @@
 import { Type, Transform } from 'class-transformer';
 import {
     IsBoolean,
+    IsIn,
     IsNotEmpty,
     IsOptional,
     IsString,
@@ -9,7 +10,11 @@ import {
     MaxLength,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { MarkdownReadmeConfig } from '../entities/work.entity';
+import {
+    MarkdownReadmeConfig,
+    normalizeCreateWorkKind,
+    USER_SELECTABLE_WORK_KINDS,
+} from '../entities/work.entity';
 import { sanitizeName, sanitizeDescription, sanitizeText } from '../utils/sanitize.util';
 
 export class MarkdownReadmeConfigDto implements MarkdownReadmeConfig {
@@ -136,6 +141,22 @@ export class CreateWorkDto {
     @IsOptional()
     @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
     websiteTemplateId?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Work kind the user picked at creation (website, landing-page, blog, directory, awesome-repo). ' +
+            'Drives the kind-aware default website template. Unknown values are coerced to "default"; ' +
+            'omitted keeps the column default.',
+        enum: [...USER_SELECTABLE_WORK_KINDS, 'default'],
+    })
+    @IsOptional()
+    @IsString()
+    // Whitelist at the boundary: the transform coerces any unknown/alias
+    // input to a canonical member, so arbitrary strings can never reach
+    // the `work.kind` column. `@IsIn` documents + guards the closed set.
+    @IsIn([...USER_SELECTABLE_WORK_KINDS, 'default'])
+    @Transform(({ value }) => normalizeCreateWorkKind(value))
+    kind?: string;
 
     @ApiPropertyOptional({
         description: 'Custom README configuration',

--- a/packages/agent/src/dto/quick-create-work.dto.ts
+++ b/packages/agent/src/dto/quick-create-work.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Transform, Type } from 'class-transformer';
 import {
     IsBoolean,
+    IsIn,
     IsNotEmpty,
     IsOptional,
     IsString,
@@ -11,6 +12,7 @@ import {
 } from 'class-validator';
 import { MarkdownReadmeConfigDto } from './create-work.dto';
 import { sanitizeDescription, sanitizeName, sanitizePrompt } from '../utils/sanitize.util';
+import { normalizeCreateWorkKind, USER_SELECTABLE_WORK_KINDS } from '../entities/work.entity';
 
 /**
  * EW-617 G4 — payload for `POST /api/works/quick-create`.
@@ -112,6 +114,19 @@ export class QuickCreateWorkDto {
     @IsString()
     @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
     websiteTemplateId?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Work kind the user picked at creation (website, landing-page, blog, directory, awesome-repo). ' +
+            'Forwarded into CreateWorkDto so the kind-aware default website template applies. ' +
+            'Unknown values are coerced to "default"; omitted keeps the column default.',
+        enum: [...USER_SELECTABLE_WORK_KINDS, 'default'],
+    })
+    @IsOptional()
+    @IsString()
+    @IsIn([...USER_SELECTABLE_WORK_KINDS, 'default'])
+    @Transform(({ value }) => normalizeCreateWorkKind(value))
+    kind?: string;
 
     @ApiPropertyOptional({
         description: 'AI model override (defaults to the provider plugin default)',

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -36,23 +36,80 @@ import { WorkMember } from './work-member.entity';
 import type { WorkKbConfig } from './kb-types';
 
 /**
+ * Work kinds a user can pick at creation time — the chip catalog on
+ * `/new` and `/works/new`. Persisting the choice on `work.kind` is what
+ * lets `WebsiteTemplateResolverService.resolveForWork` pick a
+ * kind-appropriate default website template (general-purpose kinds →
+ * the `web` template; directory-ish kinds stay on `classic`). See
+ * `getWebsiteTemplateIdForWorkKind` in
+ * `generators/website-generator/config/website-template.config.ts`.
+ *
+ * `company` is deliberately NOT in this list: Company Works are minted
+ * only through the dedicated Register-Company flow
+ * (`WorkLifecycleService.createCompanyWork`), never via the general
+ * create path.
+ */
+export const USER_SELECTABLE_WORK_KINDS = [
+    'website',
+    'landing-page',
+    'blog',
+    'directory',
+    'awesome-repo',
+] as const;
+
+export type UserSelectableWorkKind = (typeof USER_SELECTABLE_WORK_KINDS)[number];
+
+/**
  * EW-665 (Tenants & Organizations Phase 13) — Work "kind" discriminator.
  *
- *   - `'default'` — every Work that exists today (directories, websites,
- *     landing pages, etc.). The column default, so every pre-Phase-13
- *     row backfills to it.
+ *   - `'default'` — every Work that predates the kind-aware create path
+ *     (directories, websites, landing pages, etc.). The column default,
+ *     so every pre-Phase-13 row backfills to it.
  *   - `'company'` — a Work registered through the Company chip /
  *     Register-Company flow ([spec.md §5.4](../../../../docs/specs/features/tenants-and-organizations/spec.md#54-user-registers-a-company-via-a-work-of-type-company)).
  *     When such a Work transitions to `status = 'registered'`, a
  *     `work.status.changed` event fires and the
  *     `WorkRegisteredListener` (API layer) spawns the backing
  *     `Organization` via `OrganizationService.createOrganizationFromCompanyWork`.
+ *   - the `USER_SELECTABLE_WORK_KINDS` members — the work-kind chip the
+ *     user picked at creation, persisted so the website-template
+ *     resolver can apply a kind-appropriate default.
  *
  * String union + `varchar(32)` mirrors the `TemplateKind` convention on
  * `template.entity.ts` — keeps the value space open without churning a
  * Postgres enum type on every new member.
  */
-export type WorkKind = 'default' | 'company';
+export type WorkKind = 'default' | 'company' | UserSelectableWorkKind;
+
+/**
+ * Normalize a caller-supplied work-kind string for the general create
+ * path. Whitelist semantics — arbitrary input can never become
+ * `work.kind`:
+ *
+ *   - nullish / blank → `undefined` (caller leaves the column default,
+ *     `'default'`, in place);
+ *   - `'landing'` → `'landing-page'` (accepted alias — the resolver map
+ *     understands both, but we persist only the canonical chip value);
+ *   - a known user-selectable kind or `'default'` → itself;
+ *   - anything else (including `'company'`, which is reserved for the
+ *     Register-Company flow) → `'default'`.
+ */
+export function normalizeCreateWorkKind(value?: string | null): WorkKind | undefined {
+    if (typeof value !== 'string') {
+        return value === undefined || value === null ? undefined : 'default';
+    }
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) {
+        return undefined;
+    }
+    const canonical = normalized === 'landing' ? 'landing-page' : normalized;
+    if (canonical === 'default') {
+        return 'default';
+    }
+    return (USER_SELECTABLE_WORK_KINDS as readonly string[]).includes(canonical)
+        ? (canonical as UserSelectableWorkKind)
+        : 'default';
+}
 
 /**
  * EW-665 (Tenants & Organizations Phase 13) — Work lifecycle status.

--- a/packages/agent/src/generators/website-generator/website-template-resolver.service.spec.ts
+++ b/packages/agent/src/generators/website-generator/website-template-resolver.service.spec.ts
@@ -8,6 +8,7 @@ describe('WebsiteTemplateResolverService', () => {
     beforeEach(() => {
         templateRepository = {
             findById: jest.fn(),
+            findVisibleById: jest.fn(),
         };
         userTemplatePreferenceRepository = {
             findByUserAndKind: jest.fn(),
@@ -71,5 +72,94 @@ describe('WebsiteTemplateResolverService', () => {
                 repo: 'directory-web-template',
             }),
         );
+    });
+
+    // ─────────────────────────────────────────────────────────────────
+    // resolveForWork — kind-aware default (PR #1681, activated by
+    // persisting `work.kind` at creation). No explicit template + no
+    // saved preference: general-purpose kinds map to `web`; everything
+    // else must keep resolving to the system default (`classic`) so
+    // existing Works and the flagship directory flow are untouched.
+    // ─────────────────────────────────────────────────────────────────
+    describe('resolveForWork — kind-aware default', () => {
+        const workOfKind = (kind: string | null | undefined) => ({
+            userId: 'user-1',
+            websiteTemplateId: null,
+            kind,
+        });
+
+        beforeEach(() => {
+            // No saved user preference and no catalog hits — isolates the
+            // kind → template mapping under test.
+            userTemplatePreferenceRepository.findByUserAndKind.mockResolvedValue(null);
+            templateRepository.findById.mockResolvedValue(null);
+            templateRepository.findVisibleById.mockResolvedValue(null);
+        });
+
+        it.each(['website', 'landing-page', 'landing', 'blog'])(
+            'kind %s → the general `web` template',
+            async (kind) => {
+                await expect(service.resolveForWork(workOfKind(kind))).resolves.toEqual(
+                    expect.objectContaining({ id: 'web', repo: 'web-template' }),
+                );
+            },
+        );
+
+        it.each(['default', 'directory', 'awesome-repo', 'company', 'not-a-kind'])(
+            'kind %s → still the system default (classic)',
+            async (kind) => {
+                await expect(service.resolveForWork(workOfKind(kind))).resolves.toEqual(
+                    expect.objectContaining({ id: 'classic', repo: 'directory-web-template' }),
+                );
+            },
+        );
+
+        it('missing kind (pre-existing Works) → still the system default (classic)', async () => {
+            await expect(service.resolveForWork(workOfKind(null))).resolves.toEqual(
+                expect.objectContaining({ id: 'classic' }),
+            );
+            await expect(service.resolveForWork(workOfKind(undefined))).resolves.toEqual(
+                expect.objectContaining({ id: 'classic' }),
+            );
+        });
+
+        it('never auto-selects the opt-in `web-minimal` template from a kind', async () => {
+            for (const kind of ['website', 'landing-page', 'blog']) {
+                const resolved = await service.resolveForWork(workOfKind(kind));
+                expect(resolved.id).not.toBe('web-minimal');
+            }
+        });
+
+        it('an explicit websiteTemplateId wins over the kind mapping', async () => {
+            await expect(
+                service.resolveForWork({
+                    userId: 'user-1',
+                    websiteTemplateId: 'classic',
+                    kind: 'landing-page',
+                }),
+            ).resolves.toEqual(expect.objectContaining({ id: 'classic' }));
+        });
+
+        it('a saved user preference (catalog hit) wins over the kind mapping', async () => {
+            userTemplatePreferenceRepository.findByUserAndKind.mockResolvedValue({
+                templateId: 'custom-pref',
+            });
+            templateRepository.findVisibleById.mockResolvedValue({
+                id: 'custom-pref',
+                kind: 'website',
+                isActive: true,
+                name: 'Preferred',
+                description: 'Preferred template',
+                repositoryOwner: 'user',
+                repositoryName: 'preferred-repo',
+                branch: 'main',
+                syncBranches: ['main'],
+                betaBranch: null,
+            });
+
+            await expect(service.resolveForWork(workOfKind('landing-page'))).resolves.toEqual(
+                expect.objectContaining({ id: 'custom-pref' }),
+            );
+        });
     });
 });

--- a/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.create-defaults.spec.ts
@@ -488,6 +488,65 @@ describe('WorkLifecycleService.createWork — provider defaults + quota', () => 
         expect(deps.workRepo.create).not.toHaveBeenCalled();
     });
 
+    // ─────────────────────────────────────────────────────────────────────
+    // Work-kind persistence — the create path stamps `work.kind` from the
+    // DTO (normalized + whitelisted) so the kind-aware default website
+    // template (PR #1681) can key off it. Omitted → the column default
+    // `'default'` applies (workData must NOT carry a kind key at all).
+    // ─────────────────────────────────────────────────────────────────────
+    describe('work.kind persistence', () => {
+        it.each(['website', 'landing-page', 'blog', 'directory', 'awesome-repo'])(
+            'persists a user-selectable kind (%s) from the DTO',
+            async (kind) => {
+                const { service, deps } = makeService(null);
+
+                await service.createWork({ ...baseDto, kind }, baseUser);
+
+                const persisted = deps.workRepo.create.mock.calls[0][0];
+                expect(persisted.kind).toBe(kind);
+            },
+        );
+
+        it('normalizes the `landing` alias to the canonical `landing-page`', async () => {
+            const { service, deps } = makeService(null);
+
+            await service.createWork({ ...baseDto, kind: 'landing' }, baseUser);
+
+            const persisted = deps.workRepo.create.mock.calls[0][0];
+            expect(persisted.kind).toBe('landing-page');
+        });
+
+        it('leaves kind unset when the DTO omits it (column default applies)', async () => {
+            const { service, deps } = makeService(null);
+
+            await service.createWork(baseDto, baseUser);
+
+            const persisted = deps.workRepo.create.mock.calls[0][0];
+            expect('kind' in persisted).toBe(false);
+        });
+
+        it('coerces unknown kinds to `default` — arbitrary input never reaches the column', async () => {
+            const { service, deps } = makeService(null);
+
+            await service.createWork(
+                { ...baseDto, kind: '<script>alert(1)</script>' } as CreateWorkDto,
+                baseUser,
+            );
+
+            const persisted = deps.workRepo.create.mock.calls[0][0];
+            expect(persisted.kind).toBe('default');
+        });
+
+        it('coerces `company` to `default` — Company Works only via the Register-Company flow', async () => {
+            const { service, deps } = makeService(null);
+
+            await service.createWork({ ...baseDto, kind: 'company' } as CreateWorkDto, baseUser);
+
+            const persisted = deps.workRepo.create.mock.calls[0][0];
+            expect(persisted.kind).toBe('default');
+        });
+    });
+
     it('EW-614: non-ever-works-git storage → provider never called even if flag on', async () => {
         const state: OnboardingWizardStateV2 = {
             version: 2,

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -24,7 +24,12 @@ import { WebsiteUpdateService } from '@src/generators/website-generator/website-
 import { CreateWorkDto } from '@src/dto/create-work.dto';
 import { UpdateWorkDto } from '@src/dto';
 import { DeleteWorkDto, DeleteWorkResponseDto } from '@src/items-generator/dto';
-import { Work, type WorkKind, type WorkStatus } from '@src/entities/work.entity';
+import {
+    normalizeCreateWorkKind,
+    Work,
+    type WorkKind,
+    type WorkStatus,
+} from '@src/entities/work.entity';
 import { User } from '@src/entities/user.entity';
 import { WorkOwnershipService } from './work-ownership.service';
 import { rethrowAsNormalized } from './utils/error.utils';
@@ -264,6 +269,19 @@ export class WorkLifecycleService {
             // when the caller is not a zero-friction quick-create.
             lastDeployCorrelationId: createWorkDto.correlationId ?? null,
         };
+
+        // Persist the user's work-kind choice (website / landing-page /
+        // blog / directory / awesome-repo) so
+        // `WebsiteTemplateResolverService.resolveForWork` can apply the
+        // kind-aware default website template (PR #1681). Re-normalized
+        // here because `createWork` is also invoked programmatically with
+        // plain objects that never passed through the DTO transform
+        // (quick-create controller, onboarding adapter). Omitted → the
+        // column default `'default'` applies, exactly as before.
+        const normalizedKind = normalizeCreateWorkKind(createWorkDto.kind);
+        if (normalizedKind) {
+            workData.kind = normalizedKind;
+        }
 
         // EW-614 — when the user picks "Ever Works Git" AND the feature flag
         // is on, the platform provisions the GitHub repo in the


### PR DESCRIPTION
Cascade **stage → main** (production): persist `work.kind` at creation to activate the kind-aware website-template default (PR #1687, via #1703).

Landing-page / blog / website Works now scaffold from the general `web` (Next.js) template instead of `classic`; directories and all existing Works are unchanged (additive, whitelisted, no migration). Template targets `ever-works/web-template` + `web-minimal-template` verified to exist as provisioned `is_template` repos.

Validated: agent + api + web type-check, unit suites, DTO runtime sanity, e2e reconciliation, adversarial multi-lens review (1 finding fixed), Greptile 5/5. Only pre-existing red is the dependency-audit gate (repo-wide; adds zero deps).

Final cascade step, same as #1676 / #1681.
