### PR TITLE
feat(plugins): Linear + Notion connectors (Wave 8)

### DIFF
--- a/apps/api/src/migrations/1783500000000-CreateIngestCursors.ts
+++ b/apps/api/src/migrations/1783500000000-CreateIngestCursors.ts
@@ -1,0 +1,78 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Event-ingest pull path (Wave 8) — creates the `ingest_cursors` table
+ * backing the event-source pull half of the `event-ingest-tick` cron:
+ * one row per (user, event-source plugin) holding the completed-sweep
+ * `watermark` (handed to `pullEvents` as `since`), the plugin's opaque
+ * continuation `cursor` when a sweep ran out of its per-tick page
+ * budget, and `sweepStartedAt` so the watermark advances to when that
+ * sweep BEGAN on completion (overlap is free — the ingest pipeline
+ * dedupes on `(source, sourceEventId)`).
+ *
+ * Entity: `packages/agent/src/entities/ingest-cursor.entity.ts`
+ * Service: `packages/agent/src/ingest/event-source-pull.service.ts`
+ *
+ * Forward-only + idempotent (`hasTable` guard) — same shape as
+ * `1783200000000-CreateIngestedEvents`.
+ */
+export class CreateIngestCursors1783500000000 implements MigrationInterface {
+    name = 'CreateIngestCursors1783500000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('ingest_cursors')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'ingest_cursors',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'pluginId', type: 'varchar', length: '100' },
+                    { name: 'cursor', type: 'text', isNullable: true },
+                    { name: 'watermark', type: 'timestamp', isNullable: true },
+                    { name: 'sweepStartedAt', type: 'timestamp', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        // One pull state per (user, plugin) — upserts key on this.
+        await queryRunner.createIndex(
+            'ingest_cursors',
+            new TableIndex({
+                name: 'idx_ingest_cursors_user_plugin',
+                columnNames: ['userId', 'pluginId'],
+                isUnique: true,
+            }),
+        );
+
+        // Pull state is meaningless without its owner.
+        await queryRunner.createForeignKey(
+            'ingest_cursors',
+            new TableForeignKey({
+                name: 'fk_ingest_cursors_user',
+                columnNames: ['userId'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('ingest_cursors')) {
+            await queryRunner.dropTable('ingest_cursors', true);
+        }
+    }
+}

--- a/apps/api/src/trigger/trigger-internal.controller.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.spec.ts
@@ -81,6 +81,7 @@ jest.mock('@ever-works/agent/plugins', () => ({
 // TypeORM under apps/api jest) is never loaded.
 jest.mock('@ever-works/agent/ingest', () => ({
     EventIngestService: class EventIngestService {},
+    EventSourcePullService: class EventSourcePullService {},
     EventIngestModule: class EventIngestModule {},
 }));
 // Digest briefings (Wave 7) — same rationale as the ingest stub above:

--- a/apps/api/src/trigger/trigger-internal.controller.ts
+++ b/apps/api/src/trigger/trigger-internal.controller.ts
@@ -70,7 +70,7 @@ import {
     UserPluginRepository,
     WorkPluginRepository,
 } from '@ever-works/agent/plugins';
-import { EventIngestService } from '@ever-works/agent/ingest';
+import { EventIngestService, EventSourcePullService } from '@ever-works/agent/ingest';
 import { DigestService } from '@ever-works/agent/digest';
 import { CreditLedgerService } from '@ever-works/agent/subscriptions';
 
@@ -303,6 +303,13 @@ export class TriggerInternalController implements OnModuleInit {
         // LAST + @Optional() per the arity rule above.
         @Optional()
         private readonly creditLedgerService?: CreditLedgerService,
+        // Event-ingest pull path (Wave 8) — backs the pull half of the
+        // `event-ingest-tick` cron: the worker proxy calls `pullSources()`
+        // over the internal RPC channel, landing here where the
+        // event-source plugins + settings + cursors are wired. Appended
+        // LAST + @Optional() per the arity rule above.
+        @Optional()
+        private readonly eventSourcePullService?: EventSourcePullService,
     ) {}
 
     onModuleInit() {
@@ -375,6 +382,9 @@ export class TriggerInternalController implements OnModuleInit {
             // Event-ingest spine (Wave 6) — `event-ingest-tick` calls
             // `processBatch()` here (allow-list auto-derived).
             EventIngestService: this.eventIngestService,
+            // Event-ingest pull path (Wave 8) — `event-ingest-tick` calls
+            // `pullSources()` here (allow-list auto-derived).
+            EventSourcePullService: this.eventSourcePullService,
             // Digest briefings (Wave 7) — `digest-dispatcher` calls
             // `dispatchDue(period)` here (allow-list auto-derived).
             DigestService: this.digestService,

--- a/apps/api/src/trigger/trigger-internal.module.spec.ts
+++ b/apps/api/src/trigger/trigger-internal.module.spec.ts
@@ -69,6 +69,7 @@ jest.mock('@ever-works/agent/tasks-domain', () => ({
 jest.mock('@ever-works/agent/ingest', () => ({
     EventIngestModule: class EventIngestModule {},
     EventIngestService: class EventIngestService {},
+    EventSourcePullService: class EventSourcePullService {},
 }));
 // Digest briefings (Wave 7) — the module imports DigestModule (and the
 // controller it declares imports DigestService) from the digest barrel;

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -114,6 +114,7 @@ import { TenantRuntimeProviderAllowlist } from '../entities/tenant-runtime-provi
 import { TenantCredentialSnapshot } from '../entities/tenant-credential-snapshot.entity';
 import { InboundTrigger } from '../entities/inbound-trigger.entity';
 import { IngestedEvent } from '../entities/ingested-event.entity';
+import { IngestCursor } from '../entities/ingest-cursor.entity';
 import { CreditLedgerEntry } from '../entities/credit-ledger-entry.entity';
 import { PlanEntitlement } from '../entities/plan-entitlement.entity';
 import {
@@ -255,6 +256,9 @@ export const ENTITIES = [
     // Event-ingest spine (Wave 6) — normalized external events awaiting
     // Activity/Memory fan-out.
     IngestedEvent,
+    // Event-ingest pull path (Wave 8) — per-(user, plugin) event-source
+    // pull watermarks + continuation cursors.
+    IngestCursor,
     // Credits ledger + plan entitlements (pricing Wave 9 M1) — credits
     // are the usage currency layered on the costCents metering.
     CreditLedgerEntry,

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -71,6 +71,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'GitHubAppUserLink',
     // Inbound Triggers (Trigger Schedules) — signed webhook/API triggers
     'InboundTrigger',
+    // Event-ingest pull path (Wave 8) — per-(user, plugin) pull cursors
+    'IngestCursor',
     // Event-ingest spine (Wave 6) — normalized external events
     'IngestedEvent',
     'Mission',

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -116,6 +116,8 @@ export * from './team-resource.entity';
 export * from './inbound-trigger.entity';
 // Event-ingest spine (Wave 6) — normalized external events awaiting fan-out
 export * from './ingested-event.entity';
+// Event-ingest pull path (Wave 8) — per-(user, plugin) pull watermarks/cursors
+export * from './ingest-cursor.entity';
 // Credits ledger + plan entitlements (pricing Wave 9 M1)
 export * from './credit-ledger-entry.entity';
 export * from './plan-entitlement.entity';

--- a/packages/agent/src/entities/ingest-cursor.entity.ts
+++ b/packages/agent/src/entities/ingest-cursor.entity.ts
@@ -1,0 +1,62 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Event-ingest spine (Wave 8) — per-(user, plugin) pull state for the
+ * `event-ingest-tick` cron's event-source pull path.
+ *
+ * One row per enabled event-source plugin per user. `watermark` is the
+ * completed-sweep high-water mark handed to `pullEvents` as `since`;
+ * `cursor` is the plugin's opaque continuation cursor when a sweep ran
+ * out of its per-tick page budget mid-flight; `sweepStartedAt` pins
+ * when that in-flight sweep began so the watermark can advance to it
+ * (not to "now") on completion — nothing that happened during a long
+ * sweep is ever skipped. Overlap is safe: the ingest pipeline dedupes
+ * on `(source, sourceEventId)`.
+ *
+ * Scope columns are raw uuid references (no @ManyToOne) per the EW-654
+ * cycle-avoidance rule; FKs live in the migration
+ * (`1783500000000-CreateIngestCursors`).
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` — this
+ * repo has no `autoLoadEntities`, a forFeature'd-but-unregistered
+ * entity throws EntityMetadataNotFoundError on first query.
+ */
+@Entity({ name: 'ingest_cursors' })
+@Index('idx_ingest_cursors_user_plugin', ['userId', 'pluginId'], { unique: true })
+export class IngestCursor {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Owner the events are pulled for (scopes settings + envelopes). */
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    /** Producing event-source plugin id, e.g. `linear-connector`. */
+    @Column({ type: 'varchar', length: 100 })
+    pluginId: string;
+
+    /** Opaque plugin continuation cursor of an in-flight sweep. */
+    @Column({ type: 'text', nullable: true })
+    cursor?: string | null;
+
+    /** Completed-sweep high-water mark (passed as `since`). */
+    @Column({ type: 'timestamp', nullable: true })
+    watermark?: Date | null;
+
+    /** When the in-flight sweep began (null when no sweep is running). */
+    @Column({ type: 'timestamp', nullable: true })
+    sweepStartedAt?: Date | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/ingest/__tests__/event-source-pull.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/event-source-pull.service.spec.ts
@@ -1,0 +1,297 @@
+import { EventSourcePullService } from '../event-source-pull.service';
+import type { EventIngestService } from '../event-ingest.service';
+import type { IngestCursorRepository } from '../ingest-cursor.repository';
+import type { PluginRegistryService } from '../../plugins/services/plugin-registry.service';
+import type { PluginSettingsService } from '../../plugins/services/plugin-settings.service';
+import type { UserPluginRepository } from '../../plugins/repositories/user-plugin.repository';
+
+/**
+ * Event-ingest pull path (Wave 8) — unit contract for
+ * `EventSourcePullService.pullSources()`: per-(plugin, user) cursor
+ * isolation, watermark/sweep protocol and the one-broken-source-never-
+ * kills-the-batch guarantee.
+ */
+
+const EPOCH_ISO = new Date(0).toISOString();
+
+interface FakePlugin {
+    id: string;
+    capabilities: string[];
+    pullEvents?: jest.Mock;
+}
+
+function makeEnvelope(source: string, sourceEventId: string) {
+    return {
+        id: `env-${sourceEventId}`,
+        source,
+        sourceEventId,
+        kind: `${source}.thing`,
+        occurredAt: '2026-07-24T10:00:00.000Z',
+        payload: {},
+    };
+}
+
+describe('EventSourcePullService', () => {
+    let ingestMock: jest.Mock;
+    let eventIngestService: EventIngestService;
+    let cursorRows: Map<
+        string,
+        { cursor?: string | null; watermark?: Date | null; sweepStartedAt?: Date | null }
+    >;
+    let cursorSaveMock: jest.Mock;
+    let cursorRepository: IngestCursorRepository;
+    let registered: Array<{ plugin: FakePlugin; state: string }>;
+    let registry: PluginRegistryService;
+    let settingsService: PluginSettingsService;
+    let userRows: Record<string, Array<{ userId: string; enabled: boolean }>>;
+    let userPluginRepository: UserPluginRepository;
+
+    const cursorKey = (userId: string, pluginId: string) => `${userId}\0${pluginId}`;
+
+    function makeService(): EventSourcePullService {
+        return new EventSourcePullService(
+            eventIngestService,
+            cursorRepository,
+            registry,
+            settingsService,
+            userPluginRepository,
+        );
+    }
+
+    beforeEach(() => {
+        ingestMock = jest.fn().mockResolvedValue({ inserted: 1, duplicates: 0, rejected: 0 });
+        eventIngestService = { ingest: ingestMock } as unknown as EventIngestService;
+
+        cursorRows = new Map();
+        cursorSaveMock = jest.fn().mockImplementation(async (data) => {
+            cursorRows.set(cursorKey(data.userId, data.pluginId), data);
+            return data;
+        });
+        cursorRepository = {
+            findByUserAndPlugin: jest
+                .fn()
+                .mockImplementation(async (userId: string, pluginId: string) => {
+                    const row = cursorRows.get(cursorKey(userId, pluginId));
+                    return row ? { userId, pluginId, ...row } : null;
+                }),
+            save: cursorSaveMock,
+        } as unknown as IngestCursorRepository;
+
+        registered = [];
+        registry = {
+            getByCapability: jest.fn().mockImplementation(() => registered),
+            isPluginEnabledForScope: jest.fn().mockResolvedValue(true),
+        } as unknown as PluginRegistryService;
+
+        settingsService = {
+            getSettings: jest.fn().mockResolvedValue({ apiKey: 'secret-key' }),
+        } as unknown as PluginSettingsService;
+
+        userRows = {};
+        userPluginRepository = {
+            findByPlugin: jest
+                .fn()
+                .mockImplementation(async (pluginId: string) => userRows[pluginId] ?? []),
+        } as unknown as UserPluginRepository;
+    });
+
+    function addSource(id: string, state = 'loaded'): FakePlugin {
+        const plugin: FakePlugin = {
+            id,
+            capabilities: ['connector', 'event-source'],
+            pullEvents: jest.fn().mockResolvedValue({ events: [] }),
+        };
+        registered.push({ plugin, state });
+        return plugin;
+    }
+
+    it('degrades to a no-op when the plugin system is not wired in this runtime', async () => {
+        const service = new EventSourcePullService(eventIngestService, cursorRepository);
+        const result = await service.pullSources();
+        expect(result).toEqual({
+            sources: 0,
+            pulled: 0,
+            pages: 0,
+            inserted: 0,
+            duplicates: 0,
+            rejected: 0,
+            errors: 0,
+        });
+    });
+
+    it('pulls with an epoch since on first pull, resolved settings (secrets included), and ingests the envelopes', async () => {
+        const plugin = addSource('linear-connector');
+        plugin.pullEvents!.mockResolvedValueOnce({
+            events: [makeEnvelope('linear-connector', 'e1')],
+        });
+        userRows['linear-connector'] = [{ userId: 'user-1', enabled: true }];
+
+        const result = await makeService().pullSources();
+
+        expect(settingsService.getSettings).toHaveBeenCalledWith('linear-connector', {
+            userId: 'user-1',
+            includeSecrets: true,
+        });
+        expect(plugin.pullEvents).toHaveBeenCalledWith({
+            since: EPOCH_ISO,
+            settings: { apiKey: 'secret-key' },
+        });
+        expect(ingestMock).toHaveBeenCalledWith('user-1', [makeEnvelope('linear-connector', 'e1')]);
+        expect(result).toMatchObject({ sources: 1, pulled: 1, pages: 1, inserted: 1, errors: 0 });
+    });
+
+    it('completed sweeps advance the watermark to the sweep start and clear the cursor', async () => {
+        addSource('linear-connector');
+        userRows['linear-connector'] = [{ userId: 'user-1', enabled: true }];
+        const before = Date.now();
+
+        await makeService().pullSources();
+
+        expect(cursorSaveMock).toHaveBeenCalledTimes(1);
+        const saved = cursorSaveMock.mock.calls[0][0];
+        expect(saved).toMatchObject({
+            userId: 'user-1',
+            pluginId: 'linear-connector',
+            cursor: null,
+        });
+        expect(saved.sweepStartedAt).toBeNull();
+        expect(saved.watermark).toBeInstanceOf(Date);
+        expect(saved.watermark.getTime()).toBeGreaterThanOrEqual(before);
+    });
+
+    it('keeps per-(plugin, user) cursors isolated — each pair pulls with its OWN watermark and cursor', async () => {
+        const linear = addSource('linear-connector');
+        const notion = addSource('notion-connector');
+        userRows['linear-connector'] = [{ userId: 'user-1', enabled: true }];
+        userRows['notion-connector'] = [{ userId: 'user-1', enabled: true }];
+        cursorRows.set(cursorKey('user-1', 'linear-connector'), {
+            cursor: 'linear-resume',
+            watermark: new Date('2026-07-20T00:00:00.000Z'),
+            sweepStartedAt: new Date('2026-07-24T00:00:00.000Z'),
+        });
+        cursorRows.set(cursorKey('user-1', 'notion-connector'), {
+            cursor: null,
+            watermark: new Date('2026-07-22T00:00:00.000Z'),
+            sweepStartedAt: null,
+        });
+
+        await makeService().pullSources();
+
+        expect(linear.pullEvents).toHaveBeenCalledWith({
+            since: '2026-07-20T00:00:00.000Z',
+            cursor: 'linear-resume',
+            settings: { apiKey: 'secret-key' },
+        });
+        expect(notion.pullEvents).toHaveBeenCalledWith({
+            since: '2026-07-22T00:00:00.000Z',
+            settings: { apiKey: 'secret-key' },
+        });
+        // Completion writes stay per-pair too.
+        const savedFor = (pluginId: string) =>
+            cursorSaveMock.mock.calls.find((c) => c[0].pluginId === pluginId)?.[0];
+        // The resumed linear sweep completes at its ORIGINAL start, not now.
+        expect(savedFor('linear-connector').watermark.toISOString()).toBe(
+            '2026-07-24T00:00:00.000Z',
+        );
+        expect(savedFor('notion-connector').watermark.toISOString()).not.toBe(
+            '2026-07-24T00:00:00.000Z',
+        );
+    });
+
+    it('an error in one plugin does not kill the batch — the other sources still pull', async () => {
+        const broken = addSource('broken-connector');
+        broken.pullEvents!.mockRejectedValue(new Error('boom'));
+        const healthy = addSource('notion-connector');
+        userRows['broken-connector'] = [{ userId: 'user-1', enabled: true }];
+        userRows['notion-connector'] = [{ userId: 'user-1', enabled: true }];
+
+        const result = await makeService().pullSources();
+
+        expect(healthy.pullEvents).toHaveBeenCalledTimes(1);
+        expect(result.errors).toBe(1);
+        expect(result.pulled).toBe(1);
+        expect(result.sources).toBe(2);
+    });
+
+    it("one user's failure (e.g. not configured) does not stop the plugin's other users", async () => {
+        const plugin = addSource('linear-connector');
+        const notConfigured = new Error('no key');
+        notConfigured.name = 'EventSourceNotConfiguredError';
+        plugin
+            .pullEvents!.mockRejectedValueOnce(notConfigured)
+            .mockResolvedValueOnce({ events: [makeEnvelope('linear-connector', 'e2')] });
+        userRows['linear-connector'] = [
+            { userId: 'user-1', enabled: true },
+            { userId: 'user-2', enabled: true },
+        ];
+
+        const result = await makeService().pullSources();
+
+        expect(plugin.pullEvents).toHaveBeenCalledTimes(2);
+        expect(ingestMock).toHaveBeenCalledWith('user-2', expect.any(Array));
+        expect(result.errors).toBe(1);
+        expect(result.pulled).toBe(1);
+    });
+
+    it('skips disabled user rows, scope-disabled users and unloaded plugins', async () => {
+        const plugin = addSource('linear-connector');
+        const cold = addSource('cold-connector', 'registered');
+        userRows['linear-connector'] = [
+            { userId: 'user-off', enabled: false },
+            { userId: 'user-scope-off', enabled: true },
+        ];
+        (registry.isPluginEnabledForScope as jest.Mock).mockResolvedValue(false);
+
+        const result = await makeService().pullSources();
+
+        expect(plugin.pullEvents).not.toHaveBeenCalled();
+        expect(cold.pullEvents).not.toHaveBeenCalled();
+        expect(result.sources).toBe(1); // the unloaded plugin is not even visited
+        expect(result.pulled).toBe(0);
+    });
+
+    it('honors the per-tick page budget and persists the continuation cursor with the OLD watermark', async () => {
+        const plugin = addSource('linear-connector');
+        plugin.pullEvents!.mockResolvedValue({ events: [], nextCursor: 'more' });
+        userRows['linear-connector'] = [{ userId: 'user-1', enabled: true }];
+        cursorRows.set(cursorKey('user-1', 'linear-connector'), {
+            cursor: null,
+            watermark: new Date('2026-07-20T00:00:00.000Z'),
+            sweepStartedAt: null,
+        });
+
+        const result = await makeService().pullSources(3);
+
+        expect(plugin.pullEvents).toHaveBeenCalledTimes(3);
+        expect(result.pages).toBe(3);
+        const saved = cursorSaveMock.mock.calls[0][0];
+        expect(saved.cursor).toBe('more');
+        expect(saved.watermark.toISOString()).toBe('2026-07-20T00:00:00.000Z');
+        expect(saved.sweepStartedAt).toBeInstanceOf(Date);
+    });
+
+    it('materializes lazy plugin proxies before pulling and tolerates a source without pullEvents', async () => {
+        const real = {
+            id: 'lazy-connector',
+            capabilities: ['event-source'],
+            pullEvents: jest.fn().mockResolvedValue({ events: [] }),
+        };
+        const lazy = {
+            id: 'lazy-connector',
+            capabilities: ['event-source'],
+            __materialize: jest.fn().mockResolvedValue(real),
+        };
+        registered.push({ plugin: lazy as unknown as FakePlugin, state: 'loaded' });
+        const empty = addSource('no-pull-connector');
+        delete empty.pullEvents;
+        userRows['lazy-connector'] = [{ userId: 'user-1', enabled: true }];
+        userRows['no-pull-connector'] = [{ userId: 'user-1', enabled: true }];
+
+        const result = await makeService().pullSources();
+
+        expect(lazy.__materialize).toHaveBeenCalledTimes(1);
+        expect(real.pullEvents).toHaveBeenCalledTimes(1);
+        expect(result.pulled).toBe(1);
+        expect(result.errors).toBe(0);
+    });
+});

--- a/packages/agent/src/ingest/__tests__/ingest.module.spec.ts
+++ b/packages/agent/src/ingest/__tests__/ingest.module.spec.ts
@@ -1,5 +1,6 @@
 /**
- * Event-ingest spine (Wave 6) — module-shape pin for EventIngestModule.
+ * Event-ingest spine (Wave 6, pull path Wave 8) — module-shape pin for
+ * EventIngestModule.
  *
  * Pattern mirrors `knowledge-base.module.spec.ts`: heavy runtime trees
  * (TypeORM, the facades/activity-log graphs) are mocked at module scope
@@ -15,6 +16,9 @@ jest.mock('@nestjs/typeorm', () => ({
 jest.mock('../../entities/ingested-event.entity', () => ({
     IngestedEvent: class IngestedEvent {},
 }));
+jest.mock('../../entities/ingest-cursor.entity', () => ({
+    IngestCursor: class IngestCursor {},
+}));
 jest.mock('../../activity-log/activity-log.module', () => ({
     ActivityLogModule: class ActivityLogModule {},
 }));
@@ -27,23 +31,41 @@ jest.mock('../ingested-event.repository', () => ({
 jest.mock('../event-ingest.service', () => ({
     EventIngestService: class EventIngestService {},
 }));
+jest.mock('../ingest-cursor.repository', () => ({
+    IngestCursorRepository: class IngestCursorRepository {},
+}));
+jest.mock('../event-source-pull.service', () => ({
+    EventSourcePullService: class EventSourcePullService {},
+}));
 
 import 'reflect-metadata';
 import { EventIngestModule } from '../ingest.module';
 import { IngestedEventRepository } from '../ingested-event.repository';
 import { EventIngestService } from '../event-ingest.service';
+import { IngestCursorRepository } from '../ingest-cursor.repository';
+import { EventSourcePullService } from '../event-source-pull.service';
 import { ActivityLogModule } from '../../activity-log/activity-log.module';
 import { FacadesModule } from '../../facades/facades.module';
 
 describe('EventIngestModule', () => {
     const meta = (key: string): unknown[] => Reflect.getMetadata(key, EventIngestModule) ?? [];
 
-    it('provides the repository and the ingest service', () => {
-        expect(meta('providers')).toEqual([IngestedEventRepository, EventIngestService]);
+    it('provides the repositories, the ingest service and the pull service', () => {
+        expect(meta('providers')).toEqual([
+            IngestedEventRepository,
+            EventIngestService,
+            IngestCursorRepository,
+            EventSourcePullService,
+        ]);
     });
 
-    it('exports both for the API surface + trigger-internal RPC wiring', () => {
-        expect(meta('exports')).toEqual([IngestedEventRepository, EventIngestService]);
+    it('exports all four for the API surface + trigger-internal RPC wiring', () => {
+        expect(meta('exports')).toEqual([
+            IngestedEventRepository,
+            EventIngestService,
+            IngestCursorRepository,
+            EventSourcePullService,
+        ]);
     });
 
     it('imports the two processor modules (Activity log + Facades) beside the entity feature', () => {
@@ -58,10 +80,12 @@ describe('ingest barrel', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const barrel = require('../index');
 
-    it('re-exports the module, service and repository', () => {
+    it('re-exports the module, services and repositories', () => {
         expect(barrel.EventIngestModule).toBe(EventIngestModule);
         expect(barrel.EventIngestService).toBe(EventIngestService);
         expect(barrel.IngestedEventRepository).toBe(IngestedEventRepository);
+        expect(barrel.EventSourcePullService).toBe(EventSourcePullService);
+        expect(barrel.IngestCursorRepository).toBe(IngestCursorRepository);
         expect(typeof barrel.buildIngestEventTools).toBe('function');
     });
 });

--- a/packages/agent/src/ingest/event-source-pull.service.ts
+++ b/packages/agent/src/ingest/event-source-pull.service.ts
@@ -1,0 +1,237 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import type { IEventSourcePlugin, IPlugin } from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
+import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
+import { UserPluginRepository } from '../plugins/repositories/user-plugin.repository';
+import { EventIngestService } from './event-ingest.service';
+import { IngestCursorRepository } from './ingest-cursor.repository';
+
+export interface PullSourcesResult {
+    /** Loaded event-source plugins visited. */
+    sources: number;
+    /** (plugin, user) pairs actually pulled. */
+    pulled: number;
+    /** `pullEvents` pages fetched across all pairs. */
+    pages: number;
+    /** New `ingested_events` rows written. */
+    inserted: number;
+    /** Envelopes dropped as duplicates by the dedupe insert. */
+    duplicates: number;
+    /** Envelopes rejected by the ingest floor (shape/size). */
+    rejected: number;
+    /** (plugin, user) pairs that failed — never fail the batch. */
+    errors: number;
+}
+
+/**
+ * Per-tick page budget for one (plugin, user) pair. A sweep larger
+ * than this persists its continuation cursor and resumes next tick, so
+ * a single noisy source can never monopolize the cron slot.
+ */
+export const EVENT_SOURCE_PULL_PAGE_BUDGET = 5;
+
+/** `since` handed to a source that has never completed a sweep. */
+const EPOCH_ISO = new Date(0).toISOString();
+
+/**
+ * Event-ingest spine (Wave 8) — the PULL half of the
+ * `event-ingest-tick` cron.
+ *
+ * `processBatch()` (EventIngestService) drains rows that already
+ * landed; this service is what makes rows land for pull-model sources:
+ * for every loaded `event-source` plugin it resolves the users who
+ * enabled it (their `user_plugins` rows, confirmed through the same
+ * `isPluginEnabledForScope` gate the facades use), resolves their
+ * settings (4-level hierarchy, secrets included) and calls
+ * `pullEvents` with the persisted per-(user, plugin) watermark +
+ * continuation cursor (`ingest_cursors`).
+ *
+ * Sweep/watermark protocol:
+ *   - `since` = the row's `watermark` (epoch when none — connectors
+ *     interpret that as "first pull" and apply their own opt-in
+ *     backfill window).
+ *   - a sweep that exhausts the page budget persists `cursor` +
+ *     `sweepStartedAt` and resumes next tick with the SAME watermark;
+ *   - on completion the watermark advances to when the sweep STARTED
+ *     (never "now"), so events landing mid-sweep are re-covered next
+ *     tick — overlap is free, the pipeline dedupes on
+ *     `(source, sourceEventId)`.
+ *
+ * Isolation: every (plugin, user) pair is pulled inside its own
+ * try/catch — one broken connector (or one user's revoked credentials)
+ * never stops the rest of the batch. `EventSourceNotConfiguredError`
+ * is the expected quiet case (enabled but not yet configured) — debug,
+ * not warn.
+ *
+ * The plugin-system dependencies are `@Optional()`: they are `@Global`
+ * providers in the API process (the only place this service runs — the
+ * cron reaches it over the trigger-internal RPC channel) but absent in
+ * lean test bootstraps, where `pullSources()` degrades to a no-op.
+ */
+@Injectable()
+export class EventSourcePullService {
+    private readonly logger = new Logger(EventSourcePullService.name);
+
+    constructor(
+        private readonly eventIngestService: EventIngestService,
+        private readonly cursorRepository: IngestCursorRepository,
+        @Optional() private readonly registry?: PluginRegistryService,
+        @Optional() private readonly settingsService?: PluginSettingsService,
+        @Optional() private readonly userPluginRepository?: UserPluginRepository,
+    ) {}
+
+    /** Pull every enabled event-source plugin for every opted-in user. */
+    async pullSources(pageBudget = EVENT_SOURCE_PULL_PAGE_BUDGET): Promise<PullSourcesResult> {
+        const result: PullSourcesResult = {
+            sources: 0,
+            pulled: 0,
+            pages: 0,
+            inserted: 0,
+            duplicates: 0,
+            rejected: 0,
+            errors: 0,
+        };
+
+        if (!this.registry || !this.settingsService || !this.userPluginRepository) {
+            this.logger.debug('Plugin system not wired in this runtime — skipping source pull');
+            return result;
+        }
+
+        const registered = this.registry.getByCapability(PLUGIN_CAPABILITIES.EVENT_SOURCE);
+        for (const reg of registered) {
+            if (reg.state !== 'loaded') continue;
+            result.sources += 1;
+            const pluginId = reg.plugin.id;
+
+            let rows;
+            try {
+                rows = await this.userPluginRepository.findByPlugin(pluginId);
+            } catch (error) {
+                result.errors += 1;
+                this.logger.warn(
+                    `Could not list users for event-source plugin ${pluginId}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+                continue;
+            }
+
+            for (const row of rows) {
+                if (!row.enabled || !row.userId) continue;
+                try {
+                    const enabled = await this.registry.isPluginEnabledForScope(
+                        pluginId,
+                        undefined,
+                        row.userId,
+                    );
+                    if (!enabled) continue;
+                    const pulled = await this.pullForUser(
+                        reg.plugin,
+                        pluginId,
+                        row.userId,
+                        pageBudget,
+                        result,
+                    );
+                    if (pulled) result.pulled += 1;
+                } catch (error) {
+                    // Isolation contract: one (plugin, user) failure never
+                    // stops the rest of the batch.
+                    result.errors += 1;
+                    const message = `Event-source pull failed for ${pluginId} / user ${row.userId}: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`;
+                    const notConfigured =
+                        error instanceof Error && error.name === 'EventSourceNotConfiguredError';
+                    if (notConfigured) {
+                        this.logger.debug(message);
+                    } else {
+                        this.logger.warn(message);
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private async pullForUser(
+        candidate: IPlugin,
+        pluginId: string,
+        userId: string,
+        pageBudget: number,
+        result: PullSourcesResult,
+    ): Promise<boolean> {
+        const plugin = (await this.materializeForUse(candidate)) as IEventSourcePlugin;
+        // Lazy proxies over-report optional methods — tolerate a source
+        // that materializes without a real pullEvents (see the lazy-plugin
+        // proxy over-reporting gotcha).
+        if (typeof plugin.pullEvents !== 'function') return false;
+
+        const settings = await this.settingsService!.getSettings(pluginId, {
+            userId,
+            includeSecrets: true,
+        });
+
+        const row = await this.cursorRepository.findByUserAndPlugin(userId, pluginId);
+        const since = row?.watermark ? row.watermark.toISOString() : EPOCH_ISO;
+        let cursor = row?.cursor ?? undefined;
+        // Resuming an in-flight sweep keeps its original start; a fresh
+        // sweep starts now — the watermark advances to this on completion.
+        const sweepStartedAt = cursor && row?.sweepStartedAt ? row.sweepStartedAt : new Date();
+
+        for (let page = 0; page < pageBudget; page += 1) {
+            const pull = await plugin.pullEvents({
+                since,
+                ...(cursor ? { cursor } : {}),
+                settings,
+            });
+            result.pages += 1;
+
+            if (pull.events.length > 0) {
+                const ingest = await this.eventIngestService.ingest(userId, pull.events);
+                result.inserted += ingest.inserted;
+                result.duplicates += ingest.duplicates;
+                result.rejected += ingest.rejected;
+            }
+
+            cursor = pull.nextCursor;
+            if (!cursor) break;
+        }
+
+        if (cursor) {
+            // Budget exhausted mid-sweep — persist the resume point and keep
+            // the old watermark so later pages use the same window.
+            await this.cursorRepository.save({
+                userId,
+                pluginId,
+                cursor,
+                watermark: row?.watermark ?? null,
+                sweepStartedAt,
+            });
+        } else {
+            // Sweep complete — advance the watermark to the sweep start.
+            await this.cursorRepository.save({
+                userId,
+                pluginId,
+                cursor: null,
+                watermark: sweepStartedAt,
+                sweepStartedAt: null,
+            });
+        }
+        return true;
+    }
+
+    /**
+     * Materialize a (possibly lazy) plugin before use — a cold proxy's
+     * synchronous surface is empty and its method calls come back
+     * promise-wrapped (same rationale as `BaseFacadeService`).
+     */
+    private async materializeForUse(plugin: IPlugin): Promise<IPlugin> {
+        const stub = plugin as unknown as { __materialize?: () => Promise<IPlugin> };
+        if (typeof stub.__materialize === 'function') {
+            return stub.__materialize();
+        }
+        return plugin;
+    }
+}

--- a/packages/agent/src/ingest/index.ts
+++ b/packages/agent/src/ingest/index.ts
@@ -4,5 +4,8 @@
 export * from './ingest.module';
 export * from './event-ingest.service';
 export * from './ingested-event.repository';
+export * from './event-source-pull.service';
+export * from './ingest-cursor.repository';
 export * from './agent-ingest-tools';
 export { IngestedEvent } from '../entities/ingested-event.entity';
+export { IngestCursor } from '../entities/ingest-cursor.entity';

--- a/packages/agent/src/ingest/ingest-cursor.repository.ts
+++ b/packages/agent/src/ingest/ingest-cursor.repository.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { IngestCursor } from '../entities/ingest-cursor.entity';
+
+export interface SaveIngestCursorData {
+    userId: string;
+    pluginId: string;
+    cursor?: string | null;
+    watermark?: Date | null;
+    sweepStartedAt?: Date | null;
+}
+
+/**
+ * Event-ingest spine (Wave 8) — per-(user, plugin) pull-state rows for
+ * the event-source pull path. Feature-owned repository (provided by
+ * `EventIngestModule`, not `DatabaseModule` — same split as
+ * `IngestedEventRepository`).
+ */
+@Injectable()
+export class IngestCursorRepository {
+    constructor(
+        @InjectRepository(IngestCursor)
+        private readonly repository: Repository<IngestCursor>,
+    ) {}
+
+    async findByUserAndPlugin(userId: string, pluginId: string): Promise<IngestCursor | null> {
+        return this.repository.findOne({ where: { userId, pluginId } });
+    }
+
+    /**
+     * Upsert the pull state for one (user, plugin). Check-then-insert
+     * is not atomic; the UNIQUE-index race is resolved by retrying as
+     * an update (same convention as `IngestedEventRepository`).
+     */
+    async save(data: SaveIngestCursorData): Promise<IngestCursor> {
+        const existing = await this.findByUserAndPlugin(data.userId, data.pluginId);
+        if (existing) {
+            existing.cursor = data.cursor ?? null;
+            existing.watermark = data.watermark ?? null;
+            existing.sweepStartedAt = data.sweepStartedAt ?? null;
+            return this.repository.save(existing);
+        }
+        try {
+            return await this.repository.save(this.repository.create({ ...data }));
+        } catch (error) {
+            if (this.isUniqueViolation(error)) {
+                const winner = await this.findByUserAndPlugin(data.userId, data.pluginId);
+                if (winner) {
+                    winner.cursor = data.cursor ?? null;
+                    winner.watermark = data.watermark ?? null;
+                    winner.sweepStartedAt = data.sweepStartedAt ?? null;
+                    return this.repository.save(winner);
+                }
+            }
+            throw error;
+        }
+    }
+
+    private isUniqueViolation(error: unknown): boolean {
+        if (!error || typeof error !== 'object') return false;
+        const driverCode = (error as { driverError?: { code?: string } }).driverError?.code;
+        const topCode = (error as { code?: string }).code;
+        const codes = ['23505', 'ER_DUP_ENTRY', 'SQLITE_CONSTRAINT'];
+        return codes.includes(driverCode as string) || codes.includes(topCode as string);
+    }
+}

--- a/packages/agent/src/ingest/ingest.module.ts
+++ b/packages/agent/src/ingest/ingest.module.ts
@@ -1,32 +1,51 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { IngestedEvent } from '../entities/ingested-event.entity';
+import { IngestCursor } from '../entities/ingest-cursor.entity';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { FacadesModule } from '../facades/facades.module';
 import { IngestedEventRepository } from './ingested-event.repository';
 import { EventIngestService } from './event-ingest.service';
+import { IngestCursorRepository } from './ingest-cursor.repository';
+import { EventSourcePullService } from './event-source-pull.service';
 
 /**
- * Event-ingest spine (Wave 6) — agent-side module owning the
- * `ingested_events` surface: dedupe-insert (`ingest`) + the processor
- * fan-out to Activity log and agent Memory (`processBatch`, driven by
- * the `event-ingest-tick` cron over the trigger-internal RPC channel).
+ * Event-ingest spine (Wave 6, pull path Wave 8) — agent-side module
+ * owning the `ingested_events` surface: dedupe-insert (`ingest`) + the
+ * processor fan-out to Activity log and agent Memory (`processBatch`,
+ * driven by the `event-ingest-tick` cron over the trigger-internal RPC
+ * channel), plus the PULL half of the same cron
+ * (`EventSourcePullService.pullSources()` — iterates enabled
+ * event-source plugins per user with persisted `ingest_cursors`
+ * watermarks/continuation cursors). The plugin-system services the
+ * pull path needs (registry / settings / user-plugin rows) are
+ * `@Global` providers in the API process and injected `@Optional()`.
  *
- * `IngestedEvent` MUST also stay registered in the DataSource ENTITIES
- * array (`database/_entities-inventory.ts`) — this repo has no
- * `autoLoadEntities`, so a forFeature'd-but-unregistered entity throws
- * EntityMetadataNotFoundError on first query.
+ * `IngestedEvent` + `IngestCursor` MUST also stay registered in the
+ * DataSource ENTITIES array (`database/_entities-inventory.ts`) — this
+ * repo has no `autoLoadEntities`, so a forFeature'd-but-unregistered
+ * entity throws EntityMetadataNotFoundError on first query.
  */
 @Module({
     imports: [
-        TypeOrmModule.forFeature([IngestedEvent]),
+        TypeOrmModule.forFeature([IngestedEvent, IngestCursor]),
         // Processor 1 — Activity-log rows with sourceUrl provenance.
         ActivityLogModule,
         // Processor 2 — best-effort Memory observations via
         // AgentMemoryFacadeService (exported by FacadesModule).
         FacadesModule,
     ],
-    providers: [IngestedEventRepository, EventIngestService],
-    exports: [IngestedEventRepository, EventIngestService],
+    providers: [
+        IngestedEventRepository,
+        EventIngestService,
+        IngestCursorRepository,
+        EventSourcePullService,
+    ],
+    exports: [
+        IngestedEventRepository,
+        EventIngestService,
+        IngestCursorRepository,
+        EventSourcePullService,
+    ],
 })
 export class EventIngestModule {}

--- a/packages/plugin/src/contracts/facade-capabilities.ts
+++ b/packages/plugin/src/contracts/facade-capabilities.ts
@@ -54,6 +54,7 @@ export const PLUGIN_CAPABILITIES = {
 	CONNECTOR_SLACK: 'connector-slack',
 	CONNECTOR_DISCORD: 'connector-discord',
 	CONNECTOR_WHATSAPP: 'connector-whatsapp',
+	CONNECTOR_LINEAR: 'connector-linear',
 	CONNECTOR_NOTION: 'connector-notion',
 	CONNECTOR_MICROSOFT_365: 'connector-microsoft-365',
 	// Pluggable persistent memory for AI coding / generation agents.

--- a/packages/plugins/linear-connector/README.md
+++ b/packages/plugins/linear-connector/README.md
@@ -1,0 +1,33 @@
+# @ever-works/linear-connector-plugin
+
+First-party **Linear connector** for the Ever Works platform (Wave 8), built on
+the official [`@linear/sdk`](https://www.npmjs.com/package/@linear/sdk).
+
+Capabilities: `connector`, `connector-linear`, `event-source`.
+
+## What it does
+
+- **Outbound** — `send()` posts a comment on a Linear issue
+  (`targetConfig.issueId` / `defaultIssueId`), idempotent on `messageRef`.
+- **Event source** — `pullEvents()` sweeps issues (created/updated) and then
+  comments since the platform watermark, normalized into
+  `IngestedEventEnvelope`s (`linear.issue` / `linear.comment`) for the
+  event-ingest spine. Each envelope carries the issue URL as `sourceUrl` so
+  Memory/Activity rows link back to the origin.
+- **Opt-in historical backfill** — `backfillDays` (default `0` = off, max 90)
+  widens the FIRST pull's window only, bounded to
+  `LINEAR_BACKFILL_MAX_PAGES` pages per phase.
+
+## Settings
+
+| Key              | Notes                                                        |
+| ---------------- | ------------------------------------------------------------ |
+| `apiKey`         | Linear API key (`lin_api_…`) — secret, env `LINEAR_API_KEY`. |
+| `teamIds`        | Optional comma-separated team-id filter for the pull.        |
+| `backfillDays`   | Opt-in first-pull history window (0 = off, max 90).          |
+| `defaultIssueId` | Default issue for outbound comments.                         |
+
+## Testing
+
+Hermetic Vitest suite (`pnpm test`) — the SDK client is stubbed through the
+`createClient` seam; no network calls.

--- a/packages/plugins/linear-connector/package.json
+++ b/packages/plugins/linear-connector/package.json
@@ -1,0 +1,96 @@
+{
+	"name": "@ever-works/linear-connector-plugin",
+	"version": "1.0.0",
+	"description": "Linear connector plugin for Ever Works platform (outbound issue comments via @linear/sdk and event-source pull of issues/comments into the event-ingest pipeline, with opt-in historical backfill)",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@ever-works/contracts": "workspace:*",
+		"@ever-works/plugin": "workspace:*",
+		"@linear/sdk": "^88.0.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "linear-connector",
+			"name": "Linear Connector",
+			"version": "1.0.0",
+			"category": "connector",
+			"capabilities": [
+				"connector",
+				"connector-linear",
+				"event-source"
+			],
+			"description": "Linear connector. Outbound posts comments on Linear issues via the official @linear/sdk. Event-source pull ingests issues (created/updated) and comments since the last watermark into the platform event-ingest pipeline, with opt-in historical backfill (backfillDays, max 90).",
+			"systemPlugin": false,
+			"builtIn": true,
+			"isDefault": false,
+			"autoEnable": false,
+			"settings": {
+				"type": "object",
+				"required": [
+					"apiKey"
+				],
+				"properties": {
+					"apiKey": {
+						"type": "string",
+						"title": "Linear API key (lin_api_…)",
+						"x-secret": true,
+						"x-envVar": "LINEAR_API_KEY"
+					},
+					"teamIds": {
+						"type": "string",
+						"title": "Team ids to ingest events from (comma-separated; all teams when empty)"
+					},
+					"backfillDays": {
+						"type": "number",
+						"title": "Historical backfill window in days on first pull (0 = off, max 90)",
+						"default": 0,
+						"minimum": 0,
+						"maximum": 90
+					},
+					"defaultIssueId": {
+						"type": "string",
+						"title": "Default issue id for outbound comments"
+					}
+				}
+			}
+		}
+	},
+	"publishConfig": {
+		"access": "restricted",
+		"registry": "https://registry.npmjs.org"
+	}
+}

--- a/packages/plugins/linear-connector/src/index.ts
+++ b/packages/plugins/linear-connector/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @ever-works/linear-connector-plugin — Linear connector (Wave 8).
+ * Outbound issue comments via the official `@linear/sdk`; `pullEvents`
+ * event-source leg (issues + comments since watermark, opt-in
+ * historical backfill) feeding the platform event-ingest spine.
+ */
+export {
+	LinearConnectorPlugin,
+	linearConnectorPlugin,
+	clampBackfillDays,
+	LINEAR_EVENT_TEXT_MAX_CHARS,
+	LINEAR_PULL_PAGE_SIZE,
+	LINEAR_BACKFILL_MAX_PAGES
+} from './linear-connector-plugin.js';

--- a/packages/plugins/linear-connector/src/linear-connector-plugin.spec.ts
+++ b/packages/plugins/linear-connector/src/linear-connector-plugin.spec.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	LinearConnectorPlugin,
+	clampBackfillDays,
+	LINEAR_EVENT_TEXT_MAX_CHARS,
+	LINEAR_BACKFILL_MAX_PAGES
+} from './linear-connector-plugin.js';
+
+const viewerMock = vi.fn();
+const issuesMock = vi.fn();
+const commentsMock = vi.fn();
+const createCommentMock = vi.fn();
+const clientFactoryMock = vi.fn();
+
+/** Subclass overriding the client seam so no real SDK call ever happens. */
+class TestLinearConnectorPlugin extends LinearConnectorPlugin {
+	protected override createClient(apiKey: string) {
+		clientFactoryMock(apiKey);
+		return {
+			get viewer() {
+				return viewerMock();
+			},
+			issues: issuesMock,
+			comments: commentsMock,
+			createComment: createCommentMock
+		};
+	}
+}
+
+const SETTINGS = { apiKey: 'lin_api_secret_123' };
+
+function emptyPage() {
+	return { nodes: [], pageInfo: { hasNextPage: false } };
+}
+
+describe('LinearConnectorPlugin', () => {
+	let plugin: TestLinearConnectorPlugin;
+
+	beforeEach(() => {
+		plugin = new TestLinearConnectorPlugin();
+		viewerMock.mockReset();
+		issuesMock.mockReset();
+		commentsMock.mockReset();
+		createCommentMock.mockReset();
+		clientFactoryMock.mockReset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('declares the connector + connector-linear + event-source capabilities and poll metadata', () => {
+		expect(plugin.id).toBe('linear-connector');
+		expect(plugin.category).toBe('connector');
+		expect(plugin.capabilities).toContain('connector');
+		expect(plugin.capabilities).toContain('connector-linear');
+		expect(plugin.capabilities).toContain('event-source');
+		expect(plugin.providerName).toBe('linear');
+		expect(plugin.connector.direction).toBe('outbound');
+		expect(plugin.connector.transport).toBe('poll');
+		expect(plugin.connector.flags.outboundMessage).toBe(true);
+		expect(plugin.connector.flags.inbound).toBe(false);
+	});
+
+	it('marks apiKey as x-secret and bounds backfillDays to 0–90 in the settings schema', () => {
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.apiKey['x-secret']).toBe(true);
+		expect(plugin.settingsSchema.required).toContain('apiKey');
+		expect(props.backfillDays.default).toBe(0);
+		expect(props.backfillDays.minimum).toBe(0);
+		expect(props.backfillDays.maximum).toBe(90);
+	});
+
+	it('clampBackfillDays clamps to the 0–90 range and treats garbage as off', () => {
+		expect(clampBackfillDays(0)).toBe(0);
+		expect(clampBackfillDays(-5)).toBe(0);
+		expect(clampBackfillDays(30)).toBe(30);
+		expect(clampBackfillDays(90.9)).toBe(90);
+		expect(clampBackfillDays(500)).toBe(90);
+		expect(clampBackfillDays('nope')).toBe(0);
+		expect(clampBackfillDays(undefined)).toBe(0);
+	});
+
+	describe('verifyConnection', () => {
+		it('returns valid + viewer details when the viewer lookup succeeds', async () => {
+			viewerMock.mockResolvedValueOnce({ id: 'user-1', name: 'Ada', email: 'ada@acme.dev' });
+			const res = await plugin.verifyConnection({ apiKey: 'lin_api_x' }, {});
+			expect(res.valid).toBe(true);
+			expect(res.details).toMatchObject({ viewerId: 'user-1', viewerName: 'Ada' });
+			expect(clientFactoryMock).toHaveBeenCalledWith('lin_api_x');
+		});
+
+		it('returns invalid without calling the API when apiKey is missing', async () => {
+			const res = await plugin.verifyConnection({}, {});
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/apiKey/);
+			expect(clientFactoryMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('send', () => {
+		const options = { connectorId: 'conn-1', settings: SETTINGS };
+
+		it('creates a comment on the resolved issue and returns its id', async () => {
+			createCommentMock.mockResolvedValueOnce({ success: true, comment: Promise.resolve({ id: 'comment-9' }) });
+			const res = await plugin.send(
+				{
+					text: 'hello from the platform',
+					messageRef: 'ref-1',
+					attribution: { userId: 'u1' },
+					target: { issueId: 'issue-7' }
+				},
+				options
+			);
+			expect(createCommentMock).toHaveBeenCalledWith({ issueId: 'issue-7', body: 'hello from the platform' });
+			expect(res.provider).toBe('linear-connector');
+			expect(res.providerMessageId).toBe('comment-9');
+		});
+
+		it('is idempotent on messageRef — a retry never double-posts', async () => {
+			createCommentMock.mockResolvedValue({ success: true, comment: Promise.resolve({ id: 'comment-1' }) });
+			const payload = {
+				text: 'once only',
+				messageRef: 'ref-dup',
+				attribution: { userId: 'u1' },
+				target: { issueId: 'issue-1' }
+			};
+			const first = await plugin.send(payload, options);
+			const second = await plugin.send(payload, options);
+			expect(createCommentMock).toHaveBeenCalledTimes(1);
+			expect(second).toBe(first);
+		});
+
+		it('throws a clear error when no issue id can be resolved', async () => {
+			await expect(
+				plugin.send({ text: 'x', messageRef: 'r', attribution: { userId: 'u1' } }, options)
+			).rejects.toThrow(/issue id is required/);
+			expect(createCommentMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('pullEvents', () => {
+		it('throws EventSourceNotConfiguredError when apiKey is missing', async () => {
+			await expect(plugin.pullEvents({ since: new Date(0).toISOString(), settings: {} })).rejects.toMatchObject({
+				name: 'EventSourceNotConfiguredError'
+			});
+			expect(issuesMock).not.toHaveBeenCalled();
+		});
+
+		it('first pull with backfill off uses a now-anchored window (no history)', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			issuesMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({ since: new Date(0).toISOString(), settings: SETTINGS });
+			const filter = issuesMock.mock.calls[0][0].filter;
+			expect(filter.updatedAt.gte.toISOString()).toBe('2026-07-25T12:00:00.000Z');
+		});
+
+		it('first pull with backfillDays widens the window, clamped to 90 days', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			issuesMock.mockResolvedValue(emptyPage());
+			await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				settings: { ...SETTINGS, backfillDays: 30 }
+			});
+			expect(issuesMock.mock.calls[0][0].filter.updatedAt.gte.toISOString()).toBe('2026-06-25T12:00:00.000Z');
+
+			await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				settings: { ...SETTINGS, backfillDays: 500 }
+			});
+			expect(issuesMock.mock.calls[1][0].filter.updatedAt.gte.toISOString()).toBe('2026-04-26T12:00:00.000Z');
+		});
+
+		it('a non-first pull keeps the platform watermark as the window', async () => {
+			issuesMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				settings: { ...SETTINGS, backfillDays: 30 }
+			});
+			expect(issuesMock.mock.calls[0][0].filter.updatedAt.gte.toISOString()).toBe('2026-07-20T00:00:00.000Z');
+		});
+
+		it('normalizes issues into linear.issue envelopes with subject, sourceUrl and capped payload', async () => {
+			issuesMock.mockResolvedValueOnce({
+				nodes: [
+					{
+						id: 'iss-1',
+						identifier: 'ENG-42',
+						title: 'Fix the flux capacitor',
+						description: 'd'.repeat(LINEAR_EVENT_TEXT_MAX_CHARS + 100),
+						url: 'https://linear.app/acme/issue/ENG-42',
+						createdAt: new Date('2026-07-21T10:00:00.000Z'),
+						updatedAt: new Date('2026-07-22T10:00:00.000Z')
+					}
+				],
+				pageInfo: { hasNextPage: false }
+			});
+			const res = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(res.events).toHaveLength(1);
+			const env = res.events[0];
+			expect(env.source).toBe('linear-connector');
+			expect(env.kind).toBe('linear.issue');
+			expect(env.sourceEventId).toBe('iss-1:2026-07-22T10:00:00.000Z');
+			expect(env.occurredAt).toBe('2026-07-22T10:00:00.000Z');
+			expect(env.subject).toEqual({ type: 'issue', externalId: 'iss-1', title: 'Fix the flux capacitor' });
+			expect(env.sourceUrl).toBe('https://linear.app/acme/issue/ENG-42');
+			expect(env.payload.changeType).toBe('created');
+			expect((env.payload.description as string).length).toBe(LINEAR_EVENT_TEXT_MAX_CHARS);
+			// The API key must never leak into the envelope.
+			expect(JSON.stringify(res.events)).not.toContain(SETTINGS.apiKey);
+		});
+
+		it('passes the team filter when teamIds is configured', async () => {
+			issuesMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				settings: { ...SETTINGS, teamIds: 'team-a, team-b' }
+			});
+			expect(issuesMock.mock.calls[0][0].filter.team).toEqual({ id: { in: ['team-a', 'team-b'] } });
+		});
+
+		it('pages issues via the SDK cursor and keeps the SAME window across pages', async () => {
+			issuesMock.mockResolvedValueOnce({
+				nodes: [],
+				pageInfo: { hasNextPage: true, endCursor: 'page-2' }
+			});
+			const first = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(first.nextCursor).toBeDefined();
+			const parsed = JSON.parse(first.nextCursor as string);
+			expect(parsed).toMatchObject({ p: 'issues', n: 'page-2', s: '2026-07-20T00:00:00.000Z' });
+
+			issuesMock.mockResolvedValueOnce(emptyPage());
+			await plugin.pullEvents({
+				since: '2026-07-24T00:00:00.000Z', // a moved watermark must NOT shift the running sweep
+				cursor: first.nextCursor,
+				settings: SETTINGS
+			});
+			const args = issuesMock.mock.calls[1][0];
+			expect(args.after).toBe('page-2');
+			expect(args.filter.updatedAt.gte.toISOString()).toBe('2026-07-20T00:00:00.000Z');
+		});
+
+		it('advances issues → comments → done across the sweep', async () => {
+			issuesMock.mockResolvedValueOnce(emptyPage());
+			const afterIssues = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(JSON.parse(afterIssues.nextCursor as string).p).toBe('comments');
+
+			commentsMock.mockResolvedValueOnce(emptyPage());
+			const afterComments = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: afterIssues.nextCursor,
+				settings: SETTINGS
+			});
+			expect(commentsMock).toHaveBeenCalledTimes(1);
+			expect(afterComments.nextCursor).toBeUndefined();
+		});
+
+		it('normalizes comments with the awaited parent issue as subject', async () => {
+			commentsMock.mockResolvedValueOnce({
+				nodes: [
+					{
+						id: 'com-1',
+						body: 'b'.repeat(LINEAR_EVENT_TEXT_MAX_CHARS + 5),
+						url: 'https://linear.app/acme/issue/ENG-42#comment-com-1',
+						createdAt: '2026-07-22T11:00:00.000Z',
+						updatedAt: '2026-07-22T11:00:00.000Z',
+						issue: Promise.resolve({
+							id: 'iss-1',
+							identifier: 'ENG-42',
+							title: 'Fix the flux capacitor',
+							url: 'https://linear.app/acme/issue/ENG-42'
+						})
+					}
+				],
+				pageInfo: { hasNextPage: false }
+			});
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: JSON.stringify({ p: 'comments', s: '2026-07-20T00:00:00.000Z', b: 0 }),
+				settings: SETTINGS
+			});
+			expect(res.events).toHaveLength(1);
+			const env = res.events[0];
+			expect(env.kind).toBe('linear.comment');
+			expect(env.subject).toEqual({ type: 'issue', externalId: 'iss-1', title: 'Fix the flux capacitor' });
+			expect(env.sourceUrl).toBe('https://linear.app/acme/issue/ENG-42#comment-com-1');
+			expect((env.payload.body as string).length).toBe(LINEAR_EVENT_TEXT_MAX_CHARS);
+		});
+
+		it('bounds backfill sweeps to the per-phase page budget', async () => {
+			issuesMock.mockResolvedValueOnce({
+				nodes: [],
+				pageInfo: { hasNextPage: true, endCursor: 'more-issues' }
+			});
+			// Backfill sweep, one page short of the bound: this page exhausts it.
+			const res = await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				cursor: JSON.stringify({
+					p: 'issues',
+					n: 'page-n',
+					s: '2026-05-01T00:00:00.000Z',
+					f: 1,
+					b: LINEAR_BACKFILL_MAX_PAGES - 1
+				}),
+				settings: { ...SETTINGS, backfillDays: 90 }
+			});
+			// Budget hit mid-issues: jump to the comments phase instead of paging on.
+			const parsed = JSON.parse(res.nextCursor as string);
+			expect(parsed.p).toBe('comments');
+			expect(parsed.n).toBeUndefined();
+			expect(parsed.b).toBe(0);
+		});
+
+		it('treats a malformed cursor as a fresh sweep instead of crashing', async () => {
+			issuesMock.mockResolvedValueOnce(emptyPage());
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: 'not-json{{{',
+				settings: SETTINGS
+			});
+			expect(issuesMock).toHaveBeenCalledTimes(1);
+			expect(res.events).toEqual([]);
+		});
+	});
+});

--- a/packages/plugins/linear-connector/src/linear-connector-plugin.ts
+++ b/packages/plugins/linear-connector/src/linear-connector-plugin.ts
@@ -1,0 +1,476 @@
+import { randomUUID } from 'node:crypto';
+import { LinearClient } from '@linear/sdk';
+import type {
+	IConnectorPlugin,
+	IEventSourcePlugin,
+	ConnectorMetadata,
+	ConnectorCallOptions,
+	ChannelSendInput,
+	ChannelSendResult,
+	ChannelTargetConfig,
+	ChannelVerification,
+	EventSourcePullInput,
+	EventSourcePullResult,
+	PluginCategory,
+	PluginSettings,
+	JsonSchema
+} from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+
+/**
+ * Payload text cap for ingested envelopes. Envelope payloads are
+ * size-capped platform-side (32 KB serialized); issue descriptions and
+ * comment bodies never need more than this to be useful in
+ * Memory/Activities.
+ */
+export const LINEAR_EVENT_TEXT_MAX_CHARS = 4000;
+
+/** Items requested per Linear page (issues and comments alike). */
+export const LINEAR_PULL_PAGE_SIZE = 50;
+
+/**
+ * Historical backfill bound: at most this many pages per phase
+ * (issues, then comments) during the opt-in first-pull backfill, so a
+ * large workspace can never turn activation into an unbounded crawl.
+ */
+export const LINEAR_BACKFILL_MAX_PAGES = 10;
+
+/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+export function clampBackfillDays(value: unknown): number {
+	const num = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(num) || num <= 0) return 0;
+	return Math.min(Math.floor(num), 90);
+}
+
+function truncateText(text: string): string {
+	return text.length > LINEAR_EVENT_TEXT_MAX_CHARS ? text.slice(0, LINEAR_EVENT_TEXT_MAX_CHARS) : text;
+}
+
+/** Parse the team filter list: comma/space separated ids → array. */
+function resolveTeamIds(settings: PluginSettings | undefined): string[] {
+	const raw = settings?.teamIds;
+	if (typeof raw === 'string' && raw.trim().length > 0) {
+		return raw
+			.split(/[\s,]+/)
+			.map((t) => t.trim())
+			.filter((t) => t.length > 0);
+	}
+	return [];
+}
+
+/** Extract a readable message from a `@linear/sdk` error. */
+function linearErrorMessage(err: unknown): string {
+	const e = err as { message?: string; type?: string };
+	return e.message ?? e.type ?? 'unknown error';
+}
+
+/** Date | ISO string | undefined → ISO 8601 (epoch on garbage). */
+function toIso(value: unknown): string {
+	if (value instanceof Date) return value.toISOString();
+	if (typeof value === 'string') {
+		const ms = Date.parse(value);
+		if (Number.isFinite(ms)) return new Date(ms).toISOString();
+	}
+	return new Date(0).toISOString();
+}
+
+/**
+ * Opaque pull cursor. `p` is the sweep phase (issues → comments), `n`
+ * the SDK page cursor, `s` the effective since-watermark the sweep was
+ * started with (kept here so later pages of the same sweep use the
+ * SAME window), `f` flags a first-pull backfill sweep and `b` counts
+ * pages used in the current phase (backfill page bound). Malformed
+ * input restarts the sweep — safe, the ingest pipeline dedupes on
+ * `(source, sourceEventId)`.
+ */
+interface LinearPullCursor {
+	p: 'issues' | 'comments';
+	n?: string;
+	s: string;
+	f?: 1;
+	b?: number;
+}
+
+function parsePullCursor(cursor: string | undefined): LinearPullCursor | undefined {
+	if (!cursor) return undefined;
+	try {
+		const parsed = JSON.parse(cursor) as LinearPullCursor;
+		if (parsed && (parsed.p === 'issues' || parsed.p === 'comments') && typeof parsed.s === 'string') {
+			return parsed;
+		}
+	} catch {
+		// fall through — treat as no cursor
+	}
+	return undefined;
+}
+
+/** Minimal scalar shape of an issue node we consume. */
+interface LinearIssueNode {
+	id?: string;
+	identifier?: string;
+	title?: string;
+	description?: string;
+	url?: string;
+	createdAt?: Date | string;
+	updatedAt?: Date | string;
+}
+
+/** Minimal scalar shape of a comment node we consume. */
+interface LinearCommentNode {
+	id?: string;
+	body?: string;
+	url?: string;
+	createdAt?: Date | string;
+	updatedAt?: Date | string;
+	/** Lazy parent-issue fetch (awaited per node, best-effort). */
+	issue?: Promise<LinearIssueNode | undefined> | LinearIssueNode;
+}
+
+interface LinearConnectionPage<T> {
+	nodes?: T[];
+	pageInfo?: { hasNextPage?: boolean; endCursor?: string };
+}
+
+/** The subset of the `LinearClient` surface this plugin calls. */
+interface LinearClientLike {
+	viewer: Promise<{ id?: string; name?: string; email?: string }>;
+	issues(args: Record<string, unknown>): Promise<LinearConnectionPage<LinearIssueNode>>;
+	comments(args: Record<string, unknown>): Promise<LinearConnectionPage<LinearCommentNode>>;
+	createComment(input: {
+		issueId: string;
+		body: string;
+	}): Promise<{ success?: boolean; comment?: Promise<{ id?: string } | undefined> | { id?: string } }>;
+}
+
+function resolveApiKey(config: ChannelTargetConfig, options: ConnectorCallOptions): string | undefined {
+	const candidates = [config.apiKey, options.settings?.apiKey];
+	for (const c of candidates) {
+		if (typeof c === 'string' && c.length > 0) return c;
+	}
+	return undefined;
+}
+
+/**
+ * Resolve the destination issue id for an outbound comment. A per-send
+ * `issueId` overrides the connection's `defaultIssueId`; the resolved
+ * plugin `settings` default is the final fallback.
+ */
+function resolveIssueId(config: ChannelTargetConfig, options: ConnectorCallOptions): string {
+	const candidates = [config.issueId, config.defaultIssueId, options.settings?.defaultIssueId];
+	for (const c of candidates) {
+		if (typeof c === 'string' && c.length > 0) return c;
+	}
+	throw new Error('linear-connector: an issue id is required (targetConfig.issueId or defaultIssueId)');
+}
+
+/**
+ * Linear connector (Wave 8) — first-party native connector.
+ *
+ * Outbound: posts comments on Linear issues via `createComment` on the
+ * official `@linear/sdk` (API-key auth; the SDK pins the GraphQL host,
+ * so there is no SSRF surface).
+ *
+ * Event source: `pullEvents` sweeps issues (created/updated) then
+ * comments since the watermark, normalized into
+ * `IngestedEventEnvelope`s (`linear.issue` / `linear.comment`, issue
+ * url as `sourceUrl`) for the platform's event-ingest spine. The
+ * opt-in historical backfill (`backfillDays`, default 0 = off, max 90)
+ * widens the FIRST pull's window only, with a per-phase page bound so
+ * activation never becomes an unbounded crawl. Re-delivery across
+ * overlapping windows is fine — the ingest pipeline dedupes on
+ * `(source, sourceEventId)`.
+ */
+export class LinearConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin {
+	readonly id = 'linear-connector';
+	readonly name = 'Linear Connector';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'connector';
+	readonly capabilities = [
+		PLUGIN_CAPABILITIES.CONNECTOR,
+		PLUGIN_CAPABILITIES.CONNECTOR_LINEAR,
+		PLUGIN_CAPABILITIES.EVENT_SOURCE
+	] as const;
+
+	readonly providerName = 'linear';
+
+	readonly connector: ConnectorMetadata = {
+		direction: 'outbound',
+		transport: 'poll',
+		flags: {
+			outboundMessage: true,
+			outboundRecord: false,
+			inbound: false,
+			reply: false,
+			pairing: false,
+			richOutbound: false
+		}
+	};
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		required: ['apiKey'],
+		properties: {
+			apiKey: {
+				type: 'string',
+				title: 'Linear API key (lin_api_…)',
+				'x-secret': true,
+				'x-envVar': 'LINEAR_API_KEY'
+			},
+			teamIds: {
+				type: 'string',
+				title: 'Team ids to ingest events from (comma-separated; all teams when empty)'
+			},
+			backfillDays: {
+				type: 'number',
+				title: 'Historical backfill window in days on first pull (0 = off, max 90)',
+				default: 0,
+				minimum: 0,
+				maximum: 90
+			},
+			defaultIssueId: {
+				type: 'string',
+				title: 'Default issue id for outbound comments'
+			}
+		}
+	};
+
+	private readonly idempotencyCache = new Map<string, ChannelSendResult>();
+
+	async onLoad(): Promise<void> {
+		// No-op — no warm-up resources; a LinearClient is created per call.
+	}
+
+	async onUnload(): Promise<void> {
+		this.idempotencyCache.clear();
+	}
+
+	/** Testable seam — specs stub this; production uses the real SDK. */
+	protected createClient(apiKey: string): LinearClientLike {
+		return new LinearClient({ apiKey }) as unknown as LinearClientLike;
+	}
+
+	async verifyConnection(config: ChannelTargetConfig, options: ConnectorCallOptions): Promise<ChannelVerification> {
+		const apiKey = resolveApiKey(config, options);
+		if (!apiKey) {
+			return { valid: false, message: 'apiKey is required' };
+		}
+		try {
+			const viewer = await this.createClient(apiKey).viewer;
+			return {
+				valid: true,
+				details: {
+					viewerId: viewer?.id,
+					viewerName: viewer?.name,
+					...(viewer?.email ? { email: viewer.email } : {})
+				}
+			};
+		} catch (err) {
+			return { valid: false, message: `Linear viewer lookup failed: ${linearErrorMessage(err)}` };
+		}
+	}
+
+	/** Outbound leg — create a comment on a Linear issue. */
+	async send(payload: ChannelSendInput, options: ConnectorCallOptions): Promise<ChannelSendResult> {
+		const config = payload.target ?? options.target ?? {};
+		const apiKey = resolveApiKey(config, options);
+		if (!apiKey) {
+			throw new Error('linear-connector: an API key is required (targetConfig.apiKey or settings.apiKey)');
+		}
+		const issueId = resolveIssueId(config, options);
+
+		// Idempotency: scope the key to connectorId + issue + messageRef with a
+		// NUL separator so components can't collide across tenants (mirrors the
+		// slack-connector hardening — this plugin is a module-level singleton).
+		const cacheKey = `${options.connectorId ?? ''}\0${issueId}\0${payload.messageRef}`;
+		const cached = this.idempotencyCache.get(cacheKey);
+		if (cached) return cached;
+
+		let commentId: string | undefined;
+		try {
+			const res = await this.createClient(apiKey).createComment({ issueId, body: payload.text });
+			const comment = res.comment ? await res.comment : undefined;
+			commentId = typeof comment?.id === 'string' ? comment.id : undefined;
+		} catch (err) {
+			throw new Error(`Linear createComment failed: ${linearErrorMessage(err)}`);
+		}
+
+		const result: ChannelSendResult = {
+			provider: this.id,
+			providerMessageId: commentId ?? `linear-${payload.messageRef}`,
+			deliveredAt: new Date()
+		};
+		this.idempotencyCache.set(cacheKey, result);
+		if (this.idempotencyCache.size > 500) {
+			const firstKey = this.idempotencyCache.keys().next().value;
+			if (firstKey) this.idempotencyCache.delete(firstKey);
+		}
+		return result;
+	}
+
+	// ── Event source (pull) ─────────────────────────────────────────────
+
+	/**
+	 * Pull one page of the current sweep phase (issues → comments)
+	 * since the effective watermark, normalized to envelopes. The
+	 * returned cursor resumes the same phase (SDK page cursor) or
+	 * advances to the next; no cursor means the sweep is done.
+	 *
+	 * First pull (epoch/absent watermark, no cursor): the window is
+	 * `now - backfillDays` when the opt-in backfill is on, otherwise
+	 * `now` — history stays untouched unless the user asked for it.
+	 */
+	async pullEvents(input: EventSourcePullInput): Promise<EventSourcePullResult> {
+		const apiKey = input.settings?.apiKey;
+		if (typeof apiKey !== 'string' || apiKey.length === 0) {
+			throw new EventSourceNotConfiguredError('linear-connector: settings.apiKey is required to pull events');
+		}
+
+		const cursor = parsePullCursor(input.cursor);
+		let phase: 'issues' | 'comments';
+		let after: string | undefined;
+		let since: string;
+		let backfill: boolean;
+		let pagesUsed: number;
+
+		if (cursor) {
+			phase = cursor.p;
+			after = cursor.n;
+			since = cursor.s;
+			backfill = cursor.f === 1;
+			pagesUsed = cursor.b ?? 0;
+		} else {
+			const sinceMs = Date.parse(input.since);
+			const firstPull = !Number.isFinite(sinceMs) || sinceMs <= 0;
+			const backfillDays = clampBackfillDays(input.settings?.backfillDays);
+			if (firstPull) {
+				const start = backfillDays > 0 ? Date.now() - backfillDays * 86400_000 : Date.now();
+				since = new Date(start).toISOString();
+				backfill = backfillDays > 0;
+			} else {
+				since = new Date(sinceMs).toISOString();
+				backfill = false;
+			}
+			phase = 'issues';
+			after = undefined;
+			pagesUsed = 0;
+		}
+
+		const client = this.createClient(apiKey);
+		const teamIds = resolveTeamIds(input.settings);
+		const events: IngestedEventEnvelope[] = [];
+		let hasNextPage = false;
+		let endCursor: string | undefined;
+
+		if (phase === 'issues') {
+			const page = await client.issues({
+				first: LINEAR_PULL_PAGE_SIZE,
+				...(after ? { after } : {}),
+				filter: {
+					updatedAt: { gte: new Date(since) },
+					...(teamIds.length > 0 ? { team: { id: { in: teamIds } } } : {})
+				}
+			});
+			for (const issue of page.nodes ?? []) {
+				const envelope = this.normalizeIssue(issue, since);
+				if (envelope) events.push(envelope);
+			}
+			hasNextPage = page.pageInfo?.hasNextPage === true;
+			endCursor = page.pageInfo?.endCursor;
+		} else {
+			const page = await client.comments({
+				first: LINEAR_PULL_PAGE_SIZE,
+				...(after ? { after } : {}),
+				filter: { updatedAt: { gte: new Date(since) } }
+			});
+			for (const comment of page.nodes ?? []) {
+				const envelope = await this.normalizeComment(comment);
+				if (envelope) events.push(envelope);
+			}
+			hasNextPage = page.pageInfo?.hasNextPage === true;
+			endCursor = page.pageInfo?.endCursor;
+		}
+
+		pagesUsed += 1;
+		const pageBudgetExhausted = backfill && pagesUsed >= LINEAR_BACKFILL_MAX_PAGES;
+
+		let next: LinearPullCursor | undefined;
+		if (hasNextPage && endCursor && !pageBudgetExhausted) {
+			next = { p: phase, n: endCursor, s: since, ...(backfill ? { f: 1 as const } : {}), b: pagesUsed };
+		} else if (phase === 'issues') {
+			// Advance to the comments phase (page counter resets per phase).
+			next = { p: 'comments', s: since, ...(backfill ? { f: 1 as const } : {}), b: 0 };
+		}
+
+		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	private normalizeIssue(issue: LinearIssueNode, since: string): IngestedEventEnvelope | null {
+		if (!issue.id) return null;
+		const updatedAt = toIso(issue.updatedAt ?? issue.createdAt);
+		const createdAt = toIso(issue.createdAt);
+		const changeType = Date.parse(createdAt) >= Date.parse(since) ? 'created' : 'updated';
+		return {
+			id: randomUUID(),
+			source: this.id,
+			sourceEventId: `${issue.id}:${updatedAt}`,
+			kind: 'linear.issue',
+			occurredAt: updatedAt,
+			subject: {
+				type: 'issue',
+				externalId: issue.id,
+				...(issue.title ? { title: issue.title } : {})
+			},
+			...(issue.url ? { sourceUrl: issue.url } : {}),
+			payload: {
+				issueId: issue.id,
+				...(issue.identifier ? { identifier: issue.identifier } : {}),
+				...(issue.title ? { title: truncateText(issue.title) } : {}),
+				...(issue.description ? { description: truncateText(issue.description) } : {}),
+				changeType,
+				createdAt,
+				updatedAt
+			}
+		};
+	}
+
+	/**
+	 * Normalize one comment → envelope. The parent issue is a lazy SDK
+	 * fetch — awaited best-effort for the subject/sourceUrl; a failure
+	 * degrades to the comment's own permalink.
+	 */
+	private async normalizeComment(comment: LinearCommentNode): Promise<IngestedEventEnvelope | null> {
+		if (!comment.id) return null;
+		const updatedAt = toIso(comment.updatedAt ?? comment.createdAt);
+		let issue: LinearIssueNode | undefined;
+		try {
+			issue = comment.issue ? await comment.issue : undefined;
+		} catch {
+			issue = undefined;
+		}
+		const sourceUrl = comment.url ?? issue?.url;
+		return {
+			id: randomUUID(),
+			source: this.id,
+			sourceEventId: `${comment.id}:${updatedAt}`,
+			kind: 'linear.comment',
+			occurredAt: updatedAt,
+			subject: {
+				type: 'issue',
+				externalId: issue?.id ?? 'unknown',
+				...(issue?.title ? { title: issue.title } : {})
+			},
+			...(sourceUrl ? { sourceUrl } : {}),
+			payload: {
+				commentId: comment.id,
+				...(issue?.id ? { issueId: issue.id } : {}),
+				...(issue?.identifier ? { issueIdentifier: issue.identifier } : {}),
+				...(comment.body ? { body: truncateText(comment.body) } : {}),
+				createdAt: toIso(comment.createdAt),
+				updatedAt
+			}
+		};
+	}
+}
+
+export const linearConnectorPlugin = new LinearConnectorPlugin();

--- a/packages/plugins/linear-connector/tsconfig.json
+++ b/packages/plugins/linear-connector/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/linear-connector/tsup.config.ts
+++ b/packages/plugins/linear-connector/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/linear-connector/vitest.config.ts
+++ b/packages/plugins/linear-connector/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/packages/plugins/notion-connector/README.md
+++ b/packages/plugins/notion-connector/README.md
@@ -1,0 +1,37 @@
+# @ever-works/notion-connector-plugin
+
+First-party **Notion connector** for the Ever Works platform (Wave 8), built on
+the official [`@notionhq/client`](https://www.npmjs.com/package/@notionhq/client).
+
+Capabilities: `connector`, `connector-notion`, `event-source`.
+
+## What it does
+
+- **Outbound** — `send()` appends a comment to a Notion page
+  (`targetConfig.pageId` / `defaultPageId`), idempotent on `messageRef`.
+  Integration tokens without comment capabilities fail with a clear,
+  actionable error (grant "Insert comments" and share the page).
+- **Event source** — `pullEvents()` sweeps pages created/edited since the
+  platform watermark — per configured database (`databases.query` with a
+  server-side `last_edited_time` filter) or workspace-wide (`search`,
+  newest-first with client-side windowing) — normalized into
+  `IngestedEventEnvelope`s (`notion.page`) for the event-ingest spine. Each
+  envelope carries the page URL as `sourceUrl` so Memory/Activity rows link
+  back to the origin.
+- **Opt-in historical backfill** — `backfillDays` (default `0` = off, max 90)
+  widens the FIRST pull's window only, bounded to
+  `NOTION_BACKFILL_MAX_PAGES` result pages per phase.
+
+## Settings
+
+| Key             | Notes                                                         |
+| --------------- | ------------------------------------------------------------- |
+| `apiKey`        | Notion integration token — secret, env `NOTION_API_KEY`.      |
+| `databaseIds`   | Optional comma-separated database filter (search when empty). |
+| `backfillDays`  | Opt-in first-pull history window (0 = off, max 90).           |
+| `defaultPageId` | Default page for outbound comments.                           |
+
+## Testing
+
+Hermetic Vitest suite (`pnpm test`) — the SDK client is stubbed through the
+`createClient` seam; no network calls.

--- a/packages/plugins/notion-connector/package.json
+++ b/packages/plugins/notion-connector/package.json
@@ -1,0 +1,96 @@
+{
+	"name": "@ever-works/notion-connector-plugin",
+	"version": "1.0.0",
+	"description": "Notion connector plugin for Ever Works platform (outbound page comments via @notionhq/client and event-source pull of created/edited pages into the event-ingest pipeline, with opt-in historical backfill)",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@ever-works/contracts": "workspace:*",
+		"@ever-works/plugin": "workspace:*",
+		"@notionhq/client": "^2.3.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "notion-connector",
+			"name": "Notion Connector",
+			"version": "1.0.0",
+			"category": "connector",
+			"capabilities": [
+				"connector",
+				"connector-notion",
+				"event-source"
+			],
+			"description": "Notion connector. Outbound appends comments on Notion pages via the official @notionhq/client. Event-source pull ingests pages created/edited since the last watermark (workspace search or configured databases) into the platform event-ingest pipeline, with opt-in historical backfill (backfillDays, max 90).",
+			"systemPlugin": false,
+			"builtIn": true,
+			"isDefault": false,
+			"autoEnable": false,
+			"settings": {
+				"type": "object",
+				"required": [
+					"apiKey"
+				],
+				"properties": {
+					"apiKey": {
+						"type": "string",
+						"title": "Notion integration token (ntn_… / secret_…)",
+						"x-secret": true,
+						"x-envVar": "NOTION_API_KEY"
+					},
+					"databaseIds": {
+						"type": "string",
+						"title": "Database ids to ingest pages from (comma-separated; workspace-wide search when empty)"
+					},
+					"backfillDays": {
+						"type": "number",
+						"title": "Historical backfill window in days on first pull (0 = off, max 90)",
+						"default": 0,
+						"minimum": 0,
+						"maximum": 90
+					},
+					"defaultPageId": {
+						"type": "string",
+						"title": "Default page id for outbound comments"
+					}
+				}
+			}
+		}
+	},
+	"publishConfig": {
+		"access": "restricted",
+		"registry": "https://registry.npmjs.org"
+	}
+}

--- a/packages/plugins/notion-connector/src/index.ts
+++ b/packages/plugins/notion-connector/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @ever-works/notion-connector-plugin — Notion connector (Wave 8).
+ * Outbound page comments via the official `@notionhq/client`;
+ * `pullEvents` event-source leg (pages created/edited since watermark,
+ * opt-in historical backfill) feeding the platform event-ingest spine.
+ */
+export {
+	NotionConnectorPlugin,
+	notionConnectorPlugin,
+	clampBackfillDays,
+	extractPageTitle,
+	NOTION_EVENT_TEXT_MAX_CHARS,
+	NOTION_PULL_PAGE_SIZE,
+	NOTION_BACKFILL_MAX_PAGES
+} from './notion-connector-plugin.js';

--- a/packages/plugins/notion-connector/src/notion-connector-plugin.spec.ts
+++ b/packages/plugins/notion-connector/src/notion-connector-plugin.spec.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	NotionConnectorPlugin,
+	clampBackfillDays,
+	extractPageTitle,
+	NOTION_BACKFILL_MAX_PAGES
+} from './notion-connector-plugin.js';
+
+const usersMeMock = vi.fn();
+const searchMock = vi.fn();
+const databasesQueryMock = vi.fn();
+const commentsCreateMock = vi.fn();
+const clientFactoryMock = vi.fn();
+
+/** Subclass overriding the client seam so no real SDK call ever happens. */
+class TestNotionConnectorPlugin extends NotionConnectorPlugin {
+	protected override createClient(apiKey: string) {
+		clientFactoryMock(apiKey);
+		return {
+			users: { me: usersMeMock },
+			search: searchMock,
+			databases: { query: databasesQueryMock },
+			comments: { create: commentsCreateMock }
+		};
+	}
+}
+
+const SETTINGS = { apiKey: 'ntn_secret_abc' };
+
+function makePage(id: string, lastEdited: string, created = lastEdited, title = 'Doc') {
+	return {
+		object: 'page',
+		id,
+		url: `https://www.notion.so/${id}`,
+		created_time: created,
+		last_edited_time: lastEdited,
+		properties: { Name: { type: 'title', title: [{ plain_text: title }] } }
+	};
+}
+
+describe('NotionConnectorPlugin', () => {
+	let plugin: TestNotionConnectorPlugin;
+
+	beforeEach(() => {
+		plugin = new TestNotionConnectorPlugin();
+		usersMeMock.mockReset();
+		searchMock.mockReset();
+		databasesQueryMock.mockReset();
+		commentsCreateMock.mockReset();
+		clientFactoryMock.mockReset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('declares the connector + connector-notion + event-source capabilities and poll metadata', () => {
+		expect(plugin.id).toBe('notion-connector');
+		expect(plugin.category).toBe('connector');
+		expect(plugin.capabilities).toContain('connector');
+		expect(plugin.capabilities).toContain('connector-notion');
+		expect(plugin.capabilities).toContain('event-source');
+		expect(plugin.providerName).toBe('notion');
+		expect(plugin.connector.direction).toBe('outbound');
+		expect(plugin.connector.transport).toBe('poll');
+		expect(plugin.connector.flags.outboundMessage).toBe(true);
+		expect(plugin.connector.flags.inbound).toBe(false);
+	});
+
+	it('marks apiKey as x-secret and bounds backfillDays to 0–90 in the settings schema', () => {
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.apiKey['x-secret']).toBe(true);
+		expect(plugin.settingsSchema.required).toContain('apiKey');
+		expect(props.backfillDays.default).toBe(0);
+		expect(props.backfillDays.maximum).toBe(90);
+		expect(clampBackfillDays(120)).toBe(90);
+		expect(clampBackfillDays(-1)).toBe(0);
+	});
+
+	it('extractPageTitle reads the title-typed property and tolerates junk', () => {
+		expect(extractPageTitle(makePage('p1', '2026-07-20T00:00:00.000Z', undefined as never, 'Hello'))).toBe('Hello');
+		expect(extractPageTitle({ properties: {} })).toBeUndefined();
+		expect(extractPageTitle({})).toBeUndefined();
+	});
+
+	describe('verifyConnection', () => {
+		it('returns valid + bot details when users.me succeeds', async () => {
+			usersMeMock.mockResolvedValueOnce({ id: 'bot-1', name: 'Works Bot' });
+			const res = await plugin.verifyConnection({ apiKey: 'ntn_x' }, {});
+			expect(res.valid).toBe(true);
+			expect(res.details).toMatchObject({ botId: 'bot-1', botName: 'Works Bot' });
+			expect(clientFactoryMock).toHaveBeenCalledWith('ntn_x');
+		});
+
+		it('returns invalid without calling the API when apiKey is missing', async () => {
+			const res = await plugin.verifyConnection({}, {});
+			expect(res.valid).toBe(false);
+			expect(res.message).toMatch(/apiKey/);
+			expect(usersMeMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('send', () => {
+		const options = { connectorId: 'conn-1', settings: SETTINGS };
+
+		it('appends a comment to the resolved page and returns its id', async () => {
+			commentsCreateMock.mockResolvedValueOnce({ id: 'comment-3' });
+			const res = await plugin.send(
+				{
+					text: 'note from the platform',
+					messageRef: 'ref-1',
+					attribution: { userId: 'u1' },
+					target: { pageId: 'page-5' }
+				},
+				options
+			);
+			expect(commentsCreateMock).toHaveBeenCalledWith({
+				parent: { page_id: 'page-5' },
+				rich_text: [{ type: 'text', text: { content: 'note from the platform' } }]
+			});
+			expect(res.provider).toBe('notion-connector');
+			expect(res.providerMessageId).toBe('comment-3');
+		});
+
+		it('is idempotent on messageRef — a retry never double-posts', async () => {
+			commentsCreateMock.mockResolvedValue({ id: 'comment-1' });
+			const payload = {
+				text: 'once only',
+				messageRef: 'ref-dup',
+				attribution: { userId: 'u1' },
+				target: { pageId: 'page-1' }
+			};
+			const first = await plugin.send(payload, options);
+			const second = await plugin.send(payload, options);
+			expect(commentsCreateMock).toHaveBeenCalledTimes(1);
+			expect(second).toBe(first);
+		});
+
+		it('fails with a clear, actionable error when the token lacks comment capabilities', async () => {
+			commentsCreateMock.mockRejectedValueOnce(
+				Object.assign(new Error('Insufficient permissions for this endpoint.'), {
+					code: 'restricted_resource'
+				})
+			);
+			await expect(
+				plugin.send(
+					{ text: 'x', messageRef: 'r', attribution: { userId: 'u1' }, target: { pageId: 'page-1' } },
+					options
+				)
+			).rejects.toThrow(/Insert comments/);
+		});
+
+		it('throws a clear error when no page id can be resolved', async () => {
+			await expect(
+				plugin.send({ text: 'x', messageRef: 'r', attribution: { userId: 'u1' } }, options)
+			).rejects.toThrow(/page id is required/);
+			expect(commentsCreateMock).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('pullEvents', () => {
+		it('throws EventSourceNotConfiguredError when apiKey is missing', async () => {
+			await expect(plugin.pullEvents({ since: new Date(0).toISOString(), settings: {} })).rejects.toMatchObject({
+				name: 'EventSourceNotConfiguredError'
+			});
+			expect(searchMock).not.toHaveBeenCalled();
+		});
+
+		it('first pull with backfill off searches with a now-anchored window (no history)', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			searchMock.mockResolvedValueOnce({
+				results: [
+					makePage('new-page', '2026-07-25T13:00:00.000Z'),
+					makePage('old-page', '2026-07-01T00:00:00.000Z')
+				],
+				has_more: true,
+				next_cursor: 'more'
+			});
+			const res = await plugin.pullEvents({ since: new Date(0).toISOString(), settings: SETTINGS });
+			// Only the in-window page lands; the older result ends the sweep.
+			expect(res.events).toHaveLength(1);
+			expect(res.events[0].payload.pageId).toBe('new-page');
+			expect(res.nextCursor).toBeUndefined();
+		});
+
+		it('first pull with backfillDays widens the window (clamped) and pages further back', async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-07-25T12:00:00.000Z'));
+			searchMock.mockResolvedValueOnce({
+				results: [makePage('p1', '2026-07-10T00:00:00.000Z')],
+				has_more: true,
+				next_cursor: 'cursor-2'
+			});
+			const res = await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				settings: { ...SETTINGS, backfillDays: 30 }
+			});
+			expect(res.events).toHaveLength(1);
+			const parsed = JSON.parse(res.nextCursor as string);
+			expect(parsed).toMatchObject({ m: 'search', n: 'cursor-2', s: '2026-06-25T12:00:00.000Z', f: 1, b: 1 });
+		});
+
+		it('normalizes pages into notion.page envelopes with subject, sourceUrl and changeType', async () => {
+			searchMock.mockResolvedValueOnce({
+				results: [
+					makePage('p-new', '2026-07-24T10:00:00.000Z', '2026-07-24T09:00:00.000Z', 'Fresh page'),
+					makePage('p-edit', '2026-07-24T11:00:00.000Z', '2026-01-01T00:00:00.000Z', 'Old page')
+				],
+				has_more: false,
+				next_cursor: null
+			});
+			const res = await plugin.pullEvents({ since: '2026-07-20T00:00:00.000Z', settings: SETTINGS });
+			expect(res.events).toHaveLength(2);
+			const fresh = res.events[0];
+			expect(fresh.kind).toBe('notion.page');
+			expect(fresh.sourceEventId).toBe('p-new:2026-07-24T10:00:00.000Z');
+			expect(fresh.subject).toEqual({ type: 'page', externalId: 'p-new', title: 'Fresh page' });
+			expect(fresh.sourceUrl).toBe('https://www.notion.so/p-new');
+			expect(fresh.payload.changeType).toBe('created');
+			expect(res.events[1].payload.changeType).toBe('edited');
+			// The API key must never leak into the envelope.
+			expect(JSON.stringify(res.events)).not.toContain(SETTINGS.apiKey);
+		});
+
+		it('queries configured databases with a server-side last_edited_time filter', async () => {
+			databasesQueryMock.mockResolvedValueOnce({
+				results: [makePage('row-1', '2026-07-24T10:00:00.000Z')],
+				has_more: false,
+				next_cursor: null
+			});
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				settings: { ...SETTINGS, databaseIds: 'db-a, db-b' }
+			});
+			expect(searchMock).not.toHaveBeenCalled();
+			const args = databasesQueryMock.mock.calls[0][0];
+			expect(args.database_id).toBe('db-a');
+			expect(args.filter).toEqual({
+				timestamp: 'last_edited_time',
+				last_edited_time: { on_or_after: '2026-07-20T00:00:00.000Z' }
+			});
+			expect(res.events[0].payload.databaseId).toBe('db-a');
+			// db-a exhausted → advance to db-b with a reset page counter.
+			const parsed = JSON.parse(res.nextCursor as string);
+			expect(parsed).toMatchObject({ m: 'db', d: 'db-b', s: '2026-07-20T00:00:00.000Z', b: 0 });
+			expect(parsed.n).toBeUndefined();
+		});
+
+		it('pages a database via Notion cursors, keeping the SAME window across pages', async () => {
+			databasesQueryMock.mockResolvedValueOnce({
+				results: [],
+				has_more: true,
+				next_cursor: 'db-page-2'
+			});
+			const first = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				settings: { ...SETTINGS, databaseIds: 'db-a' }
+			});
+			const parsed = JSON.parse(first.nextCursor as string);
+			expect(parsed).toMatchObject({ m: 'db', d: 'db-a', n: 'db-page-2', s: '2026-07-20T00:00:00.000Z' });
+
+			databasesQueryMock.mockResolvedValueOnce({ results: [], has_more: false, next_cursor: null });
+			const second = await plugin.pullEvents({
+				since: '2026-07-24T00:00:00.000Z', // a moved watermark must NOT shift the running sweep
+				cursor: first.nextCursor,
+				settings: { ...SETTINGS, databaseIds: 'db-a' }
+			});
+			const args = databasesQueryMock.mock.calls[1][0];
+			expect(args.start_cursor).toBe('db-page-2');
+			expect(args.filter.last_edited_time.on_or_after).toBe('2026-07-20T00:00:00.000Z');
+			expect(second.nextCursor).toBeUndefined();
+		});
+
+		it('bounds backfill sweeps to the per-phase page budget', async () => {
+			databasesQueryMock.mockResolvedValueOnce({
+				results: [],
+				has_more: true,
+				next_cursor: 'even-more'
+			});
+			const res = await plugin.pullEvents({
+				since: new Date(0).toISOString(),
+				cursor: JSON.stringify({
+					m: 'db',
+					d: 'db-a',
+					n: 'page-n',
+					s: '2026-05-01T00:00:00.000Z',
+					f: 1,
+					b: NOTION_BACKFILL_MAX_PAGES - 1
+				}),
+				settings: { ...SETTINGS, databaseIds: 'db-a, db-b', backfillDays: 90 }
+			});
+			// Budget hit mid-database: advance to db-b instead of paging on.
+			const parsed = JSON.parse(res.nextCursor as string);
+			expect(parsed).toMatchObject({ m: 'db', d: 'db-b', b: 0 });
+			expect(parsed.n).toBeUndefined();
+		});
+
+		it('returns no events for a db sweep with no configured databases left', async () => {
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: JSON.stringify({ m: 'db', d: 'gone-db', s: '2026-07-20T00:00:00.000Z' }),
+				settings: SETTINGS // databaseIds cleared since the sweep started
+			});
+			expect(res.events).toEqual([]);
+			expect(res.nextCursor).toBeUndefined();
+			expect(databasesQueryMock).not.toHaveBeenCalled();
+		});
+
+		it('treats a malformed cursor as a fresh sweep instead of crashing', async () => {
+			searchMock.mockResolvedValueOnce({ results: [], has_more: false, next_cursor: null });
+			const res = await plugin.pullEvents({
+				since: '2026-07-20T00:00:00.000Z',
+				cursor: '}}}garbage',
+				settings: SETTINGS
+			});
+			expect(searchMock).toHaveBeenCalledTimes(1);
+			expect(res.events).toEqual([]);
+		});
+	});
+});

--- a/packages/plugins/notion-connector/src/notion-connector-plugin.ts
+++ b/packages/plugins/notion-connector/src/notion-connector-plugin.ts
@@ -1,0 +1,505 @@
+import { randomUUID } from 'node:crypto';
+import { Client } from '@notionhq/client';
+import type {
+	IConnectorPlugin,
+	IEventSourcePlugin,
+	ConnectorMetadata,
+	ConnectorCallOptions,
+	ChannelSendInput,
+	ChannelSendResult,
+	ChannelTargetConfig,
+	ChannelVerification,
+	EventSourcePullInput,
+	EventSourcePullResult,
+	PluginCategory,
+	PluginSettings,
+	JsonSchema
+} from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+
+/**
+ * Payload text cap for ingested envelopes. Envelope payloads are
+ * size-capped platform-side (32 KB serialized); a page title never
+ * needs more than this to be useful in Memory/Activities.
+ */
+export const NOTION_EVENT_TEXT_MAX_CHARS = 4000;
+
+/** Items requested per Notion page of results. */
+export const NOTION_PULL_PAGE_SIZE = 50;
+
+/**
+ * Historical backfill bound: at most this many result pages per phase
+ * (per database, or for the workspace search sweep) during the opt-in
+ * first-pull backfill, so activation never becomes an unbounded crawl.
+ */
+export const NOTION_BACKFILL_MAX_PAGES = 10;
+
+/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+export function clampBackfillDays(value: unknown): number {
+	const num = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(num) || num <= 0) return 0;
+	return Math.min(Math.floor(num), 90);
+}
+
+function truncateText(text: string): string {
+	return text.length > NOTION_EVENT_TEXT_MAX_CHARS ? text.slice(0, NOTION_EVENT_TEXT_MAX_CHARS) : text;
+}
+
+/** Parse the database filter list: comma/space separated ids → array. */
+function resolveDatabaseIds(settings: PluginSettings | undefined): string[] {
+	const raw = settings?.databaseIds;
+	if (typeof raw === 'string' && raw.trim().length > 0) {
+		return raw
+			.split(/[\s,]+/)
+			.map((d) => d.trim())
+			.filter((d) => d.length > 0);
+	}
+	return [];
+}
+
+/** Extract a readable message from a `@notionhq/client` error. */
+function notionErrorMessage(err: unknown): string {
+	const e = err as { code?: string; message?: string };
+	return e.message ?? e.code ?? 'unknown error';
+}
+
+/** True when the error means the integration token cannot comment. */
+function isCommentCapabilityError(err: unknown): boolean {
+	const code = (err as { code?: string }).code;
+	return code === 'restricted_resource' || code === 'insufficient_permissions' || code === 'unauthorized';
+}
+
+/**
+ * Opaque pull cursor. `m` is the sweep mode (`search` workspace-wide,
+ * `db` for the configured-databases sweep), `d` the current database
+ * id in `db` mode, `n` Notion's own page cursor, `s` the effective
+ * since-watermark the sweep was started with (later pages of the same
+ * sweep keep the SAME window), `f` flags a first-pull backfill sweep
+ * and `b` counts result pages used in the current phase (backfill
+ * bound). Malformed input restarts the sweep — safe, the ingest
+ * pipeline dedupes on `(source, sourceEventId)`.
+ */
+interface NotionPullCursor {
+	m: 'search' | 'db';
+	d?: string;
+	n?: string;
+	s: string;
+	f?: 1;
+	b?: number;
+}
+
+function parsePullCursor(cursor: string | undefined): NotionPullCursor | undefined {
+	if (!cursor) return undefined;
+	try {
+		const parsed = JSON.parse(cursor) as NotionPullCursor;
+		if (parsed && (parsed.m === 'search' || parsed.m === 'db') && typeof parsed.s === 'string') {
+			return parsed;
+		}
+	} catch {
+		// fall through — treat as no cursor
+	}
+	return undefined;
+}
+
+/** Minimal shape of a Notion page object we consume. */
+interface NotionPageObject {
+	object?: string;
+	id?: string;
+	url?: string;
+	created_time?: string;
+	last_edited_time?: string;
+	parent?: { type?: string; database_id?: string; page_id?: string };
+	properties?: Record<string, { type?: string; title?: Array<{ plain_text?: string }> }>;
+}
+
+interface NotionResultPage {
+	results?: NotionPageObject[];
+	has_more?: boolean;
+	next_cursor?: string | null;
+}
+
+/** The subset of the `@notionhq/client` surface this plugin calls. */
+interface NotionClientLike {
+	users: { me(args: Record<string, unknown>): Promise<{ id?: string; name?: string | null }> };
+	search(args: Record<string, unknown>): Promise<NotionResultPage>;
+	databases: { query(args: Record<string, unknown>): Promise<NotionResultPage> };
+	comments: { create(args: Record<string, unknown>): Promise<{ id?: string }> };
+}
+
+function resolveApiKey(config: ChannelTargetConfig, options: ConnectorCallOptions): string | undefined {
+	const candidates = [config.apiKey, options.settings?.apiKey];
+	for (const c of candidates) {
+		if (typeof c === 'string' && c.length > 0) return c;
+	}
+	return undefined;
+}
+
+/**
+ * Resolve the destination page id for an outbound comment. A per-send
+ * `pageId` overrides the connection's `defaultPageId`; the resolved
+ * plugin `settings` default is the final fallback.
+ */
+function resolvePageId(config: ChannelTargetConfig, options: ConnectorCallOptions): string {
+	const candidates = [config.pageId, config.defaultPageId, options.settings?.defaultPageId];
+	for (const c of candidates) {
+		if (typeof c === 'string' && c.length > 0) return c;
+	}
+	throw new Error('notion-connector: a page id is required (targetConfig.pageId or defaultPageId)');
+}
+
+/** Best-effort page title from the `title`-typed property. */
+export function extractPageTitle(page: NotionPageObject): string | undefined {
+	const properties = page.properties ?? {};
+	for (const prop of Object.values(properties)) {
+		if (prop?.type === 'title' && Array.isArray(prop.title)) {
+			const title = prop.title
+				.map((t) => t?.plain_text ?? '')
+				.join('')
+				.trim();
+			if (title.length > 0) return title;
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Notion connector (Wave 8) — first-party native connector.
+ *
+ * Outbound: appends a comment to a Notion page via `comments.create`
+ * on the official `@notionhq/client` (integration-token auth; the SDK
+ * pins the API host, so there is no SSRF surface). Integrations
+ * without comment capabilities fail with a clear, actionable error.
+ *
+ * Event source: `pullEvents` sweeps pages created/edited since the
+ * watermark — per configured database (`databases.query`, server-side
+ * `last_edited_time` filter) or workspace-wide (`search`, sorted by
+ * `last_edited_time` descending with client-side windowing, since the
+ * search API cannot filter by time) — normalized into
+ * `IngestedEventEnvelope`s (`notion.page`, page url as `sourceUrl`)
+ * for the platform's event-ingest spine. The opt-in historical
+ * backfill (`backfillDays`, default 0 = off, max 90) widens the FIRST
+ * pull's window only, with a per-phase page bound. Re-delivery across
+ * overlapping windows is fine — the ingest pipeline dedupes on
+ * `(source, sourceEventId)`.
+ */
+export class NotionConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin {
+	readonly id = 'notion-connector';
+	readonly name = 'Notion Connector';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'connector';
+	readonly capabilities = [
+		PLUGIN_CAPABILITIES.CONNECTOR,
+		PLUGIN_CAPABILITIES.CONNECTOR_NOTION,
+		PLUGIN_CAPABILITIES.EVENT_SOURCE
+	] as const;
+
+	readonly providerName = 'notion';
+
+	readonly connector: ConnectorMetadata = {
+		direction: 'outbound',
+		transport: 'poll',
+		flags: {
+			outboundMessage: true,
+			outboundRecord: false,
+			inbound: false,
+			reply: false,
+			pairing: false,
+			richOutbound: false
+		}
+	};
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		required: ['apiKey'],
+		properties: {
+			apiKey: {
+				type: 'string',
+				title: 'Notion integration token (ntn_… / secret_…)',
+				'x-secret': true,
+				'x-envVar': 'NOTION_API_KEY'
+			},
+			databaseIds: {
+				type: 'string',
+				title: 'Database ids to ingest pages from (comma-separated; workspace-wide search when empty)'
+			},
+			backfillDays: {
+				type: 'number',
+				title: 'Historical backfill window in days on first pull (0 = off, max 90)',
+				default: 0,
+				minimum: 0,
+				maximum: 90
+			},
+			defaultPageId: {
+				type: 'string',
+				title: 'Default page id for outbound comments'
+			}
+		}
+	};
+
+	private readonly idempotencyCache = new Map<string, ChannelSendResult>();
+
+	async onLoad(): Promise<void> {
+		// No-op — no warm-up resources; a Client is created per call.
+	}
+
+	async onUnload(): Promise<void> {
+		this.idempotencyCache.clear();
+	}
+
+	/** Testable seam — specs stub this; production uses the real SDK. */
+	protected createClient(apiKey: string): NotionClientLike {
+		return new Client({ auth: apiKey }) as unknown as NotionClientLike;
+	}
+
+	async verifyConnection(config: ChannelTargetConfig, options: ConnectorCallOptions): Promise<ChannelVerification> {
+		const apiKey = resolveApiKey(config, options);
+		if (!apiKey) {
+			return { valid: false, message: 'apiKey is required' };
+		}
+		try {
+			const me = await this.createClient(apiKey).users.me({});
+			return {
+				valid: true,
+				details: {
+					botId: me?.id,
+					...(me?.name ? { botName: me.name } : {})
+				}
+			};
+		} catch (err) {
+			return { valid: false, message: `Notion users.me failed: ${notionErrorMessage(err)}` };
+		}
+	}
+
+	/** Outbound leg — append a comment to a Notion page. */
+	async send(payload: ChannelSendInput, options: ConnectorCallOptions): Promise<ChannelSendResult> {
+		const config = payload.target ?? options.target ?? {};
+		const apiKey = resolveApiKey(config, options);
+		if (!apiKey) {
+			throw new Error('notion-connector: an API key is required (targetConfig.apiKey or settings.apiKey)');
+		}
+		const pageId = resolvePageId(config, options);
+
+		// Idempotency: scope the key to connectorId + page + messageRef with a
+		// NUL separator so components can't collide across tenants (mirrors the
+		// slack-connector hardening — this plugin is a module-level singleton).
+		const cacheKey = `${options.connectorId ?? ''}\0${pageId}\0${payload.messageRef}`;
+		const cached = this.idempotencyCache.get(cacheKey);
+		if (cached) return cached;
+
+		let commentId: string | undefined;
+		try {
+			const res = await this.createClient(apiKey).comments.create({
+				parent: { page_id: pageId },
+				rich_text: [{ type: 'text', text: { content: payload.text } }]
+			});
+			commentId = typeof res?.id === 'string' ? res.id : undefined;
+		} catch (err) {
+			if (isCommentCapabilityError(err)) {
+				// The comments endpoint is capability-gated per integration —
+				// surface exactly what to fix instead of a generic failure.
+				throw new Error(
+					'notion-connector: the integration token cannot comment on this page — grant the ' +
+						`integration "Insert comments" capabilities and share the page with it (${notionErrorMessage(err)})`
+				);
+			}
+			throw new Error(`Notion comments.create failed: ${notionErrorMessage(err)}`);
+		}
+
+		const result: ChannelSendResult = {
+			provider: this.id,
+			providerMessageId: commentId ?? `notion-${payload.messageRef}`,
+			deliveredAt: new Date()
+		};
+		this.idempotencyCache.set(cacheKey, result);
+		if (this.idempotencyCache.size > 500) {
+			const firstKey = this.idempotencyCache.keys().next().value;
+			if (firstKey) this.idempotencyCache.delete(firstKey);
+		}
+		return result;
+	}
+
+	// ── Event source (pull) ─────────────────────────────────────────────
+
+	/**
+	 * Pull one result page of the current sweep, normalized to
+	 * envelopes. With `databaseIds` configured the sweep visits each
+	 * database in turn (server-side `last_edited_time` filter);
+	 * otherwise a workspace `search` sorted by `last_edited_time`
+	 * descending is windowed client-side and stops at the first result
+	 * older than the watermark. No returned cursor means the sweep is
+	 * done.
+	 *
+	 * First pull (epoch/absent watermark, no cursor): the window is
+	 * `now - backfillDays` when the opt-in backfill is on, otherwise
+	 * `now` — history stays untouched unless the user asked for it.
+	 */
+	async pullEvents(input: EventSourcePullInput): Promise<EventSourcePullResult> {
+		const apiKey = input.settings?.apiKey;
+		if (typeof apiKey !== 'string' || apiKey.length === 0) {
+			throw new EventSourceNotConfiguredError('notion-connector: settings.apiKey is required to pull events');
+		}
+
+		const databaseIds = resolveDatabaseIds(input.settings);
+		const cursor = parsePullCursor(input.cursor);
+		let since: string;
+		let backfill: boolean;
+		let pagesUsed: number;
+		let after: string | undefined;
+		let mode: 'search' | 'db';
+		let databaseId: string | undefined;
+
+		if (cursor) {
+			since = cursor.s;
+			backfill = cursor.f === 1;
+			pagesUsed = cursor.b ?? 0;
+			after = cursor.n;
+			mode = cursor.m;
+			databaseId = cursor.d;
+		} else {
+			const sinceMs = Date.parse(input.since);
+			const firstPull = !Number.isFinite(sinceMs) || sinceMs <= 0;
+			const backfillDays = clampBackfillDays(input.settings?.backfillDays);
+			if (firstPull) {
+				const start = backfillDays > 0 ? Date.now() - backfillDays * 86400_000 : Date.now();
+				since = new Date(start).toISOString();
+				backfill = backfillDays > 0;
+			} else {
+				since = new Date(sinceMs).toISOString();
+				backfill = false;
+			}
+			pagesUsed = 0;
+			after = undefined;
+			mode = databaseIds.length > 0 ? 'db' : 'search';
+			databaseId = databaseIds[0];
+		}
+
+		const client = this.createClient(apiKey);
+		const events: IngestedEventEnvelope[] = [];
+		let hasMore = false;
+		let nextNotionCursor: string | undefined;
+		let stopSweep = false;
+
+		if (mode === 'db') {
+			// A database dropped from settings mid-sweep restarts at the first.
+			let dbIndex = databaseId ? databaseIds.indexOf(databaseId) : 0;
+			if (dbIndex === -1) dbIndex = 0;
+			databaseId = databaseIds[dbIndex];
+			if (!databaseId) {
+				// Valid outbound-only configuration — nothing to pull.
+				return { events: [] };
+			}
+			const page = await client.databases.query({
+				database_id: databaseId,
+				page_size: NOTION_PULL_PAGE_SIZE,
+				...(after ? { start_cursor: after } : {}),
+				filter: { timestamp: 'last_edited_time', last_edited_time: { on_or_after: since } },
+				sorts: [{ timestamp: 'last_edited_time', direction: 'ascending' }]
+			});
+			for (const result of page.results ?? []) {
+				const envelope = this.normalizePage(result, since, databaseId);
+				if (envelope) events.push(envelope);
+			}
+			hasMore = page.has_more === true && typeof page.next_cursor === 'string';
+			nextNotionCursor = typeof page.next_cursor === 'string' ? page.next_cursor : undefined;
+
+			pagesUsed += 1;
+			const budgetExhausted = backfill && pagesUsed >= NOTION_BACKFILL_MAX_PAGES;
+			let next: NotionPullCursor | undefined;
+			if (hasMore && nextNotionCursor && !budgetExhausted) {
+				next = {
+					m: 'db',
+					d: databaseId,
+					n: nextNotionCursor,
+					s: since,
+					...(backfill ? { f: 1 as const } : {}),
+					b: pagesUsed
+				};
+			} else if (dbIndex + 1 < databaseIds.length) {
+				// Advance to the next database (page counter resets per phase).
+				next = {
+					m: 'db',
+					d: databaseIds[dbIndex + 1],
+					s: since,
+					...(backfill ? { f: 1 as const } : {}),
+					b: 0
+				};
+			}
+			return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+		}
+
+		// Workspace-wide search sweep. The search API cannot filter by
+		// time, so we sort newest-first and stop at the first result that
+		// falls behind the window.
+		const page = await client.search({
+			filter: { property: 'object', value: 'page' },
+			sort: { direction: 'descending', timestamp: 'last_edited_time' },
+			page_size: NOTION_PULL_PAGE_SIZE,
+			...(after ? { start_cursor: after } : {})
+		});
+		for (const result of page.results ?? []) {
+			const editedMs = Date.parse(result.last_edited_time ?? '');
+			if (Number.isFinite(editedMs) && editedMs < Date.parse(since)) {
+				stopSweep = true;
+				break;
+			}
+			const envelope = this.normalizePage(result, since);
+			if (envelope) events.push(envelope);
+		}
+		hasMore = page.has_more === true && typeof page.next_cursor === 'string';
+		nextNotionCursor = typeof page.next_cursor === 'string' ? page.next_cursor : undefined;
+
+		pagesUsed += 1;
+		const budgetExhausted = backfill && pagesUsed >= NOTION_BACKFILL_MAX_PAGES;
+		let next: NotionPullCursor | undefined;
+		if (!stopSweep && hasMore && nextNotionCursor && !budgetExhausted) {
+			next = {
+				m: 'search',
+				n: nextNotionCursor,
+				s: since,
+				...(backfill ? { f: 1 as const } : {}),
+				b: pagesUsed
+			};
+		}
+		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	private normalizePage(page: NotionPageObject, since: string, databaseId?: string): IngestedEventEnvelope | null {
+		if (page.object !== 'page' || !page.id) return null;
+		const lastEdited = page.last_edited_time ?? page.created_time;
+		const editedMs = Date.parse(lastEdited ?? '');
+		if (!Number.isFinite(editedMs)) return null;
+		const occurredAt = new Date(editedMs).toISOString();
+		const createdMs = Date.parse(page.created_time ?? '');
+		const changeType = Number.isFinite(createdMs) && createdMs >= Date.parse(since) ? 'created' : 'edited';
+		const title = extractPageTitle(page);
+
+		return {
+			id: randomUUID(),
+			source: this.id,
+			sourceEventId: `${page.id}:${occurredAt}`,
+			kind: 'notion.page',
+			occurredAt,
+			subject: {
+				type: 'page',
+				externalId: page.id,
+				...(title ? { title } : {})
+			},
+			...(page.url ? { sourceUrl: page.url } : {}),
+			payload: {
+				pageId: page.id,
+				...(title ? { title: truncateText(title) } : {}),
+				changeType,
+				...(page.created_time ? { createdTime: page.created_time } : {}),
+				lastEditedTime: occurredAt,
+				...(databaseId
+					? { databaseId }
+					: page.parent?.database_id
+						? { databaseId: page.parent.database_id }
+						: {})
+			}
+		};
+	}
+}
+
+export const notionConnectorPlugin = new NotionConnectorPlugin();

--- a/packages/plugins/notion-connector/tsconfig.json
+++ b/packages/plugins/notion-connector/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/notion-connector/tsup.config.ts
+++ b/packages/plugins/notion-connector/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/notion-connector/vitest.config.ts
+++ b/packages/plugins/notion-connector/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/packages/tasks/src/tasks/trigger/event-ingest-tick.task.ts
+++ b/packages/tasks/src/tasks/trigger/event-ingest-tick.task.ts
@@ -1,23 +1,35 @@
 import { logger, schedules } from '@trigger.dev/sdk';
-import { EventIngestService } from '@ever-works/agent/ingest';
+import { EventIngestService, EventSourcePullService } from '@ever-works/agent/ingest';
 import { withWorkerContext } from '../../trigger/worker/utils/worker-context.utils';
 import { TriggerInternalModule } from '../../trigger/worker/modules/trigger-internal.module';
 
 /**
- * Event-ingest spine (Wave 6) — processor tick.
+ * Event-ingest spine (Wave 6, pull path Wave 8) — processor tick.
  *
- * Every 5 minutes, drain a batch of unprocessed `ingested_events`
- * rows through the fan-out (Activity log + best-effort Memory, each
- * carrying `sourceUrl` provenance). The real `EventIngestService`
- * lives in the API (repositories + ActivityLogService + the
- * agent-memory facade are wired there); the worker only calls
- * `processBatch()` over the internal RPC channel — same shape as the
- * task-branch-gc / mission-tick crons.
+ * Every 5 minutes:
+ *
+ *   1. PULL — `EventSourcePullService.pullSources()` sweeps every
+ *      loaded event-source plugin for every user who enabled it,
+ *      calling `pullEvents` with the persisted per-(user, plugin)
+ *      watermark + continuation cursor (`ingest_cursors`) and landing
+ *      the envelopes through the dedupe insert. A failed pull never
+ *      blocks the drain below (and inside the pull, one broken
+ *      source/user never stops the rest of the batch).
+ *   2. DRAIN — `EventIngestService.processBatch()` fans a batch of
+ *      unprocessed `ingested_events` rows out to the Activity log +
+ *      best-effort Memory, each carrying `sourceUrl` provenance.
+ *
+ * Both real services live in the API (plugin registry, repositories,
+ * ActivityLogService and the agent-memory facade are wired there); the
+ * worker only calls them over the internal RPC channel — same shape as
+ * the task-branch-gc / mission-tick crons.
  *
  * 5 minutes is deliberate: ingest is not latency-sensitive (feed +
  * Memory freshness, not user-facing request paths), rows that fail
- * their Activity write stay unprocessed and retry next tick, and the
- * batch cap keeps each run bounded regardless of connector volume.
+ * their Activity write stay unprocessed and retry next tick, sweeps
+ * that outrun the per-tick page budget resume from their cursor next
+ * tick, and the batch caps keep each run bounded regardless of
+ * connector volume.
  */
 export const eventIngestTickTask = schedules.task({
     id: 'event-ingest-tick',
@@ -26,6 +38,23 @@ export const eventIngestTickTask = schedules.task({
         return withWorkerContext(
             'EventIngestTick',
             async (appContext) => {
+                // 1. Pull event-source plugins → dedupe-insert. Best-effort:
+                // a pull-path failure must never block draining rows that
+                // already landed (webhook pushes, earlier pulls).
+                let pull;
+                try {
+                    const pullSvc = appContext.get(EventSourcePullService);
+                    pull = await pullSvc.pullSources();
+                    if (pull.pulled > 0 || pull.errors > 0) {
+                        logger.info('event-ingest-tick pulled event sources', { ...pull });
+                    }
+                } catch (error) {
+                    logger.warn('event-ingest-tick source pull failed', {
+                        error: error instanceof Error ? error.message : String(error),
+                    });
+                }
+
+                // 2. Drain unprocessed rows through the processor fan-out.
                 const svc = appContext.get(EventIngestService);
                 const limit = Number(process.env.EVENT_INGEST_BATCH_LIMIT) || 50;
                 const summary = await svc.processBatch(limit);
@@ -35,7 +64,7 @@ export const eventIngestTickTask = schedules.task({
                         limit,
                     });
                 }
-                return summary;
+                return { ...summary, pull };
             },
             TriggerInternalModule,
         );

--- a/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
+++ b/packages/tasks/src/trigger/worker/modules/trigger-internal.module.ts
@@ -25,7 +25,7 @@ import {
 } from '@ever-works/agent/tasks-domain';
 import { AgentRepository, AgentRunRepository, WorkRepository } from '@ever-works/agent/database';
 import { NotificationChannelFacadeService } from '@ever-works/agent/facades';
-import { EventIngestService } from '@ever-works/agent/ingest';
+import { EventIngestService, EventSourcePullService } from '@ever-works/agent/ingest';
 import { DigestService } from '@ever-works/agent/digest';
 import { CreditLedgerService } from '@ever-works/agent/subscriptions';
 import { TriggerInternalApiClient } from '../services/trigger-internal-api.client';
@@ -253,6 +253,16 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
                 createRemoteProxy(apiClient, 'EventIngestService'),
             inject: [TriggerInternalApiClient],
         },
+        // Event-ingest pull path (Wave 8) — the same cron's PULL half:
+        // `pullSources()` RPCs to the live API where the event-source
+        // plugins, settings resolution and `ingest_cursors` rows are
+        // wired. Same shape as EventIngestService above.
+        {
+            provide: EventSourcePullService,
+            useFactory: (apiClient: TriggerInternalApiClient) =>
+                createRemoteProxy(apiClient, 'EventSourcePullService'),
+            inject: [TriggerInternalApiClient],
+        },
         // Digest briefings (Wave 7) — the digest-dispatcher cron task
         // calls `dispatchDue(period)` on this proxy, which RPCs to the
         // live API where the digest composer's repositories + the
@@ -301,6 +311,7 @@ export const DATA_SYNC_DISPATCHER_SERVICE = 'DataSyncDispatcherService';
         AnonymousUserCleanupService,
         KnowledgeBaseReconcileService,
         EventIngestService,
+        EventSourcePullService,
         DigestService,
         CreditLedgerService,
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2085,6 +2085,31 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
+  packages/plugins/linear-connector:
+    dependencies:
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../../contracts
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@linear/sdk':
+        specifier: ^88.0.0
+        version: 88.3.0(graphql@16.13.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
   packages/plugins/linkup:
     devDependencies:
       '@ever-works/plugin':
@@ -2320,6 +2345,31 @@ importers:
       '@langchain/openai':
         specifier: ^0.6.17
         version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  packages/plugins/notion-connector:
+    dependencies:
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../../contracts
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@notionhq/client':
+        specifier: ^2.3.0
+        version: 2.3.0
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -5828,6 +5878,11 @@ packages:
   '@grammyjs/types@3.27.3':
     resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
 
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
   '@grpc/grpc-js@1.14.4':
     resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
@@ -6525,6 +6580,10 @@ packages:
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
+
+  '@linear/sdk@88.3.0':
+    resolution: {integrity: sha512-F3bTsXQBDZja/UT+whtKAzHNPk8zTwoxq2Zs5tgbbHQLC3kueMOyHKO/u2RAYjxCKu3XtqB3vV0/6P/EqO+pOw==}
+    engines: {node: '>=18.x'}
 
   '@lottiefiles/dotlottie-react@0.18.10':
     resolution: {integrity: sha512-7ZquvmoH+KrotNw2n65GHgOjP/tirFwqgGOHQWA5Qxt7wkA6gs1Y7j43DrPqcyIm69+kecsoJb+CtOS26UoKlw==}
@@ -24912,6 +24971,10 @@ snapshots:
 
   '@grammyjs/types@3.27.3': {}
 
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.13.0)':
+    dependencies:
+      graphql: 16.13.0
+
   '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.1
@@ -25800,6 +25863,12 @@ snapshots:
       '@opentelemetry/api': 1.9.0
 
   '@leichtgewicht/ip-codec@2.0.5': {}
+
+  '@linear/sdk@88.3.0(graphql@16.13.0)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.0)
+    transitivePeerDependencies:
+      - graphql
 
   '@lottiefiles/dotlottie-react@0.18.10(react@19.2.5)':
     dependencies:


### PR DESCRIPTION
## Summary

Wave 8 feature (i) **native connectors** — the first two after the Slack wedge — plus feature (l) **historical backfill opt-in**, and the previously-missing **PULL half of the `event-ingest-tick` cron** (the tick only drained `processBatch()`; nothing ever called `pullEvents` on event-source plugins).

### `packages/plugins/linear-connector` (official `@linear/sdk`)
- Capabilities `connector` + `connector-linear` + `event-source`; manifest `systemPlugin:false builtIn:true autoEnable:false` (opt-in).
- **Outbound `send()`** — creates a comment on a Linear issue (`targetConfig.issueId`/`defaultIssueId`), idempotent on `messageRef` (tenant-scoped cache key, mirrors slack-connector hardening).
- **`pullEvents`** — sweeps issues (created/updated) then comments since the watermark → `linear.issue` / `linear.comment` envelopes with `sourceUrl` = issue url and `subject {type:'issue', externalId, title}`; optional `teamIds` filter; cursor carries phase + SDK page cursor + the sweep's own `since` so later pages keep the SAME window.
- Settings: `apiKey` (`x-secret`, `LINEAR_API_KEY`), `teamIds`, `backfillDays` (default 0 = off, clamped to 90), `defaultIssueId`.

### `packages/plugins/notion-connector` (official `@notionhq/client`)
- Capabilities `connector` + `connector-notion` + `event-source`; same opt-in manifest posture.
- **Outbound `send()`** — appends a comment to a page; integration tokens without comment capabilities fail with a clear, actionable error ("grant Insert comments + share the page"), not a generic 500.
- **`pullEvents`** — pages created/edited since the watermark → `notion.page` envelopes with `sourceUrl` = page url. With `databaseIds` set: per-database `databases.query` with a server-side `last_edited_time on_or_after` filter; otherwise workspace `search` sorted newest-first with client-side windowing (the search API cannot filter by time) and early sweep stop.
- Settings: `apiKey` (`x-secret`, `NOTION_API_KEY`), `databaseIds`, `backfillDays`, `defaultPageId`.

### Opt-in historical backfill (feature l)
`backfillDays` (default **0 = off**, max **90**) widens only the FIRST pull's window (epoch watermark + no cursor = first pull), bounded to 10 pages per phase so activation never becomes an unbounded crawl. Backfilled history flows through the same envelope pipeline — indistinguishable in Memory/Activities except for older timestamps. Re-delivery is free: the spine dedupes on `(source, sourceEventId)`.

### Event-source pull path (new, `packages/agent/src/ingest`)
- **`EventSourcePullService.pullSources()`** — for every loaded `event-source` plugin: resolve opted-in users (their `user_plugins` rows, confirmed through the same `isPluginEnabledForScope` gate the facades use), resolve settings (4-level hierarchy, secrets included), call `pullEvents` with the persisted per-(user, plugin) watermark + continuation cursor, dedupe-insert via `EventIngestService.ingest()`. Per-tick page budget (5) per pair; completed sweeps advance the watermark to when the sweep STARTED (never "now"); one broken source/user never kills the batch; lazy plugin proxies are materialized first.
- **`ingest_cursors`** — `IngestCursor` entity + repository, guarded migration `1783500000000-CreateIngestCursors` (`hasTable`, unique `(userId, pluginId)`, FK users CASCADE); registered in `_entities-inventory.ts` + `_entity-names.ts` (no `autoLoadEntities` in this repo).
- **`event-ingest-tick`** now pulls sources (best-effort — a pull failure never blocks the drain) and then drains `processBatch()`; `EventSourcePullService` is exposed over the trigger-internal RPC channel (worker-side remote proxy + API controller remoteMap entry, appended-last `@Optional()` per the arity rule).
- `PLUGIN_CAPABILITIES.CONNECTOR_LINEAR` added (`CONNECTOR_NOTION` already existed).

## Verification (real output)

- `packages/plugins/linear-connector` — `pnpm build` (tsc 0 + tsup ESM/CJS/DTS) ✅; `pnpm test` → **1 file, 19 passed**
- `packages/plugins/notion-connector` — `pnpm build` ✅; `pnpm test` → **1 file, 18 passed**
- `packages/agent` — `pnpm build` → `TSC Found 0 issues`, 1023 files compiled ✅
- `packages/agent` — `npx jest --testPathPattern='ingest'` → **5 suites, 36 passed** (incl. 9 new `event-source-pull.service.spec.ts` tests: cursor isolation, watermark/sweep protocol, error isolation, lazy-proxy materialization)
- `packages/agent` — `npx jest --testPathPattern='database'` → **38 suites, 524 passed** (entity-inventory drift specs green with `IngestCursor`)
- `packages/plugin` — `pnpm test` → **23 files, 272 passed**
- `packages/tasks` — build ✅; `pnpm test` → **25 files, 394 passed**
- `apps/api` — `pnpm build --filter=ever-works-api` ✅ (14 tasks); `npx jest --testPathPattern='trigger-internal'` → **2 suites, 16 passed**
- `apps/api` — `pnpm generate:openapi` → `Wrote OpenAPI spec (420 paths)` (full-app bootstrap, DI wiring sound; `openapi.json` unchanged → excluded)
- Prettier run over every touched file.

## Notes / follow-ups
- Both connectors are **pull-first** (`transport: 'poll'`, `direction: 'outbound'` + event-source); webhook inbound legs land with a later increment, riding the same envelope shape.
- Linear comment→parent-issue subject uses the SDK's lazy per-node fetch (best-effort; degrades to the comment permalink).
- Per spec (i), Linear/JIRA issue ↔ Task import stays v2 — this ships the ingest + outbound-comment floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)