### PR TITLE
chore: cascade stage -> main (AgentRun cancel actually cancels the Trigger.dev run)

### DIFF
--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -5,6 +5,7 @@
 jest.mock('@ever-works/agent/agents', () => ({
     __esModule: true,
     AGENT_HEARTBEAT_TRIGGER: 'AGENT_HEARTBEAT_TRIGGER',
+    AGENT_RUN_CANCELLER: 'AGENT_RUN_CANCELLER',
     AGENT_FILE_NAMES: ['SOUL.md', 'AGENTS.md', 'HEARTBEAT.md', 'TOOLS.md', 'agent.yml'],
     AgentScope: {
         TENANT: 'tenant',
@@ -78,6 +79,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
     let activityLog: any;
     let heartbeatTrigger: any;
     let taskExecuteDispatcher: any;
+    let runCanceller: any;
     let controller: AgentsController;
 
     const auth = { userId: 'u1' } as any;
@@ -108,6 +110,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             findInFlightForTaskAgent: jest.fn().mockResolvedValue(null),
             markFailed: jest.fn().mockResolvedValue(undefined),
             markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
             findByIdAndUser: jest.fn().mockResolvedValue(null),
         };
         agentRunLogs = { findByRun: jest.fn().mockResolvedValue([]) };
@@ -120,6 +123,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
         };
         heartbeatTrigger = { enqueue: jest.fn() };
         taskExecuteDispatcher = { enqueue: jest.fn().mockResolvedValue({ runId }) };
+        runCanceller = { cancel: jest.fn().mockResolvedValue('cancelled') };
 
         controller = new AgentsController(
             service,
@@ -134,6 +138,7 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             activityLog,
             heartbeatTrigger,
             taskExecuteDispatcher,
+            runCanceller,
         );
     });
 
@@ -387,6 +392,82 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             agentRuns.cancel.mockResolvedValueOnce({ found: false });
             await expect(controller.cancelRun(auth, agentId, runId)).rejects.toBeInstanceOf(
                 NotFoundException,
+            );
+        });
+
+        it('also cancels the Trigger.dev run when the row carries a triggerRunId', async () => {
+            agentRuns.cancel.mockResolvedValueOnce({
+                found: true,
+                previousStatus: 'running',
+                triggerRunId: 'run_abc',
+            });
+            const result = await controller.cancelRun(auth, agentId, runId);
+            expect(result.cancelled).toBe(true);
+            // The whole point: cancelling must stop real compute, not just
+            // flip a DB row. Passes the Trigger.dev id, NOT the AgentRun UUID.
+            expect(runCanceller.cancel).toHaveBeenCalledWith('run_abc');
+        });
+
+        it('skips the remote cancel when the run was never stamped', async () => {
+            agentRuns.cancel.mockResolvedValueOnce({
+                found: true,
+                previousStatus: 'queued',
+                triggerRunId: null,
+            });
+            const result = await controller.cancelRun(auth, agentId, runId);
+            expect(result.cancelled).toBe(true);
+            expect(runCanceller.cancel).not.toHaveBeenCalled();
+        });
+
+        it('does not cancel remotely for an already-terminal run', async () => {
+            agentRuns.cancel.mockResolvedValueOnce({
+                found: true,
+                previousStatus: 'completed',
+                triggerRunId: 'run_abc',
+            });
+            const result = await controller.cancelRun(auth, agentId, runId);
+            expect(result.cancelled).toBe(false);
+            expect(runCanceller.cancel).not.toHaveBeenCalled();
+        });
+
+        it('still reports cancelled when the canceller reports a non-cancelled outcome', async () => {
+            // Trigger.dev disabled, or the run was already terminal on their
+            // side. The DB CAS is the authoritative answer, so the endpoint
+            // must not turn a benign race into a 5xx.
+            runCanceller.cancel.mockResolvedValueOnce('not-configured');
+            agentRuns.cancel.mockResolvedValueOnce({
+                found: true,
+                previousStatus: 'running',
+                triggerRunId: 'run_abc',
+            });
+            await expect(controller.cancelRun(auth, agentId, runId)).resolves.toEqual(
+                expect.objectContaining({ cancelled: true }),
+            );
+        });
+
+        it('degrades to a DB-only cancel when AGENT_RUN_CANCELLER is unbound', async () => {
+            const noCanceller = new AgentsController(
+                service,
+                files,
+                exportService,
+                dispatcher,
+                agentRuns,
+                agentRunLogs,
+                skillBindings,
+                pluginUsage,
+                tasks,
+                activityLog,
+                heartbeatTrigger,
+                taskExecuteDispatcher,
+                undefined,
+            );
+            agentRuns.cancel.mockResolvedValueOnce({
+                found: true,
+                previousStatus: 'running',
+                triggerRunId: 'run_abc',
+            });
+            await expect(noCanceller.cancelRun(auth, agentId, runId)).resolves.toEqual(
+                expect.objectContaining({ cancelled: true }),
             );
         });
     });

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -9,6 +9,7 @@ import {
     HttpStatus,
     Inject,
     InternalServerErrorException,
+    Logger,
     NotFoundException,
     Optional,
     Param,
@@ -30,6 +31,8 @@ import {
     AgentsService,
     AgentExportService,
     AgentScope,
+    AGENT_RUN_CANCELLER,
+    type AgentRunCanceller,
     SkillBindingRepository,
     type AgentDto,
     type AgentExportEnvelope,
@@ -106,6 +109,8 @@ const AGENT_LIFECYCLE_EVENT_TYPES: ActivityActionType[] = [
 @ApiTags('agents')
 @Controller('api/agents')
 export class AgentsController {
+    private readonly logger = new Logger(AgentsController.name);
+
     constructor(
         private readonly service: AgentsService,
         // Phase 4 — file read/write endpoints.
@@ -129,6 +134,13 @@ export class AgentsController {
         @Optional()
         @Inject(AGENT_TASK_EXECUTE_DISPATCHER)
         private readonly taskExecuteDispatcher?: AgentTaskExecuteDispatcher,
+        // Appended LAST on purpose — every `new AgentsController(...)` in the
+        // specs is positional, so a new trailing optional param keeps them
+        // compiling. Unlike assignTask, cancel must degrade rather than 500
+        // when this is unbound: the DB transition is the authoritative answer.
+        @Optional()
+        @Inject(AGENT_RUN_CANCELLER)
+        private readonly runCanceller?: AgentRunCanceller,
     ) {}
 
     @Get()
@@ -622,6 +634,26 @@ export class AgentsController {
             throw new NotFoundException(`AgentRun ${runId} not found.`);
         }
         const wasOpen = result.previousStatus === 'queued' || result.previousStatus === 'running';
+        // DB first, then the remote run. The reverse order risks a cancelled
+        // Trigger.dev run behind a row still reading `running`, which nothing
+        // would ever reap — there is no agent_runs sweeper. This way the worst
+        // case is wasted compute, and the worker cannot resurrect the row
+        // because markCompleted/markFailed are CAS-guarded.
+        //
+        // Awaited, not fire-and-forget: the port cannot throw by contract, so
+        // awaiting costs nothing and keeps the endpoint deterministic to test.
+        if (wasOpen && result.triggerRunId && this.runCanceller) {
+            const outcome = await this.runCanceller.cancel(result.triggerRunId);
+            if (outcome !== 'cancelled') {
+                // Deliberately not an error response — the run IS cancelled as
+                // far as the platform is concerned. Logged with both ids so an
+                // operator seeing a wall of 'not-configured' can tell a missing
+                // TRIGGER_SECRET_KEY from the benign already-terminal race.
+                this.logger.warn(
+                    `AgentRun ${runId}: DB cancel committed but Trigger.dev cancel of ${result.triggerRunId} returned '${outcome}'.`,
+                );
+            }
+        }
         if (wasOpen) {
             void this.tryLog({
                 userId: auth.userId,
@@ -749,8 +781,9 @@ export class AgentsController {
             triggerKind: 'task',
             taskId: body.taskId,
         });
+        let handle: { runId: string } | undefined;
         try {
-            await this.taskExecuteDispatcher.enqueue({
+            handle = await this.taskExecuteDispatcher.enqueue({
                 agentId: id,
                 userId: auth.userId,
                 taskId: body.taskId,
@@ -772,6 +805,12 @@ export class AgentsController {
                 .markDispatchFailed(run.id, `enqueue-failed: ${message}`)
                 .catch(() => undefined);
             throw new InternalServerErrorException(`assign-task enqueue failed: ${message}`);
+        }
+        // Stamp OUTSIDE the try above: the enqueue has already succeeded, so a
+        // stamp failure must not take the rollback path and 500 a request that
+        // did dispatch. Losing the stamp only costs a remote cancel.
+        if (handle?.runId) {
+            await this.agentRuns.setTriggerRunId(run.id, handle.runId).catch(() => undefined);
         }
         void this.tryLog({
             userId: auth.userId,

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -3,6 +3,7 @@ import {
     AgentsModule as AgentAgentsModule,
     AgentRepository,
     AGENT_HEARTBEAT_TRIGGER,
+    AGENT_RUN_CANCELLER,
     AGENT_RUN_CHAT_BACK_POSTER,
     AGENT_RUN_TASK_FINISHER,
     AGENT_PLUGIN_TOOLS_FACADE,
@@ -31,7 +32,12 @@ import {
     INBOUND_EMAIL_TASK_SPAWNER,
     type InboundEmailTaskSpawner,
 } from '@ever-works/agent/notifications';
-import { agentHeartbeatTriggerAdapter } from '@ever-works/trigger-tasks';
+import {
+    agentHeartbeatTriggerAdapter,
+    createAgentRunCancellerAdapter,
+    TriggerModule as TasksTriggerModule,
+    TriggerService,
+} from '@ever-works/trigger-tasks';
 
 // Phase 16.6 / 16.7 — commitToRepo / openPullRequest tools.
 // The `AGENT_GIT_FACADE` token (exported from `@ever-works/agent/agents`)
@@ -120,11 +126,19 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
         // Notifications v2 (EW-670) — EmailModule provides EmailService,
         // consumed by the AGENT_EMAIL_FACADE binding below.
         EmailModule,
+        // Provides TriggerService, which backs the AGENT_RUN_CANCELLER factory
+        // below. Same alias works.module.ts / webhooks.module.ts already use.
+        TasksTriggerModule,
     ],
     controllers: [AgentsController, AgentTemplatesController],
     providers: [
         AgentTemplateCatalogService,
         { provide: AGENT_HEARTBEAT_TRIGGER, useValue: agentHeartbeatTriggerAdapter },
+        {
+            provide: AGENT_RUN_CANCELLER,
+            inject: [TriggerService],
+            useFactory: createAgentRunCancellerAdapter,
+        },
         {
             provide: AGENT_RUN_CHAT_BACK_POSTER,
             inject: [TaskChatService],

--- a/packages/agent/src/agents/agent-run-canceller.ts
+++ b/packages/agent/src/agents/agent-run-canceller.ts
@@ -1,0 +1,46 @@
+/**
+ * Port for cancelling the external run behind an `AgentRun`.
+ *
+ * Cancelling an AgentRun used to be DB-only: `AgentRunRepository.cancel`
+ * flipped the row to `cancelled` and nothing stopped the Trigger.dev run, so
+ * the worker kept executing to completion. (`AgentRun.triggerRunId`'s docblock
+ * claimed it was "used to call `runs.cancel(...)` on user-initiated cancel",
+ * but no code path ever did.)
+ *
+ * Declared here as an interface + injection token so `packages/agent` stays
+ * free of a `@trigger.dev/sdk` runtime dependency — the same shape as
+ * {@link AgentHeartbeatTrigger} and the tasks-domain dispatchers. The concrete
+ * adapter lives in `@ever-works/trigger-tasks` and is bound in the API-side
+ * `AgentsModule`.
+ */
+
+/**
+ * Why an enum rather than a boolean: an operator needs to tell "the run was
+ * already finished" (normal, expected race) from "Trigger.dev is misconfigured
+ * and every cancel has silently degraded to DB-only" (a real incident). A bare
+ * `false` collapses both into one indistinguishable signal.
+ */
+export type AgentRunCancelOutcome =
+    /** Trigger.dev accepted the cancel request. */
+    | 'cancelled'
+    /** Trigger.dev is disabled or has no secret key — no request was attempted. */
+    | 'not-configured'
+    /** The request was attempted and failed, typically an unknown or already-terminal run id. */
+    | 'failed';
+
+export interface AgentRunCanceller {
+    /**
+     * Cancel the external run.
+     *
+     * @param triggerRunId the Trigger.dev `run_…` id — NOT the AgentRun UUID.
+     *
+     * Implementations MUST NOT throw. Cancellation is best-effort and strictly
+     * secondary to the DB transition: the authoritative answer to "was it
+     * cancelled?" is the repository CAS, which has already committed by the
+     * time this is called. Losing a remote cancel wastes compute; throwing
+     * would fail an HTTP request that has already succeeded.
+     */
+    cancel(triggerRunId: string): Promise<AgentRunCancelOutcome>;
+}
+
+export const AGENT_RUN_CANCELLER = 'AGENT_RUN_CANCELLER' as const;

--- a/packages/agent/src/agents/agent-schedule-dispatcher.service.ts
+++ b/packages/agent/src/agents/agent-schedule-dispatcher.service.ts
@@ -145,6 +145,7 @@ export class AgentScheduleDispatcherService {
                     runId: run.id,
                 });
                 enqueueSucceeded = true;
+                await this.stampTriggerRunId(run.id, handle.runId);
 
                 summary.dispatched += 1;
                 summary.entries.push(
@@ -261,6 +262,7 @@ export class AgentScheduleDispatcherService {
                 runId: run.id,
             });
             enqueueSucceeded = true;
+            await this.stampTriggerRunId(run.id, handle.runId);
             return { outcome: 'dispatched', runId: run?.id ?? handle.runId };
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
@@ -308,6 +310,25 @@ export class AgentScheduleDispatcherService {
      * leaving the row in RUNNING forever would make it invisible to
      * the dispatcher.
      */
+    /**
+     * Record the Trigger.dev handle id on the AgentRun so a cancel arriving
+     * before the worker starts can still reach the remote run.
+     *
+     * Deliberately swallows: this runs AFTER `enqueueSucceeded = true`, and a
+     * throw escaping here would land in the dispatch catch block and report a
+     * successful dispatch as failed — releasing the CAS claim and, before the
+     * `enqueueSucceeded` guard, marking the run dispatch-failed while its
+     * Trigger.dev run was happily executing. Losing the stamp only costs a
+     * remote cancel.
+     */
+    private async stampTriggerRunId(runId: string, triggerRunId: string): Promise<void> {
+        try {
+            await this.agentRunRepository.setTriggerRunId(runId, triggerRunId);
+        } catch (err) {
+            this.logger.warn(`Failed to stamp triggerRunId on AgentRun ${runId}: ${err}`);
+        }
+    }
+
     private async recoverStuckRunning(): Promise<number> {
         const stuckTimeoutMinutes = config.agents.getStuckTimeoutMinutes();
         const cutoff = new Date(Date.now() - stuckTimeoutMinutes * 60_000);

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -7,6 +7,7 @@ export * from './agent-schedule-dispatcher.service';
 export * from './agent-export.service';
 export * from './prompt-assembler.service';
 export * from './agent-run.service';
+export * from './agent-run-canceller';
 export * from './agent-run-post-processor';
 export * from './agent-ai-dispatch-facade';
 export * from './agent-git-facade';

--- a/packages/agent/src/database/repositories/agent-run.repository.spec.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.spec.ts
@@ -129,6 +129,93 @@ describe('AgentRunRepository — terminal transitions', () => {
         });
     });
 
+    describe('setTriggerRunId', () => {
+        it('only stamps a row that has none, so it cannot clobber markStarted', async () => {
+            await runs.setTriggerRunId('r1', 'run_abc');
+            expect(queryBuilder.set).toHaveBeenCalledWith({ triggerRunId: 'run_abc' });
+            // The worker can reach markStarted before this stamp commits. Both
+            // write the same value, so whichever lands second must no-op rather
+            // than overwrite.
+            expect(
+                queryBuilder.andWhere.mock.calls.some(([sql]) =>
+                    String(sql).includes('triggerRunId IS NULL'),
+                ),
+            ).toBe(true);
+        });
+    });
+
+    describe('markStarted', () => {
+        it('CAS-guards the claim so a cancelled run is never resurrected', async () => {
+            const ok = await runs.markStarted('r1', 'run_abc');
+            expect(ok).toBe(true);
+            // Must allow queued|running, NOT queued-only: heartbeat re-resolves
+            // an already-running row via findInFlightForAgent on retry.
+            expect(statusGuard()).toEqual(['queued', 'running']);
+        });
+
+        it('returns false and warns when the run was cancelled first', async () => {
+            queryBuilder.execute.mockResolvedValue({ affected: 0 });
+            repository.findOne.mockResolvedValue({ id: 'r1', status: 'cancelled' });
+            await expect(runs.markStarted('r1', 'run_abc')).resolves.toBe(false);
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining("already 'cancelled'"));
+        });
+
+        it('does not erase an enqueue-time triggerRunId when the worker passes null', async () => {
+            await runs.markStarted('r1', null);
+            const patch = queryBuilder.set.mock.calls[0][0];
+            expect(patch).not.toHaveProperty('triggerRunId');
+            expect(patch.status).toBe('running');
+        });
+    });
+
+    describe('cancel', () => {
+        beforeEach(() => {
+            repository.findOne.mockResolvedValue({
+                id: 'r1',
+                status: 'running',
+                triggerRunId: 'run_abc',
+            });
+        });
+
+        it('returns triggerRunId so the caller can cancel the remote run', async () => {
+            // Without this the endpoint has no id to cancel and silently
+            // degrades to a DB-only cancel.
+            await expect(runs.cancel('r1', 'u1')).resolves.toEqual(
+                expect.objectContaining({ found: true, triggerRunId: 'run_abc' }),
+            );
+        });
+
+        it('returns triggerRunId for an already-terminal run too', async () => {
+            repository.findOne.mockResolvedValue({
+                id: 'r1',
+                status: 'completed',
+                triggerRunId: 'run_abc',
+            });
+            await expect(runs.cancel('r1', 'u1')).resolves.toEqual({
+                found: true,
+                previousStatus: 'completed',
+                triggerRunId: 'run_abc',
+            });
+        });
+
+        it('re-reads triggerRunId when the CAS loses, since markStarted may have stamped it', async () => {
+            repository.findOne
+                .mockResolvedValueOnce({ id: 'r1', status: 'queued', triggerRunId: null })
+                .mockResolvedValueOnce({ id: 'r1', status: 'running', triggerRunId: 'run_late' });
+            queryBuilder.execute.mockResolvedValue({ affected: 0 });
+            await expect(runs.cancel('r1', 'u1')).resolves.toEqual({
+                found: true,
+                previousStatus: 'running',
+                triggerRunId: 'run_late',
+            });
+        });
+
+        it('reports found:false without a triggerRunId for an unknown run', async () => {
+            repository.findOne.mockResolvedValue(null);
+            await expect(runs.cancel('r1', 'u1')).resolves.toEqual({ found: false });
+        });
+    });
+
     describe('durationMs', () => {
         it('is derived from startedAt when the run had started', async () => {
             const startedAt = new Date(Date.now() - 5_000);

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -111,14 +111,24 @@ export class AgentRunRepository {
     async cancel(
         runId: string,
         userId: string,
-    ): Promise<{ found: boolean; previousStatus?: AgentRunStatus }> {
+    ): Promise<{
+        found: boolean;
+        previousStatus?: AgentRunStatus;
+        /**
+         * Trigger.dev run id of the cancelled row, so the caller can also
+         * cancel the remote run. Null when the run was never stamped —
+         * dispatch failed, or the enqueue-time stamp lost the race and the
+         * worker had not yet reached `markStarted`.
+         */
+        triggerRunId?: string | null;
+    }> {
         const run = await this.repository.findOne({
             where: { id: runId, userId },
-            select: ['id', 'status'],
+            select: ['id', 'status', 'triggerRunId'],
         });
         if (!run) return { found: false };
         if (run.status !== 'queued' && run.status !== 'running') {
-            return { found: true, previousStatus: run.status };
+            return { found: true, previousStatus: run.status, triggerRunId: run.triggerRunId };
         }
         const result = await this.repository
             .createQueryBuilder()
@@ -137,11 +147,17 @@ export class AgentRunRepository {
         if ((result.affected ?? 0) === 0) {
             const fresh = await this.repository.findOne({
                 where: { id: runId },
-                select: ['id', 'status'],
+                select: ['id', 'status', 'triggerRunId'],
             });
-            return { found: true, previousStatus: fresh?.status ?? run.status };
+            return {
+                found: true,
+                previousStatus: fresh?.status ?? run.status,
+                // Re-read: the worker may have stamped `triggerRunId` via
+                // markStarted between our first read and this CAS.
+                triggerRunId: fresh?.triggerRunId ?? run.triggerRunId,
+            };
         }
-        return { found: true, previousStatus: run.status };
+        return { found: true, previousStatus: run.status, triggerRunId: run.triggerRunId };
     }
 
     async createQueued(args: {
@@ -162,12 +178,61 @@ export class AgentRunRepository {
         return this.repository.save(run);
     }
 
-    async markStarted(runId: string, triggerRunId: string | null): Promise<void> {
-        await this.repository.update(runId, {
-            status: 'running',
-            startedAt: new Date(),
-            triggerRunId,
-        });
+    /**
+     * Stamp the Trigger.dev run id onto a row that has just been enqueued,
+     * so a cancel arriving before the worker starts still has something to
+     * cancel remotely. Without this the column stayed NULL for a run's whole
+     * lifetime and cancelling could only ever update our own DB.
+     *
+     * No-clobber by construction (`triggerRunId IS NULL`): the worker can
+     * reach `markStarted` before this stamp commits, and both write the same
+     * value, so whichever lands second must not overwrite. Best-effort —
+     * callers swallow failures, since losing the stamp costs a remote cancel,
+     * not correctness.
+     */
+    async setTriggerRunId(runId: string, triggerRunId: string): Promise<void> {
+        await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({ triggerRunId })
+            .where('id = :id', { id: runId })
+            .andWhere('triggerRunId IS NULL')
+            .execute();
+    }
+
+    /**
+     * Claim a run for execution. CAS-guarded so a cancel that lands between
+     * the worker's status check and this write is not silently reverted
+     * `cancelled -> running`.
+     *
+     * That mattered little while cancel was DB-only, but now that cancelling
+     * actually kills the Trigger.dev run, losing this race would strand the
+     * row in `running` with no worker alive to finalize it — and there is no
+     * `agent_runs` sweeper to reap it. Returns whether the claim succeeded so
+     * the worker can bail instead of executing a cancelled run.
+     *
+     * Allows `queued|running` (NOT queued-only): heartbeat re-resolves an
+     * already-`running` row via `findInFlightForAgent` on retry, and a
+     * queued-only guard would no-op every legitimate retry.
+     *
+     * `triggerRunId` is only written when non-null, so a worker passing null
+     * cannot erase a value stamped at enqueue time by {@link setTriggerRunId}.
+     */
+    async markStarted(runId: string, triggerRunId: string | null): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({
+                status: 'running',
+                startedAt: new Date(),
+                ...(triggerRunId ? { triggerRunId } : {}),
+            })
+            .where('id = :id', { id: runId })
+            .andWhere('status IN (:...statuses)', { statuses: NON_TERMINAL })
+            .execute();
+        const ok = (result.affected ?? 0) > 0;
+        if (!ok) await this.warnTerminalNoOp(runId, 'markStarted');
+        return ok;
     }
 
     /**

--- a/packages/agent/src/tasks-domain/__tests__/task-chat.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-chat.service.spec.ts
@@ -155,6 +155,7 @@ describe('TaskChatService', () => {
         it('transitions AgentRun to failed and does not fail comment posting if enqueue throws', async () => {
             const runs = {
                 createQueued: jest.fn().mockResolvedValue({ id: 'run-chat-1' }),
+                setTriggerRunId: jest.fn().mockResolvedValue(undefined),
                 markDispatchFailed: jest.fn().mockResolvedValue(undefined),
             };
             const chatDispatcher = {
@@ -197,6 +198,7 @@ describe('TaskChatService', () => {
         it('does not attempt markDispatchFailed when the queued run was never created', async () => {
             const runs = {
                 createQueued: jest.fn().mockRejectedValue(new Error('DB down')),
+                setTriggerRunId: jest.fn().mockResolvedValue(undefined),
                 markDispatchFailed: jest.fn().mockResolvedValue(undefined),
             };
             const chatDispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };

--- a/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
@@ -49,6 +49,7 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         runs = {
             createQueued: jest.fn().mockResolvedValue({ id: 'r1' }),
             markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
         };
         dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
     });
@@ -128,6 +129,36 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         await svc.transition(task, TaskStatus.DONE);
         await new Promise((r) => setImmediate(r));
         expect(dispatcher.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('stamps the Trigger.dev run id so a cancel before start can reach the remote run', async () => {
+        const svc = makeSvc();
+        const task = makeTask({ status: TaskStatus.TODO });
+        tasks.findById.mockResolvedValueOnce({ ...task, status: TaskStatus.IN_PROGRESS });
+        assignees.findAgentAssignees.mockResolvedValueOnce([
+            { assigneeType: 'agent', assigneeId: 'agent-a' },
+        ]);
+        await svc.transition(task, TaskStatus.IN_PROGRESS);
+        await new Promise((r) => setImmediate(r));
+        expect(runs.setTriggerRunId).toHaveBeenCalledWith('r1', 'trd-1');
+    });
+
+    it('does not mark a dispatched run failed when stamping the Trigger.dev id throws', async () => {
+        const svc = makeSvc();
+        // Synchronous throw, not a rejected promise: a `.catch()` would never
+        // attach, so the error would escape into the dispatch catch and report
+        // a run that DID dispatch as dispatch-failed.
+        runs.setTriggerRunId.mockImplementationOnce(() => {
+            throw new Error('DB down');
+        });
+        const task = makeTask({ status: TaskStatus.TODO });
+        tasks.findById.mockResolvedValueOnce({ ...task, status: TaskStatus.IN_PROGRESS });
+        assignees.findAgentAssignees.mockResolvedValueOnce([
+            { assigneeType: 'agent', assigneeId: 'agent-a' },
+        ]);
+        await svc.transition(task, TaskStatus.IN_PROGRESS);
+        await new Promise((r) => setImmediate(r));
+        expect(runs.markDispatchFailed).not.toHaveBeenCalled();
     });
 
     it('catches dispatcher failures, transitions AgentRun to failed, and does not fail transition', async () => {

--- a/packages/agent/src/tasks-domain/task-chat.service.ts
+++ b/packages/agent/src/tasks-domain/task-chat.service.ts
@@ -150,7 +150,7 @@ export class TaskChatService {
                                   chatMessageId: row.id,
                               })
                             : null;
-                        await this.chatDispatcher!.enqueue({
+                        const handle = await this.chatDispatcher!.enqueue({
                             agentId: mention.id,
                             userId,
                             taskId: task.id,
@@ -158,6 +158,23 @@ export class TaskChatService {
                             dedupKey,
                             runId: run?.id,
                         });
+                        // Stamp the Trigger.dev id so a cancel arriving before
+                        // the worker starts can still reach the remote run.
+                        // Swallowed separately so a stamp failure cannot reach
+                        // the catch below and mark a successfully-dispatched
+                        // run as dispatch-failed.
+                        if (run && handle?.runId) {
+                            // try/catch, not .catch() — a synchronous throw
+                            // would escape before .catch() could attach and
+                            // mark a dispatched run as dispatch-failed.
+                            try {
+                                await this.runs?.setTriggerRunId(run.id, handle.runId);
+                            } catch (stampErr) {
+                                this.logger.warn(
+                                    `Failed to stamp triggerRunId on AgentRun ${run.id}: ${stampErr}`,
+                                );
+                            }
+                        }
                     } catch (err) {
                         const message = err instanceof Error ? err.message : String(err);
                         this.logger.warn(

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -236,13 +236,31 @@ export class TaskTransitionService {
                           taskId: task.id,
                       })
                     : null;
-                await this.dispatcher.enqueue({
+                const handle = await this.dispatcher.enqueue({
                     agentId: assignee.assigneeId,
                     userId: task.userId,
                     taskId: task.id,
                     dedupKey,
                     runId: run?.id,
                 });
+                // Stamp the Trigger.dev id so a cancel arriving before the
+                // worker starts can still reach the remote run. Swallowed
+                // separately: the enqueue already succeeded, so a stamp
+                // failure must not reach the catch below and mark this run
+                // dispatch-failed while its Trigger.dev run is executing.
+                if (run && handle?.runId) {
+                    // try/catch, not .catch() — a synchronous throw (or a
+                    // repository stub without the method) would escape before
+                    // .catch() could attach, land in the catch below, and mark
+                    // a successfully-dispatched run as dispatch-failed.
+                    try {
+                        await this.runs?.setTriggerRunId(run.id, handle.runId);
+                    } catch (stampErr) {
+                        this.logger.warn(
+                            `Failed to stamp triggerRunId on AgentRun ${run.id}: ${stampErr}`,
+                        );
+                    }
+                }
             } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
                 this.logger.warn(

--- a/packages/tasks/src/__tests__/agent-run-canceller.adapter.spec.ts
+++ b/packages/tasks/src/__tests__/agent-run-canceller.adapter.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createAgentRunCancellerAdapter } from '../dispatchers/agent-task-dispatchers';
+import type { TriggerService } from '../trigger/trigger.service';
+
+/**
+ * The adapter behind `AGENT_RUN_CANCELLER`. Its whole job is to translate
+ * `TriggerService`'s boolean into an outcome an operator can act on, and to
+ * uphold the port's never-throw contract — the controller calls it after the
+ * DB cancel has already committed, so a throw would fail an HTTP request that
+ * has already succeeded.
+ */
+describe('createAgentRunCancellerAdapter', () => {
+    const makeTrigger = (over: Partial<TriggerService> = {}) =>
+        ({
+            isEnabled: vi.fn().mockReturnValue(true),
+            cancel: vi.fn().mockResolvedValue(true),
+            ...over,
+        }) as unknown as TriggerService;
+
+    it('reports "cancelled" when Trigger.dev accepts the request', async () => {
+        const trigger = makeTrigger();
+        const adapter = createAgentRunCancellerAdapter(trigger);
+        await expect(adapter.cancel('run_abc')).resolves.toBe('cancelled');
+        expect(trigger.cancel).toHaveBeenCalledWith('run_abc');
+    });
+
+    it('reports "not-configured" without calling the SDK when Trigger.dev is off', async () => {
+        // This is the distinction a bare boolean would lose: an operator seeing
+        // a wall of 'not-configured' knows TRIGGER_SECRET_KEY is missing, which
+        // looks nothing like the benign already-terminal race.
+        const trigger = makeTrigger({ isEnabled: vi.fn().mockReturnValue(false) });
+        const adapter = createAgentRunCancellerAdapter(trigger);
+        await expect(adapter.cancel('run_abc')).resolves.toBe('not-configured');
+        expect(trigger.cancel).not.toHaveBeenCalled();
+    });
+
+    it('reports "failed" when the SDK call does not succeed', async () => {
+        const trigger = makeTrigger({ cancel: vi.fn().mockResolvedValue(false) });
+        const adapter = createAgentRunCancellerAdapter(trigger);
+        await expect(adapter.cancel('run_abc')).resolves.toBe('failed');
+    });
+
+    it('passes the Trigger.dev run id through verbatim, not an AgentRun UUID', async () => {
+        const trigger = makeTrigger();
+        const adapter = createAgentRunCancellerAdapter(trigger);
+        await adapter.cancel('run_xyz789');
+        expect(trigger.cancel).toHaveBeenCalledWith('run_xyz789');
+    });
+});

--- a/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
+++ b/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
@@ -207,6 +207,19 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
         });
     });
 
+    describe('Trigger.dev run id', () => {
+        it('records ctx.run.id on the AgentRun so the run can be cancelled remotely', async () => {
+            // Before this, markStarted was hard-coded to null and
+            // AgentRun.triggerRunId was NULL for a run's entire lifetime — so
+            // cancelling could only ever update our own DB, never stop the
+            // actual Trigger.dev run.
+            await registeredConfig.run(basePayload(OWNED_TASK_ID), {
+                ctx: { run: { id: 'run_abc123' } },
+            });
+            expect(runs.markStarted).toHaveBeenCalledWith('run-1', 'run_abc123');
+        });
+    });
+
     describe('legitimate owner path (unchanged)', () => {
         it('resolves the owned task, creates + starts + executes the run, and completes', async () => {
             const result = await registeredConfig.run(basePayload(OWNED_TASK_ID));
@@ -218,6 +231,8 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
                 triggerKind: 'task',
                 taskId: OWNED_TASK_ID,
             });
+            // Null here only because this call omits the Trigger.dev run
+            // params; see the ctx test below for the real-runtime path.
             expect(runs.markStarted).toHaveBeenCalledWith('run-1', null);
             expect(runner.execute).toHaveBeenCalledTimes(1);
             expect(runner.execute.mock.calls[0][0]).toMatchObject({

--- a/packages/tasks/src/dispatchers/agent-task-dispatchers.ts
+++ b/packages/tasks/src/dispatchers/agent-task-dispatchers.ts
@@ -1,5 +1,10 @@
 import { tasks } from '@trigger.dev/sdk';
-import type { AgentHeartbeatTrigger } from '@ever-works/agent/agents';
+import type {
+    AgentHeartbeatTrigger,
+    AgentRunCanceller,
+    AgentRunCancelOutcome,
+} from '@ever-works/agent/agents';
+import type { TriggerService } from '../trigger/trigger.service';
 import type {
     AgentChatReplyDispatcher,
     AgentChatReplyDispatchPayload,
@@ -78,3 +83,26 @@ export const agentChatReplyTriggerAdapter: AgentChatReplyDispatcher = {
         return { runId: handle.id };
     },
 };
+
+/**
+ * Cancels the Trigger.dev run behind an AgentRun. Bound to
+ * `AGENT_RUN_CANCELLER` in the API-side `AgentsModule`.
+ *
+ * A factory rather than a `useValue` literal because it delegates to the
+ * injectable `TriggerService` instead of calling `runs.cancel` directly. That
+ * matters for two reasons: `TriggerService.cancel` already try/catches and
+ * logs, so the port's never-throw contract holds without a third copy of that
+ * body; and its `isEnabled()` gate lets us report "Trigger.dev is off" as a
+ * distinct outcome rather than folding a misconfiguration into the same signal
+ * as a benign already-terminal run.
+ *
+ * Unlike the stateless adapters above, this never touches the SDK directly, so
+ * it does not inherit their implicit "someone constructed TriggerService first"
+ * ordering dependency.
+ */
+export const createAgentRunCancellerAdapter = (trigger: TriggerService): AgentRunCanceller => ({
+    async cancel(triggerRunId: string): Promise<AgentRunCancelOutcome> {
+        if (!trigger.isEnabled()) return 'not-configured';
+        return (await trigger.cancel(triggerRunId)) ? 'cancelled' : 'failed';
+    },
+});

--- a/packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts
@@ -67,7 +67,10 @@ export const agentChatReplyTask = task<'agent-chat-reply', AgentChatReplyPayload
             // Best-effort — stuck-row sweep will recover.
         }
     },
-    run: async (payload: AgentChatReplyPayload) => {
+    run: async (
+        payload: AgentChatReplyPayload,
+        { ctx }: { ctx?: { run?: { id?: string } } } = {},
+    ) => {
         // Security: validate payload IDs before any DB access (defense-in-depth, mirrors agent-heartbeat).
         // triggeringMessageId is also asserted: it is a TaskChatMessage uuid PK and its raw value
         // flows into the prompt fallback (`Chat message ${...}`) and the AgentRun row.
@@ -138,7 +141,7 @@ export const agentChatReplyTask = task<'agent-chat-reply', AgentChatReplyPayload
                 });
             }
 
-            await runs.markStarted(run.id, null);
+            await runs.markStarted(run.id, ctx?.run?.id ?? null);
 
             const [taskRow, messages] = await Promise.all([
                 tasks.getOne(payload.userId, payload.taskId).catch(() => null),

--- a/packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts
@@ -74,7 +74,10 @@ export const agentHeartbeatTask = task<'agent-heartbeat', AgentHeartbeatPayload>
             // unstick the row at the next tick window.
         }
     },
-    run: async (payload: AgentHeartbeatPayload) => {
+    run: async (
+        payload: AgentHeartbeatPayload,
+        { ctx }: { ctx?: { run?: { id?: string } } } = {},
+    ) => {
         // Security: validate payload IDs before any DB access (defense-in-depth, mirrors createTaskContext)
         assertUuid(payload.agentId, 'payload.agentId');
         assertUuid(payload.userId, 'payload.userId');
@@ -132,7 +135,7 @@ export const agentHeartbeatTask = task<'agent-heartbeat', AgentHeartbeatPayload>
                 });
             }
 
-            await runs.markStarted(run.id, null);
+            await runs.markStarted(run.id, ctx?.run?.id ?? null);
             const result = await runner.execute({
                 runId: run.id,
                 agentId: agent.id,

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -88,7 +88,10 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
             // Best-effort — stuck-row sweep will recover.
         }
     },
-    run: async (payload: AgentTaskExecutePayload) => {
+    run: async (
+        payload: AgentTaskExecutePayload,
+        { ctx }: { ctx?: { run?: { id?: string } } } = {},
+    ) => {
         // Security: validate payload IDs before any DB access (defense-in-depth, mirrors agent-heartbeat)
         assertUuid(payload.agentId, 'payload.agentId');
         assertUuid(payload.userId, 'payload.userId');
@@ -172,7 +175,7 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 });
             }
 
-            await runs.markStarted(run.id, null);
+            await runs.markStarted(run.id, ctx?.run?.id ?? null);
 
             // `taskRow` was resolved above (owner-scoped) before any run
             // mutation; it is guaranteed non-null here.


### PR DESCRIPTION
Cascade of #1741, completing develop -> stage -> main.

Cancelling an AgentRun previously only flipped the DB row — `triggerRunId` was NULL for every run's entire lifetime, so nothing ever reached Trigger.dev. This populates the column at enqueue time and in the workers, CAS-guards `markStarted` so a cancel cannot be resurrected into a zombie `running` row, and wires an optional canceller port that degrades to DB-only when unbound.

Cascaded whole; no cherry-picking.

Verified: packages/agent 334 suites / 6545 tests, apps/api 194 suites / 3284 tests, packages/tasks 22 files / 369 tests, both type-checks clean, prettier clean.