### PR TITLE
feat(integrations): Slack app — connector, events receiver, chat bridge (Wave 6)

### DIFF
--- a/apps/api/src/ai-conversation/ai-conversation.module.ts
+++ b/apps/api/src/ai-conversation/ai-conversation.module.ts
@@ -15,5 +15,8 @@ import { ConversationTitleService } from './conversation-title.service';
     imports: [FacadesModule, DatabaseModule, KnowledgeBaseModule],
     controllers: [OpenAiCompatController, ConversationController],
     providers: [OpenAiCompatService, ConversationTitleService],
+    // Exported for the Slack chat bridge (IngestModule) — Slack mentions
+    // route through the SAME chat surface the web app uses.
+    exports: [OpenAiCompatService],
 })
 export class AiConversationModule {}

--- a/apps/api/src/ingest/ingest.module.ts
+++ b/apps/api/src/ingest/ingest.module.ts
@@ -1,15 +1,26 @@
 import { Module } from '@nestjs/common';
 import { EventIngestModule } from '@ever-works/agent/ingest';
+import { AiConversationModule } from '../ai-conversation/ai-conversation.module';
 import { IngestController } from './ingest.controller';
+import { SlackEventsController } from './slack/slack-events.controller';
+import { SlackChatBridgeService } from './slack/slack-chat-bridge.service';
 
 /**
  * Event-ingest spine (Wave 6) — thin API module exposing
  * `POST /api/ingest/events` over the agent-side `EventIngestModule`
- * (dedupe-insert + processor fan-out live there).
+ * (dedupe-insert + processor fan-out live there), plus the Slack
+ * Events API receiver (`POST /api/ingest/slack/events`) and its
+ * mention→platform-chat bridge (`SlackChatBridgeService`).
+ *
+ * Plugin-system services the bridge consumes (registry / settings /
+ * user-plugin repository) come from the @Global agent PluginsModule
+ * bootstrapped in api.module.ts; `OpenAiCompatService` (the platform
+ * chat surface) comes from `AiConversationModule`.
  */
 @Module({
-    imports: [EventIngestModule],
-    controllers: [IngestController],
+    imports: [EventIngestModule, AiConversationModule],
+    controllers: [IngestController, SlackEventsController],
+    providers: [SlackChatBridgeService],
     exports: [EventIngestModule],
 })
 export class IngestModule {}

--- a/apps/api/src/ingest/slack/slack-chat-bridge.service.spec.ts
+++ b/apps/api/src/ingest/slack/slack-chat-bridge.service.spec.ts
@@ -1,0 +1,263 @@
+jest.mock('@ever-works/agent/ingest', () => ({ EventIngestService: class {} }));
+jest.mock('@ever-works/agent/plugins', () => ({
+    PluginRegistryService: class {},
+    PluginSettingsService: class {},
+    UserPluginRepository: class {},
+}));
+jest.mock('../../ai-conversation/openai-compat.service', () => ({
+    OpenAiCompatService: class {},
+}));
+
+import { SlackChatBridgeService } from './slack-chat-bridge.service';
+
+/** Flush the fire-and-forget bridge promise chain. */
+function flush(): Promise<void> {
+    return new Promise((resolve) => setImmediate(resolve));
+}
+
+const BINDING = {
+    userId: 'user-1',
+    signingSecret: 'sec',
+    settings: { botToken: 'xoxb-test' },
+};
+
+function mentionBody(overrides: Record<string, unknown> = {}) {
+    return {
+        type: 'event_callback',
+        event_id: 'Ev1',
+        team_id: 'T1',
+        event: {
+            type: 'app_mention',
+            user: 'U7',
+            text: '<@UBOT> what shipped today?',
+            channel: 'C1',
+            ts: '1700000000.000100',
+            ...overrides,
+        },
+    };
+}
+
+describe('SlackChatBridgeService', () => {
+    function createService() {
+        const userPluginRepository = { findByPlugin: jest.fn().mockResolvedValue([]) };
+        const pluginSettingsService = { getSettings: jest.fn().mockResolvedValue({}) };
+        const slackPlugin = {
+            id: 'slack-connector',
+            capabilities: ['connector', 'connector-slack', 'event-source'],
+            reply: jest.fn().mockResolvedValue({ provider: 'slack-connector' }),
+            send: jest.fn().mockResolvedValue({ provider: 'slack-connector' }),
+        };
+        const pluginRegistry = {
+            getByCapability: jest.fn().mockReturnValue([{ plugin: slackPlugin, state: 'loaded' }]),
+        };
+        const eventIngestService = {
+            ingest: jest.fn().mockResolvedValue({ inserted: 1, duplicates: 0, rejected: 0 }),
+        };
+        const openAiCompatService = {
+            handleCompletion: jest.fn().mockResolvedValue({
+                choices: [{ index: 0, message: { role: 'assistant', content: 'All green.' } }],
+            }),
+        };
+        const service = new SlackChatBridgeService(
+            userPluginRepository as any,
+            pluginSettingsService as any,
+            pluginRegistry as any,
+            eventIngestService as any,
+            openAiCompatService as any,
+        );
+        return {
+            service,
+            userPluginRepository,
+            pluginSettingsService,
+            pluginRegistry,
+            eventIngestService,
+            openAiCompatService,
+            slackPlugin,
+        };
+    }
+
+    describe('resolveBinding', () => {
+        it('binds to the OLDEST enabled install whose settings carry a signing secret', async () => {
+            const { service, userPluginRepository, pluginSettingsService } = createService();
+            userPluginRepository.findByPlugin.mockResolvedValue([
+                { userId: 'u-newer', enabled: true, createdAt: new Date('2026-02-01') },
+                { userId: 'u-disabled', enabled: false, createdAt: new Date('2026-01-01') },
+                { userId: 'u-oldest', enabled: true, createdAt: new Date('2026-01-15') },
+            ]);
+            pluginSettingsService.getSettings.mockImplementation(
+                async (_pluginId: string, options: { userId: string }) =>
+                    options.userId === 'u-oldest'
+                        ? { signingSecret: 'shhh', botToken: 'xoxb' }
+                        : { botToken: 'xoxb' },
+            );
+
+            const binding = await service.resolveBinding();
+            expect(binding).toMatchObject({ userId: 'u-oldest', signingSecret: 'shhh' });
+            // Disabled installs are never consulted.
+            const consulted = pluginSettingsService.getSettings.mock.calls.map(
+                (c: any[]) => c[1].userId,
+            );
+            expect(consulted).not.toContain('u-disabled');
+            // Secrets must be requested for verification/replies to work.
+            expect(pluginSettingsService.getSettings).toHaveBeenCalledWith(
+                'slack-connector',
+                expect.objectContaining({ includeSecrets: true }),
+            );
+        });
+
+        it('returns null (fail-closed) when no enabled install has a signing secret', async () => {
+            const { service, userPluginRepository } = createService();
+            userPluginRepository.findByPlugin.mockResolvedValue([
+                { userId: 'u1', enabled: true, createdAt: new Date('2026-01-01') },
+            ]);
+            expect(await service.resolveBinding()).toBeNull();
+        });
+    });
+
+    describe('toEnvelope', () => {
+        it('normalizes an app_mention into a slack.mention envelope with channel:ts identity', () => {
+            const { service } = createService();
+            const envelope = service.toEnvelope(mentionBody() as any);
+            expect(envelope).toMatchObject({
+                source: 'slack-connector',
+                sourceEventId: 'C1:1700000000.000100',
+                kind: 'slack.mention',
+                subject: { type: 'channel', externalId: 'C1' },
+                actor: { externalId: 'U7' },
+            });
+            expect(envelope!.occurredAt).toBe(
+                new Date(Number('1700000000.000100') * 1000).toISOString(),
+            );
+            expect(envelope!.payload).toMatchObject({
+                channel: 'C1',
+                ts: '1700000000.000100',
+                teamId: 'T1',
+                providerEventId: 'Ev1',
+            });
+        });
+
+        it('skips bot-authored messages and non-message payloads', () => {
+            const { service } = createService();
+            expect(service.toEnvelope(mentionBody({ bot_id: 'B9' }) as any)).toBeNull();
+            expect(service.toEnvelope(mentionBody({ subtype: 'channel_join' }) as any)).toBeNull();
+            expect(
+                service.toEnvelope({
+                    type: 'event_callback',
+                    event: { type: 'reaction_added' },
+                } as any),
+            ).toBeNull();
+            expect(service.toEnvelope({ type: 'url_verification' } as any)).toBeNull();
+        });
+    });
+
+    describe('handleEventCallback', () => {
+        it('ingests a first-seen mention and bridges it into platform chat + thread reply', async () => {
+            const { service, eventIngestService, openAiCompatService, slackPlugin } =
+                createService();
+            const result = await service.handleEventCallback(BINDING, mentionBody() as any);
+            await flush();
+
+            expect(result.ingested).toMatchObject({ inserted: 1 });
+            expect(eventIngestService.ingest).toHaveBeenCalledWith('user-1', [
+                expect.objectContaining({ kind: 'slack.mention' }),
+            ]);
+            // Chat runs as the bound user with mention tokens stripped.
+            expect(openAiCompatService.handleCompletion).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    messages: [{ role: 'user', content: 'what shipped today?' }],
+                }),
+                { userId: 'user-1' },
+            );
+            // Reply lands in the mention's thread via the connector plugin.
+            expect(slackPlugin.reply).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    externalConversationId: 'C1:1700000000.000100',
+                    text: 'All green.',
+                }),
+                expect.objectContaining({
+                    userId: 'user-1',
+                    target: { botToken: 'xoxb-test' },
+                }),
+            );
+        });
+
+        it('does NOT bridge a duplicate delivery (retry) — dedupe gates the chat leg', async () => {
+            const { service, eventIngestService, openAiCompatService, slackPlugin } =
+                createService();
+            eventIngestService.ingest.mockResolvedValue({
+                inserted: 0,
+                duplicates: 1,
+                rejected: 0,
+            });
+            await service.handleEventCallback(BINDING, mentionBody() as any);
+            await flush();
+            expect(openAiCompatService.handleCompletion).not.toHaveBeenCalled();
+            expect(slackPlugin.reply).not.toHaveBeenCalled();
+        });
+
+        it('ingests plain channel messages without invoking the chat bridge', async () => {
+            const { service, eventIngestService, openAiCompatService } = createService();
+            await service.handleEventCallback(
+                BINDING,
+                mentionBody({ type: 'message', text: 'no bot mention here' }) as any,
+            );
+            await flush();
+            expect(eventIngestService.ingest).toHaveBeenCalledWith('user-1', [
+                expect.objectContaining({ kind: 'slack.message' }),
+            ]);
+            expect(openAiCompatService.handleCompletion).not.toHaveBeenCalled();
+        });
+
+        it('skips ingest entirely for bot-authored events', async () => {
+            const { service, eventIngestService } = createService();
+            const result = await service.handleEventCallback(
+                BINDING,
+                mentionBody({ bot_id: 'B1' }) as any,
+            );
+            expect(result.ingested).toBeNull();
+            expect(eventIngestService.ingest).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('bridgeMentionToChat (best-effort)', () => {
+        it('swallows reply failures — logs, never throws', async () => {
+            const { service, slackPlugin } = createService();
+            slackPlugin.reply.mockRejectedValue(new Error('slack down'));
+            await expect(
+                service.bridgeMentionToChat(BINDING, mentionBody() as any),
+            ).resolves.toBeUndefined();
+        });
+
+        it('swallows chat-engine failures — logs, never throws, never posts', async () => {
+            const { service, openAiCompatService, slackPlugin } = createService();
+            openAiCompatService.handleCompletion.mockRejectedValue(new Error('no provider'));
+            await expect(
+                service.bridgeMentionToChat(BINDING, mentionBody() as any),
+            ).resolves.toBeUndefined();
+            expect(slackPlugin.reply).not.toHaveBeenCalled();
+        });
+
+        it('does not attempt a reply when the binding has no botToken', async () => {
+            const { service, slackPlugin } = createService();
+            await service.bridgeMentionToChat({ ...BINDING, settings: {} }, mentionBody() as any);
+            expect(slackPlugin.reply).not.toHaveBeenCalled();
+            expect(slackPlugin.send).not.toHaveBeenCalled();
+        });
+
+        it('falls back to send() with a threadTs target when the plugin has no reply()', async () => {
+            const { service, slackPlugin } = createService();
+            (slackPlugin as any).reply = undefined;
+            await service.bridgeMentionToChat(BINDING, mentionBody() as any);
+            expect(slackPlugin.send).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    text: 'All green.',
+                    target: expect.objectContaining({
+                        channelId: 'C1',
+                        threadTs: '1700000000.000100',
+                    }),
+                }),
+                expect.anything(),
+            );
+        });
+    });
+});

--- a/apps/api/src/ingest/slack/slack-chat-bridge.service.ts
+++ b/apps/api/src/ingest/slack/slack-chat-bridge.service.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from 'node:crypto';
+import { Injectable, Logger } from '@nestjs/common';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+import { EventIngestService, type IngestResult } from '@ever-works/agent/ingest';
+import {
+    PluginRegistryService,
+    PluginSettingsService,
+    UserPluginRepository,
+} from '@ever-works/agent/plugins';
+import { PLUGIN_CAPABILITIES, isConnectorPlugin } from '@ever-works/plugin';
+import type { ChannelTargetConfig, IConnectorPlugin } from '@ever-works/plugin';
+import { OpenAiCompatService } from '../../ai-conversation/openai-compat.service';
+import type { OpenAiChatCompletionRequestDto } from '../../ai-conversation/dto/openai-compat.dto';
+
+export const SLACK_CONNECTOR_PLUGIN_ID = 'slack-connector';
+
+/** Payload text cap for envelopes built from webhook deliveries. */
+export const SLACK_EVENT_TEXT_MAX_CHARS = 4000;
+
+/**
+ * v1 workspace→user binding: the events land under the platform user who
+ * configured the slack-connector plugin (first enabled install with a
+ * signing secret). Multi-user / per-workspace `team_id` mapping is a
+ * documented follow-up (a pairing table keyed by Slack team + user id).
+ */
+export interface SlackEventsBinding {
+    readonly userId: string;
+    readonly signingSecret: string;
+    /** Resolved plugin settings (secrets included) for outbound replies. */
+    readonly settings: Record<string, unknown>;
+}
+
+/** The subset of a Slack Events API `event_callback` we consume. */
+export interface SlackEventCallbackBody {
+    type?: string;
+    event_id?: string;
+    team_id?: string;
+    event?: {
+        type?: string;
+        subtype?: string;
+        user?: string;
+        username?: string;
+        bot_id?: string;
+        text?: string;
+        channel?: string;
+        ts?: string;
+        event_ts?: string;
+        thread_ts?: string;
+    };
+}
+
+/**
+ * Slack app surface (Wave 6, feature f) — ONE service bridging the Slack
+ * Events API into the platform:
+ *
+ * 1. `resolveBinding()` — the v1 workspace→user binding (see
+ *    {@link SlackEventsBinding}) plus the signing secret the receiver
+ *    verifies deliveries with. Fail-closed: no configured install → no
+ *    binding → the endpoint 401s.
+ * 2. `handleEventCallback()` — normalizes `app_mention` / `message`
+ *    events into `IngestedEventEnvelope`s and dedupe-inserts them
+ *    through the event-ingest spine (`slack.mention` / `slack.message`,
+ *    identity `channel:ts` so webhook pushes and the connector's
+ *    `pullEvents` sweeps converge on one row).
+ * 3. `@works` mentions — on a first-seen `app_mention`, routes the text
+ *    into the EXISTING platform chat engine (`OpenAiCompatService`, the
+ *    same surface the web app uses) as the bound user, and posts the
+ *    completion back into the Slack thread via the slack-connector
+ *    plugin's `reply` (best-effort: failures are logged, never thrown —
+ *    the webhook 200s regardless).
+ */
+@Injectable()
+export class SlackChatBridgeService {
+    private readonly logger = new Logger(SlackChatBridgeService.name);
+
+    constructor(
+        private readonly userPluginRepository: UserPluginRepository,
+        private readonly pluginSettingsService: PluginSettingsService,
+        private readonly pluginRegistry: PluginRegistryService,
+        private readonly eventIngestService: EventIngestService,
+        private readonly openAiCompatService: OpenAiCompatService,
+    ) {}
+
+    /**
+     * Resolve the v1 events binding: the OLDEST enabled slack-connector
+     * install whose resolved settings carry a signing secret. Returns
+     * null when nothing is configured — callers must fail closed.
+     */
+    async resolveBinding(): Promise<SlackEventsBinding | null> {
+        const installs = await this.userPluginRepository.findByPlugin(SLACK_CONNECTOR_PLUGIN_ID);
+        const candidates = installs
+            .filter((row) => row.enabled)
+            .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+
+        for (const row of candidates) {
+            const settings = await this.pluginSettingsService.getSettings(
+                SLACK_CONNECTOR_PLUGIN_ID,
+                { userId: row.userId, includeSecrets: true },
+            );
+            const signingSecret = settings?.signingSecret;
+            if (typeof signingSecret === 'string' && signingSecret.length > 0) {
+                return { userId: row.userId, signingSecret, settings: settings ?? {} };
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Ingest one verified `event_callback` delivery and (for first-seen
+     * mentions) kick the chat bridge. The chat leg is deliberately not
+     * awaited — Slack requires a fast 200, and the reply is best-effort.
+     */
+    async handleEventCallback(
+        binding: SlackEventsBinding,
+        body: SlackEventCallbackBody,
+    ): Promise<{ ingested: IngestResult | null }> {
+        const envelope = this.toEnvelope(body);
+        if (!envelope) {
+            return { ingested: null };
+        }
+
+        const ingested = await this.eventIngestService.ingest(binding.userId, [envelope]);
+
+        // Retries and pull-path overlap dedupe to 0 inserts — only a
+        // first-seen mention triggers the chat bridge (no double replies).
+        if (envelope.kind === 'slack.mention' && ingested.inserted > 0) {
+            void this.bridgeMentionToChat(binding, body).catch((error: unknown) => {
+                // bridgeMentionToChat handles its own errors; this catch is a
+                // belt-and-suspenders guard so nothing escapes the void.
+                this.logger.warn(
+                    `Slack mention bridge failed: ${error instanceof Error ? error.message : String(error)}`,
+                );
+            });
+        }
+
+        return { ingested };
+    }
+
+    /** Normalize an `event_callback` body into an ingest envelope (or skip it). */
+    toEnvelope(body: SlackEventCallbackBody): IngestedEventEnvelope | null {
+        if (body?.type !== 'event_callback' || !body.event) return null;
+        const event = body.event;
+        if (event.type !== 'app_mention' && event.type !== 'message') return null;
+        // Never ingest bot-authored messages (incl. our own replies) or
+        // system subtypes — the spine must not echo its own output.
+        if (event.bot_id || event.subtype) return null;
+        const channel = event.channel ?? '';
+        const ts = event.ts ?? event.event_ts ?? '';
+        if (!channel || !ts) return null;
+
+        const text = event.text ?? '';
+        return {
+            id: randomUUID(),
+            source: SLACK_CONNECTOR_PLUGIN_ID,
+            // Identity is `channel:ts` (not Slack's event_id) so the webhook
+            // push path and the connector's pullEvents sweep dedupe against
+            // each other — one message, one row, regardless of arrival path.
+            sourceEventId: `${channel}:${ts}`,
+            kind: event.type === 'app_mention' ? 'slack.mention' : 'slack.message',
+            occurredAt: this.slackTsToIso(ts),
+            actor: {
+                name: event.username ?? event.user ?? 'unknown',
+                ...(event.user ? { externalId: event.user } : {}),
+            },
+            subject: { type: 'channel', externalId: channel },
+            payload: {
+                channel,
+                ts,
+                ...(event.thread_ts ? { threadTs: event.thread_ts } : {}),
+                ...(body.team_id ? { teamId: body.team_id } : {}),
+                ...(body.event_id ? { providerEventId: body.event_id } : {}),
+                text:
+                    text.length > SLACK_EVENT_TEXT_MAX_CHARS
+                        ? text.slice(0, SLACK_EVENT_TEXT_MAX_CHARS)
+                        : text,
+            },
+        };
+    }
+
+    /**
+     * Route a mention's text into the platform chat as the bound user and
+     * post the completion back into the originating Slack thread.
+     * BEST-EFFORT end to end: every failure is logged and swallowed.
+     */
+    async bridgeMentionToChat(
+        binding: SlackEventsBinding,
+        body: SlackEventCallbackBody,
+    ): Promise<void> {
+        const event = body.event;
+        const channel = event?.channel;
+        const ts = event?.ts ?? event?.event_ts;
+        if (!event || !channel || !ts) return;
+
+        const prompt = this.stripMentions(event.text ?? '');
+        if (!prompt) {
+            this.logger.debug('Slack mention carried no text after stripping mentions; skipping');
+            return;
+        }
+
+        try {
+            // `model: 'auto'` defers model selection to the user's configured
+            // AI plugin settings — the same path the web chat uses.
+            const completion = await this.openAiCompatService.handleCompletion(
+                {
+                    model: 'auto',
+                    messages: [{ role: 'user', content: prompt }],
+                } as OpenAiChatCompletionRequestDto,
+                { userId: binding.userId },
+            );
+            const replyText = completion.choices?.[0]?.message?.content?.trim();
+            if (!replyText) {
+                this.logger.warn('Slack mention chat completion returned no content; not replying');
+                return;
+            }
+            await this.postReply(binding, {
+                channel,
+                threadTs: event.thread_ts ?? ts,
+                text: replyText,
+                providerEventId: body.event_id,
+            });
+        } catch (error) {
+            // Never rethrow — the webhook already 200'd and Slack retries
+            // would only duplicate work. Message only; never settings/secrets.
+            this.logger.warn(
+                `Slack mention → chat bridge failed: ${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
+    }
+
+    /** Post a threaded reply through the slack-connector plugin (vendor SDK path). */
+    private async postReply(
+        binding: SlackEventsBinding,
+        input: { channel: string; threadTs: string; text: string; providerEventId?: string },
+    ): Promise<void> {
+        const plugin = this.getSlackConnector();
+        if (!plugin) {
+            this.logger.warn('slack-connector plugin is not loaded; cannot post reply');
+            return;
+        }
+        const botToken = binding.settings.botToken;
+        if (typeof botToken !== 'string' || botToken.length === 0) {
+            this.logger.warn('slack-connector settings have no botToken; cannot post reply');
+            return;
+        }
+        const target: ChannelTargetConfig = { botToken };
+        const options = {
+            userId: binding.userId,
+            settings: binding.settings,
+            target,
+        };
+        const conversationId = `${input.channel}:${input.threadTs}`;
+        if (plugin.reply) {
+            await plugin.reply(
+                {
+                    externalConversationId: conversationId,
+                    text: input.text,
+                    ...(input.providerEventId
+                        ? { inReplyToProviderEventId: input.providerEventId }
+                        : {}),
+                },
+                options,
+            );
+            return;
+        }
+        // Older connector builds without `reply` — fall back to a plain send.
+        await plugin.send(
+            {
+                text: input.text,
+                messageRef: `slack-mention-${input.providerEventId ?? conversationId}`,
+                attribution: { userId: binding.userId },
+                target: { ...target, channelId: input.channel, threadTs: input.threadTs },
+            },
+            options,
+        );
+    }
+
+    private getSlackConnector(): IConnectorPlugin | null {
+        const registered = this.pluginRegistry
+            .getByCapability(PLUGIN_CAPABILITIES.CONNECTOR_SLACK)
+            .find((p) => p.plugin.id === SLACK_CONNECTOR_PLUGIN_ID && p.state === 'loaded');
+        if (!registered || !isConnectorPlugin(registered.plugin)) return null;
+        return registered.plugin;
+    }
+
+    /** Strip `<@U…>` mention tokens (and stray whitespace) from the text. */
+    private stripMentions(text: string): string {
+        return text
+            .replace(/<@[^>]+>/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
+    private slackTsToIso(ts: string): string {
+        const seconds = Number(ts);
+        if (!Number.isFinite(seconds)) return new Date(0).toISOString();
+        return new Date(seconds * 1000).toISOString();
+    }
+}

--- a/apps/api/src/ingest/slack/slack-events.controller.spec.ts
+++ b/apps/api/src/ingest/slack/slack-events.controller.spec.ts
@@ -1,0 +1,127 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+
+jest.mock('@ever-works/agent/ingest', () => ({ EventIngestService: class {} }));
+jest.mock('@ever-works/agent/plugins', () => ({
+    PluginRegistryService: class {},
+    PluginSettingsService: class {},
+    UserPluginRepository: class {},
+}));
+jest.mock('../../ai-conversation/openai-compat.service', () => ({
+    OpenAiCompatService: class {},
+}));
+jest.mock('../../auth/decorators/public.decorator', () => ({
+    Public: () => () => undefined,
+}));
+
+import { SlackEventsController } from './slack-events.controller';
+import { computeSlackSignature } from './slack-signature.util';
+
+const SECRET = 'test-signing-secret';
+const BINDING = {
+    userId: 'user-1',
+    signingSecret: SECRET,
+    settings: { botToken: 'xoxb-test' },
+};
+
+describe('SlackEventsController (POST /api/ingest/slack/events)', () => {
+    function createController() {
+        const bridge = {
+            resolveBinding: jest.fn().mockResolvedValue(BINDING),
+            handleEventCallback: jest.fn().mockResolvedValue({ ingested: null }),
+        };
+        const controller = new SlackEventsController(bridge as any);
+        return { controller, bridge };
+    }
+
+    /** Build a signed request for `bodyObj` (fresh timestamp by default). */
+    function signedRequest(bodyObj: unknown, tsSeconds = Math.floor(Date.now() / 1000)) {
+        const rawBody = JSON.stringify(bodyObj);
+        const timestamp = String(tsSeconds);
+        const signature = computeSlackSignature(SECRET, timestamp, rawBody);
+        return { req: { body: bodyObj, rawBody }, timestamp, signature };
+    }
+
+    it('throws BadRequestException when the raw body is missing', async () => {
+        const { controller, bridge } = createController();
+        await expect(
+            controller.receiveEvents({ body: {}, rawBody: undefined } as any, 'sig', '123'),
+        ).rejects.toThrow(BadRequestException);
+        expect(bridge.resolveBinding).not.toHaveBeenCalled();
+    });
+
+    it('fails closed with 401 when no binding is configured — even for url_verification', async () => {
+        const { controller, bridge } = createController();
+        bridge.resolveBinding.mockResolvedValue(null);
+        const { req, timestamp, signature } = signedRequest({
+            type: 'url_verification',
+            challenge: 'abc',
+        });
+        await expect(controller.receiveEvents(req as any, signature, timestamp)).rejects.toThrow(
+            UnauthorizedException,
+        );
+        await expect(controller.receiveEvents(req as any, signature, timestamp)).rejects.toThrow(
+            'not configured',
+        );
+        expect(bridge.handleEventCallback).not.toHaveBeenCalled();
+    });
+
+    it('rejects a bad signature with 401 (and never dispatches)', async () => {
+        const { controller, bridge } = createController();
+        const { req, timestamp } = signedRequest({ type: 'event_callback', event: {} });
+        await expect(
+            controller.receiveEvents(req as any, 'v0=deadbeef', timestamp),
+        ).rejects.toThrow(UnauthorizedException);
+        expect(bridge.handleEventCallback).not.toHaveBeenCalled();
+    });
+
+    it('rejects a stale timestamp (>300s skew) even when the digest matches it', async () => {
+        const { controller, bridge } = createController();
+        const staleTs = Math.floor(Date.now() / 1000) - 301;
+        const { req, timestamp, signature } = signedRequest(
+            { type: 'event_callback', event: {} },
+            staleTs,
+        );
+        await expect(controller.receiveEvents(req as any, signature, timestamp)).rejects.toThrow(
+            UnauthorizedException,
+        );
+        expect(bridge.handleEventCallback).not.toHaveBeenCalled();
+    });
+
+    it('echoes the url_verification challenge on a validly signed handshake', async () => {
+        const { controller, bridge } = createController();
+        const { req, timestamp, signature } = signedRequest({
+            type: 'url_verification',
+            challenge: 'challenge-token-42',
+        });
+        const result = await controller.receiveEvents(req as any, signature, timestamp);
+        expect(result).toEqual({ challenge: 'challenge-token-42' });
+        expect(bridge.handleEventCallback).not.toHaveBeenCalled();
+    });
+
+    it('dispatches a verified event_callback (app_mention) to the chat bridge', async () => {
+        const { controller, bridge } = createController();
+        const body = {
+            type: 'event_callback',
+            event_id: 'Ev1',
+            event: {
+                type: 'app_mention',
+                user: 'U7',
+                text: '<@UBOT> status?',
+                channel: 'C1',
+                ts: '1700000000.000100',
+            },
+        };
+        const { req, timestamp, signature } = signedRequest(body);
+        const result = await controller.receiveEvents(req as any, signature, timestamp);
+        expect(result).toEqual({ ok: true });
+        expect(bridge.handleEventCallback).toHaveBeenCalledWith(BINDING, body);
+    });
+
+    it('acknowledges unknown (but validly signed) payload types without dispatching', async () => {
+        const { controller, bridge } = createController();
+        const { req, timestamp, signature } = signedRequest({ type: 'app_rate_limited' });
+        const result = await controller.receiveEvents(req as any, signature, timestamp);
+        expect(result).toEqual({ ok: true });
+        expect(bridge.handleEventCallback).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/ingest/slack/slack-events.controller.ts
+++ b/apps/api/src/ingest/slack/slack-events.controller.ts
@@ -1,0 +1,89 @@
+import {
+    BadRequestException,
+    Controller,
+    Headers,
+    HttpCode,
+    HttpStatus,
+    Post,
+    Req,
+    UnauthorizedException,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { Public } from '../../auth/decorators/public.decorator';
+import { SlackChatBridgeService, type SlackEventCallbackBody } from './slack-chat-bridge.service';
+import { verifySlackSignature } from './slack-signature.util';
+
+/**
+ * Slack Events API receiver (Wave 6, feature f) — the platform-side
+ * endpoint the Ever Works Slack app points its event subscription at.
+ *
+ * Public route (Slack calls it), secured by request signing instead of
+ * platform auth: every delivery is verified with the app's signing
+ * secret (HMAC v0 over `v0:{ts}:{rawBody}`, ±300s timestamp tolerance,
+ * constant-time compare) and the endpoint FAILS CLOSED — when no
+ * slack-connector install with a signing secret exists, everything is
+ * 401 (house internal-endpoint posture, same as the GitHub App webhook).
+ *
+ * Body handling mirrors `GitHubAppWebhookController`: the raw payload
+ * (captured by the bodyParser `verify` hook in main.ts) feeds signature
+ * verification; the parsed body is consumed as-is, bypassing the global
+ * whitelist ValidationPipe (Slack's event schema is theirs, not ours).
+ *
+ * Per-user resolution is the v1 binding — the user who configured the
+ * plugin owns the events (multi-workspace mapping is a documented
+ * follow-up on `SlackEventsBinding`).
+ */
+@ApiTags('ingest')
+@Controller('api/ingest')
+export class SlackEventsController {
+    constructor(private readonly slackChatBridge: SlackChatBridgeService) {}
+
+    @Public()
+    @Post('slack/events')
+    @ApiOperation({
+        summary:
+            'Slack Events API receiver — signature-verified; challenge echo, mention/message ingest, @works chat bridge.',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 300, ttl: 60_000 } })
+    async receiveEvents(
+        @Req() req: { body: unknown; rawBody?: string },
+        @Headers('x-slack-signature') signature: string | undefined,
+        @Headers('x-slack-request-timestamp') timestamp: string | undefined,
+    ) {
+        if (!req.rawBody) {
+            throw new BadRequestException('Missing raw request payload');
+        }
+
+        // Fail-closed: no configured binding → no secret → reject, including
+        // url_verification (Slack signs the handshake too).
+        const binding = await this.slackChatBridge.resolveBinding();
+        if (!binding) {
+            throw new UnauthorizedException('Slack events receiver is not configured');
+        }
+
+        const verdict = verifySlackSignature({
+            rawBody: req.rawBody,
+            timestamp,
+            signature,
+            signingSecret: binding.signingSecret,
+        });
+        if (!verdict.valid) {
+            throw new UnauthorizedException('Invalid Slack request signature');
+        }
+
+        const body = (req.body ?? {}) as SlackEventCallbackBody & { challenge?: string };
+
+        // Events API URL-verification handshake — echo the challenge.
+        if (body.type === 'url_verification' && typeof body.challenge === 'string') {
+            return { challenge: body.challenge };
+        }
+
+        if (body.type === 'event_callback') {
+            await this.slackChatBridge.handleEventCallback(binding, body);
+        }
+
+        return { ok: true };
+    }
+}

--- a/apps/api/src/ingest/slack/slack-signature.util.ts
+++ b/apps/api/src/ingest/slack/slack-signature.util.ts
@@ -1,0 +1,85 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Slack Events API request signing (v0) — API-side pure helpers.
+ *
+ * Deliveries are signed `v0=HEX(HMAC_SHA256(secret, "v0:{ts}:{rawBody}"))`
+ * (`x-slack-signature` + `x-slack-request-timestamp` headers). This is a
+ * deliberate, small twin of the helper shipped inside the slack-connector
+ * plugin: connector plugins are dynamically distributed (EW-693), so the
+ * API never takes a static import on a plugin package. Verification is
+ * FAIL-CLOSED — missing secret/headers, malformed or out-of-tolerance
+ * timestamps, and non-matching digests all yield `valid: false`; the
+ * digest comparison is constant-time (`crypto.timingSafeEqual`).
+ */
+
+/** Maximum accepted clock skew between the delivery timestamp and ours (seconds). */
+export const SLACK_SIGNATURE_TOLERANCE_SECONDS = 300;
+
+export interface SlackSignatureInput {
+    /** Raw, unparsed request body exactly as delivered. */
+    readonly rawBody: string;
+    /** `x-slack-request-timestamp` header value (unix seconds). */
+    readonly timestamp: string | undefined;
+    /** `x-slack-signature` header value (`v0=<hex>`). */
+    readonly signature: string | undefined;
+    /** The app's signing secret. Missing/empty fails closed. */
+    readonly signingSecret: string | undefined;
+    /** Override "now" (ms since epoch) — for tests. Defaults to `Date.now()`. */
+    readonly nowMs?: number;
+}
+
+export interface SlackSignatureResult {
+    readonly valid: boolean;
+    /** Stable machine-readable reason on failure (never echoes secrets). */
+    readonly reason?:
+        | 'missing-signing-secret'
+        | 'missing-headers'
+        | 'invalid-timestamp'
+        | 'stale-timestamp'
+        | 'signature-mismatch';
+}
+
+/** Compute the expected `v0=<hex>` signature for a delivery. */
+export function computeSlackSignature(
+    signingSecret: string,
+    timestamp: string,
+    rawBody: string,
+): string {
+    const digest = createHmac('sha256', signingSecret)
+        .update(`v0:${timestamp}:${rawBody}`)
+        .digest('hex');
+    return `v0=${digest}`;
+}
+
+/** Verify a Slack Events API delivery. Fail-closed on every degenerate input. */
+export function verifySlackSignature(input: SlackSignatureInput): SlackSignatureResult {
+    if (typeof input.signingSecret !== 'string' || input.signingSecret.length === 0) {
+        return { valid: false, reason: 'missing-signing-secret' };
+    }
+    if (!input.timestamp || !input.signature) {
+        return { valid: false, reason: 'missing-headers' };
+    }
+
+    const tsSeconds = Number(input.timestamp);
+    if (!Number.isFinite(tsSeconds)) {
+        return { valid: false, reason: 'invalid-timestamp' };
+    }
+    const nowSeconds = Math.floor((input.nowMs ?? Date.now()) / 1000);
+    if (Math.abs(nowSeconds - tsSeconds) > SLACK_SIGNATURE_TOLERANCE_SECONDS) {
+        return { valid: false, reason: 'stale-timestamp' };
+    }
+
+    const expected = computeSlackSignature(input.signingSecret, input.timestamp, input.rawBody);
+    const expectedBuf = Buffer.from(expected, 'utf8');
+    const actualBuf = Buffer.from(input.signature, 'utf8');
+    // timingSafeEqual requires equal lengths; a length mismatch is already a
+    // non-match and leaks nothing beyond the (public) signature format.
+    if (expectedBuf.length !== actualBuf.length) {
+        return { valid: false, reason: 'signature-mismatch' };
+    }
+    if (!timingSafeEqual(expectedBuf, actualBuf)) {
+        return { valid: false, reason: 'signature-mismatch' };
+    }
+    return { valid: true };
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -266,6 +266,21 @@
             "loadingStatus": "Loading connection status...",
             "setupGuide": "Setup guide"
         },
+        "communicationStep": {
+            "title": "Communication",
+            "description": "Connect the chat workspaces your team lives in. Mention the Ever Works bot to chat, build, and follow your Works without leaving the conversation.",
+            "slack": {
+                "name": "Slack",
+                "description": "Install the Ever Works app for Slack: mention the bot to chat with the platform, ingest channel activity into Memory and Activities, and get replies in-thread.",
+                "action": "Connect Slack"
+            },
+            "discord": {
+                "name": "Discord",
+                "description": "The Ever Works app for Discord is on the way.",
+                "comingSoon": "Coming soon"
+            },
+            "skipHint": "You can connect these anytime from Settings → Plugins."
+        },
         "plugins": {
             "byokDescription": "Connect your own key to unlock the full configuration.",
             "byokDefaultButton": "Bring your own key",

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -13,6 +13,7 @@ import { WelcomeStep } from './steps/WelcomeStep';
 import { ChoiceStep } from './steps/ChoiceStep';
 import { ConfigStep } from './steps/ConfigStep';
 import { PluginsCatalogStep } from './steps/PluginsCatalogStep';
+import { CommunicationStep } from './steps/CommunicationStep';
 import { CreateWorkStep } from './steps/CreateWorkStep';
 import { useTurnstile } from './use-turnstile';
 import { AI_ICONS, DB_ICONS, DEPLOY_ICONS, STORAGE_ICONS } from './brand-icons';
@@ -496,6 +497,8 @@ function StepBody({
                 />
             );
         }
+        case 'communication':
+            return <CommunicationStep />;
         case 'plugins-catalog':
             return (
                 <PluginsCatalogStep
@@ -651,6 +654,8 @@ function labelForStep(step: WizardStep): string {
             return 'Your deployment';
         case 'deploy-config':
             return 'Configure deployment';
+        case 'communication':
+            return 'Communication';
         case 'plugins-catalog':
             return 'Plugins & Integrations';
         case 'create-work':

--- a/apps/web/src/components/onboarding/steps/CommunicationStep.tsx
+++ b/apps/web/src/components/onboarding/steps/CommunicationStep.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { ArrowRight } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
+import { Button } from '@/components/ui/button';
+import { ROUTES } from '@/lib/constants';
+
+const ICON_CLASS = 'h-5 w-5';
+
+/** Monochrome Slack mark (four lozenges), rendered at currentColor. */
+function SlackMark() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            className={ICON_CLASS}
+            aria-hidden="true"
+            fill="currentColor"
+        >
+            <path d="M5.1 15.2a2.1 2.1 0 1 1-2.1-2.1h2.1v2.1zm1 0a2.1 2.1 0 0 1 4.2 0v5.2a2.1 2.1 0 1 1-4.2 0v-5.2zM8.2 5a2.1 2.1 0 1 1 2.1-2.1V5H8.2zm0 1.1a2.1 2.1 0 0 1 0 4.2H3a2.1 2.1 0 1 1 0-4.2h5.2zM18.9 8.8a2.1 2.1 0 1 1 2.1 2.1h-2.1V8.8zm-1 0a2.1 2.1 0 0 1-4.2 0V3.6a2.1 2.1 0 1 1 4.2 0v5.2zM15.8 19a2.1 2.1 0 1 1-2.1 2.1V19h2.1zm0-1.1a2.1 2.1 0 0 1 0-4.2H21a2.1 2.1 0 1 1 0 4.2h-5.2z" />
+        </svg>
+    );
+}
+
+/** Monochrome Discord mark, rendered at currentColor. */
+function DiscordMark() {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            className={ICON_CLASS}
+            aria-hidden="true"
+            fill="currentColor"
+        >
+            <path d="M20.32 4.37a19.8 19.8 0 0 0-4.89-1.52.07.07 0 0 0-.08.04c-.21.38-.44.87-.6 1.25a18.3 18.3 0 0 0-5.49 0 12.6 12.6 0 0 0-.61-1.25.08.08 0 0 0-.08-.04 19.7 19.7 0 0 0-4.88 1.52.07.07 0 0 0-.04.03C.53 9.05-.32 13.58.1 18.06c0 .02.01.04.03.05a19.9 19.9 0 0 0 6 3.03.08.08 0 0 0 .08-.02c.46-.63.87-1.3 1.22-2a.08.08 0 0 0-.04-.1 13 13 0 0 1-1.87-.9.08.08 0 0 1-.01-.12c.13-.1.25-.19.37-.29a.07.07 0 0 1 .08-.01c3.93 1.8 8.18 1.8 12.06 0a.07.07 0 0 1 .08 0c.12.11.25.2.37.3a.08.08 0 0 1 0 .12c-.6.35-1.22.64-1.88.9a.08.08 0 0 0-.04.1c.36.7.78 1.37 1.22 2a.08.08 0 0 0 .08.03 19.8 19.8 0 0 0 6.02-3.04.08.08 0 0 0 .03-.05c.5-5.18-.84-9.67-3.55-13.66a.06.06 0 0 0-.03-.03zM8.02 15.33c-1.18 0-2.16-1.08-2.16-2.42 0-1.33.96-2.42 2.16-2.42 1.21 0 2.18 1.1 2.16 2.42 0 1.34-.96 2.42-2.16 2.42zm7.97 0c-1.18 0-2.15-1.08-2.15-2.42 0-1.33.95-2.42 2.15-2.42 1.22 0 2.18 1.1 2.16 2.42 0 1.34-.94 2.42-2.16 2.42z" />
+        </svg>
+    );
+}
+
+/**
+ * "Communication" step (Wave 6, feature b) — connect the chat
+ * workspaces the org lives in. The Slack card links to the
+ * slack-connector plugin settings page (bot token + signing secret +
+ * default channel), where the platform-side Slack app wiring lives;
+ * Discord shows a coming-soon chip. The step is additive and always
+ * skippable via the wizard footer.
+ */
+export function CommunicationStep() {
+    const t = useTranslations('onboarding.communicationStep');
+
+    return (
+        <div className="space-y-5 max-w-3xl">
+            <header>
+                <h3 className="text-lg font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h3>
+                <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
+                    {t('description')}
+                </p>
+            </header>
+
+            <div className="space-y-2">
+                <div className="rounded-lg border border-border dark:border-border-dark bg-surface dark:bg-surface-dark hover:border-border-secondary dark:hover:border-white/15 transition-all">
+                    <div className="flex items-start gap-3 p-3">
+                        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-surface-secondary dark:bg-white/5 text-text dark:text-text-dark">
+                            <SlackMark />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                            <div className="flex items-center justify-between gap-2">
+                                <p className="text-sm font-semibold text-text dark:text-text-dark truncate">
+                                    {t('slack.name')}
+                                </p>
+                                <Button size="sm" variant="secondary" asChild>
+                                    <Link
+                                        href={`${ROUTES.DASHBOARD_PLUGINS}/slack-connector`}
+                                        data-testid="onboarding-communication-connect-slack"
+                                    >
+                                        {t('slack.action')}
+                                        <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+                                    </Link>
+                                </Button>
+                            </div>
+                            <p className="mt-1 text-xs text-text-muted dark:text-text-muted-dark leading-relaxed">
+                                {t('slack.description')}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="rounded-lg border border-border dark:border-border-dark bg-surface dark:bg-surface-dark opacity-80">
+                    <div className="flex items-start gap-3 p-3">
+                        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-surface-secondary dark:bg-white/5 text-text-muted dark:text-text-muted-dark">
+                            <DiscordMark />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                            <div className="flex items-center justify-between gap-2">
+                                <p className="text-sm font-semibold text-text dark:text-text-dark truncate">
+                                    {t('discord.name')}
+                                </p>
+                                <span
+                                    className="inline-flex items-center rounded-full bg-surface-secondary dark:bg-white/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest text-text-muted dark:text-text-muted-dark"
+                                    data-testid="onboarding-communication-discord-soon"
+                                >
+                                    {t('discord.comingSoon')}
+                                </span>
+                            </div>
+                            <p className="mt-1 text-xs text-text-muted dark:text-text-muted-dark leading-relaxed">
+                                {t('discord.description')}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <p className="text-xs text-text-muted dark:text-text-muted-dark">{t('skipHint')}</p>
+        </div>
+    );
+}

--- a/apps/web/src/components/onboarding/useOnboardingFlow.ts
+++ b/apps/web/src/components/onboarding/useOnboardingFlow.ts
@@ -24,6 +24,7 @@ export type WizardStepKind =
     | 'db-choice'
     | 'deploy-choice'
     | 'deploy-config'
+    | 'communication'
     | 'plugins-catalog'
     | 'create-work';
 
@@ -56,6 +57,9 @@ export function computeStepList(state: OnboardingWizardStateV2): WizardStep[] {
     if (state.deploy.choice === 'vercel' || state.deploy.choice === 'k8s') {
         steps.push({ kind: 'deploy-config', id: `deploy-config:${state.deploy.choice}` });
     }
+    // Communication — connect the chat workspaces the org lives in
+    // (Slack now, Discord next). Always shown, always skippable.
+    steps.push({ kind: 'communication', id: 'communication' });
     steps.push({ kind: 'plugins-catalog', id: 'plugins-catalog' });
     steps.push({ kind: 'create-work', id: 'create-work' });
     return steps;

--- a/apps/web/src/components/onboarding/useOnboardingFlow.unit.spec.ts
+++ b/apps/web/src/components/onboarding/useOnboardingFlow.unit.spec.ts
@@ -27,6 +27,7 @@ describe('computeStepList', () => {
             'storage-choice',
             'db-choice',
             'deploy-choice',
+            'communication',
             'plugins-catalog',
             'create-work',
         ]);
@@ -61,7 +62,7 @@ describe('computeStepList', () => {
         );
     });
 
-    it('builds the full 10-step list when every BYOK is chosen', () => {
+    it('builds the full 11-step list when every BYOK is chosen', () => {
         const list = computeStepList(
             defaultsWith({
                 ai: { choice: 'claude-code' },
@@ -69,7 +70,7 @@ describe('computeStepList', () => {
                 deploy: { choice: 'vercel' },
             }),
         );
-        expect(list).toHaveLength(10);
+        expect(list).toHaveLength(11);
         expect(list.map((s) => s.kind)).toEqual([
             'welcome',
             'ai-choice',
@@ -79,9 +80,16 @@ describe('computeStepList', () => {
             'db-choice',
             'deploy-choice',
             'deploy-config',
+            'communication',
             'plugins-catalog',
             'create-work',
         ]);
+    });
+
+    it('always inserts the Communication step between deployment and the plugins catalog', () => {
+        const kinds = computeStepList(ONBOARDING_DEFAULT_STATE).map((s) => s.kind);
+        expect(kinds.indexOf('communication')).toBeGreaterThan(kinds.indexOf('deploy-choice'));
+        expect(kinds.indexOf('communication')).toBe(kinds.indexOf('plugins-catalog') - 1);
     });
 
     it('encodes the chosen vendor into the step id so React keys stay stable across rechooses', () => {

--- a/packages/plugins/slack-connector/package.json
+++ b/packages/plugins/slack-connector/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ever-works/slack-connector-plugin",
-	"version": "1.0.0",
-	"description": "Slack connector plugin for Ever Works platform (bidirectional; outbound chat.postMessage via @slack/web-api)",
+	"version": "1.1.0",
+	"description": "Slack connector plugin for Ever Works platform (bidirectional; outbound chat.postMessage, inbound Events API verification/parsing, and event-source pull via @slack/web-api)",
 	"author": {
 		"name": "Ever Co. LTD",
 		"email": "ever@ever.co",
@@ -32,6 +32,7 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
+		"@ever-works/contracts": "workspace:*",
 		"@ever-works/plugin": "workspace:*",
 		"@slack/web-api": "^7.0.0"
 	},
@@ -45,13 +46,14 @@
 		"plugin": {
 			"id": "slack-connector",
 			"name": "Slack Connector",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"category": "connector",
 			"capabilities": [
 				"connector",
-				"connector-slack"
+				"connector-slack",
+				"event-source"
 			],
-			"description": "Bidirectional Slack connector. Outbound posts messages to a Slack channel with a bot token via chat.postMessage (Block Kit supported). Inbound Events API routing lands in a follow-up.",
+			"description": "Bidirectional Slack connector. Outbound posts messages to a Slack channel with a bot token via chat.postMessage (Block Kit supported, threaded replies). Inbound Events API deliveries are signature-verified and parsed; recent channel messages/mentions can be pulled into the platform event-ingest pipeline.",
 			"systemPlugin": false,
 			"builtIn": false,
 			"isDefault": false,
@@ -70,7 +72,7 @@
 					},
 					"signingSecret": {
 						"type": "string",
-						"title": "Signing secret (for inbound Events API — used in a follow-up)",
+						"title": "Signing secret (verifies inbound Events API deliveries)",
 						"x-secret": true,
 						"x-envVar": "SLACK_SIGNING_SECRET"
 					},
@@ -81,6 +83,10 @@
 					"defaultChannelId": {
 						"type": "string",
 						"title": "Default channel id (e.g. C0123456789)"
+					},
+					"eventChannelIds": {
+						"type": "string",
+						"title": "Channels to ingest events from (comma-separated ids; defaults to the default channel)"
 					}
 				}
 			},

--- a/packages/plugins/slack-connector/src/index.ts
+++ b/packages/plugins/slack-connector/src/index.ts
@@ -1,7 +1,21 @@
 /**
  * @ever-works/slack-connector-plugin — Slack connector (bidirectional).
- * Outbound `chat.postMessage` via `@slack/web-api`; inbound Events API
- * routing lands in a follow-up. See
+ * Outbound `chat.postMessage` + threaded `reply` via `@slack/web-api`;
+ * inbound Events API verification/challenge/parsing; `pullEvents`
+ * event-source leg feeding the platform event-ingest spine. See
  * `docs/specs/features/connectors/spec.md` §7.5.1.
  */
-export { SlackConnectorPlugin, slackConnectorPlugin } from './slack-connector-plugin.js';
+export {
+	SlackConnectorPlugin,
+	slackConnectorPlugin,
+	slackTsToIso,
+	isoToSlackTs,
+	SLACK_EVENT_TEXT_MAX_CHARS
+} from './slack-connector-plugin.js';
+export {
+	computeSlackSignature,
+	verifySlackSignature,
+	SLACK_SIGNATURE_TOLERANCE_SECONDS,
+	type SlackSignatureInput,
+	type SlackSignatureResult
+} from './slack-signature.js';

--- a/packages/plugins/slack-connector/src/slack-connector-plugin.spec.ts
+++ b/packages/plugins/slack-connector/src/slack-connector-plugin.spec.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createHmac } from 'node:crypto';
 
 const postMessageMock = vi.fn();
 const authTestMock = vi.fn();
+const historyMock = vi.fn();
+const permalinkMock = vi.fn();
 const ctorMock = vi.fn();
 
 vi.mock('@slack/web-api', () => ({
@@ -9,12 +12,14 @@ vi.mock('@slack/web-api', () => ({
 		constructor(token: string) {
 			ctorMock(token);
 		}
-		chat = { postMessage: postMessageMock };
+		chat = { postMessage: postMessageMock, getPermalink: permalinkMock };
 		auth = { test: authTestMock };
+		conversations = { history: historyMock };
 	}
 }));
 
-import { SlackConnectorPlugin } from './slack-connector-plugin.js';
+import { SlackConnectorPlugin, slackTsToIso, isoToSlackTs } from './slack-connector-plugin.js';
+import { computeSlackSignature, verifySlackSignature } from './slack-signature.js';
 
 const TARGET = { botToken: 'xoxb-123', defaultChannelId: 'C0123456789' };
 
@@ -25,18 +30,23 @@ describe('SlackConnectorPlugin', () => {
 		plugin = new SlackConnectorPlugin();
 		postMessageMock.mockReset();
 		authTestMock.mockReset();
+		historyMock.mockReset();
+		permalinkMock.mockReset();
 		ctorMock.mockReset();
 	});
 
-	it('declares the connector + connector-slack capabilities and outbound metadata', () => {
+	it('declares the connector + connector-slack + event-source capabilities and bidirectional metadata', () => {
 		expect(plugin.category).toBe('connector');
 		expect(plugin.capabilities).toContain('connector');
 		expect(plugin.capabilities).toContain('connector-slack');
-		expect(plugin.connector.direction).toBe('outbound');
+		expect(plugin.capabilities).toContain('event-source');
+		expect(plugin.providerName).toBe('slack');
+		expect(plugin.connector.direction).toBe('bidirectional');
 		expect(plugin.connector.transport).toBe('webhook');
 		expect(plugin.connector.flags.outboundMessage).toBe(true);
 		expect(plugin.connector.flags.richOutbound).toBe(true);
-		expect(plugin.connector.flags.inbound).toBe(false);
+		expect(plugin.connector.flags.inbound).toBe(true);
+		expect(plugin.connector.flags.reply).toBe(true);
 	});
 
 	it('marks botToken + signingSecret as x-secret in the settings schema', () => {
@@ -147,6 +157,329 @@ describe('SlackConnectorPlugin', () => {
 				{ connectorId: 'conn-1' }
 			);
 			expect(postMessageMock.mock.calls[0][0].channel).toBe('C999');
+		});
+
+		it('posts into a thread when the target carries a threadTs', async () => {
+			postMessageMock.mockResolvedValueOnce({ ok: true, ts: '1700000000.000400' });
+			await plugin.send(
+				{
+					text: 'threaded',
+					messageRef: 'ref-thread',
+					attribution: { userId: 'u1' },
+					target: { ...TARGET, threadTs: '1699999999.000001' }
+				},
+				{ connectorId: 'conn-1' }
+			);
+			expect(postMessageMock.mock.calls[0][0].thread_ts).toBe('1699999999.000001');
+		});
+	});
+
+	describe('signature helpers (HMAC v0)', () => {
+		const SECRET = 's3cr3t';
+		const BODY = '{"type":"event_callback"}';
+		const NOW_MS = 1_700_000_000_000;
+		const TS = String(Math.floor(NOW_MS / 1000));
+
+		it('accepts a correctly signed delivery inside the tolerance window', () => {
+			const signature = computeSlackSignature(SECRET, TS, BODY);
+			const res = verifySlackSignature({
+				rawBody: BODY,
+				timestamp: TS,
+				signature,
+				signingSecret: SECRET,
+				nowMs: NOW_MS
+			});
+			expect(res.valid).toBe(true);
+			// Sanity-check the wire format against a hand-rolled digest.
+			const digest = createHmac('sha256', SECRET).update(`v0:${TS}:${BODY}`).digest('hex');
+			expect(signature).toBe(`v0=${digest}`);
+		});
+
+		it('rejects a tampered body (signature mismatch)', () => {
+			const signature = computeSlackSignature(SECRET, TS, BODY);
+			const res = verifySlackSignature({
+				rawBody: BODY + 'x',
+				timestamp: TS,
+				signature,
+				signingSecret: SECRET,
+				nowMs: NOW_MS
+			});
+			expect(res).toEqual({ valid: false, reason: 'signature-mismatch' });
+		});
+
+		it('rejects a stale timestamp outside the ±300s window', () => {
+			const staleTs = String(Math.floor(NOW_MS / 1000) - 301);
+			const signature = computeSlackSignature(SECRET, staleTs, BODY);
+			const res = verifySlackSignature({
+				rawBody: BODY,
+				timestamp: staleTs,
+				signature,
+				signingSecret: SECRET,
+				nowMs: NOW_MS
+			});
+			expect(res).toEqual({ valid: false, reason: 'stale-timestamp' });
+		});
+
+		it('fails closed when the signing secret or headers are missing', () => {
+			const signature = computeSlackSignature(SECRET, TS, BODY);
+			expect(
+				verifySlackSignature({
+					rawBody: BODY,
+					timestamp: TS,
+					signature,
+					signingSecret: undefined,
+					nowMs: NOW_MS
+				})
+			).toEqual({ valid: false, reason: 'missing-signing-secret' });
+			expect(
+				verifySlackSignature({
+					rawBody: BODY,
+					timestamp: undefined,
+					signature,
+					signingSecret: SECRET,
+					nowMs: NOW_MS
+				})
+			).toEqual({ valid: false, reason: 'missing-headers' });
+		});
+	});
+
+	describe('inbound (Events API)', () => {
+		const SECRET = 'signing-secret';
+
+		function signedRequest(bodyObj: unknown, nowMs = Date.now()) {
+			const rawBody = JSON.stringify(bodyObj);
+			const ts = String(Math.floor(nowMs / 1000));
+			return {
+				rawBody,
+				headers: {
+					'x-slack-request-timestamp': ts,
+					'x-slack-signature': computeSlackSignature(SECRET, ts, rawBody)
+				}
+			};
+		}
+
+		it('verifyInbound accepts a freshly signed delivery and fails closed without a secret', async () => {
+			const req = signedRequest({ type: 'event_callback' });
+			const ok = await plugin.verifyInbound(req, { settings: { signingSecret: SECRET } });
+			expect(ok.valid).toBe(true);
+
+			const closed = await plugin.verifyInbound(req, { settings: {} });
+			expect(closed.valid).toBe(false);
+			expect(closed.reason).toBe('missing-signing-secret');
+		});
+
+		it('handleChallenge echoes url_verification and ignores other payloads', () => {
+			const challenge = plugin.handleChallenge({
+				rawBody: JSON.stringify({ type: 'url_verification', challenge: 'abc123' }),
+				headers: {}
+			});
+			expect(challenge).toEqual({ status: 200, body: { challenge: 'abc123' } });
+
+			expect(
+				plugin.handleChallenge({ rawBody: JSON.stringify({ type: 'event_callback' }), headers: {} })
+			).toBeNull();
+			expect(plugin.handleChallenge({ rawBody: 'not-json', headers: {} })).toBeNull();
+		});
+
+		it('parseInbound normalizes app_mention events and skips bot-authored messages', async () => {
+			const mention = await plugin.parseInbound(
+				{
+					rawBody: JSON.stringify({
+						type: 'event_callback',
+						event_id: 'Ev123',
+						event: {
+							type: 'app_mention',
+							user: 'U777',
+							text: '<@UBOT> hello',
+							channel: 'C42',
+							ts: '1700000100.000200',
+							thread_ts: '1700000000.000100'
+						}
+					}),
+					headers: {}
+				},
+				{}
+			);
+			expect(mention).toHaveLength(1);
+			expect(mention[0]).toMatchObject({
+				kind: 'message',
+				externalConversationId: 'C42:1700000000.000100',
+				externalUserId: 'U777',
+				providerEventId: 'Ev123'
+			});
+
+			const botMessage = await plugin.parseInbound(
+				{
+					rawBody: JSON.stringify({
+						type: 'event_callback',
+						event: { type: 'message', bot_id: 'B1', text: 'from a bot', channel: 'C42', ts: '1.2' }
+					}),
+					headers: {}
+				},
+				{}
+			);
+			expect(botMessage).toHaveLength(0);
+		});
+
+		it('reply posts into the originating thread via chat.postMessage', async () => {
+			postMessageMock.mockResolvedValueOnce({ ok: true, ts: '1700000200.000300' });
+			const res = await plugin.reply(
+				{
+					externalConversationId: 'C42:1700000000.000100',
+					text: 'answer',
+					inReplyToProviderEventId: 'Ev123'
+				},
+				{ target: { botToken: 'xoxb-123' } }
+			);
+			expect(res.providerMessageId).toBe('1700000200.000300');
+			const args = postMessageMock.mock.calls[0][0];
+			expect(args.channel).toBe('C42');
+			expect(args.thread_ts).toBe('1700000000.000100');
+			expect(args.text).toBe('answer');
+		});
+	});
+
+	describe('pullEvents (event source)', () => {
+		const SETTINGS = { botToken: 'xoxb-123', eventChannelIds: 'C1, C2' };
+
+		beforeEach(() => {
+			authTestMock.mockResolvedValue({ ok: true, user_id: 'UBOT' });
+			permalinkMock.mockResolvedValue({ ok: true, permalink: 'https://ws.slack.com/archives/C1/p1' });
+		});
+
+		it('throws EventSourceNotConfiguredError without a botToken', async () => {
+			await expect(plugin.pullEvents({ since: '2026-01-01T00:00:00.000Z', settings: {} })).rejects.toMatchObject({
+				name: 'EventSourceNotConfiguredError'
+			});
+			expect(historyMock).not.toHaveBeenCalled();
+		});
+
+		it('returns an empty result when no channels are configured (outbound-only setup)', async () => {
+			const res = await plugin.pullEvents({
+				since: '2026-01-01T00:00:00.000Z',
+				settings: { botToken: 'xoxb-123' }
+			});
+			expect(res.events).toEqual([]);
+			expect(res.nextCursor).toBeUndefined();
+			expect(historyMock).not.toHaveBeenCalled();
+		});
+
+		it('normalizes messages into envelopes (kind, identity, occurredAt, permalink, payload)', async () => {
+			historyMock.mockResolvedValueOnce({
+				ok: true,
+				messages: [{ type: 'message', user: 'U1', text: 'plain message', ts: '1700000000.000100', team: 'T1' }]
+			});
+			const res = await plugin.pullEvents({
+				since: '2026-01-01T00:00:00.000Z',
+				settings: { botToken: 'xoxb-123', eventChannelIds: 'C1' }
+			});
+			expect(res.events).toHaveLength(1);
+			const envelope = res.events[0];
+			expect(envelope.source).toBe('slack-connector');
+			expect(envelope.kind).toBe('slack.message');
+			expect(envelope.sourceEventId).toBe('C1:1700000000.000100');
+			expect(envelope.occurredAt).toBe(slackTsToIso('1700000000.000100'));
+			expect(envelope.sourceUrl).toBe('https://ws.slack.com/archives/C1/p1');
+			expect(envelope.actor).toMatchObject({ externalId: 'U1' });
+			expect(envelope.subject).toEqual({ type: 'channel', externalId: 'C1' });
+			expect(envelope.payload).toMatchObject({ channel: 'C1', ts: '1700000000.000100', teamId: 'T1' });
+			// The watermark is forwarded as Slack's `oldest`.
+			expect(historyMock.mock.calls[0][0].oldest).toBe(isoToSlackTs('2026-01-01T00:00:00.000Z'));
+		});
+
+		it('classifies bot-mention messages as slack.mention', async () => {
+			historyMock.mockResolvedValueOnce({
+				ok: true,
+				messages: [{ type: 'message', user: 'U1', text: 'hey <@UBOT> do a thing', ts: '2.1' }]
+			});
+			const res = await plugin.pullEvents({
+				since: '2026-01-01T00:00:00.000Z',
+				settings: { botToken: 'xoxb-123', eventChannelIds: 'C1' }
+			});
+			expect(res.events).toHaveLength(1);
+			expect(res.events[0].kind).toBe('slack.mention');
+		});
+
+		it('skips bot-authored and subtype messages (never re-ingests its own replies)', async () => {
+			historyMock.mockResolvedValueOnce({
+				ok: true,
+				messages: [
+					{ type: 'message', bot_id: 'B1', text: 'bot noise', ts: '3.1' },
+					{ type: 'message', user: 'UBOT', text: 'my own reply', ts: '3.2' },
+					{ type: 'message', subtype: 'channel_join', user: 'U9', ts: '3.3' },
+					{ type: 'message', user: 'U1', text: 'human words', ts: '3.4' }
+				]
+			});
+			const res = await plugin.pullEvents({
+				since: '2026-01-01T00:00:00.000Z',
+				settings: { botToken: 'xoxb-123', eventChannelIds: 'C1' }
+			});
+			expect(res.events).toHaveLength(1);
+			expect(res.events[0].payload.text).toBe('human words');
+		});
+
+		it('pages via the returned cursor: Slack next_cursor first, then the next channel', async () => {
+			// Page 1 of C1 has more.
+			historyMock.mockResolvedValueOnce({
+				ok: true,
+				messages: [{ type: 'message', user: 'U1', text: 'a', ts: '4.1' }],
+				response_metadata: { next_cursor: 'slack-cursor-2' }
+			});
+			const first = await plugin.pullEvents({ since: '2026-01-01T00:00:00.000Z', settings: SETTINGS });
+			expect(first.nextCursor).toBe(JSON.stringify({ c: 'C1', n: 'slack-cursor-2' }));
+
+			// Page 2 of C1 completes → advance to C2.
+			historyMock.mockResolvedValueOnce({
+				ok: true,
+				messages: [{ type: 'message', user: 'U1', text: 'b', ts: '4.2' }]
+			});
+			const second = await plugin.pullEvents({
+				since: '2026-01-01T00:00:00.000Z',
+				cursor: first.nextCursor,
+				settings: SETTINGS
+			});
+			expect(historyMock.mock.calls[1][0]).toMatchObject({ channel: 'C1', cursor: 'slack-cursor-2' });
+			expect(second.nextCursor).toBe(JSON.stringify({ c: 'C2' }));
+
+			// C2 completes → sweep done, no cursor.
+			historyMock.mockResolvedValueOnce({ ok: true, messages: [] });
+			const third = await plugin.pullEvents({
+				since: '2026-01-01T00:00:00.000Z',
+				cursor: second.nextCursor,
+				settings: SETTINGS
+			});
+			expect(historyMock.mock.calls[2][0]).toMatchObject({ channel: 'C2' });
+			expect(third.nextCursor).toBeUndefined();
+		});
+
+		it('tolerates permalink failures (drops sourceUrl) and truncates oversized text', async () => {
+			permalinkMock.mockRejectedValue(new Error('permalink boom'));
+			historyMock.mockResolvedValueOnce({
+				ok: true,
+				messages: [{ type: 'message', user: 'U1', text: 'x'.repeat(5000), ts: '5.1' }]
+			});
+			const res = await plugin.pullEvents({
+				since: '2026-01-01T00:00:00.000Z',
+				settings: { botToken: 'xoxb-123', eventChannelIds: 'C1' }
+			});
+			expect(res.events).toHaveLength(1);
+			expect(res.events[0].sourceUrl).toBeUndefined();
+			expect((res.events[0].payload.text as string).length).toBe(4000);
+		});
+
+		it('returns events oldest-first even though Slack history is newest-first', async () => {
+			historyMock.mockResolvedValueOnce({
+				ok: true,
+				messages: [
+					{ type: 'message', user: 'U1', text: 'newest', ts: '9.2' },
+					{ type: 'message', user: 'U1', text: 'oldest', ts: '9.1' }
+				]
+			});
+			const res = await plugin.pullEvents({
+				since: '2026-01-01T00:00:00.000Z',
+				settings: { botToken: 'xoxb-123', eventChannelIds: 'C1' }
+			});
+			expect(res.events.map((e) => e.payload.text)).toEqual(['oldest', 'newest']);
 		});
 	});
 });

--- a/packages/plugins/slack-connector/src/slack-connector-plugin.ts
+++ b/packages/plugins/slack-connector/src/slack-connector-plugin.ts
@@ -1,17 +1,29 @@
+import { randomUUID } from 'node:crypto';
 import { WebClient } from '@slack/web-api';
 import type { ChatPostMessageArguments, ChatPostMessageResponse } from '@slack/web-api';
 import type {
 	IConnectorPlugin,
+	IEventSourcePlugin,
 	ConnectorMetadata,
 	ConnectorCallOptions,
+	ConnectorInboundRequest,
+	ConnectorInboundVerification,
+	ConnectorChallengeResponse,
+	ConnectorInboundEvent,
+	ConnectorReply,
 	ChannelSendInput,
 	ChannelSendResult,
 	ChannelTargetConfig,
 	ChannelVerification,
+	EventSourcePullInput,
+	EventSourcePullResult,
 	PluginCategory,
+	PluginSettings,
 	JsonSchema
 } from '@ever-works/plugin';
-import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+import { verifySlackSignature } from './slack-signature.js';
 
 /**
  * Resolve the bot token from a connector's target config. Slack bot
@@ -46,38 +58,122 @@ function slackErrorMessage(err: unknown): string {
 	return e.data?.error ?? e.code ?? e.message ?? 'unknown error';
 }
 
+/** Slack message ts (`"1700000000.000100"`, seconds.fraction) → ISO 8601. */
+export function slackTsToIso(ts: string): string {
+	const seconds = Number(ts);
+	if (!Number.isFinite(seconds)) return new Date(0).toISOString();
+	return new Date(seconds * 1000).toISOString();
+}
+
+/** ISO 8601 → Slack `oldest` watermark (unix seconds with fraction). */
+export function isoToSlackTs(iso: string): string {
+	const ms = Date.parse(iso);
+	if (!Number.isFinite(ms)) return '0';
+	return (ms / 1000).toFixed(6);
+}
+
 /**
- * Slack connector — a first-party BIDIRECTIONAL connector. This
- * increment implements the OUTBOUND leg: it posts messages to a Slack
- * channel with a bot token via `chat.postMessage` on the official
- * `@slack/web-api` SDK (distinct from `slack-channel`'s incoming-webhook
- * `@slack/webhook` path — a connector is a superset of a channel).
+ * Payload text cap for ingested envelopes. Envelope payloads are
+ * size-capped platform-side (32 KB serialized); a single long message
+ * never needs more than this to be useful in Memory/Activities.
+ */
+export const SLACK_EVENT_TEXT_MAX_CHARS = 4000;
+
+function truncateText(text: string): string {
+	return text.length > SLACK_EVENT_TEXT_MAX_CHARS ? text.slice(0, SLACK_EVENT_TEXT_MAX_CHARS) : text;
+}
+
+/** Parse the pull channel list: `eventChannelIds` (comma/space separated) → `defaultChannelId`. */
+function resolveEventChannels(settings: PluginSettings | undefined): string[] {
+	const raw = settings?.eventChannelIds;
+	if (typeof raw === 'string' && raw.trim().length > 0) {
+		return raw
+			.split(/[\s,]+/)
+			.map((c) => c.trim())
+			.filter((c) => c.length > 0);
+	}
+	const fallback = settings?.defaultChannelId;
+	if (typeof fallback === 'string' && fallback.length > 0) return [fallback];
+	return [];
+}
+
+/**
+ * Opaque pull cursor: which channel we're on + Slack's own page cursor.
+ * Serialized as JSON; malformed input restarts from the first channel
+ * (safe — the ingest pipeline dedupes on `(source, sourceEventId)`).
+ */
+interface SlackPullCursor {
+	c: string;
+	n?: string;
+}
+
+function parsePullCursor(cursor: string | undefined): SlackPullCursor | undefined {
+	if (!cursor) return undefined;
+	try {
+		const parsed = JSON.parse(cursor) as SlackPullCursor;
+		if (parsed && typeof parsed.c === 'string') return parsed;
+	} catch {
+		// fall through — treat as no cursor
+	}
+	return undefined;
+}
+
+/** Minimal shape of a `conversations.history` message we consume. */
+interface SlackHistoryMessage {
+	type?: string;
+	subtype?: string;
+	user?: string;
+	username?: string;
+	bot_id?: string;
+	text?: string;
+	ts?: string;
+	thread_ts?: string;
+	team?: string;
+}
+
+/**
+ * Slack connector — a first-party BIDIRECTIONAL connector.
  *
- * Inbound (Slack Events API: `verifyInbound` HMAC-SHA256 over
- * `v0:{ts}:{rawBody}`, `handleChallenge` for `url_verification`,
- * `parseInbound` → route to an Agent, `reply` into the thread) is a
- * follow-up (P2) — the `signingSecret` setting is captured now so the
- * connection is inbound-ready. Metadata therefore declares
- * `direction: 'outbound'` with `inbound`/`reply`/`pairing` flags off
- * until that runtime lands.
+ * Outbound: posts messages to a Slack channel with a bot token via
+ * `chat.postMessage` on the official `@slack/web-api` SDK (distinct
+ * from `slack-channel`'s incoming-webhook `@slack/webhook` path — a
+ * connector is a superset of a channel). `reply()` posts back into the
+ * originating thread.
+ *
+ * Inbound (Wave 6): the full Events API leg — `verifyInbound` (HMAC v0
+ * over `v0:{ts}:{rawBody}`, ±300s skew, constant-time compare,
+ * fail-closed), `handleChallenge` for `url_verification`, and
+ * `parseInbound` normalizing `app_mention` / `message` events.
+ *
+ * Event source (Wave 6): `pullEvents` pages `conversations.history`
+ * over the configured channels since a watermark and normalizes each
+ * human message into an `IngestedEventEnvelope` (`slack.message` /
+ * `slack.mention`, permalink as `sourceUrl`) for the platform's
+ * event-ingest spine.
  *
  * See `docs/specs/features/connectors/spec.md` §7.5.1.
  */
-export class SlackConnectorPlugin implements IConnectorPlugin {
+export class SlackConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin {
 	readonly id = 'slack-connector';
 	readonly name = 'Slack Connector';
-	readonly version = '1.0.0';
+	readonly version = '1.1.0';
 	readonly category: PluginCategory = 'connector';
-	readonly capabilities = [PLUGIN_CAPABILITIES.CONNECTOR, PLUGIN_CAPABILITIES.CONNECTOR_SLACK] as const;
+	readonly capabilities = [
+		PLUGIN_CAPABILITIES.CONNECTOR,
+		PLUGIN_CAPABILITIES.CONNECTOR_SLACK,
+		PLUGIN_CAPABILITIES.EVENT_SOURCE
+	] as const;
+
+	readonly providerName = 'slack';
 
 	readonly connector: ConnectorMetadata = {
-		direction: 'outbound',
+		direction: 'bidirectional',
 		transport: 'webhook',
 		flags: {
 			outboundMessage: true,
 			outboundRecord: false,
-			inbound: false,
-			reply: false,
+			inbound: true,
+			reply: true,
 			pairing: false,
 			richOutbound: true
 		}
@@ -95,16 +191,23 @@ export class SlackConnectorPlugin implements IConnectorPlugin {
 			},
 			signingSecret: {
 				type: 'string',
-				title: 'Signing secret (for inbound Events API — used in a follow-up)',
+				title: 'Signing secret (verifies inbound Events API deliveries)',
 				'x-secret': true,
 				'x-envVar': 'SLACK_SIGNING_SECRET'
 			},
 			appId: { type: 'string', title: 'Slack app id' },
-			defaultChannelId: { type: 'string', title: 'Default channel id (e.g. C0123456789)' }
+			defaultChannelId: { type: 'string', title: 'Default channel id (e.g. C0123456789)' },
+			eventChannelIds: {
+				type: 'string',
+				title: 'Channels to ingest events from (comma-separated ids; defaults to the default channel)'
+			}
 		}
 	};
 
 	private readonly idempotencyCache = new Map<string, ChannelSendResult>();
+
+	/** Bot user id per token — one `auth.test` per token, then cached. */
+	private readonly botUserIdCache = new Map<string, string>();
 
 	async onLoad(): Promise<void> {
 		// No-op — no warm-up resources; a WebClient is created per send.
@@ -112,6 +215,7 @@ export class SlackConnectorPlugin implements IConnectorPlugin {
 
 	async onUnload(): Promise<void> {
 		this.idempotencyCache.clear();
+		this.botUserIdCache.clear();
 	}
 
 	async verifyConnection(config: ChannelTargetConfig, _options: ConnectorCallOptions): Promise<ChannelVerification> {
@@ -154,6 +258,11 @@ export class SlackConnectorPlugin implements IConnectorPlugin {
 		if (payload.rich?.kind === 'slack-blocks') {
 			args.blocks = payload.rich.payload;
 		}
+		// Optional threaded delivery — a `threadTs` on the target config posts
+		// into that thread instead of the channel root (used by replies).
+		if (typeof config.threadTs === 'string' && config.threadTs.length > 0) {
+			args.thread_ts = config.threadTs;
+		}
 
 		let res: ChatPostMessageResponse;
 		try {
@@ -173,6 +282,224 @@ export class SlackConnectorPlugin implements IConnectorPlugin {
 			if (firstKey) this.idempotencyCache.delete(firstKey);
 		}
 		return result;
+	}
+
+	// ── Inbound (Events API) ────────────────────────────────────────────
+
+	/**
+	 * Verify a signed Events API delivery. Fail-closed: no signing
+	 * secret resolved → invalid. The secret comes from resolved settings
+	 * (or the per-connection target config as a fallback).
+	 */
+	async verifyInbound(
+		req: ConnectorInboundRequest,
+		options: ConnectorCallOptions
+	): Promise<ConnectorInboundVerification> {
+		const secret = [options.settings?.signingSecret, options.target?.signingSecret].find(
+			(s): s is string => typeof s === 'string' && s.length > 0
+		);
+		const result = verifySlackSignature({
+			rawBody: req.rawBody,
+			timestamp: req.headers['x-slack-request-timestamp'],
+			signature: req.headers['x-slack-signature'],
+			signingSecret: secret
+		});
+		return result.valid ? { valid: true } : { valid: false, reason: result.reason };
+	}
+
+	/** Short-circuit the Events API `url_verification` handshake. */
+	handleChallenge(req: ConnectorInboundRequest): ConnectorChallengeResponse | null {
+		try {
+			const body = JSON.parse(req.rawBody) as { type?: string; challenge?: string };
+			if (body?.type === 'url_verification' && typeof body.challenge === 'string') {
+				return { status: 200, body: { challenge: body.challenge } };
+			}
+		} catch {
+			// not JSON — not a challenge
+		}
+		return null;
+	}
+
+	/** Normalize a verified `event_callback` delivery into inbound events. */
+	async parseInbound(
+		req: ConnectorInboundRequest,
+		_options: ConnectorCallOptions
+	): Promise<readonly ConnectorInboundEvent[]> {
+		let body: {
+			type?: string;
+			event_id?: string;
+			event?: SlackHistoryMessage & { type?: string; channel?: string; event_ts?: string };
+		};
+		try {
+			body = JSON.parse(req.rawBody);
+		} catch {
+			return [];
+		}
+		if (body?.type !== 'event_callback' || !body.event) return [];
+		const event = body.event;
+		if (event.type !== 'app_mention' && event.type !== 'message') return [];
+		// Never route bot-authored messages (incl. our own replies) back in.
+		if (event.bot_id || event.subtype) return [];
+		const channel = event.channel ?? '';
+		const ts = event.ts ?? event.event_ts ?? '';
+		if (!channel || !ts) return [];
+		return [
+			{
+				kind: 'message',
+				externalConversationId: event.thread_ts ? `${channel}:${event.thread_ts}` : channel,
+				externalUserId: event.user ?? '',
+				text: truncateText(event.text ?? ''),
+				providerEventId: body.event_id ?? `${channel}:${ts}`,
+				receivedAt: new Date(),
+				raw: { channel, ts, threadTs: event.thread_ts, eventType: event.type }
+			}
+		];
+	}
+
+	/** Reply into the originating conversation/thread (`channel[:thread_ts]`). */
+	async reply(reply: ConnectorReply, options: ConnectorCallOptions): Promise<ChannelSendResult> {
+		const separator = reply.externalConversationId.indexOf(':');
+		const channel =
+			separator === -1 ? reply.externalConversationId : reply.externalConversationId.slice(0, separator);
+		const threadTs = separator === -1 ? undefined : reply.externalConversationId.slice(separator + 1);
+		const target: ChannelTargetConfig = {
+			...(options.target ?? {}),
+			channelId: channel,
+			...(threadTs ? { threadTs } : {})
+		};
+		return this.send(
+			{
+				text: reply.text,
+				rich: reply.rich,
+				messageRef: `reply-${reply.inReplyToProviderEventId ?? randomUUID()}`,
+				// Attribution requires a userId; connector calls may be
+				// system-initiated (no platform user resolved yet).
+				attribution: { userId: options.userId ?? 'system' },
+				target
+			},
+			options
+		);
+	}
+
+	// ── Event source (pull) ─────────────────────────────────────────────
+
+	/**
+	 * Pull one page of `conversations.history` for the current channel
+	 * in the configured channel list, normalized to envelopes. The
+	 * returned cursor resumes the same channel (Slack page cursor) or
+	 * advances to the next channel; no cursor means the sweep is done.
+	 * Re-delivery across overlapping windows is fine — the ingest
+	 * pipeline dedupes on `(source, sourceEventId)`.
+	 */
+	async pullEvents(input: EventSourcePullInput): Promise<EventSourcePullResult> {
+		const token = input.settings?.botToken;
+		if (typeof token !== 'string' || token.length === 0) {
+			throw new EventSourceNotConfiguredError('slack-connector: settings.botToken is required to pull events');
+		}
+		const channels = resolveEventChannels(input.settings);
+		if (channels.length === 0) {
+			// Valid outbound-only configuration — nothing to pull.
+			return { events: [] };
+		}
+
+		const cursor = parsePullCursor(input.cursor);
+		let channelIndex = cursor ? channels.indexOf(cursor.c) : 0;
+		if (channelIndex === -1) channelIndex = 0;
+		const channel = channels[channelIndex];
+
+		const client = new WebClient(token);
+		const history = await client.conversations.history({
+			channel,
+			oldest: isoToSlackTs(input.since),
+			limit: 100,
+			...(cursor?.n ? { cursor: cursor.n } : {})
+		});
+
+		const botUserId = await this.getBotUserId(client, token);
+		const messages = (history.messages ?? []) as SlackHistoryMessage[];
+		const events: IngestedEventEnvelope[] = [];
+		for (const message of messages) {
+			const envelope = await this.normalizeMessage(client, channel, message, botUserId);
+			if (envelope) events.push(envelope);
+		}
+		// Oldest-first preferred by the contract; history returns newest-first.
+		events.reverse();
+
+		const nextSlackCursor = history.response_metadata?.next_cursor;
+		let nextCursor: string | undefined;
+		if (typeof nextSlackCursor === 'string' && nextSlackCursor.length > 0) {
+			nextCursor = JSON.stringify({ c: channel, n: nextSlackCursor } satisfies SlackPullCursor);
+		} else if (channelIndex + 1 < channels.length) {
+			nextCursor = JSON.stringify({ c: channels[channelIndex + 1] } satisfies SlackPullCursor);
+		}
+
+		return nextCursor ? { events, nextCursor } : { events };
+	}
+
+	/**
+	 * Normalize one history message → envelope. Bot-authored messages
+	 * (incl. this app's own replies) and system subtypes are skipped so
+	 * the spine never ingests its own output.
+	 */
+	private async normalizeMessage(
+		client: WebClient,
+		channel: string,
+		message: SlackHistoryMessage,
+		botUserId: string | undefined
+	): Promise<IngestedEventEnvelope | null> {
+		if (message.type !== 'message' || !message.ts) return null;
+		if (message.bot_id || message.subtype) return null;
+		if (botUserId && message.user === botUserId) return null;
+
+		const text = message.text ?? '';
+		const isMention = Boolean(botUserId) && text.includes(`<@${botUserId}>`);
+		const sourceUrl = await this.tryGetPermalink(client, channel, message.ts);
+
+		return {
+			id: randomUUID(),
+			source: this.id,
+			sourceEventId: `${channel}:${message.ts}`,
+			kind: isMention ? 'slack.mention' : 'slack.message',
+			occurredAt: slackTsToIso(message.ts),
+			actor: {
+				name: message.username ?? message.user ?? 'unknown',
+				...(message.user ? { externalId: message.user } : {})
+			},
+			subject: { type: 'channel', externalId: channel },
+			...(sourceUrl ? { sourceUrl } : {}),
+			payload: {
+				channel,
+				ts: message.ts,
+				...(message.thread_ts ? { threadTs: message.thread_ts } : {}),
+				...(message.team ? { teamId: message.team } : {}),
+				text: truncateText(text)
+			}
+		};
+	}
+
+	/** Permalink lookup is best-effort — a failure just drops `sourceUrl`. */
+	private async tryGetPermalink(client: WebClient, channel: string, ts: string): Promise<string | undefined> {
+		try {
+			const res = await client.chat.getPermalink({ channel, message_ts: ts });
+			return typeof res.permalink === 'string' ? res.permalink : undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
+	private async getBotUserId(client: WebClient, token: string): Promise<string | undefined> {
+		const cached = this.botUserIdCache.get(token);
+		if (cached) return cached;
+		try {
+			const res = await client.auth.test();
+			if (typeof res.user_id === 'string' && res.user_id.length > 0) {
+				this.botUserIdCache.set(token, res.user_id);
+				return res.user_id;
+			}
+		} catch {
+			// Mention detection degrades gracefully — events land as slack.message.
+		}
+		return undefined;
 	}
 }
 

--- a/packages/plugins/slack-connector/src/slack-signature.ts
+++ b/packages/plugins/slack-connector/src/slack-signature.ts
@@ -1,0 +1,80 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Slack Events API request signing (v0) — pure helpers, no SDK calls.
+ *
+ * Slack signs each delivery as `v0=HEX(HMAC_SHA256(secret, "v0:{ts}:{rawBody}"))`
+ * and sends it in `x-slack-signature` alongside `x-slack-request-timestamp`.
+ * Verification is FAIL-CLOSED: missing secret, missing headers, malformed
+ * timestamp, out-of-tolerance skew, or a non-matching digest all yield
+ * `valid: false`. The digest comparison is constant-time
+ * (`crypto.timingSafeEqual`) so the check leaks no prefix information.
+ */
+
+/** Maximum accepted clock skew between Slack's timestamp and ours (seconds). */
+export const SLACK_SIGNATURE_TOLERANCE_SECONDS = 300;
+
+export interface SlackSignatureInput {
+	/** Raw, unparsed request body exactly as delivered. */
+	readonly rawBody: string;
+	/** `x-slack-request-timestamp` header value (unix seconds). */
+	readonly timestamp: string | undefined;
+	/** `x-slack-signature` header value (`v0=<hex>`). */
+	readonly signature: string | undefined;
+	/** The app's signing secret. Missing/empty fails closed. */
+	readonly signingSecret: string | undefined;
+	/** Override "now" (ms since epoch) — for tests. Defaults to `Date.now()`. */
+	readonly nowMs?: number;
+	/** Override the skew tolerance (seconds) — for tests. */
+	readonly toleranceSeconds?: number;
+}
+
+export interface SlackSignatureResult {
+	readonly valid: boolean;
+	/** Stable machine-readable reason on failure (never echoes secrets). */
+	readonly reason?:
+		| 'missing-signing-secret'
+		| 'missing-headers'
+		| 'invalid-timestamp'
+		| 'stale-timestamp'
+		| 'signature-mismatch';
+}
+
+/** Compute the expected `v0=<hex>` signature for a delivery. */
+export function computeSlackSignature(signingSecret: string, timestamp: string, rawBody: string): string {
+	const digest = createHmac('sha256', signingSecret).update(`v0:${timestamp}:${rawBody}`).digest('hex');
+	return `v0=${digest}`;
+}
+
+/** Verify a Slack Events API delivery. Fail-closed on every degenerate input. */
+export function verifySlackSignature(input: SlackSignatureInput): SlackSignatureResult {
+	if (typeof input.signingSecret !== 'string' || input.signingSecret.length === 0) {
+		return { valid: false, reason: 'missing-signing-secret' };
+	}
+	if (!input.timestamp || !input.signature) {
+		return { valid: false, reason: 'missing-headers' };
+	}
+
+	const tsSeconds = Number(input.timestamp);
+	if (!Number.isFinite(tsSeconds)) {
+		return { valid: false, reason: 'invalid-timestamp' };
+	}
+	const nowSeconds = Math.floor((input.nowMs ?? Date.now()) / 1000);
+	const tolerance = input.toleranceSeconds ?? SLACK_SIGNATURE_TOLERANCE_SECONDS;
+	if (Math.abs(nowSeconds - tsSeconds) > tolerance) {
+		return { valid: false, reason: 'stale-timestamp' };
+	}
+
+	const expected = computeSlackSignature(input.signingSecret, input.timestamp, input.rawBody);
+	const expectedBuf = Buffer.from(expected, 'utf8');
+	const actualBuf = Buffer.from(input.signature, 'utf8');
+	// timingSafeEqual requires equal lengths; a length mismatch is already a
+	// non-match and leaks nothing beyond the (public) signature format.
+	if (expectedBuf.length !== actualBuf.length) {
+		return { valid: false, reason: 'signature-mismatch' };
+	}
+	if (!timingSafeEqual(expectedBuf, actualBuf)) {
+		return { valid: false, reason: 'signature-mismatch' };
+	}
+	return { valid: true };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2983,6 +2983,9 @@ importers:
 
   packages/plugins/slack-connector:
     dependencies:
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../../contracts
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../../plugin


### PR DESCRIPTION
## Summary

Wave 6 features **(f) first-class Slack app** and **(b) onboarding Communication step**, built on the event-ingest spine already on `wave/integration`.

### slack-connector plugin (additive, v1.1.0)
- Capabilities now `['connector','connector-slack','event-source']`; connector metadata `bidirectional` with `inbound`/`reply` flags on. Official `@slack/web-api` SDK throughout (house rule: vendor SDKs, never raw fetch).
- **`pullEvents`** (`IEventSourcePlugin`): pages `conversations.history` over configured channels (`eventChannelIds` new setting → falls back to `defaultChannelId`) since the watermark, normalized to `IngestedEventEnvelope` — kinds `slack.message`/`slack.mention` (mention detection via cached `auth.test` bot user id), `sourceUrl` = permalink via `chat.getPermalink` (best-effort), payload text capped at 4000 chars, bot/self/subtype messages skipped, oldest-first, cursor = `{channel, slackCursor}` JSON.
- **Inbound leg** per the connector contract: `verifyInbound` (HMAC v0 over `v0:{ts}:{rawBody}`, ±300s, constant-time compare, fail-closed), `handleChallenge` (`url_verification` echo), `parseInbound`, `reply` (threaded `chat.postMessage`); `send()` gains `threadTs` support. Pure signature helpers exported.

### apps/api
- **`POST /api/ingest/slack/events`** (`@Public`, throttled): signature verification with the resolved signing secret — **fail-closed 401 when unconfigured**, incl. the challenge handshake; challenge echo; `app_mention`/`message` → `EventIngestService.ingest` with identity `channel:ts` so the webhook push path and `pullEvents` sweeps dedupe against each other. Raw-body handling mirrors the GitHub App webhook controller (global whitelist ValidationPipe bypassed by design — Slack's schema is theirs).
- **`SlackChatBridgeService`** (ONE service): v1 workspace→user binding = the OLDEST enabled slack-connector install with a signing secret (**multi-user / per-`team_id` mapping documented as follow-up on `SlackEventsBinding`**); `@works` mentions route into the EXISTING platform chat (`OpenAiCompatService`, same surface as the web app, `model:'auto'`) as the bound user, reply posted back into the Slack thread via the connector plugin's `reply` (best-effort — logged, never thrown; ingest dedupe gates the bridge so Slack retries never double-reply).
- `AiConversationModule` exports `OpenAiCompatService` (additive).

### apps/web (feature b)
- Onboarding wizard gains an always-shown, skippable **Communication** step between deployment and the plugins catalog: **Connect Slack** (links to `/plugins/slack-connector` settings) + **Discord — coming soon** chip. i18n keys under `onboarding.communicationStep` in `messages/en.json`.

## Verification (real output)

- `packages/plugins/slack-connector`: `pnpm build` → `TSC 0` + tsup ESM/CJS/DTS success; `pnpm test` → **Test Files 1 passed, Tests 27 passed**
- `packages/agent`: `pnpm build` → `TSC Found 0 issues`, `Successfully compiled: 993 files with swc`
- `pnpm build --filter=ever-works-api` → `TSC Found 0 issues`, `Tasks: 14 successful, 14 total`
- `apps/api`: `pnpm generate:openapi` → `Wrote OpenAPI spec (416 paths)` (full-app DI bootstrap green; `openapi.json` intentionally not committed)
- `apps/api`: `npx jest --testPathPattern='ingest/slack'` → **Test Suites: 2 passed, Tests: 19 passed** (challenge echo, bad signature 401, stale timestamp 401, unconfigured fail-closed, mention→ingest→bridge, retry-dedupe no-double-reply, binding resolution, best-effort failure paths)
- `apps/web`: `npx tsc --noEmit` → clean; `npx vitest run src/components/onboarding/useOnboardingFlow.unit.spec.ts` → **23 passed**

## Notes / follow-ups
- **Multi-workspace user mapping**: v1 binds all events to the user who configured the plugin; a pairing table keyed by Slack `team_id` + user id is the follow-up (documented on `SlackEventsBinding`).
- **Onboarding e2e mirrors**: `apps/web/e2e/flow-onboarding-wizard*.spec.ts` keep local `computeStepIds` copies that already predate `db-choice` and now also omit `communication` — pre-existing drift, flagged for a re-sync pass (task chip filed).
- Local `eslint` run crashes on ALL files (pre-existing ESLint 8/9 hoisting conflict in this worktree, reproduced on untouched files) — relying on CI lint.
- Workspace-app store listing (Slack app manifest/install page) is ops, not code — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)