### PR TITLE
feat(api): terminal relay session registry

### DIFF
--- a/apps/api/src/terminal/__tests__/terminal-relay.registry.spec.ts
+++ b/apps/api/src/terminal/__tests__/terminal-relay.registry.spec.ts
@@ -1,5 +1,8 @@
+import { Test } from '@nestjs/testing';
 import {
     InProcessTerminalFanoutBus,
+    TERMINAL_FANOUT_BUS,
+    TERMINAL_RELAY_REGISTRY_OPTIONS,
     TerminalRelayRegistry,
     type TerminalClientRole,
     type TerminalFanoutBus,
@@ -397,6 +400,207 @@ describe('TerminalRelayRegistry', () => {
             const bus = new InProcessTerminalFanoutBus();
             expect(() => bus.publishRemote()).not.toThrow();
             expect(() => bus.onRemote()).not.toThrow();
+        });
+
+        it('a throwing bus never fails the local publish (best-effort remote)', () => {
+            const bus: TerminalFanoutBus = {
+                publishRemote() {
+                    throw new Error('redis down');
+                },
+                onRemote() {
+                    // not needed
+                },
+            };
+            const registry = new TerminalRelayRegistry(bus);
+            const client = makeClient('local');
+            registry.attach(RUN, client);
+
+            expect(() => registry.publish(RUN, stdout(0))).not.toThrow();
+            expect(registry.publish(RUN, stdout(1))).toBe(true);
+            // Local delivery and seq bookkeeping proceeded normally.
+            expect(client.received.filter((f) => f.kind === 'stdout')).toHaveLength(2);
+            expect(registry.getStatus(RUN).lastSeq).toBe(1);
+        });
+
+        function makeLinkedRegistries() {
+            // Two registries joined by a symmetric in-memory bus, the
+            // shape a Redis pub/sub impl will have: publishRemote on one
+            // replica fires onRemote handlers on the OTHER only.
+            const handlersA: Array<(runId: string, wire: string) => void> = [];
+            const handlersB: Array<(runId: string, wire: string) => void> = [];
+            const busA: TerminalFanoutBus = {
+                publishRemote: (runId, wire) => handlersB.forEach((h) => h(runId, wire)),
+                onRemote: (h) => handlersA.push(h),
+            };
+            const busB: TerminalFanoutBus = {
+                publishRemote: (runId, wire) => handlersA.forEach((h) => h(runId, wire)),
+                onRemote: (h) => handlersB.push(h),
+            };
+            return {
+                replicaA: new TerminalRelayRegistry(busA),
+                replicaB: new TerminalRelayRegistry(busB),
+            };
+        }
+
+        it('cross-replica: server frames published on one replica reach clients on the other', () => {
+            const { replicaA, replicaB } = makeLinkedRegistries();
+            const remoteViewer = makeClient('remote-viewer');
+            replicaB.attach(RUN, remoteViewer);
+
+            replicaA.publish(RUN, stdout(0));
+
+            expect(remoteViewer.received).toEqual([stdout(0)]);
+            // And the peer replica's seq bookkeeping advanced.
+            expect(replicaB.getStatus(RUN).lastSeq).toBe(0);
+        });
+
+        it('cross-replica: driver stdin reaches a worker attached to the other replica (no loops)', () => {
+            const { replicaA, replicaB } = makeLinkedRegistries();
+            const driver = makeClient('driver-1', 'driver');
+            const worker = makeClient('worker-1', 'worker');
+            replicaA.attach(RUN, driver);
+            replicaB.attach(RUN, worker);
+
+            expect(replicaA.deliverInbound(RUN, 'driver-1', { kind: 'stdin', data: B64 })).toBe(
+                true,
+            );
+
+            // The worker on replica B received the keystrokes…
+            expect(worker.received).toEqual([{ kind: 'stdin', data: B64 }]);
+            // …and nothing echoed back to the sending driver (no loop).
+            expect(driver.received).toEqual([]);
+        });
+
+        it('cross-replica: remote stdin for a run with no local session is a no-op', () => {
+            const { replicaA, replicaB } = makeLinkedRegistries();
+            const driver = makeClient('driver-1', 'driver');
+            replicaA.attach(RUN, driver);
+
+            expect(() =>
+                replicaA.deliverInbound(RUN, 'driver-1', { kind: 'stdin', data: B64 }),
+            ).not.toThrow();
+            expect(replicaB.getStatus(RUN).exists).toBe(false);
+        });
+    });
+
+    describe('scrollback accounting (decoded bytes, not wire characters)', () => {
+        it('budgets by decoded terminal bytes — a frame at the decoded budget survives', () => {
+            // 12 base64 chars decode to 9 bytes. Under WIRE-character
+            // accounting a 9-byte budget would evict this frame (12 > 9);
+            // under decoded accounting it fits exactly.
+            const registry = new TerminalRelayRegistry(undefined, { scrollbackMaxBytes: 9 });
+            registry.publish(RUN, stdout(0, 'AAAAAAAAAAAA'));
+
+            const late = makeClient('late');
+            registry.attach(RUN, late);
+            expect(late.received.filter((f) => f.kind === 'stdout')).toHaveLength(1);
+        });
+
+        it('padding does not count against the budget', () => {
+            // 'QQ==' is 4 wire chars but exactly 1 decoded byte. Ten of
+            // them fit in a 10-byte budget (40 wire chars would not).
+            const registry = new TerminalRelayRegistry(undefined, { scrollbackMaxBytes: 10 });
+            for (let i = 0; i < 10; i++) {
+                registry.publish(RUN, stdout(i, 'QQ=='));
+            }
+            const late = makeClient('late');
+            registry.attach(RUN, late);
+            expect(late.received.filter((f) => f.kind === 'stdout')).toHaveLength(10);
+        });
+    });
+
+    describe('attach reentrancy', () => {
+        it('a frame published synchronously DURING replay still reaches the attaching client exactly once', () => {
+            const registry = new TerminalRelayRegistry();
+            registry.publish(RUN, stdout(0));
+            registry.publish(RUN, stdout(1));
+
+            let reentered = false;
+            const received: TerminalFrame[] = [];
+            const reentrant: TerminalRelayClient & { received: TerminalFrame[] } = {
+                id: 'reentrant',
+                role: 'viewer',
+                received,
+                send(wire: string) {
+                    const frame = decodeTerminalFrame(wire);
+                    if (!frame) throw new Error(`invalid wire: ${wire}`);
+                    received.push(frame);
+                    if (!reentered) {
+                        reentered = true;
+                        // A same-process worker adapter can publish from
+                        // within a delivery callback.
+                        registry.publish(RUN, stdout(2));
+                    }
+                },
+            };
+
+            registry.attach(RUN, reentrant);
+
+            const seqs = received
+                .filter((f) => f.kind === 'stdout')
+                .map((f) => (f as { seq: number }).seq);
+            expect(seqs).toEqual([0, 1, 2]);
+        });
+
+        it('an exit published during replay is delivered to the attaching client', () => {
+            const registry = new TerminalRelayRegistry();
+            registry.publish(RUN, stdout(0));
+
+            let fired = false;
+            const received: TerminalFrame[] = [];
+            const client: TerminalRelayClient & { received: TerminalFrame[] } = {
+                id: 'x',
+                role: 'viewer',
+                received,
+                send(wire: string) {
+                    const frame = decodeTerminalFrame(wire);
+                    if (!frame) throw new Error('invalid wire');
+                    received.push(frame);
+                    if (!fired) {
+                        fired = true;
+                        registry.publish(RUN, { kind: 'exit', code: 0, reason: 'completed' });
+                    }
+                },
+            };
+
+            registry.attach(RUN, client);
+
+            expect(received.map((f) => f.kind)).toEqual(['stdout', 'exit']);
+        });
+    });
+
+    describe('NestJS injection tokens', () => {
+        it('a DI-provided bus and options actually reach the registry (interfaces are erased at runtime)', async () => {
+            const published: Array<{ runId: string; wire: string }> = [];
+            const bus: TerminalFanoutBus = {
+                publishRemote: (runId, wire) => published.push({ runId, wire }),
+                onRemote: () => undefined,
+            };
+            const moduleRef = await Test.createTestingModule({
+                providers: [
+                    TerminalRelayRegistry,
+                    { provide: TERMINAL_FANOUT_BUS, useValue: bus },
+                    {
+                        provide: TERMINAL_RELAY_REGISTRY_OPTIONS,
+                        useValue: { scrollbackMaxBytes: 9 },
+                    },
+                ],
+            }).compile();
+            const registry = moduleRef.get(TerminalRelayRegistry);
+
+            registry.publish(RUN, stdout(0, 'AAAAAAAAAAAA')); // 9 decoded bytes
+            registry.publish(RUN, stdout(1, 'AAAAAAAAAAAA')); // evicts seq 0
+
+            // The DI-provided bus received the publishes…
+            expect(published).toHaveLength(2);
+            // …and the DI-provided options took effect (9-byte budget
+            // keeps exactly one 9-byte frame).
+            const late = makeClient('late');
+            registry.attach(RUN, late);
+            const seqs = late.received
+                .filter((f) => f.kind === 'stdout')
+                .map((f) => (f as { seq: number }).seq);
+            expect(seqs).toEqual([1]);
         });
     });
 

--- a/apps/api/src/terminal/__tests__/terminal-relay.registry.spec.ts
+++ b/apps/api/src/terminal/__tests__/terminal-relay.registry.spec.ts
@@ -1,0 +1,418 @@
+import {
+    InProcessTerminalFanoutBus,
+    TerminalRelayRegistry,
+    type TerminalClientRole,
+    type TerminalFanoutBus,
+    type TerminalRelayClient,
+} from '../terminal-relay.registry';
+import { decodeTerminalFrame, type TerminalFrame } from '@ever-works/contracts';
+
+const RUN = '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f';
+const B64 = 'aGVsbG8='; // "hello"
+
+function makeClient(id: string, role: TerminalClientRole = 'viewer') {
+    const received: TerminalFrame[] = [];
+    const client: TerminalRelayClient & {
+        received: TerminalFrame[];
+        failNext: { value: boolean };
+    } = {
+        id,
+        role,
+        received,
+        failNext: { value: false },
+        send(wire: string) {
+            if (client.failNext.value) {
+                throw new Error('socket dead');
+            }
+            const frame = decodeTerminalFrame(wire);
+            if (!frame) {
+                throw new Error(`relay emitted invalid wire: ${wire}`);
+            }
+            received.push(frame);
+        },
+    };
+    return client;
+}
+
+function stdout(seq: number, data: string = B64): TerminalFrame {
+    return { kind: 'stdout', seq, data };
+}
+
+describe('TerminalRelayRegistry', () => {
+    describe('publish + backpressure of history', () => {
+        it('retains pre-attach banners and stdout, replays them in order on attach, exit pinned last', () => {
+            const registry = new TerminalRelayRegistry();
+            registry.publish(RUN, { kind: 'error', message: 'starting provider…' });
+            registry.publish(RUN, stdout(0));
+            registry.publish(RUN, stdout(1));
+            registry.publish(RUN, { kind: 'exit', code: 0, reason: 'completed' });
+
+            const late = makeClient('late', 'viewer');
+            const status = registry.attach(RUN, late);
+
+            expect(late.received.map((f) => f.kind)).toEqual(['error', 'stdout', 'stdout', 'exit']);
+            expect(late.received[1]).toEqual(stdout(0));
+            expect(late.received[3]).toEqual({ kind: 'exit', code: 0, reason: 'completed' });
+            expect(status.ended).toBe(true);
+            expect(status.exitReason).toBe('completed');
+        });
+
+        it('replays history to EVERY future attach, not just the first', () => {
+            const registry = new TerminalRelayRegistry();
+            registry.publish(RUN, { kind: 'error', message: 'provider not configured' });
+            registry.publish(RUN, { kind: 'exit', code: 1, reason: 'crashed' });
+
+            const first = makeClient('a');
+            registry.attach(RUN, first);
+            registry.detach(RUN, 'a');
+            const second = makeClient('b');
+            registry.attach(RUN, second);
+
+            // A session that failed before producing output still explains
+            // itself to a viewer arriving arbitrarily late.
+            expect(second.received.map((f) => f.kind)).toEqual(['error', 'exit']);
+        });
+
+        it('drops duplicate/stale stdout seq (publisher retries render nothing twice)', () => {
+            const registry = new TerminalRelayRegistry();
+            const client = makeClient('c', 'driver');
+            registry.attach(RUN, client);
+
+            expect(registry.publish(RUN, stdout(0))).toBe(true);
+            expect(registry.publish(RUN, stdout(0))).toBe(false); // retry
+            expect(registry.publish(RUN, stdout(1))).toBe(true);
+            expect(registry.publish(RUN, stdout(1))).toBe(false);
+            expect(registry.publish(RUN, stdout(0))).toBe(false); // stale
+
+            expect(client.received.filter((f) => f.kind === 'stdout')).toHaveLength(2);
+            expect(registry.getStatus(RUN).lastSeq).toBe(1);
+        });
+
+        it('evicts scrollback oldest-first under the byte budget, live clients unaffected', () => {
+            const registry = new TerminalRelayRegistry(undefined, { scrollbackMaxBytes: 24 });
+            registry.publish(RUN, stdout(0, 'AAAAAAAAAAAA')); // 12 chars
+            registry.publish(RUN, stdout(1, 'BBBBBBBBBBBB'));
+            registry.publish(RUN, stdout(2, 'CCCCCCCCCCCC')); // evicts seq 0
+
+            const late = makeClient('late');
+            registry.attach(RUN, late);
+            const seqs = late.received
+                .filter((f) => f.kind === 'stdout')
+                .map((f) => (f as { seq: number }).seq);
+            expect(seqs).toEqual([1, 2]);
+        });
+
+        it('caps retained banners (oldest evicted) while the pinned exit survives', () => {
+            const registry = new TerminalRelayRegistry(undefined, { bannersCap: 2 });
+            registry.publish(RUN, { kind: 'error', message: 'one' });
+            registry.publish(RUN, { kind: 'error', message: 'two' });
+            registry.publish(RUN, { kind: 'error', message: 'three' });
+            registry.publish(RUN, { kind: 'exit', code: 1, reason: 'crashed' });
+
+            const late = makeClient('late');
+            registry.attach(RUN, late);
+            expect(
+                late.received.map((f) =>
+                    f.kind === 'error' ? (f as { message: string }).message : f.kind,
+                ),
+            ).toEqual(['two', 'three', 'exit']);
+        });
+
+        it('errors published while clients are attached are transient (fanned out, not retained)', () => {
+            const registry = new TerminalRelayRegistry();
+            const live = makeClient('live');
+            registry.attach(RUN, live);
+            registry.publish(RUN, { kind: 'error', message: 'transient banner' });
+            expect(live.received.map((f) => f.kind)).toEqual(['error']);
+
+            registry.detach(RUN, 'live');
+            const late = makeClient('late');
+            registry.attach(RUN, late);
+            expect(late.received).toEqual([]);
+        });
+
+        it('refuses client-direction kinds on the publish leg (no forged input via publish)', () => {
+            const registry = new TerminalRelayRegistry();
+            expect(registry.publish(RUN, { kind: 'stdin', data: B64 })).toBe(false);
+            expect(registry.publish(RUN, { kind: 'resize', cols: 80, rows: 24 })).toBe(false);
+            expect(registry.publish(RUN, { kind: 'auth', token: 't' })).toBe(false);
+            expect(registry.getStatus(RUN).lastSeq).toBeNull();
+        });
+
+        it('ignores publishes after the session ended (exit is final)', () => {
+            const registry = new TerminalRelayRegistry();
+            const client = makeClient('c');
+            registry.attach(RUN, client);
+            registry.publish(RUN, { kind: 'exit', code: 0, reason: 'closed' });
+            expect(registry.publish(RUN, stdout(5))).toBe(false);
+            expect(registry.publish(RUN, { kind: 'exit', code: 1, reason: 'crashed' })).toBe(false);
+
+            expect(registry.getStatus(RUN).exitReason).toBe('closed');
+            expect(client.received.map((f) => f.kind)).toEqual(['exit']);
+        });
+    });
+
+    describe('live fan-out', () => {
+        it('fans published frames to every attached client', () => {
+            const registry = new TerminalRelayRegistry();
+            const a = makeClient('a', 'driver');
+            const b = makeClient('b', 'viewer');
+            registry.attach(RUN, a);
+            registry.attach(RUN, b);
+
+            registry.publish(RUN, stdout(0));
+
+            expect(a.received.filter((f) => f.kind === 'stdout')).toHaveLength(1);
+            expect(b.received.filter((f) => f.kind === 'stdout')).toHaveLength(1);
+        });
+
+        it('stops delivering after detach', () => {
+            const registry = new TerminalRelayRegistry();
+            const a = makeClient('a');
+            registry.attach(RUN, a);
+            registry.detach(RUN, 'a');
+            registry.publish(RUN, stdout(0));
+            expect(a.received).toEqual([]);
+        });
+
+        it('drops a client whose send throws without poisoning the rest of the fan-out', () => {
+            const registry = new TerminalRelayRegistry();
+            const dead = makeClient('dead');
+            const alive = makeClient('alive');
+            registry.attach(RUN, dead);
+            registry.attach(RUN, alive);
+            dead.failNext.value = true;
+
+            registry.publish(RUN, stdout(0));
+
+            expect(alive.received.filter((f) => f.kind === 'stdout')).toHaveLength(1);
+            expect(registry.getStatus(RUN).clientCount).toBe(1);
+
+            // Subsequent frames don't retry the dead client.
+            dead.failNext.value = false;
+            registry.publish(RUN, stdout(1));
+            expect(dead.received).toEqual([]);
+        });
+    });
+
+    describe('deliverInbound (role-checked input)', () => {
+        function attachTrio(registry: TerminalRelayRegistry) {
+            const driver = makeClient('driver-1', 'driver');
+            const viewer = makeClient('viewer-1', 'viewer');
+            const worker = makeClient('worker-1', 'worker');
+            registry.attach(RUN, driver);
+            registry.attach(RUN, viewer);
+            registry.attach(RUN, worker);
+            return { driver, viewer, worker };
+        }
+
+        it('driver stdin fans to all clients except the sender', () => {
+            const registry = new TerminalRelayRegistry();
+            const { driver, viewer, worker } = attachTrio(registry);
+
+            expect(registry.deliverInbound(RUN, 'driver-1', { kind: 'stdin', data: B64 })).toBe(
+                true,
+            );
+
+            expect(driver.received).toEqual([]);
+            expect(viewer.received).toEqual([{ kind: 'stdin', data: B64 }]);
+            expect(worker.received).toEqual([{ kind: 'stdin', data: B64 }]);
+        });
+
+        it('viewer input is refused with an error answered to the sender only', () => {
+            const registry = new TerminalRelayRegistry();
+            const { driver, viewer, worker } = attachTrio(registry);
+
+            expect(registry.deliverInbound(RUN, 'viewer-1', { kind: 'stdin', data: B64 })).toBe(
+                false,
+            );
+
+            expect(viewer.received).toHaveLength(1);
+            expect(viewer.received[0].kind).toBe('error');
+            expect(driver.received).toEqual([]);
+            expect(worker.received).toEqual([]);
+        });
+
+        it('resize follows the same role policy', () => {
+            const registry = new TerminalRelayRegistry();
+            const { viewer, worker } = attachTrio(registry);
+
+            expect(
+                registry.deliverInbound(RUN, 'driver-1', { kind: 'resize', cols: 120, rows: 40 }),
+            ).toBe(true);
+            expect(worker.received).toEqual([{ kind: 'resize', cols: 120, rows: 40 }]);
+
+            expect(
+                registry.deliverInbound(RUN, 'viewer-1', { kind: 'resize', cols: 10, rows: 10 }),
+            ).toBe(false);
+        });
+
+        it('server-direction kinds can never re-enter as input (echoed replay hardening)', () => {
+            const registry = new TerminalRelayRegistry();
+            const { driver, worker } = attachTrio(registry);
+
+            expect(registry.deliverInbound(RUN, 'driver-1', stdout(99))).toBe(false);
+            expect(
+                registry.deliverInbound(RUN, 'driver-1', {
+                    kind: 'exit',
+                    code: 0,
+                    reason: 'completed',
+                }),
+            ).toBe(false);
+            expect(registry.deliverInbound(RUN, 'driver-1', { kind: 'auth', token: 't' })).toBe(
+                false,
+            );
+            expect(worker.received).toEqual([]);
+            expect(driver.received).toEqual([]);
+            // The forged exit did not end the session.
+            expect(registry.getStatus(RUN).ended).toBe(false);
+        });
+
+        it('rejects input from unknown sessions and unattached senders', () => {
+            const registry = new TerminalRelayRegistry();
+            expect(
+                registry.deliverInbound('0f000000-0000-4000-8000-000000000000', 'x', {
+                    kind: 'stdin',
+                    data: B64,
+                }),
+            ).toBe(false);
+            registry.attach(RUN, makeClient('a', 'driver'));
+            expect(registry.deliverInbound(RUN, 'not-attached', { kind: 'stdin', data: B64 })).toBe(
+                false,
+            );
+        });
+    });
+
+    describe('status + reclaim', () => {
+        it('reports counts, ended state, and lastSeq', () => {
+            const registry = new TerminalRelayRegistry();
+            expect(registry.getStatus(RUN).exists).toBe(false);
+
+            registry.attach(RUN, makeClient('d', 'driver'));
+            registry.attach(RUN, makeClient('v', 'viewer'));
+            registry.publish(RUN, stdout(7));
+
+            const status = registry.getStatus(RUN);
+            expect(status).toEqual({
+                exists: true,
+                ended: false,
+                exitReason: null,
+                clientCount: 2,
+                viewerCount: 1,
+                lastSeq: 7,
+            });
+        });
+
+        it('reclaims only when unattached AND ended AND seen at least once', () => {
+            const registry = new TerminalRelayRegistry();
+            const client = makeClient('a');
+
+            registry.publish(RUN, stdout(0));
+            expect(registry.canReclaim(RUN)).toBe(false); // not ended
+
+            registry.publish(RUN, { kind: 'exit', code: 0, reason: 'completed' });
+            expect(registry.canReclaim(RUN)).toBe(false); // ended but never seen
+
+            registry.attach(RUN, client);
+            expect(registry.canReclaim(RUN)).toBe(false); // still attached
+
+            registry.detach(RUN, 'a');
+            expect(registry.canReclaim(RUN)).toBe(true);
+            expect(registry.reclaim(RUN)).toBe(true);
+            expect(registry.getStatus(RUN).exists).toBe(false);
+        });
+
+        it('force reclaim releases an ended-but-never-seen session (sweeper TTL path)', () => {
+            const registry = new TerminalRelayRegistry();
+            registry.publish(RUN, { kind: 'error', message: 'never seen' });
+            registry.publish(RUN, { kind: 'exit', code: 1, reason: 'crashed' });
+
+            expect(registry.reclaim(RUN)).toBe(false);
+            expect(registry.reclaim(RUN, { force: true })).toBe(true);
+            expect(registry.getStatus(RUN).exists).toBe(false);
+        });
+
+        it('force reclaim still refuses live sessions', () => {
+            const registry = new TerminalRelayRegistry();
+            registry.attach(RUN, makeClient('a'));
+            registry.publish(RUN, { kind: 'exit', code: 0, reason: 'completed' });
+            expect(registry.reclaim(RUN, { force: true })).toBe(false);
+        });
+
+        it('reclaim of an unknown session is a no-op', () => {
+            const registry = new TerminalRelayRegistry();
+            expect(registry.canReclaim('0f000000-0000-4000-8000-000000000000')).toBe(true);
+            expect(registry.reclaim('0f000000-0000-4000-8000-000000000000')).toBe(false);
+        });
+    });
+
+    describe('fan-out bus (multi-replica seam)', () => {
+        function makeLoopBus(): TerminalFanoutBus & {
+            handlers: Array<(runId: string, wire: string) => void>;
+            published: Array<{ runId: string; wire: string }>;
+        } {
+            const bus = {
+                handlers: [] as Array<(runId: string, wire: string) => void>,
+                published: [] as Array<{ runId: string; wire: string }>,
+                publishRemote(runId: string, wire: string) {
+                    bus.published.push({ runId, wire });
+                },
+                onRemote(handler: (runId: string, wire: string) => void) {
+                    bus.handlers.push(handler);
+                },
+            };
+            return bus;
+        }
+
+        it('locally published frames are forwarded to the bus', () => {
+            const bus = makeLoopBus();
+            const registry = new TerminalRelayRegistry(bus);
+            registry.publish(RUN, stdout(0));
+
+            expect(bus.published).toHaveLength(1);
+            expect(decodeTerminalFrame(bus.published[0].wire)).toEqual(stdout(0));
+        });
+
+        it('frames arriving from peers fan out locally but are NOT re-broadcast (no loops)', () => {
+            const bus = makeLoopBus();
+            const registry = new TerminalRelayRegistry(bus);
+            const client = makeClient('local-viewer');
+            registry.attach(RUN, client);
+
+            bus.handlers[0](RUN, JSON.stringify(stdout(3)));
+
+            expect(client.received).toEqual([stdout(3)]);
+            expect(bus.published).toEqual([]);
+        });
+
+        it('garbage from the bus is dropped without effect', () => {
+            const bus = makeLoopBus();
+            const registry = new TerminalRelayRegistry(bus);
+            bus.handlers[0](RUN, 'not json{{');
+            bus.handlers[0](RUN, JSON.stringify({ kind: 'stdin', data: B64 }));
+            expect(registry.getStatus(RUN).lastSeq).toBeNull();
+        });
+
+        it('the in-process bus is inert (single replica default)', () => {
+            const bus = new InProcessTerminalFanoutBus();
+            expect(() => bus.publishRemote()).not.toThrow();
+            expect(() => bus.onRemote()).not.toThrow();
+        });
+    });
+
+    describe('session isolation', () => {
+        it('frames and clients never cross run boundaries', () => {
+            const OTHER = '3a000000-0000-4000-8000-000000000001';
+            const registry = new TerminalRelayRegistry();
+            const a = makeClient('a');
+            const b = makeClient('b');
+            registry.attach(RUN, a);
+            registry.attach(OTHER, b);
+
+            registry.publish(RUN, stdout(0));
+
+            expect(a.received).toHaveLength(1);
+            expect(b.received).toEqual([]);
+        });
+    });
+});

--- a/apps/api/src/terminal/terminal-relay.registry.ts
+++ b/apps/api/src/terminal/terminal-relay.registry.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import {
     encodeTerminalFrame,
     isTerminalServerToClientFrame,
@@ -48,7 +48,12 @@ import {
  * fenced behind {@link TerminalFanoutBus} — the default in-process bus
  * is a no-op, which is correct for the current single-API-replica
  * deployments; a Redis pub/sub implementation can be injected later
- * with zero changes to registry semantics.
+ * (via {@link TERMINAL_FANOUT_BUS}) with zero changes to registry
+ * semantics. BOTH directions traverse the bus: server frames take the
+ * publish path on peers, and role-checked inbound stdin/resize fans to
+ * peers' local clients — a driver and worker attached to different
+ * replicas still form a complete loop. Bus delivery is best-effort;
+ * local truth never depends on it.
  */
 
 export type TerminalClientRole = 'driver' | 'viewer' | 'worker';
@@ -83,7 +88,7 @@ export class InProcessTerminalFanoutBus implements TerminalFanoutBus {
 }
 
 export interface TerminalRelayRegistryOptions {
-    /** Rolling scrollback budget per session, in wire characters. */
+    /** Rolling scrollback budget per session, in DECODED terminal bytes. */
     scrollbackMaxBytes?: number;
     /** Max retained pre-attach banner frames per session. */
     bannersCap?: number;
@@ -116,6 +121,29 @@ interface TerminalSession {
 export const TERMINAL_SCROLLBACK_MAX_BYTES_DEFAULT = 512 * 1024;
 export const TERMINAL_BANNERS_CAP_DEFAULT = 64;
 
+/**
+ * Injection tokens — the constructor parameters are interface-typed, and
+ * TypeScript interfaces are erased at runtime, so without explicit tokens
+ * Nest could never actually supply a configured bus or options object
+ * (the registry would silently fall back to the no-op defaults).
+ */
+export const TERMINAL_FANOUT_BUS = 'TERMINAL_FANOUT_BUS' as const;
+export const TERMINAL_RELAY_REGISTRY_OPTIONS = 'TERMINAL_RELAY_REGISTRY_OPTIONS' as const;
+
+/**
+ * Decoded size of a canonical base64 payload. Frame data is validated
+ * canonical by the codec, so padding is exactly the trailing `=` count.
+ * The scrollback budget counts REAL terminal bytes — wire characters
+ * would silently shrink the promised window by a third.
+ */
+function decodedBase64Bytes(data: string): number {
+    if (data.length === 0) return 0;
+    let padding = 0;
+    if (data.endsWith('==')) padding = 2;
+    else if (data.endsWith('=')) padding = 1;
+    return (data.length / 4) * 3 - padding;
+}
+
 @Injectable()
 export class TerminalRelayRegistry {
     private readonly logger = new Logger(TerminalRelayRegistry.name);
@@ -125,20 +153,32 @@ export class TerminalRelayRegistry {
     private readonly bus: TerminalFanoutBus;
 
     constructor(
-        @Optional() bus?: TerminalFanoutBus,
-        @Optional() options?: TerminalRelayRegistryOptions,
+        @Optional() @Inject(TERMINAL_FANOUT_BUS) bus?: TerminalFanoutBus,
+        @Optional() @Inject(TERMINAL_RELAY_REGISTRY_OPTIONS) options?: TerminalRelayRegistryOptions,
     ) {
         this.bus = bus ?? new InProcessTerminalFanoutBus();
         this.scrollbackMaxBytes =
             options?.scrollbackMaxBytes ?? TERMINAL_SCROLLBACK_MAX_BYTES_DEFAULT;
         this.bannersCap = options?.bannersCap ?? TERMINAL_BANNERS_CAP_DEFAULT;
         // Frames from peer replicas fan out locally but are never
-        // re-broadcast (fromRemote) — no bus loops.
+        // re-broadcast (fromRemote) — no bus loops. Server-direction
+        // frames take the full publish path; inbound stdin/resize from a
+        // driver attached to a PEER replica fans to all local clients
+        // (the role check already ran on the origin replica, and the
+        // sender is not local so nobody is excluded).
         this.bus.onRemote((runId, wire) => {
             const frame = decodeTerminalFrame(wire);
-            if (frame) {
-                this.publish(runId, frame, { fromRemote: true });
+            if (!frame) {
+                return;
             }
+            if (frame.kind === 'stdin' || frame.kind === 'resize') {
+                const session = this.sessions.get(runId);
+                if (session) {
+                    this.fanOut(session, wire, null);
+                }
+                return;
+            }
+            this.publish(runId, frame, { fromRemote: true });
         });
     }
 
@@ -166,13 +206,13 @@ export class TerminalRelayRegistry {
             }
             session.seenSeqMax = frame.seq;
             session.scrollback.push(frame);
-            session.scrollbackBytes += frame.data.length;
+            session.scrollbackBytes += decodedBase64Bytes(frame.data);
             while (
                 session.scrollbackBytes > this.scrollbackMaxBytes &&
                 session.scrollback.length > 0
             ) {
                 const evicted = session.scrollback.shift() as TerminalStdoutFrame;
-                session.scrollbackBytes -= evicted.data.length;
+                session.scrollbackBytes -= decodedBase64Bytes(evicted.data);
             }
         } else if (frame.kind === 'exit') {
             session.ended = true;
@@ -194,7 +234,7 @@ export class TerminalRelayRegistry {
         this.fanOut(session, wire, null);
 
         if (!opts.fromRemote) {
-            this.bus.publishRemote(runId, wire);
+            this.safePublishRemote(runId, wire);
         }
         return true;
     }
@@ -206,6 +246,14 @@ export class TerminalRelayRegistry {
      */
     attach(runId: string, client: TerminalRelayClient): TerminalSessionStatus {
         const session = this.getOrCreate(runId);
+
+        // Snapshot for the reentrancy guard below: the replay loop is
+        // synchronous, but a client.send that synchronously triggers a
+        // publish (a same-process worker adapter) would land frames in
+        // scrollback AFTER this snapshot and BEFORE this client joins
+        // the fan-out set — invisible to both paths without the catch-up.
+        const seqBeforeReplay = session.seenSeqMax;
+        const exitBeforeReplay = session.exit;
 
         const replay: TerminalFrame[] = [...session.banners, ...session.scrollback];
         if (session.exit) {
@@ -225,6 +273,32 @@ export class TerminalRelayRegistry {
 
         session.everAttached = true;
         session.clients.set(client.id, client);
+
+        // Reentrancy catch-up: deliver anything published during replay.
+        if (session.seenSeqMax > seqBeforeReplay) {
+            for (const frame of session.scrollback) {
+                if (frame.seq <= seqBeforeReplay) continue;
+                const wire = encodeTerminalFrame(frame);
+                if (wire !== null) {
+                    try {
+                        client.send(wire);
+                    } catch {
+                        session.clients.delete(client.id);
+                        return this.getStatus(runId);
+                    }
+                }
+            }
+        }
+        if (session.exit && session.exit !== exitBeforeReplay) {
+            const wire = encodeTerminalFrame(session.exit);
+            if (wire !== null) {
+                try {
+                    client.send(wire);
+                } catch {
+                    session.clients.delete(client.id);
+                }
+            }
+        }
         return this.getStatus(runId);
     }
 
@@ -273,7 +347,32 @@ export class TerminalRelayRegistry {
             return false;
         }
         this.fanOut(session, wire, senderId);
+        // A worker for this run may be attached to a PEER replica —
+        // inbound traverses the bus too, or cross-replica stdin would
+        // silently reach nobody. The origin replica already role-checked.
+        this.safePublishRemote(runId, wire);
         return true;
+    }
+
+    /**
+     * Bus delivery is best-effort: local truth (scrollback, seq, local
+     * fan-out) is already committed by the time the bus is invoked, and a
+     * publisher retry would be rejected by the seq gate — so a throwing
+     * bus implementation must degrade to a logged warning, never to an
+     * exception that makes the local replica look failed while it is not.
+     * Cross-replica catch-up on bus outage is the bus implementation's
+     * concern (e.g. Redis client retry), not the registry's.
+     */
+    private safePublishRemote(runId: string, wire: string): void {
+        try {
+            this.bus.publishRemote(runId, wire);
+        } catch (error) {
+            this.logger.warn(
+                `Terminal fan-out bus publish failed for run ${runId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
     }
 
     getStatus(runId: string): TerminalSessionStatus {

--- a/apps/api/src/terminal/terminal-relay.registry.ts
+++ b/apps/api/src/terminal/terminal-relay.registry.ts
@@ -1,0 +1,372 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import {
+    encodeTerminalFrame,
+    isTerminalServerToClientFrame,
+    decodeTerminalFrame,
+    type TerminalErrorFrame,
+    type TerminalExitFrame,
+    type TerminalFrame,
+    type TerminalStdoutFrame,
+} from '@ever-works/contracts';
+
+/**
+ * Streaming-terminal relay — in-memory session registry.
+ *
+ * Transport-agnostic core of the terminal relay: it never imports `ws`
+ * and knows nothing about sockets — a "client" is anything with an id,
+ * a role, and a `send(wire)` function, which is what makes the whole
+ * replay/fan-out/reclaim matrix unit-testable without a network. The
+ * WebSocket gateway (follow-up PR) adapts real sockets onto this
+ * interface; the internal publish endpoint calls {@link publish}.
+ *
+ * Semantics (kept deliberately boring and explicit):
+ *
+ *  - **Scrollback** — every accepted `stdout` frame lands in a
+ *    byte-bounded rolling window (default 512 KiB), evicted oldest-first.
+ *    This is what any attach replays.
+ *  - **Banners** — `error` frames published while NO client is attached
+ *    (the pre-spawn preamble: "provider not configured", "starting …")
+ *    are retained (count-capped) and replayed to EVERY future attach —
+ *    a session that failed before producing output must still explain
+ *    itself to a viewer arriving late. Errors published while clients
+ *    are attached are transient banners: fanned out live, not retained.
+ *  - **Pinned exit** — the terminal `exit` frame is stored on the
+ *    session (never evictable) and replayed LAST to every current and
+ *    future attach: a viewer can always learn the session is over.
+ *  - **Seq discipline** — `stdout` frames carry a per-session monotonic
+ *    seq; stale/duplicate seqs (publisher retries) are dropped at the
+ *    door so no client ever renders the same bytes twice.
+ *  - **Inbound fan-out** — `stdin`/`resize` from an attached client is
+ *    delivered to every OTHER attached client after a role check;
+ *    viewer input is refused with an `error` frame answered to the
+ *    sender only.
+ *  - **Reclaim** — a session's memory is released only when it has no
+ *    clients AND has ended AND at least one attach saw its history
+ *    (`force` overrides for the sweeper's abandoned-session TTL path).
+ *
+ * Multi-replica: this registry is per-process. Cross-replica fan-out is
+ * fenced behind {@link TerminalFanoutBus} — the default in-process bus
+ * is a no-op, which is correct for the current single-API-replica
+ * deployments; a Redis pub/sub implementation can be injected later
+ * with zero changes to registry semantics.
+ */
+
+export type TerminalClientRole = 'driver' | 'viewer' | 'worker';
+
+/** Anything attachable: a socket adapter, or a test double. */
+export interface TerminalRelayClient {
+    readonly id: string;
+    readonly role: TerminalClientRole;
+    /** Deliver one encoded wire frame. Throws are tolerated: a client
+     *  whose send throws is dropped from the session. */
+    send(wire: string): void;
+}
+
+/**
+ * Cross-replica fan-out seam. `publishRemote` must NOT loop back to the
+ * publishing replica; `onRemote` registers the handler for frames
+ * published by peer replicas.
+ */
+export interface TerminalFanoutBus {
+    publishRemote(runId: string, wire: string): void;
+    onRemote(handler: (runId: string, wire: string) => void): void;
+}
+
+/** Single-replica default: no peers, nothing to do. */
+export class InProcessTerminalFanoutBus implements TerminalFanoutBus {
+    publishRemote(): void {
+        // no peers in-process
+    }
+    onRemote(): void {
+        // no peers in-process
+    }
+}
+
+export interface TerminalRelayRegistryOptions {
+    /** Rolling scrollback budget per session, in wire characters. */
+    scrollbackMaxBytes?: number;
+    /** Max retained pre-attach banner frames per session. */
+    bannersCap?: number;
+}
+
+export interface TerminalSessionStatus {
+    exists: boolean;
+    ended: boolean;
+    exitReason: TerminalExitFrame['reason'] | null;
+    clientCount: number;
+    viewerCount: number;
+    lastSeq: number | null;
+}
+
+interface TerminalSession {
+    clients: Map<string, TerminalRelayClient>;
+    /** Pre-attach `error` banners, replayed to every attach. */
+    banners: TerminalErrorFrame[];
+    /** Rolling stdout window, ascending seq. */
+    scrollback: TerminalStdoutFrame[];
+    scrollbackBytes: number;
+    /** Highest stdout seq accepted (dup/stale gate). -1 = none yet. */
+    seenSeqMax: number;
+    exit: TerminalExitFrame | null;
+    ended: boolean;
+    /** At least one attach replayed this session's history. */
+    everAttached: boolean;
+}
+
+export const TERMINAL_SCROLLBACK_MAX_BYTES_DEFAULT = 512 * 1024;
+export const TERMINAL_BANNERS_CAP_DEFAULT = 64;
+
+@Injectable()
+export class TerminalRelayRegistry {
+    private readonly logger = new Logger(TerminalRelayRegistry.name);
+    private readonly sessions = new Map<string, TerminalSession>();
+    private readonly scrollbackMaxBytes: number;
+    private readonly bannersCap: number;
+    private readonly bus: TerminalFanoutBus;
+
+    constructor(
+        @Optional() bus?: TerminalFanoutBus,
+        @Optional() options?: TerminalRelayRegistryOptions,
+    ) {
+        this.bus = bus ?? new InProcessTerminalFanoutBus();
+        this.scrollbackMaxBytes =
+            options?.scrollbackMaxBytes ?? TERMINAL_SCROLLBACK_MAX_BYTES_DEFAULT;
+        this.bannersCap = options?.bannersCap ?? TERMINAL_BANNERS_CAP_DEFAULT;
+        // Frames from peer replicas fan out locally but are never
+        // re-broadcast (fromRemote) — no bus loops.
+        this.bus.onRemote((runId, wire) => {
+            const frame = decodeTerminalFrame(wire);
+            if (frame) {
+                this.publish(runId, frame, { fromRemote: true });
+            }
+        });
+    }
+
+    /**
+     * Worker-side publish leg (stdout / exit / error). Returns whether
+     * the frame was accepted. Client-direction kinds are refused here
+     * regardless of shape validity — output can only originate from the
+     * publisher, never from an attached browser.
+     */
+    publish(runId: string, frame: TerminalFrame, opts: { fromRemote?: boolean } = {}): boolean {
+        if (!isTerminalServerToClientFrame(frame)) {
+            return false;
+        }
+        const session = this.getOrCreate(runId);
+
+        if (session.ended) {
+            // The pinned exit is final; late output from a dying process
+            // is dropped rather than rendered after "session ended".
+            return false;
+        }
+
+        if (frame.kind === 'stdout') {
+            if (frame.seq <= session.seenSeqMax) {
+                return false; // publisher retry / duplicate
+            }
+            session.seenSeqMax = frame.seq;
+            session.scrollback.push(frame);
+            session.scrollbackBytes += frame.data.length;
+            while (
+                session.scrollbackBytes > this.scrollbackMaxBytes &&
+                session.scrollback.length > 0
+            ) {
+                const evicted = session.scrollback.shift() as TerminalStdoutFrame;
+                session.scrollbackBytes -= evicted.data.length;
+            }
+        } else if (frame.kind === 'exit') {
+            session.ended = true;
+            session.exit = frame;
+        } else if (frame.kind === 'error' && session.clients.size === 0) {
+            // Pre-attach preamble — retained so a late viewer still sees
+            // why a session never produced output.
+            session.banners.push(frame);
+            while (session.banners.length > this.bannersCap) {
+                session.banners.shift();
+            }
+        }
+
+        const wire = encodeTerminalFrame(frame);
+        if (wire === null) {
+            return false;
+        }
+
+        this.fanOut(session, wire, null);
+
+        if (!opts.fromRemote) {
+            this.bus.publishRemote(runId, wire);
+        }
+        return true;
+    }
+
+    /**
+     * Attach a client: replay history (banners → scrollback in seq order
+     * → pinned exit), then join the live fan-out set. Replay is sent
+     * only to the attaching client.
+     */
+    attach(runId: string, client: TerminalRelayClient): TerminalSessionStatus {
+        const session = this.getOrCreate(runId);
+
+        const replay: TerminalFrame[] = [...session.banners, ...session.scrollback];
+        if (session.exit) {
+            replay.push(session.exit);
+        }
+        for (const frame of replay) {
+            const wire = encodeTerminalFrame(frame);
+            if (wire !== null) {
+                try {
+                    client.send(wire);
+                } catch {
+                    // A client that dies mid-replay simply never joins.
+                    return this.getStatus(runId);
+                }
+            }
+        }
+
+        session.everAttached = true;
+        session.clients.set(client.id, client);
+        return this.getStatus(runId);
+    }
+
+    detach(runId: string, clientId: string): void {
+        this.sessions.get(runId)?.clients.delete(clientId);
+    }
+
+    /**
+     * Inbound leg (stdin / resize from an attached client). Role-checked:
+     * viewers are read-only — their input is refused with an `error`
+     * frame answered to the sender alone. Accepted frames fan out to
+     * every attached client EXCEPT the sender (the worker consumes
+     * stdin; other viewers observe the driver's resize).
+     */
+    deliverInbound(runId: string, senderId: string, frame: TerminalFrame): boolean {
+        const session = this.sessions.get(runId);
+        if (!session) {
+            return false;
+        }
+        const sender = session.clients.get(senderId);
+        if (!sender) {
+            return false;
+        }
+        if (frame.kind !== 'stdin' && frame.kind !== 'resize') {
+            // Auth is consumed by the gateway during handshake; every
+            // server-direction kind is refused here — an echoed replay
+            // can never re-enter the session as input.
+            return false;
+        }
+        if (sender.role === 'viewer') {
+            const refusal = encodeTerminalFrame({
+                kind: 'error',
+                message: 'read-only session: viewer input is not delivered',
+            });
+            if (refusal !== null) {
+                try {
+                    sender.send(refusal);
+                } catch {
+                    session.clients.delete(senderId);
+                }
+            }
+            return false;
+        }
+        const wire = encodeTerminalFrame(frame);
+        if (wire === null) {
+            return false;
+        }
+        this.fanOut(session, wire, senderId);
+        return true;
+    }
+
+    getStatus(runId: string): TerminalSessionStatus {
+        const session = this.sessions.get(runId);
+        if (!session) {
+            return {
+                exists: false,
+                ended: false,
+                exitReason: null,
+                clientCount: 0,
+                viewerCount: 0,
+                lastSeq: null,
+            };
+        }
+        let viewerCount = 0;
+        for (const client of session.clients.values()) {
+            if (client.role === 'viewer') viewerCount++;
+        }
+        return {
+            exists: true,
+            ended: session.ended,
+            exitReason: session.exit?.reason ?? null,
+            clientCount: session.clients.size,
+            viewerCount,
+            lastSeq: session.seenSeqMax >= 0 ? session.seenSeqMax : null,
+        };
+    }
+
+    /**
+     * May this session's memory be released? True when nothing is
+     * attached, the session has ended, and at least one attach saw its
+     * history — so a failed session's explanation is never reclaimed
+     * unseen. The sweeper's abandoned-session TTL path uses `force`.
+     */
+    canReclaim(runId: string, opts: { force?: boolean } = {}): boolean {
+        const session = this.sessions.get(runId);
+        if (!session) {
+            return true;
+        }
+        if (session.clients.size > 0) {
+            return false;
+        }
+        if (opts.force === true) {
+            return session.ended;
+        }
+        return session.ended && session.everAttached;
+    }
+
+    /** Release the session if {@link canReclaim} allows it. */
+    reclaim(runId: string, opts: { force?: boolean } = {}): boolean {
+        if (!this.sessions.has(runId)) {
+            return false;
+        }
+        if (!this.canReclaim(runId, opts)) {
+            return false;
+        }
+        this.sessions.delete(runId);
+        return true;
+    }
+
+    private getOrCreate(runId: string): TerminalSession {
+        let session = this.sessions.get(runId);
+        if (!session) {
+            session = {
+                clients: new Map(),
+                banners: [],
+                scrollback: [],
+                scrollbackBytes: 0,
+                seenSeqMax: -1,
+                exit: null,
+                ended: false,
+                everAttached: false,
+            };
+            this.sessions.set(runId, session);
+        }
+        return session;
+    }
+
+    /** Send to every attached client except `excludeId`; a client whose
+     *  send throws is dropped so one dead socket can't poison fan-out. */
+    private fanOut(session: TerminalSession, wire: string, excludeId: string | null): void {
+        for (const [id, client] of session.clients) {
+            if (id === excludeId) continue;
+            try {
+                client.send(wire);
+            } catch (error) {
+                session.clients.delete(id);
+                this.logger.debug(
+                    `Dropped terminal client ${id} after send failure: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Second milestone of the streaming-terminal capability, stacked on #1787 (the wire frame protocol). The **transport-agnostic session registry** that will sit behind the WS gateway: it never imports `ws` and knows nothing about sockets — a client is `{id, role, send(wire)}` — which makes the entire replay/fan-out/reclaim matrix unit-testable without a network. Nothing is routed yet; the gateway + attach/publish endpoints adapt real sockets onto this in the next PR.

## Semantics

- **Scrollback**: byte-bounded rolling window of `stdout` frames (512 KiB default, oldest-evicted), replayed in seq order to every attach.
- **Banners**: `error` frames published while nobody is attached (the pre-spawn preamble — "provider not configured", "starting…") are retained (count-capped) and replayed to **every** future attach, so a session that failed before producing output still explains itself to a late viewer. Errors published while clients are attached stay transient.
- **Pinned exit**: the `exit` frame lives on the session (never evictable) and is replayed last to every current and future attach — never a silently-frozen pane.
- **Seq discipline**: stale/duplicate `stdout` seqs (publisher retries) are dropped at the door; no client renders the same bytes twice.
- **Role-checked inbound**: `stdin`/`resize` fan to all-but-sender; viewer input is refused with an `error` answered to the sender alone; server-direction kinds can never re-enter as input (echoed-replay hardening) and a forged `exit` via the inbound leg cannot end a session.
- **Fault isolation**: a client whose `send` throws is dropped without poisoning the rest of the fan-out.
- **Reclaim**: released only when unattached AND ended AND seen at least once; `force` flag for the sweeper's abandoned-session TTL path.
- **Multi-replica seam**: cross-replica fan-out fenced behind a `FanoutBus` interface — in-process no-op default (correct for today's single-API-replica deployments), Redis pub/sub injectable later with zero registry changes; peer frames fan out locally without re-broadcast (no loops), and garbage from the bus is dropped via the codec.

## Tests

26 unit tests (Jest, apps/api): replay ordering + every-attach semantics, seq dedup, scrollback/banner eviction, transient-vs-retained errors, publish-leg direction refusal, post-exit publish rejection, live fan-out + detach + dead-client isolation, the full inbound role matrix, status shape, reclaim predicate incl. force paths, bus forwarding/no-loop/garbage, and cross-run isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)