### PR TITLE
feat(contracts): streaming-terminal wire frame protocol

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,3 +3,4 @@ export * from './domain/index.js';
 export * from './form/index.js';
 export * from './github/index.js';
 export * from './kb/index.js';
+export * from './terminal/index.js';

--- a/packages/contracts/src/terminal/__tests__/terminal-frame.codec.spec.ts
+++ b/packages/contracts/src/terminal/__tests__/terminal-frame.codec.spec.ts
@@ -334,4 +334,58 @@ describe('normalizeTerminalFrame (structured input path)', () => {
 		const crafted = Object.create({ kind: 'stdin', data: B64 });
 		expect(normalizeTerminalFrame(crafted)).toBeNull();
 	});
+
+	it('a throwing getter or hostile Proxy returns null, never throws', () => {
+		const throwingGetter = {
+			get kind(): string {
+				throw new Error('trap');
+			}
+		};
+		expect(normalizeTerminalFrame(throwingGetter)).toBeNull();
+
+		const throwingField = {
+			kind: 'stdin',
+			get data(): string {
+				throw new Error('trap');
+			}
+		};
+		expect(normalizeTerminalFrame(throwingField)).toBeNull();
+
+		const hostileProxy = new Proxy(
+			{},
+			{
+				has() {
+					throw new Error('trap');
+				},
+				get() {
+					throw new Error('trap');
+				},
+				getOwnPropertyDescriptor() {
+					throw new Error('trap');
+				}
+			}
+		);
+		expect(normalizeTerminalFrame(hostileProxy)).toBeNull();
+
+		// encode routes through the same normalizer — equally protected.
+		expect(encodeTerminalFrame(throwingGetter as unknown as TerminalFrame)).toBeNull();
+	});
+});
+
+describe('canonical base64 (unused final-quantum bits must be zero)', () => {
+	it('accepts the canonical representation', () => {
+		// "A" = one byte 0x41 → canonical 'QQ=='; "AB" → 'QUI='.
+		expect(decodeTerminalFrame('{"kind":"stdin","data":"QQ=="}')).not.toBeNull();
+		expect(decodeTerminalFrame('{"kind":"stdin","data":"QUI="}')).not.toBeNull();
+		expect(decodeTerminalFrame('{"kind":"stdin","data":"AA=="}')).not.toBeNull();
+	});
+
+	it('rejects non-canonical padding bits (one byte sequence, one wire form)', () => {
+		// 'AB==' decodes to the same byte as 'AA==' but with dangling
+		// nonzero bits — two wire forms for identical PTY data.
+		expect(decodeTerminalFrame('{"kind":"stdin","data":"AB=="}')).toBeNull();
+		expect(decodeTerminalFrame('{"kind":"stdin","data":"QR=="}')).toBeNull();
+		expect(decodeTerminalFrame('{"kind":"stdin","data":"QUJ="}')).toBeNull();
+		expect(decodeTerminalFrame('{"kind":"stdout","seq":0,"data":"AB=="}')).toBeNull();
+	});
 });

--- a/packages/contracts/src/terminal/__tests__/terminal-frame.codec.spec.ts
+++ b/packages/contracts/src/terminal/__tests__/terminal-frame.codec.spec.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from 'vitest';
+import {
+	decodeTerminalFrame,
+	encodeTerminalFrame,
+	isAllowedTerminalWsUrl,
+	isTerminalClientToServerFrame,
+	isTerminalFrameWithinSizeCap,
+	isTerminalServerToClientFrame,
+	isValidTerminalRunId,
+	makeTerminalErrorFrame,
+	normalizeTerminalFrame
+} from '../terminal-frame.codec.js';
+import {
+	TERMINAL_CLIENT_TO_SERVER_KINDS,
+	TERMINAL_EXIT_REASONS,
+	TERMINAL_MAX_AUTH_TOKEN_LENGTH,
+	TERMINAL_MAX_DIMENSION,
+	TERMINAL_MAX_ERROR_MESSAGE_LENGTH,
+	TERMINAL_MAX_FRAME_BYTES,
+	TERMINAL_SERVER_TO_CLIENT_KINDS,
+	type TerminalFrame,
+	type TerminalFrameKind
+} from '../terminal-frame.types.js';
+
+const RUN_ID = '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f';
+const B64 = 'aGVsbG8='; // "hello"
+
+const VALID_FRAMES: TerminalFrame[] = [
+	{ kind: 'stdout', seq: 0, data: B64 },
+	{ kind: 'stdout', seq: Number.MAX_SAFE_INTEGER, data: '' },
+	{ kind: 'stdin', data: B64 },
+	{ kind: 'resize', cols: 1, rows: 1 },
+	{ kind: 'resize', cols: TERMINAL_MAX_DIMENSION, rows: TERMINAL_MAX_DIMENSION },
+	{ kind: 'exit', code: 0, reason: 'completed' },
+	{ kind: 'exit', code: -1, reason: 'crashed' },
+	{ kind: 'exit', code: 137, reason: 'closed' },
+	{ kind: 'exit', code: 0, reason: 'parked' },
+	{ kind: 'error', message: 'provider not configured' },
+	{ kind: 'error', message: '' },
+	{ kind: 'auth', token: 'eyJhbGciOiJIUzI1NiJ9.e30.sig' }
+];
+
+describe('decodeTerminalFrame — valid frames round-trip', () => {
+	it.each(VALID_FRAMES.map((f) => [f.kind, f] as const))('round-trips a %s frame', (_kind, frame) => {
+		const wire = encodeTerminalFrame(frame);
+		expect(wire).not.toBeNull();
+		expect(decodeTerminalFrame(wire as string)).toEqual(frame);
+	});
+
+	it('decodes from Uint8Array input', () => {
+		const wire = new TextEncoder().encode(JSON.stringify({ kind: 'stdin', data: B64 }));
+		expect(decodeTerminalFrame(wire)).toEqual({ kind: 'stdin', data: B64 });
+	});
+
+	it('strips unknown extra properties (normalized construction)', () => {
+		const decoded = decodeTerminalFrame(
+			JSON.stringify({ kind: 'stdin', data: B64, extra: 'smuggled', role: 'driver' })
+		);
+		expect(decoded).toEqual({ kind: 'stdin', data: B64 });
+		expect(Object.keys(decoded as object)).toEqual(['kind', 'data']);
+	});
+
+	it('a __proto__ key stays inert and never survives decoding', () => {
+		// JSON.parse creates "__proto__" as a plain own property (no setter
+		// invoked); the normalizer must drop it like any unknown field and
+		// must not pollute Object.prototype in the process.
+		const decoded = decodeTerminalFrame('{"kind":"stdin","data":"aGk=","__proto__":{"admin":true}}');
+		expect(decoded).toEqual({ kind: 'stdin', data: 'aGk=' });
+		expect(Object.prototype.hasOwnProperty.call(decoded, '__proto__')).toBe(false);
+		expect(({} as { admin?: boolean }).admin).toBeUndefined();
+	});
+});
+
+describe('decodeTerminalFrame — null, never throw', () => {
+	const GARBAGE: Array<[string, string]> = [
+		['not JSON', 'nonsense{{{'],
+		['empty string', ''],
+		['JSON null', 'null'],
+		['JSON number', '42'],
+		['JSON string', '"stdout"'],
+		['JSON array', '[{"kind":"stdin","data":""}]'],
+		['no kind', '{"data":"aGk="}'],
+		['unknown kind', '{"kind":"shutdown"}'],
+		['kind from prototype chain', '{"data":"aGk=","toString":1}'],
+		['kind constructor', '{"kind":"constructor"}'],
+		['stdout missing seq', '{"kind":"stdout","data":"aGk="}'],
+		['stdout negative seq', '{"kind":"stdout","seq":-1,"data":"aGk="}'],
+		['stdout float seq', '{"kind":"stdout","seq":1.5,"data":"aGk="}'],
+		['stdout NaN seq', '{"kind":"stdout","seq":null,"data":"aGk="}'],
+		['stdout unsafe seq', '{"kind":"stdout","seq":9007199254740992,"data":"aGk="}'],
+		['stdout numeric-string seq', '{"kind":"stdout","seq":"3","data":"aGk="}'],
+		['stdin non-base64', '{"kind":"stdin","data":"not base64!!"}'],
+		['stdin base64 with newline', '{"kind":"stdin","data":"aGVs\\nbG8="}'],
+		['stdin bad padding', '{"kind":"stdin","data":"aGVsbG8"}'],
+		['stdin data number', '{"kind":"stdin","data":7}'],
+		['resize zero cols', '{"kind":"resize","cols":0,"rows":24}'],
+		['resize over max rows', `{"kind":"resize","cols":80,"rows":${TERMINAL_MAX_DIMENSION + 1}}`],
+		['resize float', '{"kind":"resize","cols":80.5,"rows":24}'],
+		['resize string dims', '{"kind":"resize","cols":"80","rows":"24"}'],
+		['resize missing rows', '{"kind":"resize","cols":80}'],
+		['exit unknown reason', '{"kind":"exit","code":0,"reason":"finished"}'],
+		['exit reason casing', '{"kind":"exit","code":0,"reason":"Completed"}'],
+		['exit float code', '{"kind":"exit","code":0.5,"reason":"completed"}'],
+		['exit code out of int32', '{"kind":"exit","code":2147483648,"reason":"completed"}'],
+		['exit missing code', '{"kind":"exit","reason":"completed"}'],
+		['error message number', '{"kind":"error","message":42}'],
+		['auth empty token', '{"kind":"auth","token":""}'],
+		['auth token with space', '{"kind":"auth","token":"two words"}'],
+		['auth token with newline', '{"kind":"auth","token":"a\\nb"}'],
+		['auth token number', '{"kind":"auth","token":123}']
+	];
+
+	it.each(GARBAGE)('rejects %s', (_label, wire) => {
+		expect(decodeTerminalFrame(wire)).toBeNull();
+	});
+
+	it('rejects an error message over the cap', () => {
+		const wire = JSON.stringify({
+			kind: 'error',
+			message: 'x'.repeat(TERMINAL_MAX_ERROR_MESSAGE_LENGTH + 1)
+		});
+		expect(decodeTerminalFrame(wire)).toBeNull();
+	});
+
+	it('rejects an auth token over the cap', () => {
+		const wire = JSON.stringify({ kind: 'auth', token: 'a'.repeat(TERMINAL_MAX_AUTH_TOKEN_LENGTH + 1) });
+		expect(decodeTerminalFrame(wire)).toBeNull();
+	});
+
+	it('rejects invalid UTF-8 bytes without throwing', () => {
+		expect(decodeTerminalFrame(new Uint8Array([0xff, 0xfe, 0x7b, 0x7d]))).toBeNull();
+	});
+
+	it('rejects non-string/bytes input without throwing', () => {
+		expect(decodeTerminalFrame(42 as unknown as string)).toBeNull();
+		expect(decodeTerminalFrame(null as unknown as string)).toBeNull();
+		expect(decodeTerminalFrame(undefined as unknown as string)).toBeNull();
+		expect(decodeTerminalFrame({} as unknown as string)).toBeNull();
+	});
+
+	it('fuzz: random mutations of valid wire text never throw', () => {
+		const base = VALID_FRAMES.map((f) => JSON.stringify(f));
+		let seed = 0x2f6e2b1;
+		const rand = () => {
+			// Deterministic LCG so failures reproduce.
+			seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+			return seed / 0x7fffffff;
+		};
+		for (let i = 0; i < 2000; i++) {
+			const src = base[Math.floor(rand() * base.length)];
+			const pos = Math.floor(rand() * src.length);
+			const ch = String.fromCharCode(Math.floor(rand() * 128));
+			const mutated = src.slice(0, pos) + ch + src.slice(pos + 1);
+			expect(() => decodeTerminalFrame(mutated)).not.toThrow();
+		}
+	});
+});
+
+describe('size cap — checked before parse', () => {
+	it('accepts a frame at the boundary and rejects one past it', () => {
+		// Build a stdout frame whose wire size lands exactly on the cap.
+		const overhead = JSON.stringify({ kind: 'stdout', seq: 0, data: '' }).length;
+		const padTo = TERMINAL_MAX_FRAME_BYTES - overhead;
+		const data = 'A'.repeat(padTo - (padTo % 4));
+		const atCap = JSON.stringify({ kind: 'stdout', seq: 0, data });
+		expect(atCap.length).toBeLessThanOrEqual(TERMINAL_MAX_FRAME_BYTES);
+		expect(decodeTerminalFrame(atCap)).not.toBeNull();
+
+		const past = JSON.stringify({
+			kind: 'stdout',
+			seq: 0,
+			data: 'A'.repeat(TERMINAL_MAX_FRAME_BYTES)
+		});
+		expect(past.length).toBeGreaterThan(TERMINAL_MAX_FRAME_BYTES);
+		expect(decodeTerminalFrame(past)).toBeNull();
+	});
+
+	it('rejects oversized Uint8Array input by byteLength', () => {
+		expect(isTerminalFrameWithinSizeCap(new Uint8Array(TERMINAL_MAX_FRAME_BYTES + 1))).toBe(false);
+		expect(isTerminalFrameWithinSizeCap(new Uint8Array(TERMINAL_MAX_FRAME_BYTES))).toBe(true);
+	});
+
+	it('accounts for multi-byte characters in string input', () => {
+		// Each '€' is 1 UTF-16 code unit but 3 UTF-8 bytes: a string whose
+		// code-unit length is under the cap can still overflow it in bytes.
+		const euros = '€'.repeat(Math.floor(TERMINAL_MAX_FRAME_BYTES / 3) + 10);
+		expect(euros.length).toBeLessThan(TERMINAL_MAX_FRAME_BYTES);
+		expect(isTerminalFrameWithinSizeCap(euros)).toBe(false);
+	});
+});
+
+describe('encodeTerminalFrame', () => {
+	it('refuses to encode an invalid frame', () => {
+		expect(encodeTerminalFrame({ kind: 'resize', cols: 0, rows: 24 } as TerminalFrame)).toBeNull();
+		expect(encodeTerminalFrame({ kind: 'exit', code: 0, reason: 'nope' } as unknown as TerminalFrame)).toBeNull();
+		expect(encodeTerminalFrame({ kind: 'stdout', seq: 0, data: '!!' } as TerminalFrame)).toBeNull();
+	});
+
+	it('drops smuggled extra fields on encode', () => {
+		const wire = encodeTerminalFrame({
+			kind: 'stdin',
+			data: B64,
+			role: 'driver'
+		} as unknown as TerminalFrame);
+		expect(wire).not.toBeNull();
+		expect(JSON.parse(wire as string)).toEqual({ kind: 'stdin', data: B64 });
+	});
+});
+
+describe('makeTerminalErrorFrame', () => {
+	it('passes short messages through', () => {
+		expect(makeTerminalErrorFrame('boom')).toEqual({ kind: 'error', message: 'boom' });
+	});
+
+	it('truncates instead of rejecting (banner sites must always succeed)', () => {
+		const frame = makeTerminalErrorFrame('y'.repeat(TERMINAL_MAX_ERROR_MESSAGE_LENGTH * 2));
+		expect(frame.kind).toBe('error');
+		const message = (frame as { message: string }).message;
+		expect(message.length).toBeLessThanOrEqual(TERMINAL_MAX_ERROR_MESSAGE_LENGTH);
+		expect(message.endsWith('…')).toBe(true);
+		// The truncated frame is itself wire-valid.
+		expect(encodeTerminalFrame(frame)).not.toBeNull();
+	});
+});
+
+describe('direction map', () => {
+	it('classifies every kind in exactly one direction', () => {
+		const all: TerminalFrameKind[] = ['stdout', 'stdin', 'resize', 'exit', 'error', 'auth'];
+		for (const kind of all) {
+			const c2s = (TERMINAL_CLIENT_TO_SERVER_KINDS as readonly string[]).includes(kind);
+			const s2c = (TERMINAL_SERVER_TO_CLIENT_KINDS as readonly string[]).includes(kind);
+			expect(c2s !== s2c).toBe(true);
+		}
+	});
+
+	it('replayed stdout can never re-enter as client input', () => {
+		expect(isTerminalClientToServerFrame({ kind: 'stdout', seq: 1, data: B64 })).toBe(false);
+		expect(isTerminalClientToServerFrame({ kind: 'exit', code: 0, reason: 'completed' })).toBe(false);
+		expect(isTerminalClientToServerFrame({ kind: 'stdin', data: B64 })).toBe(true);
+		expect(isTerminalClientToServerFrame({ kind: 'resize', cols: 80, rows: 24 })).toBe(true);
+		expect(isTerminalClientToServerFrame({ kind: 'auth', token: 't' })).toBe(true);
+	});
+
+	it('a client can never inject fake terminal output server-side', () => {
+		expect(isTerminalServerToClientFrame({ kind: 'stdout', seq: 1, data: B64 })).toBe(true);
+		expect(isTerminalServerToClientFrame({ kind: 'exit', code: 0, reason: 'completed' })).toBe(true);
+		expect(isTerminalServerToClientFrame({ kind: 'error', message: 'x' })).toBe(true);
+		expect(isTerminalServerToClientFrame({ kind: 'stdin', data: B64 })).toBe(false);
+		expect(isTerminalServerToClientFrame({ kind: 'auth', token: 't' })).toBe(false);
+	});
+});
+
+describe('exit reasons', () => {
+	it('every declared reason decodes', () => {
+		for (const reason of TERMINAL_EXIT_REASONS) {
+			expect(decodeTerminalFrame(JSON.stringify({ kind: 'exit', code: 0, reason }))).toEqual({
+				kind: 'exit',
+				code: 0,
+				reason
+			});
+		}
+	});
+});
+
+describe('isValidTerminalRunId', () => {
+	it('accepts RFC 4122 UUIDs (case-insensitive)', () => {
+		expect(isValidTerminalRunId(RUN_ID)).toBe(true);
+		expect(isValidTerminalRunId(RUN_ID.toUpperCase())).toBe(true);
+	});
+
+	it.each([
+		['empty', ''],
+		['not a uuid', 'agent-run-1'],
+		['path traversal', '../../../etc/passwd'],
+		['uuid with suffix', `${RUN_ID}x`],
+		['uuid with prefix', ` ${RUN_ID}`],
+		['sql-ish', `${RUN_ID}' OR '1'='1`],
+		['non-string', 42 as unknown as string],
+		['null', null as unknown as string]
+	])('rejects %s', (_label, value) => {
+		expect(isValidTerminalRunId(value)).toBe(false);
+	});
+});
+
+describe('isAllowedTerminalWsUrl', () => {
+	it.each([
+		'wss://api.ever.works/ws/terminal/run-1',
+		'wss://localhost:3100/ws/terminal/run-1',
+		'ws://localhost:3100/ws/terminal/run-1',
+		'ws://127.0.0.1:3100/ws',
+		'ws://[::1]:3100/ws'
+	])('allows %s', (url) => {
+		expect(isAllowedTerminalWsUrl(url)).toBe(true);
+	});
+
+	it.each([
+		'ws://api.ever.works/ws/terminal/run-1',
+		'ws://192.168.1.10:3100/ws',
+		'ws://evil.example.com/ws',
+		'http://localhost:3100/ws',
+		'https://localhost:3100/ws',
+		'ftp://localhost/x',
+		'not a url',
+		'',
+		'//localhost:3100/ws'
+	])('refuses %s', (url) => {
+		expect(isAllowedTerminalWsUrl(url)).toBe(false);
+	});
+
+	it('never throws on non-string input', () => {
+		expect(isAllowedTerminalWsUrl(null)).toBe(false);
+		expect(isAllowedTerminalWsUrl(12)).toBe(false);
+		expect(isAllowedTerminalWsUrl({})).toBe(false);
+	});
+});
+
+describe('normalizeTerminalFrame (structured input path)', () => {
+	it('validates a parsed publish-endpoint body element', () => {
+		expect(normalizeTerminalFrame({ kind: 'stdout', seq: 3, data: B64 })).toEqual({
+			kind: 'stdout',
+			seq: 3,
+			data: B64
+		});
+	});
+
+	it('rejects arrays, functions, and class instances masquerading as frames', () => {
+		expect(normalizeTerminalFrame([])).toBeNull();
+		expect(normalizeTerminalFrame(() => undefined)).toBeNull();
+		expect(normalizeTerminalFrame(new (class X {})())).toBeNull();
+		expect(normalizeTerminalFrame(Object.create(null))).toBeNull();
+	});
+
+	it('ignores a kind supplied via the prototype chain', () => {
+		const crafted = Object.create({ kind: 'stdin', data: B64 });
+		expect(normalizeTerminalFrame(crafted)).toBeNull();
+	});
+});

--- a/packages/contracts/src/terminal/index.ts
+++ b/packages/contracts/src/terminal/index.ts
@@ -1,0 +1,2 @@
+export * from './terminal-frame.types.js';
+export * from './terminal-frame.codec.js';

--- a/packages/contracts/src/terminal/terminal-frame.codec.ts
+++ b/packages/contracts/src/terminal/terminal-frame.codec.ts
@@ -1,0 +1,246 @@
+/**
+ * Streaming-terminal wire protocol — codec + guards.
+ *
+ * Hand-rolled (this package is zero-dependency by design) and hardened
+ * for a hot wire path: every helper returns `null`/`false` on malformed
+ * input — none of them ever throws — and decoding constructs the
+ * returned frame field-by-field so unknown properties, oversized
+ * payloads, and `__proto__`-style keys never survive validation.
+ * See `terminal-frame.types.ts` for the protocol invariants.
+ */
+
+import {
+	TERMINAL_CLIENT_TO_SERVER_KINDS,
+	TERMINAL_EXIT_REASONS,
+	TERMINAL_MAX_AUTH_TOKEN_LENGTH,
+	TERMINAL_MAX_DIMENSION,
+	TERMINAL_MAX_ERROR_MESSAGE_LENGTH,
+	TERMINAL_MAX_FRAME_BYTES,
+	TERMINAL_MIN_DIMENSION,
+	TERMINAL_SERVER_TO_CLIENT_KINDS,
+	type TerminalClientToServerFrame,
+	type TerminalExitReason,
+	type TerminalFrame,
+	type TerminalServerToClientFrame
+} from './terminal-frame.types.js';
+
+/**
+ * Canonical base64 (RFC 4648, with padding, no whitespace). The data
+ * fields carry raw PTY bytes — anything that is not clean base64 is a
+ * protocol violation, not something to repair.
+ */
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+/** RFC 4122 UUID (any version) — the shape of an AgentRun id. */
+const RUN_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** ASCII control characters (base64/JWT payloads must not contain any). */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_PATTERN = /[\x00-\x1f\x7f]/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isBase64(value: unknown): value is string {
+	return typeof value === 'string' && BASE64_PATTERN.test(value);
+}
+
+function isBoundedInt(value: unknown, min: number, max: number): value is number {
+	return typeof value === 'number' && Number.isSafeInteger(value) && value >= min && value <= max;
+}
+
+/**
+ * Byte-size gate, run BEFORE any parsing. Exact when handed bytes; for
+ * strings the cheap UTF-16 length check short-circuits the common case
+ * and `TextEncoder` is only consulted in the narrow band where
+ * multi-byte characters could push an under-length string over the cap.
+ */
+export function isTerminalFrameWithinSizeCap(raw: string | Uint8Array): boolean {
+	if (typeof raw !== 'string') {
+		return raw.byteLength <= TERMINAL_MAX_FRAME_BYTES;
+	}
+	if (raw.length > TERMINAL_MAX_FRAME_BYTES) {
+		return false;
+	}
+	// Every UTF-16 code unit encodes to at most 3 UTF-8 bytes (surrogate
+	// pairs: 2 units → 4 bytes < 2×3), so below a third of the cap the
+	// string cannot overflow it.
+	if (raw.length * 3 <= TERMINAL_MAX_FRAME_BYTES) {
+		return true;
+	}
+	return new TextEncoder().encode(raw).byteLength <= TERMINAL_MAX_FRAME_BYTES;
+}
+
+/**
+ * Decode + validate a single wire frame. Returns a freshly-constructed,
+ * fully-validated frame — or `null` for anything else: oversize input,
+ * invalid JSON, wrong shape, out-of-range values, unknown kind. Never
+ * throws.
+ */
+export function decodeTerminalFrame(raw: string | Uint8Array): TerminalFrame | null {
+	if (typeof raw !== 'string' && !(raw instanceof Uint8Array)) {
+		return null;
+	}
+	if (!isTerminalFrameWithinSizeCap(raw)) {
+		return null;
+	}
+
+	let text: string;
+	let parsed: unknown;
+	try {
+		text = typeof raw === 'string' ? raw : new TextDecoder('utf-8', { fatal: true }).decode(raw);
+		parsed = JSON.parse(text);
+	} catch {
+		return null;
+	}
+
+	return normalizeTerminalFrame(parsed);
+}
+
+/**
+ * Validate an already-parsed value and rebuild it as a canonical frame.
+ * Exposed for callers that receive structured payloads (e.g. the batch
+ * publish endpoint body) rather than raw socket text.
+ */
+export function normalizeTerminalFrame(value: unknown): TerminalFrame | null {
+	if (!isRecord(value)) {
+		return null;
+	}
+
+	// Own-property lookup only: `value.kind` on a crafted object could
+	// otherwise resolve through the prototype chain.
+	const kind = Object.prototype.hasOwnProperty.call(value, 'kind') ? value.kind : undefined;
+
+	switch (kind) {
+		case 'stdout': {
+			const { seq, data } = value;
+			if (!isBoundedInt(seq, 0, Number.MAX_SAFE_INTEGER) || !isBase64(data)) {
+				return null;
+			}
+			return { kind: 'stdout', seq, data };
+		}
+		case 'stdin': {
+			const { data } = value;
+			if (!isBase64(data)) {
+				return null;
+			}
+			return { kind: 'stdin', data };
+		}
+		case 'resize': {
+			const { cols, rows } = value;
+			if (
+				!isBoundedInt(cols, TERMINAL_MIN_DIMENSION, TERMINAL_MAX_DIMENSION) ||
+				!isBoundedInt(rows, TERMINAL_MIN_DIMENSION, TERMINAL_MAX_DIMENSION)
+			) {
+				return null;
+			}
+			return { kind: 'resize', cols, rows };
+		}
+		case 'exit': {
+			const { code, reason } = value;
+			if (!isBoundedInt(code, -2147483648, 2147483647)) {
+				return null;
+			}
+			if (typeof reason !== 'string' || !(TERMINAL_EXIT_REASONS as readonly string[]).includes(reason)) {
+				return null;
+			}
+			return { kind: 'exit', code, reason: reason as TerminalExitReason };
+		}
+		case 'error': {
+			const { message } = value;
+			if (typeof message !== 'string' || message.length > TERMINAL_MAX_ERROR_MESSAGE_LENGTH) {
+				return null;
+			}
+			return { kind: 'error', message };
+		}
+		case 'auth': {
+			const { token } = value;
+			if (
+				typeof token !== 'string' ||
+				token.length === 0 ||
+				token.length > TERMINAL_MAX_AUTH_TOKEN_LENGTH ||
+				CONTROL_CHAR_PATTERN.test(token) ||
+				/\s/.test(token)
+			) {
+				return null;
+			}
+			return { kind: 'auth', token };
+		}
+		default:
+			return null;
+	}
+}
+
+/**
+ * Encode a frame for the wire. Validates through the same normalizer —
+ * an invalid frame (out-of-range values, unknown kind) encodes to
+ * `null` rather than shipping garbage that peers would drop anyway.
+ */
+export function encodeTerminalFrame(frame: TerminalFrame): string | null {
+	const normalized = normalizeTerminalFrame(frame);
+	if (normalized === null) {
+		return null;
+	}
+	const encoded = JSON.stringify(normalized);
+	return isTerminalFrameWithinSizeCap(encoded) ? encoded : null;
+}
+
+/**
+ * Build an `error` banner frame from arbitrary text, truncating instead
+ * of rejecting — banner construction sites (spawn preambles, guard
+ * responses) must always succeed.
+ */
+export function makeTerminalErrorFrame(message: string): TerminalFrame {
+	const text = typeof message === 'string' ? message : String(message);
+	return {
+		kind: 'error',
+		message:
+			text.length > TERMINAL_MAX_ERROR_MESSAGE_LENGTH
+				? `${text.slice(0, TERMINAL_MAX_ERROR_MESSAGE_LENGTH - 1)}…`
+				: text
+	};
+}
+
+/** Direction guard — may this frame travel client → server? */
+export function isTerminalClientToServerFrame(frame: TerminalFrame): frame is TerminalClientToServerFrame {
+	return (TERMINAL_CLIENT_TO_SERVER_KINDS as readonly string[]).includes(frame.kind);
+}
+
+/** Direction guard — may this frame travel server → client? */
+export function isTerminalServerToClientFrame(frame: TerminalFrame): frame is TerminalServerToClientFrame {
+	return (TERMINAL_SERVER_TO_CLIENT_KINDS as readonly string[]).includes(frame.kind);
+}
+
+/**
+ * Shape gate for a relay channel id (an AgentRun UUID), applied before
+ * any registry lookup or DB touch.
+ */
+export function isValidTerminalRunId(value: unknown): value is string {
+	return typeof value === 'string' && RUN_ID_PATTERN.test(value);
+}
+
+/**
+ * Attach-URL guard: `wss:` anywhere; plain `ws:` only to loopback hosts
+ * (local dev / docker compose). Anything else — other protocols, ws to
+ * a routable host, unparseable input — is refused.
+ */
+export function isAllowedTerminalWsUrl(value: unknown): boolean {
+	if (typeof value !== 'string') {
+		return false;
+	}
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		return false;
+	}
+	if (url.protocol === 'wss:') {
+		return true;
+	}
+	if (url.protocol !== 'ws:') {
+		return false;
+	}
+	const host = url.hostname.toLowerCase();
+	return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+}

--- a/packages/contracts/src/terminal/terminal-frame.codec.ts
+++ b/packages/contracts/src/terminal/terminal-frame.codec.ts
@@ -27,11 +27,22 @@ import {
 /**
  * Canonical base64 (RFC 4648, with padding, no whitespace). The data
  * fields carry raw PTY bytes — anything that is not clean base64 is a
- * protocol violation, not something to repair.
+ * protocol violation, not something to repair. Canonical includes the
+ * final quantum's unused bits being zero: a 2-pad quantum must end in
+ * one of `AQgw`, a 1-pad quantum in one of `AEIMQUYcgkosw048` — so a
+ * given byte sequence has exactly ONE wire representation (`AB==` and
+ * `AA==` decode to the same byte; only `AA==` is canonical).
  */
-const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/][AQgw]==|[A-Za-z0-9+/]{2}[AEIMQUYcgkosw048]=)?$/;
 
-/** RFC 4122 UUID (any version) — the shape of an AgentRun id. */
+/**
+ * Shape gate for an AgentRun id: 8-4-4-4-12 hex. Deliberately does NOT
+ * enforce RFC 4122 version/variant bits — this is an injection barrier
+ * in front of registry/DB lookups (no traversal, no metacharacters,
+ * bounded length), not a UUID authenticity check; a well-shaped id that
+ * matches no row is simply not found. Version-agnosticism keeps ids
+ * from fixtures, imports, or a future non-v4 generator valid.
+ */
 const RUN_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /** ASCII control characters (base64/JWT payloads must not contain any). */
@@ -102,8 +113,21 @@ export function decodeTerminalFrame(raw: string | Uint8Array): TerminalFrame | n
  * Validate an already-parsed value and rebuild it as a canonical frame.
  * Exposed for callers that receive structured payloads (e.g. the batch
  * publish endpoint body) rather than raw socket text.
+ *
+ * The JSON.parse path can never hand us live getters, but a STRUCTURED
+ * caller could pass a Proxy / accessor object whose property reads
+ * throw — the try/catch preserves the null-never-throw contract even
+ * against a hostile object graph.
  */
 export function normalizeTerminalFrame(value: unknown): TerminalFrame | null {
+	try {
+		return normalizeTerminalFrameUnsafe(value);
+	} catch {
+		return null;
+	}
+}
+
+function normalizeTerminalFrameUnsafe(value: unknown): TerminalFrame | null {
 	if (!isRecord(value)) {
 		return null;
 	}

--- a/packages/contracts/src/terminal/terminal-frame.types.ts
+++ b/packages/contracts/src/terminal/terminal-frame.types.ts
@@ -1,0 +1,142 @@
+/**
+ * Streaming-terminal wire protocol — frame types + protocol constants.
+ *
+ * The contract every streaming-terminal party speaks: the worker-side
+ * session host publishing PTY bytes, the API relay/gateway fanning them
+ * out, and the browser terminal pane. Lives in `@ever-works/contracts`
+ * so all three consume one frozen definition without dragging in NestJS,
+ * `ws`, or any schema library — this package is intentionally
+ * zero-dependency, so validation is hand-rolled in the sibling codec
+ * module (`terminal-frame.codec.ts`).
+ *
+ * Protocol invariants (enforced by the codec, tested exhaustively):
+ *
+ *  - **Size-capped before parse.** A frame over
+ *    {@link TERMINAL_MAX_FRAME_BYTES} is rejected without ever reaching
+ *    `JSON.parse` — an oversized payload cannot buy CPU or memory.
+ *  - **Null, never throw.** Every decode/guard helper returns
+ *    `null`/`false` on ANY malformed input. Wire handling code must be
+ *    able to drop garbage frames without try/catch at each call site.
+ *  - **Direction-mapped kinds.** Each frame kind is valid in exactly one
+ *    direction (see {@link TERMINAL_CLIENT_TO_SERVER_KINDS} /
+ *    {@link TERMINAL_SERVER_TO_CLIENT_KINDS}), so a replayed scrollback
+ *    `stdout` can never be smuggled back into a session as keystrokes,
+ *    and a malicious client can never inject fake terminal output.
+ *  - **Normalized construction.** Decoding builds a fresh object
+ *    field-by-field from the parsed input — unknown/extra properties
+ *    (including `__proto__`-style keys) never survive into the returned
+ *    frame.
+ */
+
+/** Hard cap on a single encoded frame, checked BEFORE `JSON.parse`. */
+export const TERMINAL_MAX_FRAME_BYTES = 1024 * 1024;
+
+/** Inclusive bounds for terminal resize dimensions (cols / rows). */
+export const TERMINAL_MIN_DIMENSION = 1;
+export const TERMINAL_MAX_DIMENSION = 1000;
+
+/** Cap on `error` frame messages (banner text, not a data channel). */
+export const TERMINAL_MAX_ERROR_MESSAGE_LENGTH = 8192;
+
+/** Cap on the first-message `auth` frame token (a signed attach JWT). */
+export const TERMINAL_MAX_AUTH_TOKEN_LENGTH = 4096;
+
+/**
+ * Why a terminal session ended.
+ *
+ *  - `completed` — the child process exited on its own.
+ *  - `crashed`   — spawn failure, pump failure, or heartbeat-sweeper
+ *                  verdict on a session that stopped reporting.
+ *  - `closed`    — an authorized party explicitly ended the session.
+ *  - `parked`    — the platform killed the idle/awaiting-input process
+ *                  but kept the conversation resumable (the run stores
+ *                  the CLI's own resume id); the UI offers Resume.
+ */
+export const TERMINAL_EXIT_REASONS = ['completed', 'crashed', 'closed', 'parked'] as const;
+
+export type TerminalExitReason = (typeof TERMINAL_EXIT_REASONS)[number];
+
+/**
+ * PTY output. `seq` is the per-session monotonic sequence number the
+ * publisher assigns — attach-time replay merges persisted transcript,
+ * relay backlog, and the live tail deduplicated on it.
+ */
+export interface TerminalStdoutFrame {
+	readonly kind: 'stdout';
+	/** Non-negative safe integer, monotonic per session. */
+	readonly seq: number;
+	/** Raw PTY bytes, base64. */
+	readonly data: string;
+}
+
+/** Keystrokes from the driving viewer. Base64 bytes. */
+export interface TerminalStdinFrame {
+	readonly kind: 'stdin';
+	readonly data: string;
+}
+
+/** Viewport resize from the driving viewer. Bounded integers. */
+export interface TerminalResizeFrame {
+	readonly kind: 'resize';
+	readonly cols: number;
+	readonly rows: number;
+}
+
+/**
+ * Terminal end-of-session. Published exactly once per session and
+ * pinned by the relay so every current AND future attach learns the
+ * session is over — never a silently-frozen pane.
+ */
+export interface TerminalExitFrame {
+	readonly kind: 'exit';
+	/** Child exit code (or a platform sentinel for crashed/parked). */
+	readonly code: number;
+	readonly reason: TerminalExitReason;
+}
+
+/**
+ * Human-readable banner published into the stream — used for the
+ * pre-spawn preamble ("provider not configured", "starting …") and for
+ * protocol violations answered to a specific client. Never carries
+ * terminal bytes.
+ */
+export interface TerminalErrorFrame {
+	readonly kind: 'error';
+	readonly message: string;
+}
+
+/**
+ * First message a connecting socket MUST send: the short-lived signed
+ * attach token minted by the REST attach endpoint. Carried in the frame
+ * body — deliberately never in the URL, so tokens stay out of proxy and
+ * access logs. Consumed by the gateway during the handshake; never
+ * persisted, never fanned out, never part of replay.
+ */
+export interface TerminalAuthFrame {
+	readonly kind: 'auth';
+	readonly token: string;
+}
+
+/** Every frame that can appear on the wire. */
+export type TerminalFrame =
+	| TerminalStdoutFrame
+	| TerminalStdinFrame
+	| TerminalResizeFrame
+	| TerminalExitFrame
+	| TerminalErrorFrame
+	| TerminalAuthFrame;
+
+export type TerminalFrameKind = TerminalFrame['kind'];
+
+/**
+ * Direction map — client (browser / attached worker socket) → server.
+ * Everything else arriving on an inbound socket leg is dropped by the
+ * gateway (after decode) regardless of shape validity.
+ */
+export const TERMINAL_CLIENT_TO_SERVER_KINDS = ['auth', 'stdin', 'resize'] as const;
+
+/** Direction map — server (relay fan-out) → client. */
+export const TERMINAL_SERVER_TO_CLIENT_KINDS = ['stdout', 'exit', 'error'] as const;
+
+export type TerminalClientToServerFrame = TerminalStdinFrame | TerminalResizeFrame | TerminalAuthFrame;
+export type TerminalServerToClientFrame = TerminalStdoutFrame | TerminalExitFrame | TerminalErrorFrame;


### PR DESCRIPTION
## What

First milestone of the **streaming-terminal capability**: the frozen wire contract that every party will speak — the worker-side session host publishing PTY bytes, the API relay/gateway fanning them out, and the browser terminal pane rendering them. Pure module in `@ever-works/contracts`, **no runtime wiring** — the relay registry, WS gateway, `terminal-stream` plugin capability, and UI panes build on this in follow-up PRs.

## Design

- **6-kind discriminated union**: `stdout(seq)` / `stdin` / `resize` / `exit(code, reason)` / `error` + a first-message `auth` frame (attach token travels in the frame body — deliberately never in the URL, so tokens stay out of proxy/access logs).
- **Hand-rolled codec** — contracts stays zero-dependency (`dependencies: {}` is a package invariant):
  - size cap enforced **before** `JSON.parse` (1 MiB; exact byte accounting for multi-byte strings),
  - resize bounded 1..1000, canonical-base64 data fields, bounded error/auth strings, int32 exit codes,
  - **null-never-throw** on every decode/guard helper — wire handlers drop garbage without try/catch.
- **Normalized construction**: decoding builds the frame field-by-field — unknown/extra/`__proto__` keys never survive; `kind` resolved via own-property lookup only (prototype-chain hardening, same posture as the works-config schema fix).
- **Direction maps + guards**: `stdin`/`resize`/`auth` are client→server only; `stdout`/`exit`/`error` server→client only — a replayed scrollback `stdout` can never be smuggled back in as keystrokes, and a client can never forge terminal output.
- **Run-id shape gate** (RFC 4122) applied before any registry/DB touch, and a **ws/wss URL guard** (wss anywhere; plain ws only to loopback for local dev).
- Exit reasons include `parked` — the platform's park/resume lifecycle (kill idle process, keep conversation resumable) is a first-class wire state so the pane can offer Resume.

## Tests

93 tests: per-kind round-trips, an exhaustive malformed-input table (~35 shapes), size-cap boundary + multi-byte accounting, direction-map completeness (every kind exactly one direction), prototype-pollution cases, URL/run-id guard matrices, and a deterministic 2000-iteration mutation-fuzz loop pinning the never-throw invariant. `tsc` + tsup build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)