### PR TITLE
chore: cascade develop -> stage (gate legacy Trigger.dev cloud dev deploy)

### DIFF
--- a/.github/workflows/release-trigger-dev.yml
+++ b/.github/workflows/release-trigger-dev.yml
@@ -13,6 +13,14 @@ permissions:
 
 jobs:
   deploy:
+    # Legacy Trigger.dev CLOUD path. Unlike release-trigger-{prod,stage}.yml this
+    # job was left ungated when we migrated to self-hosted, so it kept running on
+    # every develop push and authenticating to Trigger.dev CLOUD with the cloud
+    # PAT (secrets.TRIGGER_ACCESS_TOKEN) — the one workload still reaching the
+    # cloud account we are closing. Gated here on the same flag the prod/stage
+    # workflows already use, so it is inert while TRIGGER_SELFHOSTED=true.
+    # Flip the flag back to re-enable this cloud path.
+    if: ${{ vars.TRIGGER_SELFHOSTED != 'true' }}
     runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
 
     environment: dev


### PR DESCRIPTION
Promotes #1762 from `develop` to `stage`.

`release-trigger-dev.yml` had no `if:` gate and fired on every push to develop, deploying against Trigger.dev **cloud** with `secrets.TRIGGER_ACCESS_TOKEN`. Now gated behind `TRIGGER_SELFHOSTED` so the legacy cloud path stays in the repo (no-removal rule) but is bypassed.

Whole-branch merge, no cherry-pick. Content diff vs stage is exactly one file: `.github/workflows/release-trigger-dev.yml`.

Note: `lint-and-test` is pre-existing red on this repo (pnpm-audit brace-expansion + js-yaml), unrelated to this change.