### PR TITLE
feat(agent): Digest briefings (Wave 7)

### DIFF
--- a/apps/api/src/auth/dto/update-profile.dto.ts
+++ b/apps/api/src/auth/dto/update-profile.dto.ts
@@ -7,6 +7,7 @@ import {
     IsUrl,
     IsEmail,
     IsBoolean,
+    IsIn,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
@@ -59,4 +60,16 @@ export class UpdateProfileDto {
     @IsBoolean()
     @IsOptional()
     emailBudgetAlerts?: boolean;
+
+    @ApiPropertyOptional({
+        description:
+            "Digest briefing cadence: 'off' (default — no digests), 'daily' " +
+            "(every morning), or 'weekly' (Monday mornings). Digests are " +
+            'delivered as in-app notifications plus any configured ' +
+            'notification channels.',
+        enum: ['off', 'daily', 'weekly'],
+    })
+    @IsIn(['off', 'daily', 'weekly'])
+    @IsOptional()
+    digestFrequency?: 'off' | 'daily' | 'weekly';
 }

--- a/apps/api/src/auth/services/auth.service.ts
+++ b/apps/api/src/auth/services/auth.service.ts
@@ -635,6 +635,10 @@ export class AuthService {
         }
         if (typeof updateData.emailBudgetAlerts === 'boolean')
             updateFields.emailBudgetAlerts = updateData.emailBudgetAlerts;
+        // Digest briefings (Wave 7) — DTO's @IsIn already constrained the
+        // value to 'off' | 'daily' | 'weekly'.
+        if (typeof updateData.digestFrequency === 'string')
+            updateFields.digestFrequency = updateData.digestFrequency;
 
         await this.userRepository.update(userId, updateFields);
 

--- a/apps/api/src/migrations/1783300000000-AddUserDigestPreference.ts
+++ b/apps/api/src/migrations/1783300000000-AddUserDigestPreference.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Digest briefings (Wave 7) — per-user cadence preference.
+ *
+ * `users.digestFrequency`: 'off' (default) | 'daily' | 'weekly'.
+ * Default 'off' means every existing row keeps meaning "no digests" —
+ * the feature is opt-in per user via PUT /api/auth/profile.
+ *
+ * Forward-only, idempotent per-step guard (house pattern — mirrors
+ * 1782700000000-AddTaskIsolationColumns).
+ */
+export class AddUserDigestPreference1783300000000 implements MigrationInterface {
+    name = 'AddUserDigestPreference1783300000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const users = await queryRunner.getTable('users');
+        if (users && !users.findColumnByName('digestFrequency')) {
+            await queryRunner.query(
+                `ALTER TABLE "users" ADD COLUMN "digestFrequency" varchar(8) NOT NULL DEFAULT 'off'`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const users = await queryRunner.getTable('users');
+        if (users && users.findColumnByName('digestFrequency')) {
+            await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "digestFrequency"`);
+        }
+    }
+}

--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -83,6 +83,12 @@ jest.mock('@ever-works/agent/ingest', () => ({
     EventIngestService: class EventIngestService {},
     EventIngestModule: class EventIngestModule {},
 }));
+// Digest briefings (Wave 7) — same rationale as the ingest stub above:
+// the controller imports DigestService from the digest barrel.
+jest.mock('@ever-works/agent/digest', () => ({
+    DigestService: class DigestService {},
+    DigestModule: class DigestModule {},
+}));
 jest.mock('@ever-works/agent/activity-log', () => ({
     ActivityLogService: class ActivityLogService {},
     ActivityLogModule: class ActivityLogModule {},

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -71,6 +71,7 @@ import {
     WorkPluginRepository,
 } from '@ever-works/agent/plugins';
 import { EventIngestService } from '@ever-works/agent/ingest';
+import { DigestService } from '@ever-works/agent/digest';
 
 /**
  * C-05 RPC half — methods that must never be reachable via `POST
@@ -290,6 +291,11 @@ export class TriggerInternalController implements OnModuleInit {
         // RPC channel. Appended LAST + @Optional() per the arity rule above.
         @Optional()
         private readonly eventIngestService?: EventIngestService,
+        // Digest briefings (Wave 7) — backs the `digest-dispatcher` cron:
+        // the worker proxy calls `dispatchDue(period)` over the internal
+        // RPC channel. Appended LAST + @Optional() per the arity rule above.
+        @Optional()
+        private readonly digestService?: DigestService,
     ) {}
 
     onModuleInit() {
@@ -362,6 +368,9 @@ export class TriggerInternalController implements OnModuleInit {
             // Event-ingest spine (Wave 6) — `event-ingest-tick` calls
             // `processBatch()` here (allow-list auto-derived).
             EventIngestService: this.eventIngestService,
+            // Digest briefings (Wave 7) — `digest-dispatcher` calls
+            // `dispatchDue(period)` here (allow-list auto-derived).
+            DigestService: this.digestService,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/apps/api/src/trigger/trigger-internal.module.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.module.spec.ts
@@ -70,6 +70,13 @@ jest.mock('@ever-works/agent/ingest', () => ({
     EventIngestModule: class EventIngestModule {},
     EventIngestService: class EventIngestService {},
 }));
+// Digest briefings (Wave 7) — the module imports DigestModule (and the
+// controller it declares imports DigestService) from the digest barrel;
+// stub both so the entity chain is never loaded.
+jest.mock('@ever-works/agent/digest', () => ({
+    DigestModule: class DigestModule {},
+    DigestService: class DigestService {},
+}));
 // EW-742 P3.2 T22 — trigger-internal.module imports TenantJobRuntimeModule
 // + OrganizationsModule (added by bbc24309 / 5e4e2483 / 41906b71). Loading
 // those modules pulls in real `@ever-works/agent/entities` + `@ever-works/agent/tasks`

--- a/apps/api/src/trigger/trigger-internal.module.ts
+++ b/apps/api/src/trigger/trigger-internal.module.ts
@@ -11,6 +11,7 @@ import { GoalsModule } from '@ever-works/agent/goals';
 import { AgentsModule } from '@ever-works/agent/agents';
 import { TasksDomainModule } from '@ever-works/agent/tasks-domain';
 import { EventIngestModule } from '@ever-works/agent/ingest';
+import { DigestModule } from '@ever-works/agent/digest';
 import { WorkProposalsModule } from '../work-proposals/work-proposals.module';
 import { DataSyncModule } from '../data-sync/data-sync.module';
 import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
@@ -76,6 +77,11 @@ import { OrganizationsModule } from '../organizations/organizations.module';
         // cron task (in packages/tasks) can drive `processBatch()` over
         // the internal RPC channel every 5 minutes.
         EventIngestModule,
+        // Digest briefings (Wave 7) — exposes DigestService through the
+        // remote-proxy controller so the digest-dispatcher cron task
+        // (in packages/tasks) can drive `dispatchDue(period)` over the
+        // internal RPC channel each morning.
+        DigestModule,
     ],
     controllers: [TriggerInternalController],
 })

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -180,6 +180,10 @@
         "./ingest": {
             "types": "./dist/ingest/index.d.ts",
             "default": "./dist/ingest/index.js"
+        },
+        "./digest": {
+            "types": "./dist/digest/index.d.ts",
+            "default": "./dist/digest/index.js"
         }
     },
     "scripts": {

--- a/packages/agent/src/database/repositories/user.repository.ts
+++ b/packages/agent/src/database/repositories/user.repository.ts
@@ -201,6 +201,19 @@ export class UserRepository {
      * Caller (Trigger.dev nightly task) is expected to delete them; ON DELETE
      * CASCADE on `work.userId` removes the orphan Works.
      */
+    /**
+     * Digest briefings (Wave 7) — users due a digest for one period.
+     * Only active, non-anonymous accounts; ordered oldest-first so a
+     * capped dispatch pass is stable across runs.
+     */
+    async findByDigestFrequency(frequency: 'daily' | 'weekly', limit = 200): Promise<User[]> {
+        return await this.repository.find({
+            where: { digestFrequency: frequency, isActive: true, isAnonymous: false },
+            order: { createdAt: 'ASC' },
+            take: limit,
+        });
+    }
+
     async findExpiredAnonymous(now: Date = new Date()): Promise<User[]> {
         return await this.repository.find({
             where: {

--- a/packages/agent/src/digest/__tests__/agent-digest-tools.spec.ts
+++ b/packages/agent/src/digest/__tests__/agent-digest-tools.spec.ts
@@ -1,0 +1,82 @@
+import { buildDigestTools } from '../agent-digest-tools';
+import type { ComposedDigest } from '../digest.types';
+
+const composed = (period: 'daily' | 'weekly'): ComposedDigest => ({
+    period,
+    since: '2026-07-24T07:15:00.000Z',
+    until: '2026-07-25T07:15:00.000Z',
+    quiet: false,
+    markdown: `# Your ${period} digest`,
+    text: `${period === 'daily' ? 'Daily' : 'Weekly'} digest: 1 task done.`,
+    counts: {
+        runsCompleted: 0,
+        runsFailed: 0,
+        tasksDone: 1,
+        tasksInReview: 0,
+        prsOpened: 0,
+        eventsBySource: {},
+        eventsTotal: 0,
+        goalsTracked: 0,
+    },
+});
+
+describe('buildDigestTools — get_digest', () => {
+    let digestService: { composeDigest: jest.Mock };
+
+    beforeEach(() => {
+        digestService = {
+            composeDigest: jest.fn(async (_userId: string, opts: { period: 'daily' | 'weekly' }) =>
+                composed(opts.period),
+            ),
+        };
+    });
+
+    it('exposes a single owner-scoped read tool with the descriptor shape', () => {
+        const tools = buildDigestTools({ userId: 'user-1', digestService });
+
+        expect(tools).toHaveLength(1);
+        expect(tools[0].name).toBe('get_digest');
+        expect(tools[0].parameters.type).toBe('object');
+        expect(tools[0].parameters.properties.period.type).toBe('string');
+        expect(tools[0].parameters.required).toEqual([]);
+    });
+
+    it('defaults to the daily period and composes for the bound user only', async () => {
+        const tools = buildDigestTools({ userId: 'user-1', digestService });
+
+        const result = (await tools[0].invoke({})) as ComposedDigest;
+
+        expect(digestService.composeDigest).toHaveBeenCalledWith('user-1', { period: 'daily' });
+        expect(result.period).toBe('daily');
+        expect(result.markdown).toContain('daily digest');
+    });
+
+    it('passes an explicit weekly period through', async () => {
+        const tools = buildDigestTools({ userId: 'user-1', digestService });
+
+        const result = (await tools[0].invoke({ period: 'weekly' })) as ComposedDigest;
+
+        expect(digestService.composeDigest).toHaveBeenCalledWith('user-1', { period: 'weekly' });
+        expect(result.period).toBe('weekly');
+    });
+
+    it('rejects unknown periods without calling the service', async () => {
+        const tools = buildDigestTools({ userId: 'user-1', digestService });
+
+        const result = await tools[0].invoke({ period: 'hourly' });
+
+        expect(result).toEqual({
+            error: 'Invalid period "hourly": expected "daily" or "weekly".',
+        });
+        expect(digestService.composeDigest).not.toHaveBeenCalled();
+    });
+
+    it('maps service failures to the { error } tool contract', async () => {
+        digestService.composeDigest.mockRejectedValue(new Error('compose blew up'));
+        const tools = buildDigestTools({ userId: 'user-1', digestService });
+
+        const result = await tools[0].invoke({});
+
+        expect(result).toEqual({ error: 'compose blew up' });
+    });
+});

--- a/packages/agent/src/digest/__tests__/digest.module.spec.ts
+++ b/packages/agent/src/digest/__tests__/digest.module.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Digest briefings (Wave 7) — module-shape pin for DigestModule.
+ *
+ * Pattern mirrors `ingest/__tests__/ingest.module.spec.ts`: the heavy
+ * runtime trees (TypeORM, the tasks/agents/goals graphs) are mocked at
+ * module scope so the decorator metadata can be asserted without
+ * loading them under Jest's CJS transformer.
+ */
+
+jest.mock('../../database/database.module', () => ({
+    DatabaseModule: class DatabaseModule {},
+}));
+jest.mock('../../tasks-domain/tasks.module', () => ({
+    TasksDomainModule: class TasksDomainModule {},
+}));
+jest.mock('../../agents/agents.module', () => ({
+    AgentsModule: class AgentsModule {},
+}));
+jest.mock('../../ingest/ingest.module', () => ({
+    EventIngestModule: class EventIngestModule {},
+}));
+jest.mock('../../goals/goals.module', () => ({
+    GoalsModule: class GoalsModule {},
+}));
+jest.mock('../../notifications/notifications.module', () => ({
+    NotificationsModule: class NotificationsModule {},
+}));
+jest.mock('../digest.service', () => ({
+    DigestService: class DigestService {},
+}));
+
+import 'reflect-metadata';
+import { DigestModule } from '../digest.module';
+import { DigestService } from '../digest.service';
+import { DatabaseModule } from '../../database/database.module';
+import { TasksDomainModule } from '../../tasks-domain/tasks.module';
+import { AgentsModule } from '../../agents/agents.module';
+import { EventIngestModule } from '../../ingest/ingest.module';
+import { GoalsModule } from '../../goals/goals.module';
+import { NotificationsModule } from '../../notifications/notifications.module';
+
+describe('DigestModule', () => {
+    const meta = (key: string): unknown[] => Reflect.getMetadata(key, DigestModule) ?? [];
+
+    it('provides and exports the digest service for the trigger-internal RPC wiring', () => {
+        expect(meta('providers')).toEqual([DigestService]);
+        expect(meta('exports')).toEqual([DigestService]);
+    });
+
+    it('imports the repository/producer modules the composer reads from', () => {
+        expect(meta('imports')).toEqual([
+            DatabaseModule,
+            TasksDomainModule,
+            AgentsModule,
+            EventIngestModule,
+            GoalsModule,
+            NotificationsModule,
+        ]);
+    });
+});
+
+describe('digest barrel', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const barrel = require('../index');
+
+    it('re-exports the module, service, types and the chat-tool factory', () => {
+        expect(barrel.DigestModule).toBe(DigestModule);
+        expect(barrel.DigestService).toBe(DigestService);
+        expect(typeof barrel.buildDigestTools).toBe('function');
+        expect(barrel.DIGEST_PERIODS).toEqual(['daily', 'weekly']);
+        expect(barrel.DIGEST_FREQUENCIES).toEqual(['off', 'daily', 'weekly']);
+    });
+});

--- a/packages/agent/src/digest/__tests__/digest.service.spec.ts
+++ b/packages/agent/src/digest/__tests__/digest.service.spec.ts
@@ -1,0 +1,392 @@
+import { DigestService } from '../digest.service';
+import { TaskStatus } from '../../entities/task.entity';
+import { GoalStatus } from '../../entities/goal.entity';
+
+/**
+ * Digest briefings (Wave 7) — composer/delivery/dispatcher unit specs
+ * over mocked repositories (house pattern: plain-object mocks + `as
+ * any` construction, mirroring event-ingest.service.spec).
+ */
+
+const NOW = new Date('2026-07-25T07:15:00.000Z');
+
+const hoursAgo = (h: number) => new Date(NOW.getTime() - h * 60 * 60 * 1000);
+const daysAgo = (d: number) => hoursAgo(d * 24);
+
+describe('DigestService', () => {
+    let userRepository: {
+        findById: jest.Mock;
+        findByDigestFrequency: jest.Mock;
+    };
+    let taskRepository: { findByUserIdFiltered: jest.Mock };
+    let agentRunRepository: { listSessionsForUser: jest.Mock };
+    let ingestedEventRepository: { findRecentByUser: jest.Mock };
+    let notificationService: { notifyDigest: jest.Mock };
+    let goalsService: { listForUser: jest.Mock };
+
+    const build = (opts: { withGoals?: boolean } = {}) =>
+        new DigestService(
+            userRepository as any,
+            taskRepository as any,
+            agentRunRepository as any,
+            ingestedEventRepository as any,
+            notificationService as any,
+            opts.withGoals === false ? undefined : (goalsService as any),
+        );
+
+    beforeEach(() => {
+        userRepository = {
+            findById: jest.fn().mockResolvedValue({ id: 'user-1', digestFrequency: 'daily' }),
+            findByDigestFrequency: jest.fn().mockResolvedValue([]),
+        };
+        taskRepository = {
+            findByUserIdFiltered: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
+        };
+        agentRunRepository = {
+            listSessionsForUser: jest.fn().mockResolvedValue([[], 0]),
+        };
+        ingestedEventRepository = {
+            findRecentByUser: jest.fn().mockResolvedValue([]),
+        };
+        notificationService = { notifyDigest: jest.fn().mockResolvedValue(undefined) };
+        goalsService = { listForUser: jest.fn().mockResolvedValue([]) };
+    });
+
+    describe('composeDigest', () => {
+        it('counts completed and failed agent runs inside the window and renders them', async () => {
+            agentRunRepository.listSessionsForUser.mockResolvedValue([
+                [
+                    {
+                        id: 'run-ok',
+                        status: 'completed',
+                        finishedAt: hoursAgo(2),
+                        createdAt: hoursAgo(3),
+                        summary: 'Shipped the landing page copy',
+                    },
+                    {
+                        id: 'run-bad',
+                        status: 'failed',
+                        finishedAt: hoursAgo(1),
+                        createdAt: hoursAgo(2),
+                        errorMessage: 'Build exploded',
+                    },
+                    // Non-terminal — never counted.
+                    { id: 'run-live', status: 'running', createdAt: hoursAgo(1) },
+                ],
+                3,
+            ]);
+
+            const digest = await build().composeDigest('user-1', { period: 'daily', now: NOW });
+
+            expect(digest.counts.runsCompleted).toBe(1);
+            expect(digest.counts.runsFailed).toBe(1);
+            expect(digest.quiet).toBe(false);
+            expect(digest.markdown).toContain('## Agent runs');
+            expect(digest.markdown).toContain('Completed: Shipped the landing page copy');
+            expect(digest.markdown).toContain('Failed: Build exploded');
+            expect(digest.text).toContain('1 agent run completed (1 failed)');
+        });
+
+        it('excludes runs that finished before the daily window', async () => {
+            agentRunRepository.listSessionsForUser.mockResolvedValue([
+                [
+                    {
+                        id: 'run-old',
+                        status: 'completed',
+                        finishedAt: daysAgo(2),
+                        createdAt: daysAgo(2),
+                        summary: 'Old news',
+                    },
+                ],
+                1,
+            ]);
+
+            const digest = await build().composeDigest('user-1', { period: 'daily', now: NOW });
+
+            expect(digest.counts.runsCompleted).toBe(0);
+            expect(digest.quiet).toBe(true);
+        });
+
+        it('counts tasks moved to done and in-review inside the window only', async () => {
+            taskRepository.findByUserIdFiltered.mockResolvedValue({
+                rows: [
+                    {
+                        id: 't1',
+                        title: 'Ship digest',
+                        status: TaskStatus.DONE,
+                        updatedAt: hoursAgo(3),
+                    },
+                    {
+                        id: 't2',
+                        title: 'Review gates',
+                        status: TaskStatus.IN_REVIEW,
+                        updatedAt: hoursAgo(5),
+                    },
+                    // Outside the daily window.
+                    { id: 't3', title: 'Stale', status: TaskStatus.DONE, updatedAt: daysAgo(3) },
+                    // In-window but not a digest-relevant status.
+                    {
+                        id: 't4',
+                        title: 'WIP',
+                        status: TaskStatus.IN_PROGRESS,
+                        updatedAt: hoursAgo(1),
+                    },
+                ],
+                total: 4,
+            });
+
+            const digest = await build().composeDigest('user-1', { period: 'daily', now: NOW });
+
+            expect(digest.counts.tasksDone).toBe(1);
+            expect(digest.counts.tasksInReview).toBe(1);
+            expect(digest.markdown).toContain('Done: Ship digest');
+            expect(digest.markdown).toContain('In review: Review gates');
+        });
+
+        it('lists PRs opened by agents from tasks.prUrl within the window', async () => {
+            taskRepository.findByUserIdFiltered.mockResolvedValue({
+                rows: [
+                    {
+                        id: 't1',
+                        title: 'Digest composer',
+                        status: TaskStatus.IN_REVIEW,
+                        updatedAt: hoursAgo(4),
+                        prUrl: 'https://github.com/acme/repo/pull/7',
+                    },
+                    {
+                        id: 't2',
+                        title: 'Old PR',
+                        status: TaskStatus.DONE,
+                        updatedAt: daysAgo(4),
+                        prUrl: 'https://github.com/acme/repo/pull/1',
+                    },
+                ],
+                total: 2,
+            });
+
+            const digest = await build().composeDigest('user-1', { period: 'daily', now: NOW });
+
+            expect(digest.counts.prsOpened).toBe(1);
+            expect(digest.markdown).toContain(
+                '[Digest composer](https://github.com/acme/repo/pull/7)',
+            );
+            expect(digest.markdown).not.toContain('pull/1');
+        });
+
+        it('aggregates ingested-event counts by source', async () => {
+            ingestedEventRepository.findRecentByUser.mockResolvedValue([
+                { source: 'slack-connector', occurredAt: hoursAgo(1) },
+                { source: 'slack-connector', occurredAt: hoursAgo(2) },
+                { source: 'github', occurredAt: hoursAgo(3) },
+                // Outside the window — dropped.
+                { source: 'github', occurredAt: daysAgo(2) },
+            ]);
+
+            const digest = await build().composeDigest('user-1', { period: 'daily', now: NOW });
+
+            expect(digest.counts.eventsBySource).toEqual({ 'slack-connector': 2, github: 1 });
+            expect(digest.counts.eventsTotal).toBe(3);
+            expect(digest.markdown).toContain('- slack-connector: 2 events');
+            expect(digest.markdown).toContain('- github: 1 event');
+        });
+
+        it('includes an active-goal progress snapshot when GoalsService is bound', async () => {
+            goalsService.listForUser.mockResolvedValue([
+                {
+                    id: 'g1',
+                    title: 'Weekly visitors',
+                    currentValue: 420,
+                    targetValue: 1000,
+                    unit: 'visits',
+                },
+            ]);
+
+            const digest = await build().composeDigest('user-1', { period: 'daily', now: NOW });
+
+            expect(goalsService.listForUser).toHaveBeenCalledWith('user-1', {
+                status: GoalStatus.ACTIVE,
+                limit: expect.any(Number),
+            });
+            expect(digest.counts.goalsTracked).toBe(1);
+            expect(digest.markdown).toContain('- Weekly visitors: 420 / 1000 visits');
+        });
+
+        it('composes without a goals section when GoalsService is not wired', async () => {
+            const digest = await build({ withGoals: false }).composeDigest('user-1', {
+                period: 'daily',
+                now: NOW,
+            });
+
+            expect(digest.counts.goalsTracked).toBe(0);
+            expect(digest.markdown).not.toContain('## Goal progress');
+        });
+
+        it('weekly window spans 7 days where daily spans 24 hours', async () => {
+            taskRepository.findByUserIdFiltered.mockResolvedValue({
+                rows: [
+                    {
+                        id: 't1',
+                        title: 'Three days old',
+                        status: TaskStatus.DONE,
+                        updatedAt: daysAgo(3),
+                    },
+                ],
+                total: 1,
+            });
+
+            const svc = build();
+            const daily = await svc.composeDigest('user-1', { period: 'daily', now: NOW });
+            const weekly = await svc.composeDigest('user-1', { period: 'weekly', now: NOW });
+
+            expect(daily.counts.tasksDone).toBe(0);
+            expect(weekly.counts.tasksDone).toBe(1);
+        });
+
+        it('renders the quiet empty state when the window has no activity', async () => {
+            const digest = await build().composeDigest('user-1', { period: 'weekly', now: NOW });
+
+            expect(digest.quiet).toBe(true);
+            expect(digest.markdown).toContain('A quiet week');
+            expect(digest.text).toBe('Weekly digest: a quiet week — no new activity.');
+        });
+    });
+
+    describe('deliverDigest', () => {
+        const seedActivity = () => {
+            agentRunRepository.listSessionsForUser.mockResolvedValue([
+                [
+                    {
+                        id: 'run-ok',
+                        status: 'completed',
+                        finishedAt: hoursAgo(2),
+                        createdAt: hoursAgo(3),
+                        summary: 'Did things',
+                    },
+                ],
+                1,
+            ]);
+        };
+
+        it('skips users whose digest preference is off and never notifies', async () => {
+            userRepository.findById.mockResolvedValue({ id: 'user-1', digestFrequency: 'off' });
+            seedActivity();
+
+            const result = await build().deliverDigest('user-1', 'daily', { now: NOW });
+
+            expect(result).toEqual({ delivered: false, reason: 'digest-off' });
+            expect(notificationService.notifyDigest).not.toHaveBeenCalled();
+        });
+
+        it('skips period mismatches (weekly user, daily send) unless forced', async () => {
+            userRepository.findById.mockResolvedValue({ id: 'user-1', digestFrequency: 'weekly' });
+            seedActivity();
+            const svc = build();
+
+            const mismatch = await svc.deliverDigest('user-1', 'daily', { now: NOW });
+            expect(mismatch).toEqual({ delivered: false, reason: 'period-mismatch' });
+
+            const forced = await svc.deliverDigest('user-1', 'daily', { now: NOW, force: true });
+            expect(forced.delivered).toBe(true);
+            expect(notificationService.notifyDigest).toHaveBeenCalledTimes(1);
+        });
+
+        it('delivers via the notifications producer with a windowed dedup key', async () => {
+            seedActivity();
+
+            const result = await build().deliverDigest('user-1', 'daily', { now: NOW });
+
+            expect(result.delivered).toBe(true);
+            expect(notificationService.notifyDigest).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'user-1',
+                    period: 'daily',
+                    title: 'Your daily digest',
+                    deduplicationKey: 'digest_daily_2026-07-25',
+                    message: expect.stringContaining('Daily digest:'),
+                    markdown: expect.stringContaining('# Your daily digest'),
+                }),
+            );
+        });
+
+        it('skips quiet windows instead of sending an empty briefing', async () => {
+            const result = await build().deliverDigest('user-1', 'daily', { now: NOW });
+
+            expect(result.delivered).toBe(false);
+            expect(result.reason).toBe('quiet-period');
+            expect(notificationService.notifyDigest).not.toHaveBeenCalled();
+        });
+
+        it('reports user-not-found without composing', async () => {
+            userRepository.findById.mockResolvedValue(null);
+
+            const result = await build().deliverDigest('ghost', 'daily', { now: NOW });
+
+            expect(result).toEqual({ delivered: false, reason: 'user-not-found' });
+            expect(agentRunRepository.listSessionsForUser).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('dispatchDue', () => {
+        it('selects daily users via findByDigestFrequency and tallies outcomes', async () => {
+            userRepository.findByDigestFrequency.mockResolvedValue([
+                { id: 'u-active' },
+                { id: 'u-quiet' },
+                { id: 'u-broken' },
+            ]);
+            userRepository.findById.mockImplementation(async (id: string) => ({
+                id,
+                digestFrequency: 'daily',
+            }));
+            // u-active has a run in-window; u-quiet has nothing; u-broken throws.
+            agentRunRepository.listSessionsForUser.mockImplementation(async (userId: string) => {
+                if (userId === 'u-broken') throw new Error('db down');
+                if (userId === 'u-active') {
+                    return [
+                        [
+                            {
+                                id: 'r1',
+                                status: 'completed',
+                                finishedAt: hoursAgo(1),
+                                createdAt: hoursAgo(2),
+                                summary: 'ok',
+                            },
+                        ],
+                        1,
+                    ];
+                }
+                return [[], 0];
+            });
+
+            const summary = await build().dispatchDue('daily', { now: NOW });
+
+            expect(userRepository.findByDigestFrequency).toHaveBeenCalledWith(
+                'daily',
+                expect.any(Number),
+            );
+            expect(summary).toEqual({
+                period: 'daily',
+                selected: 3,
+                delivered: 1,
+                skippedQuiet: 1,
+                skipped: 0,
+                failed: 1,
+            });
+        });
+
+        it('queries the weekly cohort for a weekly pass', async () => {
+            userRepository.findByDigestFrequency.mockResolvedValue([]);
+
+            const summary = await build().dispatchDue('weekly', { now: NOW, limit: 10 });
+
+            expect(userRepository.findByDigestFrequency).toHaveBeenCalledWith('weekly', 10);
+            expect(summary).toEqual({
+                period: 'weekly',
+                selected: 0,
+                delivered: 0,
+                skippedQuiet: 0,
+                skipped: 0,
+                failed: 0,
+            });
+        });
+    });
+});

--- a/packages/agent/src/digest/agent-digest-tools.ts
+++ b/packages/agent/src/digest/agent-digest-tools.ts
@@ -1,0 +1,63 @@
+import type { TaskToolDescriptor } from '../tasks-domain/agent-task-tools';
+import type { DigestService } from './digest.service';
+import type { ComposedDigest, DigestPeriod } from './digest.types';
+import { DIGEST_PERIODS } from './digest.types';
+
+/**
+ * Digest briefings (Wave 7) — chat tool for the digest surface, per
+ * the program DoD rule that every new entity/surface ships with chat
+ * tools + keyword slots.
+ *
+ * Mirrors `ingest/agent-ingest-tools.ts`: a descriptor-factory the
+ * tool assembly concatenates at run time (type-only import of
+ * `TaskToolDescriptor`, so the Tasks runtime graph is NOT pulled into
+ * the digest subpath).
+ *
+ * Keyword slots: "digest", "briefing", "what happened today / this
+ * week", "summary of my activity", "daily recap" style asks route
+ * here; the composed digest is deterministic (no LLM), so the chat
+ * layer can quote its counts verbatim.
+ */
+
+export interface GetDigestArgs {
+    /** 'daily' (default) or 'weekly'. */
+    period?: string;
+}
+
+export function buildDigestTools(args: {
+    /** Owner scope — the tool only ever composes this user's digest. */
+    userId: string;
+    digestService: Pick<DigestService, 'composeDigest'>;
+}): TaskToolDescriptor[] {
+    const out: TaskToolDescriptor[] = [];
+
+    out.push({
+        name: 'get_digest',
+        description:
+            'Compose an on-demand activity briefing for the current user: agent runs completed/failed, tasks done or moved to review, pull requests opened, ingested-event counts by source, and active goal progress. Returns deterministic counts plus a rendered markdown body. period is "daily" (last 24 hours, default) or "weekly" (last 7 days).',
+        parameters: {
+            type: 'object',
+            properties: {
+                period: {
+                    type: 'string',
+                    description: 'Digest window: "daily" (default) or "weekly".',
+                },
+            },
+            required: [],
+        },
+        invoke: async (raw) => {
+            const a = (raw ?? {}) as GetDigestArgs;
+            const period = (a.period ?? 'daily') as DigestPeriod;
+            if (!DIGEST_PERIODS.includes(period)) {
+                return { error: `Invalid period "${a.period}": expected "daily" or "weekly".` };
+            }
+            try {
+                return await args.digestService.composeDigest(args.userId, { period });
+            } catch (err) {
+                return { error: err instanceof Error ? err.message : String(err) };
+            }
+        },
+    } satisfies TaskToolDescriptor<GetDigestArgs, ComposedDigest>);
+
+    return out;
+}

--- a/packages/agent/src/digest/digest.module.ts
+++ b/packages/agent/src/digest/digest.module.ts
@@ -1,0 +1,39 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../database/database.module';
+import { TasksDomainModule } from '../tasks-domain/tasks.module';
+import { AgentsModule } from '../agents/agents.module';
+import { EventIngestModule } from '../ingest/ingest.module';
+import { GoalsModule } from '../goals/goals.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { DigestService } from './digest.service';
+
+/**
+ * Digest briefings (Wave 7) — agent-side module owning the digest
+ * composer + delivery + dispatcher (`DigestService`). No entity of
+ * its own: the composer is a pure read over existing repositories,
+ * delivery rides the notifications producer pattern, and the only
+ * schema surface is the `users.digestFrequency` preference column.
+ *
+ * Consumed by the API's TriggerInternalModule so the
+ * `digest-dispatcher` cron (packages/tasks) can drive
+ * `dispatchDue(period)` over the internal RPC channel.
+ */
+@Module({
+    imports: [
+        // UserRepository — preference reads + due-user selection.
+        DatabaseModule,
+        // TaskRepository — done / in-review movement + `prUrl` PR lines.
+        TasksDomainModule,
+        // AgentRunRepository — completed/failed run highlights.
+        AgentsModule,
+        // IngestedEventRepository — event counts by source (Wave 6 spine).
+        EventIngestModule,
+        // GoalsService — active-goal progress snapshot (optional section).
+        GoalsModule,
+        // NotificationService — in-app row + notifications-v2 channel fanout.
+        NotificationsModule,
+    ],
+    providers: [DigestService],
+    exports: [DigestService],
+})
+export class DigestModule {}

--- a/packages/agent/src/digest/digest.service.ts
+++ b/packages/agent/src/digest/digest.service.ts
@@ -1,0 +1,420 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { UserRepository } from '../database/repositories/user.repository';
+import { TaskRepository } from '../database/repositories/task.repository';
+import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import { IngestedEventRepository } from '../ingest/ingested-event.repository';
+import { NotificationService } from '../notifications/notification.service';
+import { GoalsService } from '../goals/goals.service';
+import { GoalStatus } from '../entities/goal.entity';
+import { Task, TaskStatus } from '../entities/task.entity';
+import type { AgentRun } from '../entities/agent-run.entity';
+import type { GoalDto } from '../goals/types';
+import {
+    ComposeDigestOptions,
+    ComposedDigest,
+    DeliverDigestOptions,
+    DeliverDigestResult,
+    DigestCounts,
+    DigestDispatchSummary,
+    DigestPeriod,
+    DispatchDueOptions,
+} from './digest.types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Window length per period. */
+const PERIOD_MS: Record<DigestPeriod, number> = {
+    daily: DAY_MS,
+    weekly: 7 * DAY_MS,
+};
+
+/** Scan caps — bound every repository read regardless of account size. */
+const RUN_SCAN_LIMIT = 100;
+const TASK_SCAN_LIMIT = 200;
+const EVENT_SCAN_LIMIT = 200;
+const GOAL_SCAN_LIMIT = 25;
+
+/** Max bullet items rendered per markdown section. */
+const MAX_ITEMS_PER_SECTION = 5;
+
+/** Max users processed per dispatch pass (cron-run bound). */
+const DEFAULT_DISPATCH_LIMIT = 200;
+
+/** Cap on a single rendered line (titles/summaries are user content). */
+const LINE_CAP = 120;
+
+/**
+ * Digest briefings (Wave 7, feature c) — per-user daily/weekly
+ * activity briefings composed DETERMINISTICALLY from existing
+ * repositories:
+ *
+ *   - agent runs completed/failed in the window (`agent_runs`),
+ *   - Tasks moved to done / in-review (`tasks.updatedAt` heuristic —
+ *     the platform has no per-transition audit column yet),
+ *   - PRs opened by agents (`tasks.prUrl` stamped by the finalize/PR
+ *     step of agent-task-execute),
+ *   - ingested-event counts by source (Wave 6 spine),
+ *   - active Goal progress snapshot (cheap: `GoalsService.listForUser`).
+ *
+ * Counts are never fabricated — the same posture as Work metrics. No
+ * LLM is involved in v1; an optional LLM "polish" pass (narrative on
+ * top of the deterministic counts, mirroring the (c) spec) is the
+ * documented FOLLOW-UP toggle and would layer over `composeDigest`'s
+ * output without changing any number in it.
+ *
+ * Delivery = in-app notification via the existing NotificationService
+ * producer pattern (`notifyDigest`), which also emits the
+ * notifications-v2 fanout event — so users with a configured channel
+ * (slack/discord/telegram/… via NotificationChannelFacadeService)
+ * get the briefing there too, best-effort, with zero digest-specific
+ * transport code.
+ *
+ * Scheduling = the `digest-dispatcher` cron (packages/tasks) calls
+ * `dispatchDue()` over the trigger-internal RPC channel.
+ */
+@Injectable()
+export class DigestService {
+    private readonly logger = new Logger(DigestService.name);
+
+    constructor(
+        private readonly userRepository: UserRepository,
+        private readonly taskRepository: TaskRepository,
+        private readonly agentRunRepository: AgentRunRepository,
+        private readonly ingestedEventRepository: IngestedEventRepository,
+        private readonly notificationService: NotificationService,
+        // Optional: the goals snapshot is a nice-to-have section; a
+        // deployment without GoalsModule wired still composes digests.
+        @Optional() private readonly goalsService?: GoalsService,
+    ) {}
+
+    /**
+     * Compose the digest for one user over the period window ending at
+     * `now`. Pure read path — no writes, no LLM, deterministic for a
+     * fixed clock + fixed rows.
+     */
+    async composeDigest(userId: string, options: ComposeDigestOptions): Promise<ComposedDigest> {
+        const until = options.now ?? new Date();
+        const since = new Date(until.getTime() - PERIOD_MS[options.period]);
+
+        const [runRows] = await this.agentRunRepository.listSessionsForUser(
+            userId,
+            {},
+            RUN_SCAN_LIMIT,
+            0,
+        );
+        const { rows: taskRows } = await this.taskRepository.findByUserIdFiltered(userId, {
+            limit: TASK_SCAN_LIMIT,
+        });
+        const eventRows = await this.ingestedEventRepository.findRecentByUser(
+            userId,
+            EVENT_SCAN_LIMIT,
+        );
+        const goals = await this.loadActiveGoals(userId);
+
+        const inWindow = (ts: Date | null | undefined): boolean =>
+            !!ts && ts.getTime() >= since.getTime() && ts.getTime() <= until.getTime();
+
+        const runsCompleted = runRows.filter(
+            (run) => run.status === 'completed' && inWindow(run.finishedAt ?? run.createdAt),
+        );
+        const runsFailed = runRows.filter(
+            (run) => run.status === 'failed' && inWindow(run.finishedAt ?? run.createdAt),
+        );
+        const tasksDone = taskRows.filter(
+            (task) => task.status === TaskStatus.DONE && inWindow(task.updatedAt),
+        );
+        const tasksInReview = taskRows.filter(
+            (task) => task.status === TaskStatus.IN_REVIEW && inWindow(task.updatedAt),
+        );
+        const prsOpened = taskRows.filter((task) => !!task.prUrl && inWindow(task.updatedAt));
+
+        const eventsBySource: Record<string, number> = {};
+        for (const event of eventRows) {
+            if (!inWindow(event.occurredAt)) continue;
+            eventsBySource[event.source] = (eventsBySource[event.source] ?? 0) + 1;
+        }
+        const eventsTotal = Object.values(eventsBySource).reduce((sum, n) => sum + n, 0);
+
+        const counts: DigestCounts = {
+            runsCompleted: runsCompleted.length,
+            runsFailed: runsFailed.length,
+            tasksDone: tasksDone.length,
+            tasksInReview: tasksInReview.length,
+            prsOpened: prsOpened.length,
+            eventsBySource,
+            eventsTotal,
+            goalsTracked: goals.length,
+        };
+
+        // Goals are a progress SNAPSHOT, not window activity — they never
+        // un-quiet a digest on their own.
+        const quiet =
+            counts.runsCompleted +
+                counts.runsFailed +
+                counts.tasksDone +
+                counts.tasksInReview +
+                counts.prsOpened +
+                counts.eventsTotal ===
+            0;
+
+        return {
+            period: options.period,
+            since: since.toISOString(),
+            until: until.toISOString(),
+            quiet,
+            markdown: this.renderMarkdown({
+                period: options.period,
+                since,
+                until,
+                quiet,
+                counts,
+                runsCompleted,
+                runsFailed,
+                tasksDone,
+                tasksInReview,
+                prsOpened,
+                goals,
+            }),
+            text: this.renderText(options.period, quiet, counts),
+            counts,
+        };
+    }
+
+    /**
+     * Compose + deliver one user's digest. Gated by the per-user
+     * cadence preference unless `force` is set (chat/manual sends);
+     * quiet windows are skipped entirely — a "nothing happened"
+     * notification every day is noise, not signal.
+     */
+    async deliverDigest(
+        userId: string,
+        period: DigestPeriod,
+        options: DeliverDigestOptions = {},
+    ): Promise<DeliverDigestResult> {
+        const user = await this.userRepository.findById(userId);
+        if (!user) {
+            return { delivered: false, reason: 'user-not-found' };
+        }
+
+        const preference = user.digestFrequency ?? 'off';
+        if (!options.force && preference !== period) {
+            return {
+                delivered: false,
+                reason: preference === 'off' ? 'digest-off' : 'period-mismatch',
+            };
+        }
+
+        const digest = await this.composeDigest(userId, { period, now: options.now });
+        if (digest.quiet && !options.force) {
+            return { delivered: false, reason: 'quiet-period', digest };
+        }
+
+        // One in-app row per user+period+window-end day; re-runs of the
+        // same cron window dedupe instead of stacking.
+        const windowDay = digest.until.slice(0, 10);
+        await this.notificationService.notifyDigest({
+            userId,
+            period,
+            title: period === 'daily' ? 'Your daily digest' : 'Your weekly digest',
+            message: digest.text,
+            markdown: digest.markdown,
+            deduplicationKey: `digest_${period}_${windowDay}`,
+        });
+
+        return { delivered: true, digest };
+    }
+
+    /**
+     * Dispatch every due digest for one period — the `digest-dispatcher`
+     * cron's RPC target. Per-user failures are logged and never abort
+     * the pass.
+     */
+    async dispatchDue(
+        period: DigestPeriod,
+        options: DispatchDueOptions = {},
+    ): Promise<DigestDispatchSummary> {
+        const users = await this.userRepository.findByDigestFrequency(
+            period,
+            options.limit ?? DEFAULT_DISPATCH_LIMIT,
+        );
+
+        const summary: DigestDispatchSummary = {
+            period,
+            selected: users.length,
+            delivered: 0,
+            skippedQuiet: 0,
+            skipped: 0,
+            failed: 0,
+        };
+
+        for (const user of users) {
+            try {
+                const result = await this.deliverDigest(user.id, period, { now: options.now });
+                if (result.delivered) {
+                    summary.delivered += 1;
+                } else if (result.reason === 'quiet-period') {
+                    summary.skippedQuiet += 1;
+                } else {
+                    summary.skipped += 1;
+                }
+            } catch (error) {
+                summary.failed += 1;
+                this.logger.warn(
+                    `Digest delivery failed for user=${user.id} period=${period}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+        }
+
+        return summary;
+    }
+
+    /** Best-effort active-goal snapshot; absence/errors yield []. */
+    private async loadActiveGoals(userId: string): Promise<GoalDto[]> {
+        if (!this.goalsService) return [];
+        try {
+            return await this.goalsService.listForUser(userId, {
+                status: GoalStatus.ACTIVE,
+                limit: GOAL_SCAN_LIMIT,
+            });
+        } catch (error) {
+            this.logger.debug(
+                `Goal snapshot skipped for user=${userId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return [];
+        }
+    }
+
+    private renderText(period: DigestPeriod, quiet: boolean, counts: DigestCounts): string {
+        const label = period === 'daily' ? 'Daily digest' : 'Weekly digest';
+        if (quiet) {
+            return `${label}: a quiet ${period === 'daily' ? 'day' : 'week'} — no new activity.`;
+        }
+        const sources = Object.keys(counts.eventsBySource).length;
+        const parts: string[] = [];
+        if (counts.runsCompleted + counts.runsFailed > 0) {
+            parts.push(
+                `${counts.runsCompleted} agent run${counts.runsCompleted === 1 ? '' : 's'} completed` +
+                    (counts.runsFailed > 0 ? ` (${counts.runsFailed} failed)` : ''),
+            );
+        }
+        if (counts.tasksDone > 0) {
+            parts.push(`${counts.tasksDone} task${counts.tasksDone === 1 ? '' : 's'} done`);
+        }
+        if (counts.tasksInReview > 0) {
+            parts.push(`${counts.tasksInReview} in review`);
+        }
+        if (counts.prsOpened > 0) {
+            parts.push(`${counts.prsOpened} PR${counts.prsOpened === 1 ? '' : 's'} opened`);
+        }
+        if (counts.eventsTotal > 0) {
+            parts.push(
+                `${counts.eventsTotal} event${counts.eventsTotal === 1 ? '' : 's'} from ${sources} source${
+                    sources === 1 ? '' : 's'
+                }`,
+            );
+        }
+        if (counts.goalsTracked > 0) {
+            parts.push(`${counts.goalsTracked} active goal${counts.goalsTracked === 1 ? '' : 's'}`);
+        }
+        return `${label}: ${parts.join(' · ')}.`;
+    }
+
+    private renderMarkdown(input: {
+        period: DigestPeriod;
+        since: Date;
+        until: Date;
+        quiet: boolean;
+        counts: DigestCounts;
+        runsCompleted: AgentRun[];
+        runsFailed: AgentRun[];
+        tasksDone: Task[];
+        tasksInReview: Task[];
+        prsOpened: Task[];
+        goals: GoalDto[];
+    }): string {
+        const { counts } = input;
+        const day = (d: Date) => d.toISOString().slice(0, 10);
+        const lines: string[] = [
+            `# Your ${input.period} digest`,
+            '',
+            `_Covering ${day(input.since)} → ${day(input.until)}._`,
+        ];
+
+        if (input.quiet) {
+            lines.push(
+                '',
+                `A quiet ${input.period === 'daily' ? 'day' : 'week'} — no new agent runs, task movement, PRs, or events in this window.`,
+            );
+        } else {
+            if (counts.runsCompleted + counts.runsFailed > 0) {
+                lines.push('', '## Agent runs', '');
+                lines.push(`- ${counts.runsCompleted} completed, ${counts.runsFailed} failed`);
+                for (const run of input.runsCompleted.slice(0, MAX_ITEMS_PER_SECTION)) {
+                    lines.push(`- Completed: ${this.runLine(run)}`);
+                }
+                for (const run of input.runsFailed.slice(0, MAX_ITEMS_PER_SECTION)) {
+                    lines.push(`- Failed: ${this.runLine(run)}`);
+                }
+            }
+
+            if (counts.tasksDone + counts.tasksInReview > 0) {
+                lines.push('', '## Tasks', '');
+                lines.push(`- ${counts.tasksDone} done, ${counts.tasksInReview} moved to review`);
+                for (const task of input.tasksDone.slice(0, MAX_ITEMS_PER_SECTION)) {
+                    lines.push(`- Done: ${this.cap(task.title)}`);
+                }
+                for (const task of input.tasksInReview.slice(0, MAX_ITEMS_PER_SECTION)) {
+                    lines.push(`- In review: ${this.cap(task.title)}`);
+                }
+            }
+
+            if (counts.prsOpened > 0) {
+                lines.push('', '## Pull requests', '');
+                for (const task of input.prsOpened.slice(0, MAX_ITEMS_PER_SECTION)) {
+                    lines.push(`- [${this.cap(task.title)}](${task.prUrl})`);
+                }
+                if (counts.prsOpened > MAX_ITEMS_PER_SECTION) {
+                    lines.push(`- …and ${counts.prsOpened - MAX_ITEMS_PER_SECTION} more`);
+                }
+            }
+
+            if (counts.eventsTotal > 0) {
+                lines.push('', '## Connected sources', '');
+                const bySource = Object.entries(counts.eventsBySource).sort(
+                    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+                );
+                for (const [source, count] of bySource) {
+                    lines.push(`- ${source}: ${count} event${count === 1 ? '' : 's'}`);
+                }
+            }
+        }
+
+        if (input.goals.length > 0) {
+            lines.push('', '## Goal progress', '');
+            for (const goal of input.goals.slice(0, MAX_ITEMS_PER_SECTION)) {
+                const current = goal.currentValue ?? '—';
+                lines.push(
+                    `- ${this.cap(goal.title)}: ${current} / ${goal.targetValue} ${goal.unit}`,
+                );
+            }
+        }
+
+        return lines.join('\n');
+    }
+
+    private runLine(run: AgentRun): string {
+        if (run.summary) return this.cap(run.summary);
+        if (run.errorMessage) return this.cap(run.errorMessage);
+        return `Run ${run.id.slice(0, 8)}`;
+    }
+
+    /** Single-line cap for user-authored strings embedded in markdown. */
+    private cap(value: string): string {
+        const oneLine = value.replace(/\s+/g, ' ').trim();
+        return oneLine.length > LINE_CAP ? `${oneLine.slice(0, LINE_CAP - 1)}…` : oneLine;
+    }
+}

--- a/packages/agent/src/digest/digest.types.ts
+++ b/packages/agent/src/digest/digest.types.ts
@@ -1,0 +1,88 @@
+/**
+ * Digest briefings (Wave 7) — shared types for the digest composer,
+ * delivery path, and dispatcher.
+ */
+
+/** A digest run always covers exactly one of these windows. */
+export type DigestPeriod = 'daily' | 'weekly';
+
+/**
+ * Per-user cadence preference (`users.digestFrequency`). Default
+ * `'off'` — existing users see nothing new until they opt in.
+ */
+export type DigestFrequency = 'off' | DigestPeriod;
+
+export const DIGEST_FREQUENCIES: readonly DigestFrequency[] = ['off', 'daily', 'weekly'];
+
+export const DIGEST_PERIODS: readonly DigestPeriod[] = ['daily', 'weekly'];
+
+/** Deterministic per-section counts — never fabricated, always from rows. */
+export interface DigestCounts {
+    runsCompleted: number;
+    runsFailed: number;
+    tasksDone: number;
+    tasksInReview: number;
+    prsOpened: number;
+    /** Ingested-event counts keyed by producing plugin id (source). */
+    eventsBySource: Record<string, number>;
+    /** Total ingested events in the window (sum of eventsBySource). */
+    eventsTotal: number;
+    /** Active goals included in the progress snapshot. */
+    goalsTracked: number;
+}
+
+export interface ComposeDigestOptions {
+    period: DigestPeriod;
+    /** Injected clock for deterministic composition (tests, backfills). */
+    now?: Date;
+}
+
+export interface ComposedDigest {
+    period: DigestPeriod;
+    /** Window start (ISO). */
+    since: string;
+    /** Window end (ISO). */
+    until: string;
+    /** True when the window contains no activity at all. */
+    quiet: boolean;
+    /** Rendered markdown body (sections; capped item lists). */
+    markdown: string;
+    /** One-line plain-text summary (notification message body). */
+    text: string;
+    counts: DigestCounts;
+}
+
+export interface DeliverDigestOptions {
+    /** Bypass the per-user cadence gate (manual/chat-triggered sends). */
+    force?: boolean;
+    /** Injected clock, forwarded to the composer. */
+    now?: Date;
+}
+
+export type DigestSkipReason = 'user-not-found' | 'digest-off' | 'period-mismatch' | 'quiet-period';
+
+export interface DeliverDigestResult {
+    delivered: boolean;
+    reason?: DigestSkipReason;
+    digest?: ComposedDigest;
+}
+
+export interface DispatchDueOptions {
+    /** Max users per dispatch pass (bounds a single cron run). */
+    limit?: number;
+    /** Injected clock, forwarded to per-user delivery. */
+    now?: Date;
+}
+
+export interface DigestDispatchSummary {
+    period: DigestPeriod;
+    /** Users whose preference matched the period. */
+    selected: number;
+    delivered: number;
+    /** Skipped because the window had no activity. */
+    skippedQuiet: number;
+    /** Skipped for any other reason (preference changed mid-flight, …). */
+    skipped: number;
+    /** Per-user failures (logged; never abort the pass). */
+    failed: number;
+}

--- a/packages/agent/src/digest/index.ts
+++ b/packages/agent/src/digest/index.ts
@@ -1,0 +1,7 @@
+// Public surface of the digest briefings feature (Wave 7): the
+// deterministic composer/delivery/dispatcher service, its module, the
+// shared types, and the `get_digest` chat tool factory.
+export * from './digest.module';
+export * from './digest.service';
+export * from './digest.types';
+export * from './agent-digest-tools';

--- a/packages/agent/src/entities/notification.types.ts
+++ b/packages/agent/src/entities/notification.types.ts
@@ -14,6 +14,8 @@ export enum NotificationCategory {
     // Agents/Skills/Tasks PR #1017 — Phase 18.3.
     AGENT = 'agent',
     TASK = 'task',
+    // Digest briefings (Wave 7) — scheduled daily/weekly activity digests.
+    DIGEST = 'digest',
 }
 
 export interface CreateNotificationDto {

--- a/packages/agent/src/entities/user.entity.ts
+++ b/packages/agent/src/entities/user.entity.ts
@@ -217,6 +217,15 @@ export class User {
     @Column({ default: true })
     emailBudgetAlerts: boolean;
 
+    /**
+     * Digest briefings (Wave 7) — per-user cadence for the scheduled
+     * activity digest. 'off' (default) | 'daily' | 'weekly'. Explicit
+     * `type: 'varchar'` so better-sqlite3 (e2e CI) doesn't choke on
+     * the inferred union type — see magicLinkToken note above.
+     */
+    @Column({ type: 'varchar', length: 8, default: 'off' })
+    digestFrequency: 'off' | 'daily' | 'weekly';
+
     // Timestamps
     @CreateDateColumn()
     createdAt: Date;

--- a/packages/agent/src/notifications/notification.service.ts
+++ b/packages/agent/src/notifications/notification.service.ts
@@ -422,6 +422,52 @@ export class NotificationService {
     }
 
     /**
+     * Digest briefings (Wave 7) — in-app digest row + notifications-v2
+     * channel fanout. `message` is the deterministic one-line summary
+     * (capped like every other producer); the full markdown body rides
+     * in `metadata.markdown` for richer renderers. Dedup key is
+     * per-user+period+window-day so a re-run of the same cron window
+     * updates nothing instead of stacking duplicates.
+     */
+    async notifyDigest(args: {
+        userId: string;
+        period: 'daily' | 'weekly';
+        title: string;
+        message: string;
+        markdown?: string;
+        deduplicationKey?: string;
+    }): Promise<void> {
+        const safeMessage = sanitizeDescription(args.message, 500);
+        const metadata: Record<string, any> = { period: args.period };
+        if (args.markdown) {
+            // Defensive cap — markdown is composed from repository rows
+            // (titles/summaries are user content) and stored as simple-json.
+            metadata.markdown =
+                args.markdown.length > 8000 ? args.markdown.slice(0, 8000) : args.markdown;
+        }
+        await this.create({
+            userId: args.userId,
+            type: NotificationType.INFO,
+            category: NotificationCategory.DIGEST,
+            title: args.title,
+            message: safeMessage,
+            actionUrl: '/activity',
+            actionLabel: 'View activity',
+            metadata,
+            deduplicationKey: args.deduplicationKey ?? `digest_${args.period}`,
+        });
+        await this.dispatchFanout({
+            userId: args.userId,
+            eventKey: 'digest_ready',
+            title: args.title,
+            message: safeMessage,
+            actionUrl: '/activity',
+            actionLabel: 'View activity',
+            urgent: false,
+        });
+    }
+
+    /**
      * Delete expired and old notifications
      * Should be called periodically by a cleanup job
      */

--- a/packages/tasks/src/tasks/trigger/digest-dispatcher.task.ts
+++ b/packages/tasks/src/tasks/trigger/digest-dispatcher.task.ts
@@ -1,0 +1,46 @@
+import { logger, schedules } from '@trigger.dev/sdk';
+import { DigestService } from '@ever-works/agent/digest';
+import type { DigestDispatchSummary } from '@ever-works/agent/digest';
+import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
+import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+
+/**
+ * Digest briefings (Wave 7) — morning dispatcher.
+ *
+ * Every day at 07:15 UTC, deliver the daily digests; on Mondays the
+ * weekly digests ride the same run (a single schedule with an
+ * in-task weekday check keeps the cadence single-sourced instead of
+ * two crons that can drift apart).
+ *
+ * The real `DigestService` lives in the API (repositories + the
+ * notifications producer + channel fanout are wired there); the
+ * worker only calls `dispatchDue(period)` over the internal RPC
+ * channel — same shape as the event-ingest-tick / mission-tick
+ * crons. Per-user preference gating, quiet-period skips, and the
+ * per-window dedup key all live in the service, so a re-run of this
+ * task is safe.
+ */
+export const digestDispatcherTask = schedules.task({
+    id: 'digest-dispatcher',
+    cron: '15 7 * * *',
+    run: async () => {
+        return withWorkerContext(
+            'DigestDispatcher',
+            async (appContext) => {
+                const svc = appContext.get(DigestService);
+
+                const daily = await svc.dispatchDue('daily');
+                logger.info('digest-dispatcher daily pass', { ...daily });
+
+                let weekly: DigestDispatchSummary | null = null;
+                if (new Date().getUTCDay() === 1) {
+                    weekly = await svc.dispatchDue('weekly');
+                    logger.info('digest-dispatcher weekly pass', { ...weekly });
+                }
+
+                return { daily, weekly };
+            },
+            TriggerInternalModule,
+        );
+    },
+});

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -26,6 +26,7 @@ import {
 import { AgentRepository, AgentRunRepository, WorkRepository } from '@ever-works/agent/database';
 import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
 import { EventIngestService } from '@ever-works/agent/ingest';
+import { DigestService } from '@ever-works/agent/digest';
 import { TriggerInternalApiClient } from '../services/trigger-internal-api.client';
 import { createRemoteProxy } from '../remote-proxy';
 
@@ -251,6 +252,17 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
                 createRemoteProxy(apiClient, 'EventIngestService'),
             inject: [TriggerInternalApiClient],
         },
+        // Digest briefings (Wave 7) — the digest-dispatcher cron task
+        // calls `dispatchDue(period)` on this proxy, which RPCs to the
+        // live API where the digest composer's repositories + the
+        // notifications producer are wired. Same shape as
+        // TaskWorkspaceService.
+        {
+            provide: DigestService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'DigestService'),
+            inject: [TriggerInternalApiClient],
+        },
     ],
     exports: [
         TriggerInternalApiClient,
@@ -278,6 +290,7 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         AnonymousUserCleanupService,
         KnowledgeBaseReconcileService,
         EventIngestService,
+        DigestService,
     ],
 })
 export class TriggerInternalModule {}


### PR DESCRIPTION
## What

Wave 7 feature (c): per-user **daily/weekly activity briefings**, composed deterministically from existing repositories and delivered through the existing notification stack. Opt-in per user (default off).

### Composer — `DigestService.composeDigest(userId, { period })`
Pure read path over EXISTING repositories, no LLM in v1 (an LLM narrative-polish toggle layered over the deterministic counts is the documented follow-up in the service doc block):
- agent runs completed/failed in the window (`AgentRunRepository.listSessionsForUser`)
- Tasks moved to done / in-review (`TaskRepository.findByUserIdFiltered`, `updatedAt` heuristic)
- PRs opened by agents (`tasks.prUrl` from the finalize/PR step)
- ingested-event counts by source (Wave 6 spine, `IngestedEventRepository`)
- active Goal progress snapshot (`GoalsService.listForUser`, optional section)

Renders BOTH a markdown body and a one-line plain-text summary; counts are never fabricated; quiet windows produce an explicit empty state.

### Delivery — `deliverDigest(userId, period)`
- In-app notification via the existing `NotificationService` producer pattern (new `notifyDigest` producer, new `DIGEST` category, per-user+period+window-day dedup key)
- Channel delivery rides the notifications-v2 fanout event → `NotificationFanoutListener` → `NotificationChannelFacadeService`, so users with a configured channel (slack/discord/telegram/…) get the briefing best-effort with zero digest-specific transport code
- Preference-gated (`off` default; period mismatch skips; `force` for manual/chat sends); quiet windows skip delivery instead of sending noise

### Settings
- `users.digestFrequency` (`'off' | 'daily' | 'weekly'`, default `'off'`) — additive column, guarded forward-only migration `1783300000000-AddUserDigestPreference` (house pattern of `1782700000000-AddTaskIsolationColumns`)
- Exposed on the existing account settings surface: `PUT /api/auth/profile` (`UpdateProfileDto.digestFrequency`, `@IsIn(['off','daily','weekly'])`); readable via the profile response (deny-list projection)

### Schedule
- `digest-dispatcher` cron in packages/tasks (`15 7 * * *` UTC); weekly digests ride the same run behind a Monday check so the cadence is single-sourced
- 3-place trigger-internal wiring (TaskWorkspaceService shape): worker remote-proxy provider + export, API controller constructor appended-LAST `@Optional()` + remote-map entry, `DigestModule` imported by `TriggerInternalModule`

### Chat (DoD rule d)
- `get_digest` read tool (`buildDigestTools`, mirrors `agent-ingest-tools`): owner-scoped, `period` arg, returns the composed digest with deterministic counts; keyword slots documented ("digest", "briefing", "what happened today/this week", "daily recap")

## Verification (all run locally on this branch)

`packages/agent` build (tsc types + swc):
```
>  TSC  Found 0 issues.
Successfully compiled: 1001 files with swc (839.58ms)
```

`packages/agent` jest digest (24 new tests):
```
Test Suites: 3 passed, 3 total
Tests:       24 passed, 24 total
```

`pnpm build --filter=ever-works-api`:
```
Tasks:    14 successful, 14 total
```

`apps/api pnpm generate:openapi` (full-app DI bootstrap gate):
```
Wrote OpenAPI spec (415 paths) to apps/api/openapi.json
```

`apps/api` jest trigger-internal:
```
Test Suites: 2 passed, 2 total
Tests:       16 passed, 16 total
```

Adjacent suites re-run because their surfaces were touched — `packages/agent` jest notification|user.repository: **8 suites / 137 tests passed**; `apps/api` jest auth (DTO + profile service): **26 suites / 575 tests passed**. `packages/tasks pnpm build` (tsc): clean.

## Notes / follow-ups
- LLM narrative polish over the deterministic counts: follow-up toggle (documented in `DigestService`).
- Mission progress is not in the v1 sections (no cheap per-user progress read exists today); goals cover the progress story.
- Per-transition Task audit timestamps would replace the `updatedAt` window heuristic when they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)