### PR TITLE
chore: cascade develop -> stage (run-lifecycle events in agent feed)

### DIFF
--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -348,6 +348,22 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             );
         });
 
+        it('queries for the run-lifecycle events this controller actually emits', async () => {
+            // run-now, cancel and assign-task all write activity rows via
+            // tryLog(), but were missing from AGENT_LIFECYCLE_EVENT_TYPES — so
+            // they were persisted and then never returned by this endpoint.
+            // Assert on the emitted set, not just the status-transition ones.
+            await controller.listEvents(auth, agentId, {});
+            const { actionTypes } = activityLog.findAgentEvents.mock.calls[0][0];
+            expect(actionTypes).toEqual(
+                expect.arrayContaining([
+                    'agent_run_triggered',
+                    'agent_run_cancelled',
+                    'agent_task_assigned',
+                ]),
+            );
+        });
+
         it('returns an empty page when ActivityLogService is unbound', async () => {
             controller = new AgentsController(
                 service,

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -104,6 +104,14 @@ const AGENT_LIFECYCLE_EVENT_TYPES: ActivityActionType[] = [
     ActivityActionType.AGENT_EXPORTED,
     ActivityActionType.AGENT_IMPORTED,
     ActivityActionType.AGENT_BUDGET_EXCEEDED,
+    // Run-lifecycle events. All three are emitted by this controller via
+    // tryLog() — run-now, cancel, and assign-task — but were absent from this
+    // list, so every one of them was written to activity_logs and then never
+    // returned by GET :id/events. Nothing surfaced the fact that a run was
+    // triggered, cancelled, or assigned.
+    ActivityActionType.AGENT_RUN_TRIGGERED,
+    ActivityActionType.AGENT_RUN_CANCELLED,
+    ActivityActionType.AGENT_TASK_ASSIGNED,
 ];
 
 @ApiTags('agents')


### PR DESCRIPTION
Cascade of #1754.

Three activity types the agents controller emits — AGENT_RUN_TRIGGERED, AGENT_RUN_CANCELLED, AGENT_TASK_ASSIGNED — were missing from AGENT_LIFECYCLE_EVENT_TYPES, so the rows were written and never returned by GET /:id/events.

Cascaded whole; no cherry-picking.

Verified on develop: apps/api 194 suites / 3285 tests, prettier clean.