### PR TITLE
fix(git): coalesce concurrent cloneOrPull for the same repo (prod exit-137 liveness kills)

### DIFF
--- a/packages/agent/src/facades/__tests__/git.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/git.facade.spec.ts
@@ -1576,6 +1576,133 @@ describe('GitFacadeService', () => {
                 }),
             );
         });
+
+        // Regression: WorkCacheWarmupService fans out workItems/workConfig/
+        // workCount/workCategoriesTags in a Promise.all, and each independently
+        // resolved the same working copy. Because isomorphic-git is pure JS,
+        // those 4 concurrent clones ran on the event loop and starved the HTTP
+        // server until the kubelet SIGKILLed the pod on a failed liveness probe.
+        // Concurrent calls for the same repo must share ONE git operation.
+        it('should coalesce concurrent calls for the same repo into one git operation', async () => {
+            const gitPlugin = createMockGitPlugin('github', 'GitHub');
+            const registered = createRegisteredPlugin(gitPlugin, {
+                capabilities: [PLUGIN_CAPABILITIES.GIT_PROVIDER],
+            });
+            registry.get.mockReturnValue(registered);
+            registry.getByCapability.mockReturnValue([registered]);
+
+            let release: (dir: string) => void = () => undefined;
+            gitPlugin.cloneOrPull = jest.fn().mockReturnValue(
+                new Promise<string>((resolve) => {
+                    release = resolve;
+                }),
+            );
+
+            const calls = [
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+            ];
+
+            // Let the facade resolve the plugin/token for every caller before
+            // the underlying git operation settles.
+            await Promise.resolve();
+            await Promise.resolve();
+            release('/tmp/repo');
+
+            const results = await Promise.all(calls);
+
+            expect(results).toEqual(['/tmp/repo', '/tmp/repo', '/tmp/repo', '/tmp/repo']);
+            expect(gitPlugin.cloneOrPull).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not coalesce calls for different repos', async () => {
+            const gitPlugin = createMockGitPlugin('github', 'GitHub');
+            const registered = createRegisteredPlugin(gitPlugin, {
+                capabilities: [PLUGIN_CAPABILITIES.GIT_PROVIDER],
+            });
+            registry.get.mockReturnValue(registered);
+            registry.getByCapability.mockReturnValue([registered]);
+
+            await Promise.all([
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'repo-a' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'repo-b' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+            ]);
+
+            expect(gitPlugin.cloneOrPull).toHaveBeenCalledTimes(2);
+        });
+
+        // The map is an in-flight dedupe, NOT a cache: once an operation
+        // settles a later caller must re-pull so it sees new commits.
+        it('should start a fresh operation once the previous one has settled', async () => {
+            const gitPlugin = createMockGitPlugin('github', 'GitHub');
+            const registered = createRegisteredPlugin(gitPlugin, {
+                capabilities: [PLUGIN_CAPABILITIES.GIT_PROVIDER],
+            });
+            registry.get.mockReturnValue(registered);
+            registry.getByCapability.mockReturnValue([registered]);
+
+            await service.cloneOrPull(
+                { owner: 'testuser', repo: 'test-repo' },
+                { providerId: 'github', token: 'test-token' },
+            );
+            await service.cloneOrPull(
+                { owner: 'testuser', repo: 'test-repo' },
+                { providerId: 'github', token: 'test-token' },
+            );
+
+            expect(gitPlugin.cloneOrPull).toHaveBeenCalledTimes(2);
+        });
+
+        // A failed clone must not poison later attempts.
+        it('should clear the in-flight entry when the git operation rejects', async () => {
+            const gitPlugin = createMockGitPlugin('github', 'GitHub');
+            const registered = createRegisteredPlugin(gitPlugin, {
+                capabilities: [PLUGIN_CAPABILITIES.GIT_PROVIDER],
+            });
+            registry.get.mockReturnValue(registered);
+            registry.getByCapability.mockReturnValue([registered]);
+
+            gitPlugin.cloneOrPull = jest
+                .fn()
+                .mockRejectedValueOnce(new Error('clone failed'))
+                .mockResolvedValueOnce('/tmp/repo');
+
+            await expect(
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+            ).rejects.toThrow('clone failed');
+
+            await expect(
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+            ).resolves.toBe('/tmp/repo');
+
+            expect(gitPlugin.cloneOrPull).toHaveBeenCalledTimes(2);
+        });
     });
 
     describe('add', () => {

--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -122,6 +122,36 @@ export class GitFacadeService implements IGitFacade {
         }
     >();
     private readonly installationTokenRequests = new Map<string, Promise<string | null>>();
+    /**
+     * In-flight `cloneOrPull` calls, keyed by the repo they target.
+     *
+     * `cloneOrPull` is backed by isomorphic-git, which is a *pure JavaScript*
+     * git implementation: inflate, SHA-1 and packfile indexing all run on the
+     * main thread. Every concurrent call is therefore CPU contention on the
+     * single Node event loop, not overlapped I/O.
+     *
+     * Callers routinely fan out several requests for the SAME repo at once —
+     * e.g. WorkCacheWarmupService issues workItems/workConfig/workCount/
+     * workCategoriesTags in a `Promise.all`, and each independently resolves
+     * the same working copy. That produced two failures in production:
+     *
+     *   1. 4x redundant pure-JS git per work starved the event loop for tens
+     *      of seconds, so even the dependency-free /api/health/live route could
+     *      not be served and the kubelet SIGKILLed the pod (exit 137).
+     *   2. Those calls raced on one directory. `cloneOrPull` falls back to
+     *      `removeDirSafe(dir)` + re-clone when a pull fails, so one caller
+     *      could delete the working copy from under another, which then hit
+     *      `git.pull` on a dir with no remote configured and threw
+     *      "The function requires a 'remote OR url' parameter but none was
+     *      provided".
+     *
+     * Coalescing concurrent same-repo calls onto one promise fixes both: the
+     * git work happens once, and only one caller ever touches the directory.
+     * Entries are removed as soon as the operation settles, so this is an
+     * in-flight dedupe, never a cache — a later call still re-pulls and sees
+     * fresh commits.
+     */
+    private readonly cloneOrPullRequests = new Map<string, Promise<string>>();
 
     constructor(
         private readonly registry: PluginRegistryService,
@@ -717,7 +747,35 @@ export class GitFacadeService implements IGitFacade {
         options: GitFacadeOptions,
     ): Promise<string> {
         const { plugin, token } = await this.resolvePluginAndToken(options);
-        return plugin.cloneOrPull({ ...cloneOptions, token });
+
+        // Key on everything that selects a distinct working copy. `token` is
+        // deliberately NOT part of the key: it is a credential, not a
+        // coordinate, and two callers with different tokens still resolve to
+        // the same on-disk directory — sharing the in-flight operation is
+        // exactly what we want, and it keeps secrets out of map keys.
+        const key = [
+            plugin.id,
+            cloneOptions.owner,
+            cloneOptions.repo,
+            cloneOptions.branch ?? '',
+            cloneOptions.autoSwitchToMainBranch === false ? 'no-switch' : 'switch',
+        ].join(' ');
+
+        const inFlight = this.cloneOrPullRequests.get(key);
+        if (inFlight) {
+            this.logger.debug(
+                `Coalescing concurrent cloneOrPull for ${cloneOptions.owner}/${cloneOptions.repo} onto the in-flight request`,
+            );
+            return inFlight;
+        }
+
+        const request = plugin.cloneOrPull({ ...cloneOptions, token }).finally(() => {
+            this.cloneOrPullRequests.delete(key);
+        });
+
+        this.cloneOrPullRequests.set(key, request);
+
+        return request;
     }
 
     async pull(


### PR DESCRIPTION
## Problem

`ever-works-api` in **production** was being SIGKILLed on a failed liveness probe (`exitCode 137, reason Error`) roughly every 10 minutes.

It was **not** OOM — RSS sat at 1152Mi of a 3Gi limit — and not a privilege problem (`ever_works` holds 105/105 relations). Both probes failed the same way:

```
Liveness probe failed:  /api/health/live: context deadline exceeded
Readiness probe failed: /api/health:      context deadline exceeded
```

Readiness timing out too is the tell: the process was alive but could not serve **anything**. Pointing liveness at a dependency-free route did not help, because no route could be served.

## Root cause: the event loop stalls

`WorkCacheWarmupService` runs on a 10-minute cron and, per work, issues:

```ts
const [items, config, count, categoriesTags] = await Promise.all([
    this.workQueryService.workItems(work.id, owner),
    this.workQueryService.workConfig(work.id, owner),
    this.workQueryService.workCount(work.id, owner),
    this.workQueryService.workCategoriesTags(work.id, owner),
]);
```

All four independently walk `WorkQueryService` → `DataGenerator` (`getExistingData` / `repositoryData` / `getCategoriesTags` / `count`) → `GitFacadeService.cloneOrPull`, and each resolves **the same working copy**. So every work triggered **four concurrent clone/pull operations of one repo**, across ~21 works per tick.

`cloneOrPull` is backed by **isomorphic-git — a pure-JavaScript git implementation**. Inflate, SHA-1 and packfile indexing all run on the main thread. Four of those in parallel is not overlapped I/O; it is four CPU-bound jobs contending for the single Node event loop.

Corroborating evidence from the prod logs:

- The warm-up window `19:43:42 → 19:44:14` (~32s) lines up with the probe timeouts.
- `WorkProposalsApiService` is a fixed-interval cron but fired at visibly **irregular** intervals (20:00:53, 20:01:41, 20:02:03, 20:03:30, …) — classic event-loop starvation.
- The Nest logger's own formatted timestamp drifted seconds behind the container's stdout timestamp during those windows.

### Same fan-out also explains the warm-up errors

```
WARN [WorkCacheWarmupService] Failed to warm detail cache for work <id>:
     The function requires a "remote OR url" parameter but none was provided.
```

`cloneOrPull` falls back to `removeDirSafe(dir)` + re-clone when a pull fails. Four concurrent callers raced on one directory, so one could delete the working copy out from under another, which then ran `git.pull` against a dir with no remote configured — exactly that isomorphic-git error.

## Fix

Dedupe **in-flight** `cloneOrPull` calls in `GitFacadeService`, keyed by `provider + owner + repo + branch + autoSwitchToMainBranch`. Concurrent callers for the same repo share one promise, so the git work happens **once** and only one caller ever touches the directory. This mirrors the `installationTokenRequests` single-flight already present in this class.

Notes:

- **The token is deliberately not part of the key.** It is a credential, not a coordinate; two callers with different tokens still resolve the same on-disk directory, and this keeps secrets out of map keys.
- **This is an in-flight dedupe, not a cache.** Entries are deleted as soon as the operation settles, so a later call still re-pulls and observes new commits, and a failed clone does not poison later attempts. Both are covered by tests.
- **The request path benefits too** — opening a work in the UI triggers the same four-way fan-out, so this cuts that to a single clone as well.

Fixing this at the facade covers every git provider with one change, rather than patching each call site.

## Verification

- New coalescing test **fails against the unpatched facade** with `Expected number of calls: 1 / Received number of calls: 4`, and passes with the fix — so it genuinely catches this regression rather than passing vacuously.
- Full `git.facade` suite: **96/96 green**.
- `@ever-works/agent` build: `TSC Found 0 issues`.
- Prettier clean.

Tests added: concurrent same-repo coalescing, different repos *not* coalesced, fresh operation after settle (proves not-a-cache), and in-flight entry cleared on rejection.

## Related / interim

An interim probe tolerance was applied in `k8s-gitops` (`apps/ever-works-app-prod/deploy-ever-works-api.json`: liveness `timeoutSeconds` 5→15, `failureThreshold` 3→6) so prod stopped being killed while this ships. Readiness was deliberately left tight — it only drains the pod, which is correct during a stall. That probe change is a mitigation and can be revisited once this lands.

## Follow-up (not in this PR)

Running pure-JS git on the API event loop **at all** is the underlying architectural risk — a single large repo can still block. Moving `cloneOrPull` to a worker thread or a dedicated worker process would remove the class of failure rather than the multiplier. Flagging rather than doing it here to keep this change small and reviewable.

## CI note

`lint-and-test` is **pre-existing red** on this repo (pnpm-audit `brace-expansion` + `js-yaml`), unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository cloning and pulling when multiple requests target the same repository simultaneously.
  * Prevented duplicate operations while an existing clone or pull is in progress.
  * Ensured separate repositories continue processing independently.
  * Subsequent requests can retry normally after an operation completes or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->