### PR TITLE
feat(agent): event-ingest spine (Wave 6 core)

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -52,6 +52,7 @@ import { TerminalModule } from './terminal/terminal.module';
 import { TeamsModule } from './teams/teams.module';
 import { SchedulesModule } from './schedules/schedules.module';
 import { InboundTriggersModule } from './triggers/inbound-triggers.module';
+import { IngestModule } from './ingest/ingest.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
 import { UsersModule } from './users/users.module';
 import { ScopeModule } from './scope/scope.module';
@@ -188,6 +189,10 @@ import { DatabaseModule } from '@ever-works/agent/database';
         // triggers that spawn Tasks on verified HMAC deliveries.
         // Management CRUD + the public /:id/fire endpoint.
         InboundTriggersModule,
+        // Event-ingest spine (Wave 6) — POST /api/ingest/events push
+        // surface over the agent-side EventIngestModule (dedupe-insert +
+        // Activity/Memory fan-out; pull rides the event-ingest-tick cron).
+        IngestModule,
         TelemetryModule,
         FunnelAnalyticsBindingModule,
         UploadsModule,

--- a/apps/api/src/ingest/dto/ingest-events.dto.spec.ts
+++ b/apps/api/src/ingest/dto/ingest-events.dto.spec.ts
@@ -1,0 +1,76 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { IngestEventsDto } from './ingest-events.dto';
+
+const validEnvelope = (overrides: Record<string, unknown> = {}) => ({
+    id: 'env-1',
+    source: 'slack-connector',
+    sourceEventId: 'evt-1',
+    kind: 'slack.message',
+    occurredAt: '2026-07-01T10:00:00.000Z',
+    actor: { name: 'Ada' },
+    subject: { type: 'channel', externalId: 'C123', title: 'general' },
+    sourceUrl: 'https://example.com/archives/C123/p1',
+    payload: { text: 'hello' },
+    ...overrides,
+});
+
+const build = (events: unknown[]) => plainToInstance(IngestEventsDto, { events });
+
+describe('IngestEventsDto', () => {
+    it('accepts a valid envelope batch', async () => {
+        const errors = await validate(build([validEnvelope()]));
+        expect(errors).toHaveLength(0);
+    });
+
+    it('rejects batches larger than 100 envelopes', async () => {
+        const events = Array.from({ length: 101 }, (_, i) =>
+            validEnvelope({ sourceEventId: `evt-${i}` }),
+        );
+        const errors = await validate(build(events));
+        expect(errors).toHaveLength(1);
+        expect(errors[0].constraints).toHaveProperty('arrayMaxSize');
+    });
+
+    it('rejects an empty batch', async () => {
+        const errors = await validate(build([]));
+        expect(errors).toHaveLength(1);
+        expect(errors[0].constraints).toHaveProperty('arrayNotEmpty');
+    });
+
+    it('rejects a payload that serialises past the 32 KB cap', async () => {
+        const errors = await validate(
+            build([validEnvelope({ payload: { blob: 'x'.repeat(33 * 1024) } })]),
+        );
+        expect(errors).toHaveLength(1);
+        expect(JSON.stringify(errors)).toContain('payloadByteCap');
+    });
+
+    it('rejects an array payload (must be an object map)', async () => {
+        const errors = await validate(build([validEnvelope({ payload: ['not', 'an', 'object'] })]));
+        expect(errors).toHaveLength(1);
+        expect(JSON.stringify(errors)).toContain('payload');
+    });
+
+    it('rejects a missing kind and a non-ISO occurredAt', async () => {
+        const missingKind = await validate(build([validEnvelope({ kind: '' })]));
+        expect(missingKind).toHaveLength(1);
+
+        const badDate = await validate(build([validEnvelope({ occurredAt: 'yesterday' })]));
+        expect(badDate).toHaveLength(1);
+        expect(JSON.stringify(badDate)).toContain('occurredAt');
+    });
+
+    it('validates nested actor/subject shapes', async () => {
+        const errors = await validate(build([validEnvelope({ actor: { name: '' } })]));
+        expect(errors).toHaveLength(1);
+        expect(JSON.stringify(errors)).toContain('name');
+    });
+
+    it('rejects a non-uuid workId routing hint', async () => {
+        const errors = await validate(build([validEnvelope({ workId: 'not-a-uuid' })]));
+        expect(errors).toHaveLength(1);
+        expect(JSON.stringify(errors)).toContain('workId');
+    });
+});

--- a/apps/api/src/ingest/dto/ingest-events.dto.ts
+++ b/apps/api/src/ingest/dto/ingest-events.dto.ts
@@ -1,0 +1,164 @@
+import {
+    ArrayMaxSize,
+    ArrayNotEmpty,
+    IsArray,
+    IsISO8601,
+    IsNotEmpty,
+    IsObject,
+    IsOptional,
+    IsString,
+    IsUUID,
+    MaxLength,
+    Validate,
+    ValidateNested,
+    ValidatorConstraint,
+    type ValidatorConstraintInterface,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { INGEST_EVENT_BATCH_MAX, INGEST_EVENT_PAYLOAD_MAX_BYTES } from '@ever-works/contracts';
+
+/**
+ * Event-ingest spine (Wave 6) — request shape for
+ * `POST /api/ingest/events`. Mirrors `IngestedEventEnvelope`
+ * (`@ever-works/contracts`) with the two hard edge caps:
+ * ≤ {@link INGEST_EVENT_BATCH_MAX} envelopes per call, and each
+ * `payload` ≤ {@link INGEST_EVENT_PAYLOAD_MAX_BYTES} bytes serialized
+ * (same constraint style as the activity-log ingest metadata cap).
+ */
+@ValidatorConstraint({ name: 'payloadByteCap', async: false })
+class PayloadByteCapConstraint implements ValidatorConstraintInterface {
+    validate(value: unknown): boolean {
+        if (value === undefined || value === null) return false;
+        if (typeof value !== 'object' || Array.isArray(value)) return false;
+        try {
+            const serialized = JSON.stringify(value);
+            return Buffer.byteLength(serialized, 'utf8') <= INGEST_EVENT_PAYLOAD_MAX_BYTES;
+        } catch {
+            return false;
+        }
+    }
+
+    defaultMessage(): string {
+        return `payload must serialise to <= ${INGEST_EVENT_PAYLOAD_MAX_BYTES} bytes`;
+    }
+}
+
+export class IngestedEventActorDto {
+    @ApiProperty({ description: 'Display name as the source reports it', maxLength: 200 })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(200)
+    name: string;
+
+    @ApiPropertyOptional({ description: 'Stable id in the source system', maxLength: 200 })
+    @IsOptional()
+    @IsString()
+    @MaxLength(200)
+    externalId?: string;
+}
+
+export class IngestedEventSubjectDto {
+    @ApiProperty({ description: 'Source-namespaced subject type (channel, page, issue, …)' })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(100)
+    type: string;
+
+    @ApiProperty({ description: 'Stable id of the subject in the source system', maxLength: 200 })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(200)
+    externalId: string;
+
+    @ApiPropertyOptional({ description: 'Human-readable subject title', maxLength: 500 })
+    @IsOptional()
+    @IsString()
+    @MaxLength(500)
+    title?: string;
+}
+
+export class IngestedEventEnvelopeDto {
+    @ApiProperty({ description: 'Connector-assigned envelope id (uuid recommended)' })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(100)
+    id: string;
+
+    @ApiProperty({ description: 'Producing plugin id' })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(100)
+    source: string;
+
+    @ApiProperty({
+        description:
+            'Stable event id in the source system. (source, sourceEventId) is the dedupe identity — retries are no-ops.',
+        maxLength: 200,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(200)
+    sourceEventId: string;
+
+    @ApiProperty({ description: 'Source-namespaced event kind, e.g. slack.message' })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(100)
+    kind: string;
+
+    @ApiProperty({ description: 'ISO 8601 timestamp of when the event happened at the source' })
+    @IsISO8601()
+    occurredAt: string;
+
+    @ApiPropertyOptional({ type: IngestedEventActorDto })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => IngestedEventActorDto)
+    actor?: IngestedEventActorDto;
+
+    @ApiPropertyOptional({ type: IngestedEventSubjectDto })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => IngestedEventSubjectDto)
+    subject?: IngestedEventSubjectDto;
+
+    @ApiPropertyOptional({
+        description: 'Deep link back to the original message / PR / page / commit',
+        maxLength: 2048,
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(2048)
+    sourceUrl?: string;
+
+    @ApiProperty({
+        description: `Source-specific details. Capped at ${INGEST_EVENT_PAYLOAD_MAX_BYTES} bytes after JSON serialisation.`,
+    })
+    @IsObject()
+    @Validate(PayloadByteCapConstraint)
+    payload: Record<string, unknown>;
+
+    @ApiPropertyOptional({ description: 'Work routing hint resolved by the connector' })
+    @IsOptional()
+    @IsUUID()
+    workId?: string;
+
+    @ApiPropertyOptional({ description: 'Organization scope hint' })
+    @IsOptional()
+    @IsUUID()
+    organizationId?: string;
+}
+
+export class IngestEventsDto {
+    @ApiProperty({
+        type: [IngestedEventEnvelopeDto],
+        description: `Normalized envelopes to ingest (1..${INGEST_EVENT_BATCH_MAX} per call).`,
+    })
+    @IsArray()
+    @ArrayNotEmpty()
+    @ArrayMaxSize(INGEST_EVENT_BATCH_MAX)
+    @ValidateNested({ each: true })
+    @Type(() => IngestedEventEnvelopeDto)
+    events: IngestedEventEnvelopeDto[];
+}

--- a/apps/api/src/ingest/ingest.controller.ts
+++ b/apps/api/src/ingest/ingest.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { EventIngestService } from '@ever-works/agent/ingest';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { IngestEventsDto } from './dto/ingest-events.dto';
+
+/**
+ * Event-ingest spine (Wave 6) — push surface for normalized external
+ * events. Connectors and (later, per-connector) webhook handlers POST
+ * `IngestedEventEnvelope` batches here; the pull model rides the
+ * `event-ingest-tick` cron instead.
+ *
+ * Auth: current user — events land owner-scoped under the caller.
+ * Dedupe: `(source, sourceEventId)` per owner, so retries are no-ops
+ * (the response's `duplicates` count makes that visible).
+ * Caps: ≤100 envelopes per call, ≤32 KB serialized payload each
+ * (class-validator DTO, shared constants from `@ever-works/contracts`).
+ */
+@ApiTags('ingest')
+@Controller('api/ingest')
+export class IngestController {
+    constructor(private readonly eventIngestService: EventIngestService) {}
+
+    @Post('events')
+    @ApiOperation({
+        summary:
+            'Ingest a batch of normalized external events (dedupe-insert; processing fans out asynchronously).',
+    })
+    @HttpCode(HttpStatus.ACCEPTED)
+    @Throttle({ long: { limit: 120, ttl: 60_000 } })
+    async ingestEvents(@CurrentUser() auth: AuthenticatedUser, @Body() dto: IngestEventsDto) {
+        return this.eventIngestService.ingest(auth.userId, dto.events);
+    }
+}

--- a/apps/api/src/ingest/ingest.module.ts
+++ b/apps/api/src/ingest/ingest.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { EventIngestModule } from '@ever-works/agent/ingest';
+import { IngestController } from './ingest.controller';
+
+/**
+ * Event-ingest spine (Wave 6) — thin API module exposing
+ * `POST /api/ingest/events` over the agent-side `EventIngestModule`
+ * (dedupe-insert + processor fan-out live there).
+ */
+@Module({
+    imports: [EventIngestModule],
+    controllers: [IngestController],
+    exports: [EventIngestModule],
+})
+export class IngestModule {}

--- a/apps/api/src/migrations/1783200000000-CreateIngestedEvents.ts
+++ b/apps/api/src/migrations/1783200000000-CreateIngestedEvents.ts
@@ -1,0 +1,129 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Event-ingest spine (Wave 6) — creates the `ingested_events` table
+ * backing the generic connector pipeline: normalized external events
+ * (`IngestedEventEnvelope`) land here via dedupe-insert, then the
+ * `event-ingest-tick` cron drains unprocessed rows into the Activity
+ * log + agent Memory with `sourceUrl` provenance.
+ *
+ * Entity: `packages/agent/src/entities/ingested-event.entity.ts`
+ *
+ * **Schema notes:**
+ *   - `dedupeKey` (varchar(64), UNIQUE) — sha256 over
+ *     `(userId, source, sourceEventId)`; makes connector re-delivery
+ *     (webhook retries, overlapping pull windows, backfill) a no-op.
+ *   - `payload` (text) — the entity's `simple-json` column; serialized
+ *     size is capped at 32 KB upstream (DTO + service).
+ *   - `processedAt` NULL = awaiting fan-out; the partial-scan index on
+ *     it backs the cron's oldest-first batch read.
+ *   - Scope columns (`organizationId`) are raw uuid references — no
+ *     entity-level @ManyToOne (cycle avoidance per EW-654).
+ *   - FK `userId` → `users.id` ON DELETE CASCADE (an ingested event is
+ *     meaningless without its owner); FK `workId` → `works.id`
+ *     ON DELETE SET NULL (deleting a Work must not delete the event —
+ *     it just loses its Work routing).
+ *
+ * Forward-only + idempotent (`hasTable` guard) — same shape as
+ * `1782100000000-CreateInboundTriggers`.
+ */
+export class CreateIngestedEvents1783200000000 implements MigrationInterface {
+    name = 'CreateIngestedEvents1783200000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('ingested_events')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'ingested_events',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    { name: 'workId', type: 'uuid', isNullable: true },
+                    { name: 'source', type: 'varchar', length: '100' },
+                    { name: 'sourceEventId', type: 'varchar', length: '200' },
+                    { name: 'kind', type: 'varchar', length: '100' },
+                    { name: 'occurredAt', type: 'timestamp' },
+                    { name: 'actorName', type: 'varchar', length: '200', isNullable: true },
+                    { name: 'subjectType', type: 'varchar', length: '100', isNullable: true },
+                    { name: 'subjectExternalId', type: 'varchar', length: '200', isNullable: true },
+                    { name: 'title', type: 'varchar', length: '500', isNullable: true },
+                    { name: 'sourceUrl', type: 'varchar', length: '2048', isNullable: true },
+                    { name: 'payload', type: 'text' },
+                    { name: 'processedAt', type: 'timestamp', isNullable: true },
+                    { name: 'dedupeKey', type: 'varchar', length: '64' },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        // Dedupe identity — connector re-delivery must be a no-op.
+        await queryRunner.createIndex(
+            'ingested_events',
+            new TableIndex({
+                name: 'idx_ingested_events_dedupe',
+                columnNames: ['dedupeKey'],
+                isUnique: true,
+            }),
+        );
+
+        // Owner-scoped recency reads (list_recent_events chat tool +
+        // future feed surfaces).
+        await queryRunner.createIndex(
+            'ingested_events',
+            new TableIndex({
+                name: 'idx_ingested_events_user_created',
+                columnNames: ['userId', 'createdAt'],
+            }),
+        );
+
+        // The event-ingest-tick cron scans WHERE processedAt IS NULL.
+        await queryRunner.createIndex(
+            'ingested_events',
+            new TableIndex({
+                name: 'idx_ingested_events_unprocessed',
+                columnNames: ['processedAt'],
+            }),
+        );
+
+        await queryRunner.createForeignKey(
+            'ingested_events',
+            new TableForeignKey({
+                name: 'fk_ingested_events_user',
+                columnNames: ['userId'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+
+        // Deleting a Work must not delete its ingested events — they
+        // just lose the Work routing and stay owner-scoped.
+        await queryRunner.createForeignKey(
+            'ingested_events',
+            new TableForeignKey({
+                name: 'fk_ingested_events_work',
+                columnNames: ['workId'],
+                referencedTableName: 'works',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('ingested_events')) {
+            await queryRunner.dropTable('ingested_events', true);
+        }
+    }
+}

--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -76,6 +76,13 @@ jest.mock('@ever-works/agent/plugins', () => ({
     UserPluginRepository: class UserPluginRepository {},
     WorkPluginRepository: class WorkPluginRepository {},
 }));
+// Event-ingest spine (Wave 6) — the controller imports EventIngestService
+// from the ingest barrel; stub it so the real barrel (entity chain →
+// TypeORM under apps/api jest) is never loaded.
+jest.mock('@ever-works/agent/ingest', () => ({
+    EventIngestService: class EventIngestService {},
+    EventIngestModule: class EventIngestModule {},
+}));
 jest.mock('@ever-works/agent/activity-log', () => ({
     ActivityLogService: class ActivityLogService {},
     ActivityLogModule: class ActivityLogModule {},

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -70,6 +70,7 @@ import {
     UserPluginRepository,
     WorkPluginRepository,
 } from '@ever-works/agent/plugins';
+import { EventIngestService } from '@ever-works/agent/ingest';
 
 /**
  * C-05 RPC half — methods that must never be reachable via `POST
@@ -284,6 +285,11 @@ export class TriggerInternalController implements OnModuleInit {
         // the same positional-spec reason as the sweeper above.
         @Optional()
         private readonly runDispatchGateService?: RunDispatchGateService,
+        // Event-ingest spine (Wave 6) — backs the `event-ingest-tick`
+        // cron: the worker proxy calls `processBatch()` over the internal
+        // RPC channel. Appended LAST + @Optional() per the arity rule above.
+        @Optional()
+        private readonly eventIngestService?: EventIngestService,
     ) {}
 
     onModuleInit() {
@@ -353,6 +359,9 @@ export class TriggerInternalController implements OnModuleInit {
             AnonymousUserCleanupService: this.anonymousUserCleanupService,
             // EW-643 Phase 3 slice 4a - `kb-reconcile` calls `reconcile()`.
             KnowledgeBaseReconcileService: this.knowledgeBaseReconcileService,
+            // Event-ingest spine (Wave 6) — `event-ingest-tick` calls
+            // `processBatch()` here (allow-list auto-derived).
+            EventIngestService: this.eventIngestService,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/apps/api/src/trigger/trigger-internal.module.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.module.spec.ts
@@ -63,6 +63,13 @@ jest.mock('@ever-works/agent/agents', () => ({
 jest.mock('@ever-works/agent/tasks-domain', () => ({
     TasksDomainModule: class TasksDomainModule {},
 }));
+// Event-ingest spine (Wave 6) — the module imports EventIngestModule
+// (and the controller it declares imports EventIngestService) from the
+// ingest barrel; stub both so the entity chain is never loaded.
+jest.mock('@ever-works/agent/ingest', () => ({
+    EventIngestModule: class EventIngestModule {},
+    EventIngestService: class EventIngestService {},
+}));
 // EW-742 P3.2 T22 — trigger-internal.module imports TenantJobRuntimeModule
 // + OrganizationsModule (added by bbc24309 / 5e4e2483 / 41906b71). Loading
 // those modules pulls in real `@ever-works/agent/entities` + `@ever-works/agent/tasks`

--- a/apps/api/src/trigger/trigger-internal.module.ts
+++ b/apps/api/src/trigger/trigger-internal.module.ts
@@ -10,6 +10,7 @@ import { WorkAgentModule } from '@ever-works/agent/work-agent';
 import { GoalsModule } from '@ever-works/agent/goals';
 import { AgentsModule } from '@ever-works/agent/agents';
 import { TasksDomainModule } from '@ever-works/agent/tasks-domain';
+import { EventIngestModule } from '@ever-works/agent/ingest';
 import { WorkProposalsModule } from '../work-proposals/work-proposals.module';
 import { DataSyncModule } from '../data-sync/data-sync.module';
 import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
@@ -70,6 +71,11 @@ import { OrganizationsModule } from '../organizations/organizations.module';
         // controller so the task-recurrence-dispatcher cron task
         // can drive `dispatchDue()` over the internal RPC channel.
         TasksDomainModule,
+        // Event-ingest spine (Wave 6) — exposes EventIngestService
+        // through the remote-proxy controller so the event-ingest-tick
+        // cron task (in packages/tasks) can drive `processBatch()` over
+        // the internal RPC channel every 5 minutes.
+        EventIngestModule,
     ],
     controllers: [TriggerInternalController],
 })

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -176,6 +176,10 @@
         "./triggers": {
             "types": "./dist/triggers/index.d.ts",
             "default": "./dist/triggers/index.js"
+        },
+        "./ingest": {
+            "types": "./dist/ingest/index.d.ts",
+            "default": "./dist/ingest/index.js"
         }
     },
     "scripts": {

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -113,6 +113,7 @@ import { TenantJobRuntimeAudit } from '../entities/tenant-job-runtime-audit.enti
 import { TenantRuntimeProviderAllowlist } from '../entities/tenant-runtime-provider-allowlist.entity';
 import { TenantCredentialSnapshot } from '../entities/tenant-credential-snapshot.entity';
 import { InboundTrigger } from '../entities/inbound-trigger.entity';
+import { IngestedEvent } from '../entities/ingested-event.entity';
 import {
     PluginEntity,
     UserPluginEntity,
@@ -249,4 +250,7 @@ export const ENTITIES = [
     // Inbound Triggers (Trigger Schedules) — signed webhook/API triggers
     // that spawn Tasks on verified HMAC deliveries.
     InboundTrigger,
+    // Event-ingest spine (Wave 6) — normalized external events awaiting
+    // Activity/Memory fan-out.
+    IngestedEvent,
 ];

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -69,6 +69,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'GitHubAppUserLink',
     // Inbound Triggers (Trigger Schedules) — signed webhook/API triggers
     'InboundTrigger',
+    // Event-ingest spine (Wave 6) — normalized external events
+    'IngestedEvent',
     'Mission',
     // Domain-model evolution PR-8 — Goals + measurement
     'Goal',

--- a/packages/agent/src/entities/activity-log.types.ts
+++ b/packages/agent/src/entities/activity-log.types.ts
@@ -200,6 +200,14 @@ export enum ActivityActionType {
     //     `WorkProposalService.generate` for MISSION-sourced runs — the
     //     domain-model train added the same literal, so it is not redefined here.
     MISSION_TICK = 'mission_tick',
+
+    // Event-ingest spine (Wave 6) — one row per external event drained
+    // from `ingested_events` by `EventIngestService.processBatch()`.
+    // `metadata` carries the provenance block (source, kind,
+    // sourceEventId, sourceUrl, actor/subject) so the feed and the AI
+    // chat can link back to the original message / PR / page. Additive
+    // member — storage is a plain varchar.
+    EXTERNAL_EVENT_INGESTED = 'external_event_ingested',
 }
 
 export enum ActivityStatus {

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -114,3 +114,5 @@ export * from './team-member.entity';
 export * from './team-resource.entity';
 // Inbound Triggers (Trigger Schedules) — signed webhook/API triggers that spawn Tasks
 export * from './inbound-trigger.entity';
+// Event-ingest spine (Wave 6) — normalized external events awaiting fan-out
+export * from './ingested-event.entity';

--- a/packages/agent/src/entities/ingested-event.entity.ts
+++ b/packages/agent/src/entities/ingested-event.entity.ts
@@ -1,0 +1,91 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * Event-ingest spine (Wave 6) — one normalized external event, landed.
+ *
+ * Rows are written by `EventIngestService.ingest()` from
+ * `IngestedEventEnvelope`s (pull-model event-source plugins, the
+ * `POST /api/ingest/events` push surface, and later per-connector
+ * webhooks + backfill) and drained by `processBatch()` into the
+ * Activity log + agent Memory, each carrying `sourceUrl` provenance
+ * back to the origin.
+ *
+ * Dedupe: `dedupeKey` is a sha256 over `(userId, source,
+ * sourceEventId)` — the envelope identity `(source, sourceEventId)`
+ * scoped per owner so one user's delivery can never swallow (or leak)
+ * another user's row. UNIQUE index makes re-delivery a no-op.
+ *
+ * Scope columns are raw uuid references (no @ManyToOne) per the EW-654
+ * cycle-avoidance rule; FKs live in the migration
+ * (`1783200000000-CreateIngestedEvents`).
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` — this
+ * repo has no `autoLoadEntities`, a forFeature'd-but-unregistered
+ * entity throws EntityMetadataNotFoundError on first query.
+ */
+@Entity({ name: 'ingested_events' })
+@Index('idx_ingested_events_dedupe', ['dedupeKey'], { unique: true })
+@Index('idx_ingested_events_user_created', ['userId', 'createdAt'])
+@Index('idx_ingested_events_unprocessed', ['processedAt'])
+export class IngestedEvent {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Owner the event was ingested for (scopes reads + processing). */
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    /** Work the connector routed the event to, when known. */
+    @Column({ type: 'uuid', nullable: true })
+    workId?: string | null;
+
+    /** Producing plugin id, e.g. `slack-connector`. */
+    @Column({ type: 'varchar', length: 100 })
+    source: string;
+
+    /** The event's stable id in the source system. */
+    @Column({ type: 'varchar', length: 200 })
+    sourceEventId: string;
+
+    /** Source-namespaced kind, e.g. `slack.message`. */
+    @Column({ type: 'varchar', length: 100 })
+    kind: string;
+
+    /** When the event happened at the source. */
+    @Column({ type: 'timestamp' })
+    occurredAt: Date;
+
+    @Column({ type: 'varchar', length: 200, nullable: true })
+    actorName?: string | null;
+
+    @Column({ type: 'varchar', length: 100, nullable: true })
+    subjectType?: string | null;
+
+    @Column({ type: 'varchar', length: 200, nullable: true })
+    subjectExternalId?: string | null;
+
+    @Column({ type: 'varchar', length: 500, nullable: true })
+    title?: string | null;
+
+    /** Deep link back to the original message / PR / page / commit. */
+    @Column({ type: 'varchar', length: 2048, nullable: true })
+    sourceUrl?: string | null;
+
+    /** Source-specific details (serialized ≤ 32 KB, capped upstream). */
+    @Column({ type: 'simple-json' })
+    payload: Record<string, unknown>;
+
+    /** Set when the processor fan-out (Activity + Memory) has run. */
+    @Column({ type: 'timestamp', nullable: true })
+    processedAt?: Date | null;
+
+    /** sha256 hex over (userId, source, sourceEventId). */
+    @Column({ type: 'varchar', length: 64 })
+    dedupeKey: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/packages/agent/src/ingest/__tests__/agent-ingest-tools.spec.ts
+++ b/packages/agent/src/ingest/__tests__/agent-ingest-tools.spec.ts
@@ -1,0 +1,87 @@
+import { buildIngestEventTools } from '../agent-ingest-tools';
+import type { IngestedEvent } from '../../entities/ingested-event.entity';
+import type { IngestedEventRepository } from '../ingested-event.repository';
+
+const row = (overrides: Partial<IngestedEvent> = {}): IngestedEvent =>
+    ({
+        id: 'row-1',
+        userId: 'user-1',
+        source: 'slack-connector',
+        sourceEventId: 'evt-1',
+        kind: 'slack.message',
+        occurredAt: new Date('2026-07-01T10:00:00.000Z'),
+        actorName: 'Ada',
+        title: 'general',
+        sourceUrl: 'https://example.com/archives/C123/p1',
+        workId: null,
+        payload: {},
+        processedAt: new Date('2026-07-01T10:05:00.000Z'),
+        dedupeKey: 'abc',
+        createdAt: new Date('2026-07-01T10:00:05.000Z'),
+        ...overrides,
+    }) as IngestedEvent;
+
+describe('buildIngestEventTools — list_recent_events', () => {
+    let findRecentByUser: jest.Mock;
+
+    const tool = () => {
+        findRecentByUser = findRecentByUser ?? jest.fn(async () => [row()]);
+        const repository = { findRecentByUser } as unknown as IngestedEventRepository;
+        const tools = buildIngestEventTools({ userId: 'user-1', repository });
+        const found = tools.find((t) => t.name === 'list_recent_events');
+        if (!found) throw new Error('list_recent_events tool not built');
+        return found;
+    };
+
+    beforeEach(() => {
+        findRecentByUser = jest.fn(async () => [row()]);
+    });
+
+    it('reads owner-scoped rows and maps them with the sourceUrl provenance', async () => {
+        const result = (await tool().invoke({})) as { events: Array<Record<string, unknown>> };
+
+        expect(findRecentByUser).toHaveBeenCalledWith('user-1', 20);
+        expect(result.events).toEqual([
+            expect.objectContaining({
+                id: 'row-1',
+                source: 'slack-connector',
+                kind: 'slack.message',
+                occurredAt: '2026-07-01T10:00:00.000Z',
+                actorName: 'Ada',
+                title: 'general',
+                sourceUrl: 'https://example.com/archives/C123/p1',
+                processed: true,
+            }),
+        ]);
+    });
+
+    it('filters by source when asked (over-fetching so the filter does not starve the page)', async () => {
+        findRecentByUser.mockResolvedValue([
+            row({ id: 'a', source: 'other-source' }),
+            row({ id: 'b' }),
+        ]);
+
+        const result = (await tool().invoke({ source: 'slack-connector', limit: 5 })) as {
+            events: Array<{ id: string }>;
+        };
+
+        expect(findRecentByUser).toHaveBeenCalledWith('user-1', 15);
+        expect(result.events.map((e) => e.id)).toEqual(['b']);
+    });
+
+    it('caps the limit at 50 and floors it at 1', async () => {
+        await tool().invoke({ limit: 500 });
+        expect(findRecentByUser).toHaveBeenLastCalledWith('user-1', 50);
+
+        await tool().invoke({ limit: -3 });
+        expect(findRecentByUser).toHaveBeenLastCalledWith('user-1', 1);
+    });
+
+    it('returns a tool-shaped error instead of throwing', async () => {
+        findRecentByUser.mockRejectedValue(new Error('db down'));
+
+        const result = await tool().invoke({});
+
+        expect(result).toEqual({ error: 'db down' });
+    });
+});

--- a/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
@@ -1,0 +1,222 @@
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+import { EventIngestService } from '../event-ingest.service';
+import { ActivityActionType, ActivityStatus } from '../../entities/activity-log.types';
+import type { IngestedEvent } from '../../entities/ingested-event.entity';
+
+const envelope = (overrides: Partial<IngestedEventEnvelope> = {}): IngestedEventEnvelope => ({
+    id: 'env-1',
+    source: 'slack-connector',
+    sourceEventId: 'evt-1',
+    kind: 'slack.message',
+    occurredAt: '2026-07-01T10:00:00.000Z',
+    actor: { name: 'Ada' },
+    subject: { type: 'channel', externalId: 'C123', title: 'general' },
+    sourceUrl: 'https://example.com/archives/C123/p1',
+    payload: { text: 'hello' },
+    ...overrides,
+});
+
+const storedEvent = (overrides: Partial<IngestedEvent> = {}): IngestedEvent =>
+    ({
+        id: 'row-1',
+        userId: 'user-1',
+        organizationId: null,
+        workId: null,
+        source: 'slack-connector',
+        sourceEventId: 'evt-1',
+        kind: 'slack.message',
+        occurredAt: new Date('2026-07-01T10:00:00.000Z'),
+        actorName: 'Ada',
+        subjectType: 'channel',
+        subjectExternalId: 'C123',
+        title: 'general',
+        sourceUrl: 'https://example.com/archives/C123/p1',
+        payload: { text: 'hello' },
+        processedAt: null,
+        dedupeKey: 'abc',
+        createdAt: new Date('2026-07-01T10:00:05.000Z'),
+        ...overrides,
+    }) as IngestedEvent;
+
+describe('EventIngestService', () => {
+    let repository: {
+        createIfNew: jest.Mock;
+        findUnprocessed: jest.Mock;
+        markProcessed: jest.Mock;
+        findRecentByUser: jest.Mock;
+    };
+    let activityLog: { log: jest.Mock };
+    let agentMemory: { saveMemory: jest.Mock };
+
+    const build = (opts: { withMemory?: boolean } = { withMemory: true }) =>
+        new EventIngestService(
+            repository as never,
+            activityLog as never,
+            opts.withMemory ? (agentMemory as never) : undefined,
+        );
+
+    beforeEach(() => {
+        repository = {
+            createIfNew: jest.fn(async () => ({ event: storedEvent(), created: true })),
+            findUnprocessed: jest.fn(async () => []),
+            markProcessed: jest.fn(async () => undefined),
+            findRecentByUser: jest.fn(async () => []),
+        };
+        activityLog = { log: jest.fn(async () => ({ id: 'activity-1' })) };
+        agentMemory = { saveMemory: jest.fn(async () => ({ id: 'memory-1' })) };
+    });
+
+    describe('ingest', () => {
+        it('maps the envelope onto the row shape (actor/subject flattened, occurredAt parsed)', async () => {
+            const result = await build().ingest('user-1', [envelope()]);
+
+            expect(result).toEqual({ inserted: 1, duplicates: 0, rejected: 0 });
+            expect(repository.createIfNew).toHaveBeenCalledWith({
+                userId: 'user-1',
+                organizationId: null,
+                workId: null,
+                source: 'slack-connector',
+                sourceEventId: 'evt-1',
+                kind: 'slack.message',
+                occurredAt: new Date('2026-07-01T10:00:00.000Z'),
+                actorName: 'Ada',
+                subjectType: 'channel',
+                subjectExternalId: 'C123',
+                title: 'general',
+                sourceUrl: 'https://example.com/archives/C123/p1',
+                payload: { text: 'hello' },
+            });
+        });
+
+        it('counts duplicates instead of inserting the same event twice', async () => {
+            repository.createIfNew
+                .mockResolvedValueOnce({ event: storedEvent(), created: true })
+                .mockResolvedValueOnce({ event: storedEvent(), created: false });
+
+            const result = await build().ingest('user-1', [envelope(), envelope()]);
+
+            expect(result).toEqual({ inserted: 1, duplicates: 1, rejected: 0 });
+            expect(repository.createIfNew).toHaveBeenCalledTimes(2);
+        });
+
+        it('rejects envelopes whose serialized payload exceeds the 32 KB cap', async () => {
+            const oversized = envelope({ payload: { blob: 'x'.repeat(33 * 1024) } });
+
+            const result = await build().ingest('user-1', [oversized, envelope()]);
+
+            expect(result).toEqual({ inserted: 1, duplicates: 0, rejected: 1 });
+            expect(repository.createIfNew).toHaveBeenCalledTimes(1);
+        });
+
+        it('rejects envelopes with an unparseable occurredAt', async () => {
+            const result = await build().ingest('user-1', [envelope({ occurredAt: 'not-a-date' })]);
+
+            expect(result).toEqual({ inserted: 0, duplicates: 0, rejected: 1 });
+            expect(repository.createIfNew).not.toHaveBeenCalled();
+        });
+
+        it('rejects envelopes missing the identity floor (source / sourceEventId / kind)', async () => {
+            const result = await build().ingest('user-1', [
+                envelope({ source: '' }),
+                envelope({ sourceEventId: '' }),
+                envelope({ kind: '' }),
+            ]);
+
+            expect(result).toEqual({ inserted: 0, duplicates: 0, rejected: 3 });
+            expect(repository.createIfNew).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('processBatch', () => {
+        it('writes an Activity row carrying the sourceUrl provenance and marks the row processed', async () => {
+            const event = storedEvent();
+            repository.findUnprocessed.mockResolvedValue([event]);
+
+            const result = await build().processBatch(10);
+
+            expect(result).toEqual({ processed: 1, activities: 1, memories: 1, failed: 0 });
+            expect(activityLog.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'user-1',
+                    actionType: ActivityActionType.EXTERNAL_EVENT_INGESTED,
+                    action: 'slack.message',
+                    status: ActivityStatus.COMPLETED,
+                    summary: expect.stringContaining('slack.message'),
+                    metadata: expect.objectContaining({
+                        source: 'slack-connector',
+                        sourceEventId: 'evt-1',
+                        sourceUrl: 'https://example.com/archives/C123/p1',
+                    }),
+                }),
+                // Feed orders by "when it happened".
+                { createdAt: event.occurredAt },
+            );
+            expect(repository.markProcessed).toHaveBeenCalledWith('row-1');
+        });
+
+        it('saves a Memory observation with provenance tags scoped to the owner (and Work when routed)', async () => {
+            repository.findUnprocessed.mockResolvedValue([storedEvent({ workId: 'work-9' })]);
+
+            await build().processBatch(10);
+
+            expect(agentMemory.saveMemory).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    tags: expect.arrayContaining([
+                        'ingested-event',
+                        'source:slack-connector',
+                        'kind:slack.message',
+                        'work:work-9',
+                    ]),
+                    metadata: expect.objectContaining({
+                        sourceUrl: 'https://example.com/archives/C123/p1',
+                    }),
+                }),
+                { userId: 'user-1', workId: 'work-9' },
+            );
+        });
+
+        it('memory failure is best-effort: the row is STILL marked processed', async () => {
+            repository.findUnprocessed.mockResolvedValue([storedEvent()]);
+            agentMemory.saveMemory.mockRejectedValue(new Error('memory backend down'));
+
+            const result = await build().processBatch(10);
+
+            expect(result).toEqual({ processed: 1, activities: 1, memories: 0, failed: 0 });
+            expect(repository.markProcessed).toHaveBeenCalledWith('row-1');
+        });
+
+        it('runs without a memory facade at all (OSS / no provider wiring)', async () => {
+            repository.findUnprocessed.mockResolvedValue([storedEvent()]);
+
+            const result = await build({ withMemory: false }).processBatch(10);
+
+            expect(result).toEqual({ processed: 1, activities: 1, memories: 0, failed: 0 });
+            expect(repository.markProcessed).toHaveBeenCalledWith('row-1');
+        });
+
+        it('activity failure leaves the row unprocessed for retry and keeps draining the batch', async () => {
+            const bad = storedEvent({ id: 'row-bad' });
+            const good = storedEvent({ id: 'row-good' });
+            repository.findUnprocessed.mockResolvedValue([bad, good]);
+            activityLog.log
+                .mockRejectedValueOnce(new Error('db write failed'))
+                .mockResolvedValueOnce({ id: 'activity-2' });
+
+            const result = await build().processBatch(10);
+
+            expect(result).toEqual({ processed: 1, activities: 1, memories: 1, failed: 1 });
+            expect(repository.markProcessed).not.toHaveBeenCalledWith('row-bad');
+            expect(repository.markProcessed).toHaveBeenCalledWith('row-good');
+        });
+
+        it('passes the batch limit through to the unprocessed read', async () => {
+            repository.findUnprocessed.mockResolvedValue([]);
+
+            await build().processBatch(7);
+            expect(repository.findUnprocessed).toHaveBeenCalledWith(7);
+
+            await build().processBatch();
+            expect(repository.findUnprocessed).toHaveBeenCalledWith(50);
+        });
+    });
+});

--- a/packages/agent/src/ingest/__tests__/ingest.module.spec.ts
+++ b/packages/agent/src/ingest/__tests__/ingest.module.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Event-ingest spine (Wave 6) — module-shape pin for EventIngestModule.
+ *
+ * Pattern mirrors `knowledge-base.module.spec.ts`: heavy runtime trees
+ * (TypeORM, the facades/activity-log graphs) are mocked at module scope
+ * so the decorator metadata can be asserted without loading them under
+ * Jest's CJS transformer.
+ */
+
+jest.mock('@nestjs/typeorm', () => ({
+    TypeOrmModule: { forFeature: () => class TypeOrmFeatureStub {} },
+    InjectRepository: () => () => undefined,
+    InjectDataSource: () => () => undefined,
+}));
+jest.mock('../../entities/ingested-event.entity', () => ({
+    IngestedEvent: class IngestedEvent {},
+}));
+jest.mock('../../activity-log/activity-log.module', () => ({
+    ActivityLogModule: class ActivityLogModule {},
+}));
+jest.mock('../../facades/facades.module', () => ({
+    FacadesModule: class FacadesModule {},
+}));
+jest.mock('../ingested-event.repository', () => ({
+    IngestedEventRepository: class IngestedEventRepository {},
+}));
+jest.mock('../event-ingest.service', () => ({
+    EventIngestService: class EventIngestService {},
+}));
+
+import 'reflect-metadata';
+import { EventIngestModule } from '../ingest.module';
+import { IngestedEventRepository } from '../ingested-event.repository';
+import { EventIngestService } from '../event-ingest.service';
+import { ActivityLogModule } from '../../activity-log/activity-log.module';
+import { FacadesModule } from '../../facades/facades.module';
+
+describe('EventIngestModule', () => {
+    const meta = (key: string): unknown[] => Reflect.getMetadata(key, EventIngestModule) ?? [];
+
+    it('provides the repository and the ingest service', () => {
+        expect(meta('providers')).toEqual([IngestedEventRepository, EventIngestService]);
+    });
+
+    it('exports both for the API surface + trigger-internal RPC wiring', () => {
+        expect(meta('exports')).toEqual([IngestedEventRepository, EventIngestService]);
+    });
+
+    it('imports the two processor modules (Activity log + Facades) beside the entity feature', () => {
+        const imports = meta('imports');
+        expect(imports).toContain(ActivityLogModule);
+        expect(imports).toContain(FacadesModule);
+        expect(imports).toHaveLength(3);
+    });
+});
+
+describe('ingest barrel', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const barrel = require('../index');
+
+    it('re-exports the module, service and repository', () => {
+        expect(barrel.EventIngestModule).toBe(EventIngestModule);
+        expect(barrel.EventIngestService).toBe(EventIngestService);
+        expect(barrel.IngestedEventRepository).toBe(IngestedEventRepository);
+        expect(typeof barrel.buildIngestEventTools).toBe('function');
+    });
+});

--- a/packages/agent/src/ingest/__tests__/ingested-event.repository.spec.ts
+++ b/packages/agent/src/ingest/__tests__/ingested-event.repository.spec.ts
@@ -1,0 +1,112 @@
+import { IsNull } from 'typeorm';
+import { computeDedupeKey, IngestedEventRepository } from '../ingested-event.repository';
+
+describe('computeDedupeKey', () => {
+    it('is deterministic for the same (userId, source, sourceEventId)', () => {
+        const a = computeDedupeKey('user-1', 'slack-connector', 'evt-1');
+        const b = computeDedupeKey('user-1', 'slack-connector', 'evt-1');
+        expect(a).toBe(b);
+        expect(a).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('scopes the identity per owner and length-prefixes segments against boundary collisions', () => {
+        // Same (source, sourceEventId), different owner → different key.
+        expect(computeDedupeKey('user-1', 'src', 'evt')).not.toBe(
+            computeDedupeKey('user-2', 'src', 'evt'),
+        );
+        // ('ab','c') vs ('a','bc') must not collide (length-prefixed).
+        expect(computeDedupeKey('u', 'ab', 'c')).not.toBe(computeDedupeKey('u', 'a', 'bc'));
+    });
+});
+
+describe('IngestedEventRepository', () => {
+    const baseData = {
+        userId: 'user-1',
+        source: 'slack-connector',
+        sourceEventId: 'evt-1',
+        kind: 'slack.message',
+        occurredAt: new Date('2026-07-01T10:00:00.000Z'),
+        payload: { text: 'hello' },
+    };
+
+    let typeormRepo: {
+        findOne: jest.Mock;
+        create: jest.Mock;
+        save: jest.Mock;
+        find: jest.Mock;
+        update: jest.Mock;
+    };
+    let repository: IngestedEventRepository;
+
+    beforeEach(() => {
+        typeormRepo = {
+            findOne: jest.fn(),
+            create: jest.fn((data) => data),
+            save: jest.fn(async (data) => ({ id: 'row-1', ...data })),
+            find: jest.fn(async () => []),
+            update: jest.fn(async () => undefined),
+        };
+        repository = new IngestedEventRepository(typeormRepo as never);
+    });
+
+    it('createIfNew inserts a new row stamped with the computed dedupeKey', async () => {
+        typeormRepo.findOne.mockResolvedValue(null);
+
+        const result = await repository.createIfNew(baseData);
+
+        expect(result.created).toBe(true);
+        const expectedKey = computeDedupeKey('user-1', 'slack-connector', 'evt-1');
+        expect(typeormRepo.findOne).toHaveBeenCalledWith({ where: { dedupeKey: expectedKey } });
+        expect(typeormRepo.save).toHaveBeenCalledWith(
+            expect.objectContaining({ dedupeKey: expectedKey, kind: 'slack.message' }),
+        );
+    });
+
+    it('createIfNew dedupes: the same (source, sourceEventId) is inserted once', async () => {
+        const existing = { id: 'row-1', ...baseData };
+        typeormRepo.findOne.mockResolvedValue(existing);
+
+        const result = await repository.createIfNew(baseData);
+
+        expect(result.created).toBe(false);
+        expect(result.event).toBe(existing);
+        expect(typeormRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('createIfNew treats the unique-index race as the idempotent outcome', async () => {
+        const winner = { id: 'row-winner', ...baseData };
+        // Check-then-insert race: existence check misses, INSERT trips the
+        // unique index, the re-read finds the row that won.
+        typeormRepo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(winner);
+        typeormRepo.save.mockRejectedValue({ code: 'SQLITE_CONSTRAINT' });
+
+        const result = await repository.createIfNew(baseData);
+
+        expect(result.created).toBe(false);
+        expect(result.event).toBe(winner);
+    });
+
+    it('createIfNew rethrows non-unique-violation errors', async () => {
+        typeormRepo.findOne.mockResolvedValue(null);
+        typeormRepo.save.mockRejectedValue(new Error('connection reset'));
+
+        await expect(repository.createIfNew(baseData)).rejects.toThrow('connection reset');
+    });
+
+    it('findUnprocessed reads oldest-first with the batch limit and processedAt IS NULL', async () => {
+        await repository.findUnprocessed(25);
+
+        expect(typeormRepo.find).toHaveBeenCalledWith({
+            where: { processedAt: IsNull() },
+            order: { occurredAt: 'ASC', createdAt: 'ASC' },
+            take: 25,
+        });
+    });
+
+    it('markProcessed stamps the row', async () => {
+        const at = new Date('2026-07-02T00:00:00.000Z');
+        await repository.markProcessed('row-1', at);
+
+        expect(typeormRepo.update).toHaveBeenCalledWith('row-1', { processedAt: at });
+    });
+});

--- a/packages/agent/src/ingest/agent-ingest-tools.ts
+++ b/packages/agent/src/ingest/agent-ingest-tools.ts
@@ -1,0 +1,93 @@
+import type { TaskToolDescriptor } from '../tasks-domain/agent-task-tools';
+import type { IngestedEventRepository } from './ingested-event.repository';
+
+/**
+ * Event-ingest spine (Wave 6) — chat tools for the ingested-event
+ * surface, per the program DoD rule that every new entity ships with
+ * chat tools + keyword slots.
+ *
+ * Mirrors `tasks-domain/agent-task-tools.ts`: a descriptor-factory the
+ * tool assembly concatenates at run time (type-only import of
+ * `TaskToolDescriptor`, so the Tasks runtime graph is NOT pulled into
+ * the ingest subpath).
+ *
+ * Keyword slots: "recent events", "what happened", "activity from
+ * <source>" style asks route here; results carry `sourceUrl` so the
+ * chat answer links back to the origin.
+ */
+
+export interface ListRecentEventsArgs {
+    /** Optional producing plugin id filter, e.g. `slack-connector`. */
+    source?: string;
+    /** Max rows (default 20, capped at 50). */
+    limit?: number;
+}
+
+export interface RecentEventSummary {
+    id: string;
+    source: string;
+    kind: string;
+    occurredAt: string;
+    actorName?: string;
+    title?: string;
+    sourceUrl?: string;
+    workId?: string;
+    processed: boolean;
+}
+
+export function buildIngestEventTools(args: {
+    /** Owner scope — tools only ever read this user's rows. */
+    userId: string;
+    repository: IngestedEventRepository;
+}): TaskToolDescriptor[] {
+    const out: TaskToolDescriptor[] = [];
+
+    out.push({
+        name: 'list_recent_events',
+        description:
+            'List recent external events ingested for the current user (messages, PRs, pages, commits from connected sources), newest first. Each event carries a sourceUrl linking back to the original item — include it when citing an event.',
+        parameters: {
+            type: 'object',
+            properties: {
+                source: {
+                    type: 'string',
+                    description: 'Optional plugin id to filter by (e.g. a connector id).',
+                },
+                limit: {
+                    type: 'integer',
+                    description: 'Max events to return (default 20, capped at 50).',
+                },
+            },
+            required: [],
+        },
+        invoke: async (raw) => {
+            const a = (raw ?? {}) as ListRecentEventsArgs;
+            const limit = Math.min(Math.max(Number(a.limit) || 20, 1), 50);
+            try {
+                // Owner-scoped read; over-fetch when a source filter is
+                // applied so the filter does not starve the page.
+                const rows = await args.repository.findRecentByUser(
+                    args.userId,
+                    a.source ? limit * 3 : limit,
+                );
+                const filtered = a.source ? rows.filter((row) => row.source === a.source) : rows;
+                const events: RecentEventSummary[] = filtered.slice(0, limit).map((row) => ({
+                    id: row.id,
+                    source: row.source,
+                    kind: row.kind,
+                    occurredAt: row.occurredAt.toISOString(),
+                    ...(row.actorName ? { actorName: row.actorName } : {}),
+                    ...(row.title ? { title: row.title } : {}),
+                    ...(row.sourceUrl ? { sourceUrl: row.sourceUrl } : {}),
+                    ...(row.workId ? { workId: row.workId } : {}),
+                    processed: !!row.processedAt,
+                }));
+                return { events };
+            } catch (err) {
+                return { error: err instanceof Error ? err.message : String(err) };
+            }
+        },
+    } satisfies TaskToolDescriptor<ListRecentEventsArgs, { events: RecentEventSummary[] }>);
+
+    return out;
+}

--- a/packages/agent/src/ingest/event-ingest.service.ts
+++ b/packages/agent/src/ingest/event-ingest.service.ts
@@ -1,0 +1,249 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+import { INGEST_EVENT_PAYLOAD_MAX_BYTES } from '@ever-works/contracts';
+import { ActivityLogService } from '../activity-log/activity-log.service';
+import { AgentMemoryFacadeService } from '../facades/agent-memory.facade';
+import { ActivityActionType, ActivityStatus } from '../entities/activity-log.types';
+import type { IngestedEvent } from '../entities/ingested-event.entity';
+import { IngestedEventRepository } from './ingested-event.repository';
+
+export interface IngestResult {
+    /** New rows written. */
+    inserted: number;
+    /** Envelopes dropped because their dedupe identity already landed. */
+    duplicates: number;
+    /** Envelopes rejected before insert (oversized payload, bad shape). */
+    rejected: number;
+}
+
+export interface ProcessBatchResult {
+    /** Rows marked processed this run. */
+    processed: number;
+    /** Activity-log rows written. */
+    activities: number;
+    /** Memory observations saved (0 when no provider is enabled). */
+    memories: number;
+    /** Rows whose Activity write failed — left unprocessed for retry. */
+    failed: number;
+}
+
+/**
+ * Event-ingest spine (Wave 6) — the ONE pipeline every connector feeds.
+ *
+ * `ingest()` lands normalized `IngestedEventEnvelope`s as
+ * `ingested_events` rows (dedupe-insert by owner-scoped
+ * `(source, sourceEventId)`); `processBatch()` — driven by the
+ * `event-ingest-tick` cron — fans each unprocessed row out to:
+ *
+ *   1. Activity log (`EXTERNAL_EVENT_INGESTED`, provenance in
+ *      `metadata` incl. `sourceUrl`) — REQUIRED: a failed write leaves
+ *      the row unprocessed so the next tick retries it.
+ *   2. Agent Memory via `AgentMemoryFacadeService.saveMemory` with
+ *      provenance tags/metadata — BEST-EFFORT: no provider enabled or a
+ *      provider error never fails the batch (mirrors
+ *      `WorkMemoryService`, incl. the quiet `NoProviderError` case).
+ *
+ * Chat surfacing rides the existing Memory/Activity recall paths plus
+ * the `list_recent_events` tool (`agent-ingest-tools.ts`) — answers
+ * link back to the origin through `sourceUrl`.
+ */
+@Injectable()
+export class EventIngestService {
+    private readonly logger = new Logger(EventIngestService.name);
+
+    constructor(
+        private readonly repository: IngestedEventRepository,
+        private readonly activityLogService: ActivityLogService,
+        @Optional() private readonly agentMemory?: AgentMemoryFacadeService,
+    ) {}
+
+    /** Dedupe-insert a batch of envelopes for one owner. */
+    async ingest(userId: string, envelopes: IngestedEventEnvelope[]): Promise<IngestResult> {
+        const result: IngestResult = { inserted: 0, duplicates: 0, rejected: 0 };
+
+        for (const envelope of envelopes) {
+            if (!this.isIngestible(envelope)) {
+                result.rejected += 1;
+                continue;
+            }
+
+            const occurredAt = new Date(envelope.occurredAt);
+            if (Number.isNaN(occurredAt.getTime())) {
+                result.rejected += 1;
+                continue;
+            }
+
+            const { created } = await this.repository.createIfNew({
+                userId,
+                organizationId: envelope.organizationId ?? null,
+                workId: envelope.workId ?? null,
+                source: envelope.source,
+                sourceEventId: envelope.sourceEventId,
+                kind: envelope.kind,
+                occurredAt,
+                actorName: envelope.actor?.name ?? null,
+                subjectType: envelope.subject?.type ?? null,
+                subjectExternalId: envelope.subject?.externalId ?? null,
+                title: envelope.subject?.title ?? null,
+                sourceUrl: envelope.sourceUrl ?? null,
+                payload: envelope.payload ?? {},
+            });
+
+            if (created) {
+                result.inserted += 1;
+            } else {
+                result.duplicates += 1;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Drain up to `limit` unprocessed rows through the processor
+     * fan-out. Never throws for a single bad row — the row is either
+     * retried next tick (Activity write failed) or completed.
+     */
+    async processBatch(limit = 50): Promise<ProcessBatchResult> {
+        const result: ProcessBatchResult = { processed: 0, activities: 0, memories: 0, failed: 0 };
+        const events = await this.repository.findUnprocessed(limit);
+
+        for (const event of events) {
+            try {
+                await this.writeActivity(event);
+                result.activities += 1;
+            } catch (error) {
+                // REQUIRED processor failed — leave the row unprocessed so
+                // the next tick retries it, and keep draining the batch.
+                result.failed += 1;
+                this.logger.warn(
+                    `Activity write failed for ingested event ${event.id}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+                continue;
+            }
+
+            if (await this.trySaveMemory(event)) {
+                result.memories += 1;
+            }
+
+            await this.repository.markProcessed(event.id);
+            result.processed += 1;
+        }
+
+        return result;
+    }
+
+    private async writeActivity(event: IngestedEvent): Promise<void> {
+        await this.activityLogService.log(
+            {
+                userId: event.userId,
+                ...(event.workId ? { workId: event.workId } : {}),
+                actionType: ActivityActionType.EXTERNAL_EVENT_INGESTED,
+                action: event.kind,
+                status: ActivityStatus.COMPLETED,
+                summary: this.summarize(event),
+                metadata: this.provenance(event),
+            },
+            // Feed orders by "when it happened", not "when the platform
+            // drained it" — same rule as ingestFromWebsite. Future
+            // timestamps are clamped there too; ingest validates
+            // occurredAt at the edge, clamp defensively anyway.
+            { createdAt: event.occurredAt > new Date() ? new Date() : event.occurredAt },
+        );
+    }
+
+    /**
+     * Memory observation — best-effort, never fails the batch. Returns
+     * true when an observation was saved. `NoProviderError` (no
+     * agent-memory provider enabled for this user/Work) is the expected
+     * quiet case — debug, not warn (see WorkMemoryService rationale).
+     */
+    private async trySaveMemory(event: IngestedEvent): Promise<boolean> {
+        if (!this.agentMemory) {
+            return false;
+        }
+
+        const facadeOptions = {
+            userId: event.userId,
+            ...(event.workId ? { workId: event.workId } : {}),
+        };
+
+        try {
+            await this.agentMemory.saveMemory(
+                {
+                    content: this.summarize(event),
+                    tags: [
+                        'ingested-event',
+                        `source:${event.source}`,
+                        `kind:${event.kind}`,
+                        ...(event.workId ? [`work:${event.workId}`] : []),
+                    ],
+                    // Provenance metadata is REQUIRED on ingest-written
+                    // memories — it drives the Memory source facets and
+                    // lets chat citations carry the sourceUrl.
+                    metadata: this.provenance(event),
+                },
+                facadeOptions,
+            );
+            return true;
+        } catch (error) {
+            const isNoProvider = error instanceof Error && error.name === 'NoProviderError';
+            const message = `Memory write skipped for ingested event ${event.id}: ${
+                error instanceof Error ? error.message : String(error)
+            }`;
+            if (isNoProvider) {
+                this.logger.debug(message);
+            } else {
+                this.logger.warn(message);
+            }
+            return false;
+        }
+    }
+
+    private summarize(event: IngestedEvent): string {
+        const parts = [
+            event.actorName ? `${event.actorName}:` : null,
+            event.kind,
+            event.title ? `— ${event.title}` : null,
+        ].filter(Boolean);
+        const summary = parts.join(' ');
+        // activity_log.summary is varchar(500); stay safely under it.
+        return summary.length > 480 ? summary.slice(0, 480) : summary;
+    }
+
+    private provenance(event: IngestedEvent): Record<string, unknown> {
+        return {
+            ingestedEventId: event.id,
+            source: event.source,
+            sourceEventId: event.sourceEventId,
+            kind: event.kind,
+            occurredAt: event.occurredAt.toISOString(),
+            ...(event.sourceUrl ? { sourceUrl: event.sourceUrl } : {}),
+            ...(event.actorName ? { actorName: event.actorName } : {}),
+            ...(event.subjectType ? { subjectType: event.subjectType } : {}),
+            ...(event.subjectExternalId ? { subjectExternalId: event.subjectExternalId } : {}),
+            ...(event.title ? { title: event.title } : {}),
+            ...(event.organizationId ? { organizationId: event.organizationId } : {}),
+        };
+    }
+
+    /** Structural floor + defensive payload cap (DTO enforces at the edge). */
+    private isIngestible(envelope: IngestedEventEnvelope): boolean {
+        if (!envelope || typeof envelope !== 'object') return false;
+        if (!envelope.source || !envelope.sourceEventId || !envelope.kind) return false;
+        if (envelope.payload !== undefined && envelope.payload !== null) {
+            if (typeof envelope.payload !== 'object' || Array.isArray(envelope.payload)) {
+                return false;
+            }
+            try {
+                const bytes = Buffer.byteLength(JSON.stringify(envelope.payload), 'utf8');
+                if (bytes > INGEST_EVENT_PAYLOAD_MAX_BYTES) return false;
+            } catch {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/packages/agent/src/ingest/index.ts
+++ b/packages/agent/src/ingest/index.ts
@@ -1,0 +1,8 @@
+// Public surface of the event-ingest spine (Wave 6): normalized
+// external events landing as `ingested_events` rows and fanning out to
+// Activity log + agent Memory, with `sourceUrl` provenance throughout.
+export * from './ingest.module';
+export * from './event-ingest.service';
+export * from './ingested-event.repository';
+export * from './agent-ingest-tools';
+export { IngestedEvent } from '../entities/ingested-event.entity';

--- a/packages/agent/src/ingest/ingest.module.ts
+++ b/packages/agent/src/ingest/ingest.module.ts
@@ -1,0 +1,32 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { IngestedEvent } from '../entities/ingested-event.entity';
+import { ActivityLogModule } from '../activity-log/activity-log.module';
+import { FacadesModule } from '../facades/facades.module';
+import { IngestedEventRepository } from './ingested-event.repository';
+import { EventIngestService } from './event-ingest.service';
+
+/**
+ * Event-ingest spine (Wave 6) — agent-side module owning the
+ * `ingested_events` surface: dedupe-insert (`ingest`) + the processor
+ * fan-out to Activity log and agent Memory (`processBatch`, driven by
+ * the `event-ingest-tick` cron over the trigger-internal RPC channel).
+ *
+ * `IngestedEvent` MUST also stay registered in the DataSource ENTITIES
+ * array (`database/_entities-inventory.ts`) — this repo has no
+ * `autoLoadEntities`, so a forFeature'd-but-unregistered entity throws
+ * EntityMetadataNotFoundError on first query.
+ */
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([IngestedEvent]),
+        // Processor 1 — Activity-log rows with sourceUrl provenance.
+        ActivityLogModule,
+        // Processor 2 — best-effort Memory observations via
+        // AgentMemoryFacadeService (exported by FacadesModule).
+        FacadesModule,
+    ],
+    providers: [IngestedEventRepository, EventIngestService],
+    exports: [IngestedEventRepository, EventIngestService],
+})
+export class EventIngestModule {}

--- a/packages/agent/src/ingest/ingested-event.repository.ts
+++ b/packages/agent/src/ingest/ingested-event.repository.ts
@@ -1,0 +1,120 @@
+import { createHash } from 'crypto';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { IngestedEvent } from '../entities/ingested-event.entity';
+
+/**
+ * Dedupe identity for an ingested event: sha256 over
+ * `(userId, source, sourceEventId)`.
+ *
+ * The envelope identity is `(source, sourceEventId)` — it is scoped per
+ * OWNER here so two users connected to the same external workspace each
+ * keep their own row (a global key would silently drop the second
+ * user's delivery and leak the first user's row back to them).
+ * Segments are length-prefixed so `('ab','c')` and `('a','bc')` can
+ * never collide.
+ */
+export function computeDedupeKey(userId: string, source: string, sourceEventId: string): string {
+    const hash = createHash('sha256');
+    for (const segment of [userId, source, sourceEventId]) {
+        hash.update(`${segment.length}:${segment}|`);
+    }
+    return hash.digest('hex');
+}
+
+export interface CreateIngestedEventData {
+    userId: string;
+    organizationId?: string | null;
+    workId?: string | null;
+    source: string;
+    sourceEventId: string;
+    kind: string;
+    occurredAt: Date;
+    actorName?: string | null;
+    subjectType?: string | null;
+    subjectExternalId?: string | null;
+    title?: string | null;
+    sourceUrl?: string | null;
+    payload: Record<string, unknown>;
+}
+
+/**
+ * Feature-owned repository (provided by `EventIngestModule`, not
+ * `DatabaseModule` — same split as `WorkProposalRepository`).
+ */
+@Injectable()
+export class IngestedEventRepository {
+    constructor(
+        @InjectRepository(IngestedEvent)
+        private readonly repository: Repository<IngestedEvent>,
+    ) {}
+
+    /**
+     * Insert the event unless a row with the same dedupe identity
+     * already exists. Check-then-insert is not atomic, so the UNIQUE
+     * index race is treated as the idempotent outcome it should be
+     * (same convention as `ActivityLogService.ingestFromWebsite`).
+     */
+    async createIfNew(
+        data: CreateIngestedEventData,
+    ): Promise<{ event: IngestedEvent; created: boolean }> {
+        const dedupeKey = computeDedupeKey(data.userId, data.source, data.sourceEventId);
+
+        const existing = await this.repository.findOne({ where: { dedupeKey } });
+        if (existing) {
+            return { event: existing, created: false };
+        }
+
+        try {
+            const event = await this.repository.save(
+                this.repository.create({ ...data, dedupeKey }),
+            );
+            return { event, created: true };
+        } catch (error) {
+            if (this.isUniqueViolation(error)) {
+                const winner = await this.repository.findOne({ where: { dedupeKey } });
+                if (winner) {
+                    return { event: winner, created: false };
+                }
+            }
+            throw error;
+        }
+    }
+
+    /** Oldest-first batch of rows the processor has not drained yet. */
+    async findUnprocessed(limit: number): Promise<IngestedEvent[]> {
+        return this.repository.find({
+            where: { processedAt: IsNull() },
+            order: { occurredAt: 'ASC', createdAt: 'ASC' },
+            take: limit,
+        });
+    }
+
+    async markProcessed(id: string, processedAt: Date = new Date()): Promise<void> {
+        await this.repository.update(id, { processedAt });
+    }
+
+    /** Owner-scoped recent events (chat tool + future feed surfaces). */
+    async findRecentByUser(userId: string, limit = 20): Promise<IngestedEvent[]> {
+        return this.repository.find({
+            where: { userId },
+            order: { occurredAt: 'DESC' },
+            take: limit,
+        });
+    }
+
+    async findById(id: string): Promise<IngestedEvent | null> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    private isUniqueViolation(error: unknown): boolean {
+        if (!error || typeof error !== 'object') return false;
+        const driverCode = (error as { driverError?: { code?: string } }).driverError?.code;
+        const topCode = (error as { code?: string }).code;
+        // Postgres 23505 / MySQL ER_DUP_ENTRY / SQLite SQLITE_CONSTRAINT —
+        // same convention as ActivityLogService.isUniqueViolation.
+        const codes = ['23505', 'ER_DUP_ENTRY', 'SQLITE_CONSTRAINT'];
+        return codes.includes(driverCode as string) || codes.includes(topCode as string);
+    }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,3 +5,4 @@ export * from './github/index.js';
 export * from './kb/index.js';
 export * from './terminal/index.js';
 export * from './tasks/index.js';
+export * from './ingest/index.js';

--- a/packages/contracts/src/ingest/index.ts
+++ b/packages/contracts/src/ingest/index.ts
@@ -1,0 +1,1 @@
+export * from './ingest.types.js';

--- a/packages/contracts/src/ingest/ingest.types.ts
+++ b/packages/contracts/src/ingest/ingest.types.ts
@@ -1,0 +1,79 @@
+/**
+ * Event-ingest spine (Wave 6) — the ONE normalized event shape every
+ * connector produces and the platform pipeline consumes.
+ *
+ * External systems (chat workspaces, issue trackers, doc suites, git
+ * hosts, …) emit wildly different event payloads. Each event-source
+ * plugin normalizes its raw events into `IngestedEventEnvelope` rows;
+ * the platform then fans a single pipeline out over them: dedupe-insert
+ * → Activity-log entry → Memory observation (best-effort, with
+ * provenance) → chat surfacing via the existing recall paths. Answers
+ * and feed rows link back to the origin through `sourceUrl`.
+ *
+ * This package is the zero-dependency wire/storage shape only — no
+ * runtime behavior lives here (same rule as `tasks/task-gates.types.ts`).
+ */
+
+/** Who did the thing in the external system (best-effort attribution). */
+export interface IngestedEventActor {
+	/** Display name as the source reports it. */
+	name: string;
+	/** Stable id in the source system (user id, login, …). */
+	externalId?: string;
+}
+
+/** What the event happened TO in the external system. */
+export interface IngestedEventSubject {
+	/** Source-namespaced subject type, e.g. `channel`, `page`, `issue`. */
+	type: string;
+	/** Stable id of the subject in the source system. */
+	externalId: string;
+	/** Human-readable subject title, when the source provides one. */
+	title?: string;
+}
+
+/**
+ * One normalized external event.
+ *
+ * Identity: `(source, sourceEventId)` — the ingest pipeline dedupes on
+ * it, so connectors may re-deliver the same event freely (webhook
+ * retries, overlapping pull windows, historical backfill).
+ */
+export interface IngestedEventEnvelope {
+	/** Connector-assigned envelope id (uuid recommended). */
+	id: string;
+	/** Producing plugin id, e.g. `slack-connector`. */
+	source: string;
+	/** The event's stable id in the source system. */
+	sourceEventId: string;
+	/**
+	 * Source-namespaced event kind, e.g. `slack.message`,
+	 * `github.pull_request.merged`. Free-form string on purpose — the
+	 * platform never enumerates connector kinds.
+	 */
+	kind: string;
+	/** ISO 8601 timestamp of when the event happened at the source. */
+	occurredAt: string;
+	actor?: IngestedEventActor;
+	subject?: IngestedEventSubject;
+	/** Deep link to the original message / PR / page / commit. */
+	sourceUrl?: string;
+	/**
+	 * Source-specific details. Size-capped: the serialized payload must
+	 * stay within {@link INGEST_EVENT_PAYLOAD_MAX_BYTES}.
+	 */
+	payload: Record<string, unknown>;
+	/** Optional Work routing hint resolved by the connector. */
+	workId?: string;
+	/** Optional Organization scope hint. */
+	organizationId?: string;
+}
+
+/**
+ * Serialized-payload byte cap per envelope. Enforced at the API edge
+ * (DTO validation) and defensively re-checked by the ingest service.
+ */
+export const INGEST_EVENT_PAYLOAD_MAX_BYTES = 32 * 1024;
+
+/** Maximum envelopes accepted per ingest call / batch. */
+export const INGEST_EVENT_BATCH_MAX = 100;

--- a/packages/plugin/src/contracts/__tests__/event-source.spec.ts
+++ b/packages/plugin/src/contracts/__tests__/event-source.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+	EventSourceNotConfiguredError,
+	isEventSourcePlugin,
+	type IEventSourcePlugin
+} from '../capabilities/event-source.interface.js';
+import { ALL_PLUGIN_CAPABILITIES, PLUGIN_CAPABILITIES } from '../facade-capabilities.js';
+import type { IPlugin } from '../plugin.interface.js';
+
+describe('event-source capability (Wave 6)', () => {
+	it('registers `event-source` in the capability registry', () => {
+		expect(PLUGIN_CAPABILITIES.EVENT_SOURCE).toBe('event-source');
+		expect(ALL_PLUGIN_CAPABILITIES).toContain('event-source');
+	});
+
+	it('isEventSourcePlugin guards on the declared capability', () => {
+		const yes = { capabilities: ['event-source'] } as unknown as IPlugin;
+		const no = { capabilities: ['search'] } as unknown as IPlugin;
+		expect(isEventSourcePlugin(yes)).toBe(true);
+		expect(isEventSourcePlugin(no)).toBe(false);
+	});
+
+	it('EventSourceNotConfiguredError keeps its stable cross-package name', () => {
+		const err = new EventSourceNotConfiguredError();
+		expect(err.name).toBe('EventSourceNotConfiguredError');
+		expect(err.message).toContain('not configured');
+		const custom = new EventSourceNotConfiguredError('workspace not connected');
+		expect(custom.message).toBe('workspace not connected');
+		expect(custom.name).toBe('EventSourceNotConfiguredError');
+	});
+
+	it('pullEvents contract round-trips envelopes + cursor', async () => {
+		const plugin: Pick<IEventSourcePlugin, 'pullEvents'> = {
+			pullEvents: async ({ since, cursor }) => ({
+				events: [
+					{
+						id: 'env-1',
+						source: 'demo-source',
+						sourceEventId: `after:${since}`,
+						kind: 'demo.event',
+						occurredAt: since,
+						payload: { cursor: cursor ?? null }
+					}
+				],
+				nextCursor: 'page-2'
+			})
+		};
+
+		const result = await plugin.pullEvents({ since: '2026-07-01T00:00:00.000Z' });
+		expect(result.events).toHaveLength(1);
+		expect(result.events[0].sourceEventId).toBe('after:2026-07-01T00:00:00.000Z');
+		expect(result.nextCursor).toBe('page-2');
+	});
+});

--- a/packages/plugin/src/contracts/capabilities/event-source.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/event-source.interface.ts
@@ -1,0 +1,64 @@
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+import type { IPlugin } from '../plugin.interface.js';
+import type { PluginSettings } from '../../settings/settings.types.js';
+
+/**
+ * Event-source capability (Wave 6) — plugins that surface external
+ * events into the platform's event-ingest spine (capability
+ * `event-source`).
+ *
+ * v1 is PULL-model: the platform's `event-ingest-tick` cron (and, per
+ * connector, activation-time backfill) calls `pullEvents` with a
+ * watermark + opaque cursor and receives normalized
+ * `IngestedEventEnvelope` rows. Webhook PUSH lands with each concrete
+ * connector — pushed events flow through the same envelope shape via
+ * `POST /api/ingest/events`, so nothing upstream changes.
+ *
+ * Dedupe contract: `(source, sourceEventId)` is the event identity.
+ * Implementations may re-deliver events freely (overlapping windows,
+ * retries, backfill) — the ingest pipeline drops duplicates.
+ */
+export interface EventSourcePullInput {
+	/** ISO 8601 watermark — return events that occurred at/after this. */
+	since: string;
+	/**
+	 * Opaque continuation cursor from a previous pull. Implementations
+	 * define the format; callers only round-trip it.
+	 */
+	cursor?: string;
+	/** Resolved plugin settings (4-level hierarchy, resolved upstream). */
+	settings?: PluginSettings;
+}
+
+export interface EventSourcePullResult {
+	/** Normalized events, oldest-first preferred. */
+	events: IngestedEventEnvelope[];
+	/** Present when more events remain — pass back on the next pull. */
+	nextCursor?: string;
+}
+
+/**
+ * Thrown when the event source cannot pull in this runtime/config
+ * (missing credentials, no workspace connected, …). Matched BY NAME
+ * across packages — maps to a loud, actionable failure upstream, never
+ * a silent no-op.
+ */
+export class EventSourceNotConfiguredError extends Error {
+	constructor(message?: string) {
+		super(message ?? 'Event-source plugin is not configured in this runtime.');
+		this.name = 'EventSourceNotConfiguredError';
+	}
+}
+
+/** Event-source plugin interface — capability `event-source`. */
+export interface IEventSourcePlugin extends IPlugin {
+	readonly providerName: string;
+
+	/** Pull normalized events since the watermark (cursor-paged). */
+	pullEvents(input: EventSourcePullInput): Promise<EventSourcePullResult>;
+}
+
+/** Type guard — true when a plugin declares the `event-source` capability. */
+export function isEventSourcePlugin(plugin: IPlugin): plugin is IEventSourcePlugin {
+	return plugin.capabilities.includes('event-source');
+}

--- a/packages/plugin/src/contracts/capabilities/index.ts
+++ b/packages/plugin/src/contracts/capabilities/index.ts
@@ -28,6 +28,10 @@ export * from './connector.interface.js';
 export * from './agent-memory.interface.js';
 export * from './terminal-stream.interface.js';
 export * from './workspace.interface.js';
+// Event-ingest spine (Wave 6) — pull-model event sources feeding the
+// normalized `IngestedEventEnvelope` pipeline (webhook push lands with
+// each concrete connector). See `event-source.interface.ts`.
+export * from './event-source.interface.js';
 // Org-wide Memory (Cortex P2) — pluggable ORG memory framework +
 // multi-doc-type RAG pipeline contracts. Additive, beside the existing
 // `agent-memory` / `vector-store` / `content-extractor` seams. See

--- a/packages/plugin/src/contracts/facade-capabilities.ts
+++ b/packages/plugin/src/contracts/facade-capabilities.ts
@@ -74,7 +74,11 @@ export const PLUGIN_CAPABILITIES = {
 	// k8s-exec. See capabilities/terminal-stream.interface.ts.
 	TERMINAL_STREAM: 'terminal-stream',
 	// Isolated git working contexts for agent Tasks (Wave 2).
-	WORKSPACE: 'workspace'
+	WORKSPACE: 'workspace',
+	// Event-ingest spine (Wave 6) — plugins that pull/push normalized
+	// external events into the platform ingest pipeline. See
+	// capabilities/event-source.interface.ts.
+	EVENT_SOURCE: 'event-source'
 } as const;
 
 export type PluginCapability = (typeof PLUGIN_CAPABILITIES)[keyof typeof PLUGIN_CAPABILITIES];

--- a/packages/tasks/src/tasks/trigger/event-ingest-tick.task.ts
+++ b/packages/tasks/src/tasks/trigger/event-ingest-tick.task.ts
@@ -1,0 +1,43 @@
+import { logger, schedules } from '@trigger.dev/sdk';
+import { EventIngestService } from '@ever-works/agent/ingest';
+import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
+import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+
+/**
+ * Event-ingest spine (Wave 6) — processor tick.
+ *
+ * Every 5 minutes, drain a batch of unprocessed `ingested_events`
+ * rows through the fan-out (Activity log + best-effort Memory, each
+ * carrying `sourceUrl` provenance). The real `EventIngestService`
+ * lives in the API (repositories + ActivityLogService + the
+ * agent-memory facade are wired there); the worker only calls
+ * `processBatch()` over the internal RPC channel — same shape as the
+ * task-branch-gc / mission-tick crons.
+ *
+ * 5 minutes is deliberate: ingest is not latency-sensitive (feed +
+ * Memory freshness, not user-facing request paths), rows that fail
+ * their Activity write stay unprocessed and retry next tick, and the
+ * batch cap keeps each run bounded regardless of connector volume.
+ */
+export const eventIngestTickTask = schedules.task({
+    id: 'event-ingest-tick',
+    cron: '*/5 * * * *',
+    run: async () => {
+        return withWorkerContext(
+            'EventIngestTick',
+            async (appContext) => {
+                const svc = appContext.get(EventIngestService);
+                const limit = Number(process.env.EVENT_INGEST_BATCH_LIMIT) || 50;
+                const summary = await svc.processBatch(limit);
+                if (summary.processed > 0 || summary.failed > 0) {
+                    logger.info('event-ingest-tick drained ingested events', {
+                        ...summary,
+                        limit,
+                    });
+                }
+                return summary;
+            },
+            TriggerInternalModule,
+        );
+    },
+});

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -25,6 +25,7 @@ import {
 } from '@ever-works/agent/tasks-domain';
 import { AgentRepository, AgentRunRepository, WorkRepository } from '@ever-works/agent/database';
 import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
+import { EventIngestService } from '@ever-works/agent/ingest';
 import { TriggerInternalApiClient } from '../services/trigger-internal-api.client';
 import { createRemoteProxy } from '../remote-proxy';
 
@@ -240,6 +241,16 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
                 createRemoteProxy(apiClient, 'KnowledgeBaseReconcileService'),
             inject: [TriggerInternalApiClient],
         },
+        // Event-ingest spine (Wave 6) — the event-ingest-tick cron task
+        // calls `processBatch()` on this proxy, which RPCs to the live
+        // API where the ingest repositories + Activity/Memory processors
+        // are wired. Same shape as TaskWorkspaceService.
+        {
+            provide: EventIngestService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'EventIngestService'),
+            inject: [TriggerInternalApiClient],
+        },
     ],
     exports: [
         TriggerInternalApiClient,
@@ -266,6 +277,7 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         NotificationChannelFacadeService,
         AnonymousUserCleanupService,
         KnowledgeBaseReconcileService,
+        EventIngestService,
     ],
 })
 export class TriggerInternalModule {}


### PR DESCRIPTION
The **event-ingest spine** (Wave 6 core): one generic pipeline every connector feeds — external events → normalized `IngestedEventEnvelope` rows → processors fan out to the Activity log and agent Memory (best-effort), each entry carrying `sourceUrl` provenance back to the origin. Chat surfacing rides the existing Memory/Activity recall paths plus a new `list_recent_events` tool.

## Deliverables

### 1. `@ever-works/contracts` — envelope (zero-dependency)
New `src/ingest/` module, exported from the package barrel:
- `IngestedEventEnvelope` `{ id, source, sourceEventId, kind, occurredAt (ISO), actor? {name, externalId?}, subject? {type, externalId, title?}, sourceUrl?, payload, workId?, organizationId? }` — identity is `(source, sourceEventId)`, connectors may re-deliver freely.
- Shared caps: `INGEST_EVENT_PAYLOAD_MAX_BYTES` (32 KB serialized) / `INGEST_EVENT_BATCH_MAX` (100) so the DTO and service share one source of truth.

### 2. `@ever-works/plugin` — `event-source` capability
- `PLUGIN_CAPABILITIES.EVENT_SOURCE = 'event-source'` + `contracts/capabilities/event-source.interface.ts`: `IEventSourcePlugin.pullEvents({since, cursor?, settings})` → `{events, nextCursor?}` (pull model v1; webhook push lands with each concrete connector through the same envelope shape).
- `isEventSourcePlugin` capability guard + stably-named `EventSourceNotConfiguredError` (matched BY NAME across packages). Exported from the capability barrel.

### 3. `@ever-works/agent` — entity + pipeline (new `ingest/` module, 22nd subpath export)
- `IngestedEvent` entity (`ingested_events`) with UNIQUE `dedupeKey`, unprocessed-scan + owner-recency indexes; registered in the DataSource ENTITIES inventory + `_entity-names` (house bug-class guard — drift specs green).
- `IngestedEventRepository` (feature-owned): `createIfNew` by dedupe key with unique-index race tolerance, `findUnprocessed(limit)` oldest-first, `markProcessed`, `findRecentByUser`.
- `EventIngestService`: `ingest(userId, envelopes[])` dedupe-insert (structural floor + defensive 32 KB payload re-check); `processBatch(limit)` → per row: Activity entry (`EXTERNAL_EVENT_INGESTED`, provenance metadata incl. `sourceUrl`, `createdAt` pinned to `occurredAt`) + best-effort Memory observation via `AgentMemoryFacadeService` (provenance tags/metadata; `NoProviderError` quiet-cased; **memory failure never fails the batch**) → `markProcessed`. A failed Activity write leaves the row unprocessed for next-tick retry.
- `buildIngestEventTools` → `list_recent_events` chat tool (owner-scoped, source filter, limit clamp; mirrors the `agent-task-tools` descriptor pattern) — program DoD: every new entity ships with chat tools.
- Dedupe note (deliberate strengthening): `dedupeKey = sha256(userId, source, sourceEventId)` — the spec'd `(source, sourceEventId)` identity scoped **per owner** with length-prefixed segments, so one user's delivery can never swallow (or leak) another user's row.

### 4. Migration (same PR, per the migrations rule)
`1783200000000-CreateIngestedEvents` — hasTable-guarded create + 3 indexes + FKs (`userId` → users CASCADE, `workId` → works SET NULL). Forward-only, idempotent; same shape as `1782100000000-CreateInboundTriggers`.

### 5. API push surface
`POST /api/ingest/events` — new thin `IngestModule`/`IngestController` over the agent-side `EventIngestModule`; auth = current user; class-validator DTO (batch 1..100 envelopes, per-envelope payload ≤ 32 KB serialized via constraint, ISO-8601 `occurredAt`, nested actor/subject, uuid routing hints); registered in `api.module.ts`; returns `{inserted, duplicates, rejected}`.

### 6. Cron + trigger-internal RPC (3-place wiring, TaskWorkspaceService shape)
- `packages/tasks` `event-ingest-tick` (`schedules.task`, id `event-ingest-tick`, cron `*/5 * * * *`) → `EventIngestService.processBatch(EVENT_INGEST_BATCH_LIMIT || 50)` via `withWorkerContext(TriggerInternalModule)`.
- Worker `TriggerInternalModule`: `EventIngestService` remote-proxy provider + export.
- `TriggerInternalController`: constructor arg appended LAST + `@Optional()` (spec arity untouched) + `remoteMap` entry; API-side `TriggerInternalModule` imports `EventIngestModule`.

## Verification (real output)

- `packages/agent` build: `TSC Found 0 issues.` / `Successfully compiled: 993 files with swc`
- `packages/agent` jest `ingest|database.(module|config).spec`: **6 suites / 81 tests passed** (27 new ingest tests + entity-inventory drift pins)
- `pnpm build --filter=ever-works-api`: **Tasks: 14 successful, 14 total**
- `apps/api` jest `trigger-internal|ingest-events.dto`: **3 suites / 24 tests passed**
- `apps/api pnpm generate:openapi` (full-app bootstrap gate): `Wrote OpenAPI spec (415 paths)`; `/api/ingest/events` present with `["post"]` (`openapi.json` is gitignored — not committed)
- `packages/tasks` build: `tsc -p tsconfig.json` clean
- `packages/plugin` vitest `event-source.spec.ts`: **4 tests passed**
- `apps/api` `npx tsc --noEmit`: error set identical to the clean base (pre-existing `@ever-works/k8s-plugin` / `@src/*` noise) — zero new errors
- Prettier run on every touched file

## Known pre-existing red (unrelated)

`packages/tasks` `src/__tests__/agent-task-execute.task.spec.ts` fails **16/20 on the clean `wave/integration` base** (verified via stash: identical failures with and without this change — `TaskRunDenormService` missing from that spec's partial `vi.mock`). Not touched here.

## Unit tests added (39 new)

- Dedupe: same `(source, sourceEventId)` inserted once; unique-index race → idempotent; per-owner scoping + segment-boundary collision proof.
- processBatch: Activity row with `sourceUrl` provenance; Memory tags/scoping; memory failure → **still processed**; no-facade path; Activity failure → retry; batch-limit pass-through.
- ingest: envelope mapping; duplicate counting; >32 KB payload, bad `occurredAt`, missing identity floor → rejected.
- DTO caps: >100 batch, >32 KB payload, empty batch, array payload, nested actor, non-uuid `workId`.
- Module-shape pin for `EventIngestModule` + barrel; `list_recent_events` tool (4); event-source capability guard + stable error name (4, vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
