### PR TITLE
ci: split the dependency audit into its own job so it cannot mask build/test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,21 @@ env:
   NODE_OPTIONS: --max-old-space-size=6144
 
 jobs:
-  lint-and-test:
+  # Relocated out of `lint-and-test` (body unchanged). It used to run BEFORE
+  # `Check formatting` / `Build all packages` / `run test on all packages`, so a
+  # dependency advisory failed the job and reported those three as `skipped`
+  # rather than run. A red `lint-and-test` then meant "nothing was built or
+  # tested" — indistinguishable at a glance from a real test failure, which is
+  # how a broken spec sat unnoticed on develop for two months.
+  #
+  # As its own job the gate is exactly as strict (still a hard fail on
+  # HIGH/CRITICAL) but it can no longer mask the build/test signal, and the two
+  # surface as separate checks so the cause is obvious from the checks list.
+  #
+  # No `pnpm install` here on purpose: `pnpm audit` resolves from
+  # `pnpm-lock.yaml` alone, so this job is checkout + pnpm + audit.
+  dependency-audit:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-
-    strategy:
-      matrix:
-        node-version: [22.x]
 
     steps:
       - name: Checkout repository
@@ -45,14 +54,10 @@ jobs:
         with:
           version: 10.33.3
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js 22.x
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          node-version: 22.x
 
       # H-15: fail the build if any production transitive dep has a HIGH or
       # CRITICAL vulnerability. The existing `pnpm.overrides` block proves
@@ -92,6 +97,33 @@ jobs:
           fi
           echo "::error title=Dependency audit failed::pnpm audit reported HIGH/CRITICAL production vulnerabilities (or an unexpected error). See the output above."
           exit "$code"
+
+  lint-and-test:
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v3
+        with:
+          version: 10.33.3
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Check formatting
         run: pnpm format:check


### PR DESCRIPTION
## The problem

`Audit production dependencies (high+)` ran as the **second step** of `lint-and-test` — before `Check formatting`, `Build all packages`, and `run test on all packages`. A dependency advisory failed the job and reported those three as **`skipped`, not run**.

So a red `lint-and-test` could mean *"nothing was built or tested"*, which is indistinguishable at a glance from a real test failure.

**This is not hypothetical.** While the audit gate was red on `develop`, two `apps/api` suites were failing to run outright and nobody could see it. The breakage dated to `81231022` (**2026-05-16**) and only surfaced two months later, once #1732 fixed the audit and CI finally reached the test step. That's the failure mode this PR removes.

## The change

Moves the step into its own `dependency-audit` job.

**The step body is byte-identical** — verified by `diff` against `develop`. The gate is exactly as strict:

- still a hard fail on HIGH/CRITICAL
- still the `ERR_PNPM_AUDIT_BAD_RESPONSE` graceful degradation for the retired npm endpoints
- **no** `continue-on-error`

What changes is only that a failing audit can no longer skip build and test, and the two now surface as **separate checks** so the cause is obvious from the checks list.

## The new job is nearly free

It deliberately does **not** run `pnpm install` — `pnpm audit` resolves from `pnpm-lock.yaml` alone. Verified by running it in a bare directory containing only `package.json`, `pnpm-lock.yaml` and `pnpm-workspace.yaml`: it completed in seconds and returned the same findings. So the job is checkout + pnpm + audit, and adds negligible load to the shared ARC pool despite being a second runner.

## The gate still discriminates

Worth proving rather than assuming, since a vacuously-passing gate would be worse than no gate:

| Command | Exit | Meaning |
|---|---|---|
| `pnpm audit --prod --audit-level=high` | **0** | current tree has 2 low + 11 moderate, no high/critical |
| `pnpm audit --prod --audit-level=moderate` | **1** | genuinely evaluating severity |

## Verification

`ci.yml` parses (js-yaml), and structurally asserted:

- jobs: `dependency-audit`, `lint-and-test`, `job-runtime-plugin-matrix`, `job-runtime-real-infra`, `secret-store-plugin-matrix`
- audit step present, **no** `continue-on-error`, still hard-exits on a real finding
- audit job does not install dependencies
- `lint-and-test` no longer audits, but still formats + builds + tests

Note `.yml` is not in CI's `format:check` glob (`ts,tsx,jsx,json,css,md`), and `develop`'s `ci.yml` was already prettier-dirty — so no formatting change is in scope here.

## Follow-up worth considering (not in this PR)

`develop` has no required status checks configured at all (`GET .../protection/required_status_checks` → 404), so every check — including this one — is advisory. Making `lint-and-test` and `dependency-audit` required would turn this new clarity into an actual gate. That's a branch-protection policy call, not a workflow change.
