### PR TITLE
feat(agent): Fleet nodes + enrollment (Wave 12)

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -54,6 +54,7 @@ import { SchedulesModule } from './schedules/schedules.module';
 import { InboundTriggersModule } from './triggers/inbound-triggers.module';
 import { IngestModule } from './ingest/ingest.module';
 import { MeetingsApiModule } from './meetings/meetings.module';
+import { FleetApiModule } from './fleet/fleet.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
 import { UsersModule } from './users/users.module';
 import { ScopeModule } from './scope/scope.module';
@@ -199,6 +200,10 @@ import { DatabaseModule } from '@ever-works/agent/database';
         // boots the zoom.recording envelope→Meeting processor on the
         // ingest spine.
         MeetingsApiModule,
+        // Fleet (Wave 12, slice 1) — /api/fleet node registry (owner
+        // CRUD-lite + public token-authenticated enroll/heartbeat) over
+        // the agent-side FleetModule.
+        FleetApiModule,
         TelemetryModule,
         FunnelAnalyticsBindingModule,
         UploadsModule,

--- a/apps/api/src/fleet/dto/fleet.dto.ts
+++ b/apps/api/src/fleet/dto/fleet.dto.ts
@@ -1,0 +1,108 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+    ArrayMaxSize,
+    IsArray,
+    IsBoolean,
+    IsIn,
+    IsOptional,
+    IsString,
+    IsUUID,
+    MaxLength,
+    MinLength,
+} from 'class-validator';
+import type { FleetNodeKind } from '@ever-works/agent/fleet';
+
+const ENROLLABLE_KINDS: FleetNodeKind[] = ['desktop-node', 'node'];
+
+/**
+ * Request body for `POST /api/fleet/nodes/enrollment-token` — issue a
+ * one-time enrollment token for a new node. Semantic rules (name floor,
+ * kind whitelist) are re-validated in `FleetService`, the single source
+ * of truth.
+ */
+export class CreateFleetEnrollmentTokenDto {
+    @ApiProperty({ minLength: 1, maxLength: 200 })
+    @IsString()
+    @MinLength(1)
+    @MaxLength(200)
+    name: string;
+
+    @ApiProperty({ enum: ENROLLABLE_KINDS, description: 'App shape of the node.' })
+    @IsIn(ENROLLABLE_KINDS)
+    kind: FleetNodeKind;
+}
+
+/** Request body for `PATCH /api/fleet/nodes/:id` (partial update). */
+export class UpdateFleetNodeDto {
+    @ApiProperty({ required: false, minLength: 1, maxLength: 200 })
+    @IsOptional()
+    @IsString()
+    @MinLength(1)
+    @MaxLength(200)
+    name?: string;
+
+    @ApiProperty({
+        required: false,
+        description:
+            'true drains the node (stops heartbeats being accepted); false re-enables it as offline until its next heartbeat.',
+    })
+    @IsOptional()
+    @IsBoolean()
+    disabled?: boolean;
+}
+
+/** Node self-description shared by enroll + heartbeat refresh. */
+export class FleetNodeSelfDescriptionDto {
+    @ApiProperty({ required: false, maxLength: 64, description: 'os/arch, e.g. linux/x64.' })
+    @IsOptional()
+    @IsString()
+    @MaxLength(64)
+    platform?: string;
+
+    @ApiProperty({ required: false, maxLength: 32 })
+    @IsOptional()
+    @IsString()
+    @MaxLength(32)
+    version?: string;
+
+    @ApiProperty({
+        required: false,
+        type: [String],
+        description: "Capability tags, e.g. ['terminal', 'workspace', 'docker'].",
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(16)
+    @IsString({ each: true })
+    @MaxLength(32, { each: true })
+    capabilities?: string[];
+}
+
+/**
+ * Request body for the PUBLIC `POST /api/fleet/enroll` — the one-time
+ * token IS the credential; auth is the constant-time hash check in
+ * `FleetService.enroll` (fail-closed 401 on any invalid path).
+ */
+export class EnrollFleetNodeDto extends FleetNodeSelfDescriptionDto {
+    @ApiProperty({ minLength: 16, maxLength: 256, description: 'One-time enrollment token.' })
+    @IsString()
+    @MinLength(16)
+    @MaxLength(256)
+    token: string;
+}
+
+/**
+ * Request body for the PUBLIC `POST /api/fleet/heartbeat` — node
+ * credential auth (constant-time hash check, fail-closed 401).
+ */
+export class FleetHeartbeatDto extends FleetNodeSelfDescriptionDto {
+    @ApiProperty({ format: 'uuid' })
+    @IsUUID()
+    nodeId: string;
+
+    @ApiProperty({ minLength: 16, maxLength: 256, description: 'Node secret minted at enroll.' })
+    @IsString()
+    @MinLength(16)
+    @MaxLength(256)
+    secret: string;
+}

--- a/apps/api/src/fleet/fleet.controller.spec.ts
+++ b/apps/api/src/fleet/fleet.controller.spec.ts
@@ -1,0 +1,198 @@
+import 'reflect-metadata';
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { IS_PUBLIC_KEY } from '../auth/decorators/public.decorator';
+import { FleetController } from './fleet.controller';
+import {
+    CreateFleetEnrollmentTokenDto,
+    EnrollFleetNodeDto,
+    FleetHeartbeatDto,
+    UpdateFleetNodeDto,
+} from './dto/fleet.dto';
+
+const auth = { userId: 'user-1' } as AuthenticatedUser;
+
+const nodeView = {
+    id: '11111111-1111-4111-8111-111111111111',
+    name: 'my laptop',
+    kind: 'desktop-node',
+    status: 'online',
+    platform: 'linux/x64',
+    version: '1.0.0',
+    capabilities: ['terminal'],
+    lastHeartbeatAt: null,
+    createdAt: null,
+    persisted: true,
+};
+
+describe('FleetController', () => {
+    let service: {
+        listForUser: jest.Mock;
+        createEnrollmentToken: jest.Mock;
+        renameForUser: jest.Mock;
+        setDisabledForUser: jest.Mock;
+        deleteForUser: jest.Mock;
+        enroll: jest.Mock;
+        heartbeat: jest.Mock;
+    };
+    let controller: FleetController;
+
+    beforeEach(() => {
+        service = {
+            listForUser: jest.fn(async () => [nodeView]),
+            createEnrollmentToken: jest.fn(async () => ({
+                node: nodeView,
+                token: 'one-time-token',
+                expiresInSec: 900,
+            })),
+            renameForUser: jest.fn(async () => ({ ...nodeView, name: 'renamed' })),
+            setDisabledForUser: jest.fn(async () => ({ ...nodeView, status: 'disabled' })),
+            deleteForUser: jest.fn(async () => undefined),
+            enroll: jest.fn(async () => null),
+            heartbeat: jest.fn(async () => null),
+        };
+        controller = new FleetController(service as never);
+    });
+
+    it('list is owner-scoped to the authenticated user', async () => {
+        const result = await controller.list(auth);
+        expect(service.listForUser).toHaveBeenCalledWith('user-1');
+        expect(result).toEqual([nodeView]);
+    });
+
+    it('createEnrollmentToken forwards the owner scope and body', async () => {
+        const body = plainToInstance(CreateFleetEnrollmentTokenDto, {
+            name: 'my laptop',
+            kind: 'desktop-node',
+        });
+        const result = await controller.createEnrollmentToken(auth, body);
+        expect(service.createEnrollmentToken).toHaveBeenCalledWith('user-1', body);
+        expect(result.token).toBe('one-time-token');
+    });
+
+    it('update renames and/or toggles disabled, owner-scoped', async () => {
+        const id = nodeView.id;
+        await controller.update(auth, id, { name: 'renamed' } as UpdateFleetNodeDto);
+        expect(service.renameForUser).toHaveBeenCalledWith('user-1', id, 'renamed');
+
+        await controller.update(auth, id, { disabled: true } as UpdateFleetNodeDto);
+        expect(service.setDisabledForUser).toHaveBeenCalledWith('user-1', id, true);
+    });
+
+    it('update rejects an empty patch', async () => {
+        await expect(
+            controller.update(auth, nodeView.id, {} as UpdateFleetNodeDto),
+        ).rejects.toBeInstanceOf(BadRequestException);
+        expect(service.renameForUser).not.toHaveBeenCalled();
+        expect(service.setDisabledForUser).not.toHaveBeenCalled();
+    });
+
+    it('remove is owner-scoped', async () => {
+        await controller.remove(auth, nodeView.id);
+        expect(service.deleteForUser).toHaveBeenCalledWith('user-1', nodeView.id);
+    });
+
+    describe('public enroll/heartbeat (fail-closed)', () => {
+        it('enroll maps every invalid path to one undifferentiated 401', async () => {
+            await expect(
+                controller.enroll({ token: 'x'.repeat(43) } as EnrollFleetNodeDto),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+        });
+
+        it('enroll returns the node secret exactly once on success', async () => {
+            service.enroll.mockResolvedValue({
+                nodeId: nodeView.id,
+                secret: 'node-secret',
+                node: nodeView,
+            });
+            const result = await controller.enroll({
+                token: 'x'.repeat(43),
+                platform: 'linux/x64',
+            } as EnrollFleetNodeDto);
+            expect(service.enroll).toHaveBeenCalledWith('x'.repeat(43), {
+                platform: 'linux/x64',
+                version: undefined,
+                capabilities: undefined,
+            });
+            expect(result.secret).toBe('node-secret');
+        });
+
+        it('heartbeat maps a rejected credential to 401 and success to ok', async () => {
+            await expect(
+                controller.heartbeat({
+                    nodeId: nodeView.id,
+                    secret: 'x'.repeat(43),
+                } as FleetHeartbeatDto),
+            ).rejects.toBeInstanceOf(UnauthorizedException);
+
+            service.heartbeat.mockResolvedValue({ node: nodeView });
+            const result = await controller.heartbeat({
+                nodeId: nodeView.id,
+                secret: 'x'.repeat(43),
+            } as FleetHeartbeatDto);
+            expect(result).toEqual({ ok: true, node: nodeView });
+        });
+
+        it('enroll and heartbeat are @Public (token/secret ARE the auth)', () => {
+            expect(Reflect.getMetadata(IS_PUBLIC_KEY, FleetController.prototype.enroll)).toBe(true);
+            expect(Reflect.getMetadata(IS_PUBLIC_KEY, FleetController.prototype.heartbeat)).toBe(
+                true,
+            );
+            // Owner-scoped routes must NOT be public.
+            expect(
+                Reflect.getMetadata(IS_PUBLIC_KEY, FleetController.prototype.list),
+            ).toBeUndefined();
+        });
+    });
+
+    describe('DTO validation (global forbidNonWhitelisted pipe contract)', () => {
+        it('CreateFleetEnrollmentTokenDto whitelists kinds (k8s is not enrollable)', async () => {
+            const bad = plainToInstance(CreateFleetEnrollmentTokenDto, {
+                name: 'x',
+                kind: 'k8s',
+            });
+            expect((await validate(bad)).length).toBeGreaterThan(0);
+
+            const good = plainToInstance(CreateFleetEnrollmentTokenDto, {
+                name: 'x',
+                kind: 'node',
+            });
+            expect(await validate(good)).toHaveLength(0);
+        });
+
+        it('EnrollFleetNodeDto bounds the token and self-description', async () => {
+            const shortToken = plainToInstance(EnrollFleetNodeDto, { token: 'short' });
+            expect((await validate(shortToken)).length).toBeGreaterThan(0);
+
+            const badCapabilities = plainToInstance(EnrollFleetNodeDto, {
+                token: 'x'.repeat(43),
+                capabilities: Array.from({ length: 17 }, (_, i) => `tag-${i}`),
+            });
+            expect((await validate(badCapabilities)).length).toBeGreaterThan(0);
+
+            const good = plainToInstance(EnrollFleetNodeDto, {
+                token: 'x'.repeat(43),
+                platform: 'linux/x64',
+                version: '1.0.0',
+                capabilities: ['terminal', 'workspace'],
+            });
+            expect(await validate(good)).toHaveLength(0);
+        });
+
+        it('FleetHeartbeatDto requires a uuid node id and a bounded secret', async () => {
+            const bad = plainToInstance(FleetHeartbeatDto, {
+                nodeId: 'not-a-uuid',
+                secret: 'x'.repeat(43),
+            });
+            expect((await validate(bad)).length).toBeGreaterThan(0);
+
+            const good = plainToInstance(FleetHeartbeatDto, {
+                nodeId: nodeView.id,
+                secret: 'x'.repeat(43),
+            });
+            expect(await validate(good)).toHaveLength(0);
+        });
+    });
+});

--- a/apps/api/src/fleet/fleet.controller.ts
+++ b/apps/api/src/fleet/fleet.controller.ts
@@ -1,0 +1,150 @@
+import {
+    BadRequestException,
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    HttpStatus,
+    Param,
+    ParseUUIDPipe,
+    Patch,
+    Post,
+    UnauthorizedException,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import type { CreateEnrollmentTokenResult, FleetNodeView } from '@ever-works/agent/fleet';
+import { FleetService } from '@ever-works/agent/fleet';
+import { Public } from '../auth/decorators/public.decorator';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import {
+    CreateFleetEnrollmentTokenDto,
+    EnrollFleetNodeDto,
+    FleetHeartbeatDto,
+    UpdateFleetNodeDto,
+} from './dto/fleet.dto';
+
+/**
+ * Fleet (Wave 12, slice 1) — thin HTTP surface over the agent-side
+ * `FleetService`.
+ *
+ * Owner-scoped (session/API-key auth via the global guard):
+ *   GET    /api/fleet/nodes                   list mine (incl. live
+ *                                             own-cluster nodes)
+ *   POST   /api/fleet/nodes/enrollment-token  issue one-time token
+ *   PATCH  /api/fleet/nodes/:id               rename / disable / enable
+ *   DELETE /api/fleet/nodes/:id               remove registration
+ *
+ * Public, self-authenticating (called by the node apps — throttled,
+ * fail-closed: any invalid credential path is one undifferentiated
+ * 401, mirroring the terminal internal endpoints' posture):
+ *   POST   /api/fleet/enroll                  consume token → secret
+ *   POST   /api/fleet/heartbeat               node secret → last-seen
+ */
+@ApiTags('fleet')
+@Controller('api/fleet')
+export class FleetController {
+    constructor(private readonly service: FleetService) {}
+
+    @Get('nodes')
+    @ApiOperation({
+        summary:
+            'List my fleet nodes (enrolled machines + live nodes of my own configured clusters)',
+    })
+    @HttpCode(HttpStatus.OK)
+    async list(@CurrentUser() auth: AuthenticatedUser): Promise<FleetNodeView[]> {
+        return this.service.listForUser(auth.userId);
+    }
+
+    @Post('nodes/enrollment-token')
+    @ApiOperation({
+        summary:
+            'Issue a one-time enrollment token for a new node (single-use, 15-minute expiry; the token is returned exactly once)',
+    })
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ long: { limit: 20, ttl: 60_000 } })
+    async createEnrollmentToken(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() body: CreateFleetEnrollmentTokenDto,
+    ): Promise<CreateEnrollmentTokenResult> {
+        return this.service.createEnrollmentToken(auth.userId, body);
+    }
+
+    @Patch('nodes/:id')
+    @ApiOperation({ summary: 'Rename and/or disable/enable a fleet node' })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async update(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Body() body: UpdateFleetNodeDto,
+    ): Promise<FleetNodeView> {
+        if (typeof body.name !== 'string' && typeof body.disabled !== 'boolean') {
+            throw new BadRequestException('Provide name and/or disabled');
+        }
+        let view: FleetNodeView | null = null;
+        if (typeof body.name === 'string') {
+            view = await this.service.renameForUser(auth.userId, id, body.name);
+        }
+        if (typeof body.disabled === 'boolean') {
+            view = await this.service.setDisabledForUser(auth.userId, id, body.disabled);
+        }
+        return view as FleetNodeView;
+    }
+
+    @Delete('nodes/:id')
+    @ApiOperation({ summary: 'Delete a fleet node registration' })
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async remove(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ): Promise<void> {
+        await this.service.deleteForUser(auth.userId, id);
+    }
+
+    @Public()
+    @Post('enroll')
+    @ApiOperation({
+        summary:
+            'Enroll a node with a one-time token (public, token-authenticated, single-use). Returns the node id + heartbeat secret exactly once.',
+    })
+    @HttpCode(HttpStatus.CREATED)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async enroll(
+        @Body() body: EnrollFleetNodeDto,
+    ): Promise<{ nodeId: string; secret: string; node: FleetNodeView }> {
+        const result = await this.service.enroll(body.token, {
+            platform: body.platform,
+            version: body.version,
+            capabilities: body.capabilities,
+        });
+        if (!result) {
+            // One undifferentiated message — never say WHICH check failed.
+            throw new UnauthorizedException('Invalid or expired enrollment token');
+        }
+        return result;
+    }
+
+    @Public()
+    @Post('heartbeat')
+    @ApiOperation({
+        summary:
+            'Node heartbeat (public, node-secret-authenticated). Server-stamps last-seen and optionally refreshes the self-description.',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 240, ttl: 60_000 } })
+    async heartbeat(@Body() body: FleetHeartbeatDto): Promise<{ ok: true; node: FleetNodeView }> {
+        const result = await this.service.heartbeat(body.nodeId, body.secret, {
+            platform: body.platform,
+            version: body.version,
+            capabilities: body.capabilities,
+        });
+        if (!result) {
+            throw new UnauthorizedException('Invalid node credential');
+        }
+        return { ok: true, node: result.node };
+    }
+}

--- a/apps/api/src/fleet/fleet.module.ts
+++ b/apps/api/src/fleet/fleet.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { FleetModule as AgentFleetModule } from '@ever-works/agent/fleet';
+import { FleetController } from './fleet.controller';
+
+/**
+ * Fleet (Wave 12, slice 1) — thin API module exposing `/api/fleet`
+ * (owner-scoped node CRUD-lite + the public token-authenticated
+ * enroll/heartbeat endpoints) over the agent-side `FleetModule`
+ * (entity, repository, enrollment/heartbeat crypto and the offline
+ * sweep all live there).
+ */
+@Module({
+    imports: [AgentFleetModule],
+    controllers: [FleetController],
+    exports: [AgentFleetModule],
+})
+export class FleetApiModule {}

--- a/apps/api/src/migrations/1783900000000-CreateFleetNodes.ts
+++ b/apps/api/src/migrations/1783900000000-CreateFleetNodes.ts
@@ -1,0 +1,112 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Fleet (Wave 12, slice 1) — creates the `fleet_nodes` table backing
+ * the node registry: machines the owner enrolls to execute their work
+ * (desktop nodes / headless nodes). Nodes of user-configured clusters
+ * are merged into list responses LIVE and are intentionally absent
+ * here — nothing cluster-side is ever persisted, and platform-operated
+ * shared clusters are structurally excluded from Fleet.
+ *
+ * Entity: `packages/agent/src/entities/fleet-node.entity.ts`
+ * Service: `packages/agent/src/fleet/fleet.service.ts`
+ *
+ * **Schema notes:**
+ *   - `enrollmentTokenHash` (varchar(128), UNIQUE, NULLABLE) — sha256
+ *     hex of the CURRENT credential: the one-time enrollment token
+ *     while `status = 'enrolling'`, the node heartbeat secret once
+ *     enrolled (the enroll CAS swaps it atomically). Plaintext never
+ *     touches the database. Unique so credential lookup is exact and
+ *     random-collision-free; every supported driver allows multiple
+ *     NULLs under a unique index.
+ *   - `capabilities` (text) — the entity's `simple-json` tag array
+ *     ('terminal', 'workspace', 'docker', ...).
+ *   - `status` / `kind` are deliberate varchar(16)s (not enums) so new
+ *     shapes ship without schema changes — same convention as
+ *     `tenant_job_runtime_config.providerId`.
+ *   - Scope columns (`organizationId`) are raw uuid references — no
+ *     entity-level @ManyToOne (cycle avoidance per EW-654).
+ *   - FK `userId` → `users.id` ON DELETE CASCADE (a node registration
+ *     is meaningless without its owner).
+ *
+ * Forward-only + idempotent (`hasTable` guard) — same shape as
+ * `1783800000000-CreateMeetings`.
+ */
+export class CreateFleetNodes1783900000000 implements MigrationInterface {
+    name = 'CreateFleetNodes1783900000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('fleet_nodes')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'fleet_nodes',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'organizationId', type: 'uuid', isNullable: true },
+                    { name: 'name', type: 'varchar', length: '200' },
+                    { name: 'kind', type: 'varchar', length: '16' },
+                    { name: 'status', type: 'varchar', length: '16' },
+                    {
+                        name: 'enrollmentTokenHash',
+                        type: 'varchar',
+                        length: '128',
+                        isNullable: true,
+                    },
+                    { name: 'lastHeartbeatAt', type: 'timestamp', isNullable: true },
+                    { name: 'capabilities', type: 'text' },
+                    { name: 'platform', type: 'varchar', length: '64', isNullable: true },
+                    { name: 'version', type: 'varchar', length: '32', isNullable: true },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        // Owner-scoped list reads (Fleet settings page, chat tool).
+        await queryRunner.createIndex(
+            'fleet_nodes',
+            new TableIndex({
+                name: 'idx_fleet_nodes_user',
+                columnNames: ['userId'],
+            }),
+        );
+
+        // Exact credential-hash lookup at enroll + heartbeat; unique so
+        // two nodes can never share a credential.
+        await queryRunner.createIndex(
+            'fleet_nodes',
+            new TableIndex({
+                name: 'idx_fleet_nodes_credential',
+                columnNames: ['enrollmentTokenHash'],
+                isUnique: true,
+            }),
+        );
+
+        await queryRunner.createForeignKey(
+            'fleet_nodes',
+            new TableForeignKey({
+                name: 'fk_fleet_nodes_user',
+                columnNames: ['userId'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('fleet_nodes')) {
+            await queryRunner.dropTable('fleet_nodes', true);
+        }
+    }
+}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1909,6 +1909,7 @@
                 "data": "Data",
                 "githubApp": "GitHub App",
                 "workAgent": "Work Agent",
+                "fleet": "Fleet",
                 "jobRuntime": "Job Runtime",
                 "gitProviders": "Git Providers",
                 "dangerZone": "Danger Zone"
@@ -2278,6 +2279,86 @@
                     "revokeSuccess": "API key revoked successfully",
                     "revokeError": "Failed to revoke API key",
                     "copyError": "Failed to copy to clipboard"
+                }
+            },
+            "fleet": {
+                "title": "Fleet",
+                "subtitle": "The machines that execute your work: enroll desktop or headless nodes with a one-time token, watch their health, and see the nodes of clusters you have configured yourself.",
+                "kinds": {
+                    "desktop-node": "Desktop node",
+                    "node": "Headless node",
+                    "k8s": "Cluster"
+                },
+                "statuses": {
+                    "enrolling": "Enrolling",
+                    "online": "Online",
+                    "offline": "Offline",
+                    "disabled": "Disabled"
+                },
+                "table": {
+                    "name": "Name",
+                    "kind": "Kind",
+                    "status": "Status",
+                    "platform": "Platform",
+                    "capabilities": "Capabilities",
+                    "lastSeen": "Last seen"
+                },
+                "empty": {
+                    "title": "No nodes enrolled yet",
+                    "description": "Add a node to lend one of your machines to the platform: a desktop node with a small status UI, or a headless node for servers and CI boxes. Issue a one-time enrollment token here and paste it into the node app during setup."
+                },
+                "cluster": {
+                    "title": "Your cluster nodes",
+                    "description": "Read-only, live node inventory of clusters you configured yourself in deployment settings. Platform-operated shared clusters are never listed here.",
+                    "empty": "No self-configured cluster is connected, or its nodes could not be read right now.",
+                    "roles": "Roles"
+                },
+                "add": {
+                    "button": "Add node",
+                    "title": "Add a node",
+                    "description": "Name the machine and pick its shape. You will get a one-time enrollment token to paste into the node during setup.",
+                    "nameLabel": "Node name",
+                    "namePlaceholder": "e.g. Office workstation",
+                    "nameRequired": "Please name the node first",
+                    "kindLabel": "Node kind",
+                    "kindHelper": {
+                        "desktop-node": "A desktop app that registers this machine and shows node status, logs and controls.",
+                        "node": "A command-line service for servers, CI boxes and scripted fleets — no UI."
+                    },
+                    "cancel": "Cancel",
+                    "submit": "Issue token",
+                    "issued": "Enrollment token issued",
+                    "tokenIntro": "Copy this one-time enrollment token. It expires in {minutes} minutes and can be used exactly once.",
+                    "copy": "Copy",
+                    "copied": "Copied",
+                    "copyError": "Failed to copy to clipboard",
+                    "instructionsTitle": "Install instructions",
+                    "instructionsBody": "Install the node app on the target machine, point it at this platform's API address, and paste the token when the setup asks for it. The node appears here as Online after its first heartbeat. (Node app downloads ship in an upcoming release.)",
+                    "tokenOnce": "For security, the token is shown only once — issue a new one if you lose it.",
+                    "done": "Done"
+                },
+                "actions": {
+                    "rename": "Rename",
+                    "disable": "Disable",
+                    "enable": "Enable",
+                    "remove": "Remove"
+                },
+                "rename": {
+                    "title": "Rename node",
+                    "cancel": "Cancel",
+                    "confirm": "Save"
+                },
+                "remove": {
+                    "title": "Remove node",
+                    "description": "Remove \"{name}\" from your fleet? Its credential stops working immediately and the machine will have to be enrolled again.",
+                    "cancel": "Cancel",
+                    "confirm": "Remove"
+                },
+                "messages": {
+                    "renamed": "Node renamed",
+                    "disabled": "Node disabled — it stops accepting work and heartbeats",
+                    "enabled": "Node enabled — it will come back online on its next heartbeat",
+                    "removed": "Node removed"
                 }
             },
             "jobRuntime": {

--- a/apps/web/src/app/[locale]/(dashboard)/settings/fleet/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/fleet/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { fleetAPI, type FleetNodeView } from '@/lib/api/fleet';
+import { FleetSettings } from '@/components/settings/FleetSettings';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.settings.fleet');
+    return { title: t('title') };
+}
+
+/**
+ * Fleet (Wave 12, slice 1) — settings page for the node registry:
+ * where the user's work CAN run (Job Runtime, directly below in the
+ * menu, stays HOW work is dispatched).
+ *
+ * Server component: fetches the merged node list (enrolled machines +
+ * live nodes of the user's own configured clusters, tagged `k8s`) and
+ * hands it to the client component. Graceful degradation: a hard fetch
+ * failure still renders the page with an empty list + error banner so
+ * the enroll flow's actions can surface the real error on submit.
+ */
+export default async function FleetSettingsPage() {
+    let initialNodes: FleetNodeView[] = [];
+    let loadError: string | null = null;
+
+    try {
+        initialNodes = await fleetAPI.listNodes();
+    } catch (error) {
+        loadError = error instanceof Error ? error.message : 'Failed to load fleet nodes';
+    }
+
+    return <FleetSettings initialNodes={initialNodes} loadError={loadError} />;
+}

--- a/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/settings/settings-layout-client.tsx
@@ -12,6 +12,7 @@ import {
     Bot,
     Cpu,
     Building2,
+    Server,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
@@ -76,6 +77,14 @@ export function SettingsLayoutClient({ children, settingsMenu }: SettingsLayoutC
                 label: t('tabs.workAgent'),
                 icon: Bot,
                 href: `${baseSettingsPath}/work-agent`,
+            },
+            // Fleet sits directly ABOVE Job Runtime by design: Fleet is
+            // WHERE work can run; Job Runtime stays HOW work is dispatched.
+            {
+                id: 'fleet',
+                label: t('tabs.fleet'),
+                icon: Server,
+                href: `${baseSettingsPath}/fleet`,
             },
             {
                 id: 'job-runtime',

--- a/apps/web/src/app/actions/settings/fleet.ts
+++ b/apps/web/src/app/actions/settings/fleet.ts
@@ -1,0 +1,98 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { ROUTES } from '@/lib/constants';
+import { getAuthFromCookie } from '@/lib/auth';
+import { ApiResponseError } from '@/lib/api/server-api';
+import {
+    fleetAPI,
+    type CreateFleetEnrollmentTokenPayload,
+    type CreateFleetEnrollmentTokenResponse,
+    type FleetNodeView,
+    type UpdateFleetNodePayload,
+} from '@/lib/api/fleet';
+
+/**
+ * Fleet (Wave 12, slice 1) — Server Actions wrapping the owner-scoped
+ * `/api/fleet` surface. Returns the discriminated `{ success, data,
+ * error }` shape so the client form can surface either a toast or an
+ * inline error without re-throwing across the RSC boundary (prod
+ * redacts thrown Server Action messages — never branch on them).
+ *
+ * Each action re-verifies the session at the Server Action boundary
+ * (defense in depth — the API tier is the final guard). The pattern
+ * mirrors `app/actions/settings/job-runtime.ts`.
+ */
+
+const SETTINGS_PAGE_PATTERN = '/[locale]/(dashboard)/settings/fleet';
+
+async function ensureAuth() {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+    return user;
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+    if (error instanceof ApiResponseError && error.message) return error.message;
+    if (error instanceof Error && error.message) return error.message;
+    return fallback;
+}
+
+export type FleetActionResult<T> =
+    | { success: true; data: T; error: null }
+    | { success: false; data: null; error: string };
+
+export async function createFleetEnrollmentTokenAction(
+    payload: CreateFleetEnrollmentTokenPayload,
+): Promise<FleetActionResult<CreateFleetEnrollmentTokenResponse>> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.createEnrollmentToken(payload);
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to issue an enrollment token'),
+        };
+    }
+}
+
+export async function updateFleetNodeAction(
+    nodeId: string,
+    payload: UpdateFleetNodePayload,
+): Promise<FleetActionResult<FleetNodeView>> {
+    await ensureAuth();
+    try {
+        const data = await fleetAPI.updateNode(nodeId, payload);
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to update the node'),
+        };
+    }
+}
+
+export async function deleteFleetNodeAction(
+    nodeId: string,
+): Promise<FleetActionResult<{ deleted: true }>> {
+    await ensureAuth();
+    try {
+        await fleetAPI.deleteNode(nodeId);
+        revalidatePath(SETTINGS_PAGE_PATTERN, 'page');
+        return { success: true, data: { deleted: true }, error: null };
+    } catch (error) {
+        return {
+            success: false,
+            data: null,
+            error: errorMessage(error, 'Failed to remove the node'),
+        };
+    }
+}

--- a/apps/web/src/components/settings/FleetSettings.tsx
+++ b/apps/web/src/components/settings/FleetSettings.tsx
@@ -1,0 +1,621 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import {
+    AlertTriangle,
+    Copy,
+    Laptop,
+    Pause,
+    Pencil,
+    Play,
+    Plus,
+    Server,
+    Boxes,
+    Trash2,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select } from '@/components/ui/select';
+import {
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import type {
+    CreateFleetEnrollmentTokenResponse,
+    FleetNodeKind,
+    FleetNodeView,
+} from '@/lib/api/fleet';
+import {
+    createFleetEnrollmentTokenAction,
+    deleteFleetNodeAction,
+    updateFleetNodeAction,
+} from '@/app/actions/settings/fleet';
+
+interface FleetSettingsProps {
+    initialNodes: FleetNodeView[];
+    loadError: string | null;
+}
+
+const ENROLLABLE_KINDS: Exclude<FleetNodeKind, 'k8s'>[] = ['desktop-node', 'node'];
+
+function formatLastSeen(value: string | null): string {
+    if (!value) return '-';
+    try {
+        return new Date(value).toLocaleString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+    } catch {
+        return value;
+    }
+}
+
+/**
+ * Fleet (Wave 12, slice 1) — settings UI for the node registry:
+ *   - Enrolled-nodes table (name, kind badge, status dot, platform,
+ *     capability chips, last-seen) with rename / disable / remove
+ *     (confirm) actions.
+ *   - "Add node" flow issuing a ONE-TIME enrollment token (copy
+ *     button + short install-instructions placeholder — the node apps
+ *     themselves are the next slice).
+ *   - Read-only section for live nodes of the user's OWN configured
+ *     clusters (never the shared platform clusters, never persisted).
+ */
+export function FleetSettings({ initialNodes, loadError }: FleetSettingsProps) {
+    const t = useTranslations('dashboard.settings.fleet');
+    const [nodes, setNodes] = useState<FleetNodeView[]>(initialNodes);
+    const [isPending, startTransition] = useTransition();
+
+    const enrolledNodes = useMemo(() => nodes.filter((node) => node.persisted), [nodes]);
+    const clusterNodes = useMemo(
+        () => nodes.filter((node) => !node.persisted && node.kind === 'k8s'),
+        [nodes],
+    );
+
+    // "Add node" dialog: form phase, then the one-time-token phase.
+    const [addOpen, setAddOpen] = useState(false);
+    const [addName, setAddName] = useState('');
+    const [addKind, setAddKind] = useState<Exclude<FleetNodeKind, 'k8s'>>('desktop-node');
+    const [issued, setIssued] = useState<CreateFleetEnrollmentTokenResponse | null>(null);
+    const [copied, setCopied] = useState(false);
+
+    // Rename dialog.
+    const [renameTarget, setRenameTarget] = useState<FleetNodeView | null>(null);
+    const [renameValue, setRenameValue] = useState('');
+
+    // Remove confirm dialog.
+    const [removeTarget, setRemoveTarget] = useState<FleetNodeView | null>(null);
+
+    const kindLabel = (kind: FleetNodeKind): string => t(`kinds.${kind}` as never);
+
+    const statusDotClass = (status: FleetNodeView['status']): string => {
+        switch (status) {
+            case 'online':
+                return 'bg-success';
+            case 'enrolling':
+                return 'bg-warning';
+            case 'disabled':
+                return 'bg-danger';
+            default:
+                return 'bg-text-muted dark:bg-text-muted-dark';
+        }
+    };
+
+    const closeAddDialog = () => {
+        setAddOpen(false);
+        // The token is shown exactly once — drop it with the dialog.
+        setIssued(null);
+        setAddName('');
+        setAddKind('desktop-node');
+        setCopied(false);
+    };
+
+    const handleIssueToken = () => {
+        if (!addName.trim()) {
+            toast.error(t('add.nameRequired'));
+            return;
+        }
+        startTransition(async () => {
+            const result = await createFleetEnrollmentTokenAction({
+                name: addName.trim(),
+                kind: addKind,
+            });
+            if (result.success) {
+                setIssued(result.data);
+                setNodes((prev) => [...prev, result.data.node]);
+                toast.success(t('add.issued'));
+            } else {
+                toast.error(result.error);
+            }
+        });
+    };
+
+    const handleCopyToken = async () => {
+        if (!issued) return;
+        try {
+            await navigator.clipboard.writeText(issued.token);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+        } catch {
+            toast.error(t('add.copyError'));
+        }
+    };
+
+    const handleRename = () => {
+        if (!renameTarget || !renameValue.trim()) return;
+        const target = renameTarget;
+        startTransition(async () => {
+            const result = await updateFleetNodeAction(target.id, { name: renameValue.trim() });
+            if (result.success) {
+                setNodes((prev) =>
+                    prev.map((node) => (node.id === target.id ? result.data : node)),
+                );
+                setRenameTarget(null);
+                toast.success(t('messages.renamed'));
+            } else {
+                toast.error(result.error);
+            }
+        });
+    };
+
+    const handleToggleDisabled = (node: FleetNodeView) => {
+        const disabled = node.status !== 'disabled';
+        startTransition(async () => {
+            const result = await updateFleetNodeAction(node.id, { disabled });
+            if (result.success) {
+                setNodes((prev) =>
+                    prev.map((entry) => (entry.id === node.id ? result.data : entry)),
+                );
+                toast.success(disabled ? t('messages.disabled') : t('messages.enabled'));
+            } else {
+                toast.error(result.error);
+            }
+        });
+    };
+
+    const handleRemove = () => {
+        if (!removeTarget) return;
+        const target = removeTarget;
+        startTransition(async () => {
+            const result = await deleteFleetNodeAction(target.id);
+            if (result.success) {
+                setNodes((prev) => prev.filter((node) => node.id !== target.id));
+                setRemoveTarget(null);
+                toast.success(t('messages.removed'));
+            } else {
+                toast.error(result.error);
+            }
+        });
+    };
+
+    return (
+        <div className="space-y-8" data-testid="fleet-settings">
+            <div className="flex items-start justify-between gap-4">
+                <div>
+                    <h2 className="text-xl font-semibold text-text dark:text-text-dark mb-2">
+                        {t('title')}
+                    </h2>
+                    <p className="text-text-muted dark:text-text-muted-dark text-sm">
+                        {t('subtitle')}
+                    </p>
+                </div>
+                <Button onClick={() => setAddOpen(true)} data-testid="fleet-add-node">
+                    <Plus className="w-4 h-4" />
+                    {t('add.button')}
+                </Button>
+            </div>
+
+            {loadError && (
+                <div className="flex items-start gap-2 p-3 bg-warning/10 border border-warning/20 rounded-lg">
+                    <AlertTriangle className="w-5 h-5 text-warning flex-shrink-0 mt-0.5" />
+                    <p className="text-sm text-text dark:text-text-dark">{loadError}</p>
+                </div>
+            )}
+
+            {enrolledNodes.length === 0 ? (
+                <div
+                    className="p-8 rounded-lg border border-dashed border-border dark:border-border-dark text-center space-y-2"
+                    data-testid="fleet-empty-state"
+                >
+                    <Server className="w-8 h-8 mx-auto text-text-muted dark:text-text-muted-dark" />
+                    <p className="text-sm font-medium text-text dark:text-text-dark">
+                        {t('empty.title')}
+                    </p>
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark max-w-lg mx-auto">
+                        {t('empty.description')}
+                    </p>
+                </div>
+            ) : (
+                <div className="overflow-x-auto rounded-lg border border-border dark:border-border-dark">
+                    <table className="w-full text-sm" data-testid="fleet-nodes-table">
+                        <thead>
+                            <tr className="border-b border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40 text-left">
+                                <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                    {t('table.name')}
+                                </th>
+                                <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                    {t('table.kind')}
+                                </th>
+                                <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                    {t('table.status')}
+                                </th>
+                                <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                    {t('table.platform')}
+                                </th>
+                                <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                    {t('table.capabilities')}
+                                </th>
+                                <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                    {t('table.lastSeen')}
+                                </th>
+                                <th className="px-4 py-2.5" />
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {enrolledNodes.map((node) => (
+                                <tr
+                                    key={node.id}
+                                    className="border-b last:border-b-0 border-border dark:border-border-dark"
+                                    data-testid={`fleet-node-row-${node.id}`}
+                                >
+                                    <td className="px-4 py-3 font-medium text-text dark:text-text-dark">
+                                        {node.name}
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium bg-surface-secondary dark:bg-surface-secondary-dark text-text dark:text-text-dark">
+                                            {node.kind === 'desktop-node' ? (
+                                                <Laptop className="w-3 h-3" />
+                                            ) : (
+                                                <Server className="w-3 h-3" />
+                                            )}
+                                            {kindLabel(node.kind)}
+                                        </span>
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        <span
+                                            className="inline-flex items-center gap-1.5 text-xs font-medium text-text dark:text-text-dark"
+                                            data-testid={`fleet-node-status-${node.id}`}
+                                        >
+                                            <span
+                                                className={`w-1.5 h-1.5 rounded-full ${statusDotClass(node.status)}`}
+                                            />
+                                            {t(`statuses.${node.status}` as never)}
+                                        </span>
+                                    </td>
+                                    <td className="px-4 py-3 text-text-muted dark:text-text-muted-dark">
+                                        {node.platform ?? '-'}
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        <div className="flex flex-wrap gap-1">
+                                            {node.capabilities.length === 0 ? (
+                                                <span className="text-text-muted dark:text-text-muted-dark">
+                                                    -
+                                                </span>
+                                            ) : (
+                                                node.capabilities.map((capability) => (
+                                                    <span
+                                                        key={capability}
+                                                        className="px-1.5 py-0.5 rounded text-xs bg-info/10 text-info"
+                                                    >
+                                                        {capability}
+                                                    </span>
+                                                ))
+                                            )}
+                                        </div>
+                                    </td>
+                                    <td className="px-4 py-3 text-text-muted dark:text-text-muted-dark whitespace-nowrap">
+                                        {formatLastSeen(node.lastHeartbeatAt)}
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        <div className="flex items-center justify-end gap-1">
+                                            <Button
+                                                variant="ghost"
+                                                onClick={() => {
+                                                    setRenameTarget(node);
+                                                    setRenameValue(node.name);
+                                                }}
+                                                disabled={isPending}
+                                                data-testid={`fleet-node-rename-${node.id}`}
+                                                title={t('actions.rename')}
+                                            >
+                                                <Pencil className="w-4 h-4" />
+                                            </Button>
+                                            <Button
+                                                variant="ghost"
+                                                onClick={() => handleToggleDisabled(node)}
+                                                disabled={isPending}
+                                                data-testid={`fleet-node-disable-${node.id}`}
+                                                title={
+                                                    node.status === 'disabled'
+                                                        ? t('actions.enable')
+                                                        : t('actions.disable')
+                                                }
+                                            >
+                                                {node.status === 'disabled' ? (
+                                                    <Play className="w-4 h-4" />
+                                                ) : (
+                                                    <Pause className="w-4 h-4" />
+                                                )}
+                                            </Button>
+                                            <Button
+                                                variant="ghost"
+                                                onClick={() => setRemoveTarget(node)}
+                                                disabled={isPending}
+                                                data-testid={`fleet-node-remove-${node.id}`}
+                                                title={t('actions.remove')}
+                                            >
+                                                <Trash2 className="w-4 h-4 text-danger" />
+                                            </Button>
+                                        </div>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            <div className="space-y-3" data-testid="fleet-cluster-section">
+                <div className="flex items-center gap-2">
+                    <Boxes className="w-4 h-4 text-text-muted dark:text-text-muted-dark" />
+                    <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                        {t('cluster.title')}
+                    </h3>
+                </div>
+                <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                    {t('cluster.description')}
+                </p>
+                {clusterNodes.length === 0 ? (
+                    <p
+                        className="text-sm text-text-muted dark:text-text-muted-dark"
+                        data-testid="fleet-cluster-empty"
+                    >
+                        {t('cluster.empty')}
+                    </p>
+                ) : (
+                    <div className="overflow-x-auto rounded-lg border border-border dark:border-border-dark">
+                        <table className="w-full text-sm" data-testid="fleet-cluster-table">
+                            <thead>
+                                <tr className="border-b border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40 text-left">
+                                    <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                        {t('table.name')}
+                                    </th>
+                                    <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                        {t('table.status')}
+                                    </th>
+                                    <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                        {t('table.platform')}
+                                    </th>
+                                    <th className="px-4 py-2.5 font-medium text-text-muted dark:text-text-muted-dark">
+                                        {t('cluster.roles')}
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {clusterNodes.map((node) => (
+                                    <tr
+                                        key={node.id}
+                                        className="border-b last:border-b-0 border-border dark:border-border-dark"
+                                    >
+                                        <td className="px-4 py-3 font-medium text-text dark:text-text-dark">
+                                            {node.name}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            <span className="inline-flex items-center gap-1.5 text-xs font-medium text-text dark:text-text-dark">
+                                                <span
+                                                    className={`w-1.5 h-1.5 rounded-full ${statusDotClass(node.status)}`}
+                                                />
+                                                {t(`statuses.${node.status}` as never)}
+                                            </span>
+                                        </td>
+                                        <td className="px-4 py-3 text-text-muted dark:text-text-muted-dark">
+                                            {node.platform ?? '-'}
+                                        </td>
+                                        <td className="px-4 py-3">
+                                            <div className="flex flex-wrap gap-1">
+                                                {node.capabilities.length === 0 ? (
+                                                    <span className="text-text-muted dark:text-text-muted-dark">
+                                                        -
+                                                    </span>
+                                                ) : (
+                                                    node.capabilities.map((role) => (
+                                                        <span
+                                                            key={role}
+                                                            className="px-1.5 py-0.5 rounded text-xs bg-surface-secondary dark:bg-surface-secondary-dark text-text dark:text-text-dark"
+                                                        >
+                                                            {role}
+                                                        </span>
+                                                    ))
+                                                )}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </div>
+
+            {/* Add node — form phase, then one-time-token phase. */}
+            <Dialog
+                open={addOpen}
+                onOpenChange={(open) => (open ? setAddOpen(true) : closeAddDialog())}
+            >
+                <DialogContent>
+                    <DialogClose onClose={closeAddDialog} />
+                    <DialogHeader>
+                        <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                            {t('add.title')}
+                        </DialogTitle>
+                    </DialogHeader>
+                    {!issued ? (
+                        <div className="space-y-4">
+                            <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                                {t('add.description')}
+                            </p>
+                            <div>
+                                <label className="block text-sm font-medium text-text dark:text-text-dark mb-1.5">
+                                    {t('add.nameLabel')}
+                                </label>
+                                <Input
+                                    value={addName}
+                                    onChange={(event) => setAddName(event.target.value)}
+                                    maxLength={200}
+                                    placeholder={t('add.namePlaceholder')}
+                                    data-testid="fleet-add-name"
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-text dark:text-text-dark mb-1.5">
+                                    {t('add.kindLabel')}
+                                </label>
+                                <Select
+                                    value={addKind}
+                                    onValueChange={(value) =>
+                                        setAddKind(value as Exclude<FleetNodeKind, 'k8s'>)
+                                    }
+                                    data-testid="fleet-add-kind"
+                                >
+                                    {ENROLLABLE_KINDS.map((kind) => (
+                                        <option key={kind} value={kind}>
+                                            {kindLabel(kind)}
+                                        </option>
+                                    ))}
+                                </Select>
+                                <p className="mt-1.5 text-xs text-text-muted dark:text-text-muted-dark">
+                                    {t(`add.kindHelper.${addKind}` as never)}
+                                </p>
+                            </div>
+                            <DialogFooter>
+                                <Button variant="secondary" onClick={closeAddDialog}>
+                                    {t('add.cancel')}
+                                </Button>
+                                <Button
+                                    onClick={handleIssueToken}
+                                    loading={isPending}
+                                    data-testid="fleet-add-submit"
+                                >
+                                    {t('add.submit')}
+                                </Button>
+                            </DialogFooter>
+                        </div>
+                    ) : (
+                        <div className="space-y-4">
+                            <p className="text-sm text-text dark:text-text-dark">
+                                {t('add.tokenIntro', {
+                                    minutes: Math.round(issued.expiresInSec / 60),
+                                })}
+                            </p>
+                            <div className="flex items-center gap-2">
+                                <code
+                                    className="flex-1 px-3 py-2 rounded-lg border border-border dark:border-border-dark bg-surface-secondary/40 dark:bg-surface-secondary-dark/40 text-sm break-all select-all"
+                                    data-testid="fleet-enroll-token"
+                                >
+                                    {issued.token}
+                                </code>
+                                <Button
+                                    variant="secondary"
+                                    onClick={handleCopyToken}
+                                    data-testid="fleet-copy-token"
+                                >
+                                    <Copy className="w-4 h-4" />
+                                    {copied ? t('add.copied') : t('add.copy')}
+                                </Button>
+                            </div>
+                            <div className="p-3 rounded-lg bg-info/10 border border-info/20 space-y-1">
+                                <p className="text-sm font-medium text-text dark:text-text-dark">
+                                    {t('add.instructionsTitle')}
+                                </p>
+                                <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                    {t('add.instructionsBody')}
+                                </p>
+                            </div>
+                            <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                                {t('add.tokenOnce')}
+                            </p>
+                            <DialogFooter>
+                                <Button onClick={closeAddDialog} data-testid="fleet-add-done">
+                                    {t('add.done')}
+                                </Button>
+                            </DialogFooter>
+                        </div>
+                    )}
+                </DialogContent>
+            </Dialog>
+
+            {/* Rename */}
+            <Dialog
+                open={renameTarget !== null}
+                onOpenChange={(open) => !open && setRenameTarget(null)}
+            >
+                <DialogContent>
+                    <DialogClose onClose={() => setRenameTarget(null)} />
+                    <DialogHeader>
+                        <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                            {t('rename.title')}
+                        </DialogTitle>
+                    </DialogHeader>
+                    <Input
+                        value={renameValue}
+                        onChange={(event) => setRenameValue(event.target.value)}
+                        maxLength={200}
+                        data-testid="fleet-rename-input"
+                    />
+                    <DialogFooter>
+                        <Button variant="secondary" onClick={() => setRenameTarget(null)}>
+                            {t('rename.cancel')}
+                        </Button>
+                        <Button
+                            onClick={handleRename}
+                            loading={isPending}
+                            data-testid="fleet-rename-confirm"
+                        >
+                            {t('rename.confirm')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Remove (confirm) */}
+            <Dialog
+                open={removeTarget !== null}
+                onOpenChange={(open) => !open && setRemoveTarget(null)}
+            >
+                <DialogContent>
+                    <DialogClose onClose={() => setRemoveTarget(null)} />
+                    <DialogHeader>
+                        <DialogTitle className="text-lg font-semibold text-text dark:text-text-dark">
+                            {t('remove.title')}
+                        </DialogTitle>
+                    </DialogHeader>
+                    <p className="text-sm text-text-muted dark:text-text-muted-dark">
+                        {t('remove.description', { name: removeTarget?.name ?? '' })}
+                    </p>
+                    <DialogFooter>
+                        <Button variant="secondary" onClick={() => setRemoveTarget(null)}>
+                            {t('remove.cancel')}
+                        </Button>
+                        <Button
+                            variant="danger"
+                            onClick={handleRemove}
+                            loading={isPending}
+                            data-testid="fleet-remove-confirm"
+                        >
+                            {t('remove.confirm')}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}

--- a/apps/web/src/lib/ai/tools/generated/registry.ts
+++ b/apps/web/src/lib/ai/tools/generated/registry.ts
@@ -246,6 +246,17 @@ export const OPERATION_REGISTRY: OperationSpec[] = [
         params: [id('Meeting id (from list_meetings)')],
     },
 
+    // ── Fleet (Wave 12, slice 1) ─────────────────────────────────
+    {
+        toolName: 'list_fleet_nodes',
+        method: 'GET',
+        path: '/api/fleet/nodes',
+        summary:
+            'List the current user’s fleet — the machines enrolled to execute their work (desktop and headless nodes) plus live nodes of their own configured clusters. Each node carries kind, online/offline status, capability tags, platform and last-seen time.',
+        kind: 'read',
+        params: [],
+    },
+
     // ── Tasks ────────────────────────────────────────────────────
     {
         toolName: 'list_tasks',

--- a/apps/web/src/lib/api/fleet.ts
+++ b/apps/web/src/lib/api/fleet.ts
@@ -1,0 +1,87 @@
+import 'server-only';
+import { serverFetch, serverMutation } from './server-api';
+
+/**
+ * Fleet (Wave 12, slice 1) — web client for the fleet node registry
+ * (mounted at `/api/fleet` on the platform API — see
+ * `apps/api/src/fleet/fleet.controller.ts`).
+ *
+ * Only the owner-scoped surface is wrapped here; the public
+ * enroll/heartbeat endpoints are called by the node apps themselves,
+ * never by this web tier. Credential material is asymmetric by design:
+ * the enrollment token appears exactly once in the create response and
+ * is never readable again.
+ */
+
+export type FleetNodeKind = 'desktop-node' | 'node' | 'k8s';
+
+export type FleetNodeStatus = 'enrolling' | 'online' | 'offline' | 'disabled';
+
+export interface FleetNodeView {
+    id: string;
+    name: string;
+    kind: FleetNodeKind;
+    status: FleetNodeStatus;
+    platform: string | null;
+    version: string | null;
+    capabilities: string[];
+    lastHeartbeatAt: string | null;
+    createdAt: string | null;
+    /** False for live nodes of the user's own configured clusters. */
+    persisted: boolean;
+}
+
+export interface CreateFleetEnrollmentTokenPayload {
+    name: string;
+    kind: Exclude<FleetNodeKind, 'k8s'>;
+}
+
+export interface CreateFleetEnrollmentTokenResponse {
+    node: FleetNodeView;
+    /** Returned exactly once — the API stores only its hash. */
+    token: string;
+    expiresInSec: number;
+}
+
+export interface UpdateFleetNodePayload {
+    name?: string;
+    disabled?: boolean;
+}
+
+// NOTE: no leading `/api` here — `serverFetch`/`serverMutation` prepend
+// `API_URL`, which `lib/constants.ts` normalises to already end in
+// `/api`. Matches every other helper in this folder.
+const BASE = '/fleet';
+
+export const fleetAPI = {
+    listNodes: async () => {
+        return serverFetch<FleetNodeView[]>(`${BASE}/nodes`);
+    },
+
+    createEnrollmentToken: async (payload: CreateFleetEnrollmentTokenPayload) => {
+        return serverMutation<CreateFleetEnrollmentTokenResponse>({
+            endpoint: `${BASE}/nodes/enrollment-token`,
+            data: payload,
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    updateNode: async (nodeId: string, payload: UpdateFleetNodePayload) => {
+        return serverMutation<FleetNodeView>({
+            endpoint: `${BASE}/nodes/${nodeId}`,
+            data: payload,
+            method: 'PATCH',
+            wrapInData: false,
+        });
+    },
+
+    deleteNode: async (nodeId: string) => {
+        return serverMutation<void>({
+            endpoint: `${BASE}/nodes/${nodeId}`,
+            data: {},
+            method: 'DELETE',
+            wrapInData: false,
+        });
+    },
+};

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -189,6 +189,10 @@
             "types": "./dist/meetings/index.d.ts",
             "default": "./dist/meetings/index.js"
         },
+        "./fleet": {
+            "types": "./dist/fleet/index.d.ts",
+            "default": "./dist/fleet/index.js"
+        },
         "./pr-review": {
             "types": "./dist/pr-review/index.d.ts",
             "default": "./dist/pr-review/index.js"

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -118,6 +118,7 @@ import { IngestCursor } from '../entities/ingest-cursor.entity';
 import { Meeting } from '../entities/meeting.entity';
 import { CreditLedgerEntry } from '../entities/credit-ledger-entry.entity';
 import { PlanEntitlement } from '../entities/plan-entitlement.entity';
+import { FleetNode } from '../entities/fleet-node.entity';
 import {
     PluginEntity,
     UserPluginEntity,
@@ -267,4 +268,7 @@ export const ENTITIES = [
     // are the usage currency layered on the costCents metering.
     CreditLedgerEntry,
     PlanEntitlement,
+    // Fleet (Wave 12, slice 1) — enrolled execution nodes (desktop /
+    // headless) with hashed credentials + heartbeat status.
+    FleetNode,
 ];

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -66,6 +66,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'CreditLedgerEntry',
     'EmailConversation',
     'EmailMessage',
+    // Fleet (Wave 12, slice 1) — enrolled execution nodes w/ heartbeat
+    'FleetNode',
     'GitHubAppInstallation',
     'GitHubAppInstallationRepository',
     'GitHubAppUserLink',

--- a/packages/agent/src/entities/fleet-node.entity.ts
+++ b/packages/agent/src/entities/fleet-node.entity.ts
@@ -1,0 +1,97 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+/**
+ * Fleet (Wave 12, slice 1) — one machine registered to execute the
+ * owner's work: a desktop node (thin connected agent app), a headless
+ * node (CLI/service), or — read-only, NEVER persisted as rows — a node
+ * of the user's OWN configured cluster surfaced live at list time.
+ *
+ * Lifecycle (`FleetService`):
+ *   1. `createEnrollmentToken` inserts the row with `status:
+ *      'enrolling'` and `enrollmentTokenHash` = sha256 of a one-time
+ *      token (returned once, never stored).
+ *   2. `enroll` CAS-consumes the token (single-use + 15-min expiry via
+ *      `createdAt`), flips the node `online` and REPLACES the hash with
+ *      the sha256 of the freshly minted node secret — so the column is
+ *      a dual-role credential hash: enrollment-token hash while
+ *      `enrolling`, heartbeat-secret hash once enrolled. The plain
+ *      token/secret never touch the database.
+ *   3. `heartbeat` authenticates with a constant-time compare against
+ *      that hash (fail-closed) and server-stamps `lastHeartbeatAt`.
+ *   4. List reads sweep `online` nodes with no heartbeat for 5 minutes
+ *      to `offline` (no dedicated cron).
+ *
+ * Cluster boundary: rows only ever describe user-enrolled machines.
+ * Nodes of user-configured clusters (`clusterSource:
+ * 'custom-kubeconfig'` in the deployment plugin settings) are merged
+ * into list responses live and tagged `kind: 'k8s'`; platform-operated
+ * shared clusters are structurally excluded and nothing cluster-side is
+ * ever written here.
+ *
+ * Scope columns are raw uuid references (no @ManyToOne) per the EW-654
+ * cycle-avoidance rule; FKs live in the migration
+ * (`1783900000000-CreateFleetNodes`).
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` — this
+ * repo has no `autoLoadEntities`, a forFeature'd-but-unregistered
+ * entity throws EntityMetadataNotFoundError on first query.
+ */
+
+/** App shape of the node ('k8s' is list-time only — never persisted). */
+export type FleetNodeKind = 'desktop-node' | 'node' | 'k8s';
+
+/** Heartbeat-derived lifecycle state. */
+export type FleetNodeStatus = 'enrolling' | 'online' | 'offline' | 'disabled';
+
+@Entity({ name: 'fleet_nodes' })
+@Index('idx_fleet_nodes_user', ['userId'])
+@Index('idx_fleet_nodes_credential', ['enrollmentTokenHash'], { unique: true })
+export class FleetNode {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /** Owner the node executes work for (scopes every read/write). */
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    @Column({ type: 'uuid', nullable: true })
+    organizationId?: string | null;
+
+    @Column({ type: 'varchar', length: 200 })
+    name: string;
+
+    /** 'desktop-node' | 'node' (enrollable); 'k8s' exists only in views. */
+    @Column({ type: 'varchar', length: 16 })
+    kind: FleetNodeKind;
+
+    /** 'enrolling' | 'online' | 'offline' | 'disabled'. */
+    @Column({ type: 'varchar', length: 16 })
+    status: FleetNodeStatus;
+
+    /**
+     * sha256 hex of the current credential — the one-time enrollment
+     * token while `enrolling`, the node heartbeat secret once enrolled.
+     * NULL only for defensively-degraded rows; heartbeat fails closed
+     * on it. The plaintext is never stored.
+     */
+    @Column({ type: 'varchar', length: 128, nullable: true })
+    enrollmentTokenHash?: string | null;
+
+    /** Server-stamped on every accepted heartbeat (never client-trusted). */
+    @Column({ type: 'timestamp', nullable: true })
+    lastHeartbeatAt?: Date | null;
+
+    /** Capability tags ('terminal', 'workspace', 'docker', ...). */
+    @Column({ type: 'simple-json' })
+    capabilities: string[];
+
+    /** os/arch self-description, e.g. 'linux/x64' (sanitized at enroll). */
+    @Column({ type: 'varchar', length: 64, nullable: true })
+    platform?: string | null;
+
+    @Column({ type: 'varchar', length: 32, nullable: true })
+    version?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -123,3 +123,5 @@ export * from './meeting.entity';
 // Credits ledger + plan entitlements (pricing Wave 9 M1)
 export * from './credit-ledger-entry.entity';
 export * from './plan-entitlement.entity';
+// Fleet (Wave 12, slice 1) — enrolled execution nodes with heartbeat
+export * from './fleet-node.entity';

--- a/packages/agent/src/fleet/__tests__/agent-fleet-tools.spec.ts
+++ b/packages/agent/src/fleet/__tests__/agent-fleet-tools.spec.ts
@@ -1,0 +1,66 @@
+import { buildFleetTools } from '../agent-fleet-tools';
+import type { FleetNodeView } from '../fleet.service';
+
+const view = (overrides: Partial<FleetNodeView> = {}): FleetNodeView => ({
+    id: 'node-1',
+    name: 'my laptop',
+    kind: 'desktop-node',
+    status: 'online',
+    platform: 'linux/x64',
+    version: '1.0.0',
+    capabilities: ['terminal'],
+    lastHeartbeatAt: new Date('2026-07-25T00:00:00Z').toISOString(),
+    createdAt: new Date('2026-07-24T00:00:00Z').toISOString(),
+    persisted: true,
+    ...overrides,
+});
+
+describe('buildFleetTools', () => {
+    it('exposes exactly the list_fleet_nodes tool', () => {
+        const tools = buildFleetTools({
+            userId: 'user-1',
+            service: { listForUser: jest.fn(async () => []) },
+        });
+        expect(tools.map((tool) => tool.name)).toEqual(['list_fleet_nodes']);
+    });
+
+    it('lists nodes owner-scoped (the tool can only ever ask for its own user)', async () => {
+        const listForUser = jest.fn(async () => [view()]);
+        const [tool] = buildFleetTools({ userId: 'user-1', service: { listForUser } });
+
+        const result = (await tool.invoke({})) as { nodes: FleetNodeView[] };
+
+        expect(listForUser).toHaveBeenCalledWith('user-1');
+        expect(result.nodes).toHaveLength(1);
+        expect(result.nodes[0].id).toBe('node-1');
+    });
+
+    it('applies kind/status filters and the limit cap', async () => {
+        const listForUser = jest.fn(async () => [
+            view({ id: 'a', kind: 'desktop-node', status: 'online' }),
+            view({ id: 'b', kind: 'node', status: 'offline' }),
+            view({ id: 'c', kind: 'k8s', status: 'online', persisted: false }),
+        ]);
+        const [tool] = buildFleetTools({ userId: 'user-1', service: { listForUser } });
+
+        const online = (await tool.invoke({ status: 'online' })) as { nodes: FleetNodeView[] };
+        expect(online.nodes.map((node) => node.id)).toEqual(['a', 'c']);
+
+        const clusters = (await tool.invoke({ kind: 'k8s' })) as { nodes: FleetNodeView[] };
+        expect(clusters.nodes.map((node) => node.id)).toEqual(['c']);
+
+        const capped = (await tool.invoke({ limit: 1 })) as { nodes: FleetNodeView[] };
+        expect(capped.nodes).toHaveLength(1);
+    });
+
+    it('returns a structured error instead of throwing', async () => {
+        const listForUser = jest.fn(async () => {
+            throw new Error('db down');
+        });
+        const [tool] = buildFleetTools({ userId: 'user-1', service: { listForUser } });
+
+        const result = (await tool.invoke({})) as { error: string };
+
+        expect(result.error).toBe('db down');
+    });
+});

--- a/packages/agent/src/fleet/__tests__/fleet.module.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet.module.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Fleet (Wave 12, slice 1) — module-shape pin for FleetModule.
+ *
+ * Pattern mirrors `meetings.module.spec.ts`: heavy runtime trees
+ * (TypeORM, the plugins services graph) are mocked at module scope so
+ * the decorator metadata can be asserted without loading them under
+ * Jest's CJS transformer.
+ */
+
+jest.mock('@nestjs/typeorm', () => ({
+    TypeOrmModule: { forFeature: () => class TypeOrmFeatureStub {} },
+    InjectRepository: () => () => undefined,
+    InjectDataSource: () => () => undefined,
+}));
+jest.mock('../../entities/fleet-node.entity', () => ({
+    FleetNode: class FleetNode {},
+}));
+jest.mock('../../plugins/services/plugin-registry.service', () => ({
+    PluginRegistryService: class PluginRegistryService {},
+}));
+jest.mock('../../plugins/services/plugin-settings.service', () => ({
+    PluginSettingsService: class PluginSettingsService {},
+}));
+jest.mock('../fleet-node.repository', () => ({
+    FleetNodeRepository: class FleetNodeRepository {},
+}));
+jest.mock('../fleet.service', () => ({
+    FleetService: class FleetService {},
+}));
+
+import 'reflect-metadata';
+import { FleetModule } from '../fleet.module';
+import { FleetNodeRepository } from '../fleet-node.repository';
+import { FleetService } from '../fleet.service';
+
+describe('FleetModule', () => {
+    const meta = (key: string): unknown[] => Reflect.getMetadata(key, FleetModule) ?? [];
+
+    it('provides the repository and the service', () => {
+        expect(meta('providers')).toEqual([FleetNodeRepository, FleetService]);
+    });
+
+    it('exports both for the API surface + chat-tool assembly', () => {
+        expect(meta('exports')).toEqual([FleetNodeRepository, FleetService]);
+    });
+
+    it('imports only the entity feature (plugins resolve via the global module)', () => {
+        expect(meta('imports')).toHaveLength(1);
+    });
+});
+
+describe('fleet barrel', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const barrel = require('../index');
+
+    it('re-exports the module, service, repository and tool factory', () => {
+        expect(barrel.FleetModule).toBe(FleetModule);
+        expect(barrel.FleetService).toBe(FleetService);
+        expect(barrel.FleetNodeRepository).toBe(FleetNodeRepository);
+        expect(typeof barrel.buildFleetTools).toBe('function');
+    });
+});

--- a/packages/agent/src/fleet/__tests__/fleet.service.spec.ts
+++ b/packages/agent/src/fleet/__tests__/fleet.service.spec.ts
@@ -1,0 +1,375 @@
+import { createHash } from 'crypto';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { FleetNode } from '../../entities/fleet-node.entity';
+import {
+    FLEET_ENROLLMENT_TOKEN_TTL_MS,
+    FLEET_NODE_OFFLINE_AFTER_MS,
+    FleetService,
+} from '../fleet.service';
+
+const sha256 = (value: string) => createHash('sha256').update(value, 'utf8').digest('hex');
+
+const node = (overrides: Partial<FleetNode> = {}): FleetNode =>
+    ({
+        id: '11111111-1111-4111-8111-111111111111',
+        userId: 'user-1',
+        organizationId: null,
+        name: 'my laptop',
+        kind: 'desktop-node',
+        status: 'enrolling',
+        enrollmentTokenHash: null,
+        lastHeartbeatAt: null,
+        capabilities: [],
+        platform: null,
+        version: null,
+        createdAt: new Date(),
+        ...overrides,
+    }) as FleetNode;
+
+describe('FleetService', () => {
+    let repository: {
+        create: jest.Mock;
+        findById: jest.Mock;
+        findByCredentialHash: jest.Mock;
+        findByUser: jest.Mock;
+        consumeEnrollment: jest.Mock;
+        update: jest.Mock;
+        delete: jest.Mock;
+        sweepOffline: jest.Mock;
+    };
+    let registry: { get: jest.Mock };
+    let settings: { getResolvedSettings: jest.Mock };
+
+    beforeEach(() => {
+        repository = {
+            create: jest.fn(async (data) => node({ ...data })),
+            findById: jest.fn(async () => null),
+            findByCredentialHash: jest.fn(async () => null),
+            findByUser: jest.fn(async () => []),
+            consumeEnrollment: jest.fn(async () => true),
+            update: jest.fn(async () => undefined),
+            delete: jest.fn(async () => undefined),
+            sweepOffline: jest.fn(async () => 0),
+        };
+        registry = { get: jest.fn(() => undefined) };
+        settings = { getResolvedSettings: jest.fn(async () => ({})) };
+    });
+
+    const build = (opts: { withPlugins?: boolean } = {}) =>
+        new FleetService(
+            repository as never,
+            (opts.withPlugins ?? false) ? (registry as never) : undefined,
+            (opts.withPlugins ?? false) ? (settings as never) : undefined,
+        );
+
+    describe('createEnrollmentToken', () => {
+        it('stores only the sha256 of the one-time token and returns the plaintext once', async () => {
+            const service = build();
+            const result = await service.createEnrollmentToken('user-1', {
+                name: '  my laptop  ',
+                kind: 'desktop-node',
+            });
+
+            expect(result.token.length).toBeGreaterThanOrEqual(32);
+            expect(result.expiresInSec).toBe(FLEET_ENROLLMENT_TOKEN_TTL_MS / 1000);
+            const created = repository.create.mock.calls[0][0];
+            expect(created.enrollmentTokenHash).toBe(sha256(result.token));
+            expect(created.enrollmentTokenHash).not.toContain(result.token);
+            expect(created.status).toBe('enrolling');
+            expect(created.name).toBe('my laptop');
+            // The view never carries the hash.
+            expect(JSON.stringify(result.node)).not.toContain(sha256(result.token));
+        });
+
+        it('rejects non-enrollable kinds (k8s rows can never be created)', async () => {
+            const service = build();
+            await expect(
+                service.createEnrollmentToken('user-1', { name: 'x', kind: 'k8s' }),
+            ).rejects.toBeInstanceOf(BadRequestException);
+        });
+    });
+
+    describe('enroll', () => {
+        const issued = (token: string, overrides: Partial<FleetNode> = {}) =>
+            node({ enrollmentTokenHash: sha256(token), status: 'enrolling', ...overrides });
+
+        it('CAS-consumes the token, flips the node online and swaps in the secret hash', async () => {
+            const token = 'tok_'.padEnd(43, 'a');
+            repository.findByCredentialHash.mockResolvedValue(issued(token));
+            const service = build();
+
+            const result = await service.enroll(token, {
+                platform: 'linux/x64',
+                version: '1.0.0',
+                capabilities: ['terminal', 'workspace'],
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.secret.length).toBeGreaterThanOrEqual(32);
+            const [id, expectedHash, patch] = repository.consumeEnrollment.mock.calls[0];
+            expect(id).toBe('11111111-1111-4111-8111-111111111111');
+            expect(expectedHash).toBe(sha256(token));
+            expect(patch.status).toBe('online');
+            expect(patch.enrollmentTokenHash).toBe(sha256(result!.secret));
+            expect(patch.platform).toBe('linux/x64');
+            expect(patch.capabilities).toEqual(['terminal', 'workspace']);
+            expect(result!.node.status).toBe('online');
+        });
+
+        it('is single-use: a lost CAS returns null even for a matching token', async () => {
+            const token = 'tok_'.padEnd(43, 'b');
+            repository.findByCredentialHash.mockResolvedValue(issued(token));
+            repository.consumeEnrollment.mockResolvedValue(false);
+            const service = build();
+
+            await expect(service.enroll(token)).resolves.toBeNull();
+        });
+
+        it('rejects expired tokens (15-minute window from createdAt)', async () => {
+            const token = 'tok_'.padEnd(43, 'c');
+            repository.findByCredentialHash.mockResolvedValue(
+                issued(token, {
+                    createdAt: new Date(Date.now() - FLEET_ENROLLMENT_TOKEN_TTL_MS - 1000),
+                }),
+            );
+            const service = build();
+
+            await expect(service.enroll(token)).resolves.toBeNull();
+            expect(repository.consumeEnrollment).not.toHaveBeenCalled();
+        });
+
+        it('fails closed on malformed tokens without touching the repository', async () => {
+            const service = build();
+            await expect(service.enroll(undefined as never)).resolves.toBeNull();
+            await expect(service.enroll('short')).resolves.toBeNull();
+            await expect(service.enroll('x'.repeat(4096))).resolves.toBeNull();
+            expect(repository.findByCredentialHash).not.toHaveBeenCalled();
+        });
+
+        it('rejects tokens whose node is no longer enrolling (revoked/disabled)', async () => {
+            const token = 'tok_'.padEnd(43, 'd');
+            repository.findByCredentialHash.mockResolvedValue(
+                issued(token, { status: 'disabled' }),
+            );
+            const service = build();
+
+            await expect(service.enroll(token)).resolves.toBeNull();
+        });
+    });
+
+    describe('heartbeat', () => {
+        const enrolled = (secret: string, overrides: Partial<FleetNode> = {}) =>
+            node({
+                status: 'offline',
+                enrollmentTokenHash: sha256(secret),
+                ...overrides,
+            });
+
+        it('flips the node online and server-stamps lastHeartbeatAt', async () => {
+            const secret = 'sec_'.padEnd(43, 'a');
+            repository.findById.mockResolvedValue(enrolled(secret));
+            const service = build();
+
+            const result = await service.heartbeat('11111111-1111-4111-8111-111111111111', secret, {
+                capabilities: ['terminal'],
+            });
+
+            expect(result).not.toBeNull();
+            const [, patch] = repository.update.mock.calls[0];
+            expect(patch.status).toBe('online');
+            expect(patch.lastHeartbeatAt).toBeInstanceOf(Date);
+            expect(patch.capabilities).toEqual(['terminal']);
+            expect(result!.node.status).toBe('online');
+        });
+
+        it('fails closed on a wrong secret (constant-time compare path)', async () => {
+            repository.findById.mockResolvedValue(enrolled('sec_'.padEnd(43, 'b')));
+            const service = build();
+
+            await expect(
+                service.heartbeat('11111111-1111-4111-8111-111111111111', 'sec_'.padEnd(43, 'c')),
+            ).resolves.toBeNull();
+            expect(repository.update).not.toHaveBeenCalled();
+        });
+
+        it('fails closed when the stored credential hash is missing', async () => {
+            const secret = 'sec_'.padEnd(43, 'd');
+            repository.findById.mockResolvedValue(enrolled(secret, { enrollmentTokenHash: null }));
+            const service = build();
+
+            await expect(
+                service.heartbeat('11111111-1111-4111-8111-111111111111', secret),
+            ).resolves.toBeNull();
+        });
+
+        it('refuses disabled and still-enrolling nodes even with a matching secret', async () => {
+            const secret = 'sec_'.padEnd(43, 'e');
+            const service = build();
+
+            repository.findById.mockResolvedValue(enrolled(secret, { status: 'disabled' }));
+            await expect(
+                service.heartbeat('11111111-1111-4111-8111-111111111111', secret),
+            ).resolves.toBeNull();
+
+            repository.findById.mockResolvedValue(enrolled(secret, { status: 'enrolling' }));
+            await expect(
+                service.heartbeat('11111111-1111-4111-8111-111111111111', secret),
+            ).resolves.toBeNull();
+        });
+
+        it('fails closed on malformed node ids / secrets without repository reads', async () => {
+            const service = build();
+            await expect(
+                service.heartbeat('not-a-uuid', 'sec_'.padEnd(43, 'f')),
+            ).resolves.toBeNull();
+            await expect(
+                service.heartbeat('11111111-1111-4111-8111-111111111111', 'short'),
+            ).resolves.toBeNull();
+            expect(repository.findById).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('listForUser', () => {
+        it('sweeps stale online nodes to offline on every list read (no cron)', async () => {
+            const service = build();
+            const before = Date.now();
+            await service.listForUser('user-1');
+
+            const [userId, cutoff] = repository.sweepOffline.mock.calls[0];
+            expect(userId).toBe('user-1');
+            const offset = before - (cutoff as Date).getTime();
+            expect(offset).toBeGreaterThanOrEqual(FLEET_NODE_OFFLINE_AFTER_MS - 1000);
+            expect(offset).toBeLessThanOrEqual(FLEET_NODE_OFFLINE_AFTER_MS + 1000);
+        });
+
+        it('maps rows to views without ever exposing the credential hash', async () => {
+            repository.findByUser.mockResolvedValue([
+                node({ status: 'online', enrollmentTokenHash: sha256('super-secret') }),
+            ]);
+            const service = build();
+
+            const views = await service.listForUser('user-1');
+
+            expect(views).toHaveLength(1);
+            expect(views[0].persisted).toBe(true);
+            expect(JSON.stringify(views)).not.toContain(sha256('super-secret'));
+        });
+
+        it('merges live own-cluster nodes tagged k8s without persisting them', async () => {
+            const listClusterNodes = jest.fn(async () => [
+                {
+                    name: 'worker-1',
+                    ready: true,
+                    platform: 'linux/amd64',
+                    version: 'v1.30.0',
+                    roles: ['worker'],
+                },
+                { name: 'cp-1', ready: false },
+            ]);
+            registry.get.mockReturnValue({ plugin: { listClusterNodes }, state: 'loaded' });
+            settings.getResolvedSettings.mockResolvedValue({
+                clusterSource: { value: 'custom-kubeconfig' },
+                kubeconfig: { value: 'apiVersion: v1\nkind: Config' },
+                kubeContext: { value: 'my-context' },
+            });
+            const service = build({ withPlugins: true });
+
+            const views = await service.listForUser('user-1');
+
+            expect(listClusterNodes).toHaveBeenCalledWith(
+                'apiVersion: v1\nkind: Config',
+                'my-context',
+            );
+            const k8sViews = views.filter((view) => view.kind === 'k8s');
+            expect(k8sViews).toHaveLength(2);
+            expect(k8sViews[0]).toMatchObject({
+                id: 'k8s:worker-1',
+                status: 'online',
+                platform: 'linux/amd64',
+                persisted: false,
+            });
+            expect(k8sViews[1].status).toBe('offline');
+            // Live cluster nodes are never written back.
+            expect(repository.create).not.toHaveBeenCalled();
+            expect(repository.update).not.toHaveBeenCalled();
+        });
+
+        it('never lists platform-managed cluster sources (custom kubeconfig only)', async () => {
+            const listClusterNodes = jest.fn(async () => [{ name: 'shared-1', ready: true }]);
+            registry.get.mockReturnValue({ plugin: { listClusterNodes }, state: 'loaded' });
+            settings.getResolvedSettings.mockResolvedValue({
+                clusterSource: { value: 'k8s-works-shared' },
+                kubeconfig: { value: 'apiVersion: v1\nkind: Config' },
+            });
+            const service = build({ withPlugins: true });
+
+            const views = await service.listForUser('user-1');
+
+            expect(listClusterNodes).not.toHaveBeenCalled();
+            expect(views.filter((view) => view.kind === 'k8s')).toHaveLength(0);
+        });
+
+        it('degrades to enrolled rows when the cluster listing throws (best-effort)', async () => {
+            repository.findByUser.mockResolvedValue([node({ status: 'online' })]);
+            registry.get.mockReturnValue({
+                plugin: {
+                    listClusterNodes: jest.fn(async () => {
+                        throw new Error('connection refused');
+                    }),
+                },
+                state: 'loaded',
+            });
+            settings.getResolvedSettings.mockResolvedValue({
+                clusterSource: { value: 'custom-kubeconfig' },
+                kubeconfig: { value: 'apiVersion: v1\nkind: Config' },
+            });
+            const service = build({ withPlugins: true });
+
+            const views = await service.listForUser('user-1');
+
+            expect(views).toHaveLength(1);
+            expect(views[0].kind).toBe('desktop-node');
+        });
+    });
+
+    describe('owner scoping', () => {
+        it("treats another user's node as missing on rename/disable/delete", async () => {
+            repository.findById.mockResolvedValue(node({ userId: 'user-2' }));
+            const service = build();
+
+            await expect(
+                service.renameForUser('user-1', '11111111-1111-4111-8111-111111111111', 'new'),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            await expect(
+                service.setDisabledForUser('user-1', '11111111-1111-4111-8111-111111111111', true),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            await expect(
+                service.deleteForUser('user-1', '11111111-1111-4111-8111-111111111111'),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(repository.update).not.toHaveBeenCalled();
+            expect(repository.delete).not.toHaveBeenCalled();
+        });
+
+        it('disable revokes an unused enrollment; enable re-arms as offline', async () => {
+            repository.findById.mockResolvedValue(node({ status: 'enrolling' }));
+            const service = build();
+
+            const disabledView = await service.setDisabledForUser(
+                'user-1',
+                '11111111-1111-4111-8111-111111111111',
+                true,
+            );
+            expect(disabledView.status).toBe('disabled');
+            expect(repository.update).toHaveBeenCalledWith('11111111-1111-4111-8111-111111111111', {
+                status: 'disabled',
+            });
+
+            const enabledView = await service.setDisabledForUser(
+                'user-1',
+                '11111111-1111-4111-8111-111111111111',
+                false,
+            );
+            expect(enabledView.status).toBe('offline');
+        });
+    });
+});

--- a/packages/agent/src/fleet/agent-fleet-tools.ts
+++ b/packages/agent/src/fleet/agent-fleet-tools.ts
@@ -1,0 +1,80 @@
+import type { TaskToolDescriptor } from '../tasks-domain/agent-task-tools';
+import type { FleetNodeKind, FleetNodeStatus } from '../entities/fleet-node.entity';
+import type { FleetNodeView, FleetService } from './fleet.service';
+
+/**
+ * Fleet (Wave 12, slice 1) — chat tools for the fleet surface, per the
+ * program DoD rule that every new entity ships with chat tools +
+ * keyword slots.
+ *
+ * Mirrors `meetings/agent-meeting-tools.ts`: a descriptor-factory the
+ * tool assembly concatenates at run time (type-only import of
+ * `TaskToolDescriptor`, so the Tasks runtime graph is NOT pulled into
+ * the fleet subpath).
+ *
+ * Keyword slots: "fleet", "nodes", "machines", "my computers",
+ * "execution nodes", "which machines are online" style asks route
+ * here.
+ */
+
+export interface ListFleetNodesArgs {
+    /** Optional kind filter: desktop-node | node | k8s. */
+    kind?: string;
+    /** Optional status filter: enrolling | online | offline | disabled. */
+    status?: string;
+    /** Max rows (default 50, capped at 100). */
+    limit?: number;
+}
+
+const VALID_KINDS: readonly string[] = ['desktop-node', 'node', 'k8s'];
+const VALID_STATUSES: readonly string[] = ['enrolling', 'online', 'offline', 'disabled'];
+
+export function buildFleetTools(args: {
+    /** Owner scope — tools only ever read this user's nodes. */
+    userId: string;
+    service: Pick<FleetService, 'listForUser'>;
+}): TaskToolDescriptor[] {
+    const out: TaskToolDescriptor[] = [];
+
+    out.push({
+        name: 'list_fleet_nodes',
+        description:
+            'List the current user’s fleet — the machines enrolled to execute their work (desktop nodes, headless nodes) plus live nodes of their own configured clusters. Each node carries kind, online/offline status, capability tags, platform and last-seen time. Use when the user asks which machines/nodes are available or online.',
+        parameters: {
+            type: 'object',
+            properties: {
+                kind: {
+                    type: 'string',
+                    description: 'Optional kind filter: desktop-node, node or k8s.',
+                },
+                status: {
+                    type: 'string',
+                    description: 'Optional status filter: enrolling, online, offline or disabled.',
+                },
+                limit: {
+                    type: 'integer',
+                    description: 'Max nodes to return (default 50, capped at 100).',
+                },
+            },
+            required: [],
+        },
+        invoke: async (raw) => {
+            const a = (raw ?? {}) as ListFleetNodesArgs;
+            const limit = Math.min(Math.max(Number(a.limit) || 50, 1), 100);
+            try {
+                let nodes = await args.service.listForUser(args.userId);
+                if (a.kind && VALID_KINDS.includes(a.kind)) {
+                    nodes = nodes.filter((node) => node.kind === (a.kind as FleetNodeKind));
+                }
+                if (a.status && VALID_STATUSES.includes(a.status)) {
+                    nodes = nodes.filter((node) => node.status === (a.status as FleetNodeStatus));
+                }
+                return { nodes: nodes.slice(0, limit) };
+            } catch (err) {
+                return { error: err instanceof Error ? err.message : String(err) };
+            }
+        },
+    } satisfies TaskToolDescriptor<ListFleetNodesArgs, { nodes: FleetNodeView[] }>);
+
+    return out;
+}

--- a/packages/agent/src/fleet/fleet-node.repository.ts
+++ b/packages/agent/src/fleet/fleet-node.repository.ts
@@ -1,0 +1,102 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import { FleetNode, FleetNodeKind, FleetNodeStatus } from '../entities/fleet-node.entity';
+
+export interface CreateFleetNodeData {
+    userId: string;
+    organizationId?: string | null;
+    name: string;
+    kind: FleetNodeKind;
+    status: FleetNodeStatus;
+    enrollmentTokenHash: string;
+    capabilities?: string[];
+}
+
+/** Columns the enroll CAS is allowed to stamp alongside the flip. */
+export interface ConsumeEnrollmentPatch {
+    enrollmentTokenHash: string;
+    status: FleetNodeStatus;
+    lastHeartbeatAt: Date;
+    platform?: string | null;
+    version?: string | null;
+    capabilities?: string[];
+}
+
+/**
+ * Feature-owned repository (provided by `FleetModule`, not
+ * `DatabaseModule` — same split as `MeetingRepository`).
+ */
+@Injectable()
+export class FleetNodeRepository {
+    constructor(
+        @InjectRepository(FleetNode)
+        private readonly repository: Repository<FleetNode>,
+    ) {}
+
+    async create(data: CreateFleetNodeData): Promise<FleetNode> {
+        return this.repository.save(
+            this.repository.create({
+                ...data,
+                capabilities: data.capabilities ?? [],
+            }),
+        );
+    }
+
+    async findById(id: string): Promise<FleetNode | null> {
+        return this.repository.findOne({ where: { id } });
+    }
+
+    /** Credential lookup (sha256 hex) — enroll resolves the row by it. */
+    async findByCredentialHash(hash: string): Promise<FleetNode | null> {
+        return this.repository.findOne({ where: { enrollmentTokenHash: hash } });
+    }
+
+    /** Owner-scoped listing, oldest first (stable table order). */
+    async findByUser(userId: string): Promise<FleetNode[]> {
+        return this.repository.find({
+            where: { userId },
+            order: { createdAt: 'ASC' },
+        });
+    }
+
+    /**
+     * CAS-consume an enrollment token: the row must STILL be
+     * `enrolling` and STILL carry the presented token hash — a raced
+     * second enroll (or a revoked/disabled node) matches zero rows and
+     * returns false. The winning update atomically swaps the credential
+     * hash to the node-secret hash and flips the node online.
+     */
+    async consumeEnrollment(
+        id: string,
+        expectedTokenHash: string,
+        patch: ConsumeEnrollmentPatch,
+    ): Promise<boolean> {
+        const result = await this.repository.update(
+            { id, status: 'enrolling', enrollmentTokenHash: expectedTokenHash },
+            patch,
+        );
+        return (result.affected ?? 0) === 1;
+    }
+
+    async update(id: string, patch: Partial<FleetNode>): Promise<void> {
+        await this.repository.update(id, patch);
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.repository.delete(id);
+    }
+
+    /**
+     * Offline sweep, piggybacked on list reads (no dedicated cron):
+     * every `online` node of this owner whose last heartbeat is older
+     * than `cutoff` flips to `offline`. Returns the flipped count.
+     */
+    async sweepOffline(userId: string, cutoff: Date): Promise<number> {
+        const result = await this.repository.update(
+            { userId, status: 'online', lastHeartbeatAt: LessThan(cutoff) },
+            { status: 'offline' },
+        );
+        return result.affected ?? 0;
+    }
+}

--- a/packages/agent/src/fleet/fleet.module.ts
+++ b/packages/agent/src/fleet/fleet.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FleetNode } from '../entities/fleet-node.entity';
+import { FleetNodeRepository } from './fleet-node.repository';
+import { FleetService } from './fleet.service';
+
+/**
+ * Fleet (Wave 12, slice 1) — agent-side module owning the node
+ * registry: one-time enrollment tokens (sha256-at-rest, single-use CAS
+ * consume, 15-min expiry), heartbeat auth (constant-time, fail-closed)
+ * and the owner-scoped node list with the piggybacked offline sweep +
+ * the best-effort merge of the user's own configured-cluster nodes.
+ *
+ * `FleetService`'s plugin lookups (`PluginRegistryService` /
+ * `PluginSettingsService`) resolve from the GLOBAL `PluginsModule` and
+ * are `@Optional()` — the module stays bootable in contexts without the
+ * plugin runtime, where cluster merging simply degrades to [].
+ *
+ * `FleetNode` MUST also stay registered in the DataSource ENTITIES
+ * array (`database/_entities-inventory.ts`) — this repo has no
+ * `autoLoadEntities`, so a forFeature'd-but-unregistered entity throws
+ * EntityMetadataNotFoundError on first query.
+ */
+@Module({
+    imports: [TypeOrmModule.forFeature([FleetNode])],
+    providers: [FleetNodeRepository, FleetService],
+    exports: [FleetNodeRepository, FleetService],
+})
+export class FleetModule {}

--- a/packages/agent/src/fleet/fleet.service.ts
+++ b/packages/agent/src/fleet/fleet.service.ts
@@ -1,0 +1,449 @@
+import { createHash, randomBytes, timingSafeEqual } from 'crypto';
+import {
+    BadRequestException,
+    Injectable,
+    Logger,
+    NotFoundException,
+    Optional,
+} from '@nestjs/common';
+import type { IPlugin } from '@ever-works/plugin';
+import { FleetNode, FleetNodeKind, FleetNodeStatus } from '../entities/fleet-node.entity';
+import { PluginRegistryService } from '../plugins/services/plugin-registry.service';
+import { PluginSettingsService } from '../plugins/services/plugin-settings.service';
+import { FleetNodeRepository } from './fleet-node.repository';
+
+/** One-time enrollment tokens expire 15 minutes after issue. */
+export const FLEET_ENROLLMENT_TOKEN_TTL_MS = 15 * 60_000;
+
+/** An `online` node with no heartbeat for this long sweeps to `offline`. */
+export const FLEET_NODE_OFFLINE_AFTER_MS = 5 * 60_000;
+
+/** Kinds a machine can enroll as ('k8s' is list-time only, never a row). */
+export const FLEET_ENROLLABLE_KINDS: readonly FleetNodeKind[] = ['desktop-node', 'node'];
+
+/** Caps on the node self-description (defensive, DTOs cap the edge too). */
+export const FLEET_MAX_CAPABILITY_TAGS = 16;
+export const FLEET_MAX_CAPABILITY_TAG_LENGTH = 32;
+
+const CREDENTIAL_MIN_LENGTH = 16;
+const CREDENTIAL_MAX_LENGTH = 256;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Sentinel `DeployFacadeService.getTokenFromSettings` returns for
+ * platform-managed cluster sources. Duplicated here (value-stable, see
+ * `PLATFORM_MANAGED_KUBECONFIG_SENTINEL` in `facades/deploy.facade.ts`)
+ * so the fleet subpath does not pull the deploy-facade graph; it is a
+ * belt-and-braces guard — the `custom-kubeconfig` source check already
+ * excludes every platform-managed cluster.
+ */
+const PLATFORM_MANAGED_KUBECONFIG_SENTINEL = '__ever-works-platform-managed-kubeconfig__';
+
+/** Wire/view shape of one fleet node (never carries credential hashes). */
+export interface FleetNodeView {
+    id: string;
+    name: string;
+    kind: FleetNodeKind;
+    status: FleetNodeStatus;
+    platform: string | null;
+    version: string | null;
+    capabilities: string[];
+    lastHeartbeatAt: string | null;
+    createdAt: string | null;
+    /**
+     * True for enrolled rows; false for nodes of the user's own
+     * configured clusters, which are surfaced live and never stored.
+     */
+    persisted: boolean;
+}
+
+export interface CreateEnrollmentTokenInput {
+    name: string;
+    kind: FleetNodeKind;
+    organizationId?: string | null;
+}
+
+export interface CreateEnrollmentTokenResult {
+    node: FleetNodeView;
+    /** Returned exactly once — only its sha256 is stored. */
+    token: string;
+    expiresInSec: number;
+}
+
+export interface EnrollInput {
+    platform?: string;
+    version?: string;
+    capabilities?: string[];
+}
+
+export interface EnrollResult {
+    nodeId: string;
+    /** Heartbeat secret, returned exactly once — only its sha256 is stored. */
+    secret: string;
+    node: FleetNodeView;
+}
+
+/** Structural shape of the cluster-node summaries the k8s plugin returns. */
+interface ClusterNodeSummary {
+    name?: string;
+    ready?: boolean;
+    platform?: string;
+    version?: string;
+    roles?: string[];
+}
+
+/**
+ * Fleet (Wave 12, slice 1) — node registry + enrollment + heartbeat.
+ *
+ * Security posture mirrors `terminal-attach.service.ts`:
+ *   - credentials are random 32-byte values, stored ONLY as sha256 hex;
+ *   - verification is constant-time (`timingSafeEqual` behind an
+ *     explicit length guard) and NEVER throws — every invalid path
+ *     returns null and the API edge maps null to 401 (fail-closed);
+ *   - enrollment tokens are single-use (CAS consume) and expire
+ *     15 minutes after issue via the row's `createdAt`;
+ *   - `lastHeartbeatAt` is server-stamped, never client-trusted.
+ *
+ * Cluster nodes: `listForUser` best-effort merges live nodes from the
+ * user's OWN configured clusters (deployment plugin `clusterSource:
+ * 'custom-kubeconfig'` only — platform-operated shared clusters are
+ * structurally excluded) tagged `kind: 'k8s'`; they are never
+ * persisted, and any plugin/settings failure degrades to the enrolled
+ * rows alone.
+ */
+@Injectable()
+export class FleetService {
+    private readonly logger = new Logger(FleetService.name);
+
+    constructor(
+        private readonly repository: FleetNodeRepository,
+        @Optional() private readonly pluginRegistry?: PluginRegistryService,
+        @Optional() private readonly pluginSettings?: PluginSettingsService,
+    ) {}
+
+    /** Issue a one-time enrollment token for a new node (owner-scoped). */
+    async createEnrollmentToken(
+        userId: string,
+        input: CreateEnrollmentTokenInput,
+    ): Promise<CreateEnrollmentTokenResult> {
+        const name = typeof input.name === 'string' ? input.name.trim() : '';
+        if (name.length < 1 || name.length > 200) {
+            throw new BadRequestException('Node name must be 1-200 characters');
+        }
+        if (!FLEET_ENROLLABLE_KINDS.includes(input.kind)) {
+            throw new BadRequestException(
+                `Node kind must be one of: ${FLEET_ENROLLABLE_KINDS.join(', ')}`,
+            );
+        }
+
+        const token = randomBytes(32).toString('base64url');
+        const node = await this.repository.create({
+            userId,
+            organizationId: input.organizationId ?? null,
+            name,
+            kind: input.kind,
+            status: 'enrolling',
+            enrollmentTokenHash: sha256Hex(token),
+            capabilities: [],
+        });
+
+        return {
+            node: this.toView(node),
+            token,
+            expiresInSec: Math.floor(FLEET_ENROLLMENT_TOKEN_TTL_MS / 1000),
+        };
+    }
+
+    /**
+     * Consume a one-time enrollment token. Returns null on ANY invalid
+     * input (unknown/expired/already-used token) — the caller maps that
+     * to a single undifferentiated 401 so nothing leaks about which
+     * check failed.
+     */
+    async enroll(token: unknown, input: EnrollInput = {}): Promise<EnrollResult | null> {
+        if (
+            typeof token !== 'string' ||
+            token.length < CREDENTIAL_MIN_LENGTH ||
+            token.length > CREDENTIAL_MAX_LENGTH
+        ) {
+            return null;
+        }
+
+        const tokenHash = sha256Hex(token);
+        const node = await this.repository.findByCredentialHash(tokenHash);
+        if (!node || node.status !== 'enrolling') {
+            return null;
+        }
+        // Constant-time re-verification of the credential the row was
+        // found by — keeps the compare posture uniform with heartbeat
+        // (and guards any lookup-layer normalization surprises).
+        if (!constantTimeEquals(node.enrollmentTokenHash, tokenHash)) {
+            return null;
+        }
+        const issuedAt = node.createdAt instanceof Date ? node.createdAt.getTime() : NaN;
+        if (!Number.isFinite(issuedAt) || Date.now() - issuedAt > FLEET_ENROLLMENT_TOKEN_TTL_MS) {
+            return null;
+        }
+
+        const secret = randomBytes(32).toString('base64url');
+        const now = new Date();
+        const patch = {
+            enrollmentTokenHash: sha256Hex(secret),
+            status: 'online' as FleetNodeStatus,
+            lastHeartbeatAt: now,
+            platform: sanitizeText(input.platform, 64),
+            version: sanitizeText(input.version, 32),
+            capabilities: sanitizeCapabilities(input.capabilities),
+        };
+        // CAS: single-use by construction — a raced duplicate enroll
+        // matches zero rows and gets the same null as a bad token.
+        const consumed = await this.repository.consumeEnrollment(node.id, tokenHash, patch);
+        if (!consumed) {
+            return null;
+        }
+
+        return {
+            nodeId: node.id,
+            secret,
+            node: this.toView({ ...node, ...patch }),
+        };
+    }
+
+    /**
+     * Authenticated node heartbeat. Constant-time secret check against
+     * the stored hash; fail-closed null on any invalid path (unknown
+     * node, disabled node, missing credential, bad secret).
+     */
+    async heartbeat(
+        nodeId: unknown,
+        secret: unknown,
+        refresh: EnrollInput = {},
+    ): Promise<{ node: FleetNodeView } | null> {
+        if (typeof nodeId !== 'string' || !UUID_RE.test(nodeId)) {
+            return null;
+        }
+        if (
+            typeof secret !== 'string' ||
+            secret.length < CREDENTIAL_MIN_LENGTH ||
+            secret.length > CREDENTIAL_MAX_LENGTH
+        ) {
+            return null;
+        }
+
+        const node = await this.repository.findById(nodeId);
+        if (!node) return null;
+        // A disabled node must stop reporting; an enrolling node has no
+        // secret yet (the hash column still holds the token hash).
+        if (node.status === 'disabled' || node.status === 'enrolling') return null;
+        if (!constantTimeEquals(node.enrollmentTokenHash, sha256Hex(secret))) {
+            return null;
+        }
+
+        const patch: Partial<FleetNode> = {
+            status: 'online',
+            // Server-stamped — the node never supplies its own clock.
+            lastHeartbeatAt: new Date(),
+        };
+        if (refresh.capabilities !== undefined) {
+            patch.capabilities = sanitizeCapabilities(refresh.capabilities);
+        }
+        const platform = sanitizeText(refresh.platform, 64);
+        if (platform) patch.platform = platform;
+        const version = sanitizeText(refresh.version, 32);
+        if (version) patch.version = version;
+
+        await this.repository.update(node.id, patch);
+        return { node: this.toView({ ...node, ...patch }) };
+    }
+
+    /**
+     * Owner-scoped node list: sweeps stale `online` rows to `offline`
+     * (5-minute heartbeat window — piggybacked here, no cron), then
+     * merges live nodes from the user's own configured clusters
+     * (best-effort, `kind: 'k8s'`, never persisted).
+     */
+    async listForUser(userId: string): Promise<FleetNodeView[]> {
+        await this.repository.sweepOffline(
+            userId,
+            new Date(Date.now() - FLEET_NODE_OFFLINE_AFTER_MS),
+        );
+        const rows = await this.repository.findByUser(userId);
+        const clusterNodes = await this.listOwnClusterNodes(userId);
+        return [...rows.map((row) => this.toView(row)), ...clusterNodes];
+    }
+
+    /** Rename an enrolled node (owner-scoped, no existence leak). */
+    async renameForUser(userId: string, nodeId: string, name: string): Promise<FleetNodeView> {
+        const trimmed = typeof name === 'string' ? name.trim() : '';
+        if (trimmed.length < 1 || trimmed.length > 200) {
+            throw new BadRequestException('Node name must be 1-200 characters');
+        }
+        const node = await this.getOwnedNode(userId, nodeId);
+        await this.repository.update(node.id, { name: trimmed });
+        return this.toView({ ...node, name: trimmed });
+    }
+
+    /**
+     * Disable (drain) or re-enable a node. Disabling an `enrolling`
+     * node revokes its unused token (the enroll CAS requires status
+     * `enrolling`); re-enabling lands on `offline` until the next
+     * accepted heartbeat proves the node alive.
+     */
+    async setDisabledForUser(
+        userId: string,
+        nodeId: string,
+        disabled: boolean,
+    ): Promise<FleetNodeView> {
+        const node = await this.getOwnedNode(userId, nodeId);
+        const status: FleetNodeStatus = disabled ? 'disabled' : 'offline';
+        await this.repository.update(node.id, { status });
+        return this.toView({ ...node, status });
+    }
+
+    /** Delete a node registration (owner-scoped, no existence leak). */
+    async deleteForUser(userId: string, nodeId: string): Promise<void> {
+        const node = await this.getOwnedNode(userId, nodeId);
+        await this.repository.delete(node.id);
+    }
+
+    private async getOwnedNode(userId: string, nodeId: string): Promise<FleetNode> {
+        const node = await this.repository.findById(nodeId);
+        // Other users' nodes are indistinguishable from missing ones.
+        if (!node || node.userId !== userId) {
+            throw new NotFoundException(`Fleet node ${nodeId} not found`);
+        }
+        return node;
+    }
+
+    /**
+     * Live nodes of the user's OWN configured clusters, via the
+     * deployment plugin. Strictly best-effort: any missing plugin,
+     * settings failure or cluster error returns []. Platform-managed
+     * cluster sources are excluded by the `custom-kubeconfig` check
+     * (and the sentinel guard) — the shared platform clusters can never
+     * appear in Fleet.
+     */
+    private async listOwnClusterNodes(userId: string): Promise<FleetNodeView[]> {
+        if (!this.pluginRegistry || !this.pluginSettings) return [];
+        try {
+            const registered = this.pluginRegistry.get('k8s');
+            if (!registered) return [];
+
+            const settings = await this.pluginSettings.getResolvedSettings('k8s', {
+                userId,
+                includeSecrets: true,
+            });
+            const clusterSource = settings.clusterSource?.value as string | undefined;
+            if (clusterSource !== 'custom-kubeconfig') return [];
+            const kubeconfig = settings.kubeconfig?.value as string | undefined;
+            if (!kubeconfig || kubeconfig === PLATFORM_MANAGED_KUBECONFIG_SENTINEL) return [];
+            const kubeContext = settings.kubeContext?.value as string | undefined;
+
+            const plugin = await this.materialize(registered.plugin);
+            const listClusterNodes = (
+                plugin as unknown as {
+                    listClusterNodes?: (
+                        kubeconfigYaml: string,
+                        contextOverride?: string,
+                    ) => Promise<ClusterNodeSummary[]>;
+                }
+            ).listClusterNodes;
+            if (typeof listClusterNodes !== 'function') return [];
+
+            const nodes = await listClusterNodes.call(plugin, kubeconfig, kubeContext);
+            if (!Array.isArray(nodes)) return [];
+            return nodes.map((node) => this.clusterNodeToView(node));
+        } catch (error) {
+            this.logger.debug(
+                `Cluster node listing degraded to enrolled rows only: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return [];
+        }
+    }
+
+    /** Under lazy plugin loading the registry hands out a proxy stub. */
+    private async materialize(plugin: IPlugin): Promise<IPlugin> {
+        const stub = plugin as unknown as { __materialize?: () => Promise<IPlugin> };
+        if (typeof stub.__materialize === 'function') {
+            return stub.__materialize();
+        }
+        return plugin;
+    }
+
+    private clusterNodeToView(node: ClusterNodeSummary): FleetNodeView {
+        const name = typeof node.name === 'string' && node.name ? node.name : 'unknown';
+        return {
+            id: `k8s:${name}`,
+            name,
+            kind: 'k8s',
+            status: node.ready ? 'online' : 'offline',
+            platform: sanitizeText(node.platform, 64),
+            version: sanitizeText(node.version, 32),
+            capabilities: sanitizeCapabilities(node.roles),
+            lastHeartbeatAt: null,
+            createdAt: null,
+            persisted: false,
+        };
+    }
+
+    /** Entity → wire view. Credential hashes never leave the service. */
+    private toView(node: FleetNode): FleetNodeView {
+        return {
+            id: node.id,
+            name: node.name,
+            kind: node.kind,
+            status: node.status,
+            platform: node.platform ?? null,
+            version: node.version ?? null,
+            capabilities: node.capabilities ?? [],
+            lastHeartbeatAt: node.lastHeartbeatAt ? toIso(node.lastHeartbeatAt) : null,
+            createdAt: node.createdAt ? toIso(node.createdAt) : null,
+            persisted: true,
+        };
+    }
+}
+
+function sha256Hex(value: string): string {
+    return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+/**
+ * Constant-time equality with the terminal-attach posture: explicit
+ * length guard BEFORE `timingSafeEqual` (which throws on mismatched
+ * lengths), null-safe, and never throws.
+ */
+function constantTimeEquals(stored: string | null | undefined, computed: string): boolean {
+    if (typeof stored !== 'string' || stored.length === 0) return false;
+    const storedBuf = Buffer.from(stored, 'utf8');
+    const computedBuf = Buffer.from(computed, 'utf8');
+    const lengthsMatch = storedBuf.length === computedBuf.length;
+    const comparisonBuf = lengthsMatch ? computedBuf : Buffer.alloc(storedBuf.length);
+    const bytesMatch = timingSafeEqual(storedBuf, comparisonBuf);
+    return lengthsMatch && bytesMatch;
+}
+
+function sanitizeText(value: unknown, maxLength: number): string | null {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    return trimmed.slice(0, maxLength);
+}
+
+function sanitizeCapabilities(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    const out: string[] = [];
+    for (const entry of value) {
+        if (typeof entry !== 'string') continue;
+        const tag = entry.trim().slice(0, FLEET_MAX_CAPABILITY_TAG_LENGTH);
+        if (!tag || out.includes(tag)) continue;
+        out.push(tag);
+        if (out.length >= FLEET_MAX_CAPABILITY_TAGS) break;
+    }
+    return out;
+}
+
+function toIso(value: Date | string): string {
+    return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}

--- a/packages/agent/src/fleet/index.ts
+++ b/packages/agent/src/fleet/index.ts
@@ -1,0 +1,11 @@
+// Public surface of Fleet (Wave 12, slice 1): the owner-scoped node
+// registry — one-time enrollment tokens, constant-time heartbeat auth,
+// the offline sweep piggybacked on list reads, the best-effort merge of
+// the user's own configured-cluster nodes, and the `list_fleet_nodes`
+// chat tool factory.
+export * from './fleet.module';
+export * from './fleet.service';
+export * from './fleet-node.repository';
+export * from './agent-fleet-tools';
+export { FleetNode } from '../entities/fleet-node.entity';
+export type { FleetNodeKind, FleetNodeStatus } from '../entities/fleet-node.entity';

--- a/packages/plugins/k8s/src/k8s-api.service.ts
+++ b/packages/plugins/k8s/src/k8s-api.service.ts
@@ -6,7 +6,7 @@
  * raw HTTP requests ourselves.
  */
 import { createRequire } from 'node:module';
-import type { IngressClassDescriptor, KubernetesClusterInfo } from './types.js';
+import type { ClusterNodeDescriptor, IngressClassDescriptor, KubernetesClusterInfo } from './types.js';
 import type { ParsedKubeconfig } from './kubeconfig.parser.js';
 import type { DeploymentStatusInput } from './status.mapper.js';
 import { K8sPluginError, scrubError } from './errors.js';
@@ -78,6 +78,19 @@ interface AppsV1ApiLike {
 }
 
 interface CoreV1ApiLike {
+	listNode(): Promise<{
+		items: Array<{
+			metadata?: { name?: string; labels?: Record<string, string> };
+			status?: {
+				conditions?: Array<{ type?: string; status?: string }>;
+				nodeInfo?: {
+					operatingSystem?: string;
+					architecture?: string;
+					kubeletVersion?: string;
+				};
+			};
+		}>;
+	}>;
 	patchNamespacedService(args: {
 		name: string;
 		namespace: string;
@@ -263,6 +276,45 @@ export class KubernetesApiService {
 				hasStrategy: hasStrategyFor(controller)
 			};
 		});
+	}
+
+	/**
+	 * Node inventory for the Fleet surface (Wave 12) — read-only summary
+	 * of every node in the cluster the kubeconfig points at. Callers are
+	 * responsible for the cluster-source boundary (custom kubeconfigs
+	 * only); this method just lists what the credentials can see.
+	 */
+	async listNodes(kubeconfigYaml: string, contextOverride?: string): Promise<ClusterNodeDescriptor[]> {
+		const client = this.factory.createKubeConfig(kubeconfigYaml, contextOverride);
+		const core = this.factory.coreV1Api(client);
+		try {
+			const resp = await core.listNode();
+			return (resp.items ?? []).map((item) => {
+				const labels = item.metadata?.labels ?? {};
+				const roles = Object.keys(labels)
+					.filter((key) => key.startsWith('node-role.kubernetes.io/'))
+					.map((key) => key.slice('node-role.kubernetes.io/'.length))
+					.filter((role) => role.length > 0);
+				const ready = (item.status?.conditions ?? []).some(
+					(condition) => condition.type === 'Ready' && condition.status === 'True'
+				);
+				const info = item.status?.nodeInfo;
+				const platform =
+					info?.operatingSystem && info?.architecture
+						? `${info.operatingSystem}/${info.architecture}`
+						: undefined;
+				return {
+					name: item.metadata?.name ?? '',
+					ready,
+					...(platform ? { platform } : {}),
+					...(info?.kubeletVersion ? { version: info.kubeletVersion } : {}),
+					...(roles.length > 0 ? { roles } : {})
+				};
+			});
+		} catch (err) {
+			const scrubbed = scrubError(err);
+			throw new K8sPluginError(scrubbed.code, scrubbed.message, err);
+		}
 	}
 
 	async getDeployment(

--- a/packages/plugins/k8s/src/k8s.plugin.ts
+++ b/packages/plugins/k8s/src/k8s.plugin.ts
@@ -36,6 +36,7 @@ import {
 	type DnsResolver
 } from './domain.handler.js';
 import type {
+	ClusterNodeDescriptor,
 	ClusterSource,
 	IngressClassDescriptor,
 	KubernetesSettings,
@@ -405,6 +406,17 @@ export class KubernetesPlugin implements IPlugin, IDeploymentPlugin {
 		// Kubernetes has no built-in teams concept. Returning [] is the
 		// honest answer; the deploy facade falls back to "no team scope".
 		return [];
+	}
+
+	/**
+	 * Fleet (Wave 12) — read-only node inventory of the cluster the
+	 * given kubeconfig points at. The platform side calls this ONLY for
+	 * user-configured clusters (`clusterSource: 'custom-kubeconfig'`);
+	 * platform-managed sources never reach here from Fleet.
+	 */
+	async listClusterNodes(kubeconfig: string, contextOverride?: string): Promise<ClusterNodeDescriptor[]> {
+		if (!kubeconfig) return [];
+		return this.api.listNodes(kubeconfig, contextOverride);
 	}
 
 	async deploy(config: DeploymentConfig, kubeconfig: string): Promise<DeploymentResult> {

--- a/packages/plugins/k8s/src/types.ts
+++ b/packages/plugins/k8s/src/types.ts
@@ -141,6 +141,23 @@ export interface KubernetesClusterInfo {
 }
 
 /**
+ * One cluster node as reported by `listClusterNodes` (Fleet, Wave 12):
+ * a read-only inventory summary for USER-configured clusters
+ * (`clusterSource: 'custom-kubeconfig'`) — never persisted platform-side.
+ */
+export interface ClusterNodeDescriptor {
+	name: string;
+	/** True when the node's Ready condition is True. */
+	ready: boolean;
+	/** os/arch, e.g. 'linux/amd64' (from nodeInfo). */
+	platform?: string;
+	/** Kubelet version, e.g. 'v1.30.2'. */
+	version?: string;
+	/** Role labels (`node-role.kubernetes.io/<role>`), e.g. ['control-plane']. */
+	roles?: string[];
+}
+
+/**
  * Per-IngressClass info reported by `validateConnection`.
  */
 export interface IngressClassDescriptor {


### PR DESCRIPTION
## Summary

Wave 12 slice 1 of the Desktop epic — the **Fleet** foundation: a node registry + enrollment protocol + settings page, per the Fleet section of the desktop-app PRD. The desktop/headless node apps themselves are the next slice; this ships the registry, the curl-able enrollment/heartbeat API, and the display surface they will land on. Everything is additive.

### Agent (`packages/agent`, new `./fleet` subpath)
- **`FleetNode` entity** (`fleet_nodes`): `kind` `desktop-node|node` (`k8s` is list-time only and never persisted), `status` `enrolling|online|offline|disabled`, **dual-role credential hash** (sha256 of the one-time enrollment token while `enrolling`, swapped atomically to the sha256 of the node heartbeat secret at enroll), capability tags (`simple-json`), platform/version, server-stamped `lastHeartbeatAt`. Registered in `_entities-inventory` + `_entity-names` (drift pins green).
- **`FleetService`**:
  - `createEnrollmentToken` — random 32 bytes, returned exactly once, hash-at-rest, 15-min expiry via `createdAt`.
  - `enroll` — **single-use CAS consume** (`UPDATE … WHERE status='enrolling' AND hash=token-hash`); mints the node secret; every invalid path returns `null` → one undifferentiated 401.
  - `heartbeat` — constant-time compare behind an explicit length guard, fail-closed (mirrors `terminal-attach.service` posture); refuses disabled/enrolling nodes; `lastHeartbeatAt` server-stamped, never client-trusted.
  - `listForUser` — offline sweep (no heartbeat 5 min → `offline`) **piggybacked on list reads, no new cron**; best-effort merge of the user's **own** configured-cluster nodes (`clusterSource: 'custom-kubeconfig'` only — **shared platform clusters are structurally excluded**, and nothing cluster-side is ever persisted).
- **Chat tool `list_fleet_nodes`** (`buildFleetTools` factory + web tools-registry entry), per the entity-ships-with-chat-tools DoD.

### API (`apps/api`)
- `GET /api/fleet/nodes` · `POST /api/fleet/nodes/enrollment-token` · `PATCH|DELETE /api/fleet/nodes/:id` (owner-scoped) + `@Public` `POST /api/fleet/enroll` and `POST /api/fleet/heartbeat` (token/secret ARE the auth, throttled, fail-closed).
- Guarded migration `1783900000000-CreateFleetNodes` (hasTable guard, unique credential index, FK → users CASCADE) in the same PR.

### Web (`apps/web`)
- Settings → **Fleet** tab **directly above Job Runtime** (Fleet = *where* work can run; Job Runtime stays *how* it is dispatched — untouched).
- Nodes table (kind badge, status dot, platform, capability chips, last-seen), **Add node** flow with the one-time token + copy button + install-instructions placeholder, rename / disable / remove (confirm) actions, read-only own-cluster nodes section, empty state. i18n (`en.json` only, deepmerge fallback) + `fleet-*` testids.

### k8s plugin (additive)
- `KubernetesApiService.listNodes` (+ `CoreV1ApiLike.listNode`) and `KubernetesPlugin.listClusterNodes` — read-only node inventory, resolved via the plugin registry (lazy-proxy materialized first).

## Verification (all run in this worktree, foreground)

```
packages/agent  pnpm build                  → nest/swc + tsc types, TSC 0 (exit 0)
packages/agent  npx jest --testPathPattern='fleet'
                → Test Suites: 3 passed, Tests: 27 passed
packages/agent  npx jest --testPathPattern='database'   (entity drift pins)
                → Test Suites: 38 passed, Tests: 530 passed
pnpm build --filter=ever-works-api
                → TSC Found 0 issues; 679 files compiled; 14 tasks successful
apps/api        pnpm generate:openapi       (full-app bootstrap gate)
                → Wrote OpenAPI spec (433 paths); fleet paths present:
                  /api/fleet/nodes, /api/fleet/nodes/enrollment-token,
                  /api/fleet/nodes/{id}, /api/fleet/enroll, /api/fleet/heartbeat
                  (openapi.json is gitignored — not committed)
apps/api        npx jest --testPathPattern='fleet'
                → Test Suites: 1 passed, Tests: 12 passed
packages/plugins/k8s  pnpm build + pnpm test
                → build OK; Test Files 9 passed, Tests 148 passed
apps/web        npx tsc --noEmit            → exit 0
                (note: a stale apps/web/tsconfig.tsbuildinfo can replay a
                phantom pre-existing kb.classes.decision error — delete it
                and tsc is clean; verified error-free on a fresh check)
apps/web        npx vitest run src/lib/ai/tools   (tools-registry pins)
                → Test Files 7 passed, Tests 78 passed
prettier --check on all touched files → clean
```

Fleet test coverage (39 total): token single-use (CAS race) + 15-min expiry + malformed/revoked token fail-closed; heartbeat flips offline→online + wrong-secret/missing-hash/disabled/enrolling fail-closed (constant-time path); offline sweep cutoff; owner scoping (foreign ids indistinguishable from missing) on rename/disable/delete; k8s merge best-effort (mock plugin: merge, platform-source exclusion, throw-degradation, never-persisted); chat-tool scoping/filters/error shape; DTO validation bounds (kind whitelist, token/secret bounds, capability caps); @Public pins on exactly enroll+heartbeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)