### PR TITLE
feat(agent): run dispatch gate + sessions API (Wave 4 M1-M3)

### DIFF
--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -29,6 +29,8 @@ jest.mock('@ever-works/agent/agents', () => ({
     AgentScheduleDispatcherService: class {},
     AgentRunRepository: class {},
     AgentRunLogRepository: class {},
+    // Wave 4 M2/M3 — dispatch gate injected for cancel-path draining.
+    RunDispatchGateService: class {},
     SkillBindingRepository: class {},
     PluginUsageRepository: class {},
 }));
@@ -112,6 +114,8 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             markDispatchFailed: jest.fn().mockResolvedValue(undefined),
             setTriggerRunId: jest.fn().mockResolvedValue(undefined),
             findByIdAndUser: jest.fn().mockResolvedValue(null),
+            // Wave 4 M3 — org-wide Sessions list (owner-scoped variant).
+            listSessionsForUser: jest.fn().mockResolvedValue([[], 0]),
         };
         agentRunLogs = { findByRun: jest.fn().mockResolvedValue([]) };
         skillBindings = { resolveActive: jest.fn().mockResolvedValue([]) };
@@ -224,6 +228,97 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             expect(result.data[0]).toMatchObject({ status: 'completed' });
             expect(agentRuns.findByAgentAndUser).toHaveBeenCalledWith(agentId, 'u1', 25, 0);
             expect(agentRuns.countByAgentAndUser).toHaveBeenCalledWith(agentId, 'u1');
+        });
+    });
+
+    describe('GET /runs — Sessions list (Wave 4 M3)', () => {
+        it('is owner-scoped at the repository layer — userId always comes from auth', async () => {
+            // Security: no agent ownership pre-check exists on this route
+            // (it spans all the caller's Agents), so the repository-level
+            // userId scope is the ONLY guard. Pin that the controller
+            // passes auth.userId, never anything caller-controlled.
+            await controller.listRunSessions(auth, {});
+            expect(agentRuns.listSessionsForUser).toHaveBeenCalledWith(
+                'u1',
+                {
+                    status: undefined,
+                    workId: undefined,
+                    agentId: undefined,
+                    triggerKind: undefined,
+                },
+                25,
+                0,
+            );
+        });
+
+        it('forwards filters (status/workId/agentId/kind) and pagination', async () => {
+            const workId = '00000000-0000-0000-0000-0000000000cc';
+            await controller.listRunSessions(auth, {
+                status: 'running',
+                workId,
+                agentId,
+                kind: 'task',
+                limit: 5,
+                offset: 10,
+            });
+            expect(agentRuns.listSessionsForUser).toHaveBeenCalledWith(
+                'u1',
+                { status: 'running', workId, agentId, triggerKind: 'task' },
+                5,
+                10,
+            );
+        });
+
+        it('returns telemetry + gate + terminal + orchestration columns per row', async () => {
+            agentRuns.listSessionsForUser.mockResolvedValueOnce([
+                [
+                    {
+                        id: runId,
+                        agentId,
+                        status: 'running',
+                        triggerKind: 'task',
+                        taskId,
+                        workId: '00000000-0000-0000-0000-0000000000cc',
+                        awaitingInput: false,
+                        queuedReason: null,
+                        runnerKind: 'claude-code',
+                        startedAt: new Date('2026-01-01T00:00:00Z'),
+                        finishedAt: null,
+                        durationMs: null,
+                        summary: null,
+                        errorMessage: null,
+                        currentActivity: 'editing src/auth/session.ts',
+                        totalTokens: 48_200,
+                        changedFilesCount: 3,
+                        costCents: 120,
+                        gateStatus: 'pending',
+                        gateAttempts: 1,
+                        persistent: true,
+                        terminalState: 'attached',
+                        terminalEndedReason: null,
+                        terminalProviderId: 'terminal-relay',
+                        createdAt: new Date('2026-01-01T00:00:00Z'),
+                    },
+                ],
+                1,
+            ]);
+            const result = await controller.listRunSessions(auth, {});
+            expect(result.meta).toEqual({ total: 1, limit: 25, offset: 0 });
+            expect(result.data[0]).toMatchObject({
+                id: runId,
+                workId: '00000000-0000-0000-0000-0000000000cc',
+                awaitingInput: false,
+                queuedReason: null,
+                runnerKind: 'claude-code',
+                currentActivity: 'editing src/auth/session.ts',
+                totalTokens: 48_200,
+                changedFilesCount: 3,
+                costCents: 120,
+                gateStatus: 'pending',
+                gateAttempts: 1,
+                persistent: true,
+                terminalState: 'attached',
+            });
         });
     });
 
@@ -444,6 +539,66 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             const result = await controller.cancelRun(auth, agentId, runId);
             expect(result.cancelled).toBe(false);
             expect(runCanceller.cancel).not.toHaveBeenCalled();
+        });
+
+        it('drains the Work concurrency queue after cancelling an open run (Wave 4 M2)', async () => {
+            const workId = '00000000-0000-0000-0000-0000000000cc';
+            const dispatchGate = {
+                drainForWork: jest.fn().mockResolvedValue({ dispatched: true }),
+            };
+            const gated = new AgentsController(
+                service,
+                files,
+                exportService,
+                dispatcher,
+                agentRuns,
+                agentRunLogs,
+                skillBindings,
+                pluginUsage,
+                tasks,
+                activityLog,
+                heartbeatTrigger,
+                taskExecuteDispatcher,
+                runCanceller,
+                dispatchGate as any,
+            );
+            agentRuns.cancel.mockResolvedValueOnce({
+                found: true,
+                previousStatus: 'running',
+                triggerRunId: 'run_abc',
+                workId,
+            });
+            await gated.cancelRun(auth, agentId, runId);
+            await new Promise((r) => setImmediate(r)); // fire-and-forget drain
+            expect(dispatchGate.drainForWork).toHaveBeenCalledWith(workId);
+        });
+
+        it('does NOT drain after a no-op cancel of an already-terminal run', async () => {
+            const dispatchGate = { drainForWork: jest.fn() };
+            const gated = new AgentsController(
+                service,
+                files,
+                exportService,
+                dispatcher,
+                agentRuns,
+                agentRunLogs,
+                skillBindings,
+                pluginUsage,
+                tasks,
+                activityLog,
+                heartbeatTrigger,
+                taskExecuteDispatcher,
+                runCanceller,
+                dispatchGate as any,
+            );
+            agentRuns.cancel.mockResolvedValueOnce({
+                found: true,
+                previousStatus: 'completed',
+                workId: '00000000-0000-0000-0000-0000000000cc',
+            });
+            await gated.cancelRun(auth, agentId, runId);
+            await new Promise((r) => setImmediate(r));
+            expect(dispatchGate.drainForWork).not.toHaveBeenCalled();
         });
 
         it('still reports cancelled when the canceller reports a non-cancelled outcome', async () => {

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -33,6 +33,7 @@ import {
     AgentScope,
     AGENT_RUN_CANCELLER,
     type AgentRunCanceller,
+    RunDispatchGateService,
     SkillBindingRepository,
     type AgentDto,
     type AgentExportEnvelope,
@@ -62,6 +63,7 @@ import {
     CreateAgentDto,
     ListAgentRunsQueryDto,
     ListAgentsQueryDto,
+    ListRunSessionsQueryDto,
     UpdateAgentDto,
     UpdateAgentGuardrailsDto,
 } from './dto/agent.dto';
@@ -149,6 +151,11 @@ export class AgentsController {
         @Optional()
         @Inject(AGENT_RUN_CANCELLER)
         private readonly runCanceller?: AgentRunCanceller,
+        // Run orchestration (Wave 4 M2) — a successful cancel frees a
+        // concurrency slot, so the Work's parked queue is drained. Trailing
+        // + Optional for the same positional-spec reason as above.
+        @Optional()
+        private readonly dispatchGate?: RunDispatchGateService,
     ) {}
 
     @Get()
@@ -203,6 +210,105 @@ export class AgentsController {
             committerName: body.committerName ?? null,
             committerEmail: body.committerEmail ?? null,
         });
+    }
+
+    /**
+     * Run orchestration (Wave 4 M3) — the Sessions list: every AgentRun
+     * of the acting user across all Agents/Works, filterable + paginated.
+     * Declared BEFORE the `:id` routes so the literal `runs` segment
+     * never reaches ParseUUIDPipe.
+     *
+     * Security: `listSessionsForUser` applies `userId = auth.userId`
+     * at the repository layer — cross-user rows are unreachable by
+     * construction, filters can only narrow the caller's own set.
+     */
+    @Get('runs')
+    @ApiOperation({
+        summary:
+            'Sessions list — my AgentRuns across all Agents (filter by status/workId/agentId/kind).',
+    })
+    @HttpCode(HttpStatus.OK)
+    async listRunSessions(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: ListRunSessionsQueryDto,
+    ): Promise<{
+        data: Array<{
+            id: string;
+            agentId: string;
+            status: string;
+            triggerKind: string;
+            taskId: string | null;
+            workId: string | null;
+            awaitingInput: boolean;
+            queuedReason: string | null;
+            runnerKind: string | null;
+            startedAt: string | null;
+            finishedAt: string | null;
+            durationMs: number | null;
+            summary: string | null;
+            errorMessage: string | null;
+            currentActivity: string | null;
+            totalTokens: number | null;
+            changedFilesCount: number | null;
+            costCents: number | null;
+            gateStatus: string | null;
+            gateAttempts: number;
+            persistent: boolean;
+            terminalState: string | null;
+            terminalEndedReason: string | null;
+            terminalProviderId: string | null;
+            createdAt: string;
+        }>;
+        meta: { total: number; limit: number; offset: number };
+    }> {
+        const limit = query.limit ?? 25;
+        const offset = query.offset ?? 0;
+        const [rows, total] = await this.agentRuns.listSessionsForUser(
+            auth.userId,
+            {
+                status: query.status,
+                workId: query.workId,
+                agentId: query.agentId,
+                triggerKind: query.kind,
+            },
+            limit,
+            offset,
+        );
+        return {
+            data: rows.map((r) => ({
+                id: r.id,
+                agentId: r.agentId,
+                status: r.status,
+                triggerKind: r.triggerKind,
+                taskId: r.taskId ?? null,
+                workId: r.workId ?? null,
+                awaitingInput: r.awaitingInput ?? false,
+                queuedReason: r.queuedReason ?? null,
+                runnerKind: r.runnerKind ?? null,
+                startedAt: r.startedAt?.toISOString() ?? null,
+                finishedAt: r.finishedAt?.toISOString() ?? null,
+                durationMs: r.durationMs ?? null,
+                summary: r.summary ?? null,
+                errorMessage: r.errorMessage ?? null,
+                // Telemetry (kanban run cockpit columns). `currentActivity`
+                // is plain text by contract — the UI must never render it
+                // as markup.
+                currentActivity: r.currentActivity ?? null,
+                totalTokens: r.totalTokens ?? null,
+                changedFilesCount: r.changedFilesCount ?? null,
+                costCents: r.costCents ?? null,
+                // Quality-gate columns.
+                gateStatus: r.gateStatus ?? null,
+                gateAttempts: r.gateAttempts ?? 0,
+                // Streaming-terminal lifecycle columns.
+                persistent: r.persistent ?? false,
+                terminalState: r.terminalState ?? null,
+                terminalEndedReason: r.terminalEndedReason ?? null,
+                terminalProviderId: r.terminalProviderId ?? null,
+                createdAt: r.createdAt.toISOString(),
+            })),
+            meta: { total, limit, offset },
+        };
     }
 
     @Get(':id')
@@ -669,6 +775,13 @@ export class AgentsController {
                 actionType: ActivityActionType.AGENT_RUN_CANCELLED,
                 details: { runId, previousStatus: result.previousStatus },
             });
+            // Run orchestration (Wave 4 M2) — the cancel freed a concurrency
+            // slot; promote the oldest parked run for the same Work. Fire-
+            // and-forget: drainForWork never throws by contract, and the
+            // cancel response must not wait on a fresh dispatch.
+            if (result.workId && this.dispatchGate) {
+                void this.dispatchGate.drainForWork(result.workId).catch(() => undefined);
+            }
         }
         return { cancelled: wasOpen, previousStatus: result.previousStatus };
     }

--- a/apps/api/src/agents/dto/agent.dto.ts
+++ b/apps/api/src/agents/dto/agent.dto.ts
@@ -446,6 +446,53 @@ export class ListAgentRunsQueryDto {
 }
 
 /**
+ * Run orchestration (Wave 4 M3) — filters for the org-wide Sessions
+ * list (`GET /api/agents/runs`). Every filter optional; unset = all of
+ * the caller's runs. Enum whitelists mirror the entity unions — an
+ * unrecognized value is a 400, never a silent full-table answer.
+ */
+export class ListRunSessionsQueryDto {
+    @ApiProperty({
+        required: false,
+        enum: ['queued', 'running', 'completed', 'failed', 'cancelled'],
+    })
+    @IsOptional()
+    @IsIn(['queued', 'running', 'completed', 'failed', 'cancelled'])
+    status?: 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+    @ApiProperty({ required: false, format: 'uuid' })
+    @IsOptional()
+    @IsUUID()
+    workId?: string;
+
+    @ApiProperty({ required: false, format: 'uuid' })
+    @IsOptional()
+    @IsUUID()
+    agentId?: string;
+
+    /** Trigger kind — named `kind` on the wire for the Sessions view. */
+    @ApiProperty({ required: false, enum: ['heartbeat', 'manual', 'task', 'chat', 'event'] })
+    @IsOptional()
+    @IsIn(['heartbeat', 'manual', 'task', 'chat', 'event'])
+    kind?: 'heartbeat' | 'manual' | 'task' | 'chat' | 'event';
+
+    @ApiProperty({ required: false, minimum: 1, maximum: 200 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(200)
+    limit?: number;
+
+    @ApiProperty({ required: false, minimum: 0 })
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(0)
+    offset?: number;
+}
+
+/**
  * FU-2 — payload for `POST /api/agents/:id/assign-task`.
  */
 export class AssignTaskToAgentDto {

--- a/apps/api/src/migrations/1783100000000-AddRunOrchestrationColumns.ts
+++ b/apps/api/src/migrations/1783100000000-AddRunOrchestrationColumns.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Run orchestration (Wave 4 M1) — `agent_runs` scheduling + telemetry
+ * columns for the dispatch gate and the Sessions view.
+ *
+ *  - `workId`        — nullable uuid, denormalized from `task.workId` at
+ *                      creation (backfilled below for historical rows);
+ *                      powers per-Work concurrency counts + grouping.
+ *  - `awaitingInput` — boolean default false; parked-on-a-human flag,
+ *                      never reaped by TTL sweeps.
+ *  - `queuedReason`  — varchar(64) nullable; why a queued run was NOT
+ *                      dispatched (`concurrency-limit` today).
+ *  - `runnerKind`    — varchar(32) nullable; pipeline plugin id.
+ *  - `costCents`     — int nullable; per-run cumulative cost estimate
+ *                      (per-event source of truth stays
+ *                      `plugin_usage_events.costCents`).
+ *
+ * Index `(workId, status)` for the gate's in-flight counts and the
+ * per-Work runs summary. Forward-only, idempotent per-step guards
+ * (house pattern, mirrors 1782700000000-AddTaskIsolationColumns).
+ */
+export class AddRunOrchestrationColumns1783100000000 implements MigrationInterface {
+    name = 'AddRunOrchestrationColumns1783100000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('agent_runs');
+        if (!table) return;
+
+        const addColumn = async (name: string, ddl: string) => {
+            if (!table.findColumnByName(name)) {
+                await queryRunner.query(`ALTER TABLE "agent_runs" ADD COLUMN ${ddl}`);
+            }
+        };
+
+        await addColumn('workId', `"workId" uuid`);
+        await addColumn('awaitingInput', `"awaitingInput" boolean NOT NULL DEFAULT false`);
+        await addColumn('queuedReason', `"queuedReason" varchar(64)`);
+        await addColumn('runnerKind', `"runnerKind" varchar(32)`);
+        await addColumn('costCents', `"costCents" int`);
+
+        // Backfill workId for historical task-attached runs where derivable.
+        // Correlated subquery is portable across Postgres and sqlite (the
+        // e2e suite runs on sqlite). Rows whose Task has no Work — or whose
+        // Task was deleted — honestly stay NULL.
+        await queryRunner.query(
+            `UPDATE "agent_runs" SET "workId" = ` +
+                `(SELECT "workId" FROM "tasks" WHERE "tasks"."id" = "agent_runs"."taskId") ` +
+                `WHERE "workId" IS NULL AND "taskId" IS NOT NULL`,
+        );
+
+        await queryRunner.query(
+            `CREATE INDEX IF NOT EXISTS "idx_agent_runs_work_status" ` +
+                `ON "agent_runs" ("workId", "status")`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "idx_agent_runs_work_status"`);
+        const table = await queryRunner.getTable('agent_runs');
+        if (!table) return;
+        for (const col of ['costCents', 'runnerKind', 'queuedReason', 'awaitingInput', 'workId']) {
+            if (table.findColumnByName(col)) {
+                await queryRunner.query(`ALTER TABLE "agent_runs" DROP COLUMN "${col}"`);
+            }
+        }
+    }
+}

--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -20,6 +20,8 @@ jest.mock('@ever-works/agent/agents', () => ({
     AgentScheduleDispatcherService: class AgentScheduleDispatcherService {},
     AgentRunService: class AgentRunService {},
     AgentRunSweeperService: class AgentRunSweeperService {},
+    // Wave 4 M2 — drain-on-terminal RPC target (run orchestration).
+    RunDispatchGateService: class RunDispatchGateService {},
     AGENT_HEARTBEAT_TRIGGER: 'AGENT_HEARTBEAT_TRIGGER',
 }));
 jest.mock('@ever-works/agent/tasks-domain', () => ({

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -49,6 +49,7 @@ import {
     AgentRunService,
     AgentRunSweeperService,
     AgentScheduleDispatcherService,
+    RunDispatchGateService,
 } from '@ever-works/agent/agents';
 import {
     TaskChatService,
@@ -271,6 +272,11 @@ export class TriggerInternalController implements OnModuleInit {
         // keeps compiling — inserting mid-list silently shifts all later args.
         @Optional()
         private readonly agentRunSweeperService?: AgentRunSweeperService,
+        // Run orchestration (Wave 4 M2) — drain-on-terminal RPC target for
+        // the agent-task-execute worker. Appended LAST + @Optional() for
+        // the same positional-spec reason as the sweeper above.
+        @Optional()
+        private readonly runDispatchGateService?: RunDispatchGateService,
     ) {}
 
     onModuleInit() {
@@ -305,6 +311,9 @@ export class TriggerInternalController implements OnModuleInit {
             // agent-heartbeat dispatcher cron + agent-heartbeat one-shot.
             AgentScheduleDispatcherService: this.agentScheduleDispatcherService,
             AgentRunSweeperService: this.agentRunSweeperService,
+            // Run orchestration (Wave 4 M2) — agent-task-execute calls
+            // drainForWork here after every terminal transition.
+            RunDispatchGateService: this.runDispatchGateService,
             AgentRunService: this.agentRunService,
             AgentRepository: this.agentRepositoryRef,
             AgentRunRepository: this.agentRunRepositoryRef,

--- a/apps/api/src/works/work-runs.controller.spec.ts
+++ b/apps/api/src/works/work-runs.controller.spec.ts
@@ -1,0 +1,70 @@
+// Short-circuit the transitive `@ever-works/agent/*` import chains so the
+// test doesn't pull `@src/entities` (which only resolves inside apps/api)
+// through the agent-package barrels. House pattern — mirrors
+// agents.controller.runtime.spec.ts.
+jest.mock('@ever-works/agent/agents', () => ({
+    __esModule: true,
+    AgentRunRepository: class {},
+}));
+jest.mock('@ever-works/agent/services', () => ({
+    __esModule: true,
+    WorkOwnershipService: class {},
+}));
+
+import { NotFoundException } from '@nestjs/common';
+import { WorkRunsController } from './work-runs.controller';
+
+/**
+ * Run orchestration (Wave 4 M3) — per-Work runs-summary endpoint.
+ * The scope-guard test is the load-bearing one: the summary counts are
+ * Work-scoped, so `ensureAccess` MUST gate the Work before any count
+ * query runs (cross-user Works 404, no existence leak).
+ */
+describe('WorkRunsController', () => {
+    const auth = { userId: 'u1' } as any;
+    const workId = '00000000-0000-0000-0000-0000000000cc';
+
+    let ownership: any;
+    let agentRuns: any;
+    let controller: WorkRunsController;
+
+    beforeEach(() => {
+        ownership = { ensureAccess: jest.fn().mockResolvedValue({ work: { id: workId } }) };
+        agentRuns = {
+            summarizeForWork: jest.fn().mockResolvedValue({
+                running: 2,
+                queued: 3,
+                awaiting: 1,
+                failedLast24h: 4,
+            }),
+        };
+        controller = new WorkRunsController(ownership, agentRuns);
+    });
+
+    it('returns the grouped summary counts for an accessible Work', async () => {
+        await expect(controller.runsSummary(auth, workId)).resolves.toEqual({
+            running: 2,
+            queued: 3,
+            awaiting: 1,
+            failedLast24h: 4,
+        });
+        expect(agentRuns.summarizeForWork).toHaveBeenCalledWith(workId);
+    });
+
+    it('gates the Work through ensureAccess with the ACTING user before counting', async () => {
+        await controller.runsSummary(auth, workId);
+        expect(ownership.ensureAccess).toHaveBeenCalledWith(workId, 'u1');
+        // Order matters: the guard must run before the count query.
+        expect(ownership.ensureAccess.mock.invocationCallOrder[0]).toBeLessThan(
+            agentRuns.summarizeForWork.mock.invocationCallOrder[0],
+        );
+    });
+
+    it('propagates the ownership 404 and never touches the repository (no cross-user leak)', async () => {
+        ownership.ensureAccess.mockRejectedValueOnce(new NotFoundException('Work not found'));
+        await expect(controller.runsSummary(auth, workId)).rejects.toBeInstanceOf(
+            NotFoundException,
+        );
+        expect(agentRuns.summarizeForWork).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/works/work-runs.controller.ts
+++ b/apps/api/src/works/work-runs.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, HttpCode, HttpStatus, Param, ParseUUIDPipe } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AgentRunRepository } from '@ever-works/agent/agents';
+import { WorkOwnershipService } from '@ever-works/agent/services';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+/**
+ * Run orchestration (Wave 4 M3) — per-Work session summary chips.
+ *
+ *   GET /api/works/:id/runs-summary → { running, queued, awaiting, failedLast24h }
+ *
+ * One grouped query over the `(workId, status)` index — the Work-detail
+ * header polls this, so it must stay a single cheap scan.
+ *
+ * Security: `WorkOwnershipService.ensureAccess` gates the Work first —
+ * cross-user Works 404 with no existence leak (architecture/security §9).
+ * The counts that follow are intentionally Work-scoped, not user-scoped:
+ * a Work's fleet summary covers every member's runs on that Work, which
+ * is exactly what the per-Work cockpit shows.
+ */
+@ApiTags('works')
+@Controller('api')
+export class WorkRunsController {
+    constructor(
+        private readonly ownership: WorkOwnershipService,
+        private readonly agentRuns: AgentRunRepository,
+    ) {}
+
+    @Get('works/:id/runs-summary')
+    @ApiOperation({
+        summary: 'Per-Work AgentRun summary counts (running / queued / awaiting / failedLast24h).',
+    })
+    @HttpCode(HttpStatus.OK)
+    async runsSummary(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ): Promise<{ running: number; queued: number; awaiting: number; failedLast24h: number }> {
+        await this.ownership.ensureAccess(id, auth.userId);
+        return this.agentRuns.summarizeForWork(id);
+    }
+}

--- a/apps/api/src/works/works.module.ts
+++ b/apps/api/src/works/works.module.ts
@@ -12,9 +12,13 @@ import { ActivityLogModule } from '@ever-works/agent/activity-log';
 import { ItemsGeneratorModule } from '@ever-works/agent/items-generator';
 import { ActivityFeedModule } from './activity-feed/activity-feed.module';
 import { OrganizationsModule } from '../organizations/organizations.module';
+// Run orchestration (Wave 4 M3) — AgentsModule exports AgentRunRepository
+// for the per-Work runs-summary endpoint (DatabaseModule does not provide it).
+import { AgentsModule } from '@ever-works/agent/agents';
 
 // Controllers
 import { WorksController } from './works.controller';
+import { WorkRunsController } from './work-runs.controller';
 import { MembersController } from './members.controller';
 import { InvitationsController } from './invitations.controller';
 import { BulkItemsController } from './bulk-items.controller';
@@ -52,6 +56,9 @@ import { WorkScheduleDispatcherCronService } from './tasks/work-schedule-dispatc
         // tenant-ownership guard OrgKbController uses to authorize its
         // raw `/api/organizations/:orgId/...` routes.
         OrganizationsModule,
+        // Run orchestration (Wave 4 M3) — AgentRunRepository for the
+        // per-Work runs-summary endpoint.
+        AgentsModule,
     ],
     providers: [
         CacheEntryRepository,
@@ -100,6 +107,8 @@ import { WorkScheduleDispatcherCronService } from './tasks/work-schedule-dispatc
     ],
     controllers: [
         WorksController,
+        // Wave 4 M3 — per-Work AgentRun summary counts.
+        WorkRunsController,
         MembersController,
         InvitationsController,
         BulkItemsController,

--- a/packages/agent/src/agents/__tests__/agent-run-sweeper.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-sweeper.service.spec.ts
@@ -61,6 +61,44 @@ describe('AgentRunSweeperService', () => {
         jest.restoreAllMocks();
     });
 
+    describe('Wave 4 M2 — drain safety net', () => {
+        function makeGatedSvc(gate: any): AgentRunSweeperService {
+            const svc = new AgentRunSweeperService(runs, gate);
+            jest.spyOn(
+                (svc as never as { logger: { warn: () => void } }).logger,
+                'warn',
+            ).mockImplementation(() => undefined);
+            jest.spyOn(
+                (svc as never as { logger: { log: () => void } }).logger,
+                'log',
+            ).mockImplementation(() => undefined);
+            return svc;
+        }
+
+        it('drains each affected Work exactly once after reaping stuck runs', async () => {
+            runs.findStuckNonTerminal.mockResolvedValue([
+                stuckRow({ id: 'r1', workId: 'work-a' }),
+                stuckRow({ id: 'r2', workId: 'work-a' }),
+                stuckRow({ id: 'r3', workId: 'work-b' }),
+                stuckRow({ id: 'r4', workId: null }),
+            ]);
+            runs.markStuckFailed.mockResolvedValue(4);
+            const gate = { drainForWork: jest.fn().mockResolvedValue({ dispatched: true }) };
+            await makeGatedSvc(gate).sweepStuckRuns();
+            expect(gate.drainForWork).toHaveBeenCalledTimes(2);
+            expect(gate.drainForWork).toHaveBeenCalledWith('work-a');
+            expect(gate.drainForWork).toHaveBeenCalledWith('work-b');
+        });
+
+        it('does not drain when the CAS lost every row (nothing was freed)', async () => {
+            runs.findStuckNonTerminal.mockResolvedValue([stuckRow({ workId: 'work-a' })]);
+            runs.markStuckFailed.mockResolvedValue(0);
+            const gate = { drainForWork: jest.fn() };
+            await makeGatedSvc(gate).sweepStuckRuns();
+            expect(gate.drainForWork).not.toHaveBeenCalled();
+        });
+    });
+
     it('⭐ reaps a run older than the cutoff', async () => {
         // THE NO-OP CATCHER. An implementation that returns { swept: 0 }
         // unconditionally passes every safety test in this file — only this

--- a/packages/agent/src/agents/__tests__/run-dispatch-gate.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-dispatch-gate.service.spec.ts
@@ -1,0 +1,215 @@
+import { QUEUED_REASON_CONCURRENCY, RunDispatchGateService } from '../run-dispatch-gate.service';
+
+/**
+ * Run orchestration (Wave 4 M2) — dispatch-gate contract:
+ * admit under/over the per-Work and per-org/user valves, valve
+ * disabling, per-Work counter isolation, and the drain path
+ * (oldest-first promotion, CAS claim, dispatch failure posture).
+ */
+describe('RunDispatchGateService', () => {
+    const ENV_KEYS = [
+        'AGENT_MAX_CONCURRENT_RUNS_PER_WORK',
+        'AGENT_MAX_CONCURRENT_RUNS_PER_ORG',
+    ] as const;
+    const savedEnv: Record<string, string | undefined> = {};
+
+    let runs: any;
+    let dispatcher: any;
+
+    beforeEach(() => {
+        for (const key of ENV_KEYS) {
+            savedEnv[key] = process.env[key];
+            delete process.env[key];
+        }
+        runs = {
+            countInFlightForWork: jest.fn().mockResolvedValue(0),
+            countInFlightForUser: jest.fn().mockResolvedValue(0),
+            countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+            findOldestQueuedForConcurrency: jest.fn().mockResolvedValue(null),
+            claimQueuedForDispatch: jest.fn().mockResolvedValue(true),
+            restoreQueuedReason: jest.fn().mockResolvedValue(undefined),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+        };
+        dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
+    });
+
+    afterEach(() => {
+        for (const key of ENV_KEYS) {
+            if (savedEnv[key] === undefined) delete process.env[key];
+            else process.env[key] = savedEnv[key];
+        }
+    });
+
+    const makeGate = (withDispatcher = true) =>
+        new RunDispatchGateService(runs, withDispatcher ? dispatcher : undefined);
+
+    const parkedRun = (over: Record<string, unknown> = {}) => ({
+        id: 'run-parked',
+        agentId: 'agent-1',
+        userId: 'user-1',
+        taskId: 'task-1',
+        workId: 'work-1',
+        organizationId: null,
+        status: 'queued',
+        queuedReason: QUEUED_REASON_CONCURRENCY,
+        ...over,
+    });
+
+    describe('admit', () => {
+        it('admits under the per-Work limit', async () => {
+            runs.countInFlightForWork.mockResolvedValueOnce(9); // default limit 10
+            const result = await makeGate().admit({ userId: 'user-1', workId: 'work-1' });
+            expect(result).toEqual({ admitted: true });
+            expect(runs.countInFlightForWork).toHaveBeenCalledWith('work-1');
+        });
+
+        it('queues at/over the per-Work limit with the concurrency reason', async () => {
+            runs.countInFlightForWork.mockResolvedValueOnce(10); // default limit 10
+            const result = await makeGate().admit({ userId: 'user-1', workId: 'work-1' });
+            expect(result).toEqual({
+                admitted: false,
+                queuedReason: QUEUED_REASON_CONCURRENCY,
+            });
+        });
+
+        it('honours the env-configured per-Work valve (configurable, not hardcoded)', async () => {
+            process.env.AGENT_MAX_CONCURRENT_RUNS_PER_WORK = '2';
+            runs.countInFlightForWork.mockResolvedValueOnce(2);
+            const result = await makeGate().admit({ userId: 'user-1', workId: 'work-1' });
+            expect(result.admitted).toBe(false);
+        });
+
+        it('a per-Work valve of 0 disables the Work limit entirely', async () => {
+            process.env.AGENT_MAX_CONCURRENT_RUNS_PER_WORK = '0';
+            const result = await makeGate().admit({ userId: 'user-1', workId: 'work-1' });
+            expect(result.admitted).toBe(true);
+            expect(runs.countInFlightForWork).not.toHaveBeenCalled();
+        });
+
+        it('counts per-org when an organizationId is present, per-user otherwise', async () => {
+            const gate = makeGate();
+            await gate.admit({ userId: 'user-1', workId: null, organizationId: 'org-1' });
+            expect(runs.countInFlightForOrganization).toHaveBeenCalledWith('org-1');
+            expect(runs.countInFlightForUser).not.toHaveBeenCalled();
+
+            await gate.admit({ userId: 'user-1', workId: null });
+            expect(runs.countInFlightForUser).toHaveBeenCalledWith('user-1');
+        });
+
+        it('queues over the org/user valve even when the Work has capacity', async () => {
+            runs.countInFlightForWork.mockResolvedValueOnce(1);
+            runs.countInFlightForUser.mockResolvedValueOnce(25); // default org valve 25
+            const result = await makeGate().admit({ userId: 'user-1', workId: 'work-1' });
+            expect(result).toEqual({
+                admitted: false,
+                queuedReason: QUEUED_REASON_CONCURRENCY,
+            });
+        });
+
+        it('isolates counters per Work — a saturated Work A never blocks Work B', async () => {
+            const counts: Record<string, number> = { 'work-a': 10, 'work-b': 0 };
+            runs.countInFlightForWork.mockImplementation(async (workId: string) => {
+                return counts[workId] ?? 0;
+            });
+            const gate = makeGate();
+            const a = await gate.admit({ userId: 'user-1', workId: 'work-a' });
+            const b = await gate.admit({ userId: 'user-1', workId: 'work-b' });
+            expect(a.admitted).toBe(false);
+            expect(b.admitted).toBe(true);
+            expect(runs.countInFlightForWork).toHaveBeenCalledWith('work-a');
+            expect(runs.countInFlightForWork).toHaveBeenCalledWith('work-b');
+        });
+
+        it('skips the Work valve for Work-less runs but still applies the user valve', async () => {
+            runs.countInFlightForUser.mockResolvedValueOnce(0);
+            const result = await makeGate().admit({ userId: 'user-1' });
+            expect(result.admitted).toBe(true);
+            expect(runs.countInFlightForWork).not.toHaveBeenCalled();
+            expect(runs.countInFlightForUser).toHaveBeenCalledWith('user-1');
+        });
+    });
+
+    describe('drainForWork', () => {
+        it('promotes the oldest parked run: claims it and dispatches with its runId', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            const result = await makeGate().drainForWork('work-1');
+            expect(runs.findOldestQueuedForConcurrency).toHaveBeenCalledWith(
+                'work-1',
+                QUEUED_REASON_CONCURRENCY,
+            );
+            expect(runs.claimQueuedForDispatch).toHaveBeenCalledWith(
+                'run-parked',
+                QUEUED_REASON_CONCURRENCY,
+            );
+            expect(dispatcher.enqueue).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    agentId: 'agent-1',
+                    userId: 'user-1',
+                    taskId: 'task-1',
+                    runId: 'run-parked',
+                }),
+            );
+            expect(runs.setTriggerRunId).toHaveBeenCalledWith('run-parked', 'trd-1');
+            expect(result).toEqual({ dispatched: true, runId: 'run-parked' });
+        });
+
+        it('no-ops when no parked run exists for the Work', async () => {
+            const result = await makeGate().drainForWork('work-1');
+            expect(result).toEqual({ dispatched: false, reason: 'no-candidate' });
+            expect(dispatcher.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('leaves the run parked while the Work is still over its limit', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            runs.countInFlightForWork.mockResolvedValueOnce(10);
+            const result = await makeGate().drainForWork('work-1');
+            expect(result).toEqual({ dispatched: false, reason: 'over-limit' });
+            expect(runs.claimQueuedForDispatch).not.toHaveBeenCalled();
+            expect(dispatcher.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('does not double-dispatch when another drain wins the CAS claim', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            runs.claimQueuedForDispatch.mockResolvedValueOnce(false);
+            const result = await makeGate().drainForWork('work-1');
+            expect(result).toEqual({ dispatched: false, reason: 'claim-lost' });
+            expect(dispatcher.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('reports no-dispatcher without claiming when the dispatcher is unbound', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            const result = await makeGate(false).drainForWork('work-1');
+            expect(result).toEqual({ dispatched: false, reason: 'no-dispatcher' });
+            // The row was never claimed, so it stays parked and drainable.
+            expect(runs.claimQueuedForDispatch).not.toHaveBeenCalled();
+        });
+
+        it('marks the drained run dispatch-failed when the enqueue throws', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            dispatcher.enqueue.mockRejectedValueOnce(new Error('Trigger.dev down'));
+            const result = await makeGate().drainForWork('work-1');
+            expect(result).toEqual({ dispatched: false, reason: 'dispatch-failed' });
+            expect(runs.markDispatchFailed).toHaveBeenCalledWith(
+                'run-parked',
+                expect.stringContaining('dispatch-failed: Trigger.dev down'),
+            );
+        });
+
+        it('never throws — a repository failure is reported, not raised', async () => {
+            runs.findOldestQueuedForConcurrency.mockRejectedValueOnce(new Error('DB down'));
+            await expect(makeGate().drainForWork('work-1')).resolves.toEqual({
+                dispatched: false,
+                reason: 'dispatch-failed',
+            });
+        });
+
+        it('uses a run-scoped dedup key so a double drain dedups at the runner', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedRun());
+            await makeGate().drainForWork('work-1');
+            expect(dispatcher.enqueue).toHaveBeenCalledWith(
+                expect.objectContaining({ dedupKey: 'task-1:agent-1:drain:run-parked' }),
+            );
+        });
+    });
+});

--- a/packages/agent/src/agents/agent-run-sweeper.service.ts
+++ b/packages/agent/src/agents/agent-run-sweeper.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { config } from '../config';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import { RunDispatchGateService } from './run-dispatch-gate.service';
 
 /**
  * Error message prefix for a swept run.
@@ -47,7 +48,13 @@ export interface AgentRunSweepSummary {
 export class AgentRunSweeperService {
     private readonly logger = new Logger(AgentRunSweeperService.name);
 
-    constructor(private readonly runs: AgentRunRepository) {}
+    constructor(
+        private readonly runs: AgentRunRepository,
+        // Run orchestration (Wave 4 M2) — drain safety net: after reaping
+        // stuck runs, promote parked runs for the affected Works. Appended
+        // LAST + Optional so positional spec constructors keep compiling.
+        @Optional() private readonly dispatchGate?: RunDispatchGateService,
+    ) {}
 
     /**
      * Zero-arg by design: the worker resolves this service as a superjson RPC
@@ -114,6 +121,20 @@ export class AgentRunSweeperService {
             this.logger.warn(
                 `AgentRun sweep: batch limit ${limit} reached — more stuck runs remain, next tick will continue`,
             );
+        }
+
+        // Run orchestration (Wave 4 M2) — drain safety net. Every reaped
+        // run may have freed a concurrency slot; promote the oldest parked
+        // run for each affected Work. Best-effort by contract (the gate
+        // never throws from drainForWork), and only when rows actually
+        // transitioned — a lost CAS race freed nothing.
+        if (this.dispatchGate && swept > 0) {
+            const workIds = [
+                ...new Set(stuck.map((r) => r.workId).filter((w): w is string => !!w)),
+            ];
+            for (const workId of workIds) {
+                await this.dispatchGate.drainForWork(workId);
+            }
         }
 
         return {

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -25,6 +25,7 @@ import { AgentRunSweeperService } from './agent-run-sweeper.service';
 import { AgentExportService } from './agent-export.service';
 import { PromptAssemblerService } from './prompt-assembler.service';
 import { AgentRunService } from './agent-run.service';
+import { RunDispatchGateService } from './run-dispatch-gate.service';
 import { AgentToolService } from './agent-tool.service';
 import { VisionContextService } from '../services/vision-context.service';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
@@ -90,6 +91,10 @@ import { FacadesModule } from '../facades/facades.module';
         // appended COMPANY VISION segment (@Optional() injection).
         VisionContextService,
         AgentRunService,
+        // Wave 4 M2 — concurrency choke point for run dispatch. The
+        // AGENT_TASK_EXECUTE_DISPATCHER it drains through is @Optional()
+        // and bound by the api-side @Global() TasksModule.
+        RunDispatchGateService,
         AgentToolService,
     ],
     exports: [
@@ -106,6 +111,7 @@ import { FacadesModule } from '../facades/facades.module';
         AgentExportService,
         PromptAssemblerService,
         AgentRunService,
+        RunDispatchGateService,
         AgentToolService,
     ],
 })

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -7,6 +7,7 @@ export * from './agent-schedule-dispatcher.service';
 export * from './agent-export.service';
 export * from './prompt-assembler.service';
 export * from './agent-run.service';
+export * from './run-dispatch-gate.service';
 export * from './agent-run-canceller';
 export * from './agent-run-abort';
 export * from './agent-run-sweeper.service';

--- a/packages/agent/src/agents/run-dispatch-gate.service.ts
+++ b/packages/agent/src/agents/run-dispatch-gate.service.ts
@@ -1,0 +1,217 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { config } from '../config';
+import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import {
+    AGENT_TASK_EXECUTE_DISPATCHER,
+    JOB_RUNTIME_NOT_CONFIGURED_REASON,
+    type AgentTaskExecuteDispatcher,
+} from '../tasks-domain/task-dispatcher';
+
+/**
+ * Stable machine token stamped into `agent_runs.queuedReason` when the
+ * gate parks a run instead of dispatching it. The drain looks rows up by
+ * this exact literal — one shared constant, never three drifting copies.
+ */
+export const QUEUED_REASON_CONCURRENCY = 'concurrency-limit' as const;
+
+export interface RunDispatchAdmitInput {
+    userId: string;
+    workId?: string | null;
+    organizationId?: string | null;
+}
+
+export interface RunDispatchAdmitResult {
+    admitted: boolean;
+    /** Set only when `admitted === false`; today always `concurrency-limit`. */
+    queuedReason?: string;
+}
+
+export interface RunDispatchDrainResult {
+    dispatched: boolean;
+    runId?: string;
+    reason?: 'no-candidate' | 'over-limit' | 'claim-lost' | 'no-dispatcher' | 'dispatch-failed';
+}
+
+/**
+ * Run orchestration (Wave 4 M2) — the single concurrency choke point for
+ * agent-run dispatch.
+ *
+ * `admit()` counts in-flight runs (`running` + dispatched-`queued`) per
+ * Work and per org/user against CONFIGURABLE safety valves
+ * (`AGENT_MAX_CONCURRENT_RUNS_PER_WORK`, default 10;
+ * `AGENT_MAX_CONCURRENT_RUNS_PER_ORG`, default 25; `<= 0` disables the
+ * valve). These are operator knobs, never product limits. A per-Work
+ * override column (`works.maxConcurrentAgentRuns`, works.yml v2) is the
+ * documented next step — it will slot in ahead of the env default inside
+ * `resolveWorkLimit()` without touching any caller.
+ *
+ * Over-limit dispatch paths create the run anyway (`status='queued'`,
+ * `queuedReason='concurrency-limit'`) and skip the job-runtime enqueue.
+ * `drainForWork()` promotes the OLDEST parked run for a Work — called on
+ * terminal transitions (worker terminal writes, user cancel) and from the
+ * stuck-run sweeper as the safety net.
+ *
+ * Races: the count is check-then-insert without an advisory lock (the
+ * e2e suite runs on sqlite, which has none), so a parallel burst can
+ * transiently exceed a valve by the burst width. Acceptable for a safety
+ * valve; the CAS claim in `claimQueuedForDispatch` is what prevents the
+ * harmful race — two drains double-dispatching one run.
+ */
+@Injectable()
+export class RunDispatchGateService {
+    private readonly logger = new Logger(RunDispatchGateService.name);
+
+    constructor(
+        private readonly runs: AgentRunRepository,
+        // Bound by the api-side @Global() TasksModule; absent in unit
+        // tests and installs without a job runtime — admit() still
+        // works, drain reports `no-dispatcher`.
+        @Optional()
+        @Inject(AGENT_TASK_EXECUTE_DISPATCHER)
+        private readonly dispatcher?: AgentTaskExecuteDispatcher,
+    ) {}
+
+    /** Env default today; per-Work override column when it lands. */
+    private resolveWorkLimit(): number {
+        return config.agents.getMaxConcurrentRunsPerWork();
+    }
+
+    private resolveOrgLimit(): number {
+        return config.agents.getMaxConcurrentRunsPerOrg();
+    }
+
+    /**
+     * Decide whether a new run may be handed to the job runtime NOW.
+     * Never throws on its own account — callers treat a thrown counting
+     * failure as fail-open (a broken safety valve must not stop work).
+     */
+    async admit(input: RunDispatchAdmitInput): Promise<RunDispatchAdmitResult> {
+        const workLimit = this.resolveWorkLimit();
+        if (input.workId && workLimit > 0) {
+            const inFlight = await this.runs.countInFlightForWork(input.workId);
+            if (inFlight >= workLimit) {
+                this.logger.log(
+                    `Dispatch gate: Work ${input.workId} at ${inFlight}/${workLimit} in-flight runs — queueing.`,
+                );
+                return { admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY };
+            }
+        }
+
+        const orgLimit = this.resolveOrgLimit();
+        if (orgLimit > 0) {
+            const inFlight = input.organizationId
+                ? await this.runs.countInFlightForOrganization(input.organizationId)
+                : await this.runs.countInFlightForUser(input.userId);
+            if (inFlight >= orgLimit) {
+                this.logger.log(
+                    `Dispatch gate: ${
+                        input.organizationId
+                            ? `org ${input.organizationId}`
+                            : `user ${input.userId}`
+                    } at ${inFlight}/${orgLimit} in-flight runs — queueing.`,
+                );
+                return { admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY };
+            }
+        }
+
+        return { admitted: true };
+    }
+
+    /**
+     * Promote the oldest concurrency-parked run for a Work, if capacity
+     * allows. One promotion per call on purpose: every terminal
+     * transition frees at most one slot, and the next terminal (or the
+     * sweeper net) drains the next row. Best-effort by contract — every
+     * failure is logged and reported in the result, never thrown, so a
+     * drain hiccup can never fail the terminal transition that hosts it.
+     */
+    async drainForWork(workId: string): Promise<RunDispatchDrainResult> {
+        try {
+            const candidate = await this.runs.findOldestQueuedForConcurrency(
+                workId,
+                QUEUED_REASON_CONCURRENCY,
+            );
+            if (!candidate) return { dispatched: false, reason: 'no-candidate' };
+            if (!candidate.taskId) {
+                // Only the task dispatch path parks runs today; a parked
+                // run without a Task cannot be re-dispatched through the
+                // agent-task-execute path. Surface loudly.
+                this.logger.warn(
+                    `Dispatch gate: parked run ${candidate.id} has no taskId — cannot drain.`,
+                );
+                return { dispatched: false, reason: 'no-candidate' };
+            }
+
+            const admission = await this.admit({
+                userId: candidate.userId,
+                workId,
+                organizationId: candidate.organizationId ?? null,
+            });
+            if (!admission.admitted) return { dispatched: false, reason: 'over-limit' };
+
+            if (!this.dispatcher) {
+                // Nothing to dispatch through — leave the row parked (it
+                // was never claimed) and tell the caller why.
+                return { dispatched: false, reason: 'no-dispatcher' };
+            }
+
+            const claimed = await this.runs.claimQueuedForDispatch(
+                candidate.id,
+                QUEUED_REASON_CONCURRENCY,
+            );
+            if (!claimed) return { dispatched: false, reason: 'claim-lost' };
+
+            try {
+                const handle = await this.dispatcher.enqueue({
+                    agentId: candidate.agentId,
+                    userId: candidate.userId,
+                    taskId: candidate.taskId,
+                    // Unique per parked row — the original generation-based
+                    // key is unknowable here, and this run was never handed
+                    // to the runtime, so a run-scoped key both dedups a
+                    // double drain at the runner AND cannot collide with the
+                    // fan-out key of the run that was admitted immediately.
+                    dedupKey: `${candidate.taskId}:${candidate.agentId}:drain:${candidate.id}`,
+                    runId: candidate.id,
+                });
+                if (handle?.runId) {
+                    try {
+                        await this.runs.setTriggerRunId(candidate.id, handle.runId);
+                    } catch (stampErr) {
+                        this.logger.warn(
+                            `Dispatch gate: failed to stamp triggerRunId on drained run ${candidate.id}: ${stampErr}`,
+                        );
+                    }
+                }
+                this.logger.log(
+                    `Dispatch gate: drained run ${candidate.id} for Work ${workId} (task ${candidate.taskId}).`,
+                );
+                return { dispatched: true, runId: candidate.id };
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                const notConfigured =
+                    err instanceof Error && err.name === 'JobRuntimeNotConfiguredError';
+                const reason = notConfigured
+                    ? `${JOB_RUNTIME_NOT_CONFIGURED_REASON}: ${message}`
+                    : `dispatch-failed: ${message}`;
+                this.logger.warn(
+                    `Dispatch gate: drain enqueue failed for ${candidate.id}: ${reason}`,
+                );
+                // Same posture as the fan-out path: a run whose enqueue
+                // threw is rolled to failed (CAS queued-only, so a runtime
+                // that accepted the job anyway keeps its live run).
+                try {
+                    await this.runs.markDispatchFailed(candidate.id, reason);
+                } catch (failErr) {
+                    this.logger.warn(
+                        `Dispatch gate: failed to mark drained run ${candidate.id} failed: ${failErr}`,
+                    );
+                }
+                return { dispatched: false, reason: 'dispatch-failed' };
+            }
+        } catch (err) {
+            this.logger.warn(`Dispatch gate: drainForWork(${workId}) failed: ${err}`);
+            return { dispatched: false, reason: 'dispatch-failed' };
+        }
+    }
+}

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -585,6 +585,28 @@ export const config = {
             const raw = parseInt(process.env.AGENT_RUN_STUCK_SWEEP_BATCH || '200', 10);
             return Number.isFinite(raw) && raw > 0 ? raw : 200;
         },
+        /**
+         * Run orchestration (Wave 4 M2) — concurrency safety valves for
+         * `RunDispatchGateService`. These are operator knobs, NOT product
+         * limits: defaults are deliberately generous (10 in-flight runs
+         * per Work, 25 per org/user) and `0` / negative disables the
+         * respective valve entirely.
+         *
+         * Future per-Work override: a nullable
+         * `works.maxConcurrentAgentRuns` column (works.yml v2 field +
+         * Work settings UI) will take precedence over this env default
+         * when it lands — the gate already resolves limits through these
+         * getters so only the resolution chain grows.
+         */
+        getMaxConcurrentRunsPerWork() {
+            const raw = parseInt(process.env.AGENT_MAX_CONCURRENT_RUNS_PER_WORK || '10', 10);
+            return Number.isFinite(raw) ? raw : 10;
+        },
+        /** Per-org (or, for org-less personal runs, per-user) valve. */
+        getMaxConcurrentRunsPerOrg() {
+            const raw = parseInt(process.env.AGENT_MAX_CONCURRENT_RUNS_PER_ORG || '25', 10);
+            return Number.isFinite(raw) ? raw : 25;
+        },
     },
 
     /**

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -156,14 +156,25 @@ export class AgentRunRepository {
          * worker had not yet reached `markStarted`.
          */
         triggerRunId?: string | null;
+        /**
+         * Wave 4 M2 — denormalized Work scope of the cancelled row, so the
+         * caller can drain the concurrency queue for that Work after a
+         * successful cancel. Null for Work-less runs.
+         */
+        workId?: string | null;
     }> {
         const run = await this.repository.findOne({
             where: { id: runId, userId },
-            select: ['id', 'status', 'triggerRunId'],
+            select: ['id', 'status', 'triggerRunId', 'workId'],
         });
         if (!run) return { found: false };
         if (run.status !== 'queued' && run.status !== 'running') {
-            return { found: true, previousStatus: run.status, triggerRunId: run.triggerRunId };
+            return {
+                found: true,
+                previousStatus: run.status,
+                triggerRunId: run.triggerRunId,
+                workId: run.workId ?? null,
+            };
         }
         const result = await this.repository
             .createQueryBuilder()
@@ -190,9 +201,15 @@ export class AgentRunRepository {
                 // Re-read: the worker may have stamped `triggerRunId` via
                 // markStarted between our first read and this CAS.
                 triggerRunId: fresh?.triggerRunId ?? run.triggerRunId,
+                workId: run.workId ?? null,
             };
         }
-        return { found: true, previousStatus: run.status, triggerRunId: run.triggerRunId };
+        return {
+            found: true,
+            previousStatus: run.status,
+            triggerRunId: run.triggerRunId,
+            workId: run.workId ?? null,
+        };
     }
 
     /**
@@ -218,7 +235,10 @@ export class AgentRunRepository {
         cutoff: Date,
         limit: number,
     ): Promise<
-        Pick<AgentRun, 'id' | 'agentId' | 'triggerKind' | 'status' | 'startedAt' | 'createdAt'>[]
+        Pick<
+            AgentRun,
+            'id' | 'agentId' | 'triggerKind' | 'status' | 'startedAt' | 'createdAt' | 'workId'
+        >[]
     > {
         return this.repository
             .createQueryBuilder('run')
@@ -229,6 +249,9 @@ export class AgentRunRepository {
                 'run.status',
                 'run.startedAt',
                 'run.createdAt',
+                // Wave 4 M2 — the sweeper drains the concurrency queue for
+                // every Work whose stuck run it just reaped.
+                'run.workId',
             ])
             .where('run.status IN (:...statuses)', { statuses: NON_TERMINAL })
             .andWhere('COALESCE(run.startedAt, run.createdAt) <= :cutoff', { cutoff })
@@ -268,6 +291,13 @@ export class AgentRunRepository {
         triggerKind: AgentRunTriggerKind;
         taskId?: string | null;
         chatMessageId?: string | null;
+        /** Wave 4 M1 — denormalized from `task.workId` at creation when present. */
+        workId?: string | null;
+        /** Wave 4 M2 — set to `concurrency-limit` when the dispatch gate parks the run. */
+        queuedReason?: string | null;
+        /** Wave 4 M1 — pipeline plugin id when known at creation. */
+        runnerKind?: string | null;
+        organizationId?: string | null;
     }): Promise<AgentRun> {
         const run = this.repository.create({
             agentId: args.agentId,
@@ -276,6 +306,12 @@ export class AgentRunRepository {
             status: 'queued',
             taskId: args.taskId ?? null,
             chatMessageId: args.chatMessageId ?? null,
+            workId: args.workId ?? null,
+            queuedReason: args.queuedReason ?? null,
+            runnerKind: args.runnerKind ?? null,
+            // Only stamp when explicitly provided — the ambient scope
+            // subscriber (EW-657) remains the default writer.
+            ...(args.organizationId !== undefined ? { organizationId: args.organizationId } : {}),
         });
         return this.repository.save(run);
     }
@@ -534,5 +570,168 @@ export class AgentRunRepository {
             })
             .orderBy('run.createdAt', 'DESC')
             .getOne();
+    }
+
+    // ── Run orchestration (Wave 4 M2/M3) ───────────────────────────
+
+    /**
+     * In-flight = `running`, plus `queued` rows that were actually handed
+     * to the job runtime (`queuedReason IS NULL`). Rows parked by the
+     * dispatch gate (`queuedReason = 'concurrency-limit'`) are WAITING for
+     * capacity, not consuming it — counting them would deadlock the drain:
+     * the parked run itself would keep the count at the limit forever.
+     */
+    private inFlightQb(alias = 'run') {
+        return this.repository
+            .createQueryBuilder(alias)
+            .where(`${alias}.status IN (:...statuses)`, {
+                statuses: ['queued', 'running'] satisfies AgentRunStatus[],
+            })
+            .andWhere(`${alias}.queuedReason IS NULL`);
+    }
+
+    /** Per-Work in-flight count for the dispatch gate. */
+    async countInFlightForWork(workId: string): Promise<number> {
+        return this.inFlightQb().andWhere('run.workId = :workId', { workId }).getCount();
+    }
+
+    /** Per-user in-flight count (the org valve for org-less personal runs). */
+    async countInFlightForUser(userId: string): Promise<number> {
+        return this.inFlightQb().andWhere('run.userId = :userId', { userId }).getCount();
+    }
+
+    /** Per-organization in-flight count for the dispatch gate. */
+    async countInFlightForOrganization(organizationId: string): Promise<number> {
+        return this.inFlightQb()
+            .andWhere('run.organizationId = :organizationId', { organizationId })
+            .getCount();
+    }
+
+    /**
+     * Oldest run parked by the dispatch gate for this Work — FIFO drain
+     * order (priority-aware ordering is a documented later milestone).
+     */
+    async findOldestQueuedForConcurrency(
+        workId: string,
+        queuedReason: string,
+    ): Promise<AgentRun | null> {
+        return this.repository
+            .createQueryBuilder('run')
+            .where('run.workId = :workId', { workId })
+            .andWhere('run.status = :status', { status: 'queued' satisfies AgentRunStatus })
+            .andWhere('run.queuedReason = :queuedReason', { queuedReason })
+            .orderBy('run.createdAt', 'ASC')
+            .getOne();
+    }
+
+    /**
+     * CAS-claim a parked run for dispatch: clears `queuedReason` only
+     * while the row is still `queued` AND still parked, so two drains
+     * racing for the same run resolve to exactly one dispatcher. Returns
+     * whether THIS caller won the claim.
+     */
+    async claimQueuedForDispatch(runId: string, queuedReason: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({ queuedReason: null })
+            .where('id = :id', { id: runId })
+            .andWhere('status = :status', { status: 'queued' satisfies AgentRunStatus })
+            .andWhere('queuedReason = :queuedReason', { queuedReason })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Roll a drain-claimed run back to parked after its dispatch could
+     * not be attempted (no dispatcher bound). No-clobber: only a still-
+     * `queued` row with a cleared reason is restored.
+     */
+    async restoreQueuedReason(runId: string, queuedReason: string): Promise<void> {
+        await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({ queuedReason })
+            .where('id = :id', { id: runId })
+            .andWhere('status = :status', { status: 'queued' satisfies AgentRunStatus })
+            .andWhere('queuedReason IS NULL')
+            .execute();
+    }
+
+    /**
+     * Sessions list (Wave 4 M3) — owner-scoped, filterable, paginated.
+     * `userId` is mandatory and always applied at the repository layer:
+     * this is the HTTP-facing method, so cross-user rows must be
+     * unreachable even if a future controller forgets its own guard.
+     */
+    async listSessionsForUser(
+        userId: string,
+        filters: {
+            status?: AgentRunStatus;
+            workId?: string;
+            agentId?: string;
+            triggerKind?: AgentRunTriggerKind;
+        },
+        limit = 25,
+        offset = 0,
+    ): Promise<[AgentRun[], number]> {
+        const qb = this.repository
+            .createQueryBuilder('run')
+            .where('run.userId = :userId', { userId });
+        if (filters.status) {
+            qb.andWhere('run.status = :status', { status: filters.status });
+        }
+        if (filters.workId) {
+            qb.andWhere('run.workId = :workId', { workId: filters.workId });
+        }
+        if (filters.agentId) {
+            qb.andWhere('run.agentId = :agentId', { agentId: filters.agentId });
+        }
+        if (filters.triggerKind) {
+            qb.andWhere('run.triggerKind = :triggerKind', { triggerKind: filters.triggerKind });
+        }
+        return qb.orderBy('run.createdAt', 'DESC').take(limit).skip(offset).getManyAndCount();
+    }
+
+    /**
+     * Per-Work session summary (Wave 4 M3) — one grouped scan over
+     * `(workId, status)` instead of four counts. CASE/SUM is portable
+     * across Postgres and sqlite (the e2e suite runs on sqlite);
+     * `awaitingInput = :true` binds a real boolean so both drivers
+     * compare their native representation.
+     */
+    async summarizeForWork(workId: string): Promise<{
+        running: number;
+        queued: number;
+        awaiting: number;
+        failedLast24h: number;
+    }> {
+        const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+        const raw = await this.repository
+            .createQueryBuilder('run')
+            .select(`SUM(CASE WHEN run.status = 'running' THEN 1 ELSE 0 END)`, 'running')
+            .addSelect(`SUM(CASE WHEN run.status = 'queued' THEN 1 ELSE 0 END)`, 'queued')
+            .addSelect(
+                `SUM(CASE WHEN run.awaitingInput = :isAwaiting AND run.status IN ('queued', 'running') THEN 1 ELSE 0 END)`,
+                'awaiting',
+            )
+            .addSelect(
+                `SUM(CASE WHEN run.status = 'failed' AND run.finishedAt >= :cutoff THEN 1 ELSE 0 END)`,
+                'failedLast24h',
+            )
+            .where('run.workId = :workId', { workId })
+            .setParameters({ isAwaiting: true, cutoff })
+            .getRawOne<{
+                running: string | number | null;
+                queued: string | number | null;
+                awaiting: string | number | null;
+                failedLast24h: string | number | null;
+            }>();
+        return {
+            running: Number(raw?.running ?? 0),
+            queued: Number(raw?.queued ?? 0),
+            awaiting: Number(raw?.awaiting ?? 0),
+            failedLast24h: Number(raw?.failedLast24h ?? 0),
+        };
     }
 }

--- a/packages/agent/src/entities/agent-run.entity.ts
+++ b/packages/agent/src/entities/agent-run.entity.ts
@@ -38,6 +38,9 @@ export type AgentRunStatus = 'queued' | 'running' | 'completed' | 'failed' | 'ca
 @Index('idx_agent_runs_status', ['status'])
 @Index('idx_agent_runs_task', ['taskId'])
 @Index('idx_agent_runs_chat_message', ['chatMessageId'])
+// Run orchestration (Wave 4 M1) — cheap per-Work concurrency counts +
+// Sessions-view grouping both scan (workId, status).
+@Index('idx_agent_runs_work_status', ['workId', 'status'])
 export class AgentRun {
     @PrimaryGeneratedColumn('uuid')
     id: string;
@@ -213,6 +216,54 @@ export class AgentRun {
     /** Number of files the run has changed in its workspace so far. */
     @Column({ type: 'int', nullable: true })
     changedFilesCount?: number | null;
+
+    // ── Run orchestration (Wave 4 M1). All additive; NULL/false on
+    // every pre-existing row. The dispatch gate + Sessions list are the
+    // consumers — nothing here changes the status state machine.
+
+    /**
+     * Denormalized Work scope, derived at creation from `task.workId`
+     * when the run is task-attached (NULL otherwise — heartbeat/manual
+     * runs have no Work). Powers per-Work concurrency counts and the
+     * Sessions view's group-by-Work without a join per row.
+     */
+    @Column({ type: 'uuid', nullable: true })
+    workId?: string | null;
+
+    /**
+     * The run is parked on a question/approval for a human. Set by
+     * lifecycle signals (never agent self-report prose); a run in this
+     * state must NEVER be reaped by TTL sweeps. Boolean (not a status
+     * member) so the existing status state machine and every CAS guard
+     * keep working unchanged.
+     */
+    @Column({ type: 'boolean', default: false })
+    awaitingInput: boolean;
+
+    /**
+     * Why a `queued` run has NOT been dispatched to the job runtime.
+     * `concurrency-limit` = parked by `RunDispatchGateService`; NULL =
+     * dispatched (or predates the gate). Cleared when a drain promotes
+     * the run. Short machine token, never free text.
+     */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    queuedReason?: string | null;
+
+    /**
+     * Which pipeline plugin id executes this run (claude-code, codex,
+     * standard-pipeline, …) — the Sessions view's "runs on" chip. NULL
+     * for runs that predate the column or never reported.
+     */
+    @Column({ type: 'varchar', length: 32, nullable: true })
+    runnerKind?: string | null;
+
+    /**
+     * Cumulative cost estimate for this run in integer cents. Sibling
+     * of `totalTokens` (per-run rollup); the per-event source of truth
+     * stays `plugin_usage_events.costCents`.
+     */
+    @Column({ type: 'int', nullable: true })
+    costCents?: number | null;
 
     @CreateDateColumn()
     createdAt: Date;

--- a/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
@@ -231,6 +231,85 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         );
     });
 
+    describe('Wave 4 M2 — dispatch gate routing', () => {
+        const makeGatedSvc = (gate: any) =>
+            new TaskTransitionService(
+                tasks,
+                blocks,
+                approvers,
+                assignees,
+                runs,
+                dispatcher,
+                undefined, // notifications
+                undefined, // runDenorm
+                gate,
+            );
+
+        const toInProgress = async (svc: TaskTransitionService, taskOver: Partial<Task> = {}) => {
+            const task = makeTask({ status: TaskStatus.TODO, ...taskOver });
+            tasks.findById.mockResolvedValueOnce({ ...task, status: TaskStatus.IN_PROGRESS });
+            assignees.findAgentAssignees.mockResolvedValueOnce([
+                { assigneeType: 'agent', assigneeId: 'agent-a' },
+            ]);
+            await svc.transition(task, TaskStatus.IN_PROGRESS);
+            await new Promise((r) => setImmediate(r));
+        };
+
+        it('consults the gate with the Task scope (userId + workId + organizationId)', async () => {
+            const gate = { admit: jest.fn().mockResolvedValue({ admitted: true }) };
+            await toInProgress(makeGatedSvc(gate), {
+                workId: 'work-1',
+                organizationId: 'org-1',
+            } as Partial<Task>);
+            expect(gate.admit).toHaveBeenCalledWith({
+                userId: 'u1',
+                workId: 'work-1',
+                organizationId: 'org-1',
+            });
+            expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
+        });
+
+        it('denormalizes task.workId onto the queued run at creation', async () => {
+            const gate = { admit: jest.fn().mockResolvedValue({ admitted: true }) };
+            await toInProgress(makeGatedSvc(gate), { workId: 'work-1' });
+            expect(runs.createQueued).toHaveBeenCalledWith(
+                expect.objectContaining({ workId: 'work-1', queuedReason: null }),
+            );
+        });
+
+        it('over-limit: parks the run (queuedReason=concurrency-limit) and SKIPS the enqueue', async () => {
+            const gate = {
+                admit: jest
+                    .fn()
+                    .mockResolvedValue({ admitted: false, queuedReason: 'concurrency-limit' }),
+            };
+            await toInProgress(makeGatedSvc(gate), { workId: 'work-1' });
+            expect(runs.createQueued).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    workId: 'work-1',
+                    queuedReason: 'concurrency-limit',
+                }),
+            );
+            expect(dispatcher.enqueue).not.toHaveBeenCalled();
+            // A parked run is not a failed run.
+            expect(runs.markDispatchFailed).not.toHaveBeenCalled();
+        });
+
+        it('fails OPEN when the gate itself throws — a broken valve never stops dispatch', async () => {
+            const gate = { admit: jest.fn().mockRejectedValue(new Error('count query died')) };
+            await toInProgress(makeGatedSvc(gate), { workId: 'work-1' });
+            expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
+            expect(runs.createQueued).toHaveBeenCalledWith(
+                expect.objectContaining({ queuedReason: null }),
+            );
+        });
+
+        it('dispatches ungated when no gate is bound (fixtures + installs without the module)', async () => {
+            await toInProgress(makeSvc(), { workId: 'work-1' });
+            expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
+        });
+    });
+
     it('catches dispatcher failures gracefully when runs repository is missing', async () => {
         const svc = new TaskTransitionService(
             tasks,

--- a/packages/agent/src/tasks-domain/task-chat.service.ts
+++ b/packages/agent/src/tasks-domain/task-chat.service.ts
@@ -148,6 +148,10 @@ export class TaskChatService {
                                   triggerKind: 'chat',
                                   taskId: task.id,
                                   chatMessageId: row.id,
+                                  // Wave 4 M1 — workId denorm at creation so
+                                  // chat-triggered runs count toward (and show
+                                  // under) their Work like task runs do.
+                                  workId: task.workId ?? null,
                               })
                             : null;
                         const handle = await this.chatDispatcher!.enqueue({

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -22,6 +22,11 @@ import {
 } from './task-dispatcher';
 import { TaskNotificationService } from './task-notification.service';
 import { TaskRunDenormService } from './task-run-denorm.service';
+// Value import (not `import type`): Nest resolves the @Optional() class
+// injection below via emitted design:paramtypes metadata, which needs the
+// real class reference. No cycle: run-dispatch-gate.service imports only
+// task-dispatcher (leaf), the run repository, and config.
+import { RunDispatchGateService } from '../agents/run-dispatch-gate.service';
 
 /**
  * Tasks feature — Phase 12.1.
@@ -91,6 +96,11 @@ export class TaskTransitionService {
         // Kanban run cockpit (Wave 2) — latest-run denorm on dispatch.
         // Optional for the same unit-test-fixture reason as the rest.
         @Optional() private readonly runDenorm?: TaskRunDenormService,
+        // Run orchestration (Wave 4 M2) — concurrency gate consulted per
+        // assignee before the job-runtime enqueue. Appended LAST so every
+        // positional `new TaskTransitionService(...)` in the specs keeps
+        // compiling; Optional so fixtures without it dispatch ungated.
+        @Optional() private readonly dispatchGate?: RunDispatchGateService,
     ) {}
 
     /**
@@ -234,14 +244,41 @@ export class TaskTransitionService {
             const dedupKey = `${task.id}:${assignee.assigneeId}:${generation}`;
             let run: { id: string } | null = null;
             try {
+                // Run orchestration (Wave 4 M2) — consult the concurrency
+                // gate BEFORE enqueuing. Fail-open on gate errors: the gate
+                // is a safety valve, and a broken valve must never stop
+                // legitimate dispatch (the valve's own counting query is the
+                // only thing that can throw here).
+                let admission: { admitted: boolean; queuedReason?: string } = {
+                    admitted: true,
+                };
+                if (this.dispatchGate) {
+                    try {
+                        admission = await this.dispatchGate.admit({
+                            userId: task.userId,
+                            workId: task.workId ?? null,
+                            organizationId: task.organizationId ?? null,
+                        });
+                    } catch (gateErr) {
+                        this.logger.warn(
+                            `Dispatch gate admit failed for task ${task.id} — failing open: ${gateErr}`,
+                        );
+                    }
+                }
                 // Pre-create a queued AgentRun row so the worker can find
                 // it via findInFlightForTaskAgent (T6 chat-dedup posture).
+                // `workId` is denormalized here (Wave 4 M1) so per-Work
+                // concurrency counts + the Sessions view need no join.
                 run = this.runs
                     ? await this.runs.createQueued({
                           agentId: assignee.assigneeId,
                           userId: task.userId,
                           triggerKind: 'task',
                           taskId: task.id,
+                          workId: task.workId ?? null,
+                          queuedReason: admission.admitted
+                              ? null
+                              : (admission.queuedReason ?? 'concurrency-limit'),
                       })
                     : null;
                 // Kanban run cockpit — mirror the freshly-queued run onto the
@@ -250,6 +287,15 @@ export class TaskTransitionService {
                 // never throws), so this cannot break the dispatch.
                 if (run) {
                     await this.runDenorm?.recordQueued(task.id, run.id);
+                }
+                // Over-limit: the run row exists (parked, queuedReason set)
+                // but the job-runtime enqueue is SKIPPED. The drain hook on
+                // terminal transitions promotes it when a slot frees.
+                if (!admission.admitted) {
+                    this.logger.log(
+                        `Run for agent ${assignee.assigneeId} on task ${task.id} parked by dispatch gate (${admission.queuedReason}).`,
+                    );
+                    continue;
                 }
                 const handle = await this.dispatcher.enqueue({
                     agentId: assignee.assigneeId,

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -1,7 +1,7 @@
 import { task } from '@trigger.dev/sdk';
 import { NestFactory } from '@nestjs/core';
 import { AgentRepository, AgentRunRepository } from '@ever-works/agent/database';
-import { AgentRunService } from '@ever-works/agent/agents';
+import { AgentRunService, RunDispatchGateService } from '@ever-works/agent/agents';
 import {
     TaskRunDenormService,
     TasksService,
@@ -104,6 +104,13 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                     await bestEffort(() =>
                         denorm.recordTerminal(payload.taskId, inFlight.id, 'failed'),
                     );
+                    // Run orchestration (Wave 4 M2) — the failure freed a
+                    // concurrency slot; drain the Work's parked queue (RPC).
+                    if (inFlight.workId) {
+                        const failedWorkId = inFlight.workId;
+                        const gate = appContext.get(RunDispatchGateService);
+                        await bestEffort(() => gate.drainForWork(failedWorkId));
+                    }
                 }
             } finally {
                 await appContext.close();
@@ -133,6 +140,14 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
             // Kanban run cockpit (Wave 2) — latest-run denorm writes after
             // claim + terminal transitions. RPC proxy; every call best-effort.
             const runDenorm = appContext.get(TaskRunDenormService);
+            // Run orchestration (Wave 4 M2) — drain-on-terminal: every
+            // terminal write below frees a concurrency slot, so the Work's
+            // parked queue is drained (RPC proxy; always best-effort).
+            const dispatchGate = appContext.get(RunDispatchGateService);
+            const drainWork = async (workId: string | null | undefined): Promise<void> => {
+                if (!workId) return;
+                await bestEffort(() => dispatchGate.drainForWork(workId));
+            };
 
             // Security: scope the Agent lookup to the payload's userId
             // (defense-in-depth IDOR guard). The legitimate dispatch path
@@ -201,6 +216,9 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                     userId: agent.userId,
                     triggerKind: 'task',
                     taskId: payload.taskId,
+                    // Wave 4 M1 — workId denorm at creation (owner-scoped
+                    // taskRow resolved above).
+                    workId: taskRow.workId ?? null,
                 });
                 // Kanban run cockpit — on-the-fly creation (dispatcher row was
                 // never found), mirror it exactly like the fan-out path does.
@@ -254,6 +272,7 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 await bestEffort(() =>
                     runDenorm.recordTerminal(payload.taskId, claimedRunId, 'failed'),
                 );
+                await drainWork(taskRow.workId);
                 return {
                     status: 'failed',
                     reason: 'workspace-provision-failed',
@@ -297,11 +316,13 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 await bestEffort(() =>
                     runDenorm.recordTerminal(payload.taskId, claimedRunId, 'completed'),
                 );
+                await drainWork(taskRow.workId);
             } else if (result.status === 'agent-not-found') {
                 await runs.markFailed(run.id, 'Agent not found');
                 await bestEffort(() =>
                     runDenorm.recordTerminal(payload.taskId, claimedRunId, 'failed'),
                 );
+                await drainWork(taskRow.workId);
             }
 
             // Wave 2 M4 — green-path finalize of the isolated workspace:
@@ -334,6 +355,7 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                     // branch — that IS a failure of the Task's promise.
                     const message = error instanceof Error ? error.message : String(error);
                     await runs.markFailed(run.id, `Workspace finalize failed: ${message}`);
+                    await drainWork(taskRow.workId);
                     // Mirror-consistency: for `assembled` runs the row was
                     // already marked completed above, so this markFailed CAS
                     // no-ops — only mirror `failed` when the row could

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -13,6 +13,7 @@ import {
     AgentRunService,
     AgentRunSweeperService,
     AgentScheduleDispatcherService,
+    RunDispatchGateService,
 } from '@ever-works/agent/agents';
 import {
     TaskChatService,
@@ -129,6 +130,17 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
                 createRemoteProxy(apiClient, 'AgentRunRepository'),
             inject: [TriggerInternalApiClient],
         },
+        // Run orchestration (Wave 4 M2) — drain-on-terminal from the
+        // agent-task-execute worker. The real gate (repository counts +
+        // the @Global dispatcher token) lives in the API; the worker only
+        // calls drainForWork over the internal RPC channel, same shape as
+        // TaskWorkspaceService.
+        {
+            provide: RunDispatchGateService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'RunDispatchGateService'),
+            inject: [TriggerInternalApiClient],
+        },
         // Agents/Skills/Tasks PR #1017 — Phase 17. Recurring Task
         // dispatcher exposed for the task-recurrence-dispatcher cron.
         {
@@ -221,6 +233,7 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         AgentRunService,
         AgentRepository,
         AgentRunRepository,
+        RunDispatchGateService,
         TaskRecurrenceDispatcherService,
         TasksService,
         TaskChatService,


### PR DESCRIPTION
## Summary

Wave 4 core (sessions-orchestration M1–M3): a real, configurable concurrency scheduler for agent runs plus the org-wide Sessions list API. Everything is additive — no status-machine changes, no removed surfaces.

### M1 — schema + entity (`AddRunOrchestrationColumns1783100000000`)

`agent_runs` gains (guarded, forward-only, house idempotent pattern):

| Column | Type | Purpose |
|---|---|---|
| `workId` | uuid nullable | denormalized from `task.workId` at creation; backfilled for historical rows via correlated subquery (Postgres + sqlite portable) |
| `awaitingInput` | boolean default false | parked-on-a-human flag; boolean, not a status member, so every existing CAS guard keeps working |
| `queuedReason` | varchar(64) nullable | why a queued run was NOT dispatched (`concurrency-limit` today) |
| `runnerKind` | varchar(32) nullable | pipeline plugin id ("runs on" chip) |
| `costCents` | int nullable | per-run cost rollup (per-event truth stays `plugin_usage_events.costCents` — checked before adding) |

Plus index `(workId, status)` for cheap per-Work in-flight counts.

### M2 — `RunDispatchGateService`

- `admit({userId, workId?, organizationId?})` counts in-flight runs (`running` + dispatched-`queued`; gate-parked rows deliberately excluded so the drain can't deadlock) per Work and per org/user.
- Limits are **configurable safety valves, not product limits**: `AGENT_MAX_CONCURRENT_RUNS_PER_WORK` (default **10**) and `AGENT_MAX_CONCURRENT_RUNS_PER_ORG` (default **25**), `<= 0` disables a valve. The future per-Work override column (`works.maxConcurrentAgentRuns`) is documented at the single resolution point.
- Task fan-out (`TaskTransitionService.fanOutAgentExecutions`) consults the gate per assignee: over-limit → run row is still created (`queued` + `queuedReason='concurrency-limit'`, board chip intact) and the Trigger enqueue is **skipped**. Gate errors fail **open**.
- **Drain**: `drainForWork` promotes the oldest parked run — CAS claim (`claimQueuedForDispatch`) prevents double-dispatch, run-scoped dedup key dedups at the runner, enqueue failure rolls the run to failed with the existing `dispatch-failed:`/`job-runtime-not-configured:` markers. Hooked at:
  - every terminal transition in `agent-task-execute` (markCompleted/markFailed/onFailure, over RPC),
  - the run-cancel endpoint (fire-and-forget after a successful cancel),
  - the stuck-run sweeper (per distinct swept `workId`) as the safety net.
- RPC 3-place wiring mirrors `TaskWorkspaceService`: worker proxy provider + export, `TriggerInternalController` constructor (trailing `@Optional()`, positional specs preserved) + `remoteMap`, agents barrel export.

### M3 — Sessions list API

- `GET /api/agents/runs` — the Sessions list: owner-scoped **at the repository layer** (`listSessionsForUser` always applies `userId = auth.userId`), filters `status`/`workId`/`agentId`/`kind`, pagination, returns telemetry (`currentActivity`/`totalTokens`/`changedFilesCount`/`costCents`) + gate (`gateStatus`/`gateAttempts`) + terminal (`persistent`/`terminalState`/`terminalEndedReason`/`terminalProviderId`) + orchestration (`workId`/`awaitingInput`/`queuedReason`/`runnerKind`) columns. Declared before the `:id` routes so the literal segment never hits `ParseUUIDPipe`.
- `GET /api/works/:id/runs-summary` → `{running, queued, awaiting, failedLast24h}` via **one** grouped CASE/SUM query over the new `(workId, status)` index, gated by `WorkOwnershipService.ensureAccess` (cross-user Works 404, no existence leak; repository untouched on rejection — pinned by test).

## Verification (real output)

- `packages/agent` `pnpm build` — `TSC Found 0 issues`, swc 977 files.
- `packages/agent` targeted jest (`run-dispatch-gate|task-transition-dispatch|agent-run-sweeper|agent-run.entity|agent-run.terminal-columns`) — **5 suites / 51 tests passed** (15 new gate specs incl. admit under/over limit, valve disable, per-Work counter isolation, drain oldest/claim-race/no-dispatcher/dispatch-failure; 5 gated fan-out specs incl. park-and-skip + fail-open; 2 sweeper drain specs).
- `pnpm build --filter=@ever-works/trigger-tasks --filter=ever-works-api` — 14 tasks successful, api `TSC Found 0 issues`.
- `apps/api` `pnpm generate:openapi` — wrote **414 paths** (includes `/api/agents/runs` + `/api/works/{id}/runs-summary`); `openapi.json` excluded from the commit.
- `apps/api` jest `trigger-internal` + `agents.controller.runtime` + `work-runs.controller` — **4 suites / 52 tests passed** (re-run post-prettier: 36 + 44 green).
- Prettier applied to every touched file; `apps/web/e2e` grepped for the touched endpoints — no collisions.

## Notes for reviewers

- In-flight counting excludes gate-parked rows on purpose — counting them would hold the limit forever (deadlocked drain). Clearing `queuedReason` at drain-claim is the state handshake.
- The count is check-then-insert without an advisory lock (sqlite e2e parity); a parallel burst can transiently exceed a valve by the burst width. The harmful race (double-dispatching one run) is closed by the CAS claim.
- Chat-triggered runs get the `workId` denorm too but stay ungated (additive; steering/chat routing is a later milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)