### PR TITLE
Cascade: develop → stage (roadmap + format + server-only fixes)

### DIFF
--- a/apps/web/src/components/agents/AgentGuardrailsCard.tsx
+++ b/apps/web/src/components/agents/AgentGuardrailsCard.tsx
@@ -13,7 +13,7 @@ import {
     type AgentGuardrailActionType,
     type AgentGuardrails,
     type AgentGuardrailsMode,
-} from '@/lib/api/agents';
+} from '@/lib/api/agents.shared';
 
 interface AgentGuardrailsCardProps {
     agentId: string;

--- a/apps/web/src/lib/api/agents.shared.ts
+++ b/apps/web/src/lib/api/agents.shared.ts
@@ -1,0 +1,43 @@
+/**
+ * Agents — client-safe contract values.
+ *
+ * Pure guardrail types + the action-type tuple carry NO server
+ * dependency, so they live apart from `agents.ts` (which is
+ * `server-only`). `'use client'` components (e.g. `AgentGuardrailsCard`)
+ * import them from here; `agents.ts` re-exports them so server-side
+ * callers keep a single import site. Importing the
+ * `AGENT_GUARDRAIL_ACTION_TYPES` value (not just a type) from `agents.ts`
+ * in a client component pulls its `server-only` guard into the client
+ * bundle and fails `next build` — this split avoids that while keeping
+ * one canonical definition.
+ */
+
+// ── Agent Dispatch Guardrails ──
+// Mirrors `AgentGuardrails` (packages/agent/src/agents/guardrails.ts)
+// and the proposal action types
+// (packages/agent/src/entities/agent-action-proposal.entity.ts).
+
+export type AgentGuardrailActionType =
+    | 'spawn_agent'
+    | 'schedule_task'
+    | 'send_message'
+    | 'budget_override'
+    | 'other';
+
+export const AGENT_GUARDRAIL_ACTION_TYPES: readonly AgentGuardrailActionType[] = [
+    'spawn_agent',
+    'schedule_task',
+    'send_message',
+    'budget_override',
+    'other',
+] as const;
+
+export type AgentGuardrailsMode = 'require_approval' | 'autonomous';
+
+export interface AgentGuardrails {
+    mode: AgentGuardrailsMode;
+    /** Autonomous-mode narrowing; omitted = every unflagged type may auto-approve. */
+    autoApproveActionTypes?: AgentGuardrailActionType[];
+    /** Action types the Agent may never take (auto-rejected with an audit row). */
+    blockedActionTypes?: AgentGuardrailActionType[];
+}

--- a/apps/web/src/lib/api/agents.ts
+++ b/apps/web/src/lib/api/agents.ts
@@ -20,34 +20,18 @@ export type AgentIdleBehavior = 'propose' | 'sleep' | 'self-improve';
 export type AgentFileName = 'SOUL.md' | 'AGENTS.md' | 'HEARTBEAT.md' | 'TOOLS.md' | 'agent.yml';
 
 // ── Agent Dispatch Guardrails ──
-// Mirrors `AgentGuardrails` (packages/agent/src/agents/guardrails.ts)
-// and the proposal action types
-// (packages/agent/src/entities/agent-action-proposal.entity.ts).
-
-export type AgentGuardrailActionType =
-    | 'spawn_agent'
-    | 'schedule_task'
-    | 'send_message'
-    | 'budget_override'
-    | 'other';
-
-export const AGENT_GUARDRAIL_ACTION_TYPES: readonly AgentGuardrailActionType[] = [
-    'spawn_agent',
-    'schedule_task',
-    'send_message',
-    'budget_override',
-    'other',
-] as const;
-
-export type AgentGuardrailsMode = 'require_approval' | 'autonomous';
-
-export interface AgentGuardrails {
-    mode: AgentGuardrailsMode;
-    /** Autonomous-mode narrowing; omitted = every unflagged type may auto-approve. */
-    autoApproveActionTypes?: AgentGuardrailActionType[];
-    /** Action types the Agent may never take (auto-rejected with an audit row). */
-    blockedActionTypes?: AgentGuardrailActionType[];
-}
+// Pure guardrail types + the action-type tuple live in a
+// `server-only`-free module (`agents.shared.ts`) so `'use client'`
+// components (e.g. AgentGuardrailsCard) can import them without pulling
+// this server-only module into the client bundle. Re-exported here so
+// server-side callers keep one import site.
+export {
+    AGENT_GUARDRAIL_ACTION_TYPES,
+    type AgentGuardrailActionType,
+    type AgentGuardrailsMode,
+    type AgentGuardrails,
+} from './agents.shared';
+import type { AgentGuardrails } from './agents.shared';
 
 export interface AgentPermissions {
     canCreateAgents: boolean;


### PR DESCRIPTION
Re-cascade with the guardrails server-only fix + format fixes. Verified locally: full monorepo build 98/98 green, agent suite 6515 tests, web/api tsc clean, format:check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)