### PR TITLE
feat(agent): worktree-per-Task isolation — schema + workspace capability (Wave 2 M1+M2)

### DIFF
--- a/apps/api/src/migrations/1782700000000-AddTaskIsolationColumns.ts
+++ b/apps/api/src/migrations/1782700000000-AddTaskIsolationColumns.ts
@@ -48,13 +48,39 @@ export class AddTaskIsolationColumns1782700000000 implements MigrationInterface 
             await add('isolationMode', `"isolationMode" varchar(8)`);
             await add('branchRef', `"branchRef" varchar(200)`);
             await add('branchState', `"branchState" varchar(16)`);
+            await add('baseSha', `"baseSha" varchar(40)`);
+            await add('prNumber', `"prNumber" int`);
+            await add('prUrl', `"prUrl" varchar(512)`);
+            await add('conflictPaths', `"conflictPaths" text`);
+            // GC sweeper + Tasks-tab filter both scan (workId, branchState).
+            await queryRunner.query(
+                `CREATE INDEX IF NOT EXISTS "idx_tasks_branch_state" ON "tasks" ("workId", "branchState")`,
+            );
+        }
+
+        const agentRuns = await queryRunner.getTable('agent_runs');
+        if (agentRuns && !agentRuns.findColumnByName('workspaceMeta')) {
+            await queryRunner.query(`ALTER TABLE "agent_runs" ADD COLUMN "workspaceMeta" text`);
         }
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        const agentRuns = await queryRunner.getTable('agent_runs');
+        if (agentRuns && agentRuns.findColumnByName('workspaceMeta')) {
+            await queryRunner.query(`ALTER TABLE "agent_runs" DROP COLUMN "workspaceMeta"`);
+        }
+        await queryRunner.query(`DROP INDEX IF EXISTS "idx_tasks_branch_state"`);
         const tasks = await queryRunner.getTable('tasks');
         if (tasks) {
-            for (const col of ['branchState', 'branchRef', 'isolationMode']) {
+            for (const col of [
+                'conflictPaths',
+                'prUrl',
+                'prNumber',
+                'baseSha',
+                'branchState',
+                'branchRef',
+                'isolationMode',
+            ]) {
                 if (tasks.findColumnByName(col)) {
                     await queryRunner.query(`ALTER TABLE "tasks" DROP COLUMN "${col}"`);
                 }

--- a/apps/api/src/migrations/1782700000000-AddTaskIsolationColumns.ts
+++ b/apps/api/src/migrations/1782700000000-AddTaskIsolationColumns.ts
@@ -1,0 +1,77 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Worktree-per-Task isolation (Wave 2 M1) — settings + identity columns.
+ *
+ * `works`: taskIsolation ('off' default — opt-in per the founder),
+ * taskIsolationBaseBranch (NULL = repo default branch),
+ * taskIsolationTargetRepo ('work-output' default), taskBranchCleanup
+ * ('on-merge' default).
+ *
+ * `tasks`: isolationMode (NULL = inherit Work), branchRef
+ * (authoritative once written), branchState (lifecycle; NULL = never
+ * engaged).
+ *
+ * Forward-only, idempotent per-step guards (house pattern). Defaults
+ * make every existing row mean "isolation off, nothing changes".
+ */
+export class AddTaskIsolationColumns1782700000000 implements MigrationInterface {
+    name = 'AddTaskIsolationColumns1782700000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const works = await queryRunner.getTable('works');
+        if (works) {
+            const add = async (name: string, ddl: string) => {
+                if (!works.findColumnByName(name)) {
+                    await queryRunner.query(`ALTER TABLE "works" ADD COLUMN ${ddl}`);
+                }
+            };
+            await add('taskIsolation', `"taskIsolation" varchar(16) NOT NULL DEFAULT 'off'`);
+            await add('taskIsolationBaseBranch', `"taskIsolationBaseBranch" varchar(128)`);
+            await add(
+                'taskIsolationTargetRepo',
+                `"taskIsolationTargetRepo" varchar(16) NOT NULL DEFAULT 'work-output'`,
+            );
+            await add(
+                'taskBranchCleanup',
+                `"taskBranchCleanup" varchar(16) NOT NULL DEFAULT 'on-merge'`,
+            );
+        }
+
+        const tasks = await queryRunner.getTable('tasks');
+        if (tasks) {
+            const add = async (name: string, ddl: string) => {
+                if (!tasks.findColumnByName(name)) {
+                    await queryRunner.query(`ALTER TABLE "tasks" ADD COLUMN ${ddl}`);
+                }
+            };
+            await add('isolationMode', `"isolationMode" varchar(8)`);
+            await add('branchRef', `"branchRef" varchar(200)`);
+            await add('branchState', `"branchState" varchar(16)`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const tasks = await queryRunner.getTable('tasks');
+        if (tasks) {
+            for (const col of ['branchState', 'branchRef', 'isolationMode']) {
+                if (tasks.findColumnByName(col)) {
+                    await queryRunner.query(`ALTER TABLE "tasks" DROP COLUMN "${col}"`);
+                }
+            }
+        }
+        const works = await queryRunner.getTable('works');
+        if (works) {
+            for (const col of [
+                'taskBranchCleanup',
+                'taskIsolationTargetRepo',
+                'taskIsolationBaseBranch',
+                'taskIsolation',
+            ]) {
+                if (works.findColumnByName(col)) {
+                    await queryRunner.query(`ALTER TABLE "works" DROP COLUMN "${col}"`);
+                }
+            }
+        }
+    }
+}

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -151,6 +151,7 @@ export class TasksController {
             status: body.status,
             priority: body.priority,
             labels: body.labels ?? null,
+            isolationMode: body.isolationMode ?? null,
             missionId: body.missionId ?? null,
             ideaId: body.ideaId ?? null,
             workId: body.workId ?? null,

--- a/apps/api/src/tasks/tasks.dto.ts
+++ b/apps/api/src/tasks/tasks.dto.ts
@@ -39,6 +39,12 @@ export class CreateTaskDto {
     @MaxLength(80, { each: true })
     labels?: string[] | null;
 
+    /** Task isolation override (worktree-per-Task, Wave 2): NULL
+     *  inherits the Work's taskIsolation setting. */
+    @IsOptional()
+    @IsIn(['on', 'off'])
+    isolationMode?: string | null;
+
     @IsOptional()
     @IsUUID()
     missionId?: string | null;
@@ -96,6 +102,12 @@ export class UpdateTaskDto {
     @IsString({ each: true })
     @MaxLength(80, { each: true })
     labels?: string[] | null;
+
+    /** Task isolation override (worktree-per-Task, Wave 2): NULL
+     *  inherits the Work's taskIsolation setting. */
+    @IsOptional()
+    @IsIn(['on', 'off'])
+    isolationMode?: string | null;
 
     /**
      * Re-filing a Task under a different owner. `null` detaches it from

--- a/apps/api/src/tasks/tasks.dto.ts
+++ b/apps/api/src/tasks/tasks.dto.ts
@@ -43,7 +43,7 @@ export class CreateTaskDto {
      *  inherits the Work's taskIsolation setting. */
     @IsOptional()
     @IsIn(['on', 'off'])
-    isolationMode?: string | null;
+    isolationMode?: 'on' | 'off' | null;
 
     @IsOptional()
     @IsUUID()
@@ -107,7 +107,7 @@ export class UpdateTaskDto {
      *  inherits the Work's taskIsolation setting. */
     @IsOptional()
     @IsIn(['on', 'off'])
-    isolationMode?: string | null;
+    isolationMode?: 'on' | 'off' | null;
 
     /**
      * Re-filing a Task under a different owner. `null` detaches it from

--- a/packages/agent/src/account-transfer/account-export.service.ts
+++ b/packages/agent/src/account-transfer/account-export.service.ts
@@ -185,6 +185,10 @@ export class AccountExportService {
                 typeof dir.providerRepositoryEnabled === 'boolean'
                     ? dir.providerRepositoryEnabled
                     : undefined,
+            taskIsolation: dir.taskIsolation || undefined,
+            taskIsolationBaseBranch: dir.taskIsolationBaseBranch ?? undefined,
+            taskIsolationTargetRepo: dir.taskIsolationTargetRepo || undefined,
+            taskBranchCleanup: dir.taskBranchCleanup || undefined,
             gitProvider: dir.gitProvider,
             deployProvider: dir.deployProvider || undefined,
             readmeConfig: dir.readmeConfig || undefined,

--- a/packages/agent/src/account-transfer/account-export.service.ts
+++ b/packages/agent/src/account-transfer/account-export.service.ts
@@ -186,7 +186,10 @@ export class AccountExportService {
                     ? dir.providerRepositoryEnabled
                     : undefined,
             taskIsolation: dir.taskIsolation || undefined,
-            taskIsolationBaseBranch: dir.taskIsolationBaseBranch ?? undefined,
+            // Serialize explicit null (= repo default branch) — omitting it
+            // would make an overwrite import silently RETAIN a custom base.
+            taskIsolationBaseBranch:
+                dir.taskIsolationBaseBranch === undefined ? undefined : dir.taskIsolationBaseBranch,
             taskIsolationTargetRepo: dir.taskIsolationTargetRepo || undefined,
             taskBranchCleanup: dir.taskBranchCleanup || undefined,
             gitProvider: dir.gitProvider,

--- a/packages/agent/src/account-transfer/account-import.service.spec.ts
+++ b/packages/agent/src/account-transfer/account-import.service.spec.ts
@@ -588,7 +588,13 @@ describe('AccountImportService', () => {
             await service.applyImport(
                 'user-1',
                 makePayload([
-                    makeWork({ slug: 'a', kind: 'blog', providerRepositoryEnabled: false }),
+                    makeWork({
+                        slug: 'a',
+                        kind: 'blog',
+                        providerRepositoryEnabled: false,
+                        taskIsolation: 'worktree',
+                        taskBranchCleanup: 'manual',
+                    }),
                 ]),
                 [],
             );
@@ -596,7 +602,12 @@ describe('AccountImportService', () => {
             // A user who deliberately disabled provider-repo generation must
             // not have it silently re-enabled by an account transfer.
             expect(mocks.workRepository.create).toHaveBeenCalledWith(
-                expect.objectContaining({ kind: 'blog', providerRepositoryEnabled: false }),
+                expect.objectContaining({
+                    kind: 'blog',
+                    providerRepositoryEnabled: false,
+                    taskIsolation: 'worktree',
+                    taskBranchCleanup: 'manual',
+                }),
                 expect.anything(),
             );
         });

--- a/packages/agent/src/account-transfer/account-import.service.ts
+++ b/packages/agent/src/account-transfer/account-import.service.ts
@@ -545,9 +545,11 @@ export class AccountImportService {
                     updateData.taskBranchCleanup = dir.taskBranchCleanup;
                 }
                 if (
-                    typeof dir.taskIsolationBaseBranch === 'string' &&
-                    dir.taskIsolationBaseBranch.length <= 128
+                    dir.taskIsolationBaseBranch === null ||
+                    (typeof dir.taskIsolationBaseBranch === 'string' &&
+                        dir.taskIsolationBaseBranch.length <= 128)
                 ) {
+                    // null = 'use repo default' and must overwrite a custom base.
                     updateData.taskIsolationBaseBranch = dir.taskIsolationBaseBranch;
                 }
                 await this.workRepository.update(existing.id, updateData);

--- a/packages/agent/src/account-transfer/account-import.service.ts
+++ b/packages/agent/src/account-transfer/account-import.service.ts
@@ -526,6 +526,30 @@ export class AccountImportService {
                 if (typeof dir.providerRepositoryEnabled === 'boolean') {
                     updateData.providerRepositoryEnabled = dir.providerRepositoryEnabled;
                 }
+                if (
+                    typeof dir.taskIsolation === 'string' &&
+                    ['off', 'worktree'].includes(dir.taskIsolation)
+                ) {
+                    updateData.taskIsolation = dir.taskIsolation;
+                }
+                if (
+                    typeof dir.taskIsolationTargetRepo === 'string' &&
+                    ['work-output', 'data', 'provider'].includes(dir.taskIsolationTargetRepo)
+                ) {
+                    updateData.taskIsolationTargetRepo = dir.taskIsolationTargetRepo;
+                }
+                if (
+                    typeof dir.taskBranchCleanup === 'string' &&
+                    ['on-merge', 'manual'].includes(dir.taskBranchCleanup)
+                ) {
+                    updateData.taskBranchCleanup = dir.taskBranchCleanup;
+                }
+                if (
+                    typeof dir.taskIsolationBaseBranch === 'string' &&
+                    dir.taskIsolationBaseBranch.length <= 128
+                ) {
+                    updateData.taskIsolationBaseBranch = dir.taskIsolationBaseBranch;
+                }
                 await this.workRepository.update(existing.id, updateData);
 
                 await this.importWorkRelations(existing.id, userId, dir, includesSecrets, result);
@@ -560,6 +584,30 @@ export class AccountImportService {
         }
         if (typeof dir.providerRepositoryEnabled === 'boolean') {
             createData.providerRepositoryEnabled = dir.providerRepositoryEnabled;
+        }
+        if (
+            typeof dir.taskIsolation === 'string' &&
+            ['off', 'worktree'].includes(dir.taskIsolation)
+        ) {
+            createData.taskIsolation = dir.taskIsolation;
+        }
+        if (
+            typeof dir.taskIsolationTargetRepo === 'string' &&
+            ['work-output', 'data', 'provider'].includes(dir.taskIsolationTargetRepo)
+        ) {
+            createData.taskIsolationTargetRepo = dir.taskIsolationTargetRepo;
+        }
+        if (
+            typeof dir.taskBranchCleanup === 'string' &&
+            ['on-merge', 'manual'].includes(dir.taskBranchCleanup)
+        ) {
+            createData.taskBranchCleanup = dir.taskBranchCleanup;
+        }
+        if (
+            typeof dir.taskIsolationBaseBranch === 'string' &&
+            dir.taskIsolationBaseBranch.length <= 128
+        ) {
+            createData.taskIsolationBaseBranch = dir.taskIsolationBaseBranch;
         }
         const newDir = await this.workRepository.create(createData, user);
 

--- a/packages/agent/src/account-transfer/types.ts
+++ b/packages/agent/src/account-transfer/types.ts
@@ -141,6 +141,12 @@ export interface ExportedWork {
      *  an export/import round-trip — omitting it would silently re-enable
      *  provider-repo generation on the imported work. */
     providerRepositoryEnabled?: boolean;
+    /** Task-isolation settings (Wave 2) — user-visible Work settings
+     *  must round-trip; absent in old payloads = leave defaults. */
+    taskIsolation?: string;
+    taskIsolationBaseBranch?: string | null;
+    taskIsolationTargetRepo?: string;
+    taskBranchCleanup?: string;
     gitProvider: string;
     deployProvider?: string;
     readmeConfig?: any;

--- a/packages/agent/src/dto/update-work.dto.ts
+++ b/packages/agent/src/dto/update-work.dto.ts
@@ -79,6 +79,24 @@ export class UpdateWorkDto {
     @IsBoolean()
     providerRepositoryEnabled?: boolean;
 
+    /** Task isolation (worktree-per-Task, Wave 2). 'off' | 'worktree'. */
+    @IsOptional()
+    @IsIn(['off', 'worktree'])
+    taskIsolation?: string;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(128)
+    taskIsolationBaseBranch?: string | null;
+
+    @IsOptional()
+    @IsIn(['work-output', 'data', 'provider'])
+    taskIsolationTargetRepo?: string;
+
+    @IsOptional()
+    @IsIn(['on-merge', 'manual'])
+    taskBranchCleanup?: string;
+
     @ApiPropertyOptional({ description: 'Whether community PR processing is enabled' })
     @IsOptional()
     @IsBoolean()

--- a/packages/agent/src/entities/agent-run.entity.ts
+++ b/packages/agent/src/entities/agent-run.entity.ts
@@ -111,6 +111,19 @@ export class AgentRun {
     @Column({ type: 'varchar', length: 128, nullable: true })
     memorySessionId?: string | null;
 
+    /** Per-run workspace audit (worktree-per-Task isolation):
+     *  `{ provider, path?, baseSha, branchRef, reused }`. The Task row
+     *  keeps the durable subset (branchRef/branchState/baseSha); this is
+     *  the run-scoped record for debugging and the run cockpit. */
+    @Column({ type: 'simple-json', nullable: true })
+    workspaceMeta?: {
+        provider: string;
+        path?: string;
+        baseSha: string;
+        branchRef: string;
+        reused: boolean;
+    } | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/task.entity.ts
+++ b/packages/agent/src/entities/task.entity.ts
@@ -134,6 +134,25 @@ export class Task {
     @Column({ type: 'uuid', nullable: true })
     parentTaskId?: string | null;
 
+    // ── Task isolation (worktree-per-Task, Wave 2 M1) ────────────────
+
+    /** Per-Task override of the Work's `taskIsolation` setting:
+     *  NULL = inherit; `'on' | 'off'` force it. Resolution lives in
+     *  `tasks-domain/task-isolation.ts` (one function, unit-tested). */
+    @Column({ type: 'varchar', length: 8, nullable: true })
+    isolationMode?: string | null;
+
+    /** The Task's branch (e.g. `task/t-42-9f3c1a2b`). AUTHORITATIVE once
+     *  written — never recomputed, so a slug edit can't orphan it. The
+     *  branch is the durable workspace identity in cloud mode. */
+    @Column({ type: 'varchar', length: 200, nullable: true })
+    branchRef?: string | null;
+
+    /** Branch lifecycle: `none | created | pushed | pr-open | conflict |
+     *  merged | discarded`. NULL = isolation never engaged. */
+    @Column({ type: 'varchar', length: 16, nullable: true })
+    branchState?: string | null;
+
     @Column({ type: 'varchar', length: 16 })
     createdByType: TaskActorType;
 

--- a/packages/agent/src/entities/task.entity.ts
+++ b/packages/agent/src/entities/task.entity.ts
@@ -64,6 +64,7 @@ export type TaskActorType = 'user' | 'agent';
 @Index('idx_tasks_agent', ['agentId', 'status'])
 @Index('idx_tasks_goal', ['goalId', 'status'])
 @Index('idx_tasks_parent', ['parentTaskId'])
+@Index('idx_tasks_branch_state', ['workId', 'branchState'])
 // Phase 17 hot path — dispatcher walks rows where (isRecurring, nextOccurrenceAt <= now).
 @Index('idx_tasks_recurrence_due', ['isRecurring', 'nextOccurrenceAt'])
 export class Task {
@@ -152,6 +153,22 @@ export class Task {
      *  merged | discarded`. NULL = isolation never engaged. */
     @Column({ type: 'varchar', length: 16, nullable: true })
     branchState?: string | null;
+
+    /** SHA of the fetched base commit the branch was cut from. */
+    @Column({ type: 'varchar', length: 40, nullable: true })
+    baseSha?: string | null;
+
+    /** PR opened from the Task branch (community-PR flow). */
+    @Column({ type: 'int', nullable: true })
+    prNumber?: number | null;
+
+    @Column({ type: 'varchar', length: 512, nullable: true })
+    prUrl?: string | null;
+
+    /** Named conflicting paths when `branchState='conflict'` — surfaced
+     *  verbatim in the blocked banner and the task-chat system message. */
+    @Column({ type: 'simple-json', nullable: true })
+    conflictPaths?: string[] | null;
 
     @Column({ type: 'varchar', length: 16 })
     createdByType: TaskActorType;

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -402,6 +402,28 @@ export class Work {
     @Column({ type: 'boolean', default: false })
     comparisonsEnabled: boolean;
 
+    // ── Task isolation (worktree-per-Task, Wave 2 M1) ────────────────
+    // Opt-in, per the founder: "not everyone needs it." A Task with
+    // isolation resolved off behaves exactly as today.
+
+    /** `'off' | 'worktree'` — default off; per-Task override on Task. */
+    @Column({ type: 'varchar', length: 16, default: 'off' })
+    taskIsolation: string;
+
+    /** Base branch Tasks branch FROM (ALWAYS fetched fresh — never a
+     *  cached HEAD). NULL = the repo's default branch. */
+    @Column({ type: 'varchar', length: 128, nullable: true })
+    taskIsolationBaseBranch?: string | null;
+
+    /** Which of the Work's repos the branch/PR flow targets:
+     *  `'work-output' | 'data' | 'provider'`. */
+    @Column({ type: 'varchar', length: 16, default: 'work-output' })
+    taskIsolationTargetRepo: string;
+
+    /** `'on-merge' | 'manual'` — when the Task branch is deleted. */
+    @Column({ type: 'varchar', length: 16, default: 'on-merge' })
+    taskBranchCleanup: string;
+
     /**
      * Whether to generate the browsable repository published to the git
      * provider — the one the UI calls the "{provider} Repository" and that

--- a/packages/agent/src/facades/__tests__/facades.module.spec.ts
+++ b/packages/agent/src/facades/__tests__/facades.module.spec.ts
@@ -15,6 +15,7 @@ import { SkillsFacadeService } from '../skills.facade';
 import { TasksFacadeService } from '../tasks.facade';
 // EW-N (agentmemory plugin) — pluggable persistent memory facade.
 import { AgentMemoryFacadeService } from '../agent-memory.facade';
+import { WorkspaceFacadeService } from '../workspace.facade';
 // Notifications v2 (EW-650 + EW-663) — email + notification-channel facades.
 import { EmailFacadeService } from '../email.facade';
 import { NotificationChannelFacadeService } from '../notification-channel.facade';
@@ -49,6 +50,8 @@ describe('FacadesModule + barrel re-exports', () => {
         TasksFacadeService,
         // EW-N — Agent-Memory facade (default plugin: agentmemory REST :3111).
         AgentMemoryFacadeService,
+        // Wave 2 M2 — workspace capability (worktree-per-Task isolation).
+        WorkspaceFacadeService,
         // Notifications v2 (EW-650 + EW-663) — email + multi-channel notifications.
         EmailFacadeService,
         NotificationChannelFacadeService,
@@ -121,6 +124,7 @@ describe('FacadesModule + barrel re-exports', () => {
             expect(facadesBarrel.SkillsFacadeService).toBe(SkillsFacadeService);
             expect(facadesBarrel.TasksFacadeService).toBe(TasksFacadeService);
             expect(facadesBarrel.AgentMemoryFacadeService).toBe(AgentMemoryFacadeService);
+            expect(facadesBarrel.WorkspaceFacadeService).toBe(WorkspaceFacadeService);
             expect(facadesBarrel.EmailFacadeService).toBe(EmailFacadeService);
             expect(facadesBarrel.NotificationChannelFacadeService).toBe(
                 NotificationChannelFacadeService,
@@ -223,6 +227,8 @@ describe('FacadesModule + barrel re-exports', () => {
                     // Agent-Memory facade (default plugin: agentmemory REST :3111).
                     'AgentMemoryFacadeError',
                     'AgentMemoryFacadeService',
+                    'WorkspaceFacadeError',
+                    'WorkspaceFacadeService',
                     // Notifications v2 (EW-650 + EW-663) — email + notification channels.
                     'EmailFacadeError',
                     'EmailFacadeService',

--- a/packages/agent/src/facades/__tests__/workspace.facade.spec.ts
+++ b/packages/agent/src/facades/__tests__/workspace.facade.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkspaceFacadeService, WorkspaceFacadeError } from '../workspace.facade';
+import {
+    PluginRegistryService,
+    type RegisteredPlugin,
+} from '../../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import type { IWorkspacePlugin, PluginManifest, WorkspaceHandle } from '@ever-works/plugin';
+import { WorkspaceNotProvisionedError } from '@ever-works/plugin';
+
+describe('WorkspaceFacadeService', () => {
+    let service: WorkspaceFacadeService;
+    let registry: jest.Mocked<PluginRegistryService>;
+
+    const handle: WorkspaceHandle = {
+        path: '/tmp/ws/task-abc12345',
+        baseSha: 'deadbeef',
+        reused: false,
+        branch: 'task/fix-thing-abc12345',
+        bindingKey: 'task-1',
+    };
+
+    const spec = {
+        repoUrl: 'https://github.com/acme/site.git',
+        baseRef: 'main',
+        branch: 'task/fix-thing-abc12345',
+        bindingKey: 'task-1',
+    };
+
+    const createMockWorkspacePlugin = (id: string): IWorkspacePlugin => ({
+        id,
+        name: id,
+        version: '1.0.0',
+        category: 'utility',
+        capabilities: ['workspace'],
+        settingsSchema: { type: 'object', properties: {} },
+        providerName: id,
+        onLoad: jest.fn(),
+        onUnload: jest.fn(),
+        provision: jest.fn().mockResolvedValue(handle),
+        finalize: jest.fn().mockResolvedValue({ pushed: true, headSha: 'cafe', empty: false }),
+        simulateMerge: jest.fn().mockResolvedValue({ clean: true, conflictPaths: [] }),
+        teardown: jest.fn().mockResolvedValue(undefined),
+    });
+
+    const createRegisteredPlugin = (
+        plugin: IWorkspacePlugin,
+        state: RegisteredPlugin['state'] = 'loaded',
+    ): RegisteredPlugin => ({
+        plugin: plugin as any,
+        manifest: {
+            id: plugin.id,
+            name: plugin.name,
+            version: plugin.version,
+            description: 'Test workspace plugin',
+            category: plugin.category,
+            capabilities: plugin.capabilities,
+        } as PluginManifest,
+        state,
+        builtIn: false,
+        stateHistory: [],
+        registeredAt: Date.now(),
+    });
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                WorkspaceFacadeService,
+                {
+                    provide: PluginRegistryService,
+                    useValue: {
+                        get: jest.fn(),
+                        getByCapability: jest.fn().mockReturnValue([]),
+                        isPluginEnabledForScope: jest.fn().mockResolvedValue(true),
+                    },
+                },
+                {
+                    provide: PluginSettingsService,
+                    useValue: { getSettings: jest.fn().mockResolvedValue({ poolDir: '/tmp/ws' }) },
+                },
+            ],
+        }).compile();
+
+        service = module.get(WorkspaceFacadeService);
+        registry = module.get(PluginRegistryService);
+    });
+
+    const arm = (plugin: IWorkspacePlugin) => {
+        const registered = createRegisteredPlugin(plugin);
+        registry.get.mockReturnValue(registered);
+        registry.getByCapability.mockReturnValue([registered]);
+    };
+
+    it('provisions through the resolved plugin with resolved settings attached', async () => {
+        const plugin = createMockWorkspacePlugin('local-workspace');
+        arm(plugin);
+
+        const result = await service.provision(spec, {
+            userId: 'u1',
+            providerOverride: 'local-workspace',
+        });
+
+        expect(result).toEqual(handle);
+        expect(plugin.provision).toHaveBeenCalledWith(
+            expect.objectContaining({ ...spec, settings: { poolDir: '/tmp/ws' } }),
+        );
+    });
+
+    it('passes WorkspaceNotProvisionedError through un-wrapped (stable name)', async () => {
+        const plugin = createMockWorkspacePlugin('local-workspace');
+        (plugin.provision as jest.Mock).mockRejectedValue(
+            new WorkspaceNotProvisionedError('no git on host'),
+        );
+        arm(plugin);
+
+        await expect(
+            service.provision(spec, { userId: 'u1', providerOverride: 'local-workspace' }),
+        ).rejects.toMatchObject({
+            name: 'WorkspaceNotProvisionedError',
+            message: 'no git on host',
+        });
+    });
+
+    it('wraps generic plugin failures in WorkspaceFacadeError with operation + provider', async () => {
+        const plugin = createMockWorkspacePlugin('local-workspace');
+        (plugin.simulateMerge as jest.Mock).mockRejectedValue(new Error('merge-tree exploded'));
+        arm(plugin);
+
+        await expect(
+            service.simulateMerge(handle, 'main', {
+                userId: 'u1',
+                providerOverride: 'local-workspace',
+            }),
+        ).rejects.toMatchObject({
+            name: 'WorkspaceFacadeError',
+            message: expect.stringContaining('merge-tree exploded'),
+        });
+    });
+
+    it('teardown never throws — plugin failure is swallowed and logged', async () => {
+        const plugin = createMockWorkspacePlugin('local-workspace');
+        (plugin.teardown as jest.Mock).mockRejectedValue(new Error('EBUSY'));
+        arm(plugin);
+
+        await expect(
+            service.teardown(handle, { userId: 'u1', providerOverride: 'local-workspace' }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('rejects a resolved plugin that lacks the workspace contract', async () => {
+        const impostor = createMockWorkspacePlugin('github');
+        (impostor as any).capabilities = ['git-provider'];
+        const registered = createRegisteredPlugin(impostor);
+        (registered.manifest as any).capabilities = ['workspace']; // registry thinks yes, instance says no
+        registry.get.mockReturnValue(registered);
+
+        await expect(
+            service.provision(spec, { userId: 'u1', providerOverride: 'github' }),
+        ).rejects.toBeInstanceOf(WorkspaceFacadeError);
+    });
+});

--- a/packages/agent/src/facades/facades.module.ts
+++ b/packages/agent/src/facades/facades.module.ts
@@ -18,6 +18,7 @@ import { TasksFacadeService } from './tasks.facade';
 import { EmailFacadeService } from './email.facade';
 import { NotificationChannelFacadeService } from './notification-channel.facade';
 import { AgentMemoryFacadeService } from './agent-memory.facade';
+import { WorkspaceFacadeService } from './workspace.facade';
 import { VectorStoreFacadeService } from './vector-store.facade';
 import { MetricsFacadeService } from './metrics.facade';
 
@@ -38,6 +39,7 @@ const FACADES = [
     EmailFacadeService,
     NotificationChannelFacadeService,
     AgentMemoryFacadeService,
+    WorkspaceFacadeService,
     // EW-724 / EW-725 — vector-store facade (KB embeddings; consumed by
     // KnowledgeBaseReembedService via FacadesModule). Provided here like every
     // other barrel facade; deps are the global PluginRegistryService plus two

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -118,6 +118,7 @@ export {
 // (default plugin `@ever-works/agentmemory-plugin` talks to a local or
 // hosted `agentmemory` REST server on :3111)
 export { AgentMemoryFacadeService, AgentMemoryFacadeError } from './agent-memory.facade';
+export { WorkspaceFacadeService, WorkspaceFacadeError } from './workspace.facade';
 
 // Vector Store Facade — EW-642 RFC §6 selection chain + D4 embedding
 // mode resolver. Routes KB chunk upsert / query / delete through the

--- a/packages/agent/src/facades/workspace.facade.ts
+++ b/packages/agent/src/facades/workspace.facade.ts
@@ -1,0 +1,125 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import type {
+    IPlugin,
+    IWorkspacePlugin,
+    IWorkspaceFacade,
+    WorkspaceProvisionSpec,
+    WorkspaceHandle,
+    WorkspaceFinalizeResult,
+    WorkspaceMergeSimulation,
+    FacadeOptions,
+} from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, isWorkspacePlugin } from '@ever-works/plugin';
+import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
+import { WorkPluginRepository } from '../plugins/repositories/work-plugin.repository';
+import { BaseFacadeService, FacadeError } from './base.facade';
+
+export class WorkspaceFacadeError extends FacadeError {
+    constructor(message: string, operation: string, provider?: string, cause?: Error) {
+        super(message, operation, provider, cause);
+        this.name = 'WorkspaceFacadeError';
+    }
+}
+
+/**
+ * Facade for the `workspace` capability (worktree-per-Task, Wave 2 M2).
+ *
+ * Standard provider resolution + settings hierarchy. The
+ * `WorkspaceNotProvisionedError` a plugin throws passes through
+ * UN-wrapped (stable name → loud, actionable failure); everything else
+ * wraps with provider identity.
+ */
+@Injectable()
+export class WorkspaceFacadeService extends BaseFacadeService implements IWorkspaceFacade {
+    protected readonly logger = new Logger(WorkspaceFacadeService.name);
+    protected readonly CAPABILITY = PLUGIN_CAPABILITIES.WORKSPACE;
+
+    constructor(
+        registry: PluginRegistryService,
+        settingsService: PluginSettingsService,
+        @Optional() workPluginRepository?: WorkPluginRepository,
+    ) {
+        super(registry, settingsService, workPluginRepository);
+    }
+
+    async provision(
+        spec: Omit<WorkspaceProvisionSpec, 'settings'>,
+        facadeOptions: FacadeOptions,
+    ): Promise<WorkspaceHandle> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        const settings = await this.getResolvedSettings(plugin.id, facadeOptions);
+        try {
+            return await plugin.provision({ ...spec, settings });
+        } catch (error) {
+            throw this.passOrWrap(error, 'provision', plugin.id);
+        }
+    }
+
+    async finalize(
+        handle: WorkspaceHandle,
+        opts: { commitMessage: string; push: boolean },
+        facadeOptions: FacadeOptions,
+    ): Promise<WorkspaceFinalizeResult> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        try {
+            return await plugin.finalize(handle, opts);
+        } catch (error) {
+            throw this.passOrWrap(error, 'finalize', plugin.id);
+        }
+    }
+
+    async simulateMerge(
+        handle: WorkspaceHandle,
+        targetRef: string,
+        facadeOptions: FacadeOptions,
+    ): Promise<WorkspaceMergeSimulation> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        try {
+            return await plugin.simulateMerge(handle, targetRef);
+        } catch (error) {
+            throw this.passOrWrap(error, 'simulateMerge', plugin.id);
+        }
+    }
+
+    async teardown(handle: WorkspaceHandle, facadeOptions: FacadeOptions): Promise<void> {
+        const plugin = await this.resolveTypedPlugin(facadeOptions);
+        try {
+            await plugin.teardown(handle);
+        } catch (error) {
+            // Teardown failures are logged, never thrown — a leaked
+            // workspace is the GC sweeper's job, not the run's problem.
+            this.logger.warn(
+                `workspace teardown failed (${plugin.id}): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    private passOrWrap(error: unknown, operation: string, provider: string): Error {
+        if (error instanceof Error && error.name === 'WorkspaceNotProvisionedError') {
+            return error;
+        }
+        if (error instanceof WorkspaceFacadeError) return error;
+        const message = error instanceof Error ? error.message : 'workspace operation failed';
+        const cause = error instanceof Error ? error : undefined;
+        return new WorkspaceFacadeError(message, operation, provider, cause);
+    }
+
+    private async resolveTypedPlugin(facadeOptions: FacadeOptions): Promise<IWorkspacePlugin> {
+        const plugin: IPlugin = await this.resolvePlugin(
+            facadeOptions.providerOverride,
+            facadeOptions.userId,
+            facadeOptions.workId,
+        );
+        if (!isWorkspacePlugin(plugin)) {
+            throw new WorkspaceFacadeError(
+                `Plugin ${plugin.id} does not implement the workspace contract.`,
+                'resolve',
+                plugin.id,
+            );
+        }
+        return plugin;
+    }
+}

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -642,6 +642,21 @@ export class WorkLifecycleService {
                 updateData.providerRepositoryEnabled = updateDto.providerRepositoryEnabled;
             }
 
+            // Task isolation settings (worktree-per-Task, Wave 2 M1).
+            // DTO enum-validated; NULL baseBranch = repo default.
+            if (updateDto.taskIsolation !== undefined) {
+                updateData.taskIsolation = updateDto.taskIsolation;
+            }
+            if (updateDto.taskIsolationBaseBranch !== undefined) {
+                updateData.taskIsolationBaseBranch = updateDto.taskIsolationBaseBranch;
+            }
+            if (updateDto.taskIsolationTargetRepo !== undefined) {
+                updateData.taskIsolationTargetRepo = updateDto.taskIsolationTargetRepo;
+            }
+            if (updateDto.taskBranchCleanup !== undefined) {
+                updateData.taskBranchCleanup = updateDto.taskBranchCleanup;
+            }
+
             // Handle community PR processing settings
             if (updateDto.communityPrEnabled !== undefined) {
                 updateData.communityPrEnabled = updateDto.communityPrEnabled;

--- a/packages/agent/src/tasks-domain/__tests__/task-isolation.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-isolation.spec.ts
@@ -45,20 +45,30 @@ describe('taskBranchName', () => {
 
     it('is deterministic and carries slug readability + id uniqueness', () => {
         const name = taskBranchName({ id, slug: 'T-42' });
-        expect(name).toBe('task/t-42-9f3c1a2b');
+        expect(name).toBe('task/t-42-9f3c1a2b111142228333444455556666');
         expect(taskBranchName({ id, slug: 'T-42' })).toBe(name);
     });
 
     it('sanitizes hostile slugs into git-safe names', () => {
         expect(taskBranchName({ id, slug: '../..//evil branch!!' })).toBe(
-            'task/evil-branch-9f3c1a2b',
+            'task/evil-branch-9f3c1a2b111142228333444455556666',
         );
-        expect(taskBranchName({ id, slug: '   ' })).toBe('task/task-9f3c1a2b');
-        expect(taskBranchName({ id, slug: null })).toBe('task/task-9f3c1a2b');
+        expect(taskBranchName({ id, slug: '   ' })).toBe(
+            'task/task-9f3c1a2b111142228333444455556666',
+        );
+        expect(taskBranchName({ id, slug: null })).toBe(
+            'task/task-9f3c1a2b111142228333444455556666',
+        );
+    });
+
+    it('distinguishes ids sharing an 8-char prefix (full-id identity)', () => {
+        const a = taskBranchName({ id: '9f3c1a2b-aaaa-4aaa-8aaa-aaaaaaaaaaaa', slug: 'T-42' });
+        const b = taskBranchName({ id: '9f3c1a2b-bbbb-4bbb-8bbb-bbbbbbbbbbbb', slug: 'T-42' });
+        expect(a).not.toBe(b);
     });
 
     it('caps slug length so branch names stay manageable', () => {
         const name = taskBranchName({ id, slug: 'x'.repeat(200) });
-        expect(name.length).toBeLessThanOrEqual('task/'.length + 40 + 1 + 8);
+        expect(name.length).toBeLessThanOrEqual('task/'.length + 40 + 1 + 32);
     });
 });

--- a/packages/agent/src/tasks-domain/__tests__/task-isolation.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-isolation.spec.ts
@@ -1,0 +1,64 @@
+import { resolveTaskIsolation, taskBranchName } from '../task-isolation';
+
+describe('resolveTaskIsolation', () => {
+    const workOn = { taskIsolation: 'worktree' };
+    const workOff = { taskIsolation: 'off' };
+
+    it('defaults OFF: no setting anywhere means exactly today’s behavior', () => {
+        expect(resolveTaskIsolation({ workId: 'w1' }, workOff)).toBe('off');
+        expect(resolveTaskIsolation({ workId: 'w1' }, null)).toBe('off');
+        expect(resolveTaskIsolation({ workId: 'w1' }, undefined)).toBe('off');
+    });
+
+    it('inherits the Work setting when the Task does not override', () => {
+        expect(resolveTaskIsolation({ workId: 'w1', isolationMode: null }, workOn)).toBe('on');
+    });
+
+    it('the per-Task override wins in BOTH directions', () => {
+        expect(resolveTaskIsolation({ workId: 'w1', isolationMode: 'off' }, workOn)).toBe('off');
+        expect(resolveTaskIsolation({ workId: 'w1', isolationMode: 'on' }, workOff)).toBe('on');
+    });
+
+    it('clamps OFF when the Task has no Work (nothing to branch)', () => {
+        expect(resolveTaskIsolation({ workId: null, isolationMode: 'on' }, workOn)).toBe('off');
+        expect(resolveTaskIsolation({}, workOn)).toBe('off');
+    });
+
+    it('clamps OFF when the Agent cannot commit to repos', () => {
+        expect(
+            resolveTaskIsolation({ workId: 'w1', isolationMode: 'on' }, workOn, {
+                agentCanCommit: false,
+            }),
+        ).toBe('off');
+    });
+
+    it('unknown isolationMode values fall back to inheritance (never crash)', () => {
+        expect(resolveTaskIsolation({ workId: 'w1', isolationMode: 'banana' }, workOn)).toBe('on');
+        expect(resolveTaskIsolation({ workId: 'w1', isolationMode: 'banana' }, workOff)).toBe(
+            'off',
+        );
+    });
+});
+
+describe('taskBranchName', () => {
+    const id = '9f3c1a2b-1111-4222-8333-444455556666';
+
+    it('is deterministic and carries slug readability + id uniqueness', () => {
+        const name = taskBranchName({ id, slug: 'T-42' });
+        expect(name).toBe('task/t-42-9f3c1a2b');
+        expect(taskBranchName({ id, slug: 'T-42' })).toBe(name);
+    });
+
+    it('sanitizes hostile slugs into git-safe names', () => {
+        expect(taskBranchName({ id, slug: '../..//evil branch!!' })).toBe(
+            'task/evil-branch-9f3c1a2b',
+        );
+        expect(taskBranchName({ id, slug: '   ' })).toBe('task/task-9f3c1a2b');
+        expect(taskBranchName({ id, slug: null })).toBe('task/task-9f3c1a2b');
+    });
+
+    it('caps slug length so branch names stay manageable', () => {
+        const name = taskBranchName({ id, slug: 'x'.repeat(200) });
+        expect(name.length).toBeLessThanOrEqual('task/'.length + 40 + 1 + 8);
+    });
+});

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -7,6 +7,7 @@ export * from './tasks.service';
 export * from './task-transition.service';
 export * from './task-chat.service';
 export * from './task-dispatcher';
+export * from './task-isolation';
 export * from './agent-task-tools';
 export * from './recurrence';
 export * from './task-recurrence-dispatcher.service';

--- a/packages/agent/src/tasks-domain/task-isolation.ts
+++ b/packages/agent/src/tasks-domain/task-isolation.ts
@@ -1,3 +1,6 @@
+/** Per-Task isolation override values accepted end-to-end (API DTO ↔ domain ↔ entity). */
+export type TaskIsolationMode = 'on' | 'off';
+
 /**
  * Task-isolation resolution + branch identity (Wave 2 M1).
  *
@@ -44,6 +47,9 @@ export function taskBranchName(task: { id: string; slug?: string | null }): stri
         .replace(/-+/g, '-')
         .replace(/^-|-$/g, '')
         .slice(0, 40);
-    const idBlock = task.id.replace(/-/g, '').slice(0, 8);
+    // FULL normalized id — an 8-char prefix is only 32 bits, and a
+    // remote-branch collision would silently share a branch between two
+    // Tasks (the binding stamp only heals the LOCAL dir).
+    const idBlock = task.id.replace(/-/g, '');
     return `task/${slug || 'task'}-${idBlock}`;
 }

--- a/packages/agent/src/tasks-domain/task-isolation.ts
+++ b/packages/agent/src/tasks-domain/task-isolation.ts
@@ -1,0 +1,49 @@
+/**
+ * Task-isolation resolution + branch identity (Wave 2 M1).
+ *
+ * ONE function decides whether a Task executes in an isolated
+ * workspace, so every caller (worker pre-run, UI chip, PR flow)
+ * agrees. Clamps:
+ *   - a Task with no `workId` has nothing to branch → off;
+ *   - an Agent without repo-commit permission → off (the isolation
+ *     flow's whole output is a branch + PR).
+ */
+export interface TaskIsolationTaskView {
+    workId?: string | null;
+    isolationMode?: string | null;
+}
+
+export interface TaskIsolationWorkView {
+    taskIsolation?: string | null;
+}
+
+export function resolveTaskIsolation(
+    task: TaskIsolationTaskView,
+    work: TaskIsolationWorkView | null | undefined,
+    opts: { agentCanCommit?: boolean } = {},
+): 'on' | 'off' {
+    if (!task.workId) return 'off';
+    if (opts.agentCanCommit === false) return 'off';
+    if (task.isolationMode === 'on') return 'on';
+    if (task.isolationMode === 'off') return 'off';
+    return work?.taskIsolation === 'worktree' ? 'on' : 'off';
+}
+
+/**
+ * Deterministic, collision-free branch name. Task slugs are per-USER
+ * unique only (two users on one Work can both own `T-42`), so the id
+ * suffix carries global uniqueness while the slug carries readability.
+ * Re-runs recompute the SAME name — the branch is the durable
+ * workspace identity in cloud mode. The stored `task.branchRef` is
+ * authoritative once written; this function is only for first cut.
+ */
+export function taskBranchName(task: { id: string; slug?: string | null }): string {
+    const slug = (task.slug ?? 'task')
+        .toLowerCase()
+        .replace(/[^a-z0-9-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '')
+        .slice(0, 40);
+    const idBlock = task.id.replace(/-/g, '').slice(0, 8);
+    return `task/${slug || 'task'}-${idBlock}`;
+}

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -6,6 +6,7 @@ import {
     NotFoundException,
     Optional,
 } from '@nestjs/common';
+import type { TaskIsolationMode } from './task-isolation';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { Repository } from 'typeorm';
 import { Task, TaskPriority, TaskStatus, type TaskActorType } from '../entities/task.entity';
@@ -39,7 +40,7 @@ export interface CreateTaskInput {
     status?: TaskStatus;
     priority?: TaskPriority;
     labels?: string[] | null;
-    isolationMode?: string | null;
+    isolationMode?: TaskIsolationMode | null;
     missionId?: string | null;
     ideaId?: string | null;
     workId?: string | null;
@@ -57,7 +58,7 @@ export interface UpdateTaskInput {
     description?: string | null;
     priority?: TaskPriority;
     labels?: string[] | null;
-    isolationMode?: string | null;
+    isolationMode?: TaskIsolationMode | null;
     missionId?: string | null;
     ideaId?: string | null;
     workId?: string | null;

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -39,6 +39,7 @@ export interface CreateTaskInput {
     status?: TaskStatus;
     priority?: TaskPriority;
     labels?: string[] | null;
+    isolationMode?: string | null;
     missionId?: string | null;
     ideaId?: string | null;
     workId?: string | null;
@@ -56,6 +57,7 @@ export interface UpdateTaskInput {
     description?: string | null;
     priority?: TaskPriority;
     labels?: string[] | null;
+    isolationMode?: string | null;
     missionId?: string | null;
     ideaId?: string | null;
     workId?: string | null;
@@ -228,6 +230,7 @@ export class TasksService {
             status: input.status ?? TaskStatus.BACKLOG,
             priority: input.priority ?? TaskPriority.P3,
             labels: input.labels ?? null,
+            isolationMode: input.isolationMode ?? null,
             missionId: input.missionId ?? null,
             ideaId: input.ideaId ?? null,
             workId: input.workId ?? null,
@@ -263,6 +266,7 @@ export class TasksService {
         }
         if (input.priority !== undefined) patch.priority = input.priority;
         if (input.labels !== undefined) patch.labels = input.labels;
+        if (input.isolationMode !== undefined) patch.isolationMode = input.isolationMode;
         if (input.requireAllApprovers !== undefined)
             patch.requireAllApprovers = input.requireAllApprovers;
 

--- a/packages/plugin/src/contracts/capabilities/index.ts
+++ b/packages/plugin/src/contracts/capabilities/index.ts
@@ -26,6 +26,7 @@ export * from './notification-channel.interface.js';
 // inbound leg in this increment (routing/pairing runtime lands in P2).
 export * from './connector.interface.js';
 export * from './agent-memory.interface.js';
+export * from './workspace.interface.js';
 // Org-wide Memory (Cortex P2) — pluggable ORG memory framework +
 // multi-doc-type RAG pipeline contracts. Additive, beside the existing
 // `agent-memory` / `vector-store` / `content-extractor` seams. See

--- a/packages/plugin/src/contracts/capabilities/workspace.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/workspace.interface.ts
@@ -1,5 +1,6 @@
 import type { IPlugin } from '../plugin.interface.js';
 import type { PluginSettings } from '../../settings/settings.types.js';
+import type { FacadeOptions } from '../../facades/facade-options.interface.js';
 
 /**
  * Workspace capability — pluggable isolated git working contexts for
@@ -111,18 +112,18 @@ export interface IWorkspacePlugin extends IPlugin {
 
 /** Facade interface — implementation lives in `@ever-works/agent`. */
 export interface IWorkspaceFacade {
-	provision(spec: Omit<WorkspaceProvisionSpec, 'settings'>, facadeOptions: unknown): Promise<WorkspaceHandle>;
+	provision(spec: Omit<WorkspaceProvisionSpec, 'settings'>, facadeOptions: FacadeOptions): Promise<WorkspaceHandle>;
 	finalize(
 		handle: WorkspaceHandle,
 		opts: { commitMessage: string; push: boolean },
-		facadeOptions: unknown
+		facadeOptions: FacadeOptions
 	): Promise<WorkspaceFinalizeResult>;
 	simulateMerge(
 		handle: WorkspaceHandle,
 		targetRef: string,
-		facadeOptions: unknown
+		facadeOptions: FacadeOptions
 	): Promise<WorkspaceMergeSimulation>;
-	teardown(handle: WorkspaceHandle, facadeOptions: unknown): Promise<void>;
+	teardown(handle: WorkspaceHandle, facadeOptions: FacadeOptions): Promise<void>;
 }
 
 /** Type guard — true when a plugin declares the `workspace` capability. */

--- a/packages/plugin/src/contracts/capabilities/workspace.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/workspace.interface.ts
@@ -1,0 +1,131 @@
+import type { IPlugin } from '../plugin.interface.js';
+import type { PluginSettings } from '../../settings/settings.types.js';
+
+/**
+ * Workspace capability — pluggable isolated git working contexts for
+ * agent-executed Tasks (capability `workspace`).
+ *
+ * A workspace is where an agent's Task run touches files: its own
+ * branch (cut FRESH from `origin/<baseRef>` — never a cached HEAD, the
+ * staleness lesson every reference implementation paid for), its own
+ * checkout, shipped as a PR, cleaned up afterward. Implementations own
+ * WHERE that checkout lives:
+ *
+ *  - `sandbox-workspace` (cloud default): fresh shallow clone inside
+ *    the ephemeral job sandbox — worktree mechanics degenerate away;
+ *    the REMOTE BRANCH is the durable identity and re-provisioning
+ *    fetches it instead of re-cutting.
+ *  - `local-workspace` (local runtime): persistent pool with real
+ *    `git worktree add`, per-repo creation serialization, binding
+ *    stamps with self-heal, GC.
+ *  - later `ssh-workspace`: the founder's own-box runner — same
+ *    contract, nothing upstream changes.
+ *
+ * Auth: the git token is resolved per-operation by the git facade and
+ * injected transiently — it must NEVER be persisted into the checkout
+ * (remote URLs, files) because the checkout runs untrusted repo code.
+ */
+export interface WorkspaceProvisionSpec {
+	/** Resolved clone URL (token-free; auth injected per operation). */
+	readonly repoUrl: string;
+	/** Base ref to branch FROM — always fetched fresh before branching. */
+	readonly baseRef: string;
+	/** Deterministic branch name (`task/<slug>-<id8>`). */
+	readonly branch: string;
+	/** Binding stamp — `${taskId}`. A mismatch on reuse self-heals by
+	 *  re-provisioning instead of bricking the workspace. */
+	readonly bindingKey: string;
+	/** Shallow clone depth (default 1). */
+	readonly depth?: number;
+	/** Per-operation auth injected by the facade (short-lived token). */
+	readonly auth?: { username?: string; token?: string };
+	readonly settings?: PluginSettings;
+}
+
+export interface WorkspaceHandle {
+	/** Absolute path of the checkout. */
+	readonly path: string;
+	/** SHA of the fetched base the branch was cut from (or found at). */
+	readonly baseSha: string;
+	/** True when an existing workspace/branch was reused (re-run). */
+	readonly reused: boolean;
+	readonly branch: string;
+	readonly bindingKey: string;
+}
+
+export interface WorkspaceFinalizeResult {
+	pushed: boolean;
+	headSha: string | null;
+	/** True when there was nothing to commit (clean tree). */
+	empty: boolean;
+}
+
+export interface WorkspaceMergeSimulation {
+	clean: boolean;
+	/** Conflicting paths, NAMED — "you are never handed a PR with a red
+	 *  merge banner"; empty when clean. */
+	conflictPaths: string[];
+}
+
+/**
+ * Thrown when the provider cannot operate in this runtime (no git, no
+ * disk, unreachable host). Matched BY NAME across packages; maps to a
+ * loud, actionable failure — never a silent no-op.
+ */
+export class WorkspaceNotProvisionedError extends Error {
+	constructor(message?: string) {
+		super(message ?? 'Workspace provider is not provisioned in this runtime.');
+		this.name = 'WorkspaceNotProvisionedError';
+	}
+}
+
+/** Workspace plugin interface — capability `workspace`. */
+export interface IWorkspacePlugin extends IPlugin {
+	readonly providerName: string;
+
+	/** Fetch-first provision: clone/fetch, cut or reuse the branch. */
+	provision(spec: WorkspaceProvisionSpec): Promise<WorkspaceHandle>;
+
+	/** Commit everything + optionally push the branch. */
+	finalize(
+		handle: WorkspaceHandle,
+		opts: { commitMessage: string; push: boolean; auth?: WorkspaceProvisionSpec['auth'] }
+	): Promise<WorkspaceFinalizeResult>;
+
+	/**
+	 * In-memory merge of the branch against a FRESH targetRef. On
+	 * conflict the caller refuses the push/PR and names the paths.
+	 */
+	simulateMerge(
+		handle: WorkspaceHandle,
+		targetRef: string,
+		auth?: WorkspaceProvisionSpec['auth']
+	): Promise<WorkspaceMergeSimulation>;
+
+	/** Route EVERY delete through here (kill processes → remove). */
+	teardown(handle: WorkspaceHandle): Promise<void>;
+
+	/** Reclaim stale workspaces (startup/cron reconcile). */
+	gc?(policy: { olderThanDays: number }): Promise<{ removed: string[] }>;
+}
+
+/** Facade interface — implementation lives in `@ever-works/agent`. */
+export interface IWorkspaceFacade {
+	provision(spec: Omit<WorkspaceProvisionSpec, 'settings'>, facadeOptions: unknown): Promise<WorkspaceHandle>;
+	finalize(
+		handle: WorkspaceHandle,
+		opts: { commitMessage: string; push: boolean },
+		facadeOptions: unknown
+	): Promise<WorkspaceFinalizeResult>;
+	simulateMerge(
+		handle: WorkspaceHandle,
+		targetRef: string,
+		facadeOptions: unknown
+	): Promise<WorkspaceMergeSimulation>;
+	teardown(handle: WorkspaceHandle, facadeOptions: unknown): Promise<void>;
+}
+
+/** Type guard — true when a plugin declares the `workspace` capability. */
+export function isWorkspacePlugin(plugin: IPlugin): plugin is IWorkspacePlugin {
+	return plugin.capabilities.includes('workspace');
+}

--- a/packages/plugin/src/contracts/facade-capabilities.ts
+++ b/packages/plugin/src/contracts/facade-capabilities.ts
@@ -67,7 +67,9 @@ export const PLUGIN_CAPABILITIES = {
 	// providers: `custom-http` (GET-only, SSRF-guarded) and `stripe`
 	// (official SDK; balance + income windows). See
 	// `capabilities/metrics-provider.interface.ts` for the contract.
-	METRICS_PROVIDER: 'metrics-provider'
+	METRICS_PROVIDER: 'metrics-provider',
+	// Isolated git working contexts for agent Tasks (Wave 2).
+	WORKSPACE: 'workspace'
 } as const;
 
 export type PluginCapability = (typeof PLUGIN_CAPABILITIES)[keyof typeof PLUGIN_CAPABILITIES];


### PR DESCRIPTION
## Wave 2 M1+M2 — Task isolation foundation

**M1 — schema + resolution:**
- `Work`: `taskIsolation` (off/worktree, default **off**), `taskIsolationBaseBranch`, `taskIsolationTargetRepo` (work-output/linked), `taskBranchCleanup` (on-merge/manual) — all configurable per-Work, guarded forward-only migration
- `Task`: `isolationMode` (per-Task override), `branchRef`, `branchState`
- `resolveTaskIsolation()` — ONE resolution rule (task override wins both ways; clamps off when no Work or agent cannot commit); deterministic `task/<slug>-<id8>` branch naming — 9 unit tests
- DTO plumbing end-to-end (UpdateWorkDto, tasks Create/Update, lifecycle update) and account-transfer round-trip for all 4 Work fields with drop-if-unrecognized enum guards on both import paths

**M2 — workspace capability:**
- `workspace` plugin capability in `@ever-works/plugin`: `provision / finalize / simulateMerge / teardown / gc`, `WorkspaceHandle`, name-matched `WorkspaceNotProvisionedError`
- `WorkspaceFacadeService` (barrel-exported + FacadesModule-registered) — 5 conformance tests

M3 (sandbox-workspace plugin + worker wiring) and M4 (finalize→PR path) follow on a stacked branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added task isolation settings at the Work and Task levels, including per-task overrides and validated branch/PR metadata.
  * Added support for isolated workspace provisioning, merge simulation, finalization, and teardown via a new workspace facade and plugin capability contract.
  * Extended work export/import to round-trip task isolation configuration.
* **Bug Fixes**
  * Improved validation for unsupported/invalid isolation inputs and inheritance/fallback behavior.
* **Chores**
  * Updated database schema to store isolation settings and added the supporting index; expanded related tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->