### PR TITLE
feat(agent): decision docs + review states (Wave 5 M4-M7)

### DIFF
--- a/apps/api/src/migrations/1783700000000-AddKbDecisionReviewColumns.ts
+++ b/apps/api/src/migrations/1783700000000-AddKbDecisionReviewColumns.ts
@@ -1,0 +1,63 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+/**
+ * Decision documents + review states (memory upgrades M4 + M7).
+ *
+ * `work_knowledge_documents.decision` — nullable `simple-json` payload
+ * of shape `{ status: 'proposed' | 'accepted' | 'superseded' |
+ * 'archived'; supersededByDocId?; supersededBySlug?; supersedesDocId?;
+ * rationale? }` backing the `decision` KB class status machine (see
+ * `packages/agent/src/entities/kb-types.ts` —
+ * `KB_DECISION_STATUS_TRANSITIONS`). `NULL` = a non-decision document.
+ *
+ * `work_knowledge_documents.review_state` — nullable varchar
+ * (`'proposed' | 'accepted'`). Agent-authored / consolidation-
+ * synthesized documents land as `proposed` and are excluded from
+ * context injection until accepted via the review-action endpoints.
+ * `NULL` (every pre-existing row + all human-authored docs) is treated
+ * as `accepted`, so the feature is additive by construction — no
+ * backfill needed.
+ *
+ * `simple-json` maps to `text` on every supported driver (Postgres in
+ * prod, SQLite in the test/CLI adapter), so a plain nullable `text`
+ * column is correct — same as `1782000000000-AddKbDocumentConsolidation`.
+ *
+ * Forward-only and idempotent (`hasColumn`-guarded), matching the house
+ * migration pattern.
+ */
+export class AddKbDecisionReviewColumns1783700000000 implements MigrationInterface {
+    name = 'AddKbDecisionReviewColumns1783700000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (!(await queryRunner.hasColumn('work_knowledge_documents', 'decision'))) {
+            await queryRunner.addColumn(
+                'work_knowledge_documents',
+                new TableColumn({
+                    name: 'decision',
+                    type: 'text',
+                    isNullable: true,
+                }),
+            );
+        }
+
+        if (!(await queryRunner.hasColumn('work_knowledge_documents', 'review_state'))) {
+            await queryRunner.addColumn(
+                'work_knowledge_documents',
+                new TableColumn({
+                    name: 'review_state',
+                    type: 'varchar',
+                    isNullable: true,
+                }),
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasColumn('work_knowledge_documents', 'review_state')) {
+            await queryRunner.dropColumn('work_knowledge_documents', 'review_state');
+        }
+        if (await queryRunner.hasColumn('work_knowledge_documents', 'decision')) {
+            await queryRunner.dropColumn('work_knowledge_documents', 'decision');
+        }
+    }
+}

--- a/apps/api/src/works/kb.controller.ts
+++ b/apps/api/src/works/kb.controller.ts
@@ -35,12 +35,14 @@ import {
     KbDocumentQueryDto,
     LockKbDocumentDto,
     RestoreKbDocumentDto,
+    TransitionKbDecisionStatusDto,
     UpdateKbDocumentDto,
     UpdateKbTagDto,
 } from '@ever-works/agent/dto';
 import { AuthSessionGuard, CurrentUser } from '../auth';
 import { AuthenticatedUser } from '@src/auth/types/auth.types';
 import type {
+    KbDecisionStatus,
     KbDocumentClass,
     KbDocumentStatus,
     KbLockMode,
@@ -249,6 +251,71 @@ export class KbController {
         return this.kb.getDocumentHistory(workId, docId, auth.userId, {
             limit: parsedLimit,
         });
+    }
+
+    @Post('works/:id/kb/documents/:docId/decision-status')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Transition the status of a decision-class KB document',
+        description:
+            'Platform-side decision status machine (proposed → accepted → superseded → archived; archived reachable from every non-terminal state). Owner-scoped; validates the transition and returns 409 on an illegal move. Transitioning to superseded with `supersededByDocId` records the replacement chain on both documents.',
+    })
+    @ApiResponse({ status: 200, description: 'Decision status transitioned' })
+    @ApiResponse({ status: 400, description: 'Not a decision-class document' })
+    @ApiResponse({ status: 404, description: 'Document (or superseding document) not found' })
+    @ApiResponse({ status: 409, description: 'Illegal status transition' })
+    async transitionDecisionStatus(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) workId: string,
+        @Param('docId', new ParseUUIDPipe()) docId: string,
+        @Body() body: TransitionKbDecisionStatusDto,
+    ) {
+        return this.kb.transitionDecisionStatus(
+            workId,
+            docId,
+            auth.userId,
+            // Contracts literal union → agent runtime enum at the
+            // controller→service boundary (same cast pattern as `class`).
+            body.status as KbDecisionStatus,
+            {
+                supersededByDocId: body.supersededByDocId,
+                rationale: body.rationale,
+            },
+        );
+    }
+
+    @Post('works/:id/kb/documents/:docId/accept')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Accept a proposed (agent-authored) KB document',
+        description:
+            'Review action (memory upgrades M7). Flips reviewState to accepted so the document starts feeding agent context; a decision-class document still in proposed status is accepted as current in the same call. Idempotent.',
+    })
+    @ApiResponse({ status: 200, description: 'Document accepted' })
+    @ApiResponse({ status: 404, description: 'Document not found' })
+    async acceptDocument(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) workId: string,
+        @Param('docId', new ParseUUIDPipe()) docId: string,
+    ) {
+        return this.kb.acceptDocument(workId, docId, auth.userId);
+    }
+
+    @Post('works/:id/kb/documents/:docId/archive')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Archive a KB document (review action — never a physical delete)',
+        description:
+            'Review action (memory upgrades M7). Sets the document status to archived (kept readable, excluded from default listings and context injection); a decision-class document has its decision status archived too. Idempotent.',
+    })
+    @ApiResponse({ status: 200, description: 'Document archived' })
+    @ApiResponse({ status: 404, description: 'Document not found' })
+    async archiveDocument(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', new ParseUUIDPipe()) workId: string,
+        @Param('docId', new ParseUUIDPipe()) docId: string,
+    ) {
+        return this.kb.archiveDocument(workId, docId, auth.userId);
     }
 
     @Get('works/:id/kb/documents/:docId/citations')

--- a/apps/web/src/components/kb/workbench/KbTreePanel.tsx
+++ b/apps/web/src/components/kb/workbench/KbTreePanel.tsx
@@ -14,6 +14,7 @@ import {
     Globe2,
     Lightbulb,
     Lock,
+    Milestone,
     Palette,
     Search,
     Sparkles,
@@ -76,6 +77,11 @@ const CLASS_ICONS: Record<KbDocumentClass, LucideIcon> = {
     research: Search,
     output: FileText,
     freeform: Lightbulb,
+    // Memory upgrades M4 — decision class. Icon only: the full decision
+    // workbench UI (status chips, supersession chain view, review queue)
+    // is a tracked follow-up; this entry keeps the exhaustive icon map
+    // total so the tree renders decision docs like any other class.
+    decision: Milestone,
 };
 
 export function KbTreePanel({ workId, currentDocPath, refreshKey }: KbTreePanelProps) {

--- a/packages/agent/src/dto/kb.dto.ts
+++ b/packages/agent/src/dto/kb.dto.ts
@@ -14,9 +14,11 @@ import {
     Min,
 } from 'class-validator';
 import {
+    KB_DECISION_STATUSES,
     KB_DOCUMENT_CLASSES,
     KB_DOCUMENT_STATUSES,
     KB_LOCK_MODES,
+    KbDecisionStatus,
     KbDocumentClass,
     KbDocumentStatus,
     KbLockMode,
@@ -245,4 +247,25 @@ export class CreateKbUploadDto {
 export class OrgKbDocumentScopeDto {
     @IsUUID()
     organizationId: string;
+}
+
+/**
+ * Body for `POST /api/works/:id/kb/documents/:docId/decision-status`
+ * (memory upgrades M4) — the platform-side decision status transition.
+ * The service validates the transition against the status machine and
+ * 409s on an illegal move; `supersededByDocId` records the replacement
+ * chain when transitioning to `superseded`.
+ */
+export class TransitionKbDecisionStatusDto {
+    @IsIn(KB_DECISION_STATUSES as unknown as readonly string[])
+    status: KbDecisionStatus;
+
+    @IsOptional()
+    @IsUUID()
+    supersededByDocId?: string;
+
+    @IsOptional()
+    @IsString()
+    @MaxLength(KB_DESCRIPTION_MAX)
+    rationale?: string;
 }

--- a/packages/agent/src/entities/kb-types.ts
+++ b/packages/agent/src/entities/kb-types.ts
@@ -25,6 +25,10 @@
  * `research`     — long-form reference material (extracted PDFs etc.)
  * `output`       — agent-authored artifacts (reports, decks, dashboards)
  * `freeform`     — catch-all user notes
+ * `decision`     — a settled call with a status lifecycle (memory
+ *                  upgrades M4): rendered status-labelled in its own
+ *                  `<kb>` section; historical statuses are excluded
+ *                  from default injection
  */
 export enum KbDocumentClass {
     BRAND = 'brand',
@@ -37,6 +41,65 @@ export enum KbDocumentClass {
     RESEARCH = 'research',
     OUTPUT = 'output',
     FREEFORM = 'freeform',
+    DECISION = 'decision',
+}
+
+/**
+ * Lifecycle status of a `decision`-class document (memory upgrades M4).
+ * Transitions are platform-side and transactional (an API call flips
+ * them — never an external event), validated against
+ * {@link KB_DECISION_STATUS_TRANSITIONS}.
+ */
+export enum KbDecisionStatus {
+    PROPOSED = 'proposed',
+    ACCEPTED = 'accepted',
+    SUPERSEDED = 'superseded',
+    ARCHIVED = 'archived',
+}
+
+/**
+ * The decision status machine: `proposed → accepted → superseded →
+ * archived`, with `archived` reachable from every non-terminal state
+ * (rejecting a proposal, retiring a live decision). `archived` is
+ * terminal; nothing ever moves backwards — a reversed call is demoted
+ * (superseded, chain-linked), never resurrected in place.
+ */
+export const KB_DECISION_STATUS_TRANSITIONS: Readonly<
+    Record<KbDecisionStatus, ReadonlyArray<KbDecisionStatus>>
+> = {
+    [KbDecisionStatus.PROPOSED]: [KbDecisionStatus.ACCEPTED, KbDecisionStatus.ARCHIVED],
+    [KbDecisionStatus.ACCEPTED]: [KbDecisionStatus.SUPERSEDED, KbDecisionStatus.ARCHIVED],
+    [KbDecisionStatus.SUPERSEDED]: [KbDecisionStatus.ARCHIVED],
+    [KbDecisionStatus.ARCHIVED]: [],
+};
+
+/**
+ * Decision lifecycle state persisted on `WorkKnowledgeDocument.decision`
+ * (nullable `simple-json` column — `null` for every non-decision class).
+ * Mirror of the contracts-side `KbDecisionState` wire shape.
+ */
+export interface KbDecisionState {
+    status: KbDecisionStatus;
+    /** The replacement decision this one was superseded by. */
+    supersededByDocId?: string | null;
+    /** Slug of the replacement, denormalized for the historical label. */
+    supersededBySlug?: string | null;
+    /** The older decision this one replaces. */
+    supersedesDocId?: string | null;
+    /** One-line rationale rendered alongside the decision in context. */
+    rationale?: string | null;
+}
+
+/**
+ * Review state of a KB document (memory upgrades M7). Agent-authored and
+ * consolidation-synthesized documents land as `proposed` and are
+ * excluded from context injection until accepted. `null` (human-authored
+ * docs and every pre-existing row) is treated as `accepted` — the
+ * feature is additive by construction.
+ */
+export enum KbReviewState {
+    PROPOSED = 'proposed',
+    ACCEPTED = 'accepted',
 }
 
 /**

--- a/packages/agent/src/entities/work-knowledge-document.entity.ts
+++ b/packages/agent/src/entities/work-knowledge-document.entity.ts
@@ -13,7 +13,14 @@ import { User } from './user.entity';
 import { Work } from './work.entity';
 import { WorkAgentRun } from './work-agent-run.entity';
 import { ClassToObject } from './types';
-import { KbDocumentClass, KbDocumentSource, KbDocumentStatus, KbLockMode } from './kb-types';
+import {
+    KbDecisionState,
+    KbDocumentClass,
+    KbDocumentSource,
+    KbDocumentStatus,
+    KbLockMode,
+    KbReviewState,
+} from './kb-types';
 import { WorkKnowledgeUpload } from './work-knowledge-upload.entity';
 import { TimestampColumn } from './_types';
 import type { KbConsolidationMarker } from '../services/memory-consolidation';
@@ -184,6 +191,26 @@ export class WorkKnowledgeDocument {
      */
     @Column({ type: 'simple-json', nullable: true })
     consolidation?: KbConsolidationMarker | null;
+
+    /**
+     * Decision lifecycle state (memory upgrades M4). Non-null only for
+     * `kbDocumentClass = 'decision'` rows. Status transitions are
+     * platform-side API calls validated against the status machine
+     * (`KB_DECISION_STATUS_TRANSITIONS`) — never an external event.
+     * Migration `1783700000000-AddKbDecisionReviewColumns` adds the
+     * column; `null` on every pre-existing row (fully additive).
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    decision?: KbDecisionState | null;
+
+    /**
+     * Review state (memory upgrades M7). `'proposed'` for agent-authored
+     * / consolidation-synthesized docs awaiting human review — such docs
+     * are excluded from context injection until accepted. `null` (all
+     * human-authored + pre-existing rows) is treated as `'accepted'`.
+     */
+    @Column({ type: 'varchar', nullable: true, name: 'review_state' })
+    reviewState?: KbReviewState | null;
 
     @CreateDateColumn()
     createdAt: Date;

--- a/packages/agent/src/services/__tests__/kb-decision-review.service.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-decision-review.service.spec.ts
@@ -1,0 +1,663 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { KbDocumentBodyDto } from '@ever-works/contracts';
+import { KB_STORAGE_PLUGIN, KnowledgeBaseService } from '../knowledge-base.service';
+import { KB_EMBED_DOCUMENT_DISPATCHER } from '../../tasks/kb-embed-document-dispatcher';
+import { WorkKnowledgeDocumentRepository } from '../../database/repositories/work-knowledge-document.repository';
+import { WorkKnowledgeUploadRepository } from '../../database/repositories/work-knowledge-upload.repository';
+import { WorkKnowledgeTagRepository } from '../../database/repositories/work-knowledge-tag.repository';
+import { WorkKnowledgeCitationRepository } from '../../database/repositories/work-knowledge-citation.repository';
+import { WorkOwnershipService } from '../work-ownership.service';
+import { ActivityLogService } from '../../activity-log/activity-log.service';
+import { WorkKnowledgeDocument } from '../../entities/work-knowledge-document.entity';
+import {
+    KbDecisionStatus,
+    KbDocumentClass,
+    KbDocumentSource,
+    KbDocumentStatus,
+    KbReviewState,
+} from '../../entities/kb-types';
+import { formatKbContext } from '../kb-prompt-formatter';
+import { buildKbContextBundle } from '../kb-context-bundle';
+
+const WORK_ID = '00000000-0000-0000-0000-000000000001';
+const USER_ID = '00000000-0000-0000-0000-000000000002';
+const DOC_ID = '00000000-0000-0000-0000-000000000010';
+const SURVIVOR_ID = '00000000-0000-0000-0000-000000000011';
+
+function buildDocument(overrides: Partial<WorkKnowledgeDocument> = {}): WorkKnowledgeDocument {
+    return {
+        id: DOC_ID,
+        workId: WORK_ID,
+        organizationId: null,
+        path: 'decision/context-store.md',
+        slug: 'context-store',
+        title: 'Context lives in files',
+        description: null,
+        kbDocumentClass: KbDocumentClass.DECISION,
+        tags: null,
+        categories: null,
+        status: KbDocumentStatus.ACTIVE,
+        locked: false,
+        lockMode: null,
+        language: 'en',
+        wordCount: 0,
+        tokenCount: 0,
+        source: KbDocumentSource.USER,
+        sourceUploadId: null,
+        sourceUrl: null,
+        generatedByAgentRunId: null,
+        createdById: USER_ID,
+        updatedById: USER_ID,
+        lastIndexedAt: null,
+        lastCommitSha: null,
+        metadata: { body: 'We keep context in files.' },
+        consolidation: null,
+        decision: { status: KbDecisionStatus.PROPOSED },
+        reviewState: null,
+        createdAt: new Date('2026-07-01T12:00:00Z'),
+        updatedAt: new Date('2026-07-01T12:00:00Z'),
+        ...overrides,
+    } as WorkKnowledgeDocument;
+}
+
+function buildBodyDto(overrides: Partial<KbDocumentBodyDto> = {}): KbDocumentBodyDto {
+    return {
+        id: overrides.id ?? DOC_ID,
+        workId: WORK_ID,
+        organizationId: null,
+        path: overrides.path ?? 'decision/context-store.md',
+        slug: overrides.slug ?? 'context-store',
+        title: overrides.title ?? 'Context lives in files',
+        description: null,
+        class: overrides.class ?? 'decision',
+        tags: [],
+        categories: [],
+        status: 'active',
+        locked: false,
+        lockMode: null,
+        language: 'en',
+        wordCount: null,
+        tokenCount: null,
+        source: 'user',
+        sourceUploadId: null,
+        sourceUrl: null,
+        generatedByAgentRunId: null,
+        createdById: null,
+        updatedById: null,
+        createdAt: '2026-07-01T12:00:00.000Z',
+        updatedAt: '2026-07-01T12:00:00.000Z',
+        lastCommitSha: null,
+        lastIndexedAt: null,
+        body: overrides.body ?? 'decision body',
+        assets: [],
+        ...overrides,
+    } as KbDocumentBodyDto;
+}
+
+describe('KnowledgeBaseService — decision docs + review states (Wave 5 M4-M7)', () => {
+    let service: KnowledgeBaseService;
+    let docRepo: jest.Mocked<WorkKnowledgeDocumentRepository>;
+
+    beforeEach(async () => {
+        const docRepoMock: Partial<jest.Mocked<WorkKnowledgeDocumentRepository>> = {
+            findById: jest.fn(),
+            findByPath: jest.fn(),
+            findOrgById: jest.fn(),
+            findOrgByPath: jest.fn(),
+            findByWorkOrPath: jest.fn(),
+            list: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+            pathExists: jest.fn().mockResolvedValue(false),
+            create: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn().mockResolvedValue(true),
+            setLock: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                KnowledgeBaseService,
+                { provide: WorkKnowledgeDocumentRepository, useValue: docRepoMock },
+                {
+                    provide: WorkKnowledgeUploadRepository,
+                    useValue: { findById: jest.fn(), create: jest.fn(), update: jest.fn() },
+                },
+                {
+                    provide: WorkKnowledgeTagRepository,
+                    useValue: {
+                        list: jest.fn().mockResolvedValue([]),
+                        findBySlug: jest.fn(),
+                        upsertBySlug: jest.fn(),
+                    },
+                },
+                {
+                    provide: WorkKnowledgeCitationRepository,
+                    useValue: { listForDocument: jest.fn().mockResolvedValue([]) },
+                },
+                {
+                    provide: WorkOwnershipService,
+                    useValue: {
+                        ensureCanView: jest.fn().mockResolvedValue({ role: 'editor' }),
+                        ensureCanEdit: jest.fn().mockResolvedValue({ role: 'editor' }),
+                    },
+                },
+                {
+                    provide: KB_STORAGE_PLUGIN,
+                    useValue: {
+                        providerName: 'local-fs',
+                        putObject: jest.fn(),
+                        getObject: jest.fn(),
+                        deleteObject: jest.fn(),
+                        isAvailable: jest.fn().mockResolvedValue(true),
+                    },
+                },
+                { provide: ActivityLogService, useValue: { log: jest.fn() } },
+                {
+                    provide: KB_EMBED_DOCUMENT_DISPATCHER,
+                    useValue: { dispatchKbEmbedDocument: jest.fn().mockResolvedValue('run-id') },
+                },
+            ],
+        }).compile();
+
+        service = module.get(KnowledgeBaseService);
+        docRepo = module.get(WorkKnowledgeDocumentRepository);
+    });
+
+    // ─── M4 — status machine ───────────────────────────────────────────
+
+    describe('transitionDecisionStatus — legal transitions', () => {
+        it('proposed → accepted succeeds and flips reviewState to accepted', async () => {
+            const doc = buildDocument({
+                decision: { status: KbDecisionStatus.PROPOSED },
+                reviewState: KbReviewState.PROPOSED,
+            });
+            docRepo.findById.mockResolvedValue(doc);
+            docRepo.update.mockImplementation(async (id, patch) => ({ ...doc, ...patch }));
+
+            const result = await service.transitionDecisionStatus(
+                WORK_ID,
+                DOC_ID,
+                USER_ID,
+                KbDecisionStatus.ACCEPTED,
+            );
+
+            expect(result.decision?.status).toBe('accepted');
+            expect(result.reviewState).toBe('accepted');
+            expect(docRepo.update).toHaveBeenCalledWith(
+                DOC_ID,
+                expect.objectContaining({
+                    decision: expect.objectContaining({ status: KbDecisionStatus.ACCEPTED }),
+                    reviewState: KbReviewState.ACCEPTED,
+                }),
+            );
+        });
+
+        it('accepted → superseded records the chain links on both documents', async () => {
+            const doc = buildDocument({ decision: { status: KbDecisionStatus.ACCEPTED } });
+            const survivor = buildDocument({
+                id: SURVIVOR_ID,
+                slug: 'context-store-v2',
+                decision: { status: KbDecisionStatus.ACCEPTED },
+            });
+            docRepo.findById.mockImplementation(async (_workId, id) =>
+                id === SURVIVOR_ID ? survivor : doc,
+            );
+            docRepo.update.mockImplementation(async (id, patch) =>
+                id === SURVIVOR_ID ? { ...survivor, ...patch } : { ...doc, ...patch },
+            );
+
+            const result = await service.transitionDecisionStatus(
+                WORK_ID,
+                DOC_ID,
+                USER_ID,
+                KbDecisionStatus.SUPERSEDED,
+                { supersededByDocId: SURVIVOR_ID, rationale: 'replaced by v2' },
+            );
+
+            expect(result.decision).toMatchObject({
+                status: 'superseded',
+                supersededByDocId: SURVIVOR_ID,
+                supersededBySlug: 'context-store-v2',
+                rationale: 'replaced by v2',
+            });
+            // Reverse link written on the survivor, status untouched.
+            expect(docRepo.update).toHaveBeenCalledWith(
+                SURVIVOR_ID,
+                expect.objectContaining({
+                    decision: expect.objectContaining({
+                        status: KbDecisionStatus.ACCEPTED,
+                        supersedesDocId: DOC_ID,
+                    }),
+                }),
+            );
+        });
+
+        it('superseded → archived succeeds', async () => {
+            const doc = buildDocument({ decision: { status: KbDecisionStatus.SUPERSEDED } });
+            docRepo.findById.mockResolvedValue(doc);
+            docRepo.update.mockImplementation(async (id, patch) => ({ ...doc, ...patch }));
+
+            const result = await service.transitionDecisionStatus(
+                WORK_ID,
+                DOC_ID,
+                USER_ID,
+                KbDecisionStatus.ARCHIVED,
+            );
+            expect(result.decision?.status).toBe('archived');
+        });
+
+        it('proposed → archived succeeds (rejecting a proposal)', async () => {
+            const doc = buildDocument({ decision: { status: KbDecisionStatus.PROPOSED } });
+            docRepo.findById.mockResolvedValue(doc);
+            docRepo.update.mockImplementation(async (id, patch) => ({ ...doc, ...patch }));
+
+            const result = await service.transitionDecisionStatus(
+                WORK_ID,
+                DOC_ID,
+                USER_ID,
+                KbDecisionStatus.ARCHIVED,
+            );
+            expect(result.decision?.status).toBe('archived');
+        });
+    });
+
+    describe('transitionDecisionStatus — illegal transitions → 409', () => {
+        it.each([
+            [KbDecisionStatus.ACCEPTED, KbDecisionStatus.PROPOSED],
+            [KbDecisionStatus.ARCHIVED, KbDecisionStatus.ACCEPTED],
+            [KbDecisionStatus.SUPERSEDED, KbDecisionStatus.ACCEPTED],
+            [KbDecisionStatus.ACCEPTED, KbDecisionStatus.ACCEPTED],
+        ])('%s → %s is rejected with ConflictException', async (current, next) => {
+            const doc = buildDocument({ decision: { status: current } });
+            docRepo.findById.mockResolvedValue(doc);
+
+            await expect(
+                service.transitionDecisionStatus(WORK_ID, DOC_ID, USER_ID, next),
+            ).rejects.toBeInstanceOf(ConflictException);
+            expect(docRepo.update).not.toHaveBeenCalled();
+        });
+
+        it('a non-decision document is rejected with BadRequestException', async () => {
+            const doc = buildDocument({
+                kbDocumentClass: KbDocumentClass.FREEFORM,
+                decision: null,
+            });
+            docRepo.findById.mockResolvedValue(doc);
+
+            await expect(
+                service.transitionDecisionStatus(
+                    WORK_ID,
+                    DOC_ID,
+                    USER_ID,
+                    KbDecisionStatus.ACCEPTED,
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('superseding by itself is rejected with BadRequestException', async () => {
+            const doc = buildDocument({ decision: { status: KbDecisionStatus.ACCEPTED } });
+            docRepo.findById.mockResolvedValue(doc);
+
+            await expect(
+                service.transitionDecisionStatus(
+                    WORK_ID,
+                    DOC_ID,
+                    USER_ID,
+                    KbDecisionStatus.SUPERSEDED,
+                    { supersededByDocId: DOC_ID },
+                ),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('a missing superseding document is rejected with NotFoundException', async () => {
+            const doc = buildDocument({ decision: { status: KbDecisionStatus.ACCEPTED } });
+            docRepo.findById.mockImplementation(async (_workId, id) =>
+                id === DOC_ID ? doc : null,
+            );
+
+            await expect(
+                service.transitionDecisionStatus(
+                    WORK_ID,
+                    DOC_ID,
+                    USER_ID,
+                    KbDecisionStatus.SUPERSEDED,
+                    { supersededByDocId: SURVIVOR_ID },
+                ),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+    });
+
+    // ─── M7 — review-state defaults on creation ────────────────────────
+
+    describe('review-state defaults on creation', () => {
+        beforeEach(() => {
+            docRepo.create.mockImplementation(async (data) =>
+                buildDocument(data as Partial<WorkKnowledgeDocument>),
+            );
+        });
+
+        it('agent-authored documents land as proposed', async () => {
+            await service.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'research/agent-note.md',
+                title: 'Agent note',
+                class: KbDocumentClass.RESEARCH,
+                body: 'learned something',
+                source: KbDocumentSource.AGENT,
+            });
+
+            expect(docRepo.create).toHaveBeenCalledWith(
+                expect.objectContaining({ reviewState: KbReviewState.PROPOSED }),
+            );
+        });
+
+        it('human-authored documents land as accepted', async () => {
+            await service.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'freeform/note.md',
+                title: 'Note',
+                class: KbDocumentClass.FREEFORM,
+                body: 'a note',
+            });
+
+            expect(docRepo.create).toHaveBeenCalledWith(
+                expect.objectContaining({ reviewState: KbReviewState.ACCEPTED }),
+            );
+        });
+
+        it('decision documents are born with decision.status=proposed', async () => {
+            await service.createDocument({
+                workId: WORK_ID,
+                userId: USER_ID,
+                path: 'decision/new-call.md',
+                title: 'New call',
+                class: KbDocumentClass.DECISION,
+                body: 'we decided',
+            });
+
+            expect(docRepo.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    decision: { status: KbDecisionStatus.PROPOSED },
+                }),
+            );
+        });
+    });
+
+    // ─── M7 — review actions ───────────────────────────────────────────
+
+    describe('acceptDocument', () => {
+        it('flips reviewState to accepted and accepts a proposed decision', async () => {
+            const doc = buildDocument({
+                reviewState: KbReviewState.PROPOSED,
+                decision: { status: KbDecisionStatus.PROPOSED },
+            });
+            docRepo.findById.mockResolvedValue(doc);
+            docRepo.update.mockImplementation(async (id, patch) => ({ ...doc, ...patch }));
+
+            const result = await service.acceptDocument(WORK_ID, DOC_ID, USER_ID);
+
+            expect(result.reviewState).toBe('accepted');
+            expect(result.decision?.status).toBe('accepted');
+        });
+
+        it('does not touch the decision status of an already-accepted decision', async () => {
+            const doc = buildDocument({
+                reviewState: KbReviewState.PROPOSED,
+                decision: { status: KbDecisionStatus.ACCEPTED },
+            });
+            docRepo.findById.mockResolvedValue(doc);
+            docRepo.update.mockImplementation(async (id, patch) => ({ ...doc, ...patch }));
+
+            await service.acceptDocument(WORK_ID, DOC_ID, USER_ID);
+
+            const patch = docRepo.update.mock.calls[0][1] as Partial<WorkKnowledgeDocument>;
+            expect(patch.reviewState).toBe(KbReviewState.ACCEPTED);
+            expect(patch.decision).toBeUndefined();
+        });
+    });
+
+    describe('archiveDocument', () => {
+        it('archives the doc + decision status without ever deleting', async () => {
+            const doc = buildDocument({ decision: { status: KbDecisionStatus.ACCEPTED } });
+            docRepo.findById.mockResolvedValue(doc);
+            docRepo.update.mockImplementation(async (id, patch) => ({ ...doc, ...patch }));
+
+            const result = await service.archiveDocument(WORK_ID, DOC_ID, USER_ID);
+
+            expect(result.status).toBe('archived');
+            expect(result.decision?.status).toBe('archived');
+            expect(docRepo.delete).not.toHaveBeenCalled();
+        });
+    });
+
+    // ─── M5 + M7 — context injection ───────────────────────────────────
+
+    describe('resolveContext — injection exclusion + decisions section', () => {
+        it('excludes proposed (unreviewed) docs from the always-injected set', async () => {
+            const acceptedDoc = buildDocument({
+                id: 'accepted-1',
+                kbDocumentClass: KbDocumentClass.BRAND,
+                decision: null,
+                reviewState: KbReviewState.ACCEPTED,
+            });
+            const proposedDoc = buildDocument({
+                id: 'proposed-1',
+                kbDocumentClass: KbDocumentClass.BRAND,
+                decision: null,
+                reviewState: KbReviewState.PROPOSED,
+            });
+            docRepo.list.mockImplementation(async (filter: { classes?: KbDocumentClass[] }) => {
+                if (filter.classes?.includes(KbDocumentClass.DECISION)) {
+                    return { items: [], total: 0 };
+                }
+                return { items: [acceptedDoc, proposedDoc], total: 2 };
+            });
+
+            const bundle = await service.resolveContext(WORK_ID);
+
+            expect(bundle.alwaysInjected.map((d) => d.id)).toEqual(['accepted-1']);
+        });
+
+        it('includes only ACCEPTED decisions in the decisions slot', async () => {
+            const accepted = buildDocument({
+                id: 'dec-accepted',
+                decision: { status: KbDecisionStatus.ACCEPTED },
+            });
+            const proposed = buildDocument({
+                id: 'dec-proposed',
+                decision: { status: KbDecisionStatus.PROPOSED },
+            });
+            const superseded = buildDocument({
+                id: 'dec-superseded',
+                decision: { status: KbDecisionStatus.SUPERSEDED },
+            });
+            const archivedDecision = buildDocument({
+                id: 'dec-archived',
+                decision: { status: KbDecisionStatus.ARCHIVED },
+            });
+            const unreviewed = buildDocument({
+                id: 'dec-unreviewed',
+                decision: { status: KbDecisionStatus.ACCEPTED },
+                reviewState: KbReviewState.PROPOSED,
+            });
+            docRepo.list.mockImplementation(async (filter: { classes?: KbDocumentClass[] }) => {
+                if (filter.classes?.includes(KbDocumentClass.DECISION)) {
+                    return {
+                        items: [accepted, proposed, superseded, archivedDecision, unreviewed],
+                        total: 5,
+                    };
+                }
+                return { items: [], total: 0 };
+            });
+
+            const bundle = await service.resolveContext(WORK_ID);
+
+            expect(bundle.decisions.map((d) => d.id)).toEqual(['dec-accepted']);
+        });
+
+        it('drops proposed docs from query retrieval and ranks decisions around generics', async () => {
+            const generic = buildDocument({
+                id: 'generic-1',
+                kbDocumentClass: KbDocumentClass.RESEARCH,
+                slug: 'note',
+                decision: null,
+            });
+            const acceptedDecision = buildDocument({
+                id: 'dec-1',
+                decision: { status: KbDecisionStatus.ACCEPTED },
+            });
+            const historicalDecision = buildDocument({
+                id: 'dec-2',
+                slug: 'old-call',
+                decision: {
+                    status: KbDecisionStatus.SUPERSEDED,
+                    supersededByDocId: 'dec-1',
+                    supersededBySlug: 'context-store',
+                },
+            });
+            const proposedDoc = buildDocument({
+                id: 'proposed-1',
+                kbDocumentClass: KbDocumentClass.RESEARCH,
+                decision: null,
+                reviewState: KbReviewState.PROPOSED,
+            });
+            const byId = new Map([
+                [generic.id, generic],
+                [acceptedDecision.id, acceptedDecision],
+                [historicalDecision.id, historicalDecision],
+                [proposedDoc.id, proposedDoc],
+            ]);
+            docRepo.list.mockResolvedValue({ items: [], total: 0 });
+            docRepo.findById.mockImplementation(async (_workId, id) => byId.get(id) ?? null);
+            jest.spyOn(service, 'semanticSearch').mockResolvedValue([
+                { documentId: 'proposed-1' },
+                { documentId: 'generic-1' },
+                { documentId: 'dec-2' },
+                { documentId: 'dec-1' },
+            ] as never);
+
+            const bundle = await service.resolveContext(WORK_ID, { query: 'context storage' });
+
+            // proposed-1 excluded; accepted decision first, generic second,
+            // historical decision demoted to the tail.
+            expect(bundle.queryRetrieved.map((d) => d.id)).toEqual(['dec-1', 'generic-1', 'dec-2']);
+        });
+    });
+});
+
+// ─── M5 — per-class rendering in the <kb> block ───────────────────────
+
+describe('formatKbContext — decision rendering (Wave 5 M5)', () => {
+    it('renders an accepted decision with a status prefix under the labelled section', () => {
+        const block = formatKbContext([
+            buildBodyDto({
+                decision: { status: 'accepted', rationale: 'files beat databases here' },
+                body: 'Context stays in files.',
+            }),
+        ]);
+
+        expect(block).toContain('# Decisions — settled calls; do not reverse without flagging');
+        expect(block).toContain(
+            '## [decision: accepted] Context lives in files (kb:decision/context-store)',
+        );
+        expect(block).toContain('Rationale: files beat databases here');
+        expect(block).toContain('Context stays in files.');
+    });
+
+    it('labels a superseded decision historical and promotes the replacement citation', () => {
+        const block = formatKbContext([
+            buildBodyDto({
+                slug: 'old-call',
+                title: 'Old call',
+                decision: {
+                    status: 'superseded',
+                    supersededByDocId: SURVIVOR_ID,
+                    supersededBySlug: 'new-call',
+                },
+            }),
+        ]);
+
+        expect(block).toContain(
+            '## [decision: superseded — historical; replaced by kb:decision/new-call] Old call (kb:decision/old-call)',
+        );
+    });
+
+    it('labels an archived decision historical without a replacement', () => {
+        const block = formatKbContext([buildBodyDto({ decision: { status: 'archived' } })]);
+
+        expect(block).toContain('## [decision: archived — historical]');
+        expect(block).not.toContain('replaced by');
+    });
+
+    it('emits the decisions section label exactly once for multiple decisions', () => {
+        const block = formatKbContext([
+            buildBodyDto({ id: 'd1', slug: 'one', decision: { status: 'accepted' } }),
+            buildBodyDto({ id: 'd2', slug: 'two', decision: { status: 'accepted' } }),
+        ]);
+
+        const labels = block.match(/# Decisions — settled calls/g) ?? [];
+        expect(labels).toHaveLength(1);
+    });
+
+    it('leaves non-decision docs untouched (no section label, no prefix)', () => {
+        const block = formatKbContext([
+            buildBodyDto({ class: 'brand', slug: 'voice', title: 'Voice', decision: null }),
+        ]);
+
+        expect(block).toBe('<kb>\n## Voice (kb:brand/voice)\ndecision body\n</kb>');
+    });
+});
+
+describe('buildKbContextBundle — decisions slot (Wave 5 M5)', () => {
+    it('groups decisions between always-injected and generic query docs in format()', () => {
+        const always = buildBodyDto({ id: 'a1', class: 'brand', slug: 'voice', title: 'Voice' });
+        const decision = buildBodyDto({
+            id: 'd1',
+            slug: 'call',
+            title: 'The call',
+            decision: { status: 'accepted' },
+        });
+        const generic = buildBodyDto({
+            id: 'q1',
+            class: 'research',
+            slug: 'note',
+            title: 'Note',
+        });
+        const historical = buildBodyDto({
+            id: 'q2',
+            slug: 'old',
+            title: 'Old',
+            decision: { status: 'superseded' },
+        });
+
+        const bundle = buildKbContextBundle([always], [generic, historical], [decision]);
+        const block = bundle.format();
+
+        const order = [
+            block.indexOf('(kb:brand/voice)'),
+            block.indexOf('[decision: accepted]'),
+            block.indexOf('[decision: superseded — historical]'),
+            block.indexOf('(kb:research/note)'),
+        ];
+        expect(order.every((i) => i >= 0)).toBe(true);
+        // always-injected → decisions section (accepted, then historical
+        // query hit) → generic query docs.
+        expect([...order].sort((a, b) => a - b)).toEqual(order);
+    });
+
+    it('dedupes queryRetrieved against the decisions slot by id', () => {
+        const decision = buildBodyDto({ id: 'd1', decision: { status: 'accepted' } });
+        const bundle = buildKbContextBundle([], [decision], [decision]);
+
+        expect(bundle.decisions).toHaveLength(1);
+        expect(bundle.queryRetrieved).toHaveLength(0);
+    });
+
+    it('keeps the empty-bundle contract when no decisions exist', () => {
+        const bundle = buildKbContextBundle([], [], []);
+        expect(bundle.decisions).toEqual([]);
+        expect(bundle.format()).toBe('<kb>\n</kb>');
+    });
+});

--- a/packages/agent/src/services/kb-context-bundle.ts
+++ b/packages/agent/src/services/kb-context-bundle.ts
@@ -8,19 +8,27 @@ import { formatKbContext, type FormatKbContextOptions } from './kb-prompt-format
  * Spec §15.4 priority: `alwaysInjected` first (default whitelist =
  * brand + legal + style + glossary; configurable per-Work via
  * `WorkKbConfig.retrievalConfig.classFilters` — row 41 budget gauge),
- * then `queryRetrieved` (RRF-fused lexical + semantic over the user's
+ * then `decisions` (memory upgrades M5 — the Work's ACCEPTED
+ * decision-class docs, rendered in their own labelled section), then
+ * `queryRetrieved` (RRF-fused lexical + semantic over the user's
  * query, when present). The bundle is the single value plumbed into
  * the pipeline plugin invocation (row 32b), so individual pipelines
  * never need to know how the context was assembled.
  *
  * `format(opts)` delegates to `formatKbContext` (row 31) — every
  * Phase 2/b consumer gets the same `<kb>...</kb>` block shape and the
- * same truncation contract without re-implementing it.
+ * same truncation contract without re-implementing it. Decision-class
+ * docs are grouped contiguously (bundle `decisions` first, then any
+ * decision docs that arrived via `queryRetrieved` — e.g. a direct
+ * query hit on a historical decision) so the formatter renders ONE
+ * labelled decisions section; accepted decisions therefore rank above
+ * generic query-retrieved docs by construction.
  *
- * **Determinism.** Input order is preserved; the bundle factory
- * dedupes `queryRetrieved` against `alwaysInjected` by `id` (always-
- * injected wins — if `brand/voice` is both always-injected AND a
- * top RRF hit, it appears once, in the always-injected slot).
+ * **Determinism.** Input order is preserved within each list; the
+ * bundle factory dedupes `decisions` against `alwaysInjected` and
+ * `queryRetrieved` against both by `id` (earlier slot wins — if a doc
+ * is both always-injected AND a top RRF hit, it appears once, in the
+ * always-injected slot).
  *
  * **Pure.** No I/O, no module state. The factory only marshals; the
  * service layer (`resolveContext`) is the one that touches the DB.
@@ -28,15 +36,19 @@ import { formatKbContext, type FormatKbContextOptions } from './kb-prompt-format
 export interface KbContextBundle extends KbContextBundleData {
     readonly alwaysInjected: ReadonlyArray<KbDocumentBodyDto>;
     readonly queryRetrieved: ReadonlyArray<KbDocumentBodyDto>;
+    readonly decisions: ReadonlyArray<KbDocumentBodyDto>;
     format(options?: FormatKbContextOptions): string;
 }
 
 /**
- * Build a `KbContextBundle` from two doc lists, deduping `queryRetrieved`
- * against `alwaysInjected` by `id`.
+ * Build a `KbContextBundle` from the doc lists, deduping later slots
+ * against earlier ones by `id` (alwaysInjected → decisions →
+ * queryRetrieved).
  *
- * The returned bundle's `format()` concatenates the two lists in
- * priority order (alwaysInjected first) and delegates to `formatKbContext`.
+ * The returned bundle's `format()` concatenates the lists in priority
+ * order — alwaysInjected first, then all decision-class docs as one
+ * contiguous group (bundle decisions + query-retrieved decisions), then
+ * the generic query-retrieved docs — and delegates to `formatKbContext`.
  *
  * Pure factory — safe for any context (service code, eval harness,
  * tests). Callers (notably `KnowledgeBaseService.resolveContext`) are
@@ -45,31 +57,56 @@ export interface KbContextBundle extends KbContextBundleData {
 export function buildKbContextBundle(
     alwaysInjected: ReadonlyArray<KbDocumentBodyDto>,
     queryRetrieved: ReadonlyArray<KbDocumentBodyDto>,
+    decisions: ReadonlyArray<KbDocumentBodyDto> = [],
 ): KbContextBundle {
     const alwaysIds = new Set<string>();
     for (const d of alwaysInjected) alwaysIds.add(d.id);
 
+    // Dedup decisions by id (within the list AND against alwaysInjected —
+    // decision-class docs shouldn't appear there, but the factory stays
+    // defensive: earlier slot wins).
+    const seenDecisions = new Set<string>();
+    const dedupedDecisions: KbDocumentBodyDto[] = [];
+    for (const d of decisions) {
+        if (alwaysIds.has(d.id)) continue;
+        if (seenDecisions.has(d.id)) continue;
+        seenDecisions.add(d.id);
+        dedupedDecisions.push(d);
+    }
+
     // Dedup queryRetrieved by id (within the list itself AND against
-    // alwaysInjected). A doc that survived RRF + appears in the always-
-    // injected whitelist would otherwise be emitted twice; keep the
-    // alwaysInjected copy and drop the duplicate from queryRetrieved.
+    // alwaysInjected + decisions). A doc that survived RRF + appears in
+    // an earlier slot would otherwise be emitted twice; keep the earlier
+    // copy and drop the duplicate from queryRetrieved.
     const seenQuery = new Set<string>();
     const dedupedQueryRetrieved: KbDocumentBodyDto[] = [];
     for (const d of queryRetrieved) {
         if (alwaysIds.has(d.id)) continue;
+        if (seenDecisions.has(d.id)) continue;
         if (seenQuery.has(d.id)) continue;
         seenQuery.add(d.id);
         dedupedQueryRetrieved.push(d);
     }
 
     const frozenAlways = Object.freeze([...alwaysInjected]);
+    const frozenDecisions = Object.freeze(dedupedDecisions);
     const frozenQuery = Object.freeze(dedupedQueryRetrieved);
 
     return {
         alwaysInjected: frozenAlways,
         queryRetrieved: frozenQuery,
+        decisions: frozenDecisions,
         format(options?: FormatKbContextOptions): string {
-            return formatKbContext([...frozenAlways, ...frozenQuery], options);
+            // Group ALL decision-class docs contiguously so the formatter
+            // emits a single labelled decisions section: the bundle's
+            // accepted decisions first, then decision docs that arrived
+            // via the query (historical hits), then generic query docs.
+            const queryDecisions = frozenQuery.filter((d) => d.class === 'decision');
+            const queryGeneric = frozenQuery.filter((d) => d.class !== 'decision');
+            return formatKbContext(
+                [...frozenAlways, ...frozenDecisions, ...queryDecisions, ...queryGeneric],
+                options,
+            );
         },
     };
 }

--- a/packages/agent/src/services/kb-prompt-formatter.ts
+++ b/packages/agent/src/services/kb-prompt-formatter.ts
@@ -24,6 +24,23 @@ import type { KbDocumentBodyDto } from '@ever-works/contracts';
  *   {body}
  *   </kb>
  *
+ * **Decision rendering (memory upgrades M5).** `decision`-class docs
+ * get per-class treatment: a `# Decisions` section label line is
+ * emitted before the first decision doc (callers group decision docs
+ * contiguously — see `KbContextBundle.format`), each decision heading
+ * carries a status prefix, historical statuses (superseded / archived)
+ * are labelled `historical — replaced by kb:decision/<slug>` so the
+ * archive is never served back as current truth, and a one-line
+ * rationale (when present) leads the body:
+ *
+ *   # Decisions — settled calls; do not reverse without flagging
+ *   ## [decision: accepted] {title} (kb:decision/{slug})
+ *   Rationale: {rationale}
+ *   {body}
+ *   ---
+ *   ## [decision: superseded — historical; replaced by kb:decision/{slug}] {title} (kb:decision/{slug})
+ *   {body}
+ *
  * - Opening/closing `<kb>` tags on their own lines so prompts can use
  *   them as delimiters (LLM is told "the KB is between `<kb>` tags").
  * - `kb:{class}/{slug}` citation reference matches the `@kb:` mention
@@ -66,6 +83,15 @@ const TRUNCATION_MARKER = '\n[…truncated]';
 const OPEN_TAG = '<kb>';
 const CLOSE_TAG = '</kb>';
 const DOC_SEPARATOR = '\n---\n';
+
+/**
+ * Section label emitted once, before the first `decision`-class doc
+ * (memory upgrades M5). Level-1 heading so it can't be confused with
+ * the level-2 per-doc headings. Callers (`KbContextBundle.format`)
+ * group decision docs contiguously; if a caller interleaves them, the
+ * label still appears exactly once — before the first decision doc.
+ */
+const DECISION_SECTION_LABEL = '# Decisions — settled calls; do not reverse without flagging';
 
 /**
  * Security (prompt-injection hardening): KB document bodies/titles are
@@ -121,6 +147,7 @@ export function formatKbContext(
     // First-pass: build per-doc full entries. The slug + class come
     // straight from the DTO so the citation reference matches the row
     // 17 `@kb:` mention syntax.
+    let decisionLabelEmitted = false;
     const entries = docs.map((doc) => {
         // Security: neutralize the trusted-region delimiter (and chat-template
         // control markers) in every attacker-controlled field interpolated
@@ -128,8 +155,41 @@ export function formatKbContext(
         // slug) — so a poisoned doc cannot forge a `</kb>` boundary or spoof
         // a system turn. Benign Markdown is unaffected.
         const cite = `kb:${neutralizeKbField(doc.class)}/${neutralizeKbField(doc.slug)}`;
-        const heading = `## ${neutralizeKbField(doc.title)} (${cite})`;
-        const body = neutralizeKbField(doc.body ?? '');
+
+        let heading: string;
+        let body = neutralizeKbField(doc.body ?? '');
+
+        if (doc.class === 'decision') {
+            // M5 per-class rendering — status prefix; historical statuses
+            // (superseded / archived) are explicitly labelled so the
+            // archive is never served back as current truth, with the
+            // replacement promoted in the label when the chain link is
+            // known. Status values come from our enum (trusted); the
+            // denormalized replacement slug + rationale are doc-authored
+            // fields, so they are neutralized like every other field.
+            const status = doc.decision?.status ?? 'proposed';
+            const historical = status === 'superseded' || status === 'archived';
+            const replacedBy = doc.decision?.supersededBySlug
+                ? `; replaced by kb:decision/${neutralizeKbField(doc.decision.supersededBySlug)}`
+                : '';
+            const prefix = historical
+                ? `[decision: ${status} — historical${replacedBy}]`
+                : `[decision: ${status}]`;
+            heading = `## ${prefix} ${neutralizeKbField(doc.title)} (${cite})`;
+            if (!decisionLabelEmitted) {
+                // Section label rides on the first decision heading so the
+                // truncation pass (which never splits heading lines) keeps
+                // it intact whenever the section renders at all.
+                heading = `${DECISION_SECTION_LABEL}\n${heading}`;
+                decisionLabelEmitted = true;
+            }
+            if (doc.decision?.rationale) {
+                body = `Rationale: ${neutralizeKbField(doc.decision.rationale)}\n${body}`;
+            }
+        } else {
+            heading = `## ${neutralizeKbField(doc.title)} (${cite})`;
+        }
+
         return { heading, body, full: `${heading}\n${body}` };
     });
 

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -39,11 +39,15 @@ import { WorkKnowledgeDocument } from '../entities/work-knowledge-document.entit
 import { WorkKnowledgeTag } from '../entities/work-knowledge-tag.entity';
 import {
     KB_ALWAYS_INJECTED_CLASSES,
+    KB_DECISION_STATUS_TRANSITIONS,
     KB_ORG_INHERITABLE_CLASSES,
+    KbDecisionState,
+    KbDecisionStatus,
     KbDocumentClass,
     KbDocumentSource,
     KbDocumentStatus,
     KbLockMode,
+    KbReviewState,
 } from '../entities/kb-types';
 import { KB_MIRROR_DOCUMENT_DISPATCHER, type KbMirrorDocumentDispatcher } from '../tasks';
 import { KB_EMBED_DOCUMENT_DISPATCHER, type KbEmbedDocumentDispatcher } from '../tasks';
@@ -98,6 +102,19 @@ interface CreateDocumentInput {
      * lacks its idempotency marker (Greptile P2 on PR #1219).
      */
     metadata?: Record<string, unknown>;
+    /**
+     * Memory upgrades M7 — explicit review state. When omitted, the
+     * service derives it from `source`: agent-authored docs land as
+     * `proposed` (excluded from injection until accepted), everything
+     * else as `accepted`.
+     */
+    reviewState?: KbReviewState;
+    /**
+     * Memory upgrades M4 — initial decision state for `class=decision`
+     * docs. When omitted, decision docs are born `proposed`; ignored for
+     * every other class.
+     */
+    decision?: KbDecisionState;
 }
 
 interface UpdateDocumentInput {
@@ -864,13 +881,21 @@ export class KnowledgeBaseService {
     ): Promise<KbContextBundle> {
         const alwaysInjected = await this.fetchAlwaysInjectedDocs(workId);
 
+        // M5 — the Work's ACCEPTED decisions ride along on every bundle,
+        // rendered in their own labelled `<kb>` section (status-prefixed)
+        // ahead of generic query-retrieved docs. Historical (superseded /
+        // archived) and proposed decisions are excluded here; a direct
+        // query hit can still surface a historical decision via
+        // `queryRetrieved`, labelled historical by the formatter.
+        const decisions = await this.fetchAcceptedDecisionDocs(workId);
+
         const trimmedQuery = opts.query?.trim() ?? '';
         const queryRetrieved =
             trimmedQuery.length > 0
                 ? await this.fetchQueryRetrievedDocs(workId, trimmedQuery, opts.limit ?? 8)
                 : [];
 
-        return buildKbContextBundle(alwaysInjected, queryRetrieved);
+        return buildKbContextBundle(alwaysInjected, queryRetrieved, decisions);
     }
 
     /**
@@ -890,8 +915,39 @@ export class KnowledgeBaseService {
         // survivor — contradictory context served as current truth. The
         // survivor is part of this same ACTIVE list, so exclusion is the
         // whole fix here.
+        //
+        // M7 — `proposed` (unreviewed agent-authored) docs are excluded
+        // from injection until a human accepts them: nothing an agent
+        // wrote teaches other agents before review (the double-learning
+        // circuit breaker).
         return items
             .filter((d) => d.consolidation?.state !== 'superseded')
+            .filter((d) => d.reviewState !== KbReviewState.PROPOSED)
+            .map((d) => this.toBodyDto(d));
+    }
+
+    /**
+     * Memory upgrades M5 — fetch the Work's ACCEPTED decision documents
+     * for the bundle's labelled decisions section.
+     *
+     * Exclusions mirror the always-inject rules: historical decision
+     * statuses (`superseded` / `archived`) and unreviewed (`proposed`
+     * reviewState) docs never ride in by default, and a
+     * consolidation-superseded doc is skipped the same way. Decisions
+     * whose own status is `proposed` are not settled yet, so they are
+     * excluded from default injection too — they surface only via a
+     * direct query hit, honestly status-labelled.
+     */
+    private async fetchAcceptedDecisionDocs(workId: string): Promise<KbDocumentBodyDto[]> {
+        const { items } = await this.documentRepository.list({
+            workId,
+            classes: [KbDocumentClass.DECISION],
+            statuses: [KbDocumentStatus.ACTIVE],
+        });
+        return items
+            .filter((d) => d.decision?.status === KbDecisionStatus.ACCEPTED)
+            .filter((d) => d.consolidation?.state !== 'superseded')
+            .filter((d) => d.reviewState !== KbReviewState.PROPOSED)
             .map((d) => this.toBodyDto(d));
     }
 
@@ -929,12 +985,33 @@ export class KnowledgeBaseService {
         for (const docId of orderedDocIds) {
             if (results.length >= limit) break;
             const doc = await this.resolveCurrentDocument(workId, docId);
-            if (doc && !included.has(doc.id)) {
-                included.add(doc.id);
-                results.push(this.toBodyDto(doc));
-            }
+            if (!doc || included.has(doc.id)) continue;
+            // M7 — unreviewed (`proposed`) docs never reach a prompt, not
+            // even via a direct semantic hit. They stay retrievable through
+            // the normal list/get endpoints (the review queue), only the
+            // injection path is gated.
+            if (doc.reviewState === KbReviewState.PROPOSED) continue;
+            included.add(doc.id);
+            results.push(this.toBodyDto(doc));
         }
-        return results;
+
+        // M5 — decision-aware ranking: within the retrieved set, ACCEPTED
+        // decisions rank above generic docs, and historical decisions
+        // (superseded / archived — served only because the query hit them
+        // directly) are demoted to the tail, labelled historical by the
+        // formatter downstream ("demote, never drop"). Stable partition —
+        // relative RRF order is preserved within each band.
+        const rankBand = (d: KbDocumentBodyDto): number => {
+            if (d.class !== 'decision') return 1;
+            const status = d.decision?.status ?? 'proposed';
+            if (status === 'accepted') return 0;
+            if (status === 'superseded' || status === 'archived') return 2;
+            return 1;
+        };
+        return results
+            .map((doc, index) => ({ doc, index }))
+            .sort((a, b) => rankBand(a.doc) - rankBand(b.doc) || a.index - b.index)
+            .map((entry) => entry.doc);
     }
 
     /**
@@ -1033,6 +1110,8 @@ export class KnowledgeBaseService {
         const wordCount = this.countWords(body);
         const tokenCount = this.estimateTokens(body);
 
+        const source = input.source ?? ('user' as KbDocumentSource);
+
         const doc = await this.documentRepository.create({
             workId: input.workId,
             organizationId: null,
@@ -1049,13 +1128,23 @@ export class KnowledgeBaseService {
             language: input.language ?? 'en',
             wordCount,
             tokenCount,
-            source: input.source ?? ('user' as KbDocumentSource),
+            source,
             sourceUploadId: input.sourceUploadId ?? null,
             sourceUrl: input.sourceUrl ?? null,
             generatedByAgentRunId: input.generatedByAgentRunId ?? null,
             createdById: input.userId,
             updatedById: input.userId,
             metadata: { ...(input.metadata ?? {}), body } as Record<string, unknown>,
+            // M7 — agent-authored docs land as `proposed` (review-gated:
+            // excluded from injection until a human accepts). Human /
+            // imported / seeded docs are `accepted` from birth.
+            reviewState: this.deriveReviewState(input.reviewState, source),
+            // M4 — decision docs are born `proposed` unless the caller
+            // supplies an explicit initial state; every other class is null.
+            decision:
+                input.class === KbDocumentClass.DECISION
+                    ? (input.decision ?? { status: KbDecisionStatus.PROPOSED })
+                    : null,
         });
 
         // Ensure any new tag slugs are in the tag catalog (create-on-first-use).
@@ -1125,6 +1214,201 @@ export class KnowledgeBaseService {
             await this.enqueueEmbed(workId, updated.id);
         }
 
+        return this.toBodyDto(updated);
+    }
+
+    /**
+     * Memory upgrades M7 — derive the review state for a freshly created
+     * document. Explicit input wins; otherwise agent-authored docs are
+     * review-gated (`proposed`, excluded from injection until accepted)
+     * and every other source is `accepted` from birth.
+     */
+    private deriveReviewState(
+        explicit: KbReviewState | undefined,
+        source: KbDocumentSource,
+    ): KbReviewState {
+        if (explicit) return explicit;
+        return source === KbDocumentSource.AGENT ? KbReviewState.PROPOSED : KbReviewState.ACCEPTED;
+    }
+
+    /**
+     * Memory upgrades M4 — platform-side decision status transition.
+     *
+     * Owner-scoped (`ensureCanEdit`), validates the status machine
+     * (`KB_DECISION_STATUS_TRANSITIONS`) and throws 409 on an illegal
+     * transition — statuses only ever move forward, transactionally,
+     * via this API call (never an external event, so a missed delivery
+     * can never strand a decision in the wrong state).
+     *
+     * Transition to `superseded` optionally records the replacement
+     * chain: `supersededByDocId` is validated (same Work, decision
+     * class), its slug is denormalized onto the doc for the historical
+     * label, and the survivor gets the reverse `supersedesDocId` link.
+     * The survivor link is written FIRST so a failure between the two
+     * writes degrades to a dangling forward-pointer on the survivor
+     * (benign), never to a superseded doc without its replacement.
+     *
+     * Accepting a `proposed` decision also flips `reviewState` to
+     * `accepted` — an explicit status acceptance IS the human review.
+     */
+    async transitionDecisionStatus(
+        workId: string,
+        docId: string,
+        userId: string,
+        next: KbDecisionStatus,
+        opts: { supersededByDocId?: string; rationale?: string } = {},
+    ): Promise<KbDocumentBodyDto> {
+        await this.ownershipService.ensureCanEdit(workId, userId);
+
+        const existing = await this.documentRepository.findById(workId, docId);
+        if (!existing) {
+            throw new NotFoundException(`KB document not found: ${docId}`);
+        }
+        if (existing.kbDocumentClass !== KbDocumentClass.DECISION) {
+            throw new BadRequestException(
+                `Decision status transitions apply only to class=decision documents (got '${existing.kbDocumentClass}')`,
+            );
+        }
+
+        const current = existing.decision?.status ?? KbDecisionStatus.PROPOSED;
+        if (!KB_DECISION_STATUS_TRANSITIONS[current].includes(next)) {
+            throw new ConflictException(
+                `Illegal decision status transition: '${current}' → '${next}'. ` +
+                    `Legal next statuses: [${KB_DECISION_STATUS_TRANSITIONS[current].join(', ')}]`,
+            );
+        }
+
+        const decision: KbDecisionState = {
+            ...(existing.decision ?? { status: current }),
+            status: next,
+        };
+        if (opts.rationale !== undefined) {
+            decision.rationale = opts.rationale;
+        }
+
+        if (next === KbDecisionStatus.SUPERSEDED && opts.supersededByDocId) {
+            if (opts.supersededByDocId === docId) {
+                throw new BadRequestException('A decision cannot supersede itself');
+            }
+            const survivor = await this.documentRepository.findById(workId, opts.supersededByDocId);
+            if (!survivor) {
+                throw new NotFoundException(
+                    `Superseding decision not found: ${opts.supersededByDocId}`,
+                );
+            }
+            if (survivor.kbDocumentClass !== KbDocumentClass.DECISION) {
+                throw new BadRequestException(
+                    `Superseding document must be class=decision (got '${survivor.kbDocumentClass}')`,
+                );
+            }
+            decision.supersededByDocId = survivor.id;
+            decision.supersededBySlug = survivor.slug;
+
+            // Reverse chain link on the survivor (its own status is NOT
+            // touched — only the explicit `supersedesDocId` pointer).
+            await this.documentRepository.update(survivor.id, {
+                decision: {
+                    ...(survivor.decision ?? { status: KbDecisionStatus.PROPOSED }),
+                    supersedesDocId: docId,
+                },
+                updatedById: userId,
+            });
+        }
+
+        const patch: Partial<WorkKnowledgeDocument> = { decision, updatedById: userId };
+        if (current === KbDecisionStatus.PROPOSED && next === KbDecisionStatus.ACCEPTED) {
+            patch.reviewState = KbReviewState.ACCEPTED;
+        }
+
+        const updated = await this.documentRepository.update(docId, patch);
+        if (!updated) {
+            throw new NotFoundException(`KB document not found after transition: ${docId}`);
+        }
+        return this.toBodyDto(updated);
+    }
+
+    /**
+     * Memory upgrades M7 — review action: accept a proposed document.
+     *
+     * Owner-scoped. Flips `reviewState` to `accepted` so the doc starts
+     * feeding context injection; for `decision`-class docs still in
+     * `proposed` status the decision itself is accepted too (the status
+     * machine's `proposed → accepted` edge — one review, one flip to
+     * current). Idempotent: accepting an already-accepted doc is a no-op.
+     */
+    async acceptDocument(
+        workId: string,
+        docId: string,
+        userId: string,
+    ): Promise<KbDocumentBodyDto> {
+        await this.ownershipService.ensureCanEdit(workId, userId);
+
+        const existing = await this.documentRepository.findById(workId, docId);
+        if (!existing) {
+            throw new NotFoundException(`KB document not found: ${docId}`);
+        }
+
+        const patch: Partial<WorkKnowledgeDocument> = {
+            reviewState: KbReviewState.ACCEPTED,
+            updatedById: userId,
+        };
+        if (
+            existing.kbDocumentClass === KbDocumentClass.DECISION &&
+            (existing.decision?.status ?? KbDecisionStatus.PROPOSED) === KbDecisionStatus.PROPOSED
+        ) {
+            patch.decision = {
+                ...(existing.decision ?? { status: KbDecisionStatus.PROPOSED }),
+                status: KbDecisionStatus.ACCEPTED,
+            };
+        }
+
+        const updated = await this.documentRepository.update(docId, patch);
+        if (!updated) {
+            throw new NotFoundException(`KB document not found after accept: ${docId}`);
+        }
+        return this.toBodyDto(updated);
+    }
+
+    /**
+     * Memory upgrades M7 — review action: archive a document.
+     *
+     * Owner-scoped. Sets the KB `status` to `archived` (NEVER a physical
+     * delete — same never-delete discipline as consolidation) which
+     * removes the doc from every default listing + injection path while
+     * keeping it readable. For `decision`-class docs the decision status
+     * is archived too (`archived` is reachable from every non-terminal
+     * state). Idempotent.
+     */
+    async archiveDocument(
+        workId: string,
+        docId: string,
+        userId: string,
+    ): Promise<KbDocumentBodyDto> {
+        await this.ownershipService.ensureCanEdit(workId, userId);
+
+        const existing = await this.documentRepository.findById(workId, docId);
+        if (!existing) {
+            throw new NotFoundException(`KB document not found: ${docId}`);
+        }
+
+        const patch: Partial<WorkKnowledgeDocument> = {
+            status: KbDocumentStatus.ARCHIVED,
+            updatedById: userId,
+        };
+        if (
+            existing.kbDocumentClass === KbDocumentClass.DECISION &&
+            existing.decision?.status !== KbDecisionStatus.ARCHIVED
+        ) {
+            patch.decision = {
+                ...(existing.decision ?? { status: KbDecisionStatus.PROPOSED }),
+                status: KbDecisionStatus.ARCHIVED,
+            };
+        }
+
+        const updated = await this.documentRepository.update(docId, patch);
+        if (!updated) {
+            throw new NotFoundException(`KB document not found after archive: ${docId}`);
+        }
         return this.toBodyDto(updated);
     }
 
@@ -1620,10 +1904,18 @@ export class KnowledgeBaseService {
             language: input.language ?? 'en',
             wordCount,
             tokenCount,
-            source: 'user' as KbDocumentSource,
+            source: input.source ?? ('user' as KbDocumentSource),
             createdById: userId,
             updatedById: userId,
             metadata: { body } as Record<string, unknown>,
+            // M7 — same review-gate derivation as `createDocument`: the
+            // consolidation synthesis path passes `source: agent` so
+            // LLM-merged docs land as `proposed` (review queue), while
+            // operator-authored org docs stay `accepted`.
+            reviewState: this.deriveReviewState(
+                input.reviewState,
+                input.source ?? ('user' as KbDocumentSource),
+            ),
         });
 
         // EW-641 Phase 2/e row 37d — fan the org overlay out to every
@@ -2685,6 +2977,8 @@ export class KnowledgeBaseService {
             updatedAt: doc.updatedAt.toISOString(),
             lastCommitSha: doc.lastCommitSha ?? null,
             lastIndexedAt: doc.lastIndexedAt ? doc.lastIndexedAt.toISOString() : null,
+            decision: doc.decision ?? null,
+            reviewState: doc.reviewState ?? null,
         };
     }
 

--- a/packages/agent/src/services/memory-consolidation.service.ts
+++ b/packages/agent/src/services/memory-consolidation.service.ts
@@ -6,6 +6,8 @@ import {
     KB_ALWAYS_INJECTED_CLASSES,
     KB_ORG_INHERITABLE_CLASSES,
     KbDocumentClass,
+    KbDocumentSource,
+    KbReviewState,
 } from '../entities/kb-types';
 import { AiFacadeService } from '../facades/ai.facade';
 import { KnowledgeBaseService } from './knowledge-base.service';
@@ -394,6 +396,12 @@ export class MemoryConsolidationService {
             body: summary,
             description: `Synthesized from ${ids.length} near-duplicate Memory documents.`,
             tags: ['synthesis'],
+            // Memory upgrades M7 — an LLM-synthesized document is
+            // agent-authored and review-gated: it lands as `proposed`
+            // (excluded from context injection) until a human accepts it,
+            // so an unreviewed merge can never teach other agents.
+            source: KbDocumentSource.AGENT,
+            reviewState: KbReviewState.PROPOSED,
         });
 
         const marker: KbConsolidationMarker = {

--- a/packages/contracts/src/kb/kb-context-bundle.types.ts
+++ b/packages/contracts/src/kb/kb-context-bundle.types.ts
@@ -25,4 +25,13 @@ import type { KbDocumentBodyDto } from './kb-document.types.js';
 export interface KbContextBundleData {
 	readonly alwaysInjected: ReadonlyArray<KbDocumentBodyDto>;
 	readonly queryRetrieved: ReadonlyArray<KbDocumentBodyDto>;
+	/**
+	 * Memory upgrades M5 — the Work's ACCEPTED `decision`-class docs,
+	 * rendered by `format()` in their own labelled section of the
+	 * `<kb>` block (status-prefixed). Superseded / archived / proposed
+	 * decisions never appear here; historical decisions can still ride
+	 * in via `queryRetrieved` (labelled historical) when the query hits
+	 * them directly. Optional so pre-existing producers stay valid.
+	 */
+	readonly decisions?: ReadonlyArray<KbDocumentBodyDto>;
 }

--- a/packages/contracts/src/kb/kb-document-class.ts
+++ b/packages/contracts/src/kb/kb-document-class.ts
@@ -21,10 +21,38 @@ export const KB_DOCUMENT_CLASSES = [
 	'personas',
 	'research',
 	'output',
-	'freeform'
+	'freeform',
+	'decision'
 ] as const;
 
 export type KbDocumentClass = (typeof KB_DOCUMENT_CLASSES)[number];
+
+/**
+ * Lifecycle status of a `decision`-class KB document (memory upgrades
+ * M4). Transitions are platform-side only — an API call flips the
+ * status transactionally, validated against the status machine:
+ *
+ *   proposed → accepted | archived
+ *   accepted → superseded | archived
+ *   superseded → archived
+ *   archived → (terminal)
+ *
+ * `superseded` / `archived` decisions are "historical": excluded from
+ * default context injection and labelled as historical when directly
+ * retrieved. See the agent-side `KB_DECISION_STATUS_TRANSITIONS`.
+ */
+export const KB_DECISION_STATUSES = ['proposed', 'accepted', 'superseded', 'archived'] as const;
+export type KbDecisionStatus = (typeof KB_DECISION_STATUSES)[number];
+
+/**
+ * Review state of a KB document (memory upgrades M7). Agent-authored
+ * and consolidation-synthesized documents land as `proposed` and are
+ * excluded from context injection until a human accepts them. `null` /
+ * absent (all human-authored docs, plus every pre-existing row) is
+ * treated as `accepted`.
+ */
+export const KB_REVIEW_STATES = ['proposed', 'accepted'] as const;
+export type KbReviewState = (typeof KB_REVIEW_STATES)[number];
 
 /**
  * Classes that may be authored at the organization level and inherited

--- a/packages/contracts/src/kb/kb-document.types.ts
+++ b/packages/contracts/src/kb/kb-document.types.ts
@@ -1,4 +1,33 @@
-import type { KbDocumentClass, KbDocumentSource, KbDocumentStatus, KbLockMode } from './kb-document-class.js';
+import type {
+	KbDecisionStatus,
+	KbDocumentClass,
+	KbDocumentSource,
+	KbDocumentStatus,
+	KbLockMode,
+	KbReviewState
+} from './kb-document-class.js';
+
+/**
+ * Decision lifecycle state carried by a `decision`-class KB document
+ * (memory upgrades M4). Persisted as a `simple-json` column on the
+ * document row — `null` for every other class.
+ *
+ * `supersededByDocId` / `supersedesDocId` are the explicit chain links
+ * ("a reversed call is demoted, never dropped"); `supersededBySlug` is
+ * denormalized at transition time so retrieval can render the
+ * "historical — replaced by kb:decision/<slug>" label without a lookup.
+ */
+export interface KbDecisionState {
+	status: KbDecisionStatus;
+	/** The replacement decision this one was superseded by. */
+	supersededByDocId?: string | null;
+	/** Slug of the replacement (denormalized for the historical label). */
+	supersededBySlug?: string | null;
+	/** The older decision this one replaces. */
+	supersedesDocId?: string | null;
+	/** One-line rationale rendered alongside the decision in context. */
+	rationale?: string | null;
+}
 
 /**
  * Metadata-only DTO for a KB document.
@@ -34,6 +63,18 @@ export interface KbDocumentDto {
 	updatedAt: string;
 	lastCommitSha: string | null;
 	lastIndexedAt: string | null;
+	/**
+	 * Decision lifecycle state (memory upgrades M4). Non-null only for
+	 * `class === 'decision'` documents. Optional so pre-existing DTO
+	 * producers stay valid — absent means `null`.
+	 */
+	decision?: KbDecisionState | null;
+	/**
+	 * Review state (memory upgrades M7). `'proposed'` = agent-authored /
+	 * synthesized, awaiting human review — excluded from context
+	 * injection. Absent / `null` is treated as `'accepted'`.
+	 */
+	reviewState?: KbReviewState | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Memory-upgrades milestones **M4 + M5 + M7** (build plan 05 §3.2/§3.3-adjacent/§3.7): decisions as a KB class with a platform-side status machine, decision-aware context rendering, and review-gated agent writes.

### M4 — `decision` KB class + status machine + transition endpoint + migration
- `KbDocumentClass` gains `decision` (agent enum + contracts `KB_DOCUMENT_CLASSES` mirror). Reuses the existing class discriminator — no new entity.
- Decision docs carry a nullable `simple-json` `decision` state (`status`, `supersededByDocId`, `supersededBySlug`, `supersedesDocId`, `rationale`) mirroring the `consolidation` marker style.
- **Status machine** (platform-side, transactional — an API call flips it, never an external event): `proposed → accepted → superseded → archived`, `archived` reachable from every non-terminal state, nothing ever moves backwards.
- `POST /api/works/:id/kb/documents/:docId/decision-status` — owner-scoped (`ensureCanEdit`), validates legal transitions (**409** on illegal, **400** for non-decision docs, **404** for a missing superseding doc). Transition to `superseded` writes the chain on both docs — survivor first, so a partial failure degrades to a dangling forward pointer, never a superseded doc without its replacement.
- Guarded migration `1783700000000-AddKbDecisionReviewColumns` (house `hasColumn` pattern, forward-only, idempotent) adds `decision` (text/simple-json) + `review_state` (varchar), both nullable — fully additive, no backfill.

### M5 — decision-aware ranking + per-class rendering in the `<kb>` block
- `resolveContext` now bundles the Work's **accepted** decisions (`bundle.decisions`, additive optional field on `KbContextBundleData`).
- `format()` renders one labelled section — `# Decisions — settled calls; do not reverse without flagging` — with per-doc status prefixes (`## [decision: accepted] … (kb:decision/<slug>)`) and a leading `Rationale:` line when present.
- **Historical labelling:** superseded/archived decisions are excluded from default injection; a direct query hit still serves them, labelled `[decision: superseded — historical; replaced by kb:decision/<slug>]` (replacement slug denormalized at transition time — the archive is never served back as current truth, the replacement is promoted in the label).
- **Ranking:** accepted decisions rank above generic query-retrieved docs (stable partition + section placement); historical decisions are demoted to the tail — demoted, never dropped.
- Doc-authored fields interpolated into the block (replacement slug, rationale) go through the existing `neutralizeKbField` fence hardening.

### M7 — review states
- Creation paths found and gated: `createDocument`/`createOrgDocument` derive `reviewState` from `source` (agent → `proposed`, everything else → `accepted`); covers the transcription path (`source=agent`) and consolidation **synthesis** (now passes `source: agent, reviewState: proposed` explicitly).
- **Injection exclusion:** `proposed` docs are excluded from all three injection paths (always-injected set, decisions section, query retrieval) until accepted — nothing an agent wrote teaches other agents before review (double-learning circuit breaker).
- Review actions: `POST …/:docId/accept` (flips `reviewState`; a still-proposed decision is accepted as current in the same call) + `POST …/:docId/archive` (KB `status=archived` — **never** a physical delete; decision status archived too). Both owner-scoped, idempotent.
- `null` reviewState = accepted, so every pre-existing row and all human-authored docs are unaffected.

### Out of scope (documented follow-up)
- **UI**: decision workbench surfaces (status chips, supersession chain view, review queue on the Memory page — M8) are a follow-up. Only the exhaustive KB class icon map got a `decision` entry to keep web type-check total.
- No create-DTO fields were added (decisions are born `proposed` and transition via the endpoint), so the `forbidNonWhitelisted` e2e rejection pins are untouched.

## Verification (all run locally, foreground)

- `packages/agent` build: `nest build -b swc && tsc -p tsconfig.types.json` → **TSC Found 0 issues**, 1028 files compiled
- `packages/agent` full Jest suite: **374 suites passed, 7000 passed / 2 skipped (7002)** — includes the new `kb-decision-review.service.spec.ts` (**28 tests**: status-machine legal/illegal incl. 409s, injection exclusion for proposed + historical, historical labelling, ranking, agent-created→proposed default, accept/archive flows, bundle ordering/dedup)
- Targeted KB sweep: `jest 'knowledge-base|kb-|memory-consolidation'` → **25 suites / 411 tests passed**
- `pnpm build --filter=ever-works-api` → **14 tasks successful** (contracts + plugin + agent + api)
- `apps/api pnpm generate:openapi` (full-app DI bootstrap gate) → **Wrote OpenAPI spec (425 paths)** — `openapi.json` not committed (gitignored)
- `apps/api` Jest touched suites (`kb`) → **6 passed** (`org-kb.controller.spec`)
- e2e sweep: grepped `apps/web/e2e` for KB endpoint/class pins — the class-enum assertions (`flow-kb-citations`, `flow-kb-document-lifecycle-deep`) all use `toContain`, tolerant to the added enum value → **no breaks expected**

🤖 Generated with [Claude Code](https://claude.com/claude-code)