### PR TITLE
fix(agents): surface run-lifecycle events in GET /:id/events

### DIFF
--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -348,6 +348,22 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             );
         });
 
+        it('queries for the run-lifecycle events this controller actually emits', async () => {
+            // run-now, cancel and assign-task all write activity rows via
+            // tryLog(), but were missing from AGENT_LIFECYCLE_EVENT_TYPES — so
+            // they were persisted and then never returned by this endpoint.
+            // Assert on the emitted set, not just the status-transition ones.
+            await controller.listEvents(auth, agentId, {});
+            const { actionTypes } = activityLog.findAgentEvents.mock.calls[0][0];
+            expect(actionTypes).toEqual(
+                expect.arrayContaining([
+                    'agent_run_triggered',
+                    'agent_run_cancelled',
+                    'agent_task_assigned',
+                ]),
+            );
+        });
+
         it('returns an empty page when ActivityLogService is unbound', async () => {
             controller = new AgentsController(
                 service,

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -104,6 +104,14 @@ const AGENT_LIFECYCLE_EVENT_TYPES: ActivityActionType[] = [
     ActivityActionType.AGENT_EXPORTED,
     ActivityActionType.AGENT_IMPORTED,
     ActivityActionType.AGENT_BUDGET_EXCEEDED,
+    // Run-lifecycle events. All three are emitted by this controller via
+    // tryLog() — run-now, cancel, and assign-task — but were absent from this
+    // list, so every one of them was written to activity_logs and then never
+    // returned by GET :id/events. Nothing surfaced the fact that a run was
+    // triggered, cancelled, or assigned.
+    ActivityActionType.AGENT_RUN_TRIGGERED,
+    ActivityActionType.AGENT_RUN_CANCELLED,
+    ActivityActionType.AGENT_TASK_ASSIGNED,
 ];
 
 @ApiTags('agents')


### PR DESCRIPTION
## Summary

`AGENT_LIFECYCLE_EVENT_TYPES` gates which activity rows the per-Agent event feed returns, and **three types this very controller emits were missing from it**:

| Type | Emitted by |
|---|---|
| `AGENT_RUN_TRIGGERED` | `run-now` |
| `AGENT_RUN_CANCELLED` | `cancel` |
| `AGENT_TASK_ASSIGNED` | `assign-task` |

All three go through `tryLog()`, so the rows were written to `activity_logs` with the correct shape — and then never read back. Triggering, cancelling or assigning a run left **no trace** in the feed.

## Verified the array is the whole fix

Worth checking rather than assuming, since a partial fix here would look identical from the outside:

- `tryLog()` stamps `resourceId: args.agentId` on every row it writes, and all three emitters route through it.
- `ActivityLogRepository.findAgentEvents` filters on `userId` + `actionType IN (:...actionTypes)` + the escaped agent id.

So the rows already match on every axis except the type filter. Adding the types is sufficient — exactly as the docblock above the array claims (*"adding a type here is enough to surface any future tryLog() emitter"*).

## Wider than I first reported

I flagged only `AGENT_RUN_CANCELLED` while finishing the cancel work in #1751. Enumerating the controller's actual emitters against the list turned up two more with the same defect.

## Testing

- `apps/api`: **194 suites / 3285 tests green**; `prettier --check` clean.
- New test asserts on the emitted set (`agent_run_triggered`, `agent_run_cancelled`, `agent_task_assigned`) rather than just the status-transition types the existing test covers. **Mutation-verified** — removing the three types again fails it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent activity feeds now include run-triggered, run-cancelled, and task-assigned lifecycle events.
  * Improved coverage ensures all emitted agent lifecycle events are returned by the events endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->