### PR TITLE
feat(web): onboarding roles + team-size step (Wave 11)

### DIFF
--- a/apps/api/src/onboarding/dto/onboarding-state.dto.spec.ts
+++ b/apps/api/src/onboarding/dto/onboarding-state.dto.spec.ts
@@ -1,0 +1,100 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate, type ValidationError } from 'class-validator';
+
+import { OnboardingStatePatchBodyDto } from './onboarding-state.dto';
+
+/**
+ * Wave 11 — DTO validation for the "What do you do" profile answers on
+ * `PATCH /api/onboarding/state`. Mirrors the global ValidationPipe
+ * posture (whitelist + forbidNonWhitelisted) so the unknown-field
+ * rejection matches what the API actually returns.
+ */
+
+const VALIDATOR_OPTIONS = { whitelist: true, forbidNonWhitelisted: true } as const;
+
+function toDto(body: unknown): OnboardingStatePatchBodyDto {
+    return plainToInstance(OnboardingStatePatchBodyDto, body);
+}
+
+/** Flatten nested ValidationErrors into constraint-message strings. */
+function flattenMessages(errors: ValidationError[]): string[] {
+    const out: string[] = [];
+    for (const error of errors) {
+        if (error.constraints) out.push(...Object.values(error.constraints));
+        if (error.children?.length) out.push(...flattenMessages(error.children));
+    }
+    return out;
+}
+
+describe('OnboardingStatePatchBodyDto — Wave 11 profile', () => {
+    it('accepts a valid profile with roles + teamSize', async () => {
+        const dto = toDto({
+            state: { profile: { roles: ['marketing', 'founder-ceo'], teamSize: 'solo' } },
+        });
+        expect(await validate(dto, VALIDATOR_OPTIONS)).toHaveLength(0);
+    });
+
+    it('accepts a roles-only profile, a teamSize-only profile, and every catalog role at once', async () => {
+        expect(
+            await validate(
+                toDto({ state: { profile: { roles: ['engineering'] } } }),
+                VALIDATOR_OPTIONS,
+            ),
+        ).toHaveLength(0);
+        expect(
+            await validate(
+                toDto({ state: { profile: { teamSize: 'enterprise-200-plus' } } }),
+                VALIDATOR_OPTIONS,
+            ),
+        ).toHaveLength(0);
+        const allRoles = [
+            'founder-ceo',
+            'engineering',
+            'product',
+            'marketing',
+            'sales',
+            'consultant',
+            'research',
+            'operations',
+            'support',
+            'finance',
+            'hr',
+            'legal',
+            'education',
+            'other',
+        ];
+        expect(
+            await validate(toDto({ state: { profile: { roles: allRoles } } }), VALIDATOR_OPTIONS),
+        ).toHaveLength(0);
+    });
+
+    it('rejects unrecognised role ids (drop-if-unrecognised is a read rule; writes 400)', async () => {
+        const errors = await validate(
+            toDto({ state: { profile: { roles: ['marketing', 'astronaut'] } } }),
+            VALIDATOR_OPTIONS,
+        );
+        expect(flattenMessages(errors).join('\n')).toContain('must be one of the following values');
+    });
+
+    it('rejects an unrecognised teamSize id', async () => {
+        const errors = await validate(
+            toDto({ state: { profile: { teamSize: 'galactic' } } }),
+            VALIDATOR_OPTIONS,
+        );
+        expect(flattenMessages(errors).join('\n')).toContain('must be one of the following values');
+    });
+
+    it('rejects non-whitelisted keys inside profile', async () => {
+        const errors = await validate(
+            toDto({ state: { profile: { roles: ['sales'], bogusField: true } } }),
+            VALIDATOR_OPTIONS,
+        );
+        expect(flattenMessages(errors).join('\n')).toContain('should not exist');
+    });
+
+    it('still accepts a patch without profile (additive change)', async () => {
+        const dto = toDto({ state: { lastStep: 3, ai: { choice: 'openrouter' } } });
+        expect(await validate(dto, VALIDATOR_OPTIONS)).toHaveLength(0);
+    });
+});

--- a/apps/api/src/onboarding/dto/onboarding-state.dto.ts
+++ b/apps/api/src/onboarding/dto/onboarding-state.dto.ts
@@ -12,6 +12,7 @@ import {
     Min,
     ValidateNested,
 } from 'class-validator';
+import { ROLE_OPTIONS, TEAM_SIZE_OPTIONS } from '@ever-works/contracts/api';
 import type {
     OnboardingAiChoice,
     OnboardingDbChoice,
@@ -63,6 +64,28 @@ class DbChoicePatchDto {
     @ApiProperty({ enum: DB_CHOICES })
     @IsIn(DB_CHOICES)
     choice!: OnboardingDbChoice;
+}
+
+// Wave 11 — "What do you do" profile answers. Ids come from the typed
+// contract consts so the accepted set can never drift from what the
+// wizard renders. Unknown values are REJECTED (400), never defaulted.
+const ROLE_IDS: readonly string[] = ROLE_OPTIONS.map((option) => option.id);
+const TEAM_SIZE_IDS: readonly string[] = TEAM_SIZE_OPTIONS.map((option) => option.id);
+
+class ProfilePatchDto {
+    @ApiPropertyOptional({ type: [String], enum: ROLE_IDS, isArray: true })
+    @IsOptional()
+    @IsArray()
+    // Multi-select over a fixed catalog — selecting every role is legal,
+    // so the bound is exactly the catalog size (DoS-bounds the column).
+    @ArrayMaxSize(ROLE_IDS.length)
+    @IsIn(ROLE_IDS, { each: true })
+    roles?: string[];
+
+    @ApiPropertyOptional({ enum: TEAM_SIZE_IDS })
+    @IsOptional()
+    @IsIn(TEAM_SIZE_IDS)
+    teamSize?: string;
 }
 
 // `OnboardingStatePatchInnerDto` MUST be declared BEFORE
@@ -127,6 +150,15 @@ export class OnboardingStatePatchInnerDto {
     @IsString()
     @MaxLength(5000)
     prompt?: string;
+
+    // Wave 11 — "What do you do" answers (roles multi-select + team size
+    // single-select). Additive and optional; nested values are validated
+    // against the contract option ids above.
+    @ApiPropertyOptional({ type: ProfilePatchDto })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => ProfilePatchDto)
+    profile?: ProfilePatchDto;
 }
 
 export class OnboardingStatePatchBodyDto {

--- a/apps/api/src/onboarding/onboarding-state.service.spec.ts
+++ b/apps/api/src/onboarding/onboarding-state.service.spec.ts
@@ -139,6 +139,30 @@ describe('OnboardingStateService', () => {
             expect(second.state.prompt).toBe('build me a cafe directory');
             expect(second.state.lastStep).toBe(3);
         });
+
+        // Wave 11 — "What do you do" answers ride the same PATCH path.
+        it('persists profile roles + teamSize and preserves them across later patches', async () => {
+            const first = await svc.patchState('u1', {
+                state: { profile: { roles: ['marketing', 'founder-ceo'], teamSize: 'solo' } },
+            });
+            expect(first.state.profile).toEqual({
+                roles: ['marketing', 'founder-ceo'],
+                teamSize: 'solo',
+            });
+
+            // A later patch without `profile` keeps the persisted value.
+            const second = await svc.patchState('u1', { state: { lastStep: 5 } });
+            expect(second.state.profile).toEqual({
+                roles: ['marketing', 'founder-ceo'],
+                teamSize: 'solo',
+            });
+
+            // A roles-only patch keeps the persisted teamSize (field-level merge).
+            const third = await svc.patchState('u1', {
+                state: { profile: { roles: ['engineering'] } },
+            });
+            expect(third.state.profile).toEqual({ roles: ['engineering'], teamSize: 'solo' });
+        });
     });
 
     describe('markCompleted', () => {
@@ -196,6 +220,43 @@ describe('OnboardingStateService', () => {
             });
             expect(merged.ai.choice).toBe('grok');
             expect(merged.storage.choice).toBe(ONBOARDING_DEFAULT_STATE.storage.choice);
+        });
+
+        // Wave 11 — unknown profile values are DROPPED on read (never
+        // defaulted), matching the account-transfer enum rule.
+        it('normaliseState keeps known profile ids and drops unrecognised ones', () => {
+            const result = __test__.normaliseState({
+                ...ONBOARDING_DEFAULT_STATE,
+                profile: {
+                    roles: ['marketing', 'astronaut', 'sales'],
+                    teamSize: 'galactic',
+                },
+            });
+            expect(result.profile).toEqual({ roles: ['marketing', 'sales'] });
+
+            const empty = __test__.normaliseState({
+                ...ONBOARDING_DEFAULT_STATE,
+                profile: { roles: ['astronaut'], teamSize: 'galactic' },
+            });
+            expect(empty.profile).toBeUndefined();
+
+            const legacy = __test__.normaliseState({ ...ONBOARDING_DEFAULT_STATE });
+            expect(legacy.profile).toBeUndefined();
+        });
+
+        it('mergeState deep-merges profile per field and clears roles via an empty array', () => {
+            const current = __test__.mergeState(ONBOARDING_DEFAULT_STATE, {
+                profile: { roles: ['sales'], teamSize: 'small-2-10' },
+            });
+            expect(current.profile).toEqual({ roles: ['sales'], teamSize: 'small-2-10' });
+
+            const sizeOnly = __test__.mergeState(current, {
+                profile: { teamSize: 'mid-11-50' },
+            });
+            expect(sizeOnly.profile).toEqual({ roles: ['sales'], teamSize: 'mid-11-50' });
+
+            const cleared = __test__.mergeState(current, { profile: { roles: [] } });
+            expect(cleared.profile).toEqual({ teamSize: 'small-2-10' });
         });
 
         // EW-722 (idx 165): prompt round-trips through both helpers; legacy

--- a/apps/api/src/onboarding/onboarding-state.service.ts
+++ b/apps/api/src/onboarding/onboarding-state.service.ts
@@ -2,6 +2,9 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { UserRepository } from '@ever-works/agent/database';
 import {
     ONBOARDING_DEFAULT_STATE,
+    ROLE_OPTIONS,
+    TEAM_SIZE_OPTIONS,
+    type OnboardingProfile,
     type OnboardingStateResponse,
     type OnboardingStatePatchRequest,
     type OnboardingWizardStateV2,
@@ -131,10 +134,19 @@ export class OnboardingStateService {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
+// Wave 11 — known "What do you do" ids. Persisted values outside these
+// sets are DROPPED on read (drop-if-unrecognised, never defaulted), so
+// a stale/foreign payload can't smuggle arbitrary strings back out.
+const KNOWN_ROLE_IDS: ReadonlySet<string> = new Set(ROLE_OPTIONS.map((option) => option.id));
+const KNOWN_TEAM_SIZE_IDS: ReadonlySet<string> = new Set(
+    TEAM_SIZE_OPTIONS.map((option) => option.id),
+);
+
 /** Coerce a possibly-null / legacy payload into a complete v2 state. */
 function normaliseState(raw: OnboardingWizardStateV2 | null | undefined): OnboardingWizardStateV2 {
     if (!raw) return { ...ONBOARDING_DEFAULT_STATE };
 
+    const profile = normaliseProfile(raw.profile);
     return {
         version: 2,
         lastStep: typeof raw.lastStep === 'number' && raw.lastStep >= 0 ? raw.lastStep : 0,
@@ -147,13 +159,46 @@ function normaliseState(raw: OnboardingWizardStateV2 | null | undefined): Onboar
         // EW-722: contract-declared optional `prompt` (EW-617 G4) round-trips
         // when persisted; non-string legacy values are dropped.
         ...(typeof raw.prompt === 'string' ? { prompt: raw.prompt } : {}),
+        // Wave 11 — optional profile answers round-trip after id filtering.
+        ...(profile ? { profile } : {}),
     };
+}
+
+/**
+ * Wave 11 — sanitise a persisted profile blob: keep only known role /
+ * team-size ids, drop everything else. Returns undefined when nothing
+ * valid remains so the field disappears instead of persisting `{}`.
+ */
+function normaliseProfile(
+    raw: OnboardingProfile | null | undefined,
+): OnboardingProfile | undefined {
+    if (!raw || typeof raw !== 'object') return undefined;
+
+    const roles = Array.isArray(raw.roles)
+        ? raw.roles.filter(
+              (role): role is string => typeof role === 'string' && KNOWN_ROLE_IDS.has(role),
+          )
+        : undefined;
+    const teamSize =
+        typeof raw.teamSize === 'string' && KNOWN_TEAM_SIZE_IDS.has(raw.teamSize)
+            ? raw.teamSize
+            : undefined;
+
+    const profile: { roles?: string[]; teamSize?: string } = {};
+    if (roles && roles.length > 0) profile.roles = roles;
+    if (teamSize) profile.teamSize = teamSize;
+    return profile.roles || profile.teamSize ? profile : undefined;
 }
 
 function mergeState(
     current: OnboardingWizardStateV2,
     patch: NonNullable<OnboardingStatePatchRequest['state']>,
 ): OnboardingWizardStateV2 {
+    // Wave 11 — profile deep-merges per field: a patch that only sends
+    // `roles` keeps the persisted `teamSize` (and vice versa); omitting
+    // `profile` entirely keeps the current value. Values arriving here
+    // were already id-validated by `OnboardingStatePatchInnerDto`.
+    const mergedProfile = mergeProfile(current.profile, patch.profile);
     return {
         version: 2,
         lastStep: typeof patch.lastStep === 'number' ? patch.lastStep : current.lastStep,
@@ -178,7 +223,23 @@ function mergeState(
             : typeof current.prompt === 'string'
               ? { prompt: current.prompt }
               : {}),
+        ...(mergedProfile ? { profile: mergedProfile } : {}),
     };
+}
+
+function mergeProfile(
+    current: OnboardingProfile | undefined,
+    patch: OnboardingProfile | undefined,
+): OnboardingProfile | undefined {
+    if (!patch) return current;
+
+    const roles = Array.isArray(patch.roles) ? [...patch.roles] : current?.roles;
+    const teamSize = typeof patch.teamSize === 'string' ? patch.teamSize : current?.teamSize;
+
+    const profile: { roles?: string[]; teamSize?: string } = {};
+    if (roles && roles.length > 0) profile.roles = [...roles];
+    if (teamSize) profile.teamSize = teamSize;
+    return profile.roles || profile.teamSize ? profile : undefined;
 }
 
 function deepEqual(a: OnboardingWizardStateV2, b: OnboardingWizardStateV2): boolean {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -281,6 +281,87 @@
             },
             "skipHint": "You can connect these anytime from Settings → Plugins."
         },
+        "profileStep": {
+            "title": "What do you do",
+            "description": "Tell us about your role and team so we can suggest better starting points — pick as many roles as apply. Nothing is hidden based on your answers.",
+            "rolesLabel": "Your roles",
+            "teamSizeLabel": "Team size",
+            "roles": {
+                "founder-ceo": {
+                    "label": "Founder / CEO",
+                    "description": "I run the company and wear many hats"
+                },
+                "engineering": {
+                    "label": "Engineering",
+                    "description": "I build and ship software"
+                },
+                "product": {
+                    "label": "Product",
+                    "description": "I define what we build and why"
+                },
+                "marketing": {
+                    "label": "Marketing",
+                    "description": "I grow awareness, content, and campaigns"
+                },
+                "sales": {
+                    "label": "Sales",
+                    "description": "I find, pitch, and close customers"
+                },
+                "consultant": {
+                    "label": "Consultant",
+                    "description": "I deliver projects and advice for clients"
+                },
+                "research": {
+                    "label": "Research",
+                    "description": "I investigate, analyze, and synthesize"
+                },
+                "operations": {
+                    "label": "Operations",
+                    "description": "I keep the business running smoothly"
+                },
+                "support": {
+                    "label": "Support",
+                    "description": "I help customers succeed and resolve issues"
+                },
+                "finance": {
+                    "label": "Finance",
+                    "description": "I manage budgets, billing, and reporting"
+                },
+                "hr": {
+                    "label": "HR",
+                    "description": "I hire, onboard, and support our people"
+                },
+                "legal": {
+                    "label": "Legal",
+                    "description": "I handle contracts, compliance, and policy"
+                },
+                "education": {
+                    "label": "Education",
+                    "description": "I teach, train, or create learning content"
+                },
+                "other": {
+                    "label": "Other",
+                    "description": "Something else — tell us more later"
+                }
+            },
+            "teamSizes": {
+                "solo": "Solo",
+                "small-2-10": "Small (2–10)",
+                "mid-11-50": "Mid (11–50)",
+                "large-51-200": "Large (51–200)",
+                "enterprise-200-plus": "Enterprise (200+)"
+            },
+            "suggestions": {
+                "title": "Suggested agents for you",
+                "description": "Based on your roles — create one now, customize it later from Agents.",
+                "create": "Create agent",
+                "creating": "Creating…",
+                "created": "Created",
+                "createdToast": "Agent created — find it under Agents.",
+                "createFailed": "Failed to create the agent. Try again."
+            },
+            "skipHint": "Optional — skip if you'd rather not say. Your answers only improve suggestions and can be changed later."
+        },
         "plugins": {
             "byokDescription": "Connect your own key to unlock the full configuration.",
             "byokDefaultButton": "Bring your own key",

--- a/apps/web/src/app/actions/onboarding/agent-suggestions.ts
+++ b/apps/web/src/app/actions/onboarding/agent-suggestions.ts
@@ -1,0 +1,44 @@
+'use server';
+
+import { agentsAPI, type Agent, type AgentTemplateSummary } from '@/lib/api/agents';
+import type { ActionResult } from '@/app/actions/plugins';
+
+/**
+ * Wave 11 — server actions behind the onboarding ProfileStep's
+ * "suggested agents" block. Thin ActionResult wrappers (discriminated
+ * unions, never thrown errors — Server Actions redact thrown messages
+ * in prod) around the Wave 10 template endpoints:
+ *
+ *   GET  /api/agents/templates            → list the prebuilt catalog
+ *   POST /api/agents/from-template/:slug  → create MY Agent from one
+ *
+ * Both are best-effort for onboarding: the step hides the block when
+ * the list call fails, and surfaces a toast when a create fails. Auth
+ * is enforced by the API tier (same posture as actions/onboarding/state.ts).
+ */
+
+/** List the prebuilt agent-template catalog for client-side role filtering. */
+export async function listAgentTemplatesForOnboarding(): Promise<
+    ActionResult<AgentTemplateSummary[]>
+> {
+    try {
+        const res = await agentsAPI.listTemplates();
+        return { success: true, data: res.data ?? [] };
+    } catch (error) {
+        console.error('Failed to list agent templates for onboarding:', error);
+        return { success: false, error: 'Failed to load agent templates' };
+    }
+}
+
+/** Create the caller's Agent from a prebuilt template (DRAFT + guardrails). */
+export async function createAgentFromTemplateForOnboarding(
+    slug: string,
+): Promise<ActionResult<Agent>> {
+    try {
+        const created = await agentsAPI.createFromTemplate(slug);
+        return { success: true, data: created };
+    } catch (error) {
+        console.error('Failed to create agent from template:', error);
+        return { success: false, error: 'Failed to create the agent' };
+    }
+}

--- a/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/EverWorksOnboardingWizard.tsx
@@ -13,6 +13,7 @@ import { WelcomeStep } from './steps/WelcomeStep';
 import { ChoiceStep } from './steps/ChoiceStep';
 import { ConfigStep } from './steps/ConfigStep';
 import { PluginsCatalogStep } from './steps/PluginsCatalogStep';
+import { ProfileStep } from './steps/ProfileStep';
 import { CommunicationStep } from './steps/CommunicationStep';
 import { CreateWorkStep } from './steps/CreateWorkStep';
 import { useTurnstile } from './use-turnstile';
@@ -497,6 +498,15 @@ function StepBody({
                 />
             );
         }
+        case 'profile':
+            return (
+                <ProfileStep
+                    roles={flow.state.profile?.roles ?? []}
+                    teamSize={flow.state.profile?.teamSize}
+                    onToggleRole={flow.toggleRole}
+                    onSelectTeamSize={flow.setTeamSize}
+                />
+            );
         case 'communication':
             return <CommunicationStep />;
         case 'plugins-catalog':
@@ -654,6 +664,8 @@ function labelForStep(step: WizardStep): string {
             return 'Your deployment';
         case 'deploy-config':
             return 'Configure deployment';
+        case 'profile':
+            return 'What do you do';
         case 'communication':
             return 'Communication';
         case 'plugins-catalog':

--- a/apps/web/src/components/onboarding/profile-suggestions.ts
+++ b/apps/web/src/components/onboarding/profile-suggestions.ts
@@ -1,0 +1,58 @@
+/**
+ * Wave 11 — pure helpers for the ProfileStep's "suggested agents"
+ * block. Kept free of React / server-only imports so both the client
+ * step component and unit tests can use them directly.
+ *
+ * Agent templates (`GET /api/agents/templates`) carry display-cased
+ * `suggestedRoles` hints such as 'Marketing' or 'Founder/CEO'; the
+ * onboarding profile stores kebab-case ROLE_OPTIONS ids such as
+ * 'marketing' or 'founder-ceo'. `normalizeRoleTag` folds both into the
+ * same kebab-case space so the client-side filter can intersect them.
+ */
+
+/** Minimal structural slice of an agent template the suggestions UI needs. */
+export interface SuggestableAgentTemplate {
+    readonly slug: string;
+    readonly name: string;
+    readonly title: string;
+    readonly description: string;
+    readonly suggestedRoles: readonly string[];
+}
+
+/**
+ * Roles whose selection reveals the suggested-agents block. The Wave 10
+ * prebuilt catalog is go-to-market focused, so only these roles have
+ * high-signal matches today; other roles simply see no block.
+ */
+export const SUGGESTION_TRIGGER_ROLES: readonly string[] = ['marketing', 'sales', 'founder-ceo'];
+
+/** Fold a role tag ('Founder/CEO', 'Marketing', 'founder-ceo') to a kebab-case id. */
+export function normalizeRoleTag(tag: string): string {
+    return tag
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+/** True when at least one selected role is a suggestion trigger. */
+export function shouldShowSuggestions(selectedRoles: readonly string[]): boolean {
+    return selectedRoles.some((role) => SUGGESTION_TRIGGER_ROLES.includes(normalizeRoleTag(role)));
+}
+
+/**
+ * Client-side filter: templates whose `suggestedRoles` intersect the
+ * selected roles (after normalisation), capped at `max` (default 3 —
+ * the block shows 2-3 cards). Catalog order is preserved.
+ */
+export function filterSuggestedTemplates<T extends SuggestableAgentTemplate>(
+    templates: readonly T[],
+    selectedRoles: readonly string[],
+    max = 3,
+): T[] {
+    const selected = new Set(selectedRoles.map(normalizeRoleTag));
+    return templates
+        .filter((template) =>
+            template.suggestedRoles.some((role) => selected.has(normalizeRoleTag(role))),
+        )
+        .slice(0, Math.max(0, max));
+}

--- a/apps/web/src/components/onboarding/profile-suggestions.unit.spec.ts
+++ b/apps/web/src/components/onboarding/profile-suggestions.unit.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+    filterSuggestedTemplates,
+    normalizeRoleTag,
+    shouldShowSuggestions,
+    type SuggestableAgentTemplate,
+} from './profile-suggestions';
+
+/**
+ * Wave 11 — the ProfileStep's suggested-agents helpers. The Wave 10
+ * template catalog tags templates with display-cased roles such as
+ * 'Founder/CEO'; the wizard stores kebab-case ROLE_OPTIONS ids such as
+ * 'founder-ceo'. These specs pin the normalisation bridge + filter.
+ */
+
+function template(slug: string, suggestedRoles: string[]): SuggestableAgentTemplate {
+    return {
+        slug,
+        name: slug,
+        title: `${slug} title`,
+        description: `${slug} description`,
+        suggestedRoles,
+    };
+}
+
+const CATALOG: SuggestableAgentTemplate[] = [
+    template('content-marketer', ['Marketing', 'Founder/CEO']),
+    template('seo-auditor', ['Marketing', 'Engineering']),
+    template('lead-researcher', ['Sales', 'Founder/CEO']),
+    template('outreach-drafter', ['Sales']),
+    template('social-scheduler', ['Marketing']),
+    template('competitive-analyst', ['Marketing', 'Product', 'Founder/CEO']),
+];
+
+describe('normalizeRoleTag', () => {
+    it('folds display-cased catalog tags onto kebab-case profile ids', () => {
+        expect(normalizeRoleTag('Founder/CEO')).toBe('founder-ceo');
+        expect(normalizeRoleTag('Marketing')).toBe('marketing');
+        expect(normalizeRoleTag('founder-ceo')).toBe('founder-ceo');
+    });
+});
+
+describe('shouldShowSuggestions', () => {
+    it('is true only when a trigger role (marketing/sales/founder-ceo) is selected', () => {
+        expect(shouldShowSuggestions(['marketing'])).toBe(true);
+        expect(shouldShowSuggestions(['sales', 'engineering'])).toBe(true);
+        expect(shouldShowSuggestions(['founder-ceo'])).toBe(true);
+        expect(shouldShowSuggestions(['engineering', 'legal'])).toBe(false);
+        expect(shouldShowSuggestions([])).toBe(false);
+    });
+});
+
+describe('filterSuggestedTemplates', () => {
+    it('returns templates whose suggestedRoles intersect the selection, capped at 3', () => {
+        const marketing = filterSuggestedTemplates(CATALOG, ['marketing']);
+        expect(marketing.map((t) => t.slug)).toEqual([
+            'content-marketer',
+            'seo-auditor',
+            'social-scheduler',
+        ]);
+        expect(marketing.length).toBeLessThanOrEqual(3);
+    });
+
+    it('matches founder-ceo against display-cased Founder/CEO tags', () => {
+        const founder = filterSuggestedTemplates(CATALOG, ['founder-ceo']);
+        expect(founder.map((t) => t.slug)).toEqual([
+            'content-marketer',
+            'lead-researcher',
+            'competitive-analyst',
+        ]);
+    });
+
+    it('returns an empty list when no selected role matches the catalog', () => {
+        expect(filterSuggestedTemplates(CATALOG, ['legal'])).toEqual([]);
+        expect(filterSuggestedTemplates(CATALOG, [])).toEqual([]);
+    });
+
+    it('honours a custom cap', () => {
+        expect(filterSuggestedTemplates(CATALOG, ['marketing'], 2)).toHaveLength(2);
+        expect(filterSuggestedTemplates(CATALOG, ['marketing'], 0)).toEqual([]);
+    });
+});

--- a/apps/web/src/components/onboarding/steps/ProfileStep.tsx
+++ b/apps/web/src/components/onboarding/steps/ProfileStep.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Check, Loader2, Plus, Sparkles } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { ROLE_OPTIONS, TEAM_SIZE_OPTIONS } from '@ever-works/contracts/api';
+import {
+    filterSuggestedTemplates,
+    shouldShowSuggestions,
+    type SuggestableAgentTemplate,
+} from '../profile-suggestions';
+import {
+    createAgentFromTemplateForOnboarding,
+    listAgentTemplatesForOnboarding,
+} from '@/app/actions/onboarding/agent-suggestions';
+
+export interface ProfileStepProps {
+    /** Currently selected role ids (kebab-case ROLE_OPTIONS ids). */
+    readonly roles: readonly string[];
+    /** Currently selected team-size id, if any. */
+    readonly teamSize?: string;
+    readonly onToggleRole: (roleId: string) => void;
+    readonly onSelectTeamSize: (teamSizeId: string) => void;
+}
+
+/**
+ * Wave 11 — "What do you do" onboarding step. Multi-select role cards
+ * (selecting several or all is fine) + single-select team-size pills.
+ * Selections are suggestion hints only — nothing is gated on them —
+ * and persist through the same wizard-state save path as every other
+ * step. Always skippable via the wizard footer.
+ *
+ * When the selected roles include a go-to-market trigger role, a
+ * best-effort "suggested agents" block appears with 2-3 prebuilt
+ * templates from `GET /api/agents/templates` (filtered client-side by
+ * `suggestedRoles`) and a one-click Create agent affordance calling
+ * `POST /api/agents/from-template/:slug`. The block hides itself when
+ * the catalog fetch fails.
+ */
+export function ProfileStep({ roles, teamSize, onToggleRole, onSelectTeamSize }: ProfileStepProps) {
+    const t = useTranslations('onboarding.profileStep');
+
+    return (
+        <div className="space-y-6 max-w-3xl">
+            <header>
+                <h3 className="text-lg font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h3>
+                <p className="mt-1 text-sm text-text-muted dark:text-text-muted-dark">
+                    {t('description')}
+                </p>
+            </header>
+
+            <section>
+                <h4 className="text-sm font-semibold text-text dark:text-text-dark mb-2">
+                    {t('rolesLabel')}
+                </h4>
+                <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                    {ROLE_OPTIONS.map((role) => {
+                        const selected = roles.includes(role.id);
+                        return (
+                            <button
+                                key={role.id}
+                                type="button"
+                                aria-pressed={selected}
+                                data-testid={`onboarding-profile-role-${role.id}`}
+                                onClick={() => onToggleRole(role.id)}
+                                className={cn(
+                                    'group relative w-full text-left rounded-xl border bg-surface dark:bg-surface-dark p-3 transition-all',
+                                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                                    'cursor-pointer hover:border-primary/40 hover:bg-surface-secondary/40 dark:hover:bg-white/5',
+                                    selected
+                                        ? 'border-primary ring-1 ring-primary/40 shadow-sm'
+                                        : 'border-border dark:border-border-dark',
+                                )}
+                            >
+                                <div className="flex items-center justify-between gap-2">
+                                    <span className="text-sm font-semibold text-text dark:text-text-dark truncate">
+                                        {t(`roles.${role.id}.label`)}
+                                    </span>
+                                    {selected ? (
+                                        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary text-white">
+                                            <Check className="h-3 w-3" />
+                                        </span>
+                                    ) : null}
+                                </div>
+                                <p className="mt-1 text-xs text-text-muted dark:text-text-muted-dark leading-relaxed">
+                                    {t(`roles.${role.id}.description`)}
+                                </p>
+                            </button>
+                        );
+                    })}
+                </div>
+            </section>
+
+            <section>
+                <h4 className="text-sm font-semibold text-text dark:text-text-dark mb-2">
+                    {t('teamSizeLabel')}
+                </h4>
+                <div className="flex flex-wrap gap-2" role="group" aria-label={t('teamSizeLabel')}>
+                    {TEAM_SIZE_OPTIONS.map((size) => {
+                        const selected = teamSize === size.id;
+                        return (
+                            <button
+                                key={size.id}
+                                type="button"
+                                aria-pressed={selected}
+                                data-testid={`onboarding-profile-team-size-${size.id}`}
+                                onClick={() => onSelectTeamSize(size.id)}
+                                className={cn(
+                                    'inline-flex items-center gap-1.5 rounded-full border px-3.5 py-1.5 text-sm transition-all',
+                                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+                                    selected
+                                        ? 'border-primary bg-primary text-white font-medium'
+                                        : 'border-border dark:border-border-dark text-text-secondary dark:text-text-secondary-dark hover:border-primary/40 hover:bg-surface-secondary/40 dark:hover:bg-white/5',
+                                )}
+                            >
+                                {selected ? <Check className="h-3.5 w-3.5" /> : null}
+                                {t(`teamSizes.${size.id}`)}
+                            </button>
+                        );
+                    })}
+                </div>
+            </section>
+
+            <SuggestedAgents roles={roles} />
+
+            <p className="text-xs text-text-muted dark:text-text-muted-dark">{t('skipHint')}</p>
+        </div>
+    );
+}
+
+// ─── Suggested agents (best-effort) ─────────────────────────────────────────
+
+function SuggestedAgents({ roles }: { readonly roles: readonly string[] }) {
+    const t = useTranslations('onboarding.profileStep.suggestions');
+    const show = shouldShowSuggestions(roles);
+
+    const [templates, setTemplates] = useState<SuggestableAgentTemplate[] | null>(null);
+    const [failed, setFailed] = useState(false);
+    const [creating, setCreating] = useState<string | null>(null);
+    const [created, setCreated] = useState<readonly string[]>([]);
+
+    // Fetch the catalog once, lazily, the first time a trigger role is
+    // selected. Best-effort: a failed fetch marks the block hidden for
+    // the rest of the wizard session (no retry storm mid-onboarding).
+    useEffect(() => {
+        if (!show || failed || templates !== null) return;
+        let cancelled = false;
+        void listAgentTemplatesForOnboarding().then((result) => {
+            if (cancelled) return;
+            if (result.success && result.data) {
+                setTemplates(result.data);
+            } else {
+                setFailed(true);
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [show, failed, templates]);
+
+    if (!show || failed || templates === null) return null;
+
+    const suggested = filterSuggestedTemplates(templates, roles);
+    if (suggested.length === 0) return null;
+
+    const handleCreate = async (slug: string) => {
+        setCreating(slug);
+        try {
+            const result = await createAgentFromTemplateForOnboarding(slug);
+            if (result.success) {
+                setCreated((prev) => (prev.includes(slug) ? prev : [...prev, slug]));
+                toast.success(t('createdToast'));
+            } else {
+                toast.error(result.error ?? t('createFailed'));
+            }
+        } finally {
+            setCreating(null);
+        }
+    };
+
+    return (
+        <section data-testid="onboarding-profile-suggestions">
+            <h4 className="flex items-center gap-1.5 text-sm font-semibold text-text dark:text-text-dark mb-1">
+                <Sparkles className="h-4 w-4" />
+                {t('title')}
+            </h4>
+            <p className="text-xs text-text-muted dark:text-text-muted-dark mb-2">
+                {t('description')}
+            </p>
+            <div className="space-y-2">
+                {suggested.map((template) => {
+                    const isCreated = created.includes(template.slug);
+                    const isCreating = creating === template.slug;
+                    return (
+                        <div
+                            key={template.slug}
+                            className="rounded-lg border border-border dark:border-border-dark bg-surface dark:bg-surface-dark p-3"
+                        >
+                            <div className="flex items-start justify-between gap-3">
+                                <div className="min-w-0 flex-1">
+                                    <p className="text-sm font-semibold text-text dark:text-text-dark truncate">
+                                        {template.name}
+                                        <span className="ml-2 font-normal text-xs text-text-muted dark:text-text-muted-dark">
+                                            {template.title}
+                                        </span>
+                                    </p>
+                                    <p className="mt-1 text-xs text-text-muted dark:text-text-muted-dark leading-relaxed line-clamp-2">
+                                        {template.description}
+                                    </p>
+                                </div>
+                                <Button
+                                    size="sm"
+                                    variant="secondary"
+                                    disabled={isCreated || isCreating}
+                                    data-testid={`onboarding-profile-suggestion-create-${template.slug}`}
+                                    onClick={() => void handleCreate(template.slug)}
+                                >
+                                    {isCreated ? (
+                                        <>
+                                            <Check className="mr-1.5 h-3.5 w-3.5" />
+                                            {t('created')}
+                                        </>
+                                    ) : isCreating ? (
+                                        <>
+                                            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                                            {t('creating')}
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Plus className="mr-1.5 h-3.5 w-3.5" />
+                                            {t('create')}
+                                        </>
+                                    )}
+                                </Button>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+        </section>
+    );
+}

--- a/apps/web/src/components/onboarding/useOnboardingFlow.ts
+++ b/apps/web/src/components/onboarding/useOnboardingFlow.ts
@@ -24,6 +24,7 @@ export type WizardStepKind =
     | 'db-choice'
     | 'deploy-choice'
     | 'deploy-config'
+    | 'profile'
     | 'communication'
     | 'plugins-catalog'
     | 'create-work';
@@ -57,6 +58,10 @@ export function computeStepList(state: OnboardingWizardStateV2): WizardStep[] {
     if (state.deploy.choice === 'vercel' || state.deploy.choice === 'k8s') {
         steps.push({ kind: 'deploy-config', id: `deploy-config:${state.deploy.choice}` });
     }
+    // Profile — Wave 11 "What do you do" (roles + team size). Slotted
+    // after the provider choices and before Communication; always
+    // shown, always skippable — selections are suggestion hints only.
+    steps.push({ kind: 'profile', id: 'profile' });
     // Communication — connect the chat workspaces the org lives in
     // (Slack now, Discord next). Always shown, always skippable.
     steps.push({ kind: 'communication', id: 'communication' });
@@ -83,6 +88,8 @@ type FlowAction =
     | { type: 'setDbChoice'; value: OnboardingDbChoice }
     | { type: 'setDeployChoice'; value: OnboardingDeployChoice }
     | { type: 'setPrompt'; value: string }
+    | { type: 'toggleRole'; value: string }
+    | { type: 'setTeamSize'; value: string }
     | { type: 'recordSkip'; stepId: string }
     | { type: 'setPluginsReviewed'; value: boolean }
     | { type: 'mergeServerState'; value: OnboardingWizardStateV2 }
@@ -153,6 +160,31 @@ function reduce(state: FlowReducerState, action: FlowAction): FlowReducerState {
                     prompt: action.value.trim() || undefined,
                 },
             };
+        case 'toggleRole': {
+            // Wave 11 — multi-select role cards. Toggling an already-selected
+            // role removes it; anything else appends. Order = click order.
+            const current = state.state.profile?.roles ?? [];
+            const roles = current.includes(action.value)
+                ? current.filter((role) => role !== action.value)
+                : [...current, action.value];
+            return {
+                ...state,
+                state: {
+                    ...state.state,
+                    profile: { ...state.state.profile, roles },
+                },
+            };
+        }
+        case 'setTeamSize':
+            // Wave 11 — single-select team-size pills (no unselect: picking
+            // another pill replaces the previous one).
+            return {
+                ...state,
+                state: {
+                    ...state.state,
+                    profile: { ...state.state.profile, teamSize: action.value },
+                },
+            };
         case 'recordSkip': {
             if (state.state.skippedSteps.includes(action.stepId)) return state;
             return {
@@ -211,6 +243,8 @@ export interface UseOnboardingFlowResult {
     readonly setDeployChoice: (value: OnboardingDeployChoice) => void;
     readonly setPluginsReviewed: (value: boolean) => void;
     readonly setPrompt: (value: string) => void;
+    readonly toggleRole: (value: string) => void;
+    readonly setTeamSize: (value: string) => void;
     readonly goNext: () => void;
     readonly goBack: () => void;
     readonly skip: () => void;
@@ -337,6 +371,22 @@ export function useOnboardingFlow({
         [trackEvent],
     );
 
+    const toggleRole = useCallback(
+        (value: string) => {
+            trackEvent('onboarding_profile_role_toggled', { role: value });
+            dispatch({ type: 'toggleRole', value });
+        },
+        [trackEvent],
+    );
+
+    const setTeamSize = useCallback(
+        (value: string) => {
+            trackEvent('onboarding_profile_team_size_selected', { teamSize: value });
+            dispatch({ type: 'setTeamSize', value });
+        },
+        [trackEvent],
+    );
+
     const refresh = useCallback(() => {
         const stepKind = currentStep?.kind ?? 'welcome';
         trackEvent('onboarding_plugin_refresh_clicked', { stepKind });
@@ -388,6 +438,8 @@ export function useOnboardingFlow({
         setDeployChoice,
         setPluginsReviewed,
         setPrompt,
+        toggleRole,
+        setTeamSize,
         goNext,
         goBack,
         skip,
@@ -400,7 +452,8 @@ export function useOnboardingFlow({
 
 function stripVersion(state: OnboardingWizardStateV2) {
     // The patch endpoint deep-merges by field; `version` is server-managed.
-    const { lastStep, ai, storage, db, deploy, skippedSteps, pluginsReviewed, prompt } = state;
+    const { lastStep, ai, storage, db, deploy, skippedSteps, pluginsReviewed, prompt, profile } =
+        state;
     return {
         lastStep,
         ai: { choice: ai.choice },
@@ -410,6 +463,15 @@ function stripVersion(state: OnboardingWizardStateV2) {
         skippedSteps: [...skippedSteps],
         pluginsReviewed,
         ...(prompt ? { prompt } : {}),
+        // Wave 11 — profile rides the same save path as every other field.
+        ...(profile
+            ? {
+                  profile: {
+                      ...(profile.roles ? { roles: [...profile.roles] } : {}),
+                      ...(profile.teamSize ? { teamSize: profile.teamSize } : {}),
+                  },
+              }
+            : {}),
     };
 }
 

--- a/apps/web/src/components/onboarding/useOnboardingFlow.unit.spec.ts
+++ b/apps/web/src/components/onboarding/useOnboardingFlow.unit.spec.ts
@@ -19,7 +19,7 @@ function initialReducerState() {
 }
 
 describe('computeStepList', () => {
-    it('returns the minimal 8-step list when every choice is the Ever Works default', () => {
+    it('returns the minimal 9-step list when every choice is the Ever Works default', () => {
         const list = computeStepList(ONBOARDING_DEFAULT_STATE);
         expect(list.map((s) => s.kind)).toEqual([
             'welcome',
@@ -27,6 +27,7 @@ describe('computeStepList', () => {
             'storage-choice',
             'db-choice',
             'deploy-choice',
+            'profile',
             'communication',
             'plugins-catalog',
             'create-work',
@@ -62,7 +63,7 @@ describe('computeStepList', () => {
         );
     });
 
-    it('builds the full 11-step list when every BYOK is chosen', () => {
+    it('builds the full 12-step list when every BYOK is chosen', () => {
         const list = computeStepList(
             defaultsWith({
                 ai: { choice: 'claude-code' },
@@ -70,7 +71,7 @@ describe('computeStepList', () => {
                 deploy: { choice: 'vercel' },
             }),
         );
-        expect(list).toHaveLength(11);
+        expect(list).toHaveLength(12);
         expect(list.map((s) => s.kind)).toEqual([
             'welcome',
             'ai-choice',
@@ -80,16 +81,31 @@ describe('computeStepList', () => {
             'db-choice',
             'deploy-choice',
             'deploy-config',
+            'profile',
             'communication',
             'plugins-catalog',
             'create-work',
         ]);
     });
 
-    it('always inserts the Communication step between deployment and the plugins catalog', () => {
+    it('always inserts the Communication step between the profile step and the plugins catalog', () => {
         const kinds = computeStepList(ONBOARDING_DEFAULT_STATE).map((s) => s.kind);
         expect(kinds.indexOf('communication')).toBeGreaterThan(kinds.indexOf('deploy-choice'));
         expect(kinds.indexOf('communication')).toBe(kinds.indexOf('plugins-catalog') - 1);
+    });
+
+    // Wave 11 — the "What do you do" step is always present, after the
+    // provider choice/config steps and immediately before Communication.
+    it('always inserts the profile step immediately before Communication', () => {
+        const minimal = computeStepList(ONBOARDING_DEFAULT_STATE).map((s) => s.kind);
+        expect(minimal.indexOf('profile')).toBeGreaterThan(minimal.indexOf('deploy-choice'));
+        expect(minimal.indexOf('profile')).toBe(minimal.indexOf('communication') - 1);
+
+        const full = computeStepList(defaultsWith({ deploy: { choice: 'vercel' } })).map(
+            (s) => s.kind,
+        );
+        expect(full.indexOf('profile')).toBe(full.indexOf('deploy-config') + 1);
+        expect(full.indexOf('profile')).toBe(full.indexOf('communication') - 1);
     });
 
     it('encodes the chosen vendor into the step id so React keys stay stable across rechooses', () => {
@@ -185,6 +201,55 @@ describe('reduce', () => {
 
         const cleared = reduce(set, { type: 'setPrompt', value: '   ' });
         expect(cleared.state.prompt).toBeUndefined();
+    });
+
+    // Wave 11 — "What do you do" reducer coverage.
+    it('toggleRole appends a role to the profile', () => {
+        const next = reduce(initialReducerState(), { type: 'toggleRole', value: 'marketing' });
+        expect(next.state.profile?.roles).toEqual(['marketing']);
+    });
+
+    it('toggleRole removes an already-selected role on the second toggle', () => {
+        const first = reduce(initialReducerState(), { type: 'toggleRole', value: 'marketing' });
+        const second = reduce(first, { type: 'toggleRole', value: 'engineering' });
+        const removed = reduce(second, { type: 'toggleRole', value: 'marketing' });
+        expect(second.state.profile?.roles).toEqual(['marketing', 'engineering']);
+        expect(removed.state.profile?.roles).toEqual(['engineering']);
+    });
+
+    it('selecting several (or all) roles is allowed', () => {
+        const all = ['founder-ceo', 'engineering', 'product', 'marketing', 'sales'];
+        const next = all.reduce(
+            (acc, role) => reduce(acc, { type: 'toggleRole', value: role }),
+            initialReducerState(),
+        );
+        expect(next.state.profile?.roles).toEqual(all);
+    });
+
+    it('setTeamSize sets and replaces the single-select team size', () => {
+        const solo = reduce(initialReducerState(), { type: 'setTeamSize', value: 'solo' });
+        expect(solo.state.profile?.teamSize).toBe('solo');
+        const mid = reduce(solo, { type: 'setTeamSize', value: 'mid-11-50' });
+        expect(mid.state.profile?.teamSize).toBe('mid-11-50');
+    });
+
+    it('toggleRole preserves the team size and setTeamSize preserves the roles', () => {
+        const withSize = reduce(initialReducerState(), { type: 'setTeamSize', value: 'solo' });
+        const withRole = reduce(withSize, { type: 'toggleRole', value: 'sales' });
+        expect(withRole.state.profile).toEqual({ teamSize: 'solo', roles: ['sales'] });
+
+        const resized = reduce(withRole, { type: 'setTeamSize', value: 'small-2-10' });
+        expect(resized.state.profile).toEqual({ teamSize: 'small-2-10', roles: ['sales'] });
+    });
+
+    it('profile survives unrelated actions (provider choices, skips)', () => {
+        const withProfile = reduce(
+            reduce(initialReducerState(), { type: 'toggleRole', value: 'marketing' }),
+            { type: 'setTeamSize', value: 'solo' },
+        );
+        const afterAi = reduce(withProfile, { type: 'setAiChoice', value: 'openrouter' });
+        const afterSkip = reduce(afterAi, { type: 'recordSkip', stepId: 'profile' });
+        expect(afterSkip.state.profile).toEqual({ roles: ['marketing'], teamSize: 'solo' });
     });
 
     it('mergeServerState replaces state and clamps the current step index', () => {

--- a/apps/web/src/lib/api/agents.ts
+++ b/apps/web/src/lib/api/agents.ts
@@ -249,6 +249,24 @@ export interface AgentImportResult {
     finalSlug: string;
 }
 
+/**
+ * Wave 10 prebuilt agent-template catalog row as served by
+ * `GET /api/agents/templates` (in-code marketing/sales/ops presets).
+ * Wave 11 consumes `suggestedRoles` to surface 2-3 suggestions on the
+ * onboarding "What do you do" step.
+ */
+export interface AgentTemplateSummary {
+    slug: string;
+    name: string;
+    title: string;
+    category: string;
+    description: string;
+    capabilities: string;
+    suggestedSkills: string[];
+    suggestedPipeline: string | null;
+    suggestedRoles: string[];
+}
+
 function buildQuery(q: ListAgentsQuery = {}): string {
     const params = new URLSearchParams();
     if (q.scope) params.set('scope', q.scope);
@@ -274,6 +292,27 @@ export const agentsAPI = {
         } catch {
             return null;
         }
+    },
+
+    /** Wave 10 — list the prebuilt agent-template catalog. */
+    async listTemplates(): Promise<{ data: AgentTemplateSummary[] }> {
+        return serverFetch<{ data: AgentTemplateSummary[] }>('/agents/templates', {
+            method: 'GET',
+        });
+    },
+
+    /**
+     * Wave 10 — create MY Agent from a prebuilt template (DRAFT,
+     * review-before-act guardrails). Body fields are optional placement
+     * overrides; the onboarding suggestion flow passes none.
+     */
+    async createFromTemplate(slug: string): Promise<Agent> {
+        return serverMutation<Agent>({
+            endpoint: `/agents/from-template/${encodeURIComponent(slug)}`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
     },
 
     async create(input: CreateAgentInput): Promise<Agent> {

--- a/packages/contracts/src/api/onboarding/index.ts
+++ b/packages/contracts/src/api/onboarding/index.ts
@@ -38,6 +38,10 @@ export type {
 	OnboardingCatalogResponse,
 	OnboardingCard,
 	OnboardingCardBadge,
-	OnboardingPluginCard
+	OnboardingPluginCard,
+	OnboardingProfile,
+	OnboardingProfileOption,
+	OnboardingRoleId,
+	OnboardingTeamSizeId
 } from './wizard-state.js';
-export { ONBOARDING_DEFAULT_STATE } from './wizard-state.js';
+export { ONBOARDING_DEFAULT_STATE, ROLE_OPTIONS, TEAM_SIZE_OPTIONS } from './wizard-state.js';

--- a/packages/contracts/src/api/onboarding/wizard-state.ts
+++ b/packages/contracts/src/api/onboarding/wizard-state.ts
@@ -20,6 +20,66 @@ export type OnboardingDbChoice = 'ever-works-db' | 'custom';
 
 export type OnboardingDeployChoice = 'ever-works' | 'vercel' | 'k8s';
 
+/**
+ * Wave 11 — "What do you do" onboarding step. A generic option row:
+ * stable kebab-case id + English display label + one-line description.
+ * The web wizard renders these through i18n keys keyed by `id`; the
+ * label/description here are the canonical English fallback used by
+ * non-web surfaces (desktop embeds, API docs).
+ */
+export interface OnboardingProfileOption<Id extends string = string> {
+	readonly id: Id;
+	readonly label: string;
+	readonly description: string;
+}
+
+/**
+ * Roles for the "What do you do" step (multi-select — picking several
+ * or all is fine). Selections are hints for suggestion surfaces, never
+ * gates: nothing is hidden based on them.
+ */
+export const ROLE_OPTIONS = [
+	{ id: 'founder-ceo', label: 'Founder / CEO', description: 'I run the company and wear many hats' },
+	{ id: 'engineering', label: 'Engineering', description: 'I build and ship software' },
+	{ id: 'product', label: 'Product', description: 'I define what we build and why' },
+	{ id: 'marketing', label: 'Marketing', description: 'I grow awareness, content, and campaigns' },
+	{ id: 'sales', label: 'Sales', description: 'I find, pitch, and close customers' },
+	{ id: 'consultant', label: 'Consultant', description: 'I deliver projects and advice for clients' },
+	{ id: 'research', label: 'Research', description: 'I investigate, analyze, and synthesize' },
+	{ id: 'operations', label: 'Operations', description: 'I keep the business running smoothly' },
+	{ id: 'support', label: 'Support', description: 'I help customers succeed and resolve issues' },
+	{ id: 'finance', label: 'Finance', description: 'I manage budgets, billing, and reporting' },
+	{ id: 'hr', label: 'HR', description: 'I hire, onboard, and support our people' },
+	{ id: 'legal', label: 'Legal', description: 'I handle contracts, compliance, and policy' },
+	{ id: 'education', label: 'Education', description: 'I teach, train, or create learning content' },
+	{ id: 'other', label: 'Other', description: 'Something else — tell us more later' }
+] as const satisfies readonly OnboardingProfileOption[];
+
+export type OnboardingRoleId = (typeof ROLE_OPTIONS)[number]['id'];
+
+/** Team size for the "What do you do" step (single-select). */
+export const TEAM_SIZE_OPTIONS = [
+	{ id: 'solo', label: 'Solo', description: 'Just me' },
+	{ id: 'small-2-10', label: 'Small (2–10)', description: '2–10 people' },
+	{ id: 'mid-11-50', label: 'Mid (11–50)', description: '11–50 people' },
+	{ id: 'large-51-200', label: 'Large (51–200)', description: '51–200 people' },
+	{ id: 'enterprise-200-plus', label: 'Enterprise (200+)', description: 'More than 200 people' }
+] as const satisfies readonly OnboardingProfileOption[];
+
+export type OnboardingTeamSizeId = (typeof TEAM_SIZE_OPTIONS)[number]['id'];
+
+/**
+ * Wave 11 — persisted answers of the "What do you do" step. Values are
+ * plain strings (not the narrowed id unions) so older clients keep
+ * round-tripping payloads written by newer ones; consumers validate
+ * against ROLE_OPTIONS / TEAM_SIZE_OPTIONS and DROP unrecognised values
+ * (never default them).
+ */
+export interface OnboardingProfile {
+	readonly roles?: readonly string[];
+	readonly teamSize?: string;
+}
+
 export interface OnboardingWizardStateV2 {
 	readonly version: 2;
 	readonly lastStep: number;
@@ -36,6 +96,8 @@ export interface OnboardingWizardStateV2 {
 	 * same 5000-char limit as `CreateItemsGeneratorDto.prompt`.
 	 */
 	readonly prompt?: string;
+	/** Wave 11 — optional "What do you do" answers (roles + team size). */
+	readonly profile?: OnboardingProfile;
 }
 
 /** Wire shape of `GET /api/onboarding/state`. */
@@ -66,6 +128,15 @@ export interface OnboardingStatePatchRequest {
 		readonly pluginsReviewed: boolean;
 		/** Max 5 000 chars — enforced by `@MaxLength(5000)` in the server DTO. */
 		readonly prompt: string;
+		/**
+		 * Wave 11 — "What do you do" answers. `roles` entries are validated
+		 * server-side against ROLE_OPTIONS ids, `teamSize` against
+		 * TEAM_SIZE_OPTIONS ids (unknown values are rejected with 400).
+		 */
+		readonly profile: {
+			readonly roles?: readonly string[];
+			readonly teamSize?: string;
+		};
 	}>;
 }
 


### PR DESCRIPTION
## Summary

Wave 11 slice (Desktop epic, web-side): the **"What do you do"** onboarding step — multi-select role cards + single-select team-size pills — per the desktop-app PRD §5. Neutral rule respected: no third-party product names anywhere in the step.

### Contracts (`@ever-works/contracts`)
- `OnboardingWizardStateV2` extended **additively** with `profile?: { roles?: string[]; teamSize?: string }` (+ `OnboardingStatePatchRequest.state.profile`).
- New typed consts: `ROLE_OPTIONS` (14 roles — founder-ceo, engineering, product, marketing, sales, consultant, research, operations, support, finance, hr, legal, education, other — each with a one-line description) and `TEAM_SIZE_OPTIONS` (solo, small-2-10, mid-11-50, large-51-200, enterprise-200-plus), plus `OnboardingRoleId` / `OnboardingTeamSizeId` / `OnboardingProfile` types.

### Web
- New `ProfileStep` (multi-select role cards with descriptions — selecting several or all is fine; team-size pills), slotted in `computeStepList` after the provider choice/config steps and **immediately before Communication**, mirroring how the Communication step was integrated. Always shown, always skippable, persists through the existing wizard-state PATCH save path (`stripVersion` → `patchOnboardingState`).
- **Template suggestions tie-in**: when selected roles include marketing / sales / founder-ceo, a best-effort block on the step shows up to 3 prebuilt agent templates (`GET /api/agents/templates`, filtered client-side by `suggestedRoles` with display-case → kebab-case normalisation, e.g. `Founder/CEO` → `founder-ceo`) with a one-click **Create agent** affordance (`POST /api/agents/from-template/:slug`). The block hides itself when the catalog fetch fails.
- New server actions (`app/actions/onboarding/agent-suggestions.ts`) return discriminated-union `ActionResult`s (no thrown-message branching — prod redacts Server-Action errors); `agentsAPI` gained `listTemplates()` / `createFromTemplate(slug)`.
- i18n keys under `onboarding.profileStep` in `apps/web/messages/en.json` (same en-only pattern as the Communication step).

### API
- `PATCH /api/onboarding/state`: `OnboardingStatePatchInnerDto` extended additively with a validated nested `ProfilePatchDto` — `roles` `@IsIn(ROLE_OPTIONS ids, { each: true })` + `@ArrayMaxSize(14)`, `teamSize` `@IsIn(TEAM_SIZE_OPTIONS ids)`. Unknown values are **rejected (400)**, unknown keys still hit `forbidNonWhitelisted`.
- `OnboardingStateService`: field-level `profile` deep-merge on write; **drop-if-unrecognised** (never default) id filtering on read.
- No entity/schema change (`users.onboarding_state` is `simple-json`) → no migration needed.
- E2e whitelist sweep for the endpoint: all 7 specs touching `/api/onboarding/state` reviewed — unknown-field rejections use `bogusField`, no spec patches or asserts `profile`, no exact-shape state assertions → **no breaks expected**.

### Tests (22 new, all green)
- `useOnboardingFlow.unit.spec.ts`: +7 (step placement incl. deploy-config variant, toggle add/remove, select-all, team-size replace, cross-field preservation, survival across unrelated actions) + 2 step-count updates.
- `profile-suggestions.unit.spec.ts` (new): 6 specs pinning role normalisation, trigger gating, and the intersect-and-cap filter.
- `onboarding-state.service.spec.ts`: +3 (PATCH round-trip + field-level merge, drop-unrecognised on read, roles-clear via empty array).
- `onboarding-state.dto.spec.ts` (new): 6 specs (valid shapes incl. all-14-roles, unknown role/teamSize → 400, non-whitelisted key → "should not exist", additive no-profile patch).

## Verification (all run locally, foreground)

- `pnpm build --filter=@ever-works/contracts` → `Tasks: 1 successful, 1 total` (tsup + DTS clean)
- `pnpm --filter @ever-works/contracts test` → `Test Files 6 passed (6) · Tests 185 passed (185) · Type Errors no errors`
- `apps/web npx tsc --noEmit` → **0 errors from this change**. 11 pre-existing errors on `wave/integration` (all `kb.classes.decision` message-key errors in KB components from the wave5/decisions merge — verified present with this branch's diff stashed; not touched here).
- `apps/web npx vitest run useOnboardingFlow.unit.spec.ts profile-suggestions.unit.spec.ts` → `Test Files 2 passed (2) · Tests 36 passed (36)`
- `apps/api npx jest --testPathPattern 'onboarding-state'` → `Test Suites: 2 passed, 2 total · Tests: 22 passed, 22 total`
- `pnpm build --filter=ever-works-api` → `Tasks: 14 successful, 14 total`
- `apps/api pnpm generate:openapi` (full-app bootstrap gate) → `Wrote OpenAPI spec (425 paths)`, `ProfilePatchDto` present in output (openapi.json is untracked; not committed)
- `npx eslint` over all touched web files → clean
- Prettier run over every touched file → no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)