### PR TITLE
fix(activity-feed): stop showing an up site as 'unreachable' when platform sync isn't wired

### DIFF
--- a/apps/api/src/works/activity-feed/__tests__/directory-website-client.service.spec.ts
+++ b/apps/api/src/works/activity-feed/__tests__/directory-website-client.service.spec.ts
@@ -246,6 +246,39 @@ describe('DirectoryWebsiteClient', () => {
             expect(httpService.get).toHaveBeenCalledTimes(2);
         });
 
+        // A live site that just isn't wired for platform sync (revived / hand-
+        // deployed outside the deploy flow) returns 503 with this specific body.
+        // It must be the benign `not_provisioned` (permanent → no retry), NOT the
+        // alarming `upstream_5xx` that falsely reads as "site unreachable".
+        it('classifies the "platform sync not configured" 503 as not_provisioned (no retry)', async () => {
+            httpService.get.mockReturnValue(
+                throwError(() =>
+                    makeAxiosError({
+                        response: {
+                            status: 503,
+                            data: { error: 'platform sync not configured on this directory' },
+                        } as never,
+                        message: 'unavailable',
+                    }),
+                ),
+            );
+            const result = await client.fetchActivityFeed(makeWork() as never, {
+                limit: 50,
+                types: ['all'],
+            });
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                const { degraded } = result as {
+                    ok: false;
+                    degraded: { reason: string; detail?: string };
+                };
+                expect(degraded.reason).toBe('not_provisioned');
+                expect(degraded.detail).toMatch(/activity sync is not configured/i);
+            }
+            // Permanent reason → the retry loop must not fire a second request.
+            expect(httpService.get).toHaveBeenCalledTimes(1);
+        });
+
         // Security (info leak): raw Axios network errors embed internal IPs /
         // hostnames (e.g. `connect ECONNREFUSED 10.96.0.1:443`) and
         // `degraded.detail` is serialised to the browser via FeedResponse, so

--- a/apps/api/src/works/activity-feed/directory-website-client.service.ts
+++ b/apps/api/src/works/activity-feed/directory-website-client.service.ts
@@ -203,6 +203,26 @@ export class DirectoryWebsiteClient {
             return degraded('unauthorized');
         }
         if (status && status >= 500) {
+            // A directory site that is UP but whose platform-sync env
+            // (PLATFORM_SYNC_SECRET) was never injected — e.g. a Work revived /
+            // hand-deployed outside the platform deploy flow — answers this
+            // endpoint with 503 {"error":"platform sync not configured on this
+            // directory"}. That is NOT an outage: the site serves normally, only
+            // the activity-feed integration isn't wired yet. Classify it as the
+            // benign, already-translated `not_provisioned` state (UI: "events not
+            // yet available" + "redeploy the directory site") instead of falsely
+            // reporting the live site as unreachable ("Upstream 5xx"). Any other
+            // 5xx (a genuinely failing/overloaded site) stays `upstream_5xx`.
+            const bodyText =
+                typeof err.response?.data === 'string'
+                    ? err.response.data
+                    : JSON.stringify(err.response?.data ?? '');
+            if (status === 503 && /platform sync not configured/i.test(bodyText)) {
+                return degraded(
+                    'not_provisioned',
+                    'Deployed site is up; activity sync is not configured on it yet',
+                );
+            }
             return degraded('upstream_5xx', `Upstream ${status}`);
         }
         if (status && status >= 400) {


### PR DESCRIPTION
## Symptom
On a Work's **Activity** tab, a red banner reads **"Deployed-site is currently unreachable / Upstream 503 / Never synced"** — but the site is actually **up** (e.g. chairs.ever.works → HTTP 200).

## Root cause
This is the **activity-feed pull-sync** banner (not the deploy-tab verifier). Loading the tab pulls `${work.website}/api/platform/activity-feed` (HMAC-signed). Works revived / hand-deployed **outside** the platform deploy flow serve normally but never had `PLATFORM_SYNC_SECRET` injected, so that endpoint returns `503 {"error":"platform sync not configured on this directory"}`. `translateError()` mapped any `status >= 500` → `upstream_5xx` → the "unreachable" banner; "Never synced" because a pull never succeeded. The homepage being 200 is irrelevant — a different path is probed.

## Fix
Reclassify *specifically* that 503 body as the benign, **already-translated** `not_provisioned` reason (UI: "events not yet available" + "redeploy the directory site") — a permanent reason, so no wasted retry. **Any other 5xx** (a genuinely failing site) still maps to `upstream_5xx`. Body-shape defensive (string or parsed JSON). Additive + reversible; normally-deployed Works (200) never enter this path.

## Validation
- api type-check clean; prettier clean.
- New unit test: "not configured" 503 → `not_provisioned` (single request, no retry); the existing plain-503 → `upstream_5xx` test still passes (not over-broadened). Full spec: 13/13.

## Follow-up (owner-gated, separate)
To *fully* clear the banner (i.e. actually enable activity sync for the 7 revived Works), inject the matching `PLATFORM_SYNC_SECRET` into each site's k8s `${slug}-runtime-env` Secret + confirm the deployed template serves `/api/platform/activity-feed`, then reload the tab. That touches prod secrets, so it's tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)