### PR TITLE
chore: cascade stage -> main (coalesce concurrent cloneOrPull)

### DIFF
--- a/packages/agent/src/facades/__tests__/git.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/git.facade.spec.ts
@@ -1576,6 +1576,133 @@ describe('GitFacadeService', () => {
                 }),
             );
         });
+
+        // Regression: WorkCacheWarmupService fans out workItems/workConfig/
+        // workCount/workCategoriesTags in a Promise.all, and each independently
+        // resolved the same working copy. Because isomorphic-git is pure JS,
+        // those 4 concurrent clones ran on the event loop and starved the HTTP
+        // server until the kubelet SIGKILLed the pod on a failed liveness probe.
+        // Concurrent calls for the same repo must share ONE git operation.
+        it('should coalesce concurrent calls for the same repo into one git operation', async () => {
+            const gitPlugin = createMockGitPlugin('github', 'GitHub');
+            const registered = createRegisteredPlugin(gitPlugin, {
+                capabilities: [PLUGIN_CAPABILITIES.GIT_PROVIDER],
+            });
+            registry.get.mockReturnValue(registered);
+            registry.getByCapability.mockReturnValue([registered]);
+
+            let release: (dir: string) => void = () => undefined;
+            gitPlugin.cloneOrPull = jest.fn().mockReturnValue(
+                new Promise<string>((resolve) => {
+                    release = resolve;
+                }),
+            );
+
+            const calls = [
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+            ];
+
+            // Let the facade resolve the plugin/token for every caller before
+            // the underlying git operation settles.
+            await Promise.resolve();
+            await Promise.resolve();
+            release('/tmp/repo');
+
+            const results = await Promise.all(calls);
+
+            expect(results).toEqual(['/tmp/repo', '/tmp/repo', '/tmp/repo', '/tmp/repo']);
+            expect(gitPlugin.cloneOrPull).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not coalesce calls for different repos', async () => {
+            const gitPlugin = createMockGitPlugin('github', 'GitHub');
+            const registered = createRegisteredPlugin(gitPlugin, {
+                capabilities: [PLUGIN_CAPABILITIES.GIT_PROVIDER],
+            });
+            registry.get.mockReturnValue(registered);
+            registry.getByCapability.mockReturnValue([registered]);
+
+            await Promise.all([
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'repo-a' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'repo-b' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+            ]);
+
+            expect(gitPlugin.cloneOrPull).toHaveBeenCalledTimes(2);
+        });
+
+        // The map is an in-flight dedupe, NOT a cache: once an operation
+        // settles a later caller must re-pull so it sees new commits.
+        it('should start a fresh operation once the previous one has settled', async () => {
+            const gitPlugin = createMockGitPlugin('github', 'GitHub');
+            const registered = createRegisteredPlugin(gitPlugin, {
+                capabilities: [PLUGIN_CAPABILITIES.GIT_PROVIDER],
+            });
+            registry.get.mockReturnValue(registered);
+            registry.getByCapability.mockReturnValue([registered]);
+
+            await service.cloneOrPull(
+                { owner: 'testuser', repo: 'test-repo' },
+                { providerId: 'github', token: 'test-token' },
+            );
+            await service.cloneOrPull(
+                { owner: 'testuser', repo: 'test-repo' },
+                { providerId: 'github', token: 'test-token' },
+            );
+
+            expect(gitPlugin.cloneOrPull).toHaveBeenCalledTimes(2);
+        });
+
+        // A failed clone must not poison later attempts.
+        it('should clear the in-flight entry when the git operation rejects', async () => {
+            const gitPlugin = createMockGitPlugin('github', 'GitHub');
+            const registered = createRegisteredPlugin(gitPlugin, {
+                capabilities: [PLUGIN_CAPABILITIES.GIT_PROVIDER],
+            });
+            registry.get.mockReturnValue(registered);
+            registry.getByCapability.mockReturnValue([registered]);
+
+            gitPlugin.cloneOrPull = jest
+                .fn()
+                .mockRejectedValueOnce(new Error('clone failed'))
+                .mockResolvedValueOnce('/tmp/repo');
+
+            await expect(
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+            ).rejects.toThrow('clone failed');
+
+            await expect(
+                service.cloneOrPull(
+                    { owner: 'testuser', repo: 'test-repo' },
+                    { providerId: 'github', token: 'test-token' },
+                ),
+            ).resolves.toBe('/tmp/repo');
+
+            expect(gitPlugin.cloneOrPull).toHaveBeenCalledTimes(2);
+        });
     });
 
     describe('add', () => {

--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -122,6 +122,36 @@ export class GitFacadeService implements IGitFacade {
         }
     >();
     private readonly installationTokenRequests = new Map<string, Promise<string | null>>();
+    /**
+     * In-flight `cloneOrPull` calls, keyed by the repo they target.
+     *
+     * `cloneOrPull` is backed by isomorphic-git, which is a *pure JavaScript*
+     * git implementation: inflate, SHA-1 and packfile indexing all run on the
+     * main thread. Every concurrent call is therefore CPU contention on the
+     * single Node event loop, not overlapped I/O.
+     *
+     * Callers routinely fan out several requests for the SAME repo at once —
+     * e.g. WorkCacheWarmupService issues workItems/workConfig/workCount/
+     * workCategoriesTags in a `Promise.all`, and each independently resolves
+     * the same working copy. That produced two failures in production:
+     *
+     *   1. 4x redundant pure-JS git per work starved the event loop for tens
+     *      of seconds, so even the dependency-free /api/health/live route could
+     *      not be served and the kubelet SIGKILLed the pod (exit 137).
+     *   2. Those calls raced on one directory. `cloneOrPull` falls back to
+     *      `removeDirSafe(dir)` + re-clone when a pull fails, so one caller
+     *      could delete the working copy from under another, which then hit
+     *      `git.pull` on a dir with no remote configured and threw
+     *      "The function requires a 'remote OR url' parameter but none was
+     *      provided".
+     *
+     * Coalescing concurrent same-repo calls onto one promise fixes both: the
+     * git work happens once, and only one caller ever touches the directory.
+     * Entries are removed as soon as the operation settles, so this is an
+     * in-flight dedupe, never a cache — a later call still re-pulls and sees
+     * fresh commits.
+     */
+    private readonly cloneOrPullRequests = new Map<string, Promise<string>>();
 
     constructor(
         private readonly registry: PluginRegistryService,
@@ -717,7 +747,35 @@ export class GitFacadeService implements IGitFacade {
         options: GitFacadeOptions,
     ): Promise<string> {
         const { plugin, token } = await this.resolvePluginAndToken(options);
-        return plugin.cloneOrPull({ ...cloneOptions, token });
+
+        // Key on everything that selects a distinct working copy. `token` is
+        // deliberately NOT part of the key: it is a credential, not a
+        // coordinate, and two callers with different tokens still resolve to
+        // the same on-disk directory — sharing the in-flight operation is
+        // exactly what we want, and it keeps secrets out of map keys.
+        const key = [
+            plugin.id,
+            cloneOptions.owner,
+            cloneOptions.repo,
+            cloneOptions.branch ?? '',
+            cloneOptions.autoSwitchToMainBranch === false ? 'no-switch' : 'switch',
+        ].join(' ');
+
+        const inFlight = this.cloneOrPullRequests.get(key);
+        if (inFlight) {
+            this.logger.debug(
+                `Coalescing concurrent cloneOrPull for ${cloneOptions.owner}/${cloneOptions.repo} onto the in-flight request`,
+            );
+            return inFlight;
+        }
+
+        const request = plugin.cloneOrPull({ ...cloneOptions, token }).finally(() => {
+            this.cloneOrPullRequests.delete(key);
+        });
+
+        this.cloneOrPullRequests.set(key, request);
+
+        return request;
     }
 
     async pull(


### PR DESCRIPTION
Promotes #1765 / #1766 to `main` (production).

Fixes the prod exit-137 liveness kills on ever-works-api by coalescing concurrent same-repo cloneOrPull calls, so the 10-minute cache warm-up no longer runs 4x redundant pure-JS git per work on the event loop.

Whole-branch merge, no cherry-pick.

Note: `lint-and-test` is pre-existing red (pnpm-audit brace-expansion + js-yaml), unrelated.