### PR TITLE
feat(tasks): terminal session host + transport + heartbeats + sweeper (M6)

### DIFF
--- a/apps/api/src/terminal/__tests__/terminal-internal.controller.spec.ts
+++ b/apps/api/src/terminal/__tests__/terminal-internal.controller.spec.ts
@@ -17,6 +17,7 @@ describe('TerminalInternalController', () => {
     const saved: Record<string, string | undefined> = {};
     let controller: TerminalInternalController;
     let registry: TerminalRelayRegistry;
+    let runsRepo: { updateTerminalColumns: jest.Mock };
 
     beforeEach(() => {
         for (const k of ENV_KEYS) {
@@ -24,7 +25,12 @@ describe('TerminalInternalController', () => {
             delete process.env[k];
         }
         registry = new TerminalRelayRegistry();
-        controller = new TerminalInternalController(registry, new TerminalAttachService());
+        runsRepo = { updateTerminalColumns: jest.fn().mockResolvedValue(undefined) };
+        controller = new TerminalInternalController(
+            registry,
+            new TerminalAttachService(),
+            runsRepo as never,
+        );
     });
 
     afterEach(() => {
@@ -43,20 +49,28 @@ describe('TerminalInternalController', () => {
 
     it('FAIL-CLOSED: refuses every publish when the internal secret is unconfigured', () => {
         expect(() =>
-            controller.publishFrames(bearer, RUN, [{ kind: 'stdout', seq: 0, data: 'aGk=' }]),
+            controller.publishFrames(bearer, undefined, RUN, [
+                { kind: 'stdout', seq: 0, data: 'aGk=' },
+            ]),
         ).toThrow(ForbiddenException);
     });
 
     it('refuses wrong/missing bearer secrets (constant-time compare path)', () => {
         configure();
-        expect(() => controller.publishFrames('Bearer wrong', RUN, [])).toThrow(ForbiddenException);
-        expect(() => controller.publishFrames(undefined, RUN, [])).toThrow(ForbiddenException);
-        expect(() => controller.publishFrames('Basic abc', RUN, [])).toThrow(ForbiddenException);
+        expect(() => controller.publishFrames('Bearer wrong', undefined, RUN, [])).toThrow(
+            ForbiddenException,
+        );
+        expect(() => controller.publishFrames(undefined, undefined, RUN, [])).toThrow(
+            ForbiddenException,
+        );
+        expect(() => controller.publishFrames('Basic abc', undefined, RUN, [])).toThrow(
+            ForbiddenException,
+        );
     });
 
     it('accepts valid frames, drops invalid ones, and counts both', () => {
         configure();
-        const result = controller.publishFrames(bearer, RUN, [
+        const result = controller.publishFrames(bearer, undefined, RUN, [
             { kind: 'stdout', seq: 0, data: 'aGk=' },
             { kind: 'stdout', seq: 1, data: 'aGk=' },
             { kind: 'stdout', seq: 1, data: 'aGk=' }, // dup seq → registry refuses
@@ -69,18 +83,55 @@ describe('TerminalInternalController', () => {
 
     it('rejects malformed run ids before any registry touch', () => {
         configure();
-        expect(() => controller.publishFrames(bearer, '../etc/passwd', [])).toThrow(
+        expect(() => controller.publishFrames(bearer, undefined, '../etc/passwd', [])).toThrow(
             ForbiddenException,
         );
     });
 
     it('mints a worker attach token behind the same gate', () => {
         configure();
-        const result = controller.mintWorkerToken(bearer, RUN);
+        const result = controller.mintWorkerToken(bearer, undefined, RUN);
         expect(result.wsPath).toBe(`/ws/terminal/${RUN}`);
         const claims = new TerminalAttachService().verify(result.token);
         expect(claims).toMatchObject({ role: 'worker', runId: RUN });
 
-        expect(() => controller.mintWorkerToken('Bearer wrong', RUN)).toThrow(ForbiddenException);
+        expect(() => controller.mintWorkerToken('Bearer wrong', undefined, RUN)).toThrow(
+            ForbiddenException,
+        );
+    });
+    it('heartbeat stamps the server clock and whitelists lifecycle fields', async () => {
+        configure();
+        await controller.heartbeat(bearer, undefined, RUN, {
+            state: 'attached',
+            providerId: 'pty-local',
+            persistent: true,
+            lastFrameSeq: 42,
+            endedReason: 'not-a-reason',
+        });
+        expect(runsRepo.updateTerminalColumns).toHaveBeenCalledWith(
+            RUN,
+            expect.objectContaining({
+                terminalState: 'attached',
+                terminalProviderId: 'pty-local',
+                persistent: true,
+                lastFrameSeq: 42,
+                lastHeartbeatAt: expect.any(Date),
+            }),
+        );
+        // Unknown endedReason value was dropped by the enum whitelist.
+        const patch = runsRepo.updateTerminalColumns.mock.calls[0][1];
+        expect('terminalEndedReason' in patch).toBe(false);
+    });
+
+    it('heartbeat also honors the x-trigger-secret header (house internal-API convention)', async () => {
+        configure();
+        await controller.heartbeat(undefined, 'internal-secret-value', RUN, {
+            state: 'ended',
+            endedReason: 'parked',
+        });
+        expect(runsRepo.updateTerminalColumns).toHaveBeenCalledWith(
+            RUN,
+            expect.objectContaining({ terminalState: 'ended', terminalEndedReason: 'parked' }),
+        );
     });
 });

--- a/apps/api/src/terminal/terminal-internal.controller.ts
+++ b/apps/api/src/terminal/terminal-internal.controller.ts
@@ -13,9 +13,13 @@ import { SkipThrottle } from '@nestjs/throttler';
 import { timingSafeEqual } from 'crypto';
 import { config } from '@ever-works/agent/config';
 import { normalizeTerminalFrame, isValidTerminalRunId } from '@ever-works/contracts';
+import { AgentRunRepository } from '@ever-works/agent/database';
 import { Public } from '../auth';
 import { TerminalAttachService } from './terminal-attach.service';
 import { TerminalRelayRegistry } from './terminal-relay.registry';
+
+const TERMINAL_STATES = new Set(['starting', 'attached', 'ended']);
+const TERMINAL_END_REASONS = new Set(['completed', 'crashed', 'closed', 'parked']);
 
 /**
  * Worker-side internal endpoints (streaming-terminal M3):
@@ -45,17 +49,22 @@ export class TerminalInternalController {
     constructor(
         private readonly registry: TerminalRelayRegistry,
         private readonly attach: TerminalAttachService,
+        private readonly runs: AgentRunRepository,
     ) {}
 
-    private ensureSecret(authorization?: string) {
+    private ensureSecret(authorization?: string, triggerSecret?: string) {
         const expectedSecret = config.trigger.getInternalSecret();
         if (!expectedSecret) {
             throw new ForbiddenException('Terminal internal secret is not configured');
         }
+        // Two accepted carriers: the house `x-trigger-secret` header (what
+        // TriggerInternalApiClient already sends) and Authorization: Bearer.
         const provided =
-            typeof authorization === 'string' && authorization.startsWith('Bearer ')
-                ? authorization.slice('Bearer '.length)
-                : '';
+            typeof triggerSecret === 'string' && triggerSecret.length > 0
+                ? triggerSecret
+                : typeof authorization === 'string' && authorization.startsWith('Bearer ')
+                  ? authorization.slice('Bearer '.length)
+                  : '';
         if (provided.length === 0) {
             throw new ForbiddenException('Invalid terminal internal secret');
         }
@@ -74,10 +83,11 @@ export class TerminalInternalController {
     @HttpCode(HttpStatus.ACCEPTED)
     publishFrames(
         @Headers('authorization') authorization: string | undefined,
+        @Headers('x-trigger-secret') triggerSecret: string | undefined,
         @Param('runId') runId: string,
         @Body() body: unknown,
     ): { accepted: number; dropped: number } {
-        this.ensureSecret(authorization);
+        this.ensureSecret(authorization, triggerSecret);
         if (!isValidTerminalRunId(runId)) {
             throw new ForbiddenException('Invalid run id');
         }
@@ -106,9 +116,10 @@ export class TerminalInternalController {
     @HttpCode(HttpStatus.CREATED)
     mintWorkerToken(
         @Headers('authorization') authorization: string | undefined,
+        @Headers('x-trigger-secret') triggerSecret: string | undefined,
         @Param('runId') runId: string,
     ): { token: string; wsPath: string; expiresInSec: number } {
-        this.ensureSecret(authorization);
+        this.ensureSecret(authorization, triggerSecret);
         if (!isValidTerminalRunId(runId)) {
             throw new ForbiddenException('Invalid run id');
         }
@@ -118,5 +129,58 @@ export class TerminalInternalController {
             role: 'worker',
         });
         return { token, wsPath: `/ws/terminal/${runId}`, expiresInSec };
+    }
+
+    /**
+     * Heartbeat + terminal-lifecycle updates from the session host (M6).
+     * Enum-whitelisted fields only — a compromised worker payload can
+     * touch nothing but the terminal columns, and even those only with
+     * known values. `lastHeartbeatAt` is server-stamped, never trusted
+     * from the body.
+     */
+    @Public()
+    @Post(':runId/heartbeat')
+    @HttpCode(HttpStatus.OK)
+    async heartbeat(
+        @Headers('authorization') authorization: string | undefined,
+        @Headers('x-trigger-secret') triggerSecret: string | undefined,
+        @Param('runId') runId: string,
+        @Body()
+        body: {
+            state?: string;
+            endedReason?: string;
+            providerId?: string;
+            cliSessionId?: string;
+            lastFrameSeq?: number;
+            persistent?: boolean;
+        },
+    ): Promise<{ ok: boolean }> {
+        this.ensureSecret(authorization, triggerSecret);
+        if (!isValidTerminalRunId(runId)) {
+            throw new ForbiddenException('Invalid run id');
+        }
+        const patch: Parameters<AgentRunRepository['updateTerminalColumns']>[1] = {
+            lastHeartbeatAt: new Date(),
+        };
+        if (typeof body?.state === 'string' && TERMINAL_STATES.has(body.state)) {
+            patch.terminalState = body.state;
+        }
+        if (typeof body?.endedReason === 'string' && TERMINAL_END_REASONS.has(body.endedReason)) {
+            patch.terminalEndedReason = body.endedReason;
+        }
+        if (typeof body?.providerId === 'string' && body.providerId.length <= 64) {
+            patch.terminalProviderId = body.providerId;
+        }
+        if (typeof body?.cliSessionId === 'string' && body.cliSessionId.length <= 128) {
+            patch.cliSessionId = body.cliSessionId;
+        }
+        if (Number.isSafeInteger(body?.lastFrameSeq) && (body.lastFrameSeq as number) >= 0) {
+            patch.lastFrameSeq = body.lastFrameSeq as number;
+        }
+        if (typeof body?.persistent === 'boolean') {
+            patch.persistent = body.persistent;
+        }
+        await this.runs.updateTerminalColumns(runId, patch);
+        return { ok: true };
     }
 }

--- a/packages/agent/src/agents/agent-run-sweeper.service.ts
+++ b/packages/agent/src/agents/agent-run-sweeper.service.ts
@@ -126,4 +126,35 @@ export class AgentRunSweeperService {
             byKind,
         };
     }
+
+    /**
+     * Streaming-terminal M6 — reap sessions whose terminal claims to be
+     * live but whose heartbeat went stale (crashed worker, killed pod).
+     * Marks them `ended/crashed` and returns the run ids so the CALLER
+     * (the worker-side sweeper task) can best-effort publish a pinned
+     * `exit` frame through the relay — no viewer stares at a frozen
+     * pane. Zero-arg like `sweepStuckRuns` (superjson RPC proxy).
+     */
+    async sweepStaleTerminalSessions(): Promise<{ swept: string[]; cutoffMinutes: number }> {
+        const cutoffMinutes = 5;
+        const cutoff = new Date(Date.now() - cutoffMinutes * 60_000);
+        const stale = await this.runs.findStaleTerminalRuns(cutoff);
+        const swept: string[] = [];
+        for (const run of stale) {
+            try {
+                await this.runs.updateTerminalColumns(run.id, {
+                    terminalState: 'ended',
+                    terminalEndedReason: 'crashed',
+                });
+                swept.push(run.id);
+            } catch (error) {
+                this.logger.warn(
+                    `terminal sweep failed for run ${run.id}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
+        return { swept, cutoffMinutes };
+    }
 }

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -405,6 +405,56 @@ export class AgentRunRepository {
     }
 
     /**
+     * Streaming-terminal M6 — patch the run's terminal lifecycle columns.
+     * Field-by-field construction from an explicit whitelist: callers
+     * (the internal heartbeat/state endpoints) receive worker-supplied
+     * payloads, and none of those may ever write status/summary/etc.
+     */
+    async updateTerminalColumns(
+        runId: string,
+        patch: {
+            persistent?: boolean;
+            terminalState?: string | null;
+            terminalEndedReason?: string | null;
+            terminalProviderId?: string | null;
+            cliSessionId?: string | null;
+            lastHeartbeatAt?: Date | null;
+            lastFrameSeq?: number | null;
+        },
+    ): Promise<void> {
+        const update: Record<string, unknown> = {};
+        if (patch.persistent !== undefined) update.persistent = patch.persistent;
+        if (patch.terminalState !== undefined) update.terminalState = patch.terminalState;
+        if (patch.terminalEndedReason !== undefined)
+            update.terminalEndedReason = patch.terminalEndedReason;
+        if (patch.terminalProviderId !== undefined)
+            update.terminalProviderId = patch.terminalProviderId;
+        if (patch.cliSessionId !== undefined) update.cliSessionId = patch.cliSessionId;
+        if (patch.lastHeartbeatAt !== undefined) update.lastHeartbeatAt = patch.lastHeartbeatAt;
+        if (patch.lastFrameSeq !== undefined) update.lastFrameSeq = patch.lastFrameSeq;
+        if (Object.keys(update).length === 0) return;
+        await this.repository.update(runId, update);
+    }
+
+    /**
+     * Streaming-terminal M6 — sweeper input: runs whose terminal claims
+     * to be live (`starting`/`attached`) but whose heartbeat is older
+     * than the cutoff. The sweeper marks them crashed and publishes a
+     * pinned exit frame so no viewer ever stares at a frozen pane.
+     */
+    async findStaleTerminalRuns(cutoff: Date, limit = 50): Promise<AgentRun[]> {
+        return this.repository
+            .createQueryBuilder('run')
+            .where('run.terminalState IN (:...states)', { states: ['starting', 'attached'] })
+            .andWhere('(run.lastHeartbeatAt IS NULL OR run.lastHeartbeatAt < :cutoff)', {
+                cutoff,
+            })
+            .orderBy('run.createdAt', 'ASC')
+            .take(limit)
+            .getMany();
+    }
+
+    /**
      * Find an in-flight run for the (taskId, agentId) pair — used by
      * the agent-chat-reply dedup guard (architecture/security §8 — T6
      * mitigation): if a chat-triggered run is already running for the

--- a/packages/tasks/package.json
+++ b/packages/tasks/package.json
@@ -42,7 +42,9 @@
         "class-transformer": "^0.5.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
-        "superjson": "^1.13.3"
+        "superjson": "^1.13.3",
+        "@ever-works/pty-local-plugin": "workspace:*",
+        "@ever-works/contracts": "workspace:*"
     },
     "devDependencies": {
         "@trigger.dev/build": "^4.4.6",

--- a/packages/tasks/src/tasks/trigger/agent-run-sweeper.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-run-sweeper.task.ts
@@ -46,6 +46,29 @@ export const agentRunSweeperTask = schedules.task({
                 const svc = appContext.get(AgentRunSweeperService);
                 const summary = await svc.sweepStuckRuns();
 
+                // Streaming-terminal M6: reap live-claiming sessions with a
+                // stale heartbeat, then best-effort publish the pinned exit
+                // frame so any attached browser learns the death instead of
+                // staring at a frozen pane. Frame publish is fully optional
+                // — the DB transition above is the source of truth.
+                const terminal = await svc.sweepStaleTerminalSessions();
+                if (terminal.swept.length > 0) {
+                    logger.warn('agent-run-sweeper reaped stale terminal sessions', {
+                        runIds: terminal.swept,
+                        cutoffMinutes: terminal.cutoffMinutes,
+                    });
+                    try {
+                        const { TerminalTransportClient } =
+                            await import('../../trigger/worker/services/terminal-transport.client.js');
+                        const client = new TerminalTransportClient();
+                        for (const runId of terminal.swept) {
+                            await client.publishExit(runId, -1, 'crashed').catch(() => undefined);
+                        }
+                    } catch {
+                        // No internal API config in this context — DB truth stands.
+                    }
+                }
+
                 if (summary.swept > 0) {
                     logger.warn('agent-run-sweeper reaped stuck runs', {
                         swept: summary.swept,

--- a/packages/tasks/src/tasks/trigger/index.ts
+++ b/packages/tasks/src/tasks/trigger/index.ts
@@ -7,6 +7,7 @@ export * from './kb-mirror-document.task';
 export * from './kb-org-overlay-fanout.task';
 export * from './kb-reconcile.task';
 export * from './agent-run-sweeper.task';
+export * from './terminal-session.task';
 export * from './user-research-rerun-dispatcher.task';
 export * from './mission-tick.task';
 // PR-4 — Idea → Work build executor (flag-gated, dry-run by default).

--- a/packages/tasks/src/tasks/trigger/terminal-session.task.ts
+++ b/packages/tasks/src/tasks/trigger/terminal-session.task.ts
@@ -1,0 +1,85 @@
+import { task } from '@trigger.dev/sdk';
+import { NestFactory } from '@nestjs/core';
+import { AgentRunRepository } from '@ever-works/agent/database';
+import { PtyLocalPlugin } from '@ever-works/pty-local-plugin';
+import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+import { createTriggerLogger } from '../../trigger/worker/trigger-logger';
+import { assertUuid } from '../../trigger/worker/utils/task-context.utils';
+import { TerminalTransportClient } from '../../trigger/worker/services/terminal-transport.client';
+import { TerminalSessionHost } from '../../trigger/worker/services/terminal-session-host';
+
+export interface TerminalSessionPayload {
+    /** The AgentRun whose id doubles as the relay channel id. */
+    runId: string;
+    userId: string;
+    agentId: string;
+    /** Argv to exec. Absolute path preferred (bundled-worker PATHs). */
+    command: string[];
+    cwd: string;
+    /** Extra env for the child. NEVER credentials — those are resolved
+     *  job-side by the facades at spawn time (see plan §7). */
+    env?: Record<string, string>;
+    persistent?: boolean;
+}
+
+/**
+ * Streaming-terminal M6 — the durable session task.
+ *
+ * Hosts one live terminal session for an AgentRun: PTY (or pipe floor)
+ * in THIS worker process, bytes relayed through the API gateway, kept
+ * alive by heartbeats, reaped by the sweeper on heartbeat loss.
+ *
+ * This is the building block the run orchestration composes: today it
+ * is dispatched explicitly (persistent/interactive runs); the
+ * agent-task-execute integration (routing a CLI pipeline's execution
+ * through a session instead of captured output) is the follow-up
+ * milestone — kept out of this task deliberately so the existing
+ * one-shot path carries zero regression risk.
+ *
+ * maxDuration 3600 is the hard cost backstop until park/resume lands
+ * for long-lived sessions (state-aware policy, orchestration wave).
+ */
+export const terminalSessionTask = task<'terminal-session', TerminalSessionPayload>({
+    id: 'terminal-session',
+    maxDuration: 3600,
+    run: async (payload: TerminalSessionPayload) => {
+        assertUuid(payload.runId, 'payload.runId');
+        assertUuid(payload.userId, 'payload.userId');
+        assertUuid(payload.agentId, 'payload.agentId');
+        if (!Array.isArray(payload.command) || payload.command.length === 0) {
+            return { status: 'skipped' as const, reason: 'empty-command' };
+        }
+
+        const appContext = await NestFactory.createApplicationContext(TriggerInternalModule);
+        appContext.useLogger(createTriggerLogger('TerminalSession'));
+        try {
+            // Ownership guard mirroring agent-task-execute: the run must
+            // belong to the payload's user + agent; forged payloads skip
+            // without leaking existence.
+            const runs = appContext.get(AgentRunRepository);
+            const run = await runs.findById(payload.runId);
+            if (!run || run.userId !== payload.userId || run.agentId !== payload.agentId) {
+                return { status: 'skipped' as const, reason: 'run-not-found' };
+            }
+
+            const client = new TerminalTransportClient();
+            const host = new TerminalSessionHost(new PtyLocalPlugin(), client);
+
+            const outcome = await host.run({
+                runId: payload.runId,
+                command: payload.command,
+                cwd: payload.cwd,
+                env: payload.env ?? {},
+                persistent: payload.persistent === true,
+                // Cost guard default: a session nobody can reach anymore
+                // does not burn compute. The state-aware park policy
+                // (orchestration wave) refines this per busy/needsInput.
+                endOnInputClose: false,
+            });
+
+            return { status: 'completed' as const, ...outcome };
+        } finally {
+            await appContext.close();
+        }
+    },
+});

--- a/packages/tasks/src/trigger/worker/services/terminal-session-host.spec.ts
+++ b/packages/tasks/src/trigger/worker/services/terminal-session-host.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TerminalFrame } from '@ever-works/contracts';
+import { PtyLocalPlugin } from '@ever-works/pty-local-plugin';
+import { TerminalSessionHost } from './terminal-session-host';
+import type { TerminalTransportClient } from './terminal-transport.client';
+
+const RUN = '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f';
+const NODE = process.execPath;
+
+/**
+ * Loopback harness: a REAL PtyLocalPlugin hosting REAL child processes,
+ * with the transport + internal-API client replaced by in-memory sinks
+ * — the complete worker-side byte path with no network and no SDK.
+ */
+function makeLoopbackClient() {
+    const published: TerminalFrame[] = [];
+    const heartbeats: Array<Record<string, unknown>> = [];
+    const client = {
+        heartbeat: vi.fn(async (_runId: string, body: Record<string, unknown>) => {
+            heartbeats.push(body);
+        }),
+        createTransport: vi.fn(async () => ({
+            publish: (frame: TerminalFrame) => {
+                published.push(frame);
+            },
+            inbound: () => ({
+                [Symbol.asyncIterator]() {
+                    return {
+                        next: () =>
+                            new Promise<IteratorResult<TerminalFrame>>(() => {
+                                // never yields — sessions in these tests end
+                                // by process exit, not by input close
+                            }),
+                    };
+                },
+            }),
+            close: async () => undefined,
+        })),
+        publishExit: vi.fn(async () => undefined),
+    };
+    return { client: client as unknown as TerminalTransportClient, published, heartbeats };
+}
+
+describe('TerminalSessionHost (loopback, real processes)', () => {
+    it('runs the full lifecycle: starting → attached → heartbeats → ended/completed', async () => {
+        const { client, published, heartbeats } = makeLoopbackClient();
+        const host = new TerminalSessionHost(new PtyLocalPlugin(), client, 50);
+
+        const result = await host.run({
+            runId: RUN,
+            command: [NODE, '-e', 'process.stdout.write("session-bytes")'],
+            cwd: process.cwd(),
+            env: {},
+            persistent: true,
+        });
+
+        expect(result.reason).toBe('completed');
+
+        // Lifecycle order: starting (with provider + persistent), attached, ended.
+        expect(heartbeats[0]).toMatchObject({
+            state: 'starting',
+            providerId: 'pty-local',
+            persistent: true,
+        });
+        expect(heartbeats[1]).toMatchObject({ state: 'attached' });
+        expect(heartbeats[heartbeats.length - 1]).toMatchObject({
+            state: 'ended',
+            endedReason: 'completed',
+        });
+
+        // Preamble banner first; bytes present; exit pinned last.
+        expect(published[0]).toMatchObject({ kind: 'error' });
+        const stdout = published
+            .filter((f): f is Extract<TerminalFrame, { kind: 'stdout' }> => f.kind === 'stdout')
+            .map((f) => Buffer.from(f.data, 'base64').toString('utf8'))
+            .join('');
+        expect(stdout).toContain('session-bytes');
+        expect(published[published.length - 1]).toMatchObject({ kind: 'exit' });
+    });
+
+    it('a crashing command still ends the lifecycle honestly (ended/crashed)', async () => {
+        const { client, heartbeats } = makeLoopbackClient();
+        const host = new TerminalSessionHost(new PtyLocalPlugin(), client, 50);
+
+        const result = await host.run({
+            runId: RUN,
+            command: [NODE, '-e', 'process.exit(7)'],
+            cwd: process.cwd(),
+            env: {},
+        });
+
+        expect(result.reason).toBe('crashed');
+        expect(heartbeats[heartbeats.length - 1]).toMatchObject({
+            state: 'ended',
+            endedReason: 'crashed',
+        });
+    });
+
+    it('spawn failure publishes banner + crashed exit and rethrows (never a black pane)', async () => {
+        const { client, published } = makeLoopbackClient();
+        const failing = {
+            providerName: 'exploding',
+            capabilities: ['terminal-stream'],
+            id: 'exploding',
+            spawn: vi.fn(async () => {
+                throw new Error('no runtime here');
+            }),
+        };
+        const host = new TerminalSessionHost(failing as never, client, 50);
+
+        await expect(
+            host.run({ runId: RUN, command: ['whatever'], cwd: '/', env: {} }),
+        ).rejects.toThrow('no runtime here');
+
+        const kinds = published.map((f) => f.kind);
+        expect(kinds).toContain('error');
+        expect(published[published.length - 1]).toMatchObject({
+            kind: 'exit',
+            reason: 'crashed',
+        });
+    });
+
+    it('heartbeats repeat while the session lives', async () => {
+        const { client, heartbeats } = makeLoopbackClient();
+        const host = new TerminalSessionHost(new PtyLocalPlugin(), client, 40);
+
+        await host.run({
+            runId: RUN,
+            // Live ~350ms so several 40ms beats land.
+            command: [NODE, '-e', 'setTimeout(()=>{},350)'],
+            cwd: process.cwd(),
+            env: {},
+        });
+
+        const attachedBeats = heartbeats.filter((h) => h.state === 'attached').length;
+        expect(attachedBeats).toBeGreaterThanOrEqual(3);
+    });
+});

--- a/packages/tasks/src/trigger/worker/services/terminal-session-host.ts
+++ b/packages/tasks/src/trigger/worker/services/terminal-session-host.ts
@@ -1,0 +1,103 @@
+import type { ITerminalStreamPlugin, TerminalSessionHandle } from '@ever-works/plugin';
+import { makeTerminalErrorFrame } from '@ever-works/contracts';
+import type { TerminalTransportClient } from './terminal-transport.client.js';
+
+/**
+ * Worker-side terminal session host (streaming-terminal M6).
+ *
+ * Orchestrates one live session end-to-end with every seam injectable
+ * (the whole byte path tests with a loopback transport and a plain
+ * child process — no PTY, no SDK, no network):
+ *
+ *   1. lifecycle → `starting` (+ provider id, persistent flag)
+ *   2. transport up (worker token + WS inbound + batched publish)
+ *   3. preamble banner, then `plugin.spawn(...)` pumps the process
+ *   4. heartbeat every {@link HEARTBEAT_INTERVAL_MS} while live
+ *   5. on exit: lifecycle → `ended` with the mapped reason (the plugin
+ *      already published the pinned exit frame BEFORE resolving)
+ *
+ * Failure honesty: a spawn failure publishes an error banner + a
+ * crashed exit through the transport (never a silently-black pane) and
+ * still transitions the lifecycle to `ended/crashed`.
+ */
+const HEARTBEAT_INTERVAL_MS = 60_000;
+
+export interface TerminalSessionSpec {
+    runId: string;
+    command: readonly string[];
+    cwd: string;
+    env: Readonly<Record<string, string>>;
+    persistent?: boolean;
+    /** Kill the child when the inbound socket dies (cost guard). */
+    endOnInputClose?: boolean;
+}
+
+export interface TerminalSessionResult {
+    code: number;
+    reason: 'completed' | 'crashed' | 'closed';
+    isPty: boolean;
+}
+
+export class TerminalSessionHost {
+    constructor(
+        private readonly plugin: ITerminalStreamPlugin,
+        private readonly client: TerminalTransportClient,
+        private readonly heartbeatIntervalMs: number = HEARTBEAT_INTERVAL_MS,
+    ) {}
+
+    async run(spec: TerminalSessionSpec): Promise<TerminalSessionResult> {
+        await this.client.heartbeat(spec.runId, {
+            state: 'starting',
+            providerId: this.plugin.providerName,
+            persistent: spec.persistent === true,
+        });
+
+        const transport = await this.client.createTransport(spec.runId);
+
+        let handle: TerminalSessionHandle;
+        try {
+            handle = await this.plugin.spawn(
+                {
+                    runId: spec.runId,
+                    command: spec.command,
+                    cwd: spec.cwd,
+                    env: spec.env,
+                    endOnInputClose: spec.endOnInputClose,
+                    preamble: [
+                        makeTerminalErrorFrame(
+                            `starting ${spec.command[0] ?? 'session'} (${this.plugin.providerName})…`,
+                        ),
+                    ],
+                },
+                transport,
+            );
+        } catch (error) {
+            // Loud failure: banner + crashed exit + ended lifecycle — a
+            // viewer attaching later still learns exactly what happened.
+            const message = error instanceof Error ? error.message : String(error);
+            transport.publish(makeTerminalErrorFrame(`session failed to start: ${message}`));
+            transport.publish({ kind: 'exit', code: -1, reason: 'crashed' });
+            await transport.close();
+            await this.client.heartbeat(spec.runId, { state: 'ended', endedReason: 'crashed' });
+            throw error;
+        }
+
+        await this.client.heartbeat(spec.runId, { state: 'attached' });
+
+        const beat = setInterval(() => {
+            void this.client.heartbeat(spec.runId, { state: 'attached' });
+        }, this.heartbeatIntervalMs);
+        beat.unref?.();
+
+        try {
+            const outcome = await handle.exited;
+            await this.client.heartbeat(spec.runId, {
+                state: 'ended',
+                endedReason: outcome.reason,
+            });
+            return { ...outcome, isPty: handle.isPty };
+        } finally {
+            clearInterval(beat);
+        }
+    }
+}

--- a/packages/tasks/src/trigger/worker/services/terminal-transport.client.ts
+++ b/packages/tasks/src/trigger/worker/services/terminal-transport.client.ts
@@ -1,0 +1,257 @@
+import { config } from '@ever-works/agent/config';
+import {
+    decodeTerminalFrame,
+    encodeTerminalFrame,
+    type TerminalFrame,
+} from '@ever-works/contracts';
+import type { TerminalTransport } from '@ever-works/plugin';
+
+/**
+ * Worker-side terminal transport (streaming-terminal M6).
+ *
+ * Bridges a hosted PTY/pipe process to the API relay:
+ *
+ *  - **Outbound**: frames buffer briefly and POST in small batches to
+ *    `POST /api/internal/terminal/:runId/frames` (x-trigger-secret —
+ *    the house internal-API header). Batches flush every
+ *    {@link FLUSH_INTERVAL_MS} or at {@link FLUSH_BYTES}, far below the
+ *    global 1MB body limit; a 413 response splits and retries once.
+ *  - **Inbound**: the worker attaches to the SAME WebSocket gateway as
+ *    browsers, with a `role: 'worker'` token brokered by run id via
+ *    `POST /:runId/worker-token` (credentials never ride the task
+ *    payload). `ws` is loaded via RUNTIME require — the deployed worker
+ *    bundle has no global WebSocket (trap: ship `ws`, never assume).
+ *  - `close()` flushes every buffered frame and is AWAITED by the
+ *    plugin before its handle resolves — the exit frame always lands.
+ */
+const FLUSH_INTERVAL_MS = 150;
+const FLUSH_BYTES = 64 * 1024;
+const MAX_BATCH_FRAMES = 512;
+
+interface WsLike {
+    on(event: string, cb: (...args: unknown[]) => void): void;
+    send(data: string): void;
+    close(): void;
+    readyState: number;
+    OPEN: number;
+}
+
+interface WsCtorLike {
+    new (url: string): WsLike;
+}
+
+export class TerminalTransportClient {
+    private readonly baseUrl: string;
+    private readonly secret: string;
+
+    constructor() {
+        this.baseUrl = (config.trigger.getInternalBaseUrl() || '').replace(/\/$/, '');
+        this.secret = config.trigger.getInternalSecret() || '';
+        if (!this.baseUrl || !this.secret) {
+            throw new Error(
+                'Terminal transport requires TRIGGER_INTERNAL_API_URL and TRIGGER_INTERNAL_SECRET.',
+            );
+        }
+    }
+
+    /** Create the transport for one run: worker token + WS + batcher. */
+    async createTransport(runId: string): Promise<TerminalTransport> {
+        const tokenRes = await this.post(`/api/internal/terminal/${runId}/worker-token`, {});
+        const { token, wsPath } = (await tokenRes.json()) as { token: string; wsPath: string };
+
+        const wsUrl = this.baseUrl.replace(/^http/, 'ws') + wsPath;
+        const socket = await this.openSocket(wsUrl, token);
+
+        // ── outbound batcher ────────────────────────────────────────
+        let buffer: TerminalFrame[] = [];
+        let bufferedBytes = 0;
+        let timer: NodeJS.Timeout | null = null;
+        let flushing: Promise<void> = Promise.resolve();
+
+        const flushNow = async (): Promise<void> => {
+            if (timer) {
+                clearTimeout(timer);
+                timer = null;
+            }
+            if (buffer.length === 0) return;
+            const batch = buffer;
+            buffer = [];
+            bufferedBytes = 0;
+            try {
+                const res = await this.post(`/api/internal/terminal/${runId}/frames`, batch);
+                if (res.status === 413 && batch.length > 1) {
+                    // Split once; single oversize frames are the codec's
+                    // problem (it caps them) so no infinite recursion.
+                    const mid = Math.ceil(batch.length / 2);
+                    await this.post(`/api/internal/terminal/${runId}/frames`, batch.slice(0, mid));
+                    await this.post(`/api/internal/terminal/${runId}/frames`, batch.slice(mid));
+                }
+            } catch {
+                // Fire-and-forget for data frames: a transient publish
+                // failure loses a window of scrollback, never the session.
+            }
+        };
+
+        const scheduleFlush = () => {
+            if (timer) return;
+            timer = setTimeout(() => {
+                flushing = flushing.then(flushNow);
+            }, FLUSH_INTERVAL_MS);
+            timer.unref?.();
+        };
+
+        // ── inbound queue ───────────────────────────────────────────
+        const inboundQueue: TerminalFrame[] = [];
+        let notify: (() => void) | null = null;
+        let closed = false;
+
+        socket.on('message', (data: unknown) => {
+            const raw =
+                typeof data === 'string'
+                    ? data
+                    : data instanceof Buffer
+                      ? new Uint8Array(data)
+                      : null;
+            if (raw === null) return;
+            const frame = decodeTerminalFrame(raw);
+            if (frame && (frame.kind === 'stdin' || frame.kind === 'resize')) {
+                inboundQueue.push(frame);
+                notify?.();
+            }
+        });
+        socket.on('close', () => {
+            closed = true;
+            notify?.();
+        });
+        socket.on('error', () => {
+            closed = true;
+            notify?.();
+        });
+
+        return {
+            publish: (frame) => {
+                const wire = encodeTerminalFrame(frame);
+                if (wire === null) return;
+                buffer.push(frame);
+                bufferedBytes += wire.length;
+                if (
+                    frame.kind === 'exit' ||
+                    bufferedBytes >= FLUSH_BYTES ||
+                    buffer.length >= MAX_BATCH_FRAMES
+                ) {
+                    flushing = flushing.then(flushNow);
+                } else {
+                    scheduleFlush();
+                }
+            },
+            inbound: () => ({
+                [Symbol.asyncIterator]() {
+                    return {
+                        next(): Promise<IteratorResult<TerminalFrame>> {
+                            if (inboundQueue.length > 0) {
+                                return Promise.resolve({
+                                    value: inboundQueue.shift() as TerminalFrame,
+                                    done: false,
+                                });
+                            }
+                            if (closed) {
+                                return Promise.resolve({
+                                    value: undefined as never,
+                                    done: true,
+                                });
+                            }
+                            return new Promise((resolve) => {
+                                notify = () => {
+                                    notify = null;
+                                    if (inboundQueue.length > 0) {
+                                        resolve({
+                                            value: inboundQueue.shift() as TerminalFrame,
+                                            done: false,
+                                        });
+                                    } else {
+                                        resolve({ value: undefined as never, done: true });
+                                    }
+                                };
+                            });
+                        },
+                    };
+                },
+            }),
+            close: async () => {
+                await flushing.then(flushNow);
+                closed = true;
+                notify?.();
+                try {
+                    socket.close();
+                } catch {
+                    // already gone
+                }
+            },
+        };
+    }
+
+    /**
+     * Best-effort pinned-exit publish for the sweeper: a session whose
+     * worker died can't publish its own exit frame, so the sweeper does
+     * it post-mortem. The relay pins it for every current/future attach.
+     */
+    async publishExit(
+        runId: string,
+        code: number,
+        reason: 'completed' | 'crashed' | 'closed' | 'parked',
+    ): Promise<void> {
+        await this.post(`/api/internal/terminal/${runId}/frames`, [{ kind: 'exit', code, reason }]);
+    }
+
+    /** Heartbeat + lifecycle updates (server stamps the timestamp). */
+    async heartbeat(
+        runId: string,
+        body: {
+            state?: 'starting' | 'attached' | 'ended';
+            endedReason?: 'completed' | 'crashed' | 'closed' | 'parked';
+            providerId?: string;
+            cliSessionId?: string;
+            lastFrameSeq?: number;
+            persistent?: boolean;
+        },
+    ): Promise<void> {
+        try {
+            await this.post(`/api/internal/terminal/${runId}/heartbeat`, body);
+        } catch {
+            // Heartbeat loss is survivable; the sweeper's cutoff has slack.
+        }
+    }
+
+    private async post(path: string, body: unknown): Promise<Response> {
+        const res = await fetch(`${this.baseUrl}${path}`, {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                'x-trigger-secret': this.secret,
+            },
+            body: JSON.stringify(body),
+        });
+        if (!res.ok && res.status !== 413) {
+            throw new Error(`terminal internal API ${path} → ${res.status}`);
+        }
+        return res;
+    }
+
+    private openSocket(wsUrl: string, token: string): Promise<WsLike> {
+        // Runtime require: the bundled Trigger.dev runtime has no global
+        // WebSocket; `ws` must be shipped and loaded lazily so worker
+        // bundling never traces browser-only paths.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { WebSocket: WsCtor } = require('ws') as { WebSocket: WsCtorLike };
+        return new Promise((resolve, reject) => {
+            const socket = new WsCtor(wsUrl);
+            socket.on('open', () => {
+                socket.send(JSON.stringify({ kind: 'auth', token }));
+                resolve(socket);
+            });
+            socket.on('error', (err: unknown) => {
+                reject(err instanceof Error ? err : new Error(String(err)));
+            });
+        });
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3223,12 +3223,18 @@ importers:
       '@ever-works/agent':
         specifier: workspace:*
         version: link:../agent
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       '@ever-works/job-runtime-trigger-plugin':
         specifier: workspace:*
         version: link:../plugins/job-runtime-trigger
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../plugin
+      '@ever-works/pty-local-plugin':
+        specifier: workspace:*
+        version: link:../plugins/pty-local
       '@nestjs/cache-manager':
         specifier: ^3.1.0
         version: 3.1.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(cache-manager@7.2.8)(keyv@5.6.0)(rxjs@7.8.2)


### PR DESCRIPTION
Wave 1 M6, stacked on #1823. The worker side of the loop: transport client (worker-token brokering, runtime-require('ws') inbound, batched publish with exit-flush + 413 split), session host (lifecycle heartbeats, loud spawn-failure banners), the `terminal-session` durable task (ownership-guarded, 3600s cost backstop; `agent-task-execute` deliberately untouched this slice), stale-heartbeat sweeper with post-mortem pinned-exit publish, and dual-header internal auth (`x-trigger-secret` house convention + Bearer). Loopback tests drive REAL child processes through the REAL pty-local plugin with in-memory transport — the complete worker byte path with zero network. 377 tasks + 62 api-terminal tests green.

**Deploy-smoke note**: node-pty/`ws` presence in the Trigger.dev image is only provable by a real `pnpm deploy:trigger` — scheduled with the wave-close cascade rather than mid-stack; the pipe floor + cannot-connect states keep a missing addon honest either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)