### PR TITLE
feat(agents): GTM pipeline + agent templates (Wave 10)

### DIFF
--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -43,6 +43,8 @@ import {
     type AgentImportResult,
     type AgentScorecardMetric,
     type AgentTarget,
+    type AgentTemplate,
+    AgentTemplatesService,
     PluginUsageRepository,
 } from '@ever-works/agent/agents';
 import {
@@ -62,6 +64,7 @@ import {
     AddAgentAttachmentDto,
     AssignTaskToAgentDto,
     CreateAgentDto,
+    CreateAgentFromTemplateDto,
     ListAgentRunsQueryDto,
     ListAgentsQueryDto,
     ListRunSessionsQueryDto,
@@ -157,6 +160,10 @@ export class AgentsController {
         // + Optional for the same positional-spec reason as above.
         @Optional()
         private readonly dispatchGate?: RunDispatchGateService,
+        // Wave 10 — prebuilt agent-template activation. Trailing +
+        // Optional for the same positional-spec reason as above.
+        @Optional()
+        private readonly agentTemplates?: AgentTemplatesService,
     ) {}
 
     @Get()
@@ -317,6 +324,51 @@ export class AgentsController {
             })),
             meta: { total, limit, offset },
         };
+    }
+
+    /**
+     * Wave 10 — prebuilt agent-template catalog (in-code, fully
+     * specified presets with prompts + safe defaults). Complements the
+     * repo-backed `GET /api/agent-templates` metadata catalog. Declared
+     * BEFORE the `:id` routes so the literal `templates` segment never
+     * reaches ParseUUIDPipe.
+     */
+    @Get('templates')
+    @ApiOperation({ summary: 'List prebuilt agent templates (marketing/sales/ops presets)' })
+    @HttpCode(HttpStatus.OK)
+    async listTemplates(): Promise<{ data: AgentTemplate[] }> {
+        if (!this.agentTemplates) {
+            throw new InternalServerErrorException('Agent templates service is not available.');
+        }
+        return { data: [...this.agentTemplates.list()] };
+    }
+
+    /**
+     * Wave 10 — create MY Agent from a prebuilt template. Owner-scoped:
+     * the created Agent belongs to the caller, starts in DRAFT with the
+     * template's prompt (SOUL.md), conservative permissions, and
+     * review-before-act guardrails. Body fields are optional placement
+     * overrides only. Declared BEFORE the `:id` routes (literal segment).
+     */
+    @Post('from-template/:slug')
+    @ApiOperation({ summary: 'Create an Agent for the current user from a prebuilt template' })
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async createFromTemplate(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('slug') slug: string,
+        @Body() body: CreateAgentFromTemplateDto,
+    ): Promise<AgentDto> {
+        if (!this.agentTemplates) {
+            throw new InternalServerErrorException('Agent templates service is not available.');
+        }
+        return this.agentTemplates.createFromTemplate(auth.userId, slug, {
+            name: body.name ?? null,
+            scope: body.scope,
+            missionId: body.missionId ?? null,
+            ideaId: body.ideaId ?? null,
+            workId: body.workId ?? null,
+        });
     }
 
     @Get(':id')

--- a/apps/api/src/agents/dto/agent.dto.ts
+++ b/apps/api/src/agents/dto/agent.dto.ts
@@ -223,6 +223,29 @@ export class CreateAgentDto {
     committerEmail?: string;
 }
 
+/**
+ * Wave 10 — POST /api/agents/from-template/:slug body. Everything is an
+ * OPTIONAL placement override: prompt, permissions, guardrails, and
+ * capabilities always come from the template itself.
+ */
+export class CreateAgentFromTemplateDto {
+    @ApiProperty({ required: false, minLength: 1, maxLength: 120 })
+    @IsOptional()
+    @IsString()
+    @MinLength(1)
+    @MaxLength(120)
+    name?: string;
+
+    @ApiProperty({ required: false, enum: AgentScope })
+    @IsOptional()
+    @IsEnum(AgentScope)
+    scope?: AgentScope;
+
+    @ApiProperty({ required: false }) @IsOptional() @IsUUID() missionId?: string;
+    @ApiProperty({ required: false }) @IsOptional() @IsUUID() ideaId?: string;
+    @ApiProperty({ required: false }) @IsOptional() @IsUUID() workId?: string;
+}
+
 export class UpdateAgentDto {
     @ApiProperty({ required: false, minLength: 1, maxLength: 120 })
     @IsOptional()

--- a/apps/web/src/lib/ai/tools/generated/registry.ts
+++ b/apps/web/src/lib/ai/tools/generated/registry.ts
@@ -105,6 +105,33 @@ export const OPERATION_REGISTRY: OperationSpec[] = [
         bodyHint: 'name, title, scope, scopeId, aiProvider, model, capabilities[].',
     },
     {
+        toolName: 'list_agent_templates',
+        method: 'GET',
+        path: '/api/agents/templates',
+        summary:
+            'List prebuilt agent templates (marketing/sales/ops presets with prompts, suggested skills, and a suggested pipeline).',
+        kind: 'read',
+    },
+    {
+        toolName: 'create_agent_from_template',
+        method: 'POST',
+        path: '/api/agents/from-template/{slug}',
+        summary:
+            'Create an agent for the current user from a prebuilt template (draft status, review-before-act guardrails).',
+        kind: 'create',
+        params: [
+            {
+                name: 'slug',
+                in: 'path',
+                required: true,
+                type: 'string',
+                description: 'Template slug from list_agent_templates (e.g. outreach-drafter)',
+            },
+        ],
+        body: true,
+        bodyHint: 'Optional placement overrides: name, scope, missionId, ideaId, workId.',
+    },
+    {
         toolName: 'update_agent',
         method: 'PATCH',
         path: '/api/agents/{id}',

--- a/packages/agent/src/agents/__tests__/agent-templates.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-templates.service.spec.ts
@@ -1,0 +1,141 @@
+import { NotFoundException } from '@nestjs/common';
+import { AgentScope } from '../../entities/agent.entity';
+import { AgentTemplatesService } from '../agent-templates.service';
+import { getAgentTemplate } from '../agent-templates';
+import type { AgentsService } from '../agents.service';
+import type { AgentFileService } from '../agent-file.service';
+
+/**
+ * Hand-rolled unit surface (same posture as agents.service.spec.ts):
+ * the service is constructed positionally with mocks — no Nest testing
+ * module needed.
+ */
+describe('AgentTemplatesService', () => {
+    const CREATED = { id: 'agent-1', name: 'Outreach Drafter' };
+    const AFTER_GUARDRAILS = {
+        id: 'agent-1',
+        name: 'Outreach Drafter',
+        guardrails: { mode: 'require_approval' },
+    };
+
+    function makeService() {
+        const agents = {
+            create: jest.fn().mockResolvedValue(CREATED),
+            setGuardrails: jest.fn().mockResolvedValue(AFTER_GUARDRAILS),
+        };
+        const files = {
+            write: jest.fn().mockResolvedValue({ newHash: 'hash' }),
+        };
+        const service = new AgentTemplatesService(
+            agents as unknown as AgentsService,
+            files as unknown as AgentFileService,
+        );
+        return { service, agents, files };
+    }
+
+    it('list() returns the full catalog and get() resolves a template', () => {
+        const { service } = makeService();
+        expect(service.list().length).toBeGreaterThanOrEqual(6);
+        expect(service.get('lead-researcher').slug).toBe('lead-researcher');
+    });
+
+    it('get() throws NotFound for an unknown slug', () => {
+        const { service } = makeService();
+        expect(() => service.get('no-such-template')).toThrow(NotFoundException);
+    });
+
+    it('createFromTemplate maps template fields onto the standard create input', async () => {
+        const { service, agents } = makeService();
+        const template = getAgentTemplate('outreach-drafter')!;
+
+        await service.createFromTemplate('user-1', 'outreach-drafter');
+
+        expect(agents.create).toHaveBeenCalledWith('user-1', {
+            scope: AgentScope.TENANT,
+            missionId: null,
+            ideaId: null,
+            workId: null,
+            name: template.name,
+            title: template.title,
+            capabilities: template.capabilities,
+            permissions: template.defaultPermissions,
+        });
+    });
+
+    it('writes the template system prompt as SOUL.md for the created Agent', async () => {
+        const { service, files } = makeService();
+        const template = getAgentTemplate('content-marketer')!;
+
+        await service.createFromTemplate('user-1', 'content-marketer');
+
+        expect(files.write).toHaveBeenCalledWith({
+            userId: 'user-1',
+            agentId: 'agent-1',
+            name: 'SOUL.md',
+            body: template.systemPrompt,
+        });
+    });
+
+    it('seeds the review-before-act guardrails and returns the refreshed DTO', async () => {
+        const { service, agents } = makeService();
+        const template = getAgentTemplate('competitive-analyst')!;
+
+        const result = await service.createFromTemplate('user-1', 'competitive-analyst');
+
+        expect(agents.setGuardrails).toHaveBeenCalledWith(
+            'user-1',
+            'agent-1',
+            template.defaultGuardrails,
+        );
+        expect(result).toBe(AFTER_GUARDRAILS);
+    });
+
+    it('is owner-scoped — every downstream call carries the acting userId', async () => {
+        const { service, agents, files } = makeService();
+
+        await service.createFromTemplate('user-42', 'seo-auditor');
+
+        expect(agents.create.mock.calls[0][0]).toBe('user-42');
+        expect(files.write.mock.calls[0][0].userId).toBe('user-42');
+        expect(agents.setGuardrails.mock.calls[0][0]).toBe('user-42');
+    });
+
+    it('honors name and scope overrides (Work-scoped activation)', async () => {
+        const { service, agents } = makeService();
+
+        await service.createFromTemplate('user-1', 'lead-researcher', {
+            name: '  Pipeline Scout  ',
+            scope: AgentScope.WORK,
+            workId: 'work-9',
+        });
+
+        const input = agents.create.mock.calls[0][1];
+        expect(input.name).toBe('Pipeline Scout');
+        expect(input.scope).toBe(AgentScope.WORK);
+        expect(input.workId).toBe('work-9');
+        expect(input.missionId).toBeNull();
+    });
+
+    it('rejects unknown template slugs before creating anything', async () => {
+        const { service, agents, files } = makeService();
+
+        await expect(service.createFromTemplate('user-1', 'ghost-template')).rejects.toThrow(
+            NotFoundException,
+        );
+        expect(agents.create).not.toHaveBeenCalled();
+        expect(files.write).not.toHaveBeenCalled();
+    });
+
+    it('still creates the Agent (with a warning path) when the file service is absent', async () => {
+        const agents = {
+            create: jest.fn().mockResolvedValue(CREATED),
+            setGuardrails: jest.fn().mockResolvedValue(AFTER_GUARDRAILS),
+        };
+        const service = new AgentTemplatesService(agents as unknown as AgentsService);
+
+        const result = await service.createFromTemplate('user-1', 'social-scheduler');
+
+        expect(agents.create).toHaveBeenCalled();
+        expect(result).toBe(AFTER_GUARDRAILS);
+    });
+});

--- a/packages/agent/src/agents/__tests__/agent-templates.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-templates.spec.ts
@@ -1,0 +1,92 @@
+import { AGENT_PERMISSIONS_DEFAULT } from '../../entities/agent.entity';
+import { assertNoSecrets } from '../../utils/secret-scan';
+import { slugifyText } from '../../utils/text.utils';
+import { validateGuardrails } from '../guardrails';
+import { AGENT_TEMPLATES, getAgentTemplate, listAgentTemplates } from '../agent-templates';
+
+/**
+ * Catalog-integrity pins for the Wave 10 prebuilt agent templates.
+ * These are pure-data checks — if a template entry drifts out of
+ * contract (duplicate slug, empty prompt, invalid guardrails, unknown
+ * permission key), the suite names the offending entry.
+ */
+describe('agent-templates catalog integrity', () => {
+    it('ships at least the six go-to-market templates', () => {
+        expect(AGENT_TEMPLATES.length).toBeGreaterThanOrEqual(6);
+        const slugs = AGENT_TEMPLATES.map((t) => t.slug);
+        expect(slugs).toEqual(
+            expect.arrayContaining([
+                'content-marketer',
+                'seo-auditor',
+                'lead-researcher',
+                'outreach-drafter',
+                'social-scheduler',
+                'competitive-analyst',
+            ]),
+        );
+    });
+
+    it('slugs are unique and kebab-case', () => {
+        const slugs = AGENT_TEMPLATES.map((t) => t.slug);
+        expect(new Set(slugs).size).toBe(slugs.length);
+        for (const slug of slugs) {
+            expect(slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+        }
+    });
+
+    it('every template name produces a valid Agent slug (create() precondition)', () => {
+        for (const template of AGENT_TEMPLATES) {
+            const slug = slugifyText(template.name);
+            expect(slug && /[a-z0-9]/i.test(slug)).toBe(true);
+        }
+    });
+
+    it('system prompts are substantial, secret-free, and review-first', () => {
+        for (const template of AGENT_TEMPLATES) {
+            expect(template.systemPrompt.trim().length).toBeGreaterThan(200);
+            // AgentFileService.write() hard-rejects secrets — the catalog
+            // must never trip that gate at activation time.
+            expect(() =>
+                assertNoSecrets(template.systemPrompt, `template ${template.slug}`),
+            ).not.toThrow();
+            expect(template.description.trim().length).toBeGreaterThan(40);
+            expect(template.capabilities.trim().length).toBeGreaterThan(20);
+        }
+    });
+
+    it('default guardrails validate and default to the require-approval posture', () => {
+        for (const template of AGENT_TEMPLATES) {
+            expect(validateGuardrails(template.defaultGuardrails)).toBeNull();
+            expect(template.defaultGuardrails.mode).toBe('require_approval');
+        }
+    });
+
+    it('default permissions only use known permission keys (conservative subset)', () => {
+        const knownKeys = new Set(Object.keys(AGENT_PERMISSIONS_DEFAULT));
+        for (const template of AGENT_TEMPLATES) {
+            for (const key of Object.keys(template.defaultPermissions)) {
+                expect(knownKeys.has(key)).toBe(true);
+            }
+        }
+    });
+
+    it('categories, roles, and suggestions stay within their vocabularies', () => {
+        for (const template of AGENT_TEMPLATES) {
+            expect(['marketing', 'sales', 'ops']).toContain(template.category);
+            expect(template.suggestedRoles.length).toBeGreaterThan(0);
+            expect(template.suggestedSkills.length).toBeGreaterThan(0);
+            for (const skill of template.suggestedSkills) {
+                expect(skill).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+            }
+            if (template.suggestedPipeline !== null) {
+                expect(template.suggestedPipeline).toBe('gtm-pipeline');
+            }
+        }
+    });
+
+    it('lookup helpers return catalog entries by slug and undefined for unknowns', () => {
+        expect(listAgentTemplates()).toBe(AGENT_TEMPLATES);
+        expect(getAgentTemplate('outreach-drafter')?.name).toBe('Outreach Drafter');
+        expect(getAgentTemplate('nonexistent-template')).toBeUndefined();
+    });
+});

--- a/packages/agent/src/agents/agent-templates.service.ts
+++ b/packages/agent/src/agents/agent-templates.service.ts
@@ -1,0 +1,102 @@
+import { Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
+import { AgentScope } from '../entities/agent.entity';
+import { AgentsService } from './agents.service';
+import { AgentFileService } from './agent-file.service';
+import type { AgentDto } from './types';
+import { getAgentTemplate, listAgentTemplates, type AgentTemplate } from './agent-templates';
+
+/**
+ * Optional placement overrides accepted by {@link AgentTemplatesService.createFromTemplate}.
+ * Everything else (prompt, permissions, guardrails, capabilities) comes
+ * from the template itself — overrides only cover naming and scope so a
+ * template can be activated into a Mission/Idea/Work context.
+ */
+export interface CreateAgentFromTemplateInput {
+    name?: string | null;
+    scope?: AgentScope;
+    missionId?: string | null;
+    ideaId?: string | null;
+    workId?: string | null;
+}
+
+/**
+ * Wave 10 — prebuilt agent-template activation.
+ *
+ * Thin orchestration over the existing Agent surfaces: `AgentsService.create`
+ * creates the row (owner-scoped, DRAFT status, same validation as manual
+ * creation), `AgentFileService.write` persists the template's system
+ * prompt as SOUL.md, and `AgentsService.setGuardrails` seeds the
+ * review-before-act guardrails. No new persistence concepts — templates
+ * are catalog data and the result is an ordinary Agent row.
+ */
+@Injectable()
+export class AgentTemplatesService {
+    private readonly logger = new Logger(AgentTemplatesService.name);
+
+    constructor(
+        private readonly agents: AgentsService,
+        // `@Optional()` mirrors the AgentsService posture for hand-rolled
+        // unit tests; production DI always provides it via AgentsModule.
+        @Optional() private readonly files?: AgentFileService,
+    ) {}
+
+    /** The full prebuilt-template catalog. */
+    list(): readonly AgentTemplate[] {
+        return listAgentTemplates();
+    }
+
+    /** One template by slug — 404 when unknown. */
+    get(slug: string): AgentTemplate {
+        const template = getAgentTemplate(slug);
+        if (!template) {
+            throw new NotFoundException(`Agent template "${slug}" not found.`);
+        }
+        return template;
+    }
+
+    /**
+     * Create an Agent for `userId` from the template `slug`.
+     *
+     * Owner-scoped and additive: the caller becomes the owner, the Agent
+     * starts in DRAFT (same as any manual create), and name conflicts
+     * surface as the standard 409 so callers can retry with an override.
+     */
+    async createFromTemplate(
+        userId: string,
+        slug: string,
+        input: CreateAgentFromTemplateInput = {},
+    ): Promise<AgentDto> {
+        const template = this.get(slug);
+        const scope = input.scope ?? AgentScope.TENANT;
+
+        const created = await this.agents.create(userId, {
+            scope,
+            missionId: input.missionId ?? null,
+            ideaId: input.ideaId ?? null,
+            workId: input.workId ?? null,
+            name: input.name?.trim() || template.name,
+            title: template.title,
+            capabilities: template.capabilities,
+            permissions: template.defaultPermissions,
+        });
+
+        // Persist the template's system prompt as the Agent's SOUL.md.
+        // Best-effort ordering: the Agent row exists first, so a failed
+        // file write surfaces loudly instead of leaving no Agent at all.
+        if (this.files) {
+            await this.files.write({
+                userId,
+                agentId: created.id,
+                name: 'SOUL.md',
+                body: template.systemPrompt,
+            });
+        } else {
+            this.logger.warn(
+                `AgentFileService unavailable — created "${created.id}" from template "${slug}" without SOUL.md.`,
+            );
+        }
+
+        // Seed the review-before-act guardrails and return the fresh DTO.
+        return this.agents.setGuardrails(userId, created.id, template.defaultGuardrails);
+    }
+}

--- a/packages/agent/src/agents/agent-templates.ts
+++ b/packages/agent/src/agents/agent-templates.ts
@@ -1,0 +1,266 @@
+import { type AgentPermissions } from '../entities/agent.entity';
+import type { AgentGuardrails } from './guardrails';
+
+/**
+ * Prebuilt Agent templates — Wave 10 (go-to-market parity).
+ *
+ * A typed, in-code catalog of marketing/sales/ops agent presets. Each
+ * entry is pure catalog DATA that activates into an ordinary Agent row
+ * for the calling user (no new top-level concept): the system prompt
+ * becomes the Agent's SOUL.md, permissions/guardrails seed the same
+ * columns every hand-created Agent uses, and the suggested skills /
+ * pipeline are hints the caller (UI or chat) can wire up next.
+ *
+ * This complements — and does not replace — the repo-backed template
+ * catalog served by `GET /api/agent-templates` (ADR-011): that surface
+ * lists external catalog metadata; this one ships fully-specified,
+ * ready-to-activate presets with prompts and safe defaults.
+ */
+
+export type AgentTemplateCategory = 'marketing' | 'sales' | 'ops';
+
+export interface AgentTemplate {
+    /** Stable kebab-case identifier used by the from-template endpoint. */
+    readonly slug: string;
+    /** Default Agent name (used unless the caller overrides it). */
+    readonly name: string;
+    /** Short role line — becomes the Agent's title. */
+    readonly title: string;
+    readonly category: AgentTemplateCategory;
+    /** One-paragraph description shown in pickers. */
+    readonly description: string;
+    /** SOUL.md body written onto the created Agent. */
+    readonly systemPrompt: string;
+    /** Free-text capabilities summary — becomes the Agent's capabilities field. */
+    readonly capabilities: string;
+    /** Skill slugs (skills catalog) that pair well with this template. */
+    readonly suggestedSkills: readonly string[];
+    /** Pipeline plugin id this template is designed to drive. */
+    readonly suggestedPipeline: string | null;
+    /** Conservative permission grants seeded at creation (unset = false). */
+    readonly defaultPermissions: Partial<AgentPermissions>;
+    /** Dispatch guardrails seeded at creation (review-before-act posture). */
+    readonly defaultGuardrails: AgentGuardrails;
+    /**
+     * Onboarding roles this template suits — forward-compatible hint for
+     * the role/team-size onboarding step (not shipped yet); consumed by
+     * suggestion surfaces once that step lands.
+     */
+    readonly suggestedRoles: readonly string[];
+}
+
+/** Review-before-act: every proposal queues for human approval. */
+const REQUIRE_APPROVAL: AgentGuardrails = { mode: 'require_approval' };
+
+export const AGENT_TEMPLATES: readonly AgentTemplate[] = [
+    {
+        slug: 'content-marketer',
+        name: 'Content Marketer',
+        title: 'Newsletter & content production',
+        category: 'marketing',
+        description:
+            'Turns raw ideas, notes, and campaign briefs into polished newsletter issues and long-form ' +
+            'content drafts on your content Works — always drafts, never publishes without review.',
+        systemPrompt: [
+            '# Content Marketer',
+            '',
+            'You are the Content Marketer agent. You produce newsletter issues, blog posts, and campaign',
+            'content from briefs, notes, and collected signals.',
+            '',
+            '## Operating rules',
+            '- Work in draft-first mode: every piece you produce is a DRAFT for human review. Never',
+            '  publish, send, or schedule content without an explicit approval.',
+            "- Ground every claim in the brief, the Work's knowledge base, or supplied signals — never",
+            '  invent metrics, quotes, or customer names.',
+            '- Match the configured tone and channel conventions (subject lines for email/newsletter,',
+            '  headings for blog posts).',
+            '- Keep newsletter bodies scannable: short sections, one clear call to action.',
+            '- When source material is thin, say so and list what additional input would raise quality.',
+        ].join('\n'),
+        capabilities:
+            'Newsletter drafting; long-form content drafting; content repurposing across channels; ' +
+            'editorial calendars; draft-first workflow with human review.',
+        suggestedSkills: ['newsletter-drafting', 'digest-compilation', 'campaign-reporting'],
+        suggestedPipeline: 'gtm-pipeline',
+        defaultPermissions: {},
+        defaultGuardrails: REQUIRE_APPROVAL,
+        suggestedRoles: ['Marketing', 'Founder/CEO'],
+    },
+    {
+        slug: 'seo-auditor',
+        name: 'SEO Auditor',
+        title: 'Site & content search-visibility review',
+        category: 'marketing',
+        description:
+            'Reviews your website and blog Works for search visibility: structure, metadata, internal ' +
+            'linking, and content gaps — and proposes prioritized, reviewable fixes.',
+        systemPrompt: [
+            '# SEO Auditor',
+            '',
+            'You are the SEO Auditor agent. You review website and blog Works for search visibility and',
+            'propose concrete, prioritized improvements.',
+            '',
+            '## Operating rules',
+            '- Audit structure (headings, metadata, internal links), content coverage, and keyword focus',
+            "  using the Work's actual pages and configuration as evidence.",
+            '- Every finding cites the page or setting it applies to and states the expected impact.',
+            '- Propose changes as reviewable edits or tasks — never modify published pages directly',
+            '  without approval.',
+            '- Prefer a short prioritized list (top 5-10) over exhaustive dumps; flag quick wins first.',
+            '- Re-audit after changes land and report movement honestly, including regressions.',
+        ].join('\n'),
+        capabilities:
+            'Site structure and metadata review; content-gap analysis; internal-linking suggestions; ' +
+            'prioritized fix lists; post-change re-audits.',
+        suggestedSkills: ['campaign-reporting', 'engagement-analysis'],
+        suggestedPipeline: null,
+        defaultPermissions: {},
+        defaultGuardrails: REQUIRE_APPROVAL,
+        suggestedRoles: ['Marketing', 'Engineering'],
+    },
+    {
+        slug: 'lead-researcher',
+        name: 'Lead Researcher',
+        title: 'Lead list building & enrichment',
+        category: 'sales',
+        description:
+            'Builds and maintains qualified lead lists from seed inputs and public signals, with ' +
+            'evidence-bound enrichment — it never invents contact details.',
+        systemPrompt: [
+            '# Lead Researcher',
+            '',
+            'You are the Lead Researcher agent. You build, score, and enrich lead lists for go-to-market',
+            'campaigns.',
+            '',
+            '## Operating rules',
+            '- Contacts come from seed lists and verifiable public sources. NEVER invent or guess',
+            '  contact details; never fabricate email addresses.',
+            '- Enrichment is evidence-bound: fill a field only when a source supports it, and record the',
+            '  supporting source in the contact notes.',
+            '- Score leads with the declarative weight table (explainable reasons per lead) and flag',
+            '  risky entries instead of silently dropping them.',
+            '- Respect the configured per-run caps; quality over volume.',
+            '- Output goes to the campaign Work for the Outreach Drafter and human review — you do not',
+            '  contact anyone.',
+        ].join('\n'),
+        capabilities:
+            'Lead list building from seeds and public signals; explainable lead scoring; risk flagging; ' +
+            'evidence-bound contact enrichment; list hygiene.',
+        suggestedSkills: ['contact-enrichment', 'lead-scoring', 'risk-filter'],
+        suggestedPipeline: 'gtm-pipeline',
+        defaultPermissions: {},
+        defaultGuardrails: REQUIRE_APPROVAL,
+        suggestedRoles: ['Sales', 'Founder/CEO'],
+    },
+    {
+        slug: 'outreach-drafter',
+        name: 'Outreach Drafter',
+        title: 'Personalized outbound drafting',
+        category: 'sales',
+        description:
+            'Writes personalized 80-120 word outreach drafts per qualified lead and channel. Hard rule: ' +
+            'drafts only — nothing is ever sent without explicit human approval.',
+        systemPrompt: [
+            '# Outreach Drafter',
+            '',
+            'You are the Outreach Drafter agent. You write personalized outbound drafts for qualified',
+            'leads.',
+            '',
+            '## Operating rules',
+            '- HARD CONSTRAINT: you produce drafts only. Nothing is sent, scheduled, or queued for',
+            '  delivery without explicit human approval of the recipient list and content.',
+            "- Personalize from the lead's known fields and collected signals only — never invent facts",
+            '  about a person or company.',
+            '- Keep bodies 80-120 words, one clear ask, in the configured tone; write subject lines only',
+            '  for channels that carry them.',
+            "- Batch work through the campaign pipeline's review gate; surface drafts grouped by lead",
+            '  score so reviewers see the best candidates first.',
+            '- Track which variants get approved vs. rejected and adapt future drafts accordingly.',
+        ].join('\n'),
+        capabilities:
+            'Personalized outreach drafting (80-120 words); subject-line writing; variant adaptation ' +
+            'from review outcomes; strict drafts-not-sends posture.',
+        suggestedSkills: ['outreach-personalization', 'follow-up-cadence', 'reply-detection'],
+        suggestedPipeline: 'gtm-pipeline',
+        defaultPermissions: {},
+        defaultGuardrails: REQUIRE_APPROVAL,
+        suggestedRoles: ['Sales'],
+    },
+    {
+        slug: 'social-scheduler',
+        name: 'Social Scheduler',
+        title: 'Social content planning & scheduling',
+        category: 'marketing',
+        description:
+            'Plans social content calendars, drafts channel-fit posts, and stages them for review — ' +
+            'publishing only ever happens after human approval.',
+        systemPrompt: [
+            '# Social Scheduler',
+            '',
+            'You are the Social Scheduler agent. You plan and draft social content across the configured',
+            'channels and stage it for review.',
+            '',
+            '## Operating rules',
+            '- Draft-first: posts are staged for human review; never publish or schedule to a live',
+            '  channel without approval.',
+            "- Fit each draft to its channel's conventions (length, hashtags, link placement) and the",
+            '  configured tone and cadence.',
+            '- Build from the campaign brief, content Works, and collected signals — never invent',
+            '  product claims or engagement numbers.',
+            '- Maintain a simple calendar view of planned posts; avoid repeating the same angle within a',
+            '  cadence window.',
+            "- After posts go live, fold engagement data into the next cycle's drafts.",
+        ].join('\n'),
+        capabilities:
+            'Social calendar planning; channel-fit post drafting; review-first staging; ' +
+            'engagement-informed iteration.',
+        suggestedSkills: ['news-signal-detection', 'engagement-analysis', 'digest-compilation'],
+        suggestedPipeline: 'gtm-pipeline',
+        defaultPermissions: {},
+        defaultGuardrails: REQUIRE_APPROVAL,
+        suggestedRoles: ['Marketing'],
+    },
+    {
+        slug: 'competitive-analyst',
+        name: 'Competitive Analyst',
+        title: 'Market & competitor monitoring digests',
+        category: 'marketing',
+        description:
+            'Monitors chosen companies and market segments across public sources and compiles a ' +
+            'structured recurring digest with trends and source-linked findings.',
+        systemPrompt: [
+            '# Competitive Analyst',
+            '',
+            'You are the Competitive Analyst agent. You monitor selected companies and market segments',
+            'and compile recurring intelligence digests.',
+            '',
+            '## Operating rules',
+            '- Collect from public sources only (websites, news, public repos); every finding carries',
+            '  its source link and date.',
+            '- Separate FACTS (sourced observations) from ANALYSIS (your interpretation) in every',
+            '  digest section.',
+            '- Track focus areas the operator configured (pricing, features, positioning, hiring) and',
+            '  highlight changes since the previous digest, including a short trend view.',
+            '- No fabrication: if a period has no meaningful signal, say exactly that.',
+            '- Deliver digests to the configured Work/channel as drafts for review.',
+        ].join('\n'),
+        capabilities:
+            'Public-source monitoring; recurring digest compilation; trend tracking; fact-vs-analysis ' +
+            'separation; source-linked findings.',
+        suggestedSkills: ['competitor-watch', 'news-signal-detection', 'digest-compilation'],
+        suggestedPipeline: 'gtm-pipeline',
+        defaultPermissions: {},
+        defaultGuardrails: REQUIRE_APPROVAL,
+        suggestedRoles: ['Marketing', 'Product', 'Founder/CEO'],
+    },
+] as const;
+
+/** List the full template catalog (stable order: as declared). */
+export function listAgentTemplates(): readonly AgentTemplate[] {
+    return AGENT_TEMPLATES;
+}
+
+/** Look up one template by slug; undefined when unknown. */
+export function getAgentTemplate(slug: string): AgentTemplate | undefined {
+    return AGENT_TEMPLATES.find((template) => template.slug === slug);
+}

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -19,6 +19,7 @@ import { AgentBudgetRepository } from '../database/repositories/agent-budget.rep
 import { AgentMembershipRepository } from '../database/repositories/agent-membership.repository';
 import { AgentAttachmentRepository } from '../database/repositories/attachment.repositories';
 import { AgentsService } from './agents.service';
+import { AgentTemplatesService } from './agent-templates.service';
 import { AgentFileService } from './agent-file.service';
 import { AgentScheduleDispatcherService } from './agent-schedule-dispatcher.service';
 import { AgentRunSweeperService } from './agent-run-sweeper.service';
@@ -82,6 +83,9 @@ import { FacadesModule } from '../facades/facades.module';
         AgentMembershipRepository,
         AgentAttachmentRepository,
         AgentsService,
+        // Wave 10 — prebuilt agent-template activation (catalog data +
+        // ordinary Agent rows; no new persistence concepts).
+        AgentTemplatesService,
         AgentFileService,
         AgentScheduleDispatcherService,
         AgentRunSweeperService,
@@ -105,6 +109,7 @@ import { FacadesModule } from '../facades/facades.module';
         AgentMembershipRepository,
         AgentAttachmentRepository,
         AgentsService,
+        AgentTemplatesService,
         AgentFileService,
         AgentScheduleDispatcherService,
         AgentRunSweeperService,

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -2,6 +2,8 @@
 // — PR #1017 specs, Phase 3 + 4 + 6).
 export * from './agents.module';
 export * from './agents.service';
+export * from './agent-templates';
+export * from './agent-templates.service';
 export * from './agent-file.service';
 export * from './agent-schedule-dispatcher.service';
 export * from './agent-export.service';

--- a/packages/plugins/gtm-pipeline/package.json
+++ b/packages/plugins/gtm-pipeline/package.json
@@ -1,0 +1,73 @@
+{
+	"name": "@ever-works/gtm-pipeline-plugin",
+	"version": "1.0.0",
+	"description": "Go-to-market pipeline plugin — research, qualify, draft, review, act, follow-up, enrich, and measure stages with declared stage input/output keys and a review-before-act human gate",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": true,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
+	},
+	"dependencies": {
+		"zod": "^3.25.0"
+	},
+	"peerDependencies": {
+		"@ever-works/plugin": "workspace:*"
+	},
+	"devDependencies": {
+		"@ever-works/plugin": "workspace:*",
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "gtm-pipeline",
+			"name": "Go-to-Market Pipeline",
+			"version": "1.0.0",
+			"category": "pipeline",
+			"capabilities": [
+				"pipeline",
+				"form-schema-provider"
+			],
+			"description": "Go-to-market pipeline with research, qualify, draft, review, act, follow-up, enrich, and measure stages. Every stage declares its input/output keys; the review stage is a human gate placed before any outbound action.",
+			"author": {
+				"name": "Ever Works Team"
+			},
+			"license": "AGPL-3.0",
+			"builtIn": true,
+			"autoEnable": false,
+			"visibility": "public",
+			"distribution": "registry",
+			"selectableProviderCategories": [
+				"ai-provider",
+				"search"
+			]
+		}
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/__tests__/gtm-pipeline.plugin.spec.ts
+++ b/packages/plugins/gtm-pipeline/src/__tests__/gtm-pipeline.plugin.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PluginContext, WorkReference } from '@ever-works/plugin';
+import { GtmPipelinePlugin } from '../gtm-pipeline.plugin.js';
+import { GtmPipelineContext, type GtmContextSnapshot } from '../context.js';
+import { GTM_STAGE_IDS } from '../types.js';
+
+const WORK: WorkReference = { id: 'work-1', name: 'Campaign', slug: 'campaign' };
+
+function loadedPlugin(): Promise<GtmPipelinePlugin> {
+	const plugin = new GtmPipelinePlugin();
+	const context = {
+		logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+	} as unknown as PluginContext;
+	return plugin.onLoad(context).then(() => plugin);
+}
+
+describe('GtmPipelinePlugin — stage sequencing', () => {
+	it('declares the 8 go-to-market stages in the canonical order', () => {
+		const plugin = new GtmPipelinePlugin();
+		const ids = plugin.getStepDefinitions().map((stage) => stage.id);
+		expect(ids).toEqual([...GTM_STAGE_IDS]);
+		expect(ids).toEqual(['research', 'qualify', 'draft', 'review', 'act', 'follow-up', 'enrich', 'measure']);
+	});
+
+	it('every stage requires only keys provided by earlier stages (auditable handoffs)', () => {
+		const plugin = new GtmPipelinePlugin();
+		const provided = new Set<string>();
+		for (const stage of plugin.getStepDefinitions()) {
+			for (const key of stage.requires ?? []) {
+				expect(provided.has(key), `stage "${stage.id}" requires "${key}" before it is provided`).toBe(true);
+			}
+			for (const key of stage.provides ?? []) {
+				provided.add(key);
+			}
+		}
+	});
+
+	it('every stage dependency references a stage declared earlier', () => {
+		const plugin = new GtmPipelinePlugin();
+		const seen = new Set<string>();
+		for (const stage of plugin.getStepDefinitions()) {
+			for (const dep of stage.dependencies ?? []) {
+				expect(seen.has(dep.stepId), `stage "${stage.id}" depends on later/unknown "${dep.stepId}"`).toBe(true);
+			}
+			seen.add(stage.id);
+		}
+	});
+
+	it('declares the review human gate between draft and act', () => {
+		const plugin = new GtmPipelinePlugin();
+		const ids = plugin.getStepDefinitions().map((stage) => stage.id);
+		expect(ids.indexOf('review')).toBeGreaterThan(ids.indexOf('draft'));
+		expect(ids.indexOf('review')).toBeLessThan(ids.indexOf('act'));
+		const review = plugin.getStepDefinition('review');
+		expect(review?.requires).toEqual(['drafts']);
+		expect(review?.provides).toEqual(['approved_drafts']);
+	});
+});
+
+describe('GtmPipelinePlugin — step IO contracts', () => {
+	it('validates known and unknown stage ids', () => {
+		const plugin = new GtmPipelinePlugin();
+		for (const id of GTM_STAGE_IDS) {
+			expect(plugin.isValidStepId(id)).toBe(true);
+		}
+		expect(plugin.isValidStepId('publish')).toBe(false);
+		expect(plugin.isValidStepId('')).toBe(false);
+	});
+
+	it('registers an executor for every declared stage on load', async () => {
+		const plugin = await loadedPlugin();
+		const health = await plugin.healthCheck();
+		expect(health.status).toBe('healthy');
+		expect(health.message).toContain('8');
+	});
+
+	it('executeStep throws for an unregistered stage', async () => {
+		const plugin = new GtmPipelinePlugin(); // not loaded — no executors
+		const ctx = new GtmPipelineContext(WORK, {});
+		await expect(plugin.executeStep('research', ctx, {} as never)).rejects.toThrow(
+			'No executor registered for stage "research"'
+		);
+	});
+
+	it('direct execute() is refused — the engine orchestrates stages', async () => {
+		const plugin = new GtmPipelinePlugin();
+		await expect(plugin.execute(WORK, {}, { items: [], categories: [], tags: [] })).rejects.toThrow(
+			/should not be called directly/
+		);
+	});
+
+	it('canSkipStep is provides-driven', () => {
+		const plugin = new GtmPipelinePlugin();
+		const ctx = new GtmPipelineContext(WORK, {});
+		expect(plugin.canSkipStep('qualify', ctx)).toBe(false);
+		ctx.scoredContacts = [{ name: 'Ada', score: 80, scoreReasons: [], riskScore: 0, riskReasons: [] }];
+		expect(plugin.canSkipStep('qualify', ctx)).toBe(true);
+	});
+});
+
+describe('GtmPipelinePlugin — context lifecycle', () => {
+	it('snapshot round-trips the full stage data set', () => {
+		const plugin = new GtmPipelinePlugin();
+		const ctx = plugin.createContext(
+			WORK,
+			{ prompt: 'launch' },
+			{ items: [], categories: [], tags: [] }
+		) as GtmPipelineContext;
+		ctx.contacts = [{ name: 'Ada', email: 'ada@example.com' }];
+		ctx.drafts = [{ ref: 'draft-1', contactName: 'Ada', channel: 'email', subject: 'Hi', body: 'Hello' }];
+		ctx.pendingReview = true;
+		ctx.shouldStop = true;
+		ctx.warnings.push('Review: awaiting human approval');
+
+		const snapshot = plugin.contextToSnapshot(ctx) as GtmContextSnapshot;
+		const restored = plugin.contextFromSnapshot(snapshot) as GtmPipelineContext;
+		expect(restored.contacts).toEqual(ctx.contacts);
+		expect(restored.drafts).toEqual(ctx.drafts);
+		expect(restored.pendingReview).toBe(true);
+		expect(restored.shouldStop).toBe(true);
+		expect(restored.warnings).toContain('Review: awaiting human approval');
+	});
+
+	it('checkpoints paused at the review gate stay viable; empty stopped runs do not', () => {
+		const plugin = new GtmPipelinePlugin();
+		const pending = new GtmPipelineContext(WORK, {});
+		pending.pendingReview = true;
+		pending.shouldStop = true;
+		expect(plugin.isCheckpointViable(pending.toSnapshot(), ['research', 'qualify', 'draft', 'review'])).toBe(true);
+
+		const stopped = new GtmPipelineContext(WORK, {});
+		stopped.shouldStop = true;
+		expect(plugin.isCheckpointViable(stopped.toSnapshot(), ['research'])).toBe(false);
+
+		const emptyAfterData = new GtmPipelineContext(WORK, {});
+		expect(plugin.isCheckpointViable(emptyAfterData.toSnapshot(), ['research'])).toBe(false);
+		expect(plugin.isCheckpointViable(new GtmPipelineContext(WORK, {}).toSnapshot(), [])).toBe(true);
+	});
+
+	it('extractResult carries stage outputs under extra keyed by declared stage keys', () => {
+		const plugin = new GtmPipelinePlugin();
+		const ctx = new GtmPipelineContext(WORK, {});
+		ctx.actionLog = [{ draftRef: 'draft-1', channel: 'email', status: 'prepared', reason: null, preparedAt: 1 }];
+		ctx.pendingReview = false;
+		const result = plugin.extractResult(ctx, { duration: 10, stepsCompleted: 8, totalSteps: 8 });
+		expect(result.success).toBe(true);
+		expect(result.outputs.items).toEqual([]);
+		const extra = result.outputs.extra as Record<string, unknown>;
+		expect(extra.action_log).toEqual(ctx.actionLog);
+		expect(extra.pending_review).toBe(false);
+	});
+});

--- a/packages/plugins/gtm-pipeline/src/__tests__/settings.spec.ts
+++ b/packages/plugins/gtm-pipeline/src/__tests__/settings.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { GtmPipelinePlugin } from '../gtm-pipeline.plugin.js';
+import { GTM_DEFAULT_SETTINGS, resolveGtmSettings, validateGtmFormInput } from '../settings.js';
+
+describe('GTM settings — resolution', () => {
+	it('falls back to safe defaults when config is missing or malformed', () => {
+		expect(resolveGtmSettings(undefined)).toEqual(GTM_DEFAULT_SETTINGS);
+		const resolved = resolveGtmSettings({
+			target_channels: 'not-an-array',
+			tone: 'aggressive',
+			cadence: 42,
+			max_contacts_per_run: 'NaN',
+			review_required: 'yes'
+		});
+		expect(resolved).toEqual(GTM_DEFAULT_SETTINGS);
+	});
+
+	it('honors explicit values and clamps out-of-range numbers', () => {
+		const resolved = resolveGtmSettings({
+			target_channels: ['email', 'social', '  '],
+			tone: 'friendly',
+			cadence: 'daily',
+			max_contacts_per_run: 9999,
+			review_required: false,
+			qualify_min_score: -5,
+			risk_exclude_threshold: 3,
+			follow_up_quiet_days: 7
+		});
+		expect(resolved.targetChannels).toEqual(['email', 'social']);
+		expect(resolved.tone).toBe('friendly');
+		expect(resolved.cadence).toBe('daily');
+		expect(resolved.maxContactsPerRun).toBe(200); // clamped to max
+		expect(resolved.reviewRequired).toBe(false);
+		expect(resolved.qualifyMinScore).toBe(0); // clamped to min
+		expect(resolved.riskExcludeThreshold).toBe(3);
+		expect(resolved.followUpQuietDays).toBe(7);
+	});
+});
+
+describe('GTM settings — form validation', () => {
+	it('accepts a valid settings payload', () => {
+		const result = validateGtmFormInput({
+			target_channels: ['email', 'newsletter'],
+			tone: 'professional',
+			cadence: 'weekly',
+			max_contacts_per_run: 25,
+			qualify_min_score: 50,
+			risk_exclude_threshold: 7,
+			review_required: true,
+			follow_up_quiet_days: 4
+		});
+		expect(result.valid).toBe(true);
+		expect(result.errors).toBeUndefined();
+	});
+
+	it('rejects unknown tone/cadence and out-of-range numbers with paths', () => {
+		const result = validateGtmFormInput({
+			tone: 'sarcastic',
+			cadence: 'hourly',
+			max_contacts_per_run: 0,
+			risk_exclude_threshold: 11
+		});
+		expect(result.valid).toBe(false);
+		const paths = (result.errors ?? []).map((e) => e.path);
+		expect(paths).toContain('tone');
+		expect(paths).toContain('cadence');
+		expect(paths).toContain('max_contacts_per_run');
+		expect(paths).toContain('risk_exclude_threshold');
+	});
+
+	it('rejects non-array and empty-string target channels', () => {
+		expect(validateGtmFormInput({ target_channels: 'email' }).valid).toBe(false);
+		const result = validateGtmFormInput({ target_channels: ['email', ''] });
+		expect(result.valid).toBe(false);
+		expect((result.errors ?? [])[0].path).toBe('target_channels[1]');
+	});
+
+	it('plugin form surface exposes defaults for the settings knobs', () => {
+		const plugin = new GtmPipelinePlugin();
+		const defaults = plugin.getDefaultValues();
+		expect(defaults.tone).toBe(GTM_DEFAULT_SETTINGS.tone);
+		expect(defaults.cadence).toBe(GTM_DEFAULT_SETTINGS.cadence);
+		expect(defaults.review_required).toBe(true);
+		expect(defaults.target_channels).toEqual([...GTM_DEFAULT_SETTINGS.targetChannels]);
+		expect(plugin.validateFormInput({ review_required: 'nope' }).valid).toBe(false);
+		// transformFormValues drops empty arrays so form submits stay clean.
+		expect(plugin.transformFormValues({ target_channels: [] })).not.toHaveProperty('target_channels');
+	});
+});

--- a/packages/plugins/gtm-pipeline/src/__tests__/steps.spec.ts
+++ b/packages/plugins/gtm-pipeline/src/__tests__/steps.spec.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { StepExecutionContext, WorkReference } from '@ever-works/plugin';
+import { GtmPipelineContext } from '../context.js';
+import { ResearchStep } from '../steps/research.step.js';
+import { QualifyStep, assessContactRisk, scoreContact } from '../steps/qualify.step.js';
+import { DraftStep } from '../steps/draft.step.js';
+import { ReviewStep } from '../steps/review.step.js';
+import { ActStep } from '../steps/act.step.js';
+import { FollowUpStep } from '../steps/follow-up.step.js';
+import { MeasureStep } from '../steps/measure.step.js';
+
+const WORK: WorkReference = { id: 'work-1', name: 'Campaign', slug: 'campaign' };
+
+function makeExecContext(overrides: Partial<Record<string, unknown>> = {}): StepExecutionContext {
+	return {
+		aiFacade: { askJson: vi.fn() },
+		searchFacade: { search: vi.fn().mockResolvedValue([]) },
+		screenshotFacade: {},
+		contentExtractorFacade: {},
+		logger: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+		work: WORK,
+		user: { id: 'user-1' },
+		...overrides
+	} as unknown as StepExecutionContext;
+}
+
+function contextWith(config: Record<string, unknown> = {}, prompt = ''): GtmPipelineContext {
+	return new GtmPipelineContext(WORK, { prompt, config });
+}
+
+describe('research stage', () => {
+	it('normalizes and dedupes seed contacts and never fabricates people', async () => {
+		const step = new ResearchStep();
+		const ctx = contextWith({
+			contacts: [
+				{ name: ' Ada Lovelace ', email: 'ada@acme.io', company: 'Acme' },
+				{ name: 'Ada Lovelace', email: 'ada@acme.io' }, // duplicate by email
+				{ email: 'no-name@acme.io' }, // kept — email present
+				{ notes: 'nameless and emailless' }, // dropped
+				'not-an-object'
+			]
+		});
+		const result = (await step.run(ctx, makeExecContext())) as GtmPipelineContext;
+		expect(result.contacts).toHaveLength(2);
+		expect(result.contacts[0]).toMatchObject({ name: 'Ada Lovelace', email: 'ada@acme.io', company: 'Acme' });
+		expect(result.contacts[1].name).toBe('no-name@acme.io');
+	});
+
+	it('collects signals via AI-planned queries and degrades with a warning on AI failure', async () => {
+		const step = new ResearchStep();
+		const okContext = makeExecContext({
+			aiFacade: {
+				askJson: vi.fn().mockResolvedValue({
+					result: { queries: ['launch news acme', ''] },
+					usage: null,
+					cost: null,
+					provider: 'p',
+					model: 'm'
+				})
+			},
+			searchFacade: {
+				search: vi
+					.fn()
+					.mockResolvedValue([{ title: 'Acme ships v2', url: 'https://news.example.com/acme-v2', score: 1 }])
+			}
+		});
+		const ctx = contextWith({}, 'Announce our launch to devtools founders');
+		const result = (await step.run(ctx, okContext)) as GtmPipelineContext;
+		expect(result.signals).toHaveLength(1);
+		expect(result.signals[0]).toMatchObject({ query: 'launch news acme', url: 'https://news.example.com/acme-v2' });
+
+		const failing = makeExecContext({
+			aiFacade: { askJson: vi.fn().mockRejectedValue(new Error('provider down')) }
+		});
+		const degraded = (await step.run(contextWith({}, 'brief'), failing)) as GtmPipelineContext;
+		expect(degraded.signals).toEqual([]);
+		expect(degraded.warnings.some((w) => w.includes('signal collection degraded'))).toBe(true);
+	});
+});
+
+describe('qualify stage', () => {
+	it('scores with the declarative weight table and explains every rule fired', () => {
+		const full = scoreContact({
+			name: 'Ada',
+			email: 'ada@acme.io',
+			company: 'Acme',
+			title: 'CTO',
+			source: 'referral',
+			notes: 'met at conf'
+		});
+		expect(full.score).toBe(100);
+		expect(full.reasons).toEqual(
+			expect.arrayContaining(['has-email +25', 'has-company +15', 'has-title +15', 'has-notes +10'])
+		);
+		const bare = scoreContact({ name: 'Mystery' });
+		expect(bare.score).toBe(30);
+
+		const risk = assessContactRisk({ name: 'Mailbox', email: 'info@gmail.com' });
+		expect(risk.riskScore).toBeGreaterThanOrEqual(3);
+		expect(risk.reasons.join(' ')).toContain('non-personal-mailbox');
+	});
+
+	it('keeps qualified contacts sorted by score and excludes risky/low-score ones', async () => {
+		const step = new QualifyStep();
+		const ctx = contextWith({ qualify_min_score: 50, risk_exclude_threshold: 5 });
+		ctx.contacts = [
+			{ name: 'Solid', email: 'cto@acme.io', company: 'Acme', title: 'CTO' },
+			{ name: 'Bare' }, // low score + high risk → excluded
+			{ name: 'Mid', email: 'mid@corp.io', company: 'Corp' }
+		];
+		const result = (await step.run(ctx, makeExecContext())) as GtmPipelineContext;
+		expect(result.scoredContacts.map((c) => c.name)).toEqual(['Solid', 'Mid']);
+		expect(result.scoredContacts[0].score).toBeGreaterThanOrEqual(result.scoredContacts[1].score);
+		expect(result.excludedContacts.map((c) => c.name)).toEqual(['Bare']);
+		expect(result.warnings.some((w) => w.startsWith('Qualify: excluded 1'))).toBe(true);
+	});
+});
+
+describe('draft stage', () => {
+	it('drafts through the AI facade with tone + channels and drops unknown contact/channel refs', async () => {
+		const step = new DraftStep();
+		const askJson = vi.fn().mockResolvedValue({
+			result: {
+				drafts: [
+					{ contactName: 'Ada', channel: 'email', subject: 'Hello Ada', body: 'A personalized note.' },
+					{ contactName: 'Nobody', channel: 'email', subject: 'x', body: 'y' }, // unknown contact
+					{ contactName: 'Ada', channel: 'fax', subject: 'x', body: 'y' } // unknown channel
+				]
+			},
+			usage: null,
+			cost: null,
+			provider: 'p',
+			model: 'm'
+		});
+		const execContext = makeExecContext({ aiFacade: { askJson } });
+		const ctx = contextWith({ target_channels: ['email'], tone: 'friendly' }, 'Launch brief');
+		ctx.scoredContacts = [
+			{
+				name: 'Ada',
+				email: 'ada@acme.io',
+				company: 'Acme',
+				score: 90,
+				scoreReasons: [],
+				riskScore: 0,
+				riskReasons: []
+			}
+		];
+		const result = (await step.run(ctx, execContext)) as GtmPipelineContext;
+		expect(result.drafts).toHaveLength(1);
+		expect(result.drafts[0]).toMatchObject({ ref: 'draft-1', contactName: 'Ada', channel: 'email' });
+		const options = askJson.mock.calls[0][2];
+		expect(options.variables.tone).toBe('friendly');
+		expect(options.variables.channels).toBe('email');
+		expect(result.warnings.filter((w) => w.startsWith('Draft: dropped'))).toHaveLength(2);
+	});
+
+	it('caps drafted contacts at max_contacts_per_run and degrades on AI failure', async () => {
+		const step = new DraftStep();
+		const askJson = vi.fn().mockRejectedValue(new Error('quota'));
+		const execContext = makeExecContext({ aiFacade: { askJson } });
+		const ctx = contextWith({ max_contacts_per_run: 1 });
+		ctx.scoredContacts = [
+			{ name: 'A', score: 90, scoreReasons: [], riskScore: 0, riskReasons: [] },
+			{ name: 'B', score: 80, scoreReasons: [], riskScore: 0, riskReasons: [] }
+		];
+		const result = (await step.run(ctx, execContext)) as GtmPipelineContext;
+		expect(result.drafts).toEqual([]);
+		expect(result.warnings.some((w) => w.startsWith('Draft: generation failed'))).toBe(true);
+		const contactsVar: string = askJson.mock.calls[0][2].variables.contacts;
+		expect(contactsVar).toContain('name: A');
+		expect(contactsVar).not.toContain('name: B');
+	});
+});
+
+describe('review stage — the human gate', () => {
+	const drafts = [
+		{ ref: 'draft-1', contactName: 'Ada', channel: 'email', subject: null, body: 'one' },
+		{ ref: 'draft-2', contactName: 'Grace', channel: 'email', subject: null, body: 'two' }
+	];
+
+	it('pauses the run awaiting approval when review is required and none was supplied', async () => {
+		const step = new ReviewStep();
+		const ctx = contextWith({});
+		ctx.drafts = [...drafts];
+		const result = (await step.run(ctx, makeExecContext())) as GtmPipelineContext;
+		expect(result.pendingReview).toBe(true);
+		expect(result.shouldStop).toBe(true);
+		expect(result.approvedDrafts).toEqual([]);
+		expect(result.warnings.some((w) => w.includes('awaiting human approval for 2'))).toBe(true);
+	});
+
+	it('approves the supplied subset and ignores unknown refs with a warning', async () => {
+		const step = new ReviewStep();
+		const ctx = contextWith({ approved_draft_refs: ['draft-2', 'draft-999'] });
+		ctx.drafts = [...drafts];
+		const result = (await step.run(ctx, makeExecContext())) as GtmPipelineContext;
+		expect(result.pendingReview).toBe(false);
+		expect(result.approvedDrafts.map((d) => d.ref)).toEqual(['draft-2']);
+		expect(result.warnings.some((w) => w.includes('unknown draft ref "draft-999"'))).toBe(true);
+	});
+
+	it("approves everything for 'all', and records an explicit warning when review is disabled", async () => {
+		const step = new ReviewStep();
+		const allCtx = contextWith({ approved_draft_refs: 'all' });
+		allCtx.drafts = [...drafts];
+		const approvedAll = (await step.run(allCtx, makeExecContext())) as GtmPipelineContext;
+		expect(approvedAll.approvedDrafts).toHaveLength(2);
+		expect(approvedAll.shouldStop).toBeUndefined();
+
+		const disabledCtx = contextWith({ review_required: false });
+		disabledCtx.drafts = [...drafts];
+		const autoApproved = (await step.run(disabledCtx, makeExecContext())) as GtmPipelineContext;
+		expect(autoApproved.approvedDrafts).toHaveLength(2);
+		expect(autoApproved.warnings.some((w) => w.includes('auto-approved 2'))).toBe(true);
+	});
+});
+
+describe('act + follow-up + measure stages', () => {
+	it('act prepares only approved drafts and never marks anything sent', async () => {
+		const step = new ActStep();
+		const ctx = contextWith({});
+		ctx.drafts = [
+			{ ref: 'draft-1', contactName: 'Ada', channel: 'email', subject: null, body: 'one' },
+			{ ref: 'draft-2', contactName: 'Grace', channel: 'social', subject: null, body: 'two' }
+		];
+		ctx.approvedDrafts = [ctx.drafts[0]];
+		const result = (await step.run(ctx, makeExecContext())) as GtmPipelineContext;
+		expect(result.actionLog).toHaveLength(2);
+		expect(result.actionLog[0]).toMatchObject({ draftRef: 'draft-1', status: 'prepared' });
+		expect(result.actionLog[1]).toMatchObject({ draftRef: 'draft-2', status: 'skipped' });
+		expect(result.actionLog.every((record) => record.status !== ('sent' as string))).toBe(true);
+	});
+
+	it('follow-up queues prepared actions with the configured quiet-days window', async () => {
+		const step = new FollowUpStep();
+		const ctx = contextWith({ follow_up_quiet_days: 6, cadence: 'weekly' });
+		ctx.actionLog = [
+			{ draftRef: 'draft-1', channel: 'email', status: 'prepared', reason: null, preparedAt: 1 },
+			{ draftRef: 'draft-2', channel: 'email', status: 'skipped', reason: 'not approved', preparedAt: 1 }
+		];
+		const result = (await step.run(ctx, makeExecContext())) as GtmPipelineContext;
+		expect(result.followUpQueue).toHaveLength(1);
+		expect(result.followUpQueue[0]).toMatchObject({ draftRef: 'draft-1', dueAfterDays: 6 });
+	});
+
+	it('measure compiles deterministic totals and survives AI narrative failure', async () => {
+		const step = new MeasureStep();
+		const execContext = makeExecContext({
+			aiFacade: { askJson: vi.fn().mockRejectedValue(new Error('down')) }
+		});
+		const ctx = contextWith({});
+		ctx.contacts = [{ name: 'Ada' }, { name: 'Grace' }];
+		ctx.scoredContacts = [{ name: 'Ada', score: 90, scoreReasons: [], riskScore: 0, riskReasons: [] }];
+		ctx.drafts = [{ ref: 'draft-1', contactName: 'Ada', channel: 'email', subject: null, body: 'x' }];
+		ctx.approvedDrafts = [...ctx.drafts];
+		ctx.actionLog = [{ draftRef: 'draft-1', channel: 'email', status: 'prepared', reason: null, preparedAt: 1 }];
+		ctx.followUpQueue = [{ draftRef: 'draft-1', channel: 'email', dueAfterDays: 4, rationale: 'quiet' }];
+		const result = (await step.run(ctx, execContext)) as GtmPipelineContext;
+		expect(result.report).not.toBeNull();
+		expect(result.report?.totals).toEqual({
+			contacts: 2,
+			qualified: 1,
+			excluded: 0,
+			drafts: 1,
+			approved: 1,
+			prepared: 1,
+			followUpsQueued: 1
+		});
+		expect(result.report?.summary).toContain('Prepared 1 of 1');
+		expect(result.warnings.some((w) => w.startsWith('Measure: narrative degraded'))).toBe(true);
+	});
+});

--- a/packages/plugins/gtm-pipeline/src/base-step.ts
+++ b/packages/plugins/gtm-pipeline/src/base-step.ts
@@ -1,0 +1,38 @@
+import type { FacadeOptions, IBuiltInStepExecutor, IPipelineContext, StepExecutionContext } from '@ever-works/plugin';
+import { GtmPipelineContext } from './context.js';
+import type { GtmStageId } from './types.js';
+import { resolveGtmSettings, type GtmPipelineSettings } from './settings.js';
+
+/**
+ * Base class for all GTM pipeline stages.
+ * run() satisfies IBuiltInStepExecutor; execute() is what stages implement.
+ */
+export abstract class BaseGtmStep implements IBuiltInStepExecutor {
+	abstract readonly name: string;
+	abstract readonly stepId: GtmStageId;
+
+	async run(context: IPipelineContext, execContext: StepExecutionContext): Promise<IPipelineContext> {
+		return this.execute(context as GtmPipelineContext, execContext);
+	}
+
+	abstract execute(context: GtmPipelineContext, execContext: StepExecutionContext): Promise<GtmPipelineContext>;
+
+	protected settingsOf(context: GtmPipelineContext): GtmPipelineSettings {
+		return resolveGtmSettings(context.request.config);
+	}
+
+	protected facadeOptions(execContext: StepExecutionContext): FacadeOptions {
+		return {
+			userId: execContext.user?.id ?? execContext.work.user?.id ?? '',
+			workId: execContext.work.id
+		};
+	}
+
+	protected addWarning(context: GtmPipelineContext, message: string): void {
+		context.warnings.push(message);
+	}
+
+	protected formatError(error: unknown): string {
+		return error instanceof Error ? error.message : String(error);
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/context.ts
+++ b/packages/plugins/gtm-pipeline/src/context.ts
@@ -1,0 +1,152 @@
+import type { GenerationRequest, IPipelineContext, PipelineOutputs, WorkReference } from '@ever-works/plugin';
+import type {
+	GtmActionRecord,
+	GtmCampaignReport,
+	GtmContact,
+	GtmDraft,
+	GtmFollowUpItem,
+	GtmScoredContact,
+	GtmSignal,
+	GtmStageDataKey
+} from './types.js';
+
+/**
+ * Serializable snapshot of the GTM pipeline context — used for
+ * stage-boundary checkpoints and resume (including resuming a run that
+ * paused at the `review` human gate once approvals arrive).
+ */
+export interface GtmContextSnapshot {
+	readonly work: WorkReference;
+	readonly request: GenerationRequest;
+	readonly shouldStop?: boolean;
+	readonly warnings: string[];
+	readonly contacts: GtmContact[];
+	readonly signals: GtmSignal[];
+	readonly scoredContacts: GtmScoredContact[];
+	readonly excludedContacts: GtmScoredContact[];
+	readonly drafts: GtmDraft[];
+	readonly approvedDrafts: GtmDraft[];
+	readonly pendingReview: boolean;
+	readonly actionLog: GtmActionRecord[];
+	readonly followUpQueue: GtmFollowUpItem[];
+	readonly enrichedContacts: GtmContact[];
+	readonly report: GtmCampaignReport | null;
+}
+
+/**
+ * Mutable pipeline context for the GTM stage set. Each stage reads its
+ * declared inputs from — and writes its declared outputs to — this
+ * context, reproducing auditable stage handoffs.
+ */
+export class GtmPipelineContext implements IPipelineContext {
+	shouldStop?: boolean;
+	warnings: string[] = [];
+
+	contacts: GtmContact[] = [];
+	signals: GtmSignal[] = [];
+	scoredContacts: GtmScoredContact[] = [];
+	excludedContacts: GtmScoredContact[] = [];
+	drafts: GtmDraft[] = [];
+	approvedDrafts: GtmDraft[] = [];
+	/** True when the review gate paused the run awaiting human approval. */
+	pendingReview = false;
+	actionLog: GtmActionRecord[] = [];
+	followUpQueue: GtmFollowUpItem[] = [];
+	enrichedContacts: GtmContact[] = [];
+	report: GtmCampaignReport | null = null;
+
+	constructor(
+		public readonly work: WorkReference,
+		public request: GenerationRequest
+	) {}
+
+	/** Whether a declared stage data key already has a result in this context. */
+	hasStageResult(key: GtmStageDataKey): boolean {
+		switch (key) {
+			case 'contacts':
+				return this.contacts.length > 0;
+			case 'signals':
+				return this.signals.length > 0;
+			case 'scored_contacts':
+				return this.scoredContacts.length > 0;
+			case 'drafts':
+				return this.drafts.length > 0;
+			case 'approved_drafts':
+				return this.approvedDrafts.length > 0;
+			case 'action_log':
+				return this.actionLog.length > 0;
+			case 'follow_up_queue':
+				return this.followUpQueue.length > 0;
+			case 'enriched_contacts':
+				return this.enrichedContacts.length > 0;
+			case 'campaign_report':
+				return this.report !== null;
+		}
+	}
+
+	toSnapshot(): GtmContextSnapshot {
+		return {
+			work: this.work,
+			request: this.request,
+			shouldStop: this.shouldStop,
+			warnings: [...this.warnings],
+			contacts: [...this.contacts],
+			signals: [...this.signals],
+			scoredContacts: [...this.scoredContacts],
+			excludedContacts: [...this.excludedContacts],
+			drafts: [...this.drafts],
+			approvedDrafts: [...this.approvedDrafts],
+			pendingReview: this.pendingReview,
+			actionLog: [...this.actionLog],
+			followUpQueue: [...this.followUpQueue],
+			enrichedContacts: [...this.enrichedContacts],
+			report: this.report
+		};
+	}
+
+	static fromSnapshot(snapshot: GtmContextSnapshot): GtmPipelineContext {
+		const ctx = new GtmPipelineContext(snapshot.work, snapshot.request);
+		ctx.shouldStop = snapshot.shouldStop;
+		ctx.warnings = [...(snapshot.warnings ?? [])];
+		ctx.contacts = [...(snapshot.contacts ?? [])];
+		ctx.signals = [...(snapshot.signals ?? [])];
+		ctx.scoredContacts = [...(snapshot.scoredContacts ?? [])];
+		ctx.excludedContacts = [...(snapshot.excludedContacts ?? [])];
+		ctx.drafts = [...(snapshot.drafts ?? [])];
+		ctx.approvedDrafts = [...(snapshot.approvedDrafts ?? [])];
+		ctx.pendingReview = snapshot.pendingReview ?? false;
+		ctx.actionLog = [...(snapshot.actionLog ?? [])];
+		ctx.followUpQueue = [...(snapshot.followUpQueue ?? [])];
+		ctx.enrichedContacts = [...(snapshot.enrichedContacts ?? [])];
+		ctx.report = snapshot.report ?? null;
+		return ctx;
+	}
+
+	/**
+	 * Canonical outputs payload. The GTM pipeline produces campaign data,
+	 * not directory items, so the item-shaped arrays stay empty and all
+	 * stage outputs travel under `extra` keyed by the declared stage keys.
+	 */
+	toPipelineOutputs(): PipelineOutputs {
+		return {
+			items: [],
+			categories: [],
+			tags: [],
+			collections: [],
+			brands: [],
+			extra: {
+				contacts: this.contacts,
+				signals: this.signals,
+				scored_contacts: this.scoredContacts,
+				excluded_contacts: this.excludedContacts,
+				drafts: this.drafts,
+				approved_drafts: this.approvedDrafts,
+				pending_review: this.pendingReview,
+				action_log: this.actionLog,
+				follow_up_queue: this.followUpQueue,
+				enriched_contacts: this.enrichedContacts,
+				campaign_report: this.report
+			}
+		};
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/gtm-pipeline.plugin.ts
+++ b/packages/plugins/gtm-pipeline/src/gtm-pipeline.plugin.ts
@@ -1,0 +1,425 @@
+import type {
+	ExistingItems,
+	FormFieldDefinition,
+	FormFieldGroup,
+	GenerationRequest,
+	IBuiltInStepExecutor,
+	IFormSchemaProvider,
+	IPipelineContext,
+	IPipelinePlugin,
+	JsonSchema,
+	PipelineExecutionOptions,
+	PipelineProgressCallback,
+	PipelineResult,
+	PipelineState,
+	PipelineStepDefinition,
+	PluginCategory,
+	PluginContext,
+	PluginHealthCheck,
+	PluginManifest,
+	StepExecutionContext,
+	StepExecutionOptions,
+	StepProgressCallback,
+	ValidationResult,
+	WorkReference
+} from '@ever-works/plugin';
+import { GtmPipelineContext, type GtmContextSnapshot } from './context.js';
+import type { GtmStageDataKey, GtmStageId } from './types.js';
+import { getGtmFormFields, getGtmFormGroups, GTM_DEFAULT_SETTINGS, validateGtmFormInput } from './settings.js';
+import { ResearchStep } from './steps/research.step.js';
+import { QualifyStep } from './steps/qualify.step.js';
+import { DraftStep } from './steps/draft.step.js';
+import { ReviewStep } from './steps/review.step.js';
+import { ActStep } from './steps/act.step.js';
+import { FollowUpStep } from './steps/follow-up.step.js';
+import { EnrichStep } from './steps/enrich.step.js';
+import { MeasureStep } from './steps/measure.step.js';
+
+/**
+ * Go-to-Market Pipeline Plugin.
+ *
+ * Engine-orchestratable pipeline with the go-to-market stage set:
+ * research → qualify → draft → review → act → follow-up → enrich → measure.
+ *
+ * Every stage declares its input/output keys (`requires`/`provides`) so
+ * stage handoffs are explicit and auditable. The `review` stage is the
+ * human gate placed BEFORE any outbound action; the `act` stage stages
+ * approved drafts for delivery but never sends (drafts-not-sends).
+ */
+export class GtmPipelinePlugin implements IPipelinePlugin<GtmStageId>, IFormSchemaProvider {
+	private static readonly STAGES: PipelineStepDefinition<GtmStageId>[] = [
+		{
+			id: 'research',
+			name: 'Research',
+			description: 'Collects seed contacts and fresh market signals for the campaign',
+			position: { type: 'first' },
+			dependencies: [],
+			provides: ['contacts', 'signals'],
+			requires: [],
+			optional: false,
+			parallelizable: false,
+			estimatedDuration: 20
+		},
+		{
+			id: 'qualify',
+			name: 'Qualify',
+			description: 'Deterministic-first scoring and risk filtering of collected contacts',
+			position: { type: 'after', stepId: 'research' },
+			dependencies: [{ stepId: 'research', required: true }],
+			provides: ['scored_contacts'],
+			requires: ['contacts'],
+			optional: false,
+			parallelizable: false,
+			estimatedDuration: 5
+		},
+		{
+			id: 'draft',
+			name: 'Draft',
+			description: 'Personalized content drafting for the configured channels and tone',
+			position: { type: 'after', stepId: 'qualify' },
+			dependencies: [{ stepId: 'qualify', required: true }],
+			provides: ['drafts'],
+			requires: ['scored_contacts'],
+			optional: false,
+			parallelizable: false,
+			estimatedDuration: 30
+		},
+		{
+			id: 'review',
+			name: 'Review',
+			description: 'Human gate before any outbound action — pauses until drafts are approved',
+			position: { type: 'after', stepId: 'draft' },
+			dependencies: [{ stepId: 'draft', required: true }],
+			provides: ['approved_drafts'],
+			requires: ['drafts'],
+			optional: false,
+			parallelizable: false,
+			estimatedDuration: 2
+		},
+		{
+			id: 'act',
+			name: 'Act',
+			description: 'Stages approved drafts for delivery (never sends directly)',
+			position: { type: 'after', stepId: 'review' },
+			dependencies: [{ stepId: 'review', required: true }],
+			provides: ['action_log'],
+			requires: ['approved_drafts'],
+			optional: false,
+			parallelizable: false,
+			estimatedDuration: 5
+		},
+		{
+			id: 'follow-up',
+			name: 'Follow-up',
+			description: 'Queues timed re-engagement for prepared actions gone quiet',
+			position: { type: 'after', stepId: 'act' },
+			dependencies: [{ stepId: 'act', required: true }],
+			provides: ['follow_up_queue'],
+			requires: ['action_log'],
+			optional: true,
+			parallelizable: false,
+			estimatedDuration: 2
+		},
+		{
+			id: 'enrich',
+			name: 'Enrich',
+			description: 'Evidence-bound backfill of missing contact fields from collected signals',
+			position: { type: 'after', stepId: 'follow-up' },
+			dependencies: [{ stepId: 'research', required: true }],
+			provides: ['enriched_contacts'],
+			requires: ['contacts'],
+			optional: true,
+			parallelizable: true,
+			estimatedDuration: 15
+		},
+		{
+			id: 'measure',
+			name: 'Measure',
+			description: 'Compiles the campaign report and next-variant hints (closes the loop)',
+			position: { type: 'last' },
+			dependencies: [{ stepId: 'act', required: true }],
+			provides: ['campaign_report'],
+			requires: ['action_log'],
+			optional: false,
+			parallelizable: false,
+			estimatedDuration: 10
+		}
+	];
+
+	private static readonly STAGES_MAP: Map<GtmStageId, PipelineStepDefinition<GtmStageId>> = new Map(
+		GtmPipelinePlugin.STAGES.map((stage) => [stage.id, stage])
+	);
+
+	// IPlugin properties
+	readonly id = 'gtm-pipeline';
+	readonly name = 'Go-to-Market Pipeline';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'pipeline';
+	readonly capabilities: readonly string[] = ['pipeline', 'form-schema-provider'];
+	readonly settingsSchema: JsonSchema = { type: 'object', properties: {} };
+	readonly handledConfigFields = ['*'] as const;
+
+	private stepExecutors = new Map<GtmStageId, IBuiltInStepExecutor>();
+	private context?: PluginContext;
+
+	// IPipelinePlugin methods
+	registerStepExecutor(stepId: GtmStageId, executor: IBuiltInStepExecutor): void {
+		this.stepExecutors.set(stepId, executor);
+	}
+
+	isValidStepId(stepId: string): stepId is GtmStageId {
+		return GtmPipelinePlugin.STAGES_MAP.has(stepId as GtmStageId);
+	}
+
+	getStepDefinition(stepId?: GtmStageId | string): PipelineStepDefinition<GtmStageId> | undefined {
+		if (stepId) {
+			return GtmPipelinePlugin.STAGES_MAP.get(stepId as GtmStageId);
+		}
+		return GtmPipelinePlugin.STAGES[0];
+	}
+
+	getStepDefinitions(): PipelineStepDefinition<GtmStageId>[] {
+		return [...GtmPipelinePlugin.STAGES];
+	}
+
+	async execute(
+		_work: WorkReference,
+		_request: GenerationRequest,
+		_existing: ExistingItems,
+		_options?: PipelineExecutionOptions,
+		_onProgress?: PipelineProgressCallback
+	): Promise<PipelineResult> {
+		// GTM pipeline is engine-orchestrated — the engine calls executeStep()
+		// for each stage individually (and honors the review gate's shouldStop).
+		throw new Error(
+			'GtmPipelinePlugin.execute() should not be called directly. ' +
+				'Use the pipeline engine to orchestrate stage execution.'
+		);
+	}
+
+	async executeStep(
+		stepId: GtmStageId | string,
+		context: IPipelineContext,
+		execContext: StepExecutionContext,
+		options?: StepExecutionOptions,
+		onProgress?: StepProgressCallback
+	): Promise<IPipelineContext> {
+		const executor = this.stepExecutors.get(stepId as GtmStageId);
+		if (!executor) {
+			throw new Error(`No executor registered for stage "${stepId}"`);
+		}
+
+		if (onProgress) {
+			onProgress({ percent: 0, message: `Starting ${executor.name}` });
+		}
+		if (options?.signal?.aborted) {
+			throw new Error(`Stage "${stepId}" was cancelled before execution`);
+		}
+
+		try {
+			const result = await executor.run(context, execContext);
+			if (onProgress) {
+				onProgress({ percent: 100, message: `Completed ${executor.name}` });
+			}
+			return result;
+		} catch (error) {
+			this.context?.logger.error(`Stage "${stepId}" failed: ${(error as Error).message}`);
+			throw error;
+		}
+	}
+
+	// --- Context lifecycle hooks ---
+
+	createContext(work: WorkReference, request: GenerationRequest, _existing: ExistingItems): IPipelineContext {
+		return new GtmPipelineContext(work, request);
+	}
+
+	contextToSnapshot(context: IPipelineContext): unknown {
+		return (context as GtmPipelineContext).toSnapshot();
+	}
+
+	contextFromSnapshot(snapshot: unknown): IPipelineContext {
+		return GtmPipelineContext.fromSnapshot(snapshot as GtmContextSnapshot);
+	}
+
+	extractResult(
+		context: IPipelineContext,
+		meta: { duration: number; stepsCompleted: number; totalSteps: number; state?: PipelineState }
+	): PipelineResult {
+		const ctx = context as GtmPipelineContext;
+		return {
+			// A run paused at the review gate is a successful (resumable)
+			// run, not a failure — pending_review travels in outputs.extra.
+			success: true,
+			outputs: ctx.toPipelineOutputs(),
+			duration: meta.duration,
+			stepsCompleted: meta.stepsCompleted,
+			totalSteps: meta.totalSteps,
+			state: meta.state,
+			warnings: ctx.warnings
+		};
+	}
+
+	/**
+	 * A checkpoint is viable when the run paused at the review gate
+	 * (resume happens once approvals arrive) or any stage data exists.
+	 */
+	isCheckpointViable(snapshot: unknown, completedSteps: string[]): boolean {
+		const ctx = snapshot as GtmContextSnapshot;
+		if (ctx.pendingReview) return true;
+		if (ctx.shouldStop) return false;
+		const hasData =
+			(ctx.contacts?.length ?? 0) > 0 ||
+			(ctx.signals?.length ?? 0) > 0 ||
+			(ctx.drafts?.length ?? 0) > 0 ||
+			(ctx.actionLog?.length ?? 0) > 0;
+		if (hasData) return true;
+		// If data-producing stages already ran but produced nothing, restart.
+		const dataStages: string[] = ['research', 'draft', 'act'];
+		return !completedSteps.some((id) => dataStages.includes(id));
+	}
+
+	canSkipStep(stepId: string, context: IPipelineContext): boolean {
+		const ctx = context as GtmPipelineContext;
+		const stage = this.getStepDefinition(stepId as GtmStageId);
+		if (!stage?.provides?.length) return false;
+		return stage.provides.every((key) => ctx.hasStageResult(key as GtmStageDataKey));
+	}
+
+	// IFormSchemaProvider methods
+	getFormFields(): FormFieldDefinition[] {
+		return getGtmFormFields();
+	}
+
+	getFormGroups(): FormFieldGroup[] {
+		return getGtmFormGroups();
+	}
+
+	validateFormInput(values: Record<string, unknown>): ValidationResult {
+		return validateGtmFormInput(values);
+	}
+
+	getDefaultValues(): Record<string, unknown> {
+		const defaults: Record<string, unknown> = {};
+		for (const field of this.getFormFields()) {
+			if (field.defaultValue !== undefined) {
+				defaults[field.name] = field.defaultValue;
+			}
+		}
+		return defaults;
+	}
+
+	transformFormValues(values: Record<string, unknown>): Record<string, unknown> {
+		const transformed = { ...values };
+		for (const key of Object.keys(transformed)) {
+			if (Array.isArray(transformed[key]) && (transformed[key] as unknown[]).length === 0) {
+				delete transformed[key];
+			}
+		}
+		return transformed;
+	}
+
+	// IPlugin lifecycle
+
+	async onLoad(context: PluginContext): Promise<void> {
+		this.context = context;
+		this.registerBuiltInStepExecutors();
+		context.logger.log(`Go-to-Market Pipeline Plugin loaded with ${this.stepExecutors.size} stage executors`);
+	}
+
+	private registerBuiltInStepExecutors(): void {
+		const stepExecutors: Record<GtmStageId, IBuiltInStepExecutor> = {
+			research: new ResearchStep(),
+			qualify: new QualifyStep(),
+			draft: new DraftStep(),
+			review: new ReviewStep(),
+			act: new ActStep(),
+			'follow-up': new FollowUpStep(),
+			enrich: new EnrichStep(),
+			measure: new MeasureStep()
+		};
+		for (const [stepId, executor] of Object.entries(stepExecutors)) {
+			this.registerStepExecutor(stepId as GtmStageId, executor);
+		}
+	}
+
+	async onUnload(): Promise<void> {
+		this.stepExecutors.clear();
+		this.context = undefined;
+	}
+
+	async healthCheck(): Promise<PluginHealthCheck> {
+		const registeredSteps = this.stepExecutors.size;
+		const totalSteps = GtmPipelinePlugin.STAGES.length;
+		const allRegistered = registeredSteps === totalSteps;
+		const missingSteps = GtmPipelinePlugin.STAGES.filter((s) => !this.stepExecutors.has(s.id)).map((s) => s.id);
+
+		return {
+			status: allRegistered ? 'healthy' : 'degraded',
+			message: allRegistered
+				? `All ${totalSteps} GTM stages registered`
+				: `Only ${registeredSteps}/${totalSteps} stages registered`,
+			checkedAt: Date.now(),
+			checks: missingSteps.map((stepId) => ({
+				name: `stage-${stepId}`,
+				status: 'unhealthy' as const,
+				message: `Missing executor for stage: ${stepId}`,
+				data: { stepId }
+			}))
+		};
+	}
+
+	getManifest(): PluginManifest {
+		return {
+			id: this.id,
+			name: this.name,
+			version: this.version,
+			description:
+				'Go-to-market pipeline with research, qualify, draft, review, act, follow-up, enrich, and measure stages',
+			category: this.category,
+			capabilities: [...this.capabilities],
+			author: { name: 'Ever Works Team' },
+			license: 'AGPL-3.0',
+			builtIn: true,
+			autoEnable: false,
+			visibility: 'public',
+			selectableProviderCategories: ['ai-provider', 'search'],
+			readme: [
+				'## What is the Go-to-Market Pipeline?',
+				'',
+				'An engine-orchestrated pipeline for go-to-market campaigns. It runs 8 stages — research, qualify, draft, review, act, follow-up, enrich, and measure — with explicit input/output keys declared per stage so every handoff is auditable.',
+				'',
+				'## Stages',
+				'',
+				'1. **Research** — normalizes seed contacts and collects fresh market signals via web search',
+				'2. **Qualify** — deterministic-first scoring (declarative weight table) plus risk filtering',
+				'3. **Draft** — personalized 80-120 word drafts per contact per channel, in the configured tone',
+				'4. **Review** — the human gate: pauses before ANY outbound action until drafts are approved',
+				'5. **Act** — stages approved drafts for delivery; never sends directly (drafts-not-sends)',
+				'6. **Follow-up** — queues timed re-engagement for prepared actions gone quiet',
+				'7. **Enrich** — evidence-bound backfill of missing contact fields from collected signals',
+				'8. **Measure** — compiles the campaign report with next-variant hints, closing the loop into the next draft cycle',
+				'',
+				'## Settings',
+				'',
+				'- **Target channels** — where content is prepared for (email, blog, social, newsletter, community)',
+				'- **Tone** — voice used for drafted content',
+				'- **Cadence** — expected run frequency, also used by follow-up rationale',
+				'- **Qualification knobs** — minimum score, risk exclusion threshold, max contacts per run',
+				'- **Review** — required by default; disabling it is recorded in the run warnings',
+				'',
+				'## Safety posture',
+				'',
+				'- Contacts come only from explicit seed lists — the pipeline never fabricates people',
+				'- The review gate pauses the run (resumable checkpoint) until approvals arrive',
+				'- The act stage records prepared actions for connectors/humans to deliver — it never sends'
+			].join('\n'),
+			icon: {
+				type: 'svg',
+				value: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11l18-8-8 18-2-8-8-2z"/></svg>'
+			}
+		};
+	}
+}
+
+export default GtmPipelinePlugin;

--- a/packages/plugins/gtm-pipeline/src/index.ts
+++ b/packages/plugins/gtm-pipeline/src/index.ts
@@ -1,0 +1,16 @@
+export { GtmPipelinePlugin, GtmPipelinePlugin as default } from './gtm-pipeline.plugin.js';
+export { GtmPipelineContext, type GtmContextSnapshot } from './context.js';
+export * from './types.js';
+export {
+	GTM_CADENCES,
+	GTM_DEFAULT_SETTINGS,
+	GTM_TARGET_CHANNELS,
+	GTM_TONES,
+	resolveGtmSettings,
+	type GtmCadence,
+	type GtmPipelineSettings,
+	type GtmTargetChannel,
+	type GtmTone
+} from './settings.js';
+export { GTM_PROMPT_KEYS } from './prompt-keys.js';
+export { GTM_RISK_WEIGHTS, GTM_SCORE_WEIGHTS, assessContactRisk, scoreContact } from './steps/qualify.step.js';

--- a/packages/plugins/gtm-pipeline/src/prompt-keys.ts
+++ b/packages/plugins/gtm-pipeline/src/prompt-keys.ts
@@ -1,0 +1,11 @@
+/**
+ * Prompt-facade keys for the GTM pipeline's AI-backed stages. When a
+ * prompt provider is configured, these keys let operators manage the
+ * stage prompts externally; otherwise the hardcoded defaults apply.
+ */
+export const GTM_PROMPT_KEYS = {
+	RESEARCH_QUERIES: 'gtm-pipeline.research-queries',
+	DRAFT: 'gtm-pipeline.draft',
+	ENRICH: 'gtm-pipeline.enrich',
+	MEASURE: 'gtm-pipeline.measure'
+} as const;

--- a/packages/plugins/gtm-pipeline/src/settings.ts
+++ b/packages/plugins/gtm-pipeline/src/settings.ts
@@ -1,0 +1,235 @@
+import type { FormFieldDefinition, FormFieldGroup, ValidationResult } from '@ever-works/plugin';
+
+/**
+ * Go-to-Market pipeline settings — target channels, tone, cadence, plus
+ * the qualification and review knobs. Exposed through the standard
+ * form-schema-provider surface and resolved from `request.config`.
+ */
+
+export const GTM_TARGET_CHANNELS = ['email', 'blog', 'social', 'newsletter', 'community'] as const;
+export type GtmTargetChannel = (typeof GTM_TARGET_CHANNELS)[number];
+
+export const GTM_TONES = ['professional', 'friendly', 'direct', 'enthusiastic'] as const;
+export type GtmTone = (typeof GTM_TONES)[number];
+
+export const GTM_CADENCES = ['daily', 'weekly', 'biweekly', 'monthly'] as const;
+export type GtmCadence = (typeof GTM_CADENCES)[number];
+
+export interface GtmPipelineSettings {
+	readonly targetChannels: readonly string[];
+	readonly tone: GtmTone;
+	readonly cadence: GtmCadence;
+	readonly maxContactsPerRun: number;
+	/** Human gate before any outbound action (default ON — drafts-not-sends). */
+	readonly reviewRequired: boolean;
+	/** Minimum qualify score (0–100) required to keep a contact. */
+	readonly qualifyMinScore: number;
+	/** Contacts with risk score ≥ this threshold (0–10) are excluded. */
+	readonly riskExcludeThreshold: number;
+	/** Days of silence after which a prepared action queues a follow-up. */
+	readonly followUpQuietDays: number;
+}
+
+export const GTM_DEFAULT_SETTINGS: GtmPipelineSettings = {
+	targetChannels: ['email'],
+	tone: 'professional',
+	cadence: 'weekly',
+	maxContactsPerRun: 20,
+	reviewRequired: true,
+	qualifyMinScore: 40,
+	riskExcludeThreshold: 7,
+	followUpQuietDays: 4
+};
+
+function clampNumber(value: unknown, min: number, max: number, fallback: number): number {
+	const num = Number(value);
+	if (value === undefined || value === null || Number.isNaN(num)) return fallback;
+	return Math.min(max, Math.max(min, num));
+}
+
+function pickEnum<T extends string>(value: unknown, allowed: readonly T[], fallback: T): T {
+	return typeof value === 'string' && (allowed as readonly string[]).includes(value) ? (value as T) : fallback;
+}
+
+/**
+ * Resolve the effective settings from the raw generator/config object
+ * (snake_case form keys), falling back to safe defaults for anything
+ * missing or out of range.
+ */
+export function resolveGtmSettings(config: Record<string, unknown> | undefined): GtmPipelineSettings {
+	const cfg = config ?? {};
+	const rawChannels = cfg.target_channels;
+	const channels = Array.isArray(rawChannels)
+		? rawChannels.filter((c): c is string => typeof c === 'string' && c.trim().length > 0).map((c) => c.trim())
+		: [];
+	return {
+		targetChannels: channels.length > 0 ? channels : GTM_DEFAULT_SETTINGS.targetChannels,
+		tone: pickEnum(cfg.tone, GTM_TONES, GTM_DEFAULT_SETTINGS.tone),
+		cadence: pickEnum(cfg.cadence, GTM_CADENCES, GTM_DEFAULT_SETTINGS.cadence),
+		maxContactsPerRun: clampNumber(cfg.max_contacts_per_run, 1, 200, GTM_DEFAULT_SETTINGS.maxContactsPerRun),
+		reviewRequired:
+			typeof cfg.review_required === 'boolean' ? cfg.review_required : GTM_DEFAULT_SETTINGS.reviewRequired,
+		qualifyMinScore: clampNumber(cfg.qualify_min_score, 0, 100, GTM_DEFAULT_SETTINGS.qualifyMinScore),
+		riskExcludeThreshold: clampNumber(cfg.risk_exclude_threshold, 0, 10, GTM_DEFAULT_SETTINGS.riskExcludeThreshold),
+		followUpQuietDays: clampNumber(cfg.follow_up_quiet_days, 1, 90, GTM_DEFAULT_SETTINGS.followUpQuietDays)
+	};
+}
+
+export function getGtmFormFields(): FormFieldDefinition[] {
+	return [
+		{
+			name: 'target_channels',
+			type: 'tags',
+			label: 'Target Channels',
+			description: `Channels to prepare content for (e.g. ${GTM_TARGET_CHANNELS.join(', ')})`,
+			defaultValue: [...GTM_DEFAULT_SETTINGS.targetChannels],
+			group: 'campaign'
+		},
+		{
+			name: 'tone',
+			type: 'select',
+			label: 'Tone',
+			description: 'Voice used for drafted content',
+			options: GTM_TONES.map((tone) => ({ value: tone, label: tone.charAt(0).toUpperCase() + tone.slice(1) })),
+			defaultValue: GTM_DEFAULT_SETTINGS.tone,
+			group: 'campaign'
+		},
+		{
+			name: 'cadence',
+			type: 'select',
+			label: 'Cadence',
+			description: 'How often this pipeline is expected to run',
+			options: GTM_CADENCES.map((cadence) => ({
+				value: cadence,
+				label: cadence.charAt(0).toUpperCase() + cadence.slice(1)
+			})),
+			defaultValue: GTM_DEFAULT_SETTINGS.cadence,
+			group: 'campaign'
+		},
+		{
+			name: 'max_contacts_per_run',
+			type: 'number',
+			label: 'Max Contacts per Run',
+			description: 'Upper bound of contacts drafted per run',
+			defaultValue: GTM_DEFAULT_SETTINGS.maxContactsPerRun,
+			validation: { min: 1, max: 200 },
+			group: 'qualification'
+		},
+		{
+			name: 'qualify_min_score',
+			type: 'number',
+			label: 'Minimum Qualify Score',
+			description: 'Contacts scoring below this (0-100) are dropped',
+			defaultValue: GTM_DEFAULT_SETTINGS.qualifyMinScore,
+			validation: { min: 0, max: 100 },
+			group: 'qualification'
+		},
+		{
+			name: 'risk_exclude_threshold',
+			type: 'number',
+			label: 'Risk Exclusion Threshold',
+			description: 'Contacts with risk score at or above this (0-10) are excluded',
+			defaultValue: GTM_DEFAULT_SETTINGS.riskExcludeThreshold,
+			validation: { min: 0, max: 10 },
+			group: 'qualification'
+		},
+		{
+			name: 'review_required',
+			type: 'boolean',
+			label: 'Require Human Review',
+			description: 'Pause before the act stage until drafts are approved (recommended)',
+			defaultValue: GTM_DEFAULT_SETTINGS.reviewRequired,
+			group: 'review'
+		},
+		{
+			name: 'follow_up_quiet_days',
+			type: 'number',
+			label: 'Follow-up Quiet Days',
+			description: 'Days of silence before a prepared action queues a follow-up',
+			defaultValue: GTM_DEFAULT_SETTINGS.followUpQuietDays,
+			validation: { min: 1, max: 90 },
+			group: 'review'
+		}
+	];
+}
+
+export function getGtmFormGroups(): FormFieldGroup[] {
+	return [
+		{
+			name: 'campaign',
+			title: 'Campaign',
+			description: 'Channels, tone, and cadence',
+			order: 1,
+			collapsible: true,
+			collapsed: false
+		},
+		{
+			name: 'qualification',
+			title: 'Qualification',
+			description: 'Scoring and risk filtering',
+			order: 2,
+			collapsible: true,
+			collapsed: true
+		},
+		{
+			name: 'review',
+			title: 'Review & Follow-up',
+			description: 'Human gate and re-engagement',
+			order: 3,
+			collapsible: true,
+			collapsed: true
+		}
+	];
+}
+
+export function validateGtmFormInput(values: Record<string, unknown>): ValidationResult {
+	const errors: Array<{ path: string; message: string }> = [];
+
+	const numericFields = [
+		{ name: 'max_contacts_per_run', min: 1, max: 200 },
+		{ name: 'qualify_min_score', min: 0, max: 100 },
+		{ name: 'risk_exclude_threshold', min: 0, max: 10 },
+		{ name: 'follow_up_quiet_days', min: 1, max: 90 }
+	];
+	for (const field of numericFields) {
+		const value = values[field.name];
+		if (value !== undefined && value !== null) {
+			const num = Number(value);
+			if (Number.isNaN(num)) {
+				errors.push({ path: field.name, message: `${field.name} must be a number` });
+			} else if (num < field.min || num > field.max) {
+				errors.push({
+					path: field.name,
+					message: `${field.name} must be between ${field.min} and ${field.max}`
+				});
+			}
+		}
+	}
+
+	if (values.tone !== undefined && !(GTM_TONES as readonly string[]).includes(values.tone as string)) {
+		errors.push({ path: 'tone', message: `tone must be one of: ${GTM_TONES.join(', ')}` });
+	}
+	if (values.cadence !== undefined && !(GTM_CADENCES as readonly string[]).includes(values.cadence as string)) {
+		errors.push({ path: 'cadence', message: `cadence must be one of: ${GTM_CADENCES.join(', ')}` });
+	}
+	if (values.target_channels !== undefined) {
+		if (!Array.isArray(values.target_channels)) {
+			errors.push({ path: 'target_channels', message: 'target_channels must be an array of channel names' });
+		} else {
+			for (let i = 0; i < values.target_channels.length; i++) {
+				const channel = values.target_channels[i];
+				if (typeof channel !== 'string' || channel.trim().length === 0) {
+					errors.push({
+						path: `target_channels[${i}]`,
+						message: 'each target channel must be a non-empty string'
+					});
+				}
+			}
+		}
+	}
+	if (values.review_required !== undefined && typeof values.review_required !== 'boolean') {
+		errors.push({ path: 'review_required', message: 'review_required must be a boolean' });
+	}
+
+	return { valid: errors.length === 0, errors: errors.length > 0 ? errors : undefined };
+}

--- a/packages/plugins/gtm-pipeline/src/steps/act.step.ts
+++ b/packages/plugins/gtm-pipeline/src/steps/act.step.ts
@@ -1,0 +1,53 @@
+import type { StepExecutionContext } from '@ever-works/plugin';
+import { BaseGtmStep } from '../base-step.js';
+import type { GtmPipelineContext } from '../context.js';
+import type { GtmActionRecord } from '../types.js';
+
+/**
+ * `act` stage — stages approved drafts for delivery.
+ *
+ * Inputs: `approved_drafts`. Outputs: `action_log`.
+ *
+ * Drafts-not-sends: this stage NEVER performs the outbound send itself.
+ * It records one `prepared` action per approved draft; actual delivery
+ * happens through channel connectors (later milestones) or a human,
+ * which consume the action log. Unapproved drafts are logged as
+ * `skipped` so the audit trail is complete.
+ */
+export class ActStep extends BaseGtmStep {
+	readonly stepId = 'act' as const;
+	readonly name = 'Act';
+
+	async execute(context: GtmPipelineContext, execContext: StepExecutionContext): Promise<GtmPipelineContext> {
+		const now = Date.now();
+		const approvedRefs = new Set(context.approvedDrafts.map((draft) => draft.ref));
+		const actionLog: GtmActionRecord[] = [];
+
+		for (const draft of context.drafts) {
+			if (approvedRefs.has(draft.ref)) {
+				actionLog.push({
+					draftRef: draft.ref,
+					channel: draft.channel,
+					status: 'prepared',
+					reason: null,
+					preparedAt: now
+				});
+			} else {
+				actionLog.push({
+					draftRef: draft.ref,
+					channel: draft.channel,
+					status: 'skipped',
+					reason: 'not approved in review',
+					preparedAt: now
+				});
+			}
+		}
+
+		context.actionLog = actionLog;
+		const prepared = actionLog.filter((record) => record.status === 'prepared').length;
+		execContext.logger.log(
+			`[${context.work.slug}] Act complete — prepared ${prepared}, skipped ${actionLog.length - prepared}`
+		);
+		return context;
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/steps/draft.step.ts
+++ b/packages/plugins/gtm-pipeline/src/steps/draft.step.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod';
+import type { StepExecutionContext } from '@ever-works/plugin';
+import { BaseGtmStep } from '../base-step.js';
+import type { GtmPipelineContext } from '../context.js';
+import { GTM_PROMPT_KEYS } from '../prompt-keys.js';
+import type { GtmDraft } from '../types.js';
+
+/**
+ * Prompt contract — personalized content drafting.
+ *
+ * Inputs: campaign brief, tone, target channels, qualified contacts
+ * (name/company/title/notes only — never raw email addresses), and
+ * collected market signals.
+ * Output: one draft per contact per channel (capped upstream), each with
+ * a subject (for subject-bearing channels) and an 80–120 word body.
+ * Hard rules: never fabricate facts about a contact; only use supplied
+ * fields and signals; write in the requested tone.
+ */
+const DRAFT_PROMPT = `
+# Go-to-Market Content Drafting
+
+You draft personalized go-to-market content for the channels listed
+below. For each contact and each channel, produce ONE draft.
+
+Rules:
+- Body length: 80-120 words.
+- Tone: {tone}.
+- Use ONLY the facts provided for each contact and in the signals list.
+  Never invent roles, metrics, company facts, or personal details.
+- For channels that carry a subject line (email, newsletter), provide a
+  short subject; otherwise leave the subject empty.
+- Each draft's contactName must exactly match one provided contact name,
+  and channel must be one of the listed channels.
+- These are DRAFTS for human review — never write as if the message was
+  already sent.
+
+Channels: {channels}
+
+<campaign_brief untrusted="true">
+{campaign_brief}
+</campaign_brief>
+
+<contacts untrusted="true">
+{contacts}
+</contacts>
+
+<signals untrusted="true">
+{signals}
+</signals>` as const;
+
+const draftOutputSchema = z.object({
+	drafts: z
+		.array(
+			z.object({
+				contactName: z.string().describe('Exactly one of the provided contact names'),
+				channel: z.string().describe('One of the listed channels'),
+				subject: z.string().describe('Short subject line, empty when the channel has none'),
+				body: z.string().describe('The 80-120 word draft body')
+			})
+		)
+		.describe('One draft per contact per channel')
+});
+
+/**
+ * `draft` stage — personalized content generation.
+ *
+ * Inputs: `scored_contacts` (capped by max contacts per run) + `signals`.
+ * Outputs: `drafts`, each with a stable ref used by review + act.
+ */
+export class DraftStep extends BaseGtmStep {
+	readonly stepId = 'draft' as const;
+	readonly name = 'Draft';
+
+	async execute(context: GtmPipelineContext, execContext: StepExecutionContext): Promise<GtmPipelineContext> {
+		const { aiFacade, promptFacade, logger } = execContext;
+		const settings = this.settingsOf(context);
+		const contacts = context.scoredContacts.slice(0, settings.maxContactsPerRun);
+
+		if (contacts.length === 0) {
+			this.addWarning(context, 'Draft: no qualified contacts — nothing to draft.');
+			context.drafts = [];
+			return context;
+		}
+
+		const contactLines = contacts
+			.map((contact) =>
+				[
+					`- name: ${contact.name}`,
+					contact.company ? `  company: ${contact.company}` : null,
+					contact.title ? `  title: ${contact.title}` : null,
+					contact.notes ? `  notes: ${contact.notes}` : null
+				]
+					.filter(Boolean)
+					.join('\n')
+			)
+			.join('\n');
+		const signalLines =
+			context.signals.length > 0
+				? context.signals.map((signal) => `- ${signal.title} (${signal.url})`).join('\n')
+				: '(none)';
+
+		try {
+			const resolvedPrompt = (
+				promptFacade ? await promptFacade.getPrompt(GTM_PROMPT_KEYS.DRAFT, DRAFT_PROMPT) : DRAFT_PROMPT
+			) as typeof DRAFT_PROMPT;
+			const { result } = await aiFacade.askJson(
+				resolvedPrompt,
+				draftOutputSchema,
+				{
+					temperature: 0.4,
+					variables: {
+						tone: settings.tone,
+						channels: settings.targetChannels.join(', '),
+						campaign_brief: context.request.prompt ?? '',
+						contacts: contactLines,
+						signals: signalLines
+					},
+					routing: { complexity: 'medium', taskId: 'gtm-draft' }
+				},
+				this.facadeOptions(execContext)
+			);
+
+			const knownNames = new Set(contacts.map((contact) => contact.name));
+			const knownChannels = new Set(settings.targetChannels);
+			const drafts: GtmDraft[] = [];
+			for (const candidate of result.drafts) {
+				if (!knownNames.has(candidate.contactName) || !knownChannels.has(candidate.channel)) {
+					this.addWarning(
+						context,
+						`Draft: dropped a draft referencing unknown contact/channel ("${candidate.contactName}" / "${candidate.channel}").`
+					);
+					continue;
+				}
+				const body = candidate.body.trim();
+				if (!body) continue;
+				drafts.push({
+					ref: `draft-${drafts.length + 1}`,
+					contactName: candidate.contactName,
+					channel: candidate.channel,
+					subject: candidate.subject.trim() || null,
+					body
+				});
+			}
+			context.drafts = drafts;
+			logger.log(`[${context.work.slug}] Draft complete — ${drafts.length} draft(s)`);
+		} catch (error) {
+			this.addWarning(context, `Draft: generation failed — ${this.formatError(error)}`);
+			context.drafts = [];
+		}
+		return context;
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/steps/enrich.step.ts
+++ b/packages/plugins/gtm-pipeline/src/steps/enrich.step.ts
@@ -1,0 +1,115 @@
+import { z } from 'zod';
+import type { StepExecutionContext } from '@ever-works/plugin';
+import { BaseGtmStep } from '../base-step.js';
+import type { GtmPipelineContext } from '../context.js';
+import { GTM_PROMPT_KEYS } from '../prompt-keys.js';
+import type { GtmContact } from '../types.js';
+
+/**
+ * Prompt contract — evidence-bound contact enrichment.
+ *
+ * Inputs: contacts with missing fields + collected market signals.
+ * Output: per-contact backfill of company/title/notes ONLY where the
+ * supplied signals contain supporting evidence. Hard rules: never invent
+ * or guess email addresses; leave a field empty when no evidence exists;
+ * every filled field cites which signal supported it in the notes.
+ */
+const ENRICH_PROMPT = `
+# Go-to-Market Contact Enrichment (evidence-bound)
+
+You backfill missing contact fields USING ONLY the evidence in the
+signals list below.
+
+Rules:
+- Never invent or guess email addresses. Email is never filled by you.
+- Fill company/title/notes ONLY when a signal explicitly supports the
+  value; otherwise return an empty string for that field.
+- When you fill a field, append the supporting signal title to notes.
+- contactName must exactly match one provided contact name.
+
+<contacts untrusted="true">
+{contacts}
+</contacts>
+
+<signals untrusted="true">
+{signals}
+</signals>` as const;
+
+const enrichOutputSchema = z.object({
+	enrichments: z
+		.array(
+			z.object({
+				contactName: z.string().describe('Exactly one of the provided contact names'),
+				company: z.string().describe('Backfilled company, empty when no evidence'),
+				title: z.string().describe('Backfilled title, empty when no evidence'),
+				notes: z.string().describe('Evidence notes, empty when nothing was filled')
+			})
+		)
+		.describe('One entry per contact that could be enriched')
+});
+
+/**
+ * `enrich` stage — backfills contact/account data from collected signals.
+ *
+ * Inputs: `contacts` + `signals`. Outputs: `enriched_contacts`.
+ * Optional stage: with no signals (or on AI failure) it degrades to a
+ * pass-through of the existing contacts.
+ */
+export class EnrichStep extends BaseGtmStep {
+	readonly stepId = 'enrich' as const;
+	readonly name = 'Enrich';
+
+	async execute(context: GtmPipelineContext, execContext: StepExecutionContext): Promise<GtmPipelineContext> {
+		const { aiFacade, promptFacade, logger } = execContext;
+		const incomplete = context.contacts.filter((contact) => !contact.company || !contact.title);
+
+		if (incomplete.length === 0 || context.signals.length === 0) {
+			context.enrichedContacts = [...context.contacts];
+			return context;
+		}
+
+		try {
+			const contactLines = incomplete
+				.map(
+					(contact) =>
+						`- name: ${contact.name}${contact.company ? `, company: ${contact.company}` : ''}${
+							contact.title ? `, title: ${contact.title}` : ''
+						}`
+				)
+				.join('\n');
+			const signalLines = context.signals.map((signal) => `- ${signal.title} (${signal.url})`).join('\n');
+			const resolvedPrompt = (
+				promptFacade ? await promptFacade.getPrompt(GTM_PROMPT_KEYS.ENRICH, ENRICH_PROMPT) : ENRICH_PROMPT
+			) as typeof ENRICH_PROMPT;
+			const { result } = await aiFacade.askJson(
+				resolvedPrompt,
+				enrichOutputSchema,
+				{
+					temperature: 0,
+					variables: { contacts: contactLines, signals: signalLines },
+					routing: { complexity: 'simple', taskId: 'gtm-enrich' }
+				},
+				this.facadeOptions(execContext)
+			);
+
+			const byName = new Map(result.enrichments.map((entry) => [entry.contactName, entry]));
+			context.enrichedContacts = context.contacts.map((contact): GtmContact => {
+				const enrichment = byName.get(contact.name);
+				if (!enrichment) return contact;
+				return {
+					...contact,
+					company: contact.company || enrichment.company.trim() || null,
+					title: contact.title || enrichment.title.trim() || null,
+					notes: enrichment.notes.trim()
+						? `${contact.notes ? `${contact.notes} | ` : ''}${enrichment.notes.trim()}`
+						: contact.notes
+				};
+			});
+			logger.log(`[${context.work.slug}] Enrich complete — considered ${incomplete.length} contact(s)`);
+		} catch (error) {
+			this.addWarning(context, `Enrich: degraded to pass-through — ${this.formatError(error)}`);
+			context.enrichedContacts = [...context.contacts];
+		}
+		return context;
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/steps/follow-up.step.ts
+++ b/packages/plugins/gtm-pipeline/src/steps/follow-up.step.ts
@@ -1,0 +1,36 @@
+import type { StepExecutionContext } from '@ever-works/plugin';
+import { BaseGtmStep } from '../base-step.js';
+import type { GtmPipelineContext } from '../context.js';
+import type { GtmFollowUpItem } from '../types.js';
+
+/**
+ * `follow-up` stage — timed re-engagement planning.
+ *
+ * Inputs: `action_log`. Outputs: `follow_up_queue`.
+ *
+ * Deterministic: every `prepared` action queues a follow-up due after the
+ * configured quiet-days window. A timer entry point re-enters the `draft`
+ * stage with this queue when the window elapses without a reply (the
+ * timer wiring rides the event-ingest spine milestone; this stage owns
+ * the declared queue contract).
+ */
+export class FollowUpStep extends BaseGtmStep {
+	readonly stepId = 'follow-up' as const;
+	readonly name = 'Follow-up';
+
+	async execute(context: GtmPipelineContext, execContext: StepExecutionContext): Promise<GtmPipelineContext> {
+		const settings = this.settingsOf(context);
+		const queue: GtmFollowUpItem[] = context.actionLog
+			.filter((record) => record.status === 'prepared')
+			.map((record) => ({
+				draftRef: record.draftRef,
+				channel: record.channel,
+				dueAfterDays: settings.followUpQuietDays,
+				rationale: `No response within ${settings.followUpQuietDays} day(s) of preparation (${settings.cadence} cadence).`
+			}));
+
+		context.followUpQueue = queue;
+		execContext.logger.log(`[${context.work.slug}] Follow-up complete — queued ${queue.length} item(s)`);
+		return context;
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/steps/measure.step.ts
+++ b/packages/plugins/gtm-pipeline/src/steps/measure.step.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+import type { StepExecutionContext } from '@ever-works/plugin';
+import { BaseGtmStep } from '../base-step.js';
+import type { GtmPipelineContext } from '../context.js';
+import { GTM_PROMPT_KEYS } from '../prompt-keys.js';
+import type { GtmCampaignReport } from '../types.js';
+
+/**
+ * Prompt contract — campaign reporting that closes the loop.
+ *
+ * Inputs: deterministic run totals + optional engagement data supplied
+ * via `request.config.engagement`. Output: a short summary, insights,
+ * and next-variant hints that feed the NEXT draft cycle (measure →
+ * draft loop). Rules: ground every insight in the supplied numbers;
+ * no invented metrics.
+ */
+const MEASURE_PROMPT = `
+# Go-to-Market Campaign Report
+
+You write a short campaign report from the run totals and (optional)
+engagement data below.
+
+Rules:
+- Ground every statement in the supplied numbers — never invent metrics.
+- summary: 2-3 sentences.
+- insights: up to 5 short bullet observations.
+- nextVariantHints: up to 3 concrete suggestions for the next draft
+  cycle (subject/angle/channel adjustments).
+
+<totals>
+{totals}
+</totals>
+
+<engagement untrusted="true">
+{engagement}
+</engagement>` as const;
+
+const measureOutputSchema = z.object({
+	summary: z.string().describe('2-3 sentence campaign summary'),
+	insights: z.array(z.string()).describe('Up to 5 grounded observations'),
+	nextVariantHints: z.array(z.string()).describe('Up to 3 suggestions for the next draft cycle')
+});
+
+/**
+ * `measure` stage — compiles the campaign report and closes the loop.
+ *
+ * Inputs: `action_log` (+ follow-up queue and qualification counts).
+ * Outputs: `campaign_report`. Totals are computed deterministically;
+ * the AI writes only the narrative. On AI failure the deterministic
+ * report still ships.
+ */
+export class MeasureStep extends BaseGtmStep {
+	readonly stepId = 'measure' as const;
+	readonly name = 'Measure';
+
+	async execute(context: GtmPipelineContext, execContext: StepExecutionContext): Promise<GtmPipelineContext> {
+		const { aiFacade, promptFacade, logger } = execContext;
+		const totals: GtmCampaignReport['totals'] = {
+			contacts: context.contacts.length,
+			qualified: context.scoredContacts.length,
+			excluded: context.excludedContacts.length,
+			drafts: context.drafts.length,
+			approved: context.approvedDrafts.length,
+			prepared: context.actionLog.filter((record) => record.status === 'prepared').length,
+			followUpsQueued: context.followUpQueue.length
+		};
+		const engagement = context.request.config?.engagement;
+		const engagementText =
+			engagement !== undefined && engagement !== null ? JSON.stringify(engagement) : '(none provided)';
+
+		let summary = `Prepared ${totals.prepared} of ${totals.drafts} draft(s) for ${totals.qualified} qualified contact(s); ${totals.followUpsQueued} follow-up(s) queued.`;
+		let insights: readonly string[] = [];
+		let nextVariantHints: readonly string[] = [];
+
+		try {
+			const resolvedPrompt = (
+				promptFacade ? await promptFacade.getPrompt(GTM_PROMPT_KEYS.MEASURE, MEASURE_PROMPT) : MEASURE_PROMPT
+			) as typeof MEASURE_PROMPT;
+			const { result } = await aiFacade.askJson(
+				resolvedPrompt,
+				measureOutputSchema,
+				{
+					temperature: 0.2,
+					variables: { totals: JSON.stringify(totals), engagement: engagementText },
+					routing: { complexity: 'simple', taskId: 'gtm-measure' }
+				},
+				this.facadeOptions(execContext)
+			);
+			summary = result.summary.trim() || summary;
+			insights = result.insights.slice(0, 5);
+			nextVariantHints = result.nextVariantHints.slice(0, 3);
+		} catch (error) {
+			this.addWarning(context, `Measure: narrative degraded to totals-only — ${this.formatError(error)}`);
+		}
+
+		context.report = { summary, totals, insights, nextVariantHints };
+		logger.log(`[${context.work.slug}] Measure complete — report compiled`);
+		return context;
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/steps/qualify.step.ts
+++ b/packages/plugins/gtm-pipeline/src/steps/qualify.step.ts
@@ -1,0 +1,127 @@
+import type { StepExecutionContext } from '@ever-works/plugin';
+import { BaseGtmStep } from '../base-step.js';
+import type { GtmPipelineContext } from '../context.js';
+import type { GtmContact, GtmScoredContact } from '../types.js';
+
+/**
+ * Declarative scoring weight table — deterministic-first qualification.
+ * Every rule is a named weight so the score is explainable; the reasons
+ * array carries the fired rule names into the stage output.
+ */
+export const GTM_SCORE_WEIGHTS = {
+	base: 30,
+	hasEmail: 25,
+	hasCompany: 15,
+	hasTitle: 15,
+	hasSource: 5,
+	hasNotes: 10
+} as const;
+
+/** Declarative risk table (0–10 scale; ≥ threshold excludes the contact). */
+export const GTM_RISK_WEIGHTS = {
+	missingEmail: 3,
+	missingCompany: 2,
+	genericTitle: 2,
+	freeMailDomain: 1,
+	nonPersonalName: 2
+} as const;
+
+const GENERIC_TITLES = ['consultant', 'freelancer', 'entrepreneur', 'self-employed', 'owner'];
+const FREE_MAIL_DOMAINS = ['gmail.com', 'yahoo.com', 'hotmail.com', 'outlook.com', 'aol.com', 'mail.com'];
+const NON_PERSONAL_PREFIXES = ['info@', 'contact@', 'sales@', 'support@', 'hello@', 'admin@', 'office@'];
+
+export function scoreContact(contact: GtmContact): { score: number; reasons: string[] } {
+	let score = GTM_SCORE_WEIGHTS.base;
+	const reasons: string[] = [`base +${GTM_SCORE_WEIGHTS.base}`];
+	if (contact.email) {
+		score += GTM_SCORE_WEIGHTS.hasEmail;
+		reasons.push(`has-email +${GTM_SCORE_WEIGHTS.hasEmail}`);
+	}
+	if (contact.company) {
+		score += GTM_SCORE_WEIGHTS.hasCompany;
+		reasons.push(`has-company +${GTM_SCORE_WEIGHTS.hasCompany}`);
+	}
+	if (contact.title) {
+		score += GTM_SCORE_WEIGHTS.hasTitle;
+		reasons.push(`has-title +${GTM_SCORE_WEIGHTS.hasTitle}`);
+	}
+	if (contact.source && contact.source !== 'seed-list') {
+		score += GTM_SCORE_WEIGHTS.hasSource;
+		reasons.push(`has-source +${GTM_SCORE_WEIGHTS.hasSource}`);
+	}
+	if (contact.notes) {
+		score += GTM_SCORE_WEIGHTS.hasNotes;
+		reasons.push(`has-notes +${GTM_SCORE_WEIGHTS.hasNotes}`);
+	}
+	return { score: Math.min(100, score), reasons };
+}
+
+export function assessContactRisk(contact: GtmContact): { riskScore: number; reasons: string[] } {
+	let risk = 0;
+	const reasons: string[] = [];
+	const email = (contact.email ?? '').toLowerCase();
+	if (!email) {
+		risk += GTM_RISK_WEIGHTS.missingEmail;
+		reasons.push(`missing-email +${GTM_RISK_WEIGHTS.missingEmail}`);
+	}
+	if (!contact.company) {
+		risk += GTM_RISK_WEIGHTS.missingCompany;
+		reasons.push(`missing-company +${GTM_RISK_WEIGHTS.missingCompany}`);
+	}
+	const title = (contact.title ?? '').toLowerCase();
+	if (title && GENERIC_TITLES.some((generic) => title.includes(generic))) {
+		risk += GTM_RISK_WEIGHTS.genericTitle;
+		reasons.push(`generic-title +${GTM_RISK_WEIGHTS.genericTitle}`);
+	}
+	if (email && FREE_MAIL_DOMAINS.some((domain) => email.endsWith(`@${domain}`))) {
+		risk += GTM_RISK_WEIGHTS.freeMailDomain;
+		reasons.push(`free-mail-domain +${GTM_RISK_WEIGHTS.freeMailDomain}`);
+	}
+	if (email && NON_PERSONAL_PREFIXES.some((prefix) => email.startsWith(prefix))) {
+		risk += GTM_RISK_WEIGHTS.nonPersonalName;
+		reasons.push(`non-personal-mailbox +${GTM_RISK_WEIGHTS.nonPersonalName}`);
+	}
+	return { riskScore: Math.min(10, risk), reasons };
+}
+
+/**
+ * `qualify` stage — deterministic-first scoring + risk filtering.
+ *
+ * Inputs: `contacts`. Outputs: `scored_contacts` (kept) with the
+ * excluded remainder recorded on the context for the report.
+ */
+export class QualifyStep extends BaseGtmStep {
+	readonly stepId = 'qualify' as const;
+	readonly name = 'Qualify';
+
+	async execute(context: GtmPipelineContext, execContext: StepExecutionContext): Promise<GtmPipelineContext> {
+		const settings = this.settingsOf(context);
+		const kept: GtmScoredContact[] = [];
+		const excluded: GtmScoredContact[] = [];
+
+		for (const contact of context.contacts) {
+			const { score, reasons: scoreReasons } = scoreContact(contact);
+			const { riskScore, reasons: riskReasons } = assessContactRisk(contact);
+			const scored: GtmScoredContact = { ...contact, score, scoreReasons, riskScore, riskReasons };
+			if (riskScore >= settings.riskExcludeThreshold || score < settings.qualifyMinScore) {
+				excluded.push(scored);
+			} else {
+				kept.push(scored);
+			}
+		}
+
+		kept.sort((a, b) => b.score - a.score);
+		context.scoredContacts = kept;
+		context.excludedContacts = excluded;
+		if (excluded.length > 0) {
+			this.addWarning(
+				context,
+				`Qualify: excluded ${excluded.length} contact(s) (risk >= ${settings.riskExcludeThreshold} or score < ${settings.qualifyMinScore}).`
+			);
+		}
+		execContext.logger.log(
+			`[${context.work.slug}] Qualify complete — kept ${kept.length}, excluded ${excluded.length}`
+		);
+		return context;
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/steps/research.step.ts
+++ b/packages/plugins/gtm-pipeline/src/steps/research.step.ts
@@ -1,0 +1,154 @@
+import { z } from 'zod';
+import type { StepExecutionContext } from '@ever-works/plugin';
+import { BaseGtmStep } from '../base-step.js';
+import type { GtmPipelineContext } from '../context.js';
+import { GTM_PROMPT_KEYS } from '../prompt-keys.js';
+import type { GtmContact, GtmSignal } from '../types.js';
+
+/**
+ * Prompt contract — research query planning.
+ *
+ * Input: the campaign brief (`{campaign_brief}`, untrusted user text).
+ * Output: up to {max_queries} short web-search queries that would surface
+ * fresh public signals (news, launches, hiring, funding, community posts)
+ * relevant to the campaign's audience. Queries only — no commentary.
+ */
+const RESEARCH_QUERIES_PROMPT = `
+# Go-to-Market Signal Query Planning
+
+You plan web-search queries that surface fresh, public market signals
+(news, launches, hiring, funding, community discussions) relevant to a
+go-to-market campaign.
+
+Rules:
+- Produce at most {max_queries} queries.
+- Each query is short (3-8 words) and self-contained.
+- Focus on signals about the campaign's target audience or market, not
+  generic definitions.
+- Never invent company or person names that are not in the brief.
+
+<campaign_brief untrusted="true">
+{campaign_brief}
+</campaign_brief>` as const;
+
+const researchQueriesSchema = z.object({
+	queries: z.array(z.string()).describe('Short web-search queries for market signals')
+});
+
+const MAX_SIGNAL_QUERIES = 3;
+const MAX_RESULTS_PER_QUERY = 5;
+
+/**
+ * `research` stage — collects leads and market signals.
+ *
+ * Inputs: seed contacts from `request.config.contacts` (explicit list —
+ * this stage never fabricates people) + the campaign brief (`request.prompt`).
+ * Outputs: `contacts` (normalized + deduplicated) and `signals`
+ * (search-facade results for AI-planned signal queries, best-effort).
+ */
+export class ResearchStep extends BaseGtmStep {
+	readonly stepId = 'research' as const;
+	readonly name = 'Research';
+
+	async execute(context: GtmPipelineContext, execContext: StepExecutionContext): Promise<GtmPipelineContext> {
+		const { logger } = execContext;
+		const config = context.request.config ?? {};
+
+		context.contacts = this.normalizeSeedContacts(config.contacts);
+		if (context.contacts.length === 0) {
+			this.addWarning(
+				context,
+				'Research: no seed contacts provided (config.contacts) — downstream stages will only produce channel content.'
+			);
+		}
+
+		const brief = (context.request.prompt ?? '').trim();
+		if (brief) {
+			context.signals = await this.collectSignals(context, execContext, brief);
+		}
+
+		logger.log(
+			`[${context.work.slug}] Research complete — ${context.contacts.length} contacts, ${context.signals.length} signals`
+		);
+		return context;
+	}
+
+	private normalizeSeedContacts(raw: unknown): GtmContact[] {
+		if (!Array.isArray(raw)) return [];
+		const seen = new Set<string>();
+		const contacts: GtmContact[] = [];
+		for (const entry of raw) {
+			if (typeof entry !== 'object' || entry === null) continue;
+			const record = entry as Record<string, unknown>;
+			const name = typeof record.name === 'string' ? record.name.trim() : '';
+			const email = typeof record.email === 'string' ? record.email.trim() : '';
+			if (!name && !email) continue;
+			const dedupeKey = (email || name).toLowerCase();
+			if (seen.has(dedupeKey)) continue;
+			seen.add(dedupeKey);
+			contacts.push({
+				name: name || email,
+				email: email || null,
+				company: typeof record.company === 'string' ? record.company.trim() || null : null,
+				title: typeof record.title === 'string' ? record.title.trim() || null : null,
+				source: typeof record.source === 'string' ? record.source.trim() || null : 'seed-list',
+				notes: typeof record.notes === 'string' ? record.notes.trim() || null : null
+			});
+		}
+		return contacts;
+	}
+
+	private async collectSignals(
+		context: GtmPipelineContext,
+		execContext: StepExecutionContext,
+		brief: string
+	): Promise<GtmSignal[]> {
+		const { aiFacade, searchFacade, promptFacade, logger } = execContext;
+		const facadeOptions = this.facadeOptions(execContext);
+		try {
+			const resolvedPrompt = (
+				promptFacade
+					? await promptFacade.getPrompt(GTM_PROMPT_KEYS.RESEARCH_QUERIES, RESEARCH_QUERIES_PROMPT)
+					: RESEARCH_QUERIES_PROMPT
+			) as typeof RESEARCH_QUERIES_PROMPT;
+			const { result } = await aiFacade.askJson(
+				resolvedPrompt,
+				researchQueriesSchema,
+				{
+					temperature: 0,
+					variables: { campaign_brief: brief, max_queries: String(MAX_SIGNAL_QUERIES) },
+					routing: { complexity: 'simple', taskId: 'gtm-research-queries' }
+				},
+				facadeOptions
+			);
+			const queries = result.queries
+				.filter((q) => typeof q === 'string' && q.trim().length > 0)
+				.slice(0, MAX_SIGNAL_QUERIES);
+
+			const signals: GtmSignal[] = [];
+			for (const query of queries) {
+				try {
+					const results = await searchFacade.search(
+						query,
+						{ maxResults: MAX_RESULTS_PER_QUERY },
+						facadeOptions
+					);
+					for (const item of results) {
+						signals.push({
+							query,
+							title: item.title,
+							url: item.url,
+							publishedDate: item.publishedDate ?? null
+						});
+					}
+				} catch (error) {
+					logger.warn(`Research signal query failed ("${query}"): ${this.formatError(error)}`);
+				}
+			}
+			return signals;
+		} catch (error) {
+			this.addWarning(context, `Research: signal collection degraded — ${this.formatError(error)}`);
+			return [];
+		}
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/steps/review.step.ts
+++ b/packages/plugins/gtm-pipeline/src/steps/review.step.ts
@@ -1,0 +1,78 @@
+import type { StepExecutionContext } from '@ever-works/plugin';
+import { BaseGtmStep } from '../base-step.js';
+import type { GtmPipelineContext } from '../context.js';
+
+/**
+ * `review` stage — the human gate placed BEFORE any outbound action.
+ *
+ * Inputs: `drafts`. Outputs: `approved_drafts`.
+ *
+ * Contract:
+ * - When review is required (default) and no approvals were supplied via
+ *   `request.config.approved_draft_refs`, the run pauses: `pendingReview`
+ *   is set, `shouldStop` stops the engine, and the checkpoint stays
+ *   viable so the run can resume once approvals arrive.
+ * - `approved_draft_refs` may be `'all'` or an array of draft refs.
+ *   Unknown refs are ignored with a warning.
+ * - When review is disabled in settings, all drafts pass with an explicit
+ *   warning so the audit trail records the auto-approval.
+ */
+export class ReviewStep extends BaseGtmStep {
+	readonly stepId = 'review' as const;
+	readonly name = 'Review';
+
+	async execute(context: GtmPipelineContext, execContext: StepExecutionContext): Promise<GtmPipelineContext> {
+		const settings = this.settingsOf(context);
+		const config = context.request.config ?? {};
+		const approvals = config.approved_draft_refs;
+
+		if (context.drafts.length === 0) {
+			context.approvedDrafts = [];
+			context.pendingReview = false;
+			return context;
+		}
+
+		if (!settings.reviewRequired) {
+			context.approvedDrafts = [...context.drafts];
+			context.pendingReview = false;
+			this.addWarning(
+				context,
+				`Review: review_required is disabled — auto-approved ${context.drafts.length} draft(s).`
+			);
+			return context;
+		}
+
+		if (approvals === 'all') {
+			context.approvedDrafts = [...context.drafts];
+			context.pendingReview = false;
+		} else if (Array.isArray(approvals)) {
+			const requested = new Set(approvals.filter((ref): ref is string => typeof ref === 'string'));
+			const known = new Set(context.drafts.map((draft) => draft.ref));
+			for (const ref of requested) {
+				if (!known.has(ref)) {
+					this.addWarning(context, `Review: ignored unknown draft ref "${ref}".`);
+				}
+			}
+			context.approvedDrafts = context.drafts.filter((draft) => requested.has(draft.ref));
+			context.pendingReview = false;
+			if (context.approvedDrafts.length === 0) {
+				this.addWarning(context, 'Review: approvals supplied but none matched — no drafts approved.');
+			}
+		} else {
+			// No approval input yet — pause the run at the gate.
+			context.approvedDrafts = [];
+			context.pendingReview = true;
+			context.shouldStop = true;
+			this.addWarning(
+				context,
+				`Review: awaiting human approval for ${context.drafts.length} draft(s) before any outbound action.`
+			);
+		}
+
+		execContext.logger.log(
+			`[${context.work.slug}] Review complete — approved ${context.approvedDrafts.length}/${context.drafts.length}` +
+				(context.pendingReview ? ' (pending human review)' : '')
+		);
+		return context;
+	}
+}

--- a/packages/plugins/gtm-pipeline/src/types.ts
+++ b/packages/plugins/gtm-pipeline/src/types.ts
@@ -1,0 +1,123 @@
+/**
+ * Go-to-Market pipeline — stage ids and stage data contracts.
+ *
+ * The stage set mirrors the roadmap's go-to-market stage list:
+ * research → qualify → draft → review → act → follow-up → enrich → measure.
+ *
+ * Every stage declares its input/output keys (`requires`/`provides` on the
+ * step definitions) so stage handoffs stay explicit and auditable. The
+ * `review` stage is the human gate placed BEFORE any outbound action —
+ * the pipeline's default posture is drafts-not-sends.
+ */
+
+export const GTM_STAGE_IDS = [
+	'research',
+	'qualify',
+	'draft',
+	'review',
+	'act',
+	'follow-up',
+	'enrich',
+	'measure'
+] as const;
+
+export type GtmStageId = (typeof GTM_STAGE_IDS)[number];
+
+/**
+ * Declared stage data keys — the vocabulary used by `provides`/`requires`
+ * on the stage definitions AND by the context's `hasStageResult`.
+ */
+export const GTM_STAGE_DATA_KEYS = [
+	'contacts',
+	'signals',
+	'scored_contacts',
+	'drafts',
+	'approved_drafts',
+	'action_log',
+	'follow_up_queue',
+	'enriched_contacts',
+	'campaign_report'
+] as const;
+
+export type GtmStageDataKey = (typeof GTM_STAGE_DATA_KEYS)[number];
+
+// ============================================================================
+// Stage IO data shapes
+// ============================================================================
+
+/** A lead/contact candidate collected by the `research` stage. */
+export interface GtmContact {
+	/** Display name (person or business). */
+	readonly name: string;
+	readonly email?: string | null;
+	readonly company?: string | null;
+	readonly title?: string | null;
+	/** Where this contact came from (seed list, signal, referral, …). */
+	readonly source?: string | null;
+	readonly notes?: string | null;
+}
+
+/** A market/news signal collected by the `research` stage. */
+export interface GtmSignal {
+	readonly query: string;
+	readonly title: string;
+	readonly url: string;
+	readonly publishedDate?: string | null;
+}
+
+/** Output of the `qualify` stage — deterministic-first scoring. */
+export interface GtmScoredContact extends GtmContact {
+	/** Priority score 0–100 (higher = better fit). */
+	readonly score: number;
+	readonly scoreReasons: readonly string[];
+	/** Risk score 0–10 (higher = riskier; ≥ threshold is excluded). */
+	readonly riskScore: number;
+	readonly riskReasons: readonly string[];
+}
+
+/** A personalized outbound draft produced by the `draft` stage. */
+export interface GtmDraft {
+	/** Stable reference used by review approvals and the action log. */
+	readonly ref: string;
+	/** Contact display name this draft targets (empty for broadcast content). */
+	readonly contactName: string;
+	readonly channel: string;
+	readonly subject?: string | null;
+	readonly body: string;
+}
+
+/** An entry in the `act` stage's action log. NEVER 'sent' — drafts-not-sends. */
+export interface GtmActionRecord {
+	readonly draftRef: string;
+	readonly channel: string;
+	/** 'prepared' = staged for a connector/human to deliver; 'skipped' = not actioned. */
+	readonly status: 'prepared' | 'skipped';
+	readonly reason?: string | null;
+	readonly preparedAt: number;
+}
+
+/** A timed re-engagement item produced by the `follow-up` stage. */
+export interface GtmFollowUpItem {
+	readonly draftRef: string;
+	readonly channel: string;
+	/** Days after preparation when a quiet thread should be re-engaged. */
+	readonly dueAfterDays: number;
+	readonly rationale: string;
+}
+
+/** Report compiled by the `measure` stage — closes the loop into the next draft cycle. */
+export interface GtmCampaignReport {
+	readonly summary: string;
+	readonly totals: {
+		readonly contacts: number;
+		readonly qualified: number;
+		readonly excluded: number;
+		readonly drafts: number;
+		readonly approved: number;
+		readonly prepared: number;
+		readonly followUpsQueued: number;
+	};
+	readonly insights: readonly string[];
+	/** Hints for the next draft cycle's variants (measure → draft loop). */
+	readonly nextVariantHints: readonly string[];
+}

--- a/packages/plugins/gtm-pipeline/tsconfig.json
+++ b/packages/plugins/gtm-pipeline/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "ES2021",
+		"types": ["node"],
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"rootDir": "./src",
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"isolatedModules": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/gtm-pipeline/tsup.config.ts
+++ b/packages/plugins/gtm-pipeline/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['cjs', 'esm'],
+	dts: true,
+	splitting: false,
+	sourcemap: false,
+	clean: true
+});

--- a/packages/plugins/gtm-pipeline/vitest.config.ts
+++ b/packages/plugins/gtm-pipeline/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+			include: ['src/**/*.ts'],
+			exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/index.ts']
+		}
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(e98a7fb1f3ff60e0b2beec3497f32f48)
+        version: 2.3.4(6df53909bc07743f1cbdc8ed07c4f22a)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.18.1)(rxjs@7.8.2)
@@ -288,16 +288,16 @@ importers:
         version: link:../../packages/plugins/postgres-db
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -537,13 +537,13 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -996,13 +996,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -1167,7 +1167,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -1878,6 +1878,28 @@ importers:
         specifier: ^0.6.17
         version: 0.6.17(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.219.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.0))(openai@6.39.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0)
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  packages/plugins/gtm-pipeline:
+    dependencies:
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
@@ -21495,6 +21517,17 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
+  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      jsonc-parser: 3.3.1
+      picomatch: 4.0.4
+      rxjs: 7.8.1
+      source-map: 0.7.4
+    optionalDependencies:
+      chokidar: 3.6.0
+
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -21516,6 +21549,26 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
+      - chokidar
+
+  '@angular-devkit/schematics@19.2.23':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.17
+      ora: 5.4.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - chokidar
+
+  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.17
+      ora: 5.4.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -26243,7 +26296,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(e98a7fb1f3ff60e0b2beec3497f32f48)':
+  '@nestjs-modules/mailer@2.3.4(6df53909bc07743f1cbdc8ed07c4f22a)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -26262,7 +26315,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.2
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.2)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@4.0.3)
+      nunjucks: 3.2.4(chokidar@3.6.0)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -26289,7 +26342,36 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
+      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+      ansis: 4.2.0
+      chokidar: 4.0.3
+      cli-table3: 0.6.5
+      commander: 4.1.1
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
+      glob: 13.0.6
+      node-emoji: 1.11.0
+      ora: 5.4.1
+      tsconfig-paths: 4.2.0
+      tsconfig-paths-webpack-plugin: 4.2.0
+      typescript: 5.9.3
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
+      webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@types/node'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -26318,7 +26400,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -26329,17 +26411,17 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21)))
       glob: 13.0.6
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.33(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -26443,10 +26525,32 @@ snapshots:
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
 
+  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
+      comment-json: 4.6.2
+      jsonc-parser: 3.3.1
+      pluralize: 8.0.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - chokidar
+
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      comment-json: 4.6.2
+      jsonc-parser: 3.3.1
+      pluralize: 8.0.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - chokidar
+
+  '@nestjs/schematics@11.0.10(typescript@5.9.3)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      '@angular-devkit/schematics': 19.2.23
       comment-json: 4.6.2
       jsonc-parser: 3.3.1
       pluralize: 8.0.0
@@ -29987,6 +30091,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)':
+    dependencies:
+      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 14.2.2
+      commander: 8.3.0
+      minimatch: 10.2.5
+      piscina: 4.9.3
+      semver: 7.8.1
+      slash: 3.0.0
+      source-map: 0.7.6
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      chokidar: 3.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
@@ -35920,7 +36043,7 @@ snapshots:
     optionalDependencies:
       express: 5.2.1
       hono: 4.12.25
-      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -38802,6 +38925,34 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
+  next@16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@next/env': 16.2.11
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.18
+      caniuse-lite: 1.0.30001787
+      postcss: 8.5.20
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.5)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.59.1
+      sharp: 0.35.3(@types/node@22.19.11)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
+    optional: true
+
   nextjs-toploader@3.9.17(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@20.19.33)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@20.19.33)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -38968,13 +39119,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@4.0.3):
+  nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 4.0.3
+      chokidar: 3.6.0
     optional: true
 
   nypm@0.6.5:


### PR DESCRIPTION
## Summary

Wave 10-ext **milestone 10.1** (`gtm-pipeline` pipeline plugin) plus a first slice of **10.7** (prebuilt marketing/sales agent templates). Additive only — no entity/schema changes, no migrations, no existing surface modified beyond registrations.

### 1. `packages/plugins/gtm-pipeline` — Go-to-Market pipeline plugin
- Engine-orchestratable pipeline (same contract as `standard-pipeline`) declaring the go-to-market stage set: **research → qualify → draft → review → act → follow-up → enrich → measure**.
- Every stage declares input/output keys (`provides`/`requires`: `contacts`/`signals` → `scored_contacts` → `drafts` → `approved_drafts` → `action_log` → `follow_up_queue`, `enriched_contacts`, `campaign_report`) so stage handoffs are explicit and auditable.
- **`review` is the human gate before any outbound action**: with no approvals supplied the run pauses (`pendingReview` + `shouldStop`) on a resumable checkpoint; approvals arrive via `config.approved_draft_refs` (`'all'` or refs). Disabling review is recorded as an explicit warning.
- **Drafts-not-sends**: the `act` stage records `prepared`/`skipped` action-log entries for connectors/humans to deliver — it never sends.
- `qualify` uses a declarative scoring + risk weight table (explainable reasons per contact); `research` never fabricates people (seed contacts only; signals via AI-planned search queries, best-effort); `enrich` is evidence-bound (never invents contact details); `measure` computes deterministic totals with AI narrative on top (degrades to totals-only) and emits next-variant hints, closing the loop into the next draft cycle.
- Settings via form-schema-provider: target channels, tone, cadence, max contacts/run, qualify min score, risk threshold, review required, follow-up quiet days.
- AI stages run through the existing `StepExecutionContext` AI facade (`askJson` + prompt-facade key overrides).

### 2. Prebuilt agent templates (packages/agent + apps/api + apps/web)
- `packages/agent/src/agents/agent-templates.ts` — typed in-code catalog of 6 presets: **Content Marketer, SEO Auditor, Lead Researcher, Outreach Drafter, Social Scheduler, Competitive Analyst** (name, slug, description, system prompt, capabilities, suggested skills, suggested pipeline, conservative default permissions, `require_approval` guardrails, `suggestedRoles` hint).
- `AgentTemplatesService.createFromTemplate(userId, slug, overrides)` — activates a template into an **ordinary owner-scoped Agent row** via the existing surfaces: `AgentsService.create` (DRAFT status, standard validation/409s), `AgentFileService.write` (template prompt → SOUL.md, secret-scanned), `AgentsService.setGuardrails`. Registered in `AgentsModule` providers/exports + agents barrel in the same commit.
- API: `GET /api/agents/templates` and `POST /api/agents/from-template/:slug` (+ `CreateAgentFromTemplateDto` with optional placement overrides only). Both declared **before** the `:id` routes so the literal segments never hit `ParseUUIDPipe`. Complements — does not replace — the repo-backed `GET /api/agent-templates` metadata catalog.
- Chat tools: `list_agent_templates` + `create_agent_from_template` added to the generated web chat-tool registry.

### 3. Onboarding tie-in — SKIPPED (documented per skip-if-unsure)
No role/team-size onboarding step or persisted answer exists yet (`OnboardingWizardStateV2` carries ai/storage/db/deploy choices + a Communication step only; the role step is planned as Wave 11-ext 11.5). The catalog ships a forward-compatible `suggestedRoles` field per template so suggestion surfaces can consume it the moment that step lands.

## Verification (all run locally on this branch)

- `pnpm build --filter=@ever-works/contracts --filter=@ever-works/plugin` — `Tasks: 2 successful, 2 total`
- `packages/plugins/gtm-pipeline`: `pnpm build` — `tsc --noEmit` clean + tsup CJS/ESM/DTS success; `pnpm test` — **Test Files 3 passed, Tests 30 passed**
- `packages/agent`: `pnpm build` — `TSC Found 0 issues`, SWC 1023 files; `npx jest --testPathPattern='agent-templates'` — **2 suites, 17 tests passed**; `npx jest --testPathPattern='module\.spec'` (module-shape pins after the AgentsModule provider add) — **22 suites, 193 tests passed**
- `pnpm build --filter=ever-works-api` — `Tasks: 14 successful, 14 total`
- `apps/api`: `pnpm generate:openapi` — full-app bootstrap OK, `Wrote OpenAPI spec (422 paths)` incl. both new endpoints (`openapi.json` is gitignored, not committed)
- `apps/api`: `npx jest --testPathPattern='agents'` — **3 suites, 47 tests passed** (incl. `agents.controller.runtime.spec.ts` with the new trailing optional ctor param)
- `apps/web`: `npx vitest run src/lib/ai/tools/generated` — **2 files, 12 tests passed** (registry/factory pins with the 2 new tools)
- Prettier run on all touched files; no e2e specs reference the new routes (grepped `apps/web/e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
