### PR TITLE
fix(agent): stop serving consolidation-superseded KB docs as current truth

### DIFF
--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -542,6 +542,167 @@ describe('KnowledgeBaseService', () => {
             // (alwaysInjected copy is what got emitted).
             expect(rendered).toContain('Always copy');
         });
+
+        // ── Consolidation supersession (memory M1) ─────────────────────
+        // The consolidation apply pass marks near-duplicate losers
+        // `consolidation.state='superseded'` but leaves status ACTIVE
+        // (never-delete invariant). resolveContext must not serve those
+        // archived docs as current truth.
+
+        function stubSemanticHit(docIds: string[]) {
+            const aiFacadeStub = {
+                embed: jest.fn().mockResolvedValue({ embeddings: [[0.1, 0.2, 0.3]] }),
+            };
+            const chunkRepoStub = {
+                findNearestByEmbedding: jest.fn().mockResolvedValue(
+                    docIds.map((documentId, i) => ({
+                        id: `c${i}`,
+                        workId: WORK_ID,
+                        documentId,
+                        chunkIndex: 0,
+                        content: `chunk ${i}`,
+                        distance: 0.1 * (i + 1),
+                    })),
+                ),
+            };
+            (service as unknown as { chunkRepository: typeof chunkRepoStub }).chunkRepository =
+                chunkRepoStub;
+            (service as unknown as { aiFacade: typeof aiFacadeStub }).aiFacade = aiFacadeStub;
+        }
+
+        it('excludes consolidation-superseded docs from alwaysInjected (survivor stays)', async () => {
+            const survivor = buildDocument({
+                id: 'surv-1',
+                kbDocumentClass: 'brand' as KbDocumentClass,
+                metadata: { body: 'Current truth' },
+            });
+            const loser = buildDocument({
+                id: 'lose-1',
+                kbDocumentClass: 'brand' as KbDocumentClass,
+                metadata: { body: 'Archived near-dup' },
+                consolidation: {
+                    state: 'superseded',
+                    supersededById: 'surv-1',
+                    reason: 'near-duplicate of Current truth',
+                    runAt: '2026-07-23T00:00:00.000Z',
+                },
+            });
+            docRepo.list.mockResolvedValue({ items: [survivor, loser], total: 2 });
+
+            const bundle = await service.resolveContext(WORK_ID);
+
+            expect(bundle.alwaysInjected.map((d) => d.id)).toEqual(['surv-1']);
+            expect(bundle.format()).not.toContain('Archived near-dup');
+        });
+
+        it('serves a promoted doc normally (only superseded is demoted)', async () => {
+            const promoted = buildDocument({
+                id: 'promo-1',
+                kbDocumentClass: 'brand' as KbDocumentClass,
+                metadata: { body: 'Promoted body' },
+                consolidation: {
+                    state: 'promoted',
+                    score: 42,
+                    reason: 'promotion score 42',
+                    runAt: '2026-07-23T00:00:00.000Z',
+                },
+            });
+            docRepo.list.mockResolvedValue({ items: [promoted], total: 1 });
+
+            const bundle = await service.resolveContext(WORK_ID);
+
+            expect(bundle.alwaysInjected.map((d) => d.id)).toEqual(['promo-1']);
+        });
+
+        it('substitutes the survivor when semantic retrieval hits a superseded doc', async () => {
+            const survivor = buildDocument({
+                id: 'surv-2',
+                kbDocumentClass: 'research' as KbDocumentClass,
+                path: 'research/current.md',
+                slug: 'current',
+                title: 'Current finding',
+                metadata: { body: 'Live finding' },
+            });
+            const loser = buildDocument({
+                id: 'lose-2',
+                kbDocumentClass: 'research' as KbDocumentClass,
+                metadata: { body: 'Stale finding' },
+                consolidation: {
+                    state: 'superseded',
+                    supersededById: 'surv-2',
+                    reason: 'near-duplicate',
+                    runAt: '2026-07-23T00:00:00.000Z',
+                },
+            });
+            // Chunk embeddings outlive consolidation: the hit lands on
+            // the LOSER. Also hit the survivor directly to prove the
+            // substitution dedupes to a single entry.
+            stubSemanticHit(['lose-2', 'surv-2']);
+            docRepo.list.mockResolvedValue({ items: [], total: 0 });
+            docRepo.findById.mockImplementation(async (_workId: string, docId: string) => {
+                if (docId === 'lose-2') return loser;
+                if (docId === 'surv-2') return survivor;
+                return null;
+            });
+
+            const bundle = await service.resolveContext(WORK_ID, { query: 'finding' });
+
+            expect(bundle.queryRetrieved.map((d) => d.id)).toEqual(['surv-2']);
+            const rendered = bundle.format();
+            expect(rendered).toContain('Live finding');
+            expect(rendered).not.toContain('Stale finding');
+        });
+
+        it('drops a superseded hit whose chain dead-ends or cycles (never serves the archive)', async () => {
+            const cycleA = buildDocument({
+                id: 'cyc-a',
+                kbDocumentClass: 'research' as KbDocumentClass,
+                metadata: { body: 'Cycle A' },
+                consolidation: {
+                    state: 'superseded',
+                    supersededById: 'cyc-b',
+                    reason: 'x',
+                    runAt: '2026-07-23T00:00:00.000Z',
+                },
+            });
+            const cycleB = buildDocument({
+                id: 'cyc-b',
+                kbDocumentClass: 'research' as KbDocumentClass,
+                metadata: { body: 'Cycle B' },
+                consolidation: {
+                    state: 'superseded',
+                    supersededById: 'cyc-a',
+                    reason: 'x',
+                    runAt: '2026-07-23T00:00:00.000Z',
+                },
+            });
+            const noSurvivor = buildDocument({
+                id: 'dead-1',
+                kbDocumentClass: 'research' as KbDocumentClass,
+                metadata: { body: 'Dead end' },
+                consolidation: {
+                    state: 'superseded',
+                    supersededById: 'gone-1',
+                    reason: 'x',
+                    runAt: '2026-07-23T00:00:00.000Z',
+                },
+            });
+            stubSemanticHit(['cyc-a', 'dead-1']);
+            docRepo.list.mockResolvedValue({ items: [], total: 0 });
+            docRepo.findById.mockImplementation(async (_workId: string, docId: string) => {
+                if (docId === 'cyc-a') return cycleA;
+                if (docId === 'cyc-b') return cycleB;
+                if (docId === 'dead-1') return noSurvivor;
+                return null;
+            });
+
+            const bundle = await service.resolveContext(WORK_ID, { query: 'anything' });
+
+            expect(bundle.queryRetrieved).toEqual([]);
+            const rendered = bundle.format();
+            expect(rendered).not.toContain('Cycle A');
+            expect(rendered).not.toContain('Dead end');
+        });
     });
 
     describe('getDocumentHistory', () => {

--- a/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
+++ b/packages/agent/src/services/__tests__/knowledge-base.service.spec.ts
@@ -653,6 +653,102 @@ describe('KnowledgeBaseService', () => {
             expect(rendered).not.toContain('Stale finding');
         });
 
+        it('over-fetches chunk hits so converging chains do not under-fill the doc limit', async () => {
+            const survivor = buildDocument({
+                id: 'conv-surv',
+                kbDocumentClass: 'research' as KbDocumentClass,
+                metadata: { body: 'Converged survivor' },
+            });
+            const loserA = buildDocument({
+                id: 'conv-a',
+                kbDocumentClass: 'research' as KbDocumentClass,
+                consolidation: {
+                    state: 'superseded',
+                    supersededById: 'conv-surv',
+                    reason: 'x',
+                    runAt: '2026-07-23T00:00:00.000Z',
+                },
+            });
+            const loserB = buildDocument({
+                id: 'conv-b',
+                kbDocumentClass: 'research' as KbDocumentClass,
+                consolidation: {
+                    state: 'superseded',
+                    supersededById: 'conv-surv',
+                    reason: 'x',
+                    runAt: '2026-07-23T00:00:00.000Z',
+                },
+            });
+            const distinct = buildDocument({
+                id: 'conv-c',
+                kbDocumentClass: 'research' as KbDocumentClass,
+                metadata: { body: 'Distinct third doc' },
+            });
+            // limit=2, but the top-2 hits converge on ONE survivor. The 2×
+            // over-fetch surfaces the third hit so the limit is still met.
+            stubSemanticHit(['conv-a', 'conv-b', 'conv-c']);
+            docRepo.list.mockResolvedValue({ items: [], total: 0 });
+            docRepo.findById.mockImplementation(async (_workId: string, docId: string) => {
+                if (docId === 'conv-a') return loserA;
+                if (docId === 'conv-b') return loserB;
+                if (docId === 'conv-surv') return survivor;
+                if (docId === 'conv-c') return distinct;
+                return null;
+            });
+
+            const bundle = await service.resolveContext(WORK_ID, { query: 'q', limit: 2 });
+
+            expect(bundle.queryRetrieved.map((d) => d.id)).toEqual(['conv-surv', 'conv-c']);
+            // The widened chunk fetch is what makes the backfill possible.
+            const chunkRepo = (
+                service as unknown as {
+                    chunkRepository: { findNearestByEmbedding: jest.Mock };
+                }
+            ).chunkRepository;
+            expect(chunkRepo.findNearestByEmbedding).toHaveBeenCalledWith(
+                WORK_ID,
+                expect.anything(),
+                4,
+            );
+        });
+
+        it('caps the supersession walk (a pathological chain cannot stall resolution)', async () => {
+            // 20-link acyclic chain: doc-0 → doc-1 → … → doc-19 (live).
+            const chain = new Map<string, ReturnType<typeof buildDocument>>();
+            for (let i = 0; i < 20; i++) {
+                const id = `chain-${i}`;
+                chain.set(
+                    id,
+                    buildDocument({
+                        id,
+                        kbDocumentClass: 'research' as KbDocumentClass,
+                        metadata: { body: `link ${i}` },
+                        consolidation:
+                            i < 19
+                                ? {
+                                      state: 'superseded',
+                                      supersededById: `chain-${i + 1}`,
+                                      reason: 'x',
+                                      runAt: '2026-07-23T00:00:00.000Z',
+                                  }
+                                : null,
+                    }),
+                );
+            }
+            stubSemanticHit(['chain-0']);
+            docRepo.list.mockResolvedValue({ items: [], total: 0 });
+            docRepo.findById.mockImplementation(
+                async (_workId: string, docId: string) => chain.get(docId) ?? null,
+            );
+
+            const bundle = await service.resolveContext(WORK_ID, { query: 'q' });
+
+            // The walk gives up at the hop cap instead of serving the
+            // archive or walking all 20 links — bounded DB cost.
+            expect(bundle.queryRetrieved).toEqual([]);
+            expect(docRepo.findById.mock.calls.length).toBeLessThanOrEqual(8);
+        });
+
         it('drops a superseded hit whose chain dead-ends or cycles (never serves the archive)', async () => {
             const cycleA = buildDocument({
                 id: 'cyc-a',

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -908,7 +908,12 @@ export class KnowledgeBaseService {
         query: string,
         limit: number,
     ): Promise<KbDocumentBodyDto[]> {
-        const chunks = await this.semanticSearch(workId, query, limit);
+        // Over-fetch chunk hits: supersession substitution below can
+        // CONVERGE several hits onto one survivor (and dead chains drop
+        // out entirely), which would under-fill the requested doc count
+        // if we only pulled `limit` chunks. 2× is a cheap single-query
+        // widening; the loop still cuts off at `limit` distinct docs.
+        const chunks = await this.semanticSearch(workId, query, limit * 2);
         if (chunks.length === 0) return [];
 
         const seen = new Set<string>();
@@ -922,6 +927,7 @@ export class KnowledgeBaseService {
         const results: KbDocumentBodyDto[] = [];
         const included = new Set<string>();
         for (const docId of orderedDocIds) {
+            if (results.length >= limit) break;
             const doc = await this.resolveCurrentDocument(workId, docId);
             if (doc && !included.has(doc.id)) {
                 included.add(doc.id);
@@ -949,9 +955,14 @@ export class KnowledgeBaseService {
         workId: string,
         docId: string,
     ): Promise<WorkKnowledgeDocument | null> {
+        // Hop cap on top of the cycle guard: each link costs a sequential
+        // findById, so a malformed or pathologically re-consolidated chain
+        // must not be able to stall prompt resolution. Real chains from
+        // repeated consolidation are survivor-of-survivor — a handful deep.
+        const MAX_SUPERSESSION_HOPS = 8;
         const visited = new Set<string>();
         let currentId = docId;
-        while (!visited.has(currentId)) {
+        while (!visited.has(currentId) && visited.size < MAX_SUPERSESSION_HOPS) {
             visited.add(currentId);
             const doc = await this.documentRepository.findById(workId, currentId);
             if (!doc) return null;

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -884,7 +884,15 @@ export class KnowledgeBaseService {
             classes: [...KB_ALWAYS_INJECTED_CLASSES],
             statuses: [KbDocumentStatus.ACTIVE],
         });
-        return items.map((d) => this.toBodyDto(d));
+        // A consolidation-superseded doc keeps status ACTIVE (the apply
+        // pass writes markers, never deletes), so status alone would let
+        // the archived loser ride into prompts right next to its
+        // survivor — contradictory context served as current truth. The
+        // survivor is part of this same ACTIVE list, so exclusion is the
+        // whole fix here.
+        return items
+            .filter((d) => d.consolidation?.state !== 'superseded')
+            .map((d) => this.toBodyDto(d));
     }
 
     /**
@@ -912,11 +920,47 @@ export class KnowledgeBaseService {
         }
 
         const results: KbDocumentBodyDto[] = [];
+        const included = new Set<string>();
         for (const docId of orderedDocIds) {
-            const doc = await this.documentRepository.findById(workId, docId);
-            if (doc) results.push(this.toBodyDto(doc));
+            const doc = await this.resolveCurrentDocument(workId, docId);
+            if (doc && !included.has(doc.id)) {
+                included.add(doc.id);
+                results.push(this.toBodyDto(doc));
+            }
         }
         return results;
+    }
+
+    /**
+     * Follow the consolidation supersession chain from a semantically
+     * retrieved doc to the doc that should be served as CURRENT truth.
+     *
+     * Retrieval works off chunk embeddings, which outlive a consolidation
+     * run — a hit can land on a doc whose `consolidation.state` is
+     * `superseded`. Serving that doc verbatim would inject the archived
+     * loser as if it were live, so instead its `supersededById` survivor
+     * is served in its place ("demote the archive, promote the
+     * replacement"). A visited-set + hop cap bounds the walk: markers are
+     * plain JSON and a hand-edited or re-consolidated pair could form a
+     * cycle. Dead ends (missing survivor, cycle, no id) return null — a
+     * degraded retrieval slot, never stale truth.
+     */
+    private async resolveCurrentDocument(
+        workId: string,
+        docId: string,
+    ): Promise<WorkKnowledgeDocument | null> {
+        const visited = new Set<string>();
+        let currentId = docId;
+        while (!visited.has(currentId)) {
+            visited.add(currentId);
+            const doc = await this.documentRepository.findById(workId, currentId);
+            if (!doc) return null;
+            if (doc.consolidation?.state !== 'superseded') return doc;
+            const nextId = doc.consolidation.supersededById;
+            if (!nextId) return null;
+            currentId = nextId;
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
## What

Memory consolidation's apply pass (`POST /api/memory/consolidate {"apply": true}`) marks near-duplicate losers `consolidation.state='superseded'` but deliberately leaves their status `ACTIVE` (never-delete invariant). `KnowledgeBaseService.resolveContext` filtered on status alone — so **both** fetch paths kept injecting the archived loser into agent prompts right next to its survivor: contradictory context served as current truth on every run after a consolidation.

## How

- **`fetchAlwaysInjectedDocs`** — exclude `superseded` docs; the survivor is part of the same ACTIVE list, so exclusion is the whole fix on this path.
- **`fetchQueryRetrievedDocs`** — chunk embeddings outlive a consolidation run, so a semantic hit can land on a superseded doc. New `resolveCurrentDocument` follows the supersession chain and serves the survivor in the loser's place (deduped against other hits). The walk is bounded by a visited set; cycles and dead-ends (missing survivor) degrade to a dropped retrieval slot — never stale truth.
- `promoted` markers are untouched — only `superseded` is demoted.

## Tests

4 new regression tests in `knowledge-base.service.spec.ts`: always-injected exclusion, promoted-doc passthrough, survivor substitution + dedupe, cycle/dead-end safety. KB service suites 81 green; pipeline + kb-context-bundle suites 432 green; agent tsc clean.

## Scope

Pure correctness, `packages/agent` only, no schema/API change. Independent of the works-types PR stack (based on `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)