### PR TITLE
feat(works-config): give .works/works.yml a real schema covering every Work kind

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -22,3 +22,11 @@ apps/docs/build
 # but a local `pnpm format:check` would otherwise flag the generated JSON).
 apps/web/e2e/.auth
 apps/web/e2e/test-results
+
+# Generated from the zod schema in
+# `packages/agent/src/works-config/schema/works-config.schema.ts` and
+# committed so it can be served without a build step. Its formatting is
+# owned by `serializeWorksConfigJsonSchema()` — a drift test asserts the
+# file is byte-identical to a fresh generation, so letting Prettier
+# reformat it would fail that test on every run.
+packages/agent/src/works-config/schema/works.v2.schema.json

--- a/apps/api/src/onboarding/onboarding.module.ts
+++ b/apps/api/src/onboarding/onboarding.module.ts
@@ -19,6 +19,7 @@ import { OnboardingTerminalService } from './onboarding-terminal.service';
 import { OnboardingAccountAdapter } from './onboarding-account.adapter';
 import { OnboardingWorkAdapter } from './onboarding-work.adapter';
 import { WellKnownController } from './well-known.controller';
+import { WorksSchemaController } from './works-schema.controller';
 import { OnboardingStateController } from './onboarding-state.controller';
 import { OnboardingStateService } from './onboarding-state.service';
 import { OnboardingCatalogController } from './onboarding-catalog.controller';
@@ -33,6 +34,7 @@ import { UsersModule } from '../users/users.module';
     controllers: [
         OnboardingController,
         WellKnownController,
+        WorksSchemaController,
         ClaimController,
         OnboardingStateController,
         OnboardingCatalogController,

--- a/apps/api/src/onboarding/works-schema.controller.ts
+++ b/apps/api/src/onboarding/works-schema.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Header } from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import { buildWorksConfigJsonSchema } from '@ever-works/agent/works-config';
+import { Public } from '../auth/decorators/public.decorator';
+
+/**
+ * Publishes the JSON Schema for `.works/works.yml`.
+ *
+ * Public and cacheable because it is meant to be referenced directly from a
+ * user's own repository:
+ *
+ *     # yaml-language-server: $schema=https://api.ever.works/api/schema/works.yml.schema.json
+ *
+ * Editors fetch it anonymously to drive completion and inline validation, so
+ * requiring auth here would make the schema useless for exactly the case it
+ * exists to serve. The document is generated from the same zod schema the
+ * server validates with, so the two cannot drift.
+ */
+@ApiExcludeController()
+@Controller()
+export class WorksSchemaController {
+    /** Generated once — the schema is static for the lifetime of the process. */
+    private readonly schema = buildWorksConfigJsonSchema();
+
+    @Public()
+    @Get('api/schema/works.yml.schema.json')
+    @Header('Cache-Control', 'public, max-age=300')
+    @Header('Content-Type', 'application/schema+json; charset=utf-8')
+    worksConfigSchema(): Record<string, unknown> {
+        return this.schema;
+    }
+}

--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -278,6 +278,7 @@ const sidebars: SidebarsConfig = {
 			label: 'Agent Services',
 			items: [
 				'agent-services/work-lifecycle',
+				'agent-services/works-yml-schema',
 				'agent-services/work-generation',
 				'agent-services/work-scheduling',
 				'agent-services/repository-management',

--- a/docs/agent-services/works-yml-schema.md
+++ b/docs/agent-services/works-yml-schema.md
@@ -1,0 +1,196 @@
+---
+title: works.yml schema
+description: The schema for .works/works.yml — the file that describes a Work to the Ever Works platform.
+---
+
+# `.works/works.yml`
+
+Every Work's **Data Repository** may carry a `.works/works.yml`. It is how a
+repository describes itself to the platform: what the Work is called, what
+kind of Work it is, and any kind-specific configuration.
+
+The file is **optional and always partial**. It overrides platform defaults;
+it is never a complete description of a Work. That is why every field below
+is optional — a `works.yml` containing only `name:` is valid.
+
+## Editor support
+
+The published JSON Schema drives completion and inline validation:
+
+```yaml
+# yaml-language-server: $schema=https://api.ever.works/api/schema/works.yml.schema.json
+name: Awesome Chairs
+kind: directory
+```
+
+The schema is generated from the same definition the server validates
+against, so the two cannot drift. It is served publicly and cached for five
+minutes:
+
+```
+GET https://api.ever.works/api/schema/works.yml.schema.json
+```
+
+## Envelope
+
+```yaml
+version: 2 # optional, advisory
+kind: directory # optional, defaults to "default"
+name: Awesome Chairs
+initial_prompt: A curated directory of ergonomic office chairs
+model: anthropic/claude-sonnet-4
+website_repo: ever-works/awesome-chairs-website
+schedule_cadence: weekly # hourly | daily | weekly | monthly
+deploy_provider: vercel
+activity_sync:
+    mode: pull # pull | push | disabled
+spec: {} # kind-specific, see below
+```
+
+| Field              | Type   | Notes                                                                      |
+| ------------------ | ------ | -------------------------------------------------------------------------- |
+| `version`          | int    | Advisory only. Absent means v1. See [Versioning](#versioning).             |
+| `kind`             | string | `website`, `landing-page`, `blog`, `directory`, `awesome-repo`, `company`. |
+| `name` / `title`   | string | Display name of the Work.                                                  |
+| `initial_prompt`   | string | Seeds generation. Capped at 8000 characters.                               |
+| `model`            | string | Preferred model id.                                                        |
+| `website_repo`     | string | `owner/repo` of the Work Repository.                                       |
+| `schedule_cadence` | enum   | How often scheduled generation runs.                                       |
+| `deploy_provider`  | string | Deployment plugin id. `deployProvider` is accepted as an alias.            |
+| `activity_sync`    | object | Activity Feed transport. See ADR-004.                                      |
+| `spec`             | object | Kind-specific configuration.                                               |
+
+## Versioning
+
+`version` is **advisory and never gating**:
+
+- **Absent** → treated as v1. Every file written before `spec` existed keeps
+  working untouched.
+- **Newer than the server understands** → a warning is recorded and the file
+  is parsed anyway. Refusing to read a file written by a newer server would
+  strand your own repository.
+
+**Unknown keys are always preserved.** The platform round-trips this file
+back into your repository, so any key it does not recognise — including one
+written by a newer build, or by hand — survives a write. Nothing is silently
+deleted.
+
+Likewise, a `kind` the server does not recognise is preserved verbatim: its
+`spec` is carried through untouched rather than validated or erased.
+
+## Per-kind `spec`
+
+`spec` holds the configuration that only some kinds of Work need. Its
+accepted shape depends on `kind`.
+
+### `website`
+
+```yaml
+kind: website
+spec:
+    kind: website
+    template: web
+    pages:
+        - path: /pricing
+          title: Pricing
+          prompt: Three tiers, emphasise the free plan
+    nav:
+        header:
+            - { label: Docs, href: /docs }
+    branding: { logo: /logo.svg, theme: slate, locale: en }
+    seo: { title: …, description: …, keywords: [...] }
+    analytics: { provider: plausible }
+```
+
+### `landing-page`
+
+```yaml
+kind: landing-page
+spec:
+    kind: landing-page
+    hero:
+        headline: Ship your directory in an afternoon
+        cta: { label: Join the waitlist, href: '#signup' }
+    sections:
+        - { type: features, title: Why us }
+    capture: { enabled: true, destination: hello@example.com }
+```
+
+### `blog`
+
+```yaml
+kind: blog
+spec:
+    kind: blog
+    content_dir: content/posts
+    authors:
+        - { name: Jane Doe, bio: Writes about agents }
+    taxonomies: { categories: [engineering], tags: [ai] }
+    feed: { enabled: true }
+    pagination: { per_page: 10 }
+    generation:
+        cadence: weekly
+        topics_prompt: Summarise notable AI agent releases
+        posts_per_run: 3
+```
+
+### `directory`
+
+```yaml
+kind: directory
+spec:
+    kind: directory
+    categories: [Ergonomic, Budget]
+    item_fields:
+        - { name: price, type: number }
+    sources:
+        - { url: https://example.com/chairs }
+    submissions: { enabled: true, moderation: manual }
+    comparisons: { enabled: true }
+```
+
+### `awesome-repo`
+
+```yaml
+kind: awesome-repo
+spec:
+    kind: awesome-repo
+    source: { repo: sindresorhus/awesome, branch: main, file: readme.md }
+    sync: { cadence: weekly }
+    readme:
+        header: '# Awesome Chairs'
+        toc: true
+        badges: [awesome]
+    enrich: { enabled: true }
+```
+
+### `company`
+
+```yaml
+kind: company
+spec:
+    kind: company
+    organization: acme
+    company_manifest: .works/company.yml
+    departments:
+        - { name: Engineering }
+    staffing:
+        - { role: Tech writer, agent: docs-bot }
+```
+
+## Validation behaviour
+
+Validation is **advisory at read time**. `.works/works.yml` lives in your
+repository, so a schema complaint must never be able to take a Work offline:
+the platform reads the fields it can, logs what did not match, and carries
+on.
+
+- A **known** `kind` has its `spec` validated strictly — a wrong type or an
+  out-of-range enum is reported.
+- An **unknown** `kind` is not validated, only preserved.
+- A malformed root (not a YAML object) is the one hard error.
+
+## See also
+
+- [`works-config` feature docs](../features/works-config.md)
+- [Repository management](./repository-management.md)

--- a/packages/agent/src/works-config/__tests__/works-config-writer-kind.spec.ts
+++ b/packages/agent/src/works-config/__tests__/works-config-writer-kind.spec.ts
@@ -1,0 +1,123 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import * as yaml from 'yaml';
+import { WorksConfigService } from '../services/works-config.service';
+import { WorksConfigWriterService } from '../services/works-config-writer.service';
+
+/**
+ * `kind` in `.works/works.yml`.
+ *
+ * The writer pushes to the user's own git repository, so the two properties
+ * that matter are: never clobber what they wrote, and never produce a diff
+ * for a Work whose kind carries no information.
+ */
+describe('WorksConfigWriterService — kind', () => {
+    const CONFIG_PATH = '.works/works.yml';
+
+    const makeService = () => new WorksConfigWriterService(new WorksConfigService({} as never));
+
+    const createWork = (kind?: string) =>
+        ({
+            name: 'Compare Cloud Pricing',
+            kind,
+            getRepoOwner: jest.fn((role?: string) =>
+                role === 'website' ? 'ever-works-web' : 'ever-works',
+            ),
+            getDataRepo: jest.fn().mockReturnValue('compare-cloud-pricing-data'),
+            getMainRepo: jest.fn().mockReturnValue('compare-cloud-pricing'),
+            getWebsiteRepo: jest.fn().mockReturnValue('compare-cloud-pricing-site'),
+            scheduledUpdatesEnabled: true,
+            scheduledCadence: 'weekly',
+        }) as never;
+
+    const write = async (repoDir: string, work: never) => {
+        await makeService().writeToDataRepository({
+            work,
+            dataRepository: { dir: repoDir } as never,
+            request: { name: 'Compare Cloud Pricing', prompt: 'Track cloud pricing' },
+        } as never);
+        return fs.readFile(path.join(repoDir, CONFIG_PATH), 'utf-8');
+    };
+
+    const tmpRepo = () => fs.mkdtemp(path.join(os.tmpdir(), 'works-config-kind-'));
+
+    it('writes the kind for a kind-aware Work', async () => {
+        const repoDir = await tmpRepo();
+        const raw = await write(repoDir, createWork('blog'));
+        expect(yaml.parse(raw).kind).toBe('blog');
+    });
+
+    it.each(['website', 'landing-page', 'directory', 'awesome-repo', 'company'])(
+        'writes the %s kind',
+        async (kind) => {
+            const repoDir = await tmpRepo();
+            expect(yaml.parse(await write(repoDir, createWork(kind))).kind).toBe(kind);
+        },
+    );
+
+    /**
+     * `default` carries no information — it is also the parse-time fallback —
+     * so writing it would add a diff to every existing repository for no
+     * gain, and break the `cacheEmpty === cfgEmpty` invariant that
+     * `flow-work-config-cache.spec.ts` pins.
+     */
+    it('omits the key entirely for a default-kind Work', async () => {
+        const repoDir = await tmpRepo();
+        const raw = await write(repoDir, createWork('default'));
+        expect(yaml.parse(raw).kind).toBeUndefined();
+        expect(raw).not.toContain('kind:');
+    });
+
+    it('omits the key when the Work has no kind at all', async () => {
+        const repoDir = await tmpRepo();
+        const raw = await write(repoDir, createWork(undefined));
+        expect(raw).not.toContain('kind:');
+    });
+
+    /**
+     * The byte-identical property, stated directly: a default-kind Work's
+     * file must be exactly what the writer produced before `kind` existed.
+     */
+    it('produces an identical file for a default-kind and a kindless Work', async () => {
+        const [a, b] = await Promise.all([tmpRepo(), tmpRepo()]);
+        expect(await write(a, createWork('default'))).toBe(await write(b, createWork(undefined)));
+    });
+
+    /**
+     * The file belongs to the user and may declare a kind this build does
+     * not know — a newer server, or hand-authored. Overwriting it with our
+     * view would corrupt their repository on a routine round-trip write.
+     */
+    it('preserves a kind already present in the file', async () => {
+        const repoDir = await tmpRepo();
+        await fs.mkdir(path.join(repoDir, '.works'), { recursive: true });
+        await fs.writeFile(
+            path.join(repoDir, CONFIG_PATH),
+            ['name: Existing', 'kind: storefront'].join('\n'),
+            'utf-8',
+        );
+
+        const raw = await write(repoDir, createWork('blog'));
+        expect(yaml.parse(raw).kind).toBe('storefront');
+    });
+
+    it('does not overwrite an existing kind even when the Work is default', async () => {
+        const repoDir = await tmpRepo();
+        await fs.mkdir(path.join(repoDir, '.works'), { recursive: true });
+        await fs.writeFile(
+            path.join(repoDir, CONFIG_PATH),
+            ['name: Existing', 'kind: directory'].join('\n'),
+            'utf-8',
+        );
+
+        expect(yaml.parse(await write(repoDir, createWork('default'))).kind).toBe('directory');
+    });
+
+    it('round-trips: what the writer emits parses back to the same kind', async () => {
+        const repoDir = await tmpRepo();
+        const raw = await write(repoDir, createWork('landing-page'));
+        const parsed = new WorksConfigService({} as never).parse(raw);
+        expect(parsed.kind).toBe('landing-page');
+    });
+});

--- a/packages/agent/src/works-config/index.ts
+++ b/packages/agent/src/works-config/index.ts
@@ -7,3 +7,5 @@ export * from './services/works-config-projection.service';
 export * from './services/works-config-repository-sync.service';
 export * from './services/works-config-sync.listener';
 export * from './works-config-data';
+export * from './schema/works-config.schema';
+export * from './schema/emit-json-schema';

--- a/packages/agent/src/works-config/schema/__tests__/emit-json-schema.spec.ts
+++ b/packages/agent/src/works-config/schema/__tests__/emit-json-schema.spec.ts
@@ -1,0 +1,81 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+    WORKS_CONFIG_SCHEMA_ID,
+    buildWorksConfigJsonSchema,
+    serializeWorksConfigJsonSchema,
+} from '../emit-json-schema';
+import { KIND_SPEC_SCHEMAS } from '../works-config.schema';
+
+const GENERATED_PATH = path.join(__dirname, '..', 'works.v2.schema.json');
+
+describe('works.yml JSON Schema', () => {
+    it('declares a draft, an $id and a title', () => {
+        const schema = buildWorksConfigJsonSchema();
+        expect(schema.$schema).toMatch(/json-schema\.org/);
+        expect(schema.$id).toBe(WORKS_CONFIG_SCHEMA_ID);
+        expect(schema.title).toContain('works.yml');
+    });
+
+    it('exposes the v1 root keys so editors complete them', () => {
+        const properties = buildWorksConfigJsonSchema().properties as Record<string, unknown>;
+        for (const key of [
+            'name',
+            'initial_prompt',
+            'website_repo',
+            'schedule_cadence',
+            'version',
+            'kind',
+            'spec',
+        ]) {
+            expect({ key, present: properties[key] !== undefined }).toEqual({
+                key,
+                present: true,
+            });
+        }
+    });
+
+    it('expands spec into one branch per known kind, plus an escape hatch', () => {
+        const properties = buildWorksConfigJsonSchema().properties as Record<string, any>;
+        const branches = properties.spec.oneOf as Array<{ title?: string }>;
+
+        // One per known kind + the unrecognised-kind passthrough.
+        expect(branches).toHaveLength(Object.keys(KIND_SPEC_SCHEMAS).length + 1);
+
+        for (const kind of Object.keys(KIND_SPEC_SCHEMAS)) {
+            expect({
+                kind,
+                hasBranch: branches.some((b) => b.title === `spec for kind: ${kind}`),
+            }).toEqual({ kind, hasBranch: true });
+        }
+        expect(branches.some((branch) => branch.title === 'spec for an unrecognised kind')).toBe(
+            true,
+        );
+    });
+
+    it('serializes deterministically', () => {
+        expect(serializeWorksConfigJsonSchema()).toBe(serializeWorksConfigJsonSchema());
+    });
+
+    /**
+     * The generated document is committed so it can be served without a build
+     * step and reviewed in diffs. This is the drift guard: change the zod
+     * schema without regenerating and CI fails here.
+     *
+     * Regenerate with:
+     *   pnpm --filter @ever-works/agent exec jest works-config/schema -u
+     * (or simply delete the file and re-run — it is written on first run.)
+     */
+    it('matches the committed works.v2.schema.json', () => {
+        const generated = serializeWorksConfigJsonSchema();
+
+        if (!fs.existsSync(GENERATED_PATH)) {
+            fs.writeFileSync(GENERATED_PATH, generated, 'utf8');
+        }
+
+        const committed = fs.readFileSync(GENERATED_PATH, 'utf8');
+        // If this fails, works.v2.schema.json is stale — regenerate it
+        // (see the comment above this test).
+        expect(committed).toBe(generated);
+    });
+});

--- a/packages/agent/src/works-config/schema/__tests__/works-config.schema.spec.ts
+++ b/packages/agent/src/works-config/schema/__tests__/works-config.schema.spec.ts
@@ -153,6 +153,31 @@ describe('worksConfigSchema', () => {
         });
 
         /**
+         * Security regression — prototype-chain kinds. `KIND_SPEC_SCHEMAS`
+         * is an object literal, so a bare index with `kind: constructor` /
+         * `__proto__` / `toString` resolved to a truthy non-schema value and
+         * `.safeParse` THREW — breaking the never-throws contract with an
+         * attacker-suppliable input, and (on the write path) permanently
+         * locking a Work whose committed file carried such a kind, because
+         * the throw happens at read, before any rewrite can repair it.
+         */
+        it.each(['constructor', '__proto__', 'toString', 'valueOf', 'hasOwnProperty'])(
+            'treats the prototype-chain kind %s as unknown instead of throwing',
+            (kind) => {
+                let result: ReturnType<typeof validateWorksConfig> | undefined;
+                expect(() => {
+                    result = validateWorksConfig({ version: 2, kind, spec: { kind } });
+                }).not.toThrow();
+
+                expect(result?.errors).toEqual([]);
+                // Preserved as data, warned as unrecognised — same handling
+                // as any other unknown kind.
+                expect(result?.data?.spec).toMatchObject({ kind });
+                expect(result?.warnings.join(' ')).toMatch(/does not recognise/i);
+            },
+        );
+
+        /**
          * A newer server may ship a kind this build has never heard of. The
          * writer round-trips whatever it parsed, so rejecting here would
          * corrupt that user's file on the next write.

--- a/packages/agent/src/works-config/schema/__tests__/works-config.schema.spec.ts
+++ b/packages/agent/src/works-config/schema/__tests__/works-config.schema.spec.ts
@@ -1,0 +1,214 @@
+import * as yaml from 'yaml';
+import {
+    WORKS_CONFIG_SCHEMA_VERSION,
+    validateWorksConfig,
+    worksConfigSchema,
+} from '../works-config.schema';
+
+describe('worksConfigSchema', () => {
+    describe('backwards compatibility with v1 files', () => {
+        it('accepts a bare v1 document with no version, kind or spec', () => {
+            const result = validateWorksConfig({
+                name: 'Awesome Chairs',
+                initial_prompt: 'A directory of ergonomic office chairs',
+                website_repo: 'ever-works/awesome-chairs-website',
+                schedule_cadence: 'weekly',
+            });
+
+            expect(result.errors).toEqual([]);
+            expect(result.warnings).toEqual([]);
+            expect(result.data?.name).toBe('Awesome Chairs');
+        });
+
+        it('accepts an empty document', () => {
+            const result = validateWorksConfig({});
+            expect(result.errors).toEqual([]);
+        });
+
+        it('accepts both the snake_case and camelCase deploy-provider spellings', () => {
+            expect(validateWorksConfig({ deploy_provider: 'vercel' }).errors).toEqual([]);
+            expect(validateWorksConfig({ deployProvider: 'vercel' }).errors).toEqual([]);
+        });
+    });
+
+    describe('root validation', () => {
+        it.each([
+            ['null', null],
+            ['a string', 'name: x'],
+            ['an array', [{ name: 'x' }]],
+            ['undefined', undefined],
+        ])('rejects %s at the root', (_label, input) => {
+            const result = validateWorksConfig(input);
+            expect(result.errors).toHaveLength(1);
+            expect(result.errors[0]).toMatch(/must contain a YAML object/);
+            expect(result.data).toBeUndefined();
+        });
+
+        it('never throws, whatever it is handed', () => {
+            for (const input of [Symbol('x'), 42, () => undefined, new Map()]) {
+                expect(() => validateWorksConfig(input)).not.toThrow();
+            }
+        });
+    });
+
+    describe('unknown keys', () => {
+        /**
+         * The writer round-trips the parsed document back into the user's git
+         * repository. A stripping schema would silently delete keys written by
+         * a newer build — or by hand — so preservation is a correctness
+         * requirement, not leniency.
+         */
+        it('preserves unknown root keys', () => {
+            const result = validateWorksConfig({
+                name: 'X',
+                some_future_key: { nested: ['a', 'b'] },
+            });
+
+            expect(result.errors).toEqual([]);
+            expect(result.data).toMatchObject({ some_future_key: { nested: ['a', 'b'] } });
+        });
+
+        it('preserves unknown keys nested inside a per-kind spec', () => {
+            const result = validateWorksConfig({
+                kind: 'website',
+                spec: { kind: 'website', template: 'web', future_thing: 42 },
+            });
+
+            expect(result.errors).toEqual([]);
+            expect(result.data?.spec).toMatchObject({ future_thing: 42 });
+        });
+
+        it('round-trips a document through YAML unchanged', () => {
+            const source = [
+                'version: 2',
+                'kind: blog',
+                'name: Engineering Blog',
+                'hand_written_extra: keep me',
+                'spec:',
+                '  kind: blog',
+                '  content_dir: content/posts',
+                '  unknown_nested: 7',
+                '  generation:',
+                '    cadence: weekly',
+                '    posts_per_run: 3',
+            ].join('\n');
+
+            const first = validateWorksConfig(yaml.parse(source));
+            expect(first.errors).toEqual([]);
+
+            const second = validateWorksConfig(yaml.parse(yaml.stringify(first.data)));
+            expect(second.errors).toEqual([]);
+            expect(second.data).toEqual(first.data);
+            expect(second.data).toMatchObject({
+                hand_written_extra: 'keep me',
+                spec: { unknown_nested: 7 },
+            });
+        });
+    });
+
+    describe('version handling', () => {
+        it('is silent about the current version', () => {
+            const result = validateWorksConfig({ version: WORKS_CONFIG_SCHEMA_VERSION });
+            expect(result.warnings).toEqual([]);
+            expect(result.errors).toEqual([]);
+        });
+
+        /**
+         * Refusing to read a file written by a newer server would strand the
+         * user's own repository, so a future version warns and parses.
+         */
+        it('warns but still parses a newer version', () => {
+            const result = validateWorksConfig({
+                version: WORKS_CONFIG_SCHEMA_VERSION + 5,
+                name: 'From the future',
+            });
+
+            expect(result.errors).toEqual([]);
+            expect(result.warnings).toHaveLength(1);
+            expect(result.warnings[0]).toMatch(/parsing leniently/i);
+            expect(result.data?.name).toBe('From the future');
+        });
+
+        it('rejects a non-positive or non-integer version', () => {
+            expect(validateWorksConfig({ version: 0 }).errors).not.toEqual([]);
+            expect(validateWorksConfig({ version: 2.5 }).errors).not.toEqual([]);
+        });
+    });
+
+    describe('per-kind spec', () => {
+        it.each([
+            ['website', { kind: 'website', template: 'web', pages: [{ path: '/pricing' }] }],
+            ['landing-page', { kind: 'landing-page', hero: { headline: 'Ship faster' } }],
+            ['blog', { kind: 'blog', generation: { cadence: 'daily', posts_per_run: 2 } }],
+            [
+                'directory',
+                { kind: 'directory', submissions: { enabled: true, moderation: 'manual' } },
+            ],
+            ['awesome-repo', { kind: 'awesome-repo', source: { repo: 'o/r', branch: 'main' } }],
+            ['company', { kind: 'company', departments: [{ name: 'Engineering' }] }],
+        ])('accepts a %s spec', (kind, spec) => {
+            const result = validateWorksConfig({ version: 2, kind, spec });
+            expect(result.errors).toEqual([]);
+            expect(result.data?.spec).toMatchObject({ kind });
+        });
+
+        /**
+         * A newer server may ship a kind this build has never heard of. The
+         * writer round-trips whatever it parsed, so rejecting here would
+         * corrupt that user's file on the next write.
+         */
+        it('accepts and preserves a spec for an unrecognised kind', () => {
+            const result = validateWorksConfig({
+                version: 2,
+                kind: 'storefront',
+                spec: { kind: 'storefront', catalog: { currency: 'USD' } },
+            });
+
+            expect(result.errors).toEqual([]);
+            expect(result.data?.spec).toMatchObject({
+                kind: 'storefront',
+                catalog: { currency: 'USD' },
+            });
+        });
+
+        it('rejects a spec whose typed field has the wrong type', () => {
+            const result = validateWorksConfig({
+                kind: 'blog',
+                spec: { kind: 'blog', generation: { posts_per_run: 'three' } },
+            });
+            expect(result.errors.join(' ')).toMatch(/posts_per_run/);
+        });
+
+        it('rejects an out-of-range enum', () => {
+            const result = validateWorksConfig({
+                kind: 'blog',
+                spec: { kind: 'blog', generation: { cadence: 'fortnightly' } },
+            });
+            expect(result.errors).not.toEqual([]);
+        });
+    });
+
+    describe('field constraints', () => {
+        it('rejects an over-long initial_prompt', () => {
+            const result = validateWorksConfig({ initial_prompt: 'x'.repeat(8001) });
+            expect(result.errors.join(' ')).toMatch(/initial_prompt/);
+        });
+
+        it('accepts an initial_prompt at the limit', () => {
+            expect(validateWorksConfig({ initial_prompt: 'x'.repeat(8000) }).errors).toEqual([]);
+        });
+
+        it('rejects an over-long kind', () => {
+            expect(validateWorksConfig({ kind: 'k'.repeat(33) }).errors).not.toEqual([]);
+        });
+
+        it('rejects an unknown schedule cadence', () => {
+            expect(validateWorksConfig({ schedule_cadence: 'fortnightly' }).errors).not.toEqual([]);
+        });
+    });
+
+    it('exposes a parseable schema object for JSON Schema emission', () => {
+        expect(worksConfigSchema).toBeDefined();
+        expect(worksConfigSchema.safeParse({}).success).toBe(true);
+    });
+});

--- a/packages/agent/src/works-config/schema/emit-json-schema.ts
+++ b/packages/agent/src/works-config/schema/emit-json-schema.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod/v4';
+import {
+    KIND_SPEC_SCHEMAS,
+    WORKS_CONFIG_SCHEMA_VERSION,
+    worksConfigSchema,
+} from './works-config.schema';
+
+/**
+ * The canonical `$id` under which the schema is published.
+ *
+ * Editors resolve `# yaml-language-server: $schema=<this>` against it, and
+ * `apps/api` serves the generated document at the matching path.
+ */
+export const WORKS_CONFIG_SCHEMA_ID = 'https://api.ever.works/api/schema/works.yml.schema.json';
+
+/**
+ * Build the published JSON Schema for `.works/works.yml`.
+ *
+ * The runtime zod schema keeps `spec` structural (see the dispatch note in
+ * `works-config.schema.ts`), but a published schema exists to drive editor
+ * completion — so here the per-kind shapes are expanded into a `oneOf` keyed
+ * on `spec.kind`. Unknown kinds still validate because every branch, and the
+ * document itself, permits additional properties.
+ */
+export function buildWorksConfigJsonSchema(): Record<string, unknown> {
+    const base = z.toJSONSchema(worksConfigSchema, { io: 'input' }) as Record<string, unknown>;
+
+    const specBranches = Object.entries(KIND_SPEC_SCHEMAS).map(([kind, schema]) => {
+        const branch = z.toJSONSchema(schema, { io: 'input' }) as Record<string, unknown>;
+        return { title: `spec for kind: ${kind}`, ...branch };
+    });
+
+    const properties = { ...(base.properties as Record<string, unknown> | undefined) };
+    properties.spec = {
+        description:
+            'Kind-specific configuration. The accepted shape depends on `kind`. ' +
+            'A kind this schema does not list is still allowed — its spec is ' +
+            'preserved as-is and not validated.',
+        oneOf: [
+            ...specBranches,
+            {
+                title: 'spec for an unrecognised kind',
+                type: 'object',
+                additionalProperties: true,
+            },
+        ],
+    };
+
+    return {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        $id: WORKS_CONFIG_SCHEMA_ID,
+        title: 'Ever Works — .works/works.yml',
+        description:
+            `Schema version ${WORKS_CONFIG_SCHEMA_VERSION}. Every field is optional: ` +
+            'works.yml is a partial override of platform defaults, never a complete ' +
+            'description of a Work. Unknown keys are preserved on write.',
+        ...base,
+        properties,
+    };
+}
+
+/** Stable, byte-reproducible serialization — CI compares against the committed file. */
+export function serializeWorksConfigJsonSchema(): string {
+    return `${JSON.stringify(buildWorksConfigJsonSchema(), null, 4)}\n`;
+}

--- a/packages/agent/src/works-config/schema/works-config.schema.ts
+++ b/packages/agent/src/works-config/schema/works-config.schema.ts
@@ -327,7 +327,18 @@ export function validateWorksConfig(raw: unknown): WorksConfigValidation {
     const spec = result.data.spec;
     if (spec) {
         const specKind = spec.kind ?? result.data.kind;
-        const kindSchema = specKind ? KIND_SPEC_SCHEMAS[specKind as KnownSpecKind] : undefined;
+        // Security: own-property lookup ONLY. `specKind` is attacker-supplied
+        // (a crafted repo's works.yml), and a bare index on an object literal
+        // resolves prototype-chain names — `kind: constructor` /
+        // `kind: __proto__` / `kind: toString` would return a truthy
+        // non-schema value whose `.safeParse` then THROWS, breaking this
+        // function's never-throws contract and (on the write path) locking
+        // the Work's config permanently: the throw happens at read, before
+        // any rewrite could repair the file.
+        const kindSchema =
+            specKind && Object.prototype.hasOwnProperty.call(KIND_SPEC_SCHEMAS, specKind)
+                ? KIND_SPEC_SCHEMAS[specKind as KnownSpecKind]
+                : undefined;
 
         if (kindSchema) {
             const specResult = kindSchema.safeParse({ ...spec, kind: specKind });

--- a/packages/agent/src/works-config/schema/works-config.schema.ts
+++ b/packages/agent/src/works-config/schema/works-config.schema.ts
@@ -1,0 +1,356 @@
+import { z } from 'zod/v4';
+
+/**
+ * `.works/works.yml` — the versioned schema.
+ *
+ * ## Why this exists
+ *
+ * Until now `.works/works.yml` had no validator at all. `WorksConfigService`
+ * hand-coerced a handful of known keys and silently dropped anything it did
+ * not recognise, so a typo produced no error — just a Work that quietly
+ * behaved as if the field had never been written. There was also no schema
+ * to point an editor at, and nothing described the fields that only some
+ * kinds of Work need.
+ *
+ * ## Design
+ *
+ * **Additive envelope.** v2 is v1 plus three optional keys — `version`,
+ * `kind`, `spec`. Every file already in the wild is a valid v2 file, and a
+ * `default`-kind Work's file stays byte-identical to what is written today.
+ *
+ * **`version` is advisory, never gating.** Absent means v1. A version newer
+ * than this build understands produces a warning and is parsed leniently
+ * rather than rejected — refusing to read a file written by a newer server
+ * would strand the user's own repository. (Docker Compose learned this the
+ * hard way with its `version:` key.)
+ *
+ * **Unknown keys are preserved, everywhere.** Every object is a
+ * `looseObject`. This is load-bearing rather than lax: the writer
+ * round-trips the parsed document back to the user's git repository, so a
+ * stripping `z.object()` would silently delete any key this build does not
+ * know — including keys written by a NEWER build, and hand-authored ones.
+ *
+ * **`spec` is discriminated on `kind`.** Per-kind configuration nests under
+ * `spec` rather than sitting at the root, which keeps the flat v1 root
+ * namespace clean and gives the deep-merge in `DataRepository.mergeConfig`
+ * exactly one new key to reason about.
+ *
+ * **Unknown kinds parse.** `spec` for an unrecognised kind falls through to
+ * a permissive passthrough, so a `kind: storefront` written by a newer
+ * server round-trips intact instead of being erased.
+ */
+
+/** Bumped only when the envelope itself changes shape, not per-kind spec edits. */
+export const WORKS_CONFIG_SCHEMA_VERSION = 2;
+
+/**
+ * Security: `initial_prompt` is attacker-controlled external content that is
+ * forwarded into the LLM generation pipeline. Bounded here as
+ * defense-in-depth; mirrors `MAX_INITIAL_PROMPT_LENGTH` in
+ * `works-config.service.ts`. Legitimate prompts are far below this.
+ */
+const MAX_INITIAL_PROMPT_LENGTH = 8000;
+
+const nonEmptyString = z.string().trim().min(1);
+
+/** A repository reference — `owner/repo`, or a full https URL. */
+const repoRef = z.string().trim().max(400);
+
+const scheduleCadence = z.enum(['hourly', 'daily', 'weekly', 'monthly']);
+
+const activitySync = z.looseObject({
+    mode: z.enum(['pull', 'push', 'disabled']).optional(),
+});
+
+const seo = z.looseObject({
+    title: z.string().optional(),
+    description: z.string().optional(),
+    keywords: z.union([z.string(), z.array(z.string())]).optional(),
+    author: z.string().optional(),
+    image: z.string().optional(),
+    twitter: z.string().optional(),
+    url: z.string().optional(),
+});
+
+const branding = z.looseObject({
+    logo: z.string().optional(),
+    favicon: z.string().optional(),
+    theme: z.string().optional(),
+    locale: z.string().optional(),
+});
+
+// ── Per-kind `spec` shapes ────────────────────────────────────────────────
+//
+// Each captures what that kind's generator actually consumes. Every field is
+// optional: `works.yml` is a partial override of platform defaults, never a
+// complete description, so requiring anything here would reject valid files.
+
+const websiteSpec = z.looseObject({
+    kind: z.literal('website'),
+    template: nonEmptyString.optional(),
+    pages: z
+        .array(
+            z.looseObject({
+                path: nonEmptyString,
+                title: z.string().optional(),
+                prompt: z.string().optional(),
+            }),
+        )
+        .optional(),
+    nav: z
+        .looseObject({
+            header: z.array(z.looseObject({ label: z.string(), href: z.string() })).optional(),
+            footer: z.array(z.looseObject({ label: z.string(), href: z.string() })).optional(),
+        })
+        .optional(),
+    branding: branding.optional(),
+    seo: seo.optional(),
+    analytics: z.looseObject({ provider: z.string().optional() }).optional(),
+});
+
+const landingPageSpec = z.looseObject({
+    kind: z.literal('landing-page'),
+    template: nonEmptyString.optional(),
+    hero: z
+        .looseObject({
+            headline: z.string().optional(),
+            subheadline: z.string().optional(),
+            cta: z.looseObject({ label: z.string(), href: z.string() }).optional(),
+        })
+        .optional(),
+    sections: z
+        .array(z.looseObject({ type: nonEmptyString, title: z.string().optional() }))
+        .optional(),
+    capture: z
+        .looseObject({
+            enabled: z.boolean().optional(),
+            destination: z.string().optional(),
+        })
+        .optional(),
+    branding: branding.optional(),
+    seo: seo.optional(),
+    analytics: z.looseObject({ provider: z.string().optional() }).optional(),
+});
+
+const blogSpec = z.looseObject({
+    kind: z.literal('blog'),
+    template: nonEmptyString.optional(),
+    content_dir: z.string().optional(),
+    authors: z
+        .array(z.looseObject({ name: nonEmptyString, bio: z.string().optional() }))
+        .optional(),
+    taxonomies: z
+        .looseObject({
+            categories: z.array(z.string()).optional(),
+            tags: z.array(z.string()).optional(),
+        })
+        .optional(),
+    feed: z.looseObject({ enabled: z.boolean().optional() }).optional(),
+    pagination: z.looseObject({ per_page: z.number().int().positive().optional() }).optional(),
+    generation: z
+        .looseObject({
+            cadence: scheduleCadence.optional(),
+            topics_prompt: z.string().max(MAX_INITIAL_PROMPT_LENGTH).optional(),
+            posts_per_run: z.number().int().positive().optional(),
+        })
+        .optional(),
+    branding: branding.optional(),
+    seo: seo.optional(),
+});
+
+const directorySpec = z.looseObject({
+    kind: z.literal('directory'),
+    template: nonEmptyString.optional(),
+    categories: z.array(z.union([z.string(), z.looseObject({ name: nonEmptyString })])).optional(),
+    tags: z.array(z.union([z.string(), z.looseObject({ name: nonEmptyString })])).optional(),
+    item_fields: z
+        .array(z.looseObject({ name: nonEmptyString, type: z.string().optional() }))
+        .optional(),
+    sources: z.array(z.looseObject({ url: z.string().optional() })).optional(),
+    submissions: z
+        .looseObject({
+            enabled: z.boolean().optional(),
+            moderation: z.enum(['auto', 'manual']).optional(),
+        })
+        .optional(),
+    comparisons: z.looseObject({ enabled: z.boolean().optional() }).optional(),
+    branding: branding.optional(),
+    seo: seo.optional(),
+});
+
+const awesomeRepoSpec = z.looseObject({
+    kind: z.literal('awesome-repo'),
+    template: nonEmptyString.optional(),
+    source: z
+        .looseObject({
+            repo: repoRef.optional(),
+            branch: z.string().optional(),
+            file: z.string().optional(),
+        })
+        .optional(),
+    sync: z.looseObject({ cadence: scheduleCadence.optional() }).optional(),
+    // Mirrors `MarkdownReadmeConfig` on the Work entity.
+    readme: z
+        .looseObject({
+            header: z.string().optional(),
+            footer: z.string().optional(),
+            overwriteDefaultHeader: z.boolean().optional(),
+            overwriteDefaultFooter: z.boolean().optional(),
+            toc: z.boolean().optional(),
+            badges: z.array(z.string()).optional(),
+        })
+        .optional(),
+    enrich: z.looseObject({ enabled: z.boolean().optional() }).optional(),
+});
+
+const companySpec = z.looseObject({
+    kind: z.literal('company'),
+    organization: z.string().optional(),
+    /** Path to the richer `agentcompanies/v1` sidecar, when present. */
+    company_manifest: z.string().optional(),
+    departments: z.array(z.looseObject({ name: nonEmptyString })).optional(),
+    staffing: z
+        .array(z.looseObject({ role: nonEmptyString, agent: z.string().optional() }))
+        .optional(),
+    branding: branding.optional(),
+});
+
+/**
+ * The per-kind spec schemas, dispatched by kind.
+ *
+ * Deliberately NOT a `z.union([discriminatedUnion, passthrough])`: a union
+ * would let an INVALID typed spec (say `blog` with `posts_per_run: "three"`)
+ * fall through to the permissive branch and validate, which defeats the
+ * point of having typed specs at all. Instead the kind is looked up here and
+ * validated strictly when known; only a genuinely unrecognised kind takes
+ * the passthrough path.
+ */
+export const KIND_SPEC_SCHEMAS = {
+    website: websiteSpec,
+    'landing-page': landingPageSpec,
+    blog: blogSpec,
+    directory: directorySpec,
+    'awesome-repo': awesomeRepoSpec,
+    company: companySpec,
+} as const;
+
+export type KnownSpecKind = keyof typeof KIND_SPEC_SCHEMAS;
+
+/**
+ * Structural schema for `spec` — every spec is an object and MAY name its
+ * kind. The per-kind field validation runs separately in
+ * `validateWorksConfig`, which is what lets an unknown kind pass through
+ * while a known one is checked strictly.
+ */
+export const worksConfigSpecSchema = z.looseObject({
+    kind: z.string().trim().max(32).optional(),
+});
+
+/**
+ * The full `.works/works.yml` document.
+ *
+ * The v1 root keys are all still here and still optional; `version`, `kind`
+ * and `spec` are the v2 additions.
+ */
+export const worksConfigSchema = z.looseObject({
+    /** Advisory. Absent ⇒ v1. Newer than we know ⇒ warn, parse anyway. */
+    version: z.number().int().positive().optional(),
+    /**
+     * Which kind of Work this repository describes. Absent ⇒ `default`.
+     * Deliberately a plain string, not an enum: an unrecognised value must
+     * round-trip rather than fail, so the server can ship a new kind
+     * without every existing client rejecting the file.
+     */
+    kind: z.string().trim().max(32).optional(),
+
+    // ── v1 root keys ──────────────────────────────────────────────────
+    name: z.string().optional(),
+    title: z.string().optional(),
+    initial_prompt: z.string().max(MAX_INITIAL_PROMPT_LENGTH).optional(),
+    model: z.string().optional(),
+    website_repo: repoRef.optional(),
+    schedule_cadence: scheduleCadence.optional(),
+    deploy_provider: z.string().optional(),
+    deployProvider: z.string().optional(),
+    activity_sync: activitySync.optional(),
+    providers: z.looseObject({}).optional(),
+
+    /** Kind-specific configuration. */
+    spec: worksConfigSpecSchema.optional(),
+});
+
+export type WorksConfigDocument = z.infer<typeof worksConfigSchema>;
+export type WorksConfigSpec = z.infer<typeof worksConfigSpecSchema>;
+
+export interface WorksConfigValidation {
+    /** The parsed document. Present whenever the root was a valid object. */
+    data?: WorksConfigDocument;
+    /** Blocking problems — the document could not be understood. */
+    errors: string[];
+    /** Non-blocking observations (e.g. a newer `version`). */
+    warnings: string[];
+}
+
+/**
+ * Validate an already-YAML-parsed document.
+ *
+ * Never throws. A `.works/works.yml` lives in the user's own repository and
+ * a schema quibble must not be able to take their Work offline — callers
+ * decide whether to surface `errors` or proceed on `data`.
+ */
+export function validateWorksConfig(raw: unknown): WorksConfigValidation {
+    const warnings: string[] = [];
+
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        return {
+            errors: ['.works/works.yml must contain a YAML object at the root'],
+            warnings,
+        };
+    }
+
+    const version = (raw as Record<string, unknown>).version;
+    if (typeof version === 'number' && version > WORKS_CONFIG_SCHEMA_VERSION) {
+        warnings.push(
+            `works.yml declares version ${version} but this build understands ` +
+                `${WORKS_CONFIG_SCHEMA_VERSION}. Parsing leniently; unrecognised keys are preserved.`,
+        );
+    }
+
+    const result = worksConfigSchema.safeParse(raw);
+    if (!result.success) {
+        return { errors: formatIssues(result.error.issues), warnings };
+    }
+
+    // Per-kind spec validation. The kind is taken from `spec.kind` when
+    // present, otherwise from the root `kind` — a file that says
+    // `kind: blog` at the root need not repeat itself inside `spec`.
+    const spec = result.data.spec;
+    if (spec) {
+        const specKind = spec.kind ?? result.data.kind;
+        const kindSchema = specKind ? KIND_SPEC_SCHEMAS[specKind as KnownSpecKind] : undefined;
+
+        if (kindSchema) {
+            const specResult = kindSchema.safeParse({ ...spec, kind: specKind });
+            if (!specResult.success) {
+                return {
+                    errors: formatIssues(specResult.error.issues, 'spec'),
+                    warnings,
+                };
+            }
+        } else if (specKind) {
+            warnings.push(
+                `works.yml declares kind "${specKind}", which this build does not recognise. ` +
+                    `The spec block is preserved as-is but not validated.`,
+            );
+        }
+    }
+
+    return { data: result.data, errors: [], warnings };
+}
+
+function formatIssues(issues: readonly z.core.$ZodIssue[], prefix?: string): string[] {
+    return issues.map((issue) => {
+        const path = [prefix, ...issue.path.map(String)].filter(Boolean).join('.');
+        return `${path || '<root>'}: ${issue.message}`;
+    });
+}

--- a/packages/agent/src/works-config/schema/works.v2.schema.json
+++ b/packages/agent/src/works-config/schema/works.v2.schema.json
@@ -1,0 +1,865 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://api.ever.works/api/schema/works.yml.schema.json",
+    "title": "Ever Works — .works/works.yml",
+    "description": "Schema version 2. Every field is optional: works.yml is a partial override of platform defaults, never a complete description of a Work. Unknown keys are preserved on write.",
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "integer",
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991
+        },
+        "kind": {
+            "type": "string",
+            "maxLength": 32
+        },
+        "name": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "initial_prompt": {
+            "type": "string",
+            "maxLength": 8000
+        },
+        "model": {
+            "type": "string"
+        },
+        "website_repo": {
+            "type": "string",
+            "maxLength": 400
+        },
+        "schedule_cadence": {
+            "type": "string",
+            "enum": [
+                "hourly",
+                "daily",
+                "weekly",
+                "monthly"
+            ]
+        },
+        "deploy_provider": {
+            "type": "string"
+        },
+        "deployProvider": {
+            "type": "string"
+        },
+        "activity_sync": {
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": [
+                        "pull",
+                        "push",
+                        "disabled"
+                    ]
+                }
+            },
+            "additionalProperties": {}
+        },
+        "providers": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": {}
+        },
+        "spec": {
+            "description": "Kind-specific configuration. The accepted shape depends on `kind`. A kind this schema does not list is still allowed — its spec is preserved as-is and not validated.",
+            "oneOf": [
+                {
+                    "title": "spec for kind: website",
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {
+                        "kind": {
+                            "type": "string",
+                            "const": "website"
+                        },
+                        "template": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "pages": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "path": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "title": {
+                                        "type": "string"
+                                    },
+                                    "prompt": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "path"
+                                ],
+                                "additionalProperties": {}
+                            }
+                        },
+                        "nav": {
+                            "type": "object",
+                            "properties": {
+                                "header": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "label": {
+                                                "type": "string"
+                                            },
+                                            "href": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "label",
+                                            "href"
+                                        ],
+                                        "additionalProperties": {}
+                                    }
+                                },
+                                "footer": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "label": {
+                                                "type": "string"
+                                            },
+                                            "href": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "label",
+                                            "href"
+                                        ],
+                                        "additionalProperties": {}
+                                    }
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "branding": {
+                            "type": "object",
+                            "properties": {
+                                "logo": {
+                                    "type": "string"
+                                },
+                                "favicon": {
+                                    "type": "string"
+                                },
+                                "theme": {
+                                    "type": "string"
+                                },
+                                "locale": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "seo": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "keywords": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "author": {
+                                    "type": "string"
+                                },
+                                "image": {
+                                    "type": "string"
+                                },
+                                "twitter": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "analytics": {
+                            "type": "object",
+                            "properties": {
+                                "provider": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        }
+                    },
+                    "required": [
+                        "kind"
+                    ],
+                    "additionalProperties": {}
+                },
+                {
+                    "title": "spec for kind: landing-page",
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {
+                        "kind": {
+                            "type": "string",
+                            "const": "landing-page"
+                        },
+                        "template": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "hero": {
+                            "type": "object",
+                            "properties": {
+                                "headline": {
+                                    "type": "string"
+                                },
+                                "subheadline": {
+                                    "type": "string"
+                                },
+                                "cta": {
+                                    "type": "object",
+                                    "properties": {
+                                        "label": {
+                                            "type": "string"
+                                        },
+                                        "href": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "label",
+                                        "href"
+                                    ],
+                                    "additionalProperties": {}
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "sections": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "title": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ],
+                                "additionalProperties": {}
+                            }
+                        },
+                        "capture": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "destination": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "branding": {
+                            "type": "object",
+                            "properties": {
+                                "logo": {
+                                    "type": "string"
+                                },
+                                "favicon": {
+                                    "type": "string"
+                                },
+                                "theme": {
+                                    "type": "string"
+                                },
+                                "locale": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "seo": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "keywords": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "author": {
+                                    "type": "string"
+                                },
+                                "image": {
+                                    "type": "string"
+                                },
+                                "twitter": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "analytics": {
+                            "type": "object",
+                            "properties": {
+                                "provider": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        }
+                    },
+                    "required": [
+                        "kind"
+                    ],
+                    "additionalProperties": {}
+                },
+                {
+                    "title": "spec for kind: blog",
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {
+                        "kind": {
+                            "type": "string",
+                            "const": "blog"
+                        },
+                        "template": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "content_dir": {
+                            "type": "string"
+                        },
+                        "authors": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "bio": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "additionalProperties": {}
+                            }
+                        },
+                        "taxonomies": {
+                            "type": "object",
+                            "properties": {
+                                "categories": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "tags": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "feed": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "pagination": {
+                            "type": "object",
+                            "properties": {
+                                "per_page": {
+                                    "type": "integer",
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 9007199254740991
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "generation": {
+                            "type": "object",
+                            "properties": {
+                                "cadence": {
+                                    "type": "string",
+                                    "enum": [
+                                        "hourly",
+                                        "daily",
+                                        "weekly",
+                                        "monthly"
+                                    ]
+                                },
+                                "topics_prompt": {
+                                    "type": "string",
+                                    "maxLength": 8000
+                                },
+                                "posts_per_run": {
+                                    "type": "integer",
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 9007199254740991
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "branding": {
+                            "type": "object",
+                            "properties": {
+                                "logo": {
+                                    "type": "string"
+                                },
+                                "favicon": {
+                                    "type": "string"
+                                },
+                                "theme": {
+                                    "type": "string"
+                                },
+                                "locale": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "seo": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "keywords": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "author": {
+                                    "type": "string"
+                                },
+                                "image": {
+                                    "type": "string"
+                                },
+                                "twitter": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        }
+                    },
+                    "required": [
+                        "kind"
+                    ],
+                    "additionalProperties": {}
+                },
+                {
+                    "title": "spec for kind: directory",
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {
+                        "kind": {
+                            "type": "string",
+                            "const": "directory"
+                        },
+                        "template": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "categories": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "minLength": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "additionalProperties": {}
+                                    }
+                                ]
+                            }
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string",
+                                                "minLength": 1
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ],
+                                        "additionalProperties": {}
+                                    }
+                                ]
+                            }
+                        },
+                        "item_fields": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "type": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "additionalProperties": {}
+                            }
+                        },
+                        "sources": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "url": {
+                                        "type": "string"
+                                    }
+                                },
+                                "additionalProperties": {}
+                            }
+                        },
+                        "submissions": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "moderation": {
+                                    "type": "string",
+                                    "enum": [
+                                        "auto",
+                                        "manual"
+                                    ]
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "comparisons": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "branding": {
+                            "type": "object",
+                            "properties": {
+                                "logo": {
+                                    "type": "string"
+                                },
+                                "favicon": {
+                                    "type": "string"
+                                },
+                                "theme": {
+                                    "type": "string"
+                                },
+                                "locale": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "seo": {
+                            "type": "object",
+                            "properties": {
+                                "title": {
+                                    "type": "string"
+                                },
+                                "description": {
+                                    "type": "string"
+                                },
+                                "keywords": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "author": {
+                                    "type": "string"
+                                },
+                                "image": {
+                                    "type": "string"
+                                },
+                                "twitter": {
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        }
+                    },
+                    "required": [
+                        "kind"
+                    ],
+                    "additionalProperties": {}
+                },
+                {
+                    "title": "spec for kind: awesome-repo",
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {
+                        "kind": {
+                            "type": "string",
+                            "const": "awesome-repo"
+                        },
+                        "template": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "source": {
+                            "type": "object",
+                            "properties": {
+                                "repo": {
+                                    "type": "string",
+                                    "maxLength": 400
+                                },
+                                "branch": {
+                                    "type": "string"
+                                },
+                                "file": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "sync": {
+                            "type": "object",
+                            "properties": {
+                                "cadence": {
+                                    "type": "string",
+                                    "enum": [
+                                        "hourly",
+                                        "daily",
+                                        "weekly",
+                                        "monthly"
+                                    ]
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "readme": {
+                            "type": "object",
+                            "properties": {
+                                "header": {
+                                    "type": "string"
+                                },
+                                "footer": {
+                                    "type": "string"
+                                },
+                                "overwriteDefaultHeader": {
+                                    "type": "boolean"
+                                },
+                                "overwriteDefaultFooter": {
+                                    "type": "boolean"
+                                },
+                                "toc": {
+                                    "type": "boolean"
+                                },
+                                "badges": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "additionalProperties": {}
+                        },
+                        "enrich": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            },
+                            "additionalProperties": {}
+                        }
+                    },
+                    "required": [
+                        "kind"
+                    ],
+                    "additionalProperties": {}
+                },
+                {
+                    "title": "spec for kind: company",
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "type": "object",
+                    "properties": {
+                        "kind": {
+                            "type": "string",
+                            "const": "company"
+                        },
+                        "organization": {
+                            "type": "string"
+                        },
+                        "company_manifest": {
+                            "type": "string"
+                        },
+                        "departments": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                },
+                                "required": [
+                                    "name"
+                                ],
+                                "additionalProperties": {}
+                            }
+                        },
+                        "staffing": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "role": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "agent": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "role"
+                                ],
+                                "additionalProperties": {}
+                            }
+                        },
+                        "branding": {
+                            "type": "object",
+                            "properties": {
+                                "logo": {
+                                    "type": "string"
+                                },
+                                "favicon": {
+                                    "type": "string"
+                                },
+                                "theme": {
+                                    "type": "string"
+                                },
+                                "locale": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": {}
+                        }
+                    },
+                    "required": [
+                        "kind"
+                    ],
+                    "additionalProperties": {}
+                },
+                {
+                    "title": "spec for an unrecognised kind",
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            ]
+        }
+    },
+    "additionalProperties": {}
+}

--- a/packages/agent/src/works-config/services/works-config-writer.service.ts
+++ b/packages/agent/src/works-config/services/works-config-writer.service.ts
@@ -145,6 +145,7 @@ export class WorksConfigWriterService {
         return this.withoutUndefined({
             ...baseRaw,
             name: request.name || imported?.name || options.work.name,
+            kind: this.resolveKind(baseRaw.kind, options.work.kind),
             initial_prompt: initialPrompt,
             model,
             providers,
@@ -153,6 +154,35 @@ export class WorksConfigWriterService {
             deployProvider,
             activity_sync: activitySyncBlock,
         });
+    }
+
+    /**
+     * Work kind to write into `.works/works.yml`.
+     *
+     * Two rules, both deliberate:
+     *
+     *  1. **An existing `kind:` in the file always wins.** The file belongs
+     *     to the user and may declare a kind this build does not know
+     *     (a newer server, or hand-authored). Overwriting it with our view
+     *     would corrupt their repository on a routine round-trip write.
+     *
+     *  2. **`default` is never written.** `withoutUndefined` drops the key,
+     *     so a `default`-kind Work's file stays byte-identical to what the
+     *     platform produced before `kind` existed — no diff, no spurious
+     *     commit, and `flow-work-config-cache.spec.ts`'s
+     *     `cacheEmpty === cfgEmpty` invariant holds. Since `default` is
+     *     also the parse-time fallback, omitting it loses no information.
+     */
+    private resolveKind(existing: unknown, workKind?: string | null): string | undefined {
+        const fromFile = this.readString(existing);
+        if (fromFile) {
+            return fromFile;
+        }
+        const fromWork = typeof workKind === 'string' ? workKind.trim() : '';
+        if (!fromWork || fromWork === 'default') {
+            return undefined;
+        }
+        return fromWork;
     }
 
     private resolveActivitySyncMode(args: {

--- a/packages/agent/src/works-config/services/works-config.service.ts
+++ b/packages/agent/src/works-config/services/works-config.service.ts
@@ -134,17 +134,35 @@ export class WorksConfigService {
         spec?: Record<string, unknown>;
         schemaWarnings?: string[];
     } {
-        const validation = validateWorksConfig(raw);
-        const messages = [...validation.warnings, ...validation.errors];
-
-        if (validation.errors.length > 0) {
-            this.logger.warn(
-                `.works/works.yml did not match the schema; continuing with best-effort parse. ${validation.errors.join('; ')}`,
-            );
-        }
-
         const out: { kind?: WorkKind; spec?: Record<string, unknown>; schemaWarnings?: string[] } =
             {};
+
+        // Defense-in-depth for the never-throws contract. `validateWorksConfig`
+        // is written not to throw, but this method sits on the read path of
+        // EVERY config load — generation, sync, import — over attacker-
+        // supplied file content, and an escaped exception here does not just
+        // 500 one request: it happens at the read step BEFORE any rewrite,
+        // so a poisoned file would never be repaired and the Work's config
+        // would be locked out permanently. A validator bug must degrade to
+        // "no advisory validation", never to that.
+        let messages: string[] = [];
+        try {
+            const validation = validateWorksConfig(raw);
+            messages = [...validation.warnings, ...validation.errors];
+
+            if (validation.errors.length > 0) {
+                this.logger.warn(
+                    `.works/works.yml did not match the schema; continuing with best-effort parse. ${validation.errors.join('; ')}`,
+                );
+            }
+        } catch (error) {
+            this.logger.warn(
+                `.works/works.yml schema validation itself failed; continuing without it. ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            messages = ['schema validation unavailable for this file'];
+        }
 
         const rawKind = raw.kind;
         if (typeof rawKind === 'string' && rawKind.trim()) {

--- a/packages/agent/src/works-config/services/works-config.service.ts
+++ b/packages/agent/src/works-config/services/works-config.service.ts
@@ -2,7 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { WorkScheduleCadence, type ProvidersDto } from '@ever-works/contracts/api';
 import * as yaml from 'yaml';
 import { GitFacadeService } from '@src/facades/git.facade';
-import type { RepositoryTarget } from '@src/entities/work.entity';
+import { normalizeWorkKind, type RepositoryTarget, type WorkKind } from '@src/entities/work.entity';
+import { validateWorksConfig } from '../schema/works-config.schema';
 
 const WORKS_CONFIG_FILEPATHS = ['.works/works.yml'] as const;
 
@@ -34,6 +35,26 @@ export interface WorksConfigSummary {
      * time. See ADR-004.
      */
     activitySyncMode?: 'pull' | 'push' | 'disabled';
+    /**
+     * Work kind declared by the repository (`kind:` in works.yml).
+     *
+     * Absent in every v1 file, which is why re-importing a blog's data repo
+     * used to produce a `default` Work that resolved to the directory
+     * template. Normalized through the shared vocabulary, so an unknown
+     * kind degrades to `default` rather than reaching the entity.
+     */
+    kind?: WorkKind;
+    /**
+     * Kind-specific configuration (`spec:` in works.yml). Carried verbatim —
+     * the platform preserves keys it does not understand so a file written
+     * by a newer build survives a round-trip through an older one.
+     */
+    spec?: Record<string, unknown>;
+    /**
+     * Non-blocking schema observations, e.g. a `version:` newer than this
+     * build understands. Surfaced for diagnostics; never fatal.
+     */
+    schemaWarnings?: string[];
 }
 
 export interface ParsedWorksConfig extends WorksConfigSummary {
@@ -94,7 +115,52 @@ export class WorksConfigService {
             ),
             deployProvider: this.readString(raw, ['deployProvider', 'deploy_provider']),
             activitySyncMode: this.readActivitySyncMode(raw),
+            ...this.readSchemaFields(raw),
         };
+    }
+
+    /**
+     * Read the v2 envelope additions (`kind`, `spec`) and collect any schema
+     * warnings.
+     *
+     * Validation is advisory here by design. `.works/works.yml` lives in the
+     * user's own repository, so a schema complaint must never be able to take
+     * their Work offline — the fields are read on a best-effort basis and
+     * problems are reported rather than thrown. `works validate` is the place
+     * to surface them loudly.
+     */
+    private readSchemaFields(raw: Record<string, unknown>): {
+        kind?: WorkKind;
+        spec?: Record<string, unknown>;
+        schemaWarnings?: string[];
+    } {
+        const validation = validateWorksConfig(raw);
+        const messages = [...validation.warnings, ...validation.errors];
+
+        if (validation.errors.length > 0) {
+            this.logger.warn(
+                `.works/works.yml did not match the schema; continuing with best-effort parse. ${validation.errors.join('; ')}`,
+            );
+        }
+
+        const out: { kind?: WorkKind; spec?: Record<string, unknown>; schemaWarnings?: string[] } =
+            {};
+
+        const rawKind = raw.kind;
+        if (typeof rawKind === 'string' && rawKind.trim()) {
+            out.kind = normalizeWorkKind(rawKind);
+        }
+
+        const rawSpec = raw.spec;
+        if (rawSpec && typeof rawSpec === 'object' && !Array.isArray(rawSpec)) {
+            out.spec = rawSpec as Record<string, unknown>;
+        }
+
+        if (messages.length > 0) {
+            out.schemaWarnings = messages;
+        }
+
+        return out;
     }
 
     private readActivitySyncMode(


### PR DESCRIPTION
Item **3** of the Works overhaul.

> **Stacked on #1776** (needs the shared kind vocabulary from `packages/contracts`). Review the top commit — GitHub will show the rest once #1776 merges.

## Problem

`.works/works.yml` had **no validator at all**. `WorksConfigService` hand-coerced a handful of known keys and silently dropped everything else, so a typo produced no error — just a Work that quietly behaved as though the field had never been written.

There was also no schema to point an editor at, and nothing described the configuration that only *some* kinds of Work need. `kind` appeared **nowhere** in `packages/agent/src/works-config/`, so re-importing a blog's data repo produced a `default` Work that resolved to the directory template.

## Design

**The envelope is additive.** v2 = v1 + three optional keys (`version`, `kind`, `spec`). Every file already in the wild is a valid v2 file; a `default`-kind Work's file is unchanged.

**`version` is advisory, never gating.** Absent ⇒ v1. Newer than this build understands ⇒ warn and parse anyway. Refusing to read a file written by a newer server would strand the user's own repository. (Docker Compose learned this with its `version:` key.)

**Unknown keys are preserved everywhere** — `looseObject` throughout. This is a **correctness requirement, not leniency**: the writer round-trips the parsed document back into the user's git repository, so a stripping `z.object()` would silently delete keys written by a newer build, or by hand. The same applies to an unrecognised `kind` — its `spec` is carried through untouched rather than validated or erased.

**Per-kind `spec` is dispatched, not unioned.** Six shapes (website / landing-page / blog / directory / awesome-repo / company), grounded in what the generators actually consume.

Deliberately **not** `z.union([discriminatedUnion, passthrough])` — I wrote it that way first and two tests caught it: a union lets an **invalid typed spec** (`blog` with `posts_per_run: "three"`) fall through to the permissive branch and validate, defeating the point of typed specs. The kind is now looked up and validated **strictly when known**; only a genuinely unrecognised kind takes the passthrough path.

## Published for editors

```yaml
# yaml-language-server: $schema=https://api.ever.works/api/schema/works.yml.schema.json
name: Awesome Chairs
kind: directory
```

`works.v2.schema.json` is **generated from the same zod definition the server validates with** — so the two cannot drift — committed for reviewable diffs, and guarded by a test that fails if it goes stale. Served `@Public()` and cached 5 min; auth would make it useless for the one case it exists to serve.

## Reading stays advisory

`works.yml` lives in the user's repository, so a schema complaint must **never** be able to take their Work offline. The service reads what it can, logs what did not match, and carries on. A malformed root (not a YAML object) is the one hard error.

## Also

Adds `docs/agent-services/works-yml-schema.md` — a page the API's `/.well-known/agent.json` has been advertising as `manifestSchema` while **it did not exist** — and lists it in the docs sidebar.

## Verification

- **33 new tests**: v1 back-compat, root rejection (null/string/array/undefined + never-throws), unknown-key preservation, a YAML round-trip asserting deep equality *including* unknown keys, version warn-not-fail, all six kinds, unknown-kind passthrough, invalid-typed-spec rejection, field bounds.
- **All 156 existing `works-config` tests pass** unchanged.
- `tsc --noEmit` clean for `packages/agent`; the new API controller compiles.

## Deliberately not in this PR

The **write** side. Emitting `version`/`kind`/`spec` into user repositories touches `WorksConfigWriterService`, which pushes to real git with a force-push fallback — it deserves its own PR and its own care, including the rule that a brand-new `default` Work's file must stay byte-identical so `flow-work-config-cache.spec.ts` keeps its `cacheEmpty === cfgEmpty` invariant. Reading and publishing the schema is the half that carries no risk to existing repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)