### PR TITLE
fix(agents): make AgentRun terminal transitions atomic (CAS)

### DIFF
--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -107,6 +107,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             createQueued: jest.fn(),
             findInFlightForTaskAgent: jest.fn().mockResolvedValue(null),
             markFailed: jest.fn().mockResolvedValue(undefined),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
             findByIdAndUser: jest.fn().mockResolvedValue(null),
         };
         agentRunLogs = { findByRun: jest.fn().mockResolvedValue([]) };
@@ -460,10 +461,14 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             await expect(controller.assignTask(auth, agentId, { taskId })).rejects.toBeInstanceOf(
                 InternalServerErrorException,
             );
-            expect(agentRuns.markFailed).toHaveBeenCalledWith(
+            // FU-3: the rollback goes through markDispatchFailed, which is
+            // `queued`-only, so it can never stomp a run the worker already
+            // started after an enqueue that timed out but was accepted.
+            expect(agentRuns.markDispatchFailed).toHaveBeenCalledWith(
                 runId,
                 expect.stringContaining('enqueue-failed'),
             );
+            expect(agentRuns.markFailed).not.toHaveBeenCalled();
         });
 
         it('throws 500 when AGENT_TASK_EXECUTE_DISPATCHER is unbound', async () => {

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -764,9 +764,12 @@ export class AgentsController {
             // assign-task calls (because the queued row passes its
             // "in flight" filter). Mark it failed so retries can
             // re-dispatch cleanly.
+            // FU-3: markDispatchFailed is `queued`-only — if this enqueue threw
+            // on a timeout but was nevertheless accepted, the worker owns the
+            // row from `markStarted` onwards and the rollback must no-op.
             const message = err instanceof Error ? err.message : String(err);
             await this.agentRuns
-                .markFailed(run.id, `enqueue-failed: ${message}`)
+                .markDispatchFailed(run.id, `enqueue-failed: ${message}`)
                 .catch(() => undefined);
             throw new InternalServerErrorException(`assign-task enqueue failed: ${message}`);
         }

--- a/packages/agent/src/agents/agent-schedule-dispatcher.service.ts
+++ b/packages/agent/src/agents/agent-schedule-dispatcher.service.ts
@@ -244,9 +244,12 @@ export class AgentScheduleDispatcherService {
             // created but the trigger enqueue failed, the row would be
             // stuck in `queued` forever (stuck-run sweeper only resets
             // RUNNING). Mark it failed so re-runs aren't blocked.
+            // FU-3: via markDispatchFailed, which is `queued`-only — an
+            // enqueue that threw on timeout may still have been accepted,
+            // and the worker owns the row once it reaches `running`.
             if (createdRun && !enqueueSucceeded) {
                 try {
-                    await this.agentRunRepository.markFailed(
+                    await this.agentRunRepository.markDispatchFailed(
                         createdRun.id,
                         `dispatch-failed: ${message}`,
                     );

--- a/packages/agent/src/database/repositories/agent-run.repository.spec.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.spec.ts
@@ -1,0 +1,148 @@
+import { AgentRunRepository } from './agent-run.repository';
+
+/**
+ * FU-3 — terminal-transition CAS.
+ *
+ * `markFailed` / `markCompleted` / `markDispatchFailed` must never overwrite a
+ * status a concurrent writer already committed. Before this, all three were a
+ * `findOne` + unconditional `update(runId, …)` keyed on the primary key alone.
+ */
+describe('AgentRunRepository — terminal transitions', () => {
+    let queryBuilder: {
+        update: jest.Mock;
+        set: jest.Mock;
+        where: jest.Mock;
+        andWhere: jest.Mock;
+        execute: jest.Mock;
+    };
+    let repository: {
+        findOne: jest.Mock;
+        createQueryBuilder: jest.Mock;
+    };
+    let runs: AgentRunRepository;
+    let warn: jest.SpyInstance;
+
+    /** The `status IN (...)` guard the CAS relies on, as passed to andWhere. */
+    function statusGuard(): string[] | undefined {
+        const call = queryBuilder.andWhere.mock.calls.find(([sql]) =>
+            String(sql).includes('status IN'),
+        );
+        return call?.[1]?.statuses;
+    }
+
+    beforeEach(() => {
+        queryBuilder = {
+            update: jest.fn().mockReturnThis(),
+            set: jest.fn().mockReturnThis(),
+            where: jest.fn().mockReturnThis(),
+            andWhere: jest.fn().mockReturnThis(),
+            execute: jest.fn().mockResolvedValue({ affected: 1 }),
+        };
+        repository = {
+            // startedAt drives durationMs; null keeps the arithmetic out of the way.
+            findOne: jest.fn().mockResolvedValue({ id: 'r1', startedAt: null }),
+            createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+        };
+        runs = new AgentRunRepository(repository as never);
+        warn = jest.spyOn((runs as never as { logger: { warn: () => void } }).logger, 'warn');
+        warn.mockImplementation(() => undefined);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    describe('markFailed', () => {
+        it('only transitions a non-terminal run', async () => {
+            await runs.markFailed('r1', 'boom');
+            expect(statusGuard()).toEqual(['queued', 'running']);
+            expect(queryBuilder.set).toHaveBeenCalledWith(
+                expect.objectContaining({ status: 'failed', errorMessage: 'boom' }),
+            );
+        });
+
+        it('warns instead of failing silently when the CAS matches nothing', async () => {
+            // A worker flipped the row terminal between our read and the update.
+            // There is no agent_runs sweeper, so a silent no-op is unrecoverable.
+            queryBuilder.execute.mockResolvedValue({ affected: 0 });
+            repository.findOne.mockResolvedValue({ id: 'r1', status: 'cancelled' });
+            await expect(runs.markFailed('r1', 'boom')).resolves.toBeUndefined();
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining("already 'cancelled'"));
+        });
+
+        it('reports a missing row distinctly from an already-terminal one', async () => {
+            queryBuilder.execute.mockResolvedValue({ affected: 0 });
+            repository.findOne.mockResolvedValue(null);
+            await runs.markFailed('r1', 'boom');
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing'));
+        });
+
+        it('does not warn on a successful transition', async () => {
+            await runs.markFailed('r1', 'boom');
+            expect(warn).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('markCompleted', () => {
+        it('only transitions a non-terminal run', async () => {
+            await runs.markCompleted('r1', 'all done');
+            expect(statusGuard()).toEqual(['queued', 'running']);
+            expect(queryBuilder.set).toHaveBeenCalledWith(
+                expect.objectContaining({ status: 'completed', summary: 'all done' }),
+            );
+        });
+
+        it('cannot resurrect a cancelled run', async () => {
+            // finalize() runs even after a user cancel, because cancelling does
+            // not stop the Trigger.dev worker. Guarding markFailed alone would
+            // leave this branch still stomping `cancelled` -> `completed`.
+            queryBuilder.execute.mockResolvedValue({ affected: 0 });
+            repository.findOne.mockResolvedValue({ id: 'r1', status: 'cancelled' });
+            await runs.markCompleted('r1', 'all done');
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining("already 'cancelled'"));
+        });
+    });
+
+    describe('markDispatchFailed', () => {
+        it('is queued-only, so a run a worker already started is never stomped', async () => {
+            await runs.markDispatchFailed('r1', 'dispatch-failed: Trigger.dev down');
+            // `running` MUST be absent: an enqueue that threw on a client-side
+            // timeout may still have been accepted, in which case the worker is
+            // already executing and owns the row.
+            expect(statusGuard()).toEqual(['queued']);
+            expect(statusGuard()).not.toContain('running');
+        });
+
+        it('sets the failure reason verbatim', async () => {
+            await runs.markDispatchFailed('r1', 'enqueue-failed: nope');
+            expect(queryBuilder.set).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    status: 'failed',
+                    errorMessage: 'enqueue-failed: nope',
+                }),
+            );
+        });
+
+        it('no-ops with a warning once the run is running', async () => {
+            queryBuilder.execute.mockResolvedValue({ affected: 0 });
+            repository.findOne.mockResolvedValue({ id: 'r1', status: 'running' });
+            await runs.markDispatchFailed('r1', 'dispatch-failed: timeout');
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining("already 'running'"));
+        });
+    });
+
+    describe('durationMs', () => {
+        it('is derived from startedAt when the run had started', async () => {
+            const startedAt = new Date(Date.now() - 5_000);
+            repository.findOne.mockResolvedValue({ id: 'r1', startedAt });
+            await runs.markFailed('r1', 'boom');
+            const patch = queryBuilder.set.mock.calls[0][0];
+            expect(patch.durationMs).toBeGreaterThanOrEqual(5_000);
+        });
+
+        it('is null for a run that never started', async () => {
+            await runs.markFailed('r1', 'boom');
+            expect(queryBuilder.set).toHaveBeenCalledWith(
+                expect.objectContaining({ durationMs: null }),
+            );
+        });
+    });
+});

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -189,8 +189,18 @@ export class AgentRunRepository {
      * NO `agent_runs` sweeper (`recoverStuckRunning()` only touches `agents`
      * rows), so a silent miss would be both unrecoverable and invisible.
      *
-     * The `durationMs` read stays non-atomic on purpose — it is a reporting
-     * field, and `startedAt` is only ever written once by `markStarted`.
+     * The `durationMs` read stays non-atomic on purpose (applies equally to
+     * `markFailed` and `markCompleted`). `startedAt` is read before the CAS
+     * write, so a `markStarted` landing in that gap is read as `null` and
+     * `durationMs` is stored as `null` for a run that technically did start.
+     * That is acceptable: to hit the window `markStarted` must land between the
+     * two round-trips, which means the run had been executing for ~0 ms anyway,
+     * so `null` and `0` carry the same information. Closing it properly needs
+     * the subtraction pushed into SQL (`RETURNING`, or `finishedAt - startedAt`
+     * as an expression), which is dialect-specific — the e2e suite runs on
+     * sqlite while production is Postgres — so it would trade a cosmetic
+     * reporting gap for a real portability hazard. `durationMs` is a reporting
+     * field only; nothing branches on it.
      */
     private async casTerminal(
         runId: string,

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -1,10 +1,28 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { AgentRun, AgentRunStatus, AgentRunTriggerKind } from '../../entities/agent-run.entity';
+
+/**
+ * Statuses a run may be transitioned OUT OF by a normal terminal write.
+ * Anything already terminal (`completed` / `failed` / `cancelled`) is left
+ * alone — see {@link AgentRunRepository.casTerminal}.
+ */
+const NON_TERMINAL: AgentRunStatus[] = ['queued', 'running'];
+
+/**
+ * Dispatch rollback may only touch a run that has NOT been picked up yet.
+ * `running` is deliberately excluded: if `enqueue()` threw on a timeout but
+ * Trigger.dev had in fact accepted the job, the worker is already executing
+ * and marking it failed would stomp a live run.
+ */
+const QUEUED_ONLY: AgentRunStatus[] = ['queued'];
 
 @Injectable()
 export class AgentRunRepository {
+    private readonly logger = new Logger(AgentRunRepository.name);
+
     constructor(
         @InjectRepository(AgentRun)
         private readonly repository: Repository<AgentRun>,
@@ -152,34 +170,84 @@ export class AgentRunRepository {
         });
     }
 
-    async markCompleted(runId: string, summary: string | null): Promise<void> {
+    /**
+     * FU-3 — atomic terminal transition, shared by {@link markCompleted},
+     * {@link markFailed} and {@link markDispatchFailed}.
+     *
+     * These were previously a `findOne` (for `durationMs`) followed by an
+     * unconditional `update(runId, …)` keyed on the primary key alone, so any
+     * of them could overwrite a status a concurrent writer had already
+     * committed:
+     *
+     *  - a dispatch-failure rollback whose `enqueue()` timed out *after*
+     *    Trigger.dev accepted the job would stomp the now-`running` run;
+     *  - `AgentRunService.finalize()` would erase a user's `cancelled` with
+     *    `failed` or `completed`, because cancelling does not stop the worker.
+     *
+     * Same CAS-style WHERE clause {@link cancel} already uses. Returns whether
+     * the row was actually transitioned so callers can report a no-op: there is
+     * NO `agent_runs` sweeper (`recoverStuckRunning()` only touches `agents`
+     * rows), so a silent miss would be both unrecoverable and invisible.
+     *
+     * The `durationMs` read stays non-atomic on purpose — it is a reporting
+     * field, and `startedAt` is only ever written once by `markStarted`.
+     */
+    private async casTerminal(
+        runId: string,
+        allowedFrom: AgentRunStatus[],
+        patch: QueryDeepPartialEntity<AgentRun>,
+    ): Promise<boolean> {
         const now = new Date();
         const run = await this.repository.findOne({
             where: { id: runId },
             select: ['id', 'startedAt'],
         });
         const durationMs = run?.startedAt ? now.getTime() - run.startedAt.getTime() : null;
-        await this.repository.update(runId, {
-            status: 'completed',
-            finishedAt: now,
-            durationMs,
-            summary,
-        });
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({ ...patch, finishedAt: now, durationMs })
+            .where('id = :id', { id: runId })
+            .andWhere('status IN (:...statuses)', { statuses: allowedFrom })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Log a CAS no-op with the status that actually won, so an operator can
+     * tell "row vanished" from "a worker beat us to it".
+     */
+    private async warnTerminalNoOp(runId: string, intent: string): Promise<void> {
+        const fresh = await this.repository
+            .findOne({ where: { id: runId }, select: ['id', 'status'] })
+            .catch(() => null);
+        this.logger.warn(
+            `AgentRun ${runId}: ${intent} skipped — row is ${fresh ? `already '${fresh.status}'` : 'missing'}.`,
+        );
+    }
+
+    async markCompleted(runId: string, summary: string | null): Promise<void> {
+        const ok = await this.casTerminal(runId, NON_TERMINAL, { status: 'completed', summary });
+        if (!ok) await this.warnTerminalNoOp(runId, 'markCompleted');
     }
 
     async markFailed(runId: string, errorMessage: string): Promise<void> {
-        const now = new Date();
-        const run = await this.repository.findOne({
-            where: { id: runId },
-            select: ['id', 'startedAt'],
-        });
-        const durationMs = run?.startedAt ? now.getTime() - run.startedAt.getTime() : null;
-        await this.repository.update(runId, {
-            status: 'failed',
-            finishedAt: now,
-            durationMs,
-            errorMessage,
-        });
+        const ok = await this.casTerminal(runId, NON_TERMINAL, { status: 'failed', errorMessage });
+        if (!ok) await this.warnTerminalNoOp(runId, 'markFailed');
+    }
+
+    /**
+     * Roll a pre-created run back to `failed` after the external enqueue threw.
+     *
+     * Narrower than {@link markFailed} by design — only a still-`queued` run may
+     * be rolled back. Callers create the row, then enqueue; if the enqueue call
+     * fails but the job was nevertheless accepted, the worker owns the row from
+     * `markStarted` onwards and this must become a no-op rather than killing a
+     * live run.
+     */
+    async markDispatchFailed(runId: string, errorMessage: string): Promise<void> {
+        const ok = await this.casTerminal(runId, QUEUED_ONLY, { status: 'failed', errorMessage });
+        if (!ok) await this.warnTerminalNoOp(runId, 'markDispatchFailed');
     }
 
     async markCancelled(runId: string): Promise<void> {

--- a/packages/agent/src/tasks-domain/__tests__/task-chat.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-chat.service.spec.ts
@@ -155,7 +155,7 @@ describe('TaskChatService', () => {
         it('transitions AgentRun to failed and does not fail comment posting if enqueue throws', async () => {
             const runs = {
                 createQueued: jest.fn().mockResolvedValue({ id: 'run-chat-1' }),
-                markFailed: jest.fn().mockResolvedValue(undefined),
+                markDispatchFailed: jest.fn().mockResolvedValue(undefined),
             };
             const chatDispatcher = {
                 enqueue: jest.fn().mockRejectedValue(new Error('Trigger.dev down')),
@@ -188,16 +188,16 @@ describe('TaskChatService', () => {
 
             // Pin the `dispatch-failed:` prefix, not just the underlying cause —
             // it is what surfaces in the Activity tab for an orphaned run.
-            expect(runs.markFailed).toHaveBeenCalledWith(
+            expect(runs.markDispatchFailed).toHaveBeenCalledWith(
                 'run-chat-1',
                 expect.stringContaining('dispatch-failed: Trigger.dev down'),
             );
         });
 
-        it('does not attempt markFailed when the queued run was never created', async () => {
+        it('does not attempt markDispatchFailed when the queued run was never created', async () => {
             const runs = {
                 createQueued: jest.fn().mockRejectedValue(new Error('DB down')),
-                markFailed: jest.fn().mockResolvedValue(undefined),
+                markDispatchFailed: jest.fn().mockResolvedValue(undefined),
             };
             const chatDispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
             const dispatchingSvc = new TaskChatService(
@@ -229,7 +229,7 @@ describe('TaskChatService', () => {
             // `run` is still null here, so the `if (run)` guard must short-circuit.
             // Without it this path throws TypeError on `run.id`.
             expect(chatDispatcher.enqueue).not.toHaveBeenCalled();
-            expect(runs.markFailed).not.toHaveBeenCalled();
+            expect(runs.markDispatchFailed).not.toHaveBeenCalled();
         });
 
         it('gracefully handles enqueue failures when runs repository is missing', async () => {

--- a/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
@@ -48,7 +48,7 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         assignees = { findAgentAssignees: jest.fn().mockResolvedValue([]) };
         runs = {
             createQueued: jest.fn().mockResolvedValue({ id: 'r1' }),
-            markFailed: jest.fn().mockResolvedValue(undefined),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
         };
         dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
     });
@@ -143,7 +143,7 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         await new Promise((r) => setImmediate(r));
         // The `dispatch-failed:` prefix is the contract the Activity tab and any
         // future triage tooling reads — pin it, not just the underlying cause.
-        expect(runs.markFailed).toHaveBeenCalledWith(
+        expect(runs.markDispatchFailed).toHaveBeenCalledWith(
             'r1',
             expect.stringContaining('dispatch-failed: Trigger.dev down'),
         );
@@ -164,7 +164,7 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         expect(result.status).toBe(TaskStatus.IN_PROGRESS); // transition itself succeeded
         await new Promise((r) => setImmediate(r));
 
-        expect(runs.markFailed).not.toHaveBeenCalled();
+        expect(runs.markDispatchFailed).not.toHaveBeenCalled();
         // The `if (run)` guard is load-bearing: without it the catch block
         // dereferences a null `run`, and because the fan-out `for` loop awaits
         // each iteration that TypeError escapes the loop and silently strands
@@ -200,6 +200,6 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         expect(dispatcher.enqueue).toHaveBeenCalledWith(
             expect.objectContaining({ runId: undefined }),
         );
-        expect(runs.markFailed).not.toHaveBeenCalled();
+        expect(runs.markDispatchFailed).not.toHaveBeenCalled();
     });
 });

--- a/packages/agent/src/tasks-domain/task-chat.service.ts
+++ b/packages/agent/src/tasks-domain/task-chat.service.ts
@@ -165,7 +165,10 @@ export class TaskChatService {
                         );
                         if (run) {
                             try {
-                                await this.runs?.markFailed(run.id, `dispatch-failed: ${message}`);
+                                await this.runs?.markDispatchFailed(
+                                    run.id,
+                                    `dispatch-failed: ${message}`,
+                                );
                             } catch (failErr) {
                                 this.logger.warn(
                                     `Failed to mark orphan AgentRun ${run.id} failed: ${failErr}`,

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -250,7 +250,7 @@ export class TaskTransitionService {
                 );
                 if (run) {
                     try {
-                        await this.runs?.markFailed(run.id, `dispatch-failed: ${message}`);
+                        await this.runs?.markDispatchFailed(run.id, `dispatch-failed: ${message}`);
                     } catch (failErr) {
                         this.logger.warn(
                             `Failed to mark orphan AgentRun ${run.id} failed: ${failErr}`,


### PR DESCRIPTION
## Summary

Fixes #1725.

`markFailed` and `markCompleted` were a `findOne` (to compute `durationMs`) followed by an unconditional `update(runId, …)` keyed on the primary key alone. Neither guarded on current status, so either could overwrite a status a concurrent writer had already committed.

`cancel()` in the same file was given a CAS guard after an earlier review caught exactly this race, and its docblock spells out the failure mode. `markFailed` / `markCompleted` never received the equivalent treatment.

## Two confirmed consequences

**1. Dispatch rollback could kill a live run.** Four call sites create a queued `AgentRun`, enqueue, then mark it failed if the enqueue throws. If `enqueue()` threw on a client-side timeout but Trigger.dev had in fact *accepted* the job, the worker proceeds to `markStarted` and the rollback then stomps a `running` run to `failed` — recomputing `durationMs` from the `startedAt` the worker just set.

**2. User cancellations were silently undone.** Cancelling flips `running -> cancelled` but does not stop the Trigger.dev run: nothing calls `runs.cancel(...)` via `triggerRunId`, despite `AgentRun.triggerRunId`'s docblock claiming it is "used to call `runs.cancel(...)` on user-initiated cancel". The worker keeps going and `AgentRunService.finalize()` overwrites the cancellation — `markFailed` on the error branch, `markCompleted` on the success branch.

Guarding only `markFailed` would have left that asymmetric (cancel+error stays `cancelled`, cancel+success still becomes `completed`), which is why both move together.

## Changes

- **`casTerminal()`** — shared private helper using the same CAS-style WHERE clause `cancel()` already uses. `markFailed` / `markCompleted` route through it with a `queued|running` guard.
- **`markDispatchFailed()`** — new, deliberately narrower at **`queued`-only**. `queued|running` is the *wrong* guard for a rollback, because `running` is precisely the state that must not be overwritten.
- **All four dispatch-failure rollback sites now use it**: `dispatchOne`, `agents.controller` assign-task, and — since #1657 merged while this branch was open — `TaskTransitionService` and `TaskChatService`.
- **Warn on a no-op CAS**, reporting the status that actually won, so an operator can tell "row vanished" from "a worker beat us to it". This matters because there is **no `agent_runs` sweeper** — `recoverStuckRunning()` only touches `agents` rows — so a silent miss would be unrecoverable and invisible.
- **`agent-run.repository.spec.ts`** — the first spec for this repository, using the mocked query-builder pattern from `work-schedule.repository.spec.ts`.

The worker `onFailure` hooks in `packages/tasks` keep `markFailed` deliberately: they already gate on `queued|running` in JS before calling, so the new CAS is exactly that set and merely narrows their check-then-act window. The `agent-not-found` calls run after `markStarted`, where `running` is the correct allowed state.

`markFailed` keeps its signature and behaviour for all other callers. Nothing is removed.

## Testing

- `packages/agent`: **334 suites / 6531 tests green**
- `tsc --noEmit` clean; `prettier --check` clean across `packages/agent` and `apps/api/src/agents`
- **Mutation-tested.** Two mutants both fail the new spec: widening `markDispatchFailed` to `queued|running`, and removing the CAS `andWhere` entirely.

## ⚠️ CI cannot currently verify this PR

`lint-and-test` fails at **"Audit production dependencies (high+)"**, which runs *before* `Check formatting`, `Build all packages`, and `run test on all packages` — so those three steps are **skipped, not passed**, on this and every other open PR.

This is pre-existing and repo-wide, not caused by this branch: `develop`'s own most recent completed CI run ([29781541257](https://github.com/ever-works/ever-works/actions/runs/29781541257)) fails on the identical step. GitHub currently reports 2 critical / 6 high production advisories on the default branch. #1732 ("refresh stale security overrides") looks like the intended fix.

Until that lands, the verification above is local-only.

## Follow-up still open

- #1726 — `dispatchDue` still doesn't reconcile its orphaned run. Follow-up PR is ready and stacked on this one; it uses `markDispatchFailed`.
- Whether cancel should actually cancel the Trigger.dev run via `triggerRunId` — or whether the entity docblock should be corrected — is a product decision, tracked in #1725.
