### PR TITLE
fix(test): inngest idempotencyKey dedup-carrier assertion uses REST, not response-id equality

### DIFF
--- a/packages/plugins/job-runtime-inngest/src/__tests__/inngest-real-infra.spec.ts
+++ b/packages/plugins/job-runtime-inngest/src/__tests__/inngest-real-infra.spec.ts
@@ -164,11 +164,16 @@ realInfra('Inngest real-infra (EW-742 P6 T32/T37)', () => {
 		expect(first).toBeTruthy();
 		expect(second).toBeTruthy();
 
-		// Dev server normalises `event.id` → `<seed>-<hash>` server-side,
-		// so two sends with the same client-supplied `id` return the
-		// SAME canonical server id (dedup invariant). The exact suffix is
-		// dev-server internal — assert equality between the two responses.
-		expect(second).toBe(first);
+		// The plugin maps `idempotencyKey` -> the outbound event's `id`
+		// (Inngest's native dedup carrier). The dev server mints its own
+		// ULID receipt per send, so the two receipt ids differ and are NOT
+		// collapsed -- but it preserves the client-supplied `id` as the
+		// stored event's `id`. Verify the carrier survives the wire: fetch
+		// each event by its receipt id and assert the stored `id` is our key.
+		const firstEvent = await waitForEvent(baseUrl, first!);
+		const secondEvent = await waitForEvent(baseUrl, second!);
+		expect(firstEvent?.id).toBe(idemKey);
+		expect(secondEvent?.id).toBe(idemKey);
 	}, 30_000);
 
 	it('T31 carrier: enqueue stamps _ew.tenantId / _ew.tags into event.data', async () => {


### PR DESCRIPTION
job-runtime-real-infra's last red: inngest-real-infra.spec.ts asserted two send() response ids are equal for the same idempotencyKey (dedup invariant). Empirically probed inngest v1.38.1 dev server: send() mints a fresh ULID receipt per call (ids differ, no collapse) and does NOT dedup the event log, but preserves the client id as the stored event's .id. So the correct check (matching the sibling 'event-by-id retrievable' test) is: fetch each event by its receipt id via waitForEvent and assert event.id === idemKey. Plugin was always correct (inngest-enqueue-options.ts:53 maps idempotencyKey->event.id); only the assertion was over-specified. Verified against a live dev server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration coverage for event idempotency.
  * Tests now verify that idempotency identifiers are preserved through delivery and correctly recorded by the development server.
  * Updated validation reflects the expected relationship between client-provided identifiers and stored event records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->