### PR TITLE
feat(web): Billing + Usage & Credits (Wave 13)

### DIFF
--- a/apps/api/src/subscriptions/credits.controller.spec.ts
+++ b/apps/api/src/subscriptions/credits.controller.spec.ts
@@ -1,0 +1,198 @@
+// Wave 13 (Billing / Usage & Credits pages) — unit spec for the
+// read-only credits surface, focused on the new `usage-summary`
+// endpoint: owner-scoping (every service call keyed on the AUTHENTICATED
+// user, never caller-supplied), groupBy dispatch, and the 4xx mapping.
+//
+// Mirrors subscriptions.controller.spec.ts: the agent barrels are
+// stubbed so the spec never drags in @ever-works/agent/database.
+jest.mock('@ever-works/agent/subscriptions', () => ({
+    InvalidUsagePeriodError: class InvalidUsagePeriodError extends Error {
+        constructor(period: string) {
+            super(`Invalid period (expected YYYY-MM, 7d, or 30d): ${period}`);
+            this.name = 'InvalidUsagePeriodError';
+        }
+    },
+    USAGE_SUMMARY_GROUP_BYS: ['day', 'model', 'agent', 'work'],
+}));
+jest.mock('@ever-works/agent/entities', () => ({
+    CreditLedgerKind: {
+        PURCHASE: 'purchase',
+        GRANT: 'grant',
+        DAILY_FREE: 'daily-free',
+        CONSUMPTION: 'consumption',
+        ADJUSTMENT: 'adjustment',
+        EXPIRY: 'expiry',
+    },
+}));
+jest.mock('../auth', () => ({
+    AuthSessionGuard: class AuthSessionGuard {},
+    CurrentUser: () => () => undefined,
+}));
+
+import { BadRequestException } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { InvalidUsagePeriodError } from '@ever-works/agent/subscriptions';
+import type { CreditLedgerService, UsageSummaryService } from '@ever-works/agent/subscriptions';
+import { CreditsController, CreditsUsageSummaryQueryDto } from './credits.controller';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+
+describe('CreditsController', () => {
+    let creditLedgerService: jest.Mocked<Pick<CreditLedgerService, 'getBalance' | 'getLedger'>>;
+    let usageSummaryService: jest.Mocked<Pick<UsageSummaryService, 'getTotals' | 'getGrouped'>>;
+    let controller: CreditsController;
+
+    const auth: AuthenticatedUser = {
+        userId: 'user-1',
+        email: 'u@e.test',
+        username: 'u',
+        provider: 'local',
+        emailVerified: true,
+        isActive: true,
+        avatar: null,
+        iat: 0,
+        iss: '',
+        aud: '',
+    } as AuthenticatedUser;
+
+    const totals = {
+        period: '2026-07',
+        from: '2026-07-01T00:00:00.000Z',
+        to: '2026-08-01T00:00:00.000Z',
+        balanceCredits: 120,
+        creditsConsumed: 30,
+        creditsAdded: 150,
+        spendCents: 25,
+        tasksCompleted: 4,
+        worksActive: 2,
+        agentRuns: 9,
+    };
+
+    beforeEach(() => {
+        creditLedgerService = {
+            getBalance: jest.fn().mockResolvedValue(120),
+            getLedger: jest.fn().mockResolvedValue({
+                entries: [],
+                total: 0,
+                page: 1,
+                pageSize: 25,
+            }),
+        } as any;
+        usageSummaryService = {
+            getTotals: jest.fn().mockResolvedValue(totals),
+            getGrouped: jest.fn().mockResolvedValue({
+                period: '2026-07',
+                from: '2026-07-01T00:00:00.000Z',
+                to: '2026-08-01T00:00:00.000Z',
+                groupBy: 'day',
+                rows: [],
+            }),
+        } as any;
+        controller = new CreditsController(
+            creditLedgerService as unknown as CreditLedgerService,
+            usageSummaryService as unknown as UsageSummaryService,
+        );
+    });
+
+    describe('getUsageSummary — totals (no groupBy)', () => {
+        it('returns the stat-tile totals scoped to the AUTHENTICATED user', async () => {
+            const result = await controller.getUsageSummary(auth, {});
+
+            expect(usageSummaryService.getTotals).toHaveBeenCalledWith('user-1', undefined);
+            expect(usageSummaryService.getGrouped).not.toHaveBeenCalled();
+            expect(result).toEqual({ status: 'success', ...totals });
+        });
+
+        it('passes the period through to the service (owner id still from auth)', async () => {
+            await controller.getUsageSummary(auth, { period: '2026-06' });
+
+            expect(usageSummaryService.getTotals).toHaveBeenCalledWith('user-1', '2026-06');
+        });
+    });
+
+    describe('getUsageSummary — grouped', () => {
+        it.each(['day', 'model', 'agent', 'work'] as const)(
+            'dispatches groupBy=%s to getGrouped, owner-scoped to the authenticated user',
+            async (groupBy) => {
+                const result = await controller.getUsageSummary(auth, { groupBy, period: '7d' });
+
+                expect(usageSummaryService.getGrouped).toHaveBeenCalledWith(
+                    'user-1',
+                    groupBy,
+                    '7d',
+                );
+                expect(usageSummaryService.getTotals).not.toHaveBeenCalled();
+                expect(result.status).toBe('success');
+            },
+        );
+
+        it('maps InvalidUsagePeriodError to a 400 BadRequestException (never an unmapped 500)', async () => {
+            usageSummaryService.getGrouped.mockRejectedValue(new InvalidUsagePeriodError('bogus'));
+
+            await expect(
+                controller.getUsageSummary(auth, { groupBy: 'day', period: '7d' }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+
+        it('propagates unexpected service errors untouched', async () => {
+            usageSummaryService.getTotals.mockRejectedValue(new Error('db down'));
+
+            await expect(controller.getUsageSummary(auth, {})).rejects.toThrow('db down');
+        });
+    });
+
+    describe('CreditsUsageSummaryQueryDto validation (grouping + period contract)', () => {
+        async function validateQuery(query: Record<string, unknown>) {
+            return validate(plainToInstance(CreditsUsageSummaryQueryDto, query));
+        }
+
+        it('accepts every documented groupBy and rejects anything else', async () => {
+            for (const groupBy of ['day', 'model', 'agent', 'work']) {
+                expect(await validateQuery({ groupBy })).toHaveLength(0);
+            }
+            expect((await validateQuery({ groupBy: 'user' })).length).toBeGreaterThan(0);
+            expect((await validateQuery({ groupBy: 'plugin' })).length).toBeGreaterThan(0);
+        });
+
+        it('accepts YYYY-MM / 7d / 30d periods and rejects malformed ones', async () => {
+            for (const period of ['2026-07', '7d', '30d']) {
+                expect(await validateQuery({ period })).toHaveLength(0);
+            }
+            for (const period of ['2026-13', '90d', 'last-week', '2026-7']) {
+                expect((await validateQuery({ period })).length).toBeGreaterThan(0);
+            }
+        });
+    });
+
+    describe('getBalance / getLedger (existing surface — owner-scope regression)', () => {
+        it('getBalance reads the AUTHENTICATED user balance', async () => {
+            const result = await controller.getBalance(auth);
+
+            expect(creditLedgerService.getBalance).toHaveBeenCalledWith('user-1');
+            expect(result).toEqual({ status: 'success', balanceCredits: 120 });
+        });
+
+        it('getLedger forwards parsed filters, owner-scoped to the authenticated user', async () => {
+            await controller.getLedger(auth, {
+                period: '2026-07',
+                kinds: 'purchase,consumption',
+                page: 2,
+                pageSize: 10,
+            });
+
+            expect(creditLedgerService.getLedger).toHaveBeenCalledWith('user-1', {
+                period: '2026-07',
+                kinds: ['purchase', 'consumption'],
+                page: 2,
+                pageSize: 10,
+            });
+        });
+
+        it('getLedger rejects an unknown ledger kind with a 400', async () => {
+            await expect(
+                controller.getLedger(auth, { kinds: 'purchase,bogus' }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+            expect(creditLedgerService.getLedger).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/apps/api/src/subscriptions/credits.controller.ts
+++ b/apps/api/src/subscriptions/credits.controller.ts
@@ -9,11 +9,35 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsInt, IsOptional, IsString, Matches, Max, Min } from 'class-validator';
+import { IsIn, IsInt, IsOptional, IsString, Matches, Max, Min } from 'class-validator';
 import { AuthSessionGuard, CurrentUser } from '@src/auth';
 import { AuthenticatedUser } from '@src/auth/types/auth.types';
-import { CreditLedgerService } from '@ever-works/agent/subscriptions';
+import {
+    CreditLedgerService,
+    InvalidUsagePeriodError,
+    USAGE_SUMMARY_GROUP_BYS,
+    UsageSummaryService,
+    type UsageSummaryGroupBy,
+} from '@ever-works/agent/subscriptions';
 import { CreditLedgerEntry, CreditLedgerKind } from '@ever-works/agent/entities';
+
+export class CreditsUsageSummaryQueryDto {
+    /**
+     * Grouping dimension for the §4.3 charts. Omitted = the §4.1/§4.2
+     * stat-tile totals (credits used/added, tasks completed, works
+     * active, agent runs).
+     */
+    @IsOptional()
+    @IsIn(USAGE_SUMMARY_GROUP_BYS)
+    groupBy?: UsageSummaryGroupBy;
+
+    /** `YYYY-MM` calendar month (default: current), or rolling `7d`/`30d`. */
+    @IsOptional()
+    @Matches(/^(\d{4}-(0[1-9]|1[0-2])|7d|30d)$/, {
+        message: 'period must be YYYY-MM, 7d, or 30d',
+    })
+    period?: string;
+}
 
 class CreditsLedgerQueryDto {
     /** Calendar month filter, e.g. `2026-07` (matches the usage controllers). */
@@ -53,7 +77,12 @@ const VALID_KINDS = new Set<string>(Object.values(CreditLedgerKind));
 @Controller('api/credits')
 @UseGuards(AuthSessionGuard)
 export class CreditsController {
-    constructor(private readonly creditLedgerService: CreditLedgerService) {}
+    constructor(
+        private readonly creditLedgerService: CreditLedgerService,
+        // Wave 13 — account-wide usage aggregations for the Usage &
+        // Credits page (`usage-summary` below).
+        private readonly usageSummaryService: UsageSummaryService,
+    ) {}
 
     @Get('balance')
     @HttpCode(HttpStatus.OK)
@@ -96,6 +125,44 @@ export class CreditsController {
             page,
             pageSize,
         };
+    }
+
+    @Get('usage-summary')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Account-wide usage summary',
+        description:
+            'Owner-scoped usage aggregations for the Usage & Credits page (Wave 13). ' +
+            'Without groupBy: period totals (credits consumed/added, metered spend, tasks completed, ' +
+            'works active, agent runs). With groupBy=day|model|agent|work: grouped spend rows for the charts. ' +
+            'period accepts YYYY-MM (default: current month), 7d, or 30d.',
+    })
+    @ApiResponse({ status: 200, description: 'Usage summary (totals or grouped rows)' })
+    @ApiResponse({ status: 400, description: 'Invalid groupBy or period' })
+    async getUsageSummary(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: CreditsUsageSummaryQueryDto,
+    ) {
+        try {
+            if (query.groupBy) {
+                const grouped = await this.usageSummaryService.getGrouped(
+                    auth.userId,
+                    query.groupBy,
+                    query.period,
+                );
+                return { status: 'success', ...grouped };
+            }
+            const totals = await this.usageSummaryService.getTotals(auth.userId, query.period);
+            return { status: 'success', ...totals };
+        } catch (error) {
+            // Defence-in-depth: the DTO regex already rejects bad periods,
+            // but the service's stable-named error must still map to a 4xx
+            // (billing PRD §6 — never an unmapped 500).
+            if (error instanceof InvalidUsagePeriodError) {
+                throw new BadRequestException(error.message);
+            }
+            throw error;
+        }
     }
 
     private parseKinds(raw?: string): CreditLedgerKind[] | undefined {

--- a/apps/api/src/subscriptions/subscriptions.controller.spec.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.spec.ts
@@ -1,4 +1,12 @@
-jest.mock('@ever-works/agent/subscriptions', () => ({}));
+jest.mock('@ever-works/agent/subscriptions', () => ({
+    // Wave 13 — the controller value-imports ENTITLEMENT_KEYS for the
+    // plans endpoint's daily-free-credits lookup.
+    ENTITLEMENT_KEYS: {
+        DAILY_FREE_CREDITS: 'daily-free-credits',
+        MAX_CONCURRENT_RUNS: 'max-concurrent-runs',
+        WORKS_LIMIT: 'works-limit',
+    },
+}));
 jest.mock('@ever-works/agent/entities', () => ({
     SubscriptionPlanCode: {
         FREE: 'free',
@@ -18,15 +26,19 @@ jest.mock('../auth', () => ({
 
 import { BadRequestException } from '@nestjs/common';
 import { SubscriptionsController } from './subscriptions.controller';
-import type { SubscriptionService } from '@ever-works/agent/subscriptions';
+import type { EntitlementsService, SubscriptionService } from '@ever-works/agent/subscriptions';
 import type { AuthService } from '../auth';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 
 describe('SubscriptionsController', () => {
     let subscriptionService: jest.Mocked<
-        Pick<SubscriptionService, 'summarizePlan' | 'isEnabled' | 'changePlanSelfService'>
+        Pick<
+            SubscriptionService,
+            'summarizePlan' | 'isEnabled' | 'changePlanSelfService' | 'listPlans'
+        >
     >;
     let authService: jest.Mocked<Pick<AuthService, 'getUser'>>;
+    let entitlementsService: jest.Mocked<Pick<EntitlementsService, 'getNumber'>>;
     let controller: SubscriptionsController;
 
     const auth: AuthenticatedUser = {
@@ -49,13 +61,18 @@ describe('SubscriptionsController', () => {
             summarizePlan: jest.fn(),
             isEnabled: jest.fn(),
             changePlanSelfService: jest.fn(),
+            listPlans: jest.fn(),
         } as any;
         authService = {
             getUser: jest.fn().mockResolvedValue(user),
         } as any;
+        entitlementsService = {
+            getNumber: jest.fn().mockResolvedValue(0),
+        } as any;
         controller = new SubscriptionsController(
             subscriptionService as unknown as SubscriptionService,
             authService as unknown as AuthService,
+            entitlementsService as unknown as EntitlementsService,
         );
     });
 
@@ -112,6 +129,97 @@ describe('SubscriptionsController', () => {
             subscriptionService.summarizePlan.mockRejectedValue(new Error('boom'));
 
             await expect(controller.getPlan(auth)).rejects.toThrow('boom');
+        });
+    });
+
+    describe('listPlans (Wave 13 — Billing page plan switcher)', () => {
+        const seededPlans = [
+            {
+                code: 'free',
+                displayName: 'Free',
+                maxWorks: 1,
+                allowedCadences: ['monthly'],
+                monthlyPrice: '0',
+                overagePricePerRun: '10',
+                currency: 'usd',
+            },
+            {
+                code: 'premium',
+                displayName: 'Premium',
+                maxWorks: 15,
+                allowedCadences: ['monthly', 'weekly'],
+                monthlyPrice: '99',
+                overagePricePerRun: '0',
+                currency: 'usd',
+            },
+        ] as any[];
+
+        it('marks the current plan and maps the credits-forward projection when enabled', async () => {
+            subscriptionService.summarizePlan.mockResolvedValue({
+                enabled: true,
+                plan: { code: 'premium', displayName: 'Premium' },
+                allowances: [],
+            } as any);
+            subscriptionService.listPlans.mockResolvedValue(seededPlans);
+            entitlementsService.getNumber.mockResolvedValue(50);
+
+            const result = await controller.listPlans(auth);
+
+            expect(authService.getUser).toHaveBeenCalledWith('user-1');
+            expect(result.status).toBe('success');
+            expect(result.enabled).toBe(true);
+            expect(result.currentPlanCode).toBe('premium');
+            expect(result.plans).toHaveLength(2);
+            expect(result.plans[0]).toEqual({
+                code: 'free',
+                name: 'Free',
+                maxWorks: 1,
+                allowedCadences: ['monthly'],
+                monthlyPrice: '0',
+                overagePricePerRun: '10',
+                currency: 'usd',
+                isCurrent: false,
+                dailyFreeCredits: 50,
+            });
+            expect(result.plans[1].isCurrent).toBe(true);
+        });
+
+        it('falls back to free as the current plan when subscriptions are disabled', async () => {
+            subscriptionService.summarizePlan.mockResolvedValue({
+                enabled: false,
+                plan: null,
+                allowances: [],
+            } as any);
+            subscriptionService.listPlans.mockResolvedValue(seededPlans);
+
+            const result = await controller.listPlans(auth);
+
+            expect(result.enabled).toBe(false);
+            expect(result.currentPlanCode).toBe('free');
+            expect(result.plans[0].isCurrent).toBe(true);
+            expect(result.plans[1].isCurrent).toBe(false);
+        });
+
+        it('reads the daily-free-credits entitlement per plan code (fallback 0)', async () => {
+            subscriptionService.summarizePlan.mockResolvedValue({
+                enabled: true,
+                plan: { code: 'free', displayName: 'Free' },
+                allowances: [],
+            } as any);
+            subscriptionService.listPlans.mockResolvedValue(seededPlans);
+
+            await controller.listPlans(auth);
+
+            expect(entitlementsService.getNumber).toHaveBeenCalledWith(
+                'free',
+                'daily-free-credits',
+                0,
+            );
+            expect(entitlementsService.getNumber).toHaveBeenCalledWith(
+                'premium',
+                'daily-free-credits',
+                0,
+            );
         });
     });
 

--- a/apps/api/src/subscriptions/subscriptions.controller.ts
+++ b/apps/api/src/subscriptions/subscriptions.controller.ts
@@ -10,7 +10,11 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AuthSessionGuard, AuthService, CurrentUser } from '@src/auth';
-import { SubscriptionService } from '@ever-works/agent/subscriptions';
+import {
+    ENTITLEMENT_KEYS,
+    EntitlementsService,
+    SubscriptionService,
+} from '@ever-works/agent/subscriptions';
 import { AuthenticatedUser } from '@src/auth/types/auth.types';
 import { SubscriptionPlanCode } from '@ever-works/agent/entities';
 import { IsEnum } from 'class-validator';
@@ -28,6 +32,9 @@ export class SubscriptionsController {
     constructor(
         private readonly subscriptionService: SubscriptionService,
         private readonly authService: AuthService,
+        // Wave 13 (Billing page) — per-plan daily-free-credits for the
+        // credits-forward plan switcher (`GET plans` below).
+        private readonly entitlementsService: EntitlementsService,
     ) {}
 
     @Get('plan')
@@ -60,6 +67,52 @@ export class SubscriptionsController {
                 name: summary.plan.displayName,
                 allowedCadences: summary.allowances,
             },
+        };
+    }
+
+    @Get('plans')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'List subscription plans',
+        description:
+            'All active plans with their feature/limit gates + credits levers (Wave 13 Billing page — ' +
+            'credits-forward plan switcher). Read-only and additive; works (degraded) when subscriptions ' +
+            'are disabled so the switcher can still render the catalog.',
+    })
+    @ApiResponse({ status: 200, description: 'Active plans + current plan code' })
+    async listPlans(@CurrentUser() auth: AuthenticatedUser) {
+        const user = await this.authService.getUser(auth.userId);
+        const [summary, plans] = await Promise.all([
+            this.subscriptionService.summarizePlan(user),
+            this.subscriptionService.listPlans(),
+        ]);
+        const currentPlanCode = summary.enabled ? summary.plan.code : 'free';
+
+        // Plan count is tiny (seeded catalog) and EntitlementsService
+        // caches reads — this is one lookup per plan, not a per-row N+1.
+        const items = await Promise.all(
+            plans.map(async (plan) => ({
+                code: plan.code,
+                name: plan.displayName,
+                maxWorks: plan.maxWorks,
+                allowedCadences: plan.allowedCadences ?? [],
+                monthlyPrice: plan.monthlyPrice,
+                overagePricePerRun: plan.overagePricePerRun,
+                currency: plan.currency,
+                isCurrent: plan.code === currentPlanCode,
+                dailyFreeCredits: await this.entitlementsService.getNumber(
+                    plan.code,
+                    ENTITLEMENT_KEYS.DAILY_FREE_CREDITS,
+                    0,
+                ),
+            })),
+        );
+
+        return {
+            status: 'success',
+            enabled: summary.enabled,
+            currentPlanCode,
+            plans: items,
         };
     }
 

--- a/apps/web/e2e/api-public-contract.spec.ts
+++ b/apps/web/e2e/api-public-contract.spec.ts
@@ -57,6 +57,12 @@ const protectedEndpoints = [
     '/api/activity-log/export',
     '/api/conversations',
     '/api/subscriptions/plan',
+    // Wave 13 (Billing/Usage UI) — new read-only surfaces are auth-gated
+    // like their siblings.
+    '/api/subscriptions/plans',
+    '/api/credits/balance',
+    '/api/credits/ledger',
+    '/api/credits/usage-summary',
     '/api/plugins',
 ];
 

--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -1591,7 +1591,9 @@
                 "githubApp": "تطبيق GitHub",
                 "workAgent": "وكيل العمل",
                 "gitProviders": "مزودو Git",
-                "dangerZone": "منطقة الخطر"
+                "dangerZone": "منطقة الخطر",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "تثبيتات تطبيق GitHub",
@@ -1958,6 +1960,108 @@
                     "revokeSuccess": "تم إلغاء مفتاح API بنجاح",
                     "revokeError": "فشل في إلغاء مفتاح API",
                     "copyError": "فشل في النسخ إلى الحافظة"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4657,7 +4761,9 @@
                 "accountSettings": "إعدادات الحساب",
                 "helpDocs": "المساعدة والوثائق",
                 "support": "الدعم",
-                "keyboardShortcuts": "اختصارات لوحة المفاتيح"
+                "keyboardShortcuts": "اختصارات لوحة المفاتيح",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "تسجيل الخروج",
             "signingOut": "جاري تسجيل الخروج..."
@@ -5447,7 +5553,9 @@
             "apiKeys": "مفاتيح API",
             "dangerZone": "منطقة الخطر",
             "pluginSettings": "إعدادات الإضافة",
-            "discover": "اكتشف"
+            "discover": "اكتشف",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -1591,7 +1591,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Работен агент",
                 "gitProviders": "Git доставчици",
-                "dangerZone": "Опасна зона"
+                "dangerZone": "Опасна зона",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "Инсталации на GitHub App",
@@ -1958,6 +1960,108 @@
                     "revokeSuccess": "API ключът е анулиран успешно",
                     "revokeError": "Грешка при анулиране на API ключ",
                     "copyError": "Грешка при копиране в клипборда"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4657,7 +4761,9 @@
                 "accountSettings": "Настройки на акаунт",
                 "helpDocs": "Помощ & Документация",
                 "support": "Поддръжка",
-                "keyboardShortcuts": "Клавишни комбинации"
+                "keyboardShortcuts": "Клавишни комбинации",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Изход",
             "signingOut": "Излизане..."
@@ -5447,7 +5553,9 @@
             "apiKeys": "API ключове",
             "dangerZone": "Опасна зона",
             "pluginSettings": "Настройки на приставките",
-            "discover": "Открийте"
+            "discover": "Открийте",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -1591,7 +1591,9 @@
                 "githubApp": "GitHub-App",
                 "workAgent": "Arbeits-Agent",
                 "gitProviders": "Git-Anbieter",
-                "dangerZone": "Gefahrenzone"
+                "dangerZone": "Gefahrenzone",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "GitHub-App-Installationen",
@@ -1958,6 +1960,108 @@
                     "revokeSuccess": "API-Schlüssel erfolgreich widerrufen",
                     "revokeError": "Fehler beim Widerrufen des API-Schlüssels",
                     "copyError": "Fehler beim Kopieren in die Zwischenablage"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4657,7 +4761,9 @@
                 "accountSettings": "Kontoeinstellungen",
                 "helpDocs": "Hilfe & Dokumentation",
                 "support": "Support",
-                "keyboardShortcuts": "Tastaturkürzel"
+                "keyboardShortcuts": "Tastaturkürzel",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Abmelden",
             "signingOut": "Melden ab..."
@@ -5447,7 +5553,9 @@
             "apiKeys": "API-Schlüssel",
             "dangerZone": "Gefahrenzone",
             "pluginSettings": "Plugin-Einstellungen",
-            "discover": "Entdecken"
+            "discover": "Entdecken",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1911,7 +1911,9 @@
                 "workAgent": "Work Agent",
                 "jobRuntime": "Job Runtime",
                 "gitProviders": "Git Providers",
-                "dangerZone": "Danger Zone"
+                "dangerZone": "Danger Zone",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "GitHub App Installations",
@@ -2371,6 +2373,108 @@
                     "requiredFieldsMissing": "Required credential fields are empty: {fields}",
                     "providerNoLongerAllowed": "Provider {provider} is no longer enabled by the operator. Revert to inherit or pick an allowed provider before saving.",
                     "noProvidersAvailable": "The operator has not enabled any job-runtime providers for tenant overlays. Switch to inherit mode or contact your operator."
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -5293,7 +5397,9 @@
                 "accountSettings": "Account Settings",
                 "helpDocs": "Help & Docs",
                 "support": "Support",
-                "keyboardShortcuts": "Keyboard Shortcuts"
+                "keyboardShortcuts": "Keyboard Shortcuts",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Sign Out",
             "signingOut": "Signing out..."
@@ -6069,7 +6175,9 @@
             "jobRuntime": "Job Runtime",
             "dangerZone": "Danger Zone",
             "pluginSettings": "Plugin Settings",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -1591,7 +1591,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Agente de trabajo",
                 "gitProviders": "Proveedores de Git",
-                "dangerZone": "Zona de peligro"
+                "dangerZone": "Zona de peligro",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "Instalaciones de GitHub App",
@@ -1958,6 +1960,108 @@
                     "revokeSuccess": "Clave API revocada correctamente",
                     "revokeError": "Error al revocar clave API",
                     "copyError": "Error al copiar al portapapeles"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4657,7 +4761,9 @@
                 "accountSettings": "Configuración de la Cuenta",
                 "helpDocs": "Ayuda y Documentación",
                 "support": "Soporte",
-                "keyboardShortcuts": "Atajos de Teclado"
+                "keyboardShortcuts": "Atajos de Teclado",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Cerrar Sesión",
             "signingOut": "Cerrando sesión..."
@@ -5447,7 +5553,9 @@
             "apiKeys": "Claves de API",
             "dangerZone": "Zona peligrosa",
             "pluginSettings": "Configuración de complementos",
-            "discover": "Descubrir"
+            "discover": "Descubrir",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -1591,7 +1591,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Agent de Travail",
                 "gitProviders": "Fournisseurs Git",
-                "dangerZone": "Zone de danger"
+                "dangerZone": "Zone de danger",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "Installations GitHub App",
@@ -1958,6 +1960,108 @@
                     "revokeSuccess": "Clé API révoquée avec succès",
                     "revokeError": "Échec de la révocation de la clé API",
                     "copyError": "Échec de la copie dans le presse-papiers"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4657,7 +4761,9 @@
                 "accountSettings": "Paramètres du compte",
                 "helpDocs": "Aide et documentation",
                 "support": "Support",
-                "keyboardShortcuts": "Raccourcis clavier"
+                "keyboardShortcuts": "Raccourcis clavier",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Se déconnecter",
             "signingOut": "Déconnexion en cours..."
@@ -5447,7 +5553,9 @@
             "apiKeys": "Clés API",
             "dangerZone": "Zone de danger",
             "pluginSettings": "Paramètres des plugins",
-            "discover": "Découvrir"
+            "discover": "Découvrir",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -1591,7 +1591,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "סוכן עבודה",
                 "gitProviders": "ספקי Git",
-                "dangerZone": "אזור סכנה"
+                "dangerZone": "אזור סכנה",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "התקנות GitHub App",
@@ -1958,6 +1960,108 @@
                     "revokeSuccess": "מפתח API בוטל בהצלחה",
                     "revokeError": "נכשל לבטל מפתח API",
                     "copyError": "נכשל להעתיק ללוח"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4657,7 +4761,9 @@
                 "accountSettings": "הגדרות חשבון",
                 "helpDocs": "עזרה ומסמכים",
                 "support": "תמיכה",
-                "keyboardShortcuts": "קיצורי מקלדת"
+                "keyboardShortcuts": "קיצורי מקלדת",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "התנתק",
             "signingOut": "מתנתק..."
@@ -5447,7 +5553,9 @@
             "apiKeys": "מפתחות API",
             "dangerZone": "אזור מסוכן",
             "pluginSettings": "הגדרות תוסף",
-            "discover": "גלה"
+            "discover": "גלה",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "GitHub ऐप",
                 "workAgent": "Work Agent",
                 "gitProviders": "Git प्रदाता",
-                "dangerZone": "खतरे का क्षेत्र"
+                "dangerZone": "खतरे का क्षेत्र",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "GitHub ऐप इंस्टॉलेशन",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "API कुंजी सफलतापूर्वक रद्द की गई",
                     "revokeError": "API कुंजी रद्द करने में विफल",
                     "copyError": "क्लिपबोर्ड पर कॉपी करने में विफल"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "खाता सेटिंग्स",
                 "helpDocs": "सहायता और दस्तावेज़",
                 "support": "समर्थन",
-                "keyboardShortcuts": "कीबोर्ड शॉर्टकट"
+                "keyboardShortcuts": "कीबोर्ड शॉर्टकट",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "साइन आउट",
             "signingOut": "साइन आउट हो रहा है..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "API कुंजियाँ",
             "dangerZone": "खतरे का क्षेत्र",
             "pluginSettings": "प्लगइन सेटिंग्स",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Work Agent",
                 "gitProviders": "Penyedia Git",
-                "dangerZone": "Zona Berbahaya"
+                "dangerZone": "Zona Berbahaya",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "Instalasi GitHub App",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "Kunci API berhasil dicabut",
                     "revokeError": "Gagal mencabut kunci API",
                     "copyError": "Gagal menyalin ke clipboard"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "Pengaturan Akun",
                 "helpDocs": "Bantuan & Dokumen",
                 "support": "Dukungan",
-                "keyboardShortcuts": "Pintasan Keyboard"
+                "keyboardShortcuts": "Pintasan Keyboard",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Keluar",
             "signingOut": "Keluar..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "Kunci API",
             "dangerZone": "Zona Bahaya",
             "pluginSettings": "Pengaturan Plugin",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Work Agent",
                 "gitProviders": "Fornitori Git",
-                "dangerZone": "Zona di pericolo"
+                "dangerZone": "Zona di pericolo",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "Installazioni GitHub App",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "Chiave API revocata con successo",
                     "revokeError": "Errore nella revoca della chiave API",
                     "copyError": "Errore nella copia negli appunti"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "Impostazioni Account",
                 "helpDocs": "Aiuto & Documentazione",
                 "support": "Supporto",
-                "keyboardShortcuts": "Scorciatoie Tastiera"
+                "keyboardShortcuts": "Scorciatoie Tastiera",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Esci",
             "signingOut": "Uscita in corso..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "Chiavi API",
             "dangerZone": "Zona pericolosa",
             "pluginSettings": "Impostazioni plugin",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -1402,7 +1402,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Work Agent",
                 "gitProviders": "Git プロバイダー",
-                "dangerZone": "危険ゾーン"
+                "dangerZone": "危険ゾーン",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "GitHub App インストール",
@@ -1769,6 +1771,108 @@
                     "revokeSuccess": "API キーが正常に取り消されました",
                     "revokeError": "API キーの取り消しに失敗しました",
                     "copyError": "クリップボードへのコピーに失敗しました"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4432,7 +4536,9 @@
                 "accountSettings": "アカウント設定",
                 "helpDocs": "ヘルプとドキュメント",
                 "support": "サポート",
-                "keyboardShortcuts": "キーボードショートカット"
+                "keyboardShortcuts": "キーボードショートカット",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "サインアウト",
             "signingOut": "サインアウト中..."
@@ -5259,7 +5365,9 @@
             "apiKeys": "APIキー",
             "dangerZone": "危険ゾーン",
             "pluginSettings": "プラグイン設定",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1402,7 +1402,9 @@
                 "githubApp": "GitHub 앱",
                 "workAgent": "Work Agent",
                 "gitProviders": "Git 공급자",
-                "dangerZone": "위험 영역"
+                "dangerZone": "위험 영역",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "GitHub 앱 설치",
@@ -1769,6 +1771,108 @@
                     "revokeSuccess": "API 키가 성공적으로 취소되었습니다",
                     "revokeError": "API 키 취소에 실패했습니다",
                     "copyError": "클립보드에 복사하는 데 실패했습니다"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4432,7 +4536,9 @@
                 "accountSettings": "계정 설정",
                 "helpDocs": "도움말 및 문서",
                 "support": "지원",
-                "keyboardShortcuts": "키보드 단축키"
+                "keyboardShortcuts": "키보드 단축키",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "로그아웃",
             "signingOut": "로그아웃 중..."
@@ -5259,7 +5365,9 @@
             "apiKeys": "API 키",
             "dangerZone": "위험 영역",
             "pluginSettings": "플러그인 설정",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -1402,7 +1402,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Work Agent",
                 "gitProviders": "Git-providers",
-                "dangerZone": "Gevaarzone"
+                "dangerZone": "Gevaarzone",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "GitHub App-installaties",
@@ -1769,6 +1771,108 @@
                     "revokeSuccess": "API-sleutel succesvol ingetrokken",
                     "revokeError": "Kon API-sleutel niet intrekken",
                     "copyError": "Kon niet kopiëren naar klembord"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4432,7 +4536,9 @@
                 "accountSettings": "Accountinstellingen",
                 "helpDocs": "Hulp en documentatie",
                 "support": "Ondersteuning",
-                "keyboardShortcuts": "Toetsencombinaties"
+                "keyboardShortcuts": "Toetsencombinaties",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Afmelden",
             "signingOut": "Aan het afmelden..."
@@ -5259,7 +5365,9 @@
             "apiKeys": "API-sleutels",
             "dangerZone": "Gevarenzone",
             "pluginSettings": "Plug-ininstellingen",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "Aplikacja GitHub",
                 "workAgent": "Work Agent",
                 "gitProviders": "Dostawcy Git",
-                "dangerZone": "Strefa niebezpieczeństwa"
+                "dangerZone": "Strefa niebezpieczeństwa",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "Instalacje aplikacji GitHub",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "Klucz API cofnięty pomyślnie",
                     "revokeError": "Nie udało się cofnąć klucza API",
                     "copyError": "Nie udało się skopiować do schowka"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "Ustawienia konta",
                 "helpDocs": "Pomoc i dokumentacja",
                 "support": "Wsparcie",
-                "keyboardShortcuts": "Skróty klawiaturowe"
+                "keyboardShortcuts": "Skróty klawiaturowe",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Wyloguj się",
             "signingOut": "Wylogowywanie..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "Klucz API",
             "dangerZone": "Strefa niebezpieczeństwa",
             "pluginSettings": "Ustawienia wtyczek",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "Modelos",
                 "workAgent": "Work Agent",
                 "gitProviders": "Provedores Git",
-                "dangerZone": "Zona de Perigo"
+                "dangerZone": "Zona de Perigo",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "Instalações do GitHub App",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "Chave de API revogada com sucesso",
                     "revokeError": "Falha ao revogar chave de API",
                     "copyError": "Falha ao copiar para a área de transferência"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "Configurações da Conta",
                 "helpDocs": "Ajuda e Documentos",
                 "support": "Suporte",
-                "keyboardShortcuts": "Atalhos de Teclado"
+                "keyboardShortcuts": "Atalhos de Teclado",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Sair",
             "signingOut": "Saindo..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "Chaves de API",
             "dangerZone": "Zona de Perigo",
             "pluginSettings": "Configurações de Plugin",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Work Agent",
                 "gitProviders": "Провайдеры Git",
-                "dangerZone": "Опасная зона"
+                "dangerZone": "Опасная зона",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "Установки GitHub App",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "Ключ API успешно отозван",
                     "revokeError": "Не удалось отозвать ключ API",
                     "copyError": "Не удалось скопировать в буфер обмена"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "Настройки аккаунта",
                 "helpDocs": "Справка и документация",
                 "support": "Поддержка",
-                "keyboardShortcuts": "Горячие клавиши"
+                "keyboardShortcuts": "Горячие клавиши",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Выйти",
             "signingOut": "Выход..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "Ключи API",
             "dangerZone": "Зона опасности",
             "pluginSettings": "Настройки плагинов",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Work Agent",
                 "gitProviders": "ผู้ให้บริการ Git",
-                "dangerZone": "โซนอันตราย"
+                "dangerZone": "โซนอันตราย",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "การติดตั้ง GitHub App",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "เพิกถอนคีย์ API สำเร็จ",
                     "revokeError": "ล้มเหลวในการเพิกถอนคีย์ API",
                     "copyError": "ล้มเหลวในการคัดลอกไปยังคลิปบอร์ด"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "การตั้งค่าบัญชี",
                 "helpDocs": "ช่วยเหลือและเอกสาร",
                 "support": "สนับสนุน",
-                "keyboardShortcuts": "ทางลัดคีย์บอร์ด"
+                "keyboardShortcuts": "ทางลัดคีย์บอร์ด",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "ออกจากระบบ",
             "signingOut": "กำลังออกจากระบบ..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "คีย์ API",
             "dangerZone": "เขตอันตราย",
             "pluginSettings": "การตั้งค่าปลั๊กอิน",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "GitHub Uygulaması",
                 "workAgent": "Work Agent",
                 "gitProviders": "Git Sağlayıcıları",
-                "dangerZone": "Tehlike Alanı"
+                "dangerZone": "Tehlike Alanı",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "GitHub App Kurulumları",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "API anahtarı başarıyla iptal edildi",
                     "revokeError": "API anahtarı iptal edilemedi",
                     "copyError": "Panoya kopyalanamadı"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "Hesap Ayarları",
                 "helpDocs": "Yardım & Belgeler",
                 "support": "Destek",
-                "keyboardShortcuts": "Klavye Kısayolları"
+                "keyboardShortcuts": "Klavye Kısayolları",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Çıkış Yap",
             "signingOut": "Çıkış yapılıyor..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "API Anahtarları",
             "dangerZone": "Tehlike Bölgesi",
             "pluginSettings": "Eklenti Ayarları",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Work Agent",
                 "gitProviders": "Постачальники Git",
-                "dangerZone": "Небезпечна зона"
+                "dangerZone": "Небезпечна зона",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "Інсталяції GitHub App",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "Ключ API успішно відкликано",
                     "revokeError": "Не вдалося відкликати ключ API",
                     "copyError": "Не вдалося скопіювати в буфер обміну"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "Налаштування облікового запису",
                 "helpDocs": "Довідка та документація",
                 "support": "Підтримка",
-                "keyboardShortcuts": "Гарячі клавіші"
+                "keyboardShortcuts": "Гарячі клавіші",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Вийти",
             "signingOut": "Вихід..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "Ключі API",
             "dangerZone": "Небезпечна зона",
             "pluginSettings": "Налаштування плагінів",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "Ứng dụng GitHub",
                 "workAgent": "Work Agent",
                 "gitProviders": "Nhà cung cấp Git",
-                "dangerZone": "Vùng nguy hiểm"
+                "dangerZone": "Vùng nguy hiểm",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "Cài đặt Ứng dụng GitHub",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "Thu hồi khóa API thành công",
                     "revokeError": "Không thể thu hồi khóa API",
                     "copyError": "Không thể sao chép vào bảng tạm"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "Cài đặt Tài khoản",
                 "helpDocs": "Trợ giúp & Tài liệu",
                 "support": "Hỗ trợ",
-                "keyboardShortcuts": "Phím tắt Bàn phím"
+                "keyboardShortcuts": "Phím tắt Bàn phím",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "Đăng xuất",
             "signingOut": "Đang đăng xuất..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "Khóa API",
             "dangerZone": "Vùng Nguy hiểm",
             "pluginSettings": "Cài đặt Plugin",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -1394,7 +1394,9 @@
                 "githubApp": "GitHub App",
                 "workAgent": "Work Agent",
                 "gitProviders": "Git 提供商",
-                "dangerZone": "危险区域"
+                "dangerZone": "危险区域",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "githubApp": {
                 "title": "GitHub App 安装",
@@ -1761,6 +1763,108 @@
                     "revokeSuccess": "API 密钥撤销成功",
                     "revokeError": "撤销 API 密钥失败",
                     "copyError": "复制到剪贴板失败"
+                }
+            },
+            "billing": {
+                "title": "Billing",
+                "subtitle": "Manage your plan, credits, payment method, and invoices.",
+                "disabledNotice": "Billing is not enabled on this deployment. Plans are shown for reference; every account runs on the Free tier.",
+                "loadError": "Some billing data could not be loaded. Refresh the page to try again.",
+                "currentPlan": {
+                    "title": "Current plan",
+                    "statusActive": "Active"
+                },
+                "plans": {
+                    "title": "Plans",
+                    "subtitle": "Plans gate features and limits; usage is billed from your credits balance.",
+                    "empty": "No plans available.",
+                    "perMonth": "/mo",
+                    "free": "Free",
+                    "maxWorks": "Up to {count} Works",
+                    "cadences": "{count} schedule cadences",
+                    "dailyFreeCredits": "{amount} daily free credits",
+                    "payAsYouGo": "Pay-as-you-go from your credits balance",
+                    "current": "Current plan",
+                    "switchFree": "Switch to {name}",
+                    "upgrade": "Upgrade",
+                    "upgradeHint": "Paid plans are activated through billing once payments launch.",
+                    "changeSuccess": "Plan updated to {name}",
+                    "changeError": "Failed to change plan"
+                },
+                "credits": {
+                    "title": "Credits",
+                    "balanceLabel": "current balance",
+                    "buy": "Buy credits",
+                    "buySubtitle": "Top up your usage balance. 1 credit = 1¢ of platform-billed usage.",
+                    "presetCredits": "You will receive {credits} credits",
+                    "customAmount": "Custom $",
+                    "comingSoon": "Payments are coming soon",
+                    "comingSoonBody": "Card top-ups are not yet available on this deployment. Your balance still tracks grants and usage."
+                },
+                "paymentMethod": {
+                    "title": "Payment method",
+                    "comingSoon": "Payment method management arrives with the payments launch.",
+                    "empty": "No payment method on file."
+                },
+                "autoRecharge": {
+                    "title": "Auto-recharge",
+                    "comingSoon": "Automatic top-ups arrive with the payments launch.",
+                    "description": "Automatically top up your balance when it falls below a threshold."
+                },
+                "invoices": {
+                    "title": "Invoice history",
+                    "empty": "No invoices yet. Invoices appear here once billing is live."
+                },
+                "ledger": {
+                    "title": "Credits ledger",
+                    "subtitle": "Every credit added or consumed, in dollars.",
+                    "empty": "No credit activity yet.",
+                    "loading": "Loading…",
+                    "loadError": "Failed to load the ledger.",
+                    "filterAll": "All types",
+                    "kinds": {
+                        "purchase": "Purchase",
+                        "grant": "Grant",
+                        "daily-free": "Daily free",
+                        "consumption": "Consumption",
+                        "adjustment": "Adjustment",
+                        "expiry": "Expiry"
+                    },
+                    "colDate": "Date",
+                    "colType": "Type",
+                    "colDescription": "Description",
+                    "colAmount": "Amount",
+                    "colBalance": "Balance",
+                    "pagePrev": "Previous",
+                    "pageNext": "Next",
+                    "pageInfo": "Page {page} of {pages}"
+                }
+            },
+            "usage": {
+                "title": "Usage & Credits",
+                "subtitle": "Where your credits and spend went — by day, model, agent, and Work.",
+                "loadError": "Some usage data could not be loaded. Refresh the page to try again.",
+                "tiles": {
+                    "balance": "Credits balance",
+                    "consumed": "Credits used",
+                    "added": "Credits added",
+                    "spend": "Month spend",
+                    "tasksCompleted": "Tasks completed",
+                    "worksActive": "Works active",
+                    "agentRuns": "Agent runs",
+                    "periodNote": "Showing period {period}"
+                },
+                "charts": {
+                    "byDay": "Usage per day",
+                    "byModel": "Usage by model",
+                    "byAgent": "Usage by agent",
+                    "byWork": "Usage by Work",
+                    "range7d": "7d",
+                    "range30d": "30d",
+                    "empty": "No usage in this period.",
+                    "loading": "Loading…",
+                    "error": "Failed to load chart data.",
+                    "unattributed": "Unattributed"
                 }
             }
         },
@@ -4424,7 +4528,9 @@
                 "accountSettings": "帐户设置",
                 "helpDocs": "帮助与文档",
                 "support": "支持",
-                "keyboardShortcuts": "键盘快捷键"
+                "keyboardShortcuts": "键盘快捷键",
+                "billing": "Billing",
+                "usageCredits": "Usage & Credits"
             },
             "signOut": "退出登录",
             "signingOut": "退出登录中..."
@@ -5251,7 +5357,9 @@
             "apiKeys": "API 密钥",
             "dangerZone": "危险区域",
             "pluginSettings": "插件设置",
-            "discover": "Discover"
+            "discover": "Discover",
+            "billing": "Billing",
+            "usage": "Usage & Credits"
         }
     },
     "api": {

--- a/apps/web/src/app/[locale]/(dashboard)/settings/billing/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/billing/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { creditsAPI, subscriptionsAPI } from '@/lib/api/credits';
+import type {
+    CreditsBalance,
+    CreditsLedgerPage,
+    SubscriptionPlanList,
+    SubscriptionPlanSummary,
+} from '@/lib/api/credits.shared';
+import { BillingSettings } from '@/components/settings/BillingSettings';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('metadata.pages');
+    return { title: t('billing') };
+}
+
+/**
+ * Wave 13 — Billing page (billing/usage PRD §3): current plan +
+ * credits-forward plan switcher, buy-credits / payment-method /
+ * auto-recharge (flag-gated until a payment provider is wired),
+ * invoice history, and the credits ledger.
+ *
+ * Server component: fetches the initial snapshot; the client handles
+ * ledger paging/filtering through the `/api/credits/ledger` proxy.
+ * Static page by design — no polling; refresh on navigation.
+ */
+export default async function BillingSettingsPage() {
+    // Each fetch degrades independently: a failed call renders that
+    // section's error/empty state instead of failing the whole page.
+    const [plan, plans, balance, ledger] = await Promise.all([
+        subscriptionsAPI.currentPlan().catch((): SubscriptionPlanSummary | null => null),
+        subscriptionsAPI.listPlans().catch((): SubscriptionPlanList | null => null),
+        creditsAPI.balance().catch((): CreditsBalance | null => null),
+        creditsAPI.ledger({ pageSize: 10 }).catch((): CreditsLedgerPage | null => null),
+    ]);
+
+    // PRD §3.2/§3.7 — the purchase/payment-method/auto-recharge surfaces
+    // ship behind a server-side flag, default OFF, until the payment
+    // provider lands (Wave 9.4). Flipping PAYMENTS_ENABLED=true reveals
+    // the interactive top-up UI; checkout itself stays disabled until
+    // the provider checkout seam exists.
+    const paymentsEnabled = process.env.PAYMENTS_ENABLED === 'true';
+
+    return (
+        <BillingSettings
+            paymentsEnabled={paymentsEnabled}
+            initialPlan={plan}
+            initialPlans={plans}
+            initialBalance={balance}
+            initialLedger={ledger}
+        />
+    );
+}

--- a/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
@@ -12,6 +12,8 @@ import {
     Bot,
     Cpu,
     Building2,
+    CreditCard,
+    BarChart3,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
@@ -82,6 +84,20 @@ export function SettingsLayoutClient({ children, settingsMenu }: SettingsLayoutC
                 label: t('tabs.jobRuntime'),
                 icon: Cpu,
                 href: `${baseSettingsPath}/job-runtime`,
+            },
+            // Wave 13 — Billing + Usage & Credits (billing/usage PRD §2):
+            // also reachable from the settings shell like api-keys/security.
+            {
+                id: 'billing',
+                label: t('tabs.billing'),
+                icon: CreditCard,
+                href: `${baseSettingsPath}/billing`,
+            },
+            {
+                id: 'usage',
+                label: t('tabs.usageCredits'),
+                icon: BarChart3,
+                href: `${baseSettingsPath}/usage`,
             },
         ],
         [t],

--- a/apps/web/src/app/[locale]/(dashboard)/settings/usage/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/usage/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { creditsAPI } from '@/lib/api/credits';
+import { usageAPI, type AccountWideUsage } from '@/lib/api/usage';
+import type { UsageSummaryGrouped, UsageSummaryTotals } from '@/lib/api/credits.shared';
+import { UsageCreditsSettings } from '@/components/settings/UsageCreditsSettings';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('metadata.pages');
+    return { title: t('usage') };
+}
+
+/**
+ * Wave 13 — Usage & Credits page (billing/usage PRD §4): period credit
+ * summary tiles + consumption counts, and per-day / per-model /
+ * per-agent / per-Work spend charts from the owner-scoped
+ * `GET /api/credits/usage-summary` aggregations.
+ *
+ * Server component fetches the initial snapshot (current month for the
+ * grouped charts, 30d for the by-day chart); the client's 7d/30d
+ * toggle refetches through the `/api/credits/usage-summary` proxy.
+ * Static page by design — no polling; refresh on navigation.
+ */
+export default async function UsageSettingsPage() {
+    const [totals, byDay, byModel, byAgent, byWork, accountWide] = await Promise.all([
+        creditsAPI.usageSummary().catch((): UsageSummaryTotals | null => null),
+        creditsAPI
+            .usageGrouped({ groupBy: 'day', period: '30d' })
+            .catch((): UsageSummaryGrouped | null => null),
+        creditsAPI.usageGrouped({ groupBy: 'model' }).catch((): UsageSummaryGrouped | null => null),
+        creditsAPI.usageGrouped({ groupBy: 'agent' }).catch((): UsageSummaryGrouped | null => null),
+        creditsAPI.usageGrouped({ groupBy: 'work' }).catch((): UsageSummaryGrouped | null => null),
+        usageAPI.accountWide().catch((): AccountWideUsage | null => null),
+    ]);
+
+    return (
+        <UsageCreditsSettings
+            initialTotals={totals}
+            initialByDay={byDay}
+            initialByModel={byModel}
+            initialByAgent={byAgent}
+            initialByWork={byWork}
+            accountWide={accountWide}
+        />
+    );
+}

--- a/apps/web/src/app/actions/dashboard/billing.ts
+++ b/apps/web/src/app/actions/dashboard/billing.ts
@@ -1,0 +1,46 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { subscriptionsAPI } from '@/lib/api/credits';
+import { getAuthFromCookie } from '@/lib/auth';
+import { ROUTES } from '@/lib/constants';
+// Security: map ApiResponseError HTTP status codes to generic client-safe
+// messages instead of forwarding raw backend strings.
+import { ApiResponseError } from '@/lib/api/server-api';
+
+/**
+ * Wave 13 — server action for the Billing page's plan switcher.
+ *
+ * Self-service moves are FREE-plan-only by design (EW-711 #23): the API
+ * rejects paid plans with 403; a paid tier is activated only through a
+ * billing-verified path once a payment provider is wired. Returns a
+ * discriminated union (never throws) — production redacts thrown server
+ * action error messages, so the client must branch on the return value.
+ */
+export async function changePlanAction(planCode: string) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    try {
+        const result = await subscriptionsAPI.changePlan(planCode);
+        revalidatePath(ROUTES.DASHBOARD_SETTINGS_BILLING);
+        return { success: true as const, plan: result.plan, error: null };
+    } catch (error) {
+        // Security: log full error server-side; return a generic client-safe message.
+        console.error('[changePlanAction]', error);
+        let message = 'Failed to change plan';
+        if (error instanceof ApiResponseError) {
+            if (error.statusCode === 403) {
+                message = 'Paid plans are activated through billing and cannot be self-assigned.';
+            } else if (error.statusCode === 400) {
+                message = 'Plan changes are not available on this deployment.';
+            } else if (error.statusCode === 404) {
+                message = 'Plan not found.';
+            }
+        }
+        return { success: false as const, plan: null, error: message };
+    }
+}

--- a/apps/web/src/app/api/credits/ledger/route.ts
+++ b/apps/web/src/app/api/credits/ledger/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+/**
+ * Wave 13 (Billing page) — Next.js proxy for the paginated credits
+ * ledger, so the client-side table can page/filter without a full
+ * navigation. Forwards the auth cookie as a Bearer token.
+ *
+ * Mirrors apps/web/src/app/api/works/[id]/usage/export/route.ts.
+ */
+
+// Security: allowlist of query parameters forwarded to the upstream API.
+const ALLOWED_PARAMS = new Set(['period', 'kinds', 'page', 'pageSize']);
+
+export async function GET(request: NextRequest) {
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    // Security: reconstruct the query string from an explicit allowlist so
+    // unknown/debug parameters are never forwarded to the internal API.
+    const upstreamParams = new URLSearchParams();
+    request.nextUrl.searchParams.forEach((value, key) => {
+        if (ALLOWED_PARAMS.has(key)) {
+            upstreamParams.set(key, value);
+        }
+    });
+    const upstreamSearch = upstreamParams.size > 0 ? `?${upstreamParams.toString()}` : '';
+
+    const response = await fetch(`${API_URL}/credits/ledger${upstreamSearch}`, {
+        method: 'GET',
+        headers,
+        cache: 'no-store',
+    });
+
+    const body = await response.json().catch(() => null);
+    if (!response.ok || !body) {
+        return NextResponse.json(
+            { error: 'Failed to load credits ledger' },
+            { status: response.status || 500 },
+        );
+    }
+
+    return NextResponse.json(body, { status: 200 });
+}

--- a/apps/web/src/app/api/credits/usage-summary/route.ts
+++ b/apps/web/src/app/api/credits/usage-summary/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+/**
+ * Wave 13 (Usage & Credits page) — Next.js proxy for the owner-scoped
+ * usage-summary aggregations, so the by-day chart's 7d/30d toggle can
+ * refetch client-side. Forwards the auth cookie as a Bearer token.
+ *
+ * Mirrors apps/web/src/app/api/works/[id]/usage/export/route.ts.
+ */
+
+// Security: allowlist of query parameters forwarded to the upstream API.
+const ALLOWED_PARAMS = new Set(['groupBy', 'period']);
+
+export async function GET(request: NextRequest) {
+    const token = await getAuthAccessCookie();
+
+    const headers = new Headers();
+    if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+    }
+
+    // Security: reconstruct the query string from an explicit allowlist so
+    // unknown/debug parameters are never forwarded to the internal API.
+    const upstreamParams = new URLSearchParams();
+    request.nextUrl.searchParams.forEach((value, key) => {
+        if (ALLOWED_PARAMS.has(key)) {
+            upstreamParams.set(key, value);
+        }
+    });
+    const upstreamSearch = upstreamParams.size > 0 ? `?${upstreamParams.toString()}` : '';
+
+    const response = await fetch(`${API_URL}/credits/usage-summary${upstreamSearch}`, {
+        method: 'GET',
+        headers,
+        cache: 'no-store',
+    });
+
+    const body = await response.json().catch(() => null);
+    if (!response.ok || !body) {
+        return NextResponse.json(
+            { error: 'Failed to load usage summary' },
+            { status: response.status || 500 },
+        );
+    }
+
+    return NextResponse.json(body, { status: 200 });
+}

--- a/apps/web/src/components/dashboard/DashboardSidebar.tsx
+++ b/apps/web/src/components/dashboard/DashboardSidebar.tsx
@@ -30,6 +30,8 @@ import {
     ListChecks,
     Sparkles,
     Users,
+    CreditCard,
+    BarChart3,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
@@ -463,6 +465,37 @@ export function DashboardSidebar({
                                             strokeWidth={1.3}
                                         />
                                         {t('profileMenu.keyboardShortcuts')}
+                                    </DropdownMenuItem>
+                                    {/* Wave 13 — Billing + Usage & Credits (billing/usage PRD §2):
+                                        a new section ABOVE the final separator + Sign Out. */}
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuItem
+                                        data-testid="profile-menu-billing"
+                                        onClick={() => {
+                                            onInteraction?.();
+                                            router.push(ROUTES.DASHBOARD_SETTINGS_BILLING);
+                                        }}
+                                        className="cursor-pointer px-3 rounded-md hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark"
+                                    >
+                                        <CreditCard
+                                            className="w-4 h-4 mr-2 shrink-0"
+                                            strokeWidth={1.5}
+                                        />
+                                        {t('profileMenu.billing')}
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        data-testid="profile-menu-usage-credits"
+                                        onClick={() => {
+                                            onInteraction?.();
+                                            router.push(ROUTES.DASHBOARD_USAGE);
+                                        }}
+                                        className="cursor-pointer px-3 rounded-md hover:bg-surface-tertiary/50 dark:hover:bg-card-primary-dark"
+                                    >
+                                        <BarChart3
+                                            className="w-4 h-4 mr-2 shrink-0"
+                                            strokeWidth={1.5}
+                                        />
+                                        {t('profileMenu.usageCredits')}
                                     </DropdownMenuItem>
                                     <DropdownMenuSeparator />
                                     <DropdownMenuItem

--- a/apps/web/src/components/settings/BillingSettings.tsx
+++ b/apps/web/src/components/settings/BillingSettings.tsx
@@ -1,0 +1,561 @@
+'use client';
+
+import { useCallback, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import { AlertCircle, CreditCard, FileText, RefreshCw, Wallet, Zap, Check } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+import { changePlanAction } from '@/app/actions/dashboard/billing';
+import {
+    CREDIT_LEDGER_KINDS,
+    CREDIT_TOPUP_PRESETS_CENTS,
+    creditsForTopupCents,
+    formatCreditsAsDollars,
+    formatMonthlyPrice,
+    formatSignedCredits,
+    isFreePlan,
+    ledgerKindTone,
+    type CreditLedgerKind,
+    type CreditsBalance,
+    type CreditsLedgerPage,
+    type SubscriptionPlanList,
+    type SubscriptionPlanListItem,
+    type SubscriptionPlanSummary,
+} from '@/lib/api/credits.shared';
+
+interface BillingSettingsProps {
+    paymentsEnabled: boolean;
+    initialPlan: SubscriptionPlanSummary | null;
+    initialPlans: SubscriptionPlanList | null;
+    initialBalance: CreditsBalance | null;
+    initialLedger: CreditsLedgerPage | null;
+}
+
+const LEDGER_PAGE_SIZE = 10;
+
+const KIND_TONE_CLASSES: Record<ReturnType<typeof ledgerKindTone>, string> = {
+    positive:
+        'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20',
+    negative: 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border border-rose-500/20',
+    neutral:
+        'bg-surface-secondary dark:bg-surface-secondary-dark text-text-muted dark:text-text-muted-dark border border-border dark:border-border-dark',
+};
+
+function SectionCard({
+    icon: Icon,
+    title,
+    subtitle,
+    children,
+    testId,
+}: {
+    icon: React.ComponentType<{ className?: string; strokeWidth?: number }>;
+    title: string;
+    subtitle?: string;
+    children: React.ReactNode;
+    testId?: string;
+}) {
+    return (
+        <div
+            data-testid={testId}
+            className="rounded-lg border border-border dark:border-border-dark p-5 space-y-4"
+        >
+            <div className="flex items-center gap-2">
+                <div className="rounded-md w-8 h-8 flex items-center justify-center bg-surface dark:bg-white/6">
+                    <Icon className="w-4.5 h-4.5" strokeWidth={1.3} />
+                </div>
+                <div>
+                    <h3 className="text-sm font-semibold text-text dark:text-text-dark">{title}</h3>
+                    {subtitle ? (
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {subtitle}
+                        </p>
+                    ) : null}
+                </div>
+            </div>
+            {children}
+        </div>
+    );
+}
+
+export function BillingSettings({
+    paymentsEnabled,
+    initialPlan,
+    initialPlans,
+    initialBalance,
+    initialLedger,
+}: BillingSettingsProps) {
+    const t = useTranslations('dashboard.settings.billing');
+    const [isPending, startTransition] = useTransition();
+
+    const subscriptionsEnabled = initialPlans?.enabled ?? initialPlan?.enabled ?? false;
+    const currentPlanCode = initialPlans?.currentPlanCode ?? initialPlan?.plan?.code ?? 'free';
+    const plans = initialPlans?.plans ?? [];
+    const currentPlan =
+        plans.find((p) => p.isCurrent) ?? plans.find((p) => p.code === currentPlanCode) ?? null;
+    const balanceCredits = initialBalance?.balanceCredits ?? null;
+
+    // ── Buy-credits selection (flag-gated; checkout seam lands later) ──
+    const [selectedTopupCents, setSelectedTopupCents] = useState<number | null>(null);
+    const [customAmount, setCustomAmount] = useState('');
+    const customCents = (() => {
+        const dollars = Number(customAmount);
+        return Number.isFinite(dollars) && dollars > 0 ? Math.round(dollars * 100) : null;
+    })();
+    const effectiveTopupCents = customCents ?? selectedTopupCents;
+
+    // ── Ledger paging + kind filter (client refetch via web proxy) ──
+    const [ledger, setLedger] = useState<CreditsLedgerPage | null>(initialLedger);
+    const [ledgerPage, setLedgerPage] = useState(initialLedger?.page ?? 1);
+    const [ledgerKind, setLedgerKind] = useState<'' | CreditLedgerKind>('');
+    const [ledgerLoading, setLedgerLoading] = useState(false);
+    const [ledgerError, setLedgerError] = useState(false);
+
+    const loadLedger = useCallback(async (page: number, kind: '' | CreditLedgerKind) => {
+        setLedgerLoading(true);
+        setLedgerError(false);
+        try {
+            const params = new URLSearchParams();
+            params.set('page', String(page));
+            params.set('pageSize', String(LEDGER_PAGE_SIZE));
+            if (kind) {
+                params.set('kinds', kind);
+            }
+            const response = await fetch(`/api/credits/ledger?${params.toString()}`, {
+                method: 'GET',
+                cache: 'no-store',
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            const data = (await response.json()) as CreditsLedgerPage;
+            setLedger(data);
+            setLedgerPage(data.page);
+        } catch {
+            setLedgerError(true);
+        } finally {
+            setLedgerLoading(false);
+        }
+    }, []);
+
+    const handleKindFilter = (kind: '' | CreditLedgerKind) => {
+        setLedgerKind(kind);
+        void loadLedger(1, kind);
+    };
+
+    const handleSwitchPlan = (plan: SubscriptionPlanListItem) => {
+        startTransition(async () => {
+            const result = await changePlanAction(plan.code);
+            if (result.success) {
+                toast.success(t('plans.changeSuccess', { name: plan.name }));
+            } else {
+                toast.error(result.error ?? t('plans.changeError'));
+            }
+        });
+    };
+
+    const ledgerTotalPages = ledger ? Math.max(1, Math.ceil(ledger.total / LEDGER_PAGE_SIZE)) : 1;
+    const dataUnavailable = !initialPlan && !initialPlans && !initialBalance && !initialLedger;
+
+    return (
+        <div className="space-y-8" data-testid="billing-settings">
+            <div>
+                <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-2">
+                    {t('title')}
+                </h2>
+                <p className="text-text-muted dark:text-text-muted-dark text-sm">{t('subtitle')}</p>
+            </div>
+
+            {dataUnavailable ? (
+                <div
+                    data-testid="billing-load-error"
+                    className="flex items-center gap-2 rounded-lg border border-warning/40 bg-warning/5 p-4 text-sm text-text dark:text-text-dark"
+                >
+                    <AlertCircle className="w-4 h-4 shrink-0 text-warning" />
+                    {t('loadError')}
+                </div>
+            ) : null}
+
+            {!subscriptionsEnabled && !dataUnavailable ? (
+                <div
+                    data-testid="billing-disabled-notice"
+                    className="flex items-center gap-2 rounded-lg border border-border dark:border-border-dark bg-surface dark:bg-surface-dark p-4 text-sm text-text-muted dark:text-text-muted-dark"
+                >
+                    <AlertCircle className="w-4 h-4 shrink-0" />
+                    {t('disabledNotice')}
+                </div>
+            ) : null}
+
+            {/* ── Current plan ─────────────────────────────────────── */}
+            <SectionCard
+                icon={CreditCard}
+                title={t('currentPlan.title')}
+                testId="billing-current-plan"
+            >
+                <div className="flex items-center justify-between">
+                    <div>
+                        <p className="text-lg font-semibold text-text dark:text-text-dark">
+                            {currentPlan?.name ?? initialPlan?.plan?.name ?? 'Free'}
+                        </p>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {currentPlan
+                                ? isFreePlan(currentPlan)
+                                    ? t('plans.free')
+                                    : `${formatMonthlyPrice(currentPlan.monthlyPrice, currentPlan.currency)}${t('plans.perMonth')}`
+                                : t('plans.free')}
+                        </p>
+                    </div>
+                    {subscriptionsEnabled ? (
+                        <span
+                            data-testid="billing-plan-status"
+                            className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 border border-emerald-500/20 px-2.5 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400"
+                        >
+                            <Check className="w-3 h-3" />
+                            {t('currentPlan.statusActive')}
+                        </span>
+                    ) : null}
+                </div>
+            </SectionCard>
+
+            {/* ── Plan switcher (credits-forward, PRD §3.1) ─────────── */}
+            <SectionCard
+                icon={Zap}
+                title={t('plans.title')}
+                subtitle={t('plans.subtitle')}
+                testId="billing-plans"
+            >
+                {plans.length === 0 ? (
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark py-4">
+                        {t('plans.empty')}
+                    </p>
+                ) : (
+                    <div className="grid gap-4 sm:grid-cols-2 @3xl/main:grid-cols-3">
+                        {plans.map((plan) => (
+                            <div
+                                key={plan.code}
+                                data-testid={`billing-plan-${plan.code}`}
+                                className={cn(
+                                    'rounded-lg border p-4 flex flex-col gap-3',
+                                    plan.isCurrent
+                                        ? 'border-primary/60 bg-primary/5'
+                                        : 'border-border dark:border-border-dark',
+                                )}
+                            >
+                                <div>
+                                    <p className="text-sm font-semibold text-text dark:text-text-dark">
+                                        {plan.name}
+                                    </p>
+                                    <p className="text-lg font-semibold text-text dark:text-text-dark">
+                                        {isFreePlan(plan)
+                                            ? t('plans.free')
+                                            : `${formatMonthlyPrice(plan.monthlyPrice, plan.currency)}${t('plans.perMonth')}`}
+                                    </p>
+                                </div>
+                                <ul className="text-xs text-text-muted dark:text-text-muted-dark space-y-1 flex-1">
+                                    <li>{t('plans.maxWorks', { count: plan.maxWorks })}</li>
+                                    <li>
+                                        {t('plans.cadences', {
+                                            count: plan.allowedCadences.length,
+                                        })}
+                                    </li>
+                                    {plan.dailyFreeCredits > 0 ? (
+                                        <li>
+                                            {t('plans.dailyFreeCredits', {
+                                                amount: formatCreditsAsDollars(
+                                                    plan.dailyFreeCredits,
+                                                    plan.currency,
+                                                ),
+                                            })}
+                                        </li>
+                                    ) : null}
+                                    <li>{t('plans.payAsYouGo')}</li>
+                                </ul>
+                                {plan.isCurrent ? (
+                                    <Button variant="secondary" disabled className="text-xs w-full">
+                                        {t('plans.current')}
+                                    </Button>
+                                ) : isFreePlan(plan) ? (
+                                    <Button
+                                        variant="secondary"
+                                        className="text-xs w-full"
+                                        disabled={!subscriptionsEnabled || isPending}
+                                        data-testid={`billing-plan-switch-${plan.code}`}
+                                        onClick={() => handleSwitchPlan(plan)}
+                                    >
+                                        {t('plans.switchFree', { name: plan.name })}
+                                    </Button>
+                                ) : (
+                                    // Paid tiers activate through a billing-verified
+                                    // path only (EW-711 #23) — until the payment
+                                    // provider lands this is a contact affordance.
+                                    <Button
+                                        className="text-xs w-full"
+                                        data-testid={`billing-plan-upgrade-${plan.code}`}
+                                        onClick={() => toast.info(t('plans.upgradeHint'))}
+                                    >
+                                        {t('plans.upgrade')}
+                                    </Button>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </SectionCard>
+
+            {/* ── Buy credits (PRD §3.2 — flag-gated until payments land) ── */}
+            <SectionCard
+                icon={Wallet}
+                title={t('credits.title')}
+                subtitle={t('credits.buySubtitle')}
+                testId="billing-buy-credits"
+            >
+                <div className="flex items-baseline gap-2">
+                    <span
+                        className="text-2xl font-semibold text-text dark:text-text-dark"
+                        data-testid="billing-balance"
+                    >
+                        {balanceCredits === null ? '—' : formatCreditsAsDollars(balanceCredits)}
+                    </span>
+                    <span className="text-xs text-text-muted dark:text-text-muted-dark">
+                        {t('credits.balanceLabel')}
+                    </span>
+                </div>
+
+                {paymentsEnabled ? (
+                    <div className="space-y-3">
+                        <div className="flex flex-wrap gap-2">
+                            {CREDIT_TOPUP_PRESETS_CENTS.map((cents) => (
+                                <Button
+                                    key={cents}
+                                    variant={
+                                        selectedTopupCents === cents && !customCents
+                                            ? 'primary'
+                                            : 'secondary'
+                                    }
+                                    className="text-xs"
+                                    data-testid={`billing-topup-${cents}`}
+                                    onClick={() => {
+                                        setSelectedTopupCents(cents);
+                                        setCustomAmount('');
+                                    }}
+                                >
+                                    {formatCreditsAsDollars(cents)}
+                                </Button>
+                            ))}
+                            <input
+                                type="number"
+                                min="1"
+                                inputMode="decimal"
+                                placeholder={t('credits.customAmount')}
+                                value={customAmount}
+                                data-testid="billing-topup-custom"
+                                onChange={(e) => setCustomAmount(e.target.value)}
+                                className="w-32 rounded-md border border-border dark:border-border-dark bg-transparent px-3 py-1.5 text-xs text-text dark:text-text-dark"
+                            />
+                        </div>
+                        {effectiveTopupCents ? (
+                            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                {t('credits.presetCredits', {
+                                    credits:
+                                        creditsForTopupCents(effectiveTopupCents).toLocaleString(
+                                            'en-US',
+                                        ),
+                                })}
+                            </p>
+                        ) : null}
+                        {/* Checkout stays disabled until the provider checkout
+                            seam (PRD §5.2) exists on the API. */}
+                        <Button disabled className="text-xs" title={t('credits.comingSoon')}>
+                            {t('credits.buy')}
+                        </Button>
+                    </div>
+                ) : (
+                    <div
+                        data-testid="billing-payments-coming-soon"
+                        className="rounded-md border border-border dark:border-border-dark bg-surface dark:bg-surface-dark p-3"
+                    >
+                        <p className="text-sm font-medium text-text dark:text-text-dark">
+                            {t('credits.comingSoon')}
+                        </p>
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('credits.comingSoonBody')}
+                        </p>
+                    </div>
+                )}
+            </SectionCard>
+
+            {/* ── Payment method + auto-recharge (flag-gated, PRD §3.3/§3.4) ── */}
+            <div className="grid gap-4 sm:grid-cols-2">
+                <SectionCard
+                    icon={CreditCard}
+                    title={t('paymentMethod.title')}
+                    testId="billing-payment-method"
+                >
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                        {paymentsEnabled ? t('paymentMethod.empty') : t('paymentMethod.comingSoon')}
+                    </p>
+                </SectionCard>
+                <SectionCard
+                    icon={RefreshCw}
+                    title={t('autoRecharge.title')}
+                    testId="billing-auto-recharge"
+                >
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                        {paymentsEnabled
+                            ? t('autoRecharge.description')
+                            : t('autoRecharge.comingSoon')}
+                    </p>
+                </SectionCard>
+            </div>
+
+            {/* ── Invoice history (PRD §3.5 — empty until the provider mirror lands) ── */}
+            <SectionCard icon={FileText} title={t('invoices.title')} testId="billing-invoices">
+                <p className="text-sm text-text-muted dark:text-text-muted-dark py-4 text-center">
+                    {t('invoices.empty')}
+                </p>
+            </SectionCard>
+
+            {/* ── Credits ledger (PRD §3.6) ─────────────────────────── */}
+            <SectionCard
+                icon={Wallet}
+                title={t('ledger.title')}
+                subtitle={t('ledger.subtitle')}
+                testId="billing-ledger"
+            >
+                <div className="flex items-center justify-between gap-3">
+                    <Select
+                        value={ledgerKind}
+                        onValueChange={(value: string) =>
+                            handleKindFilter(value as '' | CreditLedgerKind)
+                        }
+                    >
+                        <option value="">{t('ledger.filterAll')}</option>
+                        {CREDIT_LEDGER_KINDS.map((kind) => (
+                            <option key={kind} value={kind}>
+                                {t(`ledger.kinds.${kind}`)}
+                            </option>
+                        ))}
+                    </Select>
+                </div>
+
+                {ledgerLoading ? (
+                    <p
+                        className="text-sm text-text-muted dark:text-text-muted-dark py-6 text-center"
+                        data-testid="billing-ledger-loading"
+                    >
+                        {t('ledger.loading')}
+                    </p>
+                ) : ledgerError ? (
+                    <p
+                        className="text-sm text-danger py-6 text-center"
+                        data-testid="billing-ledger-error"
+                    >
+                        {t('ledger.loadError')}
+                    </p>
+                ) : !ledger || ledger.entries.length === 0 ? (
+                    <p
+                        className="text-sm text-text-muted dark:text-text-muted-dark py-6 text-center"
+                        data-testid="billing-ledger-empty"
+                    >
+                        {t('ledger.empty')}
+                    </p>
+                ) : (
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-sm" data-testid="billing-ledger-table">
+                            <thead>
+                                <tr className="text-left text-xs text-text-muted dark:text-text-muted-dark border-b border-border dark:border-border-dark">
+                                    <th className="py-2 pr-4 font-medium">{t('ledger.colDate')}</th>
+                                    <th className="py-2 pr-4 font-medium">{t('ledger.colType')}</th>
+                                    <th className="py-2 pr-4 font-medium">
+                                        {t('ledger.colDescription')}
+                                    </th>
+                                    <th className="py-2 pr-4 font-medium text-right">
+                                        {t('ledger.colAmount')}
+                                    </th>
+                                    <th className="py-2 font-medium text-right">
+                                        {t('ledger.colBalance')}
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {ledger.entries.map((entry) => (
+                                    <tr
+                                        key={entry.id}
+                                        data-testid="billing-ledger-row"
+                                        className="border-b border-border/60 dark:border-border-dark/60 last:border-0"
+                                    >
+                                        <td className="py-2 pr-4 whitespace-nowrap text-text-muted dark:text-text-muted-dark">
+                                            {new Date(entry.createdAt).toLocaleDateString(
+                                                undefined,
+                                                {
+                                                    year: 'numeric',
+                                                    month: 'short',
+                                                    day: 'numeric',
+                                                },
+                                            )}
+                                        </td>
+                                        <td className="py-2 pr-4">
+                                            <span
+                                                className={cn(
+                                                    'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+                                                    KIND_TONE_CLASSES[ledgerKindTone(entry.kind)],
+                                                )}
+                                            >
+                                                {t(`ledger.kinds.${entry.kind}`)}
+                                            </span>
+                                        </td>
+                                        <td className="py-2 pr-4 text-text dark:text-text-dark max-w-64 truncate">
+                                            {entry.description ?? '—'}
+                                        </td>
+                                        <td
+                                            className={cn(
+                                                'py-2 pr-4 text-right font-medium whitespace-nowrap',
+                                                entry.amountCredits >= 0
+                                                    ? 'text-emerald-600 dark:text-emerald-400'
+                                                    : 'text-text dark:text-text-dark',
+                                            )}
+                                        >
+                                            {formatSignedCredits(entry.amountCredits)}
+                                        </td>
+                                        <td className="py-2 text-right whitespace-nowrap text-text-muted dark:text-text-muted-dark">
+                                            {formatCreditsAsDollars(entry.balanceAfter)}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+
+                {ledger && ledger.total > LEDGER_PAGE_SIZE ? (
+                    <div className="flex items-center justify-between pt-1">
+                        <span className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('ledger.pageInfo', { page: ledgerPage, pages: ledgerTotalPages })}
+                        </span>
+                        <div className="flex gap-2">
+                            <Button
+                                variant="secondary"
+                                className="text-xs"
+                                disabled={ledgerPage <= 1 || ledgerLoading}
+                                data-testid="billing-ledger-prev"
+                                onClick={() => loadLedger(ledgerPage - 1, ledgerKind)}
+                            >
+                                {t('ledger.pagePrev')}
+                            </Button>
+                            <Button
+                                variant="secondary"
+                                className="text-xs"
+                                disabled={ledgerPage >= ledgerTotalPages || ledgerLoading}
+                                data-testid="billing-ledger-next"
+                                onClick={() => loadLedger(ledgerPage + 1, ledgerKind)}
+                            >
+                                {t('ledger.pageNext')}
+                            </Button>
+                        </div>
+                    </div>
+                ) : null}
+            </SectionCard>
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/UsageCreditsSettings.tsx
+++ b/apps/web/src/components/settings/UsageCreditsSettings.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { AlertCircle } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+import { Button } from '@/components/ui/button';
+import { UsageByDayChart } from '@/components/settings/usage/UsageByDayChart';
+import { UsageBreakdownChart } from '@/components/settings/usage/UsageBreakdownChart';
+import {
+    formatCents,
+    formatCreditsAsDollars,
+    type UsageSummaryGrouped,
+    type UsageSummaryTotals,
+} from '@/lib/api/credits.shared';
+import type { AccountWideUsage } from '@/lib/api/usage';
+
+interface UsageCreditsSettingsProps {
+    initialTotals: UsageSummaryTotals | null;
+    initialByDay: UsageSummaryGrouped | null;
+    initialByModel: UsageSummaryGrouped | null;
+    initialByAgent: UsageSummaryGrouped | null;
+    initialByWork: UsageSummaryGrouped | null;
+    accountWide: AccountWideUsage | null;
+}
+
+type DayRange = '7d' | '30d';
+
+function StatTile({ label, value, testId }: { label: string; value: string; testId: string }) {
+    // Monochrome KPI tiles per the house UI pattern — status colour
+    // belongs on table rows, never on the summary grid.
+    return (
+        <div
+            data-testid={testId}
+            className="rounded-lg border border-border dark:border-border-dark p-4"
+        >
+            <p className="text-xs text-text-muted dark:text-text-muted-dark">{label}</p>
+            <p className="mt-1 text-xl font-semibold text-text dark:text-text-dark">{value}</p>
+        </div>
+    );
+}
+
+function ChartCard({
+    title,
+    action,
+    children,
+}: {
+    title: string;
+    action?: React.ReactNode;
+    children: React.ReactNode;
+}) {
+    return (
+        <div className="rounded-lg border border-border dark:border-border-dark p-5 space-y-3">
+            <div className="flex items-center justify-between gap-2">
+                <h3 className="text-sm font-semibold text-text dark:text-text-dark">{title}</h3>
+                {action}
+            </div>
+            {children}
+        </div>
+    );
+}
+
+export function UsageCreditsSettings({
+    initialTotals,
+    initialByDay,
+    initialByModel,
+    initialByAgent,
+    initialByWork,
+    accountWide,
+}: UsageCreditsSettingsProps) {
+    const t = useTranslations('dashboard.settings.usage');
+
+    // 7d/30d toggle for the by-day chart: refetch through the web
+    // proxy, cache each range so flipping back is instant.
+    const [dayRange, setDayRange] = useState<DayRange>('30d');
+    const [byDayCache, setByDayCache] = useState<Record<DayRange, UsageSummaryGrouped | null>>({
+        '30d': initialByDay,
+        '7d': null,
+    });
+    const [dayLoading, setDayLoading] = useState(false);
+    const [dayError, setDayError] = useState(false);
+
+    const handleRangeChange = async (range: DayRange) => {
+        setDayRange(range);
+        if (byDayCache[range]) {
+            return;
+        }
+        setDayLoading(true);
+        setDayError(false);
+        try {
+            const response = await fetch(`/api/credits/usage-summary?groupBy=day&period=${range}`, {
+                method: 'GET',
+                cache: 'no-store',
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+            }
+            const data = (await response.json()) as UsageSummaryGrouped;
+            setByDayCache((cache) => ({ ...cache, [range]: data }));
+        } catch {
+            setDayError(true);
+        } finally {
+            setDayLoading(false);
+        }
+    };
+
+    const byDay = byDayCache[dayRange];
+    const dataUnavailable =
+        !initialTotals && !initialByDay && !initialByModel && !initialByAgent && !initialByWork;
+
+    return (
+        <div className="space-y-8" data-testid="usage-credits-settings">
+            <div>
+                <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-2">
+                    {t('title')}
+                </h2>
+                <p className="text-text-muted dark:text-text-muted-dark text-sm">{t('subtitle')}</p>
+            </div>
+
+            {dataUnavailable ? (
+                <div
+                    data-testid="usage-load-error"
+                    className="flex items-center gap-2 rounded-lg border border-warning/40 bg-warning/5 p-4 text-sm text-text dark:text-text-dark"
+                >
+                    <AlertCircle className="w-4 h-4 shrink-0 text-warning" />
+                    {t('loadError')}
+                </div>
+            ) : null}
+
+            {/* ── §4.1/§4.2 — period summary tiles ─────────────────── */}
+            {initialTotals ? (
+                <div
+                    className="grid grid-cols-2 gap-4 sm:grid-cols-3 @5xl/main:grid-cols-7"
+                    data-testid="usage-summary-tiles"
+                >
+                    <StatTile
+                        label={t('tiles.balance')}
+                        value={formatCreditsAsDollars(initialTotals.balanceCredits)}
+                        testId="usage-tile-balance"
+                    />
+                    <StatTile
+                        label={t('tiles.consumed')}
+                        value={formatCreditsAsDollars(initialTotals.creditsConsumed)}
+                        testId="usage-tile-consumed"
+                    />
+                    <StatTile
+                        label={t('tiles.added')}
+                        value={formatCreditsAsDollars(initialTotals.creditsAdded)}
+                        testId="usage-tile-added"
+                    />
+                    <StatTile
+                        label={t('tiles.spend')}
+                        value={formatCents(
+                            accountWide?.currentSpendCents ?? initialTotals.spendCents,
+                        )}
+                        testId="usage-tile-spend"
+                    />
+                    <StatTile
+                        label={t('tiles.tasksCompleted')}
+                        value={String(initialTotals.tasksCompleted)}
+                        testId="usage-tile-tasks"
+                    />
+                    <StatTile
+                        label={t('tiles.worksActive')}
+                        value={String(initialTotals.worksActive)}
+                        testId="usage-tile-works"
+                    />
+                    <StatTile
+                        label={t('tiles.agentRuns')}
+                        value={String(initialTotals.agentRuns)}
+                        testId="usage-tile-runs"
+                    />
+                </div>
+            ) : null}
+            {initialTotals ? (
+                <p className="text-xs text-text-muted dark:text-text-muted-dark -mt-4">
+                    {t('tiles.periodNote', { period: initialTotals.period })}
+                </p>
+            ) : null}
+
+            {/* ── §4.3 — usage per day (7d/30d toggle) ─────────────── */}
+            <ChartCard
+                title={t('charts.byDay')}
+                action={
+                    <div className="flex gap-1">
+                        {(['7d', '30d'] as const).map((range) => (
+                            <Button
+                                key={range}
+                                variant={dayRange === range ? 'primary' : 'secondary'}
+                                className={cn('text-xs px-3 py-1')}
+                                data-testid={`usage-range-${range}`}
+                                onClick={() => handleRangeChange(range)}
+                            >
+                                {t(`charts.range${range}`)}
+                            </Button>
+                        ))}
+                    </div>
+                }
+            >
+                {dayLoading ? (
+                    <p
+                        className="py-10 text-center text-xs text-text-muted dark:text-text-muted-dark"
+                        data-testid="usage-by-day-loading"
+                    >
+                        {t('charts.loading')}
+                    </p>
+                ) : dayError ? (
+                    <p
+                        className="py-10 text-center text-xs text-danger"
+                        data-testid="usage-by-day-error"
+                    >
+                        {t('charts.error')}
+                    </p>
+                ) : (
+                    <UsageByDayChart rows={byDay?.rows ?? []} emptyLabel={t('charts.empty')} />
+                )}
+            </ChartCard>
+
+            {/* ── §4.3 — by model / by agent / by Work ─────────────── */}
+            <div className="grid gap-4 @3xl/main:grid-cols-2">
+                <ChartCard title={t('charts.byModel')}>
+                    <UsageBreakdownChart
+                        rows={initialByModel?.rows ?? []}
+                        emptyLabel={t('charts.empty')}
+                        unattributedLabel={t('charts.unattributed')}
+                        testId="usage-by-model-chart"
+                    />
+                </ChartCard>
+                <ChartCard title={t('charts.byAgent')}>
+                    <UsageBreakdownChart
+                        rows={initialByAgent?.rows ?? []}
+                        emptyLabel={t('charts.empty')}
+                        unattributedLabel={t('charts.unattributed')}
+                        testId="usage-by-agent-chart"
+                    />
+                </ChartCard>
+            </div>
+            <ChartCard title={t('charts.byWork')}>
+                <UsageBreakdownChart
+                    rows={initialByWork?.rows ?? []}
+                    emptyLabel={t('charts.empty')}
+                    unattributedLabel={t('charts.unattributed')}
+                    testId="usage-by-work-chart"
+                />
+            </ChartCard>
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/usage/UsageBreakdownChart.tsx
+++ b/apps/web/src/components/settings/usage/UsageBreakdownChart.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { formatCents, type UsageSummaryGroupRow } from '@/lib/api/credits.shared';
+
+interface UsageBreakdownChartProps {
+    rows: UsageSummaryGroupRow[];
+    emptyLabel: string;
+    /** Localized label for `key === null` (unattributed) rows. */
+    unattributedLabel: string;
+    testId: string;
+    /** Cap the number of bars so one noisy dimension stays readable. */
+    maxRows?: number;
+}
+
+/**
+ * Wave 13 (PRD §4.3) — horizontal $ BarChart shared by the by-model /
+ * by-agent / by-Work charts (`UsageByModelChart` / `UsageByAgentChart`
+ * / `UsageByWorkChart` render through this with their own data +
+ * testid). Same recharts building blocks as SpendTrendCard, rotated to
+ * a category axis so long model/Agent/Work names stay legible.
+ */
+export function UsageBreakdownChart({
+    rows,
+    emptyLabel,
+    unattributedLabel,
+    testId,
+    maxRows = 8,
+}: UsageBreakdownChartProps) {
+    const chartData = rows.slice(0, maxRows).map((row) => ({
+        label: row.key === null ? unattributedLabel : row.label,
+        costCents: row.costCents,
+    }));
+
+    if (chartData.length === 0) {
+        return (
+            <p
+                className="py-10 text-center text-xs text-text-muted dark:text-text-muted-dark"
+                data-testid={`${testId}-empty`}
+            >
+                {emptyLabel}
+            </p>
+        );
+    }
+
+    // Height scales with the row count so short lists don't stretch.
+    const height = Math.max(120, chartData.length * 36);
+
+    return (
+        <div className="w-full" style={{ height }} data-testid={testId}>
+            <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                    data={chartData}
+                    layout="vertical"
+                    margin={{ top: 0, right: 8, left: 8, bottom: 0 }}
+                >
+                    <XAxis
+                        type="number"
+                        tick={{ fontSize: 10 }}
+                        axisLine={false}
+                        tickLine={false}
+                        tickFormatter={(v: number) => `$${(v / 100).toFixed(0)}`}
+                    />
+                    <YAxis
+                        type="category"
+                        dataKey="label"
+                        width={140}
+                        tick={{ fontSize: 10 }}
+                        axisLine={false}
+                        tickLine={false}
+                    />
+                    <Tooltip
+                        formatter={(value: number) => formatCents(value)}
+                        contentStyle={{
+                            background: 'rgba(15, 23, 42, 0.9)',
+                            border: '1px solid rgba(148, 163, 184, 0.2)',
+                            borderRadius: 6,
+                            fontSize: 12,
+                        }}
+                        labelStyle={{ color: '#cbd5e1' }}
+                        itemStyle={{ color: '#f1f5f9' }}
+                    />
+                    <Bar dataKey="costCents" fill="#3b82f6" radius={[0, 2, 2, 0]} barSize={18} />
+                </BarChart>
+            </ResponsiveContainer>
+        </div>
+    );
+}

--- a/apps/web/src/components/settings/usage/UsageByDayChart.tsx
+++ b/apps/web/src/components/settings/usage/UsageByDayChart.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { formatCents, type UsageSummaryGroupRow } from '@/lib/api/credits.shared';
+
+interface UsageByDayChartProps {
+    rows: UsageSummaryGroupRow[];
+    emptyLabel: string;
+}
+
+/**
+ * Wave 13 (PRD §4.3) — daily $ BarChart for the Usage & Credits page.
+ * Cloned from `components/dashboard/SpendTrendCard.tsx` (recharts
+ * ResponsiveContainer + cents→$ tick formatter + dark tooltip).
+ */
+export function UsageByDayChart({ rows, emptyLabel }: UsageByDayChartProps) {
+    const chartData = rows.map((row) => ({
+        day: row.label.slice(5), // YYYY-MM-DD → MM-DD
+        costCents: row.costCents,
+    }));
+
+    if (chartData.length === 0) {
+        return (
+            <p
+                className="py-10 text-center text-xs text-text-muted dark:text-text-muted-dark"
+                data-testid="usage-by-day-empty"
+            >
+                {emptyLabel}
+            </p>
+        );
+    }
+
+    return (
+        <div className="h-48 w-full" data-testid="usage-by-day-chart">
+            <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={chartData} margin={{ top: 0, right: 0, left: -10, bottom: 0 }}>
+                    <XAxis
+                        dataKey="day"
+                        tick={{ fontSize: 10 }}
+                        interval="preserveStartEnd"
+                        axisLine={false}
+                        tickLine={false}
+                    />
+                    <YAxis
+                        tick={{ fontSize: 10 }}
+                        width={36}
+                        axisLine={false}
+                        tickLine={false}
+                        tickFormatter={(v: number) => `$${(v / 100).toFixed(0)}`}
+                    />
+                    <Tooltip
+                        formatter={(value: number) => formatCents(value)}
+                        contentStyle={{
+                            background: 'rgba(15, 23, 42, 0.9)',
+                            border: '1px solid rgba(148, 163, 184, 0.2)',
+                            borderRadius: 6,
+                            fontSize: 12,
+                        }}
+                        labelStyle={{ color: '#cbd5e1' }}
+                        itemStyle={{ color: '#f1f5f9' }}
+                    />
+                    <Bar dataKey="costCents" fill="#3b82f6" radius={[2, 2, 0, 0]} />
+                </BarChart>
+            </ResponsiveContainer>
+        </div>
+    );
+}

--- a/apps/web/src/lib/api/credits.shared.ts
+++ b/apps/web/src/lib/api/credits.shared.ts
@@ -1,0 +1,241 @@
+/**
+ * Billing + Usage & Credits (Wave 13) — client-safe wire types + pure
+ * helpers for the `/settings/billing` and `/settings/usage` pages.
+ *
+ * Mirrors the API's read-only credits surface
+ * (`apps/api/src/subscriptions/credits.controller.ts` +
+ * `subscriptions.controller.ts`); kept apart from `credits.ts` (which
+ * is `server-only`) so `'use client'` components can import types and
+ * helpers without pulling the server guard into the client bundle —
+ * same split as `agents.shared.ts`.
+ */
+
+// ── Wire types ──────────────────────────────────────────────────────
+
+/** `credit_ledger_entries.kind` — mirrors the agent's CreditLedgerKind. */
+export type CreditLedgerKind =
+    | 'purchase'
+    | 'grant'
+    | 'daily-free'
+    | 'consumption'
+    | 'adjustment'
+    | 'expiry';
+
+export const CREDIT_LEDGER_KINDS: readonly CreditLedgerKind[] = [
+    'purchase',
+    'grant',
+    'daily-free',
+    'consumption',
+    'adjustment',
+    'expiry',
+];
+
+export interface CreditsBalance {
+    status: string;
+    balanceCredits: number;
+}
+
+export interface CreditLedgerRow {
+    id: string;
+    kind: CreditLedgerKind;
+    /** Signed: positive = credit, negative = debit. */
+    amountCredits: number;
+    balanceAfter: number;
+    costCentsRef: number | null;
+    refType: string | null;
+    refId: string | null;
+    description: string | null;
+    createdAt: string;
+}
+
+export interface CreditsLedgerPage {
+    status: string;
+    entries: CreditLedgerRow[];
+    total: number;
+    page: number;
+    pageSize: number;
+}
+
+export type UsageSummaryGroupBy = 'day' | 'model' | 'agent' | 'work';
+
+export interface UsageSummaryTotals {
+    status: string;
+    period: string;
+    from: string;
+    to: string;
+    balanceCredits: number;
+    creditsConsumed: number;
+    creditsAdded: number;
+    spendCents: number;
+    tasksCompleted: number;
+    worksActive: number;
+    agentRuns: number;
+}
+
+export interface UsageSummaryGroupRow {
+    key: string | null;
+    label: string;
+    units: number;
+    costCents: number;
+}
+
+export interface UsageSummaryGrouped {
+    status: string;
+    period: string;
+    from: string;
+    to: string;
+    groupBy: UsageSummaryGroupBy;
+    rows: UsageSummaryGroupRow[];
+}
+
+export interface SubscriptionPlanSummary {
+    status: string;
+    enabled: boolean;
+    plan: { code: string; name: string; allowedCadences?: unknown[] };
+}
+
+export interface SubscriptionPlanListItem {
+    code: string;
+    name: string;
+    maxWorks: number;
+    allowedCadences: string[];
+    /** Decimal string from the API (e.g. `'29'` / `'29.00'`). */
+    monthlyPrice: string;
+    overagePricePerRun: string;
+    currency: string;
+    isCurrent: boolean;
+    dailyFreeCredits: number;
+}
+
+export interface SubscriptionPlanList {
+    status: string;
+    enabled: boolean;
+    currentPlanCode: string;
+    plans: SubscriptionPlanListItem[];
+}
+
+// ── Pure helpers (unit-tested in credits.shared.unit.spec.ts) ───────
+
+/**
+ * Credits are USD-denominated: 1 credit = 1 cent of platform-billed
+ * usage at the default conversion (PRD §3.2), so credits render as $.
+ */
+export function formatCreditsAsDollars(credits: number, currency = 'usd'): string {
+    try {
+        return new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency: currency.toUpperCase(),
+            maximumFractionDigits: 2,
+        }).format(credits / 100);
+    } catch {
+        return `$${(credits / 100).toFixed(2)}`;
+    }
+}
+
+/** costCents → display dollars (same formatting as the budgets pages). */
+export function formatCents(cents: number, currency = 'usd'): string {
+    return formatCreditsAsDollars(cents, currency);
+}
+
+/**
+ * Signed ledger movement → display string with an explicit sign so
+ * credits (+) and debits (−) scan at a glance in the ledger table.
+ */
+export function formatSignedCredits(amountCredits: number, currency = 'usd'): string {
+    const sign = amountCredits >= 0 ? '+' : '−';
+    return `${sign}${formatCreditsAsDollars(Math.abs(amountCredits), currency)}`;
+}
+
+/** Ledger kind → badge tone bucket (colors mapped in the component). */
+export type LedgerKindTone = 'positive' | 'negative' | 'neutral';
+
+export function ledgerKindTone(kind: CreditLedgerKind): LedgerKindTone {
+    switch (kind) {
+        case 'purchase':
+        case 'grant':
+        case 'daily-free':
+            return 'positive';
+        case 'consumption':
+        case 'expiry':
+            return 'negative';
+        case 'adjustment':
+            return 'neutral';
+    }
+}
+
+/**
+ * Preset top-up amounts (PRD §3.2) with the credits each buys at the
+ * default conversion (100 credits per $1 — margin applies at debit
+ * time, not purchase time).
+ */
+export const CREDIT_TOPUP_PRESETS_CENTS: readonly number[] = [1000, 2500, 10000];
+
+export function creditsForTopupCents(amountCents: number, creditsPerDollar = 100): number {
+    if (!Number.isFinite(amountCents) || amountCents <= 0) {
+        return 0;
+    }
+    return Math.floor((amountCents / 100) * creditsPerDollar);
+}
+
+/** Build the `/credits/ledger` query string (omits empty filters). */
+export function buildLedgerQuery(params: {
+    period?: string;
+    kinds?: readonly CreditLedgerKind[];
+    page?: number;
+    pageSize?: number;
+}): string {
+    const search = new URLSearchParams();
+    if (params.period) {
+        search.set('period', params.period);
+    }
+    if (params.kinds && params.kinds.length > 0) {
+        search.set('kinds', params.kinds.join(','));
+    }
+    if (params.page && params.page > 1) {
+        search.set('page', String(params.page));
+    }
+    if (params.pageSize) {
+        search.set('pageSize', String(params.pageSize));
+    }
+    const qs = search.toString();
+    return qs ? `?${qs}` : '';
+}
+
+/** Build the `/credits/usage-summary` query string. */
+export function buildUsageSummaryQuery(params: {
+    groupBy?: UsageSummaryGroupBy;
+    period?: string;
+}): string {
+    const search = new URLSearchParams();
+    if (params.groupBy) {
+        search.set('groupBy', params.groupBy);
+    }
+    if (params.period) {
+        search.set('period', params.period);
+    }
+    const qs = search.toString();
+    return qs ? `?${qs}` : '';
+}
+
+/** `'29'` / `'29.00'` → `$29/mo`; `'0'` → localized "free" handled by caller. */
+export function formatMonthlyPrice(monthlyPrice: string, currency = 'usd'): string {
+    const price = Number(monthlyPrice);
+    if (!Number.isFinite(price)) {
+        return monthlyPrice;
+    }
+    try {
+        return new Intl.NumberFormat('en-US', {
+            style: 'currency',
+            currency: currency.toUpperCase(),
+            maximumFractionDigits: price % 1 === 0 ? 0 : 2,
+        }).format(price);
+    } catch {
+        return `$${price}`;
+    }
+}
+
+/** A plan is free (self-serviceable) only when its price parses to ≤ 0. */
+export function isFreePlan(plan: Pick<SubscriptionPlanListItem, 'monthlyPrice'>): boolean {
+    const price = Number(plan.monthlyPrice);
+    return Number.isFinite(price) && price <= 0;
+}

--- a/apps/web/src/lib/api/credits.shared.unit.spec.ts
+++ b/apps/web/src/lib/api/credits.shared.unit.spec.ts
@@ -1,0 +1,120 @@
+// Wave 13 — pure-helper spec for the Billing / Usage & Credits pages.
+
+import { describe, expect, it } from 'vitest';
+import {
+    buildLedgerQuery,
+    buildUsageSummaryQuery,
+    CREDIT_LEDGER_KINDS,
+    CREDIT_TOPUP_PRESETS_CENTS,
+    creditsForTopupCents,
+    formatCents,
+    formatCreditsAsDollars,
+    formatMonthlyPrice,
+    formatSignedCredits,
+    isFreePlan,
+    ledgerKindTone,
+} from './credits.shared';
+
+describe('formatCreditsAsDollars / formatCents', () => {
+    it('renders credits as USD (1 credit = 1¢)', () => {
+        expect(formatCreditsAsDollars(0)).toBe('$0.00');
+        expect(formatCreditsAsDollars(150)).toBe('$1.50');
+        expect(formatCreditsAsDollars(123456)).toBe('$1,234.56');
+        expect(formatCents(2500)).toBe('$25.00');
+    });
+});
+
+describe('formatSignedCredits', () => {
+    it('prefixes credits with + and debits with −', () => {
+        expect(formatSignedCredits(500)).toBe('+$5.00');
+        expect(formatSignedCredits(-500)).toBe('−$5.00');
+        expect(formatSignedCredits(0)).toBe('+$0.00');
+    });
+});
+
+describe('ledgerKindTone', () => {
+    it('buckets every ledger kind into a badge tone', () => {
+        expect(ledgerKindTone('purchase')).toBe('positive');
+        expect(ledgerKindTone('grant')).toBe('positive');
+        expect(ledgerKindTone('daily-free')).toBe('positive');
+        expect(ledgerKindTone('consumption')).toBe('negative');
+        expect(ledgerKindTone('expiry')).toBe('negative');
+        expect(ledgerKindTone('adjustment')).toBe('neutral');
+        // Contract completeness: every wire kind has a tone.
+        for (const kind of CREDIT_LEDGER_KINDS) {
+            expect(['positive', 'negative', 'neutral']).toContain(ledgerKindTone(kind));
+        }
+    });
+});
+
+describe('creditsForTopupCents', () => {
+    it('converts $ cents to credits at the default 100/dollar conversion', () => {
+        expect(creditsForTopupCents(1000)).toBe(1000);
+        expect(creditsForTopupCents(2500)).toBe(2500);
+        expect(creditsForTopupCents(10000, 200)).toBe(20000);
+    });
+
+    it('returns 0 for non-positive or non-finite amounts', () => {
+        expect(creditsForTopupCents(0)).toBe(0);
+        expect(creditsForTopupCents(-500)).toBe(0);
+        expect(creditsForTopupCents(Number.NaN)).toBe(0);
+    });
+
+    it('covers every preset amount', () => {
+        for (const preset of CREDIT_TOPUP_PRESETS_CENTS) {
+            expect(creditsForTopupCents(preset)).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe('buildLedgerQuery', () => {
+    it('returns an empty string when no filters are set', () => {
+        expect(buildLedgerQuery({})).toBe('');
+        expect(buildLedgerQuery({ page: 1 })).toBe('');
+    });
+
+    it('serializes period, kinds (comma-joined), page (>1 only), and pageSize', () => {
+        expect(
+            buildLedgerQuery({
+                period: '2026-07',
+                kinds: ['purchase', 'consumption'],
+                page: 3,
+                pageSize: 10,
+            }),
+        ).toBe('?period=2026-07&kinds=purchase%2Cconsumption&page=3&pageSize=10');
+        expect(buildLedgerQuery({ kinds: [] })).toBe('');
+    });
+});
+
+describe('buildUsageSummaryQuery', () => {
+    it('serializes groupBy and period independently', () => {
+        expect(buildUsageSummaryQuery({})).toBe('');
+        expect(buildUsageSummaryQuery({ groupBy: 'day' })).toBe('?groupBy=day');
+        expect(buildUsageSummaryQuery({ period: '7d' })).toBe('?period=7d');
+        expect(buildUsageSummaryQuery({ groupBy: 'model', period: '2026-07' })).toBe(
+            '?groupBy=model&period=2026-07',
+        );
+    });
+});
+
+describe('formatMonthlyPrice', () => {
+    it('formats whole-dollar prices without decimals and keeps fractions', () => {
+        expect(formatMonthlyPrice('29')).toBe('$29');
+        expect(formatMonthlyPrice('29.00')).toBe('$29');
+        expect(formatMonthlyPrice('9.50')).toBe('$9.50');
+        expect(formatMonthlyPrice('0')).toBe('$0');
+    });
+
+    it('falls back to the raw string when the price is not numeric', () => {
+        expect(formatMonthlyPrice('n/a')).toBe('n/a');
+    });
+});
+
+describe('isFreePlan', () => {
+    it('treats only an explicit ≤ 0 price as free (fail closed)', () => {
+        expect(isFreePlan({ monthlyPrice: '0' })).toBe(true);
+        expect(isFreePlan({ monthlyPrice: '0.00' })).toBe(true);
+        expect(isFreePlan({ monthlyPrice: '29' })).toBe(false);
+        expect(isFreePlan({ monthlyPrice: 'oops' })).toBe(false);
+    });
+});

--- a/apps/web/src/lib/api/credits.ts
+++ b/apps/web/src/lib/api/credits.ts
@@ -1,0 +1,95 @@
+import 'server-only';
+import { serverFetch } from './server-api';
+import {
+    buildLedgerQuery,
+    buildUsageSummaryQuery,
+    type CreditLedgerKind,
+    type CreditsBalance,
+    type CreditsLedgerPage,
+    type SubscriptionPlanList,
+    type SubscriptionPlanSummary,
+    type UsageSummaryGroupBy,
+    type UsageSummaryGrouped,
+    type UsageSummaryTotals,
+} from './credits.shared';
+
+export type {
+    CreditLedgerKind,
+    CreditsBalance,
+    CreditsLedgerPage,
+    SubscriptionPlanList,
+    SubscriptionPlanSummary,
+    UsageSummaryGroupBy,
+    UsageSummaryGrouped,
+    UsageSummaryTotals,
+};
+
+/**
+ * Billing + Usage & Credits (Wave 13) — server-side wrappers over the
+ * read-only credits + subscriptions surfaces. Endpoints deliberately
+ * do NOT start with `/api` (serverFetch prepends `API_URL`, which is
+ * normalized to end in `/api` — see the double-prefix regression specs
+ * beside the other lib/api wrappers).
+ */
+export const creditsAPI = {
+    /** Current credits balance for the signed-in user. */
+    async balance(): Promise<CreditsBalance> {
+        return serverFetch<CreditsBalance>('/credits/balance', { method: 'GET' });
+    },
+
+    /** Paginated credits ledger (period YYYY-MM + kind filters). */
+    async ledger(
+        params: {
+            period?: string;
+            kinds?: readonly CreditLedgerKind[];
+            page?: number;
+            pageSize?: number;
+        } = {},
+    ): Promise<CreditsLedgerPage> {
+        return serverFetch<CreditsLedgerPage>(`/credits/ledger${buildLedgerQuery(params)}`, {
+            method: 'GET',
+        });
+    },
+
+    /** §4.1/§4.2 stat-tile totals for a period (default: current month). */
+    async usageSummary(params: { period?: string } = {}): Promise<UsageSummaryTotals> {
+        return serverFetch<UsageSummaryTotals>(
+            `/credits/usage-summary${buildUsageSummaryQuery(params)}`,
+            { method: 'GET' },
+        );
+    },
+
+    /** §4.3 grouped chart rows (day / model / agent / work). */
+    async usageGrouped(params: {
+        groupBy: UsageSummaryGroupBy;
+        period?: string;
+    }): Promise<UsageSummaryGrouped> {
+        return serverFetch<UsageSummaryGrouped>(
+            `/credits/usage-summary${buildUsageSummaryQuery(params)}`,
+            { method: 'GET' },
+        );
+    },
+};
+
+export const subscriptionsAPI = {
+    /** Current plan (existing endpoint — `enabled` carries degraded state). */
+    async currentPlan(): Promise<SubscriptionPlanSummary> {
+        return serverFetch<SubscriptionPlanSummary>('/subscriptions/plan', { method: 'GET' });
+    },
+
+    /** All active plans for the credits-forward switcher (Wave 13). */
+    async listPlans(): Promise<SubscriptionPlanList> {
+        return serverFetch<SubscriptionPlanList>('/subscriptions/plans', { method: 'GET' });
+    },
+
+    /**
+     * Self-service plan change — free plans only BY DESIGN (EW-711 #23);
+     * a paid plan must be activated through a billing-verified path.
+     */
+    async changePlan(planCode: string): Promise<SubscriptionPlanSummary> {
+        return serverFetch<SubscriptionPlanSummary>('/subscriptions/plan', {
+            method: 'POST',
+            body: JSON.stringify({ planCode }),
+        });
+    },
+};

--- a/apps/web/src/lib/api/credits.unit.spec.ts
+++ b/apps/web/src/lib/api/credits.unit.spec.ts
@@ -1,0 +1,95 @@
+// Wave 13 — regression spec for the credits/subscriptions API wrappers.
+// Guards the endpoint URL shape against the `/api/api/...` double-prefix
+// bug: `serverFetch` prepends `API_URL` (normalised to end in `/api`),
+// so endpoints must NOT start with `/api`. Mirrors
+// email-addresses.unit.spec.ts.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { serverFetchMock } = vi.hoisted(() => ({
+    serverFetchMock: vi.fn(),
+}));
+
+vi.mock('./server-api', () => ({
+    serverFetch: serverFetchMock,
+}));
+
+async function importApi() {
+    return import('./credits');
+}
+
+beforeEach(() => {
+    serverFetchMock.mockReset();
+    serverFetchMock.mockResolvedValue({ status: 'success' });
+});
+afterEach(() => vi.resetModules());
+
+describe('creditsAPI — endpoint URL shape (no /api double-prefix)', () => {
+    it('balance GETs /credits/balance', async () => {
+        const { creditsAPI } = await importApi();
+        await creditsAPI.balance();
+        expect(serverFetchMock).toHaveBeenCalledWith('/credits/balance', { method: 'GET' });
+    });
+
+    it('ledger GETs /credits/ledger with only the provided filters', async () => {
+        const { creditsAPI } = await importApi();
+        await creditsAPI.ledger();
+        expect(serverFetchMock).toHaveBeenCalledWith('/credits/ledger', { method: 'GET' });
+
+        await creditsAPI.ledger({
+            period: '2026-07',
+            kinds: ['purchase', 'consumption'],
+            page: 2,
+            pageSize: 10,
+        });
+        expect(serverFetchMock).toHaveBeenCalledWith(
+            '/credits/ledger?period=2026-07&kinds=purchase%2Cconsumption&page=2&pageSize=10',
+            { method: 'GET' },
+        );
+    });
+
+    it('usageSummary GETs /credits/usage-summary (totals — no groupBy)', async () => {
+        const { creditsAPI } = await importApi();
+        await creditsAPI.usageSummary();
+        expect(serverFetchMock).toHaveBeenCalledWith('/credits/usage-summary', { method: 'GET' });
+
+        await creditsAPI.usageSummary({ period: '2026-07' });
+        expect(serverFetchMock).toHaveBeenCalledWith('/credits/usage-summary?period=2026-07', {
+            method: 'GET',
+        });
+    });
+
+    it('usageGrouped GETs /credits/usage-summary with groupBy + period', async () => {
+        const { creditsAPI } = await importApi();
+        await creditsAPI.usageGrouped({ groupBy: 'day', period: '7d' });
+        expect(serverFetchMock).toHaveBeenCalledWith(
+            '/credits/usage-summary?groupBy=day&period=7d',
+            { method: 'GET' },
+        );
+
+        await creditsAPI.usageGrouped({ groupBy: 'work' });
+        expect(serverFetchMock).toHaveBeenCalledWith('/credits/usage-summary?groupBy=work', {
+            method: 'GET',
+        });
+    });
+});
+
+describe('subscriptionsAPI — endpoint URL shape', () => {
+    it('currentPlan GETs /subscriptions/plan and listPlans GETs /subscriptions/plans', async () => {
+        const { subscriptionsAPI } = await importApi();
+        await subscriptionsAPI.currentPlan();
+        expect(serverFetchMock).toHaveBeenCalledWith('/subscriptions/plan', { method: 'GET' });
+
+        await subscriptionsAPI.listPlans();
+        expect(serverFetchMock).toHaveBeenCalledWith('/subscriptions/plans', { method: 'GET' });
+    });
+
+    it('changePlan POSTs /subscriptions/plan with the planCode body', async () => {
+        const { subscriptionsAPI } = await importApi();
+        await subscriptionsAPI.changePlan('free');
+        expect(serverFetchMock).toHaveBeenCalledWith('/subscriptions/plan', {
+            method: 'POST',
+            body: JSON.stringify({ planCode: 'free' }),
+        });
+    });
+});

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -159,6 +159,9 @@ export const ROUTES = {
     DASHBOARD_SETTINGS_GITHUB_APP: '/settings/github-app',
     DASHBOARD_SETTINGS_WORK_AGENT: '/settings/work-agent',
     DASHBOARD_SETTINGS_JOB_RUNTIME: '/settings/job-runtime',
+    // Wave 13 — Billing + Usage & Credits pages (billing/usage PRD §2).
+    DASHBOARD_SETTINGS_BILLING: '/settings/billing',
+    DASHBOARD_USAGE: '/settings/usage',
     // Dynamic plugin settings routes
     DASHBOARD_SETTINGS_PLUGIN_CATEGORY: (category: string) => `/settings/plugins/${category}`,
     // Profile (alias of settings — `/profile` redirects to `/settings`)

--- a/packages/agent/src/database/repositories/credit-ledger.repository.spec.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.spec.ts
@@ -203,4 +203,44 @@ describe('CreditLedgerRepository reads', () => {
             take: 25,
         });
     });
+
+    // Wave 13 (Billing/Usage UI) — the stat-tile period rollup.
+    it('getPeriodTotals returns consumed/added as coerced positive numbers, half-open window', async () => {
+        const { repository, topLevelRepository } = makeHarness();
+        const qb: any = {};
+        qb.select = jest.fn().mockReturnValue(qb);
+        qb.addSelect = jest.fn().mockReturnValue(qb);
+        qb.where = jest.fn().mockReturnValue(qb);
+        qb.andWhere = jest.fn().mockReturnValue(qb);
+        qb.getRawOne = jest.fn().mockResolvedValue({ consumed: '260', added: '300' });
+        topLevelRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+        const from = new Date(Date.UTC(2026, 6, 1));
+        const to = new Date(Date.UTC(2026, 7, 1));
+        const totals = await repository.getPeriodTotals('user-1', from, to);
+
+        expect(totals).toEqual({ consumedCredits: 260, addedCredits: 300 });
+        expect(qb.where).toHaveBeenCalledWith('e.userId = :userId', { userId: 'user-1' });
+        expect(qb.andWhere).toHaveBeenCalledWith('e.createdAt >= :from', { from });
+        expect(qb.andWhere).toHaveBeenCalledWith('e.createdAt < :to', { to });
+    });
+
+    it('getPeriodTotals degrades to zeros when the aggregate row is empty', async () => {
+        const { repository, topLevelRepository } = makeHarness();
+        const qb: any = {};
+        qb.select = jest.fn().mockReturnValue(qb);
+        qb.addSelect = jest.fn().mockReturnValue(qb);
+        qb.where = jest.fn().mockReturnValue(qb);
+        qb.andWhere = jest.fn().mockReturnValue(qb);
+        qb.getRawOne = jest.fn().mockResolvedValue(undefined);
+        topLevelRepository.createQueryBuilder = jest.fn().mockReturnValue(qb);
+
+        const totals = await repository.getPeriodTotals(
+            'user-1',
+            new Date(Date.UTC(2026, 6, 1)),
+            new Date(Date.UTC(2026, 7, 1)),
+        );
+
+        expect(totals).toEqual({ consumedCredits: 0, addedCredits: 0 });
+    });
 });

--- a/packages/agent/src/database/repositories/credit-ledger.repository.ts
+++ b/packages/agent/src/database/repositories/credit-ledger.repository.ts
@@ -170,6 +170,40 @@ export class CreditLedgerRepository {
     }
 
     /**
+     * Wave 13 (Billing/Usage UI) — period movement totals for the
+     * Usage & Credits stat tiles: credits consumed (sum of debits,
+     * returned positive) and credits added (sum of credits) inside a
+     * half-open `[from, to)` window. ONE grouped query using the
+     * `(userId, createdAt)` index; `CASE WHEN` is standard SQL so the
+     * same statement runs on SQLite (CI/dev) and Postgres (prod).
+     */
+    async getPeriodTotals(
+        userId: string,
+        from: Date,
+        to: Date,
+    ): Promise<{ consumedCredits: number; addedCredits: number }> {
+        const row = await this.repository
+            .createQueryBuilder('e')
+            .select(
+                'COALESCE(SUM(CASE WHEN e.amountCredits < 0 THEN -e.amountCredits ELSE 0 END), 0)',
+                'consumed',
+            )
+            .addSelect(
+                'COALESCE(SUM(CASE WHEN e.amountCredits > 0 THEN e.amountCredits ELSE 0 END), 0)',
+                'added',
+            )
+            .where('e.userId = :userId', { userId })
+            .andWhere('e.createdAt >= :from', { from })
+            .andWhere('e.createdAt < :to', { to })
+            .getRawOne<{ consumed: string; added: string }>();
+
+        return {
+            consumedCredits: Number(row?.consumed ?? 0),
+            addedCredits: Number(row?.added ?? 0),
+        };
+    }
+
+    /**
      * Serialize concurrent ledger writes for one user. Pessimistic row
      * locks are only supported on postgres/mysql/mariadb; better-sqlite3
      * throws `LockNotSupportedOnGivenDriverError` AND serializes writes

--- a/packages/agent/src/database/repositories/plugin-usage.repository.ts
+++ b/packages/agent/src/database/repositories/plugin-usage.repository.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Between, LessThan, Repository } from 'typeorm';
+import { Between, In, LessThan, Repository } from 'typeorm';
 import { PluginUsageCapability, PluginUsageEvent } from '@src/entities/plugin-usage-event.entity';
+import { Agent } from '@src/entities/agent.entity';
+import { AgentRun } from '@src/entities/agent-run.entity';
+import { Task, TaskStatus } from '@src/entities/task.entity';
+import { Work } from '@src/entities/work.entity';
 
 export type PerPluginSpend = {
     pluginId: string;
@@ -26,6 +30,25 @@ export type CrossUserSpendRow = {
 export type RunPluginSpend = {
     pluginId: string;
     costCents: number;
+};
+
+/**
+ * Wave 13 (Billing/Usage UI) — one grouped account-wide spend row.
+ * `key` is the raw grouping value (modelId / agentId / workId); NULL
+ * when the source events carry no attribution (e.g. non-Agent calls
+ * have `agentId = NULL`) — surfaced honestly, never silently dropped.
+ */
+export type UserSpendGroupRow = {
+    key: string | null;
+    units: number;
+    costCents: number;
+};
+
+/** Wave 13 — §4.2 consumption counts for the Usage & Credits page. */
+export type UserUsageCounts = {
+    tasksCompleted: number;
+    worksActive: number;
+    agentRuns: number;
 };
 
 @Injectable()
@@ -251,6 +274,158 @@ export class PluginUsageRepository {
         return Array.from(byDay.entries())
             .map(([day, costCents]) => ({ day, costCents }))
             .sort((a, b) => a.day.localeCompare(b.day));
+    }
+
+    /**
+     * Wave 13 (Billing/Usage UI) — account-wide daily spend buckets for
+     * ONE user. Same driver-agnostic JS bucketing as `getDailySpend`
+     * (no DB date functions — SQLite in CI/dev, Postgres in prod), but
+     * keyed on `userId` via the existing `(userId, occurredAt)` index.
+     * Volume is bounded by one user's events in one period window.
+     */
+    async getDailySpendForUser(
+        userId: string,
+        periodStart: Date,
+        periodEnd: Date,
+    ): Promise<DailySpendBucket[]> {
+        const events = await this.repository
+            .createQueryBuilder('e')
+            .select(['e.occurredAt', 'e.costCents'])
+            .where('e.userId = :userId', { userId })
+            .andWhere('e.occurredAt >= :start', { start: periodStart })
+            .andWhere('e.occurredAt < :end', { end: periodEnd })
+            .getMany();
+
+        const byDay = new Map<string, number>();
+        for (const event of events) {
+            const day = event.occurredAt.toISOString().slice(0, 10); // YYYY-MM-DD
+            byDay.set(day, (byDay.get(day) ?? 0) + Number(event.costCents ?? 0));
+        }
+        return Array.from(byDay.entries())
+            .map(([day, costCents]) => ({ day, costCents }))
+            .sort((a, b) => a.day.localeCompare(b.day));
+    }
+
+    /**
+     * Wave 13 — shared account-wide grouped rollup: ONE grouped query
+     * over the user's events in the window (owner-scoped, no N+1). The
+     * column is an internal whitelist — never caller-supplied.
+     */
+    private async getSpendGroupedForUser(
+        column: 'modelId' | 'agentId' | 'workId',
+        userId: string,
+        periodStart: Date,
+        periodEnd: Date,
+    ): Promise<UserSpendGroupRow[]> {
+        const rows = await this.repository
+            .createQueryBuilder('e')
+            .select(`e.${column}`, 'key')
+            .addSelect('COALESCE(SUM(e.units), 0)', 'units')
+            .addSelect('COALESCE(SUM(e.costCents), 0)', 'costCents')
+            .where('e.userId = :userId', { userId })
+            .andWhere('e.occurredAt >= :start', { start: periodStart })
+            .andWhere('e.occurredAt < :end', { end: periodEnd })
+            .groupBy(`e.${column}`)
+            .orderBy('"costCents"', 'DESC')
+            .getRawMany<{ key: string | null; units: string; costCents: string }>();
+
+        return rows.map((r) => ({
+            key: r.key ?? null,
+            units: Number(r.units ?? 0),
+            costCents: Number(r.costCents ?? 0),
+        }));
+    }
+
+    /** Wave 13 — user's spend per `modelId` in the window (one query). */
+    async getSpendByModelForUser(
+        userId: string,
+        periodStart: Date,
+        periodEnd: Date,
+    ): Promise<UserSpendGroupRow[]> {
+        return this.getSpendGroupedForUser('modelId', userId, periodStart, periodEnd);
+    }
+
+    /** Wave 13 — user's spend per Agent in the window (one query). */
+    async getSpendByAgentForUser(
+        userId: string,
+        periodStart: Date,
+        periodEnd: Date,
+    ): Promise<UserSpendGroupRow[]> {
+        return this.getSpendGroupedForUser('agentId', userId, periodStart, periodEnd);
+    }
+
+    /** Wave 13 — user's spend per Work in the window (one query). */
+    async getSpendByWorkForUser(
+        userId: string,
+        periodStart: Date,
+        periodEnd: Date,
+    ): Promise<UserSpendGroupRow[]> {
+        return this.getSpendGroupedForUser('workId', userId, periodStart, periodEnd);
+    }
+
+    /**
+     * Wave 13 — §4.2 consumption counts for the Usage & Credits page:
+     * Tasks completed in the window, currently-active Works, and Agent
+     * runs started in the window — all owner-scoped to one user.
+     *
+     * Cross-entity counts ride `repository.manager` (same precedent as
+     * `WorkRepository.getStatsForUser` counting Missions/Ideas): three
+     * COUNT queries in parallel, no N+1, no new module wiring. Each is
+     * `.catch(() => 0)`-guarded so a missing table on a half-migrated
+     * dev box degrades to 0 instead of failing the whole summary.
+     */
+    async getUsageCountsForUser(
+        userId: string,
+        periodStart: Date,
+        periodEnd: Date,
+    ): Promise<UserUsageCounts> {
+        const manager = this.repository.manager;
+        const [tasksCompleted, worksActive, agentRuns] = await Promise.all([
+            manager
+                .count(Task, {
+                    where: {
+                        userId,
+                        status: TaskStatus.DONE,
+                        completedAt: Between(periodStart, periodEnd),
+                    },
+                })
+                .catch(() => 0),
+            manager.count(Work, { where: { userId, status: 'active' } }).catch(() => 0),
+            manager
+                .count(AgentRun, {
+                    where: { userId, createdAt: Between(periodStart, periodEnd) },
+                })
+                .catch(() => 0),
+        ]);
+        return { tasksCompleted, worksActive, agentRuns };
+    }
+
+    /**
+     * Wave 13 — display-name resolution for grouped rows: ONE `IN`
+     * query per entity type (never per row). Unknown/deleted ids are
+     * simply absent from the map; callers label them honestly.
+     */
+    async getAgentNames(ids: string[]): Promise<Map<string, string>> {
+        if (ids.length === 0) {
+            return new Map();
+        }
+        const agents = await this.repository.manager.find(Agent, {
+            where: { id: In(ids) },
+            select: ['id', 'name'],
+        });
+        return new Map(agents.map((a) => [a.id, a.name]));
+    }
+
+    /** Wave 13 — Work display names for grouped rows (one `IN` query). */
+    async getWorkNames(ids: string[]): Promise<Map<string, string>> {
+        if (ids.length === 0) {
+            return new Map();
+        }
+        const works = await this.repository.manager.find(Work, {
+            where: { id: In(ids) },
+            select: ['id', 'name'],
+        });
+        return new Map(works.map((w) => [w.id, w.name]));
     }
 
     /**

--- a/packages/agent/src/subscriptions/credits/usage-summary.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/usage-summary.service.spec.ts
@@ -1,0 +1,183 @@
+import {
+    InvalidUsagePeriodError,
+    resolveUsageSummaryWindow,
+    UsageSummaryService,
+} from './usage-summary.service';
+import type { CreditLedgerRepository } from '@src/database/repositories/credit-ledger.repository';
+import type { PluginUsageRepository } from '@src/database/repositories/plugin-usage.repository';
+
+describe('resolveUsageSummaryWindow', () => {
+    const now = new Date('2026-07-25T12:00:00.000Z');
+
+    it('defaults to the current UTC calendar month (half-open window)', () => {
+        const window = resolveUsageSummaryWindow(undefined, now);
+        expect(window.period).toBe('2026-07');
+        expect(window.from.toISOString()).toBe('2026-07-01T00:00:00.000Z');
+        expect(window.to.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+    });
+
+    it('resolves an explicit YYYY-MM month (incl. December→January rollover)', () => {
+        const window = resolveUsageSummaryWindow('2025-12', now);
+        expect(window.period).toBe('2025-12');
+        expect(window.from.toISOString()).toBe('2025-12-01T00:00:00.000Z');
+        expect(window.to.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+    });
+
+    it('resolves rolling 7d and 30d windows ending now', () => {
+        const seven = resolveUsageSummaryWindow('7d', now);
+        expect(seven.period).toBe('7d');
+        expect(seven.to).toEqual(now);
+        expect(seven.from.toISOString()).toBe('2026-07-18T12:00:00.000Z');
+
+        const thirty = resolveUsageSummaryWindow('30d', now);
+        expect(thirty.from.toISOString()).toBe('2026-06-25T12:00:00.000Z');
+    });
+
+    it('throws the stable-named InvalidUsagePeriodError on malformed input', () => {
+        for (const bad of ['2026-13', '90d', 'yesterday', '7D']) {
+            expect(() => resolveUsageSummaryWindow(bad, now)).toThrow(InvalidUsagePeriodError);
+        }
+    });
+});
+
+describe('UsageSummaryService', () => {
+    let pluginUsageRepository: jest.Mocked<
+        Pick<
+            PluginUsageRepository,
+            | 'getTotalSpendCentsForUser'
+            | 'getUsageCountsForUser'
+            | 'getDailySpendForUser'
+            | 'getSpendByModelForUser'
+            | 'getSpendByAgentForUser'
+            | 'getSpendByWorkForUser'
+            | 'getAgentNames'
+            | 'getWorkNames'
+        >
+    >;
+    let creditLedgerRepository: jest.Mocked<
+        Pick<CreditLedgerRepository, 'getBalance' | 'getPeriodTotals'>
+    >;
+    let service: UsageSummaryService;
+
+    beforeEach(() => {
+        pluginUsageRepository = {
+            getTotalSpendCentsForUser: jest.fn().mockResolvedValue(240),
+            getUsageCountsForUser: jest.fn().mockResolvedValue({
+                tasksCompleted: 3,
+                worksActive: 2,
+                agentRuns: 7,
+            }),
+            getDailySpendForUser: jest.fn().mockResolvedValue([
+                { day: '2026-07-01', costCents: 100 },
+                { day: '2026-07-02', costCents: 140 },
+            ]),
+            getSpendByModelForUser: jest.fn().mockResolvedValue([
+                { key: 'gpt-x', units: 5, costCents: 200 },
+                { key: null, units: 2, costCents: 40 },
+            ]),
+            getSpendByAgentForUser: jest.fn().mockResolvedValue([
+                { key: 'agent-1', units: 4, costCents: 150 },
+                { key: null, units: 1, costCents: 90 },
+            ]),
+            getSpendByWorkForUser: jest
+                .fn()
+                .mockResolvedValue([{ key: 'work-1', units: 6, costCents: 240 }]),
+            getAgentNames: jest.fn().mockResolvedValue(new Map([['agent-1', 'Research Agent']])),
+            getWorkNames: jest.fn().mockResolvedValue(new Map([['work-1', 'My Directory']])),
+        } as any;
+        creditLedgerRepository = {
+            getBalance: jest.fn().mockResolvedValue(500),
+            getPeriodTotals: jest
+                .fn()
+                .mockResolvedValue({ consumedCredits: 260, addedCredits: 300 }),
+        } as any;
+        service = new UsageSummaryService(
+            pluginUsageRepository as unknown as PluginUsageRepository,
+            creditLedgerRepository as unknown as CreditLedgerRepository,
+        );
+    });
+
+    it('getTotals composes balance, ledger movements, spend, and counts for ONE user + window', async () => {
+        const result = await service.getTotals('user-1', '2026-07');
+
+        expect(result).toMatchObject({
+            period: '2026-07',
+            balanceCredits: 500,
+            creditsConsumed: 260,
+            creditsAdded: 300,
+            spendCents: 240,
+            tasksCompleted: 3,
+            worksActive: 2,
+            agentRuns: 7,
+        });
+
+        // Every underlying query is keyed on the SAME owner + window.
+        const from = new Date('2026-07-01T00:00:00.000Z');
+        const to = new Date('2026-08-01T00:00:00.000Z');
+        expect(creditLedgerRepository.getBalance).toHaveBeenCalledWith('user-1');
+        expect(creditLedgerRepository.getPeriodTotals).toHaveBeenCalledWith('user-1', from, to);
+        expect(pluginUsageRepository.getTotalSpendCentsForUser).toHaveBeenCalledWith(
+            'user-1',
+            from,
+            to,
+        );
+        expect(pluginUsageRepository.getUsageCountsForUser).toHaveBeenCalledWith(
+            'user-1',
+            from,
+            to,
+        );
+    });
+
+    it('getGrouped(day) maps daily buckets to chart rows', async () => {
+        const result = await service.getGrouped('user-1', 'day', '2026-07');
+
+        expect(result.groupBy).toBe('day');
+        expect(result.rows).toEqual([
+            { key: '2026-07-01', label: '2026-07-01', units: 0, costCents: 100 },
+            { key: '2026-07-02', label: '2026-07-02', units: 0, costCents: 140 },
+        ]);
+    });
+
+    it('getGrouped(model) uses modelId as the label and keeps unattributed (null) rows', async () => {
+        const result = await service.getGrouped('user-1', 'model', '2026-07');
+
+        expect(result.rows[0]).toEqual({ key: 'gpt-x', label: 'gpt-x', units: 5, costCents: 200 });
+        expect(result.rows[1].key).toBeNull();
+    });
+
+    it('getGrouped(agent) resolves Agent display names with ONE IN-query (no N+1)', async () => {
+        const result = await service.getGrouped('user-1', 'agent', '2026-07');
+
+        // Null keys are filtered OUT of the name lookup but kept as rows.
+        expect(pluginUsageRepository.getAgentNames).toHaveBeenCalledTimes(1);
+        expect(pluginUsageRepository.getAgentNames).toHaveBeenCalledWith(['agent-1']);
+        expect(result.rows[0]).toEqual({
+            key: 'agent-1',
+            label: 'Research Agent',
+            units: 4,
+            costCents: 150,
+        });
+        expect(result.rows[1].key).toBeNull();
+    });
+
+    it('getGrouped(work) resolves Work names; a deleted Work falls back to its raw id', async () => {
+        pluginUsageRepository.getSpendByWorkForUser.mockResolvedValue([
+            { key: 'work-1', units: 6, costCents: 240 },
+            { key: 'work-gone', units: 1, costCents: 10 },
+        ]);
+
+        const result = await service.getGrouped('user-1', 'work', '2026-07');
+
+        expect(pluginUsageRepository.getWorkNames).toHaveBeenCalledWith(['work-1', 'work-gone']);
+        expect(result.rows[0].label).toBe('My Directory');
+        expect(result.rows[1].label).toBe('work-gone');
+    });
+
+    it('rejects a malformed period before any repository work happens', async () => {
+        await expect(service.getTotals('user-1', 'nope')).rejects.toBeInstanceOf(
+            InvalidUsagePeriodError,
+        );
+        expect(creditLedgerRepository.getBalance).not.toHaveBeenCalled();
+        expect(pluginUsageRepository.getDailySpendForUser).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/subscriptions/credits/usage-summary.service.ts
+++ b/packages/agent/src/subscriptions/credits/usage-summary.service.ts
@@ -1,0 +1,237 @@
+import { Injectable } from '@nestjs/common';
+import { CreditLedgerRepository } from '@src/database/repositories/credit-ledger.repository';
+import {
+    PluginUsageRepository,
+    UserSpendGroupRow,
+} from '@src/database/repositories/plugin-usage.repository';
+
+/** Wave 13 — grouping dimensions for `GET /api/credits/usage-summary`. */
+export const USAGE_SUMMARY_GROUP_BYS = ['day', 'model', 'agent', 'work'] as const;
+export type UsageSummaryGroupBy = (typeof USAGE_SUMMARY_GROUP_BYS)[number];
+
+/** Resolved half-open `[from, to)` aggregation window. */
+export interface UsageSummaryWindow {
+    /** Normalized period echo (`YYYY-MM`, `7d`, or `30d`). */
+    period: string;
+    from: Date;
+    to: Date;
+}
+
+/** A period expression this surface accepts (`YYYY-MM`, `7d`, `30d`). */
+const MONTH_PERIOD_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
+const ROLLING_PERIOD_RE = /^(7|30)d$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Stable-named error so the API boundary maps a bad period/groupBy to a
+ * 400 (never an unmapped 500).
+ */
+export class InvalidUsagePeriodError extends Error {
+    constructor(period: string) {
+        super(`Invalid period (expected YYYY-MM, 7d, or 30d): ${period}`);
+        this.name = 'InvalidUsagePeriodError';
+    }
+}
+
+/**
+ * Pure, exported for unit tests + the API DTO layer: resolve a period
+ * expression to a UTC half-open window. Defaults to the current
+ * calendar month (matching the existing usage controllers' semantics).
+ * Rolling windows (`7d` / `30d`) end "now" so the by-day chart's
+ * 7d/30d toggle shows the most recent activity.
+ */
+export function resolveUsageSummaryWindow(
+    period?: string,
+    now: Date = new Date(),
+): UsageSummaryWindow {
+    if (!period) {
+        const from = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+        const to = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+        const month = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+        return { period: month, from, to };
+    }
+
+    if (MONTH_PERIOD_RE.test(period)) {
+        const [year, month] = period.split('-').map(Number);
+        return {
+            period,
+            from: new Date(Date.UTC(year, month - 1, 1)),
+            to: new Date(Date.UTC(year, month, 1)),
+        };
+    }
+
+    if (ROLLING_PERIOD_RE.test(period)) {
+        const days = period === '7d' ? 7 : 30;
+        return {
+            period,
+            from: new Date(now.getTime() - days * DAY_MS),
+            to: now,
+        };
+    }
+
+    throw new InvalidUsagePeriodError(period);
+}
+
+/** §4.1 stat-tile totals (credits + counts) for one user + window. */
+export interface UsageSummaryTotals {
+    period: string;
+    from: string;
+    to: string;
+    /** Current credits balance (not window-bound — the live number). */
+    balanceCredits: number;
+    /** Debits inside the window, returned positive. */
+    creditsConsumed: number;
+    /** Credits (purchases/grants/daily-free) inside the window. */
+    creditsAdded: number;
+    /** Metered spend (`plugin_usage_events.costCents`) in the window. */
+    spendCents: number;
+    tasksCompleted: number;
+    worksActive: number;
+    agentRuns: number;
+}
+
+/** One grouped row for the §4.3 charts. */
+export interface UsageSummaryGroupRow {
+    /** Raw grouping key (day / modelId / agentId / workId); null = unattributed. */
+    key: string | null;
+    /** Display label (day string, model id, Agent/Work name). */
+    label: string;
+    units: number;
+    costCents: number;
+}
+
+export interface UsageSummaryGrouped {
+    period: string;
+    from: string;
+    to: string;
+    groupBy: UsageSummaryGroupBy;
+    rows: UsageSummaryGroupRow[];
+}
+
+/**
+ * Wave 13 (Billing / Usage & Credits pages) — owner-scoped account-wide
+ * usage aggregations behind `GET /api/credits/usage-summary`.
+ *
+ * Reads ONLY: composes the existing metering source of truth
+ * (`plugin_usage_events` via `PluginUsageRepository`) with the credits
+ * ledger (`CreditLedgerRepository`). Every aggregation is a single
+ * grouped query per dimension (plus at most one `IN` name-resolution
+ * query) — never a per-row lookup.
+ */
+@Injectable()
+export class UsageSummaryService {
+    constructor(
+        private readonly pluginUsageRepository: PluginUsageRepository,
+        private readonly creditLedgerRepository: CreditLedgerRepository,
+    ) {}
+
+    /** §4.1/§4.2 — stat tiles + consumption counts, one user + window. */
+    async getTotals(userId: string, period?: string): Promise<UsageSummaryTotals> {
+        const window = resolveUsageSummaryWindow(period);
+        const [balanceCredits, ledgerTotals, spendCents, counts] = await Promise.all([
+            this.creditLedgerRepository.getBalance(userId),
+            this.creditLedgerRepository.getPeriodTotals(userId, window.from, window.to),
+            this.pluginUsageRepository.getTotalSpendCentsForUser(userId, window.from, window.to),
+            this.pluginUsageRepository.getUsageCountsForUser(userId, window.from, window.to),
+        ]);
+
+        return {
+            period: window.period,
+            from: window.from.toISOString(),
+            to: window.to.toISOString(),
+            balanceCredits,
+            creditsConsumed: ledgerTotals.consumedCredits,
+            creditsAdded: ledgerTotals.addedCredits,
+            spendCents,
+            tasksCompleted: counts.tasksCompleted,
+            worksActive: counts.worksActive,
+            agentRuns: counts.agentRuns,
+        };
+    }
+
+    /** §4.3 — one chart's data: grouped spend for a dimension. */
+    async getGrouped(
+        userId: string,
+        groupBy: UsageSummaryGroupBy,
+        period?: string,
+    ): Promise<UsageSummaryGrouped> {
+        const window = resolveUsageSummaryWindow(period);
+        const rows = await this.resolveRows(userId, groupBy, window);
+        return {
+            period: window.period,
+            from: window.from.toISOString(),
+            to: window.to.toISOString(),
+            groupBy,
+            rows,
+        };
+    }
+
+    private async resolveRows(
+        userId: string,
+        groupBy: UsageSummaryGroupBy,
+        window: UsageSummaryWindow,
+    ): Promise<UsageSummaryGroupRow[]> {
+        switch (groupBy) {
+            case 'day': {
+                const buckets = await this.pluginUsageRepository.getDailySpendForUser(
+                    userId,
+                    window.from,
+                    window.to,
+                );
+                return buckets.map((b) => ({
+                    key: b.day,
+                    label: b.day,
+                    units: 0,
+                    costCents: b.costCents,
+                }));
+            }
+            case 'model': {
+                const rows = await this.pluginUsageRepository.getSpendByModelForUser(
+                    userId,
+                    window.from,
+                    window.to,
+                );
+                // modelId IS the display label; null = calls that never
+                // went through a model (search/screenshot/… capabilities).
+                return rows.map((r) => this.toRow(r, r.key));
+            }
+            case 'agent': {
+                const rows = await this.pluginUsageRepository.getSpendByAgentForUser(
+                    userId,
+                    window.from,
+                    window.to,
+                );
+                const names = await this.pluginUsageRepository.getAgentNames(
+                    rows.map((r) => r.key).filter((k): k is string => k !== null),
+                );
+                return rows.map((r) => this.toRow(r, r.key ? (names.get(r.key) ?? null) : null));
+            }
+            case 'work': {
+                const rows = await this.pluginUsageRepository.getSpendByWorkForUser(
+                    userId,
+                    window.from,
+                    window.to,
+                );
+                const names = await this.pluginUsageRepository.getWorkNames(
+                    rows.map((r) => r.key).filter((k): k is string => k !== null),
+                );
+                return rows.map((r) => this.toRow(r, r.key ? (names.get(r.key) ?? null) : null));
+            }
+        }
+    }
+
+    /**
+     * Missing labels stay null-keyed but get an honest fallback label —
+     * the UI translates `key === null` rows to its localized
+     * "unattributed" copy; a resolved-but-deleted entity falls back to
+     * the raw id so the row is still identifiable.
+     */
+    private toRow(row: UserSpendGroupRow, label: string | null): UsageSummaryGroupRow {
+        return {
+            key: row.key,
+            label: label ?? row.key ?? '',
+            units: row.units,
+            costCents: row.costCents,
+        };
+    }
+}

--- a/packages/agent/src/subscriptions/index.ts
+++ b/packages/agent/src/subscriptions/index.ts
@@ -7,3 +7,5 @@ export * from './credits/credit-ledger.service';
 export * from './credits/entitlements.service';
 // Run-cost settlement + dispatch-gate credits precheck (pricing Wave 9 M2)
 export * from './credits/run-cost-settlement.service';
+// Account-wide usage aggregations for the Billing/Usage pages (Wave 13)
+export * from './credits/usage-summary.service';

--- a/packages/agent/src/subscriptions/subscription.service.ts
+++ b/packages/agent/src/subscriptions/subscription.service.ts
@@ -103,6 +103,16 @@ export class SubscriptionService implements OnModuleInit {
         return config.subscriptions.isEnabled();
     }
 
+    /**
+     * Wave 13 (Billing page) — all active seeded plans for the plan/tier
+     * switcher. Read-only; plans are seeded at boot by {@link seedPlans}
+     * regardless of the `SUBSCRIPTIONS_ENABLED` flag, so the switcher can
+     * render (degraded) even on deploys where billing is off.
+     */
+    async listPlans(): Promise<SubscriptionPlan[]> {
+        return this.planRepository.findAllActive();
+    }
+
     async getActiveSubscription(userId: string) {
         return this.userSubscriptionRepository.findActiveByUser(userId);
     }

--- a/packages/agent/src/subscriptions/subscriptions.module.spec.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.spec.ts
@@ -6,6 +6,12 @@ import { BillingProvider, ManualBillingProvider } from './billing/billing.provid
 import { CreditLedgerService, InsufficientCreditsError } from './credits/credit-ledger.service';
 import { ENTITLEMENT_KEYS, EntitlementsService } from './credits/entitlements.service';
 import { RunCostSettlementService } from './credits/run-cost-settlement.service';
+import {
+    InvalidUsagePeriodError,
+    resolveUsageSummaryWindow,
+    USAGE_SUMMARY_GROUP_BYS,
+    UsageSummaryService,
+} from './credits/usage-summary.service';
 
 /**
  * Pins the public `@ever-works/agent/subscriptions` barrel surface and the
@@ -50,6 +56,13 @@ describe('SubscriptionsModule + barrel re-exports', () => {
             expect(subscriptionsBarrel.RunCostSettlementService).toBe(RunCostSettlementService);
         });
 
+        it('re-exports the usage-summary surface (Wave 13 Billing/Usage UI)', () => {
+            expect(subscriptionsBarrel.UsageSummaryService).toBe(UsageSummaryService);
+            expect(subscriptionsBarrel.resolveUsageSummaryWindow).toBe(resolveUsageSummaryWindow);
+            expect(subscriptionsBarrel.InvalidUsagePeriodError).toBe(InvalidUsagePeriodError);
+            expect(subscriptionsBarrel.USAGE_SUMMARY_GROUP_BYS).toBe(USAGE_SUMMARY_GROUP_BYS);
+        });
+
         it('exposes the documented runtime symbols only (no extras silently appearing)', () => {
             const runtimeKeys = Object.keys(subscriptionsBarrel).sort();
             expect(runtimeKeys).toEqual(
@@ -66,6 +79,11 @@ describe('SubscriptionsModule + barrel re-exports', () => {
                     'ENTITLEMENT_KEYS',
                     // Run-cost settlement (pricing Wave 9 M2)
                     'RunCostSettlementService',
+                    // Usage-summary aggregations (Wave 13 Billing/Usage UI)
+                    'UsageSummaryService',
+                    'resolveUsageSummaryWindow',
+                    'InvalidUsagePeriodError',
+                    'USAGE_SUMMARY_GROUP_BYS',
                 ].sort(),
             );
         });
@@ -94,6 +112,11 @@ describe('SubscriptionsModule + barrel re-exports', () => {
         it('declares + exports RunCostSettlementService (Wave 9 M2)', () => {
             expect(getMeta('providers')).toContain(RunCostSettlementService);
             expect(getMeta('exports')).toContain(RunCostSettlementService);
+        });
+
+        it('declares + exports UsageSummaryService (Wave 13 — consumed by apps/api CreditsController)', () => {
+            expect(getMeta('providers')).toContain(UsageSummaryService);
+            expect(getMeta('exports')).toContain(UsageSummaryService);
         });
 
         it('binds the abstract BillingProvider token to ManualBillingProvider via useClass', () => {

--- a/packages/agent/src/subscriptions/subscriptions.module.ts
+++ b/packages/agent/src/subscriptions/subscriptions.module.ts
@@ -7,6 +7,7 @@ import { BillingProvider, ManualBillingProvider } from './billing/billing.provid
 import { CreditLedgerService } from './credits/credit-ledger.service';
 import { EntitlementsService } from './credits/entitlements.service';
 import { RunCostSettlementService } from './credits/run-cost-settlement.service';
+import { UsageSummaryService } from './credits/usage-summary.service';
 
 @Module({
     imports: [
@@ -26,6 +27,9 @@ import { RunCostSettlementService } from './credits/run-cost-settlement.service'
         // api-side @Global() SubscriptionsModule binds this instance to
         // the RUN_COST_SETTLER + RUN_CREDITS_PRECHECK tokens.
         RunCostSettlementService,
+        // Account-wide usage aggregations behind
+        // `GET /api/credits/usage-summary` (Wave 13 Billing/Usage UI).
+        UsageSummaryService,
         { provide: BillingProvider, useClass: ManualBillingProvider },
     ],
     exports: [
@@ -34,6 +38,7 @@ import { RunCostSettlementService } from './credits/run-cost-settlement.service'
         CreditLedgerService,
         EntitlementsService,
         RunCostSettlementService,
+        UsageSummaryService,
         BillingProvider,
     ],
 })


### PR DESCRIPTION
## Summary

Wave 13 — user-facing **Billing** and **Usage & Credits** pages per the billing/usage PRD (`Workspace/knowledge/notes/2026-07-25-billing-usage-prd.md`), layered on the Wave 9 credits stack already on `wave/integration`. Everything is additive.

### Web (`apps/web`)
- **Avatar menu** (`DashboardSidebar`): new section **above Sign Out** — *Billing* (credit-card icon) → `/settings/billing`, *Usage & Credits* (bar-chart icon) → `/settings/usage` (PRD §2). Both pages also appear in the settings-shell sidebar nav.
- **`/settings/billing`** (PRD §3): current-plan card w/ Active chip + disabled-deployment notice; **credits-forward plan switcher** (`GET /api/subscriptions/plans`) — free-plan moves go through the existing self-service `POST /api/subscriptions/plan` (server action, discriminated-union return), paid tiers show an Upgrade affordance only (EW-711 #23 self-serve-paid lockout untouched); **buy credits** (presets $10/$25/$100 + custom, credits preview) plus **payment-method** and **auto-recharge** cards behind `PAYMENTS_ENABLED` (server env, **default OFF**) with clear coming-soon states — checkout stays disabled until the provider seam (PRD §5.2) lands; **invoice history** empty state; **credits ledger** table ($-focused, kind badges, kind filter, pagination via web proxy).
- **`/settings/usage`** (PRD §4): summary tiles (credits balance / used / added, month spend $ from the existing account-wide endpoint, tasks completed, works active, agent runs) + recharts charts — **usage per day with 7d/30d toggle**, **by model**, **by agent**, **by Work** (cloned from `SpendTrendCard` chart chrome; by-model/agent/work share `UsageBreakdownChart` with per-chart testids).
- `lib/api/credits.ts` (+`credits.shared.ts` client-safe types & pure helpers), `/api/credits/ledger` + `/api/credits/usage-summary` web proxies (param-allowlisted), i18n keys in **all 21 locales** (English values, dup-checked before insert), data-testids and loading/empty/error states throughout. Static pages — no polling; refresh on nav.

### API (thin, additive)
- **`GET /api/credits/usage-summary?groupBy=day|model|agent|work&period=YYYY-MM|7d|30d`** — owner-scoped; no `groupBy` → stat-tile totals. New `UsageSummaryService` (`@ever-works/agent/subscriptions`, barrel-exported, module pin specs updated) over new single grouped queries on `PluginUsageRepository` (+`CreditLedgerRepository.getPeriodTotals`); Agent/Work display names resolved with one `IN` query — **no N+1**. `InvalidUsagePeriodError` maps to 400 (never an unmapped 500).
- **`GET /api/subscriptions/plans`** — active plan catalog (price, maxWorks, cadences, per-plan `daily-free-credits` entitlement, `isCurrent`); works degraded when `SUBSCRIPTIONS_ENABLED` is off.
- e2e: the four new endpoints added to the protected-401 list in `api-public-contract.spec.ts`.

### Deliberate scope notes
- No payment provider exists on this branch → purchase/payment-method/auto-recharge are flag-gated UI shells (PRD §3.7 degraded posture); invoices render an empty state (no provider surface to read).
- Plan upgrade CTA is an affordance + hint toast — paid activation remains webhook/`assignPlanToUser()`-only by design.

## Verification (all run locally in the worktree, foreground)

- `apps/web npx tsc --noEmit` → **clean** (covers e2e per tsconfig gate)
- `pnpm --filter ever-works-web test` → **113 files / 1064 tests passed** (includes the 18 new unit tests in `credits.unit.spec.ts` + `credits.shared.unit.spec.ts`)
- `apps/api npx jest --testPathPattern='subscriptions'` → **2 suites / 25 tests passed** (new `credits.controller.spec.ts`: 13 tests — owner-scope, groupBy dispatch, DTO validation, 400 mapping; `subscriptions.controller.spec.ts`: +3 `listPlans` tests)
- `packages/agent npx jest --testPathPattern='subscriptions|credit-ledger.repository|plugin-usage'` → **10 suites / 174 tests passed** (new `usage-summary.service.spec.ts`: 10 tests; `credit-ledger.repository.spec.ts`: +2 `getPeriodTotals`; module/barrel pin spec updated for the new provider/exports)
- `pnpm build --filter=ever-works-api` → **14 tasks successful**
- `apps/api pnpm generate:openapi` → **wrote 430 paths**, including `/api/credits/usage-summary` and `/api/subscriptions/plans` (`openapi.json` untracked — not committed)
- Prettier: all touched files + all 21 locale JSONs pass `--check`; web ESLint clean on touched files
- e2e sweep: existing specs touching `/api/subscriptions/plan` (`api-public-contract`, `sec-pin-authz-misc-matrix`, `subscriptions-plan-lifecycle`, billing-grace/tier flows) assert surfaces whose behavior is unchanged — no spec updates required; new endpoints added to the 401 contract list only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
