### PR TITLE
fix(ci): give packages/tasks hooks real headroom (30s → 120s)

### DIFF
--- a/packages/tasks/vitest.config.ts
+++ b/packages/tasks/vitest.config.ts
@@ -5,11 +5,14 @@ export default defineConfig({
         environment: 'node',
         globals: true,
         include: ['src/**/*.{test,spec}.ts'],
-        // Many task specs `vi.resetModules()` + `await import(...)` the worker
-        // graph in beforeEach; that cold re-import can exceed the default 10s
-        // hook timeout under CI load (flaky "Hook timed out in 10000ms"). Give
-        // hooks headroom so a slow re-import doesn't red the whole shard.
-        hookTimeout: 30000,
+        // Task specs cold-import the worker graph (@trigger.dev/sdk + the
+        // full task tree) in beforeAll/beforeEach; on saturated CI runners a
+        // single cold import has been measured past 30s (three consecutive
+        // "Hook timed out in 30000ms" reds on agent-task-execute even after
+        // the resetModules removal). The budget only matters under load —
+        // fast hooks still finish fast — so give hooks real headroom instead
+        // of chasing the runner-contention tail one bump at a time.
+        hookTimeout: 120000,
         testTimeout: 30000,
         coverage: {
             provider: 'v8',


### PR DESCRIPTION
One-line follow-up to #1785. The `packages/tasks` worker-graph cold import in `beforeAll` has been measured past 30s on saturated runners — [#1777 hit three consecutive `Hook timed out in 30000ms` failures on `agent-task-execute.task.spec.ts`](https://github.com/ever-works/ever-works/pull/1777#issuecomment-notes), the third one **with** #1785's resetModules-removal already rebased in. The hook budget only matters under load (fast hooks still finish fast), so this stops chasing the runner-contention tail one 30s bump at a time. `testTimeout` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)