### PR TITLE
feat(agent): Meetings v1 (Wave 8)

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -53,6 +53,7 @@ import { TeamsModule } from './teams/teams.module';
 import { SchedulesModule } from './schedules/schedules.module';
 import { InboundTriggersModule } from './triggers/inbound-triggers.module';
 import { IngestModule } from './ingest/ingest.module';
+import { MeetingsApiModule } from './meetings/meetings.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
 import { UsersModule } from './users/users.module';
 import { ScopeModule } from './scope/scope.module';
@@ -193,6 +194,11 @@ import { DatabaseModule } from '@ever-works/agent/database';
         // surface over the agent-side EventIngestModule (dedupe-insert +
         // Activity/Memory fan-out; pull rides the event-ingest-tick cron).
         IngestModule,
+        // Meetings v1 (Wave 8, feature a) — /api/meetings CRUD +
+        // transcript capture over the agent-side MeetingsModule; also
+        // boots the zoom.recording envelope→Meeting processor on the
+        // ingest spine.
+        MeetingsApiModule,
         TelemetryModule,
         FunnelAnalyticsBindingModule,
         UploadsModule,

--- a/apps/api/src/meetings/dto/meeting.dto.ts
+++ b/apps/api/src/meetings/dto/meeting.dto.ts
@@ -1,0 +1,164 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+    IsArray,
+    IsDateString,
+    IsIn,
+    IsOptional,
+    IsString,
+    IsUUID,
+    MaxLength,
+    MinLength,
+    ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import type { MeetingSource } from '@ever-works/agent/meetings';
+import { MEETING_TRANSCRIPT_MAX_CHARS } from '@ever-works/agent/meetings';
+
+const MEETING_SOURCES: MeetingSource[] = ['zoom', 'google-meet', 'manual', 'import'];
+
+/** One roster entry — provider rosters vary, so this stays minimal. */
+export class MeetingParticipantDto {
+    @ApiProperty({ minLength: 1, maxLength: 200 })
+    @IsString()
+    @MinLength(1)
+    @MaxLength(200)
+    name: string;
+
+    @ApiProperty({ required: false, maxLength: 320 })
+    @IsOptional()
+    @IsString()
+    @MaxLength(320)
+    email?: string;
+}
+
+/**
+ * Request body for `POST /api/meetings` (manual/import creation —
+ * provider-synced meetings land through the connector processor).
+ * Semantic rules (source membership, date parsing, title floor) are
+ * re-validated in `MeetingsService.createForUser`, the single source
+ * of truth the connector path reuses.
+ */
+export class CreateMeetingDto {
+    @ApiProperty({ minLength: 1, maxLength: 500 })
+    @IsString()
+    @MinLength(1)
+    @MaxLength(500)
+    title: string;
+
+    @ApiProperty({ description: 'When the meeting started (ISO 8601).' })
+    @IsDateString()
+    startedAt: string;
+
+    @ApiProperty({ required: false, nullable: true })
+    @IsOptional()
+    @IsDateString()
+    endedAt?: string;
+
+    @ApiProperty({ required: false, enum: MEETING_SOURCES, default: 'manual' })
+    @IsOptional()
+    @IsIn(MEETING_SOURCES)
+    source?: MeetingSource;
+
+    @ApiProperty({
+        required: false,
+        maxLength: 200,
+        description: 'Provider meeting id (dedupe key).',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(200)
+    externalId?: string;
+
+    @ApiProperty({
+        required: false,
+        description: 'Work to route the meeting to (org-wide when omitted).',
+    })
+    @IsOptional()
+    @IsUUID()
+    workId?: string;
+
+    @ApiProperty({ required: false, type: [MeetingParticipantDto] })
+    @IsOptional()
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => MeetingParticipantDto)
+    participants?: MeetingParticipantDto[];
+
+    @ApiProperty({
+        required: false,
+        maxLength: 2048,
+        description: 'Recording / provider deep link.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(2048)
+    sourceUrl?: string;
+
+    @ApiProperty({
+        required: false,
+        description:
+            'Optional transcript captured at creation — runs the full transcript pipeline.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(MEETING_TRANSCRIPT_MAX_CHARS)
+    transcriptText?: string;
+}
+
+/** Request body for `PATCH /api/meetings/:id` (partial update). */
+export class UpdateMeetingDto {
+    @ApiProperty({ required: false, minLength: 1, maxLength: 500 })
+    @IsOptional()
+    @IsString()
+    @MinLength(1)
+    @MaxLength(500)
+    title?: string;
+
+    @ApiProperty({ required: false })
+    @IsOptional()
+    @IsDateString()
+    startedAt?: string;
+
+    @ApiProperty({ required: false, nullable: true })
+    @IsOptional()
+    @IsDateString()
+    endedAt?: string;
+
+    @ApiProperty({
+        required: false,
+        nullable: true,
+        description: 'Re-route to a Work (null → org-wide).',
+    })
+    @IsOptional()
+    @IsUUID()
+    workId?: string;
+
+    @ApiProperty({ required: false, type: [MeetingParticipantDto] })
+    @IsOptional()
+    @IsArray()
+    @ValidateNested({ each: true })
+    @Type(() => MeetingParticipantDto)
+    participants?: MeetingParticipantDto[];
+
+    @ApiProperty({ required: false, maxLength: 2048 })
+    @IsOptional()
+    @IsString()
+    @MaxLength(2048)
+    sourceUrl?: string;
+}
+
+/**
+ * Request body for `POST /api/meetings/:id/transcript` — size-capped
+ * at the service-level bound (the service defensively re-truncates).
+ */
+export class IngestTranscriptDto {
+    @ApiProperty({
+        minLength: 1,
+        maxLength: MEETING_TRANSCRIPT_MAX_CHARS,
+        description: 'The transcript text to attach (plain text).',
+    })
+    @IsString()
+    @MinLength(1)
+    @MaxLength(MEETING_TRANSCRIPT_MAX_CHARS)
+    transcriptText: string;
+}

--- a/apps/api/src/meetings/meetings.controller.spec.ts
+++ b/apps/api/src/meetings/meetings.controller.spec.ts
@@ -1,0 +1,105 @@
+import { MeetingsController } from './meetings.controller';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+const auth = { userId: 'user-1' } as AuthenticatedUser;
+
+const meeting = (overrides: Record<string, unknown> = {}) => ({
+    id: 'meeting-1',
+    userId: 'user-1',
+    organizationId: null,
+    workId: 'work-9',
+    title: 'Weekly sync',
+    startedAt: new Date('2026-07-24T10:00:00.000Z'),
+    endedAt: new Date('2026-07-24T10:30:00.000Z'),
+    source: 'zoom',
+    externalId: 'uuid-1',
+    participants: [{ name: 'Alice' }],
+    transcriptText: 'Alice: Hello.',
+    summary: 'The team aligned on the launch.',
+    sourceUrl: 'https://example.zoom.us/rec/play/abc',
+    dedupeKey: 'secret-dedupe-key',
+    createdAt: new Date('2026-07-24T11:00:00.000Z'),
+    ...overrides,
+});
+
+describe('MeetingsController', () => {
+    let service: {
+        listForUser: jest.Mock;
+        createForUser: jest.Mock;
+        getForUser: jest.Mock;
+        updateForUser: jest.Mock;
+        deleteForUser: jest.Mock;
+        ingestTranscriptForUser: jest.Mock;
+    };
+    let controller: MeetingsController;
+
+    beforeEach(() => {
+        service = {
+            listForUser: jest.fn(async () => [meeting()]),
+            createForUser: jest.fn(async () => meeting()),
+            getForUser: jest.fn(async () => meeting()),
+            updateForUser: jest.fn(async () => meeting()),
+            deleteForUser: jest.fn(async () => undefined),
+            ingestTranscriptForUser: jest.fn(async () => ({
+                meeting: meeting(),
+                summary: 'The team aligned on the launch.',
+                memorySaved: true,
+                envelopeEmitted: true,
+            })),
+        };
+        controller = new MeetingsController(service as never);
+    });
+
+    it('list is owner-scoped, passes safe filters through and OMITS the transcript body', async () => {
+        const rows = await controller.list(auth, 'work-9', 'zoom', '10', undefined);
+
+        expect(service.listForUser).toHaveBeenCalledWith('user-1', {
+            workId: 'work-9',
+            source: 'zoom',
+            limit: 10,
+        });
+        expect(rows[0]).toMatchObject({
+            id: 'meeting-1',
+            hasTranscript: true,
+            summary: 'The team aligned on the launch.',
+        });
+        expect(rows[0].transcriptText).toBeUndefined();
+        // The internal dedupe key never leaves the API.
+        expect(rows[0] as unknown as Record<string, unknown>).not.toHaveProperty('dedupeKey');
+    });
+
+    it('list drops unknown source filters instead of passing them to the query', async () => {
+        await controller.list(auth, undefined, 'carrier-pigeon', undefined, undefined);
+        expect(service.listForUser).toHaveBeenCalledWith('user-1', {});
+    });
+
+    it('getOne includes the transcript body', async () => {
+        const view = await controller.getOne(auth, 'meeting-1');
+
+        expect(service.getForUser).toHaveBeenCalledWith('user-1', 'meeting-1');
+        expect(view.transcriptText).toBe('Alice: Hello.');
+    });
+
+    it('ingestTranscript returns the pipeline outcome flags with the refreshed view', async () => {
+        const result = await controller.ingestTranscript(auth, 'meeting-1', {
+            transcriptText: 'Alice: Hello.',
+        });
+
+        expect(service.ingestTranscriptForUser).toHaveBeenCalledWith(
+            'user-1',
+            'meeting-1',
+            'Alice: Hello.',
+        );
+        expect(result).toMatchObject({
+            summary: 'The team aligned on the launch.',
+            memorySaved: true,
+            envelopeEmitted: true,
+        });
+        expect(result.meeting.hasTranscript).toBe(true);
+    });
+
+    it('delete routes through the owner-scoped service path', async () => {
+        await controller.remove(auth, 'meeting-1');
+        expect(service.deleteForUser).toHaveBeenCalledWith('user-1', 'meeting-1');
+    });
+});

--- a/apps/api/src/meetings/meetings.controller.ts
+++ b/apps/api/src/meetings/meetings.controller.ts
@@ -1,0 +1,181 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Param,
+    ParseUUIDPipe,
+    Patch,
+    Post,
+    Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import type { Meeting, MeetingSource } from '@ever-works/agent/meetings';
+import { MeetingsService } from '@ever-works/agent/meetings';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { CreateMeetingDto, IngestTranscriptDto, UpdateMeetingDto } from './dto/meeting.dto';
+
+/** Wire shape of one meeting (list rows omit the transcript body). */
+export interface MeetingView {
+    id: string;
+    title: string;
+    startedAt: string;
+    endedAt: string | null;
+    source: string;
+    externalId: string | null;
+    workId: string | null;
+    organizationId: string | null;
+    participants: { name: string; email?: string }[];
+    sourceUrl: string | null;
+    summary: string | null;
+    hasTranscript: boolean;
+    transcriptText?: string | null;
+    createdAt: string;
+}
+
+const MEETING_SOURCES: readonly string[] = ['zoom', 'google-meet', 'manual', 'import'];
+
+/**
+ * Meetings v1 (Wave 8, feature a) — thin owner-scoped CRUD +
+ * transcript capture over the agent-side `MeetingsService`.
+ *
+ * Endpoints:
+ *   GET    /api/meetings                 list mine (workId/source filters)
+ *   POST   /api/meetings                 create (manual/import)
+ *   GET    /api/meetings/:id             get one (incl. transcript body)
+ *   PATCH  /api/meetings/:id             partial update
+ *   DELETE /api/meetings/:id             delete
+ *   POST   /api/meetings/:id/transcript  attach transcript (size-capped;
+ *                                        runs summary + memory + envelope)
+ *
+ * Provider-synced meetings (zoom-connector recordings) land through the
+ * ingest-spine processor, not this surface. Transcript ingest is
+ * throttled harder — it fans out to an LLM summary.
+ */
+@ApiTags('meetings')
+@Controller('api/meetings')
+export class MeetingsController {
+    constructor(private readonly service: MeetingsService) {}
+
+    @Get()
+    @ApiOperation({ summary: 'List my meetings (org-wide, or filtered to one Work), newest first' })
+    @HttpCode(HttpStatus.OK)
+    async list(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query('workId') workId?: string,
+        @Query('source') source?: string,
+        @Query('limit') limit?: string,
+        @Query('offset') offset?: string,
+    ): Promise<MeetingView[]> {
+        const meetings = await this.service.listForUser(auth.userId, {
+            ...(workId ? { workId } : {}),
+            ...(source && MEETING_SOURCES.includes(source)
+                ? { source: source as MeetingSource }
+                : {}),
+            ...(limit ? { limit: Number(limit) || undefined } : {}),
+            ...(offset ? { offset: Number(offset) || undefined } : {}),
+        });
+        return meetings.map((meeting) => this.toView(meeting));
+    }
+
+    @Post()
+    @ApiOperation({ summary: 'Create a meeting (manual/import; connectors sync their own)' })
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async create(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: CreateMeetingDto,
+    ): Promise<MeetingView> {
+        const meeting = await this.service.createForUser(auth.userId, body);
+        return this.toView(meeting, { includeTranscript: true });
+    }
+
+    @Get(':id')
+    @ApiOperation({ summary: 'Get one meeting (includes the transcript body)' })
+    @HttpCode(HttpStatus.OK)
+    async getOne(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ): Promise<MeetingView> {
+        const meeting = await this.service.getForUser(auth.userId, id);
+        return this.toView(meeting, { includeTranscript: true });
+    }
+
+    @Patch(':id')
+    @ApiOperation({ summary: 'Update meeting fields (partial)' })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async update(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Body() body: UpdateMeetingDto,
+    ): Promise<MeetingView> {
+        const meeting = await this.service.updateForUser(auth.userId, id, body);
+        return this.toView(meeting, { includeTranscript: true });
+    }
+
+    @Delete(':id')
+    @ApiOperation({ summary: 'Delete a meeting' })
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async remove(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ): Promise<void> {
+        await this.service.deleteForUser(auth.userId, id);
+    }
+
+    @Post(':id/transcript')
+    @ApiOperation({
+        summary:
+            'Attach a transcript (size-capped). Stores it, then best-effort: AI summary, Memory observation, meeting.transcript envelope (→ Activity with sourceUrl).',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async ingestTranscript(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Body() body: IngestTranscriptDto,
+    ): Promise<{
+        meeting: MeetingView;
+        summary?: string;
+        memorySaved: boolean;
+        envelopeEmitted: boolean;
+    }> {
+        const result = await this.service.ingestTranscriptForUser(
+            auth.userId,
+            id,
+            body.transcriptText,
+        );
+        return {
+            meeting: this.toView(result.meeting, { includeTranscript: true }),
+            ...(result.summary ? { summary: result.summary } : {}),
+            memorySaved: result.memorySaved,
+            envelopeEmitted: result.envelopeEmitted,
+        };
+    }
+
+    /** Entity → wire view. `dedupeKey` never leaves the API. */
+    private toView(meeting: Meeting, opts: { includeTranscript?: boolean } = {}): MeetingView {
+        return {
+            id: meeting.id,
+            title: meeting.title,
+            startedAt: meeting.startedAt.toISOString(),
+            endedAt: meeting.endedAt ? meeting.endedAt.toISOString() : null,
+            source: meeting.source,
+            externalId: meeting.externalId ?? null,
+            workId: meeting.workId ?? null,
+            organizationId: meeting.organizationId ?? null,
+            participants: meeting.participants ?? [],
+            sourceUrl: meeting.sourceUrl ?? null,
+            summary: meeting.summary ?? null,
+            hasTranscript: !!meeting.transcriptText,
+            ...(opts.includeTranscript ? { transcriptText: meeting.transcriptText ?? null } : {}),
+            createdAt: meeting.createdAt.toISOString(),
+        };
+    }
+}

--- a/apps/api/src/meetings/meetings.module.ts
+++ b/apps/api/src/meetings/meetings.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { MeetingsModule as AgentMeetingsModule } from '@ever-works/agent/meetings';
+import { MeetingsController } from './meetings.controller';
+
+/**
+ * Meetings v1 (Wave 8, feature a) — thin API module exposing the
+ * `/api/meetings` CRUD + transcript surface over the agent-side
+ * `MeetingsModule` (entity, repository, transcript pipeline and the
+ * `zoom.recording` envelope→Meeting processor all live there).
+ *
+ * Importing the agent module here (in the API process) is also what
+ * boots `MeetingsService.onModuleInit`, which registers the
+ * recordings processor on the SINGLETON `EventIngestService` — the
+ * same instance the `event-ingest-tick` cron drains over the
+ * trigger-internal RPC channel, so pulled recordings become Meeting
+ * rows with zero extra cron wiring.
+ */
+@Module({
+    imports: [AgentMeetingsModule],
+    controllers: [MeetingsController],
+    exports: [AgentMeetingsModule],
+})
+export class MeetingsApiModule {}

--- a/apps/api/src/migrations/1783800000000-CreateMeetings.ts
+++ b/apps/api/src/migrations/1783800000000-CreateMeetings.ts
@@ -1,0 +1,131 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Meetings v1 (Wave 8, feature a) — creates the `meetings` table
+ * backing org-wide + per-Work meetings with transcript capture:
+ * meetings land from the `zoom.recording` envelope processor (cloud
+ * recordings pulled by the zoom-connector event source), the
+ * `/api/meetings` CRUD surface, or manual/import creation; transcript
+ * ingest attaches the text, the best-effort AI `summary`, a Memory
+ * observation and a `meeting.transcript` envelope (whose drain writes
+ * the Activity entry with `sourceUrl` provenance).
+ *
+ * Entity: `packages/agent/src/entities/meeting.entity.ts`
+ * Service: `packages/agent/src/meetings/meetings.service.ts`
+ *
+ * **Schema notes:**
+ *   - `dedupeKey` (varchar(64), UNIQUE, NULLABLE) — sha256 over
+ *     `(userId, source, externalId)`; makes provider re-delivery
+ *     (overlapping pull windows, backfill) a no-op. NULL for manual
+ *     meetings (no external identity) — those never dedupe, and every
+ *     supported driver allows multiple NULLs under a unique index.
+ *   - `participants` (text) — the entity's `simple-json` roster.
+ *   - `transcriptText` / `summary` (text, nullable) — capped upstream
+ *     (service + DTO).
+ *   - Scope columns (`organizationId`) are raw uuid references — no
+ *     entity-level @ManyToOne (cycle avoidance per EW-654).
+ *   - FK `userId` → `users.id` ON DELETE CASCADE (a meeting is
+ *     meaningless without its owner); FK `workId` → `works.id`
+ *     ON DELETE SET NULL (deleting a Work must not delete the meeting —
+ *     it just loses its Work routing and stays org-level).
+ *
+ * Forward-only + idempotent (`hasTable` guard) — same shape as
+ * `1783200000000-CreateIngestedEvents`.
+ */
+export class CreateMeetings1783800000000 implements MigrationInterface {
+    name = 'CreateMeetings1783800000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('meetings')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'meetings',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    { name: 'workId', type: 'uuid', isNullable: true },
+                    { name: 'title', type: 'varchar', length: '500' },
+                    { name: 'startedAt', type: 'timestamp' },
+                    { name: 'endedAt', type: 'timestamp', isNullable: true },
+                    { name: 'source', type: 'varchar', length: '32' },
+                    { name: 'externalId', type: 'varchar', length: '200', isNullable: true },
+                    { name: 'participants', type: 'text' },
+                    { name: 'transcriptText', type: 'text', isNullable: true },
+                    { name: 'summary', type: 'text', isNullable: true },
+                    { name: 'sourceUrl', type: 'varchar', length: '2048', isNullable: true },
+                    { name: 'dedupeKey', type: 'varchar', length: '64', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        // Dedupe identity — provider re-delivery must be a no-op.
+        await queryRunner.createIndex(
+            'meetings',
+            new TableIndex({
+                name: 'idx_meetings_dedupe',
+                columnNames: ['dedupeKey'],
+                isUnique: true,
+            }),
+        );
+
+        // Owner-scoped recency reads (org-wide Meetings view, chat tools).
+        await queryRunner.createIndex(
+            'meetings',
+            new TableIndex({
+                name: 'idx_meetings_user_started',
+                columnNames: ['userId', 'startedAt'],
+            }),
+        );
+
+        // Per-Work Meetings tab reads.
+        await queryRunner.createIndex(
+            'meetings',
+            new TableIndex({
+                name: 'idx_meetings_work',
+                columnNames: ['workId'],
+            }),
+        );
+
+        await queryRunner.createForeignKey(
+            'meetings',
+            new TableForeignKey({
+                name: 'fk_meetings_user',
+                columnNames: ['userId'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+
+        // Deleting a Work must not delete its meetings — they just lose
+        // the Work routing and stay owner/org-scoped.
+        await queryRunner.createForeignKey(
+            'meetings',
+            new TableForeignKey({
+                name: 'fk_meetings_work',
+                columnNames: ['workId'],
+                referencedTableName: 'works',
+                referencedColumnNames: ['id'],
+                onDelete: 'SET NULL',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('meetings')) {
+            await queryRunner.dropTable('meetings', true);
+        }
+    }
+}

--- a/apps/web/src/lib/ai/tools/generated/registry.ts
+++ b/apps/web/src/lib/ai/tools/generated/registry.ts
@@ -212,6 +212,40 @@ export const OPERATION_REGISTRY: OperationSpec[] = [
         bodyHint: 'taskId.',
     },
 
+    // ── Meetings (Wave 8, feature a) ─────────────────────────────
+    {
+        toolName: 'list_meetings',
+        method: 'GET',
+        path: '/api/meetings',
+        summary:
+            'List the current user’s captured meetings (synced recordings, imported and manual), newest first — org-wide or filtered to one Work. Rows carry a sourceUrl recording link.',
+        kind: 'read',
+        params: [
+            {
+                name: 'workId',
+                in: 'query',
+                type: 'string',
+                description: 'Only meetings routed to this Work',
+            },
+            {
+                name: 'source',
+                in: 'query',
+                type: 'string',
+                description: 'Filter by source: zoom, google-meet, manual or import',
+            },
+            { name: 'limit', in: 'query', type: 'number', description: 'Max rows (default 20)' },
+        ],
+    },
+    {
+        toolName: 'get_meeting_summary',
+        method: 'GET',
+        path: '/api/meetings/{id}',
+        summary:
+            'Get one meeting’s AI summary, transcript and metadata (participants, timing, recording link). Use after list_meetings when asked what a meeting covered or decided.',
+        kind: 'read',
+        params: [id('Meeting id (from list_meetings)')],
+    },
+
     // ── Tasks ────────────────────────────────────────────────────
     {
         toolName: 'list_tasks',

--- a/apps/web/src/lib/ai/tools/tool-selection.ts
+++ b/apps/web/src/lib/ai/tools/tool-selection.ts
@@ -57,6 +57,10 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
     kb: ['knowledge', 'kb', 'document', 'doc', 'upload'],
     notifications: ['notification', 'notify', 'alert', 'channel'],
     email: ['email', 'inbox', 'message', 'mail'],
+    // Meetings v1 (Wave 8, feature a) — keyword slots ship WITH the
+    // feature (program DoD rule; the Mission-create outage is the
+    // cautionary tale for omitting them).
+    meetings: ['meeting', 'transcript', 'recording', 'standup', 'zoom', 'google meet'],
     members: ['member', 'invite', 'invitation', 'team', 'collaborator', 'people'],
     apikeys: ['api key', 'api-key', 'apikey', 'token'],
     budgets: ['budget', 'usage', 'spend', 'spending', 'cost', 'billing'],
@@ -95,6 +99,7 @@ function deriveDomain(path: string): string {
     if (p.includes('/kb/')) return 'kb';
     if (p.includes('/notification')) return 'notifications';
     if (p.includes('/api/email')) return 'email';
+    if (p.includes('/api/meetings')) return 'meetings';
     if (p.includes('/members') || p.includes('/invitations')) return 'members';
     if (p.includes('/api-keys')) return 'apikeys';
     if (p.includes('/budgets') || p.includes('/usage')) return 'budgets';

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -185,6 +185,10 @@
             "types": "./dist/digest/index.d.ts",
             "default": "./dist/digest/index.js"
         },
+        "./meetings": {
+            "types": "./dist/meetings/index.d.ts",
+            "default": "./dist/meetings/index.js"
+        },
         "./pr-review": {
             "types": "./dist/pr-review/index.d.ts",
             "default": "./dist/pr-review/index.js"

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -115,6 +115,7 @@ import { TenantCredentialSnapshot } from '../entities/tenant-credential-snapshot
 import { InboundTrigger } from '../entities/inbound-trigger.entity';
 import { IngestedEvent } from '../entities/ingested-event.entity';
 import { IngestCursor } from '../entities/ingest-cursor.entity';
+import { Meeting } from '../entities/meeting.entity';
 import { CreditLedgerEntry } from '../entities/credit-ledger-entry.entity';
 import { PlanEntitlement } from '../entities/plan-entitlement.entity';
 import {
@@ -259,6 +260,9 @@ export const ENTITIES = [
     // Event-ingest pull path (Wave 8) — per-(user, plugin) event-source
     // pull watermarks + continuation cursors.
     IngestCursor,
+    // Meetings v1 (Wave 8, feature a) — captured meetings with
+    // transcripts, summaries and provider dedupe.
+    Meeting,
     // Credits ledger + plan entitlements (pricing Wave 9 M1) — credits
     // are the usage currency layered on the costCents metering.
     CreditLedgerEntry,

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -75,6 +75,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'IngestCursor',
     // Event-ingest spine (Wave 6) — normalized external events
     'IngestedEvent',
+    // Meetings v1 (Wave 8, feature a) — captured meetings w/ transcripts
+    'Meeting',
     'Mission',
     // Domain-model evolution PR-8 — Goals + measurement
     'Goal',

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -118,6 +118,8 @@ export * from './inbound-trigger.entity';
 export * from './ingested-event.entity';
 // Event-ingest pull path (Wave 8) — per-(user, plugin) pull watermarks/cursors
 export * from './ingest-cursor.entity';
+// Meetings v1 (Wave 8, feature a) — captured meetings with transcripts
+export * from './meeting.entity';
 // Credits ledger + plan entitlements (pricing Wave 9 M1)
 export * from './credit-ledger-entry.entity';
 export * from './plan-entitlement.entity';

--- a/packages/agent/src/entities/meeting.entity.ts
+++ b/packages/agent/src/entities/meeting.entity.ts
@@ -1,0 +1,101 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * Meetings v1 (Wave 8, feature a) — one captured meeting, org-wide or
+ * per-Work, transcript-first.
+ *
+ * Rows are written by `MeetingsService`: manual/API creation, or the
+ * `zoom.recording` ingest-envelope processor (recordings pulled by the
+ * zoom-connector event source). Transcript capture goes through
+ * `MeetingsService.ingestTranscript` which also generates the AI
+ * `summary` (best-effort), saves a Memory observation (best-effort)
+ * and emits a `meeting.transcript` envelope into the event-ingest
+ * spine (whose drain writes the Activity entry with `sourceUrl`
+ * provenance).
+ *
+ * Dedupe: `dedupeKey` is a sha256 over `(userId, source, externalId)`
+ * — the provider identity `(source, externalId)` scoped per owner so
+ * one user's sync can never swallow (or leak) another user's meeting
+ * (same rationale as `ingested_events`). NULL for meetings without an
+ * `externalId` (manual notes) — those never dedupe.
+ *
+ * Scope columns are raw uuid references (no @ManyToOne) per the EW-654
+ * cycle-avoidance rule; FKs live in the migration
+ * (`1783800000000-CreateMeetings`).
+ *
+ * Live bot-join (an Ever Works bot joining meetings to capture in real
+ * time) is the documented v2 follow-up — it will write these same rows
+ * through `ingestTranscript`, so nothing here changes for it.
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` — this
+ * repo has no `autoLoadEntities`, a forFeature'd-but-unregistered
+ * entity throws EntityMetadataNotFoundError on first query.
+ */
+
+/** One meeting participant (denormalized — provider rosters vary). */
+export interface MeetingParticipant {
+    name: string;
+    email?: string;
+}
+
+/** Where a meeting row came from. */
+export type MeetingSource = 'zoom' | 'google-meet' | 'manual' | 'import';
+
+@Entity({ name: 'meetings' })
+@Index('idx_meetings_dedupe', ['dedupeKey'], { unique: true })
+@Index('idx_meetings_user_started', ['userId', 'startedAt'])
+@Index('idx_meetings_work', ['workId'])
+export class Meeting {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Owner the meeting was captured for (scopes every read/write). */
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    /** Work the meeting was routed to, when known (org-wide when null). */
+    @Column({ type: 'uuid', nullable: true })
+    workId?: string | null;
+
+    @Column({ type: 'varchar', length: 500 })
+    title: string;
+
+    @Column({ type: 'timestamp' })
+    startedAt: Date;
+
+    @Column({ type: 'timestamp', nullable: true })
+    endedAt?: Date | null;
+
+    /** Producing surface: 'zoom' | 'google-meet' | 'manual' | 'import'. */
+    @Column({ type: 'varchar', length: 32 })
+    source: MeetingSource;
+
+    /** The meeting's stable id in the source system (null for manual). */
+    @Column({ type: 'varchar', length: 200, nullable: true })
+    externalId?: string | null;
+
+    /** Denormalized roster: `[{ name, email? }]`. */
+    @Column({ type: 'simple-json' })
+    participants: MeetingParticipant[];
+
+    @Column({ type: 'text', nullable: true })
+    transcriptText?: string | null;
+
+    /** AI-generated summary (best-effort — may stay null). */
+    @Column({ type: 'text', nullable: true })
+    summary?: string | null;
+
+    /** Deep link back to the recording / provider meeting page. */
+    @Column({ type: 'varchar', length: 2048, nullable: true })
+    sourceUrl?: string | null;
+
+    /** sha256 hex over (userId, source, externalId); NULL = no dedupe. */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    dedupeKey?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
@@ -219,4 +219,65 @@ describe('EventIngestService', () => {
             expect(repository.findUnprocessed).toHaveBeenCalledWith(50);
         });
     });
+
+    // Wave 8 (Meetings v1) — kind-bound domain processors on the drain.
+    describe('kind processors', () => {
+        it('runs a registered processor for matching kinds BEFORE the Activity write', async () => {
+            const order: string[] = [];
+            const event = storedEvent({ kind: 'zoom.recording' });
+            repository.findUnprocessed.mockResolvedValue([event]);
+            activityLog.log.mockImplementation(async () => {
+                order.push('activity');
+                return { id: 'activity-1' };
+            });
+
+            const service = build();
+            const process = jest.fn(async () => {
+                order.push('processor');
+            });
+            service.registerKindProcessor({ kinds: ['zoom.recording'], process });
+
+            const result = await service.processBatch(10);
+
+            expect(process).toHaveBeenCalledWith(event);
+            expect(order).toEqual(['processor', 'activity']);
+            expect(result).toEqual({ processed: 1, activities: 1, memories: 1, failed: 0 });
+        });
+
+        it('never invokes a processor for kinds it did not register', async () => {
+            repository.findUnprocessed.mockResolvedValue([storedEvent({ kind: 'slack.message' })]);
+
+            const service = build();
+            const process = jest.fn(async () => undefined);
+            service.registerKindProcessor({ kinds: ['zoom.recording'], process });
+
+            const result = await service.processBatch(10);
+
+            expect(process).not.toHaveBeenCalled();
+            expect(result).toEqual({ processed: 1, activities: 1, memories: 1, failed: 0 });
+        });
+
+        it('processor failure is REQUIRED-grade: row left unprocessed, no Activity duplicate risk', async () => {
+            const bad = storedEvent({ id: 'row-bad', kind: 'zoom.recording' });
+            const good = storedEvent({ id: 'row-good', kind: 'slack.message' });
+            repository.findUnprocessed.mockResolvedValue([bad, good]);
+
+            const service = build();
+            service.registerKindProcessor({
+                kinds: ['zoom.recording'],
+                process: jest.fn(async () => {
+                    throw new Error('meetings table down');
+                }),
+            });
+
+            const result = await service.processBatch(10);
+
+            expect(result).toEqual({ processed: 1, activities: 1, memories: 1, failed: 1 });
+            expect(repository.markProcessed).not.toHaveBeenCalledWith('row-bad');
+            expect(repository.markProcessed).toHaveBeenCalledWith('row-good');
+            // The failed row's Activity was NOT written — the retry next
+            // tick cannot duplicate feed rows.
+            expect(activityLog.log).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/packages/agent/src/ingest/event-ingest.service.ts
+++ b/packages/agent/src/ingest/event-ingest.service.ts
@@ -23,8 +23,26 @@ export interface ProcessBatchResult {
     activities: number;
     /** Memory observations saved (0 when no provider is enabled). */
     memories: number;
-    /** Rows whose Activity write failed — left unprocessed for retry. */
+    /**
+     * Rows whose REQUIRED processor (kind processor or Activity write)
+     * failed — left unprocessed for retry.
+     */
     failed: number;
+}
+
+/**
+ * A domain processor bound to specific event kinds — e.g. the Meetings
+ * feature consuming `zoom.recording` envelopes into Meeting rows.
+ * Registered at boot (`registerKindProcessor`) by feature modules so
+ * the spine stays dependency-free of the features it feeds.
+ *
+ * Contract: `process` MUST be idempotent per event — a row whose later
+ * fan-out step failed is retried next tick, kind processor included.
+ */
+export interface IngestedEventKindProcessor {
+    /** Source-namespaced kinds this processor consumes. */
+    readonly kinds: readonly string[];
+    process(event: IngestedEvent): Promise<void>;
 }
 
 /**
@@ -46,16 +64,36 @@ export interface ProcessBatchResult {
  * Chat surfacing rides the existing Memory/Activity recall paths plus
  * the `list_recent_events` tool (`agent-ingest-tools.ts`) — answers
  * link back to the origin through `sourceUrl`.
+ *
+ * Wave 8 (Meetings v1): feature modules can additionally register
+ * KIND-BOUND processors (`registerKindProcessor`) that run before the
+ * Activity write — e.g. `zoom.recording` envelopes becoming Meeting
+ * rows. A kind-processor failure is REQUIRED-grade: the row stays
+ * unprocessed and retries next tick.
  */
 @Injectable()
 export class EventIngestService {
     private readonly logger = new Logger(EventIngestService.name);
+
+    /** Kind-bound domain processors (Meetings, …) — see the interface doc. */
+    private readonly kindProcessors: IngestedEventKindProcessor[] = [];
 
     constructor(
         private readonly repository: IngestedEventRepository,
         private readonly activityLogService: ActivityLogService,
         @Optional() private readonly agentMemory?: AgentMemoryFacadeService,
     ) {}
+
+    /**
+     * Register a domain processor for specific event kinds. Feature
+     * modules call this from `onModuleInit` (the service is a process
+     * singleton, so cron-driven `processBatch` runs see it too). The
+     * processor runs BEFORE the Activity write — its failure leaves the
+     * row unprocessed for retry WITHOUT duplicating Activity rows.
+     */
+    registerKindProcessor(processor: IngestedEventKindProcessor): void {
+        this.kindProcessors.push(processor);
+    }
 
     /** Dedupe-insert a batch of envelopes for one owner. */
     async ingest(userId: string, envelopes: IngestedEventEnvelope[]): Promise<IngestResult> {
@@ -110,6 +148,24 @@ export class EventIngestService {
 
         for (const event of events) {
             try {
+                // Kind-bound domain processors run FIRST (before the
+                // Activity write) so a processor failure retries the row
+                // next tick without duplicating Activity rows. Processors
+                // are idempotent by contract, so the inverse ordering
+                // hazard (processor reran after a later step failed) is
+                // safe.
+                await this.runKindProcessors(event);
+            } catch (error) {
+                result.failed += 1;
+                this.logger.warn(
+                    `Kind processor failed for ingested event ${event.id} (${event.kind}): ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+                continue;
+            }
+
+            try {
                 await this.writeActivity(event);
                 result.activities += 1;
             } catch (error) {
@@ -133,6 +189,15 @@ export class EventIngestService {
         }
 
         return result;
+    }
+
+    /** Run every registered processor whose kinds include this event's. */
+    private async runKindProcessors(event: IngestedEvent): Promise<void> {
+        for (const processor of this.kindProcessors) {
+            if (processor.kinds.includes(event.kind)) {
+                await processor.process(event);
+            }
+        }
     }
 
     private async writeActivity(event: IngestedEvent): Promise<void> {

--- a/packages/agent/src/meetings/__tests__/agent-meeting-tools.spec.ts
+++ b/packages/agent/src/meetings/__tests__/agent-meeting-tools.spec.ts
@@ -1,0 +1,109 @@
+import { buildMeetingTools } from '../agent-meeting-tools';
+
+const row = (overrides: Record<string, unknown> = {}) => ({
+    id: 'meeting-1',
+    userId: 'user-1',
+    title: 'Weekly sync',
+    startedAt: new Date('2026-07-24T10:00:00.000Z'),
+    endedAt: new Date('2026-07-24T10:30:00.000Z'),
+    source: 'zoom',
+    workId: 'work-9',
+    sourceUrl: 'https://example.zoom.us/rec/play/abc',
+    participants: [{ name: 'Alice', email: 'alice@example.com' }],
+    transcriptText: 'Alice: Hello.',
+    summary: 'The team aligned on the launch.',
+    ...overrides,
+});
+
+describe('buildMeetingTools', () => {
+    let repository: { findByUser: jest.Mock; findById: jest.Mock };
+
+    beforeEach(() => {
+        repository = {
+            findByUser: jest.fn(async () => [row()]),
+            findById: jest.fn(async () => row()),
+        };
+    });
+
+    const tools = () => buildMeetingTools({ userId: 'user-1', repository: repository as never });
+    const tool = (name: string) => {
+        const found = tools().find((t) => t.name === name);
+        if (!found) throw new Error(`missing tool ${name}`);
+        return found;
+    };
+
+    it('ships both meeting tools (program DoD: chat tools with the entity)', () => {
+        expect(tools().map((t) => t.name)).toEqual(['list_meetings', 'get_meeting_summary']);
+    });
+
+    describe('list_meetings', () => {
+        it('reads owner-scoped, passes filters through and maps rows to the view shape', async () => {
+            const result = (await tool('list_meetings').invoke({
+                workId: 'work-9',
+                source: 'zoom',
+                limit: 5,
+            })) as { meetings: Record<string, unknown>[] };
+
+            expect(repository.findByUser).toHaveBeenCalledWith('user-1', {
+                workId: 'work-9',
+                source: 'zoom',
+                limit: 5,
+            });
+            expect(result.meetings).toHaveLength(1);
+            expect(result.meetings[0]).toMatchObject({
+                id: 'meeting-1',
+                title: 'Weekly sync',
+                startedAt: '2026-07-24T10:00:00.000Z',
+                source: 'zoom',
+                sourceUrl: 'https://example.zoom.us/rec/play/abc',
+                hasTranscript: true,
+                summary: 'The team aligned on the launch.',
+            });
+        });
+
+        it('caps the limit at 50 and drops unknown source filters', async () => {
+            await tool('list_meetings').invoke({ limit: 500, source: 'carrier-pigeon' });
+
+            expect(repository.findByUser).toHaveBeenCalledWith('user-1', { limit: 50 });
+        });
+
+        it('returns a tool-shaped error instead of throwing', async () => {
+            repository.findByUser.mockRejectedValue(new Error('db down'));
+
+            expect(await tool('list_meetings').invoke({})).toEqual({ error: 'db down' });
+        });
+    });
+
+    describe('get_meeting_summary', () => {
+        it('returns the summary view for the caller’s own meeting', async () => {
+            const result = (await tool('get_meeting_summary').invoke({
+                meetingId: 'meeting-1',
+            })) as { meeting: Record<string, unknown> };
+
+            expect(result.meeting).toMatchObject({
+                id: 'meeting-1',
+                summary: 'The team aligned on the launch.',
+                hasTranscript: true,
+            });
+        });
+
+        it('treats other owners’ meetings exactly like missing ones (no existence leak)', async () => {
+            repository.findById.mockResolvedValue(row({ userId: 'user-2' }));
+            expect(await tool('get_meeting_summary').invoke({ meetingId: 'meeting-1' })).toEqual({
+                error: 'Meeting meeting-1 not found',
+            });
+
+            repository.findById.mockResolvedValue(null);
+            expect(await tool('get_meeting_summary').invoke({ meetingId: 'meeting-1' })).toEqual({
+                error: 'Meeting meeting-1 not found',
+            });
+        });
+
+        it('requires the meetingId argument', async () => {
+            expect(await tool('get_meeting_summary').invoke({})).toEqual({
+                error: 'meetingId is required',
+            });
+            expect(repository.findById).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/agent/src/meetings/__tests__/meeting.repository.spec.ts
+++ b/packages/agent/src/meetings/__tests__/meeting.repository.spec.ts
@@ -1,0 +1,146 @@
+import { computeMeetingDedupeKey, MeetingRepository } from '../meeting.repository';
+
+describe('computeMeetingDedupeKey', () => {
+    it('is deterministic for the same (userId, source, externalId)', () => {
+        const a = computeMeetingDedupeKey('user-1', 'zoom', 'uuid-1');
+        const b = computeMeetingDedupeKey('user-1', 'zoom', 'uuid-1');
+        expect(a).toBe(b);
+        expect(a).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('scopes the identity per owner and length-prefixes segments against boundary collisions', () => {
+        // Same (source, externalId), different owner → different key.
+        expect(computeMeetingDedupeKey('user-1', 'zoom', 'uuid-1')).not.toBe(
+            computeMeetingDedupeKey('user-2', 'zoom', 'uuid-1'),
+        );
+        // ('ab','c') vs ('a','bc') must not collide (length-prefixed).
+        expect(computeMeetingDedupeKey('u', 'ab', 'c')).not.toBe(
+            computeMeetingDedupeKey('u', 'a', 'bc'),
+        );
+    });
+});
+
+describe('MeetingRepository', () => {
+    const baseData = {
+        userId: 'user-1',
+        title: 'Weekly sync',
+        startedAt: new Date('2026-07-24T10:00:00.000Z'),
+        source: 'zoom' as const,
+        externalId: 'uuid-1',
+    };
+
+    let queryBuilder: {
+        where: jest.Mock;
+        andWhere: jest.Mock;
+        orderBy: jest.Mock;
+        take: jest.Mock;
+        skip: jest.Mock;
+        getMany: jest.Mock;
+    };
+    let typeormRepo: {
+        findOne: jest.Mock;
+        create: jest.Mock;
+        save: jest.Mock;
+        update: jest.Mock;
+        delete: jest.Mock;
+        createQueryBuilder: jest.Mock;
+    };
+    let repository: MeetingRepository;
+
+    beforeEach(() => {
+        queryBuilder = {
+            where: jest.fn().mockReturnThis(),
+            andWhere: jest.fn().mockReturnThis(),
+            orderBy: jest.fn().mockReturnThis(),
+            take: jest.fn().mockReturnThis(),
+            skip: jest.fn().mockReturnThis(),
+            getMany: jest.fn(async () => []),
+        };
+        typeormRepo = {
+            findOne: jest.fn(),
+            create: jest.fn((data) => data),
+            save: jest.fn(async (data) => ({ id: 'meeting-1', ...data })),
+            update: jest.fn(async () => undefined),
+            delete: jest.fn(async () => undefined),
+            createQueryBuilder: jest.fn(() => queryBuilder),
+        };
+        repository = new MeetingRepository(typeormRepo as never);
+    });
+
+    it('createIfNew inserts a provider-synced meeting stamped with the computed dedupeKey', async () => {
+        typeormRepo.findOne.mockResolvedValue(null);
+
+        const result = await repository.createIfNew(baseData);
+
+        expect(result.created).toBe(true);
+        const expectedKey = computeMeetingDedupeKey('user-1', 'zoom', 'uuid-1');
+        expect(typeormRepo.findOne).toHaveBeenCalledWith({ where: { dedupeKey: expectedKey } });
+        expect(typeormRepo.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+                dedupeKey: expectedKey,
+                title: 'Weekly sync',
+                participants: [],
+            }),
+        );
+    });
+
+    it('createIfNew dedupes: the same (source, externalId) is inserted once per owner', async () => {
+        const existing = { id: 'meeting-1', ...baseData };
+        typeormRepo.findOne.mockResolvedValue(existing);
+
+        const result = await repository.createIfNew(baseData);
+
+        expect(result.created).toBe(false);
+        expect(result.meeting).toBe(existing);
+        expect(typeormRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('createIfNew without an externalId always inserts (manual meetings never dedupe)', async () => {
+        const result = await repository.createIfNew({
+            ...baseData,
+            source: 'manual',
+            externalId: null,
+        });
+
+        expect(result.created).toBe(true);
+        expect(typeormRepo.findOne).not.toHaveBeenCalled();
+        expect(typeormRepo.save).toHaveBeenCalledWith(expect.objectContaining({ dedupeKey: null }));
+    });
+
+    it('createIfNew treats the unique-index race as the idempotent outcome', async () => {
+        const winner = { id: 'meeting-winner', ...baseData };
+        // Check-then-insert race: existence check misses, INSERT trips the
+        // unique index, the re-read finds the row that won.
+        typeormRepo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(winner);
+        typeormRepo.save.mockRejectedValueOnce({ driverError: { code: '23505' } });
+
+        const result = await repository.createIfNew(baseData);
+
+        expect(result.created).toBe(false);
+        expect(result.meeting).toBe(winner);
+    });
+
+    it('findByUser is owner-scoped, newest-first, and applies the work/source filters', async () => {
+        await repository.findByUser('user-1', { workId: 'work-9', source: 'zoom', limit: 5 });
+
+        expect(queryBuilder.where).toHaveBeenCalledWith('meeting.userId = :userId', {
+            userId: 'user-1',
+        });
+        expect(queryBuilder.andWhere).toHaveBeenCalledWith('meeting.workId = :workId', {
+            workId: 'work-9',
+        });
+        expect(queryBuilder.andWhere).toHaveBeenCalledWith('meeting.source = :source', {
+            source: 'zoom',
+        });
+        expect(queryBuilder.orderBy).toHaveBeenCalledWith('meeting.startedAt', 'DESC');
+        expect(queryBuilder.take).toHaveBeenCalledWith(5);
+    });
+
+    it('findByUser clamps the page size to the 1–100 bound', async () => {
+        await repository.findByUser('user-1', { limit: 5000 });
+        expect(queryBuilder.take).toHaveBeenCalledWith(100);
+
+        await repository.findByUser('user-1', { limit: -3 });
+        expect(queryBuilder.take).toHaveBeenCalledWith(1);
+    });
+});

--- a/packages/agent/src/meetings/__tests__/meetings.module.spec.ts
+++ b/packages/agent/src/meetings/__tests__/meetings.module.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Meetings v1 (Wave 8, feature a) — module-shape pin for
+ * MeetingsModule.
+ *
+ * Pattern mirrors `ingest.module.spec.ts`: heavy runtime trees
+ * (TypeORM, the ingest/facades graphs) are mocked at module scope so
+ * the decorator metadata can be asserted without loading them under
+ * Jest's CJS transformer.
+ */
+
+jest.mock('@nestjs/typeorm', () => ({
+    TypeOrmModule: { forFeature: () => class TypeOrmFeatureStub {} },
+    InjectRepository: () => () => undefined,
+    InjectDataSource: () => () => undefined,
+}));
+jest.mock('../../entities/meeting.entity', () => ({
+    Meeting: class Meeting {},
+}));
+jest.mock('../../ingest/ingest.module', () => ({
+    EventIngestModule: class EventIngestModule {},
+}));
+jest.mock('../../facades/facades.module', () => ({
+    FacadesModule: class FacadesModule {},
+}));
+jest.mock('../meeting.repository', () => ({
+    MeetingRepository: class MeetingRepository {},
+    computeMeetingDedupeKey: jest.fn(() => 'stub'),
+}));
+jest.mock('../meetings.service', () => ({
+    MeetingsService: class MeetingsService {},
+}));
+
+import 'reflect-metadata';
+import { MeetingsModule } from '../meetings.module';
+import { MeetingRepository } from '../meeting.repository';
+import { MeetingsService } from '../meetings.service';
+import { EventIngestModule } from '../../ingest/ingest.module';
+import { FacadesModule } from '../../facades/facades.module';
+
+describe('MeetingsModule', () => {
+    const meta = (key: string): unknown[] => Reflect.getMetadata(key, MeetingsModule) ?? [];
+
+    it('provides the repository and the service', () => {
+        expect(meta('providers')).toEqual([MeetingRepository, MeetingsService]);
+    });
+
+    it('exports both for the API surface + chat-tool assembly', () => {
+        expect(meta('exports')).toEqual([MeetingRepository, MeetingsService]);
+    });
+
+    it('imports the ingest spine + facades beside the entity feature', () => {
+        const imports = meta('imports');
+        expect(imports).toContain(EventIngestModule);
+        expect(imports).toContain(FacadesModule);
+        expect(imports).toHaveLength(3);
+    });
+});
+
+describe('meetings barrel', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const barrel = require('../index');
+
+    it('re-exports the module, service, repository and tool factory', () => {
+        expect(barrel.MeetingsModule).toBe(MeetingsModule);
+        expect(barrel.MeetingsService).toBe(MeetingsService);
+        expect(barrel.MeetingRepository).toBe(MeetingRepository);
+        expect(typeof barrel.buildMeetingTools).toBe('function');
+        expect(typeof barrel.computeMeetingDedupeKey).toBe('function');
+    });
+});

--- a/packages/agent/src/meetings/__tests__/meetings.service.spec.ts
+++ b/packages/agent/src/meetings/__tests__/meetings.service.spec.ts
@@ -1,0 +1,324 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import type { IngestedEvent } from '../../entities/ingested-event.entity';
+import type { Meeting } from '../../entities/meeting.entity';
+import {
+    MEETING_RECORDING_EVENT_KINDS,
+    MEETING_TRANSCRIPT_MAX_CHARS,
+    MeetingsService,
+} from '../meetings.service';
+
+const meeting = (overrides: Partial<Meeting> = {}): Meeting =>
+    ({
+        id: 'meeting-1',
+        userId: 'user-1',
+        organizationId: null,
+        workId: null,
+        title: 'Weekly sync',
+        startedAt: new Date('2026-07-24T10:00:00.000Z'),
+        endedAt: null,
+        source: 'zoom',
+        externalId: 'uuid-1',
+        participants: [],
+        transcriptText: null,
+        summary: null,
+        sourceUrl: 'https://example.zoom.us/rec/play/abc',
+        dedupeKey: 'abc',
+        createdAt: new Date('2026-07-24T11:00:00.000Z'),
+        ...overrides,
+    }) as Meeting;
+
+const recordingEvent = (overrides: Partial<IngestedEvent> = {}): IngestedEvent =>
+    ({
+        id: 'row-1',
+        userId: 'user-1',
+        organizationId: null,
+        workId: 'work-9',
+        source: 'zoom-connector',
+        sourceEventId: 'uuid-1:transcript',
+        kind: 'zoom.recording',
+        occurredAt: new Date('2026-07-24T10:00:00.000Z'),
+        actorName: null,
+        subjectType: 'meeting',
+        subjectExternalId: 'uuid-1',
+        title: 'Weekly sync',
+        sourceUrl: 'https://example.zoom.us/rec/play/abc',
+        payload: {
+            meetingExternalId: 'uuid-1',
+            topic: 'Weekly sync',
+            startTime: '2026-07-24T10:00:00.000Z',
+            durationMinutes: 30,
+            transcriptText: 'Alice: Hello.\nBob: Hi.',
+        },
+        processedAt: null,
+        dedupeKey: 'k',
+        createdAt: new Date('2026-07-24T11:00:00.000Z'),
+        ...overrides,
+    }) as IngestedEvent;
+
+describe('MeetingsService', () => {
+    let repository: {
+        createIfNew: jest.Mock;
+        findByUser: jest.Mock;
+        findById: jest.Mock;
+        attachTranscript: jest.Mock;
+        attachSummary: jest.Mock;
+        update: jest.Mock;
+        delete: jest.Mock;
+    };
+    let eventIngest: { ingest: jest.Mock; registerKindProcessor: jest.Mock };
+    let aiFacade: { createChatCompletion: jest.Mock };
+    let agentMemory: { saveMemory: jest.Mock };
+
+    const build = (opts: { withAi?: boolean; withMemory?: boolean } = {}) =>
+        new MeetingsService(
+            repository as never,
+            eventIngest as never,
+            (opts.withAi ?? true) ? (aiFacade as never) : undefined,
+            (opts.withMemory ?? true) ? (agentMemory as never) : undefined,
+        );
+
+    beforeEach(() => {
+        repository = {
+            createIfNew: jest.fn(async (data) => ({ meeting: meeting(data), created: true })),
+            findByUser: jest.fn(async () => []),
+            findById: jest.fn(async () => meeting()),
+            attachTranscript: jest.fn(async () => undefined),
+            attachSummary: jest.fn(async () => undefined),
+            update: jest.fn(async () => undefined),
+            delete: jest.fn(async () => undefined),
+        };
+        eventIngest = {
+            ingest: jest.fn(async () => ({ inserted: 1, duplicates: 0, rejected: 0 })),
+            registerKindProcessor: jest.fn(),
+        };
+        aiFacade = {
+            createChatCompletion: jest.fn(async () => ({
+                choices: [{ message: { content: 'Summary: the team aligned on the launch.' } }],
+            })),
+        };
+        agentMemory = { saveMemory: jest.fn(async () => ({ id: 'memory-1' })) };
+    });
+
+    describe('onModuleInit', () => {
+        it('registers the recordings→Meetings kind processor on the ingest spine', () => {
+            build().onModuleInit();
+
+            expect(eventIngest.registerKindProcessor).toHaveBeenCalledWith(
+                expect.objectContaining({ kinds: MEETING_RECORDING_EVENT_KINDS }),
+            );
+        });
+    });
+
+    describe('ingestTranscript', () => {
+        it('stores the transcript, attaches the AI summary, saves memory and emits the envelope', async () => {
+            const row = meeting({ workId: 'work-9' });
+
+            const result = await build().ingestTranscript(row, 'Alice: Hello.\nBob: Hi.');
+
+            expect(repository.attachTranscript).toHaveBeenCalledWith(
+                'meeting-1',
+                'Alice: Hello.\nBob: Hi.',
+            );
+            expect(repository.attachSummary).toHaveBeenCalledWith(
+                'meeting-1',
+                'Summary: the team aligned on the launch.',
+            );
+            expect(result.summary).toBe('Summary: the team aligned on the launch.');
+            expect(result.memorySaved).toBe(true);
+            expect(result.envelopeEmitted).toBe(true);
+
+            // Memory carries provenance metadata + tags, scoped owner+Work.
+            expect(agentMemory.saveMemory).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: expect.stringContaining('Weekly sync'),
+                    tags: expect.arrayContaining(['meeting', 'source:zoom', 'work:work-9']),
+                    metadata: expect.objectContaining({
+                        meetingId: 'meeting-1',
+                        source: 'zoom',
+                        sourceUrl: 'https://example.zoom.us/rec/play/abc',
+                    }),
+                }),
+                { userId: 'user-1', workId: 'work-9' },
+            );
+
+            // Envelope: kind meeting.transcript, content-hashed identity,
+            // provenance + Work routing hint.
+            expect(eventIngest.ingest).toHaveBeenCalledWith('user-1', [
+                expect.objectContaining({
+                    source: 'meetings',
+                    kind: 'meeting.transcript',
+                    sourceEventId: expect.stringMatching(/^meeting-1:transcript:[0-9a-f]{16}$/),
+                    sourceUrl: 'https://example.zoom.us/rec/play/abc',
+                    workId: 'work-9',
+                    payload: expect.objectContaining({
+                        meetingId: 'meeting-1',
+                        transcriptChars: 'Alice: Hello.\nBob: Hi.'.length,
+                    }),
+                }),
+            ]);
+        });
+
+        it('summary failure is best-effort: memory + envelope still run, ingest never throws', async () => {
+            aiFacade.createChatCompletion.mockRejectedValue(new Error('provider down'));
+
+            const result = await build().ingestTranscript(meeting(), 'Alice: Hello.');
+
+            expect(result.summary).toBeUndefined();
+            expect(repository.attachSummary).not.toHaveBeenCalled();
+            expect(result.memorySaved).toBe(true);
+            expect(result.envelopeEmitted).toBe(true);
+        });
+
+        it('memory failure is best-effort: the transcript and envelope still land', async () => {
+            agentMemory.saveMemory.mockRejectedValue(new Error('NoProviderError-ish outage'));
+
+            const result = await build().ingestTranscript(meeting(), 'Alice: Hello.');
+
+            expect(repository.attachTranscript).toHaveBeenCalled();
+            expect(result.memorySaved).toBe(false);
+            expect(result.envelopeEmitted).toBe(true);
+        });
+
+        it('envelope failure is best-effort: the transcript still lands', async () => {
+            eventIngest.ingest.mockRejectedValue(new Error('db down'));
+
+            const result = await build().ingestTranscript(meeting(), 'Alice: Hello.');
+
+            expect(repository.attachTranscript).toHaveBeenCalled();
+            expect(result.envelopeEmitted).toBe(false);
+        });
+
+        it('works without any facade wired (OSS bootstrap): transcript + envelope only', async () => {
+            const result = await build({ withAi: false, withMemory: false }).ingestTranscript(
+                meeting(),
+                'Alice: Hello.',
+            );
+
+            expect(repository.attachTranscript).toHaveBeenCalled();
+            expect(result.summary).toBeUndefined();
+            expect(result.memorySaved).toBe(false);
+            expect(result.envelopeEmitted).toBe(true);
+        });
+
+        it('caps stored transcripts at the service-level bound', async () => {
+            await build().ingestTranscript(
+                meeting(),
+                'x'.repeat(MEETING_TRANSCRIPT_MAX_CHARS + 500),
+            );
+
+            const stored = repository.attachTranscript.mock.calls[0][1] as string;
+            expect(stored.length).toBe(MEETING_TRANSCRIPT_MAX_CHARS);
+        });
+    });
+
+    describe('owner scoping', () => {
+        it('getForUser 404s other owners’ meetings exactly like missing ones', async () => {
+            repository.findById.mockResolvedValue(meeting({ userId: 'user-2' }));
+            await expect(build().getForUser('user-1', 'meeting-1')).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+
+            repository.findById.mockResolvedValue(null);
+            await expect(build().getForUser('user-1', 'meeting-1')).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+
+        it('ingestTranscriptForUser refuses other owners’ meetings before any write', async () => {
+            repository.findById.mockResolvedValue(meeting({ userId: 'user-2' }));
+
+            await expect(
+                build().ingestTranscriptForUser('user-1', 'meeting-1', 'text'),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(repository.attachTranscript).not.toHaveBeenCalled();
+        });
+
+        it('deleteForUser only deletes the caller’s own meeting', async () => {
+            repository.findById.mockResolvedValue(meeting({ userId: 'user-2' }));
+
+            await expect(build().deleteForUser('user-1', 'meeting-1')).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(repository.delete).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('createForUser', () => {
+        it('validates title and startedAt and defaults the source to manual', async () => {
+            await expect(
+                build().createForUser('user-1', { title: '  ', startedAt: new Date() }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            await expect(
+                build().createForUser('user-1', { title: 'Sync', startedAt: 'not-a-date' }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+
+            await build().createForUser('user-1', {
+                title: 'Sync',
+                startedAt: '2026-07-24T10:00:00.000Z',
+            });
+            expect(repository.createIfNew).toHaveBeenCalledWith(
+                expect.objectContaining({ userId: 'user-1', source: 'manual', title: 'Sync' }),
+            );
+        });
+
+        it('runs the transcript pipeline when a transcript is supplied at creation', async () => {
+            await build().createForUser('user-1', {
+                title: 'Sync',
+                startedAt: '2026-07-24T10:00:00.000Z',
+                transcriptText: 'Alice: Hello.',
+            });
+
+            expect(repository.attachTranscript).toHaveBeenCalled();
+            expect(eventIngest.ingest).toHaveBeenCalled();
+        });
+    });
+
+    describe('processRecordingEvent (envelope → Meeting)', () => {
+        it('turns a zoom.recording envelope into a deduped Meeting row + transcript ingest', async () => {
+            await build().processRecordingEvent(recordingEvent());
+
+            expect(repository.createIfNew).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'user-1',
+                    workId: 'work-9',
+                    title: 'Weekly sync',
+                    source: 'zoom',
+                    externalId: 'uuid-1',
+                    startedAt: new Date('2026-07-24T10:00:00.000Z'),
+                    // durationMinutes 30 → endedAt = startedAt + 30 min.
+                    endedAt: new Date('2026-07-24T10:30:00.000Z'),
+                    sourceUrl: 'https://example.zoom.us/rec/play/abc',
+                }),
+            );
+            expect(repository.attachTranscript).toHaveBeenCalledWith(
+                expect.any(String),
+                'Alice: Hello.\nBob: Hi.',
+            );
+        });
+
+        it('skips transcript ingest when the envelope carries none or the same text', async () => {
+            const { transcriptText: _dropped, ...payload } = recordingEvent().payload as Record<
+                string,
+                unknown
+            >;
+            await build().processRecordingEvent(recordingEvent({ payload }));
+            expect(repository.attachTranscript).not.toHaveBeenCalled();
+
+            // Idempotency: an existing meeting that already holds this exact
+            // transcript is not re-ingested.
+            repository.createIfNew.mockResolvedValue({
+                meeting: meeting({ transcriptText: 'Alice: Hello.\nBob: Hi.' }),
+                created: false,
+            });
+            await build().processRecordingEvent(recordingEvent());
+            expect(repository.attachTranscript).not.toHaveBeenCalled();
+        });
+
+        it('skips envelopes with no meeting identity instead of crashing the drain', async () => {
+            await build().processRecordingEvent(
+                recordingEvent({ subjectExternalId: null, payload: { topic: 'x' } }),
+            );
+            expect(repository.createIfNew).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/agent/src/meetings/agent-meeting-tools.ts
+++ b/packages/agent/src/meetings/agent-meeting-tools.ts
@@ -1,0 +1,149 @@
+import type { TaskToolDescriptor } from '../tasks-domain/agent-task-tools';
+import type { MeetingSource } from '../entities/meeting.entity';
+import type { MeetingRepository } from './meeting.repository';
+
+/**
+ * Meetings v1 (Wave 8, feature a) — chat tools for the meetings
+ * surface, per the program DoD rule that every new entity ships with
+ * chat tools + keyword slots.
+ *
+ * Mirrors `ingest/agent-ingest-tools.ts`: a descriptor-factory the
+ * tool assembly concatenates at run time (type-only import of
+ * `TaskToolDescriptor`, so the Tasks runtime graph is NOT pulled into
+ * the meetings subpath).
+ *
+ * Keyword slots: "meetings", "transcript", "recording", "call",
+ * "standup" style asks route here; results carry `sourceUrl` so chat
+ * answers link back to the recording.
+ */
+
+export interface ListMeetingsArgs {
+    /** Optional Work filter — per-Work meetings view. */
+    workId?: string;
+    /** Optional source filter: zoom | google-meet | manual | import. */
+    source?: string;
+    /** Max rows (default 20, capped at 50). */
+    limit?: number;
+}
+
+export interface MeetingSummaryView {
+    id: string;
+    title: string;
+    startedAt: string;
+    endedAt?: string;
+    source: string;
+    workId?: string;
+    sourceUrl?: string;
+    participants: { name: string; email?: string }[];
+    hasTranscript: boolean;
+    summary?: string;
+}
+
+const VALID_SOURCES: readonly string[] = ['zoom', 'google-meet', 'manual', 'import'];
+
+export function buildMeetingTools(args: {
+    /** Owner scope — tools only ever read this user's rows. */
+    userId: string;
+    repository: MeetingRepository;
+}): TaskToolDescriptor[] {
+    const out: TaskToolDescriptor[] = [];
+
+    const toView = (meeting: {
+        id: string;
+        title: string;
+        startedAt: Date;
+        endedAt?: Date | null;
+        source: string;
+        workId?: string | null;
+        sourceUrl?: string | null;
+        participants: { name: string; email?: string }[];
+        transcriptText?: string | null;
+        summary?: string | null;
+    }): MeetingSummaryView => ({
+        id: meeting.id,
+        title: meeting.title,
+        startedAt: meeting.startedAt.toISOString(),
+        ...(meeting.endedAt ? { endedAt: meeting.endedAt.toISOString() } : {}),
+        source: meeting.source,
+        ...(meeting.workId ? { workId: meeting.workId } : {}),
+        ...(meeting.sourceUrl ? { sourceUrl: meeting.sourceUrl } : {}),
+        participants: meeting.participants ?? [],
+        hasTranscript: !!meeting.transcriptText,
+        ...(meeting.summary ? { summary: meeting.summary } : {}),
+    });
+
+    out.push({
+        name: 'list_meetings',
+        description:
+            'List the current user’s captured meetings (org-wide, or filtered to one Work), newest first — synced recordings, imported and manual meetings alike. Each meeting carries a sourceUrl linking to the recording — include it when citing a meeting.',
+        parameters: {
+            type: 'object',
+            properties: {
+                workId: {
+                    type: 'string',
+                    description: 'Optional Work id — only meetings routed to that Work.',
+                },
+                source: {
+                    type: 'string',
+                    description: 'Optional source filter: zoom, google-meet, manual or import.',
+                },
+                limit: {
+                    type: 'integer',
+                    description: 'Max meetings to return (default 20, capped at 50).',
+                },
+            },
+            required: [],
+        },
+        invoke: async (raw) => {
+            const a = (raw ?? {}) as ListMeetingsArgs;
+            const limit = Math.min(Math.max(Number(a.limit) || 20, 1), 50);
+            try {
+                const rows = await args.repository.findByUser(args.userId, {
+                    ...(a.workId ? { workId: a.workId } : {}),
+                    ...(a.source && VALID_SOURCES.includes(a.source)
+                        ? { source: a.source as MeetingSource }
+                        : {}),
+                    limit,
+                });
+                return { meetings: rows.map(toView) };
+            } catch (err) {
+                return { error: err instanceof Error ? err.message : String(err) };
+            }
+        },
+    } satisfies TaskToolDescriptor<ListMeetingsArgs, { meetings: MeetingSummaryView[] }>);
+
+    out.push({
+        name: 'get_meeting_summary',
+        description:
+            'Get one meeting’s AI summary plus its metadata (participants, timing, recording link). Use after list_meetings when the user asks what a meeting was about or what was decided. When no summary exists yet, the transcript availability flag says whether one can be generated.',
+        parameters: {
+            type: 'object',
+            properties: {
+                meetingId: {
+                    type: 'string',
+                    description: 'The meeting id (from list_meetings).',
+                },
+            },
+            required: ['meetingId'],
+        },
+        invoke: async (raw) => {
+            const a = (raw ?? {}) as { meetingId?: string };
+            if (!a.meetingId) {
+                return { error: 'meetingId is required' };
+            }
+            try {
+                const meeting = await args.repository.findById(a.meetingId);
+                // Owner scope: other users' meetings are indistinguishable
+                // from missing ones — no existence leak.
+                if (!meeting || meeting.userId !== args.userId) {
+                    return { error: `Meeting ${a.meetingId} not found` };
+                }
+                return { meeting: toView(meeting) };
+            } catch (err) {
+                return { error: err instanceof Error ? err.message : String(err) };
+            }
+        },
+    } satisfies TaskToolDescriptor<{ meetingId?: string }, { meeting: MeetingSummaryView }>);
+
+    return out;
+}

--- a/packages/agent/src/meetings/index.ts
+++ b/packages/agent/src/meetings/index.ts
@@ -1,0 +1,10 @@
+// Public surface of Meetings v1 (Wave 8, feature a): owner-scoped
+// meetings with transcript capture, best-effort AI summaries + Memory
+// observations, the `zoom.recording` envelope→Meeting processor, and
+// the `list_meetings` / `get_meeting_summary` chat tool factory.
+export * from './meetings.module';
+export * from './meetings.service';
+export * from './meeting.repository';
+export * from './agent-meeting-tools';
+export { Meeting } from '../entities/meeting.entity';
+export type { MeetingParticipant, MeetingSource } from '../entities/meeting.entity';

--- a/packages/agent/src/meetings/meeting.repository.ts
+++ b/packages/agent/src/meetings/meeting.repository.ts
@@ -1,0 +1,159 @@
+import { createHash } from 'crypto';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Meeting, MeetingParticipant, MeetingSource } from '../entities/meeting.entity';
+
+/**
+ * Dedupe identity for a provider-synced meeting: sha256 over
+ * `(userId, source, externalId)`.
+ *
+ * The provider identity is `(source, externalId)` — it is scoped per
+ * OWNER here so two users syncing the same provider account each keep
+ * their own row (a global key would silently drop the second user's
+ * sync and leak the first user's row back to them — same rationale as
+ * `computeDedupeKey` in the ingest spine). Segments are
+ * length-prefixed so `('ab','c')` and `('a','bc')` can never collide.
+ */
+export function computeMeetingDedupeKey(
+    userId: string,
+    source: string,
+    externalId: string,
+): string {
+    const hash = createHash('sha256');
+    for (const segment of [userId, source, externalId]) {
+        hash.update(`${segment.length}:${segment}|`);
+    }
+    return hash.digest('hex');
+}
+
+export interface CreateMeetingData {
+    userId: string;
+    organizationId?: string | null;
+    workId?: string | null;
+    title: string;
+    startedAt: Date;
+    endedAt?: Date | null;
+    source: MeetingSource;
+    externalId?: string | null;
+    participants?: MeetingParticipant[];
+    transcriptText?: string | null;
+    summary?: string | null;
+    sourceUrl?: string | null;
+}
+
+export interface FindMeetingsFilters {
+    workId?: string;
+    source?: MeetingSource;
+    /** Only meetings that started at/after this instant. */
+    since?: Date;
+    limit?: number;
+    offset?: number;
+}
+
+/**
+ * Feature-owned repository (provided by `MeetingsModule`, not
+ * `DatabaseModule` — same split as `IngestedEventRepository`).
+ */
+@Injectable()
+export class MeetingRepository {
+    constructor(
+        @InjectRepository(Meeting)
+        private readonly repository: Repository<Meeting>,
+    ) {}
+
+    /**
+     * Insert the meeting unless a row with the same dedupe identity
+     * already exists (provider-synced meetings only — manual rows have
+     * no `externalId` and always insert). Check-then-insert is not
+     * atomic, so the UNIQUE index race is treated as the idempotent
+     * outcome it should be (same convention as
+     * `IngestedEventRepository.createIfNew`).
+     */
+    async createIfNew(data: CreateMeetingData): Promise<{ meeting: Meeting; created: boolean }> {
+        const dedupeKey = data.externalId
+            ? computeMeetingDedupeKey(data.userId, data.source, data.externalId)
+            : null;
+
+        if (dedupeKey) {
+            const existing = await this.repository.findOne({ where: { dedupeKey } });
+            if (existing) {
+                return { meeting: existing, created: false };
+            }
+        }
+
+        try {
+            const meeting = await this.repository.save(
+                this.repository.create({
+                    ...data,
+                    participants: data.participants ?? [],
+                    dedupeKey,
+                }),
+            );
+            return { meeting, created: true };
+        } catch (error) {
+            if (dedupeKey && this.isUniqueViolation(error)) {
+                const winner = await this.repository.findOne({ where: { dedupeKey } });
+                if (winner) {
+                    return { meeting: winner, created: false };
+                }
+            }
+            throw error;
+        }
+    }
+
+    /** Owner-scoped listing, newest meetings first. */
+    async findByUser(userId: string, filters: FindMeetingsFilters = {}): Promise<Meeting[]> {
+        const qb = this.repository
+            .createQueryBuilder('meeting')
+            .where('meeting.userId = :userId', { userId });
+
+        if (filters.workId) {
+            qb.andWhere('meeting.workId = :workId', { workId: filters.workId });
+        }
+        if (filters.source) {
+            qb.andWhere('meeting.source = :source', { source: filters.source });
+        }
+        if (filters.since) {
+            qb.andWhere('meeting.startedAt >= :since', { since: filters.since });
+        }
+
+        return qb
+            .orderBy('meeting.startedAt', 'DESC')
+            .take(Math.min(Math.max(filters.limit ?? 20, 1), 100))
+            .skip(Math.max(filters.offset ?? 0, 0))
+            .getMany();
+    }
+
+    async findById(id: string): Promise<Meeting | null> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    /** Attach (or replace) the captured transcript text. */
+    async attachTranscript(id: string, transcriptText: string): Promise<void> {
+        await this.repository.update(id, { transcriptText });
+    }
+
+    /** Attach the generated summary (best-effort producer). */
+    async attachSummary(id: string, summary: string): Promise<void> {
+        await this.repository.update(id, { summary });
+    }
+
+    async update(id: string, patch: Partial<CreateMeetingData>): Promise<void> {
+        await this.repository.update(id, patch);
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.repository.delete(id);
+    }
+
+    private isUniqueViolation(error: unknown): boolean {
+        if (!error || typeof error !== 'object') return false;
+        const driverCode = (error as { driverError?: { code?: string } }).driverError?.code;
+        const topCode = (error as { code?: string }).code;
+        // Postgres 23505 / MySQL ER_DUP_ENTRY / SQLite SQLITE_CONSTRAINT —
+        // same convention as IngestedEventRepository.isUniqueViolation.
+        const codes = ['23505', 'ER_DUP_ENTRY', 'SQLITE_CONSTRAINT'];
+        return codes.includes(driverCode as string) || codes.includes(topCode as string);
+    }
+}

--- a/packages/agent/src/meetings/meetings.module.ts
+++ b/packages/agent/src/meetings/meetings.module.ts
@@ -1,0 +1,36 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Meeting } from '../entities/meeting.entity';
+import { EventIngestModule } from '../ingest/ingest.module';
+import { FacadesModule } from '../facades/facades.module';
+import { MeetingRepository } from './meeting.repository';
+import { MeetingsService } from './meetings.service';
+
+/**
+ * Meetings v1 (Wave 8, feature a) — agent-side module owning the
+ * `meetings` surface: owner-scoped CRUD, the transcript pipeline
+ * (store → best-effort AI summary → best-effort Memory observation →
+ * `meeting.transcript` envelope into the ingest spine, whose drain
+ * writes the Activity entry), and the `zoom.recording`
+ * envelope→Meeting kind processor `MeetingsService` registers on the
+ * spine at boot.
+ *
+ * `Meeting` MUST also stay registered in the DataSource ENTITIES array
+ * (`database/_entities-inventory.ts`) — this repo has no
+ * `autoLoadEntities`, so a forFeature'd-but-unregistered entity throws
+ * EntityMetadataNotFoundError on first query.
+ */
+@Module({
+    imports: [
+        TypeOrmModule.forFeature([Meeting]),
+        // EventIngestService — transcript envelopes + the kind-processor
+        // registration hook the recordings processor rides.
+        EventIngestModule,
+        // AiFacadeService (best-effort summaries) +
+        // AgentMemoryFacadeService (best-effort observations).
+        FacadesModule,
+    ],
+    providers: [MeetingRepository, MeetingsService],
+    exports: [MeetingRepository, MeetingsService],
+})
+export class MeetingsModule {}

--- a/packages/agent/src/meetings/meetings.service.ts
+++ b/packages/agent/src/meetings/meetings.service.ts
@@ -1,0 +1,469 @@
+import { createHash, randomUUID } from 'crypto';
+import {
+    BadRequestException,
+    Injectable,
+    Logger,
+    NotFoundException,
+    OnModuleInit,
+    Optional,
+} from '@nestjs/common';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+import { AiFacadeService } from '../facades/ai.facade';
+import { AgentMemoryFacadeService } from '../facades/agent-memory.facade';
+import { EventIngestService } from '../ingest/event-ingest.service';
+import type { IngestedEvent } from '../entities/ingested-event.entity';
+import { Meeting, MeetingParticipant, MeetingSource } from '../entities/meeting.entity';
+import { FindMeetingsFilters, MeetingRepository } from './meeting.repository';
+
+/**
+ * Hard cap on a stored transcript (chars). The API edge enforces its
+ * own request-size cap; this is the defensive service-level floor so
+ * no path (connector processor included) can write unbounded text.
+ */
+export const MEETING_TRANSCRIPT_MAX_CHARS = 200_000;
+
+/** Transcript slice handed to the summary prompt (context safety). */
+export const MEETING_SUMMARY_INPUT_MAX_CHARS = 24_000;
+
+/** Cap on the stored/emitted summary text. */
+export const MEETING_SUMMARY_MAX_CHARS = 4_000;
+
+/** Envelope kinds the meetings processor consumes (recordings → rows). */
+export const MEETING_RECORDING_EVENT_KINDS = ['zoom.recording'] as const;
+
+export interface CreateMeetingInput {
+    title: string;
+    startedAt: Date | string;
+    endedAt?: Date | string | null;
+    source?: MeetingSource;
+    externalId?: string | null;
+    participants?: MeetingParticipant[];
+    workId?: string | null;
+    organizationId?: string | null;
+    sourceUrl?: string | null;
+    /** Optional transcript captured at creation time — runs full ingest. */
+    transcriptText?: string | null;
+}
+
+export interface UpdateMeetingInput {
+    title?: string;
+    startedAt?: Date | string;
+    endedAt?: Date | string | null;
+    workId?: string | null;
+    participants?: MeetingParticipant[];
+    sourceUrl?: string | null;
+}
+
+export interface IngestTranscriptResult {
+    meeting: Meeting;
+    /** Present when the best-effort AI summary succeeded. */
+    summary?: string;
+    /** True when a Memory observation was saved (best-effort). */
+    memorySaved: boolean;
+    /** True when the `meeting.transcript` envelope landed (best-effort). */
+    envelopeEmitted: boolean;
+}
+
+const VALID_SOURCES: readonly MeetingSource[] = ['zoom', 'google-meet', 'manual', 'import'];
+
+/**
+ * Meetings v1 (Wave 8, feature a) — org-wide and per-Work meetings,
+ * transcript-first.
+ *
+ * Owner-scoped CRUD over the `meetings` table plus the transcript
+ * pipeline:
+ *
+ *   `ingestTranscript(meeting, text)` →
+ *     1. store the transcript (capped),
+ *     2. generate an AI `summary` via `AiFacadeService` — BEST-EFFORT
+ *        (no provider / provider error never fails the ingest),
+ *     3. save a Memory observation via `AgentMemoryFacadeService` with
+ *        meeting provenance — BEST-EFFORT (mirrors the spine's quiet
+ *        `NoProviderError` handling),
+ *     4. emit a `meeting.transcript` envelope into the event-ingest
+ *        spine — the spine's drain writes the Activity entry with
+ *        `sourceUrl` provenance, so meetings surface on Activities and
+ *        chat recall exactly like every other connector event.
+ *
+ * Recordings→Meetings processor: at boot this service registers a
+ * kind processor for `zoom.recording` envelopes (pulled by the
+ * zoom-connector event source) — each becomes a Meeting row
+ * (`createIfNew`, dedupe on owner+source+externalId) and, when the
+ * envelope carries transcript text, runs `ingestTranscript`. The
+ * processor is idempotent: re-delivered envelopes dedupe on the
+ * meeting row, and a transcript identical to the stored one is not
+ * re-ingested.
+ *
+ * LIVE BOT-JOIN (an Ever Works bot joining meetings/calls to capture
+ * transcripts in real time) is the documented v2 FOLLOW-UP — it will
+ * feed this same `ingestTranscript` path, so nothing here changes for
+ * it. Google Meet lands as a sibling connector emitting its own
+ * recording kind (add it to `MEETING_RECORDING_EVENT_KINDS`).
+ */
+@Injectable()
+export class MeetingsService implements OnModuleInit {
+    private readonly logger = new Logger(MeetingsService.name);
+
+    constructor(
+        private readonly repository: MeetingRepository,
+        private readonly eventIngest: EventIngestService,
+        @Optional() private readonly aiFacade?: AiFacadeService,
+        @Optional() private readonly agentMemory?: AgentMemoryFacadeService,
+    ) {}
+
+    /** Register the recordings→Meetings processor on the ingest spine. */
+    onModuleInit(): void {
+        this.eventIngest.registerKindProcessor({
+            kinds: MEETING_RECORDING_EVENT_KINDS,
+            process: (event) => this.processRecordingEvent(event),
+        });
+    }
+
+    // ── CRUD (owner-scoped) ─────────────────────────────────────────────
+
+    async createForUser(userId: string, input: CreateMeetingInput): Promise<Meeting> {
+        const title = (input.title ?? '').trim();
+        if (!title) {
+            throw new BadRequestException('Meeting title is required');
+        }
+        const startedAt = this.toDate(input.startedAt);
+        if (!startedAt) {
+            throw new BadRequestException('Meeting startedAt must be a valid date');
+        }
+        const source = input.source ?? 'manual';
+        if (!VALID_SOURCES.includes(source)) {
+            throw new BadRequestException(`Unknown meeting source: ${String(source)}`);
+        }
+
+        const { meeting } = await this.repository.createIfNew({
+            userId,
+            organizationId: input.organizationId ?? null,
+            workId: input.workId ?? null,
+            title: title.slice(0, 500),
+            startedAt,
+            endedAt: this.toDate(input.endedAt) ?? null,
+            source,
+            externalId: input.externalId ?? null,
+            participants: input.participants ?? [],
+            sourceUrl: input.sourceUrl ?? null,
+        });
+
+        if (input.transcriptText && input.transcriptText.trim().length > 0) {
+            const { meeting: updated } = await this.ingestTranscript(meeting, input.transcriptText);
+            return updated;
+        }
+        return meeting;
+    }
+
+    async listForUser(userId: string, filters: FindMeetingsFilters = {}): Promise<Meeting[]> {
+        return this.repository.findByUser(userId, filters);
+    }
+
+    /** 404 for missing AND for other owners' rows — no existence leak. */
+    async getForUser(userId: string, id: string): Promise<Meeting> {
+        const meeting = await this.repository.findById(id);
+        if (!meeting || meeting.userId !== userId) {
+            throw new NotFoundException(`Meeting ${id} not found`);
+        }
+        return meeting;
+    }
+
+    async updateForUser(userId: string, id: string, input: UpdateMeetingInput): Promise<Meeting> {
+        const meeting = await this.getForUser(userId, id);
+
+        const patch: Record<string, unknown> = {};
+        if (input.title !== undefined) {
+            const title = input.title.trim();
+            if (!title) throw new BadRequestException('Meeting title cannot be empty');
+            patch.title = title.slice(0, 500);
+        }
+        if (input.startedAt !== undefined) {
+            const startedAt = this.toDate(input.startedAt);
+            if (!startedAt) throw new BadRequestException('Meeting startedAt must be a valid date');
+            patch.startedAt = startedAt;
+        }
+        if (input.endedAt !== undefined) {
+            patch.endedAt = this.toDate(input.endedAt) ?? null;
+        }
+        if (input.workId !== undefined) patch.workId = input.workId;
+        if (input.participants !== undefined) patch.participants = input.participants;
+        if (input.sourceUrl !== undefined) patch.sourceUrl = input.sourceUrl;
+
+        if (Object.keys(patch).length > 0) {
+            await this.repository.update(meeting.id, patch);
+        }
+        return this.getForUser(userId, id);
+    }
+
+    async deleteForUser(userId: string, id: string): Promise<void> {
+        const meeting = await this.getForUser(userId, id);
+        await this.repository.delete(meeting.id);
+    }
+
+    // ── Transcript pipeline ─────────────────────────────────────────────
+
+    /** Owner-scoped transcript ingest (the API surface). */
+    async ingestTranscriptForUser(
+        userId: string,
+        id: string,
+        transcriptText: string,
+    ): Promise<IngestTranscriptResult> {
+        const meeting = await this.getForUser(userId, id);
+        if (!transcriptText || transcriptText.trim().length === 0) {
+            throw new BadRequestException('Transcript text is required');
+        }
+        return this.ingestTranscript(meeting, transcriptText);
+    }
+
+    /**
+     * Store the transcript, then run the best-effort fan-out (summary →
+     * memory → envelope). Only the transcript WRITE can fail this call —
+     * every enrichment failure degrades gracefully and never breaks
+     * ingest.
+     */
+    async ingestTranscript(
+        meeting: Meeting,
+        transcriptText: string,
+    ): Promise<IngestTranscriptResult> {
+        const text =
+            transcriptText.length > MEETING_TRANSCRIPT_MAX_CHARS
+                ? transcriptText.slice(0, MEETING_TRANSCRIPT_MAX_CHARS)
+                : transcriptText;
+
+        await this.repository.attachTranscript(meeting.id, text);
+        meeting.transcriptText = text;
+
+        const summary = await this.trySummarize(meeting, text);
+        if (summary) {
+            await this.tryAttachSummary(meeting, summary);
+        }
+
+        const memorySaved = await this.trySaveMemory(meeting, summary);
+        const envelopeEmitted = await this.tryEmitTranscriptEnvelope(meeting, text, summary);
+
+        return {
+            meeting,
+            ...(summary ? { summary } : {}),
+            memorySaved,
+            envelopeEmitted,
+        };
+    }
+
+    /**
+     * Recordings→Meetings processor for the ingest spine (registered in
+     * `onModuleInit`). Idempotent per envelope: the meeting row dedupes
+     * on (owner, source, externalId) and an unchanged transcript is not
+     * re-ingested.
+     */
+    async processRecordingEvent(event: IngestedEvent): Promise<void> {
+        const payload = (event.payload ?? {}) as Record<string, unknown>;
+        const externalId =
+            typeof payload.meetingExternalId === 'string' && payload.meetingExternalId.length > 0
+                ? payload.meetingExternalId
+                : (event.subjectExternalId ?? null);
+        if (!externalId) {
+            this.logger.warn(`Recording event ${event.id} has no meeting external id — skipped`);
+            return;
+        }
+
+        const startedAt =
+            (typeof payload.startTime === 'string' ? this.toDate(payload.startTime) : null) ??
+            event.occurredAt;
+        const durationMinutes =
+            typeof payload.durationMinutes === 'number' && Number.isFinite(payload.durationMinutes)
+                ? payload.durationMinutes
+                : null;
+        const endedAt = durationMinutes
+            ? new Date(startedAt.getTime() + durationMinutes * 60_000)
+            : null;
+        const title =
+            (typeof payload.topic === 'string' && payload.topic.trim().length > 0
+                ? payload.topic.trim()
+                : (event.title ?? '')) || 'Meeting';
+
+        const { meeting } = await this.repository.createIfNew({
+            userId: event.userId,
+            organizationId: event.organizationId ?? null,
+            workId: event.workId ?? null,
+            title: title.slice(0, 500),
+            startedAt,
+            endedAt,
+            source: 'zoom',
+            externalId,
+            participants: [],
+            sourceUrl: event.sourceUrl ?? null,
+        });
+
+        const transcript = typeof payload.transcriptText === 'string' ? payload.transcriptText : '';
+        if (transcript.trim().length > 0 && transcript !== meeting.transcriptText) {
+            await this.ingestTranscript(meeting, transcript);
+        }
+    }
+
+    // ── Best-effort enrichment legs ─────────────────────────────────────
+
+    /**
+     * AI summary — best-effort, never fails ingest. `NoProviderError`
+     * (no AI provider enabled for this user/Work) is the expected quiet
+     * case — debug, not warn (mirrors the spine's memory leg).
+     */
+    private async trySummarize(
+        meeting: Meeting,
+        transcriptText: string,
+    ): Promise<string | undefined> {
+        if (!this.aiFacade) return undefined;
+        try {
+            const completion = await this.aiFacade.createChatCompletion(
+                {
+                    messages: [
+                        {
+                            role: 'system',
+                            content:
+                                'You summarize meeting transcripts. Write a concise summary: 2-4 sentences of what was discussed and decided, then up to 5 bullet action items when present. Never invent facts that are not in the transcript.',
+                        },
+                        {
+                            role: 'user',
+                            content: `Meeting: ${meeting.title}\nStarted: ${meeting.startedAt.toISOString()}\n\nTranscript:\n${transcriptText.slice(0, MEETING_SUMMARY_INPUT_MAX_CHARS)}`,
+                        },
+                    ],
+                    temperature: 0.2,
+                    maxTokens: 512,
+                },
+                {
+                    userId: meeting.userId,
+                    ...(meeting.workId ? { workId: meeting.workId } : {}),
+                },
+            );
+            const content = completion.choices?.[0]?.message?.content;
+            const summary = typeof content === 'string' ? content.trim() : '';
+            return summary.length > 0 ? summary.slice(0, MEETING_SUMMARY_MAX_CHARS) : undefined;
+        } catch (error) {
+            this.logBestEffort('Summary generation skipped', meeting.id, error);
+            return undefined;
+        }
+    }
+
+    /** Persist the summary — best-effort (the transcript already landed). */
+    private async tryAttachSummary(meeting: Meeting, summary: string): Promise<void> {
+        try {
+            await this.repository.attachSummary(meeting.id, summary);
+            meeting.summary = summary;
+        } catch (error) {
+            this.logBestEffort('Summary write skipped', meeting.id, error);
+        }
+    }
+
+    /**
+     * Memory observation with meeting provenance — best-effort, never
+     * fails ingest. Provenance metadata is REQUIRED on these memories
+     * (drives Memory source facets + chat citations via `sourceUrl`).
+     */
+    private async trySaveMemory(meeting: Meeting, summary: string | undefined): Promise<boolean> {
+        if (!this.agentMemory) return false;
+        try {
+            const excerpt = summary ?? (meeting.transcriptText ?? '').slice(0, 500);
+            await this.agentMemory.saveMemory(
+                {
+                    content: `Meeting "${meeting.title}" (${meeting.startedAt.toISOString()}): ${excerpt}`,
+                    tags: [
+                        'meeting',
+                        `source:${meeting.source}`,
+                        ...(meeting.workId ? [`work:${meeting.workId}`] : []),
+                    ],
+                    metadata: this.provenance(meeting),
+                },
+                {
+                    userId: meeting.userId,
+                    ...(meeting.workId ? { workId: meeting.workId } : {}),
+                },
+            );
+            return true;
+        } catch (error) {
+            this.logBestEffort('Memory write skipped', meeting.id, error);
+            return false;
+        }
+    }
+
+    /**
+     * Emit the `meeting.transcript` envelope into the event-ingest
+     * spine — its drain writes the Activity entry (with `sourceUrl`
+     * provenance) and the spine-side memory one-liner. Content-hashed
+     * `sourceEventId`, so re-ingesting the SAME transcript dedupes while
+     * a revised transcript lands as a new event. Best-effort.
+     */
+    private async tryEmitTranscriptEnvelope(
+        meeting: Meeting,
+        transcriptText: string,
+        summary: string | undefined,
+    ): Promise<boolean> {
+        try {
+            const contentHash = createHash('sha256')
+                .update(transcriptText)
+                .digest('hex')
+                .slice(0, 16);
+            const envelope: IngestedEventEnvelope = {
+                id: randomUUID(),
+                source: 'meetings',
+                sourceEventId: `${meeting.id}:transcript:${contentHash}`,
+                kind: 'meeting.transcript',
+                occurredAt: meeting.startedAt.toISOString(),
+                subject: {
+                    type: 'meeting',
+                    externalId: meeting.externalId ?? meeting.id,
+                    title: meeting.title,
+                },
+                ...(meeting.sourceUrl ? { sourceUrl: meeting.sourceUrl } : {}),
+                ...(meeting.workId ? { workId: meeting.workId } : {}),
+                ...(meeting.organizationId ? { organizationId: meeting.organizationId } : {}),
+                payload: {
+                    meetingId: meeting.id,
+                    source: meeting.source,
+                    transcriptChars: transcriptText.length,
+                    ...(summary ? { summary: summary.slice(0, 2000) } : {}),
+                },
+            };
+            const result = await this.eventIngest.ingest(meeting.userId, [envelope]);
+            return result.inserted > 0 || result.duplicates > 0;
+        } catch (error) {
+            this.logBestEffort('Transcript envelope skipped', meeting.id, error);
+            return false;
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private provenance(meeting: Meeting): Record<string, unknown> {
+        return {
+            meetingId: meeting.id,
+            source: meeting.source,
+            startedAt: meeting.startedAt.toISOString(),
+            ...(meeting.externalId ? { externalId: meeting.externalId } : {}),
+            ...(meeting.sourceUrl ? { sourceUrl: meeting.sourceUrl } : {}),
+            ...(meeting.workId ? { workId: meeting.workId } : {}),
+            ...(meeting.organizationId ? { organizationId: meeting.organizationId } : {}),
+        };
+    }
+
+    private logBestEffort(prefix: string, meetingId: string, error: unknown): void {
+        const isQuiet = error instanceof Error && error.name === 'NoProviderError';
+        const message = `${prefix} for meeting ${meetingId}: ${
+            error instanceof Error ? error.message : String(error)
+        }`;
+        if (isQuiet) {
+            this.logger.debug(message);
+        } else {
+            this.logger.warn(message);
+        }
+    }
+
+    private toDate(value: Date | string | null | undefined): Date | null {
+        if (value instanceof Date) {
+            return Number.isNaN(value.getTime()) ? null : value;
+        }
+        if (typeof value === 'string') {
+            const parsed = new Date(value);
+            return Number.isNaN(parsed.getTime()) ? null : parsed;
+        }
+        return null;
+    }
+}

--- a/packages/plugins/zoom-connector/README.md
+++ b/packages/plugins/zoom-connector/README.md
@@ -1,0 +1,63 @@
+# @ever-works/zoom-connector-plugin
+
+Zoom connector for the Ever Works platform (Wave 8, Meetings v1 — transcript-first).
+
+## What it does
+
+- **Event source (`event-source` capability)** — `pullEvents` sweeps **completed
+  cloud recordings** since the last watermark via the official
+  [`@zoom/rivet`](https://www.npmjs.com/package/@zoom/rivet) SDK
+  (`MeetingsS2SAuthClient.endpoints.cloudRecording.listAllRecordings`,
+  Server-to-Server OAuth). When a completed transcript (VTT) file exists it is
+  downloaded, converted to readable text and truncated to the envelope-safe cap
+  (24 000 chars). Each recording becomes a `zoom.recording`
+  `IngestedEventEnvelope`; the agent-side Meetings processor turns those
+  envelopes into `Meeting` rows and runs transcript ingest
+  (summary + memory + activity).
+- **Connector (`connector` capability)** — `verifyConnection` validates the
+  Server-to-Server OAuth credentials. Outbound messaging is **not** part of v1;
+  `send` rejects loudly.
+
+## Settings
+
+| Key            | Notes                                                             |
+| -------------- | ----------------------------------------------------------------- |
+| `accountId`    | Zoom account id of the Server-to-Server OAuth app                 |
+| `clientId`     | Client id of the Server-to-Server OAuth app                       |
+| `clientSecret` | Client secret (`x-secret`)                                        |
+| `backfillDays` | Opt-in historical backfill window on first pull (0–90, default 0) |
+
+## Sweep protocol
+
+The Zoom recordings list API caps `from`/`to` at one month, so a sweep advances
+through ≤30-day window chunks up to the sweep end bound, round-tripping the
+API's `next_page_token` inside each chunk. Re-delivery across overlapping
+windows is safe — the ingest pipeline dedupes on `(source, sourceEventId)`, and
+transcript availability is part of the identity (`:recording` vs
+`:transcript`) so a transcript that completes after the recording still lands.
+
+## Vendor-SDK note
+
+Every Zoom **API** call goes through the official `@zoom/rivet` SDK. The one
+exception is the transcript **file** download: Rivet wraps the REST endpoints
+but exposes neither recording-file downloads nor its internal access token, so
+the download leg performs the official Server-to-Server OAuth
+`account_credentials` token flow (`https://zoom.us/oauth/token`) and fetches the
+SDK-returned `download_url` with the bearer token. Both hosts are fixed Zoom
+origins — no user-controlled URLs.
+
+## Follow-up (documented, not in v1)
+
+**Live bot-join** — an Ever Works bot joining meetings/calls to capture audio
+and transcripts in real time — requires Zoom's Meeting Bot / RTMS surface and a
+media pipeline. It will layer onto this connector without changing the
+`zoom.recording` envelope contract.
+
+## Tests
+
+```bash
+cd packages/plugins/zoom-connector && pnpm test
+```
+
+Vitest suite with a mocked client seam (`createClient` override) — no real Zoom
+calls.

--- a/packages/plugins/zoom-connector/package.json
+++ b/packages/plugins/zoom-connector/package.json
@@ -1,0 +1,99 @@
+{
+	"name": "@ever-works/zoom-connector-plugin",
+	"version": "1.0.0",
+	"description": "Zoom connector plugin for Ever Works platform (event-source pull of completed cloud recordings with transcripts into the event-ingest pipeline via the official @zoom/rivet SDK, Server-to-Server OAuth)",
+	"author": {
+		"name": "Ever Co. LTD",
+		"email": "ever@ever.co",
+		"url": "https://ever.co"
+	},
+	"license": "AGPL-3.0",
+	"private": false,
+	"type": "module",
+	"main": "./dist/index.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsup",
+		"dev": "tsup --watch",
+		"clean": "rm -rf dist",
+		"type-check": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@ever-works/contracts": "workspace:*",
+		"@ever-works/plugin": "workspace:*",
+		"@zoom/rivet": "^0.4.0"
+	},
+	"devDependencies": {
+		"@types/node": "^22.0.0",
+		"tsup": "^8.0.0",
+		"typescript": "^5.9.3",
+		"vitest": "^4.1.0"
+	},
+	"everworks": {
+		"plugin": {
+			"id": "zoom-connector",
+			"name": "Zoom Connector",
+			"version": "1.0.0",
+			"category": "connector",
+			"capabilities": [
+				"connector",
+				"event-source"
+			],
+			"description": "Zoom connector. Event-source pull ingests completed cloud recordings (with transcripts when available) since the last watermark into the platform event-ingest pipeline via the official @zoom/rivet SDK (Server-to-Server OAuth), with opt-in historical backfill (backfillDays, max 90). Recording events become Meeting rows with transcript capture; live bot-join is a documented follow-up.",
+			"systemPlugin": false,
+			"builtIn": true,
+			"isDefault": false,
+			"autoEnable": false,
+			"settings": {
+				"type": "object",
+				"required": [
+					"accountId",
+					"clientId",
+					"clientSecret"
+				],
+				"properties": {
+					"accountId": {
+						"type": "string",
+						"title": "Zoom account id (Server-to-Server OAuth app)",
+						"x-envVar": "ZOOM_ACCOUNT_ID"
+					},
+					"clientId": {
+						"type": "string",
+						"title": "Zoom client id (Server-to-Server OAuth app)",
+						"x-envVar": "ZOOM_CLIENT_ID"
+					},
+					"clientSecret": {
+						"type": "string",
+						"title": "Zoom client secret (Server-to-Server OAuth app)",
+						"x-secret": true,
+						"x-envVar": "ZOOM_CLIENT_SECRET"
+					},
+					"backfillDays": {
+						"type": "number",
+						"title": "Historical backfill window in days on first pull (0 = off, max 90)",
+						"default": 0,
+						"minimum": 0,
+						"maximum": 90
+					}
+				}
+			}
+		}
+	},
+	"publishConfig": {
+		"access": "restricted",
+		"registry": "https://registry.npmjs.org"
+	}
+}

--- a/packages/plugins/zoom-connector/src/index.ts
+++ b/packages/plugins/zoom-connector/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * @ever-works/zoom-connector-plugin — Zoom connector (Wave 8,
+ * Meetings v1). `pullEvents` event-source leg sweeps completed cloud
+ * recordings (with transcripts when available, opt-in historical
+ * backfill) via the official `@zoom/rivet` SDK (Server-to-Server
+ * OAuth), feeding the platform event-ingest spine as `zoom.recording`
+ * envelopes that the Meetings processor turns into Meeting rows.
+ */
+export {
+	ZoomConnectorPlugin,
+	zoomConnectorPlugin,
+	clampBackfillDays,
+	parseVttToText,
+	ZOOM_TRANSCRIPT_MAX_CHARS,
+	ZOOM_PULL_PAGE_SIZE,
+	ZOOM_WINDOW_MAX_DAYS,
+	ZOOM_BACKFILL_MAX_PAGES
+} from './zoom-connector-plugin.js';
+export type {
+	ZoomClientLike,
+	ZoomRecordingsPage,
+	ZoomRecordingMeetingNode,
+	ZoomRecordingFileNode
+} from './zoom-connector-plugin.js';

--- a/packages/plugins/zoom-connector/src/zoom-connector-plugin.spec.ts
+++ b/packages/plugins/zoom-connector/src/zoom-connector-plugin.spec.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+	ZoomConnectorPlugin,
+	clampBackfillDays,
+	parseVttToText,
+	ZOOM_TRANSCRIPT_MAX_CHARS,
+	ZOOM_BACKFILL_MAX_PAGES,
+	ZOOM_WINDOW_MAX_DAYS
+} from './zoom-connector-plugin.js';
+import type { ZoomRecordingsPage } from './zoom-connector-plugin.js';
+
+const listAllRecordingsMock = vi.fn();
+const downloadTranscriptMock = vi.fn();
+const clientFactoryMock = vi.fn();
+
+/** Subclass overriding the client seam so no real SDK call ever happens. */
+class TestZoomConnectorPlugin extends ZoomConnectorPlugin {
+	protected override createClient(credentials: { accountId: string; clientId: string; clientSecret: string }) {
+		clientFactoryMock(credentials);
+		return {
+			listAllRecordings: listAllRecordingsMock,
+			downloadTranscript: downloadTranscriptMock
+		};
+	}
+}
+
+const SETTINGS = {
+	accountId: 'acc_1',
+	clientId: 'client_1',
+	clientSecret: 'secret_1'
+};
+
+const DAY_MS = 86_400_000;
+const EPOCH = new Date(0).toISOString();
+
+function emptyPage(): ZoomRecordingsPage {
+	return { meetings: [] };
+}
+
+function recordingMeeting(overrides: Record<string, unknown> = {}) {
+	return {
+		uuid: 'uuid-1',
+		id: 123456,
+		topic: 'Weekly sync',
+		start_time: '2026-07-24T10:00:00Z',
+		duration: 42,
+		host_id: 'host-1',
+		recording_files: [
+			{
+				id: 'file-mp4',
+				file_type: 'MP4',
+				play_url: 'https://example.zoom.us/rec/play/abc',
+				download_url: 'https://example.zoom.us/rec/download/abc',
+				status: 'completed'
+			}
+		],
+		...overrides
+	};
+}
+
+describe('ZoomConnectorPlugin', () => {
+	let plugin: TestZoomConnectorPlugin;
+
+	beforeEach(() => {
+		plugin = new TestZoomConnectorPlugin();
+		listAllRecordingsMock.mockReset();
+		downloadTranscriptMock.mockReset();
+		clientFactoryMock.mockReset();
+	});
+
+	it('declares the connector + event-source capabilities and secret-marked settings', () => {
+		expect(plugin.id).toBe('zoom-connector');
+		expect(plugin.category).toBe('connector');
+		expect(plugin.capabilities).toEqual(['connector', 'event-source']);
+		expect(plugin.providerName).toBe('zoom');
+		expect(plugin.connector.direction).toBe('inbound');
+		expect(plugin.connector.transport).toBe('poll');
+		expect(plugin.connector.flags.inbound).toBe(true);
+		expect(plugin.connector.flags.outboundMessage).toBe(false);
+		const props = plugin.settingsSchema.properties as Record<string, Record<string, unknown>>;
+		expect(props.clientSecret['x-secret']).toBe(true);
+		expect(plugin.settingsSchema.required).toEqual(['accountId', 'clientId', 'clientSecret']);
+	});
+
+	it('clampBackfillDays clamps to the 0–90 range and rejects garbage', () => {
+		expect(clampBackfillDays(0)).toBe(0);
+		expect(clampBackfillDays(-5)).toBe(0);
+		expect(clampBackfillDays('nope')).toBe(0);
+		expect(clampBackfillDays(14.9)).toBe(14);
+		expect(clampBackfillDays(365)).toBe(90);
+	});
+
+	it('parseVttToText strips WEBVTT headers, cue indices and timing lines', () => {
+		const vtt = [
+			'WEBVTT',
+			'',
+			'1',
+			'00:00:01.000 --> 00:00:04.000',
+			'Alice: Welcome everyone.',
+			'',
+			'2',
+			'00:00:05.000 --> 00:00:09.000',
+			'Bob: Thanks, glad to be here.'
+		].join('\n');
+		expect(parseVttToText(vtt)).toBe('Alice: Welcome everyone.\nBob: Thanks, glad to be here.');
+	});
+
+	it('pullEvents throws EventSourceNotConfiguredError without full credentials', async () => {
+		await expect(plugin.pullEvents({ since: EPOCH, settings: { accountId: 'a' } })).rejects.toMatchObject({
+			name: 'EventSourceNotConfiguredError'
+		});
+		expect(listAllRecordingsMock).not.toHaveBeenCalled();
+	});
+
+	it('normalizes a completed recording into a zoom.recording envelope', async () => {
+		listAllRecordingsMock.mockResolvedValueOnce({ meetings: [recordingMeeting()] });
+		const result = await plugin.pullEvents({
+			since: new Date(Date.now() - DAY_MS).toISOString(),
+			settings: SETTINGS
+		});
+		expect(result.events).toHaveLength(1);
+		const envelope = result.events[0];
+		expect(envelope.source).toBe('zoom-connector');
+		expect(envelope.kind).toBe('zoom.recording');
+		expect(envelope.sourceEventId).toBe('uuid-1:recording');
+		expect(envelope.occurredAt).toBe('2026-07-24T10:00:00Z');
+		expect(envelope.subject).toMatchObject({ type: 'meeting', externalId: 'uuid-1', title: 'Weekly sync' });
+		expect(envelope.sourceUrl).toBe('https://example.zoom.us/rec/play/abc');
+		expect(envelope.payload).toMatchObject({
+			meetingExternalId: 'uuid-1',
+			meetingNumber: 123456,
+			topic: 'Weekly sync',
+			durationMinutes: 42,
+			recordingCount: 1
+		});
+		expect(envelope.payload?.transcriptText).toBeUndefined();
+	});
+
+	it('downloads + parses the transcript when a completed TRANSCRIPT file exists', async () => {
+		listAllRecordingsMock.mockResolvedValueOnce({
+			meetings: [
+				recordingMeeting({
+					recording_files: [
+						{
+							id: 'file-vtt',
+							file_type: 'TRANSCRIPT',
+							download_url: 'https://example.zoom.us/rec/download/vtt',
+							status: 'completed'
+						},
+						{
+							id: 'file-mp4',
+							file_type: 'MP4',
+							play_url: 'https://example.zoom.us/rec/play/abc',
+							status: 'completed'
+						}
+					]
+				})
+			]
+		});
+		downloadTranscriptMock.mockResolvedValueOnce('WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nAlice: Hello world.');
+		const result = await plugin.pullEvents({ since: new Date().toISOString(), settings: SETTINGS });
+		expect(downloadTranscriptMock).toHaveBeenCalledWith('https://example.zoom.us/rec/download/vtt');
+		expect(result.events[0].sourceEventId).toBe('uuid-1:transcript');
+		expect(result.events[0].payload?.transcriptText).toBe('Alice: Hello world.');
+	});
+
+	it('truncates oversized transcripts to the envelope-safe cap', async () => {
+		listAllRecordingsMock.mockResolvedValueOnce({
+			meetings: [
+				recordingMeeting({
+					recording_files: [
+						{
+							file_type: 'TRANSCRIPT',
+							download_url: 'https://example.zoom.us/rec/download/vtt',
+							status: 'completed'
+						}
+					]
+				})
+			]
+		});
+		downloadTranscriptMock.mockResolvedValueOnce(`Alice: ${'a'.repeat(ZOOM_TRANSCRIPT_MAX_CHARS * 2)}`);
+		const result = await plugin.pullEvents({ since: new Date().toISOString(), settings: SETTINGS });
+		expect((result.events[0].payload?.transcriptText as string).length).toBe(ZOOM_TRANSCRIPT_MAX_CHARS);
+	});
+
+	it('degrades to a transcript-less envelope when the download fails', async () => {
+		listAllRecordingsMock.mockResolvedValueOnce({
+			meetings: [
+				recordingMeeting({
+					recording_files: [
+						{
+							file_type: 'TRANSCRIPT',
+							download_url: 'https://example.zoom.us/rec/download/vtt',
+							status: 'completed'
+						}
+					]
+				})
+			]
+		});
+		downloadTranscriptMock.mockRejectedValueOnce(new Error('HTTP 401'));
+		const result = await plugin.pullEvents({ since: new Date().toISOString(), settings: SETTINGS });
+		expect(result.events).toHaveLength(1);
+		expect(result.events[0].sourceEventId).toBe('uuid-1:recording');
+		expect(result.events[0].payload?.transcriptText).toBeUndefined();
+	});
+
+	it('round-trips the API page token through the pull cursor', async () => {
+		listAllRecordingsMock.mockResolvedValueOnce({
+			meetings: [recordingMeeting()],
+			next_page_token: 'token-2'
+		});
+		const first = await plugin.pullEvents({ since: new Date().toISOString(), settings: SETTINGS });
+		expect(first.nextCursor).toBeDefined();
+		const cursor = JSON.parse(first.nextCursor as string);
+		expect(cursor.n).toBe('token-2');
+
+		listAllRecordingsMock.mockResolvedValueOnce(emptyPage());
+		await plugin.pullEvents({
+			since: new Date().toISOString(),
+			cursor: first.nextCursor,
+			settings: SETTINGS
+		});
+		expect(listAllRecordingsMock).toHaveBeenLastCalledWith(expect.objectContaining({ next_page_token: 'token-2' }));
+	});
+
+	it('chunks sweeps older than the 30-day window bound and advances chunk by chunk', async () => {
+		const since = new Date(Date.now() - 75 * DAY_MS).toISOString();
+		listAllRecordingsMock.mockResolvedValue(emptyPage());
+
+		// Chunk 1: [since, since+30d].
+		const first = await plugin.pullEvents({ since, settings: SETTINGS });
+		const firstQuery = listAllRecordingsMock.mock.calls[0][0];
+		expect(firstQuery.from).toBe(since.slice(0, 10));
+		const chunk1To = new Date(Date.parse(since) + ZOOM_WINDOW_MAX_DAYS * DAY_MS);
+		expect(firstQuery.to).toBe(chunk1To.toISOString().slice(0, 10));
+		expect(first.nextCursor).toBeDefined();
+
+		// Chunk 2 resumes where chunk 1 ended.
+		const second = await plugin.pullEvents({ since, cursor: first.nextCursor, settings: SETTINGS });
+		const secondQuery = listAllRecordingsMock.mock.calls[1][0];
+		expect(secondQuery.from).toBe(chunk1To.toISOString().slice(0, 10));
+		expect(second.nextCursor).toBeDefined();
+
+		// Chunk 3 is the tail — the sweep completes with no cursor.
+		const third = await plugin.pullEvents({ since, cursor: second.nextCursor, settings: SETTINGS });
+		expect(third.nextCursor).toBeUndefined();
+	});
+
+	it('first pull with opt-in backfill widens the window; without it starts at now', async () => {
+		listAllRecordingsMock.mockResolvedValue(emptyPage());
+
+		await plugin.pullEvents({ since: EPOCH, settings: { ...SETTINGS, backfillDays: 7 } });
+		const backfillQuery = listAllRecordingsMock.mock.calls[0][0];
+		expect(backfillQuery.from).toBe(new Date(Date.now() - 7 * DAY_MS).toISOString().slice(0, 10));
+
+		await plugin.pullEvents({ since: EPOCH, settings: SETTINGS });
+		const freshQuery = listAllRecordingsMock.mock.calls[1][0];
+		expect(freshQuery.from).toBe(new Date().toISOString().slice(0, 10));
+	});
+
+	it('caps backfill sweeps at the per-chunk page budget', async () => {
+		listAllRecordingsMock.mockResolvedValue({ meetings: [], next_page_token: 'more' });
+		let result = await plugin.pullEvents({ since: EPOCH, settings: { ...SETTINGS, backfillDays: 7 } });
+		for (let page = 1; page < ZOOM_BACKFILL_MAX_PAGES; page += 1) {
+			expect(result.nextCursor).toBeDefined();
+			result = await plugin.pullEvents({ since: EPOCH, cursor: result.nextCursor, settings: SETTINGS });
+		}
+		// Budget spent — the cursor no longer carries a page token (the
+		// sweep either advances to the next chunk or completes).
+		const cursor = result.nextCursor ? JSON.parse(result.nextCursor) : undefined;
+		expect(cursor?.n).toBeUndefined();
+	});
+
+	it('verifyConnection reports ok with credentials and fails cleanly without', async () => {
+		listAllRecordingsMock.mockResolvedValueOnce(emptyPage());
+		const ok = await plugin.verifyConnection({}, { settings: SETTINGS });
+		expect(ok.valid).toBe(true);
+
+		const missing = await plugin.verifyConnection({}, { settings: {} });
+		expect(missing.valid).toBe(false);
+
+		listAllRecordingsMock.mockRejectedValueOnce(new Error('invalid client'));
+		const broken = await plugin.verifyConnection({}, { settings: SETTINGS });
+		expect(broken.valid).toBe(false);
+		expect(broken.message).toContain('invalid client');
+	});
+
+	it('send rejects loudly — Meetings v1 is transcript-first (bot-join is the follow-up)', async () => {
+		await expect(
+			plugin.send({ messageRef: 'ref-1', text: 'hello' } as never, { settings: SETTINGS })
+		).rejects.toThrow(/not supported in v1/);
+	});
+});

--- a/packages/plugins/zoom-connector/src/zoom-connector-plugin.ts
+++ b/packages/plugins/zoom-connector/src/zoom-connector-plugin.ts
@@ -1,0 +1,531 @@
+import { randomUUID } from 'node:crypto';
+import { MeetingsS2SAuthClient } from '@zoom/rivet/meetings';
+import type {
+	IConnectorPlugin,
+	IEventSourcePlugin,
+	ConnectorMetadata,
+	ConnectorCallOptions,
+	ChannelSendInput,
+	ChannelSendResult,
+	ChannelTargetConfig,
+	ChannelVerification,
+	EventSourcePullInput,
+	EventSourcePullResult,
+	PluginCategory,
+	PluginSettings,
+	JsonSchema
+} from '@ever-works/plugin';
+import { PLUGIN_CAPABILITIES, EventSourceNotConfiguredError } from '@ever-works/plugin';
+import type { IngestedEventEnvelope } from '@ever-works/contracts';
+
+/**
+ * Transcript text cap for ingested envelopes. Envelope payloads are
+ * size-capped platform-side (32 KB serialized) — a long meeting's VTT
+ * can exceed that, so the plugin truncates to this many characters
+ * (the full recording stays reachable via `sourceUrl`).
+ */
+export const ZOOM_TRANSCRIPT_MAX_CHARS = 24_000;
+
+/** Recordings requested per page. */
+export const ZOOM_PULL_PAGE_SIZE = 30;
+
+/**
+ * The Zoom recordings list API only accepts a window of at most one
+ * month per request — sweeps over longer ranges advance in chunks of
+ * this many days.
+ */
+export const ZOOM_WINDOW_MAX_DAYS = 30;
+
+/**
+ * Historical backfill bound: at most this many pages per window chunk
+ * during the opt-in first-pull backfill, so a recording-heavy account
+ * can never turn activation into an unbounded crawl.
+ */
+export const ZOOM_BACKFILL_MAX_PAGES = 10;
+
+const DAY_MS = 86_400_000;
+
+/** Clamp the opt-in backfill window to the supported 0–90 day range. */
+export function clampBackfillDays(value: unknown): number {
+	const num = typeof value === 'number' ? value : Number(value);
+	if (!Number.isFinite(num) || num <= 0) return 0;
+	return Math.min(Math.floor(num), 90);
+}
+
+/**
+ * WebVTT → readable text: drops the WEBVTT header, cue indices and
+ * `00:00:00.000 --> 00:00:05.000` timing lines, keeps speaker-labelled
+ * caption text, and collapses duplicate blank lines.
+ */
+export function parseVttToText(vtt: string): string {
+	const lines = vtt.split(/\r?\n/);
+	const out: string[] = [];
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (trimmed.length === 0) continue;
+		if (/^WEBVTT/i.test(trimmed)) continue;
+		if (/^\d+$/.test(trimmed)) continue;
+		if (/-->/.test(trimmed)) continue;
+		out.push(trimmed);
+	}
+	return out.join('\n');
+}
+
+function truncateTranscript(text: string): string {
+	return text.length > ZOOM_TRANSCRIPT_MAX_CHARS ? text.slice(0, ZOOM_TRANSCRIPT_MAX_CHARS) : text;
+}
+
+/** Date-only string (`yyyy-mm-dd`) the recordings list API expects. */
+function toDateOnly(iso: string): string {
+	return iso.slice(0, 10);
+}
+
+interface ZoomCredentials {
+	accountId: string;
+	clientId: string;
+	clientSecret: string;
+}
+
+function resolveCredentials(
+	settings: PluginSettings | Readonly<Record<string, unknown>> | undefined
+): ZoomCredentials | undefined {
+	const accountId = settings?.accountId;
+	const clientId = settings?.clientId;
+	const clientSecret = settings?.clientSecret;
+	if (
+		typeof accountId === 'string' &&
+		accountId.length > 0 &&
+		typeof clientId === 'string' &&
+		clientId.length > 0 &&
+		typeof clientSecret === 'string' &&
+		clientSecret.length > 0
+	) {
+		return { accountId, clientId, clientSecret };
+	}
+	return undefined;
+}
+
+/**
+ * Opaque pull cursor. Sweeps advance through ≤30-day window chunks
+ * (`from`/`to`, the Zoom month-range constraint); `n` is the API's
+ * `next_page_token` inside the current chunk, `w` the sweep end bound
+ * (fixed when the sweep started so a long sweep converges), `f` flags
+ * a first-pull backfill sweep and `b` counts pages used in the current
+ * chunk (backfill page bound). Malformed input restarts the sweep —
+ * safe, the ingest pipeline dedupes on `(source, sourceEventId)`.
+ */
+interface ZoomPullCursor {
+	from: string;
+	to: string;
+	w: string;
+	n?: string;
+	f?: 1;
+	b?: number;
+}
+
+function parsePullCursor(cursor: string | undefined): ZoomPullCursor | undefined {
+	if (!cursor) return undefined;
+	try {
+		const parsed = JSON.parse(cursor) as ZoomPullCursor;
+		if (
+			parsed &&
+			typeof parsed.from === 'string' &&
+			typeof parsed.to === 'string' &&
+			typeof parsed.w === 'string'
+		) {
+			return parsed;
+		}
+	} catch {
+		// fall through — treat as no cursor
+	}
+	return undefined;
+}
+
+/** Minimal scalar shape of a recording file node we consume. */
+export interface ZoomRecordingFileNode {
+	id?: string;
+	file_type?: string;
+	download_url?: string;
+	play_url?: string;
+	recording_type?: string;
+	status?: string;
+}
+
+/** Minimal scalar shape of a recorded-meeting node we consume. */
+export interface ZoomRecordingMeetingNode {
+	uuid?: string;
+	id?: number;
+	topic?: string;
+	start_time?: string;
+	duration?: number;
+	host_id?: string;
+	recording_files?: ZoomRecordingFileNode[];
+}
+
+export interface ZoomRecordingsPage {
+	meetings?: ZoomRecordingMeetingNode[];
+	next_page_token?: string;
+}
+
+/** The subset of the Zoom surface this plugin calls (testable seam). */
+export interface ZoomClientLike {
+	listAllRecordings(query: {
+		from?: string;
+		to?: string;
+		page_size?: number;
+		next_page_token?: string;
+	}): Promise<ZoomRecordingsPage>;
+	/** Fetch a transcript (VTT) file's raw content. */
+	downloadTranscript(url: string): Promise<string>;
+}
+
+/** In-memory S2S token cache entry (module-singleton plugin). */
+interface CachedToken {
+	token: string;
+	expiresAt: number;
+}
+
+/**
+ * Zoom connector (Wave 8, Meetings v1) — first-party native connector.
+ *
+ * Event source: `pullEvents` sweeps COMPLETED cloud recordings since
+ * the watermark via the official `@zoom/rivet` SDK
+ * (`MeetingsS2SAuthClient.endpoints.cloudRecording.listAllRecordings`,
+ * Server-to-Server OAuth — the SDK pins the API host, so there is no
+ * SSRF surface), downloads the transcript (VTT → text, truncated to
+ * `ZOOM_TRANSCRIPT_MAX_CHARS`) when one is available, and normalizes
+ * each recording into a `zoom.recording` `IngestedEventEnvelope` for
+ * the platform's event-ingest spine. The agent-side Meetings processor
+ * turns those envelopes into Meeting rows + transcript ingest.
+ *
+ * Vendor-SDK note: every Zoom API call goes through the official
+ * `@zoom/rivet` SDK. The ONE exception is the transcript FILE
+ * download — Rivet wraps the REST endpoints but exposes neither
+ * recording-file downloads nor its internal access token, so the
+ * download leg performs the official Server-to-Server OAuth
+ * `account_credentials` token flow (`https://zoom.us/oauth/token`)
+ * and fetches the SDK-returned `download_url` with the bearer token.
+ * Both URLs are fixed Zoom hosts (no user-controlled origins).
+ *
+ * Outbound: none in v1 (`send` rejects) — Meetings v1 is
+ * transcript-first. LIVE BOT-JOIN (an Ever Works bot joining the
+ * meeting to capture audio in real time) is the documented FOLLOW-UP:
+ * it requires the Meeting Bot / RTMS surface and a media pipeline,
+ * and will layer onto this connector without changing the envelope
+ * contract.
+ *
+ * Sweep protocol: the Zoom recordings list API caps `from`/`to` at one
+ * month, so a sweep advances through ≤30-day window chunks up to the
+ * sweep end bound. The opt-in historical backfill (`backfillDays`,
+ * default 0 = off, max 90) widens the FIRST pull's window only, with a
+ * per-chunk page bound so activation never becomes an unbounded crawl.
+ * Re-delivery across overlapping windows is fine — the ingest pipeline
+ * dedupes on `(source, sourceEventId)`.
+ */
+export class ZoomConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin {
+	readonly id = 'zoom-connector';
+	readonly name = 'Zoom Connector';
+	readonly version = '1.0.0';
+	readonly category: PluginCategory = 'connector';
+	readonly capabilities = [PLUGIN_CAPABILITIES.CONNECTOR, PLUGIN_CAPABILITIES.EVENT_SOURCE] as const;
+
+	readonly providerName = 'zoom';
+
+	readonly connector: ConnectorMetadata = {
+		direction: 'inbound',
+		transport: 'poll',
+		flags: {
+			outboundMessage: false,
+			outboundRecord: false,
+			inbound: true,
+			reply: false,
+			pairing: false,
+			richOutbound: false
+		}
+	};
+
+	readonly settingsSchema: JsonSchema = {
+		type: 'object',
+		required: ['accountId', 'clientId', 'clientSecret'],
+		properties: {
+			accountId: {
+				type: 'string',
+				title: 'Zoom account id (Server-to-Server OAuth app)',
+				'x-envVar': 'ZOOM_ACCOUNT_ID'
+			},
+			clientId: {
+				type: 'string',
+				title: 'Zoom client id (Server-to-Server OAuth app)',
+				'x-envVar': 'ZOOM_CLIENT_ID'
+			},
+			clientSecret: {
+				type: 'string',
+				title: 'Zoom client secret (Server-to-Server OAuth app)',
+				'x-secret': true,
+				'x-envVar': 'ZOOM_CLIENT_SECRET'
+			},
+			backfillDays: {
+				type: 'number',
+				title: 'Historical backfill window in days on first pull (0 = off, max 90)',
+				default: 0,
+				minimum: 0,
+				maximum: 90
+			}
+		}
+	};
+
+	private readonly tokenCache = new Map<string, CachedToken>();
+
+	async onLoad(): Promise<void> {
+		// No-op — no warm-up resources; a client is created per call.
+	}
+
+	async onUnload(): Promise<void> {
+		this.tokenCache.clear();
+	}
+
+	/** Testable seam — specs stub this; production uses `@zoom/rivet`. */
+	protected createClient(credentials: ZoomCredentials): ZoomClientLike {
+		const client = new MeetingsS2SAuthClient({
+			accountId: credentials.accountId,
+			clientId: credentials.clientId,
+			clientSecret: credentials.clientSecret,
+			disableReceiver: true
+		});
+		return {
+			listAllRecordings: async (query) => {
+				const res = await client.endpoints.cloudRecording.listAllRecordings({
+					path: { userId: 'me' },
+					query
+				});
+				return (res.data ?? {}) as ZoomRecordingsPage;
+			},
+			downloadTranscript: async (url) => {
+				const token = await this.getS2SToken(credentials);
+				const res = await fetch(url, {
+					headers: { Authorization: `Bearer ${token}` },
+					redirect: 'follow'
+				});
+				if (!res.ok) {
+					throw new Error(`Zoom transcript download failed: HTTP ${res.status}`);
+				}
+				return res.text();
+			}
+		};
+	}
+
+	/**
+	 * Official Server-to-Server OAuth `account_credentials` token flow —
+	 * used ONLY for the transcript file download (see the vendor-SDK
+	 * note on the class doc). Cached in-memory until shortly before
+	 * expiry; the plugin is a module singleton so the cache is shared.
+	 */
+	protected async getS2SToken(credentials: ZoomCredentials): Promise<string> {
+		const cacheKey = `${credentials.accountId}\0${credentials.clientId}`;
+		const cached = this.tokenCache.get(cacheKey);
+		if (cached && cached.expiresAt > Date.now()) {
+			return cached.token;
+		}
+		const basic = Buffer.from(`${credentials.clientId}:${credentials.clientSecret}`).toString('base64');
+		const url = new URL('https://zoom.us/oauth/token');
+		url.searchParams.set('grant_type', 'account_credentials');
+		url.searchParams.set('account_id', credentials.accountId);
+		const res = await fetch(url, {
+			method: 'POST',
+			headers: { Authorization: `Basic ${basic}` }
+		});
+		if (!res.ok) {
+			throw new Error(`Zoom S2S token request failed: HTTP ${res.status}`);
+		}
+		const body = (await res.json()) as { access_token?: string; expires_in?: number };
+		if (typeof body.access_token !== 'string' || body.access_token.length === 0) {
+			throw new Error('Zoom S2S token response missing access_token');
+		}
+		// Refresh one minute early so an almost-expired token is never used.
+		const ttlMs = Math.max(((body.expires_in ?? 3600) - 60) * 1000, 60_000);
+		this.tokenCache.set(cacheKey, { token: body.access_token, expiresAt: Date.now() + ttlMs });
+		return body.access_token;
+	}
+
+	async verifyConnection(config: ChannelTargetConfig, options: ConnectorCallOptions): Promise<ChannelVerification> {
+		const credentials = resolveCredentials(config) ?? resolveCredentials(options.settings);
+		if (!credentials) {
+			return { valid: false, message: 'accountId, clientId and clientSecret are required' };
+		}
+		try {
+			await this.createClient(credentials).listAllRecordings({ page_size: 1 });
+			return { valid: true, details: { accountId: credentials.accountId } };
+		} catch (err) {
+			return {
+				valid: false,
+				message: `Zoom recordings lookup failed: ${err instanceof Error ? err.message : String(err)}`
+			};
+		}
+	}
+
+	/**
+	 * Outbound messaging is not part of Meetings v1 — the connector is
+	 * an inbound event source (recordings + transcripts). Kept explicit
+	 * so a mis-routed send fails loudly instead of silently no-oping.
+	 */
+	async send(_payload: ChannelSendInput, _options: ConnectorCallOptions): Promise<ChannelSendResult> {
+		throw new Error(
+			'zoom-connector: outbound messaging is not supported in v1 (transcript-first event source; live bot-join is a documented follow-up)'
+		);
+	}
+
+	// ── Event source (pull) ─────────────────────────────────────────────
+
+	/**
+	 * Pull one page of the current ≤30-day window chunk since the
+	 * effective watermark, normalized to `zoom.recording` envelopes.
+	 * The returned cursor resumes the same chunk (API page token) or
+	 * advances to the next chunk; no cursor means the sweep is done.
+	 *
+	 * First pull (epoch/absent watermark, no cursor): the window is
+	 * `now - backfillDays` when the opt-in backfill is on, otherwise
+	 * `now` — history stays untouched unless the user asked for it.
+	 */
+	async pullEvents(input: EventSourcePullInput): Promise<EventSourcePullResult> {
+		const credentials = resolveCredentials(input.settings);
+		if (!credentials) {
+			throw new EventSourceNotConfiguredError(
+				'zoom-connector: settings.accountId, settings.clientId and settings.clientSecret are required to pull events'
+			);
+		}
+
+		const now = Date.now();
+		const cursor = parsePullCursor(input.cursor);
+		let from: string;
+		let to: string;
+		let sweepEnd: string;
+		let pageToken: string | undefined;
+		let backfill: boolean;
+		let pagesUsed: number;
+
+		if (cursor) {
+			from = cursor.from;
+			to = cursor.to;
+			sweepEnd = cursor.w;
+			pageToken = cursor.n;
+			backfill = cursor.f === 1;
+			pagesUsed = cursor.b ?? 0;
+		} else {
+			const sinceMs = Date.parse(input.since);
+			const firstPull = !Number.isFinite(sinceMs) || sinceMs <= 0;
+			const backfillDays = clampBackfillDays(input.settings?.backfillDays);
+			let startMs: number;
+			if (firstPull) {
+				startMs = backfillDays > 0 ? now - backfillDays * DAY_MS : now;
+				backfill = backfillDays > 0;
+			} else {
+				startMs = sinceMs;
+				backfill = false;
+			}
+			sweepEnd = new Date(now).toISOString();
+			from = new Date(startMs).toISOString();
+			to = new Date(Math.min(startMs + ZOOM_WINDOW_MAX_DAYS * DAY_MS, now)).toISOString();
+			pageToken = undefined;
+			pagesUsed = 0;
+		}
+
+		const client = this.createClient(credentials);
+		const page = await client.listAllRecordings({
+			from: toDateOnly(from),
+			to: toDateOnly(to),
+			page_size: ZOOM_PULL_PAGE_SIZE,
+			...(pageToken ? { next_page_token: pageToken } : {})
+		});
+
+		const events: IngestedEventEnvelope[] = [];
+		for (const meeting of page.meetings ?? []) {
+			const envelope = await this.normalizeRecording(meeting, client);
+			if (envelope) events.push(envelope);
+		}
+
+		pagesUsed += 1;
+		const pageBudgetExhausted = backfill && pagesUsed >= ZOOM_BACKFILL_MAX_PAGES;
+		const nextPageToken =
+			typeof page.next_page_token === 'string' && page.next_page_token.length > 0
+				? page.next_page_token
+				: undefined;
+
+		let next: ZoomPullCursor | undefined;
+		if (nextPageToken && !pageBudgetExhausted) {
+			next = { from, to, w: sweepEnd, n: nextPageToken, ...(backfill ? { f: 1 as const } : {}), b: pagesUsed };
+		} else if (Date.parse(to) < Date.parse(sweepEnd)) {
+			// Chunk finished (or its backfill budget spent) — advance to the
+			// next ≤30-day window (page counter resets per chunk).
+			const nextFrom = to;
+			const nextTo = new Date(
+				Math.min(Date.parse(to) + ZOOM_WINDOW_MAX_DAYS * DAY_MS, Date.parse(sweepEnd))
+			).toISOString();
+			next = { from: nextFrom, to: nextTo, w: sweepEnd, ...(backfill ? { f: 1 as const } : {}), b: 0 };
+		}
+
+		return next ? { events, nextCursor: JSON.stringify(next) } : { events };
+	}
+
+	/**
+	 * Normalize one completed cloud recording → envelope. The transcript
+	 * (VTT) is downloaded best-effort when a completed TRANSCRIPT file
+	 * exists — a download failure degrades to a transcript-less
+	 * envelope; the transcript re-lands later because its availability
+	 * is part of the dedupe identity (`:transcript` vs `:recording`).
+	 */
+	private async normalizeRecording(
+		meeting: ZoomRecordingMeetingNode,
+		client: ZoomClientLike
+	): Promise<IngestedEventEnvelope | null> {
+		const externalId = meeting.uuid ?? (meeting.id != null ? String(meeting.id) : undefined);
+		if (!externalId) return null;
+
+		const files = meeting.recording_files ?? [];
+		const transcriptFile = files.find(
+			(f) => f.file_type === 'TRANSCRIPT' && typeof f.download_url === 'string' && f.status !== 'processing'
+		);
+		const playUrl = files.find((f) => typeof f.play_url === 'string' && f.play_url.length > 0)?.play_url;
+
+		let transcriptText: string | undefined;
+		if (transcriptFile?.download_url) {
+			try {
+				const vtt = await client.downloadTranscript(transcriptFile.download_url);
+				const text = parseVttToText(vtt);
+				if (text.length > 0) transcriptText = truncateTranscript(text);
+			} catch {
+				transcriptText = undefined;
+			}
+		}
+
+		const occurredAt = meeting.start_time ?? new Date(0).toISOString();
+		return {
+			id: randomUUID(),
+			source: this.id,
+			// Transcript availability is PART of the identity: a recording
+			// often completes before its transcript does, and a second
+			// delivery with `:transcript` must not be dropped as a duplicate
+			// of the transcript-less first one.
+			sourceEventId: `${externalId}:${transcriptText ? 'transcript' : 'recording'}`,
+			kind: 'zoom.recording',
+			occurredAt,
+			subject: {
+				type: 'meeting',
+				externalId,
+				...(meeting.topic ? { title: meeting.topic } : {})
+			},
+			...(playUrl ? { sourceUrl: playUrl } : {}),
+			payload: {
+				meetingExternalId: externalId,
+				...(meeting.id != null ? { meetingNumber: meeting.id } : {}),
+				...(meeting.topic ? { topic: meeting.topic } : {}),
+				...(meeting.start_time ? { startTime: meeting.start_time } : {}),
+				...(meeting.duration != null ? { durationMinutes: meeting.duration } : {}),
+				...(meeting.host_id ? { hostId: meeting.host_id } : {}),
+				...(transcriptText ? { transcriptText } : {}),
+				recordingCount: files.length
+			}
+		};
+	}
+}
+
+export const zoomConnectorPlugin = new ZoomConnectorPlugin();

--- a/packages/plugins/zoom-connector/tsconfig.json
+++ b/packages/plugins/zoom-connector/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2021",
+		"types": ["node"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"declaration": true,
+		"declarationMap": true,
+		"sourceMap": true,
+		"outDir": "./dist",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugins/zoom-connector/tsup.config.ts
+++ b/packages/plugins/zoom-connector/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	noExternal: ['@ever-works/plugin'],
+	format: ['esm', 'cjs'],
+	dts: true,
+	clean: true,
+	sourcemap: false,
+	splitting: false,
+	treeshake: true,
+	target: 'es2021',
+	outDir: 'dist'
+});

--- a/packages/plugins/zoom-connector/vitest.config.ts
+++ b/packages/plugins/zoom-connector/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// CI-load resilience: unit specs doing cold `await import()` /
+		// vi.resetModules() or real file parsing can drift past vitest's 5s
+		// default under the concurrent turbo test load. Matches the 30000ms
+		// the packages/tasks + api jest configs already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		environment: 'node',
+		globals: true,
+		include: ['src/**/*.{test,spec}.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html']
+		}
+	}
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(6df53909bc07743f1cbdc8ed07c4f22a)
+        version: 2.3.4(e98a7fb1f3ff60e0b2beec3497f32f48)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.18.1)(rxjs@7.8.2)
@@ -288,16 +288,16 @@ importers:
         version: link:../../packages/plugins/postgres-db
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -537,13 +537,13 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -996,13 +996,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(typescript@5.9.3)
+        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -1167,7 +1167,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -3325,6 +3325,31 @@ importers:
       '@zapier/zapier-sdk-cli':
         specifier: ^0.39.9
         version: 0.39.9(@cfworker/json-schema@4.1.1)(@types/node@22.19.11)
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@8.0.16(@types/node@22.19.11)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  packages/plugins/zoom-connector:
+    dependencies:
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../../contracts
+      '@ever-works/plugin':
+        specifier: workspace:*
+        version: link:../../plugin
+      '@zoom/rivet':
+        specifier: ^0.4.0
+        version: 0.4.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(jiti@2.6.1)(postcss@8.5.20)(typescript@5.9.3)(yaml@2.8.3)
@@ -11570,6 +11595,9 @@ packages:
 
   '@zone-eu/mailsplit@5.4.8':
     resolution: {integrity: sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==}
+
+  '@zoom/rivet@0.4.0':
+    resolution: {integrity: sha512-bsY3PuPDmZWQtol1IWojUDye6SeaOdD+WF5B+MlWSV2VD/9+LNpBkayb4YuUp0lksANHBcNROo1QxQKPWH7IEw==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -21576,17 +21604,6 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
-  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
-    dependencies:
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      jsonc-parser: 3.3.1
-      picomatch: 4.0.4
-      rxjs: 7.8.1
-      source-map: 0.7.4
-    optionalDependencies:
-      chokidar: 3.6.0
-
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -21608,26 +21625,6 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
-      - chokidar
-
-  '@angular-devkit/schematics@19.2.23':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      jsonc-parser: 3.3.1
-      magic-string: 0.30.17
-      ora: 5.4.1
-      rxjs: 7.8.1
-    transitivePeerDependencies:
-      - chokidar
-
-  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      jsonc-parser: 3.3.1
-      magic-string: 0.30.17
-      ora: 5.4.1
-      rxjs: 7.8.1
-    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -26365,7 +26362,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(6df53909bc07743f1cbdc8ed07c4f22a)':
+  '@nestjs-modules/mailer@2.3.4(e98a7fb1f3ff60e0b2beec3497f32f48)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -26384,7 +26381,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.2
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.2)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@3.6.0)
+      nunjucks: 3.2.4(chokidar@4.0.3)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -26411,36 +26408,7 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
-      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
-      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
-      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
-      ansis: 4.2.0
-      chokidar: 4.0.3
-      cli-table3: 0.6.5
-      commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
-      glob: 13.0.6
-      node-emoji: 1.11.0
-      ora: 5.4.1
-      tsconfig-paths: 4.2.0
-      tsconfig-paths-webpack-plugin: 4.2.0
-      typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
-      webpack-node-externals: 3.0.0
-    optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
-    transitivePeerDependencies:
-      - '@types/node'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -26469,7 +26437,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -26480,17 +26448,17 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21)))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
       glob: 13.0.6
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
       '@swc/core': 1.15.33(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -26594,32 +26562,10 @@ snapshots:
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
 
-  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
-      comment-json: 4.6.2
-      jsonc-parser: 3.3.1
-      pluralize: 8.0.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - chokidar
-
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
-      comment-json: 4.6.2
-      jsonc-parser: 3.3.1
-      pluralize: 8.0.0
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - chokidar
-
-  '@nestjs/schematics@11.0.10(typescript@5.9.3)':
-    dependencies:
-      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
-      '@angular-devkit/schematics': 19.2.23
       comment-json: 4.6.2
       jsonc-parser: 3.3.1
       pluralize: 8.0.0
@@ -30161,25 +30107,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)':
-    dependencies:
-      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
-      '@swc/counter': 0.1.3
-      '@xhmikosr/bin-wrapper': 14.2.2
-      commander: 8.3.0
-      minimatch: 10.2.5
-      piscina: 4.9.3
-      semver: 7.8.1
-      slash: 3.0.0
-      source-map: 0.7.6
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      chokidar: 3.6.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-      - supports-color
-
   '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
       '@swc/core': 1.15.33(@swc/helpers@0.5.21)
@@ -31822,6 +31749,16 @@ snapshots:
       libmime: 5.3.7
       libqp: 2.1.1
     optional: true
+
+  '@zoom/rivet@0.4.0':
+    dependencies:
+      axios: 1.18.1
+      dayjs: 1.11.21
+      form-data: 4.0.6
+      jose: 5.10.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   JSONStream@1.3.5:
     dependencies:
@@ -36112,7 +36049,7 @@ snapshots:
     optionalDependencies:
       express: 5.2.1
       hono: 4.12.25
-      next: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -37825,7 +37762,7 @@ snapshots:
       d3: 7.9.0
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
-      dayjs: 1.11.19
+      dayjs: 1.11.21
       dompurify: 3.4.11
       es-toolkit: 1.48.1
       katex: 0.16.45
@@ -38994,34 +38931,6 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
-  next@16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      '@next/env': 16.2.11
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.18
-      caniuse-lite: 1.0.30001787
-      postcss: 8.5.20
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.5)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.11
-      '@next/swc-darwin-x64': 16.2.11
-      '@next/swc-linux-arm64-gnu': 16.2.11
-      '@next/swc-linux-arm64-musl': 16.2.11
-      '@next/swc-linux-x64-gnu': 16.2.11
-      '@next/swc-linux-x64-musl': 16.2.11
-      '@next/swc-win32-arm64-msvc': 16.2.11
-      '@next/swc-win32-x64-msvc': 16.2.11
-      '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.59.1
-      sharp: 0.35.3(@types/node@22.19.11)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/node'
-      - babel-plugin-macros
-    optional: true
-
   nextjs-toploader@3.9.17(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@20.19.33)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@20.19.33)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -39188,13 +39097,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@3.6.0):
+  nunjucks@3.2.4(chokidar@4.0.3):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 3.6.0
+      chokidar: 4.0.3
     optional: true
 
   nypm@0.6.5:


### PR DESCRIPTION
## Meetings v1 — Wave 8, feature (a): org-wide + per-Work meetings, transcript-first

Implements the Meetings surface on existing nouns: a `meetings` entity fed by the event-ingest spine, a transcript pipeline (summary + memory + activity provenance), a first-party Zoom recordings connector on the official SDK, the `/api/meetings` surface, and chat tools per the program DoD. **Live bot-join is the documented v2 follow-up** (plugin README + service docs) — it will feed the same `ingestTranscript` path.

### What's in
- **Meeting entity** (`packages/agent/src/entities/meeting.entity.ts`, table `meetings`) — id/userId/organizationId?/workId?/title/startedAt/endedAt?/source(32: zoom|google-meet|manual|import)/externalId?/participants simple-json/transcriptText/summary/sourceUrl/createdAt + UNIQUE nullable `dedupeKey` = sha256(userId, source, externalId) (owner-scoped per the ingest-spine rationale). Guarded migration `1783800000000-CreateMeetings` (hasTable, FK user CASCADE / work SET NULL). ENTITIES inventory + `_entity-names` pins updated same commit.
- **MeetingsService** (`packages/agent/src/meetings/`, barrel + `./meetings` subpath export): owner-scoped CRUD (404 = other-owner, no existence leak); `ingestTranscript` → stores capped transcript → **best-effort** AI summary via `AiFacadeService` → **best-effort** Memory observation with provenance metadata via the agent-memory facade → emits a `meeting.transcript` envelope (content-hashed sourceEventId) whose spine drain writes the Activity entry with `sourceUrl` provenance. Enrichment failures never break ingest.
- **Envelope→Meeting processor**: `EventIngestService` grows additive kind-bound processors (`registerKindProcessor`, runs BEFORE the Activity write so retries can't duplicate feed rows); `MeetingsService` registers for `zoom.recording` at boot. Pull rides the existing `event-ingest-tick` — `EventSourcePullService` discovers the connector via the `event-source` capability, zero trigger-internal wiring.
- **`packages/plugins/zoom-connector`** — capabilities `['connector','event-source']`, Server-to-Server OAuth settings (accountId/clientId/clientSecret `x-secret`). `pullEvents` sweeps completed cloud recordings via the **official `@zoom/rivet` SDK** (`MeetingsS2SAuthClient.endpoints.cloudRecording.listAllRecordings`), downloads + VTT-parses transcripts (truncated to the 32 KB-envelope-safe cap), ≤30-day window chunking (Zoom month-range constraint), opt-in `backfillDays` (0–90) with a page budget, transcript-availability-aware dedupe (`:recording` vs `:transcript`). Narrow vendor-SDK exception documented: transcript FILE download uses the official S2S `account_credentials` token flow because Rivet exposes neither file downloads nor its token (fixed Zoom hosts only).
- **API**: thin `MeetingsController` — `GET/POST /api/meetings`, `GET/PATCH/DELETE /api/meetings/:id`, `POST /api/meetings/:id/transcript` (size-capped DTO, harder throttle); `dedupeKey` never serialized; registered in `api.module.ts`.
- **Chat (DoD rule d)**: `list_meetings` + `get_meeting_summary` in the generated tool registry (mirrors `list_agent_templates`), `meetings` domain + keyword slots (meeting/transcript/recording/standup/zoom/google meet) in `tool-selection.ts`, plus agent-side `buildMeetingTools` mirroring the ingest/digest factories.

### Verification (real output)
- `packages/plugins/zoom-connector`: `pnpm build` → `TSC 0` + tsup ESM/CJS/DTS ✅; `pnpm test` → **14 passed (14)**
- `packages/agent`: `pnpm build` → `>  TSC  Found 0 issues.` + SWC 1041 files ✅; `npx jest --testPathPattern='meetings|ingest'` → **Suites 9 passed, Tests 73 passed**; `--testPathPattern='database'` (entity pins/drift) → **Suites 38 passed, Tests 530 passed**
- `pnpm build --filter=ever-works-api` → **14 successful, 14 total** ✅
- `apps/api pnpm generate:openapi` (full-app DI bootstrap) → `Wrote OpenAPI spec (425 paths)` incl. `/api/meetings`, `/api/meetings/{id}`, `/api/meetings/{id}/transcript` (openapi.json gitignored, not committed)
- `apps/api npx jest --testPathPattern='meetings'` → **5 passed**
- `apps/web npx tsc --noEmit` → clean; `tool-selection.realistic.unit.spec.ts` → **13 passed**
- `prettier --check` on every touched file → `All matched files use Prettier code style!`

### Notes
- Additive only; module-shape pin specs updated in the same commit (meetings module pin added, ingest pins unchanged — providers/exports untouched).
- Google Meet lands as a sibling connector emitting its own recording kind (add to `MEETING_RECORDING_EVENT_KINDS`); routing classifier + Meetings UI surfaces are follow-ups per the wave spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)