### PR TITLE
feat(health): loud degradation when no background job runtime is configured

### DIFF
--- a/apps/api/src/health/health.controller.spec.ts
+++ b/apps/api/src/health/health.controller.spec.ts
@@ -114,8 +114,8 @@ describe('HealthController', () => {
 
             expect(health.check).toHaveBeenCalledTimes(1);
             const checks = health.check.mock.calls[0][0] as Array<() => unknown>;
-            // 1 DB ping + 7 informational services (no redis when unconfigured).
-            expect(checks).toHaveLength(8);
+            // 1 DB ping + 8 informational services (no redis when unconfigured).
+            expect(checks).toHaveLength(9);
             // The DB ping is the first registered check.
             checks[0]();
             expect(db.pingCheck).toHaveBeenCalledWith('database', { timeout: 3000 });
@@ -130,8 +130,8 @@ describe('HealthController', () => {
             await controller.ready();
 
             const checks = health.check.mock.calls[0][0] as Array<() => unknown>;
-            // DB + Redis + 7 informational.
-            expect(checks).toHaveLength(9);
+            // DB + Redis + 8 informational.
+            expect(checks).toHaveLength(10);
             // Redis is the second check, right after the DB ping.
             checks[1]();
             expect(redis.isHealthy).toHaveBeenCalledWith('redis');

--- a/apps/api/src/health/service-detection.ts
+++ b/apps/api/src/health/service-detection.ts
@@ -74,6 +74,19 @@ export function detectInformationalServices(): ServiceStatus[] {
             mode: triggerConfigured ? 'enabled' : 'disabled',
         },
         {
+            // Vendor-neutral view of "can background agent runs execute at
+            // all?" — the signal the dashboard's degradation banner keys on.
+            // Today the dispatch path executes exclusively on the trigger
+            // runtime, so this mirrors trigger_dev; when the job-runtime
+            // provider registry is wired end-to-end (EW-686), this entry
+            // reflects WHICHEVER runtime `EVER_WORKS_JOB_RUNTIME` selects,
+            // while trigger_dev stays vendor-specific. Kept as a separate
+            // key so clients written against `job_runtime` never re-key.
+            key: 'job_runtime',
+            configured: triggerConfigured,
+            mode: triggerConfigured ? 'enabled' : 'disabled',
+        },
+        {
             key: 'stripe',
             configured: stripeConfigured,
             mode: stripeConfigured ? 'enabled' : 'disabled',

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -5713,6 +5713,12 @@
             "awesome-repo": "Awesome Repo",
             "company": "Company",
             "default": "Work"
+        },
+        "jobRuntimeBanner": {
+            "title": "Background job runtime is not configured.",
+            "message": "Agent runs cannot execute on this install until a job runtime (e.g. Trigger.dev credentials) is set up.",
+            "docsLink": "Setup guide",
+            "dismiss": "Dismiss"
         }
     },
     "layout": {

--- a/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout-client.tsx
@@ -27,6 +27,7 @@ import type { OAuthConnectionInfo } from '@/lib/api/plugins-capabilities/oauth';
 import type { GitProviderConnectionInfo } from '@/lib/api/plugins-capabilities/git-providers';
 import type { PluginDeviceAuthStatus } from '@/lib/api/plugins-capabilities/device-auth';
 import type { ApiVersion } from '@/lib/api/version';
+import { JobRuntimeDegradedBanner } from '@/components/dashboard/JobRuntimeDegradedBanner';
 
 interface DashboardLayoutClientProps {
     user: AuthUser;
@@ -45,6 +46,9 @@ interface DashboardLayoutClientProps {
     initialOnboardingCatalog: OnboardingCatalogResponse;
     /** Build/release identity of the API, fetched once in the server layout. */
     apiVersion?: ApiVersion | null;
+    /** health `job_runtime.configured` — false = agent runs cannot execute
+     *  on this install (loud-degradation banner); null = unknown. */
+    jobRuntimeConfigured?: boolean | null;
 }
 
 // Security: include the Secure flag when the page is served over HTTPS so these
@@ -69,6 +73,7 @@ export function DashboardLayoutClient({
     initialOnboardingState,
     initialOnboardingCatalog,
     apiVersion,
+    jobRuntimeConfigured = null,
 }: DashboardLayoutClientProps) {
     const tChat = useTranslations('dashboard.aiChat');
     const DEFAULT_CHAT_WIDTH = 380;
@@ -502,6 +507,7 @@ export function DashboardLayoutClient({
                             className="flex-1 flex flex-col overflow-y-auto bg-white dark:bg-surface-dark min-h-0"
                             id="main-content"
                         >
+                            <JobRuntimeDegradedBanner configured={jobRuntimeConfigured} />
                             <div className="flex-1 mx-auto w-full px-4 @sm/main:px-6 @3xl/main:px-8 py-6 @3xl/main:py-8 max-w-full @5xl/main:max-w-7xl">
                                 <ChatPanelProvider open={chatOpen} setOpen={setChatOpen}>
                                     {children}

--- a/apps/web/src/app/[locale]/(dashboard)/layout.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import { cookies } from 'next/headers';
 import { getAuthFromCookie } from '@/lib/auth';
 import { DashboardLayoutClient } from './layout-client';
 import { authAPI, versionAPI } from '@/lib/api';
+import { healthAPI } from '@/lib/api/health';
 import { getWorkStats } from '@/app/actions/dashboard/works';
 import { pluginsAPI } from '@/lib/api/plugins';
 import { onboardingAPI } from '@/lib/api/onboarding';
@@ -50,6 +51,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
         onboardingState,
         onboardingCatalog,
         apiVersion,
+        jobRuntimeConfigured,
     ] = await Promise.all([
         authAPI.getFreshProfile().catch(() => null),
         getWorkStats().catch(() => ({
@@ -63,6 +65,10 @@ export default async function DashboardLayout({ children }: { children: React.Re
         // 5 min) and surfaced in the footer. Returns null on failure;
         // the footer just hides the API chip.
         versionAPI.get(),
+        // Loud degradation: whether a background job runtime is
+        // configured (agent runs can execute). null on failure — the
+        // banner only renders on a KNOWN misconfiguration.
+        healthAPI.getJobRuntimeConfigured(),
     ]);
 
     const hasGithubConnected =
@@ -107,6 +113,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
             initialOnboardingState={onboardingState}
             initialOnboardingCatalog={onboardingCatalog}
             apiVersion={apiVersion}
+            jobRuntimeConfigured={jobRuntimeConfigured}
         >
             {children}
         </DashboardLayoutClient>

--- a/apps/web/src/components/dashboard/JobRuntimeDegradedBanner.tsx
+++ b/apps/web/src/components/dashboard/JobRuntimeDegradedBanner.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { AlertTriangle, X } from 'lucide-react';
+
+const DISMISS_KEY = 'ew-job-runtime-banner-dismissed';
+
+/**
+ * Loud-degradation banner: shown when the API's health reports that NO
+ * background job runtime is configured (`job_runtime.configured=false`),
+ * which means Agent runs silently cannot execute — the worst failure
+ * mode of a local install. Dismissible per browser via localStorage;
+ * `configured === null` (health unreachable/unparseable) renders
+ * nothing — this banner reports a KNOWN misconfiguration, it does not
+ * speculate.
+ *
+ * Same hydration-gating pattern as the header onboarding badge: render
+ * nothing until localStorage has been consulted so previously-dismissed
+ * users never see a one-frame flash.
+ */
+export function JobRuntimeDegradedBanner({ configured }: { configured: boolean | null }) {
+    const t = useTranslations('dashboard.jobRuntimeBanner');
+    const [dismissed, setDismissed] = useState(true);
+
+    useEffect(() => {
+        try {
+            setDismissed(window.localStorage.getItem(DISMISS_KEY) === '1');
+        } catch {
+            // localStorage unavailable (private mode, quota) — show the
+            // banner; a misconfigured install matters more than a flash.
+            setDismissed(false);
+        }
+    }, []);
+
+    if (configured !== false || dismissed) {
+        return null;
+    }
+
+    const dismiss = () => {
+        setDismissed(true);
+        try {
+            window.localStorage.setItem(DISMISS_KEY, '1');
+        } catch {
+            // Best-effort persistence; state above already hides it.
+        }
+    };
+
+    return (
+        <div
+            role="status"
+            data-testid="job-runtime-degraded-banner"
+            className="flex items-start gap-3 border-b border-amber-300/60 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-950/40 px-4 py-2.5 text-sm text-amber-900 dark:text-amber-200"
+        >
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <div className="min-w-0 flex-1">
+                <span className="font-medium">{t('title')}</span>{' '}
+                <span className="text-amber-800/90 dark:text-amber-200/80">{t('message')}</span>{' '}
+                <a
+                    href="https://docs.ever.works/"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline underline-offset-2 hover:no-underline"
+                >
+                    {t('docsLink')}
+                </a>
+            </div>
+            <button
+                type="button"
+                onClick={dismiss}
+                aria-label={t('dismiss')}
+                data-testid="job-runtime-banner-dismiss"
+                className="shrink-0 rounded p-1 hover:bg-amber-100 dark:hover:bg-amber-900/40"
+            >
+                <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+        </div>
+    );
+}

--- a/apps/web/src/components/dashboard/JobRuntimeDegradedBanner.unit.spec.tsx
+++ b/apps/web/src/components/dashboard/JobRuntimeDegradedBanner.unit.spec.tsx
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+import { JobRuntimeDegradedBanner } from './JobRuntimeDegradedBanner';
+
+describe('JobRuntimeDegradedBanner', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+
+    it('renders when the job runtime is KNOWN to be unconfigured', async () => {
+        render(<JobRuntimeDegradedBanner configured={false} />);
+        await waitFor(() =>
+            expect(screen.getByTestId('job-runtime-degraded-banner')).toBeInTheDocument(),
+        );
+        expect(screen.getByText('title')).toBeInTheDocument();
+    });
+
+    it('renders nothing when configured or unknown (never speculates)', () => {
+        const { rerender } = render(<JobRuntimeDegradedBanner configured={true} />);
+        expect(screen.queryByTestId('job-runtime-degraded-banner')).toBeNull();
+        rerender(<JobRuntimeDegradedBanner configured={null} />);
+        expect(screen.queryByTestId('job-runtime-degraded-banner')).toBeNull();
+    });
+
+    it('dismiss hides it and persists across mounts', async () => {
+        const { unmount } = render(<JobRuntimeDegradedBanner configured={false} />);
+        await waitFor(() =>
+            expect(screen.getByTestId('job-runtime-degraded-banner')).toBeInTheDocument(),
+        );
+        fireEvent.click(screen.getByTestId('job-runtime-banner-dismiss'));
+        expect(screen.queryByTestId('job-runtime-degraded-banner')).toBeNull();
+
+        unmount();
+        render(<JobRuntimeDegradedBanner configured={false} />);
+        // Hydration effect reads localStorage — stays hidden, no flash.
+        await waitFor(() => expect(screen.queryByTestId('job-runtime-degraded-banner')).toBeNull());
+    });
+});

--- a/apps/web/src/lib/api/health.ts
+++ b/apps/web/src/lib/api/health.ts
@@ -1,4 +1,7 @@
+import 'server-only';
+import { cache } from 'react';
 import { serverFetch } from './server-api';
+import { API_URL } from '../constants';
 
 export interface HealthResponse {
     status: string;
@@ -9,4 +12,32 @@ export const healthAPI = {
     check: async () => {
         return serverFetch('/health');
     },
+
+    /**
+     * Best-effort read of the API's informational service health — the
+     * `job_runtime` entry, which answers "can background agent runs
+     * execute on this install at all?" (an unconfigured local install
+     * otherwise fails runs with no visible explanation).
+     *
+     * Follows the `versionAPI` conventions: public endpoint, no auth
+     * token, deduped per render via React.cache, short cross-request
+     * revalidate, and `null` on ANY failure — a health banner must never
+     * be the thing that breaks the dashboard.
+     */
+    getJobRuntimeConfigured: cache(async (): Promise<boolean | null> => {
+        try {
+            const res = await fetch(`${API_URL}/health/ready`, {
+                next: { revalidate: 120 },
+            });
+            if (!res.ok) return null;
+            const body = (await res.json()) as {
+                info?: Record<string, { configured?: boolean }>;
+                details?: Record<string, { configured?: boolean }>;
+            };
+            const entry = body.info?.job_runtime ?? body.details?.job_runtime;
+            return typeof entry?.configured === 'boolean' ? entry.configured : null;
+        } catch {
+            return null;
+        }
+    }),
 };

--- a/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
@@ -180,6 +180,31 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         );
     });
 
+    it('classifies an unconfigured job runtime under its own stable reason marker', async () => {
+        const svc = makeSvc();
+        const notConfigured = new Error(
+            'Background job runtime is not configured on this install — agent runs cannot execute.',
+        );
+        notConfigured.name = 'JobRuntimeNotConfiguredError';
+        dispatcher.enqueue.mockRejectedValueOnce(notConfigured);
+        const task = makeTask({ status: TaskStatus.TODO });
+        tasks.findById.mockResolvedValueOnce({ ...task, status: TaskStatus.IN_PROGRESS });
+        assignees.findAgentAssignees.mockResolvedValueOnce([
+            { assigneeType: 'agent', assigneeId: 'agent-a' },
+        ]);
+
+        await svc.transition(task, TaskStatus.IN_PROGRESS);
+        await new Promise((r) => setImmediate(r));
+
+        // Loud degradation: an install-level misconfiguration must be
+        // distinguishable from a transient dispatch error — the run-detail
+        // UI and the health banner key on this marker.
+        expect(runs.markDispatchFailed).toHaveBeenCalledWith(
+            'r1',
+            expect.stringMatching(/^job-runtime-not-configured: /),
+        );
+    });
+
     it('skips reconciliation when the queued run was never created, and keeps fanning out', async () => {
         const svc = makeSvc();
         // createQueued fails for the FIRST assignee only — `run` stays null, so

--- a/packages/agent/src/tasks-domain/task-dispatcher.ts
+++ b/packages/agent/src/tasks-domain/task-dispatcher.ts
@@ -38,3 +38,30 @@ export interface AgentChatReplyDispatcher {
 
 export const AGENT_TASK_EXECUTE_DISPATCHER = 'AGENT_TASK_EXECUTE_DISPATCHER' as const;
 export const AGENT_CHAT_REPLY_DISPATCHER = 'AGENT_CHAT_REPLY_DISPATCHER' as const;
+
+/**
+ * Stable, user-readable marker the run-failure UI keys on. Kept as an
+ * exported constant so the producer (dispatcher adapters), the consumer
+ * (TaskTransitionService's failure classification), and any UI matcher
+ * share one literal instead of three drifting copies.
+ */
+export const JOB_RUNTIME_NOT_CONFIGURED_REASON = 'job-runtime-not-configured' as const;
+
+/**
+ * Thrown by dispatcher adapters when no background job runtime is
+ * usable (e.g. a local install without Trigger.dev credentials). Callers
+ * match on `.name` — the FacadeError house pattern — so the check works
+ * across package boundaries without instanceof identity issues. The
+ * point is LOUD degradation: a run must fail with a reason a human can
+ * act on, never vanish into a generic SDK stack trace.
+ */
+export class JobRuntimeNotConfiguredError extends Error {
+    constructor(message?: string) {
+        super(
+            message ??
+                'Background job runtime is not configured on this install — agent runs cannot execute. ' +
+                    'Configure a job runtime (e.g. Trigger.dev credentials) to enable agent execution.',
+        );
+        this.name = 'JobRuntimeNotConfiguredError';
+    }
+}

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -15,7 +15,11 @@ import {
     TaskApproverRepository,
 } from '../database/repositories/task-side.repositories';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
-import { AGENT_TASK_EXECUTE_DISPATCHER, type AgentTaskExecuteDispatcher } from './task-dispatcher';
+import {
+    AGENT_TASK_EXECUTE_DISPATCHER,
+    JOB_RUNTIME_NOT_CONFIGURED_REASON,
+    type AgentTaskExecuteDispatcher,
+} from './task-dispatcher';
 import { TaskNotificationService } from './task-notification.service';
 
 /**
@@ -263,12 +267,21 @@ export class TaskTransitionService {
                 }
             } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
+                // Loud degradation: an unconfigured job runtime is a distinct,
+                // ACTIONABLE failure (install-level misconfiguration), not a
+                // transient dispatch error — record it under its stable marker
+                // so the run-detail UI and the health banner tell one story.
+                const notConfigured =
+                    err instanceof Error && err.name === 'JobRuntimeNotConfiguredError';
+                const reason = notConfigured
+                    ? `${JOB_RUNTIME_NOT_CONFIGURED_REASON}: ${message}`
+                    : `dispatch-failed: ${message}`;
                 this.logger.warn(
-                    `Failed to dispatch agent-task-execute for ${assignee.assigneeId}: ${message}`,
+                    `Failed to dispatch agent-task-execute for ${assignee.assigneeId}: ${reason}`,
                 );
                 if (run) {
                     try {
-                        await this.runs?.markDispatchFailed(run.id, `dispatch-failed: ${message}`);
+                        await this.runs?.markDispatchFailed(run.id, reason);
                     } catch (failErr) {
                         this.logger.warn(
                             `Failed to mark orphan AgentRun ${run.id} failed: ${failErr}`,

--- a/packages/tasks/src/dispatchers/agent-task-dispatchers.spec.ts
+++ b/packages/tasks/src/dispatchers/agent-task-dispatchers.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@trigger.dev/sdk', () => ({
+    tasks: { trigger: vi.fn().mockResolvedValue({ id: 'run_123' }) },
+}));
+
+import { tasks } from '@trigger.dev/sdk';
+import {
+    agentChatReplyTriggerAdapter,
+    agentTaskExecuteTriggerAdapter,
+} from './agent-task-dispatchers';
+
+const PAYLOAD = {
+    agentId: 'agent-1',
+    userId: 'user-1',
+    taskId: 'task-1',
+    dedupKey: 'task-1:agent-1:1',
+};
+
+const CHAT_PAYLOAD = { ...PAYLOAD, triggeringMessageId: 'msg-1' };
+
+const RUNTIME_ENVS = ['TRIGGER_ENABLED', 'TRIGGER_SECRET_KEY', 'TRIGGER_INTERNAL_SECRET'] as const;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+    saved = Object.fromEntries(RUNTIME_ENVS.map((k) => [k, process.env[k]]));
+});
+
+afterEach(() => {
+    for (const k of RUNTIME_ENVS) {
+        if (saved[k] === undefined) delete process.env[k];
+        else process.env[k] = saved[k];
+    }
+    vi.clearAllMocks();
+});
+
+function unconfigure() {
+    for (const k of RUNTIME_ENVS) delete process.env[k];
+}
+
+function configure() {
+    process.env.TRIGGER_ENABLED = 'true';
+    process.env.TRIGGER_SECRET_KEY = 'tr_secret';
+    process.env.TRIGGER_INTERNAL_SECRET = 'internal_secret';
+}
+
+describe('dispatcher adapters — loud degradation gate', () => {
+    it('throws the stably-named JobRuntimeNotConfiguredError when the runtime is unconfigured', async () => {
+        unconfigure();
+        await expect(agentTaskExecuteTriggerAdapter.enqueue(PAYLOAD)).rejects.toMatchObject({
+            name: 'JobRuntimeNotConfiguredError',
+        });
+        await expect(agentChatReplyTriggerAdapter.enqueue(CHAT_PAYLOAD)).rejects.toMatchObject({
+            name: 'JobRuntimeNotConfiguredError',
+        });
+        // The SDK was never reached — no opaque network/auth error can mask
+        // the misconfiguration.
+        expect(tasks.trigger).not.toHaveBeenCalled();
+    });
+
+    it('the error message is actionable, not an SDK stack trace', async () => {
+        unconfigure();
+        await expect(agentTaskExecuteTriggerAdapter.enqueue(PAYLOAD)).rejects.toThrow(
+            /job runtime is not configured/i,
+        );
+    });
+
+    it('enqueues normally when the runtime is configured', async () => {
+        configure();
+        const handle = await agentTaskExecuteTriggerAdapter.enqueue(PAYLOAD);
+        expect(handle).toEqual({ runId: 'run_123' });
+        expect(tasks.trigger).toHaveBeenCalledWith(
+            'agent-task-execute',
+            expect.objectContaining({ taskId: 'task-1' }),
+            { idempotencyKey: PAYLOAD.dedupKey },
+        );
+    });
+});

--- a/packages/tasks/src/dispatchers/agent-task-dispatchers.ts
+++ b/packages/tasks/src/dispatchers/agent-task-dispatchers.ts
@@ -1,4 +1,6 @@
 import { tasks } from '@trigger.dev/sdk';
+import { config } from '@ever-works/agent/config';
+import { JobRuntimeNotConfiguredError } from '@ever-works/agent/tasks-domain';
 import type {
     AgentHeartbeatTrigger,
     AgentRunCanceller,
@@ -14,6 +16,20 @@ import type {
 import type { AgentHeartbeatPayload } from '../tasks/trigger/agent-heartbeat.task';
 import type { AgentChatReplyPayload } from '../tasks/trigger/agent-chat-reply.task';
 import type { AgentTaskExecutePayload } from '../tasks/trigger/agent-task-execute.task';
+
+/**
+ * Loud-degradation gate (mirrors `TriggerService.ensureConfigured()`:
+ * `shouldUseTrigger()` + a present secret key). Without this, an
+ * unconfigured install's enqueue dies inside the SDK with an opaque
+ * network/auth error that the run record then carries verbatim — the
+ * user sees a failed run and no clue WHY. A typed, stably-named error
+ * lets the transition service record an actionable reason instead.
+ */
+function assertJobRuntimeConfigured(): void {
+    if (!config.trigger.shouldUseTrigger() || !config.trigger.getSecretKey()) {
+        throw new JobRuntimeNotConfiguredError();
+    }
+}
 
 /**
  * Tasks feature — Phase 15.3 + 15.4. Production dispatcher adapters
@@ -41,6 +57,7 @@ export const agentHeartbeatTriggerAdapter: AgentHeartbeatTrigger = {
 
 export const agentTaskExecuteTriggerAdapter: AgentTaskExecuteDispatcher = {
     async enqueue(payload: AgentTaskExecuteDispatchPayload) {
+        assertJobRuntimeConfigured();
         // Review-fix I10: pass `idempotencyKey` to Trigger.dev so a
         // double-fire for the same (taskId, agentId, generation) tuple
         // is deduped at the runner. Previously `dedupKey` rode only as
@@ -65,6 +82,7 @@ export const agentTaskExecuteTriggerAdapter: AgentTaskExecuteDispatcher = {
 
 export const agentChatReplyTriggerAdapter: AgentChatReplyDispatcher = {
     async enqueue(payload: AgentChatReplyDispatchPayload) {
+        assertJobRuntimeConfigured();
         // Review-fix I10 (mirror of agent-task-execute adapter above).
         const handle = await tasks.trigger<
             typeof import('../tasks/trigger/agent-chat-reply.task').agentChatReplyTask


### PR DESCRIPTION
Wave 0.2 of the build program (the research plan's 07-M1: "the silent no-op is the worst local failure mode").

**API**: `job_runtime` informational health entry — vendor-neutral "can agent runs execute at all?" signal (mirrors `trigger_dev` today; evolves to reflect `EVER_WORKS_JOB_RUNTIME` when the provider registry is wired end-to-end; separate key so clients never re-key).

**Dispatch**: adapters pre-check the same gate `TriggerService.ensureConfigured()` uses and throw a stably-named `JobRuntimeNotConfiguredError` with an actionable message before the SDK can produce an opaque network/auth error; `TaskTransitionService` records it under the exported `job-runtime-not-configured:` marker so the run-detail UI and triage tooling can distinguish install-level misconfiguration from transient dispatch failures.

**Web**: dismissible amber banner on the dashboard when health reports `configured:false` — hydration-gated (no dismissed-flash), best-effort fetch that returns null on any failure (a banner must never break the dashboard), renders ONLY on a known misconfiguration.

Tests: 3 dispatcher-gate (SDK never reached when unconfigured), +1 transition classification (suite 11 green), 3 banner, health controller counts updated (7 green). Full packages/tasks suite 376 green; web tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)