### PR TITLE
fix(ci): concurrencyKey temporal search-attr needs its own create command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,9 @@ jobs:
           registered=0
           for attempt in $(seq 1 40); do
             docker exec "$cid" temporal operator search-attribute create \
-              --namespace default --name tenantId --name concurrencyKey --type Keyword >/dev/null 2>&1 || true
+              --namespace default --name tenantId --type Keyword >/dev/null 2>&1 || true
+            docker exec "$cid" temporal operator search-attribute create \
+              --namespace default --name concurrencyKey --type Keyword >/dev/null 2>&1 || true
             docker exec "$cid" temporal operator search-attribute create \
               --namespace default --name tags --type KeywordList >/dev/null 2>&1 || true
             listing="$(docker exec "$cid" temporal operator search-attribute list --namespace default 2>/dev/null || true)"


### PR DESCRIPTION
The verify-retry loop caught it: concurrencyKey never registered. temporal CLI treats --name/--type as PARALLEL arrays, so 'create --name tenantId --name concurrencyKey --type Keyword' only pairs tenantId->Keyword and drops concurrencyKey. Split into 3 single-name creates (tenantId/concurrencyKey Keyword, tags KeywordList). CI-infra-only, main-only step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when registering Temporal search attributes during environment setup.
  * Ensured `tenantId` and `concurrencyKey` are created correctly as keyword attributes in the default namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->