### PR TITLE
feat(agents): cooperative mid-run abort for cancelled AgentRuns

### DIFF
--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -315,6 +315,8 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                             tools,
                             temperature: input.temperature ?? 0.4,
                             maxTokens: input.maxTokens,
+                            // Aborts the in-flight provider request on cancel.
+                            signal: input.abortSignal,
                         },
                         {
                             userId: input.facadeOptions.userId,

--- a/packages/agent/src/agents/__tests__/agent-run-abort.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-abort.spec.ts
@@ -1,0 +1,298 @@
+import { AgentRunService } from '../agent-run.service';
+import { PromptAssemblerService } from '../prompt-assembler.service';
+import {
+    AgentAvatarMode,
+    AgentIdleBehavior,
+    AgentScope,
+    AgentStatus,
+} from '../../entities/agent.entity';
+import type { Agent } from '../../entities/agent.entity';
+import type { AgentAiDispatchResult } from '../agent-ai-dispatch-facade';
+import type { AgentToolService } from '../agent-tool.service';
+import type { AgentMemoryFacadeService } from '../../facades/agent-memory.facade';
+
+/**
+ * Cooperative mid-run abort.
+ *
+ * Cancelling an AgentRun CAS-transitions the row to 'cancelled' and cancels the
+ * Trigger.dev run. This covers what the WORKER does once it notices: stop the
+ * tool loop promptly, write no status (the row is already terminal), close the
+ * memory session, and suppress the externally-visible side effects the CAS does
+ * NOT protect — the chat-back post and the task transition.
+ */
+function makeAgent(over: Partial<Agent> = {}): Agent {
+    return {
+        id: 'a1',
+        userId: 'u1',
+        scope: AgentScope.TENANT,
+        missionId: null,
+        ideaId: null,
+        workId: null,
+        name: 'CEO',
+        slug: 'ceo',
+        title: null,
+        capabilities: null,
+        aiProviderId: null,
+        modelId: 'gpt-4o-mini',
+        maxSkillContextTokens: 4000,
+        status: AgentStatus.ACTIVE,
+        permissions: {
+            canCreateAgents: false,
+            canAssignTasks: false,
+            canEditSkills: false,
+            canEditAgentFiles: false,
+            canSpend: false,
+            canCommitToRepo: false,
+            canOpenPullRequests: false,
+            canCallExternalTools: false,
+        },
+        targets: null,
+        heartbeatCadence: null,
+        idleBehavior: AgentIdleBehavior.PROPOSE,
+        nextHeartbeatAt: null,
+        lastRunAt: null,
+        lastRunStatus: null,
+        errorCount: 0,
+        pauseAfterFailures: 3,
+        avatarMode: AgentAvatarMode.INITIALS,
+        avatarIcon: null,
+        avatarImageUploadId: null,
+        soulMd: '# Who I am\nThe boss.',
+        agentsMd: null,
+        heartbeatMd: '# Each tick\nLook at recent activity.',
+        toolsMd: null,
+        agentYml: null,
+        contentHash: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+        ...over,
+    } as Agent;
+}
+
+/** A round that always asks for another tool call, so the loop never self-terminates. */
+function toolCallRound(over: Partial<AgentAiDispatchResult> = {}): AgentAiDispatchResult {
+    return {
+        text: null,
+        toolCalls: [{ id: 'tc-1', name: 'noop', arguments: {} }],
+        finishReason: 'tool_calls',
+        usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+        model: 'gpt-4o-mini',
+        ...over,
+    } as AgentAiDispatchResult;
+}
+
+describe('AgentRunService — cooperative mid-run abort', () => {
+    let agents: any;
+    let runs: any;
+    let runLogs: any;
+    let budgets: any;
+    let skillBindings: any;
+    let activity: any;
+    let assembler: PromptAssemblerService;
+    let chatBackPoster: any;
+    let taskFinisher: any;
+    let toolService: any;
+    let ai: any;
+    let agentMemory: any;
+
+    beforeEach(() => {
+        agents = { findById: jest.fn().mockResolvedValue(makeAgent()) };
+        runs = {
+            findByAgent: jest.fn().mockResolvedValue([]),
+            findById: jest.fn().mockResolvedValue({ id: 'r1', status: 'running' }),
+            markFailed: jest.fn().mockResolvedValue(undefined),
+            markCompleted: jest.fn().mockResolvedValue(undefined),
+            setMemorySessionId: jest.fn().mockResolvedValue(undefined),
+        };
+        runLogs = { append: jest.fn().mockResolvedValue(undefined) };
+        budgets = { findByAgentId: jest.fn().mockResolvedValue(null) };
+        skillBindings = { resolveActive: jest.fn().mockResolvedValue([]) };
+        activity = { log: jest.fn().mockResolvedValue(undefined) };
+        assembler = new PromptAssemblerService();
+        chatBackPoster = { postReply: jest.fn().mockResolvedValue({ messageId: 'msg-new' }) };
+        taskFinisher = { finishTask: jest.fn().mockResolvedValue({ status: 'done' }) };
+        // A tool the loop can "invoke" so a round with tool calls keeps going.
+        toolService = {
+            resolveAllowedTools: jest.fn().mockReturnValue([
+                {
+                    name: 'noop',
+                    description: 'noop',
+                    parameters: { type: 'object', properties: {} },
+                    invoke: jest.fn().mockResolvedValue({ ok: true }),
+                },
+            ]),
+        };
+        ai = { dispatch: jest.fn().mockResolvedValue(toolCallRound()) };
+        agentMemory = {
+            openSession: jest
+                .fn()
+                .mockResolvedValue({ id: 'sess-42', startedAt: '2026-05-28T00:00:00Z' }),
+            closeSession: jest.fn().mockResolvedValue(undefined),
+            isConfigured: jest.fn().mockReturnValue(true),
+        };
+    });
+
+    function makeSvc(): AgentRunService {
+        return new AgentRunService(
+            agents,
+            runs,
+            runLogs,
+            budgets,
+            assembler,
+            skillBindings,
+            activity,
+            chatBackPoster,
+            taskFinisher,
+            toolService as unknown as AgentToolService,
+            ai,
+            agentMemory as unknown as AgentMemoryFacadeService,
+        );
+    }
+
+    const baseContext = {
+        runId: 'r1',
+        agentId: 'a1',
+        userId: 'u1',
+        kind: 'heartbeat' as const,
+    };
+
+    it('stops the tool loop on the very next round when the signal aborts', async () => {
+        // THE no-op catcher. `mockResolvedValue` (not ...Once) means an
+        // implementation that reads the flag but never breaks would run all 10
+        // iterations. Only a call-count assertion proves the loop stopped.
+        const controller = new AbortController();
+        ai.dispatch.mockImplementation(async () => {
+            controller.abort();
+            return toolCallRound();
+        });
+        const result = await makeSvc().execute({ ...baseContext, signal: controller.signal });
+        expect(ai.dispatch).toHaveBeenCalledTimes(1);
+        expect(result.status).toBe('cancelled');
+    });
+
+    it('falls back to the DB status when no signal is present', async () => {
+        // Covers the real windows where the Trigger.dev cancel never fires:
+        // the canceller returned 'failed', or triggerRunId was still NULL.
+        runs.findById
+            .mockResolvedValueOnce({ id: 'r1', status: 'running' })
+            .mockResolvedValue({ id: 'r1', status: 'cancelled' });
+        const result = await makeSvc().execute(baseContext);
+        expect(ai.dispatch).toHaveBeenCalledTimes(1);
+        expect(result.status).toBe('cancelled');
+    });
+
+    it('writes no run status — the row is already cancelled', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        await makeSvc().execute({ ...baseContext, signal: controller.signal });
+        // Both would no-op against the CAS, but calling them emits a
+        // misleading warnTerminalNoOp WARN on every user cancel.
+        expect(runs.markFailed).not.toHaveBeenCalled();
+        expect(runs.markCompleted).not.toHaveBeenCalled();
+    });
+
+    it('still closes the memory session', async () => {
+        // This is why abort routes through finalize() rather than returning
+        // early — memorySessionId is a local with no try/finally around it.
+        const controller = new AbortController();
+        controller.abort();
+        await makeSvc().execute({ ...baseContext, signal: controller.signal });
+        expect(agentMemory.closeSession).toHaveBeenCalledWith('sess-42', expect.anything());
+    });
+
+    it('reports cancelled in both the result and the finalize result', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        const result = await makeSvc().execute({ ...baseContext, signal: controller.signal });
+        expect(result.status).toBe('cancelled');
+        expect(result.finalizeResult?.status).toBe('cancelled');
+    });
+
+    it('does NOT post a chat reply for a cancelled chat run', async () => {
+        // The CAS protects the row, not the side effects. A posted reply is
+        // externally visible and not undoable.
+        const controller = new AbortController();
+        controller.abort();
+        await makeSvc().execute({
+            ...baseContext,
+            kind: 'chat',
+            taskId: 't1',
+            chatMessageId: 'm1',
+            immediateInput: 'hello',
+            signal: controller.signal,
+        });
+        expect(chatBackPoster.postReply).not.toHaveBeenCalled();
+    });
+
+    it('does NOT transition the Task for a cancelled task run', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        await makeSvc().execute({
+            ...baseContext,
+            kind: 'task',
+            taskId: 't1',
+            immediateInput: 'do the thing',
+            signal: controller.signal,
+        });
+        expect(taskFinisher.finishTask).not.toHaveBeenCalled();
+    });
+
+    it('still reports dispatch-failed for a genuine provider error', async () => {
+        // Guards against over-broadening the classifier: a real failure must
+        // not be laundered into a cancel.
+        ai.dispatch.mockRejectedValueOnce(new Error('provider exploded'));
+        const result = await makeSvc().execute(baseContext);
+        expect(result.status).toBe('dispatch-failed');
+        expect(runs.markFailed).toHaveBeenCalled();
+    });
+
+    it('classifies as cancelled when the signal aborted and the provider also threw', async () => {
+        // Cancel wins: the provider error is a consequence of the abort.
+        const controller = new AbortController();
+        ai.dispatch.mockImplementation(async () => {
+            controller.abort();
+            throw new Error('socket closed');
+        });
+        const result = await makeSvc().execute({ ...baseContext, signal: controller.signal });
+        expect(result.status).toBe('cancelled');
+        expect(runs.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('proceeds normally when the status read throws', async () => {
+        runs.findById.mockRejectedValue(new Error('DB down'));
+        ai.dispatch.mockResolvedValue({
+            text: 'done',
+            toolCalls: [],
+            finishReason: 'stop',
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: 'gpt-4o-mini',
+        } as AgentAiDispatchResult);
+        const result = await makeSvc().execute(baseContext);
+        expect(result.status).toBe('dispatched');
+    });
+
+    it('never reads the DB when the signal is already aborted', async () => {
+        // Proves the short-circuit: the happy path pays zero query cost.
+        const controller = new AbortController();
+        controller.abort();
+        await makeSvc().execute({ ...baseContext, signal: controller.signal });
+        expect(runs.findById).not.toHaveBeenCalled();
+    });
+
+    it('threads the abort signal into the model call so in-flight requests are cancelled', async () => {
+        // Without this the run only stops BETWEEN round-trips, so a cancel
+        // during a long model call waits for it to finish.
+        const controller = new AbortController();
+        ai.dispatch.mockResolvedValue({
+            text: 'done',
+            toolCalls: [],
+            finishReason: 'stop',
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: 'gpt-4o-mini',
+        } as AgentAiDispatchResult);
+        await makeSvc().execute({ ...baseContext, signal: controller.signal });
+        expect(ai.dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({ abortSignal: controller.signal }),
+        );
+    });
+});

--- a/packages/agent/src/agents/agent-ai-dispatch-facade.ts
+++ b/packages/agent/src/agents/agent-ai-dispatch-facade.ts
@@ -60,6 +60,12 @@ export interface AgentAiDispatchInput {
     temperature?: number;
     /** Optional maxTokens cap. */
     maxTokens?: number;
+    /**
+     * Aborts the in-flight provider request when the run is cancelled. Without
+     * this, cancelling only takes effect between model round-trips, so a run
+     * already inside a long call keeps going until it returns.
+     */
+    abortSignal?: AbortSignal;
 }
 
 export interface AgentAiDispatchResult {

--- a/packages/agent/src/agents/agent-run-abort.ts
+++ b/packages/agent/src/agents/agent-run-abort.ts
@@ -1,0 +1,116 @@
+import {
+    createGenerationCancelledError,
+    throwIfGenerationCancelled,
+} from '../utils/generation-cancellation.utils';
+
+/**
+ * Cooperative cancellation source for an in-flight AgentRun.
+ *
+ * Combines the two ways a run learns it was cancelled, so call sites have one
+ * checkpoint API and neither source is special-cased:
+ *
+ *  1. **Trigger.dev's `AbortSignal`** — the primary path. Delivered to every
+ *     task `run()` and aborted when the run is cancelled, so it is free,
+ *     instant, and needs no I/O.
+ *  2. **A throttled read of the AgentRun status** — the fallback. The DB row is
+ *     the authoritative cancel, and there are real windows where it says
+ *     `cancelled` but the signal never fires: `AgentRunCanceller` returned
+ *     `'failed'` (transient error reaching the Trigger.dev API, or an id it
+ *     does not recognise), or `triggerRunId` was still NULL when the cancel
+ *     arrived so there was nothing to call `runs.cancel()` on.
+ *
+ * `checkpoint()` short-circuits on the signal and never touches the DB when it
+ * is already aborted, so the common case costs zero queries.
+ */
+export interface AgentRunAbortSource {
+    /** Latched, synchronous, no I/O. True once either source has reported cancel. */
+    readonly aborted: boolean;
+    /** The underlying signal, for threading into downstream HTTP/model calls. */
+    readonly signal?: AbortSignal;
+    /** Signal-only and synchronous. Throws the canonical AbortError. For hot inner loops. */
+    throwIfAborted(): void;
+    /** Signal plus a throttled status read. Throws the canonical AbortError. */
+    checkpoint(): Promise<void>;
+}
+
+export interface CreateAgentRunAbortSourceOptions {
+    runId: string;
+    /** Trigger.dev's run signal. Absent in tests and when a run executes outside a task. */
+    signal?: AbortSignal;
+    /**
+     * Narrow status reader, deliberately a function rather than the whole
+     * repository, so this stays a pure unit with no DB import.
+     */
+    readStatus?: (runId: string) => Promise<string | null>;
+    /**
+     * Minimum wall-clock gap between status reads. Defaults to 0 — check on
+     * every checkpoint.
+     *
+     * A wall-clock throttle looks prudent but buys nothing here and costs
+     * responsiveness: the caller checkpoints once per model round-trip and the
+     * tool loop is capped at 10 iterations, so the ceiling is already ≤10
+     * primary-key SELECTs per run — against a run making 10 LLM calls. A
+     * non-zero default would also silently skip the fallback entirely whenever
+     * rounds return faster than the window, which is exactly when a cancelled
+     * run burns the most iterations.
+     */
+    minDbIntervalMs?: number;
+    /** Test seam. */
+    now?: () => number;
+}
+
+const DEFAULT_MIN_DB_INTERVAL_MS = 0;
+
+export function createAgentRunAbortSource(
+    opts: CreateAgentRunAbortSourceOptions,
+): AgentRunAbortSource {
+    const { runId, signal, readStatus, now = () => Date.now() } = opts;
+    const minDbIntervalMs = opts.minDbIntervalMs ?? DEFAULT_MIN_DB_INTERVAL_MS;
+
+    // Latched: once cancelled, always cancelled. Prevents a flaky status read
+    // from un-cancelling a run we already decided to stop.
+    let latched = false;
+    let lastReadAt: number | null = null;
+
+    const isAborted = () => latched || Boolean(signal?.aborted);
+
+    return {
+        get aborted() {
+            return isAborted();
+        },
+        get signal() {
+            return signal;
+        },
+        throwIfAborted() {
+            if (latched) throw createGenerationCancelledError();
+            throwIfGenerationCancelled(signal);
+        },
+        async checkpoint() {
+            // Signal first: when it works, the DB is never read.
+            if (latched) throw createGenerationCancelledError();
+            throwIfGenerationCancelled(signal);
+            if (!readStatus) return;
+
+            const at = now();
+            if (lastReadAt !== null && at - lastReadAt < minDbIntervalMs) return;
+            lastReadAt = at;
+
+            // A failing status read must not fail an otherwise-healthy run —
+            // the signal remains the primary path. try/catch rather than
+            // `.catch()`: readStatus can throw SYNCHRONOUSLY (a repository
+            // stub without the method, a null deref building the query), and a
+            // `.catch()` never attaches in that case, so the throw would escape
+            // and be misreported as a dispatch failure.
+            let status: string | null = null;
+            try {
+                status = await readStatus(runId);
+            } catch {
+                return;
+            }
+            if (status === 'cancelled') {
+                latched = true;
+                throw createGenerationCancelledError();
+            }
+        },
+    };
+}

--- a/packages/agent/src/agents/agent-run.service.ts
+++ b/packages/agent/src/agents/agent-run.service.ts
@@ -33,6 +33,8 @@ import {
 } from './agent-ai-dispatch-facade';
 import { AgentMemoryFacadeService } from '../facades/agent-memory.facade';
 import { VisionContextService } from '../services/vision-context.service';
+import { createAgentRunAbortSource } from './agent-run-abort';
+import { isGenerationCancelledError } from '../utils/generation-cancellation.utils';
 import { redactSecrets } from '../utils/secret-scan';
 
 export interface AgentRunContext {
@@ -61,6 +63,12 @@ export interface AgentRunContext {
      * the triggering message (T6 chat-dedup posture).
      */
     chatMessageId?: string | null;
+    /**
+     * Trigger.dev's run AbortSignal, aborted when the run is cancelled. Optional:
+     * absent in unit tests and for runs executed outside a Trigger.dev task, in
+     * which case cooperative abort falls back to the throttled DB status read.
+     */
+    signal?: AbortSignal;
 }
 
 export interface AgentRunBudgetCheck {
@@ -74,14 +82,21 @@ export interface AgentRunBudgetCheck {
 
 export interface AgentRunExecuteResult {
     runId: string;
-    status: 'assembled' | 'budget-blocked' | 'agent-not-found' | 'dispatched' | 'dispatch-failed';
+    status:
+        | 'assembled'
+        | 'budget-blocked'
+        | 'agent-not-found'
+        | 'dispatched'
+        | 'dispatch-failed'
+        /** Cancelled mid-flight; the row is already 'cancelled' and no status was written. */
+        | 'cancelled';
     prompt?: AssembledPrompt;
     budgetCheck?: AgentRunBudgetCheck;
     /** Set when the LLM-dispatch path ran end-to-end. */
     outcome?: AgentRunOutcome;
     /** Set when the LLM-dispatch path ran end-to-end. */
     finalizeResult?: {
-        status: 'completed' | 'failed';
+        status: 'completed' | 'failed' | 'cancelled';
         postedMessageId?: string;
         finishedTaskStatus?: string;
     };
@@ -342,6 +357,23 @@ export class AgentRunService {
         }
 
         const dispatchResult = await this.runToolLoop(context, agent, prompt);
+        if (dispatchResult.cancelled) {
+            const finalizeResult = await this.finalize(
+                context,
+                { ...dispatchResult.outcome, cancelled: true },
+                memorySessionId,
+                agent,
+            );
+            return {
+                runId: context.runId,
+                status: 'cancelled',
+                prompt,
+                budgetCheck,
+                outcome: dispatchResult.outcome,
+                finalizeResult,
+                toolLoopIterations: dispatchResult.iterations,
+            };
+        }
         if (dispatchResult.errored) {
             const finalizeResult = await this.finalize(
                 context,
@@ -404,11 +436,22 @@ export class AgentRunService {
         prompt: AssembledPrompt,
     ): Promise<{
         errored: boolean;
+        /**
+         * The run was cancelled mid-flight. Distinct from `errored`: the DB row
+         * is already `cancelled`, so the caller must write no status and skip
+         * every externally-visible side effect.
+         */
+        cancelled?: boolean;
         errorMessage?: string;
         outcome: AgentRunOutcome;
         iterations: number;
     }> {
         const TOOL_LOOP_MAX_ITERATIONS = 10;
+        const abort = createAgentRunAbortSource({
+            runId: context.runId,
+            signal: context.signal,
+            readStatus: (id) => this.runs.findById(id).then((r) => r?.status ?? null),
+        });
         const editsThisRunByFile = new Set<string>();
         const baseDescriptors: AgentToolDescriptor[] = this.toolService
             ? this.toolService.resolveAllowedTools(agent, {
@@ -460,7 +503,11 @@ export class AgentRunService {
         try {
             while (iterations < TOOL_LOOP_MAX_ITERATIONS) {
                 iterations += 1;
+                // One checkpoint per model round-trip. Bounded at 10 by the cap
+                // above, and the DB is only read when the signal did not fire.
+                await abort.checkpoint();
                 const round = await this.aiDispatch!.dispatch({
+                    abortSignal: abort.signal,
                     messages,
                     tools: toolDefs.length > 0 ? toolDefs : undefined,
                     model: agent.modelId ?? undefined,
@@ -506,6 +553,10 @@ export class AgentRunService {
                 });
 
                 for (const call of round.toolCalls) {
+                    // Signal-only and synchronous — a tool round can be many
+                    // calls, and a DB read per call is not worth it. Anything
+                    // the signal misses is caught by the next loop checkpoint.
+                    abort.throwIfAborted();
                     const result = await this.invokeTool(context.runId, descriptorByName, call);
                     // Security (prompt-injection): tool results frequently
                     // carry attacker-controlled text (fetched web pages, repo
@@ -526,6 +577,30 @@ export class AgentRunService {
                 }
             }
         } catch (err) {
+            // Cancel wins over a coincident provider error: if the signal is
+            // aborted, whatever the provider threw is a consequence of the
+            // abort, not an independent failure. Misclassifying here would
+            // mark a user-cancelled run as failed and, on heartbeat, count it
+            // toward the agent's auto-pause threshold.
+            if (isGenerationCancelledError(err) || abort.aborted) {
+                this.logger.log(
+                    `Run ${context.runId} cancelled after ${iterations} model round-trip(s).`,
+                );
+                await this.runLogs
+                    .append({
+                        runId: context.runId,
+                        level: 'WARN',
+                        step: 'ai-dispatch',
+                        message: 'Run cancelled — stopped before completion.',
+                        metadata: { iteration: iterations, reason: 'cancelled' },
+                    })
+                    .catch(() => undefined);
+                // No parsed outcome — the loop stopped before a final
+                // assistant turn. Deliberately empty so finalize() has no
+                // replyBody / taskFinishStatus to act on even if the
+                // cancelled guard there were ever bypassed.
+                return { errored: false, cancelled: true, outcome: { errored: false }, iterations };
+            }
             const errorMessage = err instanceof Error ? err.message : String(err);
             // Security (secrets): the provider/tool error string can echo a
             // credential (e.g. an upstream gateway reflecting an Authorization
@@ -758,16 +833,32 @@ export class AgentRunService {
      */
     async finalize(
         context: AgentRunContext,
-        outcome: AgentRunOutcome,
+        outcome: AgentRunOutcome & { cancelled?: boolean },
         memorySessionId?: string | null,
         agent?: Agent | null,
     ): Promise<{
         runId: string;
-        status: 'completed' | 'failed';
+        status: 'completed' | 'failed' | 'cancelled';
         postedMessageId?: string;
         finishedTaskStatus?: string;
     }> {
         const summary = outcome.summary ?? null;
+
+        // Cancelled: the controller already CAS'd the row to 'cancelled', so
+        // write NO status here. markFailed/markCompleted would no-op against
+        // the CAS anyway, but they would also emit a misleading
+        // warnTerminalNoOp WARN on every user cancel.
+        //
+        // The CAS protects the row; it does NOT protect the side effects
+        // below. Skipping them is the point: a cancelled chat run must not
+        // post a reply, and a cancelled task run must not flip the Task to
+        // done. Both are externally visible and neither is undoable.
+        // Memory session close still happens — that is why abort routes
+        // through finalize() instead of returning early.
+        if (outcome.cancelled) {
+            await this.tryCloseMemorySession(memorySessionId, context, agent ?? null);
+            return { runId: context.runId, status: 'cancelled' };
+        }
 
         if (outcome.errored) {
             await this.runs

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -8,6 +8,7 @@ export * from './agent-export.service';
 export * from './prompt-assembler.service';
 export * from './agent-run.service';
 export * from './agent-run-canceller';
+export * from './agent-run-abort';
 export * from './agent-run-post-processor';
 export * from './agent-ai-dispatch-facade';
 export * from './agent-git-facade';

--- a/packages/plugin/src/ai/ai-operations.ts
+++ b/packages/plugin/src/ai/ai-operations.ts
@@ -67,7 +67,13 @@ export class AiOperations {
 			const tracker = new TokenUsageTracker();
 			const messages = this.toLangChainMessages(options.messages);
 
-			const response = await llm.invoke(messages, { callbacks: [tracker] });
+			const response = await llm.invoke(messages, {
+				callbacks: [tracker],
+				// Cancels the underlying HTTP request when the run is aborted.
+				// withParamRetry only retries on a parsed rejected-param message,
+				// which an AbortError never matches, so an abort is not re-issued.
+				signal: options.signal
+			});
 			const content = typeof response.content === 'string' ? response.content : '';
 
 			// Extract tool calls from LangChain response

--- a/packages/plugin/src/contracts/capabilities/ai-provider.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/ai-provider.interface.ts
@@ -140,6 +140,12 @@ export interface ChatCompletionOptions {
 	 * Plugins should use these settings instead of their stored defaults.
 	 */
 	readonly settings?: PluginSettings;
+
+	/**
+	 * Aborts the in-flight provider request. Optional and additive — the
+	 * provider plugins are pass-throughs, so no implementer changes.
+	 */
+	readonly signal?: AbortSignal;
 }
 
 /**

--- a/packages/tasks/src/__tests__/agent-heartbeat-cancel.task.spec.ts
+++ b/packages/tasks/src/__tests__/agent-heartbeat-cancel.task.spec.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Heartbeat cancel accounting.
+ *
+ * `agent-heartbeat.task.ts` decides the Agent's post-run fate with:
+ *
+ *   const completed = result.status === 'assembled' || result.status === 'dispatched';
+ *
+ * Widening `AgentRunExecuteResult['status']` with `'cancelled'` compiles
+ * perfectly against that line and silently routes a cancelled run into the
+ * `else` branch — `incrementErrorCount` — so every user cancel would count
+ * toward `pauseAfterFailures` until the Agent auto-pauses. TypeScript cannot
+ * catch it. This spec is the guard.
+ */
+const {
+    taskMock,
+    createApplicationContextMock,
+    createTriggerLoggerMock,
+    StubInternalModule,
+    AgentRepositoryToken,
+    AgentRunRepositoryToken,
+    AgentRunServiceToken,
+} = vi.hoisted(() => {
+    class StubInternalModule {}
+    class AgentRepositoryToken {}
+    class AgentRunRepositoryToken {}
+    class AgentRunServiceToken {}
+    return {
+        taskMock: vi.fn(),
+        createApplicationContextMock: vi.fn(),
+        createTriggerLoggerMock: vi.fn().mockReturnValue({ __kind: 'trigger-logger' }),
+        StubInternalModule,
+        AgentRepositoryToken,
+        AgentRunRepositoryToken,
+        AgentRunServiceToken,
+    };
+});
+
+vi.mock('@trigger.dev/sdk', () => ({
+    task: taskMock,
+    schedules: { task: vi.fn() },
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('@nestjs/core', () => ({
+    NestFactory: { createApplicationContext: createApplicationContextMock },
+}));
+
+vi.mock('@ever-works/agent/database', () => ({
+    AgentRepository: AgentRepositoryToken,
+    AgentRunRepository: AgentRunRepositoryToken,
+}));
+
+vi.mock('@ever-works/agent/agents', () => ({
+    AgentRunService: AgentRunServiceToken,
+    computeNextHeartbeat: () => new Date('2026-01-01T00:05:00Z'),
+}));
+
+vi.mock('../trigger/worker/modules/trigger-internal.module', () => ({
+    TriggerInternalModule: StubInternalModule,
+}));
+
+vi.mock('../trigger/worker/trigger-logger', () => ({
+    createTriggerLogger: createTriggerLoggerMock,
+}));
+
+type TaskConfig = {
+    id: string;
+    run: (payload: any, params?: any) => Promise<any>;
+};
+
+const OWNER = '11111111-1111-4111-8111-111111111111';
+const AGENT_ID = '22222222-2222-4222-8222-222222222222';
+
+describe('agentHeartbeatTask — cancelled run accounting', () => {
+    let agents: any;
+    let runs: any;
+    let runner: any;
+    let registeredConfig: TaskConfig;
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        vi.resetModules();
+
+        agents = {
+            findByIdAndUser: vi.fn().mockResolvedValue({
+                id: AGENT_ID,
+                userId: OWNER,
+                heartbeatCadence: '*/5 * * * *',
+            }),
+            findById: vi.fn().mockResolvedValue({
+                id: AGENT_ID,
+                userId: OWNER,
+                heartbeatCadence: '*/5 * * * *',
+            }),
+            releaseAfterRun: vi.fn().mockResolvedValue(undefined),
+            incrementErrorCount: vi.fn().mockResolvedValue(undefined),
+        };
+        runs = {
+            findById: vi.fn().mockResolvedValue(null),
+            findInFlightForAgent: vi.fn().mockResolvedValue(null),
+            createQueued: vi.fn().mockResolvedValue({ id: 'run-1', status: 'queued' }),
+            markStarted: vi.fn().mockResolvedValue(true),
+            markCompleted: vi.fn().mockResolvedValue(undefined),
+            markFailed: vi.fn().mockResolvedValue(undefined),
+        };
+        runner = { execute: vi.fn().mockResolvedValue({ status: 'dispatched' }) };
+
+        createApplicationContextMock.mockResolvedValue({
+            useLogger: vi.fn(),
+            get: vi.fn().mockImplementation((token: unknown) => {
+                if (token === AgentRepositoryToken) return agents;
+                if (token === AgentRunRepositoryToken) return runs;
+                if (token === AgentRunServiceToken) return runner;
+                throw new Error(`Unexpected DI token: ${String(token)}`);
+            }),
+            close: vi.fn().mockResolvedValue(undefined),
+        });
+
+        await import('../tasks/trigger/agent-heartbeat.task');
+        const lastCall = taskMock.mock.calls[taskMock.mock.calls.length - 1];
+        registeredConfig = lastCall[0] as TaskConfig;
+    });
+
+    const payload = {
+        agentId: AGENT_ID,
+        userId: OWNER,
+        scheduledFor: '2026-01-01T00:00:00Z',
+    };
+
+    it('releases the Agent as cancelled and does NOT count an error', async () => {
+        runner.execute.mockResolvedValueOnce({ status: 'cancelled' });
+
+        await registeredConfig.run(payload, { ctx: { run: { id: 'run_abc' } } });
+
+        expect(agents.releaseAfterRun).toHaveBeenCalledWith(
+            AGENT_ID,
+            expect.anything(),
+            'cancelled',
+        );
+        // The regression this file exists for: without the explicit cancelled
+        // arm, a user cancel walks agents toward auto-pause.
+        expect(agents.incrementErrorCount).not.toHaveBeenCalled();
+    });
+
+    it('still counts a genuine dispatch failure as an error', async () => {
+        runner.execute.mockResolvedValueOnce({ status: 'dispatch-failed' });
+
+        await registeredConfig.run(payload, { ctx: { run: { id: 'run_abc' } } });
+
+        expect(agents.incrementErrorCount).toHaveBeenCalled();
+        expect(agents.releaseAfterRun).not.toHaveBeenCalledWith(
+            AGENT_ID,
+            expect.anything(),
+            'cancelled',
+        );
+    });
+
+    it('still releases a completed run as completed', async () => {
+        runner.execute.mockResolvedValueOnce({ status: 'dispatched' });
+
+        await registeredConfig.run(payload, { ctx: { run: { id: 'run_abc' } } });
+
+        expect(agents.releaseAfterRun).toHaveBeenCalledWith(
+            AGENT_ID,
+            expect.anything(),
+            'completed',
+        );
+        expect(agents.incrementErrorCount).not.toHaveBeenCalled();
+    });
+});

--- a/packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts
@@ -69,7 +69,9 @@ export const agentChatReplyTask = task<'agent-chat-reply', AgentChatReplyPayload
     },
     run: async (
         payload: AgentChatReplyPayload,
-        { ctx }: { ctx?: { run?: { id?: string } } } = {},
+        // NOTE: this annotation replaces the SDK RunFnParams, so anything omitted
+        // here is silently invisible — which is exactly how `signal` went unused.
+        { ctx, signal }: { ctx?: { run?: { id?: string } }; signal?: AbortSignal } = {},
     ) => {
         // Security: validate payload IDs before any DB access (defense-in-depth, mirrors agent-heartbeat).
         // triggeringMessageId is also asserted: it is a TaskChatMessage uuid PK and its raw value
@@ -165,6 +167,7 @@ export const agentChatReplyTask = task<'agent-chat-reply', AgentChatReplyPayload
                 agentId: agent.id,
                 userId: payload.userId,
                 kind: 'chat',
+                signal,
                 taskId: payload.taskId,
                 chatMessageId: payload.triggeringMessageId,
                 immediateInput,

--- a/packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts
@@ -76,7 +76,9 @@ export const agentHeartbeatTask = task<'agent-heartbeat', AgentHeartbeatPayload>
     },
     run: async (
         payload: AgentHeartbeatPayload,
-        { ctx }: { ctx?: { run?: { id?: string } } } = {},
+        // NOTE: this annotation replaces the SDK RunFnParams, so anything omitted
+        // here is silently invisible — which is exactly how `signal` went unused.
+        { ctx, signal }: { ctx?: { run?: { id?: string } }; signal?: AbortSignal } = {},
     ) => {
         // Security: validate payload IDs before any DB access (defense-in-depth, mirrors createTaskContext)
         assertUuid(payload.agentId, 'payload.agentId');
@@ -141,6 +143,7 @@ export const agentHeartbeatTask = task<'agent-heartbeat', AgentHeartbeatPayload>
                 agentId: agent.id,
                 userId: payload.userId,
                 kind: 'heartbeat',
+                signal,
             });
 
             if (result.status === 'assembled') {
@@ -152,7 +155,15 @@ export const agentHeartbeatTask = task<'agent-heartbeat', AgentHeartbeatPayload>
 
             const nextSlot = computeNextHeartbeat(agent.heartbeatCadence);
             const completed = result.status === 'assembled' || result.status === 'dispatched';
-            if (completed) {
+            const cancelled = result.status === 'cancelled';
+            if (cancelled) {
+                // A user cancel is not an agent failure. Without this arm the
+                // widened status union still compiles and silently falls into
+                // incrementErrorCount below, counting every cancel toward
+                // `pauseAfterFailures` until the agent auto-pauses. Mirrors the
+                // pre-execute cancelled path above.
+                await agents.releaseAfterRun(agent.id, nextSlot, 'cancelled');
+            } else if (completed) {
                 await agents.releaseAfterRun(agent.id, nextSlot, 'completed');
             } else {
                 await agents.incrementErrorCount(agent.id, nextSlot);

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -90,7 +90,9 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
     },
     run: async (
         payload: AgentTaskExecutePayload,
-        { ctx }: { ctx?: { run?: { id?: string } } } = {},
+        // NOTE: this annotation replaces the SDK RunFnParams, so anything omitted
+        // here is silently invisible — which is exactly how `signal` went unused.
+        { ctx, signal }: { ctx?: { run?: { id?: string } }; signal?: AbortSignal } = {},
     ) => {
         // Security: validate payload IDs before any DB access (defense-in-depth, mirrors agent-heartbeat)
         assertUuid(payload.agentId, 'payload.agentId');
@@ -198,6 +200,7 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 agentId: agent.id,
                 userId: payload.userId,
                 kind: 'task',
+                signal,
                 taskId: payload.taskId,
                 immediateInput,
                 scopeContext: taskRow


### PR DESCRIPTION
## Summary

Cancelling an AgentRun already CAS-transitions the row and cancels the Trigger.dev run (#1741). But a worker already mid-flight kept going until the container was torn down. This makes the run loop notice and stop cleanly.

## The signal was there all along

`@trigger.dev/sdk@4.4.6` delivers `signal: AbortSignal` alongside `ctx`, documented as aborted *"if the task run is cancelled"*. The repo already has the complete pattern — `work-generation.task.ts` threads it into `throwIfGenerationCancelled` checkpoints, and `packages/agent/src/utils/generation-cancellation.utils.ts` has the canonical error helpers. The three agent tasks just never used it.

Worth calling out why it was easy to miss: the hand-written params annotation on those tasks **replaces** the SDK's `RunFnParams`, so `signal` was invisible and TypeScript never complained. Widened it, with a comment so the next person doesn't repeat it.

## Signal source: both, asymmetric

- **`AbortSignal` primary** — free, instant, no I/O.
- **Throttled status read as fallback** — required, because there are real windows where the DB says `cancelled` and the signal never fires: `AgentRunCanceller` returned `'failed'`, or `triggerRunId` was still `NULL` when the cancel arrived. The DB is the authoritative cancel, so it can't be the one path that's ignored. `checkpoint()` short-circuits on the signal, so the happy path reads **zero** rows.
- **Default interval is 0, not 5s.** A wall-clock throttle looks prudent but buys nothing: the caller checkpoints once per model round-trip and the loop is capped at 10, so the ceiling is ≤10 primary-key SELECTs against a run already making 10 LLM calls. A non-zero window would skip the fallback *entirely* whenever rounds return faster than it — exactly when a cancelled run burns the most iterations.

## Threading into the model call

`AgentAiDispatchInput.abortSignal` → `ChatCompletionOptions.signal` → `llm.invoke`. This is the difference between "stops after the current 60s model call" and "stops now".

Two things I verified before doing it:

- **`withParamRetry` cannot re-issue an aborted call.** It only retries when `parseRejectedParam` matches a rejected-parameter substring (`'temperature'`, `'tools'`, `json_schema`…), which an `AbortError` never does — it falls straight through to `throw`. Had this retried on any throw, threading the signal would have caused the exact opposite of the intent.
- **`ai.facade` merges options with a shallow spread**, so the `AbortSignal` identity survives. A deep clone or `structuredClone` there would silently destroy it — worth knowing if anyone refactors that line.

The added fields are optional and the ~8 provider plugins are pass-throughs, so no implementer changes.

## What abort does — and deliberately does not do

**Writes no run status.** The row is already `cancelled`; both `markFailed` and `markCompleted` would no-op against the CAS *and* emit a misleading `warnTerminalNoOp` WARN on every user cancel.

**Routes through `finalize()` rather than returning early** — specifically so the memory session still closes. `memorySessionId` is a local with no `try`/`finally` around it, so an early return leaks it.

**Suppresses the side effects the CAS does not protect.** A cancelled chat run must not post a reply; a cancelled task run must not flip the Task to `done`. Both are externally visible and neither is undoable.

**Cancel wins over a coincident provider error** — if the signal aborted, whatever the provider threw is a consequence of the abort, not an independent failure.

## The line the compiler can't catch

```ts
const completed = result.status === 'assembled' || result.status === 'dispatched';
```

Widening the status union with `'cancelled'` compiles perfectly against this and silently routes a cancelled run into `incrementErrorCount` — walking the Agent toward `pauseAfterFailures` on **every user cancel** until it auto-pauses. Added the explicit cancelled arm, plus `agent-heartbeat-cancel.task.spec.ts`, which fails without it. Mutation-verified.

## A bug in my own new code, caught by the existing suites

`readStatus` can throw **synchronously** (a repository stub without the method), and a `.catch()` never attaches in that case — so the throw escaped and was reported as `dispatch-failed`. Fixed with `try`/`catch`. Same lesson as the `setTriggerRunId` stamp in #1741; notable that the *existing* specs caught it, which is what they're for.

## Testing

| Suite | Result |
|---|---|
| `packages/agent` | 335 suites / **6564** tests |
| `packages/tasks` | 23 files / **372** tests |
| `apps/api` | 194 suites / **3284** tests |

Both type-checks clean; `prettier --check` clean.

New `agent-run-abort.spec.ts` includes the test that catches a no-op implementation: `ai.dispatch` uses `mockResolvedValue` (not `...Once`), so an implementation that reads the flag but never breaks runs all 10 iterations and fails `toHaveBeenCalledTimes(1)`. Asserting only the result status would pass against a no-op.

## Honest limitation

LangChain honours `signal` in `RunnableConfig`, but whether a given provider integration forwards it to its HTTP client varies by integration and version. Where it does not, behaviour degrades to the loop-level check — still correct, just stopping at the next round-trip rather than instantly.

Also: the cancel-side abort trigger lives in the `trigger.dev` CLI run controller, which is `pnpm dlx`-ed and not in `node_modules`, so the signal contract is confirmed from the type declarations and `taskExecutor` wiring but **not verified end-to-end locally**. That is an independent reason the DB fallback exists rather than being belt-and-braces.

## Not in scope

- `AGENT_RUN_CANCELLED` is missing from `AGENT_LIFECYCLE_EVENT_TYPES`, so the cancel activity row is written but never read back by `GET :id/events`. Real bug, one line, broken today for cancels that never reach a worker — orthogonal to this.
- An `AGENT_HEARTBEAT_CANCELLED` activity type. This PR's cancelled branch emits nothing, which is strictly better than today's mislabelled `FAILED`.
- Trigger.dev's `onCancel` hook — its grace period isn't documented in any installed package, and `finalize()` plus the existing `finally` blocks already cover cleanup.
- An `agent_runs` sweeper. A run hard-killed before any checkpoint still sits in `running` forever; this PR doesn't make that worse.
