### PR TITLE
fix(ci): reliable lint-and-test (vitest 5s timeout flakes) + inngest real-infra dev server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,11 +291,13 @@ jobs:
         # headroom (start-period 45s + 18x10s = 225s) so a slow warm-up or a
         # postgres-not-yet-queryable retry can't tip it over.
         options: --health-cmd "nc -z localhost 7233" --health-interval 10s --health-timeout 5s --health-retries 18 --health-start-period 45s
-      inngest:
-        # Pinned (was `:latest`) — same moving-tag hardening as temporal above.
-        image: inngest/inngest:v1.38.1
-        ports: ['8288:8288']
-        options: --health-cmd "wget -qO- http://localhost:8288/ || exit 1" --health-interval 5s --health-timeout 3s --health-retries 10 --health-start-period 15s
+      # NOTE: inngest is intentionally NOT a service container. The
+      # `inngest/inngest` image's default entrypoint is the CLI (it just prints
+      # help and exits) — the dev server only starts under the `dev` subcommand,
+      # and GitHub `services:` cannot override a container's command. So the
+      # container never listened on 8288 and the job failed at "Initialize
+      # containers". Started as a `docker run` step below instead (which CAN pass
+      # `dev`), reachable at localhost:8288 the same way the service containers are.
 
     steps:
       - name: Checkout repository
@@ -334,6 +336,26 @@ jobs:
         env:
           EW_TEST_REAL_TEMPORAL_ADDRESS: localhost:7233
         run: pnpm --filter @ever-works/job-runtime-temporal-plugin test
+
+      # Start the Inngest dev server via `docker run` (not a service container —
+      # see the note in `services:` above). `dev` is the subcommand that actually
+      # serves; `--host 0.0.0.0` binds all interfaces so the loopback probe and
+      # the test's http://localhost:8288 both reach it; `--no-discovery` skips the
+      # auto-scan for a local app (there is none here). Same pinned image tag.
+      - name: Start Inngest dev server
+        run: |
+          docker run -d --name inngest -p 8288:8288 \
+            inngest/inngest:v1.38.1 dev --no-discovery --host 0.0.0.0
+          echo "Waiting for Inngest on http://localhost:8288 ..."
+          for i in $(seq 1 45); do
+            if curl -sf -o /dev/null http://localhost:8288/; then
+              echo "Inngest is ready."; exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Inngest dev server did not become ready in time"
+          docker logs inngest || true
+          exit 1
 
       - name: Inngest real-infra
         env:

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
+        // CI-load resilience: unit specs doing cold `await import()` /
+        // vi.resetModules() or real file parsing can drift past vitest's 5s
+        // default under the concurrent turbo test load. Matches the 30000ms
+        // the packages/tasks + api jest configs already use.
+        testTimeout: 30000,
+        hookTimeout: 30000,
         environment: 'node',
         globals: true,
         include: ['src/**/*.{test,spec}.ts'],

--- a/apps/internal-cli/vitest.config.ts
+++ b/apps/internal-cli/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
+        // CI-load resilience: unit specs doing cold `await import()` /
+        // vi.resetModules() or real file parsing can drift past vitest's 5s
+        // default under the concurrent turbo test load. Matches the 30000ms
+        // the packages/tasks + api jest configs already use.
+        testTimeout: 30000,
+        hookTimeout: 30000,
         environment: 'node',
         globals: true,
         include: ['src/**/*.{test,spec}.ts'],

--- a/apps/mcp/vitest.config.ts
+++ b/apps/mcp/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['test/**/*.{test,spec}.ts'],

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -26,6 +26,12 @@ export default defineConfig({
         },
     },
     test: {
+        // CI-load resilience: unit specs doing cold `await import()` /
+        // vi.resetModules() or real file parsing can drift past vitest's 5s
+        // default under the concurrent turbo test load. Matches the 30000ms
+        // the packages/tasks + api jest configs already use.
+        testTimeout: 30000,
+        hookTimeout: 30000,
         environment: 'jsdom',
         globals: true,
         include: ['src/**/*.unit.spec.{ts,tsx}'],

--- a/packages/cli-shared/vitest.config.ts
+++ b/packages/cli-shared/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/email-templates/vitest.config.ts
+++ b/packages/email-templates/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
 		jsx: 'automatic'
 	},
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.{ts,tsx}']

--- a/packages/plugin/vitest.config.ts
+++ b/packages/plugin/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/activepieces/vitest.config.ts
+++ b/packages/plugins/activepieces/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/agent-pipeline/vitest.config.ts
+++ b/packages/plugins/agent-pipeline/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/agentmemory/vitest.config.ts
+++ b/packages/plugins/agentmemory/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/anthropic/vitest.config.ts
+++ b/packages/plugins/anthropic/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/claude-managed-agent/vitest.config.ts
+++ b/packages/plugins/claude-managed-agent/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/cloudflare-dns/vitest.config.ts
+++ b/packages/plugins/cloudflare-dns/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/codex/vitest.config.ts
+++ b/packages/plugins/codex/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/comparison-generator/vitest.config.ts
+++ b/packages/plugins/comparison-generator/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/composio/vitest.config.ts
+++ b/packages/plugins/composio/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/discord-channel/vitest.config.ts
+++ b/packages/plugins/discord-channel/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/discord-connector/vitest.config.ts
+++ b/packages/plugins/discord-connector/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/github-storage/vitest.config.ts
+++ b/packages/plugins/github-storage/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/google-analytics-metrics/vitest.config.ts
+++ b/packages/plugins/google-analytics-metrics/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/google/vitest.config.ts
+++ b/packages/plugins/google/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/grok/vitest.config.ts
+++ b/packages/plugins/grok/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/groq/vitest.config.ts
+++ b/packages/plugins/groq/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/hermes-agent/vitest.config.ts
+++ b/packages/plugins/hermes-agent/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/lm-studio/vitest.config.ts
+++ b/packages/plugins/lm-studio/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/mailchimp-transactional/vitest.config.ts
+++ b/packages/plugins/mailchimp-transactional/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/mailgun/vitest.config.ts
+++ b/packages/plugins/mailgun/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/make/vitest.config.ts
+++ b/packages/plugins/make/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/memory-pipeline-modifier/vitest.config.ts
+++ b/packages/plugins/memory-pipeline-modifier/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/mistral/vitest.config.ts
+++ b/packages/plugins/mistral/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
 		}
 	},
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/novu-channel/vitest.config.ts
+++ b/packages/plugins/novu-channel/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/officecli-extractor/vitest.config.ts
+++ b/packages/plugins/officecli-extractor/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: false,
 		environment: 'node'
 	}

--- a/packages/plugins/ollama/vitest.config.ts
+++ b/packages/plugins/ollama/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/openai/vitest.config.ts
+++ b/packages/plugins/openai/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/openrouter/vitest.config.ts
+++ b/packages/plugins/openrouter/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
 		}
 	},
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/pdf-extractor/vitest.config.ts
+++ b/packages/plugins/pdf-extractor/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: false,
 		environment: 'node'
 	}

--- a/packages/plugins/pgvector/vitest.config.ts
+++ b/packages/plugins/pgvector/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/posthog-metrics/vitest.config.ts
+++ b/packages/plugins/posthog-metrics/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/postmark/vitest.config.ts
+++ b/packages/plugins/postmark/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/qdrant/vitest.config.ts
+++ b/packages/plugins/qdrant/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/resend/vitest.config.ts
+++ b/packages/plugins/resend/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/screenshotone/vitest.config.ts
+++ b/packages/plugins/screenshotone/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/sendgrid/vitest.config.ts
+++ b/packages/plugins/sendgrid/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/sim-ai/vitest.config.ts
+++ b/packages/plugins/sim-ai/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/slack-channel/vitest.config.ts
+++ b/packages/plugins/slack-channel/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/slack-connector/vitest.config.ts
+++ b/packages/plugins/slack-connector/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/standard-pipeline/vitest.config.ts
+++ b/packages/plugins/standard-pipeline/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],

--- a/packages/plugins/stripe-metrics/vitest.config.ts
+++ b/packages/plugins/stripe-metrics/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/telegram-channel/vitest.config.ts
+++ b/packages/plugins/telegram-channel/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/urlbox/vitest.config.ts
+++ b/packages/plugins/urlbox/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/vercel-ai-gateway/vitest.config.ts
+++ b/packages/plugins/vercel-ai-gateway/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
 		}
 	},
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/vllm/vitest.config.ts
+++ b/packages/plugins/vllm/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/whatsapp-channel/vitest.config.ts
+++ b/packages/plugins/whatsapp-channel/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		environment: 'node',
 		globals: true,
 		include: ['src/**/*.{test,spec}.ts'],

--- a/packages/plugins/zapier/vitest.config.ts
+++ b/packages/plugins/zapier/vitest.config.ts
@@ -2,6 +2,12 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],


### PR DESCRIPTION
## Two CI reliability fixes

Both surfaced now that `lint-and-test` runs to completion and is a **required check** on develop.

### 1. lint-and-test 5s-timeout flakes across the vitest suites
`apps/web/…/auth.unit.spec.ts`, `…/officecli-extractor.plugin.spec.ts` and others intermittently hit `Test timed out in 5000ms`. They're unit tests, but do cold `await import()` / `vi.resetModules()` / real file parsing that drifts past vitest's **5s default** under concurrent turbo test load (api now runs in-band, adding CPU pressure).

Only **6 of 61** vitest configs set a timeout — the other 55 inherit 5s. Set `testTimeout: 30000` + `hookTimeout: 30000` on those 55, matching what `packages/tasks` and the api jest configs already use. **A required check must be stable, not green-once** — and per-package patching (the 6 existing ones) doesn't scale to 61 packages.

### 2. `job-runtime-real-infra`: inngest never started
The `inngest/inngest` image's default entrypoint is the CLI — it prints help and exits; the dev server only runs under the `dev` subcommand. GitHub `services:` **can't override a container command**, so the inngest service never listened on 8288 and the job died at *Initialize containers*.

Verified on a k8s repro: the image's default output is the CLI usage screen; `inngest dev --host 0.0.0.0` logs `starting server … addr:0.0.0.0:8288` and stays up. So inngest is started as a `docker run … dev` **step** instead (reachable at localhost:8288 the same way the other service containers are on the ARC dind daemon), with a readiness wait.

The **temporal** half of that job was already fixed on main by the prior `BIND_ON_IP` change — CI confirmed *"temporal service is healthy"*.

## Scope / verification
- 55 vitest config files (mechanical + prettier-clean) + `.github/workflows/ci.yml`.
- The vitest change makes the required check robust; the inngest change is in the main-only `job-runtime-real-infra` job (not a required check), so it validates on the next push to main after cascade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability by allowing test suites and setup hooks more time to complete under concurrent load.
  * Updated integration checks to reliably start and verify the local development server before testing.
  * Added clearer failure diagnostics when the development server cannot become ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->