### PR TITLE
chore(agents): remove dead AgentRunRepository.markCancelled

### DIFF
--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -260,13 +260,6 @@ export class AgentRunRepository {
         if (!ok) await this.warnTerminalNoOp(runId, 'markDispatchFailed');
     }
 
-    async markCancelled(runId: string): Promise<void> {
-        await this.repository.update(runId, {
-            status: 'cancelled',
-            finishedAt: new Date(),
-        });
-    }
-
     /**
      * Persist the agent-memory session id once `AgentRunService.execute()`
      * has opened a session at the start of the run. Best-effort — if


### PR DESCRIPTION
## Summary

Owner-requested removal of `AgentRunRepository.markCancelled`. It is dead code in the strictest sense — declared and never wired.

## Evidence it is unreferenced

- **No static caller.** Enumerating every method actually invoked on an `AgentRunRepository` handle across `apps/` and `packages/` gives: `findById`, `findByAgentAndUser`, `countByAgentAndUser`, `findByIdAndUser`, `cancel`, `createQueued`, `markStarted`, `markCompleted`, `markFailed`, `markDispatchFailed`, `findInFlightForAgent`, `findInFlightForTaskAgent`. `markCancelled` is absent.
- **Never had one.** `git log -S 'markCancelled' --all` returns only `a961f0e2` (PR #1019, which introduced it) and a docs commit. No call site has existed at any point in history.
- **No dynamic caller.** This one needed checking: `AgentRunRepository` is a registered RPC target, its allow-list is **auto-derived by prototype walk**, and `createRemoteProxy` forwards arbitrary property names as strings — so a call without a static import was possible in principle. But the literals `'markCancelled'` / `"markCancelled"` appear nowhere in the repo and never have, and every worker resolves the proxy under the typed class token, so any call would be statically visible.
- **No test coverage.** No spec references it. The two allow-list tests enumerate *target names* only, not method names, and pass `undefined` for `agentRunRepositoryRef` — so `AgentRunRepository` isn't even a live target under test. No snapshots.
- **No name collision.** `WebhookSubscriptionRepository`, `WorkProposalRepository` and `TemplateCustomizationService` have their own `markFailed`, but none has `markCancelled`. `markCanceled` (US spelling) and `markAborted`: zero hits.

## One observable consequence

The RPC allow-list is auto-derived from the prototype, so removing the method **silently narrows it**. Anything that ever RPC'd `AgentRunRepository.markCancelled` would flip to `Method not in allow-list`. Inert today, since no such caller exists — but it is the one externally visible delta, so it is worth stating rather than burying.

## Not resurrecting it for the cancel work

`markCancelled` is the one symbol in the tree whose *name* promises what the "cancel should actually cancel the Trigger.dev run" work is about, so to be explicit: it is **not** being reused as a system-initiated cancel path. Its body is exactly the unconditional `repository.update(runId, …)` pattern #1727 removed from `markFailed`/`markCompleted`. Any future replacement should route through `casTerminal(runId, NON_TERMINAL, { status: 'cancelled' })` so it cannot stomp a concurrent terminal write.

Kept separate from the cancel PR deliberately: this touches the RPC surface, which is a different subsystem, and mixing them would make neither atomically revertable.

## Docs left alone

`docs/internal/IMPLEMENTATION-PROGRESS.md` names it, but that is a dated historical progress log ("✓ Tick 3"), not a stale instruction — amending it would rewrite a record. The two `docs/specs/features/generation-cancellation/` hits are a different (also nonexistent) `WorkGenerationService` helper, untouched.

## Testing

`packages/agent` 334 suites / 6535 tests green; `tsc --noEmit` clean; `prettier --check` clean; zero remaining references outside stale `dist/` build output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run cancellation handling by removing an unconditional cancellation path.
  * Cancellation now relies on guarded logic to help prevent inconsistent run statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->