### PR TITLE
feat(agent): credits ledger + entitlements (Wave 9 M1)

### DIFF
--- a/apps/api/src/migrations/1783400000000-CreateCreditsLedgerAndEntitlements.ts
+++ b/apps/api/src/migrations/1783400000000-CreateCreditsLedgerAndEntitlements.ts
@@ -1,0 +1,210 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+import { randomUUID } from 'crypto';
+
+/**
+ * Credits ledger + plan entitlements (pricing Wave 9 M1).
+ *
+ * `credit_ledger_entries` — append-only signed balance movements; the
+ * usage currency layered on the EXISTING costCents metering
+ * (`plugin_usage_events`). Entity:
+ * `packages/agent/src/entities/credit-ledger-entry.entity.ts`.
+ *
+ *   - `amountCredits` signed int (+credit / −debit); `balanceAfter`
+ *     materialized at write time inside the recordAtomic transaction
+ *     (SUM per user stays authoritative).
+ *   - `idempotencyKey` UNIQUE + nullable — cron re-runs and webhook
+ *     re-deliveries are no-ops (`daily:{userId}:{date}`, `run:{runId}`).
+ *   - `refType`/`refId` + `costCentsRef` correlate a movement back to
+ *     its run/generation/task and the metered cost it derived from, so
+ *     credits and the metering pipeline reconcile without
+ *     double-charging.
+ *   - Scope columns are raw uuids (no @ManyToOne — EW-654 cycle rule);
+ *     FK `userId` → `users.id` ON DELETE CASCADE only.
+ *
+ * `plan_entitlements` — per-plan feature/limit levers as (planId, key)
+ * rows, additive beside the columns already on `subscription_plans`.
+ * `planId` is the plan CODE ('free'/…): plans are seeded at boot AFTER
+ * migrations, so the row uuid cannot be referenced here. Entity:
+ * `packages/agent/src/entities/plan-entitlement.entity.ts`.
+ *
+ * Seeds (INSERT-if-missing, same migration per the Wave 9 spec): free
+ * plan `daily-free-credits` (env CREDITS_DAILY_FREE, default 50),
+ * `max-concurrent-runs` (default 3 — the D5 safety-valve posture),
+ * `works-limit` (default 1, mirroring FREE `maxWorks`).
+ *
+ * Forward-only + idempotent (`hasTable` / seed-existence guards) —
+ * house pattern of `1782700000000-AddTaskIsolationColumns` /
+ * `1783200000000-CreateIngestedEvents`.
+ */
+export class CreateCreditsLedgerAndEntitlements1783400000000 implements MigrationInterface {
+    name = 'CreateCreditsLedgerAndEntitlements1783400000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasTable('credit_ledger_entries'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'credit_ledger_entries',
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            generationStrategy: 'uuid',
+                            default: 'uuid_generate_v4()',
+                        },
+                        { name: 'userId', type: 'uuid' },
+                        { name: 'organizationId', type: 'uuid', isNullable: true },
+                        { name: 'tenantId', type: 'uuid', isNullable: true },
+                        { name: 'kind', type: 'varchar', length: '16' },
+                        { name: 'amountCredits', type: 'int' },
+                        { name: 'costCentsRef', type: 'int', isNullable: true },
+                        { name: 'refType', type: 'varchar', length: '32', isNullable: true },
+                        { name: 'refId', type: 'uuid', isNullable: true },
+                        { name: 'balanceAfter', type: 'int' },
+                        { name: 'description', type: 'varchar', length: '256', isNullable: true },
+                        {
+                            name: 'idempotencyKey',
+                            type: 'varchar',
+                            length: '128',
+                            isNullable: true,
+                        },
+                        { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                    ],
+                }),
+                true,
+            );
+
+            // Ledger reads are owner-scoped, newest-first.
+            await queryRunner.createIndex(
+                'credit_ledger_entries',
+                new TableIndex({
+                    name: 'idx_credit_ledger_user_created',
+                    columnNames: ['userId', 'createdAt'],
+                }),
+            );
+
+            // Kind filters on the Billing-page ledger table (Wave 13 UI).
+            await queryRunner.createIndex(
+                'credit_ledger_entries',
+                new TableIndex({
+                    name: 'idx_credit_ledger_user_kind',
+                    columnNames: ['userId', 'kind'],
+                }),
+            );
+
+            // Idempotent writers — re-delivery/re-run must be a no-op.
+            // UNIQUE over a nullable column: NULLs don't collide (pg/mysql).
+            await queryRunner.createIndex(
+                'credit_ledger_entries',
+                new TableIndex({
+                    name: 'idx_credit_ledger_idempotency',
+                    columnNames: ['idempotencyKey'],
+                    isUnique: true,
+                }),
+            );
+
+            await queryRunner.createForeignKey(
+                'credit_ledger_entries',
+                new TableForeignKey({
+                    name: 'fk_credit_ledger_user',
+                    columnNames: ['userId'],
+                    referencedTableName: 'users',
+                    referencedColumnNames: ['id'],
+                    onDelete: 'CASCADE',
+                }),
+            );
+        }
+
+        if (!(await queryRunner.hasTable('plan_entitlements'))) {
+            await queryRunner.createTable(
+                new Table({
+                    name: 'plan_entitlements',
+                    columns: [
+                        {
+                            name: 'id',
+                            type: 'uuid',
+                            isPrimary: true,
+                            generationStrategy: 'uuid',
+                            default: 'uuid_generate_v4()',
+                        },
+                        { name: 'planId', type: 'varchar', length: '64' },
+                        { name: 'key', type: 'varchar', length: '64' },
+                        { name: 'valueInt', type: 'int', isNullable: true },
+                        { name: 'valueText', type: 'varchar', length: '128', isNullable: true },
+                        { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                        { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                    ],
+                }),
+                true,
+            );
+
+            await queryRunner.createIndex(
+                'plan_entitlements',
+                new TableIndex({
+                    name: 'idx_plan_entitlements_plan_key',
+                    columnNames: ['planId', 'key'],
+                    isUnique: true,
+                }),
+            );
+        }
+
+        // Free-plan seeds — INSERT-if-missing so a re-run (or an operator
+        // who already tuned a lever) never duplicates or overwrites.
+        const intFromEnv = (name: string, fallback: number): number => {
+            const parsed = parseInt(process.env[name] || '');
+            return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+        };
+        const seeds: Array<{ planId: string; key: string; valueInt: number }> = [
+            {
+                planId: 'free',
+                key: 'daily-free-credits',
+                valueInt: intFromEnv('CREDITS_DAILY_FREE', 50),
+            },
+            {
+                planId: 'free',
+                key: 'max-concurrent-runs',
+                valueInt: intFromEnv('CREDITS_FREE_MAX_CONCURRENT_RUNS', 3),
+            },
+            {
+                planId: 'free',
+                key: 'works-limit',
+                valueInt: intFromEnv('CREDITS_FREE_WORKS_LIMIT', 1),
+            },
+        ];
+
+        for (const seed of seeds) {
+            const existing = await queryRunner.manager
+                .createQueryBuilder()
+                .select('pe.id', 'id')
+                .from('plan_entitlements', 'pe')
+                .where('pe.planId = :planId AND pe.key = :key', {
+                    planId: seed.planId,
+                    key: seed.key,
+                })
+                .getRawOne();
+            if (existing) {
+                continue;
+            }
+            await queryRunner.manager
+                .createQueryBuilder()
+                .insert()
+                .into('plan_entitlements', ['id', 'planId', 'key', 'valueInt'])
+                .values({
+                    id: randomUUID(),
+                    planId: seed.planId,
+                    key: seed.key,
+                    valueInt: seed.valueInt,
+                })
+                .execute();
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('plan_entitlements')) {
+            await queryRunner.dropTable('plan_entitlements', true);
+        }
+        if (await queryRunner.hasTable('credit_ledger_entries')) {
+            await queryRunner.dropTable('credit_ledger_entries', true);
+        }
+    }
+}

--- a/apps/api/src/subscriptions/credits.controller.ts
+++ b/apps/api/src/subscriptions/credits.controller.ts
@@ -1,0 +1,131 @@
+import {
+    BadRequestException,
+    Controller,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Query,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Matches, Max, Min } from 'class-validator';
+import { AuthSessionGuard, CurrentUser } from '@src/auth';
+import { AuthenticatedUser } from '@src/auth/types/auth.types';
+import { CreditLedgerService } from '@ever-works/agent/subscriptions';
+import { CreditLedgerEntry, CreditLedgerKind } from '@ever-works/agent/entities';
+
+class CreditsLedgerQueryDto {
+    /** Calendar month filter, e.g. `2026-07` (matches the usage controllers). */
+    @IsOptional()
+    @Matches(/^\d{4}-(0[1-9]|1[0-2])$/, { message: 'period must be YYYY-MM' })
+    period?: string;
+
+    /** Comma-separated entry kinds, e.g. `purchase,consumption`. */
+    @IsOptional()
+    @IsString()
+    kinds?: string;
+
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    page?: number;
+
+    @IsOptional()
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @Max(100)
+    pageSize?: number;
+}
+
+const VALID_KINDS = new Set<string>(Object.values(CreditLedgerKind));
+
+/**
+ * Read-only credits surface (pricing Wave 9 M1) — owner-scoped; the
+ * Billing / Usage & Credits pages (Wave 13) consume these. Writes never
+ * happen over public HTTP: purchases arrive via the billing-provider
+ * webhook (Wave 9.4) and consumption via the metering debit hook.
+ */
+@ApiTags('Credits')
+@ApiBearerAuth('JWT-auth')
+@Controller('api/credits')
+@UseGuards(AuthSessionGuard)
+export class CreditsController {
+    constructor(private readonly creditLedgerService: CreditLedgerService) {}
+
+    @Get('balance')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Get credits balance',
+        description:
+            'Current credits balance for the authenticated user (SUM of ledger movements).',
+    })
+    @ApiResponse({ status: 200, description: 'Current credits balance' })
+    async getBalance(@CurrentUser() auth: AuthenticatedUser) {
+        const balanceCredits = await this.creditLedgerService.getBalance(auth.userId);
+        return { status: 'success', balanceCredits };
+    }
+
+    @Get('ledger')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'List credits ledger',
+        description:
+            'Paginated credits ledger for the authenticated user. Filters: period (YYYY-MM), kinds (comma-separated: purchase, grant, daily-free, consumption, adjustment, expiry).',
+    })
+    @ApiResponse({ status: 200, description: 'Paginated ledger entries' })
+    @ApiResponse({ status: 400, description: 'Invalid period or kind filter' })
+    async getLedger(@CurrentUser() auth: AuthenticatedUser, @Query() query: CreditsLedgerQueryDto) {
+        const kinds = this.parseKinds(query.kinds);
+        const { entries, total, page, pageSize } = await this.creditLedgerService.getLedger(
+            auth.userId,
+            {
+                period: query.period,
+                kinds,
+                page: query.page,
+                pageSize: query.pageSize,
+            },
+        );
+
+        return {
+            status: 'success',
+            entries: entries.map((entry) => this.toLedgerRow(entry)),
+            total,
+            page,
+            pageSize,
+        };
+    }
+
+    private parseKinds(raw?: string): CreditLedgerKind[] | undefined {
+        if (!raw) {
+            return undefined;
+        }
+        const kinds = raw
+            .split(',')
+            .map((kind) => kind.trim())
+            .filter((kind) => kind.length > 0);
+        for (const kind of kinds) {
+            if (!VALID_KINDS.has(kind)) {
+                throw new BadRequestException(`Unknown ledger kind: ${kind}`);
+            }
+        }
+        return kinds as CreditLedgerKind[];
+    }
+
+    /** Explicit projection — owner-scoped rows, no scope columns leaked. */
+    private toLedgerRow(entry: CreditLedgerEntry) {
+        return {
+            id: entry.id,
+            kind: entry.kind,
+            amountCredits: entry.amountCredits,
+            balanceAfter: entry.balanceAfter,
+            costCentsRef: entry.costCentsRef ?? null,
+            refType: entry.refType ?? null,
+            refId: entry.refId ?? null,
+            description: entry.description ?? null,
+            createdAt: entry.createdAt,
+        };
+    }
+}

--- a/apps/api/src/subscriptions/subscriptions.module.ts
+++ b/apps/api/src/subscriptions/subscriptions.module.ts
@@ -2,9 +2,12 @@ import { Module } from '@nestjs/common';
 import { AuthModule } from '@src/auth';
 import { SubscriptionsModule as AgentSubscriptionsModule } from '@ever-works/agent/subscriptions';
 import { SubscriptionsController } from './subscriptions.controller';
+import { CreditsController } from './credits.controller';
 
 @Module({
     imports: [AuthModule, AgentSubscriptionsModule],
-    controllers: [SubscriptionsController],
+    // CreditsController (pricing Wave 9 M1) — read-only credits surface
+    // beside the existing plan endpoints; consumed by the Wave 13 UI.
+    controllers: [SubscriptionsController, CreditsController],
 })
 export class SubscriptionsModule {}

--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -83,6 +83,13 @@ jest.mock('@ever-works/agent/ingest', () => ({
     EventIngestService: class EventIngestService {},
     EventIngestModule: class EventIngestModule {},
 }));
+// Credits ledger (pricing Wave 9 M1) — the controller imports
+// CreditLedgerService from the subscriptions barrel; stub it so the real
+// barrel (repositories → TypeORM entity chain) is never loaded.
+jest.mock('@ever-works/agent/subscriptions', () => ({
+    SubscriptionsModule: class SubscriptionsModule {},
+    CreditLedgerService: class CreditLedgerService {},
+}));
 jest.mock('@ever-works/agent/activity-log', () => ({
     ActivityLogService: class ActivityLogService {},
     ActivityLogModule: class ActivityLogModule {},

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -71,6 +71,7 @@ import {
     WorkPluginRepository,
 } from '@ever-works/agent/plugins';
 import { EventIngestService } from '@ever-works/agent/ingest';
+import { CreditLedgerService } from '@ever-works/agent/subscriptions';
 
 /**
  * C-05 RPC half — methods that must never be reachable via `POST
@@ -290,6 +291,12 @@ export class TriggerInternalController implements OnModuleInit {
         // RPC channel. Appended LAST + @Optional() per the arity rule above.
         @Optional()
         private readonly eventIngestService?: EventIngestService,
+        // Credits ledger (pricing Wave 9 M1) — backs the
+        // `credits-daily-grant` cron: the worker proxy calls
+        // `dispatchDailyGrants()` over the internal RPC channel. Appended
+        // LAST + @Optional() per the arity rule above.
+        @Optional()
+        private readonly creditLedgerService?: CreditLedgerService,
     ) {}
 
     onModuleInit() {
@@ -362,6 +369,9 @@ export class TriggerInternalController implements OnModuleInit {
             // Event-ingest spine (Wave 6) — `event-ingest-tick` calls
             // `processBatch()` here (allow-list auto-derived).
             EventIngestService: this.eventIngestService,
+            // Credits ledger (pricing Wave 9 M1) — `credits-daily-grant`
+            // calls `dispatchDailyGrants()` here (allow-list auto-derived).
+            CreditLedgerService: this.creditLedgerService,
             ...(this.workProposalsApiService
                 ? { WorkProposalsApiService: this.workProposalsApiService }
                 : {}),

--- a/apps/api/src/trigger/trigger-internal.module.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.module.spec.ts
@@ -70,6 +70,14 @@ jest.mock('@ever-works/agent/ingest', () => ({
     EventIngestModule: class EventIngestModule {},
     EventIngestService: class EventIngestService {},
 }));
+// Credits ledger (pricing Wave 9 M1) — the module imports the agent
+// SubscriptionsModule to expose CreditLedgerService through the
+// remote-proxy controller; stub the barrel so the repository → TypeORM
+// entity chain is never loaded under jest.
+jest.mock('@ever-works/agent/subscriptions', () => ({
+    SubscriptionsModule: class SubscriptionsModule {},
+    CreditLedgerService: class CreditLedgerService {},
+}));
 // EW-742 P3.2 T22 — trigger-internal.module imports TenantJobRuntimeModule
 // + OrganizationsModule (added by bbc24309 / 5e4e2483 / 41906b71). Loading
 // those modules pulls in real `@ever-works/agent/entities` + `@ever-works/agent/tasks`

--- a/apps/api/src/trigger/trigger-internal.module.ts
+++ b/apps/api/src/trigger/trigger-internal.module.ts
@@ -11,6 +11,7 @@ import { GoalsModule } from '@ever-works/agent/goals';
 import { AgentsModule } from '@ever-works/agent/agents';
 import { TasksDomainModule } from '@ever-works/agent/tasks-domain';
 import { EventIngestModule } from '@ever-works/agent/ingest';
+import { SubscriptionsModule as AgentSubscriptionsModule } from '@ever-works/agent/subscriptions';
 import { WorkProposalsModule } from '../work-proposals/work-proposals.module';
 import { DataSyncModule } from '../data-sync/data-sync.module';
 import { TenantJobRuntimeModule } from '../account/tenant-job-runtime/tenant-job-runtime.module';
@@ -76,6 +77,11 @@ import { OrganizationsModule } from '../organizations/organizations.module';
         // cron task (in packages/tasks) can drive `processBatch()` over
         // the internal RPC channel every 5 minutes.
         EventIngestModule,
+        // Credits ledger (pricing Wave 9 M1) — exposes CreditLedgerService
+        // through the remote-proxy controller so the credits-daily-grant
+        // cron task (in packages/tasks) can drive `dispatchDailyGrants()`
+        // over the internal RPC channel once a day.
+        AgentSubscriptionsModule,
     ],
     controllers: [TriggerInternalController],
 })

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -327,6 +327,46 @@ export const config = {
                 return process.env.STRIPE_WEBHOOK_SECRET;
             },
         },
+        // Credits ledger (pricing Wave 9 M1) — credits are the usage
+        // currency layered on the costCents metering. Every knob is
+        // env-configurable per the Wave 9 house rule; defaults keep
+        // 1 credit = 1 cent with zero margin until pricing lands.
+        credits: {
+            /** costCents → credits conversion: credits per $1 (default 100 = 1¢/credit). */
+            getCreditsPerDollar() {
+                const parsed = parseFloat(process.env.CREDITS_PER_DOLLAR || '100');
+                return Number.isFinite(parsed) && parsed > 0 ? parsed : 100;
+            },
+            /** Platform margin applied at debit time, in percent (default 0). */
+            getMarginPercent() {
+                const parsed = parseFloat(process.env.CREDITS_MARGIN_PERCENT || '0');
+                return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+            },
+            /**
+             * When true, consumption may take a balance below zero
+             * (overdraft). Default false: a debit that would cross zero
+             * is rejected with `InsufficientCreditsError` (mapped 4xx —
+             * never an unmapped 500), per the billing/usage PRD §6.
+             */
+            allowOverdraft() {
+                return process.env.CREDITS_ALLOW_OVERDRAFT === 'true';
+            },
+            /** Daily free credits fallback when the plan has no entitlement row. */
+            getDailyFreeCredits() {
+                const parsed = parseInt(process.env.CREDITS_DAILY_FREE || '50');
+                return Number.isFinite(parsed) && parsed >= 0 ? parsed : 50;
+            },
+            /** EntitlementsService in-memory cache TTL (ms, default 60s). */
+            getEntitlementsCacheTtlMs() {
+                const parsed = parseInt(process.env.CREDITS_ENTITLEMENTS_CACHE_TTL_MS || '60000');
+                return Number.isFinite(parsed) && parsed >= 0 ? parsed : 60000;
+            },
+            /** Users per page while sweeping the daily grant (default 500). */
+            getDailyGrantBatchSize() {
+                const parsed = parseInt(process.env.CREDITS_DAILY_GRANT_BATCH || '500');
+                return Number.isFinite(parsed) && parsed > 0 ? parsed : 500;
+            },
+        },
     },
 
     branding: {

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -114,6 +114,8 @@ import { TenantRuntimeProviderAllowlist } from '../entities/tenant-runtime-provi
 import { TenantCredentialSnapshot } from '../entities/tenant-credential-snapshot.entity';
 import { InboundTrigger } from '../entities/inbound-trigger.entity';
 import { IngestedEvent } from '../entities/ingested-event.entity';
+import { CreditLedgerEntry } from '../entities/credit-ledger-entry.entity';
+import { PlanEntitlement } from '../entities/plan-entitlement.entity';
 import {
     PluginEntity,
     UserPluginEntity,
@@ -253,4 +255,8 @@ export const ENTITIES = [
     // Event-ingest spine (Wave 6) — normalized external events awaiting
     // Activity/Memory fan-out.
     IngestedEvent,
+    // Credits ledger + plan entitlements (pricing Wave 9 M1) — credits
+    // are the usage currency layered on the costCents metering.
+    CreditLedgerEntry,
+    PlanEntitlement,
 ];

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -62,6 +62,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'ComposioTriggerSubscription',
     'Conversation',
     'ConversationMessage',
+    // Credits ledger (pricing Wave 9 M1)
+    'CreditLedgerEntry',
     'EmailConversation',
     'EmailMessage',
     'GitHubAppInstallation',
@@ -86,6 +88,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'OnboardingRequest',
     'Organization',
     'OrganizationNotificationDefault',
+    // Plan entitlements (pricing Wave 9 M1)
+    'PlanEntitlement',
     'PluginUsageEvent',
     'RefreshToken',
     // Skills family (PR #1019) ──

--- a/packages/agent/src/database/_repository-inventory.ts
+++ b/packages/agent/src/database/_repository-inventory.ts
@@ -35,6 +35,7 @@ import { AgentEmailAssignmentRepository } from './repositories/agent-email-assig
 import { ApiKeyRepository } from './repositories/api-key.repository';
 import { AuthAccountRepository } from './repositories/auth-account.repository';
 import { ConversationRepository } from './repositories/conversation.repository';
+import { CreditLedgerRepository } from './repositories/credit-ledger.repository';
 import { EmailConversationRepository } from './repositories/email-conversation.repository';
 import { EmailMessageRepository } from './repositories/email-message.repository';
 import { GitHubAppInstallationRepoRepository } from './repositories/github-app-installation-repository.repository';
@@ -47,6 +48,7 @@ import { NotificationRepository } from './repositories/notification.repository';
 import { OnboardingRequestRepository } from './repositories/onboarding-request.repository';
 import { OrganizationNotificationDefaultRepository } from './repositories/organization-notification-default.repository';
 import { OrganizationRepository } from './repositories/organization.repository';
+import { PlanEntitlementRepository } from './repositories/plan-entitlement.repository';
 import { PluginUsageRepository } from './repositories/plugin-usage.repository';
 import { RefreshTokenRepository } from './repositories/refresh-token.repository';
 import { SubscriptionPlanRepository } from './repositories/subscription-plan.repository';
@@ -81,6 +83,7 @@ export const REPOSITORY_PROVIDERS: ReadonlyArray<Type<unknown>> = [
     ApiKeyRepository,
     AuthAccountRepository,
     ConversationRepository,
+    CreditLedgerRepository,
     EmailConversationRepository,
     EmailMessageRepository,
     GitHubAppInstallationRepoRepository,
@@ -93,6 +96,7 @@ export const REPOSITORY_PROVIDERS: ReadonlyArray<Type<unknown>> = [
     OnboardingRequestRepository,
     OrganizationNotificationDefaultRepository,
     OrganizationRepository,
+    PlanEntitlementRepository,
     PluginUsageRepository,
     RefreshTokenRepository,
     SubscriptionPlanRepository,

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -16,6 +16,9 @@ export * from './repositories/user-subscription.repository';
 export * from './repositories/work-schedule.repository';
 export * from './repositories/usage-ledger.repository';
 export * from './repositories/plugin-usage.repository';
+// Credits ledger + plan entitlements (pricing Wave 9 M1)
+export * from './repositories/credit-ledger.repository';
+export * from './repositories/plan-entitlement.repository';
 export * from './repositories/work-budget.repository';
 export * from './repositories/work-budget-alert-state.repository';
 export * from './repositories/notification.repository';

--- a/packages/agent/src/database/repositories/credit-ledger.repository.spec.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.spec.ts
@@ -1,0 +1,206 @@
+import { In } from 'typeorm';
+import { CreditLedgerRepository } from './credit-ledger.repository';
+import { CreditLedgerEntry, CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
+import { User } from '@src/entities/user.entity';
+
+/**
+ * CreditLedgerRepository owns the ONE ledger write path
+ * (`recordAtomic`): a single transaction that checks idempotency,
+ * serializes writers per user (postgres/mysql row lock; skipped on
+ * sqlite), sums the authoritative balance and materializes
+ * `balanceAfter` on the inserted row. These tests drive the mocked
+ * TypeORM manager through that transaction and pin the balance math,
+ * the idempotency short-circuits, the floor/ceiling guards, and the
+ * driver-gated lock.
+ */
+
+type QbMock = {
+    select: jest.Mock;
+    where: jest.Mock;
+    getRawOne: jest.Mock;
+};
+
+function makeQb(balance: number | string): QbMock {
+    const qb: any = {};
+    qb.select = jest.fn().mockReturnValue(qb);
+    qb.where = jest.fn().mockReturnValue(qb);
+    qb.getRawOne = jest.fn().mockResolvedValue({ balance });
+    return qb;
+}
+
+function makeHarness(options: { balance?: number | string; driver?: string } = {}) {
+    const entryRepo = {
+        findOne: jest.fn().mockResolvedValue(null),
+        create: jest.fn((value: any) => value),
+        save: jest.fn(async (value: any) => ({ id: 'entry-1', ...value })),
+        createQueryBuilder: jest.fn(() => makeQb(options.balance ?? 0)),
+        findAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+    const userRepo = {
+        findOne: jest.fn().mockResolvedValue({ id: 'user-1' }),
+    };
+    const manager: any = {
+        connection: { options: { type: options.driver ?? 'better-sqlite3' } },
+        getRepository: jest.fn((entity: unknown) => {
+            if (entity === CreditLedgerEntry) return entryRepo;
+            if (entity === User) return userRepo;
+            throw new Error('Unexpected repository request');
+        }),
+        transaction: jest.fn(async (cb: (m: any) => Promise<unknown>) => cb(manager)),
+    };
+    const topLevelRepository: any = {
+        manager,
+        findOne: jest.fn().mockResolvedValue(null),
+        findAndCount: jest.fn().mockResolvedValue([[], 0]),
+    };
+    const repository = new CreditLedgerRepository(topLevelRepository);
+    return { repository, entryRepo, userRepo, manager, topLevelRepository };
+}
+
+const BASE_WRITE = {
+    userId: 'user-1',
+    kind: CreditLedgerKind.GRANT,
+    amountCredits: 25,
+};
+
+describe('CreditLedgerRepository.recordAtomic', () => {
+    it('computes balanceAfter from the summed prior balance and inserts the row', async () => {
+        const { repository, entryRepo } = makeHarness({ balance: 100 });
+
+        const result = await repository.recordAtomic({ ...BASE_WRITE, amountCredits: 25 });
+
+        expect(result.status).toBe('created');
+        expect(entryRepo.save).toHaveBeenCalledTimes(1);
+        const saved = entryRepo.save.mock.calls[0][0];
+        expect(saved.amountCredits).toBe(25);
+        expect(saved.balanceAfter).toBe(125);
+    });
+
+    it('is idempotent: an existing idempotencyKey row is returned without a second insert', async () => {
+        const { repository, entryRepo } = makeHarness();
+        const existing = { id: 'existing', idempotencyKey: 'daily:user-1:2026-07-25' };
+        entryRepo.findOne.mockResolvedValue(existing);
+
+        const result = await repository.recordAtomic({
+            ...BASE_WRITE,
+            idempotencyKey: 'daily:user-1:2026-07-25',
+        });
+
+        expect(result).toEqual({ status: 'idempotent', entry: existing });
+        expect(entryRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('resolves a concurrent-duplicate unique violation to the surviving row', async () => {
+        const { repository, manager, topLevelRepository } = makeHarness();
+        const survivor = { id: 'survivor', idempotencyKey: 'run:run-9' };
+        manager.transaction.mockRejectedValue({
+            code: '23505',
+            message: 'duplicate key value violates unique constraint',
+        });
+        topLevelRepository.findOne.mockResolvedValue(survivor);
+
+        const result = await repository.recordAtomic({
+            ...BASE_WRITE,
+            idempotencyKey: 'run:run-9',
+        });
+
+        expect(result).toEqual({ status: 'idempotent', entry: survivor });
+    });
+
+    it('rejects a debit that would cross the minBalanceAfter floor (negative guard)', async () => {
+        const { repository, entryRepo } = makeHarness({ balance: 10 });
+
+        const result = await repository.recordAtomic(
+            { ...BASE_WRITE, kind: CreditLedgerKind.CONSUMPTION, amountCredits: -20 },
+            { minBalanceAfter: 0 },
+        );
+
+        expect(result).toEqual({ status: 'insufficient', balance: 10 });
+        expect(entryRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('allows the debit when no floor is set (overdraft) and materializes the negative balance', async () => {
+        const { repository, entryRepo } = makeHarness({ balance: 10 });
+
+        const result = await repository.recordAtomic({
+            ...BASE_WRITE,
+            kind: CreditLedgerKind.CONSUMPTION,
+            amountCredits: -20,
+        });
+
+        expect(result.status).toBe('created');
+        expect(entryRepo.save.mock.calls[0][0].balanceAfter).toBe(-10);
+    });
+
+    it('clamps a grant to the maxBalanceAfter ceiling (non-accumulating daily grant)', async () => {
+        const { repository, entryRepo } = makeHarness({ balance: 30 });
+
+        const result = await repository.recordAtomic(
+            { ...BASE_WRITE, kind: CreditLedgerKind.DAILY_FREE, amountCredits: 50 },
+            { maxBalanceAfter: 50 },
+        );
+
+        expect(result.status).toBe('created');
+        const saved = entryRepo.save.mock.calls[0][0];
+        expect(saved.amountCredits).toBe(20);
+        expect(saved.balanceAfter).toBe(50);
+    });
+
+    it('skips entirely when the balance is already at/above the ceiling', async () => {
+        const { repository, entryRepo } = makeHarness({ balance: 80 });
+
+        const result = await repository.recordAtomic(
+            { ...BASE_WRITE, kind: CreditLedgerKind.DAILY_FREE, amountCredits: 50 },
+            { maxBalanceAfter: 50 },
+        );
+
+        expect(result).toEqual({ status: 'skipped', balance: 80 });
+        expect(entryRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('takes a pessimistic user-row lock on postgres but skips it on sqlite', async () => {
+        const pg = makeHarness({ driver: 'postgres' });
+        await pg.repository.recordAtomic({ ...BASE_WRITE });
+        expect(pg.userRepo.findOne).toHaveBeenCalledWith({
+            where: { id: 'user-1' },
+            lock: { mode: 'pessimistic_write' },
+        });
+
+        const sqlite = makeHarness({ driver: 'better-sqlite3' });
+        await sqlite.repository.recordAtomic({ ...BASE_WRITE });
+        expect(sqlite.userRepo.findOne).not.toHaveBeenCalled();
+    });
+});
+
+describe('CreditLedgerRepository reads', () => {
+    it('getBalance sums the signed movements (string aggregates coerced to number)', async () => {
+        const { repository, manager } = makeHarness({ balance: '42' });
+        // getBalance goes through the top-level manager, not a transaction.
+        expect(await repository.getBalance('user-1')).toBe(42);
+        expect(manager.transaction).not.toHaveBeenCalled();
+    });
+
+    it('findForUser applies kind + period filters and pagination', async () => {
+        const { repository, topLevelRepository } = makeHarness();
+        const from = new Date(Date.UTC(2026, 6, 1));
+        const to = new Date(Date.UTC(2026, 7, 1));
+
+        await repository.findForUser('user-1', {
+            from,
+            to,
+            kinds: [CreditLedgerKind.PURCHASE, CreditLedgerKind.CONSUMPTION],
+            skip: 25,
+            take: 25,
+        });
+
+        expect(topLevelRepository.findAndCount).toHaveBeenCalledWith({
+            where: expect.objectContaining({
+                userId: 'user-1',
+                kind: In([CreditLedgerKind.PURCHASE, CreditLedgerKind.CONSUMPTION]),
+            }),
+            order: { createdAt: 'DESC' },
+            skip: 25,
+            take: 25,
+        });
+    });
+});

--- a/packages/agent/src/database/repositories/credit-ledger.repository.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.ts
@@ -1,0 +1,214 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, EntityManager, In, LessThan, MoreThanOrEqual, Repository } from 'typeorm';
+import { CreditLedgerEntry, CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
+import { User } from '@src/entities/user.entity';
+
+/** Column values for a new ledger movement (balanceAfter is computed). */
+export interface CreditLedgerWrite {
+    userId: string;
+    organizationId?: string | null;
+    tenantId?: string | null;
+    kind: CreditLedgerKind;
+    /** Signed: positive = credit, negative = debit. */
+    amountCredits: number;
+    costCentsRef?: number | null;
+    refType?: string | null;
+    refId?: string | null;
+    description?: string | null;
+    idempotencyKey?: string | null;
+}
+
+export interface RecordAtomicOptions {
+    /**
+     * Reject the write when the resulting balance would fall below this
+     * floor (the consumption negative-balance guard). `null`/`undefined`
+     * = no floor (overdraft allowed).
+     */
+    minBalanceAfter?: number | null;
+    /**
+     * Clamp the (positive) amount so the resulting balance never exceeds
+     * this ceiling — the non-accumulating daily-free-grant semantics. A
+     * clamp down to zero (balance already at/above the ceiling) returns
+     * `status: 'skipped'` and writes nothing.
+     */
+    maxBalanceAfter?: number | null;
+}
+
+export type RecordAtomicResult =
+    /** Row inserted in this call. */
+    | { status: 'created'; entry: CreditLedgerEntry }
+    /** A row with the same idempotencyKey already existed — no write. */
+    | { status: 'idempotent'; entry: CreditLedgerEntry }
+    /** minBalanceAfter floor would be crossed — no write. */
+    | { status: 'insufficient'; balance: number }
+    /** maxBalanceAfter ceiling clamped the amount to ≤ 0 — no write. */
+    | { status: 'skipped'; balance: number };
+
+export interface CreditLedgerQuery {
+    from?: Date;
+    to?: Date;
+    kinds?: CreditLedgerKind[];
+    skip: number;
+    take: number;
+}
+
+/**
+ * Append-only credits ledger (pricing Wave 9 M1).
+ *
+ * All writes go through {@link recordAtomic}: ONE transaction that
+ * checks idempotency, serializes concurrent writers per user (a
+ * pessimistic lock on the owning `users` row where the driver supports
+ * it — postgres/mysql; sqlite serializes writes at the connection), sums
+ * the authoritative balance, applies the floor/ceiling guards, and
+ * inserts the row with the materialized `balanceAfter`.
+ */
+@Injectable()
+export class CreditLedgerRepository {
+    constructor(
+        @InjectRepository(CreditLedgerEntry)
+        private readonly repository: Repository<CreditLedgerEntry>,
+    ) {}
+
+    async recordAtomic(
+        write: CreditLedgerWrite,
+        options: RecordAtomicOptions = {},
+    ): Promise<RecordAtomicResult> {
+        try {
+            return await this.repository.manager.transaction(async (manager) => {
+                const repo = manager.getRepository(CreditLedgerEntry);
+
+                if (write.idempotencyKey) {
+                    const existing = await repo.findOne({
+                        where: { idempotencyKey: write.idempotencyKey },
+                    });
+                    if (existing) {
+                        return { status: 'idempotent' as const, entry: existing };
+                    }
+                }
+
+                await this.lockUserRow(manager, write.userId);
+
+                const balance = await this.sumBalance(manager, write.userId);
+
+                let amount = write.amountCredits;
+                if (options.maxBalanceAfter !== null && options.maxBalanceAfter !== undefined) {
+                    const headroom = options.maxBalanceAfter - balance;
+                    if (amount > headroom) {
+                        amount = headroom;
+                    }
+                    // A positive grant fully clamped away (balance already
+                    // at/above the ceiling) writes nothing — a ceiling must
+                    // never turn a grant into a debit.
+                    if (write.amountCredits > 0 && amount <= 0) {
+                        return { status: 'skipped' as const, balance };
+                    }
+                }
+
+                const balanceAfter = balance + amount;
+                if (
+                    options.minBalanceAfter !== null &&
+                    options.minBalanceAfter !== undefined &&
+                    balanceAfter < options.minBalanceAfter
+                ) {
+                    return { status: 'insufficient' as const, balance };
+                }
+
+                const entry = await repo.save(
+                    repo.create({
+                        ...write,
+                        amountCredits: amount,
+                        balanceAfter,
+                    }),
+                );
+                return { status: 'created' as const, entry };
+            });
+        } catch (error) {
+            // Concurrent duplicate slipped past the in-tx idempotency read
+            // and hit the UNIQUE index — resolve to the surviving row.
+            if (write.idempotencyKey && this.isUniqueViolation(error)) {
+                const existing = await this.findByIdempotencyKey(write.idempotencyKey);
+                if (existing) {
+                    return { status: 'idempotent', entry: existing };
+                }
+            }
+            throw error;
+        }
+    }
+
+    async getBalance(userId: string): Promise<number> {
+        return this.sumBalance(this.repository.manager, userId);
+    }
+
+    async findByIdempotencyKey(idempotencyKey: string): Promise<CreditLedgerEntry | null> {
+        return this.repository.findOne({ where: { idempotencyKey } });
+    }
+
+    async findForUser(
+        userId: string,
+        query: CreditLedgerQuery,
+    ): Promise<{ entries: CreditLedgerEntry[]; total: number }> {
+        const where: Record<string, unknown> = { userId };
+        if (query.from && query.to) {
+            where.createdAt = Between(query.from, query.to);
+        } else if (query.from) {
+            where.createdAt = MoreThanOrEqual(query.from);
+        } else if (query.to) {
+            where.createdAt = LessThan(query.to);
+        }
+        if (query.kinds && query.kinds.length > 0) {
+            where.kind = In(query.kinds);
+        }
+
+        const [entries, total] = await this.repository.findAndCount({
+            where,
+            order: { createdAt: 'DESC' },
+            skip: query.skip,
+            take: query.take,
+        });
+        return { entries, total };
+    }
+
+    /**
+     * Serialize concurrent ledger writes for one user. Pessimistic row
+     * locks are only supported on postgres/mysql/mariadb; better-sqlite3
+     * throws `LockNotSupportedOnGivenDriverError` AND serializes writes
+     * at the connection anyway, so the lock is safely skipped there.
+     */
+    private async lockUserRow(manager: EntityManager, userId: string): Promise<void> {
+        const driver = manager.connection.options.type;
+        if (driver === 'postgres' || driver === 'mysql' || driver === 'mariadb') {
+            await manager.getRepository(User).findOne({
+                where: { id: userId },
+                lock: { mode: 'pessimistic_write' },
+            });
+        }
+    }
+
+    private async sumBalance(manager: EntityManager, userId: string): Promise<number> {
+        const raw = await manager
+            .getRepository(CreditLedgerEntry)
+            .createQueryBuilder('entry')
+            .select('COALESCE(SUM(entry.amountCredits), 0)', 'balance')
+            .where('entry.userId = :userId', { userId })
+            .getRawOne<{ balance: string | number }>();
+        return Number(raw?.balance ?? 0);
+    }
+
+    /**
+     * Driver-agnostic unique-violation detection: postgres exposes code
+     * 23505, sqlite/mysql surface "UNIQUE"/"Duplicate" in the message.
+     */
+    private isUniqueViolation(error: unknown): boolean {
+        const err = error as { code?: string; message?: string; driverError?: { code?: string } };
+        if (err?.code === '23505' || err?.driverError?.code === '23505') {
+            return true;
+        }
+        const message = String(err?.message ?? '');
+        return (
+            message.includes('UNIQUE constraint failed') ||
+            message.includes('duplicate key') ||
+            message.includes('Duplicate entry')
+        );
+    }
+}

--- a/packages/agent/src/database/repositories/plan-entitlement.repository.ts
+++ b/packages/agent/src/database/repositories/plan-entitlement.repository.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PlanEntitlement } from '@src/entities/plan-entitlement.entity';
+
+/**
+ * Plan entitlements (pricing Wave 9 M1) — per-plan feature/limit rows
+ * keyed by (planId = plan CODE, key). Read through
+ * `EntitlementsService` (TTL cache); seeds land in the
+ * `1783400000000-CreateCreditsLedgerAndEntitlements` migration.
+ */
+@Injectable()
+export class PlanEntitlementRepository {
+    constructor(
+        @InjectRepository(PlanEntitlement)
+        private readonly repository: Repository<PlanEntitlement>,
+    ) {}
+
+    async findByPlanAndKey(planId: string, key: string): Promise<PlanEntitlement | null> {
+        return this.repository.findOne({ where: { planId, key } });
+    }
+
+    async findByPlan(planId: string): Promise<PlanEntitlement[]> {
+        return this.repository.find({ where: { planId }, order: { key: 'ASC' } });
+    }
+
+    /** Insert-or-update one (planId, key) lever. */
+    async upsert(
+        entitlement: Pick<PlanEntitlement, 'planId' | 'key'> &
+            Partial<Pick<PlanEntitlement, 'valueInt' | 'valueText'>>,
+    ): Promise<PlanEntitlement> {
+        const existing = await this.findByPlanAndKey(entitlement.planId, entitlement.key);
+        if (existing) {
+            existing.valueInt = entitlement.valueInt ?? null;
+            existing.valueText = entitlement.valueText ?? null;
+            return this.repository.save(existing);
+        }
+        return this.repository.save(this.repository.create(entitlement));
+    }
+}

--- a/packages/agent/src/database/repositories/user.repository.ts
+++ b/packages/agent/src/database/repositories/user.repository.ts
@@ -211,6 +211,22 @@ export class UserRepository {
     }
 
     /**
+     * Credits ledger (pricing Wave 9 M1): stable-ordered page of active,
+     * non-anonymous users for the daily free-credit grant sweep. Loads
+     * the `defaultPlan` relation so the grant dispatcher can resolve the
+     * plan code without a per-user follow-up query.
+     */
+    async findActiveBatch(skip: number, take: number): Promise<User[]> {
+        return await this.repository.find({
+            where: { isActive: true, isAnonymous: false },
+            relations: { defaultPlan: true },
+            order: { createdAt: 'ASC', id: 'ASC' },
+            skip,
+            take,
+        });
+    }
+
+    /**
      * EW-617 G2: hard-delete an anonymous user. Cascades to its Works via
      * `work.user` ON DELETE CASCADE. Safe to call only after the row has been
      * verified `isAnonymous=true` to avoid wiping a real account by mistake.

--- a/packages/agent/src/entities/credit-ledger-entry.entity.ts
+++ b/packages/agent/src/entities/credit-ledger-entry.entity.ts
@@ -1,0 +1,101 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * Credits ledger (pricing Wave 9 M1) — one append-only balance movement.
+ *
+ * Credits are the platform's usage currency layered on top of the
+ * existing `costCents` metering (`plugin_usage_events`): 1 credit = 1
+ * cent of platform-billed usage at the default conversion
+ * (`CREDITS_PER_DOLLAR`, default 100). Rows are written ONLY through
+ * `CreditLedgerRepository.recordAtomic()` so `balanceAfter` is computed
+ * inside the same transaction as the insert; the SUM of `amountCredits`
+ * per user is the authoritative balance and `balanceAfter` is the
+ * point-in-time materialization for ledger display.
+ *
+ * Idempotency: `idempotencyKey` (UNIQUE, nullable) makes writers safe to
+ * re-run — the daily free-grant cron uses `daily:{userId}:{date}`, run
+ * consumption uses `run:{runId}`. Re-delivery returns the existing row.
+ *
+ * Correlation: `refType`/`refId` link a movement back to the thing that
+ * caused it (`agent-run`, `generation`, `task`, …) and `costCentsRef`
+ * carries the metered cost the debit was derived from, so the ledger
+ * and the `plugin_usage_events` pipeline reconcile without ever
+ * double-counting.
+ *
+ * Scope columns are raw uuid references (no @ManyToOne) per the EW-654
+ * cycle-avoidance rule; the userId FK lives in the migration
+ * (`1783400000000-CreateCreditsLedgerAndEntitlements`).
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` — this
+ * repo has no `autoLoadEntities`; a forFeature'd-but-unregistered
+ * entity throws EntityMetadataNotFoundError on first query.
+ */
+export enum CreditLedgerKind {
+    /** Top-up / auto-recharge confirmed by the billing provider (+). */
+    PURCHASE = 'purchase',
+    /** Plan-included or promotional/admin grant (+). */
+    GRANT = 'grant',
+    /** Small daily free credits granted by the scheduled job (+). */
+    DAILY_FREE = 'daily-free',
+    /** Debit from metered usage, rolled up per run/task (−). */
+    CONSUMPTION = 'consumption',
+    /** Admin/platform credit or correction (±). */
+    ADJUSTMENT = 'adjustment',
+    /** Expiring promotional/daily grants, when configured (−). */
+    EXPIRY = 'expiry',
+}
+
+@Entity({ name: 'credit_ledger_entries' })
+@Index('idx_credit_ledger_user_created', ['userId', 'createdAt'])
+@Index('idx_credit_ledger_user_kind', ['userId', 'kind'])
+@Index('idx_credit_ledger_idempotency', ['idempotencyKey'], { unique: true })
+export class CreditLedgerEntry {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Owner of the balance this movement applies to. */
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    // Tenant + Organization scope columns (Tier C denormalization
+    // pattern). Raw uuid references — no @ManyToOne, cycle avoidance
+    // per the EW-654 rule in user.entity.ts.
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    @Column({ type: 'uuid', nullable: true })
+    tenantId?: string | null;
+
+    @Column({ type: 'varchar', length: 16 })
+    kind: CreditLedgerKind;
+
+    /** Signed movement: positive = credit, negative = debit. */
+    @Column({ type: 'int' })
+    amountCredits: number;
+
+    /** The metered `costCents` this movement was derived from, if any. */
+    @Column({ type: 'int', nullable: true })
+    costCentsRef?: number | null;
+
+    /** Correlation target type: 'agent-run' | 'generation' | 'task' | … */
+    @Column({ type: 'varchar', length: 32, nullable: true })
+    refType?: string | null;
+
+    /** UUID of the correlated run/generation/task. */
+    @Column({ type: 'uuid', nullable: true })
+    refId?: string | null;
+
+    /** Balance materialized at write time (display; SUM is authoritative). */
+    @Column({ type: 'int' })
+    balanceAfter: number;
+
+    @Column({ type: 'varchar', length: 256, nullable: true })
+    description?: string | null;
+
+    /** UNIQUE (nullable) — re-running a writer with the same key is a no-op. */
+    @Column({ type: 'varchar', length: 128, nullable: true })
+    idempotencyKey?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -116,3 +116,6 @@ export * from './team-resource.entity';
 export * from './inbound-trigger.entity';
 // Event-ingest spine (Wave 6) — normalized external events awaiting fan-out
 export * from './ingested-event.entity';
+// Credits ledger + plan entitlements (pricing Wave 9 M1)
+export * from './credit-ledger-entry.entity';
+export * from './plan-entitlement.entity';

--- a/packages/agent/src/entities/plan-entitlement.entity.ts
+++ b/packages/agent/src/entities/plan-entitlement.entity.ts
@@ -1,0 +1,60 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Plan entitlements (pricing Wave 9 M1) — per-plan feature/limit values
+ * as key/value rows, additive to the columns already on
+ * `subscription_plans` (maxWorks, allowedCadences, …). New Wave 9
+ * levers (daily free credits, concurrency, retention, …) land here
+ * WITHOUT a schema change per lever.
+ *
+ * `planId` is the plan CODE (`subscription_plans.code`: 'free' /
+ * 'standard' / 'premium' / …), NOT the plan row uuid — plans are
+ * seeded at boot by `SubscriptionService.seedPlans()` AFTER migrations
+ * run, so the seed migration can only reference the stable code.
+ *
+ * Read through `EntitlementsService.get(planId, key, fallback)` (in-
+ * memory TTL cache). A key stores EITHER `valueInt` OR `valueText`;
+ * `UNIQUE(planId, key)` keeps one value per plan per lever.
+ *
+ * Seeded keys (free plan, `1783400000000` migration, INSERT-if-missing):
+ *   - `daily-free-credits`  (default 50, env CREDITS_DAILY_FREE)
+ *   - `max-concurrent-runs` (default 3 — the D5 safety-valve posture)
+ *   - `works-limit`         (default 1 — mirrors FREE `maxWorks`)
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` — this
+ * repo has no `autoLoadEntities`; a forFeature'd-but-unregistered
+ * entity throws EntityMetadataNotFoundError on first query.
+ */
+@Entity({ name: 'plan_entitlements' })
+@Index('idx_plan_entitlements_plan_key', ['planId', 'key'], { unique: true })
+export class PlanEntitlement {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Plan code (`subscription_plans.code`), e.g. 'free'. */
+    @Column({ type: 'varchar', length: 64 })
+    planId: string;
+
+    /** Entitlement lever, e.g. 'daily-free-credits'. */
+    @Column({ type: 'varchar', length: 64 })
+    key: string;
+
+    @Column({ type: 'int', nullable: true })
+    valueInt?: number | null;
+
+    @Column({ type: 'varchar', length: 128, nullable: true })
+    valueText?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
@@ -1,0 +1,367 @@
+import { CreditLedgerService, InsufficientCreditsError } from './credit-ledger.service';
+import { CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
+
+/**
+ * CreditLedgerService is the business layer over the atomic repository
+ * write path: it validates movements, applies the overdraft posture
+ * (env-configurable), converts metered costCents into credit debits
+ * (`consumeForRun`) and runs the non-accumulating daily free-grant
+ * sweep. No real DB/Nest container — collaborators are jest.fn()
+ * shells, env knobs flipped via `process.env` (usage-ledger house
+ * pattern).
+ */
+
+function makeLedgerRepository(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        recordAtomic: jest.fn().mockImplementation(async (write: any) => ({
+            status: 'created',
+            entry: { id: 'entry-1', ...write, balanceAfter: write.amountCredits },
+        })),
+        getBalance: jest.fn().mockResolvedValue(0),
+        findForUser: jest.fn().mockResolvedValue({ entries: [], total: 0 }),
+        findByIdempotencyKey: jest.fn().mockResolvedValue(null),
+        ...overrides,
+    };
+}
+
+function makeEntitlements(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        get: jest.fn(),
+        getNumber: jest.fn().mockResolvedValue(50),
+        clearCache: jest.fn(),
+        ...overrides,
+    };
+}
+
+function makeUserRepository(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        findActiveBatch: jest.fn().mockResolvedValue([]),
+        ...overrides,
+    };
+}
+
+function makeService(
+    ledger: Record<string, jest.Mock> = {},
+    entitlements: Record<string, jest.Mock> = {},
+    users: Record<string, jest.Mock> = {},
+) {
+    const ledgerRepository = makeLedgerRepository(ledger);
+    const entitlementsService = makeEntitlements(entitlements);
+    const userRepository = makeUserRepository(users);
+    const service = new CreditLedgerService(
+        ledgerRepository as any,
+        entitlementsService as any,
+        userRepository as any,
+    );
+    return { service, ledgerRepository, entitlementsService, userRepository };
+}
+
+describe('CreditLedgerService', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        delete process.env.CREDITS_PER_DOLLAR;
+        delete process.env.CREDITS_MARGIN_PERCENT;
+        delete process.env.CREDITS_ALLOW_OVERDRAFT;
+        delete process.env.CREDITS_DAILY_FREE;
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    describe('record — validation + guards', () => {
+        it('rejects zero and non-integer amounts before touching the repository', async () => {
+            const { service, ledgerRepository } = makeService();
+
+            await expect(
+                service.record({ userId: 'u1', kind: CreditLedgerKind.GRANT, amountCredits: 0 }),
+            ).rejects.toThrow('non-zero');
+            await expect(
+                service.record({ userId: 'u1', kind: CreditLedgerKind.GRANT, amountCredits: 1.5 }),
+            ).rejects.toThrow('integer');
+            expect(ledgerRepository.recordAtomic).not.toHaveBeenCalled();
+        });
+
+        it('applies the zero floor to debits by default (overdraft off)', async () => {
+            const { service, ledgerRepository } = makeService();
+
+            await service.record({
+                userId: 'u1',
+                kind: CreditLedgerKind.CONSUMPTION,
+                amountCredits: -10,
+            });
+
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({ amountCredits: -10 }),
+                expect.objectContaining({ minBalanceAfter: 0 }),
+            );
+        });
+
+        it('drops the floor when CREDITS_ALLOW_OVERDRAFT=true (configurable overdraft)', async () => {
+            process.env.CREDITS_ALLOW_OVERDRAFT = 'true';
+            const { service, ledgerRepository } = makeService();
+
+            await service.record({
+                userId: 'u1',
+                kind: CreditLedgerKind.CONSUMPTION,
+                amountCredits: -10,
+            });
+
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ minBalanceAfter: null }),
+            );
+        });
+
+        it('maps an insufficient result to InsufficientCreditsError (stable name → mapped 4xx)', async () => {
+            const { service } = makeService({
+                recordAtomic: jest.fn().mockResolvedValue({ status: 'insufficient', balance: 3 }),
+            });
+
+            const attempt = service.record({
+                userId: 'u1',
+                kind: CreditLedgerKind.CONSUMPTION,
+                amountCredits: -10,
+            });
+
+            await expect(attempt).rejects.toThrow(InsufficientCreditsError);
+            await expect(attempt).rejects.toMatchObject({
+                name: 'InsufficientCreditsError',
+                balanceCredits: 3,
+                requestedCredits: 10,
+            });
+        });
+
+        it('returns the existing entry for an idempotent replay (no duplicate write)', async () => {
+            const existing = { id: 'existing-entry' };
+            const { service } = makeService({
+                recordAtomic: jest
+                    .fn()
+                    .mockResolvedValue({ status: 'idempotent', entry: existing }),
+            });
+
+            const entry = await service.record({
+                userId: 'u1',
+                kind: CreditLedgerKind.PURCHASE,
+                amountCredits: 100,
+                idempotencyKey: 'purchase:abc',
+            });
+
+            expect(entry).toBe(existing);
+        });
+    });
+
+    describe('consumeForRun — the costCents → credits bridge', () => {
+        it('converts costCents at the default rate (100 credits/$ → 1 credit = 1 cent)', async () => {
+            const { service, ledgerRepository } = makeService();
+
+            await service.consumeForRun({ userId: 'u1', runId: 'run-1', costCents: 250 });
+
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    kind: CreditLedgerKind.CONSUMPTION,
+                    amountCredits: -250,
+                    costCentsRef: 250,
+                    refType: 'agent-run',
+                    refId: 'run-1',
+                    idempotencyKey: 'run:run-1',
+                }),
+                expect.anything(),
+            );
+        });
+
+        it('honours CREDITS_PER_DOLLAR + CREDITS_MARGIN_PERCENT (rounded up, never zero)', async () => {
+            process.env.CREDITS_PER_DOLLAR = '200'; // 2 credits per cent
+            process.env.CREDITS_MARGIN_PERCENT = '20';
+            const { service, ledgerRepository } = makeService();
+
+            await service.consumeForRun({ userId: 'u1', runId: 'run-2', costCents: 101 });
+
+            // 101 cents × 2 × 1.2 = 242.4 → ceil → 243 credits.
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({ amountCredits: -243 }),
+                expect.anything(),
+            );
+        });
+
+        it('debits nothing for zero-cost runs (streaming/embed metering gap stays honest)', async () => {
+            const { service, ledgerRepository } = makeService();
+
+            const entry = await service.consumeForRun({
+                userId: 'u1',
+                runId: 'run-3',
+                costCents: 0,
+            });
+
+            expect(entry).toBeNull();
+            expect(ledgerRepository.recordAtomic).not.toHaveBeenCalled();
+        });
+
+        it('prefers an explicit credits override over the computed conversion', async () => {
+            const { service, ledgerRepository } = makeService();
+
+            await service.consumeForRun({
+                userId: 'u1',
+                runId: 'run-4',
+                costCents: 999,
+                credits: 5,
+            });
+
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({ amountCredits: -5, costCentsRef: 999 }),
+                expect.anything(),
+            );
+        });
+    });
+
+    describe('getLedger — period/kind filters + pagination', () => {
+        it('translates a YYYY-MM period into the UTC month window', async () => {
+            const { service, ledgerRepository } = makeService();
+
+            await service.getLedger('u1', { period: '2026-07' });
+
+            expect(ledgerRepository.findForUser).toHaveBeenCalledWith(
+                'u1',
+                expect.objectContaining({
+                    from: new Date(Date.UTC(2026, 6, 1)),
+                    to: new Date(Date.UTC(2026, 7, 1)),
+                    skip: 0,
+                    take: 25,
+                }),
+            );
+        });
+
+        it('rejects a malformed period and clamps pageSize to the maximum', async () => {
+            const { service, ledgerRepository } = makeService();
+
+            await expect(service.getLedger('u1', { period: '2026-13' })).rejects.toThrow(
+                'Invalid period',
+            );
+
+            await service.getLedger('u1', { page: 3, pageSize: 9999 });
+            expect(ledgerRepository.findForUser).toHaveBeenCalledWith(
+                'u1',
+                expect.objectContaining({ skip: 200, take: 100 }),
+            );
+        });
+
+        it('passes kind filters through to the repository', async () => {
+            const { service, ledgerRepository } = makeService();
+
+            await service.getLedger('u1', {
+                kinds: [CreditLedgerKind.PURCHASE, CreditLedgerKind.DAILY_FREE],
+            });
+
+            expect(ledgerRepository.findForUser).toHaveBeenCalledWith(
+                'u1',
+                expect.objectContaining({
+                    kinds: [CreditLedgerKind.PURCHASE, CreditLedgerKind.DAILY_FREE],
+                }),
+            );
+        });
+    });
+
+    describe('dispatchDailyGrants — idempotent daily sweep', () => {
+        const NOW = new Date('2026-07-25T00:05:00.000Z');
+
+        it('grants up to the entitlement level with the daily idempotency key', async () => {
+            const users = [{ id: 'u1', defaultPlan: { code: 'free' } }];
+            const { service, ledgerRepository, entitlementsService } = makeService(
+                {},
+                { getNumber: jest.fn().mockResolvedValue(50) },
+                { findActiveBatch: jest.fn().mockResolvedValueOnce(users).mockResolvedValue([]) },
+            );
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(entitlementsService.getNumber).toHaveBeenCalledWith(
+                'free',
+                'daily-free-credits',
+                expect.any(Number),
+            );
+            expect(ledgerRepository.recordAtomic).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u1',
+                    kind: CreditLedgerKind.DAILY_FREE,
+                    amountCredits: 50,
+                    idempotencyKey: 'daily:u1:2026-07-25',
+                }),
+                expect.objectContaining({ maxBalanceAfter: 50 }),
+            );
+            expect(summary).toEqual({ granted: 1, skipped: 0, alreadyGranted: 0, scanned: 1 });
+        });
+
+        it('is a no-op on re-run: an existing daily key counts as alreadyGranted', async () => {
+            const users = [{ id: 'u1', defaultPlan: { code: 'free' } }];
+            const { service, ledgerRepository } = makeService(
+                { findByIdempotencyKey: jest.fn().mockResolvedValue({ id: 'prior-grant' }) },
+                {},
+                { findActiveBatch: jest.fn().mockResolvedValueOnce(users).mockResolvedValue([]) },
+            );
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(ledgerRepository.recordAtomic).not.toHaveBeenCalled();
+            expect(summary).toEqual({ granted: 0, skipped: 0, alreadyGranted: 1, scanned: 1 });
+        });
+
+        it('skips users whose plan has no daily-free entitlement and counts ceiling clamps as skipped', async () => {
+            const users = [
+                { id: 'paid-user', defaultPlan: { code: 'premium' } },
+                { id: 'rich-user', defaultPlan: { code: 'free' } },
+            ];
+            const { service } = makeService(
+                {
+                    // rich-user is already at the level → repository skips.
+                    recordAtomic: jest.fn().mockResolvedValue({ status: 'skipped', balance: 80 }),
+                },
+                {
+                    getNumber: jest
+                        .fn()
+                        .mockImplementation(async (planCode: string) =>
+                            planCode === 'free' ? 50 : 0,
+                        ),
+                },
+                { findActiveBatch: jest.fn().mockResolvedValueOnce(users).mockResolvedValue([]) },
+            );
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary).toEqual({ granted: 0, skipped: 2, alreadyGranted: 0, scanned: 2 });
+        });
+
+        it('keeps sweeping when one user fails (best-effort per user)', async () => {
+            const users = [
+                { id: 'boom-user', defaultPlan: { code: 'free' } },
+                { id: 'ok-user', defaultPlan: { code: 'free' } },
+            ];
+            const { service } = makeService(
+                {
+                    recordAtomic: jest
+                        .fn()
+                        .mockRejectedValueOnce(new Error('db hiccup'))
+                        .mockResolvedValue({ status: 'created', entry: { id: 'e2' } }),
+                },
+                {},
+                { findActiveBatch: jest.fn().mockResolvedValueOnce(users).mockResolvedValue([]) },
+            );
+
+            const summary = await service.dispatchDailyGrants(NOW);
+
+            expect(summary).toEqual({ granted: 1, skipped: 1, alreadyGranted: 0, scanned: 2 });
+        });
+    });
+
+    describe('getBalance', () => {
+        it('delegates to the repository SUM (authoritative balance)', async () => {
+            const { service, ledgerRepository } = makeService({
+                getBalance: jest.fn().mockResolvedValue(1234),
+            });
+
+            expect(await service.getBalance('u1')).toBe(1234);
+            expect(ledgerRepository.getBalance).toHaveBeenCalledWith('u1');
+        });
+    });
+});

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.ts
@@ -1,0 +1,319 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+    CreditLedgerQuery,
+    CreditLedgerRepository,
+    CreditLedgerWrite,
+} from '@src/database/repositories/credit-ledger.repository';
+import { UserRepository } from '@src/database/repositories/user.repository';
+import { CreditLedgerEntry, CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
+import { config } from '@src/config';
+import { ENTITLEMENT_KEYS, EntitlementsService } from './entitlements.service';
+
+/**
+ * A debit was rejected because it would take the balance below zero and
+ * overdraft is off (`CREDITS_ALLOW_OVERDRAFT`, default false). Stable
+ * `name` so the API boundary can map it to a distinct 4xx (billing PRD
+ * §6: balance exhaustion must never surface as an unmapped 500).
+ */
+export class InsufficientCreditsError extends Error {
+    constructor(
+        public readonly userId: string,
+        public readonly requestedCredits: number,
+        public readonly balanceCredits: number,
+    ) {
+        super(
+            `Insufficient credits: balance ${balanceCredits}, requested debit ${requestedCredits}`,
+        );
+        this.name = 'InsufficientCreditsError';
+    }
+}
+
+export interface RecordCreditEntryOptions {
+    userId: string;
+    kind: CreditLedgerKind;
+    /** Signed integer: positive = credit, negative = debit. */
+    amountCredits: number;
+    organizationId?: string | null;
+    tenantId?: string | null;
+    costCentsRef?: number | null;
+    refType?: string | null;
+    refId?: string | null;
+    description?: string | null;
+    /** Re-running with the same key returns the existing row (no write). */
+    idempotencyKey?: string | null;
+    /** Per-call overdraft override; defaults to `CREDITS_ALLOW_OVERDRAFT`. */
+    allowNegativeBalance?: boolean;
+    /** Ceiling for non-accumulating grants; a full clamp returns null. */
+    maxBalanceAfter?: number | null;
+}
+
+export interface CreditLedgerListOptions {
+    /** Calendar month `YYYY-MM` (matches the existing usage controllers). */
+    period?: string;
+    kinds?: CreditLedgerKind[];
+    page?: number;
+    pageSize?: number;
+}
+
+export interface ConsumeForRunOptions {
+    userId: string;
+    runId: string;
+    /** Metered spend from the costCents pipeline (`plugin_usage_events`). */
+    costCents: number;
+    /** Explicit debit override; computed from costCents when omitted. */
+    credits?: number;
+    organizationId?: string | null;
+    tenantId?: string | null;
+    description?: string | null;
+}
+
+export interface DailyGrantSummary {
+    /** Users that received a (possibly clamped) grant this run. */
+    granted: number;
+    /** Users skipped: balance at/above the level, or a zero entitlement. */
+    skipped: number;
+    /** Users whose grant already existed (cron re-run — idempotent). */
+    alreadyGranted: number;
+    /** Users scanned. */
+    scanned: number;
+}
+
+const DEFAULT_PAGE_SIZE = 25;
+const MAX_PAGE_SIZE = 100;
+const PERIOD_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+/**
+ * Credits ledger writes + reads (pricing Wave 9 M1).
+ *
+ * Credits are the platform usage currency layered on the EXISTING
+ * costCents metering — this service never meters anything itself; it
+ * converts already-metered `costCents` into balance movements
+ * (`consumeForRun`) and applies grants/purchases/adjustments through
+ * one idempotent, transactionally-balanced write path (`record`).
+ *
+ * Passthrough (P2) and local BYOS (P3) runs never reach this service —
+ * they consume no platform credits by decision; their usage events stay
+ * visible in the metering pipeline with no CONSUMPTION row.
+ */
+@Injectable()
+export class CreditLedgerService {
+    private readonly logger = new Logger(CreditLedgerService.name);
+
+    constructor(
+        private readonly creditLedgerRepository: CreditLedgerRepository,
+        private readonly entitlementsService: EntitlementsService,
+        private readonly userRepository: UserRepository,
+    ) {}
+
+    /**
+     * Append one balance movement. Idempotent by `idempotencyKey`;
+     * `balanceAfter` is computed atomically inside the repository
+     * transaction. Debits that would cross zero throw
+     * {@link InsufficientCreditsError} unless overdraft is allowed.
+     *
+     * Returns `null` only when a `maxBalanceAfter` ceiling clamped the
+     * grant to nothing (balance already at/above the level).
+     */
+    async record(options: RecordCreditEntryOptions): Promise<CreditLedgerEntry | null> {
+        if (!Number.isInteger(options.amountCredits)) {
+            throw new Error(`amountCredits must be an integer, got ${options.amountCredits}`);
+        }
+        if (options.amountCredits === 0) {
+            throw new Error('amountCredits must be non-zero');
+        }
+
+        const allowNegative =
+            options.allowNegativeBalance ?? config.billing.credits.allowOverdraft();
+        const write: CreditLedgerWrite = {
+            userId: options.userId,
+            organizationId: options.organizationId ?? null,
+            tenantId: options.tenantId ?? null,
+            kind: options.kind,
+            amountCredits: options.amountCredits,
+            costCentsRef: options.costCentsRef ?? null,
+            refType: options.refType ?? null,
+            refId: options.refId ?? null,
+            description: options.description ?? null,
+            idempotencyKey: options.idempotencyKey ?? null,
+        };
+
+        const result = await this.creditLedgerRepository.recordAtomic(write, {
+            minBalanceAfter: options.amountCredits < 0 && !allowNegative ? 0 : null,
+            maxBalanceAfter: options.maxBalanceAfter ?? null,
+        });
+
+        switch (result.status) {
+            case 'created':
+            case 'idempotent':
+                return result.entry;
+            case 'skipped':
+                return null;
+            case 'insufficient':
+                throw new InsufficientCreditsError(
+                    options.userId,
+                    Math.abs(options.amountCredits),
+                    result.balance,
+                );
+        }
+    }
+
+    /** Authoritative balance: SUM of all signed movements for the user. */
+    async getBalance(userId: string): Promise<number> {
+        return this.creditLedgerRepository.getBalance(userId);
+    }
+
+    /** Owner-scoped paginated ledger with period + kind filters. */
+    async getLedger(
+        userId: string,
+        options: CreditLedgerListOptions = {},
+    ): Promise<{
+        entries: CreditLedgerEntry[];
+        total: number;
+        page: number;
+        pageSize: number;
+    }> {
+        const page = Math.max(1, Math.trunc(options.page ?? 1));
+        const pageSize = Math.min(
+            MAX_PAGE_SIZE,
+            Math.max(1, Math.trunc(options.pageSize ?? DEFAULT_PAGE_SIZE)),
+        );
+
+        const query: CreditLedgerQuery = {
+            kinds: options.kinds,
+            skip: (page - 1) * pageSize,
+            take: pageSize,
+        };
+
+        if (options.period) {
+            if (!PERIOD_RE.test(options.period)) {
+                throw new Error(`Invalid period (expected YYYY-MM): ${options.period}`);
+            }
+            const [year, month] = options.period.split('-').map(Number);
+            // UTC month window, driver-agnostic (no DB date functions).
+            query.from = new Date(Date.UTC(year, month - 1, 1));
+            query.to = new Date(Date.UTC(year, month, 1));
+        }
+
+        const { entries, total } = await this.creditLedgerRepository.findForUser(userId, query);
+        return { entries, total, page, pageSize };
+    }
+
+    /**
+     * The bridge from metered run cost to credits: one CONSUMPTION row
+     * per run (idempotencyKey `run:{runId}`), amount derived from
+     * `costCents × (creditsPerDollar / 100) × (1 + margin%)` and rounded
+     * UP so fractional cost never debits zero. Zero-cost runs (the known
+     * streaming/embed/transcribe metering gaps record `costCents: 0`)
+     * debit nothing and write no row — the ledger never pretends.
+     */
+    async consumeForRun(options: ConsumeForRunOptions): Promise<CreditLedgerEntry | null> {
+        const credits = options.credits ?? this.creditsForCostCents(options.costCents);
+        if (!Number.isInteger(credits) || credits < 0) {
+            throw new Error(`credits must be a non-negative integer, got ${credits}`);
+        }
+        if (credits === 0) {
+            return null;
+        }
+
+        return this.record({
+            userId: options.userId,
+            organizationId: options.organizationId,
+            tenantId: options.tenantId,
+            kind: CreditLedgerKind.CONSUMPTION,
+            amountCredits: -credits,
+            costCentsRef: options.costCents,
+            refType: 'agent-run',
+            refId: options.runId,
+            description: options.description ?? `Run ${options.runId}`,
+            idempotencyKey: `run:${options.runId}`,
+        });
+    }
+
+    /** costCents → whole credits at the configured conversion + margin. */
+    creditsForCostCents(costCents: number): number {
+        if (!Number.isFinite(costCents) || costCents <= 0) {
+            return 0;
+        }
+        const creditsPerCent = config.billing.credits.getCreditsPerDollar() / 100;
+        const margin = 1 + config.billing.credits.getMarginPercent() / 100;
+        return Math.ceil(costCents * creditsPerCent * margin);
+    }
+
+    /**
+     * Daily free-credit sweep (RPC target of the `credits-daily-grant`
+     * cron, 00:05 UTC). For every active user whose plan carries the
+     * `daily-free-credits` entitlement (> 0), tops the balance back UP TO
+     * that level — non-accumulating per the PRD: a balance already at or
+     * above the level receives nothing. Idempotency key
+     * `daily:{userId}:{date}` makes cron re-runs a no-op.
+     */
+    async dispatchDailyGrants(now: Date = new Date()): Promise<DailyGrantSummary> {
+        const summary: DailyGrantSummary = {
+            granted: 0,
+            skipped: 0,
+            alreadyGranted: 0,
+            scanned: 0,
+        };
+        const date = now.toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+        const batchSize = config.billing.credits.getDailyGrantBatchSize();
+        const defaultPlanCode = config.subscriptions.getDefaultPlanCode();
+        const fallbackDailyFree = config.billing.credits.getDailyFreeCredits();
+
+        for (let skip = 0; ; skip += batchSize) {
+            const users = await this.userRepository.findActiveBatch(skip, batchSize);
+            if (users.length === 0) {
+                break;
+            }
+
+            for (const user of users) {
+                summary.scanned += 1;
+                const planCode = (user.defaultPlan?.code as string) || defaultPlanCode;
+                const level = await this.entitlementsService.getNumber(
+                    planCode,
+                    ENTITLEMENT_KEYS.DAILY_FREE_CREDITS,
+                    planCode === 'free' ? fallbackDailyFree : 0,
+                );
+                if (level <= 0) {
+                    summary.skipped += 1;
+                    continue;
+                }
+
+                try {
+                    const idempotencyKey = `daily:${user.id}:${date}`;
+                    const existing =
+                        await this.creditLedgerRepository.findByIdempotencyKey(idempotencyKey);
+                    if (existing) {
+                        summary.alreadyGranted += 1;
+                        continue;
+                    }
+                    const entry = await this.record({
+                        userId: user.id,
+                        kind: CreditLedgerKind.DAILY_FREE,
+                        amountCredits: level,
+                        maxBalanceAfter: level,
+                        description: `Daily free credits (${date})`,
+                        idempotencyKey,
+                    });
+                    if (entry) {
+                        summary.granted += 1;
+                    } else {
+                        summary.skipped += 1;
+                    }
+                } catch (error) {
+                    // Best-effort per user — one failure must not starve the
+                    // rest of the sweep; the idempotency key retries tomorrow.
+                    summary.skipped += 1;
+                    this.logger.warn(
+                        `Daily grant failed for user ${user.id}: ${(error as Error).message}`,
+                    );
+                }
+            }
+
+            if (users.length < batchSize) {
+                break;
+            }
+        }
+
+        return summary;
+    }
+}

--- a/packages/agent/src/subscriptions/credits/entitlements.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/entitlements.service.spec.ts
@@ -1,0 +1,124 @@
+import { EntitlementsService, ENTITLEMENT_KEYS } from './entitlements.service';
+
+/**
+ * EntitlementsService resolves per-plan levers from `plan_entitlements`
+ * rows (planId = plan CODE) through a small in-memory TTL cache. A
+ * missing row is never an error — it resolves to the caller-supplied
+ * fallback, which is what makes entitlements safely additive.
+ */
+
+function makeRepository(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        findByPlanAndKey: jest.fn().mockResolvedValue(null),
+        findByPlan: jest.fn().mockResolvedValue([]),
+        upsert: jest.fn(),
+        ...overrides,
+    };
+}
+
+describe('EntitlementsService', () => {
+    const originalEnv = process.env;
+    let nowSpy: jest.SpyInstance<number, []>;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        delete process.env.CREDITS_ENTITLEMENTS_CACHE_TTL_MS;
+        nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    });
+
+    afterEach(() => {
+        nowSpy.mockRestore();
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('returns valueInt when the row defines one', async () => {
+        const repository = makeRepository({
+            findByPlanAndKey: jest
+                .fn()
+                .mockResolvedValue({ planId: 'free', key: 'daily-free-credits', valueInt: 75 }),
+        });
+        const service = new EntitlementsService(repository as any);
+
+        expect(await service.get('free', ENTITLEMENT_KEYS.DAILY_FREE_CREDITS, 50)).toBe(75);
+    });
+
+    it('falls back to valueText when valueInt is null', async () => {
+        const repository = makeRepository({
+            findByPlanAndKey: jest.fn().mockResolvedValue({
+                planId: 'premium',
+                key: 'transcript-retention',
+                valueInt: null,
+                valueText: 'forever',
+            }),
+        });
+        const service = new EntitlementsService(repository as any);
+
+        expect(await service.get('premium', 'transcript-retention', 'bounded')).toBe('forever');
+    });
+
+    it('resolves to the fallback when no row exists (entitlements are additive)', async () => {
+        const repository = makeRepository();
+        const service = new EntitlementsService(repository as any);
+
+        expect(await service.get('free', 'unknown-lever', 7)).toBe(7);
+        expect(await service.get('free', 'unknown-lever', null)).toBeNull();
+    });
+
+    it('caches within the TTL and refetches after expiry', async () => {
+        const repository = makeRepository({
+            findByPlanAndKey: jest
+                .fn()
+                .mockResolvedValue({ planId: 'free', key: 'works-limit', valueInt: 1 }),
+        });
+        const service = new EntitlementsService(repository as any);
+
+        await service.get('free', ENTITLEMENT_KEYS.WORKS_LIMIT, 0);
+        await service.get('free', ENTITLEMENT_KEYS.WORKS_LIMIT, 0);
+        expect(repository.findByPlanAndKey).toHaveBeenCalledTimes(1);
+
+        // Past the default 60s TTL → the slot is stale, repo hit again.
+        nowSpy.mockReturnValue(1_000_000 + 60_001);
+        await service.get('free', ENTITLEMENT_KEYS.WORKS_LIMIT, 0);
+        expect(repository.findByPlanAndKey).toHaveBeenCalledTimes(2);
+    });
+
+    it('honours CREDITS_ENTITLEMENTS_CACHE_TTL_MS and clearCache()', async () => {
+        process.env.CREDITS_ENTITLEMENTS_CACHE_TTL_MS = '5';
+        const repository = makeRepository({
+            findByPlanAndKey: jest
+                .fn()
+                .mockResolvedValue({ planId: 'free', key: 'max-concurrent-runs', valueInt: 3 }),
+        });
+        const service = new EntitlementsService(repository as any);
+
+        await service.get('free', ENTITLEMENT_KEYS.MAX_CONCURRENT_RUNS, 0);
+        nowSpy.mockReturnValue(1_000_006);
+        await service.get('free', ENTITLEMENT_KEYS.MAX_CONCURRENT_RUNS, 0);
+        expect(repository.findByPlanAndKey).toHaveBeenCalledTimes(2);
+
+        service.clearCache();
+        await service.get('free', ENTITLEMENT_KEYS.MAX_CONCURRENT_RUNS, 0);
+        expect(repository.findByPlanAndKey).toHaveBeenCalledTimes(3);
+    });
+
+    it('getNumber coerces text values and falls back on non-numeric ones', async () => {
+        const repository = makeRepository({
+            findByPlanAndKey: jest
+                .fn()
+                .mockResolvedValueOnce({ planId: 'p', key: 'k', valueInt: null, valueText: '12' })
+                .mockResolvedValueOnce({
+                    planId: 'p',
+                    key: 'k2',
+                    valueInt: null,
+                    valueText: 'nope',
+                }),
+        });
+        const service = new EntitlementsService(repository as any);
+
+        expect(await service.getNumber('p', 'k', 1)).toBe(12);
+        expect(await service.getNumber('p', 'k2', 1)).toBe(1);
+    });
+});

--- a/packages/agent/src/subscriptions/credits/entitlements.service.ts
+++ b/packages/agent/src/subscriptions/credits/entitlements.service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+import { PlanEntitlementRepository } from '@src/database/repositories/plan-entitlement.repository';
+import { config } from '@src/config';
+
+/** Seeded entitlement keys (free plan) — see the 1783400000000 migration. */
+export const ENTITLEMENT_KEYS = {
+    DAILY_FREE_CREDITS: 'daily-free-credits',
+    MAX_CONCURRENT_RUNS: 'max-concurrent-runs',
+    WORKS_LIMIT: 'works-limit',
+} as const;
+
+type CacheSlot = {
+    value: number | string | null;
+    /** epoch ms after which the slot is stale. */
+    expiresAt: number;
+};
+
+/**
+ * Plan-entitlement reads (pricing Wave 9 M1) with a small in-memory TTL
+ * cache (`CREDITS_ENTITLEMENTS_CACHE_TTL_MS`, default 60s).
+ *
+ * `planId` is the plan CODE (`subscription_plans.code`). A missing row
+ * resolves to the caller-supplied fallback — entitlements are additive
+ * plan levers, so "no row" always means "use the platform default",
+ * never an error.
+ */
+@Injectable()
+export class EntitlementsService {
+    private readonly cache = new Map<string, CacheSlot>();
+
+    constructor(private readonly planEntitlementRepository: PlanEntitlementRepository) {}
+
+    /**
+     * Resolve one entitlement lever for a plan. Returns `valueInt` when
+     * set, else `valueText`, else the fallback.
+     */
+    async get<T extends number | string | null>(
+        planId: string,
+        key: string,
+        fallback: T,
+    ): Promise<number | string | T> {
+        const cacheKey = `${planId}:${key}`;
+        const now = Date.now();
+        const cached = this.cache.get(cacheKey);
+        if (cached && cached.expiresAt > now) {
+            return cached.value ?? fallback;
+        }
+
+        const row = await this.planEntitlementRepository.findByPlanAndKey(planId, key);
+        const value = row ? (row.valueInt ?? row.valueText ?? null) : null;
+        this.cache.set(cacheKey, {
+            value,
+            expiresAt: now + config.billing.credits.getEntitlementsCacheTtlMs(),
+        });
+        return value ?? fallback;
+    }
+
+    /** Typed convenience for numeric levers (limits, credit amounts). */
+    async getNumber(planId: string, key: string, fallback: number): Promise<number> {
+        const value = await this.get(planId, key, fallback);
+        const parsed = typeof value === 'number' ? value : Number(value);
+        return Number.isFinite(parsed) ? parsed : fallback;
+    }
+
+    /** Drop all cached slots (tests + admin edits). */
+    clearCache(): void {
+        this.cache.clear();
+    }
+}

--- a/packages/agent/src/subscriptions/index.ts
+++ b/packages/agent/src/subscriptions/index.ts
@@ -2,3 +2,6 @@ export * from './subscriptions.module';
 export * from './subscription.service';
 export * from './usage-ledger.service';
 export * from './billing/billing.provider';
+// Credits ledger + plan entitlements (pricing Wave 9 M1)
+export * from './credits/credit-ledger.service';
+export * from './credits/entitlements.service';

--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -3,6 +3,8 @@ import { SubscriptionsModule } from './subscriptions.module';
 import { SubscriptionService } from './subscription.service';
 import { UsageLedgerService } from './usage-ledger.service';
 import { BillingProvider, ManualBillingProvider } from './billing/billing.provider';
+import { CreditLedgerService, InsufficientCreditsError } from './credits/credit-ledger.service';
+import { ENTITLEMENT_KEYS, EntitlementsService } from './credits/entitlements.service';
 
 /**
  * Pins the public `@ever-works/agent/subscriptions` barrel surface and the
@@ -33,6 +35,13 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(subscriptionsBarrel.ManualBillingProvider).toBe(ManualBillingProvider);
         });
 
+        it('re-exports the credits surface (pricing Wave 9 M1)', () => {
+            expect(subscriptionsBarrel.CreditLedgerService).toBe(CreditLedgerService);
+            expect(subscriptionsBarrel.EntitlementsService).toBe(EntitlementsService);
+            expect(subscriptionsBarrel.InsufficientCreditsError).toBe(InsufficientCreditsError);
+            expect(subscriptionsBarrel.ENTITLEMENT_KEYS).toBe(ENTITLEMENT_KEYS);
+        });
+
         it('exposes the documented runtime symbols only (no extras silently appearing)', () => {
             const runtimeKeys = Object.keys(subscriptionsBarrel).sort();
             expect(runtimeKeys).toEqual(
@@ -42,6 +51,11 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'UsageLedgerService',
                     'BillingProvider',
                     'ManualBillingProvider',
+                    // Credits ledger + plan entitlements (pricing Wave 9 M1)
+                    'CreditLedgerService',
+                    'InsufficientCreditsError',
+                    'EntitlementsService',
+                    'ENTITLEMENT_KEYS',
                 ].sort(),
             );
         });
@@ -61,6 +75,12 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(providers).toContain(UsageLedgerService);
         });
 
+        it('declares the credits services (Wave 9 M1) as providers', () => {
+            const providers = getMeta('providers');
+            expect(providers).toContain(CreditLedgerService);
+            expect(providers).toContain(EntitlementsService);
+        });
+
         it('binds the abstract BillingProvider token to ManualBillingProvider via useClass', () => {
             const providers = getMeta('providers');
             const billingBinding = providers.find(
@@ -75,6 +95,12 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(exports).toContain(SubscriptionService);
             expect(exports).toContain(UsageLedgerService);
             expect(exports).toContain(BillingProvider);
+        });
+
+        it('exports the credits services (consumed by apps/api + the worker RPC proxy)', () => {
+            const exports = getMeta('exports');
+            expect(exports).toContain(CreditLedgerService);
+            expect(exports).toContain(EntitlementsService);
         });
 
         it('does NOT export ManualBillingProvider directly — consumers use the abstract token', () => {

--- a/packages/agent/src/subscriptions/subscriptions.module.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.ts
@@ -3,14 +3,26 @@ import { DatabaseModule } from '@src/database/database.module';
 import { SubscriptionService } from './subscription.service';
 import { UsageLedgerService } from './usage-ledger.service';
 import { BillingProvider, ManualBillingProvider } from './billing/billing.provider';
+import { CreditLedgerService } from './credits/credit-ledger.service';
+import { EntitlementsService } from './credits/entitlements.service';
 
 @Module({
     imports: [DatabaseModule],
     providers: [
         SubscriptionService,
         UsageLedgerService,
+        // Credits ledger + plan entitlements (pricing Wave 9 M1) —
+        // additive beside the existing plan/usage-ledger services.
+        CreditLedgerService,
+        EntitlementsService,
         { provide: BillingProvider, useClass: ManualBillingProvider },
     ],
-    exports: [SubscriptionService, UsageLedgerService, BillingProvider],
+    exports: [
+        SubscriptionService,
+        UsageLedgerService,
+        CreditLedgerService,
+        EntitlementsService,
+        BillingProvider,
+    ],
 })
 export class SubscriptionsModule {}

--- a/packages/tasks/src/tasks/trigger/credits-daily-grant.task.ts
+++ b/packages/tasks/src/tasks/trigger/credits-daily-grant.task.ts
@@ -1,0 +1,44 @@
+import { logger, schedules } from '@trigger.dev/sdk';
+import { CreditLedgerService } from '@ever-works/agent/subscriptions';
+import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
+import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
+
+/**
+ * Daily free-credit grant (pricing Wave 9 M1).
+ *
+ * Once a day (00:05 UTC — offset off the hour per the sweeper-family
+ * rationale, clear of the midnight cron crowd), top every active user
+ * whose plan carries the `daily-free-credits` entitlement back UP TO
+ * that level. Non-accumulating by design (PRD §3.6): a balance already
+ * at/above the level receives nothing, so free credits are a daily
+ * allowance, not a stockpile.
+ *
+ * The real `CreditLedgerService` lives in the API (ledger +
+ * entitlement repositories are wired there); the worker only calls
+ * `dispatchDailyGrants()` over the internal RPC channel — same shape
+ * as the event-ingest-tick / task-branch-gc crons.
+ *
+ * Idempotency: every grant is written with idempotencyKey
+ * `daily:{userId}:{date}`, so re-running the cron (retry, redeploy,
+ * manual trigger) is a no-op for already-granted users.
+ */
+export const creditsDailyGrantTask = schedules.task({
+    id: 'credits-daily-grant',
+    cron: '5 0 * * *',
+    run: async () => {
+        return withWorkerContext(
+            'CreditsDailyGrant',
+            async (appContext) => {
+                const svc = appContext.get(CreditLedgerService);
+                const summary = await svc.dispatchDailyGrants();
+                if (summary.granted > 0 || summary.skipped > 0) {
+                    logger.info('credits-daily-grant dispatched daily free credits', {
+                        ...summary,
+                    });
+                }
+                return summary;
+            },
+            TriggerInternalModule,
+        );
+    },
+});

--- a/packages/tasks/src/tasks/trigger/index.ts
+++ b/packages/tasks/src/tasks/trigger/index.ts
@@ -28,3 +28,5 @@ export * from './work-schedule-dispatcher.task';
 export * from './webhook-delivery.task';
 // EW-693 — long-running plugin execution (Phase 7 / T27).
 export * from './run-plugin-operation.task';
+// Pricing Wave 9 M1 — daily free-credit grant (idempotent per user/day).
+export * from './credits-daily-grant.task';

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -26,6 +26,7 @@ import {
 import { AgentRepository, AgentRunRepository, WorkRepository } from '@ever-works/agent/database';
 import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
 import { EventIngestService } from '@ever-works/agent/ingest';
+import { CreditLedgerService } from '@ever-works/agent/subscriptions';
 import { TriggerInternalApiClient } from '../services/trigger-internal-api.client';
 import { createRemoteProxy } from '../remote-proxy';
 
@@ -251,6 +252,16 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
                 createRemoteProxy(apiClient, 'EventIngestService'),
             inject: [TriggerInternalApiClient],
         },
+        // Credits ledger (pricing Wave 9 M1) — the credits-daily-grant
+        // cron task calls `dispatchDailyGrants()` on this proxy, which
+        // RPCs to the live API where the ledger/entitlement repositories
+        // are wired. Same shape as EventIngestService above.
+        {
+            provide: CreditLedgerService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'CreditLedgerService'),
+            inject: [TriggerInternalApiClient],
+        },
     ],
     exports: [
         TriggerInternalApiClient,
@@ -278,6 +289,7 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         AnonymousUserCleanupService,
         KnowledgeBaseReconcileService,
         EventIngestService,
+        CreditLedgerService,
     ],
 })
 export class TriggerInternalModule {}


### PR DESCRIPTION
## Summary

Pricing Wave 9 M1 — the **credits ledger + entitlements schema/service layer** (UI is Wave 13). Credits are the usage currency layered directly on the EXISTING `costCents` metering (`plugin_usage_events`); everything here is additive beside the subscriptions/usage-ledger stack — no existing flow touched. No third-party product names anywhere; payments ride the existing `BillingProvider` seam later (Wave 9.4).

### Schema — one guarded migration (`1783400000000-CreateCreditsLedgerAndEntitlements`)
- **`credit_ledger_entries`** — append-only signed movements: `kind` (`purchase`/`grant`/`daily-free`/`consumption`/`adjustment`/`expiry`), `amountCredits` (signed int), `costCentsRef`, `refType`(32)/`refId` correlation, materialized `balanceAfter` (SUM stays authoritative), `description`(256), **UNIQUE nullable `idempotencyKey`(128)**, `userId` FK CASCADE, tenant/org scope columns, `(userId, createdAt)` + `(userId, kind)` indexes. Forward-only, `hasTable`-guarded (house pattern of `1782700000000-AddTaskIsolationColumns`).
- **`plan_entitlements`** — `(planId = plan CODE, key)` levers with `UNIQUE(planId, key)`, `valueInt`/`valueText`. **Seeds INSERT-if-missing** in the same migration for the free plan: `daily-free-credits` (env `CREDITS_DAILY_FREE`, default 50), `max-concurrent-runs` (3 — D5 safety-valve posture), `works-limit` (1).
- Both entities registered in the **`ENTITIES` inventory + `_entity-names` pins + `_repository-inventory`** (the forFeature-without-registration → unmapped-500 bug class).

### Service layer (`packages/agent/src/subscriptions/credits/`)
- **`CreditLedgerService`** (barrel-exported, module-registered):
  - `record(entry)` — idempotent by `idempotencyKey`; `balanceAfter` computed **atomically in one transaction** (per-user pessimistic row lock on postgres/mysql; skipped on sqlite which serializes writes; unique-index backstop resolves concurrent duplicates to the surviving row).
  - Negative guard **per PRD §6**: a debit that would cross zero **rejects** with `InsufficientCreditsError` (stable `name` for a mapped 4xx — never an unmapped 500); overdraft configurable via `CREDITS_ALLOW_OVERDRAFT` (default off).
  - `getBalance(userId)` — authoritative SUM.
  - `getLedger(userId, {period YYYY-MM, kinds, page/pageSize})` — driver-agnostic UTC month window.
  - `consumeForRun({userId, runId, costCents, credits?})` — the Wave 4 `agent_runs.costCents` → credits bridge: `ceil(costCents × CREDITS_PER_DOLLAR/100 × (1 + CREDITS_MARGIN_PERCENT/100))` (defaults 100 / 0 — both env-configurable), one CONSUMPTION row per run (`run:{runId}`), **zero-cost runs debit nothing** (streaming/embed metering gap stays honest per PRD §6.3).
- **`EntitlementsService.get(planId, key, fallback)`** — in-memory TTL cache (`CREDITS_ENTITLEMENTS_CACHE_TTL_MS`, default 60s); missing row → fallback (entitlements are additive levers).

### Daily free-grant cron
- `credits-daily-grant` (packages/tasks, **cron `5 0 * * *`**) → `dispatchDailyGrants()` over the trigger-internal RPC — full 3-place wiring: worker proxy provider/export, API controller **appended-LAST `@Optional()`** constructor arg + remoteMap entry (spec arity preserved), `TriggerInternalModule` imports the agent SubscriptionsModule.
- Non-accumulating per PRD §3.6: tops the balance **up to** the entitlement level (`maxBalanceAfter` clamp — a ceiling can never turn a grant into a debit); `idempotencyKey daily:{userId}:{date}` makes re-runs no-ops; best-effort per user.

### Read API (Wave 13 consumes these)
- `GET /api/credits/balance` + `GET /api/credits/ledger` (owner-scoped via `@CurrentUser`, paginated, period/kind filters, explicit row projection) in a thin `CreditsController` beside the existing subscriptions controller.

## Verification (real output)

- `packages/agent` `pnpm build` → `TSC Found 0 issues.` / `Successfully compiled: 1002 files with swc`
- `packages/agent` `npx jest --testPathPattern='credit|entitlement'` → **`Test Suites: 3 passed / Tests: 33 passed`**
- Pin/drift specs (`subscriptions.module|database.module|database.config|usage-ledger|subscription.service`) → **`8 suites / 194 tests passed`**
- `pnpm build --filter=ever-works-api` → `TSC Found 0 issues.` / `651 files with swc` (`14 successful, 14 total`)
- `apps/api` `pnpm generate:openapi` → `Wrote OpenAPI spec (417 paths)` (full-app bootstrap gate; `openapi.json` excluded from the commit per convention)
- `apps/api` `jest --testPathPattern='trigger-internal'` → **`2 suites / 16 tests passed`**
- `packages/tasks` `pnpm build` (tsc) → clean
- Prettier clean on all touched files

## Skips / notes
- Repo-root `eslint` binary isn't wired for per-package invocation on this machine — lint rides the CI job (tsc-strict + prettier both green locally).
- Account-transfer whitelist untouched by design: M1 adds new entities, not new columns on transferred ones — ledger/entitlement export-import inclusion is PRD milestone B9.
- Debit hook on the metering path + margin pricing = Wave 9.1 follow-up; this PR ships the service seam it calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)