### PR TITLE
cascade: stage → main (fix prod api build break — export TriggerService)

### DIFF
--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -1,4 +1,10 @@
 export * from './trigger/trigger.module';
+// TriggerService is consumed directly by the API's AgentsModule (#1741 —
+// AGENT_RUN_CANCELLER factory). trigger.module only lists it in the NestJS DI
+// `exports` array (a runtime binding, not a TS export), so re-export the class
+// itself here or `import { TriggerService } from '@ever-works/trigger-tasks'`
+// fails to type-check (TS2305) and the API build breaks.
+export { TriggerService } from './trigger/trigger.service';
 // Tasks feature — Phase 15. Production dispatcher adapters that
 // fan out platform Task events to the Trigger.dev runtime. API-side
 // TasksModule binds these to the dispatcher tokens.


### PR DESCRIPTION
Whole-branch cascade `stage` → `main`. **No cherry-picks** (CLAUDE.md #11). Identical content to #1748.

## Unblocks the prod api image

`main` currently **cannot build `ever-works-api`**. Run [29829297098](https://github.com/ever-works/ever-works/actions/runs/29829297098):

```
apps/api/src/agents/agents.module.ts(39,5): error TS2305:
Module '"@ever-works/trigger-tasks"' has no exported member 'TriggerService'.
```

Introduced by `42e83635` (#1741), which imported `TriggerService` without it being exported from the `@ever-works/trigger-tasks` barrel. It escaped notice because the two `k8s-build` runs on `main` since the last green build were both **cancelled** by `cancel-in-progress`, so nothing completed to surface it.

| commit | what |
|---|---|
| `b5bf2d56` | fix(tasks): export `TriggerService` from the package barrel |

One additive line — nothing removed (CLAUDE.md #9).

This also unblocks the `deploy-ready-poller` fix (#1740 → #1745), which is merged to `main` but cannot ship until an api image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)