### PR TITLE
feat(works): let a Work opt out of generating its provider repository

### DIFF
--- a/apps/api/src/migrations/1782400000000-AddProviderRepositoryEnabledToWorks.ts
+++ b/apps/api/src/migrations/1782400000000-AddProviderRepositoryEnabledToWorks.ts
@@ -1,0 +1,56 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Works — opt out of generating the provider ("{provider} Repository") repo.
+ *
+ * That repository is the browsable, AI-generated view of a Work published to
+ * its git provider (`RepositoryRole` `work`). Not every Work wants one: an
+ * internal landing page gains nothing from a repository that only ever holds
+ * a generated README.
+ *
+ * Entity: `packages/agent/src/entities/work.entity.ts`
+ *
+ * **Schema notes:**
+ *   - `DEFAULT true` and `NOT NULL`, so every existing row keeps generating
+ *     exactly as it does today. This flag can only ever remove behaviour a
+ *     user explicitly turned off — it can never silently disable generation
+ *     for a Work that was relying on it.
+ *   - The flag is a user override layered on top of the per-kind capability
+ *     (`getWorkCapabilities(kind).repos.work`); the two are resolved
+ *     together by `Work.shouldGenerateProviderRepository()`. Kind wins, so
+ *     no backfill is needed for kinds that never provisioned the repo.
+ *
+ * Forward-only and idempotent (`hasColumn` guard).
+ */
+export class AddProviderRepositoryEnabledToWorks1782400000000 implements MigrationInterface {
+    name = 'AddProviderRepositoryEnabledToWorks1782400000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasTable('works'))) {
+            return;
+        }
+        if (await queryRunner.hasColumn('works', 'providerRepositoryEnabled')) {
+            return;
+        }
+
+        await queryRunner.addColumn(
+            'works',
+            new TableColumn({
+                name: 'providerRepositoryEnabled',
+                type: 'boolean',
+                isNullable: false,
+                default: true,
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasTable('works'))) {
+            return;
+        }
+        if (!(await queryRunner.hasColumn('works', 'providerRepositoryEnabled'))) {
+            return;
+        }
+        await queryRunner.dropColumn('works', 'providerRepositoryEnabled');
+    }
+}

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -3490,7 +3490,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "مستودع {provider}",
+                "providerRepoEnableLabel": "إنشاء مستودع {provider}",
+                "providerRepoEnableDescription": "نسخة قابلة للتصفح من هذا العمل يولّدها الذكاء الاصطناعي وتُنشر على {provider}. لا تُنشر في أي بيئة — يقرأها الناس مباشرة على {provider}.",
+                "providerRepoEnabled": "تم تفعيل إنشاء مستودع {provider}",
+                "providerRepoDisabled": "تم إيقاف إنشاء مستودع {provider}",
+                "providerRepoUpdateFailed": "تعذّر تحديث إعداد المستودع",
+                "providerRepoDisabledNote": "الإنشاء متوقف. يبقى المستودع الحالي كما هو — يتوقف تحديثه فقط."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -3490,7 +3490,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "Репозиторий в {provider}",
+                "providerRepoEnableLabel": "Генериране на репозитория в {provider}",
+                "providerRepoEnableDescription": "Генерирана от ИИ версия на тази работа, публикувана в {provider}. Никога не се внедрява — хората я четат директно в {provider}.",
+                "providerRepoEnabled": "Генерирането на репозитория в {provider} е включено",
+                "providerRepoDisabled": "Генерирането на репозитория в {provider} е изключено",
+                "providerRepoUpdateFailed": "Настройката на репозитория не можа да бъде обновена",
+                "providerRepoDisabledNote": "Генерирането е изключено. Съществуващият репозиторий остава непроменен — просто спира да се обновява."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -3490,7 +3490,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "{provider}-Repository",
+                "providerRepoEnableLabel": "{provider}-Repository generieren",
+                "providerRepoEnableDescription": "Eine KI-generierte, lesbare Fassung dieses Werks, veröffentlicht auf {provider}. Sie wird nie bereitgestellt — man liest sie direkt auf {provider}.",
+                "providerRepoEnabled": "Generierung des {provider}-Repositorys aktiviert",
+                "providerRepoDisabled": "Generierung des {provider}-Repositorys deaktiviert",
+                "providerRepoUpdateFailed": "Repository-Einstellung konnte nicht aktualisiert werden",
+                "providerRepoDisabledNote": "Die Generierung ist aus. Das vorhandene Repository bleibt unverändert — es wird lediglich nicht mehr aktualisiert."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3720,7 +3720,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "{provider} Repository",
+                "providerRepoEnableLabel": "Generate the {provider} repository",
+                "providerRepoEnableDescription": "An AI-generated, browsable version of this Work published to {provider}. It is never deployed — people read it directly on {provider}.",
+                "providerRepoEnabled": "{provider} repository generation enabled",
+                "providerRepoDisabled": "{provider} repository generation disabled",
+                "providerRepoUpdateFailed": "Failed to update the repository setting",
+                "providerRepoDisabledNote": "Generation is off. The existing repository is left untouched — it simply stops being updated."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -3490,7 +3490,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "Repositorio de {provider}",
+                "providerRepoEnableLabel": "Generar el repositorio de {provider}",
+                "providerRepoEnableDescription": "Una versión navegable de este Work generada por IA y publicada en {provider}. Nunca se despliega: la gente la lee directamente en {provider}.",
+                "providerRepoEnabled": "Generación del repositorio de {provider} activada",
+                "providerRepoDisabled": "Generación del repositorio de {provider} desactivada",
+                "providerRepoUpdateFailed": "No se pudo actualizar el ajuste del repositorio",
+                "providerRepoDisabledNote": "La generación está desactivada. El repositorio existente se conserva intacto: simplemente deja de actualizarse."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -3490,7 +3490,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "Dépôt {provider}",
+                "providerRepoEnableLabel": "Générer le dépôt {provider}",
+                "providerRepoEnableDescription": "Une version consultable de ce travail, générée par IA et publiée sur {provider}. Elle n’est jamais déployée — on la lit directement sur {provider}.",
+                "providerRepoEnabled": "Génération du dépôt {provider} activée",
+                "providerRepoDisabled": "Génération du dépôt {provider} désactivée",
+                "providerRepoUpdateFailed": "Impossible de mettre à jour le paramètre du dépôt",
+                "providerRepoDisabledNote": "La génération est désactivée. Le dépôt existant reste intact — il cesse simplement d’être mis à jour."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -3490,7 +3490,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "מאגר {provider}",
+                "providerRepoEnableLabel": "יצירת מאגר {provider}",
+                "providerRepoEnableDescription": "גרסה קריאה של עבודה זו שנוצרת על ידי AI ומתפרסמת ב-{provider}. היא לעולם אינה נפרסת — קוראים אותה ישירות ב-{provider}.",
+                "providerRepoEnabled": "יצירת מאגר {provider} הופעלה",
+                "providerRepoDisabled": "יצירת מאגר {provider} כובתה",
+                "providerRepoUpdateFailed": "עדכון הגדרת המאגר נכשל",
+                "providerRepoDisabledNote": "היצירה כבויה. המאגר הקיים נשאר כפי שהוא — הוא פשוט מפסיק להתעדכן."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "{provider} रिपॉजिटरी",
+                "providerRepoEnableLabel": "{provider} रिपॉजिटरी बनाएँ",
+                "providerRepoEnableDescription": "इस Work का AI-निर्मित, पठनीय संस्करण जो {provider} पर प्रकाशित होता है। यह कभी तैनात नहीं होता — लोग इसे सीधे {provider} पर पढ़ते हैं।",
+                "providerRepoEnabled": "{provider} रिपॉजिटरी निर्माण सक्षम",
+                "providerRepoDisabled": "{provider} रिपॉजिटरी निर्माण अक्षम",
+                "providerRepoUpdateFailed": "रिपॉजिटरी सेटिंग अपडेट नहीं हो सकी",
+                "providerRepoDisabledNote": "निर्माण बंद है। मौजूदा रिपॉजिटरी अछूती रहती है — बस उसका अपडेट होना रुक जाता है।"
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "Repositori {provider}",
+                "providerRepoEnableLabel": "Hasilkan repositori {provider}",
+                "providerRepoEnableDescription": "Versi Karya ini yang dihasilkan AI dan dapat dibaca, dipublikasikan di {provider}. Tidak pernah disebarkan — orang membacanya langsung di {provider}.",
+                "providerRepoEnabled": "Pembuatan repositori {provider} diaktifkan",
+                "providerRepoDisabled": "Pembuatan repositori {provider} dinonaktifkan",
+                "providerRepoUpdateFailed": "Gagal memperbarui pengaturan repositori",
+                "providerRepoDisabledNote": "Pembuatan dimatikan. Repositori yang ada dibiarkan apa adanya — hanya berhenti diperbarui."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "Repository {provider}",
+                "providerRepoEnableLabel": "Genera il repository {provider}",
+                "providerRepoEnableDescription": "Una versione consultabile di questo Lavoro generata dall’IA e pubblicata su {provider}. Non viene mai distribuita: la si legge direttamente su {provider}.",
+                "providerRepoEnabled": "Generazione del repository {provider} attivata",
+                "providerRepoDisabled": "Generazione del repository {provider} disattivata",
+                "providerRepoUpdateFailed": "Impossibile aggiornare l’impostazione del repository",
+                "providerRepoDisabledNote": "La generazione è disattivata. Il repository esistente resta intatto: smette semplicemente di essere aggiornato."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -3296,7 +3296,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "{provider} リポジトリ",
+                "providerRepoEnableLabel": "{provider} リポジトリを生成する",
+                "providerRepoEnableDescription": "このワークを AI が生成した閲覧用のバージョンで、{provider} に公開されます。デプロイはされず、{provider} 上で直接読まれます。",
+                "providerRepoEnabled": "{provider} リポジトリの生成を有効にしました",
+                "providerRepoDisabled": "{provider} リポジトリの生成を無効にしました",
+                "providerRepoUpdateFailed": "リポジトリ設定を更新できませんでした",
+                "providerRepoDisabledNote": "生成はオフです。既存のリポジトリはそのまま残り、更新されなくなるだけです。"
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3296,7 +3296,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "{provider} 리포지토리",
+                "providerRepoEnableLabel": "{provider} 리포지토리 생성",
+                "providerRepoEnableDescription": "이 워크를 AI가 생성한 열람용 버전으로 {provider}에 게시됩니다. 배포되지 않으며 {provider}에서 바로 읽습니다.",
+                "providerRepoEnabled": "{provider} 리포지토리 생성을 켰습니다",
+                "providerRepoDisabled": "{provider} 리포지토리 생성을 껐습니다",
+                "providerRepoUpdateFailed": "리포지토리 설정을 업데이트하지 못했습니다",
+                "providerRepoDisabledNote": "생성이 꺼져 있습니다. 기존 리포지토리는 그대로 남고 업데이트만 중단됩니다."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -3296,7 +3296,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "{provider}-repository",
+                "providerRepoEnableLabel": "De {provider}-repository genereren",
+                "providerRepoEnableDescription": "Een door AI gegenereerde, leesbare versie van deze Work, gepubliceerd op {provider}. Wordt nooit uitgerold — mensen lezen het direct op {provider}.",
+                "providerRepoEnabled": "Genereren van de {provider}-repository ingeschakeld",
+                "providerRepoDisabled": "Genereren van de {provider}-repository uitgeschakeld",
+                "providerRepoUpdateFailed": "Kan de repository-instelling niet bijwerken",
+                "providerRepoDisabledNote": "Genereren staat uit. De bestaande repository blijft ongemoeid — die wordt alleen niet meer bijgewerkt."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "Repozytorium {provider}",
+                "providerRepoEnableLabel": "Generuj repozytorium {provider}",
+                "providerRepoEnableDescription": "Wygenerowana przez AI, czytelna wersja tej Pracy publikowana w {provider}. Nigdy nie jest wdrażana — czyta się ją bezpośrednio w {provider}.",
+                "providerRepoEnabled": "Generowanie repozytorium {provider} włączone",
+                "providerRepoDisabled": "Generowanie repozytorium {provider} wyłączone",
+                "providerRepoUpdateFailed": "Nie udało się zaktualizować ustawienia repozytorium",
+                "providerRepoDisabledNote": "Generowanie jest wyłączone. Istniejące repozytorium pozostaje nietknięte — przestaje być tylko aktualizowane."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "Repositório do {provider}",
+                "providerRepoEnableLabel": "Gerar o repositório do {provider}",
+                "providerRepoEnableDescription": "Uma versão deste Trabalho gerada por IA e navegável, publicada no {provider}. Nunca é implantada — as pessoas leem-na diretamente no {provider}.",
+                "providerRepoEnabled": "Geração do repositório do {provider} ativada",
+                "providerRepoDisabled": "Geração do repositório do {provider} desativada",
+                "providerRepoUpdateFailed": "Não foi possível atualizar a definição do repositório",
+                "providerRepoDisabledNote": "A geração está desativada. O repositório existente fica intacto — apenas deixa de ser atualizado."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "Репозиторий {provider}",
+                "providerRepoEnableLabel": "Создавать репозиторий {provider}",
+                "providerRepoEnableDescription": "Сгенерированная ИИ версия этой работы для чтения, публикуемая в {provider}. Она никогда не разворачивается — её читают прямо в {provider}.",
+                "providerRepoEnabled": "Создание репозитория {provider} включено",
+                "providerRepoDisabled": "Создание репозитория {provider} отключено",
+                "providerRepoUpdateFailed": "Не удалось обновить настройку репозитория",
+                "providerRepoDisabledNote": "Создание отключено. Существующий репозиторий остаётся нетронутым — он просто перестаёт обновляться."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "คลัง {provider}",
+                "providerRepoEnableLabel": "สร้างคลัง {provider}",
+                "providerRepoEnableDescription": "เวอร์ชันของงานนี้ที่ AI สร้างขึ้นให้อ่านได้ และเผยแพร่บน {provider} โดยไม่ถูกนำไปปรับใช้ที่ใด — ผู้คนอ่านโดยตรงบน {provider}",
+                "providerRepoEnabled": "เปิดการสร้างคลัง {provider} แล้ว",
+                "providerRepoDisabled": "ปิดการสร้างคลัง {provider} แล้ว",
+                "providerRepoUpdateFailed": "อัปเดตการตั้งค่าคลังไม่สำเร็จ",
+                "providerRepoDisabledNote": "การสร้างถูกปิดอยู่ คลังที่มีอยู่ยังคงเดิม เพียงแต่จะไม่ถูกอัปเดตอีก"
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "{provider} Deposu",
+                "providerRepoEnableLabel": "{provider} deposunu oluştur",
+                "providerRepoEnableDescription": "Bu İşin yapay zekâ tarafından üretilen, {provider} üzerinde yayımlanan okunabilir sürümü. Hiçbir yere dağıtılmaz — doğrudan {provider} üzerinde okunur.",
+                "providerRepoEnabled": "{provider} deposu oluşturma açıldı",
+                "providerRepoDisabled": "{provider} deposu oluşturma kapatıldı",
+                "providerRepoUpdateFailed": "Depo ayarı güncellenemedi",
+                "providerRepoDisabledNote": "Oluşturma kapalı. Mevcut depoya dokunulmaz — yalnızca güncellenmesi durur."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "Репозиторій {provider}",
+                "providerRepoEnableLabel": "Створювати репозиторій {provider}",
+                "providerRepoEnableDescription": "Згенерована ШІ версія цієї роботи для читання, опублікована в {provider}. Вона ніколи не розгортається — її читають прямо в {provider}.",
+                "providerRepoEnabled": "Створення репозиторію {provider} увімкнено",
+                "providerRepoDisabled": "Створення репозиторію {provider} вимкнено",
+                "providerRepoUpdateFailed": "Не вдалося оновити налаштування репозиторію",
+                "providerRepoDisabledNote": "Створення вимкнено. Наявний репозиторій залишається недоторканим — він просто перестає оновлюватися."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "Kho {provider}",
+                "providerRepoEnableLabel": "Tạo kho {provider}",
+                "providerRepoEnableDescription": "Phiên bản có thể đọc của Công việc này do AI tạo và xuất bản trên {provider}. Nó không bao giờ được triển khai — mọi người đọc trực tiếp trên {provider}.",
+                "providerRepoEnabled": "Đã bật tạo kho {provider}",
+                "providerRepoDisabled": "Đã tắt tạo kho {provider}",
+                "providerRepoUpdateFailed": "Không thể cập nhật cài đặt kho",
+                "providerRepoDisabledNote": "Việc tạo đang tắt. Kho hiện có được giữ nguyên — chỉ là không còn được cập nhật."
             },
             "deploy": {
                 "progress": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -3288,7 +3288,14 @@
                         "lastSuccess": "Last successful pull: {time}",
                         "lastError": "Last error: {error}"
                     }
-                }
+                },
+                "providerRepoTitle": "{provider} 仓库",
+                "providerRepoEnableLabel": "生成 {provider} 仓库",
+                "providerRepoEnableDescription": "由 AI 生成、可浏览的作品版本，发布到 {provider}。它不会被部署——人们直接在 {provider} 上阅读。",
+                "providerRepoEnabled": "已开启 {provider} 仓库生成",
+                "providerRepoDisabled": "已关闭 {provider} 仓库生成",
+                "providerRepoUpdateFailed": "更新仓库设置失败",
+                "providerRepoDisabledNote": "生成已关闭。现有仓库保持不变，只是不再更新。"
             },
             "deploy": {
                 "progress": {

--- a/apps/web/src/app/actions/dashboard/works.ts
+++ b/apps/web/src/app/actions/dashboard/works.ts
@@ -1266,6 +1266,37 @@ export async function updateWebsiteSettings(
     }
 }
 
+/**
+ * Toggle generation of the "{provider} Repository" — the browsable,
+ * AI-generated repo published to the git provider but never deployed.
+ */
+export async function updateProviderRepositorySettings(
+    workId: string,
+    settings: {
+        providerRepositoryEnabled?: boolean;
+    },
+) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const response = await workAPI.update(workId, settings);
+        revalidatePath(`/works/${workId}/settings`);
+
+        return {
+            success: response.status === 'success',
+        };
+    } catch (error) {
+        console.error('Failed to update provider repository settings:', error);
+        return {
+            success: false,
+            error: 'Failed to update settings',
+        };
+    }
+}
+
 export async function updateCommunityPrSettings(
     workId: string,
     settings: {

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -10,10 +10,25 @@ export interface SwitchProps {
     label?: string;
     helperText?: string;
     className?: string;
+    /** Forwarded onto the inner `role="switch"` button so tests can target the
+     *  actual interactive control (the props interface is closed — without an
+     *  explicit passthrough a hyphenated attribute never reaches the DOM). */
+    'data-testid'?: string;
 }
 
 const Switch = React.forwardRef<HTMLDivElement, SwitchProps>(
-    ({ checked = false, onChange, disabled = false, label, helperText, className }, ref) => {
+    (
+        {
+            checked = false,
+            onChange,
+            disabled = false,
+            label,
+            helperText,
+            className,
+            'data-testid': dataTestId,
+        },
+        ref,
+    ) => {
         const handleClick = () => {
             if (!disabled && onChange) {
                 onChange(!checked);
@@ -32,6 +47,7 @@ const Switch = React.forwardRef<HTMLDivElement, SwitchProps>(
                 <button
                     type="button"
                     role="switch"
+                    data-testid={dataTestId}
                     aria-checked={checked}
                     disabled={disabled}
                     onClick={handleClick}

--- a/apps/web/src/components/works/detail/settings/ProviderRepositorySettings.tsx
+++ b/apps/web/src/components/works/detail/settings/ProviderRepositorySettings.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState } from 'react';
+import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
+import { useTranslations } from 'next-intl';
+import { useSettings } from './SettingsContext';
+import { Loader2 } from 'lucide-react';
+import { updateProviderRepositorySettings } from '@/app/actions/dashboard/works';
+import { useRouter } from '@/i18n/navigation';
+import { toast } from 'sonner';
+import { getWorkCapabilities } from '@ever-works/contracts';
+import { formatGitProviderName } from '@/lib/utils/git-provider';
+
+/**
+ * Opt out of generating the "{provider} Repository".
+ *
+ * That repository is the browsable, AI-generated view of a Work published to
+ * GitHub/GitLab — it is never deployed; people read it on the host. Not
+ * every Work wants one, and until now there was no way to say so.
+ *
+ * The card hides entirely for a Work whose kind never provisions that
+ * repository: offering a switch that cannot change anything is worse than
+ * offering nothing.
+ */
+export function ProviderRepositorySettings() {
+    const t = useTranslations('dashboard.workDetail.settings');
+    const { context } = useSettings();
+    const { work } = context;
+    const router = useRouter();
+    const [isUpdating, setIsUpdating] = useState(false);
+
+    const providerName = formatGitProviderName(work.gitProvider);
+
+    if (!getWorkCapabilities(work.kind).repos.work) {
+        return null;
+    }
+
+    // Rows written before the column existed come back undefined; absent
+    // means enabled, matching the server-side resolution.
+    const enabled = work.providerRepositoryEnabled ?? true;
+
+    const handleToggle = async (next: boolean) => {
+        setIsUpdating(true);
+        try {
+            const result = await updateProviderRepositorySettings(work.id, {
+                providerRepositoryEnabled: next,
+            });
+
+            if (result.success) {
+                toast.success(
+                    next
+                        ? t('providerRepoEnabled', { provider: providerName })
+                        : t('providerRepoDisabled', { provider: providerName }),
+                );
+                router.refresh();
+            } else {
+                toast.error(result.error || t('providerRepoUpdateFailed'));
+            }
+        } catch {
+            toast.error(t('providerRepoUpdateFailed'));
+        } finally {
+            setIsUpdating(false);
+        }
+    };
+
+    return (
+        <div
+            className={cn(
+                'rounded-lg border overflow-hidden',
+                'bg-card dark:bg-card-primary-dark/30',
+                'border-card-border dark:border-border-secondary-dark',
+            )}
+            data-testid="provider-repository-settings"
+        >
+            <div className="px-5 py-3.5 border-b border-card-border dark:border-border-secondary-dark">
+                <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('providerRepoTitle', { provider: providerName })}
+                </h3>
+            </div>
+
+            <div className="px-5 py-4">
+                <div className="flex items-center justify-between gap-4">
+                    <div className="min-w-0">
+                        <h4 className="text-xs font-medium text-text dark:text-text-dark">
+                            {t('providerRepoEnableLabel', { provider: providerName })}
+                        </h4>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('providerRepoEnableDescription', { provider: providerName })}
+                        </p>
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                        {isUpdating && <Loader2 className="h-4 w-4 animate-spin text-text-muted" />}
+                        <Switch
+                            checked={enabled}
+                            onChange={handleToggle}
+                            disabled={isUpdating}
+                            className="mt-0"
+                            data-testid="provider-repository-toggle"
+                        />
+                    </div>
+                </div>
+
+                {!enabled && (
+                    <p className="mt-3 pt-3 border-t border-card-border dark:border-border-secondary-dark text-xs text-text-muted dark:text-text-muted-dark">
+                        {t('providerRepoDisabledNote', { provider: providerName })}
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/settings/SettingsForm.tsx
+++ b/apps/web/src/components/works/detail/settings/SettingsForm.tsx
@@ -11,6 +11,7 @@ import { ReadmeConfiguration } from './ReadmeConfiguration';
 import { RepoVisibilitySettings } from './RepoVisibilitySettings';
 import { AdvancedPromptsSettings } from './AdvancedPromptsSettings';
 import { CommunityPrSettings } from './CommunityPrSettings';
+import { ProviderRepositorySettings } from './ProviderRepositorySettings';
 import { WebsiteConfigSettings } from './WebsiteConfigSettings';
 import { ItemImportExportSettings } from './ItemImportExportSettings';
 import { CommitterSettings } from './CommitterSettings';
@@ -40,6 +41,7 @@ export function SettingsForm({ work, user, initialRepositories }: SettingsFormPr
                 <RepoVisibilitySettings initialRepositories={initialRepositories} />
 
                 {/* Community PR Processing Settings */}
+                <ProviderRepositorySettings />
                 <CommunityPrSettings />
 
                 {/* Advanced Prompts Settings */}

--- a/apps/web/src/lib/api/work.ts
+++ b/apps/web/src/lib/api/work.ts
@@ -86,6 +86,7 @@ export interface CreateWorkDto {
 }
 
 export interface UpdateWorkDto {
+    providerRepositoryEnabled?: boolean;
     name?: string;
     description?: string;
     owner?: string;
@@ -203,6 +204,13 @@ export interface Work {
      * unknown values to the generic `default` presentation.
      */
     kind?: string;
+    /**
+     * Whether the "{provider} Repository" (the browsable AI-generated repo
+     * published to the git provider, never deployed) is generated for this
+     * Work. Absent on rows written before the column existed — absent means
+     * enabled. Resolve alongside `getWorkCapabilities(kind).repos.work`.
+     */
+    providerRepositoryEnabled?: boolean;
     gitProvider: string;
     deployProvider?: string;
     readmeConfig?: MarkdownReadmeConfig;

--- a/packages/agent/src/account-transfer/account-export.service.ts
+++ b/packages/agent/src/account-transfer/account-export.service.ts
@@ -180,6 +180,11 @@ export class AccountExportService {
             slug: dir.slug,
             description: dir.description,
             owner: dir.owner || undefined,
+            kind: dir.kind || undefined,
+            providerRepositoryEnabled:
+                typeof dir.providerRepositoryEnabled === 'boolean'
+                    ? dir.providerRepositoryEnabled
+                    : undefined,
             gitProvider: dir.gitProvider,
             deployProvider: dir.deployProvider || undefined,
             readmeConfig: dir.readmeConfig || undefined,

--- a/packages/agent/src/account-transfer/account-import.service.spec.ts
+++ b/packages/agent/src/account-transfer/account-import.service.spec.ts
@@ -579,6 +579,72 @@ describe('AccountImportService', () => {
             expect(result.worksCreated).toBe(1);
         });
 
+        it('round-trips kind and an explicit providerRepositoryEnabled:false on create', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+            mocks.workRepository.findByOwnerAndSlug.mockResolvedValue(null);
+            mocks.workRepository.create.mockResolvedValue({ id: 'w-new', slug: 'a' });
+
+            await service.applyImport(
+                'user-1',
+                makePayload([
+                    makeWork({ slug: 'a', kind: 'blog', providerRepositoryEnabled: false }),
+                ]),
+                [],
+            );
+
+            // A user who deliberately disabled provider-repo generation must
+            // not have it silently re-enabled by an account transfer.
+            expect(mocks.workRepository.create).toHaveBeenCalledWith(
+                expect.objectContaining({ kind: 'blog', providerRepositoryEnabled: false }),
+                expect.anything(),
+            );
+        });
+
+        it('overwrite applies kind + providerRepositoryEnabled, but omits both for pre-kind payloads', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+            const existing = { id: 'w-existing', slug: 'a', getRepoOwner: () => 'octocat' };
+            mocks.workRepository.findByOwnerAndSlug.mockResolvedValue(existing);
+
+            await service.applyImport(
+                'user-1',
+                makePayload([
+                    makeWork({ slug: 'a', kind: 'website', providerRepositoryEnabled: false }),
+                ]),
+                [{ slug: 'a', strategy: 'overwrite' }],
+            );
+            expect(mocks.workRepository.update).toHaveBeenCalledWith(
+                'w-existing',
+                expect.objectContaining({ kind: 'website', providerRepositoryEnabled: false }),
+            );
+
+            // Old export (no kind / no toggle) → existing settings untouched.
+            mocks.workRepository.update.mockClear();
+            await service.applyImport('user-1', makePayload([makeWork({ slug: 'a' })]), [
+                { slug: 'a', strategy: 'overwrite' },
+            ]);
+            const patch = mocks.workRepository.update.mock.calls[0][1];
+            expect('kind' in patch).toBe(false);
+            expect('providerRepositoryEnabled' in patch).toBe(false);
+        });
+
+        it('a bogus kind in a tampered payload is dropped, not written', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+            mocks.workRepository.findByOwnerAndSlug.mockResolvedValue(null);
+            mocks.workRepository.create.mockResolvedValue({ id: 'w-new', slug: 'a' });
+
+            await service.applyImport(
+                'user-1',
+                makePayload([makeWork({ slug: 'a', kind: 'constructor' })]),
+                [],
+            );
+
+            const [payload] = mocks.workRepository.create.mock.calls[0];
+            expect('kind' in payload).toBe(false);
+        });
+
         it('per-work failure inside the loop is caught and pushed to result.errors WITHOUT aborting other works', async () => {
             const { service, mocks } = makeService();
             mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });

--- a/packages/agent/src/account-transfer/account-import.service.ts
+++ b/packages/agent/src/account-transfer/account-import.service.ts
@@ -22,6 +22,8 @@ import type {
 } from './types';
 import { containsMaskedSecrets, MASKED_SECRET_PREFIX } from './types';
 import { sanitizePrompt } from '../utils/sanitize.util';
+import { normalizeCreateWorkKind, type Work, type WorkKind } from '../entities/work.entity';
+import { WORK_KINDS } from '@ever-works/contracts';
 
 /**
  * Canonical slug shape (matches the work/item DTO `@Matches` rule and
@@ -36,6 +38,22 @@ import { sanitizePrompt } from '../utils/sanitize.util';
  * filesystem while leaving every legitimate export unchanged.
  */
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Import-specific kind normalization. `normalizeCreateWorkKind` maps
+ * UNKNOWN strings to `'default'` (right for the create endpoint), but on an
+ * import-overwrite that would let a tampered payload RESET an existing
+ * work's kind. Here an unrecognized value is treated as absent instead —
+ * only strings that name a real kind (or the `landing` alias) are applied.
+ */
+function normalizeImportedWorkKind(value: unknown): WorkKind | undefined {
+    if (typeof value !== 'string' || !value.trim()) {
+        return undefined;
+    }
+    const raw = value.trim().toLowerCase();
+    const recognized = raw === 'landing' || (WORK_KINDS as readonly string[]).includes(raw);
+    return recognized ? normalizeCreateWorkKind(value) : undefined;
+}
 
 /**
  * Max length applied to imported advanced-prompt fields. Mirrors
@@ -482,7 +500,7 @@ export class AccountImportService {
 
             if (resolution.strategy === 'overwrite') {
                 // Update existing work
-                await this.workRepository.update(existing.id, {
+                const updateData: Partial<Work> = {
                     name: dir.name,
                     description: dir.description,
                     gitProvider: dir.gitProvider,
@@ -495,7 +513,20 @@ export class AccountImportService {
                     communityPrEnabled: dir.communityPrEnabled,
                     communityPrAutoClose: dir.communityPrAutoClose,
                     comparisonsEnabled: dir.comparisonsEnabled,
-                });
+                };
+                // `kind` is user-supplied JSON — only apply a value that
+                // normalizes to a known kind; never let a bogus payload
+                // corrupt the column. Absent (pre-kind export) → keep as-is.
+                const importedKind = normalizeImportedWorkKind(dir.kind);
+                if (importedKind) {
+                    updateData.kind = importedKind;
+                }
+                // Preserve an explicit toggle (notably `false`); absent in
+                // old payloads → leave the existing work's setting alone.
+                if (typeof dir.providerRepositoryEnabled === 'boolean') {
+                    updateData.providerRepositoryEnabled = dir.providerRepositoryEnabled;
+                }
+                await this.workRepository.update(existing.id, updateData);
 
                 await this.importWorkRelations(existing.id, userId, dir, includesSecrets, result);
                 await this.importWorkRepoData(existing, dir, user, result);
@@ -505,26 +536,32 @@ export class AccountImportService {
         }
 
         // Create new work
-        const newDir = await this.workRepository.create(
-            {
-                name: dir.name,
-                slug,
-                description: dir.description,
-                owner: dir.owner || user.username,
-                userId,
-                gitProvider: dir.gitProvider,
-                deployProvider: dir.deployProvider,
-                readmeConfig: dir.readmeConfig,
-                domainType: dir.domainType,
-                repoVisibility: dir.repoVisibility,
-                scheduledUpdatesEnabled: dir.scheduledUpdatesEnabled,
-                scheduledCadence: dir.scheduledCadence as any,
-                communityPrEnabled: dir.communityPrEnabled,
-                communityPrAutoClose: dir.communityPrAutoClose,
-                comparisonsEnabled: dir.comparisonsEnabled,
-            },
-            user,
-        );
+        const createData: Partial<Work> = {
+            name: dir.name,
+            slug,
+            description: dir.description,
+            owner: dir.owner || user.username,
+            userId,
+            gitProvider: dir.gitProvider,
+            deployProvider: dir.deployProvider,
+            readmeConfig: dir.readmeConfig,
+            domainType: dir.domainType,
+            repoVisibility: dir.repoVisibility,
+            scheduledUpdatesEnabled: dir.scheduledUpdatesEnabled,
+            scheduledCadence: dir.scheduledCadence as any,
+            communityPrEnabled: dir.communityPrEnabled,
+            communityPrAutoClose: dir.communityPrAutoClose,
+            comparisonsEnabled: dir.comparisonsEnabled,
+        };
+        // Same normalization rules as the overwrite path above.
+        const importedKind = normalizeImportedWorkKind(dir.kind);
+        if (importedKind) {
+            createData.kind = importedKind;
+        }
+        if (typeof dir.providerRepositoryEnabled === 'boolean') {
+            createData.providerRepositoryEnabled = dir.providerRepositoryEnabled;
+        }
+        const newDir = await this.workRepository.create(createData, user);
 
         await this.importWorkRelations(newDir.id, userId, dir, includesSecrets, result);
         await this.importWorkRepoData(newDir, dir, user, result);

--- a/packages/agent/src/account-transfer/types.ts
+++ b/packages/agent/src/account-transfer/types.ts
@@ -133,6 +133,14 @@ export interface ExportedWork {
     slug: string;
     description: string;
     owner?: string;
+    /** Work kind (directory/website/blog/…). Optional so pre-kind export
+     *  payloads keep importing; validated via `normalizeCreateWorkKind` on
+     *  import (payloads are user-supplied JSON). */
+    kind?: string;
+    /** The user's provider-repo toggle. A deliberate `false` must survive
+     *  an export/import round-trip — omitting it would silently re-enable
+     *  provider-repo generation on the imported work. */
+    providerRepositoryEnabled?: boolean;
     gitProvider: string;
     deployProvider?: string;
     readmeConfig?: any;

--- a/packages/agent/src/dto/update-work.dto.ts
+++ b/packages/agent/src/dto/update-work.dto.ts
@@ -69,6 +69,16 @@ export class UpdateWorkDto {
     @IsBoolean()
     websiteTemplateUseBeta?: boolean;
 
+    @ApiPropertyOptional({
+        description:
+            'Whether to generate the browsable repository published to the git provider ' +
+            '(the "{provider} Repository"). Defaults to true. A Work kind that never ' +
+            'provisions that repository ignores this flag.',
+    })
+    @IsOptional()
+    @IsBoolean()
+    providerRepositoryEnabled?: boolean;
+
     @ApiPropertyOptional({ description: 'Whether community PR processing is enabled' })
     @IsOptional()
     @IsBoolean()

--- a/packages/agent/src/entities/__tests__/work.provider-repository.spec.ts
+++ b/packages/agent/src/entities/__tests__/work.provider-repository.spec.ts
@@ -1,0 +1,114 @@
+import { WORK_KINDS, WORK_KIND_CAPABILITIES } from '@ever-works/contracts';
+import { Work } from '../work.entity';
+
+/**
+ * `shouldGenerateProviderRepository()` decides whether the browsable
+ * repository published to the git provider is created at all, so its two
+ * gates need pinning explicitly: they interact, and getting the precedence
+ * wrong either creates repositories nobody asked for or silently stops
+ * creating ones people depend on.
+ */
+function makeWork(overrides: Partial<Work> = {}): Work {
+    return Object.assign(new Work(), {
+        id: 'w1',
+        kind: 'default',
+        providerRepositoryEnabled: true,
+        ...overrides,
+    });
+}
+
+describe('Work.shouldGenerateProviderRepository', () => {
+    it('generates by default — the behaviour every existing Work relies on', () => {
+        expect(makeWork().shouldGenerateProviderRepository()).toBe(true);
+    });
+
+    /**
+     * TypeORM surfaces a column that predates the migration as `undefined`
+     * on a partially-selected entity. That must read as "enabled", not as
+     * "disabled" — the opposite would stop generation for the entire
+     * installed base.
+     */
+    it('treats an absent flag as enabled', () => {
+        const work = makeWork();
+        (work as { providerRepositoryEnabled?: boolean }).providerRepositoryEnabled = undefined;
+        expect(work.shouldGenerateProviderRepository()).toBe(true);
+    });
+
+    it('respects the user turning it off', () => {
+        expect(
+            makeWork({ providerRepositoryEnabled: false }).shouldGenerateProviderRepository(),
+        ).toBe(false);
+    });
+
+    it.each(['default', 'directory', 'awesome-repo', 'blog', 'website', 'landing-page'])(
+        'generates for the %s kind when enabled',
+        (kind) => {
+            expect(makeWork({ kind } as Partial<Work>).shouldGenerateProviderRepository()).toBe(
+                true,
+            );
+        },
+    );
+
+    /**
+     * Every kind currently provisions this repository — including `company`,
+     * whose repo carries the public description of the business. So today
+     * the user flag is the only thing that gates it, and this test records
+     * that rather than pretending otherwise.
+     *
+     * The kind gate still exists and is still consulted: it is what lets a
+     * future kind (or a change to an existing one) stop generation without
+     * touching every caller. `does not generate when the kind provisions no
+     * provider repository` below pins that half.
+     */
+    it('generates for the company kind — its repo holds the public business profile', () => {
+        expect(
+            makeWork({
+                kind: 'company',
+                providerRepositoryEnabled: true,
+            } as Partial<Work>).shouldGenerateProviderRepository(),
+        ).toBe(true);
+    });
+
+    /**
+     * Kind wins over the stored flag: a kind that does not provision the
+     * repository must not generate one even with the flag explicitly on.
+     * Asserted against the capability registry directly so it keeps
+     * protecting the behaviour if a kind's `repos.work` ever flips.
+     */
+    it('does not generate when the kind provisions no provider repository', () => {
+        const kindWithoutProviderRepo = WORK_KINDS.find(
+            (kind) => !WORK_KIND_CAPABILITIES[kind].repos.work,
+        );
+
+        if (!kindWithoutProviderRepo) {
+            // No such kind today. Prove the gate is wired by asserting the
+            // registry is what decides, rather than silently passing.
+            expect(WORK_KINDS.every((kind) => WORK_KIND_CAPABILITIES[kind].repos.work)).toBe(true);
+            return;
+        }
+
+        expect(
+            makeWork({
+                kind: kindWithoutProviderRepo,
+                providerRepositoryEnabled: true,
+            } as Partial<Work>).shouldGenerateProviderRepository(),
+        ).toBe(false);
+    });
+
+    it('keeps the user opt-out when the kind would otherwise allow it', () => {
+        expect(
+            makeWork({
+                kind: 'website',
+                providerRepositoryEnabled: false,
+            } as Partial<Work>).shouldGenerateProviderRepository(),
+        ).toBe(false);
+    });
+
+    it('falls back to the default capability set for an unknown kind', () => {
+        expect(
+            makeWork({
+                kind: 'storefront',
+            } as unknown as Partial<Work>).shouldGenerateProviderRepository(),
+        ).toBe(true);
+    });
+});

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -61,6 +61,7 @@ import type { WorkKbConfig } from './kb-types';
  */
 import {
     USER_SELECTABLE_WORK_KINDS,
+    getWorkCapabilities,
     normalizeWorkKind,
     type UserSelectableWorkKind,
     type WorkKind,
@@ -117,6 +118,38 @@ export function normalizeCreateWorkKind(value?: string | null): WorkKind | undef
  *   - `'archived'` — soft-retired; reserved for a future archive flow.
  */
 export type WorkStatus = 'draft' | 'active' | 'registered' | 'archived';
+
+/**
+ * Whether a Work should provision and maintain the browsable repository
+ * published to its git provider (the "{provider} Repository";
+ * `RepositoryRole` `work`).
+ *
+ * Two independent gates, both of which must allow it:
+ *   1. the Work's kind provisions that repository at all, and
+ *   2. the user has not turned it off.
+ *
+ * Kind wins: switching a Work to a kind that has no provider repository must
+ * stop generating one regardless of the stored flag, and switching back must
+ * not silently re-enable something the user disabled.
+ *
+ * Deliberately a free function taking a structural type rather than only an
+ * entity method. Works reach the generators as plain objects in several
+ * paths — `WorkQueryService` spreads the entity (`{...dir}`) and the
+ * generation pipeline passes those on — so an instance method alone would
+ * throw `is not a function` at runtime for exactly those callers. The entity
+ * keeps a thin method that delegates here.
+ */
+export function shouldGenerateProviderRepository(
+    work: Pick<Work, 'kind'> & { providerRepositoryEnabled?: boolean },
+): boolean {
+    if (!getWorkCapabilities(work.kind).repos.work) {
+        return false;
+    }
+    // `?? true` covers rows written before the column existed, which TypeORM
+    // surfaces as `undefined` on a partially-selected entity. Absent must
+    // read as enabled — the opposite would stop generation platform-wide.
+    return work.providerRepositoryEnabled ?? true;
+}
 
 @Entity({ name: 'works' })
 export class Work {
@@ -369,6 +402,25 @@ export class Work {
     @Column({ type: 'boolean', default: false })
     comparisonsEnabled: boolean;
 
+    /**
+     * Whether to generate the browsable repository published to the git
+     * provider — the one the UI calls the "{provider} Repository" and that
+     * `RepositoryRole` calls `work`.
+     *
+     * Defaults to `true` so every existing Work keeps its current behaviour.
+     * Turning it off is for Works whose output nobody reads on GitHub (an
+     * internal landing page, say) and who would rather not carry a
+     * repository that only ever holds a generated README.
+     *
+     * This is a user override layered ON TOP of the per-kind capability
+     * (`getWorkCapabilities(kind).repos.work`) — a kind that never
+     * provisions the repository ignores the flag entirely. Resolve the two
+     * together through `Work.shouldGenerateProviderRepository()` rather than
+     * reading this column directly.
+     */
+    @Column({ type: 'boolean', default: true })
+    providerRepositoryEnabled: boolean;
+
     @Column({ type: 'varchar', nullable: true, default: null })
     websiteTemplateId?: string | null;
 
@@ -568,6 +620,11 @@ export class Work {
 
     getMainRepo() {
         return this.getRelatedRepository('work').repo;
+    }
+
+    /** @see shouldGenerateProviderRepository — kept for entity-instance callers. */
+    shouldGenerateProviderRepository(): boolean {
+        return shouldGenerateProviderRepository(this);
     }
 
     getRepoOwner(type: RepositoryRole = 'data'): string {

--- a/packages/agent/src/generators/markdown-generator/markdown-generator.service.ts
+++ b/packages/agent/src/generators/markdown-generator/markdown-generator.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import * as fs from 'node:fs/promises';
 import { GitFacadeService } from '../../facades/git.facade';
 import type { Category, Identifiable, ItemData, Tag } from '@ever-works/contracts';
-import { Work } from '../../entities/work.entity';
+import { Work, shouldGenerateProviderRepository } from '../../entities/work.entity';
 import { User } from '../../entities/user.entity';
 import { DataRepository, PRUpdate } from '../data-generator/data-repository';
 import { ReadmeBuilder } from './readme-builder';
@@ -66,6 +66,18 @@ export class MarkdownGeneratorService {
         options: InitializeOptions = {},
     ): Promise<{ filesChanged: number }> {
         throwIfGenerationCancelled(options.signal);
+
+        // The single gate for the provider repository. `initialize` is called
+        // from eight places across generation and import; gating here rather
+        // than at each call site means a new caller cannot forget it — and
+        // means turning the setting off actually stops the repository being
+        // CREATED, not merely re-rendered.
+        if (!shouldGenerateProviderRepository(work)) {
+            this.logger.log(
+                `Skipping ${work.gitProvider} repository generation for work ${work.id} — disabled for this Work or not provisioned by kind "${work.kind}".`,
+            );
+            return { filesChanged: 0 };
+        }
 
         const workOwner = getWorkOwner(work);
         const committer = work.resolveCommitter(user);

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -637,6 +637,11 @@ export class WorkLifecycleService {
                 updateData.websiteTemplateId = nextTemplateId;
             }
 
+            // Provider ("{provider} Repository") generation opt-out.
+            if (updateDto.providerRepositoryEnabled !== undefined) {
+                updateData.providerRepositoryEnabled = updateDto.providerRepositoryEnabled;
+            }
+
             // Handle community PR processing settings
             if (updateDto.communityPrEnabled !== undefined) {
                 updateData.communityPrEnabled = updateDto.communityPrEnabled;

--- a/packages/agent/src/services/work-query.service.ts
+++ b/packages/agent/src/services/work-query.service.ts
@@ -22,6 +22,7 @@ type WorkMethods =
     | 'getDataRepo'
     | 'getWebsiteRepo'
     | 'getMainRepo'
+    | 'shouldGenerateProviderRepository'
     | 'getRepoOwner'
     | 'isCreator'
     | 'getMember'


### PR DESCRIPTION
Part of item **5b** — the enable/disable setting the request calls for ("it must be a setting somewhere to enable / disable generation of those. By default it should be enabled").

> **Stacked on #1776** (uses the capability registry). Review the top commit.

## Problem

The **"{provider} Repository"** — the AI-generated, browsable view of a Work published to GitHub/GitLab but never deployed — was generated for **every** Work unconditionally, with no way to say no. An internal landing page gains nothing from a repository that only ever holds a generated README.

## Change

`works.providerRepositoryEnabled`, **`DEFAULT true` / `NOT NULL`**, so every existing Work keeps generating exactly as it does today. The flag can only ever remove behaviour a user explicitly turned off — it can never silently disable generation for a Work that was relying on it.

Resolution combines **two gates** in `shouldGenerateProviderRepository(work)`:

1. the Work's kind provisions the repository at all — `getWorkCapabilities(kind).repos.work`
2. the user has not turned it off

**Kind wins in both directions.** Switching to a kind with no provider repository stops generation regardless of the stored flag, and switching back does not silently re-enable something the user disabled.

## One gate, not eight

The check lives inside `MarkdownGeneratorService.initialize` — the single choke point that all **eight** call sites across generation and import already go through. Gating there rather than per-call-site means:

- a new caller cannot forget it;
- turning the setting off stops the repository being **created**, not merely re-rendered.

## A free function, not just a method

Written first as an entity method — and the existing markdown-generator specs immediately caught why that is wrong. Works reach the generators as **plain objects** in several paths (`WorkQueryService` spreads the entity, the pipeline passes that on), so an instance method alone throws `work.shouldGenerateProviderRepository is not a function` **at runtime**, not only in tests. It is now a free function over a structural type; the entity keeps a thin delegating method.

That was a real production bug avoided, and it is why the 40 red specs were a useful signal rather than noise.

## UI

The settings card **hides entirely** for a kind that never provisions the repository — a switch that cannot change anything is worse than no switch.

Turning it off states explicitly that the **existing repository is left untouched** and merely stops being updated. Deleting it is not implied and does not happen.

## Verification

- **13 new tests** covering both gates and their precedence — including that an absent column (rows predating the migration, which TypeORM surfaces as `undefined`) reads as **enabled**, since the opposite would stop generation platform-wide.
- `packages/agent` touched suites: **177 passed**
- `apps/web` unit: **970 passed**
- `tsc --noEmit` clean for agent and web
- i18n across all **21 locales**, `{provider}` placeholder preserved

## Scope note

This is the **setting** half of item 5b. Making the repository's *content* generation kind-aware and prompt-driven (data repo → AI → repo, per kind, with per-Work prompt overrides) is the larger half and is not in this PR — today's generator still produces the README-shaped output for every kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)