### PR TITLE
chore: cascade stage -> main (trigger-internal spec fix + dead markCancelled)

### DIFF
--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -49,6 +49,17 @@ jest.mock('@ever-works/agent/missions', () => ({
 jest.mock('@ever-works/agent/work-agent', () => ({
     IdeaBuildExecutorService: class IdeaBuildExecutorService {},
 }));
+// PR-8 — the controller now imports GoalEvaluationService from the goals
+// barrel. That barrel is the deepest chain yet: goals.service ->
+// goal-evaluation.service -> facades/metrics.facade -> usage/plugin-usage.service,
+// which imports `@src/database/repositories/plugin-usage.repository`. The
+// `@src/*` alias belongs to BOTH packages, and apps/api's jest maps it to
+// apps/api/src, where that module does not exist — so the suite died with
+// "Could not locate module ... mapped as apps/api/src/$1" before a single test
+// ran. Stub the barrel, same as every sibling above.
+jest.mock('@ever-works/agent/goals', () => ({
+    GoalEvaluationService: class GoalEvaluationService {},
+}));
 jest.mock('@ever-works/agent/notifications', () => ({
     NotificationService: class NotificationService {},
 }));

--- a/apps/api/src/trigger/trigger-internal.module.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.module.spec.ts
@@ -36,6 +36,24 @@ jest.mock('../data-sync/data-sync.module', () => ({
 jest.mock('@ever-works/agent/missions', () => ({
     MissionsModule: class MissionsModule {},
 }));
+// PR-8 — trigger-internal.module imports GoalsModule, and the controller it
+// declares imports GoalEvaluationService, from the goals barrel. That barrel
+// reaches facades/metrics.facade -> usage/plugin-usage.service, which imports
+// `@src/database/repositories/plugin-usage.repository`. `@src/*` is an alias in
+// BOTH packages; apps/api's jest maps it to apps/api/src, where that module
+// does not exist, so the suite failed to run outright. Stub the barrel — both
+// symbols, since this spec loads the module and the module loads the controller.
+jest.mock('@ever-works/agent/goals', () => ({
+    GoalsModule: class GoalsModule {},
+    GoalEvaluationService: class GoalEvaluationService {},
+}));
+// Same class of breakage, different chain: work-agent.module -> database.module
+// -> database.config, which imports `@src/config`. The controller spec already
+// stubs this barrel (for IdeaBuildExecutorService); the module spec needs
+// WorkAgentModule from it.
+jest.mock('@ever-works/agent/work-agent', () => ({
+    WorkAgentModule: class WorkAgentModule {},
+}));
 // FU-2 post-CI fix: trigger-internal.module imports AgentsModule +
 // TasksDomainModule (added by PR #1019). Stub them to avoid pulling
 // the entity transitive imports under jest.

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -260,13 +260,6 @@ export class AgentRunRepository {
         if (!ok) await this.warnTerminalNoOp(runId, 'markDispatchFailed');
     }
 
-    async markCancelled(runId: string): Promise<void> {
-        await this.repository.update(runId, {
-            status: 'cancelled',
-            finishedAt: new Date(),
-        });
-    }
-
     /**
      * Persist the agent-memory session id once `AgentRunService.execute()`
      * has opened a session at the start of the run. Best-effort — if


### PR DESCRIPTION
Routine cascade, completing develop -> stage -> main. Content payload is exactly two commits:

- **#1737** `fix(ci): stub the goals + work-agent barrels in the trigger-internal specs` — test-harness stubs only, zero production code.
- **#1736** `chore(agents): remove dead AgentRunRepository.markCancelled` — dead method, zero callers, none in the entire git history.

Cascaded whole per the develop -> stage -> main rule; no cherry-picking.

Verified: `apps/api` 194 suites / 3279 tests green, `packages/agent` 334 suites / 6535 tests green, `tsc --noEmit` clean, `prettier --check` clean.
