### PR TITLE
chore: cascade stage -> main (agent_runs sweeper + CI audit job split)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,21 @@ env:
   NODE_OPTIONS: --max-old-space-size=6144
 
 jobs:
-  lint-and-test:
+  # Relocated out of `lint-and-test` (body unchanged). It used to run BEFORE
+  # `Check formatting` / `Build all packages` / `run test on all packages`, so a
+  # dependency advisory failed the job and reported those three as `skipped`
+  # rather than run. A red `lint-and-test` then meant "nothing was built or
+  # tested" — indistinguishable at a glance from a real test failure, which is
+  # how a broken spec sat unnoticed on develop for two months.
+  #
+  # As its own job the gate is exactly as strict (still a hard fail on
+  # HIGH/CRITICAL) but it can no longer mask the build/test signal, and the two
+  # surface as separate checks so the cause is obvious from the checks list.
+  #
+  # No `pnpm install` here on purpose: `pnpm audit` resolves from
+  # `pnpm-lock.yaml` alone, so this job is checkout + pnpm + audit.
+  dependency-audit:
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
-
-    strategy:
-      matrix:
-        node-version: [22.x]
 
     steps:
       - name: Checkout repository
@@ -45,14 +54,10 @@ jobs:
         with:
           version: 10.33.3
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js 22.x
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+          node-version: 22.x
 
       # H-15: fail the build if any production transitive dep has a HIGH or
       # CRITICAL vulnerability. The existing `pnpm.overrides` block proves
@@ -92,6 +97,33 @@ jobs:
           fi
           echo "::error title=Dependency audit failed::pnpm audit reported HIGH/CRITICAL production vulnerabilities (or an unexpected error). See the output above."
           exit "$code"
+
+  lint-and-test:
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v3
+        with:
+          version: 10.33.3
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Check formatting
         run: pnpm format:check

--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -19,6 +19,7 @@ jest.mock('@ever-works/agent/database', () => ({
 jest.mock('@ever-works/agent/agents', () => ({
     AgentScheduleDispatcherService: class AgentScheduleDispatcherService {},
     AgentRunService: class AgentRunService {},
+    AgentRunSweeperService: class AgentRunSweeperService {},
     AGENT_HEARTBEAT_TRIGGER: 'AGENT_HEARTBEAT_TRIGGER',
 }));
 jest.mock('@ever-works/agent/tasks-domain', () => ({

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -45,7 +45,11 @@ import {
 import { MissionTickService } from '@ever-works/agent/missions';
 import { IdeaBuildExecutorService } from '@ever-works/agent/work-agent';
 import { GoalEvaluationService } from '@ever-works/agent/goals';
-import { AgentRunService, AgentScheduleDispatcherService } from '@ever-works/agent/agents';
+import {
+    AgentRunService,
+    AgentRunSweeperService,
+    AgentScheduleDispatcherService,
+} from '@ever-works/agent/agents';
 import {
     TaskChatService,
     TaskRecurrenceDispatcherService,
@@ -255,6 +259,11 @@ export class TriggerInternalController implements OnModuleInit {
         @Optional()
         @Inject(forwardRef(() => WorkProposalsApiService))
         private readonly workProposalsApiService?: WorkProposalsApiService,
+        // Backs the `agent-run-sweeper` cron. Appended LAST and @Optional() so
+        // every positional `new TriggerInternalController(...)` in the specs
+        // keeps compiling — inserting mid-list silently shifts all later args.
+        @Optional()
+        private readonly agentRunSweeperService?: AgentRunSweeperService,
     ) {}
 
     onModuleInit() {
@@ -288,6 +297,7 @@ export class TriggerInternalController implements OnModuleInit {
             // Agents/Skills/Tasks PR #1017 — Phase 6. Exposed for the
             // agent-heartbeat dispatcher cron + agent-heartbeat one-shot.
             AgentScheduleDispatcherService: this.agentScheduleDispatcherService,
+            AgentRunSweeperService: this.agentRunSweeperService,
             AgentRunService: this.agentRunService,
             AgentRepository: this.agentRepositoryRef,
             AgentRunRepository: this.agentRunRepositoryRef,

--- a/packages/agent/src/agents/__tests__/agent-run-abort.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-abort.spec.ts
@@ -258,6 +258,19 @@ describe('AgentRunService — cooperative mid-run abort', () => {
         expect(runs.markFailed).not.toHaveBeenCalled();
     });
 
+    it('treats a swept (failed) run as a stop signal, not just a cancelled one', async () => {
+        // The stuck-run sweeper reaps abandoned rows to `failed`. If it ever
+        // lands on a worker that is somehow still alive, that worker must bail
+        // here — otherwise it runs to completion, applies its side effects, and
+        // only then discovers its terminal write no-ops against the CAS.
+        runs.findById
+            .mockResolvedValueOnce({ id: 'r1', status: 'running' })
+            .mockResolvedValue({ id: 'r1', status: 'failed' });
+        const result = await makeSvc().execute(baseContext);
+        expect(ai.dispatch).toHaveBeenCalledTimes(1);
+        expect(result.status).toBe('cancelled');
+    });
+
     it('proceeds normally when the status read throws', async () => {
         runs.findById.mockRejectedValue(new Error('DB down'));
         ai.dispatch.mockResolvedValue({

--- a/packages/agent/src/agents/__tests__/agent-run-sweeper.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-sweeper.service.spec.ts
@@ -1,0 +1,181 @@
+import { AgentRunSweeperService, STUCK_SWEEP_PREFIX } from '../agent-run-sweeper.service';
+
+/**
+ * Stuck-run sweeper.
+ *
+ * Two tests here carry the entire safety argument and are called out inline:
+ * one proves the sweep actually reaps (a no-op implementation would pass every
+ * other test in this file), the other proves a live run is NOT reaped.
+ */
+describe('AgentRunSweeperService', () => {
+    const ENV_KEYS = [
+        'AGENT_RUN_SWEEPER_ENABLED',
+        'AGENT_RUN_STUCK_SWEEP_MINUTES',
+        'AGENT_RUN_STUCK_SWEEP_BATCH',
+        'AGENT_MAX_RUN_DURATION_SECONDS',
+    ];
+    let saved: Record<string, string | undefined>;
+    let runs: any;
+    let warn: jest.SpyInstance;
+
+    function makeSvc(): AgentRunSweeperService {
+        const svc = new AgentRunSweeperService(runs);
+        warn = jest.spyOn((svc as never as { logger: { warn: () => void } }).logger, 'warn');
+        warn.mockImplementation(() => undefined);
+        jest.spyOn(
+            (svc as never as { logger: { log: () => void } }).logger,
+            'log',
+        ).mockImplementation(() => undefined);
+        return svc;
+    }
+
+    function stuckRow(over: Record<string, unknown> = {}) {
+        return {
+            id: 'r1',
+            agentId: 'a1',
+            triggerKind: 'task',
+            status: 'running',
+            startedAt: new Date(Date.now() - 24 * 60 * 60_000),
+            createdAt: new Date(Date.now() - 24 * 60 * 60_000),
+            ...over,
+        };
+    }
+
+    beforeEach(() => {
+        saved = {};
+        for (const k of ENV_KEYS) {
+            saved[k] = process.env[k];
+            delete process.env[k];
+        }
+        runs = {
+            findStuckNonTerminal: jest.fn().mockResolvedValue([]),
+            markStuckFailed: jest.fn().mockResolvedValue(0),
+        };
+    });
+
+    afterEach(() => {
+        for (const k of ENV_KEYS) {
+            if (saved[k] === undefined) delete process.env[k];
+            else process.env[k] = saved[k];
+        }
+        jest.restoreAllMocks();
+    });
+
+    it('⭐ reaps a run older than the cutoff', async () => {
+        // THE NO-OP CATCHER. An implementation that returns { swept: 0 }
+        // unconditionally passes every safety test in this file — only this
+        // one fails it.
+        runs.findStuckNonTerminal.mockResolvedValue([stuckRow()]);
+        runs.markStuckFailed.mockResolvedValue(1);
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary.swept).toBe(1);
+        expect(runs.markStuckFailed).toHaveBeenCalledWith(['r1'], expect.any(String));
+    });
+
+    it('⭐ uses a cutoff far longer than the longest agent run, so a live run is never reaped', async () => {
+        // THE LIVE-RUN TEST. agent-task-execute pins maxDuration 3600s, so a
+        // cutoff at or below 60m could reap a run that is still executing —
+        // destroying its result while its side effects still fire. This line
+        // fails loudly if anyone "simplifies" the config to reuse
+        // getStuckTimeoutMinutes() (60m).
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary.cutoffMinutes).toBeGreaterThan(60);
+
+        const cutoff: Date = runs.findStuckNonTerminal.mock.calls[0][0];
+        const ageMinutes = (Date.now() - cutoff.getTime()) / 60_000;
+        expect(ageMinutes).toBeGreaterThan(60);
+        expect(Math.round(ageMinutes)).toBe(summary.cutoffMinutes);
+    });
+
+    it('clamps a dangerously low configured cutoff up to the retry-chain floor', async () => {
+        // Without the floor clamp this silently reintroduces the exact bug the
+        // previous test guards against.
+        process.env.AGENT_RUN_STUCK_SWEEP_MINUTES = '5';
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary.cutoffMinutes).toBeGreaterThanOrEqual(180);
+    });
+
+    it('sweeps a queued row that never started, keyed on createdAt', async () => {
+        runs.findStuckNonTerminal.mockResolvedValue([
+            stuckRow({ status: 'queued', startedAt: null, triggerKind: 'heartbeat' }),
+        ]);
+        runs.markStuckFailed.mockResolvedValue(1);
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary.swept).toBe(1);
+        expect(summary.byKind).toEqual({ heartbeat: 1 });
+    });
+
+    it('reports what the CAS actually transitioned, not the number scanned', async () => {
+        // A worker that finished in the gap wins the CAS. Reporting ids.length
+        // would overstate every sweep that loses that race.
+        runs.findStuckNonTerminal.mockResolvedValue([
+            stuckRow({ id: 'r1' }),
+            stuckRow({ id: 'r2' }),
+            stuckRow({ id: 'r3' }),
+        ]);
+        runs.markStuckFailed.mockResolvedValue(1);
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary.scanned).toBe(3);
+        expect(summary.swept).toBe(1);
+    });
+
+    it('uses a distinct errorMessage prefix that cannot collide with the dispatch prefixes', async () => {
+        runs.findStuckNonTerminal.mockResolvedValue([stuckRow()]);
+        runs.markStuckFailed.mockResolvedValue(1);
+        await makeSvc().sweepStuckRuns();
+        const message: string = runs.markStuckFailed.mock.calls[0][1];
+        expect(message).toContain(STUCK_SWEEP_PREFIX);
+        // Existing specs pin these with toContain — a collision would make them
+        // pass against a swept run.
+        expect(message).not.toContain('dispatch-failed');
+        expect(message).not.toContain('enqueue-failed');
+    });
+
+    it('flags a full batch loudly instead of truncating silently', async () => {
+        process.env.AGENT_RUN_STUCK_SWEEP_BATCH = '2';
+        runs.findStuckNonTerminal.mockResolvedValue([
+            stuckRow({ id: 'r1' }),
+            stuckRow({ id: 'r2' }),
+        ]);
+        runs.markStuckFailed.mockResolvedValue(2);
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary.batchLimitReached).toBe(true);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('batch limit'));
+    });
+
+    it('does nothing and touches no rows when disabled', async () => {
+        process.env.AGENT_RUN_SWEEPER_ENABLED = 'false';
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary).toEqual(expect.objectContaining({ enabled: false, swept: 0 }));
+        expect(runs.findStuckNonTerminal).not.toHaveBeenCalled();
+        expect(runs.markStuckFailed).not.toHaveBeenCalled();
+    });
+
+    it('stays quiet when nothing is stuck', async () => {
+        // Prevents WARN-noise regression: the warn is the anomaly signal, so it
+        // must not fire on the common path.
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary.swept).toBe(0);
+        expect(warn).not.toHaveBeenCalled();
+        expect(runs.markStuckFailed).not.toHaveBeenCalled();
+    });
+
+    it('reports oldest age and per-kind counts so an operator can triage', async () => {
+        runs.findStuckNonTerminal.mockResolvedValue([
+            stuckRow({
+                id: 'r1',
+                triggerKind: 'task',
+                startedAt: new Date(Date.now() - 90 * 60_000),
+            }),
+            stuckRow({
+                id: 'r2',
+                triggerKind: 'chat',
+                startedAt: new Date(Date.now() - 600 * 60_000),
+            }),
+        ]);
+        runs.markStuckFailed.mockResolvedValue(2);
+        const summary = await makeSvc().sweepStuckRuns();
+        expect(summary.byKind).toEqual({ task: 1, chat: 1 });
+        expect(Math.round((summary.oldestAgeMs ?? 0) / 60_000)).toBe(600);
+    });
+});

--- a/packages/agent/src/agents/agent-run-abort.ts
+++ b/packages/agent/src/agents/agent-run-abort.ts
@@ -107,7 +107,13 @@ export function createAgentRunAbortSource(
             } catch {
                 return;
             }
-            if (status === 'cancelled') {
+            // `failed` counts as a stop signal too, not just `cancelled`: the
+            // stuck-run sweeper reaps abandoned rows to `failed`, and if it
+            // ever lands on a worker that is somehow still alive, that worker
+            // must bail here rather than run to completion and then discover
+            // its terminal write no-ops against the CAS — having already
+            // applied the side effects.
+            if (status === 'cancelled' || status === 'failed') {
                 latched = true;
                 throw createGenerationCancelledError();
             }

--- a/packages/agent/src/agents/agent-run-sweeper.service.ts
+++ b/packages/agent/src/agents/agent-run-sweeper.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { config } from '../config';
+import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+
+/**
+ * Error message prefix for a swept run.
+ *
+ * Deliberately distinct from `dispatch-failed:` and `enqueue-failed:` and
+ * containing neither substring, so the existing specs that pin those (all
+ * `toContain`/`stringContaining`) cannot collide with it. Kept short because it
+ * renders as the user-facing cell in the Activity tab — a swept run has no
+ * `summary`, so this string is what the user reads.
+ */
+export const STUCK_SWEEP_PREFIX = 'stuck-timeout';
+
+export interface AgentRunSweepSummary {
+    enabled: boolean;
+    cutoffMinutes: number;
+    /** Rows matching the stuck predicate this tick (bounded by the batch size). */
+    scanned: number;
+    /** Rows actually transitioned. Lower than `scanned` when a worker won the CAS race. */
+    swept: number;
+    /** True when the batch filled — more stuck rows remain for the next tick. */
+    batchLimitReached: boolean;
+    oldestAgeMs: number | null;
+    byKind: Record<string, number>;
+}
+
+/**
+ * Reaps `agent_runs` rows abandoned by a worker that died without reaching any
+ * checkpoint. Nothing else does: `recoverStuckRunning()` sweeps `agents` rows
+ * only, so a hard-killed run sat in `queued`/`running` forever and kept
+ * `findInFlightForTaskAgent` suppressing dispatch for that task-agent pair.
+ *
+ * 🛑 The cutoff is intentionally measured in HOURS, and must stay that way.
+ * `apps/web/e2e/flow-agent-runs-pagination.spec.ts` asserts on failed runs with
+ * a null `startedAt`; a swept `running` row has `startedAt` set, so lowering
+ * the cutoff to test-visible durations — or exposing this sweep on an
+ * e2e-reachable HTTP route — would make that spec flaky for a real reason.
+ *
+ * Safety rests on more than the cutoff. The worker also honours
+ * `markStarted`'s CAS result and treats a `failed` status as an abort signal at
+ * its next checkpoint, so even in the impossible case where a sweep lands on a
+ * live run, the worker bails before applying side effects.
+ */
+@Injectable()
+export class AgentRunSweeperService {
+    private readonly logger = new Logger(AgentRunSweeperService.name);
+
+    constructor(private readonly runs: AgentRunRepository) {}
+
+    /**
+     * Zero-arg by design: the worker resolves this service as a superjson RPC
+     * proxy, so arguments would have to survive serialization. Everything it
+     * needs comes from config.
+     */
+    async sweepStuckRuns(): Promise<AgentRunSweepSummary> {
+        const cutoffMinutes = config.agents.getRunStuckSweepMinutes();
+        const empty: AgentRunSweepSummary = {
+            enabled: true,
+            cutoffMinutes,
+            scanned: 0,
+            swept: 0,
+            batchLimitReached: false,
+            oldestAgeMs: null,
+            byKind: {},
+        };
+
+        if (!config.agents.getRunSweeperEnabled()) {
+            this.logger.log('AgentRun sweeper disabled (AGENT_RUN_SWEEPER_ENABLED=false)');
+            return { ...empty, enabled: false };
+        }
+
+        const limit = config.agents.getRunStuckSweepBatch();
+        const now = Date.now();
+        const cutoff = new Date(now - cutoffMinutes * 60_000);
+
+        const stuck = await this.runs.findStuckNonTerminal(cutoff, limit);
+        if (stuck.length === 0) {
+            // Logged even on zero so the ABSENCE of sweeps is positively
+            // confirmed rather than inferred from silence.
+            this.logger.log(`AgentRun sweep: none stuck (cutoff ${cutoffMinutes}m)`);
+            return empty;
+        }
+
+        const byKind: Record<string, number> = {};
+        let oldestAgeMs = 0;
+        for (const row of stuck) {
+            byKind[row.triggerKind] = (byKind[row.triggerKind] ?? 0) + 1;
+            const at = (row.startedAt ?? row.createdAt)?.getTime?.();
+            if (typeof at === 'number') oldestAgeMs = Math.max(oldestAgeMs, now - at);
+        }
+
+        const swept = await this.runs.markStuckFailed(
+            stuck.map((r) => r.id),
+            `${STUCK_SWEEP_PREFIX}: no worker checkpoint for ${cutoffMinutes}m`,
+        );
+
+        const batchLimitReached = stuck.length >= limit;
+        // Every non-zero sweep is an anomaly — a worker died. Loud on purpose:
+        // a silent sweeper hides the upstream failure it is compensating for.
+        // The per-kind breakdown is what separates "one node was evicted" from
+        // "agent-task-execute is systematically dying".
+        this.logger.warn(
+            `AgentRun sweep: reaped ${swept}/${stuck.length} stuck run(s) — ` +
+                `cutoff=${cutoffMinutes}m oldest=${Math.round(oldestAgeMs / 60_000)}m ` +
+                `byKind=${JSON.stringify(byKind)} ids=${JSON.stringify(
+                    stuck.slice(0, 20).map((r) => r.id),
+                )}`,
+        );
+        if (batchLimitReached) {
+            // Never truncate silently — that is how a backlog never drains and
+            // nobody notices.
+            this.logger.warn(
+                `AgentRun sweep: batch limit ${limit} reached — more stuck runs remain, next tick will continue`,
+            );
+        }
+
+        return {
+            enabled: true,
+            cutoffMinutes,
+            scanned: stuck.length,
+            swept,
+            batchLimitReached,
+            oldestAgeMs,
+            byKind,
+        };
+    }
+}

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -21,6 +21,7 @@ import { AgentAttachmentRepository } from '../database/repositories/attachment.r
 import { AgentsService } from './agents.service';
 import { AgentFileService } from './agent-file.service';
 import { AgentScheduleDispatcherService } from './agent-schedule-dispatcher.service';
+import { AgentRunSweeperService } from './agent-run-sweeper.service';
 import { AgentExportService } from './agent-export.service';
 import { PromptAssemblerService } from './prompt-assembler.service';
 import { AgentRunService } from './agent-run.service';
@@ -82,6 +83,7 @@ import { FacadesModule } from '../facades/facades.module';
         AgentsService,
         AgentFileService,
         AgentScheduleDispatcherService,
+        AgentRunSweeperService,
         AgentExportService,
         PromptAssemblerService,
         // PR-6 — company-vision prompt context for AgentRunService's
@@ -100,6 +102,7 @@ import { FacadesModule } from '../facades/facades.module';
         AgentsService,
         AgentFileService,
         AgentScheduleDispatcherService,
+        AgentRunSweeperService,
         AgentExportService,
         PromptAssemblerService,
         AgentRunService,

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -9,6 +9,7 @@ export * from './prompt-assembler.service';
 export * from './agent-run.service';
 export * from './agent-run-canceller';
 export * from './agent-run-abort';
+export * from './agent-run-sweeper.service';
 export * from './agent-run-post-processor';
 export * from './agent-ai-dispatch-facade';
 export * from './agent-git-facade';

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -496,6 +496,49 @@ export const config = {
             const raw = parseInt(process.env.AGENT_MAX_RUN_DURATION_SECONDS || '1800', 10);
             return Number.isFinite(raw) && raw > 0 ? raw : 1800;
         },
+        /** Kill switch for the agent_runs stuck-run sweeper. Default on. */
+        getRunSweeperEnabled() {
+            return process.env.AGENT_RUN_SWEEPER_ENABLED !== 'false';
+        },
+        /**
+         * Age past which a `queued`/`running` AgentRun is considered abandoned.
+         *
+         * Deliberately generous, because the two error costs are wildly
+         * asymmetric. Sweeping too LATE means one task-agent pair cannot
+         * dispatch for a few extra hours — recoverable. Sweeping too EARLY
+         * destroys a live run's real result: the row reads `failed`, the
+         * worker's `markCompleted` then no-ops against the CAS, and the user
+         * sees the sweeper's message in the Activity tab where the summary
+         * should be. That is unrecoverable, and it manufactures exactly the
+         * class of corruption the terminal-transition CAS exists to prevent.
+         *
+         * Derived from the run-duration ceiling rather than hard-coded, so it
+         * self-corrects if that ceiling is raised. The ceiling is the largest
+         * `maxDuration` across the three agent tasks (agent-task-execute pins
+         * 3600s), not just this config's value.
+         *
+         * The floor clamp is the most important line here: a worker may burn
+         * up to 3 attempts, so anything below 3x the ceiling can reap a run
+         * that is legitimately still retrying. Without the clamp,
+         * `AGENT_RUN_STUCK_SWEEP_MINUTES=30` would silently reintroduce that.
+         */
+        getRunStuckSweepMinutes() {
+            const ceilingMinutes = Math.ceil(Math.max(3600, this.getMaxRunDurationSeconds()) / 60);
+            const floor = ceilingMinutes * 3;
+            const raw = parseInt(process.env.AGENT_RUN_STUCK_SWEEP_MINUTES || '', 10);
+            const configured = Number.isFinite(raw) && raw > 0 ? raw : ceilingMinutes * 6;
+            return Math.max(floor, configured);
+        },
+        /**
+         * Rows swept per tick. Bounded on purpose — `agent_runs` is the
+         * high-cardinality child table, and a post-outage backlog is precisely
+         * when this runs. Successive ticks drain; there is no pagination loop,
+         * so a runaway predicate cannot become an unbounded write storm.
+         */
+        getRunStuckSweepBatch() {
+            const raw = parseInt(process.env.AGENT_RUN_STUCK_SWEEP_BATCH || '200', 10);
+            return Number.isFinite(raw) && raw > 0 ? raw : 200;
+        },
     },
 
     /**

--- a/packages/agent/src/database/repositories/agent-run.repository.spec.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.spec.ts
@@ -14,6 +14,11 @@ describe('AgentRunRepository — terminal transitions', () => {
         where: jest.Mock;
         andWhere: jest.Mock;
         execute: jest.Mock;
+        // Sweep path: findStuckNonTerminal is a SELECT terminating in getMany.
+        select: jest.Mock;
+        orderBy: jest.Mock;
+        limit: jest.Mock;
+        getMany: jest.Mock;
     };
     let repository: {
         findOne: jest.Mock;
@@ -37,6 +42,10 @@ describe('AgentRunRepository — terminal transitions', () => {
             where: jest.fn().mockReturnThis(),
             andWhere: jest.fn().mockReturnThis(),
             execute: jest.fn().mockResolvedValue({ affected: 1 }),
+            select: jest.fn().mockReturnThis(),
+            orderBy: jest.fn().mockReturnThis(),
+            limit: jest.fn().mockReturnThis(),
+            getMany: jest.fn().mockResolvedValue([]),
         };
         repository = {
             // startedAt drives durationMs; null keeps the arithmetic out of the way.
@@ -213,6 +222,50 @@ describe('AgentRunRepository — terminal transitions', () => {
         it('reports found:false without a triggerRunId for an unknown run', async () => {
             repository.findOne.mockResolvedValue(null);
             await expect(runs.cancel('r1', 'u1')).resolves.toEqual({ found: false });
+        });
+    });
+
+    describe('stuck-run sweep', () => {
+        it('scans both non-terminal statuses on an age predicate that covers queued and running', async () => {
+            const cutoff = new Date('2026-01-01T00:00:00Z');
+            await runs.findStuckNonTerminal(cutoff, 200);
+            // This is a SELECT, so the status filter is the leading `where`,
+            // not an `andWhere` like the CAS updates — statusGuard() would miss it.
+            const whereCall = queryBuilder.where.mock.calls.find(([sql]) =>
+                String(sql).includes('status IN'),
+            );
+            expect(whereCall?.[1]?.statuses).toEqual(['queued', 'running']);
+            // COALESCE, because startedAt is NULL while queued — one predicate
+            // must cover both statuses or the queued half is never swept.
+            expect(
+                queryBuilder.andWhere.mock.calls.some(([sql]) => String(sql).includes('COALESCE')),
+            ).toBe(true);
+            expect(queryBuilder.limit).toHaveBeenCalledWith(200);
+        });
+
+        it('CAS-guards the bulk update so a run that finished first is never re-stamped', async () => {
+            queryBuilder.execute.mockResolvedValue({ affected: 2 });
+            await runs.markStuckFailed(['r1', 'r2'], 'stuck-timeout: x');
+            expect(statusGuard()).toEqual(['queued', 'running']);
+            expect(queryBuilder.set).toHaveBeenCalledWith(
+                expect.objectContaining({ status: 'failed', errorMessage: 'stuck-timeout: x' }),
+            );
+        });
+
+        it('returns rows actually affected, not the number of ids passed', async () => {
+            // A worker winning the race must not be counted as swept.
+            queryBuilder.execute.mockResolvedValue({ affected: 1 });
+            await expect(
+                runs.markStuckFailed(['r1', 'r2', 'r3'], 'stuck-timeout: x'),
+            ).resolves.toBe(1);
+        });
+
+        it('issues no query at all for an empty id list', async () => {
+            // TypeORM renders `IN (:...ids)` as invalid SQL for an empty array,
+            // so this is a runtime break, not a compile one.
+            repository.createQueryBuilder.mockClear();
+            await expect(runs.markStuckFailed([], 'stuck-timeout: x')).resolves.toBe(0);
+            expect(repository.createQueryBuilder).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -160,6 +160,73 @@ export class AgentRunRepository {
         return { found: true, previousStatus: run.status, triggerRunId: run.triggerRunId };
     }
 
+    /**
+     * Rows abandoned by a worker that died without reaching any checkpoint —
+     * OOM, node eviction, deploy, Trigger.dev teardown. Nothing else reaps
+     * them: `recoverStuckRunning()` operates exclusively on `agents` rows.
+     *
+     * Left alone they stay `queued`/`running` forever, and
+     * {@link findInFlightForTaskAgent} keeps treating them as in-flight — which
+     * permanently suppresses dispatch for that task-agent pair. That is the
+     * same user-visible bug as an orphaned queued run, reached by a different
+     * route.
+     *
+     * `COALESCE(startedAt, createdAt)` covers both statuses in one predicate:
+     * `startedAt` is NULL while queued, and {@link markStarted} is provably the
+     * only writer of `status='running'` and sets both in one atomic UPDATE, so
+     * `running` implies `startedAt IS NOT NULL` with no torn window. The
+     * COALESCE is also defence against a future second writer.
+     *
+     * Bounded by `limit` on purpose — see {@link markStuckFailed}.
+     */
+    async findStuckNonTerminal(
+        cutoff: Date,
+        limit: number,
+    ): Promise<
+        Pick<AgentRun, 'id' | 'agentId' | 'triggerKind' | 'status' | 'startedAt' | 'createdAt'>[]
+    > {
+        return this.repository
+            .createQueryBuilder('run')
+            .select([
+                'run.id',
+                'run.agentId',
+                'run.triggerKind',
+                'run.status',
+                'run.startedAt',
+                'run.createdAt',
+            ])
+            .where('run.status IN (:...statuses)', { statuses: NON_TERMINAL })
+            .andWhere('COALESCE(run.startedAt, run.createdAt) <= :cutoff', { cutoff })
+            .orderBy('COALESCE(run.startedAt, run.createdAt)', 'ASC')
+            .limit(limit)
+            .getMany();
+    }
+
+    /**
+     * Bulk-reap the ids returned by {@link findStuckNonTerminal}.
+     *
+     * One statement, CAS-guarded on `queued|running`, so a worker that finished
+     * in the gap between the select and this update keeps its result — the row
+     * simply is not counted. Returns `affected`, NOT `runIds.length`: reporting
+     * the input size would overstate the sweep every time that race is lost.
+     *
+     * `durationMs` is deliberately left NULL. It cannot be computed in a bulk
+     * statement, and NULL is the honest value for "we do not know when this
+     * died" — nothing branches on it.
+     */
+    async markStuckFailed(runIds: string[], errorMessage: string): Promise<number> {
+        // TypeORM renders `IN (:...ids)` as invalid SQL for an empty array.
+        if (runIds.length === 0) return 0;
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({ status: 'failed', finishedAt: new Date(), errorMessage })
+            .where('id IN (:...runIds)', { runIds })
+            .andWhere('status IN (:...statuses)', { statuses: NON_TERMINAL })
+            .execute();
+        return result.affected ?? 0;
+    }
+
     async createQueued(args: {
         agentId: string;
         userId: string;
@@ -207,9 +274,11 @@ export class AgentRunRepository {
      *
      * That mattered little while cancel was DB-only, but now that cancelling
      * actually kills the Trigger.dev run, losing this race would strand the
-     * row in `running` with no worker alive to finalize it — and there is no
-     * `agent_runs` sweeper to reap it. Returns whether the claim succeeded so
-     * the worker can bail instead of executing a cancelled run.
+     * row in `running` with no worker alive to finalize it. {@link findStuckNonTerminal}
+     * + {@link markStuckFailed} now reap such rows, but only after hours — the
+     * CAS is what keeps the row correct in the meantime. Returns whether the
+     * claim succeeded so the worker can bail instead of executing a run that
+     * was cancelled or swept.
      *
      * Allows `queued|running` (NOT queued-only): heartbeat re-resolves an
      * already-`running` row via `findInFlightForAgent` on retry, and a
@@ -250,9 +319,10 @@ export class AgentRunRepository {
      *    `failed` or `completed`, because cancelling does not stop the worker.
      *
      * Same CAS-style WHERE clause {@link cancel} already uses. Returns whether
-     * the row was actually transitioned so callers can report a no-op: there is
-     * NO `agent_runs` sweeper (`recoverStuckRunning()` only touches `agents`
-     * rows), so a silent miss would be both unrecoverable and invisible.
+     * the row was actually transitioned so callers can report a no-op. The
+     * `agent_runs` sweeper ({@link markStuckFailed}) only reaps rows that are
+     * hours old, so within a normal run a silent miss here is still effectively
+     * unrecoverable and invisible — keep reporting it.
      *
      * The `durationMs` read stays non-atomic on purpose (applies equally to
      * `markFailed` and `markCompleted`). `startedAt` is read before the CAS

--- a/packages/tasks/src/__tests__/agent-heartbeat-cancel.task.spec.ts
+++ b/packages/tasks/src/__tests__/agent-heartbeat-cancel.task.spec.ts
@@ -157,6 +157,18 @@ describe('agentHeartbeatTask — cancelled run accounting', () => {
         );
     });
 
+    it('abandons the run when markStarted loses the CAS, without executing', async () => {
+        // The row went terminal first — a user cancel, or the stuck-run sweeper
+        // reaping it. Executing anyway burns the work and then loses it, because
+        // the terminal write at the end no-ops against the same guard.
+        runs.markStarted.mockResolvedValueOnce(false);
+
+        const result = await registeredConfig.run(payload, { ctx: { run: { id: 'run_abc' } } });
+
+        expect(runner.execute).not.toHaveBeenCalled();
+        expect(result).toEqual(expect.objectContaining({ reason: 'run-already-terminal' }));
+    });
+
     it('still releases a completed run as completed', async () => {
         runner.execute.mockResolvedValueOnce({ status: 'dispatched' });
 

--- a/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
+++ b/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
@@ -120,7 +120,8 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
             findById: vi.fn().mockResolvedValue(null),
             findInFlightForTaskAgent: vi.fn().mockResolvedValue(null),
             createQueued: vi.fn().mockResolvedValue({ id: 'run-1' }),
-            markStarted: vi.fn().mockResolvedValue(undefined),
+            // Returns the CAS result — the task bails when the claim is lost.
+            markStarted: vi.fn().mockResolvedValue(true),
             markCompleted: vi.fn().mockResolvedValue(undefined),
             markFailed: vi.fn().mockResolvedValue(undefined),
         };

--- a/packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts
@@ -143,7 +143,16 @@ export const agentChatReplyTask = task<'agent-chat-reply', AgentChatReplyPayload
                 });
             }
 
-            await runs.markStarted(run.id, ctx?.run?.id ?? null);
+            const claimed = await runs.markStarted(run.id, ctx?.run?.id ?? null);
+            // Honour the CAS: markStarted returns false when the row went terminal
+            // first — a user cancel, or the stuck-run sweeper reaping it. Executing
+            // anyway would burn the work and then lose it, because the terminal
+            // write at the end no-ops against the same guard. No behaviour change on
+            // the happy path: the CAS allows queued|running, so a legitimate retry
+            // re-claiming an already-running row still returns true.
+            if (!claimed) {
+                return { status: 'skipped', reason: 'run-already-terminal', runId: run.id };
+            }
 
             const [taskRow, messages] = await Promise.all([
                 tasks.getOne(payload.userId, payload.taskId).catch(() => null),

--- a/packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts
@@ -137,7 +137,16 @@ export const agentHeartbeatTask = task<'agent-heartbeat', AgentHeartbeatPayload>
                 });
             }
 
-            await runs.markStarted(run.id, ctx?.run?.id ?? null);
+            const claimed = await runs.markStarted(run.id, ctx?.run?.id ?? null);
+            // Honour the CAS: markStarted returns false when the row went terminal
+            // first — a user cancel, or the stuck-run sweeper reaping it. Executing
+            // anyway would burn the work and then lose it, because the terminal
+            // write at the end no-ops against the same guard. No behaviour change on
+            // the happy path: the CAS allows queued|running, so a legitimate retry
+            // re-claiming an already-running row still returns true.
+            if (!claimed) {
+                return { status: 'skipped', reason: 'run-already-terminal', runId: run.id };
+            }
             const result = await runner.execute({
                 runId: run.id,
                 agentId: agent.id,

--- a/packages/tasks/src/tasks/trigger/agent-run-sweeper.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-run-sweeper.task.ts
@@ -1,0 +1,70 @@
+import { logger, schedules } from '@trigger.dev/sdk';
+import { AgentRunSweeperService } from '@ever-works/agent/agents';
+import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
+import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+
+/**
+ * Stuck-run sweep for `agent_runs`.
+ *
+ * A worker killed without reaching any checkpoint — OOM, node eviction,
+ * deploy, Trigger.dev teardown — leaves its row in `queued`/`running` forever.
+ * Nothing reaped it: `AgentScheduleDispatcherService.recoverStuckRunning()`
+ * sweeps `agents` rows only. The stranded row then keeps
+ * `findInFlightForTaskAgent` reporting an in-flight run, which permanently
+ * suppresses dispatch for that task-agent pair.
+ *
+ * Its own schedule rather than a step inside the heartbeat dispatcher, mirroring
+ * `kb-reconcile` (the same job for a different table). Three reasons:
+ *
+ *   1. The dispatcher runs every minute against a multi-hour cutoff — ~360x
+ *      more often than useful.
+ *   2. `agent-heartbeat-dispatcher` has no upper clamp on its interval, so a
+ *      large `AGENT_DISPATCH_INTERVAL_MINUTES` would silently disable a
+ *      piggybacked sweep.
+ *   3. A reap is a signal that something upstream died. Buried inside one of
+ *      ~1440 daily dispatcher ticks it is invisible; with its own task id it
+ *      has its own run history.
+ *
+ * It also keeps firing when `AGENTS_DISPATCHER_ENABLED=false`, which is exactly
+ * when rows are most likely to be stranded.
+ *
+ * Cron offset off the hour, per the `kb-reconcile` rationale, so it does not
+ * collide with `anonymous-user-cleanup` (03:17) or the per-minute crons. Every
+ * 2h against a multi-hour cutoff bounds detection lag to `cutoff + 2h`.
+ */
+export const agentRunSweeperTask = schedules.task({
+    id: 'agent-run-sweeper',
+    cron: '23 */2 * * *',
+    run: async () => {
+        // NOTE the third argument. `withWorkerContext` defaults to
+        // `TriggerWorkerModule`, which does NOT register the
+        // AgentRunSweeperService remote proxy — omitting it fails at runtime
+        // on every fire, silently, forever.
+        return withWorkerContext(
+            'AgentRunSweeper',
+            async (appContext) => {
+                const svc = appContext.get(AgentRunSweeperService);
+                const summary = await svc.sweepStuckRuns();
+
+                if (summary.swept > 0) {
+                    logger.warn('agent-run-sweeper reaped stuck runs', {
+                        swept: summary.swept,
+                        scanned: summary.scanned,
+                        cutoffMinutes: summary.cutoffMinutes,
+                        oldestAgeMs: summary.oldestAgeMs,
+                        byKind: summary.byKind,
+                        batchLimitReached: summary.batchLimitReached,
+                    });
+                } else {
+                    logger.info('agent-run-sweeper found nothing stuck', {
+                        enabled: summary.enabled,
+                        cutoffMinutes: summary.cutoffMinutes,
+                    });
+                }
+
+                return { status: 'completed' as const, ...summary };
+            },
+            TriggerInternalModule,
+        );
+    },
+});

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -177,7 +177,16 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 });
             }
 
-            await runs.markStarted(run.id, ctx?.run?.id ?? null);
+            const claimed = await runs.markStarted(run.id, ctx?.run?.id ?? null);
+            // Honour the CAS: markStarted returns false when the row went terminal
+            // first — a user cancel, or the stuck-run sweeper reaping it. Executing
+            // anyway would burn the work and then lose it, because the terminal
+            // write at the end no-ops against the same guard. No behaviour change on
+            // the happy path: the CAS allows queued|running, so a legitimate retry
+            // re-claiming an already-running row still returns true.
+            if (!claimed) {
+                return { status: 'skipped', reason: 'run-already-terminal', runId: run.id };
+            }
 
             // `taskRow` was resolved above (owner-scoped) before any run
             // mutation; it is guaranteed non-null here.

--- a/packages/tasks/src/tasks/trigger/index.ts
+++ b/packages/tasks/src/tasks/trigger/index.ts
@@ -6,6 +6,7 @@ export * from './kb-embed-document.task';
 export * from './kb-mirror-document.task';
 export * from './kb-org-overlay-fanout.task';
 export * from './kb-reconcile.task';
+export * from './agent-run-sweeper.task';
 export * from './user-research-rerun-dispatcher.task';
 export * from './mission-tick.task';
 // PR-4 — Idea → Work build executor (flag-gated, dry-run by default).

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -9,7 +9,11 @@ import {
 import { MissionTickService } from '@ever-works/agent/missions';
 import { IdeaBuildExecutorService } from '@ever-works/agent/work-agent';
 import { GoalEvaluationService } from '@ever-works/agent/goals';
-import { AgentRunService, AgentScheduleDispatcherService } from '@ever-works/agent/agents';
+import {
+    AgentRunService,
+    AgentRunSweeperService,
+    AgentScheduleDispatcherService,
+} from '@ever-works/agent/agents';
 import {
     TaskChatService,
     TaskRecurrenceDispatcherService,
@@ -98,6 +102,13 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
                 createRemoteProxy(apiClient, 'AgentScheduleDispatcherService'),
             inject: [TriggerInternalApiClient],
         },
+        // Backs the `agent-run-sweeper` cron task.
+        {
+            provide: AgentRunSweeperService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'AgentRunSweeperService'),
+            inject: [TriggerInternalApiClient],
+        },
         {
             provide: AgentRunService,
             useFactory: (apiClient: TriggerInternalApiClient) =>
@@ -181,6 +192,7 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         IdeaBuildExecutorService,
         GoalEvaluationService,
         AgentScheduleDispatcherService,
+        AgentRunSweeperService,
         AgentRunService,
         AgentRepository,
         AgentRunRepository,


### PR DESCRIPTION
Cascade of #1759 and #1757, completing develop -> stage -> main.

The sweeper reaps AgentRuns abandoned by a dead worker, which previously sat in queued/running forever and suppressed dispatch for that task-agent pair. Ships with two interlocks (tasks honour markStarted's CAS result; the abort latch treats failed as a stop signal) so a sweep cannot corrupt a live run.

The CI change moves the dependency audit into its own job so an advisory can no longer report format/build/test as skipped.

Cascaded whole; no cherry-picking.

Verified: packages/agent 336 suites / 6579 tests, packages/tasks 23 files / 373 tests, apps/api 194 suites / 3285 tests, both type-checks clean, prettier clean.