### PR TITLE
feat(agent): AgentRun terminal columns + migration + status merge (M4)

### DIFF
--- a/apps/api/src/migrations/1782600000000-AddAgentRunTerminalColumns.ts
+++ b/apps/api/src/migrations/1782600000000-AddAgentRunTerminalColumns.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Streaming-terminal M4 — AgentRun terminal columns.
+ *
+ * All nullable (except `persistent`, boolean default false): NULL =
+ * "this run has no terminal", which is every pre-existing row. Partial
+ * index on non-null `terminalState` for the sweeper's stale-heartbeat
+ * scan. Forward-only, idempotent per-step guards (house pattern).
+ *
+ * Deliberately NO content/transcript/token columns — terminal bytes
+ * live only in log chunks and the in-memory relay window (the schema
+ * invariant test pins this).
+ */
+export class AddAgentRunTerminalColumns1782600000000 implements MigrationInterface {
+    name = 'AddAgentRunTerminalColumns1782600000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('agent_runs');
+        if (!table) return;
+
+        const addColumn = async (name: string, ddl: string) => {
+            if (!table.findColumnByName(name)) {
+                await queryRunner.query(`ALTER TABLE "agent_runs" ADD COLUMN ${ddl}`);
+            }
+        };
+
+        await addColumn('persistent', `"persistent" boolean NOT NULL DEFAULT false`);
+        await addColumn('terminalState', `"terminalState" varchar(16)`);
+        await addColumn('terminalEndedReason', `"terminalEndedReason" varchar(32)`);
+        await addColumn('terminalProviderId', `"terminalProviderId" varchar(64)`);
+        await addColumn('cliSessionId', `"cliSessionId" varchar(128)`);
+        await addColumn('lastHeartbeatAt', `"lastHeartbeatAt" timestamp`);
+        await addColumn('lastFrameSeq', `"lastFrameSeq" int`);
+
+        // Partial index: the sweeper scans only live-terminal rows.
+        await queryRunner.query(
+            `CREATE INDEX IF NOT EXISTS "idx_agent_runs_terminal_state" ` +
+                `ON "agent_runs" ("terminalState") WHERE "terminalState" IS NOT NULL`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "idx_agent_runs_terminal_state"`);
+        const table = await queryRunner.getTable('agent_runs');
+        if (!table) return;
+        for (const col of [
+            'lastFrameSeq',
+            'lastHeartbeatAt',
+            'cliSessionId',
+            'terminalProviderId',
+            'terminalEndedReason',
+            'terminalState',
+            'persistent',
+        ]) {
+            if (table.findColumnByName(col)) {
+                await queryRunner.query(`ALTER TABLE "agent_runs" DROP COLUMN "${col}"`);
+            }
+        }
+    }
+}

--- a/apps/api/src/terminal/terminal-attach.controller.ts
+++ b/apps/api/src/terminal/terminal-attach.controller.ts
@@ -71,14 +71,34 @@ export class TerminalAttachController {
     }
 
     @Get()
-    @ApiOperation({ summary: 'Live terminal session status for this run (relay view).' })
+    @ApiOperation({
+        summary:
+            'Terminal session status for this run — live relay view merged with ' +
+            'the persisted AgentRun terminal columns (M4).',
+    })
     @HttpCode(HttpStatus.OK)
     async status(
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) agentId: string,
         @Param('runId', ParseUUIDPipe) runId: string,
     ) {
-        await this.authorizeRun(auth.userId, agentId, runId);
-        return this.registry.getStatus(runId);
+        const run = await this.authorizeRun(auth.userId, agentId, runId);
+        return {
+            // Live relay view (empty/exists:false when no session is
+            // resident in this replica's registry).
+            ...this.registry.getStatus(runId),
+            // Persisted lifecycle (survives replica restarts; the source
+            // of truth for dead sessions and the Resume affordance).
+            run: {
+                persistent: run.persistent ?? false,
+                terminalState: run.terminalState ?? null,
+                terminalEndedReason: run.terminalEndedReason ?? null,
+                terminalProviderId: run.terminalProviderId ?? null,
+                // Presence only — the resume id itself stays server-side.
+                hasCliSession: Boolean(run.cliSessionId),
+                lastHeartbeatAt: run.lastHeartbeatAt?.toISOString() ?? null,
+                lastFrameSeq: run.lastFrameSeq ?? null,
+            },
+        };
     }
 }

--- a/packages/agent/src/entities/__tests__/agent-run.terminal-columns.spec.ts
+++ b/packages/agent/src/entities/__tests__/agent-run.terminal-columns.spec.ts
@@ -1,0 +1,38 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { AgentRun } from '../agent-run.entity';
+
+/**
+ * Streaming-terminal M4 — schema invariant ("Gate J").
+ *
+ * `agent_runs` must NEVER grow content/transcript/byte columns:
+ * terminal output lives ONLY in coalesced log chunks and the relay's
+ * in-memory window. A column that smells like payload storage here is
+ * a design regression (unbounded row growth + a second, unredacted
+ * copy of terminal bytes), so the test fails on NAME — the reviewer
+ * has to consciously delete this pin to break the invariant.
+ */
+describe('AgentRun terminal columns — schema invariants', () => {
+    const columns = getMetadataArgsStorage()
+        .columns.filter((c) => c.target === AgentRun)
+        .map((c) => c.propertyName);
+
+    it('has the M4 terminal lifecycle columns', () => {
+        for (const expected of [
+            'persistent',
+            'terminalState',
+            'terminalEndedReason',
+            'terminalProviderId',
+            'cliSessionId',
+            'lastHeartbeatAt',
+            'lastFrameSeq',
+        ]) {
+            expect(columns).toContain(expected);
+        }
+    });
+
+    it('NEVER stores terminal content on the run row', () => {
+        const forbidden = /transcript|scrollback|stdout|stderr|bytes|content|buffer|output/i;
+        const offenders = columns.filter((name) => forbidden.test(name));
+        expect(offenders).toEqual([]);
+    });
+});

--- a/packages/agent/src/entities/agent-run.entity.ts
+++ b/packages/agent/src/entities/agent-run.entity.ts
@@ -111,6 +111,43 @@ export class AgentRun {
     @Column({ type: 'varchar', length: 128, nullable: true })
     memorySessionId?: string | null;
 
+    // ── Streaming-terminal columns (M4). All nullable: NULL means "this
+    // run has no terminal" — every pre-existing and non-interactive run.
+    // INVARIANT (schema test): agent_runs gains no content/transcript
+    // bytes — terminal output lives in log chunks + the relay window.
+
+    /** Run intends a long-lived interactive session (park/resume-able). */
+    @Column({ type: 'boolean', default: false })
+    persistent: boolean;
+
+    /** `starting | attached | ended` — live terminal lifecycle. */
+    @Column({ type: 'varchar', length: 16, nullable: true })
+    terminalState?: string | null;
+
+    /** `completed | crashed | closed | parked` (+ provider hints). */
+    @Column({ type: 'varchar', length: 32, nullable: true })
+    terminalEndedReason?: string | null;
+
+    /** Which terminal-stream plugin hosted the session. */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    terminalProviderId?: string | null;
+
+    /**
+     * The pipeline CLI's own resume id (conversation lifetime — sibling
+     * of `memorySessionId`). Park kills the process but keeps this, so
+     * Resume = new run + this id handed to the pipeline plugin.
+     */
+    @Column({ type: 'varchar', length: 128, nullable: true })
+    cliSessionId?: string | null;
+
+    /** Sweeper input: stale heartbeat + live terminalState ⇒ crashed. */
+    @Column({ type: 'timestamp', nullable: true })
+    lastHeartbeatAt?: Date | null;
+
+    /** Highest published stdout seq (transcript/replay bookkeeping). */
+    @Column({ type: 'int', nullable: true })
+    lastFrameSeq?: number | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }


### PR DESCRIPTION
Wave 1 M4, stacked on #1821. Seven nullable/default terminal-lifecycle columns on `agent_runs` + guarded forward-only migration + partial index for the sweeper. The 'Gate J' schema-invariant test pins that the run row can NEVER grow content/transcript/byte columns (terminal output lives only in log chunks + the relay window) — it fails on column NAME so breaking the invariant requires consciously deleting the pin. Terminal status endpoint merges live relay view + persisted lifecycle; `cliSessionId` is presence-only in responses. Tests: 2 new invariants; all 60 terminal suite tests still green; agent build TSC-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)