### PR TITLE
Cascade: develop → stage (roadmap features + format fix)

### DIFF
--- a/apps/api/src/teams/teams.controller.ts
+++ b/apps/api/src/teams/teams.controller.ts
@@ -209,7 +209,8 @@ export class TeamsController {
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
     @ApiOperation({
         summary: 'Attach a resource (Work/Task/Agent/Mission/Idea) to a team',
-        description: 'The resource must belong to the same Organization (404-never-403 on mismatch).',
+        description:
+            'The resource must belong to the same Organization (404-never-403 on mismatch).',
     })
     @ApiResponse({ status: 201, description: 'Resource attached' })
     @ApiResponse({ status: 404, description: 'Team or resource not found in this Organization' })

--- a/apps/api/src/triggers/dto/inbound-trigger.dto.ts
+++ b/apps/api/src/triggers/dto/inbound-trigger.dto.ts
@@ -23,7 +23,8 @@ export class CreateInboundTriggerDto {
 
     @ApiPropertyOptional({
         enum: TRIGGER_KINDS,
-        description: "Delivery style — informational; both kinds share the same fire endpoint. Defaults to 'webhook'.",
+        description:
+            "Delivery style — informational; both kinds share the same fire endpoint. Defaults to 'webhook'.",
     })
     @IsOptional()
     @IsIn(TRIGGER_KINDS)
@@ -71,7 +72,8 @@ export class UpdateInboundTriggerDto {
     targetAgentId?: string | null;
 
     @ApiPropertyOptional({
-        description: "Title template for spawned Tasks; '{name}' expands to the trigger name; null resets to the default",
+        description:
+            "Title template for spawned Tasks; '{name}' expands to the trigger name; null resets to the default",
         maxLength: 200,
     })
     @IsOptional()

--- a/apps/api/src/triggers/inbound-triggers.controller.ts
+++ b/apps/api/src/triggers/inbound-triggers.controller.ts
@@ -113,7 +113,9 @@ export class InboundTriggersController {
     @Patch(':id')
     @ApiBearerAuth('JWT-auth')
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
-    @ApiOperation({ summary: 'Update an inbound trigger (name, description, agent, title template)' })
+    @ApiOperation({
+        summary: 'Update an inbound trigger (name, description, agent, title template)',
+    })
     @ApiParam({ name: 'id', description: 'Trigger ID' })
     @ApiResponse({ status: 200, description: 'Updated trigger view' })
     @ApiResponse({ status: 404, description: 'Not found (or not yours)' })

--- a/apps/web/src/app/actions/dashboard/inbound-triggers.ts
+++ b/apps/web/src/app/actions/dashboard/inbound-triggers.ts
@@ -3,10 +3,10 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import {
-	inboundTriggersAPI,
-	type CreateInboundTriggerInput,
-	type InboundTriggerView,
-	type InboundTriggerWithSecret
+    inboundTriggersAPI,
+    type CreateInboundTriggerInput,
+    type InboundTriggerView,
+    type InboundTriggerWithSecret,
 } from '@/lib/api/inbound-triggers';
 // Security: defense-in-depth authn guard, mirroring actions/dashboard/schedules.ts.
 // serverFetch only attaches the bearer token when an auth cookie is present, so
@@ -16,88 +16,92 @@ import { getAuthFromCookie } from '@/lib/auth';
 import { ROUTES } from '@/lib/constants';
 
 async function requireAuth() {
-	const user = await getAuthFromCookie();
-	if (!user) {
-		redirect(ROUTES.AUTH_LOGIN);
-	}
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
 }
 
 /** The Schedules view lives on the Activity page — bust its cache after a mutation. */
 function revalidateTriggerSurfaces() {
-	revalidatePath('/[locale]/(dashboard)/activity', 'page');
+    revalidatePath('/[locale]/(dashboard)/activity', 'page');
 }
 
 type ActionResult<T> = { success: true; data: T } | { success: false; error: string };
 
 function toError(error: unknown, fallback: string): { success: false; error: string } {
-	console.error(fallback, error);
-	return { success: false, error: error instanceof Error ? error.message : fallback };
+    console.error(fallback, error);
+    return { success: false, error: error instanceof Error ? error.message : fallback };
 }
 
 export async function listInboundTriggersAction(): Promise<ActionResult<InboundTriggerView[]>> {
-	await requireAuth();
-	try {
-		return { success: true, data: await inboundTriggersAPI.list() };
-	} catch (error) {
-		return toError(error, 'Failed to list triggers');
-	}
+    await requireAuth();
+    try {
+        return { success: true, data: await inboundTriggersAPI.list() };
+    } catch (error) {
+        return toError(error, 'Failed to list triggers');
+    }
 }
 
 export async function createInboundTriggerAction(
-	input: CreateInboundTriggerInput
+    input: CreateInboundTriggerInput,
 ): Promise<ActionResult<InboundTriggerWithSecret>> {
-	await requireAuth();
-	try {
-		const data = await inboundTriggersAPI.create(input);
-		revalidateTriggerSurfaces();
-		return { success: true, data };
-	} catch (error) {
-		return toError(error, 'Failed to create trigger');
-	}
+    await requireAuth();
+    try {
+        const data = await inboundTriggersAPI.create(input);
+        revalidateTriggerSurfaces();
+        return { success: true, data };
+    } catch (error) {
+        return toError(error, 'Failed to create trigger');
+    }
 }
 
 export async function rotateInboundTriggerSecretAction(
-	id: string
+    id: string,
 ): Promise<ActionResult<InboundTriggerWithSecret>> {
-	await requireAuth();
-	try {
-		const data = await inboundTriggersAPI.rotateSecret(id);
-		revalidateTriggerSurfaces();
-		return { success: true, data };
-	} catch (error) {
-		return toError(error, 'Failed to rotate secret');
-	}
+    await requireAuth();
+    try {
+        const data = await inboundTriggersAPI.rotateSecret(id);
+        revalidateTriggerSurfaces();
+        return { success: true, data };
+    } catch (error) {
+        return toError(error, 'Failed to rotate secret');
+    }
 }
 
-export async function pauseInboundTriggerAction(id: string): Promise<ActionResult<InboundTriggerView>> {
-	await requireAuth();
-	try {
-		const data = await inboundTriggersAPI.pause(id);
-		revalidateTriggerSurfaces();
-		return { success: true, data };
-	} catch (error) {
-		return toError(error, 'Failed to pause trigger');
-	}
+export async function pauseInboundTriggerAction(
+    id: string,
+): Promise<ActionResult<InboundTriggerView>> {
+    await requireAuth();
+    try {
+        const data = await inboundTriggersAPI.pause(id);
+        revalidateTriggerSurfaces();
+        return { success: true, data };
+    } catch (error) {
+        return toError(error, 'Failed to pause trigger');
+    }
 }
 
-export async function resumeInboundTriggerAction(id: string): Promise<ActionResult<InboundTriggerView>> {
-	await requireAuth();
-	try {
-		const data = await inboundTriggersAPI.resume(id);
-		revalidateTriggerSurfaces();
-		return { success: true, data };
-	} catch (error) {
-		return toError(error, 'Failed to resume trigger');
-	}
+export async function resumeInboundTriggerAction(
+    id: string,
+): Promise<ActionResult<InboundTriggerView>> {
+    await requireAuth();
+    try {
+        const data = await inboundTriggersAPI.resume(id);
+        revalidateTriggerSurfaces();
+        return { success: true, data };
+    } catch (error) {
+        return toError(error, 'Failed to resume trigger');
+    }
 }
 
 export async function deleteInboundTriggerAction(id: string): Promise<ActionResult<null>> {
-	await requireAuth();
-	try {
-		await inboundTriggersAPI.remove(id);
-		revalidateTriggerSurfaces();
-		return { success: true, data: null };
-	} catch (error) {
-		return toError(error, 'Failed to delete trigger');
-	}
+    await requireAuth();
+    try {
+        await inboundTriggersAPI.remove(id);
+        revalidateTriggerSurfaces();
+        return { success: true, data: null };
+    } catch (error) {
+        return toError(error, 'Failed to delete trigger');
+    }
 }

--- a/apps/web/src/components/teams/TeamDetailClient.tsx
+++ b/apps/web/src/components/teams/TeamDetailClient.tsx
@@ -26,10 +26,7 @@ import { Button } from '@/components/ui/button';
 import { Link, useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import { addTeamMemberAction, removeTeamMemberAction } from '@/app/actions/dashboard/teams';
-import {
-    TeamResourcesSection,
-    type ResourceOption,
-} from '@/components/teams/TeamResourcesSection';
+import { TeamResourcesSection, type ResourceOption } from '@/components/teams/TeamResourcesSection';
 import type {
     Team,
     TeamDetail,

--- a/apps/web/src/components/teams/TeamResourcesSection.tsx
+++ b/apps/web/src/components/teams/TeamResourcesSection.tsx
@@ -7,10 +7,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Link, useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
-import {
-    attachTeamResourceAction,
-    detachTeamResourceAction,
-} from '@/app/actions/dashboard/teams';
+import { attachTeamResourceAction, detachTeamResourceAction } from '@/app/actions/dashboard/teams';
 import type {
     TeamResourceItem,
     TeamResourcesGrouped,
@@ -48,7 +45,7 @@ const GROUP_ICON: Record<TeamResourceType, LucideIcon> = {
     agent: Bot,
     mission: Target,
     idea: Lightbulb,
-    task: ListChecks
+    task: ListChecks,
 };
 
 function resourceHref(type: TeamResourceType, id: string): string {
@@ -79,7 +76,7 @@ export function TeamResourcesSection({
     teamId,
     resources,
     works,
-    agents
+    agents,
 }: TeamResourcesSectionProps) {
     const t = useTranslations('dashboard.teamsPage');
     const router = useRouter();
@@ -89,10 +86,7 @@ export function TeamResourcesSection({
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [removingId, setRemovingId] = useState<string | null>(null);
 
-    const allItems = useMemo(
-        () => GROUP_ORDER.flatMap((type) => resources[type]),
-        [resources],
-    );
+    const allItems = useMemo(() => GROUP_ORDER.flatMap((type) => resources[type]), [resources]);
     const hasAny = allItems.length > 0;
 
     // Ids already attached (per type) — filtered out of the add options.
@@ -129,7 +123,7 @@ export function TeamResourcesSection({
         try {
             await attachTeamResourceAction(org.id, teamId, {
                 resourceType: addType,
-                resourceId: selectedId
+                resourceId: selectedId,
             });
             setSelectedId('');
             setSearch('');
@@ -212,7 +206,10 @@ export function TeamResourcesSection({
                                             </div>
                                             <div className="min-w-0 flex-1">
                                                 <Link
-                                                    href={resourceHref(item.resourceType, item.resourceId)}
+                                                    href={resourceHref(
+                                                        item.resourceType,
+                                                        item.resourceId,
+                                                    )}
                                                     className="text-sm text-text dark:text-text-dark truncate hover:text-primary transition-colors block"
                                                 >
                                                     {item.name ?? item.resourceId}
@@ -257,7 +254,9 @@ export function TeamResourcesSection({
                         <select
                             id="team-resource-type"
                             value={addType}
-                            onChange={(event) => handleTypeChange(event.target.value as AddableType)}
+                            onChange={(event) =>
+                                handleTypeChange(event.target.value as AddableType)
+                            }
                             className={SELECT_CLASSES}
                         >
                             <option value="work">{t('detail.resourceTypeWork')}</option>

--- a/apps/web/src/lib/api/inbound-triggers.ts
+++ b/apps/web/src/lib/api/inbound-triggers.ts
@@ -13,64 +13,68 @@ export type InboundTriggerKind = 'webhook' | 'api';
 export type InboundTriggerStatus = 'active' | 'paused';
 
 export interface InboundTriggerView {
-	id: string;
-	name: string;
-	description: string | null;
-	kind: InboundTriggerKind;
-	status: InboundTriggerStatus;
-	targetAgentId: string | null;
-	taskTitleTemplate: string | null;
-	/** ISO 8601, or null when the trigger never fired. */
-	lastFiredAt: string | null;
-	fireCount: number;
-	/** ISO 8601, or null when the secret was never rotated. */
-	rotatedAt: string | null;
-	createdAt: string;
-	updatedAt: string;
+    id: string;
+    name: string;
+    description: string | null;
+    kind: InboundTriggerKind;
+    status: InboundTriggerStatus;
+    targetAgentId: string | null;
+    taskTitleTemplate: string | null;
+    /** ISO 8601, or null when the trigger never fired. */
+    lastFiredAt: string | null;
+    fireCount: number;
+    /** ISO 8601, or null when the secret was never rotated. */
+    rotatedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export interface CreateInboundTriggerInput {
-	name: string;
-	description?: string;
-	kind?: InboundTriggerKind;
-	targetAgentId?: string;
-	taskTitleTemplate?: string;
+    name: string;
+    description?: string;
+    kind?: InboundTriggerKind;
+    targetAgentId?: string;
+    taskTitleTemplate?: string;
 }
 
 /** The RAW signing secret is present ONLY in create + rotate responses. */
 export interface InboundTriggerWithSecret {
-	trigger: InboundTriggerView;
-	secret: string;
+    trigger: InboundTriggerView;
+    secret: string;
 }
 
 export const inboundTriggersAPI = {
-	list: async (): Promise<InboundTriggerView[]> => {
-		const res = await serverFetch<{ triggers: InboundTriggerView[] }>('/api/inbound-triggers');
-		return res.triggers;
-	},
+    list: async (): Promise<InboundTriggerView[]> => {
+        const res = await serverFetch<{ triggers: InboundTriggerView[] }>('/api/inbound-triggers');
+        return res.triggers;
+    },
 
-	create: async (input: CreateInboundTriggerInput): Promise<InboundTriggerWithSecret> => {
-		return serverFetch<InboundTriggerWithSecret>('/api/inbound-triggers', {
-			method: 'POST',
-			body: JSON.stringify(input)
-		});
-	},
+    create: async (input: CreateInboundTriggerInput): Promise<InboundTriggerWithSecret> => {
+        return serverFetch<InboundTriggerWithSecret>('/api/inbound-triggers', {
+            method: 'POST',
+            body: JSON.stringify(input),
+        });
+    },
 
-	rotateSecret: async (id: string): Promise<InboundTriggerWithSecret> => {
-		return serverFetch<InboundTriggerWithSecret>(`/api/inbound-triggers/${id}/rotate-secret`, {
-			method: 'POST'
-		});
-	},
+    rotateSecret: async (id: string): Promise<InboundTriggerWithSecret> => {
+        return serverFetch<InboundTriggerWithSecret>(`/api/inbound-triggers/${id}/rotate-secret`, {
+            method: 'POST',
+        });
+    },
 
-	pause: async (id: string): Promise<InboundTriggerView> => {
-		return serverFetch<InboundTriggerView>(`/api/inbound-triggers/${id}/pause`, { method: 'POST' });
-	},
+    pause: async (id: string): Promise<InboundTriggerView> => {
+        return serverFetch<InboundTriggerView>(`/api/inbound-triggers/${id}/pause`, {
+            method: 'POST',
+        });
+    },
 
-	resume: async (id: string): Promise<InboundTriggerView> => {
-		return serverFetch<InboundTriggerView>(`/api/inbound-triggers/${id}/resume`, { method: 'POST' });
-	},
+    resume: async (id: string): Promise<InboundTriggerView> => {
+        return serverFetch<InboundTriggerView>(`/api/inbound-triggers/${id}/resume`, {
+            method: 'POST',
+        });
+    },
 
-	remove: async (id: string): Promise<void> => {
-		await serverFetch<void>(`/api/inbound-triggers/${id}`, { method: 'DELETE' });
-	}
+    remove: async (id: string): Promise<void> => {
+        await serverFetch<void>(`/api/inbound-triggers/${id}`, { method: 'DELETE' });
+    },
 };

--- a/packages/agent/src/entities/inbound-trigger.entity.ts
+++ b/packages/agent/src/entities/inbound-trigger.entity.ts
@@ -1,10 +1,10 @@
 import {
-	Entity,
-	Column,
-	PrimaryGeneratedColumn,
-	Index,
-	CreateDateColumn,
-	UpdateDateColumn,
+    Entity,
+    Column,
+    PrimaryGeneratedColumn,
+    Index,
+    CreateDateColumn,
+    UpdateDateColumn,
 } from 'typeorm';
 import { TimestampColumn } from './_types';
 
@@ -40,70 +40,70 @@ export type InboundTriggerStatus = 'active' | 'paused';
 @Index('idx_inbound_triggers_user', ['userId'])
 @Index('idx_inbound_triggers_org_status', ['organizationId', 'status'])
 export class InboundTrigger {
-	@PrimaryGeneratedColumn('uuid')
-	id: string;
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
 
-	/** Owning user (raw uuid — FK in the migration). */
-	@Column({ type: 'uuid' })
-	userId: string;
+    /** Owning user (raw uuid — FK in the migration). */
+    @Column({ type: 'uuid' })
+    userId: string;
 
-	@Column({ type: 'varchar', length: 120 })
-	name: string;
+    @Column({ type: 'varchar', length: 120 })
+    name: string;
 
-	@Column({ type: 'text', nullable: true })
-	description: string | null;
+    @Column({ type: 'text', nullable: true })
+    description: string | null;
 
-	@Column({ type: 'varchar', length: 16, default: 'webhook' })
-	kind: InboundTriggerKind;
+    @Column({ type: 'varchar', length: 16, default: 'webhook' })
+    kind: InboundTriggerKind;
 
-	@Column({ type: 'varchar', length: 16, default: 'active' })
-	status: InboundTriggerStatus;
+    @Column({ type: 'varchar', length: 16, default: 'active' })
+    status: InboundTriggerStatus;
 
-	/**
-	 * HMAC-SHA256 signing secret, encrypted at rest.
-	 * x-secret: true — never log or echo this column.
-	 */
-	@Column({ type: 'text' })
-	secretEncrypted: string;
+    /**
+     * HMAC-SHA256 signing secret, encrypted at rest.
+     * x-secret: true — never log or echo this column.
+     */
+    @Column({ type: 'text' })
+    secretEncrypted: string;
 
-	/**
-	 * Previous signing secret (encrypted) — accepted alongside the current
-	 * one for ROTATION_GRACE_MS (24h) after `rotatedAt`, then dead.
-	 * x-secret: true — never log or echo this column.
-	 */
-	@Column({ type: 'text', nullable: true })
-	previousSecretEncrypted: string | null;
+    /**
+     * Previous signing secret (encrypted) — accepted alongside the current
+     * one for ROTATION_GRACE_MS (24h) after `rotatedAt`, then dead.
+     * x-secret: true — never log or echo this column.
+     */
+    @Column({ type: 'text', nullable: true })
+    previousSecretEncrypted: string | null;
 
-	/** When the secret was last rotated (starts the 24h grace window). */
-	@TimestampColumn({ nullable: true })
-	rotatedAt: Date | null;
+    /** When the secret was last rotated (starts the 24h grace window). */
+    @TimestampColumn({ nullable: true })
+    rotatedAt: Date | null;
 
-	/** Optional Agent assigned to spawned Tasks (raw uuid — FK in the migration). */
-	@Column({ type: 'uuid', nullable: true })
-	targetAgentId: string | null;
+    /** Optional Agent assigned to spawned Tasks (raw uuid — FK in the migration). */
+    @Column({ type: 'uuid', nullable: true })
+    targetAgentId: string | null;
 
-	/** Title template for spawned Tasks; `{name}` → trigger name. Defaults to 'Trigger: {name}'. */
-	@Column({ type: 'varchar', length: 200, nullable: true })
-	taskTitleTemplate: string | null;
+    /** Title template for spawned Tasks; `{name}` → trigger name. Defaults to 'Trigger: {name}'. */
+    @Column({ type: 'varchar', length: 200, nullable: true })
+    taskTitleTemplate: string | null;
 
-	@TimestampColumn({ nullable: true })
-	lastFiredAt: Date | null;
+    @TimestampColumn({ nullable: true })
+    lastFiredAt: Date | null;
 
-	@Column({ type: 'int', default: 0 })
-	fireCount: number;
+    @Column({ type: 'int', default: 0 })
+    fireCount: number;
 
-	// Tier A scope FKs (EW-655) — nullable, auto-stamped on insert by
-	// ScopeStampingSubscriber. No @ManyToOne to avoid the entities
-	// import cycle that bit Phase 2 — see user.entity.ts EW-654 comment.
-	@Column({ type: 'uuid', nullable: true })
-	tenantId?: string | null;
+    // Tier A scope FKs (EW-655) — nullable, auto-stamped on insert by
+    // ScopeStampingSubscriber. No @ManyToOne to avoid the entities
+    // import cycle that bit Phase 2 — see user.entity.ts EW-654 comment.
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
 
-	@Column({ type: 'uuid', nullable: true })
-	organizationId?: string | null;
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
 
-	@CreateDateColumn()
-	createdAt: Date;
+    @CreateDateColumn()
+    createdAt: Date;
 
-	@UpdateDateColumn()
-	updatedAt: Date;
+    @UpdateDateColumn()
+    updatedAt: Date;
 }

--- a/packages/agent/src/entities/team-resource.entity.ts
+++ b/packages/agent/src/entities/team-resource.entity.ts
@@ -38,7 +38,9 @@ export const TEAM_RESOURCE_TYPES: readonly TeamResourceType[] = [
 ];
 
 @Entity({ name: 'team_resources' })
-@Index('uq_team_resources_team_resource', ['teamId', 'resourceType', 'resourceId'], { unique: true })
+@Index('uq_team_resources_team_resource', ['teamId', 'resourceType', 'resourceId'], {
+    unique: true,
+})
 @Index('idx_team_resources_resource', ['resourceType', 'resourceId'])
 export class TeamResource {
     @PrimaryGeneratedColumn('uuid')

--- a/packages/agent/src/triggers/inbound-trigger.types.ts
+++ b/packages/agent/src/triggers/inbound-trigger.types.ts
@@ -26,59 +26,59 @@ export const INBOUND_TRIGGER_TIMESTAMP_HEADER = 'x-everworks-timestamp';
 
 /** Caller scope for management routes — mirrors `ScheduleScope` (Tier A read conventions). */
 export interface InboundTriggerScope {
-	userId: string;
-	/** Active Organization id, or null for the bare-Tenant (personal) scope. */
-	organizationId: string | null;
+    userId: string;
+    /** Active Organization id, or null for the bare-Tenant (personal) scope. */
+    organizationId: string | null;
 }
 
 /** Secret-free projection returned by every management read. */
 export interface InboundTriggerView {
-	id: string;
-	name: string;
-	description: string | null;
-	kind: InboundTriggerKind;
-	status: InboundTriggerStatus;
-	targetAgentId: string | null;
-	taskTitleTemplate: string | null;
-	/** ISO 8601, or null when the trigger never fired. */
-	lastFiredAt: string | null;
-	fireCount: number;
-	/** ISO 8601, or null when the secret was never rotated. */
-	rotatedAt: string | null;
-	createdAt: string;
-	updatedAt: string;
+    id: string;
+    name: string;
+    description: string | null;
+    kind: InboundTriggerKind;
+    status: InboundTriggerStatus;
+    targetAgentId: string | null;
+    taskTitleTemplate: string | null;
+    /** ISO 8601, or null when the trigger never fired. */
+    lastFiredAt: string | null;
+    fireCount: number;
+    /** ISO 8601, or null when the secret was never rotated. */
+    rotatedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
 }
 
 export interface CreateInboundTriggerInput {
-	name: string;
-	description?: string | null;
-	kind?: InboundTriggerKind;
-	targetAgentId?: string | null;
-	taskTitleTemplate?: string | null;
+    name: string;
+    description?: string | null;
+    kind?: InboundTriggerKind;
+    targetAgentId?: string | null;
+    taskTitleTemplate?: string | null;
 }
 
 export interface UpdateInboundTriggerInput {
-	name?: string;
-	description?: string | null;
-	/** `null` clears the assignment. */
-	targetAgentId?: string | null;
-	taskTitleTemplate?: string | null;
+    name?: string;
+    description?: string | null;
+    /** `null` clears the assignment. */
+    targetAgentId?: string | null;
+    taskTitleTemplate?: string | null;
 }
 
 /** Raw fire-request material — verified inside the service, never pre-parsed. */
 export interface FireInboundTriggerInput {
-	/** Exact raw request body the sender signed. */
-	rawBody: string;
-	/** `x-everworks-signature` header value (hex, optional `sha256=` prefix). */
-	signatureHeader: string | undefined;
-	/** `x-everworks-timestamp` header value — the exact string that was signed. */
-	timestampHeader: string | undefined;
-	/** Request Content-Type; JSON types get a payload-shape check. */
-	contentType?: string | undefined;
+    /** Exact raw request body the sender signed. */
+    rawBody: string;
+    /** `x-everworks-signature` header value (hex, optional `sha256=` prefix). */
+    signatureHeader: string | undefined;
+    /** `x-everworks-timestamp` header value — the exact string that was signed. */
+    timestampHeader: string | undefined;
+    /** Request Content-Type; JSON types get a payload-shape check. */
+    contentType?: string | undefined;
 }
 
 export interface FireInboundTriggerResult {
-	ok: true;
-	taskId: string;
-	taskSlug: string;
+    ok: true;
+    taskId: string;
+    taskSlug: string;
 }

--- a/packages/agent/src/triggers/inbound-triggers.module.ts
+++ b/packages/agent/src/triggers/inbound-triggers.module.ts
@@ -18,8 +18,8 @@ import { InboundTriggersService } from './inbound-triggers.service';
  *   module uses) rather than dragging in a broader services module.
  */
 @Module({
-	imports: [DatabaseModule, TasksDomainModule],
-	providers: [InboundTriggersService, WebhookSubscriptionSecretService],
-	exports: [InboundTriggersService],
+    imports: [DatabaseModule, TasksDomainModule],
+    providers: [InboundTriggersService, WebhookSubscriptionSecretService],
+    exports: [InboundTriggersService],
 })
 export class InboundTriggersModule {}

--- a/packages/agent/src/triggers/index.ts
+++ b/packages/agent/src/triggers/index.ts
@@ -1,19 +1,19 @@
 export { InboundTriggersService } from './inbound-triggers.service';
 export { InboundTriggersModule } from './inbound-triggers.module';
 export {
-	REPLAY_WINDOW_MS,
-	ROTATION_GRACE_MS,
-	MAX_FIRE_PAYLOAD_BYTES,
-	DEFAULT_TASK_TITLE_TEMPLATE,
-	INBOUND_TRIGGER_SIGNATURE_HEADER,
-	INBOUND_TRIGGER_TIMESTAMP_HEADER,
+    REPLAY_WINDOW_MS,
+    ROTATION_GRACE_MS,
+    MAX_FIRE_PAYLOAD_BYTES,
+    DEFAULT_TASK_TITLE_TEMPLATE,
+    INBOUND_TRIGGER_SIGNATURE_HEADER,
+    INBOUND_TRIGGER_TIMESTAMP_HEADER,
 } from './inbound-trigger.types';
 export type {
-	InboundTriggerScope,
-	InboundTriggerView,
-	CreateInboundTriggerInput,
-	UpdateInboundTriggerInput,
-	FireInboundTriggerInput,
-	FireInboundTriggerResult,
+    InboundTriggerScope,
+    InboundTriggerView,
+    CreateInboundTriggerInput,
+    UpdateInboundTriggerInput,
+    FireInboundTriggerInput,
+    FireInboundTriggerResult,
 } from './inbound-trigger.types';
 export type { InboundTriggerKind, InboundTriggerStatus } from '../entities/inbound-trigger.entity';


### PR DESCRIPTION
Re-cascade after the stage format:check gate. develop now includes the prettier fix for the 12 teams/triggers files. Verified: format:check clean, agent build clean + full suite (6515 tests), web+api tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)