### PR TITLE
feat(agents): GTM skills + template wiring (Wave 10 slice 2)

### DIFF
--- a/apps/web/messages/ar.json
+++ b/apps/web/messages/ar.json
@@ -5465,6 +5465,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "حملة",
             "default": "Work"
         }
     },

--- a/apps/web/messages/bg.json
+++ b/apps/web/messages/bg.json
@@ -5465,6 +5465,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Кампания",
             "default": "Work"
         }
     },

--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -5465,6 +5465,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Kampagne",
             "default": "Work"
         }
     },

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6149,6 +6149,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Campaign",
             "default": "Work"
         },
         "terminal": {

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -5465,6 +5465,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Campaña",
             "default": "Work"
         }
     },

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -5465,6 +5465,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Campagne",
             "default": "Work"
         }
     },

--- a/apps/web/messages/he.json
+++ b/apps/web/messages/he.json
@@ -5465,6 +5465,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "קמפיין",
             "default": "Work"
         }
     },

--- a/apps/web/messages/hi.json
+++ b/apps/web/messages/hi.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "अभियान",
             "default": "Work"
         }
     },

--- a/apps/web/messages/id.json
+++ b/apps/web/messages/id.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Kampanye",
             "default": "Work"
         }
     },

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Campagna",
             "default": "Work"
         }
     },

--- a/apps/web/messages/ja.json
+++ b/apps/web/messages/ja.json
@@ -5277,6 +5277,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "キャンペーン",
             "default": "Work"
         }
     },

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -5277,6 +5277,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "캠페인",
             "default": "Work"
         }
     },

--- a/apps/web/messages/nl.json
+++ b/apps/web/messages/nl.json
@@ -5277,6 +5277,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Campagne",
             "default": "Work"
         }
     },

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Kampania",
             "default": "Work"
         }
     },

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Campanha",
             "default": "Work"
         }
     },

--- a/apps/web/messages/ru.json
+++ b/apps/web/messages/ru.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Кампания",
             "default": "Work"
         }
     },

--- a/apps/web/messages/th.json
+++ b/apps/web/messages/th.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "แคมเปญ",
             "default": "Work"
         }
     },

--- a/apps/web/messages/tr.json
+++ b/apps/web/messages/tr.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Kampanya",
             "default": "Work"
         }
     },

--- a/apps/web/messages/uk.json
+++ b/apps/web/messages/uk.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Кампанія",
             "default": "Work"
         }
     },

--- a/apps/web/messages/vi.json
+++ b/apps/web/messages/vi.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "Chiến dịch",
             "default": "Work"
         }
     },

--- a/apps/web/messages/zh.json
+++ b/apps/web/messages/zh.json
@@ -5269,6 +5269,7 @@
             "directory": "Directory",
             "awesome-repo": "Awesome Repo",
             "company": "Company",
+            "campaign": "营销活动",
             "default": "Work"
         }
     },

--- a/apps/web/src/lib/ai/tools/tool-selection.ts
+++ b/apps/web/src/lib/ai/tools/tool-selection.ts
@@ -32,6 +32,32 @@ export const MIN_MATCHED_SLOTS = 48;
 /** Domains that are always available regardless of the message. */
 const CORE_DOMAINS = new Set(['core', 'works']);
 
+/**
+ * Go-to-market vocabulary (Wave 10).
+ *
+ * The prebuilt Agent templates and the first-party Skills catalog are both
+ * reached with campaign language ("draft outreach", "audit my SEO", "build a
+ * lead list") that shares no stem with `agent` or `skill`. Without these
+ * slots the tools for the surface the user just asked for are gated out of
+ * the turn — the Mission-create outage is the cautionary tale for shipping a
+ * surface without its keyword slots. Applied to both domains because the
+ * flows cross them: pick a template (agents) → wire its Skills (skills).
+ */
+const GTM_KEYWORDS = [
+    'campaign',
+    'outreach',
+    'go-to-market',
+    'gtm',
+    'lead',
+    'prospect',
+    'newsletter',
+    'digest',
+    'competitor',
+    'seo',
+    'enrichment',
+    'follow-up',
+];
+
 /** Keywords that pull a domain's tools into the active set. */
 const DOMAIN_KEYWORDS: Record<string, string[]> = {
     works: [
@@ -47,9 +73,9 @@ const DOMAIN_KEYWORDS: Record<string, string[]> = {
         'readme',
         'markdown',
     ],
-    agents: ['agent'],
+    agents: ['agent', ...GTM_KEYWORDS],
     tasks: ['task'],
-    skills: ['skill'],
+    skills: ['skill', ...GTM_KEYWORDS],
     missions: ['mission'],
     ideas: ['idea', 'proposal'],
     workagent: ['work agent', 'work-agent', 'goal'],

--- a/apps/web/src/lib/ai/tools/tool-selection.unit.spec.ts
+++ b/apps/web/src/lib/ai/tools/tool-selection.unit.spec.ts
@@ -45,6 +45,28 @@ describe('selectActiveToolNames', () => {
         expect(selected).toContain('pause_agent');
     });
 
+    /**
+     * Wave 10 — the go-to-market surfaces (Agent templates + the first-party
+     * Skills catalog) are reached with campaign language that shares no stem
+     * with "agent" or "skill". Without these slots the very tools the user
+     * asked for are gated out of the turn.
+     */
+    it.each([
+        ['draft outreach for my top leads', 'pause_agent'],
+        ['plan the launch campaign', 'list_agents'],
+        ['audit the seo on my blog', 'list_agents'],
+        ['write this week newsletter digest', 'pause_agent'],
+        ['what changed at that competitor', 'list_agents'],
+    ])('pulls the go-to-market surfaces in for %j', (text, expected) => {
+        expect(selectActiveToolNames(NAMES, { text })).toContain(expected);
+    });
+
+    it('leaves unrelated domains out of a go-to-market turn', () => {
+        const selected = selectActiveToolNames(NAMES, { text: 'draft outreach for my top leads' });
+        expect(selected).not.toContain('list_webhooks');
+        expect(selected).not.toContain('list_notifications');
+    });
+
     it('never exceeds the cap', () => {
         const many = Array.from({ length: 300 }, (_, i) => `unknown_tool_${i}`);
         const selected = selectActiveToolNames(many, {

--- a/apps/web/src/lib/work-kinds/catalog.ts
+++ b/apps/web/src/lib/work-kinds/catalog.ts
@@ -1,4 +1,13 @@
-import { BookOpen, Building2, Files, FolderClosed, FolderOpen, Globe, Star } from 'lucide-react';
+import {
+    BookOpen,
+    Building2,
+    Files,
+    FolderClosed,
+    FolderOpen,
+    Globe,
+    Megaphone,
+    Star,
+} from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { WORK_KINDS, normalizeWorkKind, type WorkKind } from '@ever-works/contracts';
 
@@ -18,12 +27,14 @@ import { WORK_KINDS, normalizeWorkKind, type WorkKind } from '@ever-works/contra
  * does a badge use?" — so every read-only surface (cards, headers, info
  * blocks, filters) renders a kind identically.
  *
- * Every member of `WorkKind` is represented, including the two that are
+ * Every member of `WorkKind` is represented, including the three that are
  * never user-selectable at creation time:
  *   - `default` — the column default, carried by every Work that predates
  *     the kind-aware create path. Presented as the generic "Work".
  *   - `company` — minted only by the Register-Company flow
  *     (`WorkLifecycleService.createCompanyWork`).
+ *   - `campaign` — the go-to-market campaign Work, minted by template
+ *     activation rather than the general create path.
  */
 export { WORK_KINDS, normalizeWorkKind };
 
@@ -63,6 +74,10 @@ export const WORK_KIND_PRESENTATION: Record<WorkKindValue, WorkKindPresentation>
     company: {
         icon: Building2,
         tone: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300',
+    },
+    campaign: {
+        icon: Megaphone,
+        tone: 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300',
     },
     default: {
         icon: FolderClosed,

--- a/packages/agent/src/agents/__tests__/agent-templates.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-templates.spec.ts
@@ -1,3 +1,4 @@
+import { GTM_SKILL_SLUGS, GTM_SKILLS, getGtmSkill } from '@ever-works/contracts';
 import { AGENT_PERMISSIONS_DEFAULT } from '../../entities/agent.entity';
 import { assertNoSecrets } from '../../utils/secret-scan';
 import { slugifyText } from '../../utils/text.utils';
@@ -88,5 +89,77 @@ describe('agent-templates catalog integrity', () => {
         expect(listAgentTemplates()).toBe(AGENT_TEMPLATES);
         expect(getAgentTemplate('outreach-drafter')?.name).toBe('Outreach Drafter');
         expect(getAgentTemplate('nonexistent-template')).toBeUndefined();
+    });
+});
+
+/**
+ * The load-bearing cross-package pin.
+ *
+ * A template's `suggestedSkills` is the contract the Skills catalog has to
+ * honour: activating a template hands the caller a list of Skill slugs to
+ * wire up, and a slug that resolves to nothing turns a "ready-to-run" preset
+ * into a dead end that only shows up in a live run. This suite makes the
+ * drift a build failure and names the offending slug.
+ */
+describe('agent templates ↔ go-to-market Skills catalog integrity', () => {
+    it('every suggested skill of every template resolves in the catalog', () => {
+        const missing: string[] = [];
+        for (const template of AGENT_TEMPLATES) {
+            for (const slug of template.suggestedSkills) {
+                if (!getGtmSkill(slug)) {
+                    missing.push(`${template.slug} → ${slug}`);
+                }
+            }
+        }
+        expect(missing).toEqual([]);
+    });
+
+    it('covers every template with at least one resolvable skill', () => {
+        for (const template of AGENT_TEMPLATES) {
+            const resolved = template.suggestedSkills.filter((slug) => getGtmSkill(slug));
+            expect(resolved.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('no template repeats a suggested skill', () => {
+        for (const template of AGENT_TEMPLATES) {
+            const slugs = [...template.suggestedSkills];
+            expect(new Set(slugs).size).toBe(slugs.length);
+        }
+    });
+
+    it('the six shipped templates cover the go-to-market work they advertise', () => {
+        const suggested = (slug: string) => getAgentTemplate(slug)?.suggestedSkills ?? [];
+        // Each template's headline job must be backed by a real Skill, not
+        // only by the generic reporting pair every template could claim.
+        expect(suggested('content-marketer')).toContain('newsletter-drafting');
+        expect(suggested('seo-auditor')).toContain('seo-audit');
+        expect(suggested('lead-researcher')).toContain('lead-research');
+        expect(suggested('outreach-drafter')).toContain('outreach-personalization');
+        expect(suggested('social-scheduler')).toContain('social-scheduling');
+        expect(suggested('competitive-analyst')).toContain('competitor-watch');
+    });
+
+    it('templates driving the go-to-market pipeline suggest skills from more than one stage', () => {
+        for (const template of AGENT_TEMPLATES) {
+            if (template.suggestedPipeline !== 'gtm-pipeline') continue;
+            const stages = new Set(
+                template.suggestedSkills
+                    .map((slug) => getGtmSkill(slug)?.stage)
+                    .filter((stage): stage is NonNullable<typeof stage> => Boolean(stage)),
+            );
+            expect(stages.size).toBeGreaterThan(1);
+        }
+    });
+
+    it('skill bodies are secret-free — they are written into Agent files verbatim', () => {
+        for (const skill of GTM_SKILLS) {
+            expect(() => assertNoSecrets(skill.body, `skill ${skill.slug}`)).not.toThrow();
+        }
+    });
+
+    it('exposes a slug list consistent with the catalog itself', () => {
+        expect(GTM_SKILL_SLUGS).toEqual(GTM_SKILLS.map((skill) => skill.slug));
+        expect(new Set(GTM_SKILL_SLUGS).size).toBe(GTM_SKILL_SLUGS.length);
     });
 });

--- a/packages/agent/src/agents/agent-templates.ts
+++ b/packages/agent/src/agents/agent-templates.ts
@@ -33,7 +33,14 @@ export interface AgentTemplate {
     readonly systemPrompt: string;
     /** Free-text capabilities summary — becomes the Agent's capabilities field. */
     readonly capabilities: string;
-    /** Skill slugs (skills catalog) that pair well with this template. */
+    /**
+     * Skill slugs (skills catalog) that pair well with this template.
+     *
+     * Every slug here MUST exist in the first-party go-to-market Skill
+     * catalog (`GTM_SKILLS` in `@ever-works/contracts`) — the integrity
+     * suite fails the build otherwise. That pin is what stops the list
+     * from decaying back into aspirational names with nothing behind them.
+     */
     readonly suggestedSkills: readonly string[];
     /** Pipeline plugin id this template is designed to drive. */
     readonly suggestedPipeline: string | null;
@@ -112,7 +119,7 @@ export const AGENT_TEMPLATES: readonly AgentTemplate[] = [
         capabilities:
             'Site structure and metadata review; content-gap analysis; internal-linking suggestions; ' +
             'prioritized fix lists; post-change re-audits.',
-        suggestedSkills: ['campaign-reporting', 'engagement-analysis'],
+        suggestedSkills: ['seo-audit', 'campaign-reporting', 'engagement-analysis'],
         suggestedPipeline: null,
         defaultPermissions: {},
         defaultGuardrails: REQUIRE_APPROVAL,
@@ -146,7 +153,7 @@ export const AGENT_TEMPLATES: readonly AgentTemplate[] = [
         capabilities:
             'Lead list building from seeds and public signals; explainable lead scoring; risk flagging; ' +
             'evidence-bound contact enrichment; list hygiene.',
-        suggestedSkills: ['contact-enrichment', 'lead-scoring', 'risk-filter'],
+        suggestedSkills: ['lead-research', 'contact-enrichment', 'lead-scoring', 'risk-filter'],
         suggestedPipeline: 'gtm-pipeline',
         defaultPermissions: {},
         defaultGuardrails: REQUIRE_APPROVAL,
@@ -214,7 +221,12 @@ export const AGENT_TEMPLATES: readonly AgentTemplate[] = [
         capabilities:
             'Social calendar planning; channel-fit post drafting; review-first staging; ' +
             'engagement-informed iteration.',
-        suggestedSkills: ['news-signal-detection', 'engagement-analysis', 'digest-compilation'],
+        suggestedSkills: [
+            'social-scheduling',
+            'news-signal-detection',
+            'engagement-analysis',
+            'digest-compilation',
+        ],
         suggestedPipeline: 'gtm-pipeline',
         defaultPermissions: {},
         defaultGuardrails: REQUIRE_APPROVAL,

--- a/packages/contracts/src/domain/__tests__/work-capabilities.spec.ts
+++ b/packages/contracts/src/domain/__tests__/work-capabilities.spec.ts
@@ -129,9 +129,41 @@ describe('workKindHasItems', () => {
 	it('is false where an Items tab would be noise', () => {
 		expect(workKindHasItems('landing-page')).toBe(false);
 		expect(workKindHasItems('company')).toBe(false);
+		expect(workKindHasItems('campaign')).toBe(false);
 	});
 
 	it('defaults to true for an unknown kind, so nothing is hidden by accident', () => {
 		expect(workKindHasItems('storefront')).toBe(true);
+	});
+});
+
+/**
+ * The go-to-market campaign kind — the artifact home for what a go-to-market
+ * pipeline produces (lead lists, drafts awaiting the review gate, reports).
+ */
+describe('the campaign work kind', () => {
+	it('is a known kind that no longer degrades to "default"', () => {
+		expect(normalizeWorkKind('campaign')).toBe('campaign');
+		expect(normalizeWorkKind('  CAMPAIGN ')).toBe('campaign');
+	});
+
+	it('stays out of the create-path chip catalog, like company', () => {
+		expect(USER_SELECTABLE_WORK_KINDS as readonly string[]).not.toContain('campaign');
+		expect(WORK_KINDS as readonly string[]).toContain('campaign');
+	});
+
+	it('is a non-deployable, non-taxonomy shell with the knowledge base on', () => {
+		const caps = WORK_KIND_CAPABILITIES.campaign;
+		expect(caps.items.enabled).toBe(false);
+		expect(caps.taxonomy).toBe(false);
+		expect(caps.comparisons).toBe(false);
+		expect(caps.communityPr).toBe(false);
+		expect(caps.deploy).toBe(false);
+		expect(caps.kb).toBe(true);
+		expect(caps.repos.website).toBe(false);
+	});
+
+	it('maps to metrics that describe campaign effort and outcome', () => {
+		expect(WORK_KIND_CAPABILITIES.campaign.metrics).toEqual(['agents', 'open-tasks', 'conversions', 'days-active']);
 	});
 });

--- a/packages/contracts/src/domain/work-capabilities.ts
+++ b/packages/contracts/src/domain/work-capabilities.ts
@@ -143,6 +143,26 @@ export const WORK_KIND_CAPABILITIES: Record<WorkKind, WorkCapabilities> = {
 		kb: true,
 		metrics: ['works-owned', 'team-members', 'agents', 'open-tasks', 'days-active'],
 		repos: { data: true, work: true, website: false }
+	},
+
+	// A campaign Work is where a go-to-market pipeline's output LIVES: lead
+	// lists, drafts awaiting the review gate, and period reports. It produces
+	// no deployable site, so `deploy` and the website repo are off; the
+	// knowledge base stays on because the campaign brief and the approved
+	// messaging belong there. Metrics reuse the existing vocabulary — the
+	// people and work driving the campaign, plus provider-backed conversions
+	// once an analytics provider is connected.
+	campaign: {
+		items: { enabled: false, labelKey: 'items' },
+		taxonomy: false,
+		comparisons: false,
+		communityPr: false,
+		itemImportExport: false,
+		sourceValidation: false,
+		deploy: false,
+		kb: true,
+		metrics: ['agents', 'open-tasks', 'conversions', 'days-active'],
+		repos: { data: true, work: true, website: false }
 	}
 };
 

--- a/packages/contracts/src/domain/work-kind.ts
+++ b/packages/contracts/src/domain/work-kind.ts
@@ -28,8 +28,12 @@ export type UserSelectableWorkKind = (typeof USER_SELECTABLE_WORK_KINDS)[number]
  *     of existing rows. It must behave identically to `directory`; see
  *     `WORK_KIND_CAPABILITIES` for why that invariant is load-bearing.
  *   - `company` — see above.
+ *   - `campaign` — a go-to-market campaign Work: the artifact home for the
+ *     lead lists, drafts, and reports a go-to-market pipeline produces. Like
+ *     `company` it is minted by a dedicated flow (template activation), not
+ *     by the general create path, so it stays out of the chip catalog.
  */
-export const WORK_KINDS = [...USER_SELECTABLE_WORK_KINDS, 'company', 'default'] as const;
+export const WORK_KINDS = [...USER_SELECTABLE_WORK_KINDS, 'company', 'campaign', 'default'] as const;
 
 export type WorkKind = (typeof WORK_KINDS)[number];
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -6,3 +6,4 @@ export * from './kb/index.js';
 export * from './terminal/index.js';
 export * from './tasks/index.js';
 export * from './ingest/index.js';
+export * from './skills/index.js';

--- a/packages/contracts/src/skills/__tests__/gtm-skills.spec.ts
+++ b/packages/contracts/src/skills/__tests__/gtm-skills.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+	GTM_SKILLS,
+	GTM_SKILL_SLUGS,
+	GTM_SKILL_STAGES,
+	getGtmSkill,
+	isGtmSkillSlug,
+	listGtmSkills,
+	listGtmSkillsForStage
+} from '../gtm-skills.js';
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const IO_KEY_PATTERN = /^[a-z0-9]+(?:_[a-z0-9]+)*$/;
+const SEMVER_PATTERN = /^\d+\.\d+\.\d+$/;
+
+describe('GTM_SKILLS catalog integrity', () => {
+	it('ships the full go-to-market skill set', () => {
+		expect(GTM_SKILLS.length).toBeGreaterThanOrEqual(16);
+		expect(GTM_SKILL_SLUGS).toEqual(
+			expect.arrayContaining([
+				'lead-research',
+				'competitor-watch',
+				'news-signal-detection',
+				'lead-scoring',
+				'risk-filter',
+				'outreach-personalization',
+				'newsletter-drafting',
+				'social-scheduling',
+				'digest-compilation',
+				'crm-sync-hygiene',
+				'follow-up-cadence',
+				'reply-detection',
+				'contact-enrichment',
+				'seo-audit',
+				'campaign-reporting',
+				'engagement-analysis'
+			])
+		);
+	});
+
+	it('slugs are unique and kebab-case', () => {
+		expect(new Set(GTM_SKILL_SLUGS).size).toBe(GTM_SKILL_SLUGS.length);
+		for (const slug of GTM_SKILL_SLUGS) {
+			expect(slug).toMatch(SLUG_PATTERN);
+		}
+	});
+
+	it('every skill carries a substantial description, title, and instruction body', () => {
+		for (const skill of GTM_SKILLS) {
+			expect(skill.title.trim().length).toBeGreaterThan(3);
+			expect(skill.description.trim().length).toBeGreaterThan(40);
+			expect(skill.body.trim().length).toBeGreaterThan(200);
+			expect(skill.version).toMatch(SEMVER_PATTERN);
+		}
+	});
+
+	it('every skill declares a stage from the go-to-market stage vocabulary', () => {
+		for (const skill of GTM_SKILLS) {
+			expect(GTM_SKILL_STAGES).toContain(skill.stage);
+		}
+	});
+
+	/**
+	 * The point of the Skill being "deterministic about its own contract":
+	 * a Skill that declares no output has not said what it is responsible
+	 * for producing, and the stage that runs it cannot hand anything on.
+	 */
+	it('every skill declares at least one input and one output, in the shared key vocabulary', () => {
+		for (const skill of GTM_SKILLS) {
+			expect(skill.inputs.length).toBeGreaterThan(0);
+			expect(skill.outputs.length).toBeGreaterThan(0);
+			for (const io of [...skill.inputs, ...skill.outputs]) {
+				expect(io.key).toMatch(IO_KEY_PATTERN);
+				expect(io.description.trim().length).toBeGreaterThan(10);
+			}
+		}
+	});
+
+	it('no skill declares a duplicate input or output key', () => {
+		for (const skill of GTM_SKILLS) {
+			const inputKeys = skill.inputs.map((io) => io.key);
+			const outputKeys = skill.outputs.map((io) => io.key);
+			expect(new Set(inputKeys).size).toBe(inputKeys.length);
+			expect(new Set(outputKeys).size).toBe(outputKeys.length);
+		}
+	});
+
+	it('tags always include the gtm family tag and stay kebab-case', () => {
+		for (const skill of GTM_SKILLS) {
+			expect(skill.tags).toContain('gtm');
+			for (const tag of skill.tags) {
+				expect(tag).toMatch(SLUG_PATTERN);
+			}
+		}
+	});
+
+	it('allowedTools is an advisory allowlist of known tool families', () => {
+		const known = new Set(['search', 'content-extractor', 'connector', 'metrics']);
+		for (const skill of GTM_SKILLS) {
+			for (const tool of skill.allowedTools) {
+				expect(known.has(tool)).toBe(true);
+			}
+		}
+	});
+
+	it('covers every stage that has outbound consequences with at least one skill', () => {
+		for (const stage of ['research', 'qualify', 'draft', 'act', 'follow-up', 'enrich', 'measure'] as const) {
+			expect(listGtmSkillsForStage(stage).length).toBeGreaterThan(0);
+		}
+	});
+
+	it('leaves the review stage to the policy gate rather than a skill', () => {
+		// `review` is a human approval gate governed by guardrails and the
+		// policy matrix — modelling it as a Skill would imply the model can
+		// approve its own output.
+		expect(listGtmSkillsForStage('review')).toEqual([]);
+	});
+});
+
+describe('GTM skill lookup helpers', () => {
+	it('listGtmSkills returns the catalog in declared order', () => {
+		expect(listGtmSkills()).toBe(GTM_SKILLS);
+	});
+
+	it('getGtmSkill resolves a known slug and tolerates casing and padding', () => {
+		expect(getGtmSkill('lead-scoring')?.title).toBe('Lead scoring');
+		expect(getGtmSkill('  LEAD-SCORING ')?.slug).toBe('lead-scoring');
+	});
+
+	it.each([
+		['an unknown slug', 'not-a-skill'],
+		['an empty string', ''],
+		['undefined', undefined],
+		['null', null],
+		['a number', 42 as unknown as string]
+	])('getGtmSkill degrades %s to undefined and never throws', (_label, input) => {
+		expect(() => getGtmSkill(input as string | null | undefined)).not.toThrow();
+		expect(getGtmSkill(input as string | null | undefined)).toBeUndefined();
+	});
+
+	it('isGtmSkillSlug mirrors getGtmSkill', () => {
+		expect(isGtmSkillSlug('contact-enrichment')).toBe(true);
+		expect(isGtmSkillSlug('contact-enrichment-v2')).toBe(false);
+		expect(isGtmSkillSlug(null)).toBe(false);
+	});
+
+	it('listGtmSkillsForStage returns only that stage, in declared order', () => {
+		const qualify = listGtmSkillsForStage('qualify');
+		expect(qualify.map((skill) => skill.slug)).toEqual(['lead-scoring', 'risk-filter']);
+		for (const skill of qualify) {
+			expect(skill.stage).toBe('qualify');
+		}
+	});
+});

--- a/packages/contracts/src/skills/gtm-skills.ts
+++ b/packages/contracts/src/skills/gtm-skills.ts
@@ -1,0 +1,695 @@
+/**
+ * First-party go-to-market Skills — Wave 10 (agent-platform parity).
+ *
+ * The prebuilt Agent templates (`@ever-works/agent` → `agent-templates.ts`)
+ * name the Skills they pair with by slug. Those slugs were a promise with
+ * nothing behind them: the first-party skills-provider plugin served a
+ * three-entry builtin fallback plus whatever the catalog repo happened to
+ * publish, so activating a template produced an Agent whose suggested
+ * Skills resolved to nothing.
+ *
+ * This module is the missing half — a typed, in-code catalog of the
+ * go-to-market Skills those templates reference. It lives in
+ * `@ever-works/contracts` for the same reason `work-kind.ts` does: the
+ * skills-provider plugin (which serves them) and the agent package (which
+ * references them from templates) share no other runtime package, and the
+ * catalog-integrity check that keeps the two halves honest needs one list
+ * to compare against.
+ *
+ * A Skill here is pure DATA — a declared input/output contract plus the
+ * instruction body injected at AI-call time. No Skill runs anything on its
+ * own: the LLM work happens through the existing AI facade, and the
+ * connector work happens through the existing plugin grants. What each
+ * Skill IS deterministic about is its own contract — which keys it reads,
+ * which keys it writes, and which tool families it expects to be granted.
+ */
+
+/**
+ * Go-to-market pipeline stage a Skill belongs to.
+ *
+ * Mirrors the stage vocabulary of the `gtm-pipeline` pipeline plugin
+ * (research → qualify → draft → review → act → follow-up → enrich →
+ * measure). Duplicated as a literal union rather than imported because
+ * `@ever-works/contracts` sits BELOW the plugin packages in the dependency
+ * graph — the stage-parity check lives in the plugin's own suite.
+ */
+export const GTM_SKILL_STAGES = [
+	'research',
+	'qualify',
+	'draft',
+	'review',
+	'act',
+	'follow-up',
+	'enrich',
+	'measure'
+] as const;
+
+export type GtmSkillStage = (typeof GTM_SKILL_STAGES)[number];
+
+/**
+ * One declared input or output key of a Skill.
+ *
+ * Keys are snake_case and share the vocabulary of the go-to-market
+ * pipeline's stage data keys (`contacts`, `signals`, `scored_contacts`,
+ * `drafts`, …) so a Skill's contract can be read against the stage that
+ * invokes it without a translation table.
+ */
+export interface GtmSkillIo {
+	/** snake_case data key. */
+	readonly key: string;
+	/** What the key carries — one line, shown in the Skill detail view. */
+	readonly description: string;
+}
+
+/**
+ * A first-party go-to-market Skill.
+ *
+ * `body` is the SKILL.md text WITHOUT frontmatter: the skills-provider
+ * plugin re-emits it as a canonical catalog entry, and the platform stores
+ * frontmatter and body separately (see `SkillCatalogEntry` in
+ * `@ever-works/plugin`).
+ */
+export interface GtmSkillDefinition {
+	/** Stable kebab-case identifier — the catalog slug and the id templates reference. */
+	readonly slug: string;
+	/** Human-readable title shown in the Skills catalog. */
+	readonly title: string;
+	/** One-line summary shown in pickers and search results. */
+	readonly description: string;
+	/** Which go-to-market stage this Skill powers. */
+	readonly stage: GtmSkillStage;
+	/** Catalog tags — drive the Skills page filters. */
+	readonly tags: readonly string[];
+	/** Semver of the Skill body; bumped when the instructions change materially. */
+	readonly version: string;
+	/** Data keys the Skill expects to be present before it runs. */
+	readonly inputs: readonly GtmSkillIo[];
+	/** Data keys the Skill is responsible for producing. */
+	readonly outputs: readonly GtmSkillIo[];
+	/**
+	 * Tool families the Skill expects to be granted, as an allowlist hint.
+	 * Advisory, not enforcement: actual grants come from the Agent's
+	 * permissions and the plugin capability grants. An empty array means the
+	 * Skill needs no tools beyond the model itself.
+	 */
+	readonly allowedTools: readonly string[];
+	/** SKILL.md body — the instruction text injected into the AI call. */
+	readonly body: string;
+}
+
+const VERSION = '1.0.0';
+
+/**
+ * The catalog.
+ *
+ * Ordered by pipeline stage so the list reads as the campaign lifecycle.
+ * Every slug referenced by an Agent template MUST appear here — the
+ * catalog-integrity suite in `@ever-works/agent` fails the build otherwise.
+ */
+export const GTM_SKILLS: readonly GtmSkillDefinition[] = [
+	// ── research ────────────────────────────────────────────────────────
+	{
+		slug: 'lead-research',
+		title: 'Lead research',
+		description:
+			'Build a candidate lead list from seed criteria and public sources, recording a supporting source for every contact.',
+		stage: 'research',
+		tags: ['gtm', 'sales', 'research'],
+		version: VERSION,
+		inputs: [
+			{ key: 'icp', description: 'Ideal-customer description: segment, size, geography, role titles.' },
+			{ key: 'seed_sources', description: 'Seed lists, domains, or saved searches to start from.' },
+			{ key: 'max_leads', description: 'Hard cap on how many candidates this run may collect.' }
+		],
+		outputs: [
+			{ key: 'contacts', description: 'Candidate contacts with name, company, title, and a source reference.' }
+		],
+		allowedTools: ['search', 'content-extractor'],
+		body: [
+			'Build a candidate lead list from the supplied criteria and seed sources.',
+			'',
+			'## Rules',
+			'- NEVER invent a contact detail. An email address, phone number, or title is recorded only',
+			'  when a source supports it; otherwise leave the field empty.',
+			'- Record `source` on every contact — the URL or seed list the entry came from. A contact',
+			'  without a source is not a lead, it is a guess.',
+			'- Respect `max_leads` exactly. Stop collecting when the cap is reached and say how many',
+			'  candidates were left unexamined.',
+			'- De-duplicate by email when present, otherwise by (company, name).',
+			'- Exclude anyone who has asked not to be contacted, and any source that forbids collection.',
+			'',
+			'## Output',
+			'Write `contacts`. Each entry carries `name`, and any of `email`, `company`, `title`,',
+			'`source`, `notes` that a source supports. Report the counts examined, kept, and dropped,',
+			'with the reason for each drop category.'
+		].join('\n')
+	},
+	{
+		slug: 'competitor-watch',
+		title: 'Competitor watch',
+		description:
+			'Monitor a watchlist of companies across public sources and emit dated, source-linked change signals.',
+		stage: 'research',
+		tags: ['gtm', 'marketing', 'research'],
+		version: VERSION,
+		inputs: [
+			{ key: 'watchlist', description: 'Companies to monitor: name, website, public repositories.' },
+			{ key: 'focus_areas', description: 'What to watch: pricing, features, positioning, hiring.' },
+			{ key: 'since', description: 'Only report changes observed after this date.' }
+		],
+		outputs: [{ key: 'signals', description: 'Dated observations with a source URL and the focus area they hit.' }],
+		allowedTools: ['search', 'content-extractor'],
+		body: [
+			'Monitor the watchlist across public sources and report what changed.',
+			'',
+			'## Rules',
+			'- Public sources only: published pages, public announcements, public repositories.',
+			'- Every signal carries a source URL and an observation date. No date or no URL means the',
+			'  signal is not reportable.',
+			'- Separate FACT (what the source says) from ANALYSIS (what you infer). Never blend them in',
+			'  the same sentence.',
+			'- Report only changes since `since`. If a focus area produced nothing, say so explicitly —',
+			'  an empty period is a finding, not a gap to fill.',
+			'- Do not speculate about unannounced plans, internal metrics, or private information.',
+			'',
+			'## Output',
+			'Write `signals`. Each entry carries `title`, `url`, `publishedDate`, the focus area, and a',
+			'one-line factual summary.'
+		].join('\n')
+	},
+	{
+		slug: 'news-signal-detection',
+		title: 'News signal detection',
+		description:
+			'Scan configured topics for newsworthy events and rank them by relevance to the campaign, discarding noise.',
+		stage: 'research',
+		tags: ['gtm', 'marketing', 'research'],
+		version: VERSION,
+		inputs: [
+			{ key: 'topics', description: 'Topics, keywords, or accounts to scan.' },
+			{ key: 'lookback_days', description: 'How far back the scan reaches.' },
+			{ key: 'relevance_threshold', description: 'Minimum relevance (0-1) an item must clear to be kept.' }
+		],
+		outputs: [{ key: 'signals', description: 'Relevance-ranked news items with source URL and publish date.' }],
+		allowedTools: ['search', 'content-extractor'],
+		body: [
+			'Scan the configured topics and keep only what is genuinely newsworthy for this campaign.',
+			'',
+			'## Rules',
+			'- Score each candidate 0-1 for relevance to the campaign brief and drop anything below',
+			'  `relevance_threshold`. State the score and the one-line reason for every item you keep.',
+			'- Prefer primary sources over aggregators; when both exist, link the primary.',
+			'- Collapse duplicate coverage of the same event into one signal with the best source.',
+			'- Nothing older than `lookback_days`. Undated items are dropped, not guessed at.',
+			'- Never restate a headline as fact when the source hedges it — carry the hedge through.',
+			'',
+			'## Output',
+			'Write `signals` ordered by descending relevance, each with `title`, `url`, `publishedDate`,',
+			'the relevance score, and the reason it matters here.'
+		].join('\n')
+	},
+
+	// ── qualify ─────────────────────────────────────────────────────────
+	{
+		slug: 'lead-scoring',
+		title: 'Lead scoring',
+		description:
+			'Score contacts 0-100 against a declarative weight table and attach an explainable reason per point awarded.',
+		stage: 'qualify',
+		tags: ['gtm', 'sales', 'scoring'],
+		version: VERSION,
+		inputs: [
+			{ key: 'contacts', description: 'Candidate contacts to score.' },
+			{ key: 'score_weights', description: 'Weight table: signal name → points awarded.' }
+		],
+		outputs: [
+			{ key: 'scored_contacts', description: 'Contacts with `score` (0-100) and `scoreReasons` per contact.' }
+		],
+		allowedTools: [],
+		body: [
+			'Score every contact against the supplied weight table.',
+			'',
+			'## Rules',
+			'- The weight table is the whole model. Award points ONLY for signals it names; never invent',
+			'  a bonus, and never award points for a signal the contact data does not actually support.',
+			'- Clamp the final score to 0-100. Record one `scoreReasons` line per point awarded, in the',
+			'  form `<signal> +<points>`, so any score can be re-derived by hand.',
+			'- A missing field is worth zero points, never an assumed value.',
+			'- Scoring is deterministic: the same contact and the same weight table must always produce',
+			'  the same score. Do not break ties with judgement calls — leave ties tied.',
+			'',
+			'## Output',
+			'Write `scored_contacts` sorted by descending score, then report the score distribution and',
+			'the three signals that moved the list most.'
+		].join('\n')
+	},
+	{
+		slug: 'risk-filter',
+		title: 'Risk filter',
+		description:
+			'Flag low-quality or unsafe contacts against a risk weight table and exclude those at or above the threshold.',
+		stage: 'qualify',
+		tags: ['gtm', 'sales', 'safety'],
+		version: VERSION,
+		inputs: [
+			{ key: 'scored_contacts', description: 'Contacts already carrying a priority score.' },
+			{ key: 'risk_weights', description: 'Risk weight table: risk signal → points.' },
+			{ key: 'risk_threshold', description: 'Risk score at or above which a contact is excluded.' }
+		],
+		outputs: [
+			{
+				key: 'scored_contacts',
+				description: 'The same contacts, now carrying `riskScore`, `riskReasons`, and an excluded flag.'
+			}
+		],
+		allowedTools: [],
+		body: [
+			'Assess each scored contact for risk and mark — never silently delete — the excluded ones.',
+			'',
+			'## Rules',
+			'- Apply the risk weight table exactly as given; record one `riskReasons` line per point.',
+			'- Contacts at or above `risk_threshold` are EXCLUDED from outbound, but they stay in the',
+			'  data set with their reasons attached so a human can overturn the call.',
+			'- Never drop a contact without a recorded reason. "Looked wrong" is not a reason.',
+			'- Risk is about deliverability and safety (unverifiable identity, throwaway domains,',
+			'  do-not-contact signals) — it is not a second opinion on fit. Fit is `lead-scoring`.',
+			'',
+			'## Output',
+			'Write the enriched `scored_contacts` and report how many were excluded, grouped by the',
+			'dominant risk reason.'
+		].join('\n')
+	},
+
+	// ── draft ───────────────────────────────────────────────────────────
+	{
+		slug: 'outreach-personalization',
+		title: 'Outreach personalization',
+		description:
+			'Write one 80-120 word personalized outbound draft per qualified contact, grounded only in known facts.',
+		stage: 'draft',
+		tags: ['gtm', 'sales', 'writing'],
+		version: VERSION,
+		inputs: [
+			{ key: 'scored_contacts', description: 'Qualified, non-excluded contacts to write for.' },
+			{ key: 'campaign_brief', description: 'Offer, proof points, and the single ask.' },
+			{ key: 'tone', description: 'Configured tone for the campaign.' }
+		],
+		outputs: [{ key: 'drafts', description: 'One draft per contact with `ref`, `channel`, `subject`, `body`.' }],
+		allowedTools: [],
+		body: [
+			'Write one outbound draft per qualified contact.',
+			'',
+			'## Rules',
+			'- HARD CONSTRAINT: drafts only. Nothing is sent, scheduled, or queued for delivery here.',
+			'- 80-120 words in the body. One ask. No multi-part asks, no "quick question" openers that',
+			'  the rest of the message contradicts.',
+			'- Personalize ONLY from fields and signals actually present on the contact. If there is no',
+			'  personalization material, write the generic version and say so — a fabricated detail is',
+			'  worse than a generic opener.',
+			'- Write a subject line only for channels that carry one.',
+			'- No invented metrics, customer names, or mutual connections. Ever.',
+			'',
+			'## Output',
+			'Write `drafts`, ordered by descending contact score so the review gate sees the best',
+			'candidates first. Each draft carries a stable `ref` used later by review and the action log.'
+		].join('\n')
+	},
+	{
+		slug: 'newsletter-drafting',
+		title: 'Newsletter drafting',
+		description:
+			'Turn briefs, notes, and collected signals into a scannable newsletter issue with one clear call to action.',
+		stage: 'draft',
+		tags: ['gtm', 'marketing', 'content', 'writing'],
+		version: VERSION,
+		inputs: [
+			{ key: 'campaign_brief', description: 'Issue theme, audience, and the call to action.' },
+			{ key: 'signals', description: 'Collected source material for the issue.' },
+			{ key: 'tone', description: 'Configured editorial tone.' }
+		],
+		outputs: [{ key: 'drafts', description: 'A single newsletter draft: subject line plus sectioned body.' }],
+		allowedTools: ['content-extractor'],
+		body: [
+			'Draft one newsletter issue from the brief and the collected material.',
+			'',
+			'## Rules',
+			'- Draft-first: the issue is produced for human review. Never send or schedule it.',
+			'- Structure: subject line, one-sentence hook, 3-5 short sections, one call to action.',
+			'  Scannable beats comprehensive.',
+			'- Every claim traces to the brief, the knowledge base, or a supplied signal. Link the',
+			'  source when the section rests on one.',
+			'- Never invent metrics, quotes, or customer names.',
+			'- When the source material is thin, say so and list what extra input would raise quality',
+			'  rather than padding the issue.',
+			'',
+			'## Output',
+			'Write `drafts` with a single entry: `subject` plus the sectioned `body`.'
+		].join('\n')
+	},
+	{
+		slug: 'social-scheduling',
+		title: 'Social scheduling',
+		description:
+			'Plan a channel-fit social calendar and stage each post for review, respecting cadence and angle variety.',
+		stage: 'draft',
+		tags: ['gtm', 'marketing', 'social', 'writing'],
+		version: VERSION,
+		inputs: [
+			{ key: 'campaign_brief', description: 'Campaign themes, channels, and cadence.' },
+			{ key: 'signals', description: 'Source material and trends to build posts from.' },
+			{ key: 'cadence', description: 'Posts per channel per period.' }
+		],
+		outputs: [
+			{ key: 'drafts', description: 'Channel-fit post drafts, each with its planned slot in the calendar.' }
+		],
+		allowedTools: [],
+		body: [
+			'Plan the social calendar for the cadence window and draft each post.',
+			'',
+			'## Rules',
+			'- Draft-first: posts are STAGED for review. Never publish, never schedule to a live channel.',
+			'- Fit each draft to its channel: length, hashtag conventions, and link placement differ and',
+			'  a cross-posted body is a tell.',
+			'- Do not repeat the same angle inside one cadence window. Track the angle per slot and vary',
+			'  it deliberately.',
+			'- Build only from the brief, the content Works, and supplied signals. Never invent product',
+			'  claims or engagement numbers.',
+			'- Respect `cadence` exactly — proposing more slots than the operator configured is not',
+			'  ambition, it is a spam risk.',
+			'',
+			'## Output',
+			'Write `drafts` with the planned slot (channel + relative day) on each entry, plus a compact',
+			'calendar view of the window.'
+		].join('\n')
+	},
+	{
+		slug: 'digest-compilation',
+		title: 'Digest compilation',
+		description:
+			'Compile collected signals into a recurring digest that separates facts from analysis and highlights change.',
+		stage: 'draft',
+		tags: ['gtm', 'marketing', 'reporting', 'writing'],
+		version: VERSION,
+		inputs: [
+			{ key: 'signals', description: 'Signals collected this period.' },
+			{ key: 'previous_digest', description: 'The prior issue, used to compute what changed.' },
+			{ key: 'focus_areas', description: 'Sections the digest must cover.' }
+		],
+		outputs: [{ key: 'drafts', description: 'A digest draft: sections, change highlights, and a trend view.' }],
+		allowedTools: [],
+		body: [
+			'Compile the period digest from the collected signals.',
+			'',
+			'## Rules',
+			'- One section per focus area, in the configured order, every issue. A stable shape is what',
+			'  makes a recurring digest readable.',
+			'- Every section splits FACTS (sourced, dated, linked) from ANALYSIS (your interpretation),',
+			'  under those labels.',
+			'- Lead with what CHANGED since `previous_digest`. Unchanged areas get one line, not a',
+			'  restatement of last issue.',
+			'- No fabrication and no padding: if a focus area produced no signal this period, write',
+			'  exactly that.',
+			'- Close with a short trend view over the recent periods — direction, not prophecy.',
+			'',
+			'## Output',
+			'Write `drafts` with a single digest entry for review.'
+		].join('\n')
+	},
+
+	// ── act ─────────────────────────────────────────────────────────────
+	{
+		slug: 'crm-sync-hygiene',
+		title: 'CRM sync hygiene',
+		description:
+			'Prepare reviewed records for a customer-record sync: normalized fields, no duplicates, no destructive overwrites.',
+		stage: 'act',
+		tags: ['gtm', 'sales', 'operations'],
+		version: VERSION,
+		inputs: [
+			{ key: 'approved_drafts', description: 'Records cleared by the review gate.' },
+			{ key: 'field_map', description: 'Local field → destination field mapping.' }
+		],
+		outputs: [
+			{ key: 'action_log', description: 'Prepared record writes with the field diff and the reason for each.' }
+		],
+		allowedTools: ['connector'],
+		body: [
+			'Prepare reviewed records for the destination system without losing data.',
+			'',
+			'## Rules',
+			'- Only records that passed the review gate are eligible. Nothing else, no exceptions.',
+			'- NEVER overwrite a populated destination field with an empty local value. Blank does not',
+			'  mean "clear it", it means "we do not know".',
+			'- Match before you create: search by the destination key (email, then domain + name) and',
+			'  update the existing record rather than minting a duplicate.',
+			'- Normalize on the way out — casing, phone format, domain form — per `field_map`.',
+			'- Record every intended write in `action_log` with its field-level diff BEFORE it is',
+			'  applied, so the change is auditable and reversible.',
+			'',
+			'## Output',
+			'Write `action_log` with one entry per record, status `prepared` or `skipped`, and the',
+			'reason for every skip.'
+		].join('\n')
+	},
+
+	// ── follow-up ───────────────────────────────────────────────────────
+	{
+		slug: 'follow-up-cadence',
+		title: 'Follow-up cadence',
+		description:
+			'Schedule timed re-engagement for quiet threads, with strict caps and an unconditional stop on any reply.',
+		stage: 'follow-up',
+		tags: ['gtm', 'sales', 'cadence'],
+		version: VERSION,
+		inputs: [
+			{ key: 'action_log', description: 'What was prepared, for whom, and when.' },
+			{ key: 'reply_state', description: 'Which threads have received a reply.' },
+			{ key: 'cadence', description: 'Follow-up spacing and the maximum number of touches.' }
+		],
+		outputs: [
+			{ key: 'follow_up_queue', description: 'Queued follow-ups with a due offset and the rationale for each.' }
+		],
+		allowedTools: [],
+		body: [
+			'Queue follow-ups for threads that have gone quiet.',
+			'',
+			'## Rules',
+			'- HARD STOP on any reply, bounce, or opt-out: that thread leaves the cadence immediately and',
+			'  permanently. This overrides every other rule here.',
+			'- Never exceed the configured maximum touches per contact, and never shorten the configured',
+			'  spacing to fit more in.',
+			'- Each follow-up must add something — a new angle, a new proof point, a genuine deadline.',
+			'  "Bumping this to the top of your inbox" is not a follow-up.',
+			'- Follow-ups are drafts like any other outbound: they re-enter the review gate before',
+			'  anything is prepared for delivery.',
+			'',
+			'## Output',
+			'Write `follow_up_queue` with `draftRef`, `channel`, `dueAfterDays`, and the rationale.'
+		].join('\n')
+	},
+	{
+		slug: 'reply-detection',
+		title: 'Reply detection',
+		description:
+			'Classify inbound replies into interested / not-now / decline / opt-out and route each to the right next step.',
+		stage: 'follow-up',
+		tags: ['gtm', 'sales', 'classification'],
+		version: VERSION,
+		inputs: [
+			{ key: 'inbound_messages', description: 'Replies received against prepared outbound.' },
+			{ key: 'action_log', description: 'The outbound each reply responds to.' }
+		],
+		outputs: [
+			{ key: 'reply_state', description: 'Per-thread classification, confidence, and the routing decision.' }
+		],
+		allowedTools: ['connector'],
+		body: [
+			'Classify each inbound reply and decide what happens to its thread.',
+			'',
+			'## Classes',
+			'`interested` · `not_now` · `decline` · `opt_out` · `auto_reply` · `unclear`',
+			'',
+			'## Rules',
+			'- `opt_out` and `decline` stop the cadence permanently. When in doubt between `opt_out` and',
+			'  anything else, choose `opt_out` — the cost of a wrong stop is far below the cost of a',
+			'  wrong send.',
+			'- `auto_reply` (out-of-office, autoresponder) does NOT count as a reply for cadence',
+			'  purposes, but it does update the contact record if it names a new owner.',
+			'- Use `unclear` rather than guessing; unclear threads route to a human, they do not route',
+			'  to the next touch.',
+			'- Record a confidence value and the phrase that drove the classification.',
+			'',
+			'## Output',
+			'Write `reply_state` with the class, confidence, evidence phrase, and routing decision per',
+			'thread.'
+		].join('\n')
+	},
+
+	// ── enrich ──────────────────────────────────────────────────────────
+	{
+		slug: 'contact-enrichment',
+		title: 'Contact enrichment',
+		description:
+			'Backfill missing contact and account fields from verifiable sources, recording the evidence for each fill.',
+		stage: 'enrich',
+		tags: ['gtm', 'sales', 'data'],
+		version: VERSION,
+		inputs: [
+			{ key: 'contacts', description: 'Contacts with gaps to fill.' },
+			{ key: 'enrichment_fields', description: 'Which fields this run is allowed to fill.' }
+		],
+		outputs: [
+			{ key: 'enriched_contacts', description: 'Contacts with filled fields and a source note per filled field.' }
+		],
+		allowedTools: ['search', 'content-extractor', 'connector'],
+		body: [
+			'Fill the requested gaps on each contact — and only those gaps.',
+			'',
+			'## Rules',
+			'- Evidence-bound: a field is filled ONLY when a source supports it, and the source goes in',
+			'  the contact notes alongside the value. No source, no fill.',
+			'- NEVER guess or pattern-generate an email address. Constructing `first.last@domain` because',
+			'  it usually works is fabrication, and it is the single most damaging thing this Skill can do.',
+			'- Never overwrite an existing non-empty value. Enrichment fills gaps; corrections are a',
+			'  human decision.',
+			'- Only touch fields named in `enrichment_fields`.',
+			'- When two sources disagree, leave the field empty and flag the conflict.',
+			'',
+			'## Output',
+			'Write `enriched_contacts` and report fill rate per field plus every conflict flagged.'
+		].join('\n')
+	},
+
+	// ── measure ─────────────────────────────────────────────────────────
+	{
+		slug: 'seo-audit',
+		title: 'Search-visibility audit',
+		description:
+			'Audit a site or content Work for search visibility and return a prioritized, evidence-cited fix list.',
+		stage: 'measure',
+		tags: ['gtm', 'marketing', 'seo', 'audit'],
+		version: VERSION,
+		inputs: [
+			{ key: 'pages', description: 'Pages or posts in scope, with their current metadata and headings.' },
+			{ key: 'target_keywords', description: 'Keywords or topics the Work is meant to rank for.' },
+			{ key: 'previous_audit', description: 'The prior audit, used to report movement and regressions.' }
+		],
+		outputs: [
+			{ key: 'campaign_report', description: 'Prioritized findings with page reference, impact, and fix.' }
+		],
+		allowedTools: ['content-extractor', 'search'],
+		body: [
+			'Audit the in-scope pages for search visibility and propose fixes.',
+			'',
+			'## What to check',
+			'Title and description metadata · heading structure and hierarchy · internal linking and',
+			'orphan pages · keyword coverage against `target_keywords` and the gaps between them ·',
+			'duplicate or thin content · canonical and indexability signals.',
+			'',
+			'## Rules',
+			'- Every finding cites the specific page or setting it applies to and states the expected',
+			'  impact. A finding without a page reference is an opinion.',
+			'- Return a prioritized top 5-10, quick wins first — not an exhaustive dump.',
+			'- Propose changes as reviewable edits or tasks. Never modify published pages directly.',
+			'- When `previous_audit` is present, report movement honestly, INCLUDING regressions. A',
+			'  clean report that hides a regression is worse than no report.',
+			'- No traffic or ranking projections. Estimate effort and impact qualitatively instead.',
+			'',
+			'## Output',
+			'Write `campaign_report` with the prioritized findings and the movement summary.'
+		].join('\n')
+	},
+	{
+		slug: 'campaign-reporting',
+		title: 'Campaign reporting',
+		description:
+			'Summarize a campaign period into counted totals, honest insights, and concrete hints for the next cycle.',
+		stage: 'measure',
+		tags: ['gtm', 'reporting'],
+		version: VERSION,
+		inputs: [
+			{ key: 'action_log', description: 'What the campaign prepared and skipped.' },
+			{ key: 'reply_state', description: 'How recipients responded.' },
+			{ key: 'scored_contacts', description: 'The qualified population the period worked from.' }
+		],
+		outputs: [{ key: 'campaign_report', description: 'Totals, insights, and next-cycle variant hints.' }],
+		allowedTools: [],
+		body: [
+			'Report the campaign period and close the loop into the next one.',
+			'',
+			'## Rules',
+			'- Totals are COUNTED from the supplied data, never estimated: contacts, qualified, excluded,',
+			'  drafts, approved, prepared, follow-ups queued.',
+			'- State the denominator on every rate. A percentage without its base is not a metric.',
+			'- Below roughly 30 observations, report counts and refuse to draw a conclusion — small',
+			'  samples produce confident nonsense.',
+			'- Insights must be falsifiable and tied to a number in the totals.',
+			'- End with `nextVariantHints`: concrete, testable changes for the next draft cycle, one per',
+			'  line. This is the loop closing — a report that ends at description wasted the period.',
+			'',
+			'## Output',
+			'Write `campaign_report` with `summary`, `totals`, `insights`, and `nextVariantHints`.'
+		].join('\n')
+	},
+	{
+		slug: 'engagement-analysis',
+		title: 'Engagement analysis',
+		description: 'Compare engagement across variants, channels, and segments, and say which differences are real.',
+		stage: 'measure',
+		tags: ['gtm', 'marketing', 'reporting'],
+		version: VERSION,
+		inputs: [
+			{ key: 'engagement_events', description: 'Per-item engagement observations for the period.' },
+			{ key: 'drafts', description: 'The variants the events belong to.' },
+			{ key: 'comparison_window', description: 'Prior period to compare against.' }
+		],
+		outputs: [
+			{ key: 'campaign_report', description: 'Per-variant and per-segment engagement with a confidence call.' }
+		],
+		allowedTools: ['metrics'],
+		body: [
+			'Analyze engagement and report what actually differs.',
+			'',
+			'## Rules',
+			'- Compare like with like: same channel, same audience segment, comparable send window.',
+			'  Cross-channel comparisons need an explicit caveat.',
+			'- Report absolute counts alongside every rate.',
+			'- Say plainly when a difference is within noise. Declaring a winner on a handful of',
+			'  observations is the most common way this analysis misleads a campaign for months.',
+			'- Separate what changed (observation) from why (hypothesis), and label hypotheses as such.',
+			'- Surface the losing variants too — a variant that consistently underperforms is the',
+			'  cheapest thing to stop doing.',
+			'',
+			'## Output',
+			'Write `campaign_report` with the per-variant table, the segment breakdown, and an explicit',
+			'confidence statement per comparison.'
+		].join('\n')
+	}
+] as const;
+
+/** Every slug in the first-party go-to-market Skill catalog. */
+export const GTM_SKILL_SLUGS: readonly string[] = GTM_SKILLS.map((skill) => skill.slug);
+
+const GTM_SKILL_BY_SLUG: ReadonlyMap<string, GtmSkillDefinition> = new Map(
+	GTM_SKILLS.map((skill) => [skill.slug, skill])
+);
+
+/** The full catalog, in declared (pipeline-stage) order. */
+export function listGtmSkills(): readonly GtmSkillDefinition[] {
+	return GTM_SKILLS;
+}
+
+/** One Skill by slug; `undefined` when the slug is unknown. NEVER throws. */
+export function getGtmSkill(slug?: string | null): GtmSkillDefinition | undefined {
+	return typeof slug === 'string' ? GTM_SKILL_BY_SLUG.get(slug.trim().toLowerCase()) : undefined;
+}
+
+/** True when `slug` names a first-party go-to-market Skill. */
+export function isGtmSkillSlug(slug?: string | null): boolean {
+	return getGtmSkill(slug) !== undefined;
+}
+
+/** Skills powering a given go-to-market stage, in declared order. */
+export function listGtmSkillsForStage(stage: GtmSkillStage): readonly GtmSkillDefinition[] {
+	return GTM_SKILLS.filter((skill) => skill.stage === stage);
+}

--- a/packages/contracts/src/skills/index.ts
+++ b/packages/contracts/src/skills/index.ts
@@ -1,0 +1,1 @@
+export * from './gtm-skills.js';

--- a/packages/plugins/everworks-skills/package.json
+++ b/packages/plugins/everworks-skills/package.json
@@ -30,6 +30,7 @@
 		"test:coverage": "vitest run --coverage"
 	},
 	"dependencies": {
+		"@ever-works/contracts": "workspace:*",
 		"@ever-works/plugin": "workspace:*",
 		"gray-matter": "^4.0.3"
 	},

--- a/packages/plugins/everworks-skills/src/everworks-skills.plugin.spec.ts
+++ b/packages/plugins/everworks-skills/src/everworks-skills.plugin.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EverWorksSkillsPlugin } from './everworks-skills.plugin.js';
+import { GTM_CATALOG_ENTRIES } from './gtm-catalog.js';
 
 function textResponse(body: string, status = 200): Response {
 	return {
@@ -176,9 +177,14 @@ A skill for creating new skills, defaulting cron to UTC.`;
 		expect(entry?.body).not.toContain('---');
 	});
 
-	it('lists the live catalog entries', async () => {
+	it('lists the live catalog entries first, then the first-party pack', async () => {
 		const result = await plugin.listEntries({ limit: 50, offset: 0 });
-		expect(result.total).toBe(1);
+		// The served manifest entry leads; the compiled-in go-to-market pack
+		// is merged underneath it so template-suggested Skills always resolve.
 		expect(result.entries[0].slug).toBe('skill-creator');
+		expect(result.total).toBe(1 + GTM_CATALOG_ENTRIES.length);
+		expect(result.entries.map((e) => e.slug)).toEqual(
+			expect.arrayContaining(['skill-creator', 'lead-scoring', 'outreach-personalization'])
+		);
 	});
 });

--- a/packages/plugins/everworks-skills/src/everworks-skills.plugin.ts
+++ b/packages/plugins/everworks-skills/src/everworks-skills.plugin.ts
@@ -14,6 +14,8 @@ import type {
 
 import matter from 'gray-matter';
 
+import { mergeGtmCatalog } from './gtm-catalog.js';
+
 const RAW_CONTENT_BASE = 'https://raw.githubusercontent.com';
 const DEFAULT_CATALOG_REPO = 'ever-works/skills';
 const DEFAULT_CATALOG_BRANCH = 'main';
@@ -51,6 +53,14 @@ interface SkillsManifestRow {
  * malformed) the loader falls back to the small `BUILTIN_CATALOG`
  * below so the plugin always returns SOMETHING — the platform
  * self-recovers when the repo becomes reachable again.
+ *
+ * On TOP of either source, the first-party go-to-market Skill pack
+ * (`GTM_CATALOG_ENTRIES`, defined in `@ever-works/contracts`) is always
+ * merged in. Those Skills are the ones the prebuilt Agent templates name
+ * by slug, so they cannot be allowed to depend on a network fetch — an
+ * activated template whose suggested Skills resolve to nothing is a
+ * broken template. The merge keeps served entries on a slug collision,
+ * so the catalog repo can still revise a first-party Skill.
  */
 const BUILTIN_CATALOG: SkillCatalogEntry[] = [
 	{
@@ -193,8 +203,8 @@ export class EverWorksSkillsPlugin implements IPlugin, ISkillsProviderPlugin {
 			if (entries.length === 0) {
 				throw new Error('catalog manifest yielded no entries');
 			}
-			this.cache = { entries, fetchedAt: now };
-			return entries;
+			this.cache = { entries: mergeGtmCatalog(entries), fetchedAt: now };
+			return this.cache.entries;
 		} catch (err) {
 			// Fall back to the builtin catalog on ANY failure (network,
 			// non-200, malformed manifest/frontmatter) so the plugin
@@ -205,7 +215,7 @@ export class EverWorksSkillsPlugin implements IPlugin, ISkillsProviderPlugin {
 				`Ever Works Skills: catalog fetch from ${repo}@${branch} failed; using builtin fallback. ` +
 					`${err instanceof Error ? err.message : String(err)}`
 			);
-			this.cache = { entries: BUILTIN_CATALOG.slice(), fetchedAt: now };
+			this.cache = { entries: mergeGtmCatalog(BUILTIN_CATALOG.slice()), fetchedAt: now };
 			return this.cache.entries;
 		}
 	}

--- a/packages/plugins/everworks-skills/src/gtm-catalog.spec.ts
+++ b/packages/plugins/everworks-skills/src/gtm-catalog.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { GTM_SKILLS } from '@ever-works/contracts';
+import type { SkillCatalogEntry } from '@ever-works/plugin';
+import { GTM_CATALOG_ENTRIES, buildGtmSkillBody, mergeGtmCatalog, toSkillCatalogEntry } from './gtm-catalog.js';
+import { EverWorksSkillsPlugin } from './everworks-skills.plugin.js';
+
+function stubEntry(slug: string, overrides: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry {
+	return {
+		slug,
+		title: `stub ${slug}`,
+		description: 'stub',
+		frontmatter: { name: slug, description: 'stub' },
+		body: 'stub body',
+		version: '9.9.9',
+		tags: [],
+		...overrides
+	};
+}
+
+describe('GTM catalog projection', () => {
+	it('projects every first-party skill into a catalog entry', () => {
+		expect(GTM_CATALOG_ENTRIES).toHaveLength(GTM_SKILLS.length);
+		expect(GTM_CATALOG_ENTRIES.map((e) => e.slug)).toEqual(GTM_SKILLS.map((s) => s.slug));
+	});
+
+	it('carries the declared IO contract into the entry body and frontmatter', () => {
+		const skill = GTM_SKILLS.find((s) => s.slug === 'lead-scoring');
+		expect(skill).toBeDefined();
+		const entry = toSkillCatalogEntry(skill!);
+		expect(entry.body).toContain('## Inputs');
+		expect(entry.body).toContain('## Outputs');
+		expect(entry.body).toContain('`score_weights`');
+		expect(entry.frontmatter.inputs).toEqual(['contacts', 'score_weights']);
+		expect(entry.frontmatter.outputs).toEqual(['scored_contacts']);
+		expect(entry.frontmatter.stage).toBe('qualify');
+	});
+
+	it('keeps the instruction text intact under the contract tables', () => {
+		for (const skill of GTM_SKILLS) {
+			const body = buildGtmSkillBody(skill);
+			expect(body).toContain('## Instructions');
+			expect(body.endsWith(skill.body)).toBe(true);
+		}
+	});
+
+	it('renders an empty IO list without emitting a broken table', () => {
+		const entry = toSkillCatalogEntry({
+			...GTM_SKILLS[0]!,
+			slug: 'io-less',
+			inputs: [],
+			outputs: []
+		});
+		expect(entry.body).toContain('_None._');
+		expect(entry.body).not.toContain('| --- |');
+	});
+
+	it('copies tags and allowedTools into the entry rather than sharing the frozen arrays', () => {
+		const skill = GTM_SKILLS.find((s) => s.slug === 'contact-enrichment')!;
+		const entry = toSkillCatalogEntry(skill);
+		expect(entry.tags).toEqual([...skill.tags]);
+		expect(entry.tags).not.toBe(skill.tags);
+		expect(entry.frontmatter.allowedTools).toEqual([...skill.allowedTools]);
+	});
+});
+
+describe('mergeGtmCatalog', () => {
+	it('adds the whole pack to an empty catalog', () => {
+		expect(mergeGtmCatalog([]).map((e) => e.slug)).toEqual(GTM_CATALOG_ENTRIES.map((e) => e.slug));
+	});
+
+	it('keeps served entries on a slug collision so the catalog repo can revise a skill', () => {
+		const served = stubEntry('lead-scoring', { title: 'Published lead scoring' });
+		const merged = mergeGtmCatalog([served]);
+		const hit = merged.filter((e) => e.slug === 'lead-scoring');
+		expect(hit).toHaveLength(1);
+		expect(hit[0]!.title).toBe('Published lead scoring');
+	});
+
+	it('preserves served-first ordering and appends only the missing pack members', () => {
+		const merged = mergeGtmCatalog([stubEntry('zzz-custom')]);
+		expect(merged[0]!.slug).toBe('zzz-custom');
+		expect(merged).toHaveLength(1 + GTM_CATALOG_ENTRIES.length);
+	});
+});
+
+describe('EverWorksSkillsPlugin serves the first-party pack', () => {
+	let plugin: EverWorksSkillsPlugin;
+
+	beforeEach(async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => {
+				throw new Error('network disabled in test');
+			})
+		);
+		plugin = new EverWorksSkillsPlugin();
+		await plugin.onLoad({
+			logger: { log: () => undefined, warn: () => undefined, error: () => undefined }
+		} as never);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	/**
+	 * The whole reason the pack is a compiled-in floor: an activated Agent
+	 * template whose suggested Skills resolve to nothing is a broken
+	 * template, and that must not depend on the catalog repo being up.
+	 */
+	it('serves every go-to-market skill even when the catalog repo is unreachable', async () => {
+		const result = await plugin.listEntries({ limit: 500, offset: 0 });
+		const slugs = result.entries.map((e) => e.slug);
+		for (const skill of GTM_SKILLS) {
+			expect(slugs, `missing ${skill.slug}`).toContain(skill.slug);
+		}
+		expect(result.total).toBeGreaterThanOrEqual(GTM_SKILLS.length);
+	});
+
+	it('still serves the pre-existing builtin entries alongside the pack', async () => {
+		const result = await plugin.listEntries({ limit: 500, offset: 0 });
+		expect(result.entries.map((e) => e.slug)).toEqual(
+			expect.arrayContaining(['cron-defaults', 'secret-handling', 'commit-message-style'])
+		);
+	});
+
+	it('getEntry resolves a first-party skill by slug', async () => {
+		const entry = await plugin.getEntry('outreach-personalization');
+		expect(entry?.title).toBe('Outreach personalization');
+		expect(entry?.body).toContain('## Inputs');
+	});
+
+	it('filters the pack by tag', async () => {
+		const result = await plugin.listEntries({ limit: 500, offset: 0, tags: ['sales'] });
+		expect(result.entries.length).toBeGreaterThan(0);
+		for (const entry of result.entries) {
+			expect(entry.tags).toContain('sales');
+		}
+	});
+
+	it('finds a first-party skill via search', async () => {
+		const result = await plugin.listEntries({ limit: 500, offset: 0, search: 'newsletter' });
+		expect(result.entries.map((e) => e.slug)).toContain('newsletter-drafting');
+	});
+});

--- a/packages/plugins/everworks-skills/src/gtm-catalog.ts
+++ b/packages/plugins/everworks-skills/src/gtm-catalog.ts
@@ -1,0 +1,84 @@
+import { GTM_SKILLS, type GtmSkillDefinition, type GtmSkillIo } from '@ever-works/contracts';
+import type { SkillCatalogEntry } from '@ever-works/plugin';
+
+/**
+ * First-party go-to-market Skills, projected into catalog entries.
+ *
+ * The Skill DEFINITIONS live in `@ever-works/contracts` because the agent
+ * package references their slugs from the prebuilt Agent templates and the
+ * two packages share no other runtime dependency. This module owns only the
+ * projection into the plugin-facing `SkillCatalogEntry` shape — the same
+ * shape `SKILL.md` files from the catalog repo are parsed into, so the
+ * platform stores, renders, and installs them through exactly one path.
+ *
+ * These entries are a FLOOR, not a ceiling: `EverWorksSkillsPlugin` merges
+ * them under whatever the catalog repo serves, so a published `SKILL.md`
+ * with the same slug wins and the pack can be revised without a deploy.
+ */
+
+/** Render a Skill's declared IO contract as a Markdown table. */
+function ioTable(heading: string, rows: readonly GtmSkillIo[]): string[] {
+	if (rows.length === 0) {
+		return [`## ${heading}`, '', '_None._'];
+	}
+	return [
+		`## ${heading}`,
+		'',
+		'| Key | Meaning |',
+		'| --- | --- |',
+		...rows.map((row) => `| \`${row.key}\` | ${row.description} |`)
+	];
+}
+
+/**
+ * Build the canonical Markdown body for a Skill: the declared input/output
+ * contract first (it is what makes the Skill deterministic about itself),
+ * then the instruction text.
+ */
+export function buildGtmSkillBody(skill: GtmSkillDefinition): string {
+	return [
+		...ioTable('Inputs', skill.inputs),
+		'',
+		...ioTable('Outputs', skill.outputs),
+		'',
+		'## Instructions',
+		'',
+		skill.body
+	].join('\n');
+}
+
+/** Project one Skill definition into a catalog entry. */
+export function toSkillCatalogEntry(skill: GtmSkillDefinition): SkillCatalogEntry {
+	return {
+		slug: skill.slug,
+		title: skill.title,
+		description: skill.description,
+		frontmatter: {
+			name: skill.slug,
+			description: skill.description,
+			tags: [...skill.tags],
+			allowedTools: [...skill.allowedTools],
+			// Extra keys are preserved verbatim by the platform, so the
+			// stage + IO contract survive install and stay inspectable.
+			stage: skill.stage,
+			inputs: skill.inputs.map((io) => io.key),
+			outputs: skill.outputs.map((io) => io.key)
+		},
+		body: buildGtmSkillBody(skill),
+		version: skill.version,
+		tags: [...skill.tags]
+	};
+}
+
+/** The whole first-party go-to-market pack as catalog entries. */
+export const GTM_CATALOG_ENTRIES: SkillCatalogEntry[] = GTM_SKILLS.map(toSkillCatalogEntry);
+
+/**
+ * Union `entries` with the first-party pack, keeping `entries` on a slug
+ * collision. Order is stable: served entries first, then the pack members
+ * that were missing.
+ */
+export function mergeGtmCatalog(entries: SkillCatalogEntry[]): SkillCatalogEntry[] {
+	const seen = new Set(entries.map((entry) => entry.slug));
+	return [...entries, ...GTM_CATALOG_ENTRIES.filter((entry) => !seen.has(entry.slug))];
+}

--- a/packages/plugins/everworks-skills/src/index.ts
+++ b/packages/plugins/everworks-skills/src/index.ts
@@ -1,2 +1,3 @@
 export { EverWorksSkillsPlugin } from './everworks-skills.plugin.js';
 export { EverWorksSkillsPlugin as default } from './everworks-skills.plugin.js';
+export { GTM_CATALOG_ENTRIES, buildGtmSkillBody, mergeGtmCatalog, toSkillCatalogEntry } from './gtm-catalog.js';

--- a/packages/plugins/everworks-skills/tsup.config.ts
+++ b/packages/plugins/everworks-skills/tsup.config.ts
@@ -2,7 +2,12 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
 	entry: ['src/index.ts'],
-	noExternal: ['@ever-works/plugin'],
+	// `@ever-works/contracts` is bundled, not merely externalised as the
+	// sibling plugins do: this plugin imports RUNTIME VALUES from it (the
+	// first-party go-to-market Skill pack), not just types, so the pack has
+	// to travel inside the plugin bundle rather than depend on the loader's
+	// module resolution.
+	noExternal: ['@ever-works/plugin', '@ever-works/contracts'],
 	format: ['cjs', 'esm'],
 	dts: true,
 	clean: true,

--- a/packages/plugins/gtm-pipeline/package.json
+++ b/packages/plugins/gtm-pipeline/package.json
@@ -39,6 +39,7 @@
 		"@ever-works/plugin": "workspace:*"
 	},
 	"devDependencies": {
+		"@ever-works/contracts": "workspace:*",
 		"@ever-works/plugin": "workspace:*",
 		"@types/node": "^22.0.0",
 		"tsup": "^8.0.0",

--- a/packages/plugins/gtm-pipeline/src/__tests__/gtm-skills-parity.spec.ts
+++ b/packages/plugins/gtm-pipeline/src/__tests__/gtm-skills-parity.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { GTM_SKILLS, GTM_SKILL_STAGES, listGtmSkillsForStage } from '@ever-works/contracts';
+import { GTM_STAGE_IDS } from '../types.js';
+
+/**
+ * Stage-vocabulary parity pin.
+ *
+ * The first-party go-to-market Skills declare which stage they power, but
+ * they live in `@ever-works/contracts` — BELOW this plugin in the dependency
+ * graph — so the stage list is spelled out in both places rather than
+ * imported. That duplication is only safe while something fails when the two
+ * drift apart. This is that something.
+ *
+ * A drifted vocabulary is quiet and expensive: a Skill would declare a stage
+ * this pipeline never runs, and it would simply never be reached.
+ */
+describe('go-to-market stage vocabulary parity', () => {
+	it('the skill catalog and the pipeline agree on the stage list, in order', () => {
+		expect([...GTM_SKILL_STAGES]).toEqual([...GTM_STAGE_IDS]);
+	});
+
+	it('every skill names a stage this pipeline actually runs', () => {
+		const stages = new Set<string>(GTM_STAGE_IDS);
+		for (const skill of GTM_SKILLS) {
+			expect(stages.has(skill.stage), `skill "${skill.slug}" targets unknown stage "${skill.stage}"`).toBe(true);
+		}
+	});
+
+	it('every executing stage has at least one skill behind it', () => {
+		// `review` is deliberately empty — it is a human approval gate, not
+		// model work, so a Skill there would imply self-approval.
+		for (const stage of GTM_STAGE_IDS) {
+			if (stage === 'review') continue;
+			expect(listGtmSkillsForStage(stage).length, `stage "${stage}" has no skills`).toBeGreaterThan(0);
+		}
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         version: 1.2.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/throttler@6.5.0(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(reflect-metadata@0.2.2))(ioredis@5.10.1)(reflect-metadata@0.2.2)
       '@nestjs-modules/mailer':
         specifier: ^2.3.4
-        version: 2.3.4(e98a7fb1f3ff60e0b2beec3497f32f48)
+        version: 2.3.4(6df53909bc07743f1cbdc8ed07c4f22a)
       '@nestjs/axios':
         specifier: ^4.0.1
         version: 4.0.1(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.18.1)(rxjs@7.8.2)
@@ -288,16 +288,16 @@ importers:
         version: link:../../packages/plugins/postgres-db
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(chokidar@3.6.0)(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -537,13 +537,13 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(typescript@5.9.3)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -996,13 +996,13 @@ importers:
         version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
-        version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+        version: 11.0.10(typescript@5.9.3)
       '@nestjs/testing':
         specifier: ^11.1.18
         version: 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.18)(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)
       '@swc/cli':
         specifier: ^0.8.1
-        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+        version: 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.15.24
         version: 1.15.33(@swc/helpers@0.5.21)
@@ -1167,7 +1167,7 @@ importers:
     devDependencies:
       '@nestjs/cli':
         specifier: ^11.0.18
-        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
+        version: 11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)
       '@nestjs/schematics':
         specifier: ^11.0.10
         version: 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
@@ -1646,6 +1646,9 @@ importers:
 
   packages/plugins/everworks-skills:
     dependencies:
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../../contracts
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../../plugin
@@ -1897,6 +1900,9 @@ importers:
         specifier: ^3.25.0
         version: 3.25.76
     devDependencies:
+      '@ever-works/contracts':
+        specifier: workspace:*
+        version: link:../../contracts
       '@ever-works/plugin':
         specifier: workspace:*
         version: link:../../plugin
@@ -21604,6 +21610,17 @@ snapshots:
 
   '@analytics/type-utils@0.6.4': {}
 
+  '@angular-devkit/core@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      jsonc-parser: 3.3.1
+      picomatch: 4.0.4
+      rxjs: 7.8.1
+      source-map: 0.7.4
+    optionalDependencies:
+      chokidar: 3.6.0
+
   '@angular-devkit/core@19.2.23(chokidar@4.0.3)':
     dependencies:
       ajv: 8.18.0
@@ -21625,6 +21642,26 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
+      - chokidar
+
+  '@angular-devkit/schematics@19.2.23':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.17
+      ora: 5.4.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - chokidar
+
+  '@angular-devkit/schematics@19.2.23(chokidar@3.6.0)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      jsonc-parser: 3.3.1
+      magic-string: 0.30.17
+      ora: 5.4.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
       - chokidar
 
   '@angular-devkit/schematics@19.2.23(chokidar@4.0.3)':
@@ -26362,7 +26399,7 @@ snapshots:
       reflect-metadata: 0.2.2
       tslib: 2.8.1
 
-  '@nestjs-modules/mailer@2.3.4(e98a7fb1f3ff60e0b2beec3497f32f48)':
+  '@nestjs-modules/mailer@2.3.4(6df53909bc07743f1cbdc8ed07c4f22a)':
     dependencies:
       '@css-inline/css-inline': 0.20.0
       '@nestjs/common': 11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -26381,7 +26418,7 @@ snapshots:
       handlebars: 4.7.9
       liquidjs: 10.27.2
       mjml: 5.0.0-beta.2(relateurl@0.2.7)(svgo@4.0.2)(terser@5.46.1)(typescript@5.9.3)
-      nunjucks: 3.2.4(chokidar@4.0.3)
+      nunjucks: 3.2.4(chokidar@3.6.0)
       preview-email: 3.1.3
       pug: 3.0.4
     transitivePeerDependencies:
@@ -26408,7 +26445,36 @@ snapshots:
       keyv: 5.6.0
       rxjs: 7.8.2
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      '@angular-devkit/schematics-cli': 19.2.23(@types/node@22.19.11)(chokidar@4.0.3)
+      '@inquirer/prompts': 7.10.1(@types/node@22.19.11)
+      '@nestjs/schematics': 11.0.10(chokidar@4.0.3)(typescript@5.9.3)
+      ansis: 4.2.0
+      chokidar: 4.0.3
+      cli-table3: 0.6.5
+      commander: 4.1.1
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
+      glob: 13.0.6
+      node-emoji: 1.11.0
+      ora: 5.4.1
+      tsconfig-paths: 4.2.0
+      tsconfig-paths-webpack-plugin: 4.2.0
+      typescript: 5.9.3
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
+      webpack-node-externals: 3.0.0
+    optionalDependencies:
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
+      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+    transitivePeerDependencies:
+      - '@types/node'
+      - esbuild
+      - uglify-js
+      - webpack-cli
+
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -26437,7 +26503,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)(esbuild@0.28.1)':
+  '@nestjs/cli@11.0.18(@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21)))(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@22.19.11)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
@@ -26448,17 +26514,17 @@ snapshots:
       chokidar: 4.0.3
       cli-table3: 0.6.5
       commander: 4.1.1
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.9.3)(webpack@5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21)))
       glob: 13.0.6
       node-emoji: 1.11.0
       ora: 5.4.1
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
       typescript: 5.9.3
-      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))(esbuild@0.28.1)
+      webpack: 5.105.4(@swc/core@1.15.33(@swc/helpers@0.5.21))
       webpack-node-externals: 3.0.0
     optionalDependencies:
-      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)
+      '@swc/cli': 0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)
       '@swc/core': 1.15.33(@swc/helpers@0.5.21)
     transitivePeerDependencies:
       - '@types/node'
@@ -26562,10 +26628,32 @@ snapshots:
       '@nestjs/core': 11.1.18(@nestjs/common@11.1.18(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/microservices@11.1.19)(@nestjs/platform-express@11.1.18)(@nestjs/websockets@11.1.18)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cron: 4.4.0
 
+  '@nestjs/schematics@11.0.10(chokidar@3.6.0)(typescript@5.9.3)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      '@angular-devkit/schematics': 19.2.23(chokidar@3.6.0)
+      comment-json: 4.6.2
+      jsonc-parser: 3.3.1
+      pluralize: 8.0.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - chokidar
+
   '@nestjs/schematics@11.0.10(chokidar@4.0.3)(typescript@5.9.3)':
     dependencies:
       '@angular-devkit/core': 19.2.23(chokidar@4.0.3)
       '@angular-devkit/schematics': 19.2.23(chokidar@4.0.3)
+      comment-json: 4.6.2
+      jsonc-parser: 3.3.1
+      pluralize: 8.0.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - chokidar
+
+  '@nestjs/schematics@11.0.10(typescript@5.9.3)':
+    dependencies:
+      '@angular-devkit/core': 19.2.23(chokidar@3.6.0)
+      '@angular-devkit/schematics': 19.2.23
       comment-json: 4.6.2
       jsonc-parser: 3.3.1
       pluralize: 8.0.0
@@ -30106,6 +30194,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@3.6.0)':
+    dependencies:
+      '@swc/core': 1.15.33(@swc/helpers@0.5.21)
+      '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 14.2.2
+      commander: 8.3.0
+      minimatch: 10.2.5
+      piscina: 4.9.3
+      semver: 7.8.1
+      slash: 3.0.0
+      source-map: 0.7.6
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      chokidar: 3.6.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
 
   '@swc/cli@0.8.1(@swc/core@1.15.33(@swc/helpers@0.5.21))(chokidar@4.0.3)':
     dependencies:
@@ -36049,7 +36156,7 @@ snapshots:
     optionalDependencies:
       express: 5.2.1
       hono: 4.12.25
-      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -38931,6 +39038,34 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
+  next@16.2.11(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@22.19.11)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@next/env': 16.2.11
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.18
+      caniuse-lite: 1.0.30001787
+      postcss: 8.5.20
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.5)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.59.1
+      sharp: 0.35.3(@types/node@22.19.11)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/node'
+      - babel-plugin-macros
+    optional: true
+
   nextjs-toploader@3.9.17(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@20.19.33)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.59.1)(@types/node@20.19.33)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -39097,13 +39232,13 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.105.4
 
-  nunjucks@3.2.4(chokidar@4.0.3):
+  nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
       a-sync-waterfall: 1.0.1
       asap: 2.0.6
       commander: 5.1.0
     optionalDependencies:
-      chokidar: 4.0.3
+      chokidar: 3.6.0
     optional: true
 
   nypm@0.6.5:


### PR DESCRIPTION
## Why

The six prebuilt go-to-market Agent templates that shipped earlier in Wave 10 name the Skills they pair with by slug — `lead-scoring`, `outreach-personalization`, `newsletter-drafting`, and so on. **Nothing implemented those slugs.** The first-party skills-provider plugin served a three-entry builtin fallback plus whatever the catalog repo happened to publish, so activating a "ready-to-run" template produced an Agent whose suggested Skills resolved to nothing. The templates were a promise with no delivery behind it.

This PR ships the missing half, additively.

## What

### 1. First-party go-to-market Skills catalog (16 Skills)

`packages/contracts/src/skills/gtm-skills.ts` — a typed, in-code catalog ordered by pipeline stage:

| Stage | Skills |
|---|---|
| `research` | `lead-research`, `competitor-watch`, `news-signal-detection` |
| `qualify` | `lead-scoring`, `risk-filter` |
| `draft` | `outreach-personalization`, `newsletter-drafting`, `social-scheduling`, `digest-compilation` |
| `act` | `crm-sync-hygiene` |
| `follow-up` | `follow-up-cadence`, `reply-detection` |
| `enrich` | `contact-enrichment` |
| `measure` | `seo-audit`, `campaign-reporting`, `engagement-analysis` |

Every Skill declares `slug`, `title`, `description`, `stage`, `tags`, `version`, a **declared input/output contract** (snake_case keys sharing the pipeline's stage data-key vocabulary), an advisory `allowedTools` family hint, and the instruction `body`. Each is deterministic about **its own contract**; the LLM work still happens through the existing AI facade and the connector work through existing plugin grants. `review` is deliberately skill-less — it is a human approval gate, and a Skill there would imply self-approval.

**Why contracts:** the skills-provider plugin (which serves them) and the agent package (which references them from templates) share no other runtime package. Same argument that already puts `work-kind.ts` there.

### 2. Served by the first-party provider, always

`everworks-skills` gains a `gtm-catalog.ts` projection into `SkillCatalogEntry` (contract tables rendered into the Markdown body, stage + IO keys preserved in frontmatter) and merges the pack **under** whatever the catalog repo serves. So:

- template-suggested Skills resolve even when the catalog repo is unreachable;
- a published `SKILL.md` with the same slug still wins, so the pack is revisable without a deploy.

`@ever-works/contracts` is `noExternal` in this plugin's tsup config (unlike its siblings) because this is a **runtime value** import, not a type import — the pack has to travel inside the plugin bundle.

### 3. `campaign` Work kind

The registry had no home for what a go-to-market pipeline produces. Added additively: registry entry, capabilities (no items/taxonomy/comparisons/deploy, KB on, no website repo), and the metric mapping `['agents', 'open-tasks', 'conversions', 'days-active']` — **reusing the existing metric vocabulary**, no new metric ids or stats message keys. Not user-selectable, same posture as `company`, so the create-path chip catalog and the `normalizeCreateWorkKind` whitelist are untouched. Web presentation entry + `dashboard.workKind.campaign` in all 21 locales (real translations, not English placeholders).

*Checked before adding:* `directory`/`default` are the generic installed-base profile, `blog`/`website`/`landing-page` are deployable site kinds, `awesome-repo` is a curated index, `company` is an organizational shell backing an Organization. None of them fits a campaign, so the kind is new rather than reused.

### 4. Template wiring + keyword slots

- `seo-auditor` gains `seo-audit`, `lead-researcher` gains `lead-research`, `social-scheduler` gains `social-scheduling` — every template's headline job is now backed by a real Skill, not just the generic reporting pair.
- Go-to-market keyword slots (`campaign`, `outreach`, `gtm`, `lead`, `newsletter`, `digest`, `competitor`, `seo`, …) added to the `agents` and `skills` chat-tool domains. The template + Skills chat tools already exist in the generated registry; without these slots the campaign language that reaches them ("draft outreach for my top leads") matched no domain and the tools were gated out of the turn.

### 5. Tests — 52 new cases (44 `it` declarations), and the load-bearing one

`agent templates ↔ go-to-market Skills catalog integrity` (`packages/agent`) asserts **every template's `suggestedSkills` resolves in the catalog**, naming the offending `template → slug` pair on failure. That is the pin that stops the list decaying back into aspirational names. Alongside it: no repeated suggestions, each template's headline Skill present, multi-stage coverage for pipeline-driven templates, secret-free Skill bodies.

`go-to-market stage vocabulary parity` (`gtm-pipeline`) pins `GTM_SKILL_STAGES` against `GTM_STAGE_IDS` — the stage list is spelled out in both packages (contracts sits below the plugins in the dep graph), and a drifted vocabulary would be quiet and expensive: a Skill would declare a stage the pipeline never runs and simply never be reached.

## Verification — real output

**`packages/contracts` — build + vitest (incl. typecheck)**

```
@ever-works/contracts:build:  DTS dist\item\index.d.cts 5.75 KB
 Tasks:    1 successful, 1 total

 Test Files  7 passed (7)
      Tests  209 passed (209)
Type Errors  no errors
```

**`packages/plugins/everworks-skills` — build (`tsc --noEmit && tsup`) + vitest**

```
 ESM Build success in 211ms
 CJS Build success in 211ms
 DTS Build success in 2097ms

 Test Files  2 passed (2)
      Tests  25 passed (25)
```

**`packages/plugins/gtm-pipeline` — build + vitest**

```
 CJS Build success in 51ms
 ESM Build success in 52ms
 DTS Build success in 2995ms

 Test Files  4 passed (4)
      Tests  33 passed (33)
```

**`packages/agent` — build (TSC 0 issues) + jest**

```
-  TSC  Initializing type checker...
   TSC  Initializing type checker...
>  TSC  Found 0 issues.
>  SWC  Running...
Successfully compiled: 1053 files with swc (554.41ms)

PASS src/agents/__tests__/agent-templates.spec.ts (33.115 s)
PASS src/agents/__tests__/agent-templates.service.spec.ts (33.236 s)

Test Suites: 2 passed, 2 total
Tests:       24 passed, 24 total
```

**`ever-works-api` build**

```
ever-works-api:build: >  TSC  Found 0 issues.
ever-works-api:build: >  SWC  Running...
ever-works-api:build: Successfully compiled: 680 files with swc (853.5ms)

 Tasks:    14 successful, 14 total
```

**`apps/api` full-app bootstrap (`pnpm generate:openapi`)**

```
Wrote OpenAPI spec (435 paths) to apps/api/openapi.json
```

(`openapi.json` itself is excluded from the commit — regenerating produced no diff.)

**`apps/web` type-check** (after removing `tsconfig.tsbuildinfo`)

```
TSC-EXIT=0
```

**`apps/web` unit tests for the touched surfaces**

```
 Test Files  3 passed (3)
      Tests  38 passed (38)
```

## Notes

- Additive throughout: no existing Skill, kind, template, or capability removed or renamed. The only pre-existing test changed is the plugin's live-catalog listing assertion, which now reflects the merge (served entry leads, pack appended).
- No new top-level concepts — a Skill catalog, a Work kind registry entry, and template data.

## Not in this PR

From the gap list, deliberately out of scope here (each needs its own slice): G1 Goal weighted criteria/constraints, G2 gate RETRY-with-feedback, G3 escalation logging schema, G4 allowlist-only tool-grant default, G5 stage transition rules incl. LLM routing, G6 spillover/compaction, G7 prompt onion, G8s HITL typed question payloads, G9 sub-agent delegation contract, G10 stall monitor, G11 memory caps/reflection writer, G12 capability-gated skill pre-activation (only the keyword half landed), G13 trigger declarations in works.yml, G14 CI credential-to-tool mapping, G15 pre-run middleware chain, G16 credits parameter tuning, G17 design artifact metadata, G18 evolution loop, G19 measure-stage close-the-loop wiring (the `campaign-reporting` Skill emits `nextVariantHints`, but nothing consumes them yet), G20 template activation surface beyond the `web` kind, and the whole proposed connector / browser-automation / site-audit / catalog-buildout set (G21-G27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
