### PR TITLE
fix(ci): inngest dev needs 'inngest' binary prefix (real-infra exit 127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
       - name: Start Inngest dev server
         run: |
           docker run -d --name inngest -p 8288:8288 \
-            inngest/inngest:v1.38.1 dev --no-discovery --host 0.0.0.0
+            inngest/inngest:v1.38.1 inngest dev --no-discovery --host 0.0.0.0
           echo "Waiting for Inngest on http://localhost:8288 ..."
           for i in $(seq 1 45); do
             if curl -sf -o /dev/null http://localhost:8288/; then


### PR DESCRIPTION
job-runtime-real-infra's 'Start Inngest dev server' fails exit 127: exec 'dev' not found. The inngest/inngest:v1.38.1 image has Entrypoint=null, Cmd=[inngest], so 'docker run … dev …' execs 'dev' directly. Prepend the binary: 'inngest dev …'. Verified flags (--host/--no-discovery/--port) against the image. CI-infra-only, main-only step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development server startup command in continuous integration to use the pinned Inngest image’s explicit development command.
  * Preserved existing network settings and server options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->