### PR TITLE
feat(plugins): local-workspace provider — persistent worktree pool (Wave 2 M8)

### DIFF
--- a/packages/plugins/local-workspace/package.json
+++ b/packages/plugins/local-workspace/package.json
@@ -1,0 +1,62 @@
+{
+	"name": "@ever-works/local-workspace-plugin",
+	"version": "1.0.0",
+	"description": "Local Workspace - System plugin providing isolated git working contexts (branch-per-Task) from a persistent local worktree pool",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"type-check": "tsc --noEmit",
+		"clean": "rm -rf dist",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "local-workspace",
+			"name": "Local Workspace",
+			"version": "1.0.0",
+			"category": "utility",
+			"capabilities": [
+				"workspace"
+			],
+			"description": "System plugin providing isolated git working contexts for agent-executed Tasks on local runtimes: a persistent pool with one base clone per repository and a real `git worktree` per Task branch, worktree reuse across runs, per-repository creation serialization, binding stamps with self-heal, and workspace GC.",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"autoEnable": false,
+			"systemPlugin": true,
+			"builtIn": true,
+			"visibility": "public"
+		}
+	}
+}

--- a/packages/plugins/local-workspace/src/__tests__/local-workspace.spec.ts
+++ b/packages/plugins/local-workspace/src/__tests__/local-workspace.spec.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import { LocalWorkspacePlugin } from '../local-workspace.plugin.js';
+
+/**
+ * Hermetic loopback suite: a real local BARE repo plays "origin"
+ * (file:// URL — no network, no tokens), and the plugin runs real git
+ * against it. Beyond the shared workspace-contract behaviour
+ * (fetch-first provision, finalize commit+push, merge simulation with
+ * NAMED conflict paths), this suite pins down what makes the local
+ * provider LOCAL: the persistent pool (one base clone per repo, real
+ * `git worktree add` per task), worktree REUSE across runs, binding
+ * self-heal by recreate, per-repo provision serialization, and GC with
+ * `git worktree prune`.
+ */
+
+const git = (cwd: string, ...args: string[]): string =>
+	execFileSync('git', args, { cwd, encoding: 'utf8', windowsHide: true }).trim();
+
+let root: string;
+let originDir: string;
+let originUrl: string;
+let seedDir: string;
+let baseDir: string;
+let plugin: LocalWorkspacePlugin;
+
+const settings = () => ({ baseDir, fetchDepth: 1 });
+
+const spec = (bindingKey: string, branch: string) => ({
+	repoUrl: originUrl,
+	baseRef: 'main',
+	branch,
+	bindingKey,
+	settings: settings()
+});
+
+const seedCommit = (file: string, content: string, message: string): string => {
+	writeFileSync(join(seedDir, file), content);
+	git(seedDir, 'add', '-A');
+	git(seedDir, '-c', 'user.name=Seed', '-c', 'user.email=seed@test.local', 'commit', '-m', message);
+	git(seedDir, 'push', originUrl, 'HEAD:refs/heads/main');
+	return git(seedDir, 'rev-parse', 'HEAD');
+};
+
+/** The pool must hold exactly ONE base clone for the loopback origin. */
+const poolRepoDir = (): string => {
+	const repos = join(baseDir, 'repos');
+	const entries = existsSync(repos) ? readdirSync(repos) : [];
+	if (entries.length !== 1) {
+		throw new Error(`expected exactly 1 pool repo, found ${entries.length}`);
+	}
+	return join(repos, entries[0]);
+};
+
+beforeAll(() => {
+	root = mkdtempSync(join(tmpdir(), 'ew-local-ws-'));
+	originDir = join(root, 'origin.git');
+	seedDir = join(root, 'seed');
+	baseDir = join(root, 'workspaces');
+	mkdirSync(originDir, { recursive: true });
+	mkdirSync(seedDir, { recursive: true });
+	git(originDir, 'init', '--bare', '--initial-branch', 'main');
+	originUrl = pathToFileURL(originDir).toString();
+	git(seedDir, 'init', '--initial-branch', 'main');
+	seedCommit('README.md', 'hello\n', 'seed: initial');
+	plugin = new LocalWorkspacePlugin();
+});
+
+afterAll(async () => {
+	await fs.rm(root, { recursive: true, force: true, maxRetries: 3 });
+});
+
+describe('provision (persistent pool + worktree)', () => {
+	it('cuts a fresh worktree branch from the CURRENT origin base (fetch-first)', async () => {
+		const latest = seedCommit('a.txt', 'a\n', 'seed: advance base');
+		const handle = await plugin.provision(spec('lw-task-1', 'task/first-run-aaaa1111'));
+		expect(handle.reused).toBe(false);
+		expect(handle.baseSha).toBe(latest);
+		expect(handle.path).toBe(join(baseDir, 'worktrees', 'lw-task-1'));
+		expect(git(handle.path, 'rev-parse', 'HEAD')).toBe(latest);
+		expect(git(handle.path, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('task/first-run-aaaa1111');
+		// The persisted remote must be token-free (here: the plain URL).
+		expect(git(handle.path, 'remote', 'get-url', 'origin')).toBe(originUrl);
+		// The checkout is a REAL linked worktree of the pool repo, not a clone.
+		const gitFile = await fs.stat(join(handle.path, '.git'));
+		expect(gitFile.isFile()).toBe(true);
+	});
+
+	it('REUSES the worktree across runs — same path, no teardown, no re-clone', async () => {
+		const h1 = await plugin.provision(spec('lw-task-2', 'task/reuse-bbbb2222'));
+		writeFileSync(join(h1.path, 'work.txt'), 'agent output\n');
+		const fin = await plugin.finalize(h1, { commitMessage: 'agent: work', push: true });
+		expect(fin.pushed).toBe(true);
+
+		// Scratch state left behind by the run — a persistent worktree
+		// must carry it into the next run (NOT torn down in between).
+		writeFileSync(join(h1.path, 'scratch.txt'), 'uncommitted scratch\n');
+		const pool = poolRepoDir();
+		const configMtimeBefore = (await fs.stat(join(pool, 'config'))).mtimeMs;
+
+		const h2 = await plugin.provision(spec('lw-task-2', 'task/reuse-bbbb2222'));
+		expect(h2.path).toBe(h1.path);
+		expect(h2.reused).toBe(true);
+		expect(git(h2.path, 'rev-parse', 'HEAD')).toBe(fin.headSha);
+		await expect(fs.readFile(join(h2.path, 'scratch.txt'), 'utf8')).resolves.toBe('uncommitted scratch\n');
+		// No re-clone / remote rewrite: the pool repo config was untouched.
+		const configMtimeAfter = (await fs.stat(join(pool, 'config'))).mtimeMs;
+		expect(configMtimeAfter).toBe(configMtimeBefore);
+	});
+
+	it('self-heals a branch collision: same binding, different branch → recreate', async () => {
+		const h1 = await plugin.provision(spec('lw-task-3', 'task/heal-cccc3333'));
+		writeFileSync(join(h1.path, 'stale.txt'), 'stale\n');
+
+		// The stamp says task/heal-cccc3333; asking for another branch on
+		// the same binding is a collision → remove --force + recreate.
+		const h2 = await plugin.provision(spec('lw-task-3', 'task/heal-dddd4444'));
+		expect(h2.path).toBe(h1.path);
+		expect(h2.reused).toBe(false);
+		expect(git(h2.path, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('task/heal-dddd4444');
+		expect(existsSync(join(h2.path, 'stale.txt'))).toBe(false);
+	});
+
+	it('self-heals a foreign/corrupt binding stamp instead of bricking', async () => {
+		const h1 = await plugin.provision(spec('lw-task-4', 'task/stamp-eeee5555'));
+		writeFileSync(join(h1.path, 'stale.txt'), 'stale\n');
+
+		// Corrupt the stamp INSIDE the worktree's private gitdir (it must
+		// live there, never in the working tree).
+		const gitDir = git(h1.path, 'rev-parse', '--path-format=absolute', '--git-dir');
+		expect(existsSync(join(gitDir, 'ew-workspace.json'))).toBe(true);
+		writeFileSync(
+			join(gitDir, 'ew-workspace.json'),
+			JSON.stringify({ bindingKey: 'someone-else', branch: 'task/stamp-eeee5555' })
+		);
+
+		const h2 = await plugin.provision(spec('lw-task-4', 'task/stamp-eeee5555'));
+		expect(h2.path).toBe(h1.path);
+		expect(git(h2.path, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('task/stamp-eeee5555');
+		expect(existsSync(join(h2.path, 'stale.txt'))).toBe(false);
+	});
+
+	it('provisions two tasks in PARALLEL into two worktrees of ONE pool repo', async () => {
+		const latest = git(seedDir, 'rev-parse', 'HEAD');
+		// Promise.all on one repo-key exercises the per-repo mutex —
+		// unserialized concurrent `git worktree add` corrupts refs.
+		const [ha, hb] = await Promise.all([
+			plugin.provision(spec('lw-par-a', 'task/par-a-11112222')),
+			plugin.provision(spec('lw-par-b', 'task/par-b-33334444'))
+		]);
+		expect(ha.path).not.toBe(hb.path);
+		expect(git(ha.path, 'rev-parse', 'HEAD')).toBe(latest);
+		expect(git(hb.path, 'rev-parse', 'HEAD')).toBe(latest);
+		expect(git(ha.path, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('task/par-a-11112222');
+		expect(git(hb.path, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('task/par-b-33334444');
+
+		// ONE base clone serves both.
+		const repos = await fs.readdir(join(baseDir, 'repos'));
+		expect(repos).toHaveLength(1);
+		const list = git(join(baseDir, 'repos', repos[0]), 'worktree', 'list');
+		expect(list).toContain('lw-par-a');
+		expect(list).toContain('lw-par-b');
+	});
+});
+
+describe('finalize', () => {
+	it('reports empty when the run produced no changes', async () => {
+		const handle = await plugin.provision(spec('lw-task-5', 'task/empty-ffff6666'));
+		const fin = await plugin.finalize(handle, { commitMessage: 'agent: nothing', push: true });
+		expect(fin.empty).toBe(true);
+		expect(fin.pushed).toBe(false);
+	});
+
+	it('commits and pushes changes to the task branch, never the base', async () => {
+		const baseBefore = git(seedDir, 'rev-parse', 'HEAD');
+		const handle = await plugin.provision(spec('lw-task-6', 'task/push-77778888'));
+		writeFileSync(join(handle.path, 'feature.txt'), 'new feature\n');
+		const fin = await plugin.finalize(handle, { commitMessage: 'agent: feature', push: true });
+		expect(fin.pushed).toBe(true);
+		expect(fin.headSha).not.toBe(handle.baseSha);
+
+		// Remote task branch has the commit; remote main is untouched.
+		const remoteBranch = git(originDir, 'rev-parse', 'refs/heads/task/push-77778888');
+		expect(remoteBranch).toBe(fin.headSha);
+		expect(git(originDir, 'rev-parse', 'refs/heads/main')).toBe(baseBefore);
+	});
+});
+
+describe('simulateMerge', () => {
+	it('reports clean when the branch applies onto the target', async () => {
+		const handle = await plugin.provision(spec('lw-task-7', 'task/clean-9999aaaa'));
+		writeFileSync(join(handle.path, 'clean-add.txt'), 'no conflict here\n');
+		await plugin.finalize(handle, { commitMessage: 'agent: clean add', push: false });
+
+		const sim = await plugin.simulateMerge(handle, 'main');
+		expect(sim.clean).toBe(true);
+		expect(sim.conflictPaths).toEqual([]);
+	});
+
+	it('NAMES the conflicting paths when base moved incompatibly', async () => {
+		const handle = await plugin.provision(spec('lw-task-8', 'task/conflict-bbbbcccc'));
+
+		// Branch edits README one way…
+		writeFileSync(join(handle.path, 'README.md'), 'branch version\n');
+		await plugin.finalize(handle, { commitMessage: 'agent: edit readme', push: false });
+
+		// …meanwhile the base moves the SAME file the other way.
+		seedCommit('README.md', 'base version\n', 'seed: conflicting readme');
+
+		const sim = await plugin.simulateMerge(handle, 'main');
+		expect(sim.clean).toBe(false);
+		expect(sim.conflictPaths).toContain('README.md');
+	});
+});
+
+describe('teardown', () => {
+	it('removes the worktree AND its pool registration, keeping the pool repo', async () => {
+		const handle = await plugin.provision(spec('lw-task-9', 'task/tear-ddddeeee'));
+		const pool = poolRepoDir();
+		expect(git(pool, 'worktree', 'list')).toContain('lw-task-9');
+
+		await plugin.teardown(handle);
+		expect(existsSync(handle.path)).toBe(false);
+		expect(git(pool, 'worktree', 'list')).not.toContain('lw-task-9');
+		// The pool repo itself PERSISTS — that is the whole point.
+		expect(existsSync(join(pool, 'HEAD'))).toBe(true);
+	});
+});
+
+describe('gc', () => {
+	it('removes only worktrees older than the cutoff and prunes the pool', async () => {
+		process.env.EW_WORKSPACES_DIR = baseDir;
+		try {
+			const oldHandle = await plugin.provision(spec('lw-gc-old', 'task/gc-old-ffff0000'));
+			const past = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+			await fs.utimes(oldHandle.path, past, past);
+
+			const freshHandle = await plugin.provision(spec('lw-gc-fresh', 'task/gc-fresh-00001111'));
+
+			const { removed } = await plugin.gc({ olderThanDays: 14 });
+			expect(removed).toContain('lw-gc-old');
+			expect(removed).not.toContain('lw-gc-fresh');
+			expect(existsSync(oldHandle.path)).toBe(false);
+			expect(existsSync(freshHandle.path)).toBe(true);
+
+			// The pool repo survives GC and its bookkeeping was pruned.
+			const pool = poolRepoDir();
+			expect(existsSync(join(pool, 'HEAD'))).toBe(true);
+			const list = git(pool, 'worktree', 'list');
+			expect(list).not.toContain('lw-gc-old');
+			expect(list).toContain('lw-gc-fresh');
+		} finally {
+			delete process.env.EW_WORKSPACES_DIR;
+		}
+	});
+});

--- a/packages/plugins/local-workspace/src/index.ts
+++ b/packages/plugins/local-workspace/src/index.ts
@@ -1,0 +1,2 @@
+export { LocalWorkspacePlugin } from './local-workspace.plugin.js';
+export { LocalWorkspacePlugin as default } from './local-workspace.plugin.js';

--- a/packages/plugins/local-workspace/src/local-workspace.plugin.ts
+++ b/packages/plugins/local-workspace/src/local-workspace.plugin.ts
@@ -1,0 +1,609 @@
+import type {
+	IPlugin,
+	IWorkspacePlugin,
+	PluginContext,
+	PluginCategory,
+	PluginHealthCheck,
+	JsonSchema,
+	WorkspaceProvisionSpec,
+	WorkspaceHandle,
+	WorkspaceFinalizeResult,
+	WorkspaceMergeSimulation
+} from '@ever-works/plugin';
+import { WorkspaceNotProvisionedError } from '@ever-works/plugin';
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { join, resolve as resolvePath } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/** Binding stamp kept INSIDE the worktree's gitdir so it can never be
+ *  committed and never shows up in the working tree. */
+const STAMP_FILE = 'ew-workspace.json';
+
+/** Pool sub-directories under the base dir. */
+const REPOS_DIR = 'repos';
+const WORKTREES_DIR = 'worktrees';
+
+interface GitResult {
+	code: number;
+	stdout: string;
+	stderr: string;
+}
+
+interface BindingStamp {
+	bindingKey: string;
+	branch: string;
+}
+
+/**
+ * Local Workspace — the `workspace` provider for persistent local
+ * runtimes.
+ *
+ * Where sandbox-workspace's ephemeral sandbox degenerates worktree
+ * mechanics into fresh-clone-per-run, this provider keeps a PERSISTENT
+ * pool on disk: one bare base clone per repository under
+ * `<baseDir>/repos/<repo-key>` and one real `git worktree` per Task
+ * branch under `<baseDir>/worktrees/<bindingKey>`. Worktrees survive
+ * between runs — a re-run resumes in the same directory with the same
+ * branch instead of re-cloning.
+ *
+ * Sharp edges this provider owns:
+ *  - **Per-repo creation serialization**: concurrent `git worktree add`
+ *    against one clone corrupts refs, so provision calls are serialized
+ *    per repo-key with an in-process promise-chain mutex.
+ *  - **Binding stamps with self-heal**: every worktree is stamped (in
+ *    its gitdir, never the working tree) with `{ bindingKey, branch }`.
+ *    A mismatch on reuse removes and re-provisions the worktree instead
+ *    of bricking it.
+ *  - **GC**: stale worktrees past the cutoff are removed and the pool
+ *    repos are `git worktree prune`d so their bookkeeping never leaks.
+ *
+ * Auth posture (identical to sandbox-workspace): the pool clone's
+ * `origin` remote is always TOKEN-FREE. Credentials arrive per-operation
+ * in the spec and are injected into the URL of that single command
+ * invocation only; they are never written to git config, the stamp file,
+ * or the working tree (the checkout runs untrusted repo code). Tokens
+ * are scrubbed from every error message before it can propagate into
+ * logs.
+ */
+export class LocalWorkspacePlugin implements IPlugin, IWorkspacePlugin {
+	readonly id = 'local-workspace';
+	readonly name = 'Local Workspace';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'utility';
+	readonly capabilities: readonly string[] = ['workspace'];
+	readonly providerName = 'Local (persistent worktree pool)';
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		properties: {
+			baseDir: {
+				type: 'string',
+				title: 'Workspace base directory',
+				description:
+					'Directory the worktree pool lives under. Defaults to EW_WORKSPACES_DIR or the OS temp dir.',
+				'x-hidden': true
+			},
+			fetchDepth: {
+				type: 'number',
+				title: 'Fetch depth',
+				description: 'Shallow fetch depth for the base-ref fetch.',
+				default: 1,
+				minimum: 1,
+				maximum: 1000,
+				'x-hidden': true
+			},
+			committerName: {
+				type: 'string',
+				title: 'Committer name',
+				default: 'Ever Works Agent',
+				'x-hidden': true
+			},
+			committerEmail: {
+				type: 'string',
+				title: 'Committer email',
+				default: 'agent@ever.works',
+				'x-hidden': true
+			}
+		}
+	};
+
+	private gitAvailable: boolean | null = null;
+
+	/** Per-repo promise-chain mutex — see class doc. */
+	private readonly repoLocks = new Map<string, Promise<void>>();
+
+	async onLoad(_context: PluginContext): Promise<void> {
+		// Availability is probed lazily on first use — onLoad must stay
+		// cheap and never fail registration (the API process loads every
+		// plugin; only local runtimes actually run git).
+	}
+
+	async onUnload(): Promise<void> {
+		this.gitAvailable = null;
+		this.repoLocks.clear();
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		const ok = await this.ensureGit().then(
+			() => true,
+			() => false
+		);
+		return {
+			status: ok ? 'healthy' : 'unhealthy',
+			message: ok ? 'git available' : 'git binary not found in this runtime',
+			checkedAt: Date.now()
+		};
+	}
+
+	async provision(spec: WorkspaceProvisionSpec): Promise<WorkspaceHandle> {
+		await this.ensureGit();
+		// Concurrent `git worktree add` on one clone corrupts refs —
+		// serialize ALL provision work per repo-key.
+		return this.withRepoLock(repoKey(spec.repoUrl), () => this.provisionLocked(spec));
+	}
+
+	private async provisionLocked(spec: WorkspaceProvisionSpec): Promise<WorkspaceHandle> {
+		const base = this.baseDir(spec.settings);
+		const poolDir = join(base, REPOS_DIR, repoKey(spec.repoUrl));
+		const worktreeDir = join(base, WORKTREES_DIR, sanitizeSegment(spec.bindingKey));
+		const depth = Number(spec.settings?.fetchDepth) > 0 ? Number(spec.settings?.fetchDepth) : 1;
+
+		// ── pool repo: one BARE base clone per repository ─────────────
+		await fs.mkdir(poolDir, { recursive: true });
+		if (!(await exists(join(poolDir, 'HEAD')))) {
+			await this.gitOrThrow(['init', '--bare'], poolDir, spec.auth, 'pool repo init failed');
+			await this.gitOrThrow(
+				['remote', 'add', 'origin', spec.repoUrl],
+				poolDir,
+				spec.auth,
+				'pool remote add failed'
+			);
+		} else {
+			// Keep the persisted remote token-free and current — but only
+			// touch config when the URL actually changed (a reused pool
+			// must not be rewritten on every provision).
+			const current = await this.git(['remote', 'get-url', 'origin'], poolDir, spec.auth);
+			if (current.code !== 0) {
+				await this.gitOrThrow(
+					['remote', 'add', 'origin', spec.repoUrl],
+					poolDir,
+					spec.auth,
+					'pool remote add failed'
+				);
+			} else if (current.stdout.trim() !== spec.repoUrl) {
+				await this.gitOrThrow(
+					['remote', 'set-url', 'origin', spec.repoUrl],
+					poolDir,
+					spec.auth,
+					'pool remote set-url failed'
+				);
+			}
+		}
+
+		const authedUrl = this.authedUrl(spec.repoUrl, spec.auth);
+
+		// Fetch-first, ALWAYS: the base is branched from origin/<baseRef>
+		// as of NOW, never a cached ref.
+		await this.gitOrThrow(
+			[
+				'fetch',
+				'--depth',
+				String(depth),
+				authedUrl,
+				`+refs/heads/${spec.baseRef}:refs/remotes/origin/${spec.baseRef}`
+			],
+			poolDir,
+			spec.auth,
+			`fetch of base ref '${spec.baseRef}' failed`
+		);
+
+		// A previously pushed task branch is the durable identity — reuse
+		// it when it exists (re-run / conflict-fix loop).
+		const branchFetch = await this.git(
+			['fetch', authedUrl, `+refs/heads/${spec.branch}:refs/remotes/origin/${spec.branch}`],
+			poolDir,
+			spec.auth
+		);
+		const remoteBranchExists = branchFetch.code === 0;
+
+		const baseSha = (
+			await this.gitOrThrow(
+				['rev-parse', `refs/remotes/origin/${spec.baseRef}`],
+				poolDir,
+				spec.auth,
+				'base ref did not resolve after fetch'
+			)
+		).stdout.trim();
+
+		// ── worktree: reuse when the binding stamp matches ────────────
+		if (await exists(worktreeDir)) {
+			const stamp = await this.readStamp(worktreeDir, spec.auth);
+			const checkedOut =
+				stamp !== null ? await this.git(['rev-parse', '--abbrev-ref', 'HEAD'], worktreeDir, spec.auth) : null;
+			const healthy =
+				stamp !== null &&
+				stamp.bindingKey === spec.bindingKey &&
+				stamp.branch === spec.branch &&
+				checkedOut !== null &&
+				checkedOut.code === 0 &&
+				checkedOut.stdout.trim() === spec.branch;
+
+			if (healthy) {
+				// The worktree persists across runs on purpose — resume in
+				// place, no re-clone, no branch re-cut.
+				return {
+					path: worktreeDir,
+					baseSha,
+					reused: true,
+					branch: spec.branch,
+					bindingKey: spec.bindingKey
+				};
+			}
+
+			// Self-heal: stale dir, corrupt/missing stamp, foreign binding
+			// or a branch collision — remove and recreate instead of
+			// bricking the workspace.
+			await this.removeWorktree(poolDir, worktreeDir, spec.auth);
+		}
+
+		const startPoint = remoteBranchExists
+			? `refs/remotes/origin/${spec.branch}`
+			: `refs/remotes/origin/${spec.baseRef}`;
+		await this.gitOrThrow(
+			['worktree', 'add', '-B', spec.branch, worktreeDir, startPoint],
+			poolDir,
+			spec.auth,
+			'worktree add failed'
+		);
+
+		await this.writeStamp(worktreeDir, { bindingKey: spec.bindingKey, branch: spec.branch }, spec.auth);
+
+		return {
+			path: worktreeDir,
+			baseSha,
+			reused: remoteBranchExists,
+			branch: spec.branch,
+			bindingKey: spec.bindingKey
+		};
+	}
+
+	async finalize(
+		handle: WorkspaceHandle,
+		opts: { commitMessage: string; push: boolean; auth?: WorkspaceProvisionSpec['auth'] }
+	): Promise<WorkspaceFinalizeResult> {
+		await this.ensureGit();
+		const dir = handle.path;
+		await this.gitOrThrow(['add', '-A'], dir, opts.auth, 'git add failed');
+
+		const status = await this.gitOrThrow(['status', '--porcelain'], dir, opts.auth, 'git status failed');
+		const dirty = status.stdout.trim().length > 0;
+		if (dirty) {
+			await this.gitOrThrow(
+				[
+					'-c',
+					'user.name=Ever Works Agent',
+					'-c',
+					'user.email=agent@ever.works',
+					'commit',
+					'-m',
+					opts.commitMessage
+				],
+				dir,
+				opts.auth,
+				'git commit failed'
+			);
+		}
+
+		const head = await this.git(['rev-parse', 'HEAD'], dir, opts.auth);
+		const headSha = head.code === 0 ? head.stdout.trim() : null;
+
+		// Empty run: no new commit AND the branch has nothing beyond the
+		// base — there is nothing worth pushing or PR-ing.
+		if (!dirty && (headSha === null || headSha === handle.baseSha)) {
+			return { pushed: false, headSha, empty: true };
+		}
+
+		let pushed = false;
+		if (opts.push) {
+			const repoUrl = (
+				await this.gitOrThrow(['remote', 'get-url', 'origin'], dir, opts.auth, 'origin remote missing')
+			).stdout.trim();
+			await this.gitOrThrow(
+				['push', this.authedUrl(repoUrl, opts.auth), `HEAD:refs/heads/${handle.branch}`],
+				dir,
+				opts.auth,
+				'git push failed'
+			);
+			pushed = true;
+		}
+
+		return { pushed, headSha, empty: false };
+	}
+
+	async simulateMerge(
+		handle: WorkspaceHandle,
+		targetRef: string,
+		auth?: WorkspaceProvisionSpec['auth']
+	): Promise<WorkspaceMergeSimulation> {
+		await this.ensureGit();
+		const dir = handle.path;
+		const repoUrl = (
+			await this.gitOrThrow(['remote', 'get-url', 'origin'], dir, auth, 'origin remote missing')
+		).stdout.trim();
+
+		// Merge against the target AS OF NOW — a stale target is how you
+		// end up shipping a PR with a red merge banner.
+		await this.gitOrThrow(
+			['fetch', this.authedUrl(repoUrl, auth), `+refs/heads/${targetRef}:refs/remotes/origin/${targetRef}`],
+			dir,
+			auth,
+			`fetch of merge target '${targetRef}' failed`
+		);
+
+		let result = await this.git(
+			['merge-tree', '--write-tree', '--name-only', `refs/remotes/origin/${targetRef}`, 'HEAD'],
+			dir,
+			auth
+		);
+
+		// Shallow histories can lack a merge base; deepen once and retry.
+		if (result.code > 1) {
+			await this.git(['fetch', this.authedUrl(repoUrl, auth), '--unshallow'], dir, auth);
+			result = await this.git(
+				['merge-tree', '--write-tree', '--name-only', `refs/remotes/origin/${targetRef}`, 'HEAD'],
+				dir,
+				auth
+			);
+		}
+
+		if (result.code === 0) {
+			return { clean: true, conflictPaths: [] };
+		}
+		if (result.code === 1) {
+			// Output: first line = written tree OID, following lines = the
+			// conflicted file names (--name-only).
+			const lines = result.stdout
+				.split('\n')
+				.map((l) => l.trim())
+				.filter(Boolean);
+			return { clean: false, conflictPaths: lines.slice(1) };
+		}
+		throw new Error(`merge simulation failed: ${this.scrub(result.stderr, auth)}`);
+	}
+
+	async teardown(handle: WorkspaceHandle): Promise<void> {
+		const poolDir = await this.poolDirOf(handle.path);
+		if (poolDir) {
+			await this.removeWorktree(poolDir, handle.path, undefined);
+		} else {
+			await fs.rm(handle.path, { recursive: true, force: true, maxRetries: 3 });
+		}
+	}
+
+	async gc(policy: { olderThanDays: number }): Promise<{ removed: string[] }> {
+		const base = this.baseDir(undefined);
+		const removed: string[] = [];
+		const cutoff = Date.now() - policy.olderThanDays * 24 * 60 * 60 * 1000;
+
+		// 1) Remove stale worktrees past the cutoff.
+		const worktreesRoot = join(base, WORKTREES_DIR);
+		let entries: string[] = [];
+		try {
+			entries = await fs.readdir(worktreesRoot);
+		} catch {
+			entries = [];
+		}
+		for (const entry of entries) {
+			const dir = join(worktreesRoot, entry);
+			try {
+				const stat = await fs.stat(dir);
+				if (stat.isDirectory() && stat.mtimeMs < cutoff) {
+					await fs.rm(dir, { recursive: true, force: true, maxRetries: 3 });
+					removed.push(entry);
+				}
+			} catch {
+				// Entry vanished mid-scan — GC is best-effort by design.
+			}
+		}
+
+		// 2) Prune the pool repos' worktree bookkeeping so removed dirs
+		//    never linger as phantom registrations.
+		const reposRoot = join(base, REPOS_DIR);
+		let repos: string[] = [];
+		try {
+			repos = await fs.readdir(reposRoot);
+		} catch {
+			repos = [];
+		}
+		for (const repo of repos) {
+			await this.git(['worktree', 'prune'], join(reposRoot, repo), undefined);
+		}
+
+		return { removed };
+	}
+
+	// ── internals ────────────────────────────────────────────────────
+
+	private baseDir(settings: WorkspaceProvisionSpec['settings']): string {
+		const configured = (typeof settings?.baseDir === 'string' && settings.baseDir) || process.env.EW_WORKSPACES_DIR;
+		return configured || join(tmpdir(), 'ew-local-workspaces');
+	}
+
+	/**
+	 * Serialize work per repo-key with an in-process promise chain. The
+	 * stored chain always resolves (rejections are swallowed into it) so
+	 * one failed provision never poisons the queue behind it.
+	 */
+	private withRepoLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+		const prev = this.repoLocks.get(key) ?? Promise.resolve();
+		const run = prev.then(fn);
+		this.repoLocks.set(
+			key,
+			run.then(
+				() => undefined,
+				() => undefined
+			)
+		);
+		return run;
+	}
+
+	private async ensureGit(): Promise<void> {
+		if (this.gitAvailable === true) return;
+		const probe = await this.git(['--version'], undefined, undefined);
+		if (probe.code !== 0) {
+			this.gitAvailable = false;
+			throw new WorkspaceNotProvisionedError(
+				'git is not available in this runtime — the local-workspace provider cannot operate.'
+			);
+		}
+		this.gitAvailable = true;
+	}
+
+	/** Resolve the pool repo a worktree belongs to (its common gitdir). */
+	private async poolDirOf(worktreePath: string): Promise<string | null> {
+		const result = await this.git(
+			['rev-parse', '--path-format=absolute', '--git-common-dir'],
+			worktreePath,
+			undefined
+		);
+		if (result.code !== 0) return null;
+		const common = result.stdout.trim();
+		return common ? resolvePath(common) : null;
+	}
+
+	/**
+	 * Route EVERY worktree delete through git so the pool repo's
+	 * bookkeeping stays consistent; fall back to rm + prune when git
+	 * refuses (broken worktree, missing admin files).
+	 */
+	private async removeWorktree(
+		poolDir: string,
+		worktreeDir: string,
+		auth: WorkspaceProvisionSpec['auth']
+	): Promise<void> {
+		await this.git(['worktree', 'remove', '--force', worktreeDir], poolDir, auth);
+		await fs.rm(worktreeDir, { recursive: true, force: true, maxRetries: 3 });
+		await this.git(['worktree', 'prune'], poolDir, auth);
+	}
+
+	/** Inject per-operation auth into the URL of ONE command invocation. */
+	private authedUrl(repoUrl: string, auth: WorkspaceProvisionSpec['auth']): string {
+		if (!auth?.token) return repoUrl;
+		try {
+			const url = new URL(repoUrl);
+			url.username = auth.username || 'x-access-token';
+			url.password = auth.token;
+			return url.toString();
+		} catch {
+			return repoUrl;
+		}
+	}
+
+	/** Remove any credential material from text before it can be logged. */
+	private scrub(text: string, auth: WorkspaceProvisionSpec['auth']): string {
+		let out = text;
+		if (auth?.token) out = out.split(auth.token).join('***');
+		// Belt-and-braces: strip userinfo from any URL that slipped through.
+		out = out.replace(/(https?:\/\/)[^/@\s]+@/g, '$1***@');
+		return out;
+	}
+
+	private git(args: string[], cwd: string | undefined, auth: WorkspaceProvisionSpec['auth']): Promise<GitResult> {
+		return new Promise((resolve) => {
+			execFile(
+				'git',
+				args,
+				{
+					cwd,
+					env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+					maxBuffer: 16 * 1024 * 1024,
+					windowsHide: true
+				},
+				(error, stdout, stderr) => {
+					const code =
+						error && typeof (error as { code?: unknown }).code === 'number'
+							? ((error as { code?: number }).code ?? 1)
+							: error
+								? 1
+								: 0;
+					resolve({
+						code,
+						stdout: String(stdout ?? ''),
+						stderr: this.scrub(String(stderr ?? ''), auth)
+					});
+				}
+			);
+		});
+	}
+
+	private async gitOrThrow(
+		args: string[],
+		cwd: string | undefined,
+		auth: WorkspaceProvisionSpec['auth'],
+		what: string
+	): Promise<GitResult> {
+		const result = await this.git(args, cwd, auth);
+		if (result.code !== 0) {
+			throw new Error(`${what}: ${result.stderr.trim() || `git exited ${result.code}`}`);
+		}
+		return result;
+	}
+
+	/** The worktree's PRIVATE gitdir (never the shared common dir, never
+	 *  the working tree — the stamp must not be committable). */
+	private async gitDirOf(worktreeDir: string, auth: WorkspaceProvisionSpec['auth']): Promise<string | null> {
+		const result = await this.git(['rev-parse', '--path-format=absolute', '--git-dir'], worktreeDir, auth);
+		if (result.code !== 0) return null;
+		const dir = result.stdout.trim();
+		return dir ? resolvePath(dir) : null;
+	}
+
+	private async readStamp(worktreeDir: string, auth: WorkspaceProvisionSpec['auth']): Promise<BindingStamp | null> {
+		try {
+			const gitDir = await this.gitDirOf(worktreeDir, auth);
+			if (!gitDir) return null;
+			const raw = await fs.readFile(join(gitDir, STAMP_FILE), 'utf8');
+			const parsed = JSON.parse(raw) as { bindingKey?: unknown; branch?: unknown };
+			return typeof parsed.bindingKey === 'string' && typeof parsed.branch === 'string'
+				? { bindingKey: parsed.bindingKey, branch: parsed.branch }
+				: null;
+		} catch {
+			return null;
+		}
+	}
+
+	private async writeStamp(
+		worktreeDir: string,
+		stamp: BindingStamp,
+		auth: WorkspaceProvisionSpec['auth']
+	): Promise<void> {
+		const gitDir = await this.gitDirOf(worktreeDir, auth);
+		if (!gitDir) {
+			throw new Error('cannot stamp workspace: worktree gitdir did not resolve');
+		}
+		await fs.writeFile(join(gitDir, STAMP_FILE), JSON.stringify(stamp), 'utf8');
+	}
+}
+
+function sanitizeSegment(value: string): string {
+	return value.replace(/[^a-zA-Z0-9._-]/g, '-').slice(0, 80) || 'workspace';
+}
+
+/** Deterministic pool key for a repo URL (token- and scheme-free). */
+function repoKey(repoUrl: string): string {
+	const stripped = repoUrl
+		.replace(/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, '')
+		.replace(/^[^/@\s]+@/, '')
+		.replace(/\.git$/, '');
+	return sanitizeSegment(stripped);
+}
+
+async function exists(path: string): Promise<boolean> {
+	return fs.access(path).then(
+		() => true,
+		() => false
+	);
+}
+
+export default LocalWorkspacePlugin;

--- a/packages/plugins/local-workspace/tsconfig.json
+++ b/packages/plugins/local-workspace/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"types": ["node"],
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/local-workspace/tsup.config.ts
+++ b/packages/plugins/local-workspace/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(6df53909bc07743f1cbdc8ed07c4f22a)
+        version: 2.3.4(e98a7fb1f3ff60e0b2beec3497f32f48)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.18.1)(rxjs@7.8.2)
@@ -288,16 +288,16 @@ importers:
         version: link:../../packages/plugins/postgres-db
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -537,13 +537,13 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -996,13 +996,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -1167,7 +1167,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -2163,6 +2163,24 @@ importers:
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/plugins/local-fs:
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  packages/plugins/local-workspace:
     devDependencies:
       '@ever-works/plugin':
         specifier: workspace:*
@@ -21474,17 +21492,6 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
-  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
-    dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      jsonc-parser: 3.3.1
-      picomatch: 4.0.4
-      rxjs: 7.8.1
-      source-map: 0.7.4
-    optionalDependencies:
-      chokidar: 3.6.0
-
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -21506,26 +21513,6 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
-      - chokidar
-
-  '@angular-devkit/schematics@19.2.23':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      jsonc-parser: 3.3.1
-      magic-string: 0.30.17
-      ora: 5.4.1
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - chokidar
-
-  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      jsonc-parser: 3.3.1
-      magic-string: 0.30.17
-      ora: 5.4.1
-      rxjs: 7.8.1
-    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -26253,7 +26240,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(6df53909bc07743f1cbdc8ed07c4f22a)':
+  '@nestjs-modules/mailer@2.3.4(e98a7fb1f3ff60e0b2beec3497f32f48)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -26272,7 +26259,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.2
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.2)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@3.6.0)
+      nunjucks: 3.2.4(chokidar@4.0.3)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -26299,36 +26286,7 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
-      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
-      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
-      ansis: 4.2.0
-      chokidar: 4.0.3
-      cli-table3: 0.6.5
-      commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
-      glob: 13.0.6
-      node-emoji: 1.11.0
-      ora: 5.4.1
-      tsconfig-paths: 4.2.0
-      tsconfig-paths-webpack-plugin: 4.2.0
-      typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
-      webpack-node-externals: 3.0.0
-    optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
-    transitivePeerDependencies:
-      - '@types/node'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -26357,7 +26315,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -26368,17 +26326,17 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21)))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
       glob: 13.0.6
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core': 1.15.33(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -26482,32 +26440,10 @@ snapshots:
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
 
-  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
-      comment-json: 4.6.2
-      jsonc-parser: 3.3.1
-      pluralize: 8.0.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - chokidar
-
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
-      comment-json: 4.6.2
-      jsonc-parser: 3.3.1
-      pluralize: 8.0.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - chokidar
-
-  '@nestjs/schematics@11.0.10(typescript@5.9.3)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      '@angular-devkit/schematics': 19.2.23
       comment-json: 4.6.2
       jsonc-parser: 3.3.1
       pluralize: 8.0.0
@@ -30048,25 +29984,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)':
-    dependencies:
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
-      '@swc/counter': 0.1.3
-      '@xhmikosr/bin-wrapper': 14.2.2
-      commander: 8.3.0
-      minimatch: 10.2.5
-      piscina: 4.9.3
-      semver: 7.8.1
-      slash: 3.0.0
-      source-map: 0.7.6
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      chokidar: 3.6.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
@@ -34272,8 +34189,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.3
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -34299,7 +34216,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -34310,21 +34227,21 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -34335,7 +34252,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.4
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -36000,7 +35917,7 @@ snapshots:
     optionalDependencies:
       express: 5.2.1
       hono: 4.12.25
-      next: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -38882,34 +38799,6 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
-  next@16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      '@next/env': 16.2.11
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.18
-      caniuse-lite: 1.0.30001787
-      postcss: 8.5.20
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.5)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.11
-      '@next/swc-darwin-x64': 16.2.11
-      '@next/swc-linux-arm64-gnu': 16.2.11
-      '@next/swc-linux-arm64-musl': 16.2.11
-      '@next/swc-linux-x64-gnu': 16.2.11
-      '@next/swc-linux-x64-musl': 16.2.11
-      '@next/swc-win32-arm64-msvc': 16.2.11
-      '@next/swc-win32-x64-msvc': 16.2.11
-      '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.59.1
-      sharp: 0.35.3(@types/node@22.19.11)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/node'
-      - babel-plugin-macros
-    optional: true
-
   nextjs-toploader@3.9.17(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@20.19.33)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@20.19.33)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -39076,13 +38965,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@3.6.0):
+  nunjucks@3.2.4(chokidar@4.0.3):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 3.6.0
+      chokidar: 4.0.3
     optional: true
 
   nypm@0.6.5:


### PR DESCRIPTION
## What

Wave 2 M8: the **local-runtime `workspace` capability provider** — a persistent worktree pool, sibling to `sandbox-workspace` (which keeps `defaultForCapabilities: ["workspace"]`; this plugin is `autoEnable: false`, opt-in for local runtimes).

New package: `packages/plugins/local-workspace/` (id `local-workspace`, category `utility`, capabilities `["workspace"]`, `systemPlugin`/`builtIn` true).

### Mechanics (vs sandbox-workspace's ephemeral clones)

- **Persistent pool**: one BARE base clone per repository under `<baseDir>/repos/<sanitized-repo-key>`, one real `git worktree add -B <branch> <dir> <startPoint>` per Task under `<baseDir>/worktrees/<bindingKey>`. `baseDir` = `settings.baseDir` || `EW_WORKSPACES_DIR` || `join(os.tmpdir(), 'ew-local-workspaces')`.
- **Fetch-first, always**: base ref + task branch are fetched per-provision via a per-operation authed URL; startPoint = fetched remote task branch when it exists (`reused: true`) else the fetched base (`reused: false`).
- **Worktree REUSE across runs**: an existing worktree whose binding stamp (stored in the worktree's private gitdir, never the working tree) matches `{bindingKey, branch}` and has the right branch checked out is resumed in place — no teardown between runs, no re-clone, pool repo config untouched.
- **Self-heal**: stamp mismatch (foreign binding, branch collision, corrupt stamp, broken worktree) → `git worktree remove --force` + recreate instead of bricking.
- **Per-repo creation serialization**: provision calls are serialized per repo-key with an in-process promise-chain mutex (concurrent `git worktree add` on one clone corrupts refs); the stored chain swallows rejections so one failure never poisons the queue.
- **finalize / simulateMerge**: same contracts as sandbox-workspace (commit-if-dirty + empty-run detection + push via authed URL; `merge-tree --write-tree --name-only` against a freshly fetched target with one `--unshallow` deepen-retry, conflict paths NAMED).
- **teardown**: resolves the pool via `--git-common-dir`, `git worktree remove --force`, rm fallback, `git worktree prune`.
- **gc**: removes worktrees older than the cutoff AND `git worktree prune`s every pool repo; pool repos persist.
- **Auth posture identical to sandbox-workspace**: persisted `origin` remote is always token-free (config only rewritten when the URL actually changed), token injected into single command invocations only, scrubbed from all stderr before it can reach logs.

## Verification (real output)

`packages/plugins/local-workspace`: `pnpm build`

```
TSC tsc --noEmit: clean
ESM dist\index.js 14.40 KB — Build success
CJS dist\index.cjs 14.59 KB — Build success
DTS Build success (dist\index.d.ts 4.06 KB)
```

`packages/plugins/local-workspace`: `pnpm test` — hermetic vitest loopback suite (real bare `file://` origin, real git, no network/tokens)

```
Test Files  1 passed (1)
     Tests  11 passed (11)
  Duration  24.90s
```

11 tests: fresh fetch-first provision (linked worktree, token-free remote) / worktree reuse across runs (same path, uncommitted scratch survives, pool config mtime unchanged) / branch-collision self-heal / corrupt-stamp self-heal / parallel two-tasks-one-pool-repo via `Promise.all` (mutex) / finalize empty / finalize commit+push (base untouched) / simulateMerge clean / simulateMerge named conflicts / teardown (worktree deregistered, pool persists) / gc (cutoff + prune, pool persists).

`packages/agent`: `pnpm build` — barrel untouched:

```
TSC Found 0 issues.
Successfully compiled: 975 files with swc
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)