### PR TITLE
fix(migrations): ResetStrandedQueuedIdeas queries the pre-rename table name

### DIFF
--- a/apps/api/src/migrations/1782200000000-ResetStrandedQueuedIdeas.ts
+++ b/apps/api/src/migrations/1782200000000-ResetStrandedQueuedIdeas.ts
@@ -19,7 +19,7 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  *
  * PRECISION — only truly-stranded Ideas are reset. An Idea is
  * "stranded" iff it is `queued` AND has NO corresponding
- * `work_agent_goals` row (matched on `ideaId`) in a NON-TERMINAL
+ * `work_build_requests` row (matched on `ideaId`) in a NON-TERMINAL
  * state. Non-terminal goal statuses are `pending`, `planning`,
  * `waiting-for-approval`, `running`. If a non-terminal Goal exists,
  * the Idea is legitimately mid-flight (or about to be) and is left
@@ -44,6 +44,13 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  */
 export class ResetStrandedQueuedIdeas1782200000000 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
+        // Postgres-only, matching `1782000000000-RenameWorkAgentGoalsToWorkBuildRequests`,
+        // which is itself postgres-guarded. On a non-postgres connection that rename
+        // never runs, so `work_build_requests` does not exist and this statement would
+        // throw. Same guard, same reason, same ordering.
+        if (queryRunner.connection.options.type !== 'postgres') {
+            return;
+        }
         await queryRunner.query(`
             UPDATE "work_proposals" AS wp
                SET "status" = 'pending',
@@ -52,7 +59,7 @@ export class ResetStrandedQueuedIdeas1782200000000 implements MigrationInterface
              WHERE wp."status" = 'queued'
                AND NOT EXISTS (
                    SELECT 1
-                     FROM "work_agent_goals" AS g
+                     FROM "work_build_requests" AS g
                     WHERE g."ideaId" = wp."id"
                       AND g."status" IN (
                           'pending',


### PR DESCRIPTION
## What

One migration fix, blocking the Ever Works production unfreeze.

`1782200000000-ResetStrandedQueuedIdeas` queries `work_agent_goals`. But
`1782000000000-RenameWorkAgentGoalsToWorkBuildRequests` carries a **lower timestamp**, so TypeORM runs it
**first** and renames that table to `work_build_requests`. The later migration then hits a table that no
longer exists.

```
1782000000000-RenameWorkAgentGoalsToWorkBuildRequests   <-- runs first, renames the table
1782100000000-CreateGoalsTables
1782200000000-ResetStrandedQueuedIdeas                  <-- queries the OLD name
```

`migrationsTransactionMode: 'all'` means this does not fail in isolation — it rolls back **the entire
pending batch**, and every new api pod then crash-loops on the same failure.

## Why this is urgent

Production is the **only** environment that runs this batch. `RUN_MIGRATIONS=true` is baked into the api
image and `entrypoint.sh` executes `migrationsRun` in-process on every start, and there is no
`ever-works-app-stage` environment to rehearse against. This bug would have surfaced first in production,
at the exact moment we unfreeze it.

## Changes

1. `FROM "work_agent_goals"` → `FROM "work_build_requests"`.
2. Added the postgres guard that the rename migration itself uses. The rename is postgres-only, so on a
   non-postgres connection `work_build_requests` is never created and an unguarded query against the new
   name would throw there instead. Same guard, same reason, same placement as its sibling.
3. Docstring updated to name the current table.

## Deliberately NOT done

**No migration is renumbered or renamed.** There are duplicate-timestamp pairs repo-wide and
`1779800000000` is already applied in production. TypeORM keys `executed` on **class name** — renaming a
migration makes it re-run against the prod DB. Fixing the query is the safe fix; renumbering is not.

## Verification

The DI regression from #1712 is already fixed on `develop` (006a2a6a) and confirmed green: the
`ever-works-mcp` build leg is the only stage that bootstraps Nest (`generate-openapi.js`), and it passed on
`main` @ `207d9fc6` after failing with `UnknownDependenciesException ... AgentRepository at index [3]`
before. This PR is the remaining blocker.

Migration correctness itself is not covered by CI (no migration test harness runs the batch against
Postgres), so this was verified by reading the execution order and both migrations' `up()` bodies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of stranded queued ideas by accurately detecting active build requests.
  * Prevented migration errors on unsupported database connections.
  * Preserved failure details clearing and status reset behavior for affected queued ideas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->