### PR TITLE
feat: PostgreSQL DB plugin — per-Work database config end-to-end

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -88,6 +88,7 @@
         "@ever-works/aws-s3-plugin": "workspace:*",
         "@ever-works/github-storage-plugin": "workspace:*",
         "@ever-works/minio-plugin": "workspace:*",
+        "@ever-works/postgres-db-plugin": "workspace:*",
         "@nestjs/cli": "^11.0.18",
         "@nestjs/schematics": "^11.0.10",
         "@nestjs/testing": "^11.1.18",

--- a/apps/api/src/onboarding/onboarding-catalog.service.ts
+++ b/apps/api/src/onboarding/onboarding-catalog.service.ts
@@ -139,15 +139,21 @@ export class OnboardingCatalogService {
                 default: true,
                 available: everWorksDbEnabled,
                 badges: everWorksDbEnabled ? ['default'] : ['default', 'planned'],
+                // The DB step is driven by the PostgreSQL DB plugin (its
+                // settingsSchema renders the Ever Works DB / Custom selector +
+                // connection string); the choice is persisted as the plugin's
+                // user-scoped `mode`, not the bespoke onboarding `db` bucket.
+                pluginId: 'postgres-db',
             },
             {
                 choice: 'custom',
                 title: 'Custom DB',
                 description:
-                    'Bring your own database — enter the connection details on the Deploy page after your Work is created.',
+                    'Bring your own database — enter the connection string during setup (used for all your Works; a database is created per Work).',
                 default: false,
                 available: true,
                 badges: ['byok'],
+                pluginId: 'postgres-db',
             },
         ];
 
@@ -186,6 +192,7 @@ export class OnboardingCatalogService {
             [
                 ...ai.map((c) => c.pluginId),
                 ...storage.map((c) => c.pluginId),
+                ...db.map((c) => c.pluginId),
                 ...deploy.map((c) => c.pluginId),
             ].filter((id): id is string => Boolean(id)),
         );

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.spec.ts
@@ -65,6 +65,7 @@ describe('DeployController', () => {
         addDomain: jest.Mock;
         removeDomain: jest.Mock;
         verifyDomain: jest.Mock;
+        setWorkDbOverride: jest.Mock;
     };
     let ownershipService: {
         ensureCanEdit: jest.Mock;
@@ -123,6 +124,9 @@ describe('DeployController', () => {
             addDomain: jest.fn(),
             removeDomain: jest.fn(),
             verifyDomain: jest.fn(),
+            // Mirrors the per-Work DB override into the PostgreSQL DB plugin;
+            // the controller calls this best-effort (.catch) on runtime-env save.
+            setWorkDbOverride: jest.fn().mockResolvedValue(undefined),
         };
         ownershipService = {
             ensureCanEdit: jest.fn(),

--- a/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.controller.ts
@@ -367,9 +367,18 @@ export class DeployController {
             // Provision (or re-point) the shared DB now so it is set + visible
             // immediately; also re-runs idempotently on the next deploy.
             await this.dbProvisionService.ensureDatabaseForWork(id, { force: true });
+            // Keep the PostgreSQL DB plugin authoritative: clear any per-Work
+            // override so the Work inherits the account-level setting. Best-
+            // effort — never fail the deploy config if the plugin isn't loaded.
+            await this.deployFacade.setWorkDbOverride(id, '').catch(() => {});
         } else {
             await this.workRuntimeEnvService.setDatabaseUrl(id, dto.databaseUrl as string);
             await this.workRuntimeEnvService.setDatabaseMode(id, 'custom');
+            // Mirror the per-Work override into the PostgreSQL DB plugin's
+            // work-scoped setting (source of truth). Best-effort as above.
+            await this.deployFacade
+                .setWorkDbOverride(id, dto.databaseUrl as string)
+                .catch(() => {});
         }
         this.activityLogService
             .log({

--- a/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
+++ b/apps/api/src/plugins-capabilities/deploy/deploy.service.ts
@@ -1262,10 +1262,33 @@ export class DeployService {
             await this.setSecret(ctx, 'COOKIE_SECURE', 'true');
 
             let databaseUrl = await this.workRuntimeEnvService.getDatabaseUrl(work.id);
-            // Shared "Ever Works DB": auto-provision a per-Work database on the
-            // first deploy when none is set and the Work isn't explicitly using
-            // a custom connection string. No-op when the feature isn't wired
-            // (isReady() false) or the Work already has a URL.
+            // PostgreSQL DB plugin is the source of truth for per-Work DB
+            // config: resolve from its settings (work-scoped override >
+            // user-scoped custom server > managed "Ever Works DB"). Wrapped so a
+            // missing/unloaded plugin (e.g. older image) falls through to the
+            // legacy mode-based path below rather than failing the deploy.
+            if (!databaseUrl && this.dbProvisionService) {
+                try {
+                    const pgSettings = await this.deployFacade.getOtherPluginSettings(
+                        'postgres-db',
+                        { userId: work.userId, workId: work.id },
+                    );
+                    databaseUrl = await this.dbProvisionService.resolveFromPluginSettings(
+                        work.id,
+                        pgSettings,
+                    );
+                } catch (pluginError) {
+                    this.logger.debug(
+                        `postgres-db plugin settings unavailable for work ${work.id}; using legacy DB resolution: ${
+                            pluginError instanceof Error ? pluginError.message : String(pluginError)
+                        }`,
+                    );
+                }
+            }
+            // Legacy fallback — shared "Ever Works DB": auto-provision a per-Work
+            // database on the first deploy when none is set and the Work isn't
+            // explicitly using a custom connection string. No-op when the feature
+            // isn't wired (isReady() false) or the Work already has a URL.
             if (!databaseUrl && this.dbProvisionService?.isReady()) {
                 const mode = await this.workRuntimeEnvService.getDatabaseMode(work.id);
                 if (mode !== 'custom') {

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -427,7 +427,24 @@ function StepBody({
                     onPlannedClick={(c) => flow.notePlannedClick('storage', c)}
                 />
             );
-        case 'db-choice':
+        case 'db-choice': {
+            // Driven by the PostgreSQL DB plugin: its settingsSchema renders the
+            // Ever Works DB / Custom selector + (for custom) the connection
+            // string, saved as the plugin's user-scoped settings — replacing the
+            // bespoke `db` bucket. Falls back to the choice cards until the
+            // plugin is loaded in the running API image (graceful, additive).
+            const dbPlugin = pluginsById['postgres-db'] ?? null;
+            if (dbPlugin) {
+                return (
+                    <ConfigStep
+                        title="Your DB Storage"
+                        description="Choose where your Works store data — the managed Ever Works DB (a database is provisioned per Work) or your own Postgres server."
+                        plugin={dbPlugin}
+                        connection={connections['postgres-db'] ?? null}
+                        isStatusLoading={isStatusLoading}
+                    />
+                );
+            }
             return (
                 <ChoiceStep
                     title="Your DB Storage"
@@ -439,6 +456,7 @@ function StepBody({
                     onPlannedClick={(c) => flow.notePlannedClick('db', c)}
                 />
             );
+        }
         case 'storage-config': {
             // Only `user-github` reaches here (others are auto-skipped).
             const plugin = pluginsById['github'] ?? null;

--- a/apps/web/src/lib/utils/plugin-category-icons.ts
+++ b/apps/web/src/lib/utils/plugin-category-icons.ts
@@ -45,6 +45,9 @@ export const CATEGORY_ICONS: Record<PluginCategory, LucideIcon> = {
     theme: Palette,
     // EW-637 — object storage backends (local-fs, S3, MinIO, GitHub blob)
     storage: HardDrive,
+    // PostgreSQL DB plugin — per-Work relational database backends
+    // (managed "Ever Works DB" or a custom Postgres server).
+    database: Database,
     // EW-650 / EW-663 — Notifications v2 surfaces
     'email-provider': Mail,
     'notification-channel': Bell,
@@ -87,6 +90,7 @@ export const CATEGORY_LABELS: Record<PluginCategory, string> = {
     utility: 'Utilities',
     theme: 'Themes',
     storage: 'Storage',
+    database: 'Databases',
     'email-provider': 'Email Providers',
     'notification-channel': 'Notification Channels',
     'vector-store': 'Vector Stores',
@@ -187,6 +191,7 @@ export const CATEGORY_DISPLAY_ORDER: readonly PluginCategory[] = [
     'deployment',
     'data-source',
     'storage',
+    'database',
     'vector-store',
     'dns',
     'email-provider',

--- a/packages/agent/src/ever-works-providers/__tests__/ever-works-db-provision.service.spec.ts
+++ b/packages/agent/src/ever-works-providers/__tests__/ever-works-db-provision.service.spec.ts
@@ -8,11 +8,16 @@ import type { WorkRuntimeEnvService } from '../../services/work-runtime-env.serv
  */
 describe('EverWorksDbProvisionService', () => {
     const ORIGINAL_ENV = { ...process.env };
-    let runtimeEnv: jest.Mocked<Pick<WorkRuntimeEnvService, 'getDatabaseUrl'>>;
+    let runtimeEnv: jest.Mocked<
+        Pick<WorkRuntimeEnvService, 'getDatabaseUrl' | 'setDatabaseUrlIfNull'>
+    >;
     let service: EverWorksDbProvisionService;
 
     beforeEach(() => {
-        runtimeEnv = { getDatabaseUrl: jest.fn() } as never;
+        runtimeEnv = {
+            getDatabaseUrl: jest.fn(),
+            setDatabaseUrlIfNull: jest.fn(),
+        } as never;
         service = new EverWorksDbProvisionService(runtimeEnv as unknown as WorkRuntimeEnvService);
     });
 
@@ -44,6 +49,40 @@ describe('EverWorksDbProvisionService', () => {
             const result = await service.testConnection('mysql://user:pw@host/db');
             expect(result.ok).toBe(false);
             expect(result.error).toMatch(/postgres/i);
+        });
+    });
+
+    describe('resolveFromPluginSettings', () => {
+        it('uses a work-scoped override connection string as-is (trimmed)', async () => {
+            runtimeEnv.setDatabaseUrlIfNull.mockResolvedValue('postgresql://o:p@h/db');
+            const url = await service.resolveFromPluginSettings('w1', {
+                overrideConnectionString: '  postgresql://o:p@h/db  ',
+            });
+            expect(runtimeEnv.setDatabaseUrlIfNull).toHaveBeenCalledWith(
+                'w1',
+                'postgresql://o:p@h/db',
+            );
+            expect(url).toBe('postgresql://o:p@h/db');
+        });
+
+        it('returns null for custom mode with a blank connection string', async () => {
+            await expect(
+                service.resolveFromPluginSettings('w1', {
+                    mode: 'custom',
+                    customConnectionString: '   ',
+                }),
+            ).resolves.toBeNull();
+            expect(runtimeEnv.setDatabaseUrlIfNull).not.toHaveBeenCalled();
+        });
+
+        it('falls back to the managed Ever Works DB by default (null when not wired)', async () => {
+            delete process.env.DB_EVER_WORKS_SHARED_ENABLED;
+            delete process.env.DB_EVER_WORKS_SHARED_ADMIN_URL;
+            delete process.env.DB_EVER_WORKS_SHARED_HOST;
+            await expect(service.resolveFromPluginSettings('w1', {})).resolves.toBeNull();
+            await expect(
+                service.resolveFromPluginSettings('w1', { mode: 'ever-works-db' }),
+            ).resolves.toBeNull();
         });
     });
 });

--- a/packages/agent/src/ever-works-providers/ever-works-db-provision.service.ts
+++ b/packages/agent/src/ever-works-providers/ever-works-db-provision.service.ts
@@ -86,6 +86,88 @@ export class EverWorksDbProvisionService {
     }
 
     /**
+     * Resolve the per-Work `DATABASE_URL` from the **PostgreSQL DB plugin's**
+     * resolved settings (the plugin is the source of truth — see
+     * `PostgresDbPlugin`). Precedence mirrors the plugin's scopes:
+     *  1. `overrideConnectionString` (work-scope) — a full per-Work URL; used
+     *     as-is (their server + their database for this one Work).
+     *  2. `mode: 'custom'` + `customConnectionString` (user-scope) — the user's
+     *     own server used for all their Works; a dedicated per-Work database
+     *     `ew_<hex>` is created on it when the role allows, else the connection
+     *     is used as-is.
+     *  3. `mode: 'ever-works-db'` (default) — the managed shared cluster; a
+     *     dedicated per-Work database is provisioned (`ensureDatabaseForWork`).
+     * Returns the composed URL (persisted for the Work when it wasn't set), or
+     * `null` when nothing is resolvable (custom mode with no string, or
+     * ever-works-db mode while the shared feature isn't wired).
+     */
+    async resolveFromPluginSettings(
+        workId: string,
+        settings: {
+            mode?: unknown;
+            customConnectionString?: unknown;
+            overrideConnectionString?: unknown;
+        },
+    ): Promise<string | null> {
+        const override = this.asTrimmed(settings.overrideConnectionString);
+        if (override) {
+            return this.workRuntimeEnvService.setDatabaseUrlIfNull(workId, override);
+        }
+        const mode = this.asTrimmed(settings.mode) || 'ever-works-db';
+        if (mode === 'custom') {
+            const server = this.asTrimmed(settings.customConnectionString);
+            if (!server) {
+                return null;
+            }
+            const url = await this.provisionOnServer(workId, server);
+            return this.workRuntimeEnvService.setDatabaseUrlIfNull(workId, url);
+        }
+        // Managed "Ever Works DB" (default) — no-op when the feature isn't wired.
+        return this.ensureDatabaseForWork(workId);
+    }
+
+    /**
+     * Create a dedicated per-Work database (`ew_<hex>`) on a **user-supplied**
+     * Postgres server and return a connection string pointing at it (same
+     * host/credentials, swapped database name). If the connecting role can't
+     * `CREATE DATABASE` (or the server is unreachable for DDL), falls back to
+     * returning the supplied connection string unchanged so the Work at least
+     * boots against the user's existing database. Never throws.
+     */
+    async provisionOnServer(workId: string, serverUrl: string): Promise<string> {
+        const hex = workId.replace(/-/g, '').toLowerCase();
+        const dbName = `${config.everWorks.sharedDb.getNamePrefix()}_${hex}`;
+        const client = new Client({
+            connectionString: serverUrl,
+            ssl: this.sslFor(serverUrl),
+            connectionTimeoutMillis: 10000,
+        });
+        try {
+            await client.connect();
+            const db = await client.query('SELECT 1 FROM pg_database WHERE datname = $1', [dbName]);
+            if (!db.rowCount) {
+                // CREATE DATABASE cannot run inside a transaction — the pg client
+                // autocommits each simple query, so this is fine.
+                await client.query(`CREATE DATABASE "${dbName}"`);
+            }
+            const url = this.swapDatabaseName(serverUrl, dbName);
+            this.logger.log(
+                `Provisioned per-Work database "${dbName}" on custom server for work ${workId}`,
+            );
+            return url;
+        } catch (err) {
+            this.logger.warn(
+                `Custom-server per-Work DB provision fell back to as-is for work ${workId}: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            return serverUrl;
+        } finally {
+            await client.end().catch(() => {});
+        }
+    }
+
+    /**
      * Validate a user-supplied custom Postgres connection string: attempt a
      * short-timeout connect + `SELECT 1`. Returns `{ ok }` or `{ ok:false,
      * error }` — never throws, so the caller can surface a friendly message.
@@ -172,5 +254,24 @@ export class EverWorksDbProvisionService {
     private randomPassword(): string {
         // 32 hex chars — safe to embed in SQL literals and connection strings.
         return randomBytes(16).toString('hex');
+    }
+
+    private asTrimmed(v: unknown): string {
+        return typeof v === 'string' ? v.trim() : '';
+    }
+
+    /**
+     * Replace the database (pathname) of a Postgres connection string, keeping
+     * host, credentials, and query params (sslmode, etc.). Returns the input
+     * unchanged if it can't be parsed.
+     */
+    private swapDatabaseName(connString: string, dbName: string): string {
+        try {
+            const u = new URL(connString);
+            u.pathname = `/${dbName}`;
+            return u.toString();
+        } catch {
+            return connString;
+        }
     }
 }

--- a/packages/agent/src/facades/deploy.facade.ts
+++ b/packages/agent/src/facades/deploy.facade.ts
@@ -28,10 +28,12 @@ const EVER_WORKS_DEPLOY_PROVIDER_ID = 'ever-works';
 // Security: allow-list of plugin IDs whose secret settings the deploy
 // orchestrator is permitted to read via `getOtherPluginSettings`. The k8s
 // deploy only needs the GitHub plugin's `readPackagesPat*` to mint a GHCR
-// imagePullSecret. Restricting this prevents the open-ended "fetch any
+// imagePullSecret, plus the `postgres-db` plugin's resolved DB connection
+// (mode / custom / per-Work override) to compose the deployed site's
+// `DATABASE_URL`. Restricting this prevents the open-ended "fetch any
 // plugin's secrets" method from being repurposed to exfiltrate unrelated
 // credentials (e.g. an AI provider's API key) for the request's user.
-const CROSS_PLUGIN_SETTINGS_ALLOWLIST: ReadonlySet<string> = new Set(['github']);
+const CROSS_PLUGIN_SETTINGS_ALLOWLIST: ReadonlySet<string> = new Set(['github', 'postgres-db']);
 
 function resolvePluginProviderId(providerId: string): string {
     return providerId === EVER_WORKS_DEPLOY_PROVIDER_ID
@@ -422,6 +424,29 @@ export class DeployFacadeService implements IDeployFacade {
             userId: options.userId,
             workId: options.workId,
             includeSecrets: true,
+        });
+    }
+
+    /**
+     * Persist the PostgreSQL DB plugin's per-Work override connection string
+     * (its work-scoped `overrideConnectionString`). The Deploy page is the only
+     * UI that edits a Work's database, so it writes here to keep the plugin the
+     * source of truth for the override. Pass an empty string to clear it (the
+     * Work then inherits the account-level Ever Works DB / custom setting).
+     * Confined to `postgres-db` via the same allow-list as
+     * `getOtherPluginSettings`.
+     */
+    async setWorkDbOverride(workId: string, connectionString: string): Promise<void> {
+        const pluginId = 'postgres-db';
+        if (!CROSS_PLUGIN_SETTINGS_ALLOWLIST.has(pluginId)) {
+            throw new DeployFacadeError(
+                `Cross-plugin settings write is not permitted for plugin '${pluginId}'`,
+                'setWorkDbOverride',
+                pluginId,
+            );
+        }
+        await this.settingsService.updateWorkSettings(pluginId, workId, {
+            overrideConnectionString: connectionString ?? '',
         });
     }
 

--- a/packages/plugin/src/contracts/capabilities/datastore.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/datastore.interface.ts
@@ -1,0 +1,41 @@
+import type { IPlugin } from '../plugin.interface.js';
+
+/**
+ * Pluggable relational-database backend for deployed Works (the "PostgreSQL DB"
+ * plugin). Distinct from `storage` (object storage / blobs).
+ *
+ * The plugin holds the **tenant-level connection choice** in its settings —
+ * either the managed **Ever Works DB** (a shared Postgres cluster the platform
+ * runs) or a **custom connection string** (the user's own server) — plus an
+ * optional **per-Work override** connection string. The per-Work database name
+ * is derived (`ew_<workId>`) so every Work shares the same server but gets its
+ * own database.
+ *
+ * Provisioning + URL composition are orchestrated **server-side** by the deploy
+ * pipeline, which reads this plugin's resolved settings and delegates the DDL
+ * to `EverWorksDbProvisionService` (it needs the shared-cluster admin
+ * connection + the `pg` client). The plugin itself only declares availability
+ * and validates a connection string, so it stays a thin, dependency-light
+ * config surface.
+ */
+export interface DatastoreConnectionTestResult {
+	readonly ok: boolean;
+	readonly error?: string;
+}
+
+export interface IDatastorePlugin extends IPlugin {
+	/**
+	 * True when the backend can actually be used — e.g. the Ever Works DB env is
+	 * wired (`DB_EVER_WORKS_SHARED_*`) for the managed mode, or a custom
+	 * connection string is configured. The onboarding card / Deploy selector use
+	 * this to decide whether to offer the option.
+	 */
+	isAvailable(): boolean | Promise<boolean>;
+
+	/**
+	 * Validate a user-supplied Postgres connection string (short-timeout connect
+	 * + `SELECT 1`). Never throws — returns `{ ok:false, error }` on failure so
+	 * the UI can surface a friendly message.
+	 */
+	testDatabaseConnection(connectionString: string): Promise<DatastoreConnectionTestResult>;
+}

--- a/packages/plugin/src/contracts/capabilities/index.ts
+++ b/packages/plugin/src/contracts/capabilities/index.ts
@@ -13,6 +13,7 @@ export * from './form-schema-provider.interface.js';
 export * from './prompt-provider.interface.js';
 export * from './device-auth-provider.interface.js';
 export * from './storage.interface.js';
+export * from './datastore.interface.js';
 export * from './skills-provider.interface.js';
 export * from './task-tracker.interface.js';
 // Notifications v2 (EW-650 + siblings) — email + chat channel contracts.

--- a/packages/plugin/src/contracts/plugin-manifest.types.ts
+++ b/packages/plugin/src/contracts/plugin-manifest.types.ts
@@ -18,6 +18,11 @@ export const PLUGIN_CATEGORIES = [
 	// EW-637 — pluggable object storage backends (local-fs, S3, MinIO, GitHub).
 	// See packages/plugin/src/contracts/capabilities/storage.interface.ts.
 	'storage',
+	// Pluggable relational database backend for deployed Works (the "PostgreSQL
+	// DB" plugin). Holds the tenant-level connection (Ever Works DB vs a custom
+	// server) and provisions/derives a per-Work database. Distinct from
+	// `storage` (object storage). See `capabilities/datastore.interface.ts`.
+	'database',
 	// Notifications v2 (EW-650 + EW-663) — email + chat-channel providers.
 	// See `capabilities/email-provider.interface.ts` and
 	// `capabilities/notification-channel.interface.ts`.

--- a/packages/plugins/postgres-db/package.json
+++ b/packages/plugins/postgres-db/package.json
@@ -1,0 +1,103 @@
+{
+	"name": "@ever-works/postgres-db-plugin",
+	"version": "1.0.0",
+	"description": "PostgreSQL database backend for Ever Works — gives deployed Works a database (the managed Ever Works DB or a custom server), one database per Work.",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"dependencies": {
+		"pg": "^8.16.3"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"@types/pg": "^8.15.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "postgres-db",
+			"name": "PostgreSQL DB",
+			"version": "1.0.0",
+			"category": "database",
+			"capabilities": [
+				"database",
+				"datastore"
+			],
+			"description": "Gives your deployed Works a PostgreSQL database — the managed Ever Works DB or your own server. One database is provisioned per Work on the same server.",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"systemPlugin": true,
+			"builtIn": true,
+			"autoEnable": true,
+			"distribution": "core",
+			"envVars": [
+				{
+					"name": "DB_EVER_WORKS_SHARED_ENABLED",
+					"required": false,
+					"secret": false,
+					"description": "Enable the managed 'Ever Works DB' option (a shared Postgres cluster the platform runs)."
+				},
+				{
+					"name": "DB_EVER_WORKS_SHARED_ADMIN_URL",
+					"required": false,
+					"secret": true,
+					"description": "Least-privilege provisioner connection (CREATEDB+CREATEROLE) on the Ever Works DB cluster. DDL only; direct/session endpoint."
+				},
+				{
+					"name": "DB_EVER_WORKS_SHARED_HOST",
+					"required": false,
+					"secret": false,
+					"description": "Host used to compose the per-Work DATABASE_URL injected into the deployed site."
+				},
+				{
+					"name": "DB_EVER_WORKS_SHARED_PORT",
+					"required": false,
+					"secret": false,
+					"description": "Port for the composed per-Work DATABASE_URL (default 5432)."
+				},
+				{
+					"name": "DB_EVER_WORKS_SHARED_SSLMODE",
+					"required": false,
+					"secret": false,
+					"description": "sslmode for the composed per-Work DATABASE_URL (default require)."
+				}
+			]
+		}
+	},
+	"private": false,
+	"publishConfig": {
+		"access": "restricted",
+		"registry": "https://registry.npmjs.org"
+	}
+}

--- a/packages/plugins/postgres-db/src/index.ts
+++ b/packages/plugins/postgres-db/src/index.ts
@@ -1,0 +1,2 @@
+export { PostgresDbPlugin } from './postgres-db.plugin.js';
+export { PostgresDbPlugin as default } from './postgres-db.plugin.js';

--- a/packages/plugins/postgres-db/src/postgres-db.plugin.test.ts
+++ b/packages/plugins/postgres-db/src/postgres-db.plugin.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { PostgresDbPlugin } from './postgres-db.plugin';
+
+/**
+ * Deterministic unit coverage that does NOT require a live Postgres: identity,
+ * the connection-string format guard (returns before any `pg` client is built),
+ * the managed "Ever Works DB" env gate, and the manifest.
+ */
+describe('PostgresDbPlugin', () => {
+	const ORIGINAL_ENV = { ...process.env };
+
+	afterEach(() => {
+		process.env = { ...ORIGINAL_ENV };
+	});
+
+	it('exposes the expected identity + capabilities', () => {
+		const p = new PostgresDbPlugin();
+		expect(p.id).toBe('postgres-db');
+		expect(p.category).toBe('database');
+		expect(p.capabilities).toEqual(['database', 'datastore']);
+		expect(p.isAvailable()).toBe(true);
+	});
+
+	it('rejects a non-postgres connection string without connecting', async () => {
+		const p = new PostgresDbPlugin();
+		const r = await p.testDatabaseConnection('mysql://u:pw@h/db');
+		expect(r.ok).toBe(false);
+		expect(r.error).toMatch(/postgres/i);
+	});
+
+	it('validateConnection requires a connection string in custom mode', async () => {
+		const p = new PostgresDbPlugin();
+		const r = await p.validateConnection({ mode: 'custom', customConnectionString: '   ' });
+		expect(r.success).toBe(false);
+	});
+
+	it('offers the managed Ever Works DB only when its env is wired', () => {
+		const p = new PostgresDbPlugin();
+		delete process.env.DB_EVER_WORKS_SHARED_ENABLED;
+		delete process.env.DB_EVER_WORKS_SHARED_ADMIN_URL;
+		delete process.env.DB_EVER_WORKS_SHARED_HOST;
+		expect(p.isEverWorksDbAvailable()).toBe(false);
+
+		process.env.DB_EVER_WORKS_SHARED_ENABLED = 'true';
+		process.env.DB_EVER_WORKS_SHARED_ADMIN_URL = 'postgresql://admin@h/postgres';
+		process.env.DB_EVER_WORKS_SHARED_HOST = 'h';
+		expect(p.isEverWorksDbAvailable()).toBe(true);
+	});
+
+	it('validateConnection succeeds in default mode when Ever Works DB is wired', async () => {
+		const p = new PostgresDbPlugin();
+		process.env.DB_EVER_WORKS_SHARED_ENABLED = 'true';
+		process.env.DB_EVER_WORKS_SHARED_ADMIN_URL = 'postgresql://admin@h/postgres';
+		process.env.DB_EVER_WORKS_SHARED_HOST = 'h';
+		const r = await p.validateConnection({ mode: 'ever-works-db' });
+		expect(r.success).toBe(true);
+	});
+
+	it('getManifest advertises the database category + onboarding hints', () => {
+		const p = new PostgresDbPlugin();
+		const m = p.getManifest();
+		expect(m.id).toBe('postgres-db');
+		expect(m.category).toBe('database');
+		expect(m.uiHints?.includeInOnboarding).toBe(true);
+		expect(m.defaultForCapabilities).toContain('datastore');
+	});
+});

--- a/packages/plugins/postgres-db/src/postgres-db.plugin.ts
+++ b/packages/plugins/postgres-db/src/postgres-db.plugin.ts
@@ -1,0 +1,215 @@
+import { Client } from 'pg';
+import type {
+	IPlugin,
+	IDatastorePlugin,
+	DatastoreConnectionTestResult,
+	PluginContext,
+	PluginManifest,
+	PluginCategory,
+	JsonSchema,
+	ConnectionValidationResult
+} from '@ever-works/plugin';
+
+/** Snapshot of the managed "Ever Works DB" wiring from env. */
+function sharedDbEnv() {
+	return {
+		enabled: process.env.DB_EVER_WORKS_SHARED_ENABLED === 'true',
+		adminUrl: process.env.DB_EVER_WORKS_SHARED_ADMIN_URL || '',
+		host: process.env.DB_EVER_WORKS_SHARED_HOST || ''
+	};
+}
+
+/** Managed Ever Works DB is usable when the feature flag + provisioner + host are set. */
+function isSharedReady(): boolean {
+	const s = sharedDbEnv();
+	return s.enabled && Boolean(s.adminUrl) && Boolean(s.host);
+}
+
+/** Self-signed managed cluster → encrypt without CA verification (libpq `require`). */
+function sslFor(url: string): { rejectUnauthorized: boolean } | undefined {
+	return /sslmode=(require|prefer|verify)/i.test(url) ? { rejectUnauthorized: false } : undefined;
+}
+
+/**
+ * "PostgreSQL DB" — gives deployed Works a Postgres database.
+ *
+ * The user picks a backend ONCE at the account level (onboarding): the managed
+ * **Ever Works DB** (a shared Postgres cluster the platform runs) or a **custom
+ * connection string** (their own server). By default every Work uses that same
+ * server but gets its own database (`ew_<workId>`); a Work can override with a
+ * full connection string on its Deploy page.
+ *
+ * This plugin is the CONFIG + VALIDATION surface (settings schema + connection
+ * test). The actual per-Work database provisioning + `DATABASE_URL` composition
+ * is done server-side by the deploy pipeline (it needs the shared-cluster admin
+ * connection), which reads this plugin's resolved settings — see
+ * `DeployService.ensureRuntimeEnv` + `EverWorksDbProvisionService`.
+ */
+export class PostgresDbPlugin implements IPlugin, IDatastorePlugin {
+	readonly id = 'postgres-db';
+	readonly name = 'PostgreSQL DB';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'database';
+	readonly capabilities: readonly string[] = ['database', 'datastore'];
+	readonly configurationMode: 'admin-only' | 'user-required' | 'hybrid' = 'hybrid';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			// Account-level (user-scope) backend choice — cascades to every Work
+			// via `autoEnableForWorks`.
+			mode: {
+				type: 'string',
+				enum: ['ever-works-db', 'custom'],
+				default: 'ever-works-db',
+				title: 'Database',
+				description:
+					"'Ever Works DB' — a managed database provisioned for you (one per Work), no setup needed. 'Custom' — connect your own Postgres server.",
+				'x-scope': 'user'
+			},
+			customConnectionString: {
+				type: 'string',
+				title: 'Connection string',
+				description:
+					'postgresql://user:password@host:5432/db — used as the server for all your Works. A database is created per Work on it when the role allows (CREATE DATABASE); otherwise the connection is used as-is. Stored encrypted; shown masked.',
+				'x-secret': true,
+				'x-scope': 'user',
+				'x-widget': 'password',
+				'x-showIf': { field: 'mode', value: 'custom' }
+			},
+			// Per-Work override (work-scope) — only writable/visible on the Deploy
+			// page (the scope guards enforce this).
+			overrideConnectionString: {
+				type: 'string',
+				title: 'Per-Work override (optional)',
+				description:
+					'Override the database for THIS Work only with a full connection string. Leave blank to use the account-level setting.',
+				'x-secret': true,
+				'x-scope': 'work',
+				'x-widget': 'password'
+			}
+		}
+	};
+
+	async onLoad(_context: PluginContext): Promise<void> {
+		// Stateless — config is resolved per request from settings + env.
+	}
+
+	async onUnload(): Promise<void> {
+		// no-op
+	}
+
+	/**
+	 * The plugin is always usable: 'custom' is always an option, and the managed
+	 * 'Ever Works DB' option additionally requires its env to be wired
+	 * (surfaced separately via the onboarding card's `available` flag).
+	 */
+	isAvailable(): boolean {
+		return true;
+	}
+
+	/** Whether the managed Ever Works DB option can actually be offered. */
+	isEverWorksDbAvailable(): boolean {
+		return isSharedReady();
+	}
+
+	async testDatabaseConnection(connectionString: string): Promise<DatastoreConnectionTestResult> {
+		if (!/^postgres(ql)?:\/\//i.test(connectionString)) {
+			return {
+				ok: false,
+				error: 'Connection string must start with postgres:// or postgresql://'
+			};
+		}
+		const client = new Client({
+			connectionString,
+			ssl: sslFor(connectionString),
+			connectionTimeoutMillis: 8000,
+			statement_timeout: 8000
+		});
+		try {
+			await client.connect();
+			await client.query('SELECT 1');
+			return { ok: true };
+		} catch (err) {
+			return { ok: false, error: err instanceof Error ? err.message : String(err) };
+		} finally {
+			await client.end().catch(() => {});
+		}
+	}
+
+	/** Save & verify (verifiesOnSave): validate the chosen backend. */
+	async validateConnection(settings: Record<string, unknown>): Promise<ConnectionValidationResult> {
+		const mode = (settings.mode as string) ?? 'ever-works-db';
+		if (mode === 'custom') {
+			const conn = ((settings.customConnectionString as string) ?? '').trim();
+			if (!conn) {
+				return { success: false, message: 'Enter a custom Postgres connection string.' };
+			}
+			const r = await this.testDatabaseConnection(conn);
+			return r.ok
+				? { success: true, message: 'Connected to your database successfully.' }
+				: { success: false, message: r.error ?? 'Connection failed.' };
+		}
+		return isSharedReady()
+			? {
+					success: true,
+					message: 'Ever Works DB is available — a database is provisioned per Work.'
+				}
+			: {
+					success: false,
+					message:
+						'Ever Works DB is not configured on this instance. Ask an operator to enable it, or use a custom database.'
+				};
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description:
+				'Gives your deployed Works a PostgreSQL database — the managed Ever Works DB or your own server. One database is provisioned per Work.',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			author: { name: 'Ever Works Team' },
+			license: 'AGPL-3.0',
+			builtIn: true,
+			systemPlugin: true,
+			autoEnable: true,
+			visibility: 'user-only',
+			defaultForCapabilities: ['datastore'],
+			readme: [
+				'## What does the PostgreSQL DB plugin do?',
+				'',
+				'It gives every deployed Work a PostgreSQL database. Configure it once for',
+				'your account; each Work then gets its own database on the same server.',
+				'',
+				'## Two backends',
+				'',
+				'- **Ever Works DB** — a managed Postgres cluster the platform runs. A',
+				'  dedicated database is provisioned per Work automatically. No setup.',
+				'- **Custom** — connect your own Postgres server with a connection string.',
+				'  A database is created per Work on it when your role allows; otherwise',
+				'  the connection is used as-is.',
+				'',
+				'## Per-Work override',
+				'',
+				'Any Work can override the account default on its **Deploy** page with a',
+				'full connection string (its own server + database).'
+			].join('\n'),
+			uiHints: {
+				includeInOnboarding: true,
+				onboardingPriority: 3,
+				onboardingDescription:
+					'Choose where your Works store data — the managed Ever Works DB or your own Postgres.',
+				completionFields: ['mode'],
+				verifiesOnSave: true
+			},
+			icon: {
+				type: 'lucide',
+				value: 'Database',
+				backgroundColor: '#336791'
+			}
+		};
+	}
+}

--- a/packages/plugins/postgres-db/tsconfig.json
+++ b/packages/plugins/postgres-db/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/postgres-db/tsup.config.ts
+++ b/packages/plugins/postgres-db/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2540,6 +2540,31 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
+  packages/plugins/postgres-db:
+    dependencies:
+      pg:
+        specifier: ^8.16.3
+        version: 8.18.0
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      '@types/pg':
+        specifier: ^8.15.0
+        version: 8.15.6
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
   packages/plugins/posthog-metrics:
     devDependencies:
       '@ever-works/plugin':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -278,6 +278,9 @@ importers:
       '@ever-works/minio-plugin':
         specifier: workspace:*
         version: link:../../packages/plugins/minio
+      '@ever-works/postgres-db-plugin':
+        specifier: workspace:*
+        version: link:../../packages/plugins/postgres-db
       '@nestjs/cli':
         specifier: ^11.0.18
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)


### PR DESCRIPTION
Makes **DB configuration a plugin** ("PostgreSQL DB", enabled by default) that stores the connection at the account (tenant/user) level and drives per-Work database provisioning — replacing the bespoke onboarding `db` bucket / runtime-env as the source of truth.

## What it does
- **Onboarding** — the "Your DB Storage" step renders the plugin's own config form: pick **Ever Works DB** (managed; a database is provisioned per Work) or **Custom** (your own Postgres server, used for all your Works; a DB is created per Work when the role allows). Saved as the plugin's user-scoped settings.
- **By default every Work** uses the same server, different database (`ew_<workId>`).
- **Per-Work override** — the Deploy page's custom connection string is mirrored into the plugin's work-scoped `overrideConnectionString`.
- **Backend** — `DeployService.ensureRuntimeEnv` resolves the per-Work `DATABASE_URL` from the plugin (work override → user custom server → managed Ever Works DB), with custom-server provisioning; wrapped so an older image without the plugin falls back to the legacy path.

## Safety
- Fully additive: the legacy mode-based path + choice cards remain as graceful fallbacks; the 7 live Works keep their existing URLs (idempotent).
- `postgres-db` added to the deploy cross-plugin settings allow-list (github-only before).

## Validation
- agent + api + web type-check clean; plugin builds.
- Unit tests: `resolveFromPluginSettings` + plugin identity/validation/manifest/env-gate; deploy controller/service/facade + onboarding-catalog specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL database integration for managed and custom database connections.
  * Onboarding now supports configuring database connections directly through the database plugin.
  * Added connection validation with clearer success and error feedback.
  * Custom database servers can provision dedicated databases per Work when supported.
  * Added a Databases category and icon for plugin discovery.

* **Bug Fixes**
  * Kept deployment database settings synchronized across runtime configuration and database plugin settings.
  * Added fallback behavior for older or unavailable database configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->