### PR TITLE
fix(trigger): resolve Nest DI failures for anonymous-user-cleanup + kb-reconcile

### DIFF
--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -162,6 +162,11 @@ describe('TriggerInternalController', () => {
             undefined, // credentialVersionService
             undefined, // organizationRepository
             undefined, // webhookSubscriptionRepository
+            // EW-617 G2 / EW-643 - two new constructor args exposing the
+            // anonymous-user-cleanup + kb-reconcile services through the
+            // remote-proxy controller. Not exercised by these tests.
+            undefined, // anonymousUserCleanupService
+            undefined, // knowledgeBaseReconcileService
             undefined, // workProposalsApiService (Optional trailing)
         );
         c.onModuleInit();

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -35,7 +35,9 @@ import { WorkOperationsService } from '@ever-works/agent/work-operations';
 import { WorkContextResponse } from '@ever-works/agent/tasks';
 import { SkipThrottle } from '@nestjs/throttler';
 import {
+    AnonymousUserCleanupService,
     DeployReadyPollerService,
+    KnowledgeBaseReconcileService,
     WorkOwnershipService,
     WorkScheduleDispatcherService,
     WorkScheduleService,
@@ -242,6 +244,14 @@ export class TriggerInternalController implements OnModuleInit {
         // the worker-side resolver can derive tenantId for the
         // webhook-delivery task.
         private readonly webhookSubscriptionRepository: WebhookSubscriptionRepository,
+        // EW-617 G2 / EW-637 - exposes AnonymousUserCleanupService for the
+        // nightly `anonymous-user-cleanup` cron task. Provided by WorkModule,
+        // already imported by TriggerInternalModule.
+        private readonly anonymousUserCleanupService: AnonymousUserCleanupService,
+        // EW-643 Phase 3 slice 4a - exposes KnowledgeBaseReconcileService for
+        // the daily `kb-reconcile` cron task. Provided by KnowledgeBaseModule,
+        // already imported by TriggerInternalModule.
+        private readonly knowledgeBaseReconcileService: KnowledgeBaseReconcileService,
         @Optional()
         @Inject(forwardRef(() => WorkProposalsApiService))
         private readonly workProposalsApiService?: WorkProposalsApiService,
@@ -298,6 +308,11 @@ export class TriggerInternalController implements OnModuleInit {
             // EW-742 P3.2 T22 — exposed for resolveForSubscription on
             // the worker-host resolver (webhook-delivery task).
             WebhookSubscriptionRepository: this.webhookSubscriptionRepository,
+            // EW-617 G2 / EW-637 - `anonymous-user-cleanup` calls
+            // `purgeExpired()` here (allow-list auto-derived).
+            AnonymousUserCleanupService: this.anonymousUserCleanupService,
+            // EW-643 Phase 3 slice 4a - `kb-reconcile` calls `reconcile()`.
+            KnowledgeBaseReconcileService: this.knowledgeBaseReconcileService,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/packages/agent/src/services/knowledge-base.module.ts
+++ b/packages/agent/src/services/knowledge-base.module.ts
@@ -24,6 +24,7 @@ import { KnowledgeBaseBufferExtractorService } from './knowledge-base-buffer-ext
 import { KnowledgeBaseMediaNormalizeService } from './knowledge-base-media-normalize.service';
 import { KnowledgeBaseTranscribeService } from './knowledge-base-transcribe.service';
 import { KnowledgeBaseReembedService } from './knowledge-base-reembed.service';
+import { KnowledgeBaseReconcileService } from './knowledge-base-reconcile.service';
 import { KbMentionResolverService } from './kb-mention-resolver.service';
 import { KbAgentToolsService } from './kb-agent-tools.service';
 import { KbToolsFacadeAdapter } from './kb-tools-facade.adapter';
@@ -102,6 +103,14 @@ import { WorkOwnershipService } from './work-ownership.service';
         KnowledgeBaseMediaNormalizeService,
         KnowledgeBaseTranscribeService,
         KnowledgeBaseReembedService,
+        // EW-643 Phase 3 slice 4a - the daily `kb-reconcile` cron task
+        // resolves this service through the remote-proxy controller. It was
+        // never registered in any module, so `appContext.get()` threw
+        // `Nest could not find KnowledgeBaseReconcileService element` on
+        // every run since the task shipped. Its deps are already in scope:
+        // `WorkKnowledgeUploadRepository` below, and `KB_STORAGE_PLUGIN`
+        // from the `@Global()` `KbStorageModule` in apps/api.
+        KnowledgeBaseReconcileService,
         KbMentionResolverService,
         KbAgentToolsService,
         KbToolsFacadeAdapter,
@@ -120,6 +129,7 @@ import { WorkOwnershipService } from './work-ownership.service';
         KnowledgeBaseMediaNormalizeService,
         KnowledgeBaseTranscribeService,
         KnowledgeBaseReembedService,
+        KnowledgeBaseReconcileService,
         KbMentionResolverService,
         KbAgentToolsService,
         KbToolsFacadeAdapter,

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import {
+    AnonymousUserCleanupService,
     DeployReadyPollerService,
+    KnowledgeBaseReconcileService,
     WorkScheduleDispatcherService,
     WorkScheduleService,
 } from '@ever-works/agent/services';
@@ -143,6 +145,31 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
                 createRemoteProxy(apiClient, 'NotificationChannelFacadeService'),
             inject: [TriggerInternalApiClient],
         },
+        // EW-617 G2 / EW-637 - the nightly `anonymous-user-cleanup` cron
+        // task resolved this service from a module that never provided it,
+        // so every run since it shipped died with `Nest could not find
+        // AnonymousUserCleanupService element`. Proxied to the API for the
+        // same reason as NotificationChannelFacadeService above: the real
+        // service needs the storage plugins, which are only loaded in the
+        // API process (the task's own local ANON_CLEANUP_STORAGE_PLUGIN
+        // factory imports an apps/api path that never resolves in worker
+        // scope, so file GC silently no-opped).
+        {
+            provide: AnonymousUserCleanupService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'AnonymousUserCleanupService'),
+            inject: [TriggerInternalApiClient],
+        },
+        // EW-643 Phase 3 slice 4a - same defect for the daily
+        // `kb-reconcile` cron task. The real service reads the KB upload
+        // rows and lists the storage backend's `kb-originals/` prefix,
+        // both of which live API-side.
+        {
+            provide: KnowledgeBaseReconcileService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'KnowledgeBaseReconcileService'),
+            inject: [TriggerInternalApiClient],
+        },
     ],
     exports: [
         TriggerInternalApiClient,
@@ -161,6 +188,8 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         TasksService,
         TaskChatService,
         NotificationChannelFacadeService,
+        AnonymousUserCleanupService,
+        KnowledgeBaseReconcileService,
     ],
 })
 export class TriggerInternalModule {}


### PR DESCRIPTION
## Problem

Two scheduled tasks have failed **100% of runs since they shipped** — 4 runs, 4 failures, all-time:

| Task | Cron | Error |
|---|---|---|
| `anonymous-user-cleanup` | `17 3 * * *` | `Nest could not find AnonymousUserCleanupService element (this provider does not exist in the current context)` |
| `kb-reconcile` | `42 3 * * *` | `Nest could not find KnowledgeBaseReconcileService element (this provider does not exist in the current context)` |

Both are Nest DI resolution failures — the same class of bug as the `AgentRepository` one, and the same fix shape (`docs/runbooks/T22_NEW_DISPATCHER_WIRING.md` §"Step 4 — RPC plumbing").

Verified present at `develop` HEAD — this is **not** a stale-prod artifact.

## Root cause

**`kb-reconcile`** — `withWorkerContext('KbReconcile', …)` defaults to `TriggerWorkerModule` (`worker-context.utils.ts:13`), then calls `appContext.get(KnowledgeBaseReconcileService)`. That service was **never registered in any module anywhere in the repo** — it is the only KB service missing from `KnowledgeBaseModule`, whose sibling services (`KnowledgeBaseTranscribeService`, `KnowledgeBaseMediaNormalizeService`, `KnowledgeBaseReembedService`) are all registered.

**`anonymous-user-cleanup`** — the task builds its own `AnonymousUserCleanupTaskModule` importing `TriggerInternalModule`, then calls `appContext.get(AnonymousUserCleanupService)`. `TriggerInternalModule` neither provided nor exported it.

## Changes

**1. `packages/agent/src/services/knowledge-base.module.ts`** — register `KnowledgeBaseReconcileService` as a provider + export. Its deps are already in scope: `WorkKnowledgeUploadRepository` is provided by this same module, and `KB_STORAGE_PLUGIN` comes from the `@Global()` `KbStorageModule` in `apps/api`.

**2. `packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts`** — add `createRemoteProxy` providers + exports for both services, matching the 15 existing proxies.

**3. `apps/api/src/trigger/trigger-internal.controller.ts`** — constructor injection + `remoteMap` entries for both. No new module imports needed: `TriggerInternalModule` (API side) **already imports** `WorkModule` (which exports `AnonymousUserCleanupService`) and `KnowledgeBaseModule`. The method allow-list is auto-derived by `buildMethodAllowList`.

**4. `apps/api/src/trigger/trigger-internal.controller.spec.ts`** — the spec constructs the controller positionally; added the two `undefined` args in the matching position, before the trailing `@Optional() workProposalsApiService`.

## Why proxy rather than provide locally

Same rationale as `NotificationChannelFacadeService`: the real work needs plugins that are only loaded in the API process.

This also fixes a **silent data bug** in `anonymous-user-cleanup`. Its local `ANON_CLEANUP_STORAGE_PLUGIN` factory dynamically imports `@src/uploads/storage-backend.factory` — an `apps/api` path that never resolves in worker scope — so `resolveStorageBackend()` always caught and returned `undefined`, and the service's graceful-degradation path skipped file deletion entirely. Even had DI resolved, uploaded files would have leaked while user rows were deleted. Running it API-side via the proxy means the storage backend is actually present.

Per the no-removal rule, the now-vestigial local `ANON_CLEANUP_STORAGE_PLUGIN` provider is **left in place**, not deleted.

## Verification

Next scheduled firings are **2026-07-21 03:17Z** and **03:42Z**:

```bash
kubectl -n databases exec pg-1 -- psql -U postgres -d trigger -tAc \
  "SELECT \"taskIdentifier\", status, \"createdAt\" FROM \"TaskRun\"
   WHERE \"taskIdentifier\" IN ('anonymous-user-cleanup','kb-reconcile')
   ORDER BY \"createdAt\" DESC LIMIT 10;"
```

## ⚠️ Delivery blocker — merging this does not deploy it

The two halves ship via **two different pipelines, both currently blocked**:

- The **worker half** (`packages/tasks`) ships as a Trigger.dev **BackgroundWorker artifact** via `trigger.dev deploy` — latest prod is `20260719.1`. Merging to `develop` changes nothing until a new version is published.
- The **API half** ships in the `ever-works-api` image, currently **sha-pinned/frozen** at `sha-b4d5289…`.

Both halves must land together — the proxy and the `remoteMap` entry are two sides of one RPC contract. Promote `develop → stage → main` per CLAUDE.md #10/#11 (no cherry-pick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal support for automated anonymous-user cleanup tasks.
  * Added internal support for knowledge-base reconciliation tasks.
  * Enabled these tasks to run through the worker’s scheduled task system.

* **Tests**
  * Updated controller tests to support the expanded internal task configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->