### PR TITLE
feat(agent): metering debit hook + soft enforcement (Wave 9 M2)

### DIFF
--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -214,6 +214,7 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                     workId,
                     agentId,
                     taskId,
+                    runId,
                     query,
                     maxResults,
                     includeDomains,
@@ -222,7 +223,8 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                     const results = await search.search(
                         query,
                         { maxResults, includeDomains, excludeDomains },
-                        { userId, workId, agentId, taskId },
+                        // Wave 9 M2 — runId feeds per-run cost attribution.
+                        { userId, workId, agentId, taskId, runId },
                     );
                     return {
                         results: results.map((r) => ({
@@ -239,6 +241,7 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                     workId,
                     agentId,
                     taskId,
+                    runId,
                     url,
                     viewportWidth,
                     viewportHeight,
@@ -246,7 +249,8 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                 }) {
                     const result = await screenshot.capture(
                         { url, viewportWidth, viewportHeight, fullPage } as any,
-                        { userId, workId, agentId, taskId },
+                        // Wave 9 M2 — runId feeds per-run cost attribution.
+                        { userId, workId, agentId, taskId, runId },
                     );
                     return {
                         success: result.success,
@@ -254,12 +258,14 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                         cacheUrl: result.cacheUrl ?? null,
                     };
                 },
-                async extractContent({ userId, workId, agentId, taskId, url, maxChars }) {
+                async extractContent({ userId, workId, agentId, taskId, runId, url, maxChars }) {
                     const result = await extractor.extractContent(url, undefined, {
                         userId,
                         workId,
                         agentId,
                         taskId,
+                        // Wave 9 M2 — runId feeds per-run cost attribution.
+                        runId,
                     });
                     const raw = result?.rawContent ?? '';
                     const cap = maxChars && maxChars > 0 ? Math.min(maxChars, 200_000) : 50_000;
@@ -329,6 +335,8 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                             workId: input.facadeOptions.workId,
                             agentId: input.facadeOptions.agentId,
                             taskId: input.facadeOptions.taskId,
+                            // Wave 9 M2 — per-run cost attribution.
+                            runId: input.facadeOptions.runId,
                             providerOverride: input.facadeOptions.providerOverride,
                         },
                     );

--- a/apps/api/src/migrations/1783600000000-AddRunIdToPluginUsageEvents.ts
+++ b/apps/api/src/migrations/1783600000000-AddRunIdToPluginUsageEvents.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Pricing Wave 9 M2 — per-run cost attribution on the metering pipeline.
+ *
+ *  - `runId` — nullable uuid on `plugin_usage_events`; populated when a
+ *    usage event is recorded inside an `AgentRun` (threaded through
+ *    `FacadeOptions.runId`). The run-cost accumulator sums `costCents`
+ *    over rows tagged with the run id at run-terminal time to stamp
+ *    `agent_runs.costCents` and emit the credits CONSUMPTION debit
+ *    (idempotency key `run:{runId}`). NULL for all historical rows and
+ *    for calls made outside a run — honestly "not attributable", never
+ *    backfilled (there is no reliable historical mapping from events to
+ *    runs; agentId/taskId attribution predates per-run granularity).
+ *
+ * No FK to `agent_runs` — deleting an Agent (CASCADE onto its runs)
+ * must NOT drop usage audit rows, mirroring the agentId/taskId columns.
+ *
+ * Index `(runId, occurredAt)` for the accumulator's per-run sum.
+ * Forward-only, idempotent per-step guards (house pattern, mirrors
+ * 1783100000000-AddRunOrchestrationColumns).
+ */
+export class AddRunIdToPluginUsageEvents1783600000000 implements MigrationInterface {
+    name = 'AddRunIdToPluginUsageEvents1783600000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('plugin_usage_events');
+        if (!table) return;
+
+        if (!table.findColumnByName('runId')) {
+            await queryRunner.query(`ALTER TABLE "plugin_usage_events" ADD COLUMN "runId" uuid`);
+        }
+
+        await queryRunner.query(
+            `CREATE INDEX IF NOT EXISTS "idx_plugin_usage_events_run_occurred" ` +
+                `ON "plugin_usage_events" ("runId", "occurredAt")`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "idx_plugin_usage_events_run_occurred"`);
+        const table = await queryRunner.getTable('plugin_usage_events');
+        if (!table) return;
+        if (table.findColumnByName('runId')) {
+            await queryRunner.query(`ALTER TABLE "plugin_usage_events" DROP COLUMN "runId"`);
+        }
+    }
+}

--- a/apps/api/src/subscriptions/subscriptions.module.ts
+++ b/apps/api/src/subscriptions/subscriptions.module.ts
@@ -1,13 +1,38 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { AuthModule } from '@src/auth';
-import { SubscriptionsModule as AgentSubscriptionsModule } from '@ever-works/agent/subscriptions';
+import {
+    SubscriptionsModule as AgentSubscriptionsModule,
+    RunCostSettlementService,
+} from '@ever-works/agent/subscriptions';
+import { RUN_COST_SETTLER } from '@ever-works/agent/database';
+import { RUN_CREDITS_PRECHECK } from '@ever-works/agent/agents';
 import { SubscriptionsController } from './subscriptions.controller';
 import { CreditsController } from './credits.controller';
 
+/**
+ * Pricing Wave 9 M2 — @Global() for the same reason as the api-side
+ * AgentsModule / TasksModule: the token bindings below are consumed by
+ * @Optional() @Inject() sites that live in OTHER agent-package modules
+ * (`AgentRunRepository` — provided in both DatabaseModule and the
+ * agent-side AgentsModule — fires RUN_COST_SETTLER after every terminal
+ * transition; `RunDispatchGateService` in AgentsModule consults
+ * RUN_CREDITS_PRECHECK). Without @Global() those optional injections
+ * silently resolve to undefined in production while every unit test
+ * passes.
+ */
+@Global()
 @Module({
     imports: [AuthModule, AgentSubscriptionsModule],
     // CreditsController (pricing Wave 9 M1) — read-only credits surface
     // beside the existing plan endpoints; consumed by the Wave 13 UI.
     controllers: [SubscriptionsController, CreditsController],
+    providers: [
+        // Wave 9 M2 — metering → credits debit hook (run terminal writes)
+        // + the dispatch gate's soft enforcement precheck. One service
+        // instance behind both tokens (useExisting keeps it a singleton).
+        { provide: RUN_COST_SETTLER, useExisting: RunCostSettlementService },
+        { provide: RUN_CREDITS_PRECHECK, useExisting: RunCostSettlementService },
+    ],
+    exports: [RUN_COST_SETTLER, RUN_CREDITS_PRECHECK],
 })
 export class SubscriptionsModule {}

--- a/packages/agent/src/agents/__tests__/run-dispatch-gate.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-dispatch-gate.service.spec.ts
@@ -1,4 +1,8 @@
-import { QUEUED_REASON_CONCURRENCY, RunDispatchGateService } from '../run-dispatch-gate.service';
+import {
+    QUEUED_REASON_CONCURRENCY,
+    QUEUED_REASON_INSUFFICIENT_CREDITS,
+    RunDispatchGateService,
+} from '../run-dispatch-gate.service';
 
 /**
  * Run orchestration (Wave 4 M2) — dispatch-gate contract:
@@ -10,6 +14,8 @@ describe('RunDispatchGateService', () => {
     const ENV_KEYS = [
         'AGENT_MAX_CONCURRENT_RUNS_PER_WORK',
         'AGENT_MAX_CONCURRENT_RUNS_PER_ORG',
+        // Wave 9 M2 — soft credits-enforcement kill-switch (default OFF).
+        'CREDITS_ENFORCEMENT',
     ] as const;
     const savedEnv: Record<string, string | undefined> = {};
 
@@ -43,6 +49,10 @@ describe('RunDispatchGateService', () => {
 
     const makeGate = (withDispatcher = true) =>
         new RunDispatchGateService(runs, withDispatcher ? dispatcher : undefined);
+
+    // Wave 9 M2 — gate with the credits precheck token bound.
+    const makeGateWithCredits = (precheck: { shouldQueueForCredits: jest.Mock }) =>
+        new RunDispatchGateService(runs, dispatcher, precheck as never);
 
     const parkedRun = (over: Record<string, unknown> = {}) => ({
         id: 'run-parked',
@@ -127,6 +137,69 @@ describe('RunDispatchGateService', () => {
             expect(result.admitted).toBe(true);
             expect(runs.countInFlightForWork).not.toHaveBeenCalled();
             expect(runs.countInFlightForUser).toHaveBeenCalledWith('user-1');
+        });
+    });
+
+    describe('admit — soft credits precheck (Wave 9 M2, ship-dark)', () => {
+        it('is DARK by default: precheck bound but CREDITS_ENFORCEMENT unset ⇒ never consulted', async () => {
+            const precheck = { shouldQueueForCredits: jest.fn().mockResolvedValue(true) };
+            const result = await makeGateWithCredits(precheck).admit({
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+            expect(result).toEqual({ admitted: true });
+            expect(precheck.shouldQueueForCredits).not.toHaveBeenCalled();
+        });
+
+        it('queues with insufficient-credits when enabled AND the user is broke', async () => {
+            process.env.CREDITS_ENFORCEMENT = 'on';
+            const precheck = { shouldQueueForCredits: jest.fn().mockResolvedValue(true) };
+            const result = await makeGateWithCredits(precheck).admit({
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+            expect(result).toEqual({
+                admitted: false,
+                queuedReason: QUEUED_REASON_INSUFFICIENT_CREDITS,
+            });
+            expect(precheck.shouldQueueForCredits).toHaveBeenCalledWith('user-1');
+        });
+
+        it('admits normally when enabled but the user has balance', async () => {
+            process.env.CREDITS_ENFORCEMENT = 'on';
+            const precheck = { shouldQueueForCredits: jest.fn().mockResolvedValue(false) };
+            const result = await makeGateWithCredits(precheck).admit({
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+            expect(result).toEqual({ admitted: true });
+        });
+
+        it('fails OPEN when the precheck throws — a broken billing check never stops work', async () => {
+            process.env.CREDITS_ENFORCEMENT = 'on';
+            const precheck = {
+                shouldQueueForCredits: jest.fn().mockRejectedValue(new Error('credits DB down')),
+            };
+            const result = await makeGateWithCredits(precheck).admit({
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+            expect(result).toEqual({ admitted: true });
+        });
+
+        it('the concurrency valve wins over the credits precheck (checked first)', async () => {
+            process.env.CREDITS_ENFORCEMENT = 'on';
+            runs.countInFlightForWork.mockResolvedValueOnce(10);
+            const precheck = { shouldQueueForCredits: jest.fn().mockResolvedValue(true) };
+            const result = await makeGateWithCredits(precheck).admit({
+                userId: 'user-1',
+                workId: 'work-1',
+            });
+            expect(result).toEqual({
+                admitted: false,
+                queuedReason: QUEUED_REASON_CONCURRENCY,
+            });
+            expect(precheck.shouldQueueForCredits).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/agent/src/agents/agent-ai-dispatch-facade.ts
+++ b/packages/agent/src/agents/agent-ai-dispatch-facade.ts
@@ -54,6 +54,8 @@ export interface AgentAiDispatchInput {
         workId?: string;
         agentId: string;
         taskId?: string;
+        /** Wave 9 M2 — per-run cost attribution (FacadeOptions.runId). */
+        runId?: string;
         providerOverride?: string;
     };
     /** Optional temperature override. Default 0.4 (agent runs prefer determinism). */

--- a/packages/agent/src/agents/agent-plugin-tools-facade.ts
+++ b/packages/agent/src/agents/agent-plugin-tools-facade.ts
@@ -20,6 +20,8 @@ export interface AgentSearchWebInput {
     agentId: string;
     workId?: string;
     taskId?: string;
+    /** Wave 9 M2 — per-run cost attribution (FacadeOptions.runId). */
+    runId?: string;
     query: string;
     maxResults?: number;
     includeDomains?: string[];
@@ -41,6 +43,8 @@ export interface AgentScreenshotInput {
     agentId: string;
     workId?: string;
     taskId?: string;
+    /** Wave 9 M2 — per-run cost attribution (FacadeOptions.runId). */
+    runId?: string;
     url: string;
     viewportWidth?: number;
     viewportHeight?: number;
@@ -58,6 +62,8 @@ export interface AgentExtractContentInput {
     agentId: string;
     workId?: string;
     taskId?: string;
+    /** Wave 9 M2 — per-run cost attribution (FacadeOptions.runId). */
+    runId?: string;
     url: string;
     /** Cap on raw content length returned to the model (defaults to 50 KB). */
     maxChars?: number;

--- a/packages/agent/src/agents/agent-run.service.ts
+++ b/packages/agent/src/agents/agent-run.service.ts
@@ -600,6 +600,10 @@ export class AgentRunService {
                         workId: agent.workId ?? undefined,
                         agentId: agent.id,
                         taskId: context.taskId ?? undefined,
+                        // Wave 9 M2 — tag every usage event this round
+                        // records with the run id so the run-cost
+                        // accumulator can sum exactly this run's spend.
+                        runId: context.runId,
                         providerOverride: agent.aiProviderId ?? undefined,
                     },
                 });

--- a/packages/agent/src/agents/agent-tool.service.ts
+++ b/packages/agent/src/agents/agent-tool.service.ts
@@ -209,9 +209,11 @@ export class AgentToolService {
         // token presence so when the platform hasn't wired the adapter
         // the model never sees the tools.
         if (agent.permissions?.canCallExternalTools && this.pluginTools) {
-            tools.push(this.buildSearchWebTool(agent));
-            tools.push(this.buildScreenshotTool(agent));
-            tools.push(this.buildExtractContentTool(agent));
+            // Wave 9 M2 — thread the run id so pass-through usage events
+            // carry per-run cost attribution (the accumulator sums them).
+            tools.push(this.buildSearchWebTool(agent, runContext));
+            tools.push(this.buildScreenshotTool(agent, runContext));
+            tools.push(this.buildExtractContentTool(agent, runContext));
         }
 
         // Notifications v2 (EW-670) — sendEmail. Same canCallExternalTools
@@ -511,7 +513,19 @@ export class AgentToolService {
         };
     }
 
-    private buildSearchWebTool(agent: Agent): AgentToolDescriptor<
+    /**
+     * Wave 9 M2 — the pass-through builders receive the run context so the
+     * resulting `PluginUsageEvent` rows carry per-run cost attribution.
+     * The `'no-run'` sentinel (default context) maps to `undefined`.
+     */
+    private runIdFor(runContext: { runId: string }): string | undefined {
+        return runContext.runId === 'no-run' ? undefined : runContext.runId;
+    }
+
+    private buildSearchWebTool(
+        agent: Agent,
+        runContext: { runId: string },
+    ): AgentToolDescriptor<
         {
             query: string;
             maxResults?: number;
@@ -558,6 +572,7 @@ export class AgentToolService {
                         userId: agent.userId,
                         agentId: agent.id,
                         workId: agent.workId ?? undefined,
+                        runId: this.runIdFor(runContext),
                         query: args.query,
                         maxResults: args.maxResults,
                         includeDomains: args.includeDomains,
@@ -779,6 +794,7 @@ export class AgentToolService {
 
     private buildScreenshotTool(
         agent: Agent,
+        runContext: { runId: string },
     ): AgentToolDescriptor<
         { url: string; viewportWidth?: number; viewportHeight?: number; fullPage?: boolean },
         AgentScreenshotResult
@@ -826,6 +842,7 @@ export class AgentToolService {
                         userId: agent.userId,
                         agentId: agent.id,
                         workId: agent.workId ?? undefined,
+                        runId: this.runIdFor(runContext),
                         url: args.url,
                         viewportWidth: args.viewportWidth,
                         viewportHeight: args.viewportHeight,
@@ -840,6 +857,7 @@ export class AgentToolService {
 
     private buildExtractContentTool(
         agent: Agent,
+        runContext: { runId: string },
     ): AgentToolDescriptor<{ url: string; maxChars?: number }, AgentExtractContentResult> {
         return {
             name: 'extractContent',
@@ -879,6 +897,7 @@ export class AgentToolService {
                         userId: agent.userId,
                         agentId: agent.id,
                         workId: agent.workId ?? undefined,
+                        runId: this.runIdFor(runContext),
                         url: args.url,
                         maxChars: args.maxChars,
                     });

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -8,6 +8,7 @@ export * from './agent-export.service';
 export * from './prompt-assembler.service';
 export * from './agent-run.service';
 export * from './run-dispatch-gate.service';
+export * from './run-credits-precheck';
 export * from './agent-run-canceller';
 export * from './agent-run-abort';
 export * from './agent-run-sweeper.service';

--- a/packages/agent/src/agents/run-credits-precheck.ts
+++ b/packages/agent/src/agents/run-credits-precheck.ts
@@ -1,0 +1,26 @@
+/**
+ * Pricing Wave 9 M2 — soft credits-enforcement precheck for the run
+ * dispatch gate.
+ *
+ * Token + contract only (leaf file, zero imports — same circular-dep
+ * dodge as the other agent injection tokens, see
+ * `docs/architecture/agent-injection-tokens.md`).
+ * `RunDispatchGateService` consumes it via `@Optional() @Inject(...)`;
+ * the implementation (`RunCostSettlementService`, subscriptions/credits)
+ * is bound to the token by the api-side `@Global()` SubscriptionsModule.
+ * Unbound (unit tests, installs without the credits stack) the gate's
+ * credits precheck simply never runs — and the env kill-switch
+ * `CREDITS_ENFORCEMENT` (default OFF) keeps it dark even when bound.
+ */
+export interface RunCreditsPrecheck {
+    /**
+     * True ⇒ the user's plan is credit-limited AND the balance is
+     * exhausted ⇒ the gate parks the run
+     * (`queuedReason='insufficient-credits'`) instead of dispatching.
+     * Implementations must be cheap and must never throw (callers
+     * fail-open regardless).
+     */
+    shouldQueueForCredits(userId: string): Promise<boolean>;
+}
+
+export const RUN_CREDITS_PRECHECK = 'RUN_CREDITS_PRECHECK' as const;

--- a/packages/agent/src/agents/run-dispatch-gate.service.ts
+++ b/packages/agent/src/agents/run-dispatch-gate.service.ts
@@ -6,6 +6,7 @@ import {
     JOB_RUNTIME_NOT_CONFIGURED_REASON,
     type AgentTaskExecuteDispatcher,
 } from '../tasks-domain/task-dispatcher';
+import { RUN_CREDITS_PRECHECK, type RunCreditsPrecheck } from './run-credits-precheck';
 
 /**
  * Stable machine token stamped into `agent_runs.queuedReason` when the
@@ -13,6 +14,17 @@ import {
  * this exact literal — one shared constant, never three drifting copies.
  */
 export const QUEUED_REASON_CONCURRENCY = 'concurrency-limit' as const;
+
+/**
+ * Pricing Wave 9 M2 — stamped when the soft credits precheck parks a run
+ * (credit-limited plan + exhausted balance, `CREDITS_ENFORCEMENT=on`).
+ * Deliberately NOT drained by {@link RunDispatchGateService.drainForWork}
+ * (that promotes concurrency-parked rows only): a credits-parked run
+ * waits for a top-up, not for capacity. Promotion-on-top-up is a
+ * documented Wave 9 follow-up; until then the run stays visibly queued
+ * with this reason in the Sessions view.
+ */
+export const QUEUED_REASON_INSUFFICIENT_CREDITS = 'insufficient-credits' as const;
 
 export interface RunDispatchAdmitInput {
     userId: string;
@@ -69,6 +81,14 @@ export class RunDispatchGateService {
         @Optional()
         @Inject(AGENT_TASK_EXECUTE_DISPATCHER)
         private readonly dispatcher?: AgentTaskExecuteDispatcher,
+        // Pricing Wave 9 M2 — soft credits precheck. Bound (to
+        // RunCostSettlementService) by the api-side @Global()
+        // SubscriptionsModule; absent in unit tests and credit-less
+        // installs. Appended LAST + @Optional() per the positional-spec
+        // arity rule.
+        @Optional()
+        @Inject(RUN_CREDITS_PRECHECK)
+        private readonly creditsPrecheck?: RunCreditsPrecheck,
     ) {}
 
     /** Env default today; per-Work override column when it lands. */
@@ -111,6 +131,31 @@ export class RunDispatchGateService {
                     } at ${inFlight}/${orgLimit} in-flight runs — queueing.`,
                 );
                 return { admitted: false, queuedReason: QUEUED_REASON_CONCURRENCY };
+            }
+        }
+
+        // Pricing Wave 9 M2 — soft credits enforcement (ship-dark). Runs
+        // ONLY when the CREDITS_ENFORCEMENT kill-switch is on AND the
+        // precheck token is bound. Fail-open on any error: a broken
+        // billing check must never stop work (same posture as a broken
+        // concurrency valve).
+        if (this.creditsPrecheck && config.billing.credits.isEnforcementEnabled()) {
+            try {
+                if (await this.creditsPrecheck.shouldQueueForCredits(input.userId)) {
+                    this.logger.log(
+                        `Dispatch gate: user ${input.userId} is credit-limited with an ` +
+                            `exhausted balance — queueing.`,
+                    );
+                    return {
+                        admitted: false,
+                        queuedReason: QUEUED_REASON_INSUFFICIENT_CREDITS,
+                    };
+                }
+            } catch (err) {
+                this.logger.warn(
+                    `Dispatch gate: credits precheck failed for user ${input.userId} ` +
+                        `(fail-open): ${err}`,
+                );
             }
         }
 

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -366,6 +366,20 @@ export const config = {
                 const parsed = parseInt(process.env.CREDITS_DAILY_GRANT_BATCH || '500');
                 return Number.isFinite(parsed) && parsed > 0 ? parsed : 500;
             },
+            /**
+             * Soft credits enforcement kill-switch (pricing Wave 9 M2 —
+             * ship dark). Default OFF: the dispatch gate's credits
+             * precheck only runs when `CREDITS_ENFORCEMENT=on` (or
+             * `true`). Debits/metering are unaffected by this flag —
+             * it gates ONLY whether a credit-limited plan with an
+             * exhausted balance parks new runs
+             * (`queuedReason='insufficient-credits'`) instead of
+             * dispatching them.
+             */
+            isEnforcementEnabled() {
+                const raw = (process.env.CREDITS_ENFORCEMENT || '').toLowerCase();
+                return raw === 'on' || raw === 'true' || raw === '1';
+            },
         },
     },
 

--- a/packages/agent/src/database/index.ts
+++ b/packages/agent/src/database/index.ts
@@ -1,6 +1,8 @@
 export * from './database-config.factory';
 export * from './database.config';
 export * from './database.module';
+// Pricing Wave 9 M2 — run-cost settlement seam (token + contract).
+export * from './run-cost-settler';
 export * from './repositories/api-key.repository';
 export * from './repositories/work.repository';
 export * from './repositories/work-deployment.repository';

--- a/packages/agent/src/database/repositories/agent-run.repository.spec.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.spec.ts
@@ -319,4 +319,58 @@ describe('AgentRunRepository — terminal transitions', () => {
             expect(update).not.toHaveBeenCalled();
         });
     });
+
+    // ── Wave 9 M2 — run-cost settlement hook ─────────────────────────
+    // Terminal writes are the ONE choke point every run lifecycle path
+    // shares, so the metering → credits debit hangs off them here.
+    describe('run-cost settlement hook (RUN_COST_SETTLER)', () => {
+        let settler: { settleRun: jest.Mock };
+        let hookedRuns: AgentRunRepository;
+
+        beforeEach(() => {
+            settler = { settleRun: jest.fn().mockResolvedValue({ status: 'settled' }) };
+            hookedRuns = new AgentRunRepository(repository as never, settler as never);
+            jest.spyOn(
+                (hookedRuns as never as { logger: { warn: () => void } }).logger,
+                'warn',
+            ).mockImplementation(() => undefined);
+        });
+
+        it('settles after a WINNING markCompleted', async () => {
+            await hookedRuns.markCompleted('r1', 'done');
+            expect(settler.settleRun).toHaveBeenCalledWith('r1');
+        });
+
+        it('settles after a WINNING markFailed — failed runs still consumed spend', async () => {
+            await hookedRuns.markFailed('r1', 'boom');
+            expect(settler.settleRun).toHaveBeenCalledWith('r1');
+        });
+
+        it('does NOT settle when the terminal CAS lost (the winner already settled)', async () => {
+            queryBuilder.execute.mockResolvedValue({ affected: 0 });
+            repository.findOne.mockResolvedValue({ id: 'r1', status: 'cancelled' });
+            await hookedRuns.markCompleted('r1', 'done');
+            expect(settler.settleRun).not.toHaveBeenCalled();
+        });
+
+        it('a throwing settler never fails the terminal write (defence-in-depth)', async () => {
+            settler.settleRun.mockRejectedValue(new Error('credits stack down'));
+            await expect(hookedRuns.markCompleted('r1', 'done')).resolves.toBeUndefined();
+            await expect(hookedRuns.markFailed('r1', 'boom')).resolves.toBeUndefined();
+        });
+
+        it('no settler bound (unit tests / credit-less installs) ⇒ terminal writes unchanged', async () => {
+            await expect(runs.markCompleted('r1', 'done')).resolves.toBeUndefined();
+            expect(queryBuilder.set).toHaveBeenCalledWith(
+                expect.objectContaining({ status: 'completed' }),
+            );
+        });
+
+        it('markStuckFailed settles every reaped id (idempotent per contract)', async () => {
+            await hookedRuns.markStuckFailed(['r1', 'r2'], 'stuck');
+            expect(settler.settleRun).toHaveBeenCalledTimes(2);
+            expect(settler.settleRun).toHaveBeenCalledWith('r1');
+            expect(settler.settleRun).toHaveBeenCalledWith('r2');
+        });
+    });
 });

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -1,9 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import type { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import type { GateStatus, TaskAcceptanceCheck, TaskCheckResult } from '@ever-works/contracts';
 import { AgentRun, AgentRunStatus, AgentRunTriggerKind } from '../../entities/agent-run.entity';
+import { RUN_COST_SETTLER, type RunCostSettler } from '../run-cost-settler';
 
 /**
  * Statuses a run may be transitioned OUT OF by a normal terminal write.
@@ -27,7 +28,38 @@ export class AgentRunRepository {
     constructor(
         @InjectRepository(AgentRun)
         private readonly repository: Repository<AgentRun>,
+        // Pricing Wave 9 M2 — run-cost settlement seam. Terminal writes
+        // are the ONE choke point every run lifecycle path shares (the
+        // worker's RPC proxy included), so the metering→credits debit
+        // hangs off them here. @Optional(): bound by the api-side
+        // @Global() SubscriptionsModule; absent in unit tests and
+        // installs without the credits stack — every hook site no-ops.
+        @Optional()
+        @Inject(RUN_COST_SETTLER)
+        private readonly runCostSettler?: RunCostSettler,
     ) {}
+
+    /**
+     * Fire the run-cost settlement for a run that just went terminal.
+     * Best-effort BY CONTRACT — a settlement failure must never fail (or
+     * bubble into) the terminal write that hosted it; the settler itself
+     * also never rejects, this guard is defence-in-depth. Awaited (not
+     * fire-and-forget) so callers that need read-your-write semantics on
+     * `agent_runs.costCents` — and the tests — observe a completed
+     * settlement when the terminal write resolves.
+     */
+    private async settleRunCost(runId: string): Promise<void> {
+        if (!this.runCostSettler) return;
+        try {
+            await this.runCostSettler.settleRun(runId);
+        } catch (err) {
+            this.logger.warn(
+                `AgentRun ${runId}: run-cost settlement failed (ignored): ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+        }
+    }
 
     async findById(id: string): Promise<AgentRun | null> {
         return this.repository.findOne({ where: { id } });
@@ -205,6 +237,9 @@ export class AgentRunRepository {
                 workId: run.workId ?? null,
             };
         }
+        // Wave 9 M2 — a user-cancelled run consumed provider spend up to
+        // the moment it was cancelled; settle what was actually metered.
+        await this.settleRunCost(runId);
         return {
             found: true,
             previousStatus: run.status,
@@ -283,6 +318,13 @@ export class AgentRunRepository {
             .where('id IN (:...runIds)', { runIds })
             .andWhere('status IN (:...statuses)', { statuses: NON_TERMINAL })
             .execute();
+        // Wave 9 M2 — every input id is terminal after this statement
+        // (either this bulk CAS won or a worker's own terminal write did,
+        // which already settled). Settling all ids is safe: settlement is
+        // idempotent (`run:{runId}` ledger key) and zero-event runs skip.
+        for (const runId of runIds) {
+            await this.settleRunCost(runId);
+        }
         return result.affected ?? 0;
     }
 
@@ -446,11 +488,18 @@ export class AgentRunRepository {
     async markCompleted(runId: string, summary: string | null): Promise<void> {
         const ok = await this.casTerminal(runId, NON_TERMINAL, { status: 'completed', summary });
         if (!ok) await this.warnTerminalNoOp(runId, 'markCompleted');
+        // Wave 9 M2 — settle metered cost → credits debit on the winning
+        // terminal write only; a CAS loser's re-settle would be a
+        // harmless idempotent no-op but is skipped to avoid double work.
+        if (ok) await this.settleRunCost(runId);
     }
 
     async markFailed(runId: string, errorMessage: string): Promise<void> {
         const ok = await this.casTerminal(runId, NON_TERMINAL, { status: 'failed', errorMessage });
         if (!ok) await this.warnTerminalNoOp(runId, 'markFailed');
+        // Wave 9 M2 — failed runs still consumed provider spend; the
+        // accumulator sums whatever the run actually metered (often 0).
+        if (ok) await this.settleRunCost(runId);
     }
 
     /**
@@ -465,6 +514,10 @@ export class AgentRunRepository {
     async markDispatchFailed(runId: string, errorMessage: string): Promise<void> {
         const ok = await this.casTerminal(runId, QUEUED_ONLY, { status: 'failed', errorMessage });
         if (!ok) await this.warnTerminalNoOp(runId, 'markDispatchFailed');
+        // Wave 9 M2 — a dispatch-failed run normally metered nothing (the
+        // settler skips runs with zero tagged events); kept for the ONE
+        // terminal choke-point invariant.
+        if (ok) await this.settleRunCost(runId);
     }
 
     /**
@@ -474,6 +527,19 @@ export class AgentRunRepository {
      */
     async setMemorySessionId(runId: string, memorySessionId: string): Promise<void> {
         await this.repository.update(runId, { memorySessionId });
+    }
+
+    /**
+     * Pricing Wave 9 M2 — stamp the run's cumulative metered cost
+     * (sum of its tagged `plugin_usage_events.costCents`) onto the
+     * Wave-4 `costCents` rollup column. Written by the run-cost
+     * settlement on terminal transitions; deliberately NOT part of
+     * {@link updateTelemetry}'s worker-facing whitelist — workers
+     * self-report tokens/activity, but cost comes from the metering
+     * pipeline only.
+     */
+    async stampCostCents(runId: string, costCents: number): Promise<void> {
+        await this.repository.update(runId, { costCents });
     }
 
     /**

--- a/packages/agent/src/database/repositories/plugin-usage.repository.ts
+++ b/packages/agent/src/database/repositories/plugin-usage.repository.ts
@@ -22,6 +22,12 @@ export type CrossUserSpendRow = {
     costCents: number;
 };
 
+/** Pricing Wave 9 M2 — one run's metered spend, grouped per plugin. */
+export type RunPluginSpend = {
+    pluginId: string;
+    costCents: number;
+};
+
 @Injectable()
 export class PluginUsageRepository {
     constructor(
@@ -160,6 +166,30 @@ export class PluginUsageRepository {
         }
         const row = await qb.getRawOne<{ total: string }>();
         return Number(row?.total ?? 0);
+    }
+
+    /**
+     * Pricing Wave 9 M2 — the run-cost accumulator's input: this run's
+     * metered spend summed per plugin. Grouped by plugin (rather than a
+     * single SUM) so the settlement can exclude plugins whose calls ran
+     * on user-supplied keys (BYOK — free per founder decision P2/P3)
+     * without a second query. Uses the `(runId, occurredAt)` index from
+     * the 1783600000000 migration. Rows recorded before per-run tagging
+     * existed have `runId = NULL` and are honestly not attributable.
+     */
+    async getRunCostByPlugin(runId: string): Promise<RunPluginSpend[]> {
+        const rows = await this.repository
+            .createQueryBuilder('e')
+            .select('e.pluginId', 'pluginId')
+            .addSelect('COALESCE(SUM(e.costCents), 0)', 'costCents')
+            .where('e.runId = :runId', { runId })
+            .groupBy('e.pluginId')
+            .getRawMany<{ pluginId: string; costCents: string }>();
+
+        return rows.map((r) => ({
+            pluginId: r.pluginId,
+            costCents: Number(r.costCents ?? 0),
+        }));
     }
 
     async getSpendByPlugin(

--- a/packages/agent/src/database/run-cost-settler.ts
+++ b/packages/agent/src/database/run-cost-settler.ts
@@ -1,0 +1,47 @@
+/**
+ * Pricing Wave 9 M2 — run-cost settlement seam.
+ *
+ * Token + contract for the hook `AgentRunRepository` fires after every
+ * terminal transition (completed / failed / dispatch-failed / cancelled /
+ * stuck-swept). Same circular-dep dodge as the agent injection tokens
+ * (`docs/architecture/agent-injection-tokens.md`): the repository lives
+ * in `DatabaseModule`, while the implementation
+ * (`RunCostSettlementService`) lives in `SubscriptionsModule` which
+ * itself imports `DatabaseModule` — direct injection would cycle. The
+ * api-side `@Global()` SubscriptionsModule binds this token to the real
+ * service; unit tests and installs without the credits stack leave it
+ * unbound and the repository's `@Optional()` injection no-ops.
+ *
+ * The settlement itself is best-effort BY CONTRACT: implementations must
+ * never throw (a credits/metering outage must never fail or delay a
+ * run's terminal write), and the repository additionally guards the call.
+ */
+
+/** Outcome of one settlement pass — returned for observability/tests. */
+export interface RunSettlementResult {
+    runId: string;
+    /**
+     * - `settled`   — costCents stamped; debit recorded (or nothing owed).
+     * - `partial`   — balance could not cover the debit; a partial debit
+     *                 down to zero was recorded + notification emitted.
+     * - `exhausted` — balance was already ≤ 0; zero debit + notification.
+     * - `skipped`   — no run row, or no usage events tagged with the run.
+     * - `error`     — settlement failed internally (logged, never thrown).
+     */
+    status: 'settled' | 'partial' | 'exhausted' | 'skipped' | 'error';
+    /** Metered spend summed over the run's tagged usage events. */
+    totalCostCents: number;
+    /** Spend actually billable to credits (BYOK-exempt plugins removed). */
+    billableCostCents: number;
+    /** Credits actually debited (0 when nothing was owed / exhausted). */
+    debitedCredits: number;
+    /** Plugins excluded because their calls ran on user-supplied keys. */
+    exemptPluginIds: string[];
+}
+
+export interface RunCostSettler {
+    /** Never rejects — failures are absorbed + logged by the implementation. */
+    settleRun(runId: string): Promise<RunSettlementResult>;
+}
+
+export const RUN_COST_SETTLER = 'RUN_COST_SETTLER' as const;

--- a/packages/agent/src/entities/plugin-usage-event.entity.ts
+++ b/packages/agent/src/entities/plugin-usage-event.entity.ts
@@ -44,6 +44,10 @@ export enum PluginUsageCapability {
 // `AddTaskIdToPluginUsageEvents1779978014000` adds the column + index.
 // No FK to `tasks` — task delete must NOT cascade-drop audit rows.
 @Index('idx_plugin_usage_events_task_occurred', ['taskId', 'occurredAt'])
+// Pricing Wave 9 M2 — per-run cost accumulation filter. Migration
+// `AddRunIdToPluginUsageEvents1783600000000` adds the column + index.
+// No FK to `agent_runs` — run deletion must NOT cascade-drop audit rows.
+@Index('idx_plugin_usage_events_run_occurred', ['runId', 'occurredAt'])
 @Entity({ name: 'plugin_usage_events' })
 export class PluginUsageEvent {
     @PrimaryGeneratedColumn('uuid')
@@ -104,6 +108,18 @@ export class PluginUsageEvent {
      */
     @Column({ type: 'uuid', nullable: true })
     taskId?: string | null;
+
+    /**
+     * Per-run attribution (pricing Wave 9 M2). Populated when the call
+     * was made inside an `AgentRun` (threaded through
+     * `FacadeOptions.runId` by the run's AI-dispatch + tool
+     * pass-through adapters). The run-cost accumulator sums
+     * `costCents` over rows tagged with this id at run-terminal time
+     * to stamp `agent_runs.costCents` and emit the credits debit. Null
+     * for calls made outside a run. No FK — audit rows outlive runs.
+     */
+    @Column({ type: 'uuid', nullable: true })
+    runId?: string | null;
 
     /**
      * Polymorphic-owner discriminator (Missions/Ideas/Works spec §8.2).

--- a/packages/agent/src/facades/ai.facade.ts
+++ b/packages/agent/src/facades/ai.facade.ts
@@ -196,6 +196,8 @@ export class AiFacadeService extends BaseFacadeService implements IAiFacade {
             // Phase 15.6 — Agent/Task attribution propagation.
             agentId: facadeOptions.agentId,
             taskId: facadeOptions.taskId,
+            // Wave 9 M2 — per-run cost attribution.
+            runId: facadeOptions.runId,
             pluginId: plugin.id,
             capability: PluginUsageCapability.AI,
             units: response.usage?.totalTokens ?? 1,
@@ -379,6 +381,8 @@ export class AiFacadeService extends BaseFacadeService implements IAiFacade {
             // Phase 15.6 — Agent/Task attribution propagation.
             agentId: facadeOptions.agentId,
             taskId: facadeOptions.taskId,
+            // Wave 9 M2 — per-run cost attribution.
+            runId: facadeOptions.runId,
             pluginId: plugin.id,
             capability: PluginUsageCapability.AI,
             units: response.usage?.totalTokens ?? 1,
@@ -453,6 +457,8 @@ export class AiFacadeService extends BaseFacadeService implements IAiFacade {
                         // Phase 15.6 — Agent/Task attribution propagation.
                         agentId: facadeOptions.agentId,
                         taskId: facadeOptions.taskId,
+                        // Wave 9 M2 — per-run cost attribution.
+                        runId: facadeOptions.runId,
                         pluginId: plugin.id,
                         capability: PluginUsageCapability.AI,
                         units: chunkCount,
@@ -531,6 +537,8 @@ export class AiFacadeService extends BaseFacadeService implements IAiFacade {
                 // Phase 15.6 — Agent/Task attribution propagation.
                 agentId: facadeOptions.agentId,
                 taskId: facadeOptions.taskId,
+                // Wave 9 M2 — per-run cost attribution.
+                runId: facadeOptions.runId,
                 pluginId: plugin.id,
                 capability: PluginUsageCapability.AI,
                 units,
@@ -604,6 +612,8 @@ export class AiFacadeService extends BaseFacadeService implements IAiFacade {
                 userId: facadeOptions.userId,
                 agentId: facadeOptions.agentId,
                 taskId: facadeOptions.taskId,
+                // Wave 9 M2 — per-run cost attribution.
+                runId: facadeOptions.runId,
                 pluginId: plugin.id,
                 capability: PluginUsageCapability.AI,
                 units: minutes,

--- a/packages/agent/src/facades/content-extractor.facade.ts
+++ b/packages/agent/src/facades/content-extractor.facade.ts
@@ -177,6 +177,8 @@ export class ContentExtractorFacadeService
                     // Phase 15.6 — Agent/Task attribution propagation.
                     agentId: facadeOptions.agentId,
                     taskId: facadeOptions.taskId,
+                    // Wave 9 M2 — per-run cost attribution.
+                    runId: facadeOptions.runId,
                     pluginId: candidate.id,
                     capability: PluginUsageCapability.EXTRACTOR,
                     units: 1,

--- a/packages/agent/src/facades/metrics.facade.ts
+++ b/packages/agent/src/facades/metrics.facade.ts
@@ -189,6 +189,8 @@ export class MetricsFacadeService extends BaseFacadeService {
             // Phase 15.6 — Agent/Task attribution propagation.
             agentId: facadeOptions.agentId,
             taskId: facadeOptions.taskId,
+            // Wave 9 M2 — per-run cost attribution.
+            runId: facadeOptions.runId,
             pluginId,
             capability: PluginUsageCapability.METRICS,
             units: 1,

--- a/packages/agent/src/facades/screenshot.facade.ts
+++ b/packages/agent/src/facades/screenshot.facade.ts
@@ -83,6 +83,8 @@ export class ScreenshotFacadeService extends BaseFacadeService implements IScree
                 // Phase 15.6 — Agent/Task attribution propagation.
                 agentId: facadeOptions.agentId,
                 taskId: facadeOptions.taskId,
+                // Wave 9 M2 — per-run cost attribution.
+                runId: facadeOptions.runId,
                 pluginId: plugin.id,
                 capability: PluginUsageCapability.SCREENSHOT,
                 units: 1,

--- a/packages/agent/src/facades/search.facade.ts
+++ b/packages/agent/src/facades/search.facade.ts
@@ -74,6 +74,8 @@ export class SearchFacadeService extends BaseFacadeService implements ISearchFac
             // Phase 15.6 — Agent/Task attribution propagation.
             agentId: facadeOptions.agentId,
             taskId: facadeOptions.taskId,
+            // Wave 9 M2 — per-run cost attribution.
+            runId: facadeOptions.runId,
             pluginId: plugin.id,
             capability: PluginUsageCapability.SEARCH,
             units: 1,

--- a/packages/agent/src/notifications/notification.service.ts
+++ b/packages/agent/src/notifications/notification.service.ts
@@ -262,6 +262,52 @@ export class NotificationService {
         });
     }
 
+    /**
+     * Pricing Wave 9 M2 — platform credits balance could not cover a
+     * run's metered spend. Emitted by the run-cost settlement when a
+     * CONSUMPTION debit comes back insufficient (a zero-or-partial debit
+     * was recorded per the billing PRD policy; the run itself is never
+     * failed). Category reuses AI_CREDITS — the nearest existing
+     * billing-shaped category (no BILLING category exists yet).
+     */
+    async notifyCreditsBalanceExhausted(args: {
+        userId: string;
+        runId: string;
+        requiredCredits: number;
+        balanceCredits: number;
+    }): Promise<void> {
+        const balance = Math.max(0, Math.trunc(args.balanceCredits));
+        const message =
+            `A run's metered usage needed ${Math.trunc(args.requiredCredits)} credits but your ` +
+            `balance is ${balance}. The run finished normally; the uncovered remainder was not ` +
+            `debited. Top up credits to keep usage billing normally.`;
+        await this.create({
+            userId: args.userId,
+            type: NotificationType.ERROR,
+            category: NotificationCategory.AI_CREDITS,
+            title: 'Credits Balance Exhausted',
+            message,
+            actionUrl: '/settings',
+            actionLabel: 'Top Up Credits',
+            isPersistent: true,
+            metadata: {
+                runId: args.runId,
+                requiredCredits: Math.trunc(args.requiredCredits),
+                balanceCredits: balance,
+            },
+            deduplicationKey: 'credits_balance_exhausted',
+        });
+        await this.dispatchFanout({
+            userId: args.userId,
+            eventKey: 'credits_balance_exhausted',
+            title: 'Credits Balance Exhausted',
+            message,
+            actionUrl: '/settings',
+            actionLabel: 'Top Up Credits',
+            urgent: true,
+        });
+    }
+
     async notifyAiProviderError(
         userId: string,
         provider: string,

--- a/packages/agent/src/subscriptions/credits/entitlements.service.ts
+++ b/packages/agent/src/subscriptions/credits/entitlements.service.ts
@@ -7,6 +7,15 @@ export const ENTITLEMENT_KEYS = {
     DAILY_FREE_CREDITS: 'daily-free-credits',
     MAX_CONCURRENT_RUNS: 'max-concurrent-runs',
     WORKS_LIMIT: 'works-limit',
+    /**
+     * Pricing Wave 9 M2 — whether the plan's runs are billed against the
+     * credits balance (1 = credit-limited, 0/absent = not). Consumed by
+     * the dispatch gate's soft-enforcement precheck: only a
+     * credit-limited plan with balance ≤ 0 parks new runs (and only when
+     * `CREDITS_ENFORCEMENT=on`). No row seeded yet — every plan resolves
+     * to the fallback 0, keeping enforcement doubly dark.
+     */
+    CREDIT_LIMITED: 'credit-limited',
 } as const;
 
 type CacheSlot = {

--- a/packages/agent/src/subscriptions/credits/run-cost-settlement.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/run-cost-settlement.service.spec.ts
@@ -1,0 +1,435 @@
+import { RunCostSettlementService } from './run-cost-settlement.service';
+import { InsufficientCreditsError } from './credit-ledger.service';
+import { CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
+
+/**
+ * Pricing Wave 9 M2 — the metering → credits bridge fired by
+ * `AgentRunRepository` on run terminal transitions.
+ *
+ * Contract under test:
+ *  - accumulation sums ONLY this run's tagged usage events and stamps
+ *    `agent_runs.costCents` with the FULL metered total;
+ *  - the debit goes through `CreditLedgerService.consumeForRun`
+ *    (idempotency key `run:{runId}` — re-running a terminal write can
+ *    never double-debit);
+ *  - insufficient balance ⇒ zero-or-partial debit + notification, and
+ *    the settlement NEVER rejects (a credits outage must never fail a
+ *    run — PRD §6);
+ *  - BYOK exemption: plugins whose apiKey resolved from user/work
+ *    settings are excluded from the billable amount (founder decision
+ *    P2/P3 — user-supplied keys consume no platform credits).
+ *
+ * No real DB/Nest container — collaborators are jest.fn() shells (house
+ * pattern, mirrors credit-ledger.service.spec.ts).
+ */
+
+const RUN = {
+    id: 'run-1',
+    userId: 'user-1',
+    workId: 'work-1',
+    organizationId: 'org-1',
+    tenantId: 'tenant-1',
+    triggerKind: 'task',
+    status: 'completed',
+};
+
+function makeAgentRuns(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        findOne: jest.fn().mockResolvedValue({ ...RUN }),
+        update: jest.fn().mockResolvedValue(undefined),
+        ...overrides,
+    };
+}
+
+function makeUsage(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        getRunCostByPlugin: jest
+            .fn()
+            .mockResolvedValue([{ pluginId: 'openrouter', costCents: 37 }]),
+        ...overrides,
+    };
+}
+
+function makeLedger(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        consumeForRun: jest.fn().mockImplementation(async (opts: any) => ({
+            id: 'entry-1',
+            kind: CreditLedgerKind.CONSUMPTION,
+            amountCredits: -(opts.credits ?? opts.costCents),
+            idempotencyKey: `run:${opts.runId}`,
+        })),
+        record: jest.fn().mockImplementation(async (opts: any) => ({
+            id: 'entry-partial',
+            ...opts,
+        })),
+        getBalance: jest.fn().mockResolvedValue(0),
+        creditsForCostCents: jest.fn((cents: number) => cents),
+        ...overrides,
+    };
+}
+
+function makeEntitlements(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        getNumber: jest.fn().mockResolvedValue(0),
+        ...overrides,
+    };
+}
+
+function makeUsers(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        findByIdForScheduledRun: jest
+            .fn()
+            .mockResolvedValue({ id: 'user-1', defaultPlan: { code: 'free' } }),
+        ...overrides,
+    };
+}
+
+function makeNotifications(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        notifyCreditsBalanceExhausted: jest.fn().mockResolvedValue(undefined),
+        ...overrides,
+    };
+}
+
+function makeSettings(overrides: Record<string, jest.Mock> = {}) {
+    return {
+        getResolvedSettings: jest.fn().mockResolvedValue({
+            apiKey: { key: 'apiKey', value: 'sk-platform', source: 'env', isFallback: false },
+        }),
+        ...overrides,
+    };
+}
+
+function makeService(
+    parts: {
+        agentRuns?: Record<string, jest.Mock>;
+        usage?: Record<string, jest.Mock>;
+        ledger?: Record<string, jest.Mock>;
+        entitlements?: Record<string, jest.Mock>;
+        users?: Record<string, jest.Mock>;
+        notifications?: Record<string, jest.Mock> | null;
+        settings?: Record<string, jest.Mock> | null;
+    } = {},
+) {
+    const agentRuns = makeAgentRuns(parts.agentRuns);
+    const usage = makeUsage(parts.usage);
+    const ledger = makeLedger(parts.ledger);
+    const entitlements = makeEntitlements(parts.entitlements);
+    const users = makeUsers(parts.users);
+    const notifications =
+        parts.notifications === null ? undefined : makeNotifications(parts.notifications);
+    const settings = parts.settings === null ? undefined : makeSettings(parts.settings);
+    const service = new RunCostSettlementService(
+        agentRuns as any,
+        usage as any,
+        ledger as any,
+        entitlements as any,
+        users as any,
+        notifications as any,
+        settings as any,
+    );
+    return { service, agentRuns, usage, ledger, entitlements, users, notifications, settings };
+}
+
+describe('RunCostSettlementService', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        process.env = { ...originalEnv };
+        delete process.env.CREDITS_ENFORCEMENT;
+        delete process.env.CREDITS_PER_DOLLAR;
+        delete process.env.CREDITS_MARGIN_PERCENT;
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    describe('settleRun — accumulation', () => {
+        it("sums only THIS run's tagged events and stamps agent_runs.costCents", async () => {
+            const { service, agentRuns, usage } = makeService({
+                usage: {
+                    getRunCostByPlugin: jest.fn().mockResolvedValue([
+                        { pluginId: 'openrouter', costCents: 30 },
+                        { pluginId: 'tavily', costCents: 12 },
+                    ]),
+                },
+            });
+
+            const result = await service.settleRun('run-1');
+
+            // The per-run query IS the scoping — nothing else is summed.
+            expect(usage.getRunCostByPlugin).toHaveBeenCalledWith('run-1');
+            expect(result.totalCostCents).toBe(42);
+            expect(agentRuns.update).toHaveBeenCalledWith('run-1', { costCents: 42 });
+            expect(result.status).toBe('settled');
+        });
+
+        it('skips (no stamp, no debit) when the run has zero tagged events', async () => {
+            const { service, agentRuns, ledger } = makeService({
+                usage: { getRunCostByPlugin: jest.fn().mockResolvedValue([]) },
+            });
+
+            const result = await service.settleRun('run-1');
+
+            expect(result.status).toBe('skipped');
+            expect(agentRuns.update).not.toHaveBeenCalled();
+            expect(ledger.consumeForRun).not.toHaveBeenCalled();
+        });
+
+        it('skips when the run row does not exist', async () => {
+            const { service, ledger } = makeService({
+                agentRuns: { findOne: jest.fn().mockResolvedValue(null) },
+            });
+
+            const result = await service.settleRun('run-missing');
+
+            expect(result.status).toBe('skipped');
+            expect(ledger.consumeForRun).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('settleRun — debit', () => {
+        it('debits the billable total through consumeForRun with the run + scope', async () => {
+            const { service, ledger } = makeService();
+
+            const result = await service.settleRun('run-1');
+
+            expect(ledger.consumeForRun).toHaveBeenCalledWith({
+                userId: 'user-1',
+                runId: 'run-1',
+                costCents: 37,
+                organizationId: 'org-1',
+                tenantId: 'tenant-1',
+                description: 'Run run-1 (task)',
+            });
+            expect(result.debitedCredits).toBe(37);
+            expect(result.status).toBe('settled');
+        });
+
+        it('is idempotent across terminal-write re-runs — the SAME run key both times', async () => {
+            const entry = { id: 'entry-1', amountCredits: -37 };
+            const consumeForRun = jest
+                .fn()
+                // First terminal write: row created. Second: the ledger's
+                // `run:{runId}` idempotency key returns the SAME row, no
+                // second debit (CreditLedgerRepository.recordAtomic contract).
+                .mockResolvedValueOnce(entry)
+                .mockResolvedValueOnce(entry);
+            const { service, ledger } = makeService({ ledger: { consumeForRun } });
+
+            const first = await service.settleRun('run-1');
+            const second = await service.settleRun('run-1');
+
+            expect(ledger.consumeForRun).toHaveBeenCalledTimes(2);
+            expect(ledger.consumeForRun.mock.calls[0][0].runId).toBe('run-1');
+            expect(ledger.consumeForRun.mock.calls[1][0].runId).toBe('run-1');
+            // Same ledger row observed both times — debited once.
+            expect(first.debitedCredits).toBe(37);
+            expect(second.debitedCredits).toBe(37);
+            expect(ledger.record).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('settleRun — insufficient balance (PRD §6 policy)', () => {
+        it('records a PARTIAL debit down to zero + emits the notification, never rejects', async () => {
+            const { service, ledger, notifications } = makeService({
+                ledger: {
+                    consumeForRun: jest
+                        .fn()
+                        .mockRejectedValue(new InsufficientCreditsError('user-1', 37, 20)),
+                },
+            });
+
+            const result = await service.settleRun('run-1');
+
+            expect(result.status).toBe('partial');
+            expect(result.debitedCredits).toBe(20);
+            expect(ledger.record).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'user-1',
+                    kind: CreditLedgerKind.CONSUMPTION,
+                    amountCredits: -20,
+                    refId: 'run-1',
+                    idempotencyKey: 'run:run-1',
+                }),
+            );
+            expect(notifications!.notifyCreditsBalanceExhausted).toHaveBeenCalledWith({
+                userId: 'user-1',
+                runId: 'run-1',
+                requiredCredits: 37,
+                balanceCredits: 20,
+            });
+        });
+
+        it('records NO debit when the balance is already exhausted (≤ 0), still notifies', async () => {
+            const { service, ledger, notifications } = makeService({
+                ledger: {
+                    consumeForRun: jest
+                        .fn()
+                        .mockRejectedValue(new InsufficientCreditsError('user-1', 37, 0)),
+                },
+            });
+
+            const result = await service.settleRun('run-1');
+
+            expect(result.status).toBe('exhausted');
+            expect(result.debitedCredits).toBe(0);
+            expect(ledger.record).not.toHaveBeenCalled();
+            expect(notifications!.notifyCreditsBalanceExhausted).toHaveBeenCalled();
+        });
+
+        it('never rejects even when the ledger AND the notification both fail', async () => {
+            const { service } = makeService({
+                ledger: {
+                    consumeForRun: jest.fn().mockRejectedValue(new Error('ledger down')),
+                },
+                notifications: {
+                    notifyCreditsBalanceExhausted: jest
+                        .fn()
+                        .mockRejectedValue(new Error('notify down')),
+                },
+            });
+
+            await expect(service.settleRun('run-1')).resolves.toMatchObject({
+                status: 'error',
+            });
+        });
+
+        it('never rejects when the run lookup itself throws (terminal write is protected)', async () => {
+            const { service } = makeService({
+                agentRuns: { findOne: jest.fn().mockRejectedValue(new Error('DB down')) },
+            });
+
+            await expect(service.settleRun('run-1')).resolves.toMatchObject({ status: 'error' });
+        });
+    });
+
+    describe('settleRun — BYOK/BYOS exemption (founder decision P2/P3)', () => {
+        it('excludes plugins whose apiKey resolved from USER settings; stamp keeps the full total', async () => {
+            const { service, agentRuns, ledger } = makeService({
+                usage: {
+                    getRunCostByPlugin: jest.fn().mockResolvedValue([
+                        { pluginId: 'user-keyed-provider', costCents: 30 },
+                        { pluginId: 'platform-provider', costCents: 12 },
+                    ]),
+                },
+                settings: {
+                    getResolvedSettings: jest.fn().mockImplementation(async (pluginId: string) => ({
+                        apiKey: {
+                            key: 'apiKey',
+                            value: 'sk-x',
+                            source: pluginId === 'user-keyed-provider' ? 'user' : 'env',
+                            isFallback: false,
+                        },
+                    })),
+                },
+            });
+
+            const result = await service.settleRun('run-1');
+
+            expect(result.exemptPluginIds).toEqual(['user-keyed-provider']);
+            expect(result.totalCostCents).toBe(42);
+            expect(result.billableCostCents).toBe(12);
+            // costCents rollup stays the honest FULL metered figure.
+            expect(agentRuns.update).toHaveBeenCalledWith('run-1', { costCents: 42 });
+            expect(ledger.consumeForRun).toHaveBeenCalledWith(
+                expect.objectContaining({ costCents: 12 }),
+            );
+        });
+
+        it('a WORK-scoped user key is exempt too; a fully-exempt run debits nothing', async () => {
+            const { service, ledger } = makeService({
+                settings: {
+                    getResolvedSettings: jest.fn().mockResolvedValue({
+                        apiKey: { key: 'apiKey', value: 'sk-x', source: 'work', isFallback: false },
+                    }),
+                },
+            });
+
+            const result = await service.settleRun('run-1');
+
+            expect(result.status).toBe('settled');
+            expect(result.billableCostCents).toBe(0);
+            expect(ledger.consumeForRun).not.toHaveBeenCalled();
+        });
+
+        it('bills the FULL amount when key provenance is not derivable (no settings service)', async () => {
+            // Documented posture: BYOK_EXEMPTION_UNRESOLVED_BILLS_FULL —
+            // never silently give usage away when provenance is unknown.
+            const { service, ledger } = makeService({ settings: null });
+
+            const result = await service.settleRun('run-1');
+
+            expect(RunCostSettlementService.BYOK_EXEMPTION_UNRESOLVED_BILLS_FULL).toBe(true);
+            expect(result.exemptPluginIds).toEqual([]);
+            expect(ledger.consumeForRun).toHaveBeenCalledWith(
+                expect.objectContaining({ costCents: 37 }),
+            );
+        });
+
+        it('a per-plugin provenance failure bills that plugin (never exempt on doubt)', async () => {
+            const { service, ledger } = makeService({
+                settings: {
+                    getResolvedSettings: jest.fn().mockRejectedValue(new Error('registry down')),
+                },
+            });
+
+            const result = await service.settleRun('run-1');
+
+            expect(result.exemptPluginIds).toEqual([]);
+            expect(ledger.consumeForRun).toHaveBeenCalledWith(
+                expect.objectContaining({ costCents: 37 }),
+            );
+        });
+    });
+
+    describe('shouldQueueForCredits — gate precheck (ship-dark)', () => {
+        it('returns false when CREDITS_ENFORCEMENT is off (the default)', async () => {
+            const { service, users } = makeService({
+                entitlements: { getNumber: jest.fn().mockResolvedValue(1) },
+                ledger: { getBalance: jest.fn().mockResolvedValue(-5) },
+            });
+
+            await expect(service.shouldQueueForCredits('user-1')).resolves.toBe(false);
+            // Dark means dark — no lookups at all.
+            expect(users.findByIdForScheduledRun).not.toHaveBeenCalled();
+        });
+
+        it('returns false when the plan is NOT credit-limited (no entitlement row ⇒ 0)', async () => {
+            process.env.CREDITS_ENFORCEMENT = 'on';
+            const { service, entitlements } = makeService({
+                ledger: { getBalance: jest.fn().mockResolvedValue(-5) },
+            });
+
+            await expect(service.shouldQueueForCredits('user-1')).resolves.toBe(false);
+            expect(entitlements.getNumber).toHaveBeenCalledWith('free', 'credit-limited', 0);
+        });
+
+        it('returns true only for credit-limited plan + balance ≤ 0', async () => {
+            process.env.CREDITS_ENFORCEMENT = 'on';
+            const { service } = makeService({
+                entitlements: { getNumber: jest.fn().mockResolvedValue(1) },
+                ledger: { getBalance: jest.fn().mockResolvedValue(0) },
+            });
+
+            await expect(service.shouldQueueForCredits('user-1')).resolves.toBe(true);
+        });
+
+        it('returns false (fail-open) when the balance is positive or resolution throws', async () => {
+            process.env.CREDITS_ENFORCEMENT = 'on';
+            const healthy = makeService({
+                entitlements: { getNumber: jest.fn().mockResolvedValue(1) },
+                ledger: { getBalance: jest.fn().mockResolvedValue(120) },
+            });
+            await expect(healthy.service.shouldQueueForCredits('user-1')).resolves.toBe(false);
+
+            const broken = makeService({
+                users: {
+                    findByIdForScheduledRun: jest.fn().mockRejectedValue(new Error('DB down')),
+                },
+            });
+            await expect(broken.service.shouldQueueForCredits('user-1')).resolves.toBe(false);
+        });
+    });
+});

--- a/packages/agent/src/subscriptions/credits/run-cost-settlement.service.ts
+++ b/packages/agent/src/subscriptions/credits/run-cost-settlement.service.ts
@@ -1,0 +1,270 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AgentRun } from '@src/entities/agent-run.entity';
+import {
+    PluginUsageRepository,
+    type RunPluginSpend,
+} from '@src/database/repositories/plugin-usage.repository';
+import type { RunCostSettler, RunSettlementResult } from '@src/database/run-cost-settler';
+import { NotificationService } from '@src/notifications/notification.service';
+import { PluginSettingsService } from '@src/plugins/services/plugin-settings.service';
+import { config } from '@src/config';
+import { CreditLedgerService, InsufficientCreditsError } from './credit-ledger.service';
+import { ENTITLEMENT_KEYS, EntitlementsService } from './entitlements.service';
+import { CreditLedgerKind } from '@src/entities/credit-ledger-entry.entity';
+import { UserRepository } from '@src/database/repositories/user.repository';
+// The gate-precheck contract lives in the agents leaf file (consumed by
+// RunDispatchGateService, implemented here, bound to the
+// RUN_CREDITS_PRECHECK token by the api-side @Global() SubscriptionsModule).
+import type { RunCreditsPrecheck } from '../../agents/run-credits-precheck';
+
+/**
+ * Pricing Wave 9 M2 — wires real usage metering into the credits ledger.
+ *
+ * ACCUMULATION: when a run reaches a terminal status
+ * (`AgentRunRepository` fires the `RUN_COST_SETTLER` hook), this service
+ * sums the run's attributable spend — `plugin_usage_events` rows tagged
+ * with the run id (`FacadeOptions.runId`, threaded by the run's
+ * AI-dispatch + tool pass-through adapters) — and stamps the total onto
+ * `agent_runs.costCents`.
+ *
+ * DEBIT: the billable share converts to ONE credits CONSUMPTION row via
+ * `CreditLedgerService.consumeForRun` (idempotency key `run:{runId}` —
+ * re-running a terminal write can never double-debit). Best-effort per
+ * the billing PRD §6: a credits outage never fails a run; an
+ * insufficient balance records a zero-or-partial debit (down to exactly
+ * 0) and emits an AI_CREDITS notification instead of erroring.
+ *
+ * BYOK/BYOS EXEMPTION (founder decisions P2/P3 — user-supplied provider
+ * subscriptions and local BYOS runs consume no platform credits): a
+ * plugin whose `apiKey` resolved from the USER or WORK settings level
+ * (i.e. the user supplied their own key, not the platform's env/admin
+ * key) is excluded from the billable sum — its spend stays visible in
+ * `agent_runs.costCents` and the usage surfaces, labeled, but produces
+ * no CONSUMPTION debit. Resolution provenance comes from
+ * `PluginSettingsService.getResolvedSettings` (`ResolvedSetting.source`).
+ * When that service is not wired (`@Optional()` — e.g. a deployment
+ * without the plugins module), the exemption is skipped and the full
+ * metered cost is billed; see `BYOK_EXEMPTION_UNRESOLVED_BILLS_FULL`.
+ */
+@Injectable()
+export class RunCostSettlementService implements RunCostSettler, RunCreditsPrecheck {
+    private readonly logger = new Logger(RunCostSettlementService.name);
+
+    /**
+     * Documented posture (TODO, Wave 9 follow-up): when key provenance is
+     * NOT derivable (no PluginSettingsService bound, or resolution throws
+     * for a plugin), the affected spend is billed at the platform rate
+     * rather than silently given away. Revisit once passthrough runs
+     * (P2) carry an explicit per-event billing flag on the usage row —
+     * that flag should replace settlement-time provenance resolution.
+     */
+    static readonly BYOK_EXEMPTION_UNRESOLVED_BILLS_FULL = true;
+
+    constructor(
+        @InjectRepository(AgentRun)
+        private readonly agentRuns: Repository<AgentRun>,
+        private readonly pluginUsageRepository: PluginUsageRepository,
+        private readonly creditLedgerService: CreditLedgerService,
+        private readonly entitlementsService: EntitlementsService,
+        private readonly userRepository: UserRepository,
+        @Optional() private readonly notificationService?: NotificationService,
+        @Optional() private readonly pluginSettingsService?: PluginSettingsService,
+    ) {}
+
+    /** Never rejects — see the RunCostSettler contract. */
+    async settleRun(runId: string): Promise<RunSettlementResult> {
+        const result: RunSettlementResult = {
+            runId,
+            status: 'skipped',
+            totalCostCents: 0,
+            billableCostCents: 0,
+            debitedCredits: 0,
+            exemptPluginIds: [],
+        };
+
+        try {
+            const run = await this.agentRuns.findOne({ where: { id: runId } });
+            if (!run || !run.userId) {
+                return result;
+            }
+
+            const spend = await this.pluginUsageRepository.getRunCostByPlugin(runId);
+            if (spend.length === 0) {
+                // Nothing metered for this run (or predates runId tagging)
+                // — no stamp, no debit; NULL costCents stays honest.
+                return result;
+            }
+
+            result.totalCostCents = spend.reduce((sum, row) => sum + row.costCents, 0);
+
+            // Stamp the full metered rollup — BYOK spend included: the
+            // column is a cost ESTIMATE surface, not the billable amount.
+            try {
+                await this.agentRuns.update(runId, { costCents: result.totalCostCents });
+            } catch (err) {
+                this.logger.warn(`Run ${runId}: costCents stamp failed (ignored): ${err}`);
+            }
+
+            result.exemptPluginIds = await this.resolveExemptPlugins(
+                spend,
+                run.userId,
+                run.workId ?? undefined,
+            );
+            result.billableCostCents = spend
+                .filter((row) => !result.exemptPluginIds.includes(row.pluginId))
+                .reduce((sum, row) => sum + row.costCents, 0);
+
+            if (result.billableCostCents <= 0) {
+                result.status = 'settled';
+                return result;
+            }
+
+            try {
+                const entry = await this.creditLedgerService.consumeForRun({
+                    userId: run.userId,
+                    runId,
+                    costCents: result.billableCostCents,
+                    organizationId: run.organizationId ?? null,
+                    tenantId: run.tenantId ?? null,
+                    description: `Run ${runId} (${run.triggerKind})`,
+                });
+                result.debitedCredits = entry ? Math.abs(entry.amountCredits) : 0;
+                result.status = 'settled';
+                return result;
+            } catch (err) {
+                if (err instanceof InsufficientCreditsError) {
+                    return await this.settleInsufficient(result, run, err);
+                }
+                throw err;
+            }
+        } catch (err) {
+            // Never fails the terminal write that hosted it (PRD §6).
+            this.logger.warn(
+                `Run ${runId}: cost settlement failed (ignored): ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            result.status = 'error';
+            return result;
+        }
+    }
+
+    /**
+     * PRD §6 exhaustion policy: record a zero-or-partial debit (down to
+     * exactly 0 — same `run:{runId}` idempotency key, so a later retry
+     * can never top it up into a double debit) and notify the user. The
+     * run's terminal status is never affected.
+     */
+    private async settleInsufficient(
+        result: RunSettlementResult,
+        run: AgentRun,
+        err: InsufficientCreditsError,
+    ): Promise<RunSettlementResult> {
+        const balance = err.balanceCredits;
+        const partial = Math.max(0, Math.trunc(balance));
+
+        if (partial > 0) {
+            try {
+                const entry = await this.creditLedgerService.record({
+                    userId: run.userId,
+                    organizationId: run.organizationId ?? null,
+                    tenantId: run.tenantId ?? null,
+                    kind: CreditLedgerKind.CONSUMPTION,
+                    amountCredits: -partial,
+                    costCentsRef: result.billableCostCents,
+                    refType: 'agent-run',
+                    refId: run.id,
+                    description: `Run ${run.id} (${run.triggerKind}) — partial, balance exhausted`,
+                    idempotencyKey: `run:${run.id}`,
+                });
+                result.debitedCredits = entry ? Math.abs(entry.amountCredits) : 0;
+            } catch (partialErr) {
+                this.logger.warn(`Run ${run.id}: partial debit failed (ignored): ${partialErr}`);
+            }
+        }
+
+        try {
+            await this.notificationService?.notifyCreditsBalanceExhausted({
+                userId: run.userId,
+                runId: run.id,
+                requiredCredits: err.requestedCredits,
+                balanceCredits: balance,
+            });
+        } catch (notifyErr) {
+            this.logger.warn(
+                `Run ${run.id}: exhaustion notification failed (ignored): ${notifyErr}`,
+            );
+        }
+
+        result.status = result.debitedCredits > 0 ? 'partial' : 'exhausted';
+        return result;
+    }
+
+    /**
+     * BYOK exemption: plugins whose `apiKey` resolved from the `user` or
+     * `work` settings level ran on user-supplied credentials — free per
+     * founder decision. `admin`/`env`/`default` sources are
+     * platform-supplied and bill normally. Per-plugin failures bill that
+     * plugin (never exempt on doubt); no settings service ⇒ no exemption.
+     */
+    private async resolveExemptPlugins(
+        spend: RunPluginSpend[],
+        userId: string,
+        workId?: string,
+    ): Promise<string[]> {
+        if (!this.pluginSettingsService) return [];
+        const exempt: string[] = [];
+        for (const row of spend) {
+            if (row.costCents <= 0) continue;
+            try {
+                const resolved = await this.pluginSettingsService.getResolvedSettings(
+                    row.pluginId,
+                    { userId, workId, includeSecrets: true },
+                );
+                const source = resolved['apiKey']?.source;
+                if (source === 'user' || source === 'work') {
+                    exempt.push(row.pluginId);
+                }
+            } catch (err) {
+                this.logger.debug(
+                    `Run settlement: apiKey provenance unresolved for plugin ${row.pluginId} ` +
+                        `(billing at platform rate): ${err}`,
+                );
+            }
+        }
+        return exempt;
+    }
+
+    /**
+     * Dispatch-gate soft precheck (Wave 9 M2, ship-dark). Blocks only
+     * when EVERY lever agrees: `CREDITS_ENFORCEMENT=on` (the gate also
+     * early-outs on this), the user's plan carries the `credit-limited`
+     * entitlement (> 0 — no rows are seeded, so default is never
+     * limited), AND the balance is ≤ 0. Any resolution failure returns
+     * false — a broken precheck must never stop work.
+     */
+    async shouldQueueForCredits(userId: string): Promise<boolean> {
+        try {
+            if (!config.billing.credits.isEnforcementEnabled()) {
+                return false;
+            }
+            const user = await this.userRepository.findByIdForScheduledRun(userId);
+            if (!user) return false;
+            const planCode =
+                (user.defaultPlan?.code as string) || config.subscriptions.getDefaultPlanCode();
+            const creditLimited = await this.entitlementsService.getNumber(
+                planCode,
+                ENTITLEMENT_KEYS.CREDIT_LIMITED,
+                0,
+            );
+            if (creditLimited <= 0) return false;
+            const balance = await this.creditLedgerService.getBalance(userId);
+            return balance <= 0;
+        } catch (err) {
+            this.logger.warn(`Credits precheck failed for user ${userId} (fail-open): ${err}`);
+            return false;
+        }
+    }
+}

--- a/packages/agent/src/subscriptions/index.ts
+++ b/packages/agent/src/subscriptions/index.ts
@@ -5,3 +5,5 @@ export * from './billing/billing.provider';
 // Credits ledger + plan entitlements (pricing Wave 9 M1)
 export * from './credits/credit-ledger.service';
 export * from './credits/entitlements.service';
+// Run-cost settlement + dispatch-gate credits precheck (pricing Wave 9 M2)
+export * from './credits/run-cost-settlement.service';

--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -5,6 +5,7 @@ import { UsageLedgerService } from './usage-ledger.service';
 import { BillingProvider, ManualBillingProvider } from './billing/billing.provider';
 import { CreditLedgerService, InsufficientCreditsError } from './credits/credit-ledger.service';
 import { ENTITLEMENT_KEYS, EntitlementsService } from './credits/entitlements.service';
+import { RunCostSettlementService } from './credits/run-cost-settlement.service';
 
 /**
  * Pins the public `@ever-works/agent/subscriptions` barrel surface and the
@@ -42,6 +43,13 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(subscriptionsBarrel.ENTITLEMENT_KEYS).toBe(ENTITLEMENT_KEYS);
         });
 
+        it('re-exports the run-cost settlement surface (pricing Wave 9 M2)', () => {
+            // The RUN_CREDITS_PRECHECK / RUN_COST_SETTLER tokens live in
+            // the agents / database barrels respectively (leaf files
+            // beside their consumers) — only the implementation is here.
+            expect(subscriptionsBarrel.RunCostSettlementService).toBe(RunCostSettlementService);
+        });
+
         it('exposes the documented runtime symbols only (no extras silently appearing)', () => {
             const runtimeKeys = Object.keys(subscriptionsBarrel).sort();
             expect(runtimeKeys).toEqual(
@@ -56,6 +64,8 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'InsufficientCreditsError',
                     'EntitlementsService',
                     'ENTITLEMENT_KEYS',
+                    // Run-cost settlement (pricing Wave 9 M2)
+                    'RunCostSettlementService',
                 ].sort(),
             );
         });
@@ -79,6 +89,11 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             const providers = getMeta('providers');
             expect(providers).toContain(CreditLedgerService);
             expect(providers).toContain(EntitlementsService);
+        });
+
+        it('declares + exports RunCostSettlementService (Wave 9 M2)', () => {
+            expect(getMeta('providers')).toContain(RunCostSettlementService);
+            expect(getMeta('exports')).toContain(RunCostSettlementService);
         });
 
         it('binds the abstract BillingProvider token to ManualBillingProvider via useClass', () => {
@@ -110,10 +125,15 @@ describe('SubscriptionsModule + barrel re-exports', () => {
 
         it('imports DatabaseModule (where the repositories are bound)', () => {
             const imports = getMeta('imports');
-            // DatabaseModule is the first (and only) import — pin its presence
-            // by name to avoid coupling this test to its constructor identity.
+            // Pin presence by name to avoid coupling this test to the
+            // modules' constructor identities.
             const importNames = imports.map((m: any) => m?.name ?? String(m));
             expect(importNames).toContain('DatabaseModule');
+        });
+
+        it('imports NotificationsModule (Wave 9 M2 — exhaustion notifications)', () => {
+            const importNames = getMeta('imports').map((m: any) => m?.name ?? String(m));
+            expect(importNames).toContain('NotificationsModule');
         });
     });
 });

--- a/packages/agent/src/subscriptions/subscriptions.module.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.ts
@@ -1,13 +1,20 @@
 import { Module } from '@nestjs/common';
 import { DatabaseModule } from '@src/database/database.module';
+import { NotificationsModule } from '@src/notifications/notifications.module';
 import { SubscriptionService } from './subscription.service';
 import { UsageLedgerService } from './usage-ledger.service';
 import { BillingProvider, ManualBillingProvider } from './billing/billing.provider';
 import { CreditLedgerService } from './credits/credit-ledger.service';
 import { EntitlementsService } from './credits/entitlements.service';
+import { RunCostSettlementService } from './credits/run-cost-settlement.service';
 
 @Module({
-    imports: [DatabaseModule],
+    imports: [
+        DatabaseModule,
+        // Wave 9 M2 — RunCostSettlementService emits the balance-exhausted
+        // notification through the existing NotificationService.
+        NotificationsModule,
+    ],
     providers: [
         SubscriptionService,
         UsageLedgerService,
@@ -15,6 +22,10 @@ import { EntitlementsService } from './credits/entitlements.service';
         // additive beside the existing plan/usage-ledger services.
         CreditLedgerService,
         EntitlementsService,
+        // Run-cost settlement + gate precheck (pricing Wave 9 M2) — the
+        // api-side @Global() SubscriptionsModule binds this instance to
+        // the RUN_COST_SETTLER + RUN_CREDITS_PRECHECK tokens.
+        RunCostSettlementService,
         { provide: BillingProvider, useClass: ManualBillingProvider },
     ],
     exports: [
@@ -22,6 +33,7 @@ import { EntitlementsService } from './credits/entitlements.service';
         UsageLedgerService,
         CreditLedgerService,
         EntitlementsService,
+        RunCostSettlementService,
         BillingProvider,
     ],
 })

--- a/packages/agent/src/usage/plugin-usage.service.spec.ts
+++ b/packages/agent/src/usage/plugin-usage.service.spec.ts
@@ -216,4 +216,39 @@ describe('PluginUsageService.record', () => {
             );
         });
     });
+
+    /**
+     * Pricing Wave 9 M2 — per-run attribution: rows tagged with the run
+     * id are what the run-cost accumulator sums at run-terminal time.
+     */
+    describe('runId attribution (Wave 9 M2)', () => {
+        it('persists runId when supplied', async () => {
+            const { service, repository } = makeService();
+            await service.record({
+                workId: 'work-1',
+                userId: 'user-1',
+                agentId: 'agent-9',
+                runId: 'run-7',
+                pluginId: 'openai',
+                capability: PluginUsageCapability.AI,
+                costCents: 12,
+            });
+            expect(repository.record).toHaveBeenCalledWith(
+                expect.objectContaining({ runId: 'run-7' }),
+            );
+        });
+
+        it('defaults runId to null when omitted (non-run calls stay untagged)', async () => {
+            const { service, repository } = makeService();
+            await service.record({
+                workId: 'work-1',
+                userId: 'user-1',
+                pluginId: 'openai',
+                capability: PluginUsageCapability.AI,
+            });
+            expect(repository.record).toHaveBeenCalledWith(
+                expect.objectContaining({ runId: null }),
+            );
+        });
+    });
 });

--- a/packages/agent/src/usage/plugin-usage.service.ts
+++ b/packages/agent/src/usage/plugin-usage.service.ts
@@ -22,6 +22,12 @@ export type RecordPluginUsageInput = {
      */
     agentId?: string | null;
     taskId?: string | null;
+    /**
+     * Pricing Wave 9 M2 — per-run attribution. Set when the call was
+     * made inside an `AgentRun`; the run-cost accumulator sums tagged
+     * rows at run-terminal time for the credits debit.
+     */
+    runId?: string | null;
 };
 
 /**
@@ -66,6 +72,8 @@ export class PluginUsageService {
                 // Phase 15.6 — propagate Agent/Task attribution when set.
                 agentId: input.agentId ?? null,
                 taskId: input.taskId ?? null,
+                // Wave 9 M2 — propagate per-run attribution when set.
+                runId: input.runId ?? null,
             });
         } catch (error) {
             this.logger.warn(

--- a/packages/plugin/src/facades/facade-options.interface.ts
+++ b/packages/plugin/src/facades/facade-options.interface.ts
@@ -23,4 +23,16 @@ export interface FacadeOptions {
 	 * Heartbeat runs leave this undefined.
 	 */
 	readonly taskId?: string;
+
+	/**
+	 * Pricing Wave 9 M2 — per-run cost attribution.
+	 *
+	 * Set on calls dispatched from inside an `AgentRun` (any trigger
+	 * kind). Rows tagged with the run id are what the run-cost
+	 * accumulator sums when the run reaches a terminal status, so the
+	 * resulting credits CONSUMPTION debit covers exactly this run's
+	 * metered spend. Undefined outside a run (the existing
+	 * agentId/taskId attribution is unaffected).
+	 */
+	readonly runId?: string;
 }


### PR DESCRIPTION
Wave 9 M2 — wires real usage metering into the credits ledger, per the billing/usage PRD (metering + consumption sections) and the recorded founder pricing decisions (credits-forward on costCents; user-supplied keys / local BYOS are free).

## What's in here

### 1. Per-run cost attribution (`runId` on the metering pipeline)
- `FacadeOptions.runId` (packages/plugin) — threaded by the run orchestrator through the AI-dispatch adapter AND the searchWeb/screenshot/extractContent tool pass-through adapters, so every `plugin_usage_events` row recorded inside an AgentRun is tagged with the run id.
- All five `AiFacadeService` record sites + search/screenshot/content-extractor/metrics facades propagate it.
- Additive `plugin_usage_events.runId` uuid column + `(runId, occurredAt)` index — guarded migration `1783600000000-AddRunIdToPluginUsageEvents` (no FK: audit rows outlive runs; no backfill: historical rows are honestly unattributable).

### 2. RunCostAccumulator seam + debit hook
- New `RunCostSettlementService` (`packages/agent/src/subscriptions/credits/run-cost-settlement.service.ts`): sums the run's tagged `costCents` per plugin (`PluginUsageRepository.getRunCostByPlugin`), stamps `agent_runs.costCents` (Wave-4 column) with the FULL metered total, and emits ONE credits CONSUMPTION debit via the existing `CreditLedgerService.consumeForRun` — idempotency key `run:{runId}`, so terminal-write re-runs can never double-debit.
- Hook lives at the ONE terminal-write choke point: `AgentRunRepository` (markCompleted / markFailed / markDispatchFailed / cancel / markStuckFailed) fires the new `RUN_COST_SETTLER` token via `@Optional() @Inject` — bound by the api-side SubscriptionsModule (now `@Global()`, same posture as api AgentsModule/TasksModule). Worker terminal writes go through the remote-proxy RPC to this same API-side repository, so **no new worker RPC wiring was needed**.
- Best-effort by contract (PRD §6): settlement never throws, and the repository guards it again — a credits outage can never fail a run.
- Insufficient balance ⇒ **zero-or-partial debit** (down to exactly 0, same idempotency key) + persistent `AI_CREDITS` notification (`notifyCreditsBalanceExhausted`, nearest existing category to BILLING) + channel fanout.

### 3. BYOK / local-BYOS exemption (free per founder decision)
- A plugin whose `apiKey` resolved from the **user** or **work** settings level (`ResolvedSetting.source` from `PluginSettingsService.getResolvedSettings`) ran on user-supplied keys ⇒ excluded from the billable sum. Its spend stays visible in `agent_runs.costCents` and usage surfaces — it just produces no CONSUMPTION debit.
- When provenance is NOT derivable (settings service unbound, or per-plugin resolution fails), the spend bills at platform rate — documented TODO constant `BYOK_EXEMPTION_UNRESOLVED_BILLS_FULL` (to be replaced by an explicit per-event billing flag once P2 passthrough lands).

### 4. Soft enforcement seam (ship dark)
- `RunDispatchGateService.admit` gains an optional credits precheck behind the new `RUN_CREDITS_PRECHECK` token: only when `CREDITS_ENFORCEMENT=on` (**default OFF**) AND the plan carries the new `credit-limited` entitlement (> 0 — **no rows seeded**, doubly dark) AND balance ≤ 0, the run queues with `queuedReason='insufficient-credits'` instead of dispatching. Fail-open on every error; concurrency valves win (checked first). Credits-parked runs are deliberately NOT drained by `drainForWork` (they wait for a top-up, not capacity) — promotion-on-top-up is a documented follow-up.

### Config (all env-configurable, house rule)
- `CREDITS_ENFORCEMENT` (default off) — new `config.billing.credits.isEnforcementEnabled()`.
- New entitlement key `credit-limited` (unseeded).

## Tests (+22 new)
- `run-cost-settlement.service.spec.ts` (new, 16): accumulation sums only this run's events + stamps costCents; zero-event/missing-run skips; debit args + idempotent re-run (same `run:{runId}` key, one ledger row); partial debit down to 0 + notification; exhausted ⇒ no debit + notification; never rejects (ledger down / notify down / DB down); BYOK user-source exempt, work-source exempt, unresolvable bills full, per-plugin failure bills; precheck dark-by-default / not-credit-limited / limited+broke ⇒ true / fail-open.
- `agent-run.repository.spec.ts` (+6): settles on winning markCompleted/markFailed; NOT on CAS loss; throwing settler never fails the terminal write; unbound settler unchanged; markStuckFailed settles every reaped id.
- `run-dispatch-gate.service.spec.ts` (+5): dark by default (precheck never consulted); queues `insufficient-credits` when enabled+broke; admits with balance; fail-open on precheck throw; concurrency reason wins.
- `plugin-usage.service.spec.ts` (+2): runId persisted / defaults null.
- Pin specs updated same commit: `subscriptions.module.spec.ts` (barrel keys + providers/exports + NotificationsModule import).

## Verification (all run locally, foreground)

`packages/agent` build (`nest build -b swc && tsc -p tsconfig.types.json`):
```
>  TSC  Found 0 issues.
Successfully compiled: 1027 files with swc (139.87ms)
```

`packages/agent` full jest (includes `credit|entitle|agent-run`):
```
Test Suites: 372 passed, 372 total
Tests:       2 skipped, 6988 passed, 6990 total
```

`pnpm build --filter=ever-works-api --filter=@ever-works/trigger-tasks`:
```
ever-works-api:build: >  TSC  Found 0 issues.
 Tasks:    14 successful, 14 total
```

`apps/api pnpm generate:openapi` (full-app DI bootstrap — the boot-crash gate):
```
Wrote OpenAPI spec (420 paths) to apps\api\openapi.json   (file unchanged — no API-surface drift)
```

`apps/api` jest `trigger-internal` (+ subscriptions/agents controllers):
```
Test Suites: 2 passed, 2 total    Tests: 16 passed  (trigger-internal)
Test Suites: 4 passed, 4 total    Tests: 56 passed  (subscriptions|agents)
```

`packages/plugin` vitest (FacadeOptions touched):
```
Test Files  23 passed (23)   Tests  272 passed (272)
```

## Notes for reviewers
- Additive only: no behavior change anywhere until events carry `runId` (only run-scoped calls tag it), and enforcement is double-dark (env off + entitlement unseeded).
- `apps/api/src/subscriptions/subscriptions.module.ts` became `@Global()` — required so the `@Optional()` token injections inside agent-package modules (DatabaseModule/AgentsModule) actually resolve in production; without it they'd silently be undefined while unit tests pass.
- Streaming/embed/transcribe still record `costCents: 0` (known metering gap, PRD §6.3) — those runs debit 0 credits until the recorder gap is fixed; the ledger never pretends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
