### PR TITLE
fix(ci): stub the goals + work-agent barrels in the trigger-internal specs

### DIFF
--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -49,6 +49,17 @@ jest.mock('@ever-works/agent/missions', () => ({
 jest.mock('@ever-works/agent/work-agent', () => ({
     IdeaBuildExecutorService: class IdeaBuildExecutorService {},
 }));
+// PR-8 — the controller now imports GoalEvaluationService from the goals
+// barrel. That barrel is the deepest chain yet: goals.service ->
+// goal-evaluation.service -> facades/metrics.facade -> usage/plugin-usage.service,
+// which imports `@src/database/repositories/plugin-usage.repository`. The
+// `@src/*` alias belongs to BOTH packages, and apps/api's jest maps it to
+// apps/api/src, where that module does not exist — so the suite died with
+// "Could not locate module ... mapped as apps/api/src/$1" before a single test
+// ran. Stub the barrel, same as every sibling above.
+jest.mock('@ever-works/agent/goals', () => ({
+    GoalEvaluationService: class GoalEvaluationService {},
+}));
 jest.mock('@ever-works/agent/notifications', () => ({
     NotificationService: class NotificationService {},
 }));

--- a/apps/api/src/trigger/trigger-internal.module.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.module.spec.ts
@@ -36,6 +36,24 @@ jest.mock('../data-sync/data-sync.module', () => ({
 jest.mock('@ever-works/agent/missions', () => ({
     MissionsModule: class MissionsModule {},
 }));
+// PR-8 — trigger-internal.module imports GoalsModule, and the controller it
+// declares imports GoalEvaluationService, from the goals barrel. That barrel
+// reaches facades/metrics.facade -> usage/plugin-usage.service, which imports
+// `@src/database/repositories/plugin-usage.repository`. `@src/*` is an alias in
+// BOTH packages; apps/api's jest maps it to apps/api/src, where that module
+// does not exist, so the suite failed to run outright. Stub the barrel — both
+// symbols, since this spec loads the module and the module loads the controller.
+jest.mock('@ever-works/agent/goals', () => ({
+    GoalsModule: class GoalsModule {},
+    GoalEvaluationService: class GoalEvaluationService {},
+}));
+// Same class of breakage, different chain: work-agent.module -> database.module
+// -> database.config, which imports `@src/config`. The controller spec already
+// stubs this barrel (for IdeaBuildExecutorService); the module spec needs
+// WorkAgentModule from it.
+jest.mock('@ever-works/agent/work-agent', () => ({
+    WorkAgentModule: class WorkAgentModule {},
+}));
 // FU-2 post-CI fix: trigger-internal.module imports AgentsModule +
 // TasksDomainModule (added by PR #1019). Stub them to avoid pulling
 // the entity transitive imports under jest.


### PR DESCRIPTION
## Summary

`develop` is red. `trigger-internal.controller.spec.ts` and `trigger-internal.module.spec.ts` **fail to run at all** — 0 tests executed, not 0 tests passing:

```
Could not locate module @src/database/repositories/plugin-usage.repository
mapped as: /home/runner/.../apps/api/src/$1
```

## Root cause: an alias collision, not a bad import

`@src/*` is defined in **both** packages — `packages/agent/tsconfig.json` maps it to its own `src`, and `apps/api/jest.config.js` maps it to `apps/api/src`. `packages/agent` uses the alias for **107 distinct paths, 102 of which have no `apps/api` counterpart**. So any `apps/api` spec that loads real agent source resolves those to `apps/api/src` and dies.

Most `apps/api` specs never notice, because they `jest.mock()` the `@ever-works/agent/*` entrypoints. These two specs already carry ~20 such stubs, added incrementally as imports appeared — the file literally has comments like *"FU-2 post-CI fix"* and *"PR-4 — controller now imports…"*. PR-8 added two more entrypoints without matching stubs:

- **controller** → `GoalEvaluationService` from `@ever-works/agent/goals`
  `goals.service → goal-evaluation.service → facades/metrics.facade → usage/plugin-usage.service → @src/database/repositories/…`
- **module** → `GoalsModule` from the same barrel, plus `WorkAgentModule` from `@ever-works/agent/work-agent`
  `work-agent.module → database.module → database.config → @src/config`

This PR adds the missing stubs, following the established pattern exactly.

## Considered and rejected

Making apps/api's `'^@src/(.*)$'` mapping an **ordered array** so cross-package paths fall through to `packages/agent`:

```js
'^@src/(.*)$': ['<rootDir>/$1', '<rootDir>/../../../packages/agent/src/$1'],
```

One line, fixes all 102 paths, and jest supports it. I tried it — **it OOMs**. Resolving instead of erroring makes jest load the real agent import graph, and the run dies at 4 GB with *"Ineffective mark-compacts near heap limit"*. Reverted. The per-barrel stub is what these files already do and what keeps them fast.

## Why this went unnoticed for two months

The offending `@src/` import in `plugin-usage.service.ts` dates to `81231022` (**2026-05-16**). CI never reached the test step: the `Audit production dependencies (high+)` step runs *before* `Check formatting` / `Build all packages` / `run test on all packages`, and had been hard-failing on `develop` — so those three were reported as **`skipped`, not `passed`**. A red `lint-and-test` meant *nothing was built or tested*.

#1732 fixed the audit gate. The very next run with a green audit ([29797329530](https://github.com/ever-works/ever-works/actions/runs/29797329530)) exposed this.

Worth considering separately: that step ordering makes a dependency-advisory failure indistinguishable from a test failure at a glance, and silently voids the entire test signal. Moving the audit after `run test on all packages` — or making it `continue-on-error` with a separate required check — would make the failure mode honest.

## Testing

- `apps/api`: **194 suites / 3279 tests green** — previously 2 suites failed to run and 3263 tests ran
- `prettier --check` clean

No production code changes; test-harness stubs only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test reliability by isolating trigger-related module tests from unrelated package dependencies.
  * Prevented module-resolution failures when running the trigger controller and module test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->