### PR TITLE
chore(ci): gate the legacy Trigger.dev CLOUD dev deploy behind TRIGGER_SELFHOSTED

### DIFF
--- a/.github/workflows/release-trigger-dev.yml
+++ b/.github/workflows/release-trigger-dev.yml
@@ -13,6 +13,14 @@ permissions:
 
 jobs:
   deploy:
+    # Legacy Trigger.dev CLOUD path. Unlike release-trigger-{prod,stage}.yml this
+    # job was left ungated when we migrated to self-hosted, so it kept running on
+    # every develop push and authenticating to Trigger.dev CLOUD with the cloud
+    # PAT (secrets.TRIGGER_ACCESS_TOKEN) — the one workload still reaching the
+    # cloud account we are closing. Gated here on the same flag the prod/stage
+    # workflows already use, so it is inert while TRIGGER_SELFHOSTED=true.
+    # Flip the flag back to re-enable this cloud path.
+    if: ${{ vars.TRIGGER_SELFHOSTED != 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev


### PR DESCRIPTION
## Why

`release-trigger-prod.yml` and `release-trigger-stage.yml` were both gated with `if: ${{ vars.TRIGGER_SELFHOSTED != 'true' }}` when we migrated to self-hosted Trigger.dev. **`release-trigger-dev.yml` was left ungated.**

`TRIGGER_SELFHOSTED=true` is set at repo level, so prod and stage are correctly inert — but the dev workflow still fires on every CI run over `develop` and runs:

```yaml
env:
  TRIGGER_ACCESS_TOKEN: ${{ secrets.TRIGGER_ACCESS_TOKEN }}   # CLOUD PAT
run: pnpm dlx trigger.dev@4.4.6 login
```

It only performs `login`, not `deploy` — so nothing is published to cloud. But it is the one remaining CI job that authenticates against the Trigger.dev **cloud** account, and once that account is closed it will fail on every `develop` push.

## Change

Adds the same guard the sibling workflows already carry. No files, steps, or secrets removed — per the no-removal rule the cloud token and the workflow stay put, and flipping `TRIGGER_SELFHOSTED` back re-enables the cloud path unchanged.

## Scope of the wider sweep

| repo | state |
|---|---|
| `ever-co/ever-works` | prod/stage gated ✅ · **dev ungated → this PR** |
| `cloc-co/platform` | only `trigger-selfhosted-deploy.yml`; `TRIGGER_SELFHOSTED=true`; no cloud deploy workflow ✅ |
| `git-hands/githands` | only `trigger-selfhosted-deploy.yml`; `TRIGGER_SELFHOSTED=true`; only a self-hosted token ✅ |
| `cloc-co/zero` | no Trigger workflows, vars, or secrets ✅ |

Runtime is already fully self-hosted — `TRIGGER_API_URL` in all three `cloc-platform*` namespaces points at `http://trigger-webapp.trigger.svc.cluster.local:3030`, and there is no `api.trigger.dev` anywhere in `k8s-gitops`.

**Separate follow-up (not this PR):** `cloc-co/platform` has two code paths that read a differently-named env var, `TRIGGER_API_BASE`, which is set nowhere — so they fall back to `https://api.trigger.dev`. See `apps/app/app/(authenticated)/console/_lib/v2/triggerdev-relay.ts` and `apps/app/app/api/webhooks/data-repo/_lib/internal-build-trigger.ts`.