### PR TITLE
feat(agent): acceptance-check runner + PR gate (Wave 3 M2+M3)

### DIFF
--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -183,6 +183,9 @@ describe('TriggerInternalController', () => {
             undefined, // anonymousUserCleanupService
             undefined, // knowledgeBaseReconcileService
             undefined, // workProposalsApiService (Optional trailing)
+            undefined, // agentRunSweeperService (Optional trailing)
+            // Wave 3 M2 — quality gates. Not exercised by these tests.
+            undefined, // taskGateRunnerService (Optional trailing)
         );
         c.onModuleInit();
         return c;

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -52,6 +52,7 @@ import {
 } from '@ever-works/agent/agents';
 import {
     TaskChatService,
+    TaskGateRunnerService,
     TaskRunDenormService,
     TaskWorkspaceService,
     TaskRecurrenceDispatcherService,
@@ -271,6 +272,12 @@ export class TriggerInternalController implements OnModuleInit {
         // keeps compiling — inserting mid-list silently shifts all later args.
         @Optional()
         private readonly agentRunSweeperService?: AgentRunSweeperService,
+        // Wave 3 M2 — acceptance-check runner (quality gates). The
+        // agent-task-execute worker calls `runChecks` over the internal RPC
+        // channel after the agent loop, before the finalize/PR step. Same
+        // appended-last @Optional() posture as the sweeper above.
+        @Optional()
+        private readonly taskGateRunnerService?: TaskGateRunnerService,
     ) {}
 
     onModuleInit() {
@@ -313,6 +320,9 @@ export class TriggerInternalController implements OnModuleInit {
             TasksService: this.tasksService,
             TaskChatService: this.taskChatService,
             TaskWorkspaceService: this.taskWorkspaceService,
+            // Wave 3 M2 — agent-task-execute calls `runChecks` here after the
+            // agent loop (quality gates; allow-list auto-derived).
+            TaskGateRunnerService: this.taskGateRunnerService,
             // Kanban run cockpit (Wave 2) — agent-task-execute calls
             // recordQueued/recordStarted/recordTerminal here.
             TaskRunDenormService: this.taskRunDenormService,

--- a/packages/agent/src/database/repositories/agent-run.repository.spec.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.spec.ts
@@ -285,4 +285,36 @@ describe('AgentRunRepository — terminal transitions', () => {
             );
         });
     });
+
+    describe('updateGateResults (quality gates, Wave 3 M2)', () => {
+        let update: jest.Mock;
+
+        beforeEach(() => {
+            update = jest.fn().mockResolvedValue(undefined);
+            (repository as { update?: jest.Mock }).update = update;
+        });
+
+        it('writes only the whitelisted gate columns that were provided', async () => {
+            await runs.updateGateResults('r1', {
+                checkResults: [{ id: 'build', exitCode: 1, status: 'red', durationMs: 10 }],
+                gateStatus: 'red',
+                gateAttempts: 1,
+            });
+            expect(update).toHaveBeenCalledWith('r1', {
+                checkResults: [{ id: 'build', exitCode: 1, status: 'red', durationMs: 10 }],
+                gateStatus: 'red',
+                gateAttempts: 1,
+            });
+        });
+
+        it('omitted fields are NOT written — a snapshot-only patch touches nothing else', async () => {
+            await runs.updateGateResults('r1', { resolvedChecks: [] });
+            expect(update).toHaveBeenCalledWith('r1', { resolvedChecks: [] });
+        });
+
+        it('an empty patch is a no-op (no SQL round-trip)', async () => {
+            await runs.updateGateResults('r1', {});
+            expect(update).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import type { GateStatus, TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
 import { AgentRun, AgentRunStatus, AgentRunTriggerKind } from '../../entities/agent-run.entity';
 
 /**
@@ -487,6 +488,36 @@ export class AgentRunRepository {
             .orderBy('run.createdAt', 'ASC')
             .take(limit)
             .getMany();
+    }
+
+    /**
+     * Quality gates (Wave 3 M2) — persist the gate columns for one run.
+     *
+     * Explicit field-by-field whitelist, mirroring
+     * {@link updateTerminalColumns}: the callers (the dispatch-freeze
+     * snapshot in `agent-task-execute` and `TaskGateRunnerService`) hand
+     * over worker-influenced payloads, and none of those may ever write
+     * status/summary/telemetry columns through this path. Deliberately no
+     * status CAS — the gate columns are additive facts about the run, not
+     * lifecycle transitions, and the runner reports them right before the
+     * terminal write.
+     */
+    async updateGateResults(
+        runId: string,
+        patch: {
+            resolvedChecks?: TaskAcceptanceCheck[] | null;
+            checkResults?: TaskCheckResult[] | null;
+            gateStatus?: GateStatus | null;
+            gateAttempts?: number;
+        },
+    ): Promise<void> {
+        const update: Record<string, unknown> = {};
+        if (patch.resolvedChecks !== undefined) update.resolvedChecks = patch.resolvedChecks;
+        if (patch.checkResults !== undefined) update.checkResults = patch.checkResults;
+        if (patch.gateStatus !== undefined) update.gateStatus = patch.gateStatus;
+        if (patch.gateAttempts !== undefined) update.gateAttempts = patch.gateAttempts;
+        if (Object.keys(update).length === 0) return;
+        await this.repository.update(runId, update);
     }
 
     /**

--- a/packages/agent/src/tasks-domain/__tests__/task-gate-runner.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-gate-runner.service.spec.ts
@@ -1,0 +1,246 @@
+import { join } from 'path';
+import type { TaskAcceptanceCheck } from '@ever-works/contracts';
+import { TaskGateRunnerService, CHECK_LOG_TAIL_BYTES } from '../task-gate-runner.service';
+
+/**
+ * Quality gates (Wave 3 M2) — the acceptance-check runner, exercised with
+ * REAL subprocesses. `node -e "…"` is the one command guaranteed present
+ * wherever this suite runs (the tests themselves run under node), and it
+ * gives deterministic exit codes / output / hangs on every platform.
+ */
+
+const RUN_ID = 'run-gate-1';
+
+function check(overrides: Partial<TaskAcceptanceCheck> & { id: string }): TaskAcceptanceCheck {
+    return {
+        name: overrides.id,
+        kind: 'custom',
+        command: 'node -e "process.exit(0)"',
+        required: true,
+        ...overrides,
+    };
+}
+
+describe('TaskGateRunnerService.runChecks', () => {
+    let runs: { updateGateResults: jest.Mock };
+    let runner: TaskGateRunnerService;
+
+    beforeEach(() => {
+        runs = { updateGateResults: jest.fn().mockResolvedValue(undefined) };
+        runner = new TaskGateRunnerService(runs as never);
+        jest.spyOn(
+            (runner as never as { logger: { warn: (m: string) => void } }).logger,
+            'warn',
+        ).mockImplementation(() => undefined);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it('exit 0 → check green with the real exit code, gate green', async () => {
+        const outcome = await runner.runChecks({
+            checks: [check({ id: 'ok' })],
+            cwd: process.cwd(),
+            runId: RUN_ID,
+        });
+        expect(outcome.gateStatus).toBe('green');
+        expect(outcome.results).toHaveLength(1);
+        expect(outcome.results[0]).toMatchObject({ id: 'ok', status: 'green', exitCode: 0 });
+        expect(outcome.results[0].durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('nonzero exit on a required check → check red with its exit code, gate red', async () => {
+        const outcome = await runner.runChecks({
+            checks: [check({ id: 'boom', command: 'node -e "process.exit(3)"' })],
+            cwd: process.cwd(),
+            runId: RUN_ID,
+        });
+        expect(outcome.gateStatus).toBe('red');
+        expect(outcome.results[0]).toMatchObject({ id: 'boom', status: 'red', exitCode: 3 });
+    });
+
+    it('a required:false check can fail without turning the gate red', async () => {
+        const outcome = await runner.runChecks({
+            checks: [
+                check({ id: 'ok' }),
+                check({
+                    id: 'advisory',
+                    required: false,
+                    command: 'node -e "process.exit(1)"',
+                }),
+            ],
+            cwd: process.cwd(),
+            runId: RUN_ID,
+        });
+        // The informational failure is still REPORTED honestly…
+        expect(outcome.results[1]).toMatchObject({ id: 'advisory', status: 'red', exitCode: 1 });
+        // …but never blocks.
+        expect(outcome.gateStatus).toBe('green');
+    });
+
+    it('a hung check is killed at its timeoutSec → status timeout, null exit code, gate red', async () => {
+        const startedAt = Date.now();
+        const outcome = await runner.runChecks({
+            checks: [
+                check({
+                    id: 'hang',
+                    command: 'node -e "setTimeout(function () {}, 5000)"',
+                    timeoutSec: 1,
+                }),
+            ],
+            cwd: process.cwd(),
+            runId: RUN_ID,
+        });
+        expect(outcome.results[0]).toMatchObject({ id: 'hang', status: 'timeout', exitCode: null });
+        expect(outcome.gateStatus).toBe('red');
+        // Killed at ~1s, not at the command's own 5s sleep.
+        expect(Date.now() - startedAt).toBeLessThan(4500);
+    }, 15000);
+
+    it('an unspawnable check (nonexistent cwd) → status error, distinguished from red', async () => {
+        const outcome = await runner.runChecks({
+            checks: [check({ id: 'no-cwd', cwd: 'definitely-not-a-real-subdir-xyz' })],
+            cwd: process.cwd(),
+            runId: RUN_ID,
+        });
+        expect(outcome.results[0]).toMatchObject({ id: 'no-cwd', status: 'error', exitCode: null });
+        expect(outcome.gateStatus).toBe('red');
+    });
+
+    it('captures combined stdout/stderr as logTail', async () => {
+        const outcome = await runner.runChecks({
+            checks: [
+                check({
+                    id: 'noisy',
+                    command:
+                        'node -e "console.log(String.fromCharCode(111,117,116,45,109,97,114,107,101,114)); console.error(String.fromCharCode(101,114,114,45,109,97,114,107,101,114)); process.exit(1)"',
+                }),
+            ],
+            cwd: process.cwd(),
+            runId: RUN_ID,
+        });
+        expect(outcome.results[0].logTail).toContain('out-marker');
+        expect(outcome.results[0].logTail).toContain('err-marker');
+    });
+
+    it('keeps only the LAST ~4KB of output as logTail', async () => {
+        const outcome = await runner.runChecks({
+            checks: [
+                check({
+                    id: 'chatty',
+                    // 10KB of 'a', then a tail marker — the head must be
+                    // dropped, the tail kept.
+                    command:
+                        'node -e "process.stdout.write(new Array(10001).join(String.fromCharCode(97))); process.stdout.write(String.fromCharCode(84,65,73,76,45,69,78,68))"',
+                }),
+            ],
+            cwd: process.cwd(),
+            runId: RUN_ID,
+        });
+        const tail = outcome.results[0].logTail ?? '';
+        expect(tail.length).toBeLessThanOrEqual(CHECK_LOG_TAIL_BYTES);
+        expect(tail.endsWith('TAIL-END')).toBe(true);
+    });
+
+    it('joins check.cwd under the checkout root', async () => {
+        const outcome = await runner.runChecks({
+            checks: [
+                check({
+                    id: 'where',
+                    cwd: '__tests__',
+                    command: 'node -e "console.log(process.cwd())"',
+                }),
+            ],
+            cwd: join(__dirname, '..'),
+            runId: RUN_ID,
+        });
+        expect(outcome.results[0].status).toBe('green');
+        expect(outcome.results[0].logTail).toContain('__tests__');
+    });
+
+    it('runs checks sequentially, reporting results in declared order', async () => {
+        const outcome = await runner.runChecks({
+            checks: [
+                check({ id: 'first' }),
+                check({ id: 'second', command: 'node -e "process.exit(2)"' }),
+                check({ id: 'third' }),
+            ],
+            cwd: process.cwd(),
+            runId: RUN_ID,
+        });
+        expect(outcome.results.map((r) => r.id)).toEqual(['first', 'second', 'third']);
+        expect(outcome.gateStatus).toBe('red');
+    });
+
+    describe('empty check set — gate per policy, skipped is never green', () => {
+        it("policy 'off' → gateStatus none", async () => {
+            const outcome = await runner.runChecks({
+                checks: [],
+                cwd: process.cwd(),
+                runId: RUN_ID,
+                policy: 'off',
+            });
+            expect(outcome).toEqual({ gateStatus: 'none', results: [] });
+        });
+
+        it("policy 'warn' → gateStatus none (reports, never blocks)", async () => {
+            const outcome = await runner.runChecks({
+                checks: [],
+                cwd: process.cwd(),
+                runId: RUN_ID,
+                policy: 'warn',
+            });
+            expect(outcome).toEqual({ gateStatus: 'none', results: [] });
+        });
+
+        it("policy 'required' → gateStatus skipped — a gate that did not run must never read green", async () => {
+            const outcome = await runner.runChecks({
+                checks: [],
+                cwd: process.cwd(),
+                runId: RUN_ID,
+                policy: 'required',
+            });
+            expect(outcome).toEqual({ gateStatus: 'skipped', results: [] });
+        });
+
+        it('omitted policy fails toward none, and no gate attempt is recorded', async () => {
+            const outcome = await runner.runChecks({
+                checks: [],
+                cwd: process.cwd(),
+                runId: RUN_ID,
+            });
+            expect(outcome.gateStatus).toBe('none');
+            expect(runs.updateGateResults).toHaveBeenCalledWith(RUN_ID, {
+                checkResults: [],
+                gateStatus: 'none',
+            });
+        });
+    });
+
+    describe('persistence', () => {
+        it('persists checkResults + gateStatus + gateAttempts=1 onto the run', async () => {
+            await runner.runChecks({
+                checks: [check({ id: 'ok' })],
+                cwd: process.cwd(),
+                runId: RUN_ID,
+            });
+            expect(runs.updateGateResults).toHaveBeenCalledTimes(1);
+            const [runId, patch] = runs.updateGateResults.mock.calls[0];
+            expect(runId).toBe(RUN_ID);
+            expect(patch.gateStatus).toBe('green');
+            expect(patch.gateAttempts).toBe(1);
+            expect(patch.checkResults).toHaveLength(1);
+            expect(patch.checkResults[0]).toMatchObject({ id: 'ok', status: 'green' });
+        });
+
+        it('a persistence failure is swallowed — the verdict the caller enforces still returns', async () => {
+            runs.updateGateResults.mockRejectedValue(new Error('db down'));
+            const outcome = await runner.runChecks({
+                checks: [check({ id: 'boom', command: 'node -e "process.exit(1)"' })],
+                cwd: process.cwd(),
+                runId: RUN_ID,
+            });
+            expect(outcome.gateStatus).toBe('red');
+            expect(outcome.results[0].status).toBe('red');
+        });
+    });
+});

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -5,6 +5,7 @@
 export * from './tasks.module';
 export * from './tasks.service';
 export * from './task-gates';
+export * from './task-gate-runner.service';
 export * from './task-transition.service';
 export * from './task-chat.service';
 export * from './task-dispatcher';

--- a/packages/agent/src/tasks-domain/task-gate-runner.service.ts
+++ b/packages/agent/src/tasks-domain/task-gate-runner.service.ts
@@ -1,0 +1,221 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { spawn } from 'child_process';
+import { join } from 'path';
+import type {
+    GateStatus,
+    TaskAcceptanceCheck,
+    TaskCheckResult,
+    WorkChecksPolicy,
+} from '@ever-works/contracts';
+import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+
+/** Wall-clock budget applied when a check declares no `timeoutSec`. */
+export const DEFAULT_CHECK_TIMEOUT_SEC = 600;
+
+/**
+ * Hard per-check ceiling. A hostile/typo'd `timeoutSec` on a simple-json
+ * column must never let one check eat the whole Trigger.dev `maxDuration`.
+ */
+export const MAX_CHECK_TIMEOUT_SEC = 1800;
+
+/** Last-N-bytes window of combined stdout/stderr kept as `logTail`. */
+export const CHECK_LOG_TAIL_BYTES = 4096;
+
+export interface RunChecksInput {
+    /** The dispatch-frozen check set (`agent_runs.resolvedChecks`). */
+    checks: TaskAcceptanceCheck[];
+    /** Checkout root the commands run in (`check.cwd` joins under it). */
+    cwd: string;
+    /** Run the results are persisted onto. */
+    runId: string;
+    /**
+     * The Work's enforcement policy — only consulted for the empty-check
+     * mapping (`required` → 'skipped', anything else → 'none'). When the
+     * caller omits it, the mapping fails toward 'none' (never toward
+     * blocking), mirroring `resolveChecksPolicy`'s posture.
+     */
+    policy?: WorkChecksPolicy;
+}
+
+export interface RunChecksOutcome {
+    gateStatus: GateStatus;
+    results: TaskCheckResult[];
+}
+
+/**
+ * Quality gates (Wave 3 M2) — the acceptance-check runner.
+ *
+ * Harness code, not agent tool calls: after the agent loop for a Task run
+ * completes, the worker step hands this service the run's dispatch-frozen
+ * check set and the workspace checkout, and each check's command is
+ * spawned as a real subprocess. Exit codes are observed by the process
+ * supervisor — the agent's transcript claims are irrelevant.
+ *
+ * Verdict rules:
+ * - exit 0 → check 'green'; nonzero → 'red'; killed at its timeout →
+ *   'timeout'; unspawnable (bad cwd, missing shell) → 'error' — infra
+ *   problems are distinguishable from code problems.
+ * - the GATE is red iff any REQUIRED check is not green. `required:false`
+ *   checks report but can never turn the gate red.
+ * - zero checks: 'skipped' under policy 'required' (a skipped gate must
+ *   never render as green), 'none' otherwise.
+ *
+ * Checks run sequentially, in declared order — deterministic reports, no
+ * resource contention between e.g. a build and a test run.
+ */
+@Injectable()
+export class TaskGateRunnerService {
+    private readonly logger = new Logger(TaskGateRunnerService.name);
+
+    constructor(private readonly runs: AgentRunRepository) {}
+
+    async runChecks(input: RunChecksInput): Promise<RunChecksOutcome> {
+        const checks = Array.isArray(input.checks) ? input.checks : [];
+
+        if (checks.length === 0) {
+            const gateStatus: GateStatus = input.policy === 'required' ? 'skipped' : 'none';
+            // gateAttempts stays untouched (default 0): nothing executed,
+            // so no attempt was consumed.
+            await this.persist(input.runId, [], gateStatus);
+            return { gateStatus, results: [] };
+        }
+
+        const results: TaskCheckResult[] = [];
+        for (const check of checks) {
+            results.push(await this.executeCheck(check, input.cwd));
+        }
+
+        const failedRequired = checks.filter(
+            (check, index) => check.required !== false && results[index].status !== 'green',
+        );
+        const gateStatus: GateStatus = failedRequired.length > 0 ? 'red' : 'green';
+
+        // One attempt only in M2/M3 — the bounded iterate loop (M5)
+        // threads the real attempt counter through here later.
+        await this.persist(input.runId, results, gateStatus, 1);
+        return { gateStatus, results };
+    }
+
+    /**
+     * Persist the verdict onto the run. Best-effort BY DESIGN: the gate
+     * decision the worker enforces is the returned value; a DB hiccup here
+     * must not convert an honest verdict into a failed run. The warn keeps
+     * the miss observable.
+     */
+    private async persist(
+        runId: string,
+        checkResults: TaskCheckResult[],
+        gateStatus: GateStatus,
+        gateAttempts?: number,
+    ): Promise<void> {
+        try {
+            await this.runs.updateGateResults(runId, {
+                checkResults,
+                gateStatus,
+                ...(gateAttempts !== undefined ? { gateAttempts } : {}),
+            });
+        } catch (error) {
+            this.logger.warn(
+                `gate results persist failed for run ${runId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /**
+     * Spawn one check command and observe its real exit code.
+     *
+     * `shell: true` — a check is "a command and an exit code", authored the
+     * way package scripts are (`pnpm build`, `npm test -- --ci`), so it gets
+     * the platform shell. This adds no privilege beyond the status quo:
+     * pipeline agents already run arbitrary commands in the same checkout,
+     * and only Work members with settings/Task-edit rights author checks.
+     */
+    private executeCheck(check: TaskAcceptanceCheck, rootCwd: string): Promise<TaskCheckResult> {
+        const cwd = check.cwd ? join(rootCwd, check.cwd) : rootCwd;
+        const timeoutSec = Math.min(
+            typeof check.timeoutSec === 'number' && check.timeoutSec > 0
+                ? check.timeoutSec
+                : DEFAULT_CHECK_TIMEOUT_SEC,
+            MAX_CHECK_TIMEOUT_SEC,
+        );
+        const startedAt = Date.now();
+
+        return new Promise<TaskCheckResult>((resolve) => {
+            let settled = false;
+            let timedOut = false;
+            let tail = '';
+            let timer: ReturnType<typeof setTimeout> | undefined;
+
+            const finish = (status: TaskCheckResult['status'], exitCode: number | null) => {
+                if (settled) return;
+                settled = true;
+                if (timer) clearTimeout(timer);
+                resolve({
+                    id: check.id,
+                    exitCode,
+                    status,
+                    durationMs: Date.now() - startedAt,
+                    ...(tail.length > 0 ? { logTail: tail } : {}),
+                });
+            };
+
+            let child: ReturnType<typeof spawn>;
+            try {
+                child = spawn(check.command, { cwd, shell: true, windowsHide: true });
+            } catch (error) {
+                tail = error instanceof Error ? error.message : String(error);
+                finish('error', null);
+                return;
+            }
+
+            timer = setTimeout(() => {
+                timedOut = true;
+                try {
+                    child.kill('SIGKILL');
+                } catch {
+                    // Process already gone — the close handler settles.
+                }
+            }, timeoutSec * 1000);
+
+            const append = (chunk: Buffer | string) => {
+                tail = (tail + chunk.toString()).slice(-CHECK_LOG_TAIL_BYTES);
+            };
+            child.stdout?.on('data', append);
+            child.stderr?.on('data', append);
+
+            // Spawn failures (nonexistent cwd, missing shell) surface here,
+            // not as a throw — 'error' status keeps infra problems from
+            // reading as code problems.
+            child.on('error', (error) => {
+                append(`\n${error.message}`);
+                finish('error', null);
+            });
+
+            // On timeout, settle on 'exit' (process death) instead of
+            // 'close' (stdio drain): a killed shell can leave a grandchild
+            // holding the pipes open, and the gate must not wait for it.
+            // Destroying our read ends releases those handles immediately.
+            child.on('exit', () => {
+                if (timedOut) {
+                    child.stdout?.destroy();
+                    child.stderr?.destroy();
+                    finish('timeout', null);
+                }
+            });
+
+            child.on('close', (code) => {
+                if (timedOut) {
+                    finish('timeout', null);
+                } else if (code === 0) {
+                    finish('green', 0);
+                } else {
+                    // Killed by an external signal (code null) is still not
+                    // a pass — red, with the null exit code preserved.
+                    finish('red', code);
+                }
+            });
+        });
+    }
+}

--- a/packages/agent/src/tasks-domain/task-workspace.service.ts
+++ b/packages/agent/src/tasks-domain/task-workspace.service.ts
@@ -180,6 +180,13 @@ export class TaskWorkspaceService {
         /** From `agent.permissions.canOpenPullRequests` (default true). */
         agentCanOpenPullRequests: boolean;
         workspace: ProvisionedTaskWorkspace;
+        /**
+         * Wave 3 M3 — optional note that a green quality gate preceded this
+         * finalize; surfaces on the PR body. The gate DECISION stays in the
+         * worker step (a red gate never reaches finalizeRun at all) — this
+         * is presentation only, which is why omitting it changes nothing.
+         */
+        gate?: { checksPassed: number };
     }): Promise<TaskWorkspaceFinalizeOutcome> {
         const { task, userId, workspace } = input;
         if (!this.workspaceFacade || !this.gitFacade) {
@@ -254,6 +261,9 @@ export class TaskWorkspaceService {
             return { outcome: 'pushed-no-pr' };
         }
 
+        const gateNote = input.gate
+            ? `\n\nQuality gate: all ${input.gate.checksPassed} acceptance checks green.`
+            : '';
         const pr = await this.gitFacade.createPullRequest(
             {
                 owner,
@@ -261,7 +271,7 @@ export class TaskWorkspaceService {
                 title: `Task ${task.slug}: ${task.title ?? 'agent run output'}`,
                 head: workspace.branch,
                 base: baseRef,
-                body: `Automated changes for Task \`${task.slug}\` (agent run). Review before merging — merge policy is governed by the Work's merge-policy settings.`,
+                body: `Automated changes for Task \`${task.slug}\` (agent run). Review before merging — merge policy is governed by the Work's merge-policy settings.${gateNote}`,
             },
             gitOptions,
         );

--- a/packages/agent/src/tasks-domain/tasks.module.ts
+++ b/packages/agent/src/tasks-domain/tasks.module.ts
@@ -36,6 +36,7 @@ import {
 import { TaskTransitionService } from './task-transition.service';
 import { TasksService } from './tasks.service';
 import { TaskChatService } from './task-chat.service';
+import { TaskGateRunnerService } from './task-gate-runner.service';
 import { TaskRecurrenceDispatcherService } from './task-recurrence-dispatcher.service';
 import { TaskNotificationService } from './task-notification.service';
 import { TaskRunDenormService } from './task-run-denorm.service';
@@ -113,6 +114,10 @@ import { NotificationsModule } from '../notifications/notifications.module';
         TaskNotificationService,
         TaskRunDenormService,
         TaskWorkspaceService,
+        // Wave 3 M2 — acceptance-check runner (quality gates). Needs only
+        // AgentRunRepository (exported by AgentsModule above) to persist
+        // per-run gate results.
+        TaskGateRunnerService,
     ],
     exports: [
         TaskRepository,
@@ -136,6 +141,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
         TaskNotificationService,
         TaskRunDenormService,
         TaskWorkspaceService,
+        TaskGateRunnerService,
     ],
 })
 export class TasksDomainModule {}

--- a/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
+++ b/packages/tasks/src/__tests__/agent-task-execute.task.spec.ts
@@ -27,12 +27,24 @@ const {
     AgentRunRepositoryToken,
     AgentRunServiceToken,
     TasksServiceToken,
+    TaskChatServiceToken,
+    TaskGateRunnerServiceToken,
+    TaskRunDenormServiceToken,
+    TaskWorkspaceServiceToken,
+    WorkRepositoryToken,
+    resolveAcceptanceChecksMock,
+    resolveChecksPolicyMock,
 } = vi.hoisted(() => {
     class StubInternalModule {}
     class AgentRepositoryToken {}
     class AgentRunRepositoryToken {}
     class AgentRunServiceToken {}
     class TasksServiceToken {}
+    class TaskChatServiceToken {}
+    class TaskGateRunnerServiceToken {}
+    class TaskRunDenormServiceToken {}
+    class TaskWorkspaceServiceToken {}
+    class WorkRepositoryToken {}
     return {
         taskMock: vi.fn(),
         createApplicationContextMock: vi.fn(),
@@ -42,6 +54,16 @@ const {
         AgentRunRepositoryToken,
         AgentRunServiceToken,
         TasksServiceToken,
+        TaskChatServiceToken,
+        TaskGateRunnerServiceToken,
+        TaskRunDenormServiceToken,
+        TaskWorkspaceServiceToken,
+        WorkRepositoryToken,
+        // Quality gates (Wave 3): the pure resolution helpers are mocked as
+        // controllable fns — their merge/clamp logic is pinned by the agent
+        // package's own task-gates.spec; THIS suite tests the orchestration.
+        resolveAcceptanceChecksMock: vi.fn(),
+        resolveChecksPolicyMock: vi.fn(),
     };
 });
 
@@ -58,6 +80,7 @@ vi.mock('@nestjs/core', () => ({
 vi.mock('@ever-works/agent/database', () => ({
     AgentRepository: AgentRepositoryToken,
     AgentRunRepository: AgentRunRepositoryToken,
+    WorkRepository: WorkRepositoryToken,
 }));
 
 vi.mock('@ever-works/agent/agents', () => ({
@@ -66,6 +89,12 @@ vi.mock('@ever-works/agent/agents', () => ({
 
 vi.mock('@ever-works/agent/tasks-domain', () => ({
     TasksService: TasksServiceToken,
+    TaskChatService: TaskChatServiceToken,
+    TaskGateRunnerService: TaskGateRunnerServiceToken,
+    TaskRunDenormService: TaskRunDenormServiceToken,
+    TaskWorkspaceService: TaskWorkspaceServiceToken,
+    resolveAcceptanceChecks: resolveAcceptanceChecksMock,
+    resolveChecksPolicy: resolveChecksPolicyMock,
 }));
 
 vi.mock('../trigger/worker/modules/trigger-internal.module', () => ({
@@ -106,9 +135,23 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
         markStarted: ReturnType<typeof vi.fn>;
         markCompleted: ReturnType<typeof vi.fn>;
         markFailed: ReturnType<typeof vi.fn>;
+        updateTelemetry: ReturnType<typeof vi.fn>;
+        updateGateResults: ReturnType<typeof vi.fn>;
     };
     let runner: { execute: ReturnType<typeof vi.fn> };
     let tasks: { getOne: ReturnType<typeof vi.fn> };
+    let taskChat: { post: ReturnType<typeof vi.fn> };
+    let gateRunner: { runChecks: ReturnType<typeof vi.fn> };
+    let runDenorm: {
+        recordQueued: ReturnType<typeof vi.fn>;
+        recordStarted: ReturnType<typeof vi.fn>;
+        recordTerminal: ReturnType<typeof vi.fn>;
+    };
+    let taskWorkspace: {
+        provisionForRun: ReturnType<typeof vi.fn>;
+        finalizeRun: ReturnType<typeof vi.fn>;
+    };
+    let works: { findById: ReturnType<typeof vi.fn> };
     let registeredConfig: TaskConfig;
 
     /**
@@ -148,11 +191,30 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
             markStarted: vi.fn().mockResolvedValue(true),
             markCompleted: vi.fn().mockResolvedValue(undefined),
             markFailed: vi.fn().mockResolvedValue(undefined),
+            updateTelemetry: vi.fn().mockResolvedValue(undefined),
+            updateGateResults: vi.fn().mockResolvedValue(undefined),
         };
         runner = {
             execute: vi.fn().mockResolvedValue({ status: 'assembled' }),
         };
         tasks = { getOne: vi.fn() };
+        taskChat = { post: vi.fn().mockResolvedValue(undefined) };
+        gateRunner = { runChecks: vi.fn() };
+        runDenorm = {
+            recordQueued: vi.fn().mockResolvedValue(undefined),
+            recordStarted: vi.fn().mockResolvedValue(undefined),
+            recordTerminal: vi.fn().mockResolvedValue(undefined),
+        };
+        // Isolation off by default — the overwhelmingly common path.
+        taskWorkspace = {
+            provisionForRun: vi.fn().mockResolvedValue(null),
+            finalizeRun: vi.fn().mockResolvedValue({ outcome: 'no-changes' }),
+        };
+        works = { findById: vi.fn().mockResolvedValue(null) };
+        // Quality gates default OFF — pre-gate behavior everywhere unless a
+        // test opts in.
+        resolveAcceptanceChecksMock.mockReturnValue([]);
+        resolveChecksPolicyMock.mockReturnValue('off');
 
         // The owner owns AGENT_ID and OWNED_TASK_ID. A foreign taskId is
         // rejected by TasksService.getOne exactly like the real
@@ -185,6 +247,11 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
                 if (token === AgentRunRepositoryToken) return runs;
                 if (token === AgentRunServiceToken) return runner;
                 if (token === TasksServiceToken) return tasks;
+                if (token === TaskChatServiceToken) return taskChat;
+                if (token === TaskGateRunnerServiceToken) return gateRunner;
+                if (token === TaskRunDenormServiceToken) return runDenorm;
+                if (token === TaskWorkspaceServiceToken) return taskWorkspace;
+                if (token === WorkRepositoryToken) return works;
                 throw new Error(`Unexpected DI token: ${String(token)}`);
             }),
             close: vi.fn().mockResolvedValue(undefined),
@@ -394,6 +461,188 @@ describe('agentTaskExecuteTask — Task ownership IDOR guard', () => {
                 }),
             ).rejects.toThrow(/Invalid payload\.userId/);
             expect(createApplicationContextMock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('quality gates (Wave 3 M2+M3) — dispatch-freeze + PR gate', () => {
+        const WORK_ID = '88888888-8888-4888-8888-888888888888';
+        const WORKSPACE = {
+            cwd: '/workspaces/task-1',
+            branch: 'task/owned-task',
+            baseSha: 'a'.repeat(40),
+            reused: false,
+            provider: 'workspace',
+        };
+        const BUILD_CHECK = {
+            id: 'build',
+            name: 'build',
+            kind: 'build',
+            command: 'pnpm build',
+            required: true,
+        };
+
+        /** Point the owned task at a Work so the gate path can resolve it. */
+        const useWorkTask = () => {
+            tasks.getOne.mockImplementation(async (userId: string, taskId: string) => {
+                if (userId === OWNER && taskId === OWNED_TASK_ID) {
+                    return {
+                        id: OWNED_TASK_ID,
+                        slug: 'owned-task',
+                        title: 'Owned Task',
+                        description: null,
+                        status: 'in_progress',
+                        priority: 'medium',
+                        labels: [],
+                        missionId: null,
+                        ideaId: null,
+                        workId: WORK_ID,
+                    };
+                }
+                throw new Error(`Task ${taskId} not found.`);
+            });
+            works.findById.mockResolvedValue({ id: WORK_ID, checksPolicy: 'required' });
+        };
+
+        it('snapshots the resolved checks onto the run right after the claim (dispatch-freeze)', async () => {
+            useWorkTask();
+            resolveAcceptanceChecksMock.mockReturnValue([BUILD_CHECK]);
+            resolveChecksPolicyMock.mockReturnValue('off');
+
+            await registeredConfig.run(basePayload(OWNED_TASK_ID));
+
+            expect(works.findById).toHaveBeenCalledWith(WORK_ID);
+            expect(runs.updateGateResults).toHaveBeenCalledWith('run-1', {
+                resolvedChecks: [BUILD_CHECK],
+            });
+        });
+
+        it("policy 'off' never invokes the gate runner and finalizes exactly as before", async () => {
+            useWorkTask();
+            taskWorkspace.provisionForRun.mockResolvedValue(WORKSPACE);
+            taskWorkspace.finalizeRun.mockResolvedValue({ outcome: 'pr-opened', prNumber: 7 });
+            resolveChecksPolicyMock.mockReturnValue('off');
+
+            const result = await registeredConfig.run(basePayload(OWNED_TASK_ID));
+
+            expect(gateRunner.runChecks).not.toHaveBeenCalled();
+            expect(taskWorkspace.finalizeRun).toHaveBeenCalledTimes(1);
+            expect(result).toMatchObject({ status: 'completed', workspaceOutcome: 'pr-opened' });
+        });
+
+        it("red gate + policy 'required' → NO finalize/PR, run completes naming the failing check, task chat notified", async () => {
+            useWorkTask();
+            taskWorkspace.provisionForRun.mockResolvedValue(WORKSPACE);
+            resolveAcceptanceChecksMock.mockReturnValue([BUILD_CHECK]);
+            resolveChecksPolicyMock.mockReturnValue('required');
+            gateRunner.runChecks.mockResolvedValue({
+                gateStatus: 'red',
+                results: [{ id: 'build', status: 'red', exitCode: 1, durationMs: 12 }],
+            });
+
+            const result = await registeredConfig.run(basePayload(OWNED_TASK_ID));
+
+            // The single load-bearing assertion of the whole feature:
+            // a red check opens no PR.
+            expect(taskWorkspace.finalizeRun).not.toHaveBeenCalled();
+            expect(gateRunner.runChecks).toHaveBeenCalledWith({
+                checks: [BUILD_CHECK],
+                cwd: WORKSPACE.cwd,
+                runId: 'run-1',
+                policy: 'required',
+            });
+            expect(runs.markCompleted).toHaveBeenCalledTimes(1);
+            expect(runs.markCompleted.mock.calls[0][1]).toContain('build');
+            expect(runs.markCompleted.mock.calls[0][1]).toContain('PR withheld');
+            expect(taskChat.post).toHaveBeenCalledTimes(1);
+            const [chatUserId, chatInput] = taskChat.post.mock.calls[0];
+            expect(chatUserId).toBe(OWNER);
+            expect(chatInput).toMatchObject({
+                taskId: OWNED_TASK_ID,
+                authorType: 'agent',
+                authorId: AGENT_ID,
+            });
+            expect(chatInput.body).toContain('build');
+            expect(chatInput.body).toContain('no PR was opened');
+            expect(result).toMatchObject({
+                status: 'completed',
+                reason: 'gate-red',
+                gateStatus: 'red',
+            });
+        });
+
+        it("green gate → finalize proceeds carrying the 'all checks green' PR note", async () => {
+            useWorkTask();
+            taskWorkspace.provisionForRun.mockResolvedValue(WORKSPACE);
+            taskWorkspace.finalizeRun.mockResolvedValue({ outcome: 'pr-opened', prNumber: 9 });
+            resolveAcceptanceChecksMock.mockReturnValue([BUILD_CHECK]);
+            resolveChecksPolicyMock.mockReturnValue('required');
+            gateRunner.runChecks.mockResolvedValue({
+                gateStatus: 'green',
+                results: [{ id: 'build', status: 'green', exitCode: 0, durationMs: 12 }],
+            });
+
+            const result = await registeredConfig.run(basePayload(OWNED_TASK_ID));
+
+            expect(taskWorkspace.finalizeRun).toHaveBeenCalledTimes(1);
+            expect(taskWorkspace.finalizeRun.mock.calls[0][0]).toMatchObject({
+                gate: { checksPassed: 1 },
+            });
+            expect(result).toMatchObject({ status: 'completed', workspaceOutcome: 'pr-opened' });
+        });
+
+        it("policy 'required' with ZERO checks → gate skipped, PR withheld, 'no checks configured' in chat", async () => {
+            useWorkTask();
+            taskWorkspace.provisionForRun.mockResolvedValue(WORKSPACE);
+            resolveAcceptanceChecksMock.mockReturnValue([]);
+            resolveChecksPolicyMock.mockReturnValue('required');
+            gateRunner.runChecks.mockResolvedValue({ gateStatus: 'skipped', results: [] });
+
+            const result = await registeredConfig.run(basePayload(OWNED_TASK_ID));
+
+            expect(taskWorkspace.finalizeRun).not.toHaveBeenCalled();
+            expect(runs.markCompleted.mock.calls[0][1]).toContain('no checks configured');
+            expect(taskChat.post.mock.calls[0][1].body).toContain('no checks configured');
+            expect(result).toMatchObject({
+                status: 'completed',
+                reason: 'gate-red',
+                gateStatus: 'skipped',
+            });
+        });
+
+        it("red gate + policy 'warn' → reports but never blocks; finalize proceeds WITHOUT the green note", async () => {
+            useWorkTask();
+            taskWorkspace.provisionForRun.mockResolvedValue(WORKSPACE);
+            taskWorkspace.finalizeRun.mockResolvedValue({ outcome: 'pr-opened', prNumber: 11 });
+            resolveAcceptanceChecksMock.mockReturnValue([BUILD_CHECK]);
+            resolveChecksPolicyMock.mockReturnValue('warn');
+            gateRunner.runChecks.mockResolvedValue({
+                gateStatus: 'red',
+                results: [{ id: 'build', status: 'red', exitCode: 1, durationMs: 12 }],
+            });
+
+            const result = await registeredConfig.run(basePayload(OWNED_TASK_ID));
+
+            expect(taskWorkspace.finalizeRun).toHaveBeenCalledTimes(1);
+            expect(taskWorkspace.finalizeRun.mock.calls[0][0].gate).toBeUndefined();
+            expect(taskChat.post).not.toHaveBeenCalled();
+            expect(result).toMatchObject({ status: 'completed', workspaceOutcome: 'pr-opened' });
+        });
+
+        it('a crashed gate step marks the run FAILED — never green', async () => {
+            useWorkTask();
+            taskWorkspace.provisionForRun.mockResolvedValue(WORKSPACE);
+            resolveAcceptanceChecksMock.mockReturnValue([BUILD_CHECK]);
+            resolveChecksPolicyMock.mockReturnValue('required');
+            gateRunner.runChecks.mockRejectedValue(new Error('rpc down'));
+
+            const result = await registeredConfig.run(basePayload(OWNED_TASK_ID));
+
+            expect(taskWorkspace.finalizeRun).not.toHaveBeenCalled();
+            expect(runs.markFailed).toHaveBeenCalledWith(
+                'run-1',
+                expect.stringContaining('Quality gate execution failed'),
+            );
+            expect(result).toMatchObject({ status: 'failed', reason: 'gate-execution-failed' });
         });
     });
 });

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -1,8 +1,13 @@
 import { task } from '@trigger.dev/sdk';
 import { NestFactory } from '@nestjs/core';
-import { AgentRepository, AgentRunRepository } from '@ever-works/agent/database';
+import type { TaskAcceptanceCheck } from '@ever-works/contracts';
+import { AgentRepository, AgentRunRepository, WorkRepository } from '@ever-works/agent/database';
 import { AgentRunService } from '@ever-works/agent/agents';
 import {
+    resolveAcceptanceChecks,
+    resolveChecksPolicy,
+    TaskChatService,
+    TaskGateRunnerService,
     TaskRunDenormService,
     TasksService,
     TaskWorkspaceService,
@@ -229,6 +234,25 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 }),
             );
 
+            // Wave 3 M2 — dispatch-freeze: resolve the acceptance-check set
+            // (Task checks merged over Work defaults) ONCE, right after the
+            // claim, and snapshot it onto the run. An in-flight run is graded
+            // against what was agreed when it started — later edits to the
+            // Task or the Work defaults affect the next run, not this one.
+            let gateWork: Awaited<ReturnType<WorkRepository['findById']>> = null;
+            let resolvedChecks: TaskAcceptanceCheck[] = [];
+            const works = appContext.get(WorkRepository);
+            try {
+                gateWork = taskRow.workId ? await works.findById(taskRow.workId) : null;
+                resolvedChecks = resolveAcceptanceChecks(taskRow, gateWork);
+            } catch {
+                // Work lookup failed (RPC hiccup). gateWork stays null, so the
+                // policy resolves 'off' below and the run proceeds exactly as
+                // it did before quality gates existed — fail toward the
+                // status quo, never toward a half-resolved gate.
+            }
+            await bestEffort(() => runs.updateGateResults(claimedRunId, { resolvedChecks }));
+
             // Wave 2 M3 — worktree-per-Task isolation. Resolves the Work +
             // Task settings and provisions the isolated workspace when (and
             // only when) isolation resolves on; null on the default-off
@@ -292,6 +316,102 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                     : null,
             });
 
+            // Wave 3 M3 — the PR gate: "a red check opens no PR". After the
+            // agent loop succeeds and BEFORE any terminal bookkeeping or the
+            // finalize/PR step, run the dispatch-frozen acceptance checks in
+            // the provisioned workspace. Green (or a warn-only policy)
+            // proceeds to finalize exactly as before; red under a 'required'
+            // policy withholds the PR. One attempt only in M3 — the bounded
+            // iterate loop is M5.
+            const runSucceeded = result.status === 'assembled' || result.status === 'dispatched';
+            const gatePolicy = resolveChecksPolicy(gateWork);
+            let gateOutcome: Awaited<ReturnType<TaskGateRunnerService['runChecks']>> | null = null;
+            if (provisioned && runSucceeded && gatePolicy !== 'off') {
+                const gateRunner = appContext.get(TaskGateRunnerService);
+                try {
+                    gateOutcome = await gateRunner.runChecks({
+                        checks: resolvedChecks,
+                        cwd: provisioned.cwd,
+                        runId: run.id,
+                        policy: gatePolicy,
+                    });
+                } catch (error) {
+                    // A crashed gate step marks the run FAILED, never green —
+                    // a gate that did not run must not pass anything.
+                    const message = error instanceof Error ? error.message : String(error);
+                    await runs.markFailed(run.id, `Quality gate execution failed: ${message}`);
+                    await bestEffort(() =>
+                        runDenorm.recordTerminal(payload.taskId, claimedRunId, 'failed'),
+                    );
+                    return {
+                        status: 'failed',
+                        reason: 'gate-execution-failed',
+                        runId: run.id,
+                        taskId: payload.taskId,
+                    };
+                }
+
+                if (gatePolicy === 'required' && gateOutcome.gateStatus !== 'green') {
+                    // Red — or 'skipped' when the required policy found zero
+                    // checks. Either way: no finalize, no PR. The workspace
+                    // and the Task's branchState stay exactly as they are.
+                    const requiredFailed = gateOutcome.results.filter((checkResult) => {
+                        const check = resolvedChecks.find((c) => c.id === checkResult.id);
+                        return checkResult.status !== 'green' && check?.required !== false;
+                    });
+                    const summary =
+                        resolvedChecks.length === 0
+                            ? 'Quality gate: no checks configured — PR withheld (checks policy is required).'
+                            : `Quality gate red: ${requiredFailed
+                                  .map((checkResult) => checkResult.id)
+                                  .join(', ')} — PR withheld.`;
+                    await runs.markCompleted(run.id, summary);
+                    await bestEffort(() =>
+                        runDenorm.recordTerminal(payload.taskId, claimedRunId, 'completed'),
+                    );
+                    // Task chat gets the human-facing breakdown. Plain text —
+                    // the chat surface never renders agent messages as markup.
+                    const taskChat = appContext.get(TaskChatService);
+                    const chatBody =
+                        resolvedChecks.length === 0
+                            ? 'Quality gate: no checks configured, and this Work requires acceptance checks — no PR was opened. Add checks to the Task or to the Work defaults, then send a message here to re-run.'
+                            : [
+                                  'Quality gate red — no PR was opened.',
+                                  '',
+                                  'Failed checks:',
+                                  ...requiredFailed.map(
+                                      (checkResult) =>
+                                          `- ${checkResult.id}: ${
+                                              checkResult.status === 'timeout'
+                                                  ? 'timed out'
+                                                  : checkResult.status === 'error'
+                                                    ? 'could not run'
+                                                    : `exit code ${checkResult.exitCode}`
+                                          }`,
+                                  ),
+                                  '',
+                                  'Fix the issues (or adjust the checks), then send a message here to re-run.',
+                              ].join('\n');
+                    await bestEffort(() =>
+                        taskChat.post(payload.userId, {
+                            taskId: payload.taskId,
+                            authorType: 'agent',
+                            authorId: agent.id,
+                            body: chatBody,
+                        }),
+                    );
+                    return {
+                        status: 'completed',
+                        reason: 'gate-red',
+                        agentId: agent.id,
+                        taskId: payload.taskId,
+                        runId: run.id,
+                        dedupKey: payload.dedupKey,
+                        gateStatus: gateOutcome.gateStatus,
+                    };
+                }
+            }
+
             if (result.status === 'assembled') {
                 await runs.markCompleted(run.id, `Prompt assembled for task ${payload.taskId}`);
                 await bestEffort(() =>
@@ -309,8 +429,17 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
             // a FRESH base, then open the PR (→ in_review) or refuse it
             // with NAMED conflict paths (→ blocked). Only runs when a
             // workspace was provisioned and the run itself succeeded.
-            const runSucceeded = result.status === 'assembled' || result.status === 'dispatched';
             if (provisioned && runSucceeded) {
+                // Wave 3 M3 — a green gate earns a note on the PR body. Only
+                // when EVERY check (required and informational) came back
+                // green, so the note can never overstate the verdict.
+                const gateNote =
+                    gateOutcome &&
+                    gateOutcome.gateStatus === 'green' &&
+                    gateOutcome.results.length > 0 &&
+                    gateOutcome.results.every((checkResult) => checkResult.status === 'green')
+                        ? { checksPassed: gateOutcome.results.length }
+                        : undefined;
                 try {
                     const finalize = await taskWorkspace.finalizeRun({
                         task: taskRow,
@@ -320,6 +449,7 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                             (agent as { permissions?: { canOpenPullRequests?: boolean } })
                                 .permissions?.canOpenPullRequests !== false,
                         workspace: provisioned,
+                        ...(gateNote ? { gate: gateNote } : {}),
                     });
                     return {
                         status: 'completed',

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -16,12 +16,13 @@ import {
 } from '@ever-works/agent/agents';
 import {
     TaskChatService,
+    TaskGateRunnerService,
     TaskRecurrenceDispatcherService,
     TaskRunDenormService,
     TasksService,
     TaskWorkspaceService,
 } from '@ever-works/agent/tasks-domain';
-import { AgentRepository, AgentRunRepository } from '@ever-works/agent/database';
+import { AgentRepository, AgentRunRepository, WorkRepository } from '@ever-works/agent/database';
 import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
 import { TriggerInternalApiClient } from '../services/trigger-internal-api.client';
 import { createRemoteProxy } from '../remote-proxy';
@@ -155,6 +156,27 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
             useFactory: (apiClient) => createRemoteProxy(apiClient, 'TaskWorkspaceService'),
             inject: [TriggerInternalApiClient],
         },
+        // Wave 3 M2/M3 — quality gates. The acceptance-check runner lives
+        // API-side (same filesystem as the provisioned workspace — see the
+        // TaskWorkspaceService note above); agent-task-execute calls
+        // runChecks over the internal RPC channel after the agent loop and
+        // before the finalize/PR step.
+        {
+            provide: TaskGateRunnerService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'TaskGateRunnerService'),
+            inject: [TriggerInternalApiClient],
+        },
+        // Wave 3 M2 — dispatch-freeze. agent-task-execute loads the Task's
+        // Work to resolve the acceptance-check set + policy right after the
+        // run claim. The API already exposes 'WorkRepository' in its remote
+        // map; this is just the worker-side proxy for it.
+        {
+            provide: WorkRepository,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'WorkRepository'),
+            inject: [TriggerInternalApiClient],
+        },
         // Kanban run cockpit (Wave 2) — latest-run denorm writes from the
         // agent-task-execute worker (after claim + terminal transitions).
         // The real service (TaskRepository graph) lives in the API; the
@@ -226,6 +248,8 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         TaskChatService,
         TaskRunDenormService,
         TaskWorkspaceService,
+        TaskGateRunnerService,
+        WorkRepository,
         NotificationChannelFacadeService,
         AnonymousUserCleanupService,
         KnowledgeBaseReconcileService,


### PR DESCRIPTION
## What

Quality gates milestones **M2 (check runner)** + **M3 (PR gate)**, stacked on the Wave 3 M1 schema (#1830). Core invariant shipped here: **a red check opens no PR.**

### M2 — acceptance-check runner (harness, not agent)
- **`TaskGateRunnerService.runChecks({checks, cwd, runId, policy})`** (`packages/agent/src/tasks-domain/task-gate-runner.service.ts`): spawns each check command as a real subprocess (shell) in the run's workspace checkout (`check.cwd` joins under it), sequentially in declared order. Real observed exit codes — never agent-asserted.
  - per-check `timeoutSec` default **600s**, hard cap 1800s; kill on timeout → status `timeout` (settles on process `exit`, so an orphaned grandchild holding pipes can't stall the gate)
  - spawn failure (bad cwd etc.) → status `error` — infra problems don't read as code problems
  - last **~4KB** of combined stdout/stderr kept as `logTail`
  - `required:false` checks report but **never** turn the gate red
  - empty check set → `off`/`warn` → gateStatus `none`; `required` → `skipped` (a gate that did not run never renders green)
- **`AgentRunRepository.updateGateResults(runId, {resolvedChecks?, checkResults, gateStatus, gateAttempts?})`** — explicit column whitelist, mirrors `updateTerminalColumns`.
- **Dispatch-freeze**: `agent-task-execute` snapshots `resolveAcceptanceChecks(task, work)` onto `agent_runs.resolvedChecks` right after the run claim (Work loaded via `WorkRepository` when `task.workId`); later Task/Work edits affect the next run, not the in-flight one.
- **RPC wiring** exactly like `TaskWorkspaceService`: worker remote-proxy providers (`TaskGateRunnerService`, `WorkRepository`) in `packages/tasks/.../trigger-internal.module.ts`, controller constructor (+`@Optional()` appended last) + remote map in `apps/api/src/trigger/trigger-internal.controller.ts`, spec arity updated.

### M3 — PR gate in the worker step
In `agent-task-execute`, after the agent loop succeeds and **before** `TaskWorkspaceService.finalizeRun`:
- policy `off` (default) → no gate, finalize exactly as today
- gate **green** (or policy `warn`) → finalize as today; a fully-green gate adds a PR-body note: *"Quality gate: all N acceptance checks green."* (only when every check, incl. informational ones, passed — the note can't overstate)
- gate **red** + policy `required` → **no finalize, no PR**: gate results persisted, run marked completed with a summary naming the failing check ids, task chat gets a plain-text breakdown of the failed checks, `branchState` left as-is
- policy `required` + zero checks → same treatment with gateStatus `skipped` and a "no checks configured" message
- a **crashed gate step marks the run failed** — never green
- one attempt only, `gateAttempts=1` (bounded iterate loop is M5, out of scope)
- `finalizeRun` signature unchanged (optional `gate` note field only)

### Also
- Repaired `packages/tasks/src/__tests__/agent-task-execute.task.spec.ts` — its DI-token mocks were left behind by the Wave 2 merge (9 pre-existing failures on `wave/integration` baseline); suite green again + 7 new gate-path cases.

## Verification (real output)

`packages/agent` build — **TSC 0**:
```
@ever-works/agent:build: >  TSC  Found 0 issues.
@ever-works/agent:build: Successfully compiled: 977 files with swc (540.37ms)
```
`packages/agent` jest `task-gate-runner|task-gates`:
```
PASS src/tasks-domain/__tests__/task-gates.spec.ts (14.561 s)
PASS src/tasks-domain/__tests__/task-gate-runner.service.spec.ts (19.687 s)
Test Suites: 2 passed, 2 total
Tests:       31 passed, 31 total
```
`packages/agent` jest `agent-run.repository`: `26 passed, 26 total`
`packages/agent` jest `tasks-domain` (full): `13 suites passed, 146 tests passed`
`pnpm build --filter=ever-works-api`:
```
ever-works-api:build: Successfully compiled: 640 files with swc (734ms)
Tasks:    14 successful, 14 total
```
`apps/api` `pnpm generate:openapi` (full-app bootstrap):
```
Wrote OpenAPI spec (412 paths) to ...\apps\api\openapi.json
```
(openapi.json not committed)
`apps/api` jest `trigger-internal`:
```
PASS src/trigger/trigger-internal.module.spec.ts
PASS src/trigger/trigger-internal.controller.spec.ts
Tests:       16 passed, 16 total
```
`packages/tasks` `pnpm build` (tsc): clean
`packages/tasks` vitest (full): `25 files passed, 387 tests passed` (baseline had 9 failures in agent-task-execute spec — fixed here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)