### PR TITLE
fix(ci): drop oversized release body — the first release 422'd

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -58,4 +58,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          # No explicit `body`: `generateReleaseNotes: true` above makes GitHub
+          # build the notes. Passing the tag action's `changelog` as well fails the
+          # very FIRST release in a repo with 422 'body is too long (maximum is
+          # 125000 characters)', because with no previous tag its changelog spans
+          # the entire history. That is exactly what happened on v0.0.1 here.

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -59,4 +59,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          # No explicit `body`: `generateReleaseNotes: true` above makes GitHub
+          # build the notes. Passing the tag action's `changelog` as well fails the
+          # very FIRST release in a repo with 422 'body is too long (maximum is
+          # 125000 characters)', because with no previous tag its changelog spans
+          # the entire history. That is exactly what happened on v0.0.1 here.

--- a/.github/workflows/release-stage.yml
+++ b/.github/workflows/release-stage.yml
@@ -58,4 +58,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.tag_version.outputs.new_tag }}
           name: ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          # No explicit `body`: `generateReleaseNotes: true` above makes GitHub
+          # build the notes. Passing the tag action's `changelog` as well fails the
+          # very FIRST release in a repo with 422 'body is too long (maximum is
+          # 125000 characters)', because with no previous tag its changelog spans
+          # the entire history. That is exactly what happened on v0.0.1 here.


### PR DESCRIPTION
## Problem

The release workflows added in #1732 **tagged fine but never created a release**:

```
Error 422: Validation Failed: {"resource":"Release","code":"custom","field":"body",
"message":"body is too long (maximum is 125000 characters)"}
```

`v0.0.1`, `v0.0.2`, `v0.0.3` exist as tags; **zero release objects** were created.

## Cause

`body: ${{ steps.tag_version.outputs.changelog }}` is safe in `ever-gauzy` because that repo already had tags, so each changelog only spans commits since the previous one. `ever-works` had **zero** tags — so the very first changelog covered the entire repo history and blew the 125k limit.

## Fix

Drop `body`. It was redundant: `generateReleaseNotes: true` already has GitHub build the notes, and that output is better than the raw changelog dump.

Worth noting: re-running today would now succeed *by luck*, because a tag exists so the changelog is small again. The bug would silently return for the next repo that adopts these files — so this is fixed at the source rather than papered over.

Verified all three files still parse and `generateReleaseNotes: true` is retained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release creation across development, staging, and production workflows.
  * Release notes are now generated automatically by GitHub, including for a repository’s first release.
  * Prevented potential release failures caused by oversized manually supplied release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->