### PR TITLE
feat(works): write what a scheduled Work run learned into shared Memory

### DIFF
--- a/packages/agent/src/services/__tests__/work-memory.service.spec.ts
+++ b/packages/agent/src/services/__tests__/work-memory.service.spec.ts
@@ -1,0 +1,193 @@
+import { WorkMemoryService } from '../work-memory.service';
+
+/**
+ * `WorkMemoryService` runs at the tail of a scheduled generation, AFTER the
+ * run's output is already committed to git and its status written. So the
+ * governing property is that it can never turn a succeeded run into a
+ * failed one — every test here exists to pin some version of "does not
+ * throw".
+ */
+function makeFacade(overrides: Partial<Record<string, jest.Mock>> = {}) {
+    return {
+        openSession: overrides.openSession ?? jest.fn().mockResolvedValue({ id: 'sess-1' }),
+        saveMemory: overrides.saveMemory ?? jest.fn().mockResolvedValue({ id: 'mem-1' }),
+        closeSession: overrides.closeSession ?? jest.fn().mockResolvedValue(undefined),
+        searchMemory:
+            overrides.searchMemory ??
+            jest.fn().mockResolvedValue({ results: [{ content: 'prior finding', score: 0.9 }] }),
+    };
+}
+
+const WORK = {
+    id: 'work-1',
+    name: 'Awesome Chairs',
+    slug: 'awesome-chairs',
+    kind: 'directory',
+    userId: 'user-1',
+} as never;
+
+function noProviderError(): Error {
+    const error = new Error('no agent-memory provider enabled');
+    error.name = 'NoProviderError';
+    return error;
+}
+
+describe('WorkMemoryService.recordRun', () => {
+    it('opens a session, saves the finding, then closes the session', async () => {
+        const facade = makeFacade();
+        const service = new WorkMemoryService(facade as never);
+
+        const sessionId = await service.recordRun({
+            work: WORK,
+            userId: 'user-1',
+            summary: 'Scheduled run completed. 3 new items.',
+            historyId: 'hist-1',
+            scheduleId: 'sched-1',
+            stats: { newItems: 3, updatedItems: 1, totalItems: 42 },
+        });
+
+        expect(sessionId).toBe('sess-1');
+        expect(facade.openSession).toHaveBeenCalledTimes(1);
+        expect(facade.saveMemory).toHaveBeenCalledTimes(1);
+        expect(facade.closeSession).toHaveBeenCalledWith('sess-1', {
+            userId: 'user-1',
+            workId: 'work-1',
+        });
+    });
+
+    /**
+     * `workId` scopes provider resolution to the Work's own configured
+     * memory provider. Without it a Work would write into a different store
+     * from the one its own agents read.
+     */
+    it('scopes every call to the Work so it shares its agents store', async () => {
+        const facade = makeFacade();
+        const service = new WorkMemoryService(facade as never);
+
+        await service.recordRun({ work: WORK, userId: 'user-1', summary: 'x' });
+
+        for (const call of [facade.openSession, facade.saveMemory]) {
+            expect(call.mock.calls[0][1]).toEqual({ userId: 'user-1', workId: 'work-1' });
+        }
+    });
+
+    it('tags the memory so the Work can retrieve its own history later', async () => {
+        const facade = makeFacade();
+        const service = new WorkMemoryService(facade as never);
+
+        await service.recordRun({ work: WORK, userId: 'user-1', summary: 'x' });
+
+        const [saved] = facade.saveMemory.mock.calls[0];
+        expect(saved.tags).toEqual(['work-run', 'work:work-1', 'kind:directory']);
+        expect(saved.sessionId).toBe('sess-1');
+        expect(saved.metadata).toMatchObject({ workId: 'work-1', workSlug: 'awesome-chairs' });
+    });
+
+    it('falls back to the default kind tag when the Work has none', async () => {
+        const facade = makeFacade();
+        const service = new WorkMemoryService(facade as never);
+
+        await service.recordRun({
+            work: { ...(WORK as object), kind: undefined } as never,
+            userId: 'user-1',
+            summary: 'x',
+        });
+
+        expect(facade.saveMemory.mock.calls[0][0].tags).toContain('kind:default');
+    });
+
+    it('is a no-op when no memory facade is wired at all', async () => {
+        const service = new WorkMemoryService(undefined);
+        await expect(
+            service.recordRun({ work: WORK, userId: 'user-1', summary: 'x' }),
+        ).resolves.toBeNull();
+    });
+
+    it('stays quiet when the user has no memory provider enabled', async () => {
+        const facade = makeFacade({
+            openSession: jest.fn().mockRejectedValue(noProviderError()),
+        });
+        const service = new WorkMemoryService(facade as never);
+
+        await expect(
+            service.recordRun({ work: WORK, userId: 'user-1', summary: 'x' }),
+        ).resolves.toBeNull();
+        expect(facade.saveMemory).not.toHaveBeenCalled();
+        expect(facade.closeSession).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when saving fails, and still closes the session', async () => {
+        const facade = makeFacade({
+            saveMemory: jest.fn().mockRejectedValue(new Error('provider exploded')),
+        });
+        const service = new WorkMemoryService(facade as never);
+
+        await expect(
+            service.recordRun({ work: WORK, userId: 'user-1', summary: 'x' }),
+        ).resolves.toBeNull();
+        // The session was opened, so it must be released even though the
+        // save failed — otherwise a provider leaks an open session per run.
+        expect(facade.closeSession).toHaveBeenCalledWith('sess-1', expect.anything());
+    });
+
+    /**
+     * A save that succeeded must not be reported as a failure because the
+     * close afterwards did not land.
+     */
+    it('still reports success when only the close fails', async () => {
+        const facade = makeFacade({
+            closeSession: jest.fn().mockRejectedValue(new Error('close failed')),
+        });
+        const service = new WorkMemoryService(facade as never);
+
+        await expect(
+            service.recordRun({ work: WORK, userId: 'user-1', summary: 'x' }),
+        ).resolves.toBe('sess-1');
+    });
+});
+
+describe('WorkMemoryService.recall', () => {
+    it('returns prior findings scoped to this Work', async () => {
+        const facade = makeFacade();
+        const service = new WorkMemoryService(facade as never);
+
+        const results = await service.recall({
+            work: { id: 'work-1' } as never,
+            userId: 'user-1',
+            query: 'what did we learn about pricing',
+        });
+
+        expect(results).toEqual([{ content: 'prior finding', score: 0.9 }]);
+        expect(facade.searchMemory.mock.calls[0][0]).toMatchObject({
+            tags: ['work:work-1'],
+            limit: 10,
+        });
+    });
+
+    it('returns an empty list rather than throwing when no provider exists', async () => {
+        const service = new WorkMemoryService(undefined);
+        await expect(
+            service.recall({ work: { id: 'work-1' } as never, userId: 'u', query: 'q' }),
+        ).resolves.toEqual([]);
+    });
+
+    it('returns an empty list when the provider errors', async () => {
+        const facade = makeFacade({
+            searchMemory: jest.fn().mockRejectedValue(new Error('down')),
+        });
+        const service = new WorkMemoryService(facade as never);
+
+        await expect(
+            service.recall({ work: { id: 'work-1' } as never, userId: 'u', query: 'q' }),
+        ).resolves.toEqual([]);
+    });
+
+    it('tolerates a provider returning no results field', async () => {
+        const facade = makeFacade({ searchMemory: jest.fn().mockResolvedValue({}) });
+        const service = new WorkMemoryService(facade as never);
+
+        await expect(
+            service.recall({ work: { id: 'work-1' } as never, userId: 'u', query: 'q' }),
+        ).resolves.toEqual([]);
+    });
+});

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -6,6 +6,7 @@ export * from './work.module';
 export * from './work-generation.service';
 export * from './work-schedule.service';
 export * from './work-schedule-dispatcher.service';
+export * from './work-memory.service';
 export * from './work-member.service';
 export * from './work-invitation.service';
 export * from './work-import.service';

--- a/packages/agent/src/services/work-generation.service.ts
+++ b/packages/agent/src/services/work-generation.service.ts
@@ -51,6 +51,7 @@ import {
 } from '@src/tasks';
 import { WorkScheduleBillingMode, GenerateStatusType } from '@src/entities/types';
 import { WorkOwnershipService } from './work-ownership.service';
+import { WorkMemoryService } from './work-memory.service';
 import { normalizeGeneratorError } from './utils/error.utils';
 import {
     classifyGenerationError,
@@ -160,6 +161,11 @@ export class WorkGenerationService {
         // shared pattern.
         @Optional()
         private readonly runtimeBindingStamper?: RuntimeBindingStamperService,
+        // Optional so the many isolated unit tests that construct this
+        // service positionally keep working; when absent, scheduled runs
+        // simply record no memory (the previous behaviour).
+        @Optional()
+        private readonly workMemory?: WorkMemoryService,
     ) {}
 
     async generateItems(
@@ -1152,6 +1158,69 @@ Only include image URLs that are absolute URLs (starting with http).`;
                 step: null,
             }),
         ]);
+
+        // Persist what this run learned into the shared Memory, so the next
+        // scheduled run starts from what this one found instead of
+        // re-deriving it. Deliberately AFTER the status writes and awaited
+        // separately: a memory provider being unreachable must never turn a
+        // succeeded run into a failed one.
+        await this.recordRunInMemory(workId, scheduleId, historyId);
+    }
+
+    /**
+     * Best-effort Memory write for a completed scheduled run.
+     *
+     * Never throws — `WorkMemoryService` already swallows provider errors,
+     * and the extra guard here covers the lookups this method does itself.
+     */
+    private async recordRunInMemory(
+        workId: string,
+        scheduleId: string,
+        historyId: string,
+    ): Promise<void> {
+        if (!this.workMemory) {
+            return;
+        }
+
+        try {
+            const [work, history] = await Promise.all([
+                this.workRepository.findById(workId),
+                this.generationHistoryRepository.findById(historyId),
+            ]);
+            if (!work) {
+                return;
+            }
+
+            const stats = {
+                newItems: history?.newItemsCount ?? 0,
+                updatedItems: history?.updatedItemsCount ?? 0,
+                totalItems: history?.totalItemsCount ?? 0,
+            };
+
+            const changelog = history?.changelog?.summary?.trim();
+            const summary = [
+                `Scheduled run of "${work.name}" completed.`,
+                `Items: ${stats.newItems} new, ${stats.updatedItems} updated, ${stats.totalItems} total.`,
+                changelog ? `Changes: ${changelog}` : null,
+            ]
+                .filter(Boolean)
+                .join(' ');
+
+            await this.workMemory.recordRun({
+                work,
+                userId: work.userId,
+                summary,
+                historyId,
+                scheduleId,
+                stats,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Failed to record scheduled-run memory for work ${workId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
     }
 
     private async handleSyncFailure(

--- a/packages/agent/src/services/work-memory.service.ts
+++ b/packages/agent/src/services/work-memory.service.ts
@@ -1,0 +1,173 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { AgentMemoryFacadeService } from '../facades/agent-memory.facade';
+import type { Work } from '../entities/work.entity';
+
+/**
+ * What a Work run learned, written into the shared Memory.
+ *
+ * Agents already open a memory session per run
+ * (`AgentRunService.tryOpenMemorySession`) so their findings survive the
+ * session that produced them. Scheduled Work runs did not: a Work could
+ * research a topic every night for a month and retain nothing — each run
+ * started from zero, re-derived the same conclusions, and threw them away.
+ *
+ * This service closes that gap using the same `agent-memory` plugin
+ * capability, so Work memories land in the same store agents read from and
+ * are searchable alongside them.
+ *
+ * Everything here is **best-effort and never throws**. A generation run that
+ * succeeded must not be reported as failed because a memory provider was
+ * unreachable — the run's own output is already committed to git by this
+ * point.
+ */
+export interface WorkRunMemoryInput {
+    readonly work: Pick<Work, 'id' | 'name' | 'slug' | 'kind' | 'userId'>;
+    /** Owner of the run — scopes provider resolution. */
+    readonly userId: string;
+    /** Human-readable account of what this run did. */
+    readonly summary: string;
+    /** Generation-history row this memory describes, for traceability. */
+    readonly historyId?: string;
+    readonly scheduleId?: string;
+    readonly stats?: {
+        readonly newItems?: number;
+        readonly updatedItems?: number;
+        readonly totalItems?: number;
+    };
+}
+
+@Injectable()
+export class WorkMemoryService {
+    private readonly logger = new Logger(WorkMemoryService.name);
+
+    constructor(@Optional() private readonly agentMemory?: AgentMemoryFacadeService) {}
+
+    /**
+     * Record one Work run in Memory: open a session, save the finding,
+     * close the session.
+     *
+     * Mirrors `AgentRunService.tryOpenMemorySession` deliberately, including
+     * NOT calling `isConfigured()` first — that check is registry-global
+     * (true whenever any agent-memory plugin is loaded, regardless of user
+     * enablement), so it false-positives and produces a warning on every
+     * run for users who have no provider enabled. `openSession` does the
+     * real resolution and throws `NoProviderError`, which is the expected
+     * quiet case.
+     */
+    async recordRun(input: WorkRunMemoryInput): Promise<string | null> {
+        if (!this.agentMemory) {
+            return null;
+        }
+
+        const { work, userId, summary } = input;
+        // `workId` scopes provider resolution to the Work's own configured
+        // memory provider and its Work-level settings, falling back to the
+        // user's. Without it a Work would write into a different store from
+        // the one its own agents read.
+        const facadeOptions = { userId, workId: work.id };
+
+        let sessionId: string | null = null;
+        try {
+            const session = await this.agentMemory.openSession(
+                {
+                    source: 'work-run',
+                    workId: work.id,
+                    workName: work.name,
+                    workSlug: work.slug,
+                    workKind: work.kind,
+                    ...(input.historyId ? { historyId: input.historyId } : {}),
+                    ...(input.scheduleId ? { scheduleId: input.scheduleId } : {}),
+                },
+                facadeOptions,
+            );
+            sessionId = session.id;
+
+            await this.agentMemory.saveMemory(
+                {
+                    content: summary,
+                    // Tags are what make a Work's own history retrievable
+                    // later: `work:<id>` narrows to this Work, `work-run`
+                    // separates scheduled output from agent chatter, and the
+                    // kind lets a query span every Work of a type.
+                    tags: ['work-run', `work:${work.id}`, `kind:${work.kind ?? 'default'}`],
+                    metadata: {
+                        workId: work.id,
+                        workSlug: work.slug,
+                        ...(input.historyId ? { historyId: input.historyId } : {}),
+                        ...(input.scheduleId ? { scheduleId: input.scheduleId } : {}),
+                        ...(input.stats ? { stats: input.stats } : {}),
+                    },
+                    sessionId,
+                },
+                facadeOptions,
+            );
+
+            return sessionId;
+        } catch (error) {
+            this.logFailure(error, work.id);
+            return null;
+        } finally {
+            if (sessionId) {
+                // Closing is its own try/catch: a save that succeeded must
+                // not be reported as a failure because the close call
+                // afterwards did not land.
+                try {
+                    await this.agentMemory.closeSession(sessionId, facadeOptions);
+                } catch (error) {
+                    this.logFailure(error, work.id, 'close');
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieve what this Work has learned previously.
+     *
+     * Returns an empty array rather than throwing when no provider is
+     * configured, so callers can inject prior findings into a prompt without
+     * branching on whether Memory exists.
+     */
+    async recall(input: {
+        work: Pick<Work, 'id'>;
+        userId: string;
+        query: string;
+        limit?: number;
+    }): Promise<Array<{ content: string; score?: number }>> {
+        if (!this.agentMemory) {
+            return [];
+        }
+
+        try {
+            const response = await this.agentMemory.searchMemory(
+                {
+                    query: input.query,
+                    limit: input.limit ?? 10,
+                    tags: [`work:${input.work.id}`],
+                },
+                { userId: input.userId, workId: input.work.id },
+            );
+            return (response?.results ?? []).map((result) => ({
+                content: result.content,
+                ...(typeof result.score === 'number' ? { score: result.score } : {}),
+            }));
+        } catch (error) {
+            this.logFailure(error, input.work.id, 'search');
+            return [];
+        }
+    }
+
+    private logFailure(error: unknown, workId: string, operation = 'record'): void {
+        // `NoProviderError` is the expected case for users with no
+        // agent-memory provider enabled — debug, not warn, so it does not
+        // fill ops logs on every scheduled run.
+        const isNoProvider = error instanceof Error && error.name === 'NoProviderError';
+        const message = `WorkMemoryService: ${operation} failed for work ${workId}: ${
+            error instanceof Error ? error.message : String(error)
+        }`;
+        if (isNoProvider) {
+            this.logger.debug(message);
+        } else {
+            this.logger.warn(message);
+        }
+    }
+}

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -15,6 +15,7 @@ import { WorkOwnershipService } from './work-ownership.service';
 import { WorkQueryService } from './work-query.service';
 import { WorkLifecycleService } from './work-lifecycle.service';
 import { WorkGenerationService } from './work-generation.service';
+import { WorkMemoryService } from './work-memory.service';
 import { WorkScheduleService } from './work-schedule.service';
 import { WorkScheduleDispatcherService } from './work-schedule-dispatcher.service';
 import { AnonymousUserCleanupService } from './anonymous-user-cleanup.service';
@@ -87,6 +88,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorkQueryService,
         WorkLifecycleService,
         WorkGenerationService,
+        WorkMemoryService,
         WorkDetailService,
         WorkScheduleService,
         WorkScheduleDispatcherService,
@@ -148,6 +150,7 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorkQueryService,
         WorkLifecycleService,
         WorkGenerationService,
+        WorkMemoryService,
         WorkDetailService,
         WorkScheduleService,
         WorkScheduleDispatcherService,


### PR DESCRIPTION
First slice of item **10** — "when a Work runs on schedule and does some research or activity, it should be able to add memory of that session into that global Memory".

> **Stacked on #1776.** Review the top commit.

## Problem

Agents already open a memory session per run (`AgentRunService.tryOpenMemorySession`), so their findings outlive the session that produced them.

**Scheduled Work runs did not.** A Work could research a topic every night for a month and retain nothing — each run started from zero, re-derived the same conclusions, and threw them away.

## Change

`WorkMemoryService`, built on the **existing `agent-memory` plugin capability** rather than a new store — so Work memories land in the *same* place agents read from and are searchable alongside them, instead of in a parallel silo.

- **`recordRun`** — open a session, save what the run did, close it. Called from `handleSyncSuccess`, the completion point of a scheduled generation.
- **`recall`** — retrieve this Work's prior findings, scoped by a `work:<id>` tag. Returns `[]` when no provider is configured, so a caller can inject prior findings into a prompt without branching on whether Memory exists.

### Scoping

Every call passes `workId`, not just `userId`. Without it a Work would write into a **different store from the one its own agents read**, because provider resolution otherwise falls back to the user-level provider.

Memories are tagged `work-run`, `work:<id>`, `kind:<kind>` — that is what makes them retrievable later: by this Work, by scheduled output vs agent chatter, or across every Work of a type.

## Nothing here can fail a run

This executes *after* the run's output is committed to git and its status written. A memory provider being unreachable must never turn a succeeded run into a failed one. Errors are swallowed at three levels:

1. inside the service;
2. around the caller's own lookups;
3. `closeSession` **separately** from `saveMemory` — a save that succeeded is not reported as a failure because the close afterwards did not land.

An open session is still released when the save fails, so a provider cannot leak one session per run.

`NoProviderError` — the expected case for users with no memory provider enabled — logs at **debug**, not warn, so it does not fill ops logs on every scheduled run. This mirrors the deliberate choice already made in `AgentRunService`, which also skips `isConfigured()` because that check is registry-global and false-positives for users without the provider enabled.

## Verification

- **12 new tests**, mostly pinning the "never throws" property: no facade wired, no provider enabled, save fails (session still closed), close fails (still reports success), search fails, provider returns no `results` field.
- `packages/agent` generation + schedule suites: **202 passed**
- `tsc --noEmit` clean

## Scope

This is the **write** half plus the retrieval primitive. Injecting recalled memories into the generation prompt — so a run actually *uses* what previous runs learned — is the natural next step and is not in this PR; `recall()` exists and is tested so that change is a small one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create Missions manually with titles, descriptions, types, and schedules.
  * Associate tasks with multiple work areas, including teams, agents, and goals, and filter tasks by these associations.
  * View Work kind badges, capability-aware tabs, and expanded statistics.
  * Scheduled Work runs can preserve summaries for later reference.
* **Bug Fixes**
  * Improved chat tool availability across follow-up messages.
  * Added safer handling for unavailable chat and external repository links.
* **Localization**
  * Updated translations across supported languages with clearer Work, Mission, repository, and deployment terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->