### PR TITLE
fix(job-runtime-pgboss): migrate to pg-boss v10 (queue creation, idempotency, cancel)

### DIFF
--- a/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-enqueue-options.spec.ts
+++ b/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-enqueue-options.spec.ts
@@ -7,7 +7,7 @@ import type { PgBossInstance, PgBossJobView } from '../pgboss-types.js';
 describe('mapEnqueueOptions (EW-742 P4 T31 pg-boss stamping)', () => {
 	it('translates idempotencyKey → sendOptions.singletonKey', () => {
 		expect(mapEnqueueOptions({ idempotencyKey: 'idem-1' })).toEqual({
-			sendOptions: { singletonKey: 'idem-1' },
+			sendOptions: { singletonKey: 'idem-1', singletonSeconds: 21_600 },
 			metaForPayload: {}
 		});
 	});
@@ -60,7 +60,7 @@ describe('mapEnqueueOptions (EW-742 P4 T31 pg-boss stamping)', () => {
 			machineHint: 'medium-1x'
 		};
 		expect(mapEnqueueOptions(opts)).toEqual({
-			sendOptions: { singletonKey: 'idem-A', expireInSeconds: 600 },
+			sendOptions: { singletonKey: 'idem-A', expireInSeconds: 600, singletonSeconds: 21_600 },
 			metaForPayload: {
 				_ew: {
 					tenantId: 'tenant-A',
@@ -118,7 +118,7 @@ describe('PgBossDispatcherFactory.enqueue (EW-742 P4 T31)', () => {
 				workId: 'w7',
 				_ew: { tenantId: 't-acme', tags: ['kb'] }
 			},
-			options: { singletonKey: 'idem-1', expireInSeconds: 900 }
+			options: { singletonKey: 'idem-1', expireInSeconds: 900, singletonSeconds: 21_600 }
 		});
 	});
 
@@ -146,6 +146,7 @@ describe('PgBossDispatcherFactory.enqueue (EW-742 P4 T31)', () => {
 		);
 		expect(boss.sendCalls[0].options).toEqual({
 			singletonKey: 'idem-operator',
+			singletonSeconds: 21_600,
 			retryLimit: 5
 		});
 	});

--- a/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-factories.spec.ts
+++ b/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-factories.spec.ts
@@ -43,7 +43,7 @@ class FakeBoss implements PgBossInstance {
 		return `sub${this.nextSubId++}`;
 	}
 
-	async cancel(id: string): Promise<void> {
+	async cancel(_name: string, id: string): Promise<void> {
 		this.cancelled.push(id);
 	}
 
@@ -99,15 +99,20 @@ describe('PgBossDispatcherFactory', () => {
 		await expect(factory.send('q1', {})).resolves.toBeNull();
 	});
 
-	it('cancel returns true on resolve, false on throw', async () => {
+	it('cancel resolves the queue from a prior send, then true on resolve / false on throw', async () => {
 		const boss = new FakeBoss();
 		const factory = new PgBossDispatcherFactory({ boss });
-		await expect(factory.cancel('j1')).resolves.toBe(true);
+		// v10 cancel needs the queue name; the dispatcher learns it from the send.
+		const id1 = await factory.send('q1', {}); // 'j1'
+		await expect(factory.cancel(id1!)).resolves.toBe(true);
 		expect(boss.cancelled).toEqual(['j1']);
+		const id2 = await factory.send('q1', {}); // 'j2'
 		boss.cancel = vi.fn(async () => {
 			throw new Error('boom');
 		});
-		await expect(factory.cancel('j2')).resolves.toBe(false);
+		await expect(factory.cancel(id2!)).resolves.toBe(false);
+		// A job this dispatcher never sent has no known queue -> false, no throw.
+		await expect(factory.cancel('never-sent')).resolves.toBe(false);
 	});
 
 	it('getJob returns null when boss.getJobById is absent or throws', async () => {

--- a/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-plugin-operator-hooks.spec.ts
+++ b/packages/plugins/job-runtime-pgboss/src/__tests__/pgboss-plugin-operator-hooks.spec.ts
@@ -24,7 +24,7 @@ class FakeBoss implements PgBossInstance {
 	) {
 		return 'sub-1';
 	}
-	async cancel(id: string) {
+	async cancel(_name: string, id: string) {
 		this.cancelled.push(id);
 	}
 	async schedule(name: string, cron: string, data?: unknown) {
@@ -88,11 +88,13 @@ describe('PgBossJobRuntimePlugin — operator hooks', () => {
 		const boss = new FakeBoss();
 		const factory = new PgBossDispatcherFactory({ boss });
 		const plugin = new PgBossJobRuntimePlugin().useDispatcherFactory(factory);
-		await expect(plugin.cancel('j1')).resolves.toBe(true);
-		expect(boss.cancelled).toEqual(['j1']);
+		// v10 cancel needs the queue; the dispatcher learns it from the send.
+		const id = await factory.send('q1', {}); // 'jb-1'
+		await expect(plugin.cancel(id!)).resolves.toBe(true);
+		expect(boss.cancelled).toEqual(['jb-1']);
 
 		const orphan = new PgBossJobRuntimePlugin();
-		await expect(orphan.cancel('j1')).resolves.toBe(false);
+		await expect(orphan.cancel('jb-1')).resolves.toBe(false);
 	});
 
 	it('getRunStatus projects pg-boss state onto JobRunStatus', async () => {

--- a/packages/plugins/job-runtime-pgboss/src/pgboss-dispatcher-factory.ts
+++ b/packages/plugins/job-runtime-pgboss/src/pgboss-dispatcher-factory.ts
@@ -31,6 +31,52 @@ import { mapEnqueueOptions } from './pgboss-enqueue-options.js';
 export class PgBossDispatcherFactory {
 	constructor(private readonly opts: PgBossFactoryOptions) {}
 
+	/** Queues already created this process (createQueue is idempotent but hits the DB). */
+	private readonly ensuredQueues = new Set<string>();
+
+	/**
+	 * jobId -> queue name for jobs this dispatcher has sent, so `cancel(jobId)`
+	 * can call pg-boss v10's `cancel(name, id)` (v10 removed the by-id-only form).
+	 * Bounded (insertion-order eviction) so a long-lived dispatcher can't leak;
+	 * the realistic cancel pattern is "cancel a job I just scheduled", which is
+	 * always in the recent window.
+	 *
+	 * LIMITATION: only the instance that SENT the job knows its queue. A cancel
+	 * issued from a different process/instance won't find it here and returns
+	 * false. The fully general fix is to thread the queue name through the
+	 * platform's `cancel(runId)` contract (or persist a jobId->queue map);
+	 * tracked as a follow-up.
+	 */
+	private readonly sentJobQueue = new Map<string, string>();
+	private static readonly MAX_TRACKED = 50_000;
+
+	private rememberJobQueue(id: string | null, queue: string): void {
+		if (!id) return;
+		if (this.sentJobQueue.size >= PgBossDispatcherFactory.MAX_TRACKED) {
+			const oldest = this.sentJobQueue.keys().next().value;
+			if (oldest !== undefined) this.sentJobQueue.delete(oldest);
+		}
+		this.sentJobQueue.set(id, queue);
+	}
+
+	/**
+	 * pg-boss v10 no longer auto-creates a queue on first `send` — sending to a
+	 * queue that was never `createQueue`'d silently returns `null` and drops the
+	 * job. Ensure it exists before the first send (cached per process so the hot
+	 * path only pays the DB round-trip once per queue).
+	 */
+	private async ensureQueue(name: string): Promise<void> {
+		if (this.ensuredQueues.has(name) || !this.opts.boss.createQueue) return;
+		// Default ('standard') policy: a queue must hold many concurrent jobs
+		// (multi-tenant, batched). Idempotency is NOT a queue policy here — a
+		// keyed 'short'/'stately' policy would cap the queue to one job and break
+		// those. Instead `mapEnqueueOptions` pairs `singletonKey` with
+		// `singletonSeconds` per send, which dedups same-key jobs on a standard
+		// queue while leaving unkeyed/different-key jobs unaffected.
+		await this.opts.boss.createQueue(name);
+		this.ensuredQueues.add(name);
+	}
+
 	/** Underlying pg-boss instance — exposed for operator advanced lifecycle. */
 	get boss(): PgBossInstance {
 		return this.opts.boss;
@@ -44,7 +90,10 @@ export class PgBossDispatcherFactory {
 		const merged = this.opts.defaultSendOptions
 			? { ...this.opts.defaultSendOptions, ...(callOpts ?? {}) }
 			: callOpts;
-		return this.opts.boss.send(name, payload, merged);
+		await this.ensureQueue(name);
+		const id = await this.opts.boss.send(name, payload, merged);
+		this.rememberJobQueue(id, name);
+		return id;
 	}
 
 	/**
@@ -82,13 +131,25 @@ export class PgBossDispatcherFactory {
 			? { ...this.opts.defaultSendOptions, ...sendOptions }
 			: sendOptions;
 		const mergedOpts = extraOpts ? { ...baseOpts, ...extraOpts } : baseOpts;
-		return this.opts.boss.send(name, mergedPayload, mergedOpts);
+		await this.ensureQueue(name);
+		const id = await this.opts.boss.send(name, mergedPayload, mergedOpts);
+		this.rememberJobQueue(id, name);
+		return id;
 	}
 
-	/** Cancel an in-flight job by id. Returns true once the cancel call resolves. */
+	/**
+	 * Cancel an in-flight job by id. pg-boss v10 requires the queue name
+	 * (`cancel(name, id)` — the by-id-only form was removed), so this resolves
+	 * the queue from what this dispatcher sent. Returns false if the queue is
+	 * unknown here (e.g. the job was sent by a different instance — see
+	 * `sentJobQueue`) or the cancel call itself fails.
+	 */
 	async cancel(jobId: string): Promise<boolean> {
+		const queue = this.sentJobQueue.get(jobId);
+		if (!queue) return false;
 		try {
-			await this.opts.boss.cancel(jobId);
+			await this.opts.boss.cancel(queue, jobId);
+			this.sentJobQueue.delete(jobId);
 			return true;
 		} catch {
 			return false;

--- a/packages/plugins/job-runtime-pgboss/src/pgboss-enqueue-options.ts
+++ b/packages/plugins/job-runtime-pgboss/src/pgboss-enqueue-options.ts
@@ -38,10 +38,28 @@ export interface MappedPgBossEnqueue {
 	readonly metaForPayload: Readonly<Record<string, unknown>>;
 }
 
+/**
+ * Dedup horizon for a keyed (`idempotencyKey`) send — see mapEnqueueOptions.
+ * 6h. pg-boss rejects a `singletonSeconds` greater than the queue's archive
+ * interval (default 12h), so this stays comfortably under that ceiling while
+ * still covering the realistic duplicate window (retries, double-submits).
+ */
+export const IDEMPOTENCY_WINDOW_SECONDS = 21_600;
+
 export function mapEnqueueOptions(opts: JobEnqueueOptions): MappedPgBossEnqueue {
 	const sendOptions: Record<string, unknown> = {};
 	const meta: Record<string, unknown> = {};
-	if (opts.idempotencyKey !== undefined) sendOptions['singletonKey'] = opts.idempotencyKey;
+	if (opts.idempotencyKey !== undefined) {
+		sendOptions['singletonKey'] = opts.idempotencyKey;
+		// pg-boss v10 no longer dedups on `singletonKey` alone (v9 did). On a
+		// 'standard' queue, dedup requires pairing the key with `singletonSeconds`
+		// — "at most one job per key within this window". We default to 24h so a
+		// re-send of the same logical job (the point of an idempotencyKey) is
+		// suppressed for a generous horizon; distinct keys are unaffected. This is
+		// the multi-job-safe alternative to a keyed queue policy (which would cap
+		// the whole queue to one job).
+		sendOptions['singletonSeconds'] = IDEMPOTENCY_WINDOW_SECONDS;
+	}
 	if (opts.maxDurationSeconds !== undefined) sendOptions['expireInSeconds'] = opts.maxDurationSeconds;
 	if (opts.tenantId !== undefined) meta['tenantId'] = opts.tenantId;
 	if (opts.concurrencyKey !== undefined) meta['concurrencyKey'] = opts.concurrencyKey;

--- a/packages/plugins/job-runtime-pgboss/src/pgboss-types.ts
+++ b/packages/plugins/job-runtime-pgboss/src/pgboss-types.ts
@@ -22,6 +22,15 @@
  * Structural subset of `PgBoss` the plugin uses. Maps to pg-boss >=8.0.
  */
 export interface PgBossInstance {
+	/**
+	 * Create a queue (idempotent). REQUIRED before `send`/`work` since pg-boss
+	 * v10 — v9 auto-created queues on first send, but v10 makes creation
+	 * explicit and `send()` to a non-existent queue silently returns `null`
+	 * (the job is dropped). The dispatcher and worker-host factories call this
+	 * before their first `send`/`work` on a queue so a missing bootstrap can't
+	 * silently swallow every job.
+	 */
+	createQueue?(name: string, options?: Readonly<Record<string, unknown>>): Promise<void>;
 	/** Enqueue one job. Returns the pg-boss job id, or `null` on dedup hit. */
 	send(name: string, data: unknown, options?: Readonly<Record<string, unknown>>): Promise<string | null>;
 	/**
@@ -33,8 +42,8 @@ export interface PgBossInstance {
 		options: Readonly<Record<string, unknown>>,
 		handler: (job: PgBossJobView | readonly PgBossJobView[]) => Promise<unknown>
 	): Promise<string>;
-	/** Cancel an in-flight job by id. Idempotent — returns void either way. */
-	cancel(id: string): Promise<void>;
+	/** Cancel an in-flight job. pg-boss v10 takes the queue name AND the id. */
+	cancel(name: string, id: string): Promise<void>;
 	/** Lookup a single job by id. Returns shape includes a `state` field. */
 	getJobById?(id: string): Promise<PgBossJobRecord | null>;
 	/** Register a cron-like recurring job. */

--- a/packages/plugins/job-runtime-pgboss/src/pgboss-worker-host-factory.ts
+++ b/packages/plugins/job-runtime-pgboss/src/pgboss-worker-host-factory.ts
@@ -85,6 +85,11 @@ export class PgBossWorkerHostFactory {
 			if (hostOpts.concurrency !== undefined && merged['teamSize'] === undefined) {
 				merged['teamSize'] = hostOpts.concurrency;
 			}
+			// pg-boss v10 requires the queue to exist before work() — unlike v9
+			// there is no implicit creation, and work() on a missing queue never
+			// receives jobs. createQueue is idempotent, so this is safe whether
+			// the dispatcher (or a bootstrap) already made it.
+			if (this.opts.boss.createQueue) await this.opts.boss.createQueue(reg.queueName);
 			const id = await this.opts.boss.work(reg.queueName, merged, reg.handler);
 			ids.push(id);
 		}


### PR DESCRIPTION
## What

Migrates `@ever-works/job-runtime-pgboss-plugin` to **pg-boss v10** semantics. The `job-runtime-real-infra` CI job (which the temporal/inngest fixes just unblocked past *Initialize containers*) then failed **every** pg-boss test — because the plugin was written for pg-boss v9 but the dep is v10. All three are genuine **production** bugs, reproduced against a real Postgres:

1. **Queues aren't auto-created in v10.** v9 created the queue on first `send()`; v10 `send()` to a non-existent queue silently returns `null` and **drops the job**. Nothing in the repo ever called `createQueue`, so every dispatched job would have been lost. The dispatcher now `createQueue`s (idempotent, cached) before its first send; the worker host before `work()`. `createQueue` is optional on `PgBossInstance`, so existing mocks are untouched.

2. **`singletonKey` alone no longer dedups.** v10 needs it paired with `singletonSeconds` on a standard queue. (A keyed queue *policy* would cap the whole queue to one job and break the multi-tenant/batched queues — verified.) `mapEnqueueOptions` now emits `singletonSeconds` (6h, under pg-boss's archive-interval ceiling) for an `idempotencyKey`, so the plugin's documented idempotency holds again.

3. **`cancel(id)` → `cancel(name, id)`.** v10 removed the by-id-only form. The dispatcher records the queue for jobs it sends (bounded map) and resolves it at cancel. **Documented limitation:** only the sending instance can cancel; cross-instance cancel needs the queue threaded through the platform `cancel(runId)` contract (follow-up).

## Verification

Against a real Postgres with the repo's pinned pnpm: **120/120** pgboss tests pass, including all **6** real-infra specs (were 6/6 failing). `lint-and-test` runs the unit tests (real-infra skips without `EW_TEST_REAL_PGBOSS_URL`).

## Note

This is the pg-boss half of `job-runtime-real-infra`. The temporal (`BIND_ON_IP`) and inngest (dev-server-as-step) infra fixes are already on main; their *test* steps were skipped behind the failing pg-boss step and will execute for the first time once this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic queue creation before sending jobs or starting workers.
  - Updated job cancellation to support queue-aware cancellation.
  - Added bounded tracking for recently submitted jobs to enable reliable cancellation.
  - Configured a 6-hour deduplication window for idempotent job submissions.
- **Bug Fixes**
  - Cancellation now safely returns failure when a job is unknown or cancellation encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->