### PR TITLE
cascade: develop → stage (fix prod api build break — export TriggerService)

### DIFF
--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -1,4 +1,10 @@
 export * from './trigger/trigger.module';
+// TriggerService is consumed directly by the API's AgentsModule (#1741 —
+// AGENT_RUN_CANCELLER factory). trigger.module only lists it in the NestJS DI
+// `exports` array (a runtime binding, not a TS export), so re-export the class
+// itself here or `import { TriggerService } from '@ever-works/trigger-tasks'`
+// fails to type-check (TS2305) and the API build breaks.
+export { TriggerService } from './trigger/trigger.service';
 // Tasks feature — Phase 15. Production dispatcher adapters that
 // fan out platform Task events to the Trigger.dev runtime. API-side
 // TasksModule binds these to the dispatcher tokens.


### PR DESCRIPTION
Whole-branch cascade `develop` → `stage`. **No cherry-picks** (CLAUDE.md #11). Single commit.

## Why this is urgent

**`main` cannot build the prod api image right now.** `k8s-build` run [29829297098](https://github.com/ever-works/ever-works/actions/runs/29829297098) failed:

```
apps/api/src/agents/agents.module.ts(39,5): error TS2305:
Module '"@ever-works/trigger-tasks"' has no exported member 'TriggerService'.
```

`42e83635` (#1741, *"cancelling an AgentRun now cancels the Trigger.dev run"*) added the `TriggerService` import, but the package barrel only re-exports `./trigger/trigger.module` — and `trigger.module.ts` merely *imports* `TriggerService` for its DI array, it never re-exports it.

This went unnoticed because the two `k8s-build` runs on `main` between the last green build (03:00) and now were both **cancelled** by `cancel-in-progress` during cascades, so no build actually completed to surface it.

`b5bf2d56` on `develop` fixes it with a one-line additive barrel export. `stage` and `main` still lack it — confirmed:

```
develop: imports TriggerService=3  barrel exports trigger.service=1
stage:   imports TriggerService=3  barrel exports trigger.service=0
main:    imports TriggerService=3  barrel exports trigger.service=0
```

## Contents

| commit | what |
|---|---|
| `b5bf2d56` | fix(tasks): export `TriggerService` from the package barrel (develop build break) |

Purely additive — an export is added, nothing removed (CLAUDE.md #9).

Until this reaches `main`, **no api image can be published**, which also blocks the `deploy-ready-poller` fix (#1740) from reaching production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)