### PR TITLE
feat(tasks): run telemetry + board run chips (kanban cockpit M1+M2)

### DIFF
--- a/apps/api/src/migrations/1782900000000-AddRunTelemetryColumns.ts
+++ b/apps/api/src/migrations/1782900000000-AddRunTelemetryColumns.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Kanban run cockpit (Wave 2 M1) — run telemetry + latest-run denorm.
+ *
+ * `agent_runs`: currentActivity (one-line live activity feed, plain
+ * text), totalTokens (cumulative token usage), changedFilesCount
+ * (workspace files touched). Written by the worker via
+ * `AgentRunRepository.updateTelemetry`.
+ *
+ * `tasks`: latestRunId (pointer to the most recent AgentRun dispatched
+ * for the Task), latestRunStatus (status mirror). Maintained by
+ * `TaskRunDenormService` so the board list can batch-embed the latest
+ * run per card with a single IN query.
+ *
+ * Forward-only, idempotent per-step guards (house pattern). Every
+ * column is nullable — existing rows simply carry no telemetry.
+ */
+export class AddRunTelemetryColumns1782900000000 implements MigrationInterface {
+    name = 'AddRunTelemetryColumns1782900000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const agentRuns = await queryRunner.getTable('agent_runs');
+        if (agentRuns) {
+            const add = async (name: string, ddl: string) => {
+                if (!agentRuns.findColumnByName(name)) {
+                    await queryRunner.query(`ALTER TABLE "agent_runs" ADD COLUMN ${ddl}`);
+                }
+            };
+            await add('currentActivity', `"currentActivity" varchar(300)`);
+            await add('totalTokens', `"totalTokens" int`);
+            await add('changedFilesCount', `"changedFilesCount" int`);
+        }
+
+        const tasks = await queryRunner.getTable('tasks');
+        if (tasks) {
+            const add = async (name: string, ddl: string) => {
+                if (!tasks.findColumnByName(name)) {
+                    await queryRunner.query(`ALTER TABLE "tasks" ADD COLUMN ${ddl}`);
+                }
+            };
+            await add('latestRunId', `"latestRunId" uuid`);
+            await add('latestRunStatus', `"latestRunStatus" varchar(16)`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const tasks = await queryRunner.getTable('tasks');
+        if (tasks) {
+            for (const col of ['latestRunStatus', 'latestRunId']) {
+                if (tasks.findColumnByName(col)) {
+                    await queryRunner.query(`ALTER TABLE "tasks" DROP COLUMN "${col}"`);
+                }
+            }
+        }
+        const agentRuns = await queryRunner.getTable('agent_runs');
+        if (agentRuns) {
+            for (const col of ['changedFilesCount', 'totalTokens', 'currentActivity']) {
+                if (agentRuns.findColumnByName(col)) {
+                    await queryRunner.query(`ALTER TABLE "agent_runs" DROP COLUMN "${col}"`);
+                }
+            }
+        }
+    }
+}

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -123,6 +123,10 @@ export class TasksController {
         @Query('search') search?: string,
         @Query('limit') limit?: string,
         @Query('offset') offset?: string,
+        // Kanban run cockpit (Wave 2 M2) — opt-in latest-run embed. The
+        // batch is keyed on the owner-scoped rows' `latestRunId` pointers
+        // server-side; this flag only toggles the embed, it carries no ids.
+        @Query('includeRun') includeRun?: string,
     ) {
         const filter: ListTasksFilter = {
             status: this.parseStatusList(status),
@@ -139,7 +143,9 @@ export class TasksController {
             limit: limit ? Math.min(200, Math.max(1, parseInt(limit, 10) || 50)) : 50,
             offset: offset ? Math.max(0, parseInt(offset, 10) || 0) : 0,
         };
-        const { rows, total } = await this.service.list(auth.userId, filter);
+        const { rows, total } = await this.service.list(auth.userId, filter, {
+            includeRun: includeRun === 'true',
+        });
         return { data: rows, meta: { total, limit: filter.limit, offset: filter.offset } };
     }
 

--- a/apps/api/src/tasks/tasks.dto.ts
+++ b/apps/api/src/tasks/tasks.dto.ts
@@ -14,7 +14,12 @@ import {
     Min,
     ValidateNested,
 } from 'class-validator';
-import { TaskPriority, TaskStatus, type TaskActorType } from '@ever-works/agent/tasks-domain';
+import {
+    TaskPriority,
+    TaskStatus,
+    type TaskActorType,
+    type TaskIsolationMode,
+} from '@ever-works/agent/tasks-domain';
 
 export class CreateTaskDto {
     @IsString()
@@ -43,7 +48,7 @@ export class CreateTaskDto {
      *  inherits the Work's taskIsolation setting. */
     @IsOptional()
     @IsIn(['on', 'off'])
-    isolationMode?: string | null;
+    isolationMode?: TaskIsolationMode | null;
 
     @IsOptional()
     @IsUUID()
@@ -107,7 +112,7 @@ export class UpdateTaskDto {
      *  inherits the Work's taskIsolation setting. */
     @IsOptional()
     @IsIn(['on', 'off'])
-    isolationMode?: string | null;
+    isolationMode?: TaskIsolationMode | null;
 
     /**
      * Re-filing a Task under a different owner. `null` detaches it from

--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -26,6 +26,7 @@ jest.mock('@ever-works/agent/tasks-domain', () => ({
     TaskRecurrenceDispatcherService: class TaskRecurrenceDispatcherService {},
     TasksService: class TasksService {},
     TaskChatService: class TaskChatService {},
+    TaskRunDenormService: class TaskRunDenormService {},
 }));
 jest.mock('@ever-works/agent/entities', () => ({}));
 jest.mock('@ever-works/agent/cache', () => ({
@@ -166,6 +167,7 @@ describe('TriggerInternalController', () => {
             tasksService,
             taskChatService,
             undefined, // taskWorkspaceService (Wave 2 — not exercised here)
+            undefined, // taskRunDenormService (kanban run cockpit — not exercised here)
             undefined, // notificationChannelFacade
             // EW-742 P3.2 T22 — three new constructor args added by PRs
             // bbc24309 / 5e4e2483 / 41906b71 to expose the worker-host

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -52,6 +52,7 @@ import {
 } from '@ever-works/agent/agents';
 import {
     TaskChatService,
+    TaskRunDenormService,
     TaskWorkspaceService,
     TaskRecurrenceDispatcherService,
     TasksService,
@@ -232,6 +233,9 @@ export class TriggerInternalController implements OnModuleInit {
         private readonly taskChatService: TaskChatService,
         // Wave 2 — worktree-per-Task workspace lifecycle for worker RPC.
         private readonly taskWorkspaceService: TaskWorkspaceService,
+        // Kanban run cockpit (Wave 2) — latest-run denorm writes from the
+        // agent-task-execute worker over the internal RPC channel.
+        private readonly taskRunDenormService: TaskRunDenormService,
         // Notifications v2 (EW-663) — exposed for the
         // notification-channel-delivery Trigger task to run a single
         // channel attempt (plugins are loaded here, not in the worker).
@@ -309,6 +313,9 @@ export class TriggerInternalController implements OnModuleInit {
             TasksService: this.tasksService,
             TaskChatService: this.taskChatService,
             TaskWorkspaceService: this.taskWorkspaceService,
+            // Kanban run cockpit (Wave 2) — agent-task-execute calls
+            // recordQueued/recordStarted/recordTerminal here.
+            TaskRunDenormService: this.taskRunDenormService,
             // Notifications v2 (EW-663) — notification-channel-delivery task
             // calls `deliverToChannelOrThrow` here (allow-list auto-derived).
             NotificationChannelFacadeService: this.notificationChannelFacade,

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -921,6 +921,14 @@
                 "title": "No Tasks yet.",
                 "subtitle": "Tasks ship in a later phase of the Agents/Skills/Tasks rollout. The page is reserved so the sidebar nav route resolves."
             },
+            "runChip": {
+                "queued": "Queued",
+                "running": "Running",
+                "completed": "Completed",
+                "failed": "Failed",
+                "cancelled": "Cancelled",
+                "tokens": "{count} tokens"
+            },
             "list": {
                 "newTask": "New Task",
                 "noDescription": "No description yet",

--- a/apps/web/src/app/[locale]/(dashboard)/ideas/[id]/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/ideas/[id]/tasks/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = { title: 'Tasks' };
  */
 export default async function IdeaTasksTabPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
-    const result = await tasksAPI.list({ ideaId: id, limit: 100 });
+    const result = await tasksAPI.list({ ideaId: id, limit: 100, includeRun: true });
     return (
         <div className="p-6 max-w-screen-2xl mx-auto">
             <TasksScopedSection tasks={result.data} scopeLabel="Idea" scopeId={id} />

--- a/apps/web/src/app/[locale]/(dashboard)/missions/[id]/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/missions/[id]/tasks/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = { title: 'Tasks' };
  */
 export default async function MissionTasksTabPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
-    const result = await tasksAPI.list({ missionId: id, limit: 100 });
+    const result = await tasksAPI.list({ missionId: id, limit: 100, includeRun: true });
     return (
         <div className="p-6 max-w-screen-2xl mx-auto">
             <TasksScopedSection tasks={result.data} scopeLabel="Mission" scopeId={id} />

--- a/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/tasks/page.tsx
@@ -78,6 +78,9 @@ export default async function TasksPage({ searchParams }: { searchParams: TasksS
         label: label || undefined,
         limit,
         offset,
+        // Kanban run cockpit (Wave 2) — embed each row's latest AgentRun so
+        // the board chips render on first paint (polling takes over after).
+        includeRun: true,
     };
     const result = await tasksAPI.list(query);
     const nextOffset = result.meta.offset + result.meta.limit;

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/tasks/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = { title: 'Tasks' };
  */
 export default async function WorkTasksTabPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
-    const result = await tasksAPI.list({ workId: id, limit: 100 });
+    const result = await tasksAPI.list({ workId: id, limit: 100, includeRun: true });
     return (
         <div className="p-6 max-w-screen-2xl mx-auto">
             <TasksScopedSection tasks={result.data} scopeLabel="Work" scopeId={id} />

--- a/apps/web/src/app/actions/tasks.ts
+++ b/apps/web/src/app/actions/tasks.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import {
     tasksAPI,
+    type ListTasksQuery,
     type Task,
     type TaskChatMessage,
     type TaskPriority,
@@ -79,6 +80,28 @@ export async function transitionTaskAction(
     revalidatePath('/tasks');
     revalidatePath(`/tasks/${id}`);
     return task;
+}
+
+/**
+ * Kanban run cockpit (Wave 2) — read-only refresh used by the board's
+ * run-chip polling hook. Re-fetches the user's tasks WITH the latest-run
+ * embed (`includeRun=true`); the client merges run data by task id, so a
+ * plain, filter-free page (bounded limit) is sufficient. No
+ * revalidatePath on purpose — this is a poll, not a mutation.
+ */
+export async function listTasksWithRunsAction(
+    query: Omit<ListTasksQuery, 'includeRun'> = {},
+): Promise<Task[]> {
+    // Security: verify session server-side before reading data
+    const user = await getAuthFromCookie();
+    if (!user) redirect(ROUTES.AUTH_LOGIN);
+
+    const result = await tasksAPI.list({
+        ...query,
+        limit: Math.min(200, query.limit ?? 200),
+        includeRun: true,
+    });
+    return result.data;
 }
 
 /**

--- a/apps/web/src/components/tasks/TaskRunChip.tsx
+++ b/apps/web/src/components/tasks/TaskRunChip.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import type { Task, TaskRunStatus } from '@/lib/api/tasks';
+
+/**
+ * Kanban run cockpit (Wave 2) — compact live-run chip for Task kanban
+ * cards, rendered next to the branch chip whenever the list embedded a
+ * latest run (`includeRun=true`).
+ *
+ * Status dot: queued = gray pulse, running = blue pulse, completed =
+ * green, failed = red (cancelled = static gray). `currentActivity` is
+ * rendered strictly as a text node — NEVER as markup — and truncated;
+ * the token counter is compacted ("12.4k").
+ */
+
+const STATUS_DOTS: Record<TaskRunStatus, string> = {
+    queued: 'bg-slate-400 animate-pulse',
+    running: 'bg-blue-500 animate-pulse',
+    completed: 'bg-emerald-500',
+    failed: 'bg-red-500',
+    cancelled: 'bg-slate-400',
+};
+
+const STATUS_TONES: Record<TaskRunStatus, string> = {
+    queued: 'bg-slate-100 dark:bg-slate-800/40 text-slate-600 dark:text-slate-300',
+    running: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300',
+    completed: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300',
+    failed: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300',
+    cancelled: 'bg-slate-100 dark:bg-slate-800/40 text-slate-500 dark:text-slate-400',
+};
+
+const FALLBACK_DOT = 'bg-slate-400';
+const FALLBACK_TONE = 'bg-slate-100 dark:bg-slate-800/40 text-slate-600 dark:text-slate-300';
+
+/** 999 → "999", 12_400 → "12.4k", 3_100_000 → "3.1M". */
+export function formatCompactTokens(count: number): string {
+    if (!Number.isFinite(count) || count < 0) return '0';
+    if (count < 1000) return String(Math.round(count));
+    const compact = (value: number, suffix: string) => {
+        const rounded = (Math.round(value * 10) / 10).toFixed(1).replace(/\.0$/, '');
+        return `${rounded}${suffix}`;
+    };
+    if (count < 1_000_000) return compact(count / 1000, 'k');
+    return compact(count / 1_000_000, 'M');
+}
+
+export function TaskRunChip({ task }: { task: Task }) {
+    const t = useTranslations('dashboard.tasksPage.runChip');
+    const run = task.run;
+    if (!run) return null;
+
+    const dot = STATUS_DOTS[run.status] ?? FALLBACK_DOT;
+    const tone = STATUS_TONES[run.status] ?? FALLBACK_TONE;
+    const statusLabel = STATUS_DOTS[run.status] ? t(run.status) : run.status;
+
+    return (
+        <span
+            data-testid="task-run-chip"
+            // Plain-text title only — currentActivity must never be markup.
+            title={run.currentActivity ?? statusLabel}
+            className={cn(
+                'inline-flex items-center gap-1.5 max-w-full text-[10px] px-1.5 py-0.5 rounded',
+                tone,
+            )}
+        >
+            <span className={cn('w-1.5 h-1.5 rounded-full shrink-0', dot)} aria-hidden="true" />
+            <span className="font-medium uppercase tracking-wide shrink-0">{statusLabel}</span>
+            {run.currentActivity ? <span className="truncate">{run.currentActivity}</span> : null}
+            {run.totalTokens != null && (
+                <span
+                    className="font-mono shrink-0"
+                    title={t('tokens', { count: run.totalTokens })}
+                >
+                    {formatCompactTokens(run.totalTokens)}
+                </span>
+            )}
+        </span>
+    );
+}

--- a/apps/web/src/components/tasks/TasksKanbanView.tsx
+++ b/apps/web/src/components/tasks/TasksKanbanView.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useEffect, useMemo, useState, useTransition } from 'react';
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
 import { cn } from '@/lib/utils/cn';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import type { Task, TaskStatus, TaskPriority } from '@/lib/api/tasks';
 import { transitionTaskAction } from '@/app/actions/tasks';
+import { useTaskRunPolling } from '@/lib/hooks/use-task-run-polling';
 import { TaskBranchChip } from './TaskBranchChip';
+import { TaskRunChip } from './TaskRunChip';
 import {
     Inbox,
     Circle,
@@ -215,10 +217,11 @@ function TaskKanbanCard({
                 {task.title}
             </Link>
 
-            {/* Wave 2 M7 — isolated-branch chip */}
-            {task.branchRef && (
-                <div className="flex">
-                    <TaskBranchChip task={task} />
+            {/* Wave 2 M7 — isolated-branch chip · Wave 2 run cockpit — run chip */}
+            {(task.branchRef || task.run) && (
+                <div className="flex flex-wrap gap-1">
+                    {task.branchRef && <TaskBranchChip task={task} />}
+                    {task.run && <TaskRunChip task={task} />}
                 </div>
             )}
 
@@ -417,6 +420,27 @@ export function TasksKanbanView({ tasks: initialTasks }: { tasks: Task[] }) {
     useEffect(() => {
         setTasks(initialTasks);
     }, [initialTasks]);
+
+    // Kanban run cockpit (Wave 2) — while any visible card carries a
+    // queued/running run, poll for fresh run telemetry every 10s and merge
+    // ONLY the run-related fields by task id (never status/title — those
+    // may hold un-flushed optimistic updates from a drag in progress).
+    const mergeRunData = useCallback((rows: Task[]) => {
+        const freshById = new Map(rows.map((row) => [row.id, row]));
+        setTasks((prev) =>
+            prev.map((task) => {
+                const fresh = freshById.get(task.id);
+                if (!fresh) return task;
+                return {
+                    ...task,
+                    run: fresh.run ?? null,
+                    latestRunId: fresh.latestRunId ?? task.latestRunId,
+                    latestRunStatus: fresh.latestRunStatus ?? task.latestRunStatus,
+                };
+            }),
+        );
+    }, []);
+    useTaskRunPolling(tasks, mergeRunData);
 
     const grouped = useMemo(() => {
         const map = new Map<TaskStatus, Task[]>(COLUMNS.map((c) => [c.key, []]));

--- a/apps/web/src/lib/api/tasks.ts
+++ b/apps/web/src/lib/api/tasks.ts
@@ -27,6 +27,23 @@ export type TaskBranchState =
     | 'discarded'
     | 'cleaned';
 
+/** Kanban run cockpit (Wave 2) — AgentRun lifecycle mirrored on the board. */
+export type TaskRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+/**
+ * Kanban run cockpit (Wave 2) — compact latest-run embed attached to
+ * list rows when `includeRun=true` is requested. `currentActivity` is
+ * plain text by contract — never render it as markup.
+ */
+export interface TaskRun {
+    id: string;
+    status: TaskRunStatus;
+    currentActivity: string | null;
+    totalTokens: number | null;
+    changedFilesCount: number | null;
+    startedAt: string | null;
+}
+
 export interface Task {
     id: string;
     userId: string;
@@ -63,6 +80,11 @@ export interface Task {
     prNumber: number | null;
     prUrl: string | null;
     conflictPaths: string[] | null;
+    // Kanban run cockpit (Wave 2) — latest-run denorm columns + the
+    // opt-in `run` embed (present only on `includeRun=true` responses).
+    latestRunId?: string | null;
+    latestRunStatus?: TaskRunStatus | null;
+    run?: TaskRun | null;
     createdAt: string;
     updatedAt: string;
 }
@@ -78,6 +100,8 @@ export interface ListTasksQuery {
     search?: string;
     limit?: number;
     offset?: number;
+    /** Kanban run cockpit (Wave 2) — embed each row's latest AgentRun. */
+    includeRun?: boolean;
 }
 
 function buildQuery(q: ListTasksQuery = {}): string {
@@ -93,6 +117,7 @@ function buildQuery(q: ListTasksQuery = {}): string {
     if (q.search) params.set('search', q.search);
     if (q.limit !== undefined) params.set('limit', String(q.limit));
     if (q.offset !== undefined) params.set('offset', String(q.offset));
+    if (q.includeRun) params.set('includeRun', 'true');
     const s = params.toString();
     return s ? `?${s}` : '';
 }

--- a/apps/web/src/lib/hooks/use-task-run-polling.ts
+++ b/apps/web/src/lib/hooks/use-task-run-polling.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { Task } from '@/lib/api/tasks';
+import { listTasksWithRunsAction } from '@/app/actions/tasks';
+
+const POLL_INTERVAL_MS = 10_000;
+
+/**
+ * Kanban run cockpit (Wave 2) — lightweight run-chip polling.
+ *
+ * Every 10s, and ONLY while at least one visible task carries a
+ * queued/running run, re-fetch the task list with the latest-run embed
+ * and hand the fresh rows to the caller (which merges run data by task
+ * id). The interval tears down as soon as no run is active, so an idle
+ * board costs zero requests. Poll failures are swallowed — the board
+ * simply keeps the last-known chips until the next tick.
+ *
+ * Same setInterval-in-effect shape as the existing pollers
+ * (`NotificationDropdown`, `WorkActivity`).
+ */
+export function useTaskRunPolling(tasks: Task[], onFreshRows: (rows: Task[]) => void): void {
+    // Keep the callback in a ref so a new inline function per render
+    // doesn't tear the interval down and re-create it every 10s render.
+    const onFreshRowsRef = useRef(onFreshRows);
+    useEffect(() => {
+        onFreshRowsRef.current = onFreshRows;
+    }, [onFreshRows]);
+
+    const hasActiveRun = tasks.some(
+        (task) => task.run && (task.run.status === 'queued' || task.run.status === 'running'),
+    );
+
+    useEffect(() => {
+        if (!hasActiveRun) return;
+        let cancelled = false;
+        let inFlight = false;
+
+        const tick = async () => {
+            if (inFlight) return; // never stack slow polls
+            inFlight = true;
+            try {
+                const rows = await listTasksWithRunsAction();
+                if (!cancelled) onFreshRowsRef.current(rows);
+            } catch {
+                // Poll is best-effort — keep last-known chips.
+            } finally {
+                inFlight = false;
+            }
+        };
+
+        const interval = setInterval(() => void tick(), POLL_INTERVAL_MS);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
+    }, [hasActiveRun]);
+}

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { AgentRun, AgentRunStatus, AgentRunTriggerKind } from '../../entities/agent-run.entity';
 
@@ -30,6 +30,41 @@ export class AgentRunRepository {
 
     async findById(id: string): Promise<AgentRun | null> {
         return this.repository.findOne({ where: { id } });
+    }
+
+    /**
+     * Kanban run cockpit (Wave 2) — batch-load runs for the `includeRun`
+     * list embed. One IN query, no N+1.
+     *
+     * @internal Security: unscoped by design — callers MUST pass only ids
+     * derived server-side from rows the acting user already owns (the
+     * Tasks list hands over its own `latestRunId` pointers, never client
+     * input). HTTP handlers must not expose this with caller-supplied ids.
+     */
+    async findByIds(ids: string[]): Promise<AgentRun[]> {
+        // TypeORM renders `In([])` as invalid SQL on some drivers; and an
+        // empty batch has an obvious answer anyway.
+        if (ids.length === 0) return [];
+        return this.repository.find({ where: { id: In(ids) } });
+    }
+
+    /**
+     * Kanban run cockpit (Wave 2) — worker-side telemetry feed. A single
+     * `repository.update` so the worker can stream progress (current
+     * activity line, token counter, changed-files count) without touching
+     * status columns; the status lifecycle stays exclusively with the
+     * CAS-guarded transitions above. Best-effort — callers swallow
+     * failures, telemetry must never fail a run.
+     */
+    async updateTelemetry(
+        runId: string,
+        patch: {
+            currentActivity?: string | null;
+            totalTokens?: number | null;
+            changedFilesCount?: number | null;
+        },
+    ): Promise<void> {
+        await this.repository.update(runId, patch);
     }
 
     /**

--- a/packages/agent/src/database/repositories/task.repository.ts
+++ b/packages/agent/src/database/repositories/task.repository.ts
@@ -171,6 +171,37 @@ export class TaskRepository {
         return (result.affected ?? 0) === 1;
     }
 
+    /**
+     * Kanban run cockpit (Wave 2) — latest-run denorm write, used only by
+     * `TaskRunDenormService`.
+     *
+     * When `expectRunId` is given the write lands ONLY while the row still
+     * points at that run (or at no run yet), so a stale claim/terminal
+     * write from an OLDER run can never clobber the pointer a NEWER queued
+     * run already installed. Queued creation passes no `expectRunId` — the
+     * newest dispatch always wins the pointer.
+     *
+     * Query-builder update on purpose: unlike `repository.update` it does
+     * NOT touch `updatedAt`, so silent telemetry denorms never reshuffle
+     * the updatedAt-ordered task lists.
+     */
+    async updateLatestRun(
+        taskId: string,
+        patch: { latestRunId: string; latestRunStatus: string },
+        expectRunId?: string,
+    ): Promise<boolean> {
+        const qb = this.repository
+            .createQueryBuilder()
+            .update(Task)
+            .set(patch)
+            .where('id = :taskId', { taskId });
+        if (expectRunId) {
+            qb.andWhere('(latestRunId = :expectRunId OR latestRunId IS NULL)', { expectRunId });
+        }
+        const result = await qb.execute();
+        return (result.affected ?? 0) > 0;
+    }
+
     async deleteById(id: string): Promise<void> {
         await this.repository.delete(id);
     }

--- a/packages/agent/src/entities/agent-run.entity.ts
+++ b/packages/agent/src/entities/agent-run.entity.ts
@@ -124,6 +124,26 @@ export class AgentRun {
         reused: boolean;
     } | null;
 
+    // ── Run cockpit telemetry (kanban run cockpit, Wave 2) ──────────
+    // Written by the worker via `AgentRunRepository.updateTelemetry` and
+    // surfaced on the board through the `includeRun` list embed. All
+    // nullable — runs that predate these columns (or workers that never
+    // report) simply show no telemetry. branchRef/prUrl/prNumber are NOT
+    // duplicated here: the Task row + `workspaceMeta` already carry them.
+
+    /** One-line "what the agent is doing right now" feed for the board
+     *  chip. Plain text only — the UI must never render it as markup. */
+    @Column({ type: 'varchar', length: 300, nullable: true })
+    currentActivity?: string | null;
+
+    /** Cumulative token usage reported by the worker for this run. */
+    @Column({ type: 'int', nullable: true })
+    totalTokens?: number | null;
+
+    /** Number of files the run has changed in its workspace so far. */
+    @Column({ type: 'int', nullable: true })
+    changedFilesCount?: number | null;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/entities/task.entity.ts
+++ b/packages/agent/src/entities/task.entity.ts
@@ -170,6 +170,23 @@ export class Task {
     @Column({ type: 'simple-json', nullable: true })
     conflictPaths?: string[] | null;
 
+    // ── Latest-run denorm (kanban run cockpit, Wave 2) ───────────────
+    // Maintained by `TaskRunDenormService` on queued creation, claim and
+    // terminal transition of task-kind AgentRuns. Denormalized so the
+    // board list can batch-embed the latest run per card (single IN
+    // query on `latestRunId`) without a per-task latest-run subquery.
+    // No `@ManyToOne` — same entities-import-cycle rule as the owner
+    // columns above; the pointer is best-effort telemetry, not a FK.
+
+    /** Id of the most recent AgentRun dispatched for this Task. */
+    @Column({ type: 'uuid', nullable: true })
+    latestRunId?: string | null;
+
+    /** Status mirror of that run (`queued|running|completed|failed|
+     *  cancelled`) so list filters/chips don't need the runs table. */
+    @Column({ type: 'varchar', length: 16, nullable: true })
+    latestRunStatus?: string | null;
+
     @Column({ type: 'varchar', length: 16 })
     createdByType: TaskActorType;
 

--- a/packages/agent/src/tasks-domain/__tests__/task-run-denorm.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-run-denorm.service.spec.ts
@@ -1,0 +1,88 @@
+import { TaskRunDenormService } from '../task-run-denorm.service';
+import type { TaskRepository } from '../../database/repositories/task.repository';
+
+/**
+ * Kanban run cockpit (Wave 2 M1) — latest-run denorm on the Task row.
+ *
+ * The service is a thin, best-effort mirror over
+ * `TaskRepository.updateLatestRun`; these tests pin down the three
+ * contract points that matter for the board:
+ *
+ *  1. queued creation installs the pointer UNCONDITIONALLY (newest
+ *     dispatch wins),
+ *  2. claim + terminal transitions are GUARDED on the run id (a stale
+ *     write from an older run can never clobber a newer run's pointer),
+ *  3. nothing thrown here may ever escape (denorm is telemetry, not
+ *     truth — a failure must not fail the run or the transition).
+ */
+describe('TaskRunDenormService', () => {
+    const TASK_ID = 'task-1111';
+    const RUN_ID = 'run-aaaa';
+
+    let updateLatestRun: jest.Mock;
+    let service: TaskRunDenormService;
+
+    beforeEach(() => {
+        updateLatestRun = jest.fn().mockResolvedValue(true);
+        service = new TaskRunDenormService({
+            updateLatestRun,
+        } as unknown as TaskRepository);
+    });
+
+    it('recordQueued installs the pointer unconditionally (no expectRunId guard)', async () => {
+        await expect(service.recordQueued(TASK_ID, RUN_ID)).resolves.toBe(true);
+        expect(updateLatestRun).toHaveBeenCalledTimes(1);
+        expect(updateLatestRun).toHaveBeenCalledWith(
+            TASK_ID,
+            { latestRunId: RUN_ID, latestRunStatus: 'queued' },
+            undefined,
+        );
+    });
+
+    it('recordStarted mirrors running, guarded on its own run id', async () => {
+        await expect(service.recordStarted(TASK_ID, RUN_ID)).resolves.toBe(true);
+        expect(updateLatestRun).toHaveBeenCalledWith(
+            TASK_ID,
+            { latestRunId: RUN_ID, latestRunStatus: 'running' },
+            RUN_ID,
+        );
+    });
+
+    it.each(['completed', 'failed', 'cancelled'] as const)(
+        'recordTerminal mirrors %s, guarded on its own run id',
+        async (status) => {
+            await expect(service.recordTerminal(TASK_ID, RUN_ID, status)).resolves.toBe(true);
+            expect(updateLatestRun).toHaveBeenCalledWith(
+                TASK_ID,
+                { latestRunId: RUN_ID, latestRunStatus: status },
+                RUN_ID,
+            );
+        },
+    );
+
+    it('full happy-path lifecycle: queued → running → completed in order', async () => {
+        await service.recordQueued(TASK_ID, RUN_ID);
+        await service.recordStarted(TASK_ID, RUN_ID);
+        await service.recordTerminal(TASK_ID, RUN_ID, 'completed');
+
+        expect(updateLatestRun.mock.calls).toEqual([
+            [TASK_ID, { latestRunId: RUN_ID, latestRunStatus: 'queued' }, undefined],
+            [TASK_ID, { latestRunId: RUN_ID, latestRunStatus: 'running' }, RUN_ID],
+            [TASK_ID, { latestRunId: RUN_ID, latestRunStatus: 'completed' }, RUN_ID],
+        ]);
+    });
+
+    it('reports (not throws) when the guarded write loses to a newer run', async () => {
+        // Repository CAS found the pointer already advanced → affected 0.
+        updateLatestRun.mockResolvedValue(false);
+        await expect(service.recordTerminal(TASK_ID, RUN_ID, 'failed')).resolves.toBe(false);
+        await expect(service.recordStarted(TASK_ID, RUN_ID)).resolves.toBe(false);
+    });
+
+    it('swallows repository failures — a denorm error must never escape', async () => {
+        updateLatestRun.mockRejectedValue(new Error('db down'));
+        await expect(service.recordQueued(TASK_ID, RUN_ID)).resolves.toBe(false);
+        await expect(service.recordStarted(TASK_ID, RUN_ID)).resolves.toBe(false);
+        await expect(service.recordTerminal(TASK_ID, RUN_ID, 'completed')).resolves.toBe(false);
+    });
+});

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -8,6 +8,7 @@ export * from './task-transition.service';
 export * from './task-chat.service';
 export * from './task-dispatcher';
 export * from './task-isolation';
+export * from './task-run-denorm.service';
 export * from './task-workspace.service';
 export * from './agent-task-tools';
 export * from './recurrence';

--- a/packages/agent/src/tasks-domain/task-run-denorm.service.ts
+++ b/packages/agent/src/tasks-domain/task-run-denorm.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { TaskRepository } from '../database/repositories/task.repository';
+
+/**
+ * Statuses `TaskRunDenormService` mirrors onto the Task row. Matches the
+ * `AgentRunStatus` lifecycle for task-kind runs; `cancelled` is included
+ * so a user cancel is reflected on the board too.
+ */
+export type TaskRunTerminalStatus = 'completed' | 'failed' | 'cancelled';
+
+/**
+ * Kanban run cockpit (Wave 2 M1) — latest-run denorm on the Task row.
+ *
+ * Keeps `tasks.latestRunId` / `tasks.latestRunStatus` in sync with the
+ * task-kind AgentRun lifecycle so the board list can batch-embed the
+ * latest run per card (one IN query on `latestRunId`) instead of a
+ * per-task latest-run subquery:
+ *
+ * - `recordQueued`   — dispatch fan-out pre-created a queued row
+ *   (`TaskTransitionService.fanOutAgentExecutions`) or the worker
+ *   created one on the fly. Unconditional: the newest dispatch always
+ *   takes the pointer.
+ * - `recordStarted`  — worker claimed the run (`markStarted` in
+ *   `agent-task-execute`). Guarded on the run id so a stale claim from
+ *   an older retry can't steal the pointer from a newer queued run.
+ * - `recordTerminal` — `markCompleted` / `markFailed` /
+ *   `markDispatchFailed` / user cancel. Same guard.
+ *
+ * Every write is best-effort by contract: the denorm is board telemetry,
+ * never source of truth (`agent_runs` is), so a failure here logs WARN
+ * and returns false — it must never fail the run or the transition that
+ * triggered it.
+ */
+@Injectable()
+export class TaskRunDenormService {
+    private readonly logger = new Logger(TaskRunDenormService.name);
+
+    constructor(private readonly tasks: TaskRepository) {}
+
+    /** New run dispatched for the Task — unconditional pointer install. */
+    async recordQueued(taskId: string, runId: string): Promise<boolean> {
+        return this.write(taskId, runId, 'queued');
+    }
+
+    /** Worker claimed the run — only while the pointer is ours (or unset). */
+    async recordStarted(taskId: string, runId: string): Promise<boolean> {
+        return this.write(taskId, runId, 'running', runId);
+    }
+
+    /** Run reached a terminal state — only while the pointer is ours (or unset). */
+    async recordTerminal(
+        taskId: string,
+        runId: string,
+        status: TaskRunTerminalStatus,
+    ): Promise<boolean> {
+        return this.write(taskId, runId, status, runId);
+    }
+
+    private async write(
+        taskId: string,
+        runId: string,
+        status: string,
+        expectRunId?: string,
+    ): Promise<boolean> {
+        try {
+            const applied = await this.tasks.updateLatestRun(
+                taskId,
+                { latestRunId: runId, latestRunStatus: status },
+                expectRunId,
+            );
+            if (!applied) {
+                // Not an error: either the task row is gone, or a newer run
+                // already owns the pointer — both mean "nothing to mirror".
+                this.logger.debug(
+                    `latest-run denorm skipped for task ${taskId}: run ${runId} → ${status} (pointer already advanced or task missing).`,
+                );
+            }
+            return applied;
+        } catch (err) {
+            // Best-effort by contract — the denorm is telemetry, never truth.
+            this.logger.warn(
+                `latest-run denorm failed for task ${taskId}: run ${runId} → ${status}: ${err}`,
+            );
+            return false;
+        }
+    }
+}

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -21,6 +21,7 @@ import {
     type AgentTaskExecuteDispatcher,
 } from './task-dispatcher';
 import { TaskNotificationService } from './task-notification.service';
+import { TaskRunDenormService } from './task-run-denorm.service';
 
 /**
  * Tasks feature — Phase 12.1.
@@ -87,6 +88,9 @@ export class TaskTransitionService {
         // + blocked event. Optional so unit-test fixtures without the
         // Notifications graph still work.
         @Optional() private readonly notifications?: TaskNotificationService,
+        // Kanban run cockpit (Wave 2) — latest-run denorm on dispatch.
+        // Optional for the same unit-test-fixture reason as the rest.
+        @Optional() private readonly runDenorm?: TaskRunDenormService,
     ) {}
 
     /**
@@ -240,6 +244,13 @@ export class TaskTransitionService {
                           taskId: task.id,
                       })
                     : null;
+                // Kanban run cockpit — mirror the freshly-queued run onto the
+                // Task row so the board chip appears before the worker even
+                // claims it. The service is best-effort by contract (logs +
+                // never throws), so this cannot break the dispatch.
+                if (run) {
+                    await this.runDenorm?.recordQueued(task.id, run.id);
+                }
                 const handle = await this.dispatcher.enqueue({
                     agentId: assignee.assigneeId,
                     userId: task.userId,
@@ -287,6 +298,9 @@ export class TaskTransitionService {
                             `Failed to mark orphan AgentRun ${run.id} failed: ${failErr}`,
                         );
                     }
+                    // Kanban run cockpit — mirror the dispatch failure so the
+                    // board chip doesn't show a phantom queued run forever.
+                    await this.runDenorm?.recordTerminal(task.id, run.id, 'failed');
                 }
             }
         }

--- a/packages/agent/src/tasks-domain/tasks.module.ts
+++ b/packages/agent/src/tasks-domain/tasks.module.ts
@@ -38,6 +38,7 @@ import { TasksService } from './tasks.service';
 import { TaskChatService } from './task-chat.service';
 import { TaskRecurrenceDispatcherService } from './task-recurrence-dispatcher.service';
 import { TaskNotificationService } from './task-notification.service';
+import { TaskRunDenormService } from './task-run-denorm.service';
 import { TaskWorkspaceService } from './task-workspace.service';
 import { FacadesModule } from '../facades/facades.module';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
@@ -110,6 +111,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
         TaskChatService,
         TaskRecurrenceDispatcherService,
         TaskNotificationService,
+        TaskRunDenormService,
         TaskWorkspaceService,
     ],
     exports: [
@@ -132,6 +134,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
         TaskChatService,
         TaskRecurrenceDispatcherService,
         TaskNotificationService,
+        TaskRunDenormService,
         TaskWorkspaceService,
     ],
 })

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -29,6 +29,8 @@ import { ActivityActionType, ActivityStatus } from '../entities/activity-log.typ
 import { assertNoSecrets } from '../utils/secret-scan';
 import { computeNextOccurrence, validateRecurrenceRule } from './recurrence';
 import { AgentRepository } from '../database/repositories/agent.repository';
+import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import type { AgentRunStatus } from '../entities/agent-run.entity';
 import { TaskNotificationService } from './task-notification.service';
 import { WorkKnowledgeUploadRepository } from '../database/repositories/work-knowledge-upload.repository';
 import { WorkRepository } from '../database/repositories/work.repository';
@@ -87,6 +89,24 @@ export const TASK_OWNER_KEYS = [
 
 export type TaskOwnerKey = (typeof TASK_OWNER_KEYS)[number];
 
+/**
+ * Kanban run cockpit (Wave 2 M2) — compact latest-run embed attached to
+ * list rows when the caller passes `includeRun=true`. Deliberately a
+ * projection, not the AgentRun entity: the board chip needs exactly
+ * these six fields and nothing sensitive (no errorMessage/summary/
+ * workspaceMeta) should ride along on every list response.
+ */
+export interface TaskRunEmbed {
+    id: string;
+    status: AgentRunStatus;
+    currentActivity: string | null;
+    totalTokens: number | null;
+    changedFilesCount: number | null;
+    startedAt: Date | null;
+}
+
+export type TaskWithRun = Task & { run?: TaskRunEmbed | null };
+
 @Injectable()
 export class TasksService {
     private readonly logger = new Logger(TasksService.name);
@@ -120,6 +140,11 @@ export class TasksService {
         @Optional()
         @InjectRepository(Goal)
         private readonly goals?: Repository<Goal>,
+        // Kanban run cockpit (Wave 2 M2) — batch latest-run embed for the
+        // `includeRun` list option. Appended LAST + Optional so positional
+        // test fixtures keep compiling and graphs without the Agents module
+        // simply skip the embed.
+        @Optional() private readonly agentRuns?: AgentRunRepository,
     ) {}
 
     /**
@@ -151,8 +176,60 @@ export class TasksService {
     async list(
         userId: string,
         filter: ListTasksFilter = {},
-    ): Promise<{ rows: Task[]; total: number }> {
-        return this.tasks.findByUserIdFiltered(userId, filter);
+        opts: { includeRun?: boolean } = {},
+    ): Promise<{ rows: TaskWithRun[]; total: number }> {
+        const { rows, total } = await this.tasks.findByUserIdFiltered(userId, filter);
+        if (!opts.includeRun || rows.length === 0 || !this.agentRuns) {
+            return { rows, total };
+        }
+        // Kanban run cockpit (Wave 2 M2) — batch-embed the latest AgentRun
+        // per returned row via ONE IN query on the denormalized
+        // `latestRunId` pointers. No N+1 by construction.
+        //
+        // Security: the batch is keyed exclusively on the `latestRunId`
+        // values of rows `findByUserIdFiltered` already scoped to the
+        // acting user — never on client input — so a foreign run id can
+        // only enter this query if it was denormalized onto a task the
+        // user owns, which only `TaskRunDenormService` (server-side, from
+        // owner-validated dispatch paths) ever does. Cross-user runs are
+        // therefore unreachable through this embed.
+        const runIds = [
+            ...new Set(
+                rows
+                    .map((row) => row.latestRunId)
+                    .filter((id): id is string => typeof id === 'string' && id.length > 0),
+            ),
+        ];
+        if (runIds.length === 0) {
+            return { rows, total };
+        }
+        let runsById = new Map<string, TaskRunEmbed>();
+        try {
+            const runs = await this.agentRuns.findByIds(runIds);
+            runsById = new Map(
+                runs.map((run) => [
+                    run.id,
+                    {
+                        id: run.id,
+                        status: run.status,
+                        currentActivity: run.currentActivity ?? null,
+                        totalTokens: run.totalTokens ?? null,
+                        changedFilesCount: run.changedFilesCount ?? null,
+                        startedAt: run.startedAt ?? null,
+                    },
+                ]),
+            );
+        } catch (err) {
+            // Best-effort embed: the list itself must not fail because the
+            // runs table hiccuped — rows simply ship without `run`.
+            this.logger.warn(`includeRun embed failed (${runIds.length} run ids): ${err}`);
+            return { rows, total };
+        }
+        const withRuns: TaskWithRun[] = rows.map((row) => ({
+            ...row,
+            run: (row.latestRunId && runsById.get(row.latestRunId)) || null,
+        }));
+        return { rows: withRuns, total };
     }
 
     async getOne(userId: string, id: string): Promise<Task> {

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -2,7 +2,11 @@ import { task } from '@trigger.dev/sdk';
 import { NestFactory } from '@nestjs/core';
 import { AgentRepository, AgentRunRepository } from '@ever-works/agent/database';
 import { AgentRunService } from '@ever-works/agent/agents';
-import { TasksService, TaskWorkspaceService } from '@ever-works/agent/tasks-domain';
+import {
+    TaskRunDenormService,
+    TasksService,
+    TaskWorkspaceService,
+} from '@ever-works/agent/tasks-domain';
 import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
 import { createTriggerLogger } from '../../trigger/worker/trigger-logger';
 // Security: import assertUuid to validate Trigger.dev payload fields before any DB access
@@ -32,6 +36,21 @@ const CHAT_TEMPLATE_MARKER_PATTERN =
  */
 function neutralizeControlTokens(value: string): string {
     return value.replace(CHAT_TEMPLATE_MARKER_PATTERN, '');
+}
+
+/**
+ * Kanban run cockpit (Wave 2) — the latest-run denorm + telemetry writes
+ * are board decoration, never source of truth (`agent_runs` is). They go
+ * over the internal RPC proxy, so the transport itself can throw even
+ * though `TaskRunDenormService` swallows its own DB errors — wrap every
+ * call so a telemetry hiccup can never fail or skip the run.
+ */
+async function bestEffort(write: () => Promise<unknown>): Promise<void> {
+    try {
+        await write();
+    } catch {
+        // Best-effort by contract.
+    }
 }
 
 export interface AgentTaskExecutePayload {
@@ -80,6 +99,11 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                     : await runs.findInFlightForTaskAgent(payload.taskId, payload.agentId);
                 if (inFlight && (inFlight.status === 'queued' || inFlight.status === 'running')) {
                     await runs.markFailed(inFlight.id, message);
+                    // Kanban run cockpit — mirror the failure onto the board.
+                    const denorm = appContext.get(TaskRunDenormService);
+                    await bestEffort(() =>
+                        denorm.recordTerminal(payload.taskId, inFlight.id, 'failed'),
+                    );
                 }
             } finally {
                 await appContext.close();
@@ -106,6 +130,9 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
             const runs = appContext.get(AgentRunRepository);
             const runner = appContext.get(AgentRunService);
             const tasks = appContext.get(TasksService);
+            // Kanban run cockpit (Wave 2) — latest-run denorm writes after
+            // claim + terminal transitions. RPC proxy; every call best-effort.
+            const runDenorm = appContext.get(TaskRunDenormService);
 
             // Security: scope the Agent lookup to the payload's userId
             // (defense-in-depth IDOR guard). The legitimate dispatch path
@@ -175,6 +202,10 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                     triggerKind: 'task',
                     taskId: payload.taskId,
                 });
+                // Kanban run cockpit — on-the-fly creation (dispatcher row was
+                // never found), mirror it exactly like the fan-out path does.
+                const createdRunId = run.id;
+                await bestEffort(() => runDenorm.recordQueued(payload.taskId, createdRunId));
             }
 
             const claimed = await runs.markStarted(run.id, ctx?.run?.id ?? null);
@@ -187,6 +218,16 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
             if (!claimed) {
                 return { status: 'skipped', reason: 'run-already-terminal', runId: run.id };
             }
+            // Kanban run cockpit — claim succeeded: flip the board chip to
+            // `running` and seed the live-activity line so the card shows
+            // what the run is doing from its very first seconds.
+            const claimedRunId = run.id;
+            await bestEffort(() => runDenorm.recordStarted(payload.taskId, claimedRunId));
+            await bestEffort(() =>
+                runs.updateTelemetry(claimedRunId, {
+                    currentActivity: `Executing task ${taskRow.slug ?? payload.taskId}`,
+                }),
+            );
 
             // Wave 2 M3 — worktree-per-Task isolation. Resolves the Work +
             // Task settings and provisions the isolated workspace when (and
@@ -210,6 +251,9 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
             } catch (error) {
                 const message = error instanceof Error ? error.message : String(error);
                 await runs.markFailed(run.id, `Workspace provisioning failed: ${message}`);
+                await bestEffort(() =>
+                    runDenorm.recordTerminal(payload.taskId, claimedRunId, 'failed'),
+                );
                 return {
                     status: 'failed',
                     reason: 'workspace-provision-failed',
@@ -250,8 +294,14 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
 
             if (result.status === 'assembled') {
                 await runs.markCompleted(run.id, `Prompt assembled for task ${payload.taskId}`);
+                await bestEffort(() =>
+                    runDenorm.recordTerminal(payload.taskId, claimedRunId, 'completed'),
+                );
             } else if (result.status === 'agent-not-found') {
                 await runs.markFailed(run.id, 'Agent not found');
+                await bestEffort(() =>
+                    runDenorm.recordTerminal(payload.taskId, claimedRunId, 'failed'),
+                );
             }
 
             // Wave 2 M4 — green-path finalize of the isolated workspace:
@@ -284,6 +334,15 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                     // branch — that IS a failure of the Task's promise.
                     const message = error instanceof Error ? error.message : String(error);
                     await runs.markFailed(run.id, `Workspace finalize failed: ${message}`);
+                    // Mirror-consistency: for `assembled` runs the row was
+                    // already marked completed above, so this markFailed CAS
+                    // no-ops — only mirror `failed` when the row could
+                    // actually flip (still running, i.e. `dispatched`).
+                    if (result.status !== 'assembled') {
+                        await bestEffort(() =>
+                            runDenorm.recordTerminal(payload.taskId, claimedRunId, 'failed'),
+                        );
+                    }
                     return {
                         status: 'failed',
                         reason: 'workspace-finalize-failed',

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -17,6 +17,7 @@ import {
 import {
     TaskChatService,
     TaskRecurrenceDispatcherService,
+    TaskRunDenormService,
     TasksService,
     TaskWorkspaceService,
 } from '@ever-works/agent/tasks-domain';
@@ -154,6 +155,17 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
             useFactory: (apiClient) => createRemoteProxy(apiClient, 'TaskWorkspaceService'),
             inject: [TriggerInternalApiClient],
         },
+        // Kanban run cockpit (Wave 2) — latest-run denorm writes from the
+        // agent-task-execute worker (after claim + terminal transitions).
+        // The real service (TaskRepository graph) lives in the API; the
+        // worker only calls recordQueued/recordStarted/recordTerminal over
+        // the internal RPC channel, same shape as TaskWorkspaceService.
+        {
+            provide: TaskRunDenormService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'TaskRunDenormService'),
+            inject: [TriggerInternalApiClient],
+        },
         {
             provide: TaskChatService,
             useFactory: (apiClient: TriggerInternalApiClient) =>
@@ -212,6 +224,7 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         TaskRecurrenceDispatcherService,
         TasksService,
         TaskChatService,
+        TaskRunDenormService,
         TaskWorkspaceService,
         NotificationChannelFacadeService,
         AnonymousUserCleanupService,


### PR DESCRIPTION
Task cards on the kanban board become live run cockpits — a run chip with status, current activity line, and token counter, fed by telemetry the worker writes.

## M1 — telemetry columns + worker writes

- **`AgentRun`**: nullable `currentActivity` (varchar 300), `totalTokens` (int), `changedFilesCount` (int). branchRef/prUrl/prNumber deliberately NOT duplicated (Task + `workspaceMeta` already carry them).
- **`Task`**: nullable denorms `latestRunId` (uuid), `latestRunStatus` (varchar 16).
- **Migration** `1782900000000-AddRunTelemetryColumns` — guarded, forward-only, idempotent per-step (exact house pattern of `1782700000000-AddTaskIsolationColumns`).
- **`AgentRunRepository.updateTelemetry(runId, patch)`** — single `repository.update`, status lifecycle untouched; plus `findByIds(ids)` (one IN query) for the M2 embed.
- **`TaskRunDenormService`** (tasks-domain, barrel-exported, registered in `TasksDomainModule`): `recordQueued` (unconditional — newest dispatch wins the pointer) / `recordStarted` / `recordTerminal` (CAS-guarded on the run id via `TaskRepository.updateLatestRun` so a stale claim/terminal write from an older run can never clobber a newer run's pointer; QB update so denorms never bump `updatedAt`/reshuffle lists). Best-effort by contract — logs, never throws, never fails a run.
- **Wired**: queued creation in `TaskTransitionService.fanOutAgentExecutions` (+ dispatch-failure mirror), and in `agent-task-execute` after claim (`recordStarted` + first `updateTelemetry` activity line) and after every terminal write incl. the `onFailure` handler (mirror-consistent with the run row's CAS semantics).
- **RPC registry**: `TaskRunDenormService` exposed exactly like `TaskWorkspaceService` — worker proxy factory (`trigger-internal.module.ts`), API controller constructor + registry map (`trigger-internal.controller.ts`), spec constructor arity updated with an `undefined` arg.

## M2 — includeRun embed + board chips

- **`GET /api/tasks?includeRun=true`**: batch-loads the latest AgentRun per returned row via ONE IN query on `latestRunId` (`findByIds`) and attaches `run: {id, status, currentActivity, totalTokens, changedFilesCount, startedAt}`. No N+1. **Security**: the batch is keyed exclusively on the owner-scoped rows' `latestRunId` pointers (server-derived), never client input — cross-user runs unreachable. Default (no flag) response shape is byte-identical to before.
- **`apps/web`**: `TaskRunChip.tsx` (status dot: queued=gray pulse, running=blue pulse, completed=green, failed=red; truncated `currentActivity` rendered strictly as a text node — never markup; compact token count like "12.4k"), rendered on `TasksKanbanView` cards next to `TaskBranchChip`; `use-task-run-polling.ts` (10s interval, active ONLY while a visible task has a queued/running run, non-stacking, best-effort) merging run fields by id; `dashboard.tasksPage.runChip` i18n strings in `messages/en.json`; task pages fetch with `includeRun: true` so chips render on first paint.
- `data-testid="task-run-chip"`. Additive only — no existing UI removed.
- Also narrows the tasks DTO `isolationMode` typing to `TaskIsolationMode` (`'on'|'off'`) — fixes a pre-existing fresh-build TS2322 on the base branch; values were already runtime-validated by `@IsIn(['on','off'])`.

## Verification (real output)

- `packages/agent` `pnpm build` → `TSC Found 0 issues.` + `Successfully compiled: 969 files with swc`
- `packages/agent` jest `task-run-denorm|task-transition` → `Test Suites: 3 passed, Tests: 31 passed`
- `packages/agent` jest `tasks-domain` (full) → `Test Suites: 11 passed, Tests: 115 passed`
- `pnpm build --filter=ever-works-api` → `TSC Found 0 issues.` + `Successfully compiled: 628 files with swc` (13/13 tasks successful)
- `apps/api` `pnpm generate:openapi` → `Wrote OpenAPI spec (410 paths)` (full-app DI bootstrap green; `openapi.json` excluded from the commit)
- `apps/api` jest `trigger-internal` → `Test Suites: 2 passed, Tests: 16 passed`
- `apps/web` `npx tsc --noEmit` → clean (covers e2e specs via tsconfig glob)
- `packages/tasks` `pnpm type-check` → clean
- e2e shape sweep: no `apps/web/e2e` spec asserts exact tasks-list row shapes or the new chip testids; the embed is opt-in and no DTO body field was added, so no `forbidNonWhitelisted` rejection specs are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)