### PR TITLE
feat(agents): replace the Runtime free-text id fields with searchable pickers

### DIFF
--- a/apps/web/src/app/[locale]/(dashboard)/agents/[id]/settings/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/[id]/settings/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { agentsAPI } from '@/lib/api/agents';
 import { teamsAPI } from '@/lib/api/teams';
+import { pluginsAPI } from '@/lib/api/plugins';
 import {
     AgentSettingsClient,
     type AgentSettingsOrganization,
@@ -18,6 +19,21 @@ export default async function AgentSettingsPage({ params }: { params: Promise<{ 
     // API never 500s the settings page — without an Organization the
     // card simply doesn't render. `currentTeamIds` is derived from the
     // org chart payload (one flat call) instead of N per-team lookups.
+    // Runtime picker options. Both AI categories are offered because either
+    // can back an Agent: a direct `ai-provider` (openai, anthropic, …) or an
+    // `ai-gateway` that fronts many models (openrouter). Failures degrade to
+    // an empty list — the picker still accepts a typed provider id, so a
+    // flaky plugins API never blocks the settings page.
+    const aiProviders = (
+        await Promise.all([
+            pluginsAPI.listByCategory('ai-provider').catch(() => []),
+            pluginsAPI.listByCategory('ai-gateway').catch(() => []),
+        ])
+    )
+        .flat()
+        .map((plugin) => ({ id: plugin.id, name: plugin.name ?? plugin.id }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
     const orgs = await teamsAPI.listOrganizations().catch(() => []);
     const activeOrg = orgs[0];
     let organization: AgentSettingsOrganization | undefined;
@@ -40,5 +56,7 @@ export default async function AgentSettingsPage({ params }: { params: Promise<{ 
         };
     }
 
-    return <AgentSettingsClient agent={agent} organization={organization} />;
+    return (
+        <AgentSettingsClient agent={agent} organization={organization} aiProviders={aiProviders} />
+    );
 }

--- a/apps/web/src/components/agents/AgentSettingsClient.tsx
+++ b/apps/web/src/components/agents/AgentSettingsClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useTransition } from 'react';
+import { useMemo, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
 import { Archive, Building2, Cpu, IdCard, Pause, Play, Save, ShieldCheck } from 'lucide-react';
 import { toast } from 'sonner';
@@ -20,6 +20,8 @@ import {
 // card's Team select (v1 UI: one team per Agent).
 import { addTeamMemberAction, removeTeamMemberAction } from '@/app/actions/dashboard/teams';
 import { AgentScorecardCard } from '@/components/agents/AgentScorecardCard';
+import { SearchableSelect, type SearchableSelectOption } from '@/components/ui/searchable-select';
+import { PluginModelSelect } from '@/components/plugins/form/PluginModelSelect';
 import type { Agent, AgentIdleBehavior, AgentPermissions } from '@/lib/api/agents';
 
 const permissionLabels: Array<{ key: keyof AgentPermissions; label: string }> = [
@@ -52,16 +54,48 @@ export interface AgentSettingsOrganization {
     agentOptions: Array<{ id: string; label: string }>;
 }
 
+/**
+ * Common heartbeat cadences, offered as presets.
+ *
+ * The field accepts any cron expression, so this is a shortcut list rather
+ * than an enumeration — `allowCustom` keeps arbitrary crons reachable.
+ */
+const heartbeatCadenceOptions: SearchableSelectOption[] = [
+    { value: 'manual', label: 'Manual', description: 'Only runs when you trigger it' },
+    { value: '0 * * * *', label: 'Hourly', description: '0 * * * *' },
+    { value: '0 */6 * * *', label: 'Every 6 hours', description: '0 */6 * * *' },
+    { value: '0 9 * * *', label: 'Daily at 09:00', description: '0 9 * * *' },
+    { value: '0 9 * * 1', label: 'Weekly on Monday', description: '0 9 * * 1' },
+    { value: '0 9 1 * *', label: 'Monthly on the 1st', description: '0 9 1 * *' },
+];
+
 interface AgentSettingsClientProps {
     agent: Agent;
     organization?: AgentSettingsOrganization;
+    /**
+     * AI provider plugins available to this user, for the Runtime picker.
+     * Empty when the plugins API is unreachable — the picker still renders
+     * and still accepts a typed provider id, so a flaky call degrades the
+     * affordance rather than blocking the page.
+     */
+    aiProviders?: Array<{ id: string; name: string; category?: string }>;
 }
 
 export function AgentSettingsClient({
     agent: initialAgent,
     organization,
+    aiProviders = [],
 }: AgentSettingsClientProps) {
     const router = useRouter();
+    const aiProviderOptions = useMemo<SearchableSelectOption[]>(
+        () =>
+            aiProviders.map((provider) => ({
+                value: provider.id,
+                label: provider.name,
+                description: provider.id,
+            })),
+        [aiProviders],
+    );
     const [agent, setAgent] = useState(initialAgent);
     const [isSaving, startSaving] = useTransition();
     const [isChangingStatus, startChangingStatus] = useTransition();
@@ -289,26 +323,56 @@ export function AgentSettingsClient({
                     </div>
                 </div>
                 <div className="grid gap-4 md:grid-cols-2">
-                    <Input
-                        label="AI provider id"
-                        variant="form"
+                    {/* Provider and model were free-text id fields, which
+                        required the user to already know the exact string.
+                        Both are pickers now; both still accept a typed value
+                        so an id this build doesn't know about stays reachable. */}
+                    <SearchableSelect
+                        label="AI provider"
                         value={aiProviderId}
-                        onChange={(event) => setAiProviderId(event.target.value)}
+                        onChange={(value) => {
+                            setAiProviderId(value);
+                            // The model list is provider-specific, so a model
+                            // chosen under the previous provider is almost
+                            // certainly invalid under the new one. Clearing
+                            // falls back to the provider default rather than
+                            // silently keeping an unroutable id.
+                            setModelId('');
+                        }}
+                        options={aiProviderOptions}
+                        emptyOptionLabel="Account default"
                         placeholder="Account default"
+                        allowCustom
+                        customLabel="Enter a provider id…"
+                        customPlaceholder="e.g. openrouter"
+                        testId="agent-ai-provider"
                     />
-                    <Input
-                        label="Model id"
-                        variant="form"
-                        value={modelId}
-                        onChange={(event) => setModelId(event.target.value)}
-                        placeholder="Provider default"
-                    />
-                    <Input
+                    <div>
+                        <label className="block text-xs font-medium text-text dark:text-text-dark mb-2">
+                            Model
+                        </label>
+                        <PluginModelSelect
+                            pluginId={aiProviderId}
+                            value={modelId}
+                            onChange={setModelId}
+                            disabled={!aiProviderId}
+                        />
+                        <p className="mt-1 text-xs text-text-muted dark:text-text-muted-dark">
+                            {aiProviderId
+                                ? 'Leave empty to use the provider default.'
+                                : 'Pick an AI provider first.'}
+                        </p>
+                    </div>
+                    <SearchableSelect
                         label="Heartbeat cadence"
-                        variant="form"
                         value={heartbeatCadence}
-                        onChange={(event) => setHeartbeatCadence(event.target.value)}
+                        onChange={setHeartbeatCadence}
+                        options={heartbeatCadenceOptions}
                         placeholder="manual or cron expression"
+                        allowCustom
+                        customLabel="Enter a cron expression…"
+                        customPlaceholder="0 9 * * *"
+                        testId="agent-heartbeat-cadence"
                     />
                     <div>
                         <label className="block text-xs font-medium text-text dark:text-text-dark mb-2">

--- a/apps/web/src/components/agents/AgentSettingsClient.tsx
+++ b/apps/web/src/components/agents/AgentSettingsClient.tsx
@@ -363,10 +363,15 @@ export function AgentSettingsClient({
                             pluginId={aiProviderId}
                             value={modelId}
                             onChange={setModelId}
-                            disabled={!aiProviderId}
+                            // NOT `!aiProviderId` alone: an Agent can hold a
+                            // pinned modelId with no provider (the DTO fields
+                            // are independent), and disabling then would make
+                            // that model uneditable without first adopting a
+                            // provider — which clears the model.
+                            disabled={!aiProviderId && !modelId}
                         />
                         <p className="mt-1 text-xs text-text-muted dark:text-text-muted-dark">
-                            {aiProviderId
+                            {aiProviderId || modelId
                                 ? 'Leave empty to use the provider default.'
                                 : 'Pick an AI provider first.'}
                         </p>

--- a/apps/web/src/components/agents/AgentSettingsClient.tsx
+++ b/apps/web/src/components/agents/AgentSettingsClient.tsx
@@ -337,7 +337,15 @@ export function AgentSettingsClient({
                             // certainly invalid under the new one. Clearing
                             // falls back to the provider default rather than
                             // silently keeping an unroutable id.
-                            setModelId('');
+                            //
+                            // Only when the provider ACTUALLY changes: the
+                            // picker fires onChange even when the user
+                            // re-selects what was already chosen, and
+                            // clearing then would silently discard a
+                            // configured model on a no-op interaction.
+                            if (value !== aiProviderId) {
+                                setModelId('');
+                            }
                         }}
                         options={aiProviderOptions}
                         emptyOptionLabel="Account default"

--- a/apps/web/src/components/ui/searchable-select.tsx
+++ b/apps/web/src/components/ui/searchable-select.tsx
@@ -78,6 +78,9 @@ export function SearchableSelect({
         setIsOpen(false);
         setSearch('');
         setShowCustom(false);
+        // Reset the draft too — reopening with a stale half-typed value
+        // invites committing something the user abandoned.
+        setCustom('');
     }, []);
 
     useEffect(() => {
@@ -160,7 +163,6 @@ export function SearchableSelect({
 
                 {isOpen && !disabled && (
                     <div
-                        role="listbox"
                         data-testid={testId ? `${testId}-panel` : undefined}
                         className="absolute z-50 mt-1 w-full rounded-lg border border-border dark:border-border-dark bg-surface dark:bg-surface-dark shadow-lg max-h-80 overflow-hidden"
                     >
@@ -179,7 +181,10 @@ export function SearchableSelect({
                             </div>
                         )}
 
-                        <div className="max-h-56 overflow-y-auto py-1">
+                        {/* role=listbox sits HERE, not on the panel: a text
+                            input is not a valid listbox descendant, and the
+                            search box + custom-entry live outside this list. */}
+                        <div role="listbox" className="max-h-56 overflow-y-auto py-1">
                             {emptyOptionLabel && !search && (
                                 <button
                                     type="button"

--- a/apps/web/src/components/ui/searchable-select.tsx
+++ b/apps/web/src/components/ui/searchable-select.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Check, ChevronDown, Search } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+
+export interface SearchableSelectOption {
+    /** The value stored when this option is picked. */
+    value: string;
+    /** Primary line. */
+    label: string;
+    /** Optional secondary line — an id, a description, a hint. */
+    description?: string;
+}
+
+interface SearchableSelectProps {
+    label?: string;
+    value: string;
+    onChange: (value: string) => void;
+    options: ReadonlyArray<SearchableSelectOption>;
+    /** Shown on the trigger when `value` is empty. */
+    placeholder?: string;
+    /** Helper text under the control. */
+    hint?: string;
+    disabled?: boolean;
+    /**
+     * Allow typing a value that is not in `options`.
+     *
+     * Needed wherever the option list is a convenience rather than the
+     * authority — e.g. a provider id the server knows about but this build
+     * does not, or a cron expression outside the preset list. Without it a
+     * picker becomes strictly less capable than the free-text input it
+     * replaces, which is a regression rather than an improvement.
+     */
+    allowCustom?: boolean;
+    customLabel?: string;
+    customPlaceholder?: string;
+    /** Label for the option that clears the value (e.g. "Account default"). */
+    emptyOptionLabel?: string;
+    /** Stable prefix for e2e selectors. */
+    testId?: string;
+}
+
+/**
+ * Searchable single-select combobox.
+ *
+ * Exists because several settings that are effectively enumerations — AI
+ * provider, model, run cadence — shipped as free-text `<input>`s, which
+ * means the user has to already know the exact id to type. The list is
+ * filterable because these enumerations can be long (a gateway exposes
+ * hundreds of models).
+ *
+ * Modeled on the interaction of `PluginModelSelect`, which solves the same
+ * problem for models specifically and remains the right component when the
+ * options must be fetched per-provider.
+ */
+export function SearchableSelect({
+    label,
+    value,
+    onChange,
+    options,
+    placeholder,
+    hint,
+    disabled = false,
+    allowCustom = false,
+    customLabel,
+    customPlaceholder,
+    emptyOptionLabel,
+    testId,
+}: SearchableSelectProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [search, setSearch] = useState('');
+    const [custom, setCustom] = useState('');
+    const [showCustom, setShowCustom] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const close = useCallback(() => {
+        setIsOpen(false);
+        setSearch('');
+        setShowCustom(false);
+    }, []);
+
+    useEffect(() => {
+        if (!isOpen) return;
+        const onPointerDown = (event: MouseEvent) => {
+            if (!containerRef.current?.contains(event.target as Node)) {
+                close();
+            }
+        };
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') close();
+        };
+        document.addEventListener('mousedown', onPointerDown);
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.removeEventListener('mousedown', onPointerDown);
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [isOpen, close]);
+
+    const filtered = useMemo(() => {
+        if (!search) return options;
+        const needle = search.toLowerCase();
+        return options.filter(
+            (option) =>
+                option.label.toLowerCase().includes(needle) ||
+                option.value.toLowerCase().includes(needle) ||
+                (option.description?.toLowerCase().includes(needle) ?? false),
+        );
+    }, [options, search]);
+
+    const selected = options.find((option) => option.value === value);
+    // A value with no matching option is still shown verbatim — it is either
+    // a custom entry or an id from a newer server, and blanking it would
+    // misrepresent what is actually saved.
+    const display = selected?.label || value || placeholder || '';
+
+    const commitCustom = () => {
+        const trimmed = custom.trim();
+        if (!trimmed) return;
+        onChange(trimmed);
+        setCustom('');
+        close();
+    };
+
+    return (
+        <div>
+            {label && (
+                <label className="block text-xs font-medium text-text dark:text-text-dark mb-2">
+                    {label}
+                </label>
+            )}
+            <div ref={containerRef} className="relative">
+                <button
+                    type="button"
+                    disabled={disabled}
+                    onClick={() => setIsOpen((open) => !open)}
+                    aria-haspopup="listbox"
+                    aria-expanded={isOpen}
+                    data-testid={testId ? `${testId}-trigger` : undefined}
+                    className={cn(
+                        'w-full px-3 py-2 rounded-lg border border-border dark:border-border-dark',
+                        'bg-surface-secondary dark:bg-surface-secondary-dark/30',
+                        'text-text dark:text-text-dark text-left text-sm',
+                        'focus:outline-none focus:ring-2 focus:ring-primary/50',
+                        'flex items-center justify-between gap-2',
+                        disabled && 'opacity-50 cursor-not-allowed',
+                    )}
+                >
+                    <span
+                        className={cn(
+                            'truncate',
+                            !value && 'text-text-muted dark:text-text-muted-dark',
+                        )}
+                    >
+                        {display}
+                    </span>
+                    <ChevronDown className="w-4 h-4 shrink-0 text-text-muted" />
+                </button>
+
+                {isOpen && !disabled && (
+                    <div
+                        role="listbox"
+                        data-testid={testId ? `${testId}-panel` : undefined}
+                        className="absolute z-50 mt-1 w-full rounded-lg border border-border dark:border-border-dark bg-surface dark:bg-surface-dark shadow-lg max-h-80 overflow-hidden"
+                    >
+                        {options.length > 6 && (
+                            <div className="p-2 border-b border-border dark:border-border-dark">
+                                <div className="relative">
+                                    <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-text-muted" />
+                                    <input
+                                        autoFocus
+                                        type="text"
+                                        value={search}
+                                        onChange={(event) => setSearch(event.target.value)}
+                                        className="w-full pl-7 pr-2 py-1.5 text-sm rounded-md bg-surface-secondary dark:bg-surface-secondary-dark/30 border border-border dark:border-border-dark focus:outline-none focus:ring-1 focus:ring-primary/50"
+                                    />
+                                </div>
+                            </div>
+                        )}
+
+                        <div className="max-h-56 overflow-y-auto py-1">
+                            {emptyOptionLabel && !search && (
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        onChange('');
+                                        close();
+                                    }}
+                                    className="w-full px-3 py-2 text-left text-sm hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark/40 flex items-center justify-between gap-2"
+                                >
+                                    <span className="text-text-muted dark:text-text-muted-dark">
+                                        {emptyOptionLabel}
+                                    </span>
+                                    {!value && <Check className="w-3.5 h-3.5 text-primary" />}
+                                </button>
+                            )}
+
+                            {filtered.map((option) => (
+                                <button
+                                    key={option.value}
+                                    type="button"
+                                    role="option"
+                                    aria-selected={option.value === value}
+                                    onClick={() => {
+                                        onChange(option.value);
+                                        close();
+                                    }}
+                                    className="w-full px-3 py-2 text-left hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark/40 flex items-start justify-between gap-2"
+                                >
+                                    <span className="min-w-0">
+                                        <span className="block text-sm text-text dark:text-text-dark truncate">
+                                            {option.label}
+                                        </span>
+                                        {option.description && (
+                                            <span className="block text-xs text-text-muted dark:text-text-muted-dark truncate">
+                                                {option.description}
+                                            </span>
+                                        )}
+                                    </span>
+                                    {option.value === value && (
+                                        <Check className="w-3.5 h-3.5 shrink-0 mt-0.5 text-primary" />
+                                    )}
+                                </button>
+                            ))}
+
+                            {filtered.length === 0 && !allowCustom && (
+                                <p className="px-3 py-3 text-xs text-text-muted dark:text-text-muted-dark">
+                                    {search ? `No match for "${search}"` : 'Nothing to choose from'}
+                                </p>
+                            )}
+                        </div>
+
+                        {allowCustom && (
+                            <div className="border-t border-border dark:border-border-dark p-2">
+                                {showCustom ? (
+                                    <div className="flex items-center gap-1.5">
+                                        <input
+                                            autoFocus
+                                            type="text"
+                                            value={custom}
+                                            placeholder={customPlaceholder}
+                                            onChange={(event) => setCustom(event.target.value)}
+                                            onKeyDown={(event) => {
+                                                if (event.key === 'Enter') {
+                                                    event.preventDefault();
+                                                    commitCustom();
+                                                }
+                                            }}
+                                            className="flex-1 min-w-0 px-2 py-1.5 text-sm rounded-md bg-surface-secondary dark:bg-surface-secondary-dark/30 border border-border dark:border-border-dark focus:outline-none focus:ring-1 focus:ring-primary/50"
+                                        />
+                                        <button
+                                            type="button"
+                                            onClick={commitCustom}
+                                            className="shrink-0 px-2 py-1.5 text-xs rounded-md bg-primary text-white"
+                                        >
+                                            Set
+                                        </button>
+                                    </div>
+                                ) : (
+                                    <button
+                                        type="button"
+                                        onClick={() => setShowCustom(true)}
+                                        className="w-full px-2 py-1.5 text-xs text-left text-primary hover:underline"
+                                    >
+                                        {customLabel ?? 'Enter a custom value…'}
+                                    </button>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                )}
+            </div>
+            {hint && (
+                <p className="mt-1 text-xs text-text-muted dark:text-text-muted-dark">{hint}</p>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/components/ui/searchable-select.unit.spec.tsx
+++ b/apps/web/src/components/ui/searchable-select.unit.spec.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SearchableSelect, type SearchableSelectOption } from './searchable-select';
+
+const OPTIONS: SearchableSelectOption[] = [
+    { value: 'openai', label: 'OpenAI', description: 'openai' },
+    { value: 'anthropic', label: 'Anthropic', description: 'anthropic' },
+    { value: 'openrouter', label: 'OpenRouter', description: 'openrouter' },
+];
+
+function setup(props: Partial<React.ComponentProps<typeof SearchableSelect>> = {}) {
+    const onChange = vi.fn();
+    render(
+        <SearchableSelect
+            label="AI provider"
+            value=""
+            onChange={onChange}
+            options={OPTIONS}
+            placeholder="Account default"
+            testId="picker"
+            {...props}
+        />,
+    );
+    return { onChange };
+}
+
+describe('SearchableSelect', () => {
+    it('shows the placeholder when nothing is selected', () => {
+        setup();
+        expect(screen.getByTestId('picker-trigger')).toHaveTextContent('Account default');
+    });
+
+    it('shows the selected option label, not its raw value', () => {
+        setup({ value: 'anthropic' });
+        expect(screen.getByTestId('picker-trigger')).toHaveTextContent('Anthropic');
+    });
+
+    /**
+     * A value with no matching option must still render verbatim. The
+     * options list is a convenience, not the authority — the server may
+     * know provider ids this build does not, and blanking the trigger
+     * would misrepresent what is actually saved.
+     */
+    it('renders an unknown value verbatim rather than blanking it', () => {
+        setup({ value: 'some-future-provider' });
+        expect(screen.getByTestId('picker-trigger')).toHaveTextContent('some-future-provider');
+    });
+
+    it('opens on click and lists every option', () => {
+        setup();
+        fireEvent.click(screen.getByTestId('picker-trigger'));
+        expect(screen.getByTestId('picker-panel')).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /OpenAI/ })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /Anthropic/ })).toBeInTheDocument();
+    });
+
+    it('reports the picked value and closes', () => {
+        const { onChange } = setup();
+        fireEvent.click(screen.getByTestId('picker-trigger'));
+        fireEvent.click(screen.getByRole('option', { name: /OpenRouter/ }));
+        expect(onChange).toHaveBeenCalledWith('openrouter');
+        expect(screen.queryByTestId('picker-panel')).not.toBeInTheDocument();
+    });
+
+    it('clears the value through the empty option', () => {
+        const { onChange } = setup({ value: 'openai', emptyOptionLabel: 'Account default' });
+        fireEvent.click(screen.getByTestId('picker-trigger'));
+        fireEvent.click(screen.getByRole('button', { name: 'Account default' }));
+        expect(onChange).toHaveBeenCalledWith('');
+    });
+
+    it('accepts a custom value so an unlisted id stays reachable', () => {
+        const { onChange } = setup({
+            allowCustom: true,
+            customLabel: 'Enter a provider id…',
+            customPlaceholder: 'e.g. openrouter',
+        });
+        fireEvent.click(screen.getByTestId('picker-trigger'));
+        fireEvent.click(screen.getByRole('button', { name: 'Enter a provider id…' }));
+        const input = screen.getByPlaceholderText('e.g. openrouter');
+        fireEvent.change(input, { target: { value: '  my-gateway  ' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Set' }));
+        expect(onChange).toHaveBeenCalledWith('my-gateway');
+    });
+
+    it('ignores a blank custom value', () => {
+        const { onChange } = setup({ allowCustom: true, customLabel: 'Custom' });
+        fireEvent.click(screen.getByTestId('picker-trigger'));
+        fireEvent.click(screen.getByRole('button', { name: 'Custom' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Set' }));
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('closes on Escape without selecting anything', () => {
+        const { onChange } = setup();
+        fireEvent.click(screen.getByTestId('picker-trigger'));
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(screen.queryByTestId('picker-panel')).not.toBeInTheDocument();
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not render a search box for a short list', () => {
+        setup();
+        fireEvent.click(screen.getByTestId('picker-trigger'));
+        expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+
+    it('filters a long list by label, value or description', () => {
+        const many: SearchableSelectOption[] = Array.from({ length: 10 }, (_, i) => ({
+            value: `p-${i}`,
+            label: `Provider ${i}`,
+            description: i === 7 ? 'needle-here' : `desc-${i}`,
+        }));
+        setup({ options: many });
+        fireEvent.click(screen.getByTestId('picker-trigger'));
+
+        const search = screen.getByRole('textbox');
+        fireEvent.change(search, { target: { value: 'needle' } });
+
+        expect(screen.getAllByRole('option')).toHaveLength(1);
+        expect(screen.getByRole('option', { name: /Provider 7/ })).toBeInTheDocument();
+    });
+
+    it('is inert when disabled', () => {
+        setup({ disabled: true });
+        const trigger = screen.getByTestId('picker-trigger');
+        expect(trigger).toBeDisabled();
+        fireEvent.click(trigger);
+        expect(screen.queryByTestId('picker-panel')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
Item **9** of the Works overhaul. Independent of #1774 and #1776 — no shared files.

## Problem

The Agent → Runtime section asked users to type an **"AI provider id"** and a **"Model id"** into plain `<input>`s:

```
AI provider id  [ Account default        ]
Model id        [ Provider default       ]
Heartbeat cadence [ manual or cron expression ]
```

All three are things the platform already knows. The provider list is the installed `ai-provider` / `ai-gateway` plugins; the model list is what those plugins advertise (there is already a `fetchModels(pluginId)` action and a `PluginModelSelect` component using it elsewhere). So the only way to fill these correctly was to already know the exact string, with no feedback when you got it wrong.

## Change

- **AI provider** → searchable picker over the installed AI plugins, fetched server-side. Both AI categories are offered because either can back an Agent: a direct provider (`openai`, `anthropic`, …) or a gateway fronting many models (`openrouter`).
- **Model** → reuses the existing **`PluginModelSelect`**, which already solves exactly this for plugin settings: per-provider fetch, module-level cache, in-flight dedupe, search, and context-window/pricing in each row. Disabled until a provider is chosen, since the list is provider-specific.
- Changing the provider **clears the model** — a model picked under the previous provider is almost certainly unroutable under the new one, and keeping it would fail at run time instead of at edit time.
- **Heartbeat cadence** → the common cadences as presets (manual / hourly / 6-hourly / daily / weekly / monthly), each showing its cron.

## All three still accept a typed value

`allowCustom` is deliberate, not a hedge. The option list is a **convenience, not the authority**:

- the server can know provider ids this build does not;
- any cron outside the preset list must stay expressible.

Otherwise the picker would be strictly *less* capable than the input it replaced. For the same reason, a value with **no matching option renders verbatim** rather than showing blank — blanking it would misrepresent what is actually saved. Both behaviours are pinned by tests.

## Failure behaviour

The plugins fetch is `.catch(() => [])` **per category**, so a flaky plugins API degrades the affordance to "type the id" — the same capability as today — rather than breaking the settings page.

## New primitive

`SearchableSelect` (`components/ui/searchable-select.tsx`), modeled on `PluginModelSelect`'s interaction so the two read the same. It's the generic case (static options); `PluginModelSelect` remains correct where options must be fetched per-provider.

**12 unit tests**: placeholder, unknown-value passthrough, open/select/close, clearing via the empty option, custom entry including the blank-input no-op, Escape-to-close, search filtering by label/value/description, search hidden for short lists, disabled inertness.

## Verification

- `apps/web` unit (agents + ui): **31 passed**
- `tsc --noEmit`: clean
- No i18n changes — this section's labels are currently hardcoded English in `AgentSettingsClient`; localizing the whole section is a separate, larger sweep and is deliberately not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an AI provider picker to agent settings using available plugin-based providers, with sorted display and graceful fallback.
  - Reworked model selection to use a searchable model picker tied to the selected provider.
  - Improved heartbeat cadence selection with preset options plus support for custom cron expressions.
  - Introduced a reusable `SearchableSelect` control with optional clearing and custom-value entry.
- **Bug Fixes**
  - Agent settings now safely degrades when provider plugin data can’t be loaded.
- **Tests**
  - Added unit tests for `SearchableSelect` covering selection, clearing, filtering, custom entry, Escape, and disabled behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->