### PR TITLE
fix(agents): reconcile orphaned queued AgentRun when heartbeat dispatch fails

### DIFF
--- a/packages/agent/src/agents/__tests__/agent-schedule-dispatcher.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-schedule-dispatcher.service.spec.ts
@@ -78,6 +78,7 @@ describe('AgentScheduleDispatcherService', () => {
         };
         runRepo = {
             createQueued: jest.fn().mockResolvedValue({ id: 'run-1' }),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
         };
         trigger = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
         svc = new AgentScheduleDispatcherService(agentRepo, runRepo);
@@ -134,6 +135,59 @@ describe('AgentScheduleDispatcherService', () => {
         expect(summary.failed).toBe(1);
         expect(summary.entries[0].outcome).toBe('failed');
         expect(summary.entries[0].message).toMatch(/Trigger\.dev down/);
+    });
+
+    it('reconciles the pre-created AgentRun when heartbeat enqueue fails', async () => {
+        const agent = makeAgent();
+        agentRepo.findDueForHeartbeat.mockResolvedValueOnce([agent]);
+        agentRepo.tryClaimForRun.mockResolvedValueOnce(agent.nextHeartbeatAt);
+        trigger.enqueue.mockRejectedValueOnce(new Error('Trigger.dev down'));
+
+        await svc.dispatchDue(trigger);
+
+        // Without this the row stays `queued` forever and the next heartbeat
+        // adopts the orphan via findInFlightForAgent instead of recording the
+        // dispatch failure. Mirrors what dispatchOne already does.
+        expect(runRepo.markDispatchFailed).toHaveBeenCalledWith(
+            'run-1',
+            expect.stringContaining('dispatch-failed: Trigger.dev down'),
+        );
+    });
+
+    it('does NOT reconcile a run that was never created (claim lost before createQueued)', async () => {
+        const agent = makeAgent();
+        agentRepo.findDueForHeartbeat.mockResolvedValueOnce([agent]);
+        agentRepo.tryClaimForRun.mockResolvedValueOnce(null);
+
+        await svc.dispatchDue(trigger);
+
+        expect(runRepo.createQueued).not.toHaveBeenCalled();
+        expect(runRepo.markDispatchFailed).not.toHaveBeenCalled();
+    });
+
+    it('does NOT reconcile when the enqueue succeeded', async () => {
+        const agent = makeAgent();
+        agentRepo.findDueForHeartbeat.mockResolvedValueOnce([agent]);
+        agentRepo.tryClaimForRun.mockResolvedValueOnce(agent.nextHeartbeatAt);
+
+        await svc.dispatchDue(trigger);
+
+        expect(runRepo.markDispatchFailed).not.toHaveBeenCalled();
+    });
+
+    it('survives a reconciliation failure without derailing the dispatch loop', async () => {
+        const agent = makeAgent();
+        agentRepo.findDueForHeartbeat.mockResolvedValueOnce([agent]);
+        agentRepo.tryClaimForRun.mockResolvedValueOnce(agent.nextHeartbeatAt);
+        trigger.enqueue.mockRejectedValueOnce(new Error('Trigger.dev down'));
+        runRepo.markDispatchFailed.mockRejectedValueOnce(new Error('DB down'));
+
+        const summary = await svc.dispatchDue(trigger);
+
+        // The CAS claim must still be released even if reconciliation threw —
+        // otherwise the Agent stays stuck in RUNNING until the 30-min sweep.
+        expect(summary.failed).toBe(1);
+        expect(agentRepo.releaseAfterRun).toHaveBeenCalled();
     });
 
     it('Review-fix C11: releases the CAS claim when enqueue fails after a successful claim', async () => {

--- a/packages/agent/src/agents/agent-schedule-dispatcher.service.ts
+++ b/packages/agent/src/agents/agent-schedule-dispatcher.service.ts
@@ -111,6 +111,10 @@ export class AgentScheduleDispatcherService {
             // for ~30 min until the stuck-recovery sweeper picks it up.
             let originalNext: Date | null = null;
             let enqueueSucceeded = false;
+            // Hoisted so the catch can reconcile a row that was created before
+            // the enqueue threw — `dispatchOne` already does this; this path
+            // did not, leaving the run orphaned in `queued`.
+            let createdRun: { id: string } | null = null;
             try {
                 originalNext = await this.agentRepository.tryClaimForRun(agent.id);
                 if (!originalNext) {
@@ -132,6 +136,7 @@ export class AgentScheduleDispatcherService {
                     userId: agent.userId,
                     triggerKind: 'heartbeat',
                 });
+                createdRun = run ?? null;
 
                 const handle = await trigger.enqueue({
                     agentId: agent.id,
@@ -156,6 +161,26 @@ export class AgentScheduleDispatcherService {
                 );
                 summary.failed += 1;
                 summary.entries.push(this.entry(agent, { outcome: 'failed', message }));
+                // Reconcile the pre-created run, mirroring `dispatchOne`.
+                // Without this the row stays `queued` forever: there is no
+                // agent_runs sweeper, and the next heartbeat ADOPTS the orphan
+                // via findInFlightForAgent (which matches "regardless of
+                // trigger kind") rather than creating a fresh row — so the
+                // failed dispatch is never recorded as failed and never shows
+                // up in the Activity tab, which is the whole reason the row is
+                // pre-created.
+                if (createdRun && !enqueueSucceeded) {
+                    try {
+                        await this.agentRunRepository.markDispatchFailed(
+                            createdRun.id,
+                            `dispatch-failed: ${message}`,
+                        );
+                    } catch (failErr) {
+                        this.logger.warn(
+                            `Failed to mark orphan AgentRun ${createdRun.id} failed: ${failErr}`,
+                        );
+                    }
+                }
                 // Review-fix C11: release the CAS claim so the Agent
                 // returns to ACTIVE immediately. Without this the row
                 // stays in RUNNING with no worker until the next


### PR DESCRIPTION
## Summary

Fixes #1726. Stacked on #1727 (now merged), whose `markDispatchFailed` this uses.

`dispatchDue` persists a queued `AgentRun` before calling `trigger.enqueue()`. If the enqueue throws, the catch released the Agent's CAS claim but never reconciled the run row, leaving it orphaned in `queued`.

`dispatchOne`, ~80 lines below in the same file, already had exactly this block. `run` was declared `const` **inside** the `try`, so the catch could not reach it — hoisted to `let createdRun: { id: string } | null = null`, matching the shape `dispatchOne` already uses.

## Why this was split out rather than folded into #1657

Severity is genuinely lower. A heartbeat run has `taskId: null`, so `findInFlightForTaskAgent` cannot see it and it does **not** cause the permanent task-agent dispatch suppression that motivated #1629. The CAS claim is released, so the schedule keeps running.

The real damage is subtler:

- **The next heartbeat adopts the orphan.** `agent-heartbeat.task.ts` calls `findInFlightForAgent`, explicitly "regardless of trigger kind", and `markStarted`s whatever it finds — so it reuses the stale row instead of creating a fresh one. Self-healing, but the new run is recorded against the wrong row.
- **The failure is never recorded as a failure.** It sits in `queued` until adopted, so it never shows as failed in the Activity tab — which the inline comment says is the whole reason the row is pre-created ("so the Activity tab shows the run before the worker boots").
- Orphans accumulate in `agent_runs` during a sustained Trigger.dev outage.

## Uses `markDispatchFailed`, not `markFailed`

Queued-only, per #1727 — so a rollback after an enqueue that timed out but was in fact accepted cannot stomp a run the worker has already started.

## Testing

- `packages/agent`: **334 suites / 6535 tests green**; `tsc --noEmit` clean; `prettier --check` clean
- Disabling the new reconciliation block fails the suite (mutation-verified)
- Four new cases: reconciles on enqueue failure; does **not** reconcile when the claim was lost before `createQueued`; does **not** reconcile when enqueue succeeded; and survives reconciliation itself throwing — that last one asserts the CAS claim is *still* released, so a failure here cannot leave the Agent stuck in `RUNNING` until the 30-minute sweep.

## ⚠️ CI cannot currently verify this

`lint-and-test` fails at **"Audit production dependencies (high+)"**, which runs *before* `Check formatting`, `Build all packages`, and `run test on all packages` — so those three are **skipped, not passed**, on every open PR. Pre-existing and repo-wide: `develop`'s own recent runs fail on the identical step. #1732 looks like the intended fix. Verification above is local-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented scheduled agent runs from remaining indefinitely in a queued state when heartbeat dispatch fails.
  * Added reconciliation for partially dispatched runs while preserving claim release and safe failure handling.
  * Improved coverage for dispatch failures, successful enqueues, missing runs, and reconciliation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->