### PR TITLE
feat(agent): quality-gate schema + contracts (Wave 3 M1)

### DIFF
--- a/apps/api/src/migrations/1782800000000-AddQualityGateColumns.ts
+++ b/apps/api/src/migrations/1782800000000-AddQualityGateColumns.ts
@@ -1,0 +1,124 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Quality gates — schema for Task acceptance checks (Wave 3 M1).
+ *
+ * An acceptance check is a named command whose exit code decides whether an
+ * agent run is green or red. Tasks declare checks, Works carry defaults, and
+ * agent runs snapshot the resolved list plus per-check results. This
+ * migration is schema only — the runner ships in a later milestone.
+ *
+ * Entities:
+ *   - `packages/agent/src/entities/task.entity.ts`
+ *   - `packages/agent/src/entities/agent-run.entity.ts`
+ *   - `packages/agent/src/entities/work.entity.ts`
+ *
+ * **Schema notes:**
+ *   - `simple-json` entity columns are plain `text` at the DB level, matching
+ *     the convention used by `tasks.labels` / `works.configCache`.
+ *   - `tasks.maxGateAttempts` is NULLABLE (null = inherit the Work) while
+ *     `works.maxGateAttempts` is NOT NULL DEFAULT 2 — the Work is the end of
+ *     the inheritance chain, so it must always hold a concrete value.
+ *   - `works.checksPolicy` NOT NULL DEFAULT 'off': existing Works keep
+ *     exactly today's behaviour; checks only run for Works that opt in.
+ *   - `agent_runs.gateStatus` varchar(12) fits every `GateStatus` member and
+ *     is nullable because pre-gate runs have no gate outcome to report.
+ *   - `agent_runs.gateAttempts` NOT NULL DEFAULT 0 so existing rows read as
+ *     "never attempted" rather than unknown.
+ *
+ * Forward-only and idempotent (getTable + findColumnByName guards) so a
+ * partially-applied run is safe to repeat.
+ */
+export class AddQualityGateColumns1782800000000 implements MigrationInterface {
+    name = 'AddQualityGateColumns1782800000000';
+
+    private static readonly COLUMNS: ReadonlyArray<{ table: string; column: TableColumn }> = [
+        {
+            table: 'tasks',
+            column: new TableColumn({ name: 'acceptanceChecks', type: 'text', isNullable: true }),
+        },
+        {
+            table: 'tasks',
+            column: new TableColumn({ name: 'maxGateAttempts', type: 'int', isNullable: true }),
+        },
+        {
+            table: 'agent_runs',
+            column: new TableColumn({ name: 'resolvedChecks', type: 'text', isNullable: true }),
+        },
+        {
+            table: 'agent_runs',
+            column: new TableColumn({ name: 'checkResults', type: 'text', isNullable: true }),
+        },
+        {
+            table: 'agent_runs',
+            column: new TableColumn({
+                name: 'gateStatus',
+                type: 'varchar',
+                length: '12',
+                isNullable: true,
+            }),
+        },
+        {
+            table: 'agent_runs',
+            column: new TableColumn({
+                name: 'gateAttempts',
+                type: 'int',
+                isNullable: false,
+                default: 0,
+            }),
+        },
+        {
+            table: 'works',
+            column: new TableColumn({ name: 'checkDefaults', type: 'text', isNullable: true }),
+        },
+        {
+            table: 'works',
+            column: new TableColumn({
+                name: 'checksPolicy',
+                type: 'varchar',
+                length: '12',
+                isNullable: false,
+                default: "'off'",
+            }),
+        },
+        {
+            table: 'works',
+            column: new TableColumn({
+                name: 'maxGateAttempts',
+                type: 'int',
+                isNullable: false,
+                default: 2,
+            }),
+        },
+    ];
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, column } of AddQualityGateColumns1782800000000.COLUMNS) {
+            // Guarded per column, not per table: a partially-applied previous
+            // attempt must be completable on re-run, never permanent.
+            if (!(await queryRunner.hasTable(table))) {
+                continue;
+            }
+            const existing = await queryRunner.getTable(table);
+            if (existing?.findColumnByName(column.name)) {
+                continue;
+            }
+            // clone() so the shared static definition is never mutated by a
+            // driver that normalizes the TableColumn it receives.
+            await queryRunner.addColumn(table, column.clone());
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (const { table, column } of [...AddQualityGateColumns1782800000000.COLUMNS].reverse()) {
+            if (!(await queryRunner.hasTable(table))) {
+                continue;
+            }
+            const existing = await queryRunner.getTable(table);
+            if (!existing?.findColumnByName(column.name)) {
+                continue;
+            }
+            await queryRunner.dropColumn(table, column.name);
+        }
+    }
+}

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -161,6 +161,8 @@ export class TasksController {
             createdByType: 'user',
             createdById: auth.userId,
             requireAllApprovers: body.requireAllApprovers,
+            acceptanceChecks: body.acceptanceChecks ?? null,
+            maxGateAttempts: body.maxGateAttempts ?? null,
         });
     }
 

--- a/apps/api/src/tasks/tasks.dto.ts
+++ b/apps/api/src/tasks/tasks.dto.ts
@@ -1,5 +1,6 @@
 import { Type } from 'class-transformer';
 import {
+    ArrayMaxSize,
     IsArray,
     IsBoolean,
     IsDateString,
@@ -15,6 +16,7 @@ import {
     ValidateNested,
 } from 'class-validator';
 import { TaskPriority, TaskStatus, type TaskActorType } from '@ever-works/agent/tasks-domain';
+import { AcceptanceCheckDto } from '@ever-works/agent/dto';
 
 export class CreateTaskDto {
     @IsString()
@@ -75,6 +77,25 @@ export class CreateTaskDto {
     @IsOptional()
     @IsBoolean()
     requireAllApprovers?: boolean;
+
+    /**
+     * Acceptance checks for this Task (quality gates). Merge over the
+     * Work's `checkDefaults` by id: a same-id entry overrides the default,
+     * `disabled: true` suppresses it. `null` = inherit the defaults as-is.
+     */
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(20)
+    @ValidateNested({ each: true })
+    @Type(() => AcceptanceCheckDto)
+    acceptanceChecks?: AcceptanceCheckDto[] | null;
+
+    /** Gate-attempt budget (1..5). `null` = inherit the Work's value. */
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Max(5)
+    maxGateAttempts?: number | null;
 }
 
 export class UpdateTaskDto {
@@ -132,6 +153,25 @@ export class UpdateTaskDto {
     @IsOptional()
     @IsBoolean()
     requireAllApprovers?: boolean;
+
+    /**
+     * Replaces the Task's declared checks wholesale (same merge-over-Work
+     * semantics as on create). `null` reverts to inheriting the Work's
+     * `checkDefaults` untouched.
+     */
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(20)
+    @ValidateNested({ each: true })
+    @Type(() => AcceptanceCheckDto)
+    acceptanceChecks?: AcceptanceCheckDto[] | null;
+
+    /** Gate-attempt budget (1..5). `null` reverts to inheriting the Work. */
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Max(5)
+    maxGateAttempts?: number | null;
 }
 
 export class SetTaskRecurringDto {

--- a/packages/agent/src/account-transfer/account-export.service.ts
+++ b/packages/agent/src/account-transfer/account-export.service.ts
@@ -195,6 +195,13 @@ export class AccountExportService {
             communityPrEnabled: dir.communityPrEnabled,
             communityPrAutoClose: dir.communityPrAutoClose,
             comparisonsEnabled: dir.comparisonsEnabled,
+            // Quality-gate settings must round-trip: a Work that opted into
+            // 'warn'/'required' or curated checkDefaults must not silently
+            // fall back to 'off'/none on the imported side.
+            checkDefaults: Array.isArray(dir.checkDefaults) ? dir.checkDefaults : undefined,
+            checksPolicy: dir.checksPolicy || undefined,
+            maxGateAttempts:
+                typeof dir.maxGateAttempts === 'number' ? dir.maxGateAttempts : undefined,
             members: members.map((m) => ({
                 userId: m.userId,
                 role: m.role,

--- a/packages/agent/src/account-transfer/account-import.service.spec.ts
+++ b/packages/agent/src/account-transfer/account-import.service.spec.ts
@@ -629,6 +629,98 @@ describe('AccountImportService', () => {
             expect('providerRepositoryEnabled' in patch).toBe(false);
         });
 
+        it('round-trips quality-gate fields (checkDefaults / checksPolicy / maxGateAttempts) on create', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+            mocks.workRepository.findByOwnerAndSlug.mockResolvedValue(null);
+            mocks.workRepository.create.mockResolvedValue({ id: 'w-new', slug: 'a' });
+
+            const checkDefaults = [
+                {
+                    id: 'build',
+                    name: 'Build',
+                    kind: 'build',
+                    command: 'pnpm build',
+                    required: true,
+                },
+            ];
+            await service.applyImport(
+                'user-1',
+                makePayload([
+                    makeWork({
+                        slug: 'a',
+                        checkDefaults,
+                        checksPolicy: 'required',
+                        maxGateAttempts: 4,
+                    } as any),
+                ]),
+                [],
+            );
+
+            // A Work that curated checks and opted into enforcement must not
+            // silently come back as policy 'off' with no defaults.
+            expect(mocks.workRepository.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    checkDefaults,
+                    checksPolicy: 'required',
+                    maxGateAttempts: 4,
+                }),
+                expect.anything(),
+            );
+        });
+
+        it('overwrite applies quality-gate fields; tampered values are dropped, not defaulted', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+            const existing = { id: 'w-existing', slug: 'a', getRepoOwner: () => 'octocat' };
+            mocks.workRepository.findByOwnerAndSlug.mockResolvedValue(existing);
+
+            const checkDefaults = [
+                { id: 'test', name: 'Test', kind: 'test', command: 'pnpm test', required: true },
+            ];
+            await service.applyImport(
+                'user-1',
+                makePayload([
+                    makeWork({
+                        slug: 'a',
+                        checkDefaults,
+                        checksPolicy: 'warn',
+                        maxGateAttempts: 3,
+                    } as any),
+                ]),
+                [{ slug: 'a', strategy: 'overwrite' }],
+            );
+            expect(mocks.workRepository.update).toHaveBeenCalledWith(
+                'w-existing',
+                expect.objectContaining({
+                    checkDefaults,
+                    checksPolicy: 'warn',
+                    maxGateAttempts: 3,
+                }),
+            );
+
+            // Tampered payload: unknown policy, non-array defaults and an
+            // out-of-range budget must ALL be dropped — never clamped or
+            // defaulted — leaving the existing Work's settings alone.
+            mocks.workRepository.update.mockClear();
+            await service.applyImport(
+                'user-1',
+                makePayload([
+                    makeWork({
+                        slug: 'a',
+                        checkDefaults: 'not-an-array',
+                        checksPolicy: 'block-everything',
+                        maxGateAttempts: 99,
+                    } as any),
+                ]),
+                [{ slug: 'a', strategy: 'overwrite' }],
+            );
+            const patch = mocks.workRepository.update.mock.calls[0][1];
+            expect('checkDefaults' in patch).toBe(false);
+            expect('checksPolicy' in patch).toBe(false);
+            expect('maxGateAttempts' in patch).toBe(false);
+        });
+
         it('a bogus kind in a tampered payload is dropped, not written', async () => {
             const { service, mocks } = makeService();
             mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });

--- a/packages/agent/src/account-transfer/account-import.service.ts
+++ b/packages/agent/src/account-transfer/account-import.service.ts
@@ -23,7 +23,7 @@ import type {
 import { containsMaskedSecrets, MASKED_SECRET_PREFIX } from './types';
 import { sanitizePrompt } from '../utils/sanitize.util';
 import { normalizeCreateWorkKind, type Work, type WorkKind } from '../entities/work.entity';
-import { WORK_KINDS } from '@ever-works/contracts';
+import { WORK_CHECKS_POLICIES, WORK_KINDS, type WorkChecksPolicy } from '@ever-works/contracts';
 
 /**
  * Canonical slug shape (matches the work/item DTO `@Matches` rule and
@@ -53,6 +53,27 @@ function normalizeImportedWorkKind(value: unknown): WorkKind | undefined {
     const raw = value.trim().toLowerCase();
     const recognized = raw === 'landing' || (WORK_KINDS as readonly string[]).includes(raw);
     return recognized ? normalizeCreateWorkKind(value) : undefined;
+}
+
+/**
+ * Quality-gate fields arrive from user-supplied JSON, so they follow the
+ * same posture as `normalizeImportedWorkKind`: drop-if-unrecognized, never
+ * default-if-unrecognized. A tampered `checksPolicy` must not be able to
+ * reset an existing Work's enforcement, and an out-of-range attempts
+ * budget is treated as absent rather than clamped — clamping would launder
+ * a bogus payload value into a legitimate-looking setting.
+ */
+function normalizeImportedChecksPolicy(value: unknown): WorkChecksPolicy | undefined {
+    return typeof value === 'string' && (WORK_CHECKS_POLICIES as readonly string[]).includes(value)
+        ? (value as WorkChecksPolicy)
+        : undefined;
+}
+
+/** Gate-attempt budget: integers within the resolve-time clamp range only. */
+function normalizeImportedMaxGateAttempts(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 5
+        ? value
+        : undefined;
 }
 
 /**
@@ -526,6 +547,23 @@ export class AccountImportService {
                 if (typeof dir.providerRepositoryEnabled === 'boolean') {
                     updateData.providerRepositoryEnabled = dir.providerRepositoryEnabled;
                 }
+                // Quality-gate fields: arrays only ever import as arrays;
+                // enum/int values are drop-if-unrecognized (see the
+                // normalizeImported* helpers above). Absent → existing
+                // Work's settings untouched.
+                if (Array.isArray(dir.checkDefaults)) {
+                    updateData.checkDefaults = dir.checkDefaults;
+                }
+                const importedChecksPolicy = normalizeImportedChecksPolicy(dir.checksPolicy);
+                if (importedChecksPolicy) {
+                    updateData.checksPolicy = importedChecksPolicy;
+                }
+                const importedMaxGateAttempts = normalizeImportedMaxGateAttempts(
+                    dir.maxGateAttempts,
+                );
+                if (importedMaxGateAttempts !== undefined) {
+                    updateData.maxGateAttempts = importedMaxGateAttempts;
+                }
                 await this.workRepository.update(existing.id, updateData);
 
                 await this.importWorkRelations(existing.id, userId, dir, includesSecrets, result);
@@ -560,6 +598,17 @@ export class AccountImportService {
         }
         if (typeof dir.providerRepositoryEnabled === 'boolean') {
             createData.providerRepositoryEnabled = dir.providerRepositoryEnabled;
+        }
+        if (Array.isArray(dir.checkDefaults)) {
+            createData.checkDefaults = dir.checkDefaults;
+        }
+        const importedChecksPolicy = normalizeImportedChecksPolicy(dir.checksPolicy);
+        if (importedChecksPolicy) {
+            createData.checksPolicy = importedChecksPolicy;
+        }
+        const importedMaxGateAttempts = normalizeImportedMaxGateAttempts(dir.maxGateAttempts);
+        if (importedMaxGateAttempts !== undefined) {
+            createData.maxGateAttempts = importedMaxGateAttempts;
         }
         const newDir = await this.workRepository.create(createData, user);
 

--- a/packages/agent/src/account-transfer/types.ts
+++ b/packages/agent/src/account-transfer/types.ts
@@ -3,6 +3,7 @@
  * Supports versioned JSON export (v1) with full work data including
  * items, comparisons, site config, schedules, and advanced prompts.
  */
+import type { TaskAcceptanceCheck } from '@ever-works/contracts';
 
 // ─── Export Types ────────────────────────────────────────────────
 
@@ -151,6 +152,17 @@ export interface ExportedWork {
     communityPrEnabled: boolean;
     communityPrAutoClose: boolean;
     comparisonsEnabled: boolean;
+    /** Work-level default acceptance checks (quality gates). Payloads are
+     *  user-supplied JSON — import only applies this when it is actually
+     *  an array. */
+    checkDefaults?: TaskAcceptanceCheck[] | null;
+    /** Quality-gate enforcement policy. Import is drop-if-unrecognized —
+     *  never default-if-unrecognized — so a tampered value cannot reset an
+     *  existing Work's enforcement. */
+    checksPolicy?: string;
+    /** Gate-attempt budget (1..5). Out-of-range values are dropped on
+     *  import, not clamped. */
+    maxGateAttempts?: number;
     members: ExportedWorkMember[];
     customDomains: ExportedCustomDomain[];
     workPlugins: ExportedWorkPlugin[];

--- a/packages/agent/src/dto/acceptance-check.dto.ts
+++ b/packages/agent/src/dto/acceptance-check.dto.ts
@@ -1,0 +1,104 @@
+import { Type } from 'class-transformer';
+import {
+    IsBoolean,
+    IsIn,
+    IsInt,
+    IsOptional,
+    IsString,
+    Matches,
+    Max,
+    MaxLength,
+    Min,
+    MinLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+    TASK_ACCEPTANCE_CHECK_KINDS,
+    type TaskAcceptanceCheck,
+    type TaskAcceptanceCheckKind,
+} from '@ever-works/contracts';
+
+/**
+ * Slug-safe check id: lowercase alphanumeric start, then up to 40 more of
+ * `[a-z0-9-_]`. The id is the override/suppression merge key between Task
+ * checks and Work defaults, so it must be stable and unambiguous — no
+ * whitespace, case variants, or exotic characters.
+ */
+export const ACCEPTANCE_CHECK_ID_PATTERN = /^[a-z0-9][a-z0-9-_]{0,40}$/;
+
+/**
+ * Validated body shape for one acceptance check (quality gates, Wave 3 M1).
+ * Shared by the Task create/update DTOs (`apps/api/src/tasks/tasks.dto.ts`)
+ * and the Work `checkDefaults` update path (`update-work.dto.ts`) so both
+ * surfaces enforce identical constraints on what is, at rest, the same
+ * `simple-json` shape.
+ */
+export class AcceptanceCheckDto implements TaskAcceptanceCheck {
+    @ApiProperty({
+        description:
+            'Stable slug identifying the check; also the merge key that overrides/suppresses a same-id Work default.',
+        pattern: ACCEPTANCE_CHECK_ID_PATTERN.source,
+    })
+    @IsString()
+    @Matches(ACCEPTANCE_CHECK_ID_PATTERN, {
+        message: 'id must be slug-safe: start with [a-z0-9], then up to 40 chars of [a-z0-9-_].',
+    })
+    id: string;
+
+    @ApiProperty({ description: 'Human-readable label shown in run reports.', maxLength: 120 })
+    @IsString()
+    @MinLength(1)
+    @MaxLength(120)
+    name: string;
+
+    @ApiProperty({
+        description: 'Category of the check (display/grouping only).',
+        enum: TASK_ACCEPTANCE_CHECK_KINDS,
+    })
+    @IsIn(TASK_ACCEPTANCE_CHECK_KINDS)
+    kind: TaskAcceptanceCheckKind;
+
+    @ApiProperty({
+        description: 'Command to execute; exit code 0 = green, anything else = red.',
+        maxLength: 2000,
+    })
+    @IsString()
+    @MinLength(1)
+    @MaxLength(2000)
+    command: string;
+
+    @ApiPropertyOptional({
+        description: 'Working directory relative to the checkout root; omitted = root.',
+        maxLength: 512,
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(512)
+    cwd?: string;
+
+    @ApiPropertyOptional({
+        description: 'Wall-clock budget in seconds; exceeding it reports `timeout`, not `red`.',
+        minimum: 1,
+        maximum: 3600,
+    })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(3600)
+    timeoutSec?: number;
+
+    @ApiProperty({
+        description: 'Required checks decide the gate; non-required ones only report.',
+    })
+    @IsBoolean()
+    required: boolean;
+
+    @ApiPropertyOptional({
+        description:
+            'true removes the check from the resolved list; on a Task entry this suppresses the same-id inherited Work default.',
+    })
+    @IsOptional()
+    @IsBoolean()
+    disabled?: boolean;
+}

--- a/packages/agent/src/dto/index.ts
+++ b/packages/agent/src/dto/index.ts
@@ -1,3 +1,4 @@
+export * from './acceptance-check.dto';
 export * from './create-work.dto';
 export * from './quick-create-work.dto';
 export * from './generate-data.dto';

--- a/packages/agent/src/dto/update-work.dto.ts
+++ b/packages/agent/src/dto/update-work.dto.ts
@@ -1,15 +1,22 @@
 import { Type, Transform } from 'class-transformer';
 import {
+    ArrayMaxSize,
+    IsArray,
     IsOptional,
     IsString,
     IsBoolean,
     IsEmail,
     IsIn,
+    IsInt,
     IsUUID,
+    Max,
     ValidateNested,
     MaxLength,
+    Min,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { WORK_CHECKS_POLICIES, type WorkChecksPolicy } from '@ever-works/contracts';
+import { AcceptanceCheckDto } from './acceptance-check.dto';
 import { MarkdownReadmeConfigDto } from './create-work.dto';
 import { sanitizeName, sanitizeDescription } from '../utils/sanitize.util';
 
@@ -78,6 +85,42 @@ export class UpdateWorkDto {
     @IsOptional()
     @IsBoolean()
     providerRepositoryEnabled?: boolean;
+
+    @ApiPropertyOptional({
+        description:
+            'Work-level default acceptance checks inherited by agent-executed Tasks under this Work. ' +
+            'Pass `null` to clear the defaults. Max 20 entries.',
+        type: AcceptanceCheckDto,
+        isArray: true,
+        nullable: true,
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(20)
+    @ValidateNested({ each: true })
+    @Type(() => AcceptanceCheckDto)
+    checkDefaults?: AcceptanceCheckDto[] | null;
+
+    @ApiPropertyOptional({
+        description:
+            "Enforcement policy for acceptance checks: 'off' (never run), 'warn' (run + report, red does not block) or 'required' (red blocks Task completion).",
+        enum: WORK_CHECKS_POLICIES,
+    })
+    @IsOptional()
+    @IsIn(WORK_CHECKS_POLICIES)
+    checksPolicy?: WorkChecksPolicy;
+
+    @ApiPropertyOptional({
+        description:
+            "Default gate-attempt budget for Tasks that don't set their own maxGateAttempts.",
+        minimum: 1,
+        maximum: 5,
+    })
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Max(5)
+    maxGateAttempts?: number;
 
     @ApiPropertyOptional({ description: 'Whether community PR processing is enabled' })
     @IsOptional()

--- a/packages/agent/src/entities/agent-run.entity.ts
+++ b/packages/agent/src/entities/agent-run.entity.ts
@@ -1,5 +1,6 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 import { PortableDateColumn } from './_types';
+import type { GateStatus, TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
 
 /**
  * What kicked off this run.
@@ -80,6 +81,39 @@ export class AgentRun {
     /** Populated only when `triggerKind = 'chat'`. FK to `task_chat_messages.id`. */
     @Column('uuid', { nullable: true })
     chatMessageId?: string | null;
+
+    // ── Quality gates ──────────────────────────────────────────────
+    /**
+     * The acceptance checks this run is judged by, snapshotted at dispatch
+     * time via `resolveAcceptanceChecks(task, work)`. A snapshot, not a
+     * reference: editing the Task or the Work mid-run must not change what
+     * an in-flight run is graded against.
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    resolvedChecks?: TaskAcceptanceCheck[] | null;
+
+    /**
+     * Per-check outcomes keyed by `TaskAcceptanceCheck.id`. `null` until
+     * the gate runner (a later milestone — this PR is schema only) reports.
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    checkResults?: TaskCheckResult[] | null;
+
+    /**
+     * Aggregate gate outcome. `null` on runs that predate quality gates or
+     * that never reached the gate (crashed/cancelled before it). varchar(12)
+     * fits every `GateStatus` member.
+     */
+    @Column({ type: 'varchar', length: 12, nullable: true })
+    gateStatus?: GateStatus | null;
+
+    /**
+     * Gate attempts consumed by this run. NOT NULL default 0 so existing
+     * rows read as "never attempted" rather than unknown; bounded by
+     * `resolveMaxGateAttempts` (1..5) once the runner lands.
+     */
+    @Column({ type: 'int', default: 0 })
+    gateAttempts: number;
 
     // Tenant + Organization scope FKs (EW-657 Tier C denormalization).
     // No @ManyToOne — cycle-avoidance, see user.entity.ts EW-654 comment.

--- a/packages/agent/src/entities/task.entity.ts
+++ b/packages/agent/src/entities/task.entity.ts
@@ -10,6 +10,7 @@ import {
 } from 'typeorm';
 import { User } from './user.entity';
 import { PortableDateColumn } from './_types';
+import type { TaskAcceptanceCheck } from '@ever-works/contracts';
 
 /**
  * Tasks feature — Phase 11.1 (`features/task-tracking/plan.md §3.1` +
@@ -152,6 +153,26 @@ export class Task {
     // Reserve-only column — populated in v2 when "promote Task → Idea" lands.
     @Column({ type: 'uuid', nullable: true })
     promotedToIdeaId?: string | null;
+
+    // ── Quality gates ──────────────────────────────────────────────
+    /**
+     * Acceptance checks declared on this Task. `null` = inherit the Work's
+     * `checkDefaults` untouched. Merge semantics (a same-id entry replaces
+     * the Work default; `disabled: true` suppresses it) live in
+     * `tasks-domain/task-gates.ts#resolveAcceptanceChecks` — executors must
+     * read the resolved list, never this column directly, or suppression
+     * entries would be run as commands.
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    acceptanceChecks?: TaskAcceptanceCheck[] | null;
+
+    /**
+     * Gate-attempt budget for this Task. `null` = inherit the Work's value
+     * (whose column default is 2). Clamped to 1..5 at resolve time so a
+     * hand-edited row can never grant an unbounded retry loop.
+     */
+    @Column({ type: 'int', nullable: true })
+    maxGateAttempts?: number | null;
 
     // ── Recurring (F5 override) ────────────────────────────────────
     @Column({ type: 'boolean', default: false })

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -63,7 +63,9 @@ import {
     USER_SELECTABLE_WORK_KINDS,
     getWorkCapabilities,
     normalizeWorkKind,
+    type TaskAcceptanceCheck,
     type UserSelectableWorkKind,
+    type WorkChecksPolicy,
     type WorkKind,
 } from '@ever-works/contracts';
 
@@ -401,6 +403,32 @@ export class Work {
     // Comparison Generation FIELDS
     @Column({ type: 'boolean', default: false })
     comparisonsEnabled: boolean;
+
+    // Quality Gates FIELDS
+    /**
+     * Work-level default acceptance checks inherited by every agent-executed
+     * Task under this Work. A Task's own `acceptanceChecks` merge over these
+     * by id (same-id override, `disabled: true` suppression) — resolve via
+     * `tasks-domain/task-gates.ts`, never read this column directly when
+     * executing checks.
+     */
+    @Column('simple-json', { nullable: true })
+    checkDefaults?: TaskAcceptanceCheck[] | null;
+
+    /**
+     * Enforcement policy for the resolved checks. Defaults to `'off'` so the
+     * feature landing changes nothing for existing Works — checks only ever
+     * run for a Work that explicitly opted in to `'warn'` or `'required'`.
+     */
+    @Column({ type: 'varchar', length: 12, default: 'off' })
+    checksPolicy: WorkChecksPolicy;
+
+    /**
+     * Default gate-attempt budget for Tasks that leave their own
+     * `maxGateAttempts` null. Clamped to 1..5 at resolve time.
+     */
+    @Column({ type: 'int', default: 2 })
+    maxGateAttempts: number;
 
     /**
      * Whether to generate the browsable repository published to the git

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -642,6 +642,20 @@ export class WorkLifecycleService {
                 updateData.providerRepositoryEnabled = updateDto.providerRepositoryEnabled;
             }
 
+            // Quality-gate settings. `checkDefaults: null` clears the
+            // Work-level defaults; checksPolicy / maxGateAttempts are
+            // NOT NULL columns, so only defined values flow through (the
+            // DTO already constrains them to the known set / 1..5).
+            if (updateDto.checkDefaults !== undefined) {
+                updateData.checkDefaults = updateDto.checkDefaults;
+            }
+            if (updateDto.checksPolicy !== undefined) {
+                updateData.checksPolicy = updateDto.checksPolicy;
+            }
+            if (updateDto.maxGateAttempts !== undefined) {
+                updateData.maxGateAttempts = updateDto.maxGateAttempts;
+            }
+
             // Handle community PR processing settings
             if (updateDto.communityPrEnabled !== undefined) {
                 updateData.communityPrEnabled = updateDto.communityPrEnabled;

--- a/packages/agent/src/tasks-domain/__tests__/task-gates.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-gates.spec.ts
@@ -1,0 +1,170 @@
+import type { TaskAcceptanceCheck } from '@ever-works/contracts';
+import {
+    DEFAULT_GATE_ATTEMPTS,
+    MAX_GATE_ATTEMPTS,
+    MIN_GATE_ATTEMPTS,
+    resolveAcceptanceChecks,
+    resolveChecksPolicy,
+    resolveMaxGateAttempts,
+} from '../task-gates';
+
+function check(overrides: Partial<TaskAcceptanceCheck> & { id: string }): TaskAcceptanceCheck {
+    return {
+        name: overrides.id,
+        kind: 'custom',
+        command: `echo ${overrides.id}`,
+        required: true,
+        ...overrides,
+    };
+}
+
+describe('resolveAcceptanceChecks', () => {
+    it('returns [] when neither the Task nor the Work declares anything', () => {
+        expect(resolveAcceptanceChecks(null, null)).toEqual([]);
+        expect(
+            resolveAcceptanceChecks({ acceptanceChecks: null }, { checkDefaults: null }),
+        ).toEqual([]);
+    });
+
+    it('falls back to the Work defaults when the Task declares nothing', () => {
+        const build = check({ id: 'build', kind: 'build', command: 'pnpm build' });
+        const test = check({ id: 'test', kind: 'test', command: 'pnpm test' });
+        expect(
+            resolveAcceptanceChecks({ acceptanceChecks: null }, { checkDefaults: [build, test] }),
+        ).toEqual([build, test]);
+    });
+
+    it('uses the Task checks when the Work has no defaults', () => {
+        const lint = check({ id: 'lint', kind: 'lint', command: 'pnpm lint' });
+        expect(
+            resolveAcceptanceChecks({ acceptanceChecks: [lint] }, { checkDefaults: null }),
+        ).toEqual([lint]);
+    });
+
+    it('a same-id Task check overrides the Work default wholesale, keeping its position', () => {
+        const defaultBuild = check({ id: 'build', kind: 'build', command: 'pnpm build' });
+        const test = check({ id: 'test', kind: 'test', command: 'pnpm test' });
+        const overriddenBuild = check({
+            id: 'build',
+            kind: 'build',
+            command: 'pnpm build --filter=web',
+            required: false,
+        });
+
+        const resolved = resolveAcceptanceChecks(
+            { acceptanceChecks: [overriddenBuild] },
+            { checkDefaults: [defaultBuild, test] },
+        );
+        // Override replaces in place — Work-default ordering is preserved.
+        expect(resolved).toEqual([overriddenBuild, test]);
+    });
+
+    it('a Task-only check is appended after the inherited defaults', () => {
+        const build = check({ id: 'build', kind: 'build', command: 'pnpm build' });
+        const smoke = check({ id: 'smoke', command: 'pnpm smoke' });
+        expect(
+            resolveAcceptanceChecks({ acceptanceChecks: [smoke] }, { checkDefaults: [build] }),
+        ).toEqual([build, smoke]);
+    });
+
+    it('a disabled Task entry suppresses the inherited default without redeclaring the rest', () => {
+        const build = check({ id: 'build', kind: 'build', command: 'pnpm build' });
+        const test = check({ id: 'test', kind: 'test', command: 'pnpm test' });
+        const suppression = check({ id: 'test', disabled: true });
+
+        expect(
+            resolveAcceptanceChecks(
+                { acceptanceChecks: [suppression] },
+                { checkDefaults: [build, test] },
+            ),
+        ).toEqual([build]);
+    });
+
+    it('filters disabled entries from Work defaults and from Task-declared checks alike', () => {
+        const activeDefault = check({ id: 'build', kind: 'build', command: 'pnpm build' });
+        const disabledDefault = check({ id: 'lint', kind: 'lint', disabled: true });
+        const disabledOwn = check({ id: 'smoke', disabled: true });
+
+        expect(
+            resolveAcceptanceChecks(null, { checkDefaults: [activeDefault, disabledDefault] }),
+        ).toEqual([activeDefault]);
+        expect(
+            resolveAcceptanceChecks(
+                { acceptanceChecks: [disabledOwn] },
+                { checkDefaults: [activeDefault] },
+            ),
+        ).toEqual([activeDefault]);
+    });
+
+    it('an EMPTY Task array keeps the inherited defaults (only `null` and suppressions detach)', () => {
+        const build = check({ id: 'build', kind: 'build', command: 'pnpm build' });
+        expect(
+            resolveAcceptanceChecks({ acceptanceChecks: [] }, { checkDefaults: [build] }),
+        ).toEqual([build]);
+    });
+
+    it('tolerates malformed simple-json content (non-array values, id-less entries)', () => {
+        const build = check({ id: 'build', kind: 'build', command: 'pnpm build' });
+        expect(
+            resolveAcceptanceChecks(
+                { acceptanceChecks: 'not-an-array' as unknown as TaskAcceptanceCheck[] },
+                { checkDefaults: [build] },
+            ),
+        ).toEqual([build]);
+        expect(
+            resolveAcceptanceChecks(
+                { acceptanceChecks: [{} as TaskAcceptanceCheck] },
+                { checkDefaults: [build] },
+            ),
+        ).toEqual([build]);
+    });
+});
+
+describe('resolveChecksPolicy', () => {
+    it("defaults to 'off' for a missing Work or unset column", () => {
+        expect(resolveChecksPolicy(null)).toBe('off');
+        expect(resolveChecksPolicy(undefined)).toBe('off');
+        expect(resolveChecksPolicy({})).toBe('off');
+    });
+
+    it('passes through every known policy value', () => {
+        expect(resolveChecksPolicy({ checksPolicy: 'off' })).toBe('off');
+        expect(resolveChecksPolicy({ checksPolicy: 'warn' })).toBe('warn');
+        expect(resolveChecksPolicy({ checksPolicy: 'required' })).toBe('required');
+    });
+
+    it("resolves an unrecognized value to 'off' — never toward blocking", () => {
+        expect(resolveChecksPolicy({ checksPolicy: 'block-everything' as unknown as 'off' })).toBe(
+            'off',
+        );
+    });
+});
+
+describe('resolveMaxGateAttempts', () => {
+    it('prefers the Task value over the Work value', () => {
+        expect(resolveMaxGateAttempts({ maxGateAttempts: 3 }, { maxGateAttempts: 5 })).toBe(3);
+    });
+
+    it('falls back to the Work value, then to the default of 2', () => {
+        expect(resolveMaxGateAttempts({ maxGateAttempts: null }, { maxGateAttempts: 4 })).toBe(4);
+        expect(resolveMaxGateAttempts(null, null)).toBe(DEFAULT_GATE_ATTEMPTS);
+        expect(resolveMaxGateAttempts({ maxGateAttempts: null }, {})).toBe(DEFAULT_GATE_ATTEMPTS);
+    });
+
+    it('clamps below-range and above-range values into 1..5', () => {
+        expect(resolveMaxGateAttempts({ maxGateAttempts: 0 }, null)).toBe(MIN_GATE_ATTEMPTS);
+        expect(resolveMaxGateAttempts({ maxGateAttempts: -7 }, null)).toBe(MIN_GATE_ATTEMPTS);
+        expect(resolveMaxGateAttempts({ maxGateAttempts: 99 }, null)).toBe(MAX_GATE_ATTEMPTS);
+        expect(resolveMaxGateAttempts(null, { maxGateAttempts: 42 })).toBe(MAX_GATE_ATTEMPTS);
+    });
+
+    it('normalizes non-integer and non-finite values instead of propagating them', () => {
+        expect(resolveMaxGateAttempts({ maxGateAttempts: 3.9 }, null)).toBe(3);
+        expect(resolveMaxGateAttempts({ maxGateAttempts: Number.NaN }, null)).toBe(
+            DEFAULT_GATE_ATTEMPTS,
+        );
+        expect(resolveMaxGateAttempts({ maxGateAttempts: Number.POSITIVE_INFINITY }, null)).toBe(
+            DEFAULT_GATE_ATTEMPTS,
+        );
+    });
+});

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -4,6 +4,7 @@
 // — this module owns the per-Task DB entities + repositories.
 export * from './tasks.module';
 export * from './tasks.service';
+export * from './task-gates';
 export * from './task-transition.service';
 export * from './task-chat.service';
 export * from './task-dispatcher';

--- a/packages/agent/src/tasks-domain/task-gates.ts
+++ b/packages/agent/src/tasks-domain/task-gates.ts
@@ -1,0 +1,92 @@
+import {
+    WORK_CHECKS_POLICIES,
+    type TaskAcceptanceCheck,
+    type WorkChecksPolicy,
+} from '@ever-works/contracts';
+import type { Task } from '../entities/task.entity';
+import type { Work } from '../entities/work.entity';
+
+/**
+ * Quality gates — pure resolution helpers (Wave 3 M1, schema milestone).
+ *
+ * Everything here is side-effect free and takes plain row shapes, so the
+ * eventual gate runner, the API layer, and tests all share one set of
+ * inheritance rules instead of re-deriving them.
+ */
+
+/** Bounds for the gate-attempt budget. The clamp exists because the value
+ *  reaches us from three writable places (Task column, Work column, import
+ *  payloads) and an out-of-range number must never grant an unbounded
+ *  retry loop (or a zero-attempt deadlock). */
+export const MIN_GATE_ATTEMPTS = 1;
+export const MAX_GATE_ATTEMPTS = 5;
+export const DEFAULT_GATE_ATTEMPTS = 2;
+
+type TaskChecksSource = Partial<Pick<Task, 'acceptanceChecks'>> | null | undefined;
+type WorkChecksSource = Partial<Pick<Work, 'checkDefaults'>> | null | undefined;
+type TaskAttemptsSource = Partial<Pick<Task, 'maxGateAttempts'>> | null | undefined;
+type WorkAttemptsSource = Partial<Pick<Work, 'maxGateAttempts'>> | null | undefined;
+type WorkPolicySource = Partial<Pick<Work, 'checksPolicy'>> | null | undefined;
+
+/**
+ * Resolve the acceptance checks an agent run is judged by.
+ *
+ * Inheritance: the Work's `checkDefaults` are the base; the Task's
+ * `acceptanceChecks` merge over them by id —
+ *   - a Task entry with a NEW id is appended;
+ *   - a Task entry with the SAME id as a Work default replaces it
+ *     wholesale (no field-level merging);
+ *   - a Task entry with `disabled: true` therefore suppresses the
+ *     inherited default without redeclaring the rest.
+ * Disabled entries are filtered from the result, so executors can run the
+ * returned list as-is. Order is stable: Work defaults first (in declared
+ * order), then Task-only additions (in declared order).
+ */
+export function resolveAcceptanceChecks(
+    task: TaskChecksSource,
+    work: WorkChecksSource,
+): TaskAcceptanceCheck[] {
+    // Array.isArray (not truthiness) — both columns are simple-json, so a
+    // hand-edited or imported row could hold any JSON shape.
+    const defaults = Array.isArray(work?.checkDefaults) ? work.checkDefaults : [];
+    const declared = Array.isArray(task?.acceptanceChecks) ? task.acceptanceChecks : null;
+
+    if (!declared) {
+        return defaults.filter((check) => check?.disabled !== true);
+    }
+
+    const merged = new Map<string, TaskAcceptanceCheck>();
+    for (const check of defaults) {
+        if (check?.id) merged.set(check.id, check);
+    }
+    for (const check of declared) {
+        if (check?.id) merged.set(check.id, check);
+    }
+    return [...merged.values()].filter((check) => check.disabled !== true);
+}
+
+/**
+ * Resolve the Work's enforcement policy. Anything that is not a known
+ * policy value — including `undefined` on a partially-selected row —
+ * resolves to `'off'`: an unrecognized policy must fail toward "don't run
+ * checks", never toward blocking a Task.
+ */
+export function resolveChecksPolicy(work: WorkPolicySource): WorkChecksPolicy {
+    const policy = work?.checksPolicy;
+    return typeof policy === 'string' &&
+        (WORK_CHECKS_POLICIES as readonly string[]).includes(policy)
+        ? (policy as WorkChecksPolicy)
+        : 'off';
+}
+
+/**
+ * Resolve the gate-attempt budget: Task value, else Work value, else 2 —
+ * always clamped to 1..5 (fractions truncate toward the clamp range).
+ */
+export function resolveMaxGateAttempts(task: TaskAttemptsSource, work: WorkAttemptsSource): number {
+    const raw = task?.maxGateAttempts ?? work?.maxGateAttempts ?? DEFAULT_GATE_ATTEMPTS;
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+        return DEFAULT_GATE_ATTEMPTS;
+    }
+    return Math.min(MAX_GATE_ATTEMPTS, Math.max(MIN_GATE_ATTEMPTS, Math.trunc(raw)));
+}

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { Repository } from 'typeorm';
+import type { TaskAcceptanceCheck } from '@ever-works/contracts';
 import { Task, TaskPriority, TaskStatus, type TaskActorType } from '../entities/task.entity';
 import { Mission } from '../entities/mission.entity';
 import { Team } from '../entities/team.entity';
@@ -49,6 +50,10 @@ export interface CreateTaskInput {
     createdByType: TaskActorType;
     createdById: string;
     requireAllApprovers?: boolean;
+    /** Quality gates: `null` = inherit the Work's `checkDefaults` untouched. */
+    acceptanceChecks?: TaskAcceptanceCheck[] | null;
+    /** Quality gates: `null` = inherit the Work's budget (clamped 1..5 at resolve). */
+    maxGateAttempts?: number | null;
 }
 
 export interface UpdateTaskInput {
@@ -64,6 +69,10 @@ export interface UpdateTaskInput {
     goalId?: string | null;
     parentTaskId?: string | null;
     requireAllApprovers?: boolean;
+    /** Quality gates: `null` reverts to inheriting the Work's `checkDefaults`. */
+    acceptanceChecks?: TaskAcceptanceCheck[] | null;
+    /** Quality gates: `null` reverts to inheriting the Work's budget. */
+    maxGateAttempts?: number | null;
 }
 
 /**
@@ -238,6 +247,8 @@ export class TasksService {
             createdByType: input.createdByType,
             createdById: input.createdById,
             requireAllApprovers: input.requireAllApprovers ?? true,
+            acceptanceChecks: input.acceptanceChecks ?? null,
+            maxGateAttempts: input.maxGateAttempts ?? null,
         });
 
         await this.logActivity({
@@ -263,6 +274,8 @@ export class TasksService {
         }
         if (input.priority !== undefined) patch.priority = input.priority;
         if (input.labels !== undefined) patch.labels = input.labels;
+        if (input.acceptanceChecks !== undefined) patch.acceptanceChecks = input.acceptanceChecks;
+        if (input.maxGateAttempts !== undefined) patch.maxGateAttempts = input.maxGateAttempts;
         if (input.requireAllApprovers !== undefined)
             patch.requireAllApprovers = input.requireAllApprovers;
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -4,3 +4,4 @@ export * from './form/index.js';
 export * from './github/index.js';
 export * from './kb/index.js';
 export * from './terminal/index.js';
+export * from './tasks/index.js';

--- a/packages/contracts/src/tasks/index.ts
+++ b/packages/contracts/src/tasks/index.ts
@@ -1,0 +1,1 @@
+export * from './task-gates.types.js';

--- a/packages/contracts/src/tasks/task-gates.types.ts
+++ b/packages/contracts/src/tasks/task-gates.types.ts
@@ -1,0 +1,109 @@
+/**
+ * Quality gates — acceptance checks for agent-executed Tasks.
+ *
+ * An acceptance check is a named command whose exit code decides whether an
+ * agent run comes back green or red. Tasks declare their own checks and/or
+ * inherit per-Work defaults (`Work.checkDefaults`); the merge rules
+ * (same-id override, `disabled: true` suppression) live in
+ * `@ever-works/agent` (`tasks-domain/task-gates.ts`), not here — this
+ * package is the zero-dependency storage/wire shape only.
+ */
+
+/**
+ * What a check verifies. Drives grouping/labelling in run reports only —
+ * execution is identical for every kind (`custom` covers anything that is
+ * not one of the four conventional gates).
+ */
+export type TaskAcceptanceCheckKind = 'build' | 'test' | 'lint' | 'typecheck' | 'custom';
+
+/**
+ * Canonical list of check kinds. Kept as a const so validators (DTO
+ * `@IsIn`, import sanitizers) share one source of truth with the type.
+ */
+export const TASK_ACCEPTANCE_CHECK_KINDS: readonly TaskAcceptanceCheckKind[] = [
+	'build',
+	'test',
+	'lint',
+	'typecheck',
+	'custom'
+];
+
+/**
+ * One acceptance check: a named command whose exit code decides green/red.
+ */
+export interface TaskAcceptanceCheck {
+	/**
+	 * Stable slug identifying the check. Also the merge key: a Task entry
+	 * with the same id as a Work default replaces (or, with
+	 * `disabled: true`, suppresses) that default.
+	 */
+	id: string;
+	/** Human-readable label shown in run reports. */
+	name: string;
+	/** Category of the check; display/grouping only. */
+	kind: TaskAcceptanceCheckKind;
+	/** Command to execute. Exit code 0 = green, anything else = red. */
+	command: string;
+	/** Working directory relative to the checkout root; omitted = root. */
+	cwd?: string;
+	/**
+	 * Wall-clock budget in seconds. A check that exceeds it reports
+	 * `timeout` (distinct from `red`: the command was killed, not failed).
+	 */
+	timeoutSec?: number;
+	/** Required checks decide the gate; non-required ones only report. */
+	required: boolean;
+	/**
+	 * `true` removes the check from the resolved list. On a Task entry
+	 * this is how an inherited Work default is suppressed without
+	 * redeclaring the rest.
+	 */
+	disabled?: boolean;
+}
+
+/**
+ * Outcome of one executed acceptance check, keyed back to
+ * `TaskAcceptanceCheck.id`.
+ */
+export interface TaskCheckResult {
+	/** `TaskAcceptanceCheck.id` this result belongs to. */
+	id: string;
+	/**
+	 * Process exit code. `null` when the process never yielded one
+	 * (timeout kill or spawn failure) — `status` says which.
+	 */
+	exitCode: number | null;
+	/**
+	 * `green`/`red` mirror the exit code; `timeout` = killed at
+	 * `timeoutSec`; `error` = the check could not be executed at all.
+	 */
+	status: 'green' | 'red' | 'timeout' | 'error';
+	/** Wall-clock duration of the check. */
+	durationMs: number;
+	/** Last lines of combined stdout/stderr, for the run report. */
+	logTail?: string;
+}
+
+/**
+ * Aggregate gate outcome for one agent run:
+ * - `green`   — every required check passed;
+ * - `red`     — at least one required check did not pass;
+ * - `skipped` — checks resolved but the Work's policy said not to run them;
+ * - `none`    — no checks resolved for this run.
+ */
+export type GateStatus = 'green' | 'red' | 'skipped' | 'none';
+
+/**
+ * Per-Work enforcement policy for acceptance checks:
+ * - `off`      — checks never run (the default, so existing Works are
+ *                untouched by the feature landing);
+ * - `warn`     — checks run and report, but red does not block;
+ * - `required` — red blocks the Task from completing.
+ */
+export type WorkChecksPolicy = 'off' | 'warn' | 'required';
+
+/**
+ * Canonical list of policies. Import sanitizers treat anything outside
+ * this set as drop-if-unrecognized (never default-if-unrecognized).
+ */
+export const WORK_CHECKS_POLICIES: readonly WorkChecksPolicy[] = ['off', 'warn', 'required'];


### PR DESCRIPTION
Wave 3 M1 of the quality-gates program: every agent-executed Task can declare acceptance checks (named commands whose exit codes decide green/red), with per-Work defaults. **Schema + contracts + DTO plumbing only — no runner, no UI** (those are later milestones).

## Deliverables

### 1. `@ever-works/contracts` — shared types (zero-dependency)
New `src/tasks/` module, exported from the package barrel:
- `TaskAcceptanceCheck` `{ id, name, kind: 'build'|'test'|'lint'|'typecheck'|'custom', command, cwd?, timeoutSec?, required, disabled? }`
- `TaskCheckResult` `{ id, exitCode: number|null, status: 'green'|'red'|'timeout'|'error', durationMs, logTail? }`
- `GateStatus` = `'green'|'red'|'skipped'|'none'`
- `WorkChecksPolicy` = `'off'|'warn'|'required'` + `WORK_CHECKS_POLICIES` / `TASK_ACCEPTANCE_CHECK_KINDS` consts so DTO validators and import sanitizers share one source of truth with the types.

### 2. Entities + migration (same PR, per the migrations rule)
- `tasks`: `acceptanceChecks` simple-json nullable, `maxGateAttempts` int nullable (null = inherit Work).
- `agent_runs`: `resolvedChecks` simple-json nullable (dispatch-time snapshot), `checkResults` simple-json nullable, `gateStatus` varchar(12) nullable, `gateAttempts` int NOT NULL default 0.
- `works` (placed after `comparisonsEnabled` — develop has no `taskBranchCleanup` column): `checkDefaults` simple-json nullable, `checksPolicy` varchar(12) NOT NULL default `'off'`, `maxGateAttempts` int NOT NULL default 2.
- Migration `1782800000000-AddQualityGateColumns` — forward-only, idempotent (`getTable` + `findColumnByName` guards per column), `text` columns for simple-json. `checksPolicy` defaults `'off'` so existing Works keep exactly today's behaviour.

### 3. Resolution helpers — `packages/agent/src/tasks-domain/task-gates.ts`
- `resolveAcceptanceChecks(task, work)` — Work `checkDefaults` are the base, Task checks merge over them by id (same-id override, `disabled: true` suppresses an inherited default without redeclaring the rest); disabled entries filtered from the result; stable ordering (defaults first, Task-only additions appended).
- `resolveChecksPolicy(work)` — unrecognized values fail toward `'off'`, never toward blocking.
- `resolveMaxGateAttempts(task, work)` — task ?? work ?? 2, clamped 1..5.
- Barrel-exported from `tasks-domain/index.ts` (real export). 16 Jest cases in `__tests__/task-gates.spec.ts` covering override, suppression, empty/malformed inputs, policy fallback, and clamping.

### 4. DTO plumbing
- Shared nested `AcceptanceCheckDto` (`packages/agent/src/dto/acceptance-check.dto.ts`, barrel-exported): id slug-safe `/^[a-z0-9][a-z0-9-_]{0,40}$/`, command non-empty max 2000, timeoutSec 1..3600, kind `@IsIn`, `@ValidateNested` + `@Type` per house style.
- `apps/api/src/tasks/tasks.dto.ts`: Create + Update accept `acceptanceChecks` (array max 20) and `maxGateAttempts` (int 1..5).
- Persisted through `tasks.controller.ts` create mapping and `tasks-domain/tasks.service.ts` (input interfaces, create, update patch) — same flow as `labels`.
- `update-work.dto.ts`: optional `checkDefaults` (same nested validation), `checksPolicy` `@IsIn(WORK_CHECKS_POLICIES)`, `maxGateAttempts` 1..5; wired in `work-lifecycle.service.ts` update flow with `!== undefined` blocks (same pattern as `providerRepositoryEnabled`).

### 5. Account-transfer round-trip
`ExportedWork` + export service + BOTH import paths (overwrite + create) carry `checkDefaults` / `checksPolicy` / `maxGateAttempts`. Import posture matches `normalizeImportedWorkKind`: arrays only import as arrays; `checksPolicy` is drop-if-unrecognized (never default-if-unrecognized); out-of-range attempt budgets are dropped, not clamped. Round-trip + tampered-payload cases added to `account-import.service.spec.ts`.

### 6. e2e whitelist sweep
Grepped `apps/web/e2e` for `acceptanceChecks|checkDefaults|checksPolicy|maxGateAttempts`: zero hits — no forbidNonWhitelisted-rejection spec asserts rejection of any field added here (the existing rejection specs use made-up bogus fields).

## Verification

- `packages/agent` `pnpm build`: TSC **0 issues**, SWC 964 files compiled.
- `npx jest --testPathPattern='task-gates|account-import'`: **2 suites / 70 tests passed**.
- `pnpm build --filter=ever-works-api`: **13/13 tasks successful** (TSC 0 issues).
- `apps/api` `pnpm generate:openapi`: bootstrap completed, **wrote 408 paths** (`openapi.json` regenerated but deliberately left out of the commit — generated artifact).
- Prettier run on every touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
