### PR TITLE
fix(web): green develop — goals server-only client import + prettier drift

### DIFF
--- a/apps/api/src/missions/missions.controller.ts
+++ b/apps/api/src/missions/missions.controller.ts
@@ -36,7 +36,11 @@ import {
     CreateMissionDto,
     UpdateMissionDto,
 } from './dto/mission.dto';
-import { MISSION_WORK_RELATIONS, MissionOutcome, type MissionWorkRelation } from '@ever-works/agent/entities';
+import {
+    MISSION_WORK_RELATIONS,
+    MissionOutcome,
+    type MissionWorkRelation,
+} from '@ever-works/agent/entities';
 
 /**
  * Phase 3 PR H — full Missions CRUD + lifecycle surface
@@ -217,7 +221,11 @@ export class MissionsController {
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body?: CompleteMissionDto,
     ): Promise<MissionDto> {
-        return this.service.complete(auth.userId, id, (body?.outcome ?? null) as MissionOutcome | null);
+        return this.service.complete(
+            auth.userId,
+            id,
+            (body?.outcome ?? null) as MissionOutcome | null,
+        );
     }
 
     @Post(':id/clone')

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -940,7 +940,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -940,7 +940,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -940,7 +940,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1002,7 +1002,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -940,7 +940,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -940,7 +940,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -940,7 +940,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -798,7 +798,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",
@@ -4863,7 +4863,7 @@
         },
         "missionDetail": {
             "attachedWorks": {
-				"pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
+                "pickerTruncated": "Showing your 100 most recent Works - open the Works page for the full list.",
                 "title": "Attached Works",
                 "empty": "No Works attached to this Mission yet. Attach one below.",
                 "attachTitle": "Attach a Work",

--- a/apps/web/src/components/goals/GoalForm.tsx
+++ b/apps/web/src/components/goals/GoalForm.tsx
@@ -15,7 +15,7 @@ import {
     DEFAULT_CHECK_FREQUENCY_MINUTES,
     type GoalComparator,
     type GoalWindow,
-} from '@/lib/api/goals';
+} from '@/lib/api/goals.shared';
 import { createGoalAction } from './actions';
 
 const COMPARATORS: GoalComparator[] = ['gte', 'lte'];

--- a/apps/web/src/lib/api/goals.shared.ts
+++ b/apps/web/src/lib/api/goals.shared.ts
@@ -1,0 +1,25 @@
+/**
+ * Goals & Metrics — client-safe contract values.
+ *
+ * These pure union types and numeric constants carry NO server
+ * dependency, so they live apart from `goals.ts` (which is
+ * `server-only`). `'use client'` components (e.g. `GoalForm`) import
+ * them from here directly; `goals.ts` re-exports them so server-side
+ * callers keep a single import site. Importing a value (not just a
+ * type) from `goals.ts` in a client component pulls its `server-only`
+ * guard into the client bundle and fails the build — this split
+ * avoids that while keeping one canonical definition.
+ */
+export type GoalStatus = 'draft' | 'active' | 'paused' | 'completed';
+export type GoalOutcome = 'achieved' | 'missed' | 'abandoned';
+export type GoalComparator = 'gte' | 'lte';
+export type GoalWindow = 'day' | 'week' | 'month' | 'total' | 'point';
+
+/**
+ * Spec FR-12: per-Goal evaluation frequency is clamped server-side to
+ * a minimum of 15 minutes regardless of what the form submits. Mirror
+ * of `MIN_CHECK_FREQUENCY_MINUTES` from the agent package so the form
+ * can surface the hint without importing the agent barrel.
+ */
+export const MIN_CHECK_FREQUENCY_MINUTES = 15;
+export const DEFAULT_CHECK_FREQUENCY_MINUTES = 60;

--- a/apps/web/src/lib/api/goals.ts
+++ b/apps/web/src/lib/api/goals.ts
@@ -13,19 +13,20 @@ import { serverFetch, serverMutation } from './server-api';
  * as ISO strings on the API side (NestJS class-transformer default);
  * we keep them as strings until a renderer actually formats them.
  */
-export type GoalStatus = 'draft' | 'active' | 'paused' | 'completed';
-export type GoalOutcome = 'achieved' | 'missed' | 'abandoned';
-export type GoalComparator = 'gte' | 'lte';
-export type GoalWindow = 'day' | 'week' | 'month' | 'total' | 'point';
 
-/**
- * Spec FR-12: per-Goal evaluation frequency is clamped server-side to
- * a minimum of 15 minutes regardless of what the form submits. Mirror
- * of `MIN_CHECK_FREQUENCY_MINUTES` from the agent package so the form
- * can surface the hint without importing the agent barrel.
- */
-export const MIN_CHECK_FREQUENCY_MINUTES = 15;
-export const DEFAULT_CHECK_FREQUENCY_MINUTES = 60;
+// Pure contract values/types shared with `'use client'` components live
+// in a `server-only`-free module (`goals.shared.ts`) so forms can import
+// them without pulling this server-only module into the client bundle.
+// Re-exported here so existing server-side callers keep one import site.
+export {
+    MIN_CHECK_FREQUENCY_MINUTES,
+    DEFAULT_CHECK_FREQUENCY_MINUTES,
+    type GoalStatus,
+    type GoalOutcome,
+    type GoalComparator,
+    type GoalWindow,
+} from './goals.shared';
+import type { GoalStatus, GoalOutcome, GoalComparator, GoalWindow } from './goals.shared';
 
 export interface GoalMetricSource {
     pluginId: string;

--- a/packages/agent/src/missions/__tests__/missions.service.spec.ts
+++ b/packages/agent/src/missions/__tests__/missions.service.spec.ts
@@ -649,5 +649,4 @@ describe('MissionsService', () => {
             });
         });
     });
-
 });

--- a/packages/agent/src/work-agent/__tests__/idea-build-executor.service.spec.ts
+++ b/packages/agent/src/work-agent/__tests__/idea-build-executor.service.spec.ts
@@ -201,7 +201,10 @@ describe('IdeaBuildExecutorService', () => {
 
             // Goal transitioned RUNNING then COMPLETED (observable via save order).
             const statuses = goals._saved.map((g) => g.status);
-            expect(statuses).toEqual([WorkBuildRequestStatus.RUNNING, WorkBuildRequestStatus.COMPLETED]);
+            expect(statuses).toEqual([
+                WorkBuildRequestStatus.RUNNING,
+                WorkBuildRequestStatus.COMPLETED,
+            ]);
 
             expect(result).toEqual({
                 status: 'completed',
@@ -262,7 +265,10 @@ describe('IdeaBuildExecutorService', () => {
                 'failure',
             );
             const statuses = goals._saved.map((g) => g.status);
-            expect(statuses).toEqual([WorkBuildRequestStatus.RUNNING, WorkBuildRequestStatus.FAILED]);
+            expect(statuses).toEqual([
+                WorkBuildRequestStatus.RUNNING,
+                WorkBuildRequestStatus.FAILED,
+            ]);
             expect(result.status).toBe('failed');
         });
     });

--- a/packages/plugins/google-analytics-metrics/README.md
+++ b/packages/plugins/google-analytics-metrics/README.md
@@ -43,8 +43,8 @@ the `stripe-metrics` sibling, then sent as GA4 `dateRanges`
 `windowAnchor` (ISO-8601) selects "the day/week/month containing this
 instant"; omitted = now.
 
-**Caveat:** the GA4 API interprets report dates in the *property's
-reporting time zone*, not UTC. We deliberately anchor the calendar math
+**Caveat:** the GA4 API interprets report dates in the _property's
+reporting time zone_, not UTC. We deliberately anchor the calendar math
 in UTC so every metrics provider agrees on which day/week/month an
 instant belongs to; for properties whose reporting zone differs from
 UTC, the day boundaries within GA are the property's own.
@@ -75,10 +75,10 @@ Grant the service account only the **Viewer** role:
 
 ## Settings
 
-| Setting              | Required | Description                                                                                                     |
-| -------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
+| Setting              | Required | Description                                                                                                                     |
+| -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `propertyId`         | yes      | Numeric GA4 property id (e.g. `123456789`; `properties/123456789` also accepted). Env fallback: `GOOGLE_ANALYTICS_PROPERTY_ID`. |
-| `serviceAccountJson` | yes      | Full JSON service-account key file. Secret; env fallback: `GOOGLE_ANALYTICS_SERVICE_ACCOUNT_JSON`.               |
+| `serviceAccountJson` | yes      | Full JSON service-account key file. Secret; env fallback: `GOOGLE_ANALYTICS_SERVICE_ACCOUNT_JSON`.                              |
 
 ## Development
 

--- a/packages/plugins/google-analytics-metrics/src/__tests__/google-analytics-metrics.plugin.spec.ts
+++ b/packages/plugins/google-analytics-metrics/src/__tests__/google-analytics-metrics.plugin.spec.ts
@@ -137,9 +137,7 @@ describe('GoogleAnalyticsMetricsPlugin', () => {
 					projectId: SERVICE_ACCOUNT.project_id
 				})
 			);
-			expect(runReportMock).toHaveBeenCalledWith(
-				expect.objectContaining({ property: 'properties/987654321' })
-			);
+			expect(runReportMock).toHaveBeenCalledWith(expect.objectContaining({ property: 'properties/987654321' }));
 		});
 
 		it('prefers settings over the environment variables', async () => {
@@ -157,17 +155,13 @@ describe('GoogleAnalyticsMetricsPlugin', () => {
 					credentials: expect.objectContaining({ client_email: SERVICE_ACCOUNT.client_email })
 				})
 			);
-			expect(runReportMock).toHaveBeenCalledWith(
-				expect.objectContaining({ property: 'properties/123456789' })
-			);
+			expect(runReportMock).toHaveBeenCalledWith(expect.objectContaining({ property: 'properties/123456789' }));
 		});
 
 		it('accepts a "properties/123" resource name and normalizes it', async () => {
 			runReportMock.mockResolvedValueOnce(report('5'));
 			await plugin.getMetricValue(query(), { ...SETTINGS, propertyId: 'properties/123456789' });
-			expect(runReportMock).toHaveBeenCalledWith(
-				expect.objectContaining({ property: 'properties/123456789' })
-			);
+			expect(runReportMock).toHaveBeenCalledWith(expect.objectContaining({ property: 'properties/123456789' }));
 		});
 
 		it('throws invalid_settings on unparsable service-account JSON', async () => {
@@ -199,9 +193,7 @@ describe('GoogleAnalyticsMetricsPlugin', () => {
 		])('queries the %s metric as GA4 "%s"', async (metricId, apiName) => {
 			runReportMock.mockResolvedValueOnce(report('1'));
 			await plugin.getMetricValue(query({ metricId }), SETTINGS);
-			expect(runReportMock).toHaveBeenCalledWith(
-				expect.objectContaining({ metrics: [{ name: apiName }] })
-			);
+			expect(runReportMock).toHaveBeenCalledWith(expect.objectContaining({ metrics: [{ name: apiName }] }));
 		});
 
 		it('sends a single-day UTC dateRange for the day window', async () => {
@@ -375,7 +367,10 @@ describe('GoogleAnalyticsMetricsPlugin', () => {
 			const r = plugin.validateSettings({ ...SETTINGS, serviceAccountJson: '{oops' });
 			expect(r.valid).toBe(false);
 			expect(r.errors).toEqual([
-				expect.objectContaining({ path: 'serviceAccountJson', message: expect.stringMatching(/not valid JSON/i) })
+				expect.objectContaining({
+					path: 'serviceAccountJson',
+					message: expect.stringMatching(/not valid JSON/i)
+				})
 			]);
 		});
 
@@ -455,9 +450,7 @@ describe('GoogleAnalyticsMetricsPlugin', () => {
 			runReportMock.mockResolvedValueOnce(report('0'));
 			const r = await plugin.validateConnection(SETTINGS);
 			expect(r.success).toBe(true);
-			expect(runReportMock).toHaveBeenCalledWith(
-				expect.objectContaining({ metrics: [{ name: 'activeUsers' }] })
-			);
+			expect(runReportMock).toHaveBeenCalledWith(expect.objectContaining({ metrics: [{ name: 'activeUsers' }] }));
 		});
 
 		it('reports the SDK error message on failure', async () => {

--- a/packages/plugins/google-analytics-metrics/src/google-analytics-metrics.plugin.ts
+++ b/packages/plugins/google-analytics-metrics/src/google-analytics-metrics.plugin.ts
@@ -490,7 +490,8 @@ export class GoogleAnalyticsMetricsPlugin implements IMetricsProviderPlugin {
 	async healthCheck(): Promise<PluginHealthCheck> {
 		return {
 			status: 'healthy',
-			message: 'Google Analytics Metrics plugin is ready (GA4 property + service account key required for operations)',
+			message:
+				'Google Analytics Metrics plugin is ready (GA4 property + service account key required for operations)',
 			checkedAt: Date.now()
 		};
 	}

--- a/packages/plugins/posthog-metrics/README.md
+++ b/packages/plugins/posthog-metrics/README.md
@@ -20,10 +20,10 @@ errors). The rationale is also documented in the module doc block of
 
 ## Metrics
 
-| Metric id      | What it reads                                             | Windows                | Unit    | Params              |
-| -------------- | --------------------------------------------------------- | ---------------------- | ------- | ------------------- |
-| `event_count`  | `count()` of one event via HogQL over the window          | `day`, `week`, `month` | `count` | `{ event: string }` |
-| `active_users` | `count(DISTINCT person_id)` via HogQL over the window     | `day`, `week`, `month` | `count` | —                   |
+| Metric id      | What it reads                                         | Windows                | Unit    | Params              |
+| -------------- | ----------------------------------------------------- | ---------------------- | ------- | ------------------- |
+| `event_count`  | `count()` of one event via HogQL over the window      | `day`, `week`, `month` | `count` | `{ event: string }` |
+| `active_users` | `count(DISTINCT person_id)` via HogQL over the window | `day`, `week`, `month` | `count` | —                   |
 
 Notes:
 
@@ -44,16 +44,16 @@ it executes a fixed HogQL `SELECT` and mutates nothing (the
 Use a **personal API key scoped to `Query: Read`** only:
 
 1. PostHog → **Settings** → **Personal API keys**
-2. **Create personal API key** → scope it to *Query: Read* on your project
+2. **Create personal API key** → scope it to _Query: Read_ on your project
 3. Configure the `phx_...` key + your **Project ID** (Settings → Project)
 
 ## Settings
 
-| Setting          | Required | Default                  | Notes                                                             |
-| ---------------- | -------- | ------------------------ | ----------------------------------------------------------------- |
-| `apiHost`        | no       | `https://us.posthog.com` | EU Cloud: `https://eu.posthog.com`; self-hosted URLs work too     |
-| `projectId`      | yes      | —                        | Numeric project id; env fallback `POSTHOG_PROJECT_ID`             |
-| `personalApiKey` | yes      | —                        | Secret (`x-secret`); env fallback `POSTHOG_PERSONAL_API_KEY`      |
+| Setting          | Required | Default                  | Notes                                                         |
+| ---------------- | -------- | ------------------------ | ------------------------------------------------------------- |
+| `apiHost`        | no       | `https://us.posthog.com` | EU Cloud: `https://eu.posthog.com`; self-hosted URLs work too |
+| `projectId`      | yes      | —                        | Numeric project id; env fallback `POSTHOG_PROJECT_ID`         |
+| `personalApiKey` | yes      | —                        | Secret (`x-secret`); env fallback `POSTHOG_PERSONAL_API_KEY`  |
 
 ## Typed errors
 

--- a/packages/plugins/posthog-metrics/src/__tests__/posthog-metrics.plugin.spec.ts
+++ b/packages/plugins/posthog-metrics/src/__tests__/posthog-metrics.plugin.spec.ts
@@ -371,7 +371,9 @@ describe('PostHogMetricsPlugin', () => {
 		});
 
 		it('maps an aborted request to timeout', async () => {
-			fetchMock.mockRejectedValueOnce(Object.assign(new Error('The operation timed out'), { name: 'TimeoutError' }));
+			fetchMock.mockRejectedValueOnce(
+				Object.assign(new Error('The operation timed out'), { name: 'TimeoutError' })
+			);
 
 			await expect(plugin.getMetricValue(query(), SETTINGS)).rejects.toMatchObject({ code: 'timeout' });
 		});
@@ -403,9 +405,9 @@ describe('PostHogMetricsPlugin', () => {
 		});
 
 		it('throws on an unparsable windowAnchor', async () => {
-			await expect(
-				plugin.getMetricValue(query({ windowAnchor: 'not-a-date' }), SETTINGS)
-			).rejects.toThrow(/Invalid windowAnchor/);
+			await expect(plugin.getMetricValue(query({ windowAnchor: 'not-a-date' }), SETTINGS)).rejects.toThrow(
+				/Invalid windowAnchor/
+			);
 			expect(fetchMock).not.toHaveBeenCalled();
 		});
 	});
@@ -422,9 +424,9 @@ describe('PostHogMetricsPlugin', () => {
 			const { dateFrom, dateTo } = resolveWindowRange('week', '2026-07-19T12:00:00Z');
 			expect(dateFrom).toBe('2026-07-13 00:00:00');
 			expect(dateTo).toBe('2026-07-20 00:00:00');
-			expect((Date.parse(dateTo.replace(' ', 'T') + 'Z') - Date.parse(dateFrom.replace(' ', 'T') + 'Z')) / 1000).toBe(
-				7 * DAY_SECONDS
-			);
+			expect(
+				(Date.parse(dateTo.replace(' ', 'T') + 'Z') - Date.parse(dateFrom.replace(' ', 'T') + 'Z')) / 1000
+			).toBe(7 * DAY_SECONDS);
 
 			// A Monday anchor is its own week start.
 			const monday = resolveWindowRange('week', '2026-07-13T00:00:00Z');

--- a/packages/plugins/posthog-metrics/src/posthog-metrics.plugin.ts
+++ b/packages/plugins/posthog-metrics/src/posthog-metrics.plugin.ts
@@ -308,7 +308,7 @@ export class PostHogMetricsPlugin implements IMetricsProviderPlugin {
 	isAvailable(settings?: PluginSettings): boolean {
 		return Boolean(
 			this.resolvePersonalApiKey(settings, { optional: true }) &&
-				this.resolveProjectId(settings, { optional: true })
+			this.resolveProjectId(settings, { optional: true })
 		);
 	}
 
@@ -375,7 +375,7 @@ export class PostHogMetricsPlugin implements IMetricsProviderPlugin {
 				'',
 				'## Metrics',
 				'',
-				"- **Event count** (`event_count`) — how many times a given event (e.g. `$pageview`, `signup`) occurred over a day, week, or month (UTC). Takes a `{ event }` parameter.",
+				'- **Event count** (`event_count`) — how many times a given event (e.g. `$pageview`, `signup`) occurred over a day, week, or month (UTC). Takes a `{ event }` parameter.',
 				'- **Active users** (`active_users`) — unique persons (`count(DISTINCT person_id)`) with at least one event over a day, week, or month (UTC).',
 				'',
 				'## Read-only by design',

--- a/packages/plugins/stripe-metrics/README.md
+++ b/packages/plugins/stripe-metrics/README.md
@@ -10,9 +10,9 @@ Node SDK** (no hand-rolled REST).
 
 ## Metrics
 
-| Metric id           | What it reads                                          | Windows                  | Unit                             |
-| ------------------- | ------------------------------------------------------ | ------------------------ | -------------------------------- |
-| `balance_available` | Current available balance (`stripe.balance.retrieve`)  | `point`                  | configured currency (e.g. `usd`) |
+| Metric id           | What it reads                                            | Windows                | Unit                             |
+| ------------------- | -------------------------------------------------------- | ---------------------- | -------------------------------- |
+| `balance_available` | Current available balance (`stripe.balance.retrieve`)    | `point`                | configured currency (e.g. `usd`) |
 | `gross_volume`      | Sum of successful (paid) charges (`stripe.charges.list`) | `day`, `week`, `month` | configured currency              |
 
 Notes:
@@ -27,7 +27,7 @@ Notes:
 - `gross_volume` is **single-currency**: it counts **paid** charges in the
   configured `currency` only — charges in any other currency are excluded
   from the sum (multi-currency accounts get the configured-currency slice,
-  not a mixed-denomination total). Refunds are *not* subtracted (that is
+  not a mixed-denomination total). Refunds are _not_ subtracted (that is
   what makes it gross).
 - Because `charges.list` has no server-side currency filter, excluded
   foreign-currency charges are still walked and **count toward the
@@ -66,10 +66,10 @@ contract forbids it). Don't hand it more power than it needs: use a
 
 ## Settings
 
-| Setting     | Required | Description                                                                                  |
-| ----------- | -------- | -------------------------------------------------------------------------------------------- |
-| `secretKey` | yes      | Stripe secret key (`rk_...` recommended). Secret; env fallback: `STRIPE_SECRET_KEY`.          |
-| `currency`  | no       | Lowercase ISO-4217 code metric values are reported in. Default `usd`.                         |
+| Setting     | Required | Description                                                                          |
+| ----------- | -------- | ------------------------------------------------------------------------------------ |
+| `secretKey` | yes      | Stripe secret key (`rk_...` recommended). Secret; env fallback: `STRIPE_SECRET_KEY`. |
+| `currency`  | no       | Lowercase ISO-4217 code metric values are reported in. Default `usd`.                |
 
 ## Development
 

--- a/packages/plugins/stripe-metrics/src/__tests__/stripe-metrics.plugin.spec.ts
+++ b/packages/plugins/stripe-metrics/src/__tests__/stripe-metrics.plugin.spec.ts
@@ -143,7 +143,10 @@ describe('StripeMetricsPlugin', () => {
 			balanceRetrieveMock.mockResolvedValueOnce({ available: [{ amount: 100, currency: 'usd' }] });
 
 			await plugin.getMetricValue(query({ metricId: 'balance_available', window: 'point' }), {});
-			expect(stripeCtorMock).toHaveBeenCalledWith('rk_env_456', expect.objectContaining({ maxNetworkRetries: 2 }));
+			expect(stripeCtorMock).toHaveBeenCalledWith(
+				'rk_env_456',
+				expect.objectContaining({ maxNetworkRetries: 2 })
+			);
 		});
 
 		it('prefers the settings key over the environment variable', async () => {
@@ -162,10 +165,9 @@ describe('StripeMetricsPlugin', () => {
 			expect(stripeCtorMock).toHaveBeenCalledTimes(1);
 
 			// A different secret key gets its own client.
-			await plugin.getMetricValue(
-				query({ metricId: 'balance_available', window: 'point' }),
-				{ secretKey: 'sk_test_other' }
-			);
+			await plugin.getMetricValue(query({ metricId: 'balance_available', window: 'point' }), {
+				secretKey: 'sk_test_other'
+			});
 			expect(stripeCtorMock).toHaveBeenCalledTimes(2);
 			expect(stripeCtorMock).toHaveBeenLastCalledWith('sk_test_other', expect.anything());
 		});
@@ -195,10 +197,10 @@ describe('StripeMetricsPlugin', () => {
 				]
 			});
 
-			const sample = await plugin.getMetricValue(
-				query({ metricId: 'balance_available', window: 'point' }),
-				{ ...SETTINGS, currency: 'eur' }
-			);
+			const sample = await plugin.getMetricValue(query({ metricId: 'balance_available', window: 'point' }), {
+				...SETTINGS,
+				currency: 'eur'
+			});
 
 			expect(sample.value).toBe(6.78);
 			expect(sample.unit).toBe('eur');
@@ -377,9 +379,9 @@ describe('StripeMetricsPlugin', () => {
 
 	describe('unknown metric', () => {
 		it('throws listing the available metric ids', async () => {
-			await expect(
-				plugin.getMetricValue(query({ metricId: 'net_income' }), SETTINGS)
-			).rejects.toThrow(/Unknown metric 'net_income'.*balance_available, gross_volume/);
+			await expect(plugin.getMetricValue(query({ metricId: 'net_income' }), SETTINGS)).rejects.toThrow(
+				/Unknown metric 'net_income'.*balance_available, gross_volume/
+			);
 		});
 	});
 


### PR DESCRIPTION
## Why develop is red

`develop`'s `lint-and-test (22.x)` job fails at **Check formatting** (32 files), and once that's fixed the **Build** step fails on a `server-only` import in a client component. Both are carried in from the domain-model / Goals train, unrelated to any one feature PR — and they block the whole merge train + cascade. This PR fixes both.

## 1. `server-only` pulled into a client bundle

`components/goals/GoalForm.tsx` is a `'use client'` component that value-imports `MIN_CHECK_FREQUENCY_MINUTES` / `DEFAULT_CHECK_FREQUENCY_MINUTES` from `lib/api/goals.ts`, which starts with `import 'server-only'`. That poisons the client bundle → `next build` fails.

**Fix (additive, no behavior change):** extract the pure contract constants + union types (`GoalStatus`/`GoalOutcome`/`GoalComparator`/`GoalWindow`) into a new client-safe `lib/api/goals.shared.ts`. `goals.ts` re-exports them (server callers keep one import site); `GoalForm` imports from the shared module. The other four Goals client components already used `import type`, so they were unaffected.

Verified with a full `next build` (web compiles clean).

## 2. Prettier drift (32 files)

Locale JSON + the metrics plugins (google-analytics / posthog / stripe) + two mission specs + the missions controller landed unformatted. `prettier --write` applied; `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)