### PR TITLE
fix(ci): de-flake KbCitationHover Escape test (listener-registration race)

### DIFF
--- a/apps/web/src/components/works/detail/kb/KbCitationHover.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/kb/KbCitationHover.unit.spec.tsx
@@ -218,6 +218,15 @@ describe('KbCitationHover', () => {
         });
         fireEvent.keyDown(document, { key: 'Escape' });
         await waitFor(() => {
+            // Re-dispatch on every retry: the component attaches its
+            // document keydown listener in an [open]-gated passive effect,
+            // so under a starved CI runner the first Escape can land in the
+            // window between the popover's DOM commit and that effect's
+            // flush — a keypress into a document with no listener, and the
+            // popover then stays open forever (observed as a rare
+            // load-flake on this exact assertion). Extra presses are
+            // idempotent once the listener exists.
+            fireEvent.keyDown(document, { key: 'Escape' });
             expect(screen.queryByTestId('kb-citation-popover')).toBeNull();
         });
     });


### PR DESCRIPTION
Test-only, one assertion block. The `Escape closes the popover` test dispatches a single keydown, but the component attaches its document listener in an `[open]`-gated passive effect — under a starved CI runner the keypress can land in the window between the popover's DOM commit and the effect flush, after which the popover never closes and the `waitFor` burns its full budget (observed on #1777's run: 968/969 green, this one red with the popover still `data-open="true"`). Fix: re-dispatch Escape inside the `waitFor` retry loop — extra presses are idempotent once the listener exists. This is the last member of the known ~1-UI-test/run load-flake tail that has been intermittently reddening runs this week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)