### PR TITLE
Cascade: stage → main (CRITICAL: InboundTriggers boot-crash fix + k8s-build retry)

### DIFF
--- a/.github/workflows/k8s-build.yml
+++ b/.github/workflows/k8s-build.yml
@@ -60,7 +60,45 @@ jobs:
           VERSION=$(grep -m1 '"version"' "${{ matrix.pkg }}" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')
           echo "version=${VERSION:-0.0.0}" >> "$GITHUB_OUTPUT"
           echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-      - uses: docker/build-push-action@v7.3.0
+      # First build + push attempt. ghcr.io intermittently returns
+      # `403 Forbidden` on the blob HEAD when several matrix images push
+      # concurrently under the same GITHUB_TOKEN — a transient registry
+      # rate-limit / session race, NOT a package-permission problem (a
+      # different image fails on each run: web+docs one build, mcp+docs the
+      # next). So we don't fail the job on the first attempt; we back off
+      # and retry. The build layers are cached by `cache-to` on the first
+      # pass, so the retry only re-pushes and is fast.
+      - id: buildpush
+        uses: docker/build-push-action@v7.3.0
+        continue-on-error: true
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          build-args: |
+            NODE_ENV=production
+            BUILD_VERSION=${{ steps.meta.outputs.version }}
+            GIT_SHA=${{ github.sha }}
+            GIT_REF=${{ github.ref_name }}
+            BUILD_RUN=${{ github.run_number }}
+            BUILD_TIME=${{ steps.meta.outputs.build_time }}
+            NEXT_PUBLIC_BUILD_VERSION=${{ steps.meta.outputs.version }}
+            NEXT_PUBLIC_BUILD_SHA=${{ github.sha }}
+            NEXT_PUBLIC_BUILD_REF=${{ github.ref_name }}
+            NEXT_PUBLIC_BUILD_RUN=${{ github.run_number }}
+            NEXT_PUBLIC_BUILD_TIME=${{ steps.meta.outputs.build_time }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ steps.t.outputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max
+      # Back off to let the transient ghcr rate-limit window clear.
+      - if: steps.buildpush.outcome == 'failure'
+        run: sleep 45
+      # Retry (cached build → push-only, fast). This step is NOT
+      # continue-on-error, so a genuine/persistent failure still fails the job.
+      - if: steps.buildpush.outcome == 'failure'
+        uses: docker/build-push-action@v7.3.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/packages/agent/src/triggers/inbound-triggers.module.ts
+++ b/packages/agent/src/triggers/inbound-triggers.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../database/database.module';
+import { AgentRepository } from '../database/repositories/agent.repository';
 import { TasksDomainModule } from '../tasks-domain/tasks.module';
 import { WebhookSubscriptionSecretService } from '../services/webhook-subscription-secret.service';
 import { InboundTriggersService } from './inbound-triggers.service';
@@ -7,9 +8,14 @@ import { InboundTriggersService } from './inbound-triggers.service';
 /**
  * Inbound Triggers ("Trigger Schedules") — agent-side module.
  *
- * - `DatabaseModule` exports `TypeOrmModule.forFeature(ENTITIES)` (which
- *   includes `InboundTrigger`) plus the repository inventory
- *   (`AgentRepository` for targetAgentId ownership checks).
+ * - `DatabaseModule` exports `TypeOrmModule.forFeature(ENTITIES)`, which
+ *   registers every entity's TypeORM repository token (`InboundTrigger`,
+ *   `Agent`, …) — but NOT the hand-rolled custom repositories.
+ * - `AgentRepository` (a custom repository injected by `InboundTriggersService`
+ *   for targetAgentId ownership checks) is therefore provided locally; it
+ *   only needs `@InjectRepository(Agent)`, which `DatabaseModule` supplies.
+ *   Same pattern as `AgentsModule`. Without this the app fails to boot with
+ *   "Nest can't resolve dependencies of InboundTriggersService … AgentRepository".
  * - `TasksModule` (tasks-domain) provides `TasksService`, the canonical
  *   programmatic Task-creation path — a verified fire spawns a Task
  *   through the exact same code every other surface uses.
@@ -19,7 +25,7 @@ import { InboundTriggersService } from './inbound-triggers.service';
  */
 @Module({
     imports: [DatabaseModule, TasksDomainModule],
-    providers: [InboundTriggersService, WebhookSubscriptionSecretService],
+    providers: [InboundTriggersService, WebhookSubscriptionSecretService, AgentRepository],
     exports: [InboundTriggersService],
 })
 export class InboundTriggersModule {}


### PR DESCRIPTION
Critical production fix. InboundTriggersModule (from the #1712 Inbound Triggers feature merged in the roadmap cascade) never provided AgentRepository, crashing every full-app boot — this crash-looped the new prod api pods so ArgoCD held the old b4d5289f image and api.ever.works never advanced. Verified: generate-openapi boots the full app (407 paths); triggers suite green.

Also hardens k8s-build with a push-retry for the transient ghcr 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)