### PR TITLE
fix(tasks): export TriggerService — develop build break from #1741

### DIFF
--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -1,4 +1,10 @@
 export * from './trigger/trigger.module';
+// TriggerService is consumed directly by the API's AgentsModule (#1741 —
+// AGENT_RUN_CANCELLER factory). trigger.module only lists it in the NestJS DI
+// `exports` array (a runtime binding, not a TS export), so re-export the class
+// itself here or `import { TriggerService } from '@ever-works/trigger-tasks'`
+// fails to type-check (TS2305) and the API build breaks.
+export { TriggerService } from './trigger/trigger.service';
 // Tasks feature — Phase 15. Production dispatcher adapters that
 // fan out platform Task events to the Trigger.dev runtime. API-side
 // TasksModule binds these to the dispatcher tokens.


### PR DESCRIPTION
## Urgent: develop's API build is broken

#1741 (cancelling an AgentRun cancels the Trigger.dev run) added `import { TriggerService } from '@ever-works/trigger-tasks'` to the API's `AgentsModule`, but **never exported `TriggerService`** from the package. The `@ever-works/trigger-tasks` barrel (`packages/tasks/src/index.ts`) only re-exports `trigger.module` — which lists `TriggerService` in its NestJS DI `exports` array (a runtime binding, **not** a TypeScript export) — and `agent-task-dispatchers` imports it `type`-only.

Result: `ever-works-api#build` fails with
```
src/agents/agents.module.ts:39:5 - error TS2305: Module '"@ever-works/trigger-tasks"' has no exported member 'TriggerService'.
```
which breaks the **entire API build** (and every deploy) on `develop`.

## Fix
Re-export the class from the barrel: `export { TriggerService } from './trigger/trigger.service';`

## Verified
`pnpm --filter ever-works-api build` → **0 issues**; full `pnpm build --filter=!./apps/docs` → **98/98 tasks successful**.

One line, zero runtime/behaviour change (a pure type re-export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package exports so integrations can reliably access trigger task functionality.
  * Resolved TypeScript import issues affecting agent run cancellation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->