### PR TITLE
feat(web): sessions tab + gates UI (Wave 4 M4 / Wave 3 M6)

### DIFF
--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -55,6 +55,7 @@ import {
     ActivityActionType,
     ActivityStatus,
 } from '@ever-works/agent/activity-log';
+import type { TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 import {
@@ -253,6 +254,8 @@ export class AgentsController {
             costCents: number | null;
             gateStatus: string | null;
             gateAttempts: number;
+            resolvedChecks: TaskAcceptanceCheck[] | null;
+            checkResults: TaskCheckResult[] | null;
             persistent: boolean;
             terminalState: string | null;
             terminalEndedReason: string | null;
@@ -269,6 +272,7 @@ export class AgentsController {
                 status: query.status,
                 workId: query.workId,
                 agentId: query.agentId,
+                taskId: query.taskId,
                 triggerKind: query.kind,
             },
             limit,
@@ -297,9 +301,13 @@ export class AgentsController {
                 totalTokens: r.totalTokens ?? null,
                 changedFilesCount: r.changedFilesCount ?? null,
                 costCents: r.costCents ?? null,
-                // Quality-gate columns.
+                // Quality-gate columns. `resolvedChecks` is the dispatch-
+                // frozen definition set; `checkResults` carries per-check
+                // exit/duration/logTail for the Task-detail Checks section.
                 gateStatus: r.gateStatus ?? null,
                 gateAttempts: r.gateAttempts ?? 0,
+                resolvedChecks: r.resolvedChecks ?? null,
+                checkResults: r.checkResults ?? null,
                 // Streaming-terminal lifecycle columns.
                 persistent: r.persistent ?? false,
                 terminalState: r.terminalState ?? null,

--- a/apps/api/src/agents/dto/agent.dto.ts
+++ b/apps/api/src/agents/dto/agent.dto.ts
@@ -479,6 +479,13 @@ export class ListRunSessionsQueryDto {
     @IsUUID()
     agentId?: string;
 
+    /** Quality gates (Wave 3 M6) — the Task detail Checks section fetches
+     *  the latest run for one Task (`taskId` + `limit=1`). */
+    @ApiProperty({ required: false, format: 'uuid' })
+    @IsOptional()
+    @IsUUID()
+    taskId?: string;
+
     /** Trigger kind — named `kind` on the wire for the Sessions view. */
     @ApiProperty({ required: false, enum: ['heartbeat', 'manual', 'task', 'chat', 'event'] })
     @IsOptional()

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -928,6 +928,32 @@
                 "saveSuccess": "Guardrails saved",
                 "saveError": "Could not save guardrails",
                 "resetSuccess": "Guardrails reset to default"
+            },
+            "pageTabs": {
+                "agents": "Agents",
+                "sessions": "Sessions"
+            },
+            "sessions": {
+                "title": "Sessions",
+                "subtitle": "Every agent run across your Agents and Works — live activity, tokens, cost and quality gates in one place.",
+                "status": {
+                    "queued": "Queued",
+                    "running": "Running",
+                    "completed": "Completed",
+                    "failed": "Failed",
+                    "cancelled": "Cancelled"
+                },
+                "awaitingInput": "Awaiting input",
+                "queuedConcurrency": "Waiting for a concurrency slot",
+                "tokens": "{count} tokens",
+                "attach": "Attach",
+                "notStarted": "Not started",
+                "filterStatusAll": "All statuses",
+                "filterWorkAll": "All Works",
+                "groupByWork": "Group by Work",
+                "noWork": "No Work",
+                "emptyTitle": "No sessions yet",
+                "emptyBody": "Runs appear here as soon as an agent starts working. Queued sessions are waiting for a free concurrency slot, running sessions are actively working, and sessions awaiting input need a reply before they continue."
             }
         },
         "tasksPage": {
@@ -990,7 +1016,11 @@
                 "priorityP4": "P4 — low",
                 "createError": "Failed to create Task",
                 "cancel": "Cancel",
-                "create": "Create"
+                "create": "Create",
+                "acceptanceChecks": "Acceptance checks",
+                "acceptanceChecksHint": "Commands that must exit 0 before this Task's agent work can open a pull request. Leave empty to inherit the Work's default checks.",
+                "maxGateAttempts": "Max gate attempts",
+                "maxGateAttemptsInherit": "Inherit from Work"
             },
             "detail": {
                 "moveTo": "Move to",
@@ -1077,6 +1107,53 @@
                 "p2": "Medium",
                 "p3": "Normal",
                 "p4": "Low"
+            },
+            "gateChip": {
+                "green": "Gate passed",
+                "red": "Gate failed",
+                "skipped": "Gate skipped",
+                "none": "No checks"
+            },
+            "checks": {
+                "title": "Checks",
+                "edit": "Edit",
+                "cancel": "Cancel",
+                "save": "Save",
+                "saveError": "Failed to save checks",
+                "empty": "No acceptance checks declared. This Task inherits the Work's default checks, if any.",
+                "optional": "optional",
+                "notRun": "not run yet",
+                "exit": "exit {code}",
+                "attempts": "Attempt {count}",
+                "attemptsOf": "Attempt {count} of {max}",
+                "maxAttempts": "Max gate attempts",
+                "maxAttemptsInherit": "Inherit from Work",
+                "result": {
+                    "green": "Passed",
+                    "red": "Failed",
+                    "timeout": "Timeout",
+                    "error": "Error"
+                }
+            },
+            "checksEditor": {
+                "empty": "No checks yet. Add a command whose exit code decides green or red.",
+                "name": "Name",
+                "namePlaceholder": "e.g. Build",
+                "id": "Id",
+                "kind": "Kind",
+                "command": "Command",
+                "commandPlaceholder": "e.g. pnpm build",
+                "timeout": "Timeout (s)",
+                "required": "Required",
+                "remove": "Remove",
+                "addCheck": "Add check",
+                "kinds": {
+                    "build": "Build",
+                    "test": "Test",
+                    "lint": "Lint",
+                    "typecheck": "Type check",
+                    "custom": "Custom"
+                }
             }
         },
         "skillsPage": {
@@ -3792,7 +3869,27 @@
                 "providerRepoEnabled": "{provider} repository generation enabled",
                 "providerRepoDisabled": "{provider} repository generation disabled",
                 "providerRepoUpdateFailed": "Failed to update the repository setting",
-                "providerRepoDisabledNote": "Generation is off. The existing repository is left untouched — it simply stops being updated."
+                "providerRepoDisabledNote": "Generation is off. The existing repository is left untouched — it simply stops being updated.",
+                "qualityGates": {
+                    "title": "Quality gates",
+                    "subtitle": "Default acceptance checks agent-executed Tasks under this Work must pass before opening a pull request.",
+                    "saved": "Quality gates settings saved",
+                    "saveFailed": "Failed to save quality gates settings",
+                    "policyLabel": "Checks policy",
+                    "policyHint": {
+                        "off": "Checks never run. Existing behavior — the gate is disabled for this Work.",
+                        "warn": "Checks run and report, but a red gate does not block the Task.",
+                        "required": "A red or skipped gate blocks the Task from opening a pull request."
+                    },
+                    "policyOff": "Off — never run checks",
+                    "policyWarn": "Warn — run and report only",
+                    "policyRequired": "Required — red blocks",
+                    "maxAttemptsLabel": "Max gate attempts",
+                    "maxAttemptsDescription": "How many times a run may retry after a red gate before it gives up and asks for help (1–5).",
+                    "defaultsLabel": "Default checks",
+                    "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
+                    "defaultsSave": "Save default checks"
+                }
             },
             "deploy": {
                 "progress": {
@@ -4335,6 +4432,12 @@
                         "close": "Close"
                     }
                 }
+            },
+            "runsSummary": {
+                "running": "running",
+                "queued": "queued",
+                "awaiting": "awaiting input",
+                "failedLast24h": "failed (24h)"
             }
         },
         "newPage": {

--- a/apps/web/src/app/[locale]/(dashboard)/agents/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/page.tsx
@@ -4,6 +4,7 @@ import { agentsAPI, type Agent } from '@/lib/api/agents';
 import type { AstTemplateEntry } from '@/lib/api/agent-templates';
 import { fetchAgentTemplateCatalog } from '@/lib/api/agent-templates.server';
 import { AgentsList } from '@/components/agents';
+import { AgentsPageTabs } from '@/components/agents/AgentsPageTabs';
 
 export async function generateMetadata(): Promise<Metadata> {
     const t = await getTranslations('dashboard.agentsPage');
@@ -40,5 +41,12 @@ export default async function AgentsPage() {
         iconName: a.avatarIcon ?? undefined,
     }));
 
-    return <AgentsList agents={result.data} templates={templates} userTemplates={userTemplates} />;
+    // Run orchestration (Wave 4 M4) — Agents | Sessions tab strip above
+    // the catalog; the Sessions tab is the org-wide fleet view.
+    return (
+        <div className="w-full">
+            <AgentsPageTabs active="agents" />
+            <AgentsList agents={result.data} templates={templates} userTemplates={userTemplates} />
+        </div>
+    );
 }

--- a/apps/web/src/app/[locale]/(dashboard)/agents/sessions/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/agents/sessions/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { agentsAPI } from '@/lib/api/agents';
+import { workAPI } from '@/lib/api';
+import type { AgentRunSession } from '@/lib/api/agents.shared';
+import { AgentsPageTabs } from '@/components/agents/AgentsPageTabs';
+import { AgentSessionsClient } from '@/components/agents/AgentSessionsClient';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.agentsPage.sessions');
+    return { title: t('title') };
+}
+
+/**
+ * Run orchestration (Wave 4 M4) — `/agents/sessions`, the Sessions tab
+ * under the Agents page: every AgentRun of the acting user across all
+ * Agents/Works (`GET /api/agents/runs`), with the Agent/Work id → name
+ * maps resolved server-side once. All three fetches are defensive so a
+ * flaky API renders the empty state instead of a 500 (same posture as
+ * the Agents catalog page).
+ */
+export default async function AgentSessionsPage() {
+    const [sessions, agents, works] = await Promise.all([
+        agentsAPI
+            .listSessions({ limit: 100 })
+            .then((r) => r.data)
+            .catch(() => [] as AgentRunSession[]),
+        agentsAPI
+            .list({ limit: 200 })
+            .then((r) => r.data)
+            .catch(() => []),
+        workAPI
+            .getAll({ limit: 200 })
+            .then((r) => r.works)
+            .catch(() => []),
+    ]);
+
+    const agentNames: Record<string, string> = {};
+    for (const agent of agents) agentNames[agent.id] = agent.name;
+    const workNames: Record<string, string> = {};
+    for (const work of works) workNames[work.id] = work.name;
+
+    const t = await getTranslations('dashboard.agentsPage.sessions');
+
+    return (
+        <div className="w-full space-y-4">
+            <AgentsPageTabs active="sessions" />
+            <div>
+                <h1 className="text-2xl font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h1>
+                <p className="text-sm text-text-secondary dark:text-text-secondary-dark mt-1">
+                    {t('subtitle')}
+                </p>
+            </div>
+            <AgentSessionsClient
+                initialSessions={sessions}
+                agentNames={agentNames}
+                workNames={workNames}
+            />
+        </div>
+    );
+}

--- a/apps/web/src/app/[locale]/(dashboard)/tasks/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/tasks/[id]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { tasksAPI, type TaskChatMessage } from '@/lib/api/tasks';
+import { agentsAPI } from '@/lib/api/agents';
 import { TaskDetailClient } from '@/components/tasks/TaskDetailClient';
 
 function errorMessage(err: unknown, fallback: string): string {
@@ -33,23 +34,31 @@ export default async function TaskDetailPage({ params }: { params: Promise<{ id:
     const task = await tasksAPI.get(id);
     if (!task) notFound();
 
-    const [chatResult, attachmentResult] = await Promise.allSettled([
+    const [chatResult, attachmentResult, gateRunResult] = await Promise.allSettled([
         tasksAPI.listChat(id, { limit: 50 }),
         // FU-5 — list initial attachments alongside the chat thread so
         // the detail page hydrates in one round-trip and the panel
         // renders without a client-side flash of "no attachments".
         tasksAPI.listAttachments(id),
+        // Quality gates (Wave 3 M6) — latest run for this Task with its
+        // gate columns (resolvedChecks / checkResults / gateStatus /
+        // gateAttempts) for the Checks section. Best-effort: a miss just
+        // renders the pre-dispatch declared checks.
+        agentsAPI.listSessions({ taskId: id, limit: 1 }),
     ]);
 
     const chat =
         chatResult.status === 'fulfilled' ? chatResult.value : { data: [] as TaskChatMessage[] };
     const attachments = attachmentResult.status === 'fulfilled' ? attachmentResult.value : [];
+    const gateRun =
+        gateRunResult.status === 'fulfilled' ? (gateRunResult.value.data[0] ?? null) : null;
 
     return (
         <TaskDetailClient
             task={task}
             initialChat={chat.data ?? []}
             initialAttachments={attachments}
+            initialGateRun={gateRun}
             initialChatError={
                 chatResult.status === 'rejected'
                     ? errorMessage(chatResult.reason, 'Failed to load conversation')

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/tasks/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { tasksAPI } from '@/lib/api/tasks';
+import { workAPI } from '@/lib/api';
 import { TasksScopedSection } from '@/components/tasks/TasksScopedSection';
 
 export const metadata: Metadata = { title: 'Tasks' };
@@ -17,10 +18,20 @@ export const metadata: Metadata = { title: 'Tasks' };
  */
 export default async function WorkTasksTabPage({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
-    const result = await tasksAPI.list({ workId: id, limit: 100, includeRun: true });
+    // Wave 4 M4 — the fleet summary chips ride the Tasks tab header.
+    // Best-effort: a summary miss must never break the Tasks tab.
+    const [result, runsSummary] = await Promise.all([
+        tasksAPI.list({ workId: id, limit: 100, includeRun: true }),
+        workAPI.getRunsSummary(id).catch(() => null),
+    ]);
     return (
         <div className="p-6 max-w-screen-2xl mx-auto">
-            <TasksScopedSection tasks={result.data} scopeLabel="Work" scopeId={id} />
+            <TasksScopedSection
+                tasks={result.data}
+                scopeLabel="Work"
+                scopeId={id}
+                runsSummary={runsSummary}
+            />
         </div>
     );
 }

--- a/apps/web/src/app/actions/agents.ts
+++ b/apps/web/src/app/actions/agents.ts
@@ -12,6 +12,7 @@ import {
     type CreateAgentInput,
     type UpdateAgentInput,
     type AgentFileName,
+    type ListRunSessionsQuery,
 } from '@/lib/api/agents';
 import { getAuthFromCookie } from '@/lib/auth';
 import { ROUTES } from '@/lib/constants';
@@ -215,4 +216,14 @@ export async function detachAgentAttachmentAction(agentId: string, attachmentId:
     const result = await agentsAPI.removeAttachment(agentId, attachmentId);
     revalidatePath(`/agents/${agentId}`);
     return result;
+}
+
+/**
+ * Run orchestration (Wave 4 M4) — read-only refresh used by the Sessions
+ * tab's polling hook. No revalidatePath on purpose — this is a poll, not
+ * a mutation (same posture as `listTasksWithRunsAction`).
+ */
+export async function listRunSessionsAction(query: ListRunSessionsQuery = {}) {
+    await ensureAuth();
+    return agentsAPI.listSessions(query);
 }

--- a/apps/web/src/app/actions/dashboard/works.ts
+++ b/apps/web/src/app/actions/dashboard/works.ts
@@ -16,6 +16,7 @@ import {
     GitProviderConnectionInfo,
 } from '@/lib/api';
 import type { Work } from '@/lib/api/types-only';
+import type { TaskAcceptanceCheck, WorkChecksPolicy } from '@ever-works/contracts';
 // Security: server actions are reachable as POST endpoints via the
 // `Next-Action` header, so every exported action must independently verify
 // authentication at the Next.js layer before proxying to backend
@@ -1422,6 +1423,70 @@ export async function updateTaskIsolationSettings(
             success: false,
             error:
                 error instanceof Error ? error.message : 'Failed to update task isolation settings',
+        };
+    }
+}
+
+/**
+ * Quality gates (Wave 3 M6) — Work-level default acceptance checks +
+ * enforcement policy + gate-attempt budget. Saves flow through the same
+ * `PATCH /works/:id` UpdateWorkDto path as the sibling settings cards
+ * (TaskIsolationSettings / CommitterSettings).
+ */
+export async function updateQualityGatesSettings(
+    workId: string,
+    settings: {
+        checkDefaults?: TaskAcceptanceCheck[] | null;
+        checksPolicy?: WorkChecksPolicy;
+        maxGateAttempts?: number;
+    },
+) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    const checkSchema = z.object({
+        id: z
+            .string()
+            .min(1)
+            .max(64)
+            .regex(/^[a-z0-9][a-z0-9-]*$/),
+        name: z.string().min(1).max(120),
+        kind: z.enum(['build', 'test', 'lint', 'typecheck', 'custom']),
+        command: z.string().min(1).max(500),
+        cwd: z.string().max(200).optional(),
+        timeoutSec: z.number().int().min(1).max(1800).optional(),
+        required: z.boolean(),
+        disabled: z.boolean().optional(),
+    });
+    const qualityGatesSchema = z.object({
+        checkDefaults: z.array(checkSchema).max(20).nullable().optional(),
+        checksPolicy: z.enum(['off', 'warn', 'required']).optional(),
+        maxGateAttempts: z.number().int().min(1).max(5).optional(),
+    });
+
+    try {
+        const validation = qualityGatesSchema.safeParse(settings);
+        if (!validation.success) {
+            return {
+                success: false,
+                error: validation.error.errors[0].message,
+            };
+        }
+
+        const response = await workAPI.update(workId, validation.data);
+        revalidatePath(`/works/${workId}/settings`);
+
+        return {
+            success: response.status === 'success',
+        };
+    } catch (error) {
+        console.error('Failed to update quality gates settings:', error);
+        return {
+            success: false,
+            error:
+                error instanceof Error ? error.message : 'Failed to update quality gates settings',
         };
     }
 }

--- a/apps/web/src/app/actions/tasks.ts
+++ b/apps/web/src/app/actions/tasks.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
+import type { TaskAcceptanceCheck } from '@ever-works/contracts';
 import {
     tasksAPI,
     type ListTasksQuery,
@@ -22,6 +23,9 @@ export async function createTaskAction(input: {
     ideaId?: string | null;
     workId?: string | null;
     parentTaskId?: string | null;
+    /** Quality gates (Wave 3 M6) — acceptance checks declared at create. */
+    acceptanceChecks?: TaskAcceptanceCheck[] | null;
+    maxGateAttempts?: number | null;
 }): Promise<Task> {
     // Security: verify session server-side before mutating data
     const user = await getAuthFromCookie();
@@ -44,6 +48,8 @@ export async function updateTaskAction(
             | 'parentTaskId'
             | 'requireAllApprovers'
             | 'isolationMode'
+            | 'acceptanceChecks'
+            | 'maxGateAttempts'
         >
     >,
 ): Promise<Task> {

--- a/apps/web/src/components/agents/AgentSessionsClient.tsx
+++ b/apps/web/src/components/agents/AgentSessionsClient.tsx
@@ -1,0 +1,381 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { Loader2, SquareTerminal } from 'lucide-react';
+import { Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
+import { Select } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import type {
+    AgentRunSession,
+    AgentRunSessionStatus,
+    ListRunSessionsQuery,
+} from '@/lib/api/agents.shared';
+import { listRunSessionsAction } from '@/app/actions/agents';
+import { useSessionPolling } from '@/lib/hooks/use-session-polling';
+import { formatCompactTokens } from '@/components/tasks/TaskRunChip';
+import { GateChip } from '@/components/tasks/GateChip';
+import { countFailedRequired } from '@/components/tasks/TaskChecksSection';
+
+/**
+ * Run orchestration (Wave 4 M4) — the Sessions tab body.
+ *
+ * A filtered, org-wide projection of `agent_runs`: one row per session
+ * with status pill, agent, Work, live current-activity line (PLAIN TEXT
+ * by contract — never rendered as markup), token/cost counters, gate
+ * chip, started time + duration, and an Attach link into the run's
+ * terminal tab when the run carries terminal state. Queued rows explain
+ * *why* they wait (`queuedReason`). While anything is queued/running
+ * the list re-polls every 10s (`useSessionPolling`); an idle fleet
+ * costs zero requests.
+ */
+
+const STATUS_DOTS: Record<AgentRunSessionStatus, string> = {
+    queued: 'bg-slate-400 animate-pulse',
+    running: 'bg-blue-500 animate-pulse',
+    completed: 'bg-emerald-500',
+    failed: 'bg-red-500',
+    cancelled: 'bg-slate-400',
+};
+
+const STATUS_TONES: Record<AgentRunSessionStatus, string> = {
+    queued: 'bg-slate-100 dark:bg-slate-800/40 text-slate-600 dark:text-slate-300',
+    running: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300',
+    completed: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300',
+    failed: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300',
+    cancelled: 'bg-slate-100 dark:bg-slate-800/40 text-slate-500 dark:text-slate-400',
+};
+
+const SESSION_STATUSES: AgentRunSessionStatus[] = [
+    'queued',
+    'running',
+    'completed',
+    'failed',
+    'cancelled',
+];
+
+function formatDuration(ms: number): string {
+    if (!Number.isFinite(ms) || ms < 0) return '—';
+    const seconds = Math.floor(ms / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+    const hours = Math.floor(minutes / 60);
+    return `${hours}h ${minutes % 60}m`;
+}
+
+function sessionDurationMs(session: AgentRunSession): number | null {
+    if (session.durationMs != null) return session.durationMs;
+    if (!session.startedAt) return null;
+    const started = new Date(session.startedAt).getTime();
+    if (Number.isNaN(started)) return null;
+    const end = session.finishedAt ? new Date(session.finishedAt).getTime() : Date.now();
+    return Math.max(0, end - started);
+}
+
+function SessionRow({
+    session,
+    agentName,
+    workName,
+}: {
+    session: AgentRunSession;
+    agentName: string;
+    workName: string | null;
+}) {
+    const t = useTranslations('dashboard.agentsPage.sessions');
+    const tone = STATUS_TONES[session.status] ?? STATUS_TONES.cancelled;
+    const dot = STATUS_DOTS[session.status] ?? STATUS_DOTS.cancelled;
+    const statusLabel = STATUS_TONES[session.status]
+        ? t(`status.${session.status}`)
+        : session.status;
+    const durationMs = sessionDurationMs(session);
+    // "Waiting for a concurrency slot" for the gate's concurrency parks;
+    // any other reason renders as plain text.
+    const queuedReason =
+        session.status === 'queued' && session.queuedReason
+            ? session.queuedReason.startsWith('concurrency')
+                ? t('queuedConcurrency')
+                : session.queuedReason
+            : null;
+
+    return (
+        <li
+            className="rounded-lg border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-4 py-3"
+            data-testid="agent-session-row"
+            data-session-status={session.status}
+        >
+            <div className="flex items-center gap-3 min-w-0">
+                {/* Status pill */}
+                <span
+                    className={cn(
+                        'inline-flex items-center gap-1.5 text-[10px] px-1.5 py-0.5 rounded shrink-0',
+                        tone,
+                    )}
+                    data-testid="agent-session-status"
+                >
+                    <span className={cn('w-1.5 h-1.5 rounded-full shrink-0', dot)} aria-hidden />
+                    <span className="font-medium uppercase tracking-wide">{statusLabel}</span>
+                </span>
+                {session.awaitingInput && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 shrink-0">
+                        {t('awaitingInput')}
+                    </span>
+                )}
+
+                {/* Agent + Work */}
+                <span className="text-xs font-medium text-text dark:text-text-dark truncate shrink-0 max-w-40">
+                    {agentName}
+                </span>
+                {workName && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface-secondary dark:bg-surface-secondary-dark text-text-secondary dark:text-text-secondary-dark truncate shrink-0 max-w-40">
+                        {workName}
+                    </span>
+                )}
+
+                {/* Current activity — plain text by contract, never markup. */}
+                <span
+                    className="text-xs text-text-secondary dark:text-text-secondary-dark truncate flex-1 min-w-0"
+                    title={session.currentActivity ?? undefined}
+                >
+                    {session.currentActivity ?? session.summary ?? ''}
+                </span>
+
+                {/* Gate chip */}
+                {session.gateStatus && (
+                    <GateChip
+                        status={session.gateStatus}
+                        failedCount={countFailedRequired(
+                            session.resolvedChecks,
+                            session.checkResults,
+                        )}
+                        className="shrink-0"
+                    />
+                )}
+
+                {/* Tokens + cost */}
+                {session.totalTokens != null && (
+                    <span
+                        className="text-[10px] font-mono text-text-muted shrink-0"
+                        title={t('tokens', { count: session.totalTokens })}
+                    >
+                        {formatCompactTokens(session.totalTokens)}
+                    </span>
+                )}
+                {session.costCents != null && (
+                    <span className="text-[10px] font-mono text-text-muted shrink-0">
+                        ${(session.costCents / 100).toFixed(2)}
+                    </span>
+                )}
+
+                {/* Started + duration */}
+                <span className="text-[10px] text-text-muted shrink-0 tabular-nums">
+                    {session.startedAt
+                        ? new Date(session.startedAt).toLocaleString(undefined, {
+                              month: 'short',
+                              day: 'numeric',
+                              hour: '2-digit',
+                              minute: '2-digit',
+                          })
+                        : t('notStarted')}
+                    {durationMs != null && ` · ${formatDuration(durationMs)}`}
+                </span>
+
+                {/* Attach → the run's terminal tab (streaming-terminal M7). */}
+                {session.terminalState && (
+                    <Link
+                        href={`${ROUTES.DASHBOARD_AGENT_TERMINAL(session.agentId)}?run=${session.id}`}
+                        className="inline-flex items-center gap-1 text-[11px] text-primary hover:underline shrink-0"
+                        data-testid="agent-session-attach"
+                    >
+                        <SquareTerminal className="w-3.5 h-3.5" />
+                        {t('attach')}
+                    </Link>
+                )}
+            </div>
+            {queuedReason && (
+                <p
+                    className="mt-1.5 text-[11px] text-text-muted dark:text-text-muted-dark"
+                    data-testid="agent-session-queued-reason"
+                >
+                    {queuedReason}
+                </p>
+            )}
+        </li>
+    );
+}
+
+export function AgentSessionsClient({
+    initialSessions,
+    agentNames,
+    workNames,
+}: {
+    initialSessions: AgentRunSession[];
+    /** id → display name maps, server-resolved once. */
+    agentNames: Record<string, string>;
+    workNames: Record<string, string>;
+}) {
+    const t = useTranslations('dashboard.agentsPage.sessions');
+    const [sessions, setSessions] = useState(initialSessions);
+    const [statusFilter, setStatusFilter] = useState<'all' | AgentRunSessionStatus>('all');
+    const [workFilter, setWorkFilter] = useState<string>('all');
+    const [groupByWork, setGroupByWork] = useState(true);
+    const [refreshing, startRefresh] = useTransition();
+
+    const query = useMemo<ListRunSessionsQuery>(
+        () => ({
+            ...(statusFilter !== 'all' ? { status: statusFilter } : {}),
+            ...(workFilter !== 'all' ? { workId: workFilter } : {}),
+            limit: 100,
+        }),
+        [statusFilter, workFilter],
+    );
+
+    // Re-fetch on filter change (skipping the initial render — the server
+    // page already delivered the unfiltered first page).
+    const firstRender = useRef(true);
+    useEffect(() => {
+        if (firstRender.current) {
+            firstRender.current = false;
+            return;
+        }
+        startRefresh(async () => {
+            try {
+                const result = await listRunSessionsAction(query);
+                setSessions(result.data);
+            } catch {
+                // Keep last-known rows; the poll (if active) will retry.
+            }
+        });
+    }, [query]);
+
+    // 10s poll while anything is queued/running (fleet-idle = zero requests).
+    const onFreshRows = useCallback((rows: AgentRunSession[]) => setSessions(rows), []);
+    useSessionPolling(sessions, query, onFreshRows);
+
+    const workOptions = useMemo(() => {
+        const ids = Object.keys(workNames);
+        ids.sort((a, b) => (workNames[a] ?? '').localeCompare(workNames[b] ?? ''));
+        return ids;
+    }, [workNames]);
+
+    const grouped = useMemo(() => {
+        if (!groupByWork) return null;
+        const map = new Map<string, AgentRunSession[]>();
+        for (const session of sessions) {
+            const key = session.workId ?? '';
+            const list = map.get(key);
+            if (list) list.push(session);
+            else map.set(key, [session]);
+        }
+        // Named Works first (alphabetical), the no-Work bucket last.
+        return [...map.entries()].sort(([a], [b]) => {
+            if (a === '') return 1;
+            if (b === '') return -1;
+            return (workNames[a] ?? a).localeCompare(workNames[b] ?? b);
+        });
+    }, [groupByWork, sessions, workNames]);
+
+    const agentNameOf = (session: AgentRunSession) =>
+        agentNames[session.agentId] ?? `${session.agentId.slice(0, 8)}…`;
+    const workNameOf = (session: AgentRunSession) =>
+        session.workId ? (workNames[session.workId] ?? `${session.workId.slice(0, 8)}…`) : null;
+
+    return (
+        <div data-testid="agent-sessions">
+            {/* ── Filters ─────────────────────────────────────────────── */}
+            <div className="flex flex-wrap items-center gap-3 mb-4">
+                <Select
+                    value={statusFilter}
+                    onValueChange={(next) => setStatusFilter(next as 'all' | AgentRunSessionStatus)}
+                    size="sm"
+                    className="w-36"
+                    data-testid="agent-sessions-status-filter"
+                >
+                    <option value="all">{t('filterStatusAll')}</option>
+                    {SESSION_STATUSES.map((status) => (
+                        <option key={status} value={status}>
+                            {t(`status.${status}`)}
+                        </option>
+                    ))}
+                </Select>
+                <Select
+                    value={workFilter}
+                    onValueChange={setWorkFilter}
+                    size="sm"
+                    className="w-48"
+                    data-testid="agent-sessions-work-filter"
+                >
+                    <option value="all">{t('filterWorkAll')}</option>
+                    {workOptions.map((id) => (
+                        <option key={id} value={id}>
+                            {workNames[id]}
+                        </option>
+                    ))}
+                </Select>
+                <label className="flex items-center gap-2 text-xs text-text-secondary dark:text-text-secondary-dark">
+                    {t('groupByWork')}
+                    <Switch
+                        checked={groupByWork}
+                        onChange={setGroupByWork}
+                        className="mt-0"
+                        data-testid="agent-sessions-group-toggle"
+                    />
+                </label>
+                {refreshing && (
+                    <Loader2 className="w-4 h-4 animate-spin text-text-muted" aria-hidden />
+                )}
+            </div>
+
+            {/* ── List ────────────────────────────────────────────────── */}
+            {sessions.length === 0 ? (
+                <div
+                    className="rounded-lg border border-border/60 dark:border-border-dark/60 p-8 text-center"
+                    data-testid="agent-sessions-empty"
+                >
+                    <p className="text-sm text-text dark:text-text-dark font-medium">
+                        {t('emptyTitle')}
+                    </p>
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark mt-2 max-w-md mx-auto">
+                        {t('emptyBody')}
+                    </p>
+                </div>
+            ) : grouped ? (
+                <div className="space-y-5" data-testid="agent-sessions-list">
+                    {grouped.map(([workId, rows]) => (
+                        <section key={workId || 'no-work'}>
+                            <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted mb-2">
+                                {workId
+                                    ? (workNames[workId] ?? `${workId.slice(0, 8)}…`)
+                                    : t('noWork')}
+                                <span className="ml-2 font-mono normal-case">({rows.length})</span>
+                            </h3>
+                            <ul className="space-y-2">
+                                {rows.map((session) => (
+                                    <SessionRow
+                                        key={session.id}
+                                        session={session}
+                                        agentName={agentNameOf(session)}
+                                        workName={null}
+                                    />
+                                ))}
+                            </ul>
+                        </section>
+                    ))}
+                </div>
+            ) : (
+                <ul className="space-y-2" data-testid="agent-sessions-list">
+                    {sessions.map((session) => (
+                        <SessionRow
+                            key={session.id}
+                            session={session}
+                            agentName={agentNameOf(session)}
+                            workName={workNameOf(session)}
+                        />
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/components/agents/AgentsPageTabs.tsx
+++ b/apps/web/src/components/agents/AgentsPageTabs.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Run orchestration (Wave 4 M4) — top-level tab strip on the Agents
+ * page: the Agents catalog and the org-wide Sessions view (a filtered
+ * projection of `agent_runs`, exactly as the Tasks kanban is a view
+ * over Task). Same visual language as the per-agent `AgentDetailTabs`.
+ */
+export function AgentsPageTabs({ active }: { active: 'agents' | 'sessions' }) {
+    const t = useTranslations('dashboard.agentsPage.pageTabs');
+
+    const tabs = [
+        { key: 'agents' as const, href: ROUTES.DASHBOARD_AGENTS, label: t('agents') },
+        {
+            key: 'sessions' as const,
+            href: ROUTES.DASHBOARD_AGENT_SESSIONS,
+            label: t('sessions'),
+        },
+    ];
+
+    return (
+        <nav
+            className="border-b border-border/60 dark:border-border-dark/60 mb-6"
+            data-testid="agents-page-tabs"
+        >
+            <ul className="flex items-center gap-1 overflow-x-auto">
+                {tabs.map((tab) => (
+                    <li key={tab.key}>
+                        <Link
+                            href={tab.href}
+                            data-testid={`agents-page-tab-${tab.key}`}
+                            className={cn(
+                                'inline-flex items-center px-3 h-10 text-sm border-b-2 transition-colors',
+                                tab.key === active
+                                    ? 'border-primary text-text dark:text-text-dark'
+                                    : 'border-transparent text-text-secondary dark:text-text-secondary-dark hover:text-text dark:hover:text-text-dark',
+                            )}
+                        >
+                            {tab.label}
+                        </Link>
+                    </li>
+                ))}
+            </ul>
+        </nav>
+    );
+}

--- a/apps/web/src/components/tasks/ChecksEditor.tsx
+++ b/apps/web/src/components/tasks/ChecksEditor.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Plus, Trash2 } from 'lucide-react';
+import type { TaskAcceptanceCheck, TaskAcceptanceCheckKind } from '@ever-works/contracts';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+
+/**
+ * Quality gates (Wave 3 M6) — the acceptance-checks list editor.
+ *
+ * Deliberately a flat command list, not a workflow builder: one row per
+ * check (id slug, display name, kind, command, timeout, required
+ * toggle). Shared by the Task create form, the Task-detail Checks
+ * section (pre-dispatch edit) and the Work-settings "Quality gates"
+ * card — the parent owns the value and persists it through its own
+ * save path.
+ */
+
+const CHECK_KINDS: TaskAcceptanceCheckKind[] = ['build', 'test', 'lint', 'typecheck', 'custom'];
+
+/** "Type check!" → "type-check" — mirrors the Task-label slugifier. */
+function slugifyCheckId(raw: string): string {
+    return raw
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function nextCheckId(existing: TaskAcceptanceCheck[]): string {
+    const taken = new Set(existing.map((c) => c.id));
+    let n = existing.length + 1;
+    while (taken.has(`check-${n}`)) n += 1;
+    return `check-${n}`;
+}
+
+export function ChecksEditor({
+    value,
+    onChange,
+    disabled = false,
+    testIdPrefix = 'checks-editor',
+}: {
+    value: TaskAcceptanceCheck[];
+    onChange: (next: TaskAcceptanceCheck[]) => void;
+    disabled?: boolean;
+    /** Distinguishes surfaces in tests (task form vs Work settings). */
+    testIdPrefix?: string;
+}) {
+    const t = useTranslations('dashboard.tasksPage.checksEditor');
+
+    const patchRow = (index: number, patch: Partial<TaskAcceptanceCheck>) => {
+        onChange(value.map((row, i) => (i === index ? { ...row, ...patch } : row)));
+    };
+
+    const removeRow = (index: number) => {
+        onChange(value.filter((_, i) => i !== index));
+    };
+
+    const addRow = () => {
+        onChange([
+            ...value,
+            {
+                id: nextCheckId(value),
+                name: '',
+                kind: 'custom',
+                command: '',
+                required: true,
+            },
+        ]);
+    };
+
+    return (
+        <div className="space-y-3" data-testid={testIdPrefix}>
+            {value.length === 0 && (
+                <p className="text-xs text-text-muted dark:text-text-muted-dark">{t('empty')}</p>
+            )}
+            {value.map((check, index) => (
+                <div
+                    key={index}
+                    className="rounded-md border border-border/60 dark:border-border-dark/60 p-3 space-y-2"
+                    data-testid={`${testIdPrefix}-row`}
+                >
+                    <div className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_8rem] gap-2">
+                        <div>
+                            <label className="block text-[10px] uppercase tracking-wide text-text-muted mb-1">
+                                {t('name')}
+                            </label>
+                            <Input
+                                type="text"
+                                value={check.name}
+                                onChange={(e) => {
+                                    // Keep the id slug following the name until
+                                    // the id was hand-edited away from the slug.
+                                    const name = e.target.value;
+                                    const auto =
+                                        check.id === slugifyCheckId(check.name) ||
+                                        /^check-\d+$/.test(check.id);
+                                    patchRow(index, {
+                                        name,
+                                        ...(auto && slugifyCheckId(name)
+                                            ? { id: slugifyCheckId(name) }
+                                            : {}),
+                                    });
+                                }}
+                                placeholder={t('namePlaceholder')}
+                                disabled={disabled}
+                                variant="form"
+                                data-testid={`${testIdPrefix}-name`}
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-[10px] uppercase tracking-wide text-text-muted mb-1">
+                                {t('id')}
+                            </label>
+                            <Input
+                                type="text"
+                                value={check.id}
+                                onChange={(e) =>
+                                    patchRow(index, { id: slugifyCheckId(e.target.value) })
+                                }
+                                placeholder="build"
+                                disabled={disabled}
+                                variant="form"
+                                data-testid={`${testIdPrefix}-id`}
+                            />
+                        </div>
+                        <div>
+                            <label className="block text-[10px] uppercase tracking-wide text-text-muted mb-1">
+                                {t('kind')}
+                            </label>
+                            <Select
+                                value={check.kind}
+                                onValueChange={(next) =>
+                                    patchRow(index, { kind: next as TaskAcceptanceCheckKind })
+                                }
+                                disabled={disabled}
+                                size="sm"
+                                data-testid={`${testIdPrefix}-kind`}
+                            >
+                                {CHECK_KINDS.map((kind) => (
+                                    <option key={kind} value={kind}>
+                                        {t(`kinds.${kind}`)}
+                                    </option>
+                                ))}
+                            </Select>
+                        </div>
+                    </div>
+                    <div>
+                        <label className="block text-[10px] uppercase tracking-wide text-text-muted mb-1">
+                            {t('command')}
+                        </label>
+                        <Input
+                            type="text"
+                            value={check.command}
+                            onChange={(e) => patchRow(index, { command: e.target.value })}
+                            placeholder={t('commandPlaceholder')}
+                            disabled={disabled}
+                            variant="form"
+                            className="font-mono"
+                            data-testid={`${testIdPrefix}-command`}
+                        />
+                    </div>
+                    <div className="flex items-end justify-between gap-3">
+                        <div className="w-32">
+                            <label className="block text-[10px] uppercase tracking-wide text-text-muted mb-1">
+                                {t('timeout')}
+                            </label>
+                            <Input
+                                type="number"
+                                min={1}
+                                max={1800}
+                                value={check.timeoutSec ?? ''}
+                                onChange={(e) => {
+                                    const parsed = parseInt(e.target.value, 10);
+                                    patchRow(index, {
+                                        timeoutSec: Number.isFinite(parsed) ? parsed : undefined,
+                                    });
+                                }}
+                                placeholder="600"
+                                disabled={disabled}
+                                variant="form"
+                                data-testid={`${testIdPrefix}-timeout`}
+                            />
+                        </div>
+                        <div className="flex items-center gap-4">
+                            <label className="flex items-center gap-2 text-xs text-text-secondary dark:text-text-secondary-dark">
+                                {t('required')}
+                                <Switch
+                                    checked={check.required !== false}
+                                    onChange={(next: boolean) =>
+                                        patchRow(index, { required: next })
+                                    }
+                                    disabled={disabled}
+                                    className="mt-0"
+                                    data-testid={`${testIdPrefix}-required`}
+                                />
+                            </label>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="text-xs gap-1 text-danger"
+                                disabled={disabled}
+                                onClick={() => removeRow(index)}
+                                data-testid={`${testIdPrefix}-remove`}
+                            >
+                                <Trash2 className="w-3.5 h-3.5" />
+                                {t('remove')}
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            ))}
+            <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="text-xs gap-1.5"
+                disabled={disabled}
+                onClick={addRow}
+                data-testid={`${testIdPrefix}-add`}
+            >
+                <Plus className="w-3.5 h-3.5" />
+                {t('addCheck')}
+            </Button>
+        </div>
+    );
+}

--- a/apps/web/src/components/tasks/GateChip.tsx
+++ b/apps/web/src/components/tasks/GateChip.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Check, Minus, X } from 'lucide-react';
+import type { GateStatus } from '@ever-works/contracts';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Quality gates (Wave 3 M6) — compact gate-verdict chip.
+ *
+ * One glance answers "can this open a PR": green = every required
+ * acceptance check passed, red = at least one required check did not,
+ * skipped = checks resolved but were not run (a skipped gate must NEVER
+ * render as green), none = no checks resolved for the run.
+ *
+ * Rendered on kanban cards next to the run chip, on Sessions rows, and
+ * in the Task-detail Checks section. Parents decide *whether* to render
+ * (e.g. only when the latest run carries a gateStatus); this component
+ * renders any of the four verdicts.
+ */
+
+const TONES: Record<GateStatus, string> = {
+    green: 'bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300',
+    red: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300',
+    skipped: 'bg-slate-100 dark:bg-slate-800/40 text-slate-500 dark:text-slate-400',
+    none: 'bg-slate-100 dark:bg-slate-800/40 text-slate-500 dark:text-slate-400',
+};
+
+const ICONS: Record<GateStatus, typeof Check> = {
+    green: Check,
+    red: X,
+    skipped: Minus,
+    none: Minus,
+};
+
+export function GateChip({
+    status,
+    failedCount,
+    className,
+}: {
+    status: GateStatus;
+    /** Red only — number of failed required checks, shown as "· N". */
+    failedCount?: number;
+    className?: string;
+}) {
+    const t = useTranslations('dashboard.tasksPage.gateChip');
+    const tone = TONES[status] ?? TONES.none;
+    const Icon = ICONS[status] ?? Minus;
+    const label = TONES[status] ? t(status) : status;
+
+    return (
+        <span
+            data-testid="task-gate-chip"
+            data-gate-status={status}
+            title={label}
+            className={cn(
+                'inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded whitespace-nowrap',
+                tone,
+                className,
+            )}
+        >
+            <Icon className="w-3 h-3 shrink-0" aria-hidden="true" />
+            <span className="font-medium uppercase tracking-wide">{label}</span>
+            {status === 'red' && typeof failedCount === 'number' && failedCount > 0 && (
+                <span className="font-mono">· {failedCount}</span>
+            )}
+        </span>
+    );
+}

--- a/apps/web/src/components/tasks/NewTaskForm.tsx
+++ b/apps/web/src/components/tasks/NewTaskForm.tsx
@@ -2,13 +2,15 @@
 
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslations } from 'next-intl';
-import { ListChecks } from 'lucide-react';
+import { ChevronDown, ChevronRight, ListChecks } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
+import type { TaskAcceptanceCheck } from '@ever-works/contracts';
 import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
 import { useRouter } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import type { Task, TaskPriority } from '@/lib/api/tasks';
+import { ChecksEditor } from './ChecksEditor';
 // PASS-4 review fix (CRITICAL): templates dead end. Pre-fill from
 // ?from=<slug> when the user clicked "Use template" on /tasks/templates.
 import { listAstTemplates } from '@/lib/api/agent-templates';
@@ -24,6 +26,8 @@ type CreateTaskFn = (input: {
     missionId?: string | null;
     ideaId?: string | null;
     workId?: string | null;
+    acceptanceChecks?: TaskAcceptanceCheck[] | null;
+    maxGateAttempts?: number | null;
 }) => Promise<Task>;
 
 /**
@@ -61,6 +65,10 @@ export function NewTaskForm({ createTask }: { createTask: CreateTaskFn }) {
     // can show a visible notice to the user (guards against phishing deep-links
     // that silently inject content into the form before submission).
     const [preFillSource, setPreFillSource] = useState<'prompt' | 'template' | null>(null);
+    // Quality gates (Wave 3 M6) — optional acceptance-checks declaration.
+    const [checksOpen, setChecksOpen] = useState(false);
+    const [checks, setChecks] = useState<TaskAcceptanceCheck[]>([]);
+    const [maxGateAttempts, setMaxGateAttempts] = useState<string>('inherit');
     const [pending, startTransition] = useTransition();
     const [error, setError] = useState<string | null>(null);
 
@@ -169,6 +177,16 @@ export function NewTaskForm({ createTask }: { createTask: CreateTaskFn }) {
                         workId: scopeCount === 1 ? workId : null,
                         missionId: scopeCount === 1 ? missionId : null,
                         ideaId: scopeCount === 1 ? ideaId : null,
+                        // Quality gates — only declared rows with a command
+                        // count; empty declaration = inherit Work defaults.
+                        acceptanceChecks: (() => {
+                            const rows = checks.filter((c) => c.command.trim().length > 0);
+                            return rows.length > 0 ? rows : undefined;
+                        })(),
+                        maxGateAttempts:
+                            maxGateAttempts === 'inherit'
+                                ? undefined
+                                : parseInt(maxGateAttempts, 10),
                     });
                     router.push(ROUTES.DASHBOARD_TASK(task.id));
                 } catch (err) {
@@ -272,6 +290,60 @@ export function NewTaskForm({ createTask }: { createTask: CreateTaskFn }) {
                             className="w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark px-3 h-9 text-sm text-text dark:text-text-dark"
                         />
                     </div>
+                </div>
+                {/* Quality gates (Wave 3 M6) — collapsible acceptance-checks
+                    declaration. Left empty, the Task inherits the Work's
+                    checkDefaults untouched. */}
+                <div className="rounded-md border border-border/60 dark:border-border-dark/60">
+                    <button
+                        type="button"
+                        onClick={() => setChecksOpen((v) => !v)}
+                        aria-expanded={checksOpen}
+                        className="flex w-full items-center gap-1.5 px-3 py-2 text-xs font-medium text-text-secondary dark:text-text-secondary-dark hover:text-text dark:hover:text-text-dark"
+                        data-testid="new-task-checks-toggle"
+                    >
+                        {checksOpen ? (
+                            <ChevronDown className="w-3.5 h-3.5" />
+                        ) : (
+                            <ChevronRight className="w-3.5 h-3.5" />
+                        )}
+                        {t('acceptanceChecks')}
+                        {checks.length > 0 && (
+                            <span className="ml-1 text-[10px] font-mono text-text-muted">
+                                ({checks.length})
+                            </span>
+                        )}
+                    </button>
+                    {checksOpen && (
+                        <div className="px-3 pb-3 space-y-3">
+                            <p className="text-[11px] text-text-muted dark:text-text-muted-dark">
+                                {t('acceptanceChecksHint')}
+                            </p>
+                            <ChecksEditor
+                                value={checks}
+                                onChange={setChecks}
+                                disabled={pending}
+                                testIdPrefix="new-task-checks"
+                            />
+                            <label className="flex items-center gap-2 text-xs text-text-secondary dark:text-text-secondary-dark">
+                                {t('maxGateAttempts')}
+                                <Select
+                                    value={maxGateAttempts}
+                                    onValueChange={setMaxGateAttempts}
+                                    disabled={pending}
+                                    size="sm"
+                                    data-testid="new-task-max-gate-attempts"
+                                >
+                                    <option value="inherit">{t('maxGateAttemptsInherit')}</option>
+                                    {[1, 2, 3, 4, 5].map((n) => (
+                                        <option key={n} value={String(n)}>
+                                            {n}
+                                        </option>
+                                    ))}
+                                </Select>
+                            </label>
+                        </div>
+                    )}
                 </div>
                 {error && (
                     <p className="text-xs text-danger" role="alert">

--- a/apps/web/src/components/tasks/TaskChecksSection.tsx
+++ b/apps/web/src/components/tasks/TaskChecksSection.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { ChevronDown, ChevronRight, Pencil, ShieldCheck } from 'lucide-react';
+import type { TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
+import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+import { cn } from '@/lib/utils/cn';
+import type { Task } from '@/lib/api/tasks';
+import type { AgentRunSession } from '@/lib/api/agents.shared';
+import { updateTaskAction } from '@/app/actions/tasks';
+import { GateChip } from './GateChip';
+import { ChecksEditor } from './ChecksEditor';
+
+/**
+ * Quality gates (Wave 3 M6) — the Task-detail "Checks" section.
+ *
+ * Shows the latest run's dispatch-frozen check set with per-check
+ * verdicts (exit code, duration, collapsible output tail) plus the
+ * gate chip and the attempt counter; falls back to the Task's declared
+ * `acceptanceChecks` when no run has executed yet. Pre-dispatch the
+ * check set is editable in place — saves ride the same task PATCH as
+ * the sibling fields (`updateTaskAction`).
+ *
+ * `logTail` is untrusted subprocess output: rendered strictly as a
+ * text node inside a <pre>, never as markup.
+ */
+
+const RESULT_TONES: Record<TaskCheckResult['status'], string> = {
+    green: 'text-emerald-600 dark:text-emerald-400',
+    red: 'text-red-600 dark:text-red-400',
+    timeout: 'text-amber-600 dark:text-amber-400',
+    error: 'text-amber-600 dark:text-amber-400',
+};
+
+/** Failed REQUIRED checks — what the red gate actually counts. */
+export function countFailedRequired(
+    resolvedChecks: TaskAcceptanceCheck[] | null | undefined,
+    checkResults: TaskCheckResult[] | null | undefined,
+): number {
+    const requiredById = new Map((resolvedChecks ?? []).map((c) => [c.id, c.required !== false]));
+    return (checkResults ?? []).filter(
+        (r) => r.status !== 'green' && (requiredById.get(r.id) ?? true),
+    ).length;
+}
+
+function formatDuration(ms: number): string {
+    if (!Number.isFinite(ms) || ms < 0) return '—';
+    if (ms < 1000) return `${Math.round(ms)}ms`;
+    const seconds = ms / 1000;
+    if (seconds < 60) return `${seconds.toFixed(1)}s`;
+    const minutes = Math.floor(seconds / 60);
+    return `${minutes}m ${Math.round(seconds % 60)}s`;
+}
+
+function CheckRow({
+    check,
+    result,
+}: {
+    check: TaskAcceptanceCheck;
+    result: TaskCheckResult | null;
+}) {
+    const t = useTranslations('dashboard.tasksPage.checks');
+    const tEditor = useTranslations('dashboard.tasksPage.checksEditor');
+    const [logOpen, setLogOpen] = useState(false);
+    const hasLog = Boolean(result?.logTail);
+
+    return (
+        <li
+            className="rounded-md border border-border/40 dark:border-border-dark/40 px-3 py-2"
+            data-testid="task-check-row"
+        >
+            <div className="flex items-center gap-2 min-w-0">
+                {hasLog ? (
+                    <button
+                        type="button"
+                        onClick={() => setLogOpen((v) => !v)}
+                        aria-expanded={logOpen}
+                        className="shrink-0 text-text-muted hover:text-text dark:hover:text-text-dark"
+                        data-testid="task-check-log-toggle"
+                    >
+                        {logOpen ? (
+                            <ChevronDown className="w-3.5 h-3.5" />
+                        ) : (
+                            <ChevronRight className="w-3.5 h-3.5" />
+                        )}
+                    </button>
+                ) : (
+                    <span className="w-3.5 shrink-0" aria-hidden="true" />
+                )}
+                <span className="text-xs font-medium text-text dark:text-text-dark truncate">
+                    {check.name || check.id}
+                </span>
+                <span className="text-[10px] uppercase tracking-wide px-1.5 py-0.5 rounded bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted shrink-0">
+                    {tEditor(`kinds.${check.kind}`)}
+                </span>
+                {check.required === false && (
+                    <span className="text-[10px] text-text-muted shrink-0">{t('optional')}</span>
+                )}
+                <span className="flex-1" />
+                {result ? (
+                    <>
+                        <span
+                            className={cn(
+                                'text-[10px] font-semibold uppercase tracking-wide shrink-0',
+                                RESULT_TONES[result.status] ?? 'text-text-muted',
+                            )}
+                        >
+                            {t(`result.${result.status}`)}
+                        </span>
+                        <span className="text-[10px] font-mono text-text-muted shrink-0">
+                            {t('exit', { code: result.exitCode ?? '—' })}
+                        </span>
+                        <span className="text-[10px] font-mono text-text-muted shrink-0">
+                            {formatDuration(result.durationMs)}
+                        </span>
+                    </>
+                ) : (
+                    <span className="text-[10px] text-text-muted shrink-0">{t('notRun')}</span>
+                )}
+            </div>
+            {hasLog && logOpen && (
+                <pre
+                    className="mt-2 max-h-64 overflow-auto rounded bg-surface-secondary dark:bg-black/40 p-2 text-[11px] font-mono leading-snug text-text-secondary dark:text-text-secondary-dark whitespace-pre-wrap break-all"
+                    data-testid="task-check-log-tail"
+                >
+                    {result?.logTail}
+                </pre>
+            )}
+        </li>
+    );
+}
+
+export function TaskChecksSection({
+    task,
+    initialGateRun,
+}: {
+    task: Task;
+    /** Latest AgentRun for this Task (gate columns included) — server-fetched. */
+    initialGateRun: AgentRunSession | null;
+}) {
+    const t = useTranslations('dashboard.tasksPage.checks');
+    const [editing, setEditing] = useState(false);
+    const [declaredChecks, setDeclaredChecks] = useState<TaskAcceptanceCheck[] | null>(
+        task.acceptanceChecks ?? null,
+    );
+    const [maxAttempts, setMaxAttempts] = useState<number | null>(task.maxGateAttempts ?? null);
+    const [draftChecks, setDraftChecks] = useState<TaskAcceptanceCheck[]>([]);
+    const [draftMaxAttempts, setDraftMaxAttempts] = useState<string>('inherit');
+    const [pending, startTransition] = useTransition();
+    const [error, setError] = useState<string | null>(null);
+
+    const run = initialGateRun;
+    const resultsById = new Map((run?.checkResults ?? []).map((r) => [r.id, r]));
+    // Prefer the dispatch-frozen set (what actually ran); fall back to the
+    // Task's declared checks for the pre-dispatch view.
+    const displayChecks: TaskAcceptanceCheck[] = (
+        run?.resolvedChecks?.length ? run.resolvedChecks : (declaredChecks ?? [])
+    ).filter((c) => !c.disabled);
+
+    const startEditing = () => {
+        setDraftChecks((declaredChecks ?? []).map((c) => ({ ...c })));
+        setDraftMaxAttempts(maxAttempts == null ? 'inherit' : String(maxAttempts));
+        setError(null);
+        setEditing(true);
+    };
+
+    const save = () => {
+        setError(null);
+        startTransition(() => {
+            void (async () => {
+                try {
+                    const nextMax =
+                        draftMaxAttempts === 'inherit' ? null : parseInt(draftMaxAttempts, 10);
+                    const updated = await updateTaskAction(task.id, {
+                        acceptanceChecks: draftChecks.length > 0 ? draftChecks : null,
+                        maxGateAttempts: nextMax,
+                    });
+                    setDeclaredChecks(updated.acceptanceChecks ?? null);
+                    setMaxAttempts(updated.maxGateAttempts ?? null);
+                    setEditing(false);
+                } catch (err) {
+                    setError(err instanceof Error ? err.message : t('saveError'));
+                }
+            })();
+        });
+    };
+
+    return (
+        <section
+            className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5"
+            data-testid="task-checks-section"
+        >
+            <div className="flex items-center justify-between mb-3 gap-2">
+                <div className="flex items-center gap-2 min-w-0">
+                    <ShieldCheck className="w-4 h-4 text-text-muted shrink-0" />
+                    <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                        {t('title')}
+                    </h2>
+                    {run?.gateStatus && (
+                        <GateChip
+                            status={run.gateStatus}
+                            failedCount={countFailedRequired(run.resolvedChecks, run.checkResults)}
+                        />
+                    )}
+                    {run && run.gateAttempts > 0 && (
+                        <span
+                            className="text-[10px] text-text-muted shrink-0"
+                            data-testid="task-gate-attempts"
+                        >
+                            {maxAttempts != null
+                                ? t('attemptsOf', { count: run.gateAttempts, max: maxAttempts })
+                                : t('attempts', { count: run.gateAttempts })}
+                        </span>
+                    )}
+                </div>
+                {!editing && (
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="text-xs gap-1.5"
+                        onClick={startEditing}
+                        data-testid="task-checks-edit"
+                    >
+                        <Pencil className="w-3.5 h-3.5" />
+                        {t('edit')}
+                    </Button>
+                )}
+            </div>
+
+            {editing ? (
+                <div className="space-y-3">
+                    <ChecksEditor
+                        value={draftChecks}
+                        onChange={setDraftChecks}
+                        disabled={pending}
+                        testIdPrefix="task-checks-editor"
+                    />
+                    <div className="flex items-center justify-between gap-3">
+                        <label className="flex items-center gap-2 text-xs text-text-secondary dark:text-text-secondary-dark">
+                            {t('maxAttempts')}
+                            <Select
+                                value={draftMaxAttempts}
+                                onValueChange={setDraftMaxAttempts}
+                                disabled={pending}
+                                size="sm"
+                                data-testid="task-checks-max-attempts"
+                            >
+                                <option value="inherit">{t('maxAttemptsInherit')}</option>
+                                {[1, 2, 3, 4, 5].map((n) => (
+                                    <option key={n} value={String(n)}>
+                                        {n}
+                                    </option>
+                                ))}
+                            </Select>
+                        </label>
+                        <div className="flex items-center gap-2">
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                disabled={pending}
+                                onClick={() => setEditing(false)}
+                            >
+                                {t('cancel')}
+                            </Button>
+                            <Button
+                                type="button"
+                                size="sm"
+                                disabled={pending}
+                                onClick={save}
+                                data-testid="task-checks-save"
+                            >
+                                {pending ? '…' : t('save')}
+                            </Button>
+                        </div>
+                    </div>
+                    {error && (
+                        <p className="text-xs text-danger" role="alert">
+                            {error}
+                        </p>
+                    )}
+                </div>
+            ) : displayChecks.length === 0 ? (
+                <p className="text-xs text-text-muted">{t('empty')}</p>
+            ) : (
+                <ul className="space-y-2">
+                    {displayChecks.map((check) => (
+                        <CheckRow
+                            key={check.id}
+                            check={check}
+                            result={resultsById.get(check.id) ?? null}
+                        />
+                    ))}
+                </ul>
+            )}
+        </section>
+    );
+}

--- a/apps/web/src/components/tasks/TaskDetailClient.tsx
+++ b/apps/web/src/components/tasks/TaskDetailClient.tsx
@@ -14,10 +14,12 @@ import type {
     TaskPriority,
     TaskStatus,
 } from '@/lib/api/tasks';
+import type { AgentRunSession } from '@/lib/api/agents.shared';
 import { postTaskChatAction, transitionTaskAction, updateTaskAction } from '@/app/actions/tasks';
 import { TaskRecurringSection } from './TaskRecurringSection';
 import { TaskAttachmentsSection } from './TaskAttachmentsSection';
 import { TaskBranchSection } from './TaskBranchSection';
+import { TaskChecksSection } from './TaskChecksSection';
 
 // Status tones + dots mirror /tasks (TasksList) so colours stay
 // consistent across the list filter and the detail workflow buttons.
@@ -95,12 +97,15 @@ export function TaskDetailClient({
     initialAttachments = [],
     initialChatError = null,
     initialAttachmentsError = null,
+    initialGateRun = null,
 }: {
     task: Task;
     initialChat: TaskChatMessage[];
     initialAttachments?: TaskAttachmentRow[];
     initialChatError?: string | null;
     initialAttachmentsError?: string | null;
+    /** Quality gates (Wave 3 M6) — latest run w/ gate columns, server-fetched. */
+    initialGateRun?: AgentRunSession | null;
 }) {
     const t = useTranslations('dashboard.tasksPage.detail');
     const tStatus = useTranslations('dashboard.tasksPage.status');
@@ -324,6 +329,9 @@ export function TaskDetailClient({
                             <p className="text-sm text-text-muted italic">{t('noDescription')}</p>
                         )}
                     </section>
+
+                    {/* Quality gates (Wave 3 M6) — Checks section */}
+                    <TaskChecksSection task={task} initialGateRun={initialGateRun} />
 
                     {/* FU-5 — Attachments */}
                     <TaskAttachmentsSection

--- a/apps/web/src/components/tasks/TasksKanbanView.tsx
+++ b/apps/web/src/components/tasks/TasksKanbanView.tsx
@@ -9,6 +9,7 @@ import { transitionTaskAction } from '@/app/actions/tasks';
 import { useTaskRunPolling } from '@/lib/hooks/use-task-run-polling';
 import { TaskBranchChip } from './TaskBranchChip';
 import { TaskRunChip } from './TaskRunChip';
+import { GateChip } from './GateChip';
 import {
     Inbox,
     Circle,
@@ -217,11 +218,14 @@ function TaskKanbanCard({
                 {task.title}
             </Link>
 
-            {/* Wave 2 M7 — isolated-branch chip · Wave 2 run cockpit — run chip */}
+            {/* Wave 2 M7 — isolated-branch chip · Wave 2 run cockpit — run
+                chip · Wave 3 M6 — gate chip when the latest run carries a
+                gate verdict. */}
             {(task.branchRef || task.run) && (
                 <div className="flex flex-wrap gap-1">
                     {task.branchRef && <TaskBranchChip task={task} />}
                     {task.run && <TaskRunChip task={task} />}
+                    {task.run?.gateStatus && <GateChip status={task.run.gateStatus} />}
                 </div>
             )}
 

--- a/apps/web/src/components/tasks/TasksScopedSection.tsx
+++ b/apps/web/src/components/tasks/TasksScopedSection.tsx
@@ -2,6 +2,8 @@ import { ListChecks, Plus } from 'lucide-react';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import type { Task } from '@/lib/api/tasks';
+import type { WorkRunsSummary } from '@/lib/api/types-only';
+import { WorkRunsSummaryBadges } from '@/components/works/detail/WorkRunsSummaryBadges';
 import { TasksList } from './TasksList';
 
 /**
@@ -17,10 +19,13 @@ export function TasksScopedSection({
     tasks,
     scopeLabel,
     scopeId,
+    runsSummary = null,
 }: {
     tasks: Task[];
     scopeLabel: 'Work' | 'Mission' | 'Idea';
     scopeId: string;
+    /** Wave 4 M4 — per-Work AgentRun summary counts (Work scope only). */
+    runsSummary?: WorkRunsSummary | null;
 }) {
     const doneCount = tasks.filter((t) => t.status === 'done').length;
     const openCount = tasks.filter((t) => !['done', 'cancelled'].includes(t.status)).length;
@@ -50,6 +55,8 @@ export function TasksScopedSection({
                                     <span>done</span>
                                 </span>
                             )}
+                            {/* Wave 4 M4 — per-Work fleet summary chips. */}
+                            {runsSummary && <WorkRunsSummaryBadges summary={runsSummary} />}
                         </div>
                         <p className="text-xs text-text-secondary dark:text-text-secondary-dark mt-0.5">
                             {openCount > 0

--- a/apps/web/src/components/works/detail/WorkRunsSummaryBadges.tsx
+++ b/apps/web/src/components/works/detail/WorkRunsSummaryBadges.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils/cn';
+import type { WorkRunsSummary } from '@/lib/api/types-only';
+
+/**
+ * Run orchestration (Wave 4 M4) — per-Work fleet summary badges fed by
+ * `GET /api/works/:id/runs-summary`. A small always-scannable row
+ * (running / queued / failed in 24h) on the Work's Tasks tab header;
+ * zero-count badges stay hidden so a quiet Work shows nothing.
+ */
+export function WorkRunsSummaryBadges({ summary }: { summary: WorkRunsSummary }) {
+    const t = useTranslations('dashboard.workDetail.runsSummary');
+
+    const allBadges: Array<{
+        key: 'running' | 'queued' | 'awaiting' | 'failedLast24h';
+        count: number;
+        className: string;
+    }> = [
+        {
+            key: 'running',
+            count: summary.running,
+            className: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300',
+        },
+        {
+            key: 'queued',
+            count: summary.queued,
+            className: 'bg-slate-100 dark:bg-slate-800/40 text-slate-600 dark:text-slate-300',
+        },
+        {
+            key: 'awaiting',
+            count: summary.awaiting,
+            className: 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300',
+        },
+        {
+            key: 'failedLast24h',
+            count: summary.failedLast24h,
+            className: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300',
+        },
+    ];
+    const badges = allBadges.filter((badge) => badge.count > 0);
+
+    if (badges.length === 0) return null;
+
+    return (
+        <span
+            className="inline-flex items-center gap-1.5 flex-wrap"
+            data-testid="work-runs-summary"
+        >
+            {badges.map((badge) => (
+                <span
+                    key={badge.key}
+                    className={cn(
+                        'inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded',
+                        badge.className,
+                    )}
+                    data-testid={`work-runs-summary-${badge.key}`}
+                >
+                    <span className="font-mono">{badge.count}</span>
+                    {t(badge.key)}
+                </span>
+            ))}
+        </span>
+    );
+}

--- a/apps/web/src/components/works/detail/settings/QualityGatesSettings.tsx
+++ b/apps/web/src/components/works/detail/settings/QualityGatesSettings.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import type { TaskAcceptanceCheck, WorkChecksPolicy } from '@ever-works/contracts';
+import { Select } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useRouter } from '@/i18n/navigation';
+import { updateQualityGatesSettings } from '@/app/actions/dashboard/works';
+import { ChecksEditor } from '@/components/tasks/ChecksEditor';
+import { useSettings } from './SettingsContext';
+
+/**
+ * Quality gates (Wave 3 M6) — Work-level acceptance-check defaults.
+ *
+ * `checkDefaults` are inherited by every agent-executed Task under this
+ * Work (a Task's own checks override by id); `checksPolicy` decides
+ * whether the gate runs and whether red blocks; `maxGateAttempts`
+ * bounds the in-run iterate loop. Saves flow through the same
+ * `PATCH /works/:id` UpdateWorkDto path as the sibling settings cards
+ * (TaskIsolationSettings / CommitterSettings).
+ */
+export function QualityGatesSettings() {
+    const t = useTranslations('dashboard.workDetail.settings.qualityGates');
+    const { context } = useSettings();
+    const { work } = context;
+    const router = useRouter();
+
+    const policy: WorkChecksPolicy = work.checksPolicy ?? 'off';
+    const maxAttempts = work.maxGateAttempts ?? 2;
+
+    const [defaults, setDefaults] = useState<TaskAcceptanceCheck[]>(
+        (work.checkDefaults ?? []).map((c) => ({ ...c })),
+    );
+    const [pendingField, setPendingField] = useState<'policy' | 'maxAttempts' | 'defaults' | null>(
+        null,
+    );
+    const [, startTransition] = useTransition();
+
+    const save = (
+        field: 'policy' | 'maxAttempts' | 'defaults',
+        settings: Parameters<typeof updateQualityGatesSettings>[1],
+    ) => {
+        setPendingField(field);
+        startTransition(async () => {
+            try {
+                const result = await updateQualityGatesSettings(work.id, settings);
+                if (result.success) {
+                    toast.success(t('saved'));
+                    router.refresh();
+                } else {
+                    toast.error(result.error || t('saveFailed'));
+                }
+            } catch {
+                toast.error(t('saveFailed'));
+            } finally {
+                setPendingField(null);
+            }
+        });
+    };
+
+    const busy = pendingField !== null;
+
+    return (
+        <div
+            className={cn(
+                'rounded-lg border overflow-hidden',
+                'bg-card dark:bg-card-primary-dark/30',
+                'border-card-border dark:border-border-secondary-dark',
+            )}
+            data-testid="quality-gates-settings"
+        >
+            <div className="px-5 py-3.5 border-b border-card-border dark:border-border-secondary-dark">
+                <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h3>
+                <p className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark">
+                    {t('subtitle')}
+                </p>
+            </div>
+
+            <div className="px-5 py-4 space-y-4">
+                {/* Enforcement policy */}
+                <div>
+                    <div className="flex items-center gap-2 mb-1">
+                        <h4 className="text-xs font-medium text-text dark:text-text-dark">
+                            {t('policyLabel')}
+                        </h4>
+                        {pendingField === 'policy' && (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin text-text-muted" />
+                        )}
+                    </div>
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark mb-2">
+                        {t(`policyHint.${policy}`)}
+                    </p>
+                    <Select
+                        value={policy}
+                        onValueChange={(next) =>
+                            save('policy', { checksPolicy: next as WorkChecksPolicy })
+                        }
+                        disabled={busy}
+                        size="sm"
+                        data-testid="quality-gates-policy"
+                    >
+                        <option value="off">{t('policyOff')}</option>
+                        <option value="warn">{t('policyWarn')}</option>
+                        <option value="required">{t('policyRequired')}</option>
+                    </Select>
+                </div>
+
+                {/* Gate-attempt budget */}
+                <div>
+                    <div className="flex items-center gap-2 mb-1">
+                        <h4 className="text-xs font-medium text-text dark:text-text-dark">
+                            {t('maxAttemptsLabel')}
+                        </h4>
+                        {pendingField === 'maxAttempts' && (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin text-text-muted" />
+                        )}
+                    </div>
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark mb-2">
+                        {t('maxAttemptsDescription')}
+                    </p>
+                    <Select
+                        value={String(maxAttempts)}
+                        onValueChange={(next) =>
+                            save('maxAttempts', { maxGateAttempts: parseInt(next, 10) })
+                        }
+                        disabled={busy}
+                        size="sm"
+                        data-testid="quality-gates-max-attempts"
+                    >
+                        {[1, 2, 3, 4, 5].map((n) => (
+                            <option key={n} value={String(n)}>
+                                {n}
+                            </option>
+                        ))}
+                    </Select>
+                </div>
+
+                {/* Default checks */}
+                <div className="pt-2 border-t border-card-border dark:border-border-secondary-dark">
+                    <h4 className="text-xs font-medium text-text dark:text-text-dark mb-1">
+                        {t('defaultsLabel')}
+                    </h4>
+                    <p className="text-xs text-text-muted dark:text-text-muted-dark mb-3">
+                        {t('defaultsDescription')}
+                    </p>
+                    <ChecksEditor
+                        value={defaults}
+                        onChange={setDefaults}
+                        disabled={busy}
+                        testIdPrefix="quality-gates-defaults"
+                    />
+                    <div className="mt-3 flex justify-end">
+                        <Button
+                            type="button"
+                            size="sm"
+                            disabled={busy}
+                            onClick={() => {
+                                const rows = defaults.filter(
+                                    (c) => c.command.trim().length > 0 || c.disabled,
+                                );
+                                save('defaults', {
+                                    checkDefaults: rows.length > 0 ? rows : null,
+                                });
+                            }}
+                            data-testid="quality-gates-defaults-save"
+                        >
+                            {pendingField === 'defaults' ? '…' : t('defaultsSave')}
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/settings/SettingsForm.tsx
+++ b/apps/web/src/components/works/detail/settings/SettingsForm.tsx
@@ -17,6 +17,7 @@ import { ItemImportExportSettings } from './ItemImportExportSettings';
 import { CommitterSettings } from './CommitterSettings';
 import { ActivitySyncSettings } from './ActivitySyncSettings';
 import { TaskIsolationSettings } from './TaskIsolationSettings';
+import { QualityGatesSettings } from './QualityGatesSettings';
 interface SettingsFormProps {
     work: Work;
     user: AuthUser;
@@ -47,6 +48,9 @@ export function SettingsForm({ work, user, initialRepositories }: SettingsFormPr
 
                 {/* Wave 2 M7 — worktree-per-Task isolation */}
                 <TaskIsolationSettings />
+
+                {/* Wave 3 M6 — quality gates (acceptance-check defaults) */}
+                <QualityGatesSettings />
 
                 {/* Advanced Prompts Settings */}
                 <AdvancedPromptsSettings workId={work.id} />

--- a/apps/web/src/lib/api/agents.shared.ts
+++ b/apps/web/src/lib/api/agents.shared.ts
@@ -12,6 +12,8 @@
  * one canonical definition.
  */
 
+import type { GateStatus, TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
+
 // ── Agent Dispatch Guardrails ──
 // Mirrors `AgentGuardrails` (packages/agent/src/agents/guardrails.ts)
 // and the proposal action types
@@ -40,4 +42,55 @@ export interface AgentGuardrails {
     autoApproveActionTypes?: AgentGuardrailActionType[];
     /** Action types the Agent may never take (auto-rejected with an audit row). */
     blockedActionTypes?: AgentGuardrailActionType[];
+}
+
+// ── Sessions view (Wave 4 M4) ──
+// Client-safe mirror of the `GET /api/agents/runs` row shape
+// (AgentsController.listRunSessions). Lives here so the `'use client'`
+// Sessions tab can type its rows without pulling the `server-only`
+// `agents.ts` module into the bundle.
+
+export type AgentRunSessionStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled';
+
+export type AgentRunTriggerKind = 'heartbeat' | 'manual' | 'task' | 'chat' | 'event';
+
+export interface AgentRunSession {
+    id: string;
+    agentId: string;
+    status: AgentRunSessionStatus;
+    triggerKind: AgentRunTriggerKind;
+    taskId: string | null;
+    workId: string | null;
+    awaitingInput: boolean;
+    queuedReason: string | null;
+    runnerKind: string | null;
+    startedAt: string | null;
+    finishedAt: string | null;
+    durationMs: number | null;
+    summary: string | null;
+    errorMessage: string | null;
+    /** Plain text BY CONTRACT — never render as markup. */
+    currentActivity: string | null;
+    totalTokens: number | null;
+    changedFilesCount: number | null;
+    costCents: number | null;
+    gateStatus: GateStatus | null;
+    gateAttempts: number;
+    resolvedChecks: TaskAcceptanceCheck[] | null;
+    checkResults: TaskCheckResult[] | null;
+    persistent: boolean;
+    terminalState: string | null;
+    terminalEndedReason: string | null;
+    terminalProviderId: string | null;
+    createdAt: string;
+}
+
+export interface ListRunSessionsQuery {
+    status?: AgentRunSessionStatus;
+    workId?: string;
+    agentId?: string;
+    taskId?: string;
+    kind?: AgentRunTriggerKind;
+    limit?: number;
+    offset?: number;
 }

--- a/apps/web/src/lib/api/agents.ts
+++ b/apps/web/src/lib/api/agents.ts
@@ -30,8 +30,12 @@ export {
     type AgentGuardrailActionType,
     type AgentGuardrailsMode,
     type AgentGuardrails,
+    type AgentRunSession,
+    type AgentRunSessionStatus,
+    type AgentRunTriggerKind,
+    type ListRunSessionsQuery,
 } from './agents.shared';
-import type { AgentGuardrails } from './agents.shared';
+import type { AgentGuardrails, AgentRunSession, ListRunSessionsQuery } from './agents.shared';
 
 export interface AgentPermissions {
     canCreateAgents: boolean;
@@ -378,6 +382,30 @@ export const agentsAPI = {
             method: 'POST',
             wrapInData: false,
         });
+    },
+
+    /**
+     * Run orchestration (Wave 4 M4) — the Sessions list: every AgentRun
+     * of the acting user across all Agents/Works, filterable + paginated
+     * (`GET /api/agents/runs`). Rows carry telemetry (currentActivity /
+     * totalTokens / costCents), quality-gate columns (gateStatus /
+     * resolvedChecks / checkResults) and terminal lifecycle columns for
+     * the attach link.
+     */
+    async listSessions(query: ListRunSessionsQuery = {}): Promise<{
+        data: AgentRunSession[];
+        meta: { total: number; limit: number; offset: number };
+    }> {
+        const params = new URLSearchParams();
+        if (query.status) params.set('status', query.status);
+        if (query.workId) params.set('workId', query.workId);
+        if (query.agentId) params.set('agentId', query.agentId);
+        if (query.taskId) params.set('taskId', query.taskId);
+        if (query.kind) params.set('kind', query.kind);
+        if (query.limit != null) params.set('limit', String(query.limit));
+        if (query.offset != null) params.set('offset', String(query.offset));
+        const qs = params.toString();
+        return serverFetch(`/agents/runs${qs ? `?${qs}` : ''}`, { method: 'GET' });
     },
 
     // FU-2 + FU-4 — runtime surfaces.

--- a/apps/web/src/lib/api/tasks.ts
+++ b/apps/web/src/lib/api/tasks.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import type { GateStatus, TaskAcceptanceCheck } from '@ever-works/contracts';
 import { ApiResponseError, serverFetch, serverMutation } from './server-api';
 
 export type TaskStatus =
@@ -42,6 +43,9 @@ export interface TaskRun {
     totalTokens: number | null;
     changedFilesCount: number | null;
     startedAt: string | null;
+    /** Quality gates (Wave 3 M6) — latest-run gate verdict for the board
+     *  chip. `null`/absent = the run has no gate verdict. */
+    gateStatus?: GateStatus | null;
 }
 
 export interface Task {
@@ -85,6 +89,11 @@ export interface Task {
     latestRunId?: string | null;
     latestRunStatus?: TaskRunStatus | null;
     run?: TaskRun | null;
+    // Quality gates (Wave 3 M6) — acceptance checks declared on this Task.
+    // `null` = inherit the Work's `checkDefaults` untouched.
+    acceptanceChecks?: TaskAcceptanceCheck[] | null;
+    /** Gate-attempt budget; `null` = inherit the Work default. */
+    maxGateAttempts?: number | null;
     createdAt: string;
     updatedAt: string;
 }
@@ -153,6 +162,8 @@ export const tasksAPI = {
         parentTaskId?: string | null;
         requireAllApprovers?: boolean;
         isolationMode?: TaskIsolationMode | null;
+        acceptanceChecks?: TaskAcceptanceCheck[] | null;
+        maxGateAttempts?: number | null;
     }) {
         return serverMutation<Task>({
             endpoint: '/tasks',
@@ -174,6 +185,8 @@ export const tasksAPI = {
                 | 'parentTaskId'
                 | 'requireAllApprovers'
                 | 'isolationMode'
+                | 'acceptanceChecks'
+                | 'maxGateAttempts'
             >
         >,
     ) {

--- a/apps/web/src/lib/api/types-only.ts
+++ b/apps/web/src/lib/api/types-only.ts
@@ -51,6 +51,7 @@ export type {
     RepositoryStatus,
     RepositoryType,
     SourceValidationSettingsDto,
+    WorkRunsSummary,
     // GenerateStatus now has dynamic step support
 } from './work';
 

--- a/apps/web/src/lib/api/work.ts
+++ b/apps/web/src/lib/api/work.ts
@@ -25,6 +25,7 @@ import {
     type SourceRepository as ContractSourceRepository,
     type WorksConfigSnapshot as ContractWorksConfigSnapshot,
 } from '@ever-works/contracts/api';
+import type { TaskAcceptanceCheck, WorkChecksPolicy } from '@ever-works/contracts';
 import { APIResponse, ItemData, Category, Tag, Collection } from './types';
 import { CreateItemsGeneratorDto, ItemsGeneratorResponse } from './items-generator';
 
@@ -111,6 +112,14 @@ export interface UpdateWorkDto {
     taskIsolationTargetRepo?: TaskIsolationTargetRepo;
     /** When Task branches are deleted after merge. */
     taskBranchCleanup?: TaskBranchCleanup;
+    // Quality gates (Wave 3 M6) — Work-level default acceptance checks
+    // inherited by agent-executed Tasks; `null` clears the defaults.
+    checkDefaults?: TaskAcceptanceCheck[] | null;
+    /** Enforcement policy: 'off' (never run) / 'warn' (report only) /
+     *  'required' (red blocks). */
+    checksPolicy?: WorkChecksPolicy;
+    /** Default gate-attempt budget (1..5) for Tasks without their own. */
+    maxGateAttempts?: number;
 }
 
 /** Wave 2 M7 — Work-level worktree-per-Task isolation settings. */
@@ -288,6 +297,20 @@ export interface Work {
     taskIsolationBaseBranch?: string | null;
     taskIsolationTargetRepo?: TaskIsolationTargetRepo;
     taskBranchCleanup?: TaskBranchCleanup;
+    // Quality gates (Wave 3 M6). Absent on rows written before the
+    // columns existed — absent means no defaults / policy 'off' / 2.
+    checkDefaults?: TaskAcceptanceCheck[] | null;
+    checksPolicy?: WorkChecksPolicy;
+    maxGateAttempts?: number;
+}
+
+/** Wave 4 M3 — per-Work AgentRun summary counts
+ *  (`GET /api/works/:id/runs-summary`). */
+export interface WorkRunsSummary {
+    running: number;
+    queued: number;
+    awaiting: number;
+    failedLast24h: number;
 }
 
 export interface WorksResponse {
@@ -620,6 +643,11 @@ export const workAPI = {
     // Get aggregated stats for the current user's works
     getStats: async () => {
         return serverFetch<WorkStatsResponse>(`/works/stats`);
+    },
+
+    // Wave 4 M3 — per-Work AgentRun summary counts for the fleet chips.
+    getRunsSummary: async (id: string) => {
+        return serverFetch<WorkRunsSummary>(`/works/${id}/runs-summary`);
     },
 
     // Live slug-availability check for the create-Work form.

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -119,6 +119,7 @@ export const ROUTES = {
     DASHBOARD_TEMPLATES: '/templates',
     // Agents (Agents/Skills/Tasks PR #1017 — Phase 5)
     DASHBOARD_AGENTS: '/agents',
+    DASHBOARD_AGENT_SESSIONS: '/agents/sessions',
     DASHBOARD_AGENT_NEW: '/agents/new',
     DASHBOARD_AGENT: (id: string) => `/agents/${id}`,
     DASHBOARD_AGENT_DASHBOARD: (id: string) => `/agents/${id}`,

--- a/apps/web/src/lib/hooks/use-session-polling.ts
+++ b/apps/web/src/lib/hooks/use-session-polling.ts
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { AgentRunSession, ListRunSessionsQuery } from '@/lib/api/agents.shared';
+import { listRunSessionsAction } from '@/app/actions/agents';
+
+const POLL_INTERVAL_MS = 10_000;
+
+/**
+ * Run orchestration (Wave 4 M4) — Sessions-tab polling.
+ *
+ * Every 10s, and ONLY while at least one visible session is
+ * queued/running, re-fetch the sessions list with the current filters
+ * and hand the fresh rows to the caller. The interval tears down as
+ * soon as nothing is active, so an idle fleet costs zero requests.
+ * Poll failures are swallowed — the view keeps the last-known rows
+ * until the next tick.
+ *
+ * Same setInterval-in-effect shape as `use-task-run-polling` (and the
+ * older pollers it mirrors: NotificationDropdown, WorkActivity).
+ */
+export function useSessionPolling(
+    sessions: AgentRunSession[],
+    query: ListRunSessionsQuery,
+    onFreshRows: (rows: AgentRunSession[]) => void,
+): void {
+    // Refs so a new inline callback/query object per render doesn't tear
+    // the interval down and re-create it every 10s render.
+    const onFreshRowsRef = useRef(onFreshRows);
+    useEffect(() => {
+        onFreshRowsRef.current = onFreshRows;
+    }, [onFreshRows]);
+    const queryRef = useRef(query);
+    useEffect(() => {
+        queryRef.current = query;
+    }, [query]);
+
+    const hasActiveRun = sessions.some((s) => s.status === 'queued' || s.status === 'running');
+
+    useEffect(() => {
+        if (!hasActiveRun) return;
+        let cancelled = false;
+        let inFlight = false;
+
+        const tick = async () => {
+            if (inFlight) return; // never stack slow polls
+            inFlight = true;
+            try {
+                const result = await listRunSessionsAction(queryRef.current);
+                if (!cancelled) onFreshRowsRef.current(result.data);
+            } catch {
+                // Poll is best-effort — keep last-known rows.
+            } finally {
+                inFlight = false;
+            }
+        };
+
+        const interval = setInterval(() => void tick(), POLL_INTERVAL_MS);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
+    }, [hasActiveRun]);
+}

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -721,6 +721,7 @@ export class AgentRunRepository {
             status?: AgentRunStatus;
             workId?: string;
             agentId?: string;
+            taskId?: string;
             triggerKind?: AgentRunTriggerKind;
         },
         limit = 25,
@@ -737,6 +738,9 @@ export class AgentRunRepository {
         }
         if (filters.agentId) {
             qb.andWhere('run.agentId = :agentId', { agentId: filters.agentId });
+        }
+        if (filters.taskId) {
+            qb.andWhere('run.taskId = :taskId', { taskId: filters.taskId });
         }
         if (filters.triggerKind) {
             qb.andWhere('run.triggerKind = :triggerKind', { triggerKind: filters.triggerKind });

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -9,7 +9,7 @@ import {
 import type { TaskIsolationMode } from './task-isolation';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { Repository } from 'typeorm';
-import type { TaskAcceptanceCheck } from '@ever-works/contracts';
+import type { GateStatus, TaskAcceptanceCheck } from '@ever-works/contracts';
 import { Task, TaskPriority, TaskStatus, type TaskActorType } from '../entities/task.entity';
 import { Mission } from '../entities/mission.entity';
 import { Team } from '../entities/team.entity';
@@ -112,6 +112,9 @@ export interface TaskRunEmbed {
     totalTokens: number | null;
     changedFilesCount: number | null;
     startedAt: Date | null;
+    /** Quality gates (Wave 3 M6) — latest-run gate verdict for the board
+     *  chip. `null` = the run never reached (or has no) gate step. */
+    gateStatus: GateStatus | null;
 }
 
 export type TaskWithRun = Task & { run?: TaskRunEmbed | null };
@@ -225,6 +228,7 @@ export class TasksService {
                         totalTokens: run.totalTokens ?? null,
                         changedFilesCount: run.changedFilesCount ?? null,
                         startedAt: run.startedAt ?? null,
+                        gateStatus: run.gateStatus ?? null,
                     },
                 ]),
             );


### PR DESCRIPTION
## What

Web surfaces for run orchestration (Sessions tab) and quality gates, on top of the backend already on `wave/integration`.

### Sessions tab (Wave 4 M4)
- New `/agents/sessions` page + **Agents | Sessions** tab strip on the Agents page (`AgentsPageTabs`).
- `AgentSessionsClient`: one row per AgentRun — status pill (+ awaiting-input badge), agent name, Work badge, **current-activity line rendered strictly as plain text**, token counter (compact), cost when present, gate chip, started time + duration, and an **Attach** link into the run's terminal tab (`/agents/[id]/terminal?run=<id>`) when the run carries terminal state.
- Filters (status, Work) + **group-by-Work toggle** (default on); queued rows show their reason ("Waiting for a concurrency slot" for `concurrency:*` parks).
- **10s polling only while anything is queued/running** (`use-session-polling`, same shape as `use-task-run-polling`); idle fleet costs zero requests.

### Quality gates UI (Wave 3 M6)
- `GateChip.tsx` (`data-testid="task-gate-chip"`, green/red/skipped/none, red carries failed-required count) — on kanban cards next to `TaskRunChip` when the latest run has a gate verdict, on Sessions rows, and in Task detail.
- **Task detail "Checks" section**: per-check name/kind/exit code/duration with collapsible monospace `logTail` (plain text node — never markup), attempt counter ("Attempt N of M"), and in-place editing of `acceptanceChecks` + `maxGateAttempts` through the same task PATCH as sibling fields.
- **Checks editor** (`ChecksEditor`, flat command list: id slug / name / kind select / command / timeout / required toggle) on Task create (collapsible section in `NewTaskForm`) and Task detail.
- **Work settings "Quality gates" card**: `checkDefaults` editor + `checksPolicy` select (off/warn/required with one-line explanations) + `maxGateAttempts` (1..5), saved via `PATCH /works/:id` exactly like `TaskIsolationSettings`.
- **Per-Work runs-summary badges** (`GET /api/works/:id/runs-summary`) on the Work → Tasks tab header (least-invasive anchor; zero counts hidden).
- i18n: all new strings in `apps/web/messages/en.json` under the existing `dashboard.*` key patterns; `data-testid`s on interactive elements.

### Small additive API projections (read-only, needed by the UI)
- `TaskRunEmbed` (+`gateStatus`) on the task-list `includeRun` embed — feeds the kanban gate chip.
- `GET /api/agents/runs`: rows now include `resolvedChecks`/`checkResults`; new optional `taskId` filter — feeds the Task-detail Checks section (`taskId + limit=1`).

## Verification (real output)

- `apps/web` `npx tsc --noEmit` → clean, exit 0 (e2e specs are covered by this tsconfig).
- `apps/api` `npx tsc -p tsconfig.build.json --noEmit` → clean, exit 0.
- `pnpm build --filter=ever-works-web` (webpack prod build) → `Tasks: 3 successful, 3 total` (3m12s), exit 0.
- `pnpm --filter ever-works-web test` → `Test Files 110 passed (110) · Tests 1033 passed (1033)`.
- `apps/api` `npx jest --testPathPattern='agents.controller|work-runs'` → `Test Suites: 2 passed · Tests: 36 passed`.
- `packages/agent` `npx jest --testPathPattern='tasks-domain|agent-run'` → `Test Suites: 24 passed · Tests: 270 passed`.
- e2e sweep: no spec pins the agents-page tab structure, the task-detail section list, `GET /api/agents/runs` row keys, or the `includeRun` embed shape. `flow-a11y-key-flows-axe` asserts "at least one nav" (additive tab strip safe); `flow-tasks-recurring-reviewers` pins bogus-field rejection on fields untouched here; `flow-agents-ui-journey` asserts headings only. No e2e changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)