### PR TITLE
feat(agent): run steering + attach action (Wave 4 M5+M8)

### DIFF
--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -31,6 +31,8 @@ jest.mock('@ever-works/agent/agents', () => ({
     AgentRunLogRepository: class {},
     // Wave 4 M2/M3 — dispatch gate injected for cancel-path draining.
     RunDispatchGateService: class {},
+    // Wave 4 M5 — steer / interrupt / resume run controls.
+    RunSteeringService: class {},
     SkillBindingRepository: class {},
     PluginUsageRepository: class {},
 }));
@@ -319,6 +321,200 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
                 persistent: true,
                 terminalState: 'attached',
             });
+        });
+
+        describe('sessionAttachable (Wave 4 M8)', () => {
+            function sessionRow(over: Record<string, unknown> = {}) {
+                return {
+                    id: runId,
+                    agentId,
+                    status: 'running',
+                    triggerKind: 'task',
+                    taskId,
+                    workId: null,
+                    awaitingInput: false,
+                    queuedReason: null,
+                    runnerKind: null,
+                    startedAt: null,
+                    finishedAt: null,
+                    durationMs: null,
+                    summary: null,
+                    errorMessage: null,
+                    currentActivity: null,
+                    totalTokens: null,
+                    changedFilesCount: null,
+                    costCents: null,
+                    gateStatus: null,
+                    gateAttempts: 0,
+                    persistent: true,
+                    terminalState: 'attached',
+                    terminalEndedReason: null,
+                    terminalProviderId: null,
+                    createdAt: new Date('2026-01-01T00:00:00Z'),
+                    ...over,
+                };
+            }
+
+            async function attachableFor(over: Record<string, unknown>) {
+                agentRuns.listSessionsForUser.mockResolvedValueOnce([[sessionRow(over)], 1]);
+                const result = await controller.listRunSessions(auth, {});
+                return result.data[0].sessionAttachable;
+            }
+
+            it('⭐ is true for a live run with an attached terminal', async () => {
+                expect(await attachableFor({ status: 'running', terminalState: 'attached' })).toBe(
+                    true,
+                );
+            });
+
+            it('is true while the terminal is still starting', async () => {
+                expect(await attachableFor({ status: 'queued', terminalState: 'starting' })).toBe(
+                    true,
+                );
+            });
+
+            it('⭐ is FALSE for a terminal run whose columns still read attached', async () => {
+                // The worker's last write before it died can legitimately still
+                // say `attached` for minutes, until the terminal sweeper
+                // corrects it. Offering Attach there is a guaranteed dead end —
+                // this is exactly what gating on `terminalState` alone got
+                // wrong.
+                expect(
+                    await attachableFor({ status: 'completed', terminalState: 'attached' }),
+                ).toBe(false);
+            });
+
+            it('is false once the terminal has ended', async () => {
+                expect(await attachableFor({ status: 'running', terminalState: 'ended' })).toBe(
+                    false,
+                );
+            });
+
+            it('is false for a run that never had a terminal', async () => {
+                expect(await attachableFor({ status: 'running', terminalState: null })).toBe(false);
+            });
+        });
+    });
+
+    /**
+     * Run steering (Wave 4 M5) — steer / interrupt / resume.
+     *
+     * The controller is deliberately thin: it re-asserts Agent ownership
+     * (cross-user 404 via `service.getOne`) and hands off to
+     * `RunSteeringService`, which owns the run-level ownership scope and the
+     * 409 state rules. These tests pin the wiring and the two things the
+     * controller itself does — the ownership pre-check and the executor
+     * activity trail.
+     */
+    describe('run controls — steer / interrupt / resume', () => {
+        let steering: any;
+
+        function makeControllerWithSteering(bound = true): AgentsController {
+            return new AgentsController(
+                service,
+                files,
+                exportService,
+                dispatcher,
+                agentRuns,
+                agentRunLogs,
+                skillBindings,
+                pluginUsage,
+                tasks,
+                activityLog,
+                heartbeatTrigger,
+                taskExecuteDispatcher,
+                runCanceller,
+                undefined,
+                undefined,
+                bound ? steering : undefined,
+            );
+        }
+
+        beforeEach(() => {
+            steering = {
+                steer: jest
+                    .fn()
+                    .mockResolvedValue({ dispatched: 'injected', runId, queuedCount: 1 }),
+                interrupt: jest.fn().mockResolvedValue({ interrupted: true, runId }),
+                resume: jest.fn().mockResolvedValue({
+                    dispatched: 'new-run',
+                    runId: '00000000-0000-0000-0000-0000000000dd',
+                    resumedFromRunId: runId,
+                    carriedCliSession: true,
+                    queued: false,
+                }),
+            };
+            controller = makeControllerWithSteering();
+        });
+
+        it('⭐ steer forwards the auth user, never a caller-supplied one', async () => {
+            const result = await controller.steerRun(auth, agentId, runId, { message: 'go left' });
+            expect(result).toMatchObject({ dispatched: 'injected', runId });
+            expect(steering.steer).toHaveBeenCalledWith({
+                runId,
+                userId: 'u1',
+                message: 'go left',
+            });
+        });
+
+        it('steer 404s a cross-user Agent before touching the run', async () => {
+            service.getOne.mockRejectedValueOnce(new NotFoundException('nope'));
+            await expect(
+                controller.steerRun(auth, agentId, runId, { message: 'go left' }),
+            ).rejects.toBeInstanceOf(NotFoundException);
+            expect(steering.steer).not.toHaveBeenCalled();
+        });
+
+        it('steer answers new-run for an already-finished run (not an error)', async () => {
+            steering.steer.mockResolvedValueOnce({ dispatched: 'new-run', runId });
+            const result = await controller.steerRun(auth, agentId, runId, { message: 'go left' });
+            expect(result.dispatched).toBe('new-run');
+        });
+
+        it('⭐ interrupt surfaces the service 409 for a terminal run', async () => {
+            steering.interrupt.mockRejectedValueOnce(new ConflictException('already terminal'));
+            await expect(controller.interruptRun(auth, agentId, runId)).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+        });
+
+        it('interrupt records an activity row for the acting user', async () => {
+            await controller.interruptRun(auth, agentId, runId);
+            expect(activityLog.log).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    userId: 'u1',
+                    details: expect.objectContaining({ runId, control: 'interrupt' }),
+                }),
+            );
+        });
+
+        it('resume forwards the optional message and returns the NEW run id', async () => {
+            const result = await controller.resumeRun(auth, agentId, runId, { message: 'go on' });
+            expect(steering.resume).toHaveBeenCalledWith(runId, 'u1', 'go on');
+            expect(result).toMatchObject({
+                dispatched: 'new-run',
+                resumedFromRunId: runId,
+                carriedCliSession: true,
+            });
+        });
+
+        it('resume passes null when no message was sent ("carry on")', async () => {
+            await controller.resumeRun(auth, agentId, runId, {});
+            expect(steering.resume).toHaveBeenCalledWith(runId, 'u1', null);
+        });
+
+        it('resume surfaces the service 409 for a non-resumable run', async () => {
+            steering.resume.mockRejectedValueOnce(new ConflictException('still running'));
+            await expect(controller.resumeRun(auth, agentId, runId, {})).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+        });
+
+        it('500s rather than answering 200 when the steering service is unbound', async () => {
+            const unbound = makeControllerWithSteering(false);
+            await expect(
+                unbound.steerRun(auth, agentId, runId, { message: 'x' }),
+            ).rejects.toBeInstanceOf(InternalServerErrorException);
         });
     });
 

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -34,6 +34,7 @@ import {
     AGENT_RUN_CANCELLER,
     type AgentRunCanceller,
     RunDispatchGateService,
+    RunSteeringService,
     SkillBindingRepository,
     type AgentDto,
     type AgentExportEnvelope,
@@ -68,6 +69,8 @@ import {
     ListAgentRunsQueryDto,
     ListAgentsQueryDto,
     ListRunSessionsQueryDto,
+    ResumeRunDto,
+    SteerRunDto,
     UpdateAgentDto,
     UpdateAgentGuardrailsDto,
 } from './dto/agent.dto';
@@ -120,6 +123,29 @@ const AGENT_LIFECYCLE_EVENT_TYPES: ActivityActionType[] = [
     ActivityActionType.AGENT_TASK_ASSIGNED,
 ];
 
+/**
+ * Attach-session action (Wave 4 M8) — is this run's terminal actually
+ * attachable RIGHT NOW?
+ *
+ * Two conditions, both required:
+ *  - the terminal lifecycle says a session exists or is coming up
+ *    (`starting` | `attached`) — `ended` sessions have no PTY to join; and
+ *  - the run itself is still open (`queued` | `running`) — a terminal run's
+ *    columns can legitimately still read `attached` (the last write the
+ *    worker managed before it died, which the terminal sweeper only corrects
+ *    minutes later), and offering Attach there is a guaranteed dead end.
+ *
+ * Computed server-side and shipped as one boolean so the Sessions list, the
+ * Task detail controls and any future surface can never drift on the rule.
+ */
+export function isSessionAttachable(run: {
+    status: string;
+    terminalState?: string | null;
+}): boolean {
+    const live = run.status === 'queued' || run.status === 'running';
+    return live && (run.terminalState === 'attached' || run.terminalState === 'starting');
+}
+
 @ApiTags('agents')
 @Controller('api/agents')
 export class AgentsController {
@@ -164,6 +190,12 @@ export class AgentsController {
         // Optional for the same positional-spec reason as above.
         @Optional()
         private readonly agentTemplates?: AgentTemplatesService,
+        // Run steering (Wave 4 M5) — steer / interrupt / resume. Trailing +
+        // Optional for the same positional-spec reason as above; when unbound
+        // the three endpoints report 500 "not available" rather than
+        // pretending the control landed.
+        @Optional()
+        private readonly steering?: RunSteeringService,
     ) {}
 
     @Get()
@@ -267,6 +299,7 @@ export class AgentsController {
             terminalState: string | null;
             terminalEndedReason: string | null;
             terminalProviderId: string | null;
+            sessionAttachable: boolean;
             createdAt: string;
         }>;
         meta: { total: number; limit: number; offset: number };
@@ -320,6 +353,10 @@ export class AgentsController {
                 terminalState: r.terminalState ?? null,
                 terminalEndedReason: r.terminalEndedReason ?? null,
                 terminalProviderId: r.terminalProviderId ?? null,
+                // Attach-session action (Wave 4 M8) — the UI gates its
+                // terminal-icon deep link on this, never on `terminalState`
+                // alone (see isSessionAttachable above).
+                sessionAttachable: isSessionAttachable(r),
                 createdAt: r.createdAt.toISOString(),
             })),
             meta: { total, limit, offset },
@@ -845,6 +882,130 @@ export class AgentsController {
             }
         }
         return { cancelled: wasOpen, previousStatus: result.previousStatus };
+    }
+
+    /**
+     * Run steering (Wave 4 M5) — send a message to a run.
+     *
+     * LIVE run ⇒ the message is queued for the executing tool loop, which
+     * injects it between model round-trips (`dispatched: 'injected'`).
+     * TERMINAL run ⇒ `dispatched: 'new-run'`, telling the caller to start a
+     * fresh run instead. Deliberately NOT a 409: "the run finished while you
+     * were typing" is a normal race, not a client error, and the caller has a
+     * defined next step.
+     *
+     * Ownership is enforced twice — `getOne` 404s a cross-user Agent, and
+     * `RunSteeringService` loads the run through `findByIdAndUser`, so a run
+     * id belonging to someone else is indistinguishable from a missing one.
+     */
+    @Post(':id/runs/:runId/steer')
+    @ApiOperation({
+        summary:
+            'Send a steering message to a run: injected into the live session, or ' +
+            'answered with new-run when the run already finished.',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async steerRun(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Param('runId', ParseUUIDPipe) runId: string,
+        @Body() body: SteerRunDto,
+    ): Promise<{ dispatched: 'injected' | 'new-run'; runId: string; queuedCount?: number }> {
+        await this.service.getOne(auth.userId, id);
+        const steering = this.requireSteering();
+        return steering.steer({ runId, userId: auth.userId, message: body.message });
+    }
+
+    /**
+     * Run steering (Wave 4 M5) — cooperative stop request.
+     *
+     * The run's tool loop honours it at its next per-iteration checkpoint, so
+     * the run stops BETWEEN iterations and finishes `completed` with a summary
+     * instead of being killed mid-round-trip. 409 when the run is already
+     * terminal — unlike steer, there is no meaningful fallback action.
+     *
+     * "Stop" (kill the process now) stays the existing
+     * `POST :id/runs/:runId/cancel` endpoint; it is not duplicated here.
+     */
+    @Post(':id/runs/:runId/interrupt')
+    @ApiOperation({
+        summary:
+            'Request a cooperative stop: the run halts between tool-loop iterations ' +
+            'and completes with a summary. 409 when the run is already terminal.',
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async interruptRun(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Param('runId', ParseUUIDPipe) runId: string,
+    ): Promise<{ interrupted: boolean; runId: string }> {
+        await this.service.getOne(auth.userId, id);
+        const steering = this.requireSteering();
+        const outcome = await steering.interrupt(runId, auth.userId);
+        void this.tryLog({
+            userId: auth.userId,
+            agentId: id,
+            actionType: ActivityActionType.AGENT_RUN_CANCELLED,
+            details: { runId, control: 'interrupt' },
+        });
+        return outcome;
+    }
+
+    /**
+     * Run steering (Wave 4 M5) — resume a parked / awaiting-input run.
+     *
+     * Dispatches a NEW run carrying the source run's `cliSessionId` (the
+     * pipeline plugin's own conversation id) and, optionally, a first message.
+     * Runs are immutable: the source row stays terminal. 409 when the run is
+     * not resumable (still live, or ended for a non-parked reason).
+     */
+    @Post(':id/runs/:runId/resume')
+    @ApiOperation({
+        summary:
+            'Resume a parked / awaiting-input run as a NEW run carrying the same ' +
+            'pipeline session. 409 when the run is not resumable.',
+    })
+    @HttpCode(HttpStatus.ACCEPTED)
+    @Throttle({ long: { limit: 30, ttl: 60_000 } })
+    async resumeRun(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Param('runId', ParseUUIDPipe) runId: string,
+        @Body() body: ResumeRunDto,
+    ): Promise<{
+        dispatched: 'new-run';
+        runId: string;
+        resumedFromRunId: string;
+        carriedCliSession: boolean;
+        queued: boolean;
+    }> {
+        await this.service.getOne(auth.userId, id);
+        const steering = this.requireSteering();
+        const outcome = await steering.resume(runId, auth.userId, body.message ?? null);
+        void this.tryLog({
+            userId: auth.userId,
+            agentId: id,
+            actionType: ActivityActionType.AGENT_RUN_TRIGGERED,
+            details: { runId: outcome.runId, source: 'resume', resumedFromRunId: runId },
+        });
+        return outcome;
+    }
+
+    /**
+     * The steering service is @Optional() so every positional spec
+     * constructor keeps compiling. An unbound service means the deployment is
+     * misconfigured — say so loudly rather than answering 200 for a control
+     * that never reached anything.
+     */
+    private requireSteering(): RunSteeringService {
+        if (!this.steering) {
+            throw new InternalServerErrorException(
+                'RunSteeringService is not available on this deployment.',
+            );
+        }
+        return this.steering;
     }
 
     @Get(':id/skills')

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -11,6 +11,7 @@ import {
     AGENT_GIT_FACADE,
     AGENT_EMAIL_FACADE,
     AGENT_NOTIFY_CHANNEL_FACADE,
+    RunSteeringService,
     type AgentRunChatBackPoster,
     type AgentRunTaskFinisher,
     type AgentPluginToolsFacade,
@@ -52,6 +53,7 @@ import {
     TaskChatService,
     TasksService,
     TaskStatus,
+    RUN_STEERING_PORT,
 } from '@ever-works/agent/tasks-domain';
 import {
     FacadesModule,
@@ -172,6 +174,14 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                 },
             }),
         },
+        // Run steering (Wave 4 M5) — bind the port `TaskChatService` reaches
+        // for when a chat message mentions an agent that already has a LIVE
+        // run on the Task. Same @Global() token posture as the post-processor
+        // bindings above: the implementation lives in the agent-side
+        // AgentsModule (imported here), the consumer lives in
+        // TasksDomainModule, and neither package gains a runtime import of
+        // the other.
+        { provide: RUN_STEERING_PORT, useExisting: RunSteeringService },
         // Notifications v2 (EW-670) — INBOUND_EMAIL_TASK_SPAWNER binding.
         // The inbound-email dispatcher's `task-spawn` mode delegates here:
         // create a Task from the inbound email (scoped to the address
@@ -633,6 +643,7 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
         AGENT_EMAIL_FACADE,
         AGENT_NOTIFY_CHANNEL_FACADE,
         INBOUND_EMAIL_TASK_SPAWNER,
+        RUN_STEERING_PORT,
     ],
 })
 export class AgentsModule {}

--- a/apps/api/src/agents/dto/agent.dto.ts
+++ b/apps/api/src/agents/dto/agent.dto.ts
@@ -532,6 +532,36 @@ export class ListRunSessionsQueryDto {
 }
 
 /**
+ * Run steering (Wave 4 M5) — payload for
+ * `POST /api/agents/:id/runs/:runId/steer`.
+ *
+ * The body cap mirrors the task-chat body cap (16 KB): steering is short
+ * by intent, and the message crosses a trust boundary into a live session's
+ * message list, so it is size-capped at the edge as well as in the service.
+ */
+export class SteerRunDto {
+    @ApiProperty({ maxLength: 16384 })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(16384)
+    message: string;
+}
+
+/**
+ * Run steering (Wave 4 M5) — payload for
+ * `POST /api/agents/:id/runs/:runId/resume`. The message is optional:
+ * resuming a parked session with no new instruction is a valid, common
+ * action ("carry on").
+ */
+export class ResumeRunDto {
+    @ApiProperty({ required: false, maxLength: 16384 })
+    @IsOptional()
+    @IsString()
+    @MaxLength(16384)
+    message?: string;
+}
+
+/**
  * FU-2 — payload for `POST /api/agents/:id/assign-task`.
  */
 export class AssignTaskToAgentDto {

--- a/apps/api/src/migrations/1784100000000-AddRunSteeringColumns.ts
+++ b/apps/api/src/migrations/1784100000000-AddRunSteeringColumns.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Run steering (Wave 4 M5) — the two `agent_runs` columns the
+ * steer / interrupt loop needs.
+ *
+ *  - `pendingInput`       — persisted FIFO queue of steering messages
+ *                           waiting to be injected into the LIVE run.
+ *                           `simple-json` on the entity, which is plain
+ *                           `text` at the DB level on every supported
+ *                           driver (Postgres in prod, sqlite in e2e).
+ *  - `interruptRequested` — boolean NOT NULL DEFAULT false; cooperative
+ *                           stop request the tool loop honours between
+ *                           iterations.
+ *
+ * Forward-only, idempotent per-step guards (house pattern, mirrors
+ * 1783100000000-AddRunOrchestrationColumns). No index: both columns are
+ * only ever read by primary key (the executing run reads its own row).
+ */
+export class AddRunSteeringColumns1784100000000 implements MigrationInterface {
+    name = 'AddRunSteeringColumns1784100000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('agent_runs');
+        if (!table) return;
+
+        const addColumn = async (name: string, ddl: string) => {
+            if (!table.findColumnByName(name)) {
+                await queryRunner.query(`ALTER TABLE "agent_runs" ADD COLUMN ${ddl}`);
+            }
+        };
+
+        await addColumn('pendingInput', `"pendingInput" text`);
+        await addColumn(
+            'interruptRequested',
+            `"interruptRequested" boolean NOT NULL DEFAULT false`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('agent_runs');
+        if (!table) return;
+        for (const col of ['interruptRequested', 'pendingInput']) {
+            if (table.findColumnByName(col)) {
+                await queryRunner.query(`ALTER TABLE "agent_runs" DROP COLUMN "${col}"`);
+            }
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/AddRunSteeringColumns.spec.ts
+++ b/apps/api/src/migrations/__tests__/AddRunSteeringColumns.spec.ts
@@ -1,0 +1,96 @@
+import { DataSource } from 'typeorm';
+import { AddRunSteeringColumns1784100000000 } from '../1784100000000-AddRunSteeringColumns';
+
+/**
+ * Run steering (Wave 4 M5) — migration test for the two `agent_runs`
+ * steering columns, run against an in-memory better-sqlite3 DataSource
+ * (same harness as `AddWorkKindAndStatus.spec.ts`).
+ *
+ * The load-bearing assertion is the `interruptRequested` DEFAULT: the tool
+ * loop reads it on every iteration, and a NULL there on a pre-existing row
+ * would make `interruptRequested === true` comparisons behave unpredictably
+ * across drivers. `false` for every historical run is the only correct
+ * backfill.
+ */
+describe('AddRunSteeringColumns1784100000000 (Wave 4 M5)', () => {
+    let dataSource: DataSource;
+    const migration = new AddRunSteeringColumns1784100000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        await dataSource.query(
+            `CREATE TABLE "agent_runs" ("id" varchar PRIMARY KEY NOT NULL, "status" varchar NOT NULL)`,
+        );
+    });
+
+    afterEach(async () => {
+        await dataSource.destroy();
+    });
+
+    async function columnNames(): Promise<string[]> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA table_info("agent_runs")`,
+        );
+        return rows.map((r) => r.name);
+    }
+
+    it('adds pendingInput + interruptRequested', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        expect(await columnNames()).toEqual(
+            expect.arrayContaining(['pendingInput', 'interruptRequested']),
+        );
+    });
+
+    it('⭐ backfills every historical run to interruptRequested = false, pendingInput = NULL', async () => {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+
+        await dataSource.query(
+            `INSERT INTO "agent_runs" ("id", "status") VALUES ('run-1', 'running')`,
+        );
+        const [row] = await dataSource.query(
+            `SELECT "pendingInput", "interruptRequested" FROM "agent_runs" WHERE "id" = 'run-1'`,
+        );
+        expect(row.pendingInput).toBeNull();
+        // sqlite renders booleans as 0/1; both drivers must read "not requested".
+        expect(Boolean(row.interruptRequested)).toBe(false);
+    });
+
+    it('is idempotent — running up() twice does not throw or duplicate columns', async () => {
+        const r1 = dataSource.createQueryRunner();
+        await migration.up(r1);
+        await r1.release();
+
+        const r2 = dataSource.createQueryRunner();
+        await expect(migration.up(r2)).resolves.toBeUndefined();
+        await r2.release();
+
+        const cols = await columnNames();
+        expect(cols.filter((c) => c === 'pendingInput')).toHaveLength(1);
+        expect(cols.filter((c) => c === 'interruptRequested')).toHaveLength(1);
+    });
+
+    it('down() drops both columns', async () => {
+        const up = dataSource.createQueryRunner();
+        await migration.up(up);
+        await up.release();
+
+        const down = dataSource.createQueryRunner();
+        await migration.down(down);
+        await down.release();
+
+        const cols = await columnNames();
+        expect(cols).not.toContain('pendingInput');
+        expect(cols).not.toContain('interruptRequested');
+    });
+});

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1134,7 +1134,27 @@
                 "updated": "Updated",
                 "scopeWork": "Work",
                 "scopeMission": "Mission",
-                "scopeIdea": "Idea"
+                "scopeIdea": "Idea",
+                "runControls": {
+                    "title": "Run controls",
+                    "liveHint": "This run is live. Send a message to steer it — the agent picks it up between steps.",
+                    "parkedHint": "This run is parked. Resume it to continue the same session, optionally with a new instruction.",
+                    "steerPlaceholder": "Message the running agent…",
+                    "resumePlaceholder": "Optional instruction to resume with…",
+                    "steer": "Steer",
+                    "interrupt": "Interrupt",
+                    "resume": "Resume",
+                    "attach": "Attach",
+                    "attachHint": "Open this run's live terminal session",
+                    "awaitingInput": "Awaiting input",
+                    "confirmInterrupt": "Ask this agent to stop after its current step? It will finish with a summary of the work done so far.",
+                    "steerInjected": "Message delivered to the running agent.",
+                    "steerNeedsNewRun": "That run already finished, so the message was not delivered. Mention the agent in the conversation to start a new run.",
+                    "interruptRequested": "Interrupt requested — the agent will stop after its current step.",
+                    "resumeDispatched": "Resumed — a new run is picking up the same session.",
+                    "resumeQueued": "Resume queued — it starts as soon as a concurrency slot frees up.",
+                    "genericError": "That run control could not be applied."
+                }
             },
             "recurring": {
                 "section": "Recurring schedule",

--- a/apps/web/src/app/actions/agents.ts
+++ b/apps/web/src/app/actions/agents.ts
@@ -200,6 +200,35 @@ export async function cancelAgentRunAction(id: string, runId: string) {
     return res;
 }
 
+/**
+ * Run steering (Wave 4 M5) — the three run controls behind the Task-detail
+ * buttons. "Stop" stays `cancelAgentRunAction` above.
+ *
+ * Errors are deliberately NOT swallowed: the API answers 409 when the control
+ * does not apply to the run's state ("already finished", "not resumable"), and
+ * that is exactly what the caller must show the user.
+ */
+export async function steerAgentRunAction(id: string, runId: string, message: string) {
+    await ensureAuth();
+    const res = await agentsAPI.steerRun(id, runId, message);
+    revalidatePath(`/agents/${id}/activity`);
+    return res;
+}
+
+export async function interruptAgentRunAction(id: string, runId: string) {
+    await ensureAuth();
+    const res = await agentsAPI.interruptRun(id, runId);
+    revalidatePath(`/agents/${id}/activity`);
+    return res;
+}
+
+export async function resumeAgentRunAction(id: string, runId: string, message?: string | null) {
+    await ensureAuth();
+    const res = await agentsAPI.resumeRun(id, runId, message ?? null);
+    revalidatePath(`/agents/${id}/activity`);
+    return res;
+}
+
 // Attachment actions — used by the PromptComposer-driven flow on
 // /new (Agent chip). Lets the caller wire uploads to an Agent once
 // we have its id.

--- a/apps/web/src/components/agents/AgentSessionsClient.tsx
+++ b/apps/web/src/components/agents/AgentSessionsClient.tsx
@@ -182,8 +182,18 @@ function SessionRow({
                     {durationMs != null && ` · ${formatDuration(durationMs)}`}
                 </span>
 
-                {/* Attach → the run's terminal tab (streaming-terminal M7). */}
-                {session.terminalState && (
+                {/* Attach → the run's terminal tab (streaming-terminal M7).
+                    Gated on the server-computed `sessionAttachable` (Wave 4
+                    M8), NOT on `terminalState` alone: a dead run's columns can
+                    keep reading `attached` for minutes until the terminal
+                    sweeper corrects them, and a link into a session nobody can
+                    join is worse than no link. Falls back to the old rule for
+                    rows served by an API replica that predates the field. */}
+                {(session.sessionAttachable ??
+                    Boolean(
+                        session.terminalState &&
+                        (session.status === 'running' || session.status === 'queued'),
+                    )) && (
                     <Link
                         href={`${ROUTES.DASHBOARD_AGENT_TERMINAL(session.agentId)}?run=${session.id}`}
                         className="inline-flex items-center gap-1 text-[11px] text-primary hover:underline shrink-0"

--- a/apps/web/src/components/tasks/TaskDetailClient.tsx
+++ b/apps/web/src/components/tasks/TaskDetailClient.tsx
@@ -20,6 +20,7 @@ import { TaskRecurringSection } from './TaskRecurringSection';
 import { TaskAttachmentsSection } from './TaskAttachmentsSection';
 import { TaskBranchSection } from './TaskBranchSection';
 import { TaskChecksSection } from './TaskChecksSection';
+import { TaskRunControls } from './TaskRunControls';
 
 // Status tones + dots mirror /tasks (TasksList) so colours stay
 // consistent across the list filter and the detail workflow buttons.
@@ -104,7 +105,13 @@ export function TaskDetailClient({
     initialAttachments?: TaskAttachmentRow[];
     initialChatError?: string | null;
     initialAttachmentsError?: string | null;
-    /** Quality gates (Wave 3 M6) — latest run w/ gate columns, server-fetched. */
+    /**
+     * Latest run for this Task, server-fetched (`listSessions({ taskId,
+     * limit: 1 })`). Feeds BOTH the quality-gate Checks section (Wave 3 M6 —
+     * where the prop got its name) and the run controls (Wave 4 M5/M8): they
+     * read different columns of the same row, so re-fetching it twice would
+     * be pure waste.
+     */
     initialGateRun?: AgentRunSession | null;
 }) {
     const t = useTranslations('dashboard.tasksPage.detail');
@@ -329,6 +336,11 @@ export function TaskDetailClient({
                             <p className="text-sm text-text-muted italic">{t('noDescription')}</p>
                         )}
                     </section>
+
+                    {/* Run steering (Wave 4 M5) + attach action (M8) — steer /
+                        interrupt / resume the Task's latest run. Renders
+                        nothing when there is no actionable run. */}
+                    <TaskRunControls run={initialGateRun} />
 
                     {/* Quality gates (Wave 3 M6) — Checks section */}
                     <TaskChecksSection task={task} initialGateRun={initialGateRun} />

--- a/apps/web/src/components/tasks/TaskRunControls.tsx
+++ b/apps/web/src/components/tasks/TaskRunControls.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { Loader2, OctagonPause, PlayCircle, SendHorizontal, SquareTerminal } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import type { AgentRunSession } from '@/lib/api/agents.shared';
+import {
+    interruptAgentRunAction,
+    resumeAgentRunAction,
+    steerAgentRunAction,
+} from '@/app/actions/agents';
+
+/**
+ * Run steering (Wave 4 M5) + attach-session action (Wave 4 M8) — the run
+ * cockpit on Task detail.
+ *
+ * Four verbs on the Task's latest run, exactly the ones the orchestration
+ * model defines:
+ *
+ *  - **Steer**     — send a message into the LIVE session. The server injects
+ *                    it between the agent's tool-loop iterations; if the run
+ *                    finished while the user was typing, the server answers
+ *                    `new-run` and we say so instead of silently dropping it.
+ *  - **Interrupt** — cooperative stop, behind a confirm. The run halts between
+ *                    iterations and completes with a summary — it does NOT
+ *                    kill the process mid-flight (that is Cancel, which lives
+ *                    on the Sessions/Activity surfaces).
+ *  - **Resume**    — for a parked / awaiting-input run: start a NEW run
+ *                    carrying the same pipeline session, optionally with a
+ *                    first message.
+ *  - **Attach**    — deep link into the run's terminal pane, shown only when
+ *                    the server says the session is actually joinable
+ *                    (`sessionAttachable`).
+ *
+ * Renders nothing when the Task has no run yet: an empty control strip on a
+ * Task that never dispatched is noise.
+ */
+export function TaskRunControls({ run }: { run: AgentRunSession | null }) {
+    const t = useTranslations('dashboard.tasksPage.detail.runControls');
+    const [draft, setDraft] = useState('');
+    const [notice, setNotice] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [pending, startAction] = useTransition();
+
+    if (!run) return null;
+
+    const isLive = run.status === 'queued' || run.status === 'running';
+    const isResumable = run.awaitingInput === true || run.terminalEndedReason === 'parked';
+    // Nothing actionable on a plain finished run — don't render a dead strip.
+    if (!isLive && !isResumable && !run.sessionAttachable) return null;
+
+    const act = (fn: () => Promise<string | null>) => {
+        setError(null);
+        setNotice(null);
+        startAction(() => {
+            void (async () => {
+                try {
+                    setNotice(await fn());
+                } catch (err) {
+                    setError(err instanceof Error ? err.message : t('genericError'));
+                }
+            })();
+        });
+    };
+
+    const handleSteer = (e: React.FormEvent) => {
+        e.preventDefault();
+        const message = draft.trim();
+        if (!message) return;
+        act(async () => {
+            const result = await steerAgentRunAction(run.agentId, run.id, message);
+            setDraft('');
+            // `new-run` is a normal race, not a failure — but the user MUST be
+            // told, because their message did not reach the agent.
+            return result.dispatched === 'injected' ? t('steerInjected') : t('steerNeedsNewRun');
+        });
+    };
+
+    const handleInterrupt = () => {
+        if (!window.confirm(t('confirmInterrupt'))) return;
+        act(async () => {
+            await interruptAgentRunAction(run.agentId, run.id);
+            return t('interruptRequested');
+        });
+    };
+
+    const handleResume = () => {
+        const message = draft.trim();
+        act(async () => {
+            const result = await resumeAgentRunAction(run.agentId, run.id, message || null);
+            setDraft('');
+            return result.queued ? t('resumeQueued') : t('resumeDispatched');
+        });
+    };
+
+    return (
+        <section
+            className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5"
+            data-testid="task-run-controls"
+            data-run-status={run.status}
+        >
+            <div className="flex items-center justify-between gap-3 mb-3">
+                <h2 className="text-sm font-medium text-text dark:text-text-dark">{t('title')}</h2>
+                <div className="flex items-center gap-2">
+                    {run.awaitingInput && (
+                        <span
+                            className="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300"
+                            data-testid="task-run-awaiting-badge"
+                        >
+                            {t('awaitingInput')}
+                        </span>
+                    )}
+                    {/* Attach-session action (Wave 4 M8) — terminal icon → the
+                        run's session pane. Gated on the server's own
+                        joinability verdict. */}
+                    {run.sessionAttachable && (
+                        <Link
+                            href={`${ROUTES.DASHBOARD_AGENT_TERMINAL(run.agentId)}?run=${run.id}`}
+                            className="inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
+                            data-testid="task-run-attach"
+                            title={t('attachHint')}
+                        >
+                            <SquareTerminal className="w-3.5 h-3.5" />
+                            {t('attach')}
+                        </Link>
+                    )}
+                </div>
+            </div>
+
+            <p className="text-xs text-text-muted dark:text-text-muted-dark mb-3">
+                {isLive ? t('liveHint') : t('parkedHint')}
+            </p>
+
+            <form onSubmit={handleSteer} className="space-y-2">
+                <textarea
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    rows={2}
+                    maxLength={16384}
+                    placeholder={isLive ? t('steerPlaceholder') : t('resumePlaceholder')}
+                    className="w-full rounded-md border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-3 text-sm text-text dark:text-text-dark"
+                    data-testid="task-run-steer-input"
+                />
+                {error && (
+                    <p className="text-xs text-danger" role="alert" data-testid="task-run-error">
+                        {error}
+                    </p>
+                )}
+                {notice && (
+                    <p
+                        className="text-xs text-text-secondary dark:text-text-secondary-dark"
+                        role="status"
+                        data-testid="task-run-notice"
+                    >
+                        {notice}
+                    </p>
+                )}
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                    {pending && <Loader2 className="w-4 h-4 animate-spin text-text-muted" />}
+                    {isLive && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="text-xs gap-1.5"
+                            disabled={pending}
+                            onClick={handleInterrupt}
+                            data-testid="task-run-interrupt"
+                        >
+                            <OctagonPause className="w-3.5 h-3.5" />
+                            {t('interrupt')}
+                        </Button>
+                    )}
+                    {isResumable && (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="text-xs gap-1.5"
+                            disabled={pending}
+                            onClick={handleResume}
+                            data-testid="task-run-resume"
+                        >
+                            <PlayCircle className="w-3.5 h-3.5" />
+                            {t('resume')}
+                        </Button>
+                    )}
+                    {isLive && (
+                        <Button
+                            type="submit"
+                            size="sm"
+                            className="text-xs gap-1.5"
+                            disabled={pending || !draft.trim()}
+                            data-testid="task-run-steer-submit"
+                        >
+                            <SendHorizontal className="w-3.5 h-3.5" />
+                            {t('steer')}
+                        </Button>
+                    )}
+                </div>
+            </form>
+        </section>
+    );
+}

--- a/apps/web/src/lib/api/agents.shared.ts
+++ b/apps/web/src/lib/api/agents.shared.ts
@@ -82,7 +82,41 @@ export interface AgentRunSession {
     terminalState: string | null;
     terminalEndedReason: string | null;
     terminalProviderId: string | null;
+    /**
+     * Attach-session action (Wave 4 M8) — server-computed "can a viewer join
+     * this run's terminal RIGHT NOW?". True only when the terminal is
+     * `starting`/`attached` AND the run is still open. The UI gates its
+     * terminal-icon deep link on THIS, never on `terminalState` alone: a run
+     * that died can keep reading `attached` for minutes until the terminal
+     * sweeper corrects it, and offering Attach there is a dead end.
+     */
+    sessionAttachable: boolean;
     createdAt: string;
+}
+
+/**
+ * Run steering (Wave 4 M5) — the shape returned by the steer endpoint.
+ * `new-run` is a normal answer, not an error: the run finished while the
+ * user was typing, so the caller starts a fresh one.
+ */
+export interface RunSteerResponse {
+    dispatched: 'injected' | 'new-run';
+    runId: string;
+    queuedCount?: number;
+}
+
+export interface RunInterruptResponse {
+    interrupted: boolean;
+    runId: string;
+}
+
+export interface RunResumeResponse {
+    dispatched: 'new-run';
+    /** The NEW run. The source run stays terminal — runs are immutable. */
+    runId: string;
+    resumedFromRunId: string;
+    carriedCliSession: boolean;
+    queued: boolean;
 }
 
 export interface ListRunSessionsQuery {

--- a/apps/web/src/lib/api/agents.ts
+++ b/apps/web/src/lib/api/agents.ts
@@ -34,8 +34,18 @@ export {
     type AgentRunSessionStatus,
     type AgentRunTriggerKind,
     type ListRunSessionsQuery,
+    type RunSteerResponse,
+    type RunInterruptResponse,
+    type RunResumeResponse,
 } from './agents.shared';
-import type { AgentGuardrails, AgentRunSession, ListRunSessionsQuery } from './agents.shared';
+import type {
+    AgentGuardrails,
+    AgentRunSession,
+    ListRunSessionsQuery,
+    RunSteerResponse,
+    RunInterruptResponse,
+    RunResumeResponse,
+} from './agents.shared';
 
 export interface AgentPermissions {
     canCreateAgents: boolean;
@@ -561,6 +571,41 @@ export const agentsAPI = {
         return serverMutation({
             endpoint: `/agents/${id}/runs/${runId}/cancel`,
             data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    // ── Run controls (Wave 4 M5) ──
+    // steer / interrupt / resume. "Stop" is the existing `cancelRun` above —
+    // deliberately not duplicated here.
+
+    async steerRun(id: string, runId: string, message: string): Promise<RunSteerResponse> {
+        return serverMutation({
+            endpoint: `/agents/${id}/runs/${runId}/steer`,
+            data: { message },
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    async interruptRun(id: string, runId: string): Promise<RunInterruptResponse> {
+        return serverMutation({
+            endpoint: `/agents/${id}/runs/${runId}/interrupt`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    async resumeRun(
+        id: string,
+        runId: string,
+        message?: string | null,
+    ): Promise<RunResumeResponse> {
+        return serverMutation({
+            endpoint: `/agents/${id}/runs/${runId}/resume`,
+            data: message && message.trim().length > 0 ? { message: message.trim() } : {},
             method: 'POST',
             wrapInData: false,
         });

--- a/packages/agent/src/agents/__tests__/agent-run-steering-loop.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-steering-loop.spec.ts
@@ -1,0 +1,257 @@
+import { AgentRunService } from '../agent-run.service';
+import { PromptAssemblerService } from '../prompt-assembler.service';
+import {
+    AgentAvatarMode,
+    AgentIdleBehavior,
+    AgentScope,
+    AgentStatus,
+} from '../../entities/agent.entity';
+import type { Agent } from '../../entities/agent.entity';
+import type { AgentAiDispatchFacade, AgentAiDispatchResult } from '../agent-ai-dispatch-facade';
+import type { AgentRunChatBackPoster, AgentRunTaskFinisher } from '../agent-run-post-processor';
+
+/**
+ * Run steering (Wave 4 M5) — the tool-loop guard.
+ *
+ * The steering signals are read at the SAME per-iteration checkpoint as the
+ * cancel/abort signal, so the loop has exactly one place that answers "should
+ * I keep going, and has anyone said anything?". These tests pin:
+ *
+ *  - an interrupt stops the loop BETWEEN iterations (never mid-round-trip) and
+ *    the run is completed with an honest summary, not failed and not cancelled;
+ *  - an interrupt applies NO externally-visible side effect (a stopped run must
+ *    not flip its Task to done or post a chat reply);
+ *  - queued steering messages are injected as `user` turns on the next round;
+ *  - a repository without the steering methods (older replica / partial spec
+ *    stub) degrades to today's behaviour instead of throwing inside the loop.
+ */
+function makeAgent(over: Partial<Agent> = {}): Agent {
+    return {
+        id: 'a1',
+        userId: 'u1',
+        scope: AgentScope.TENANT,
+        missionId: null,
+        ideaId: null,
+        workId: null,
+        name: 'Builder',
+        slug: 'builder',
+        title: null,
+        capabilities: null,
+        aiProviderId: null,
+        modelId: 'gpt-4o-mini',
+        maxSkillContextTokens: 4000,
+        status: AgentStatus.ACTIVE,
+        permissions: {
+            canCreateAgents: false,
+            canAssignTasks: false,
+            canEditSkills: false,
+            canEditAgentFiles: false,
+            canSpend: false,
+            canCommitToRepo: false,
+            canOpenPullRequests: false,
+            canCallExternalTools: false,
+        },
+        targets: null,
+        heartbeatCadence: null,
+        idleBehavior: AgentIdleBehavior.PROPOSE,
+        nextHeartbeatAt: null,
+        lastRunAt: null,
+        lastRunStatus: null,
+        errorCount: 0,
+        pauseAfterFailures: 3,
+        avatarMode: AgentAvatarMode.INITIALS,
+        avatarIcon: null,
+        avatarImageUploadId: null,
+        soulMd: '# Who I am\nA builder.',
+        agentsMd: null,
+        heartbeatMd: '# Each tick\nBuild.',
+        toolsMd: null,
+        agentYml: null,
+        contentHash: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+        ...over,
+    } as Agent;
+}
+
+describe('AgentRunService — steering signals in the tool loop (Wave 4 M5)', () => {
+    let agents: any;
+    let runs: any;
+    let runLogs: any;
+    let budgets: any;
+    let skillBindings: any;
+    let activity: any;
+    let assembler: PromptAssemblerService;
+    let chatBackPoster: jest.Mocked<AgentRunChatBackPoster>;
+    let taskFinisher: jest.Mocked<AgentRunTaskFinisher>;
+    let ai: jest.Mocked<AgentAiDispatchFacade>;
+
+    function aiResponse(over: Partial<AgentAiDispatchResult> = {}): AgentAiDispatchResult {
+        return {
+            text: 'Working on it.',
+            toolCalls: [],
+            finishReason: 'stop',
+            usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+            model: 'gpt-4o-mini',
+            ...over,
+        };
+    }
+
+    beforeEach(() => {
+        agents = { findById: jest.fn().mockResolvedValue(makeAgent()) };
+        runs = {
+            findByAgent: jest.fn().mockResolvedValue([]),
+            findById: jest.fn().mockResolvedValue({ status: 'running' }),
+            markFailed: jest.fn().mockResolvedValue(undefined),
+            markCompleted: jest.fn().mockResolvedValue(undefined),
+            setAwaitingInput: jest.fn().mockResolvedValue(undefined),
+            takeSteeringSignals: jest
+                .fn()
+                .mockResolvedValue({ pendingInput: [], interruptRequested: false }),
+        };
+        runLogs = { append: jest.fn().mockResolvedValue(undefined) };
+        budgets = { findByAgentId: jest.fn().mockResolvedValue(null) };
+        skillBindings = { resolveActive: jest.fn().mockResolvedValue([]) };
+        activity = { log: jest.fn().mockResolvedValue(undefined) };
+        assembler = new PromptAssemblerService();
+        chatBackPoster = { postReply: jest.fn().mockResolvedValue({ messageId: 'm1' }) };
+        taskFinisher = { finishTask: jest.fn().mockResolvedValue({ status: 'done' }) };
+        ai = { dispatch: jest.fn().mockResolvedValue(aiResponse()) };
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    function makeSvc(): AgentRunService {
+        return new AgentRunService(
+            agents,
+            runs,
+            runLogs,
+            budgets,
+            assembler,
+            skillBindings,
+            activity,
+            chatBackPoster,
+            taskFinisher,
+            undefined,
+            ai,
+        );
+    }
+
+    const ctx = { runId: 'r1', agentId: 'a1', userId: 'u1', kind: 'task' as const, taskId: 't1' };
+
+    it('⭐ an interrupt requested before the first round stops the loop without calling the model', async () => {
+        // THE BETWEEN-ITERATIONS TEST. If the guard were placed after the
+        // dispatch, an interrupt would still burn a full model round-trip —
+        // which is exactly the cost the control exists to avoid.
+        runs.takeSteeringSignals.mockResolvedValue({
+            pendingInput: [],
+            interruptRequested: true,
+        });
+
+        const result = await makeSvc().execute(ctx);
+
+        expect(result.status).toBe('interrupted');
+        expect(ai.dispatch).not.toHaveBeenCalled();
+        expect(result.toolLoopIterations).toBe(0);
+    });
+
+    it('⭐ marks the run COMPLETED with a summary — not failed, not cancelled', async () => {
+        runs.takeSteeringSignals
+            .mockResolvedValueOnce({ pendingInput: [], interruptRequested: false })
+            .mockResolvedValue({ pendingInput: [], interruptRequested: true });
+        ai.dispatch.mockResolvedValue(
+            aiResponse({ toolCalls: [{ id: 'c1', name: 'noSuchTool', args: {} }] }),
+        );
+
+        const result = await makeSvc().execute(ctx);
+
+        expect(result.status).toBe('interrupted');
+        expect(result.finalizeResult?.status).toBe('completed');
+        expect(runs.markCompleted).toHaveBeenCalledWith('r1', expect.stringContaining('Interrupt'));
+        expect(runs.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('applies no externally-visible side effect when interrupted', async () => {
+        // An interrupted task run must not flip the Task to done: the human
+        // stopped it precisely because the work was not what they wanted.
+        runs.takeSteeringSignals.mockResolvedValue({
+            pendingInput: [],
+            interruptRequested: true,
+        });
+        await makeSvc().execute(ctx);
+        expect(taskFinisher.finishTask).not.toHaveBeenCalled();
+        expect(chatBackPoster.postReply).not.toHaveBeenCalled();
+    });
+
+    it('⭐ injects a queued steering message as a user turn on the next round', async () => {
+        runs.takeSteeringSignals.mockResolvedValue({
+            pendingInput: ['actually, target the staging bucket'],
+            interruptRequested: false,
+        });
+
+        await makeSvc().execute(ctx);
+
+        expect(ai.dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                messages: expect.arrayContaining([
+                    expect.objectContaining({
+                        role: 'user',
+                        content: 'actually, target the staging bucket',
+                    }),
+                ]),
+            }),
+        );
+        expect(runLogs.append).toHaveBeenCalledWith(expect.objectContaining({ step: 'steering' }));
+    });
+
+    it('injects several queued messages in order (nothing is dropped)', async () => {
+        runs.takeSteeringSignals.mockResolvedValue({
+            pendingInput: ['first', 'second'],
+            interruptRequested: false,
+        });
+
+        await makeSvc().execute(ctx);
+
+        const messages = ai.dispatch.mock.calls[0][0].messages;
+        const userTurns = messages.filter((m: { role: string }) => m.role === 'user');
+        expect(userTurns.map((m: { content: string }) => m.content)).toEqual(
+            expect.arrayContaining(['first', 'second']),
+        );
+        expect(userTurns.findIndex((m: { content: string }) => m.content === 'first')).toBeLessThan(
+            userTurns.findIndex((m: { content: string }) => m.content === 'second'),
+        );
+    });
+
+    it('degrades to today’s behaviour when the repository has no steering methods', async () => {
+        // Older API replica mid-rollout, or one of the many partial repo stubs
+        // in the existing specs. A missing method must never throw inside the
+        // loop and be misreported as a dispatch failure.
+        delete runs.takeSteeringSignals;
+        const result = await makeSvc().execute(ctx);
+        expect(result.status).toBe('dispatched');
+        expect(ai.dispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('degrades the same way when the steering read throws', async () => {
+        runs.takeSteeringSignals.mockRejectedValue(new Error('db blip'));
+        const result = await makeSvc().execute(ctx);
+        expect(result.status).toBe('dispatched');
+    });
+
+    describe('awaiting-input lifecycle signal', () => {
+        it('parks the run when the outcome reports it (never from prose)', async () => {
+            await makeSvc().finalize(ctx, { errored: false, awaitingInput: true });
+            expect(runs.setAwaitingInput).toHaveBeenCalledWith('r1', true);
+        });
+
+        it('leaves an ordinary completion unparked', async () => {
+            await makeSvc().finalize(ctx, { errored: false, summary: 'all done' });
+            expect(runs.setAwaitingInput).not.toHaveBeenCalled();
+        });
+
+        it('markAwaitingInput is a no-op on a repository without the column support', async () => {
+            delete runs.setAwaitingInput;
+            await expect(makeSvc().markAwaitingInput('r1')).resolves.toBeUndefined();
+        });
+    });
+});

--- a/packages/agent/src/agents/__tests__/agent-run-sweeper.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-sweeper.service.spec.ts
@@ -99,6 +99,43 @@ describe('AgentRunSweeperService', () => {
         });
     });
 
+    describe('Wave 4 M5 — awaiting-input runs are never reaped', () => {
+        it('⭐ skips a stuck-looking run that is parked on human input', async () => {
+            // THE NEVER-REAP TEST. A run awaiting a human answer is not stuck,
+            // it is waiting — possibly for days. Reaping it destroys work
+            // nobody can recover, and it is the single production bug this
+            // whole rule exists to prevent. The repository predicate already
+            // excludes these rows; this asserts the service refuses them too,
+            // so an older API replica handing one back still cannot reap it.
+            runs.findStuckNonTerminal.mockResolvedValue([
+                stuckRow({ id: 'parked', awaitingInput: true }),
+            ]);
+            const summary = await makeSvc().sweepStuckRuns();
+            expect(summary.swept).toBe(0);
+            expect(summary.scanned).toBe(0);
+            expect(runs.markStuckFailed).not.toHaveBeenCalled();
+        });
+
+        it('still reaps the non-awaiting rows in the same batch', async () => {
+            // The exemption must be per-row, not "abort the whole sweep".
+            runs.findStuckNonTerminal.mockResolvedValue([
+                stuckRow({ id: 'parked', awaitingInput: true }),
+                stuckRow({ id: 'dead', awaitingInput: false }),
+            ]);
+            runs.markStuckFailed.mockResolvedValue(1);
+            const summary = await makeSvc().sweepStuckRuns();
+            expect(summary.swept).toBe(1);
+            expect(runs.markStuckFailed).toHaveBeenCalledWith(['dead'], expect.any(String));
+        });
+
+        it('treats a row with no awaitingInput column (pre-migration) as reapable', async () => {
+            runs.findStuckNonTerminal.mockResolvedValue([stuckRow({ id: 'legacy' })]);
+            runs.markStuckFailed.mockResolvedValue(1);
+            const summary = await makeSvc().sweepStuckRuns();
+            expect(summary.swept).toBe(1);
+        });
+    });
+
     it('⭐ reaps a run older than the cutoff', async () => {
         // THE NO-OP CATCHER. An implementation that returns { swept: 0 }
         // unconditionally passes every safety test in this file — only this

--- a/packages/agent/src/agents/__tests__/run-steering.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-steering.service.spec.ts
@@ -1,0 +1,267 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { RunSteeringService } from '../run-steering.service';
+
+/**
+ * Run steering (Wave 4 M5) — steer / interrupt / resume.
+ *
+ * The load-bearing behaviours, each called out inline:
+ *  - steer on a LIVE run injects (does not spawn a second run);
+ *  - steer on a TERMINAL run refuses to inject and tells the caller to start
+ *    a new one — the whole point of the routing rule;
+ *  - resume carries `cliSessionId`, which is what makes it a *resume* rather
+ *    than a fresh conversation.
+ */
+describe('RunSteeringService', () => {
+    const userId = 'user-1';
+    const runId = 'run-1';
+
+    let runs: any;
+    let runLogs: any;
+    let dispatcher: any;
+    let gate: any;
+
+    function makeRun(over: Record<string, unknown> = {}) {
+        return {
+            id: runId,
+            agentId: 'agent-1',
+            userId,
+            status: 'running',
+            taskId: 'task-1',
+            workId: 'work-1',
+            organizationId: 'org-1',
+            awaitingInput: false,
+            terminalEndedReason: null,
+            cliSessionId: null,
+            runnerKind: null,
+            pendingInput: null,
+            ...over,
+        };
+    }
+
+    function makeSvc(): RunSteeringService {
+        const svc = new RunSteeringService(runs, runLogs, dispatcher, gate);
+        for (const level of ['log', 'warn'] as const) {
+            jest.spyOn(
+                (svc as never as { logger: Record<string, () => void> }).logger,
+                level,
+            ).mockImplementation(() => undefined);
+        }
+        return svc;
+    }
+
+    beforeEach(() => {
+        runs = {
+            findByIdAndUser: jest.fn().mockResolvedValue(makeRun()),
+            findById: jest.fn().mockResolvedValue(makeRun({ pendingInput: ['hi'] })),
+            appendPendingInput: jest.fn().mockResolvedValue(true),
+            requestInterrupt: jest.fn().mockResolvedValue(true),
+            setAwaitingInput: jest.fn().mockResolvedValue(undefined),
+            seedResumeContext: jest.fn().mockResolvedValue(undefined),
+            createQueued: jest.fn().mockResolvedValue({ id: 'run-2' }),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+        };
+        runLogs = { append: jest.fn().mockResolvedValue(undefined) };
+        dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trigger-run-2' }) };
+        gate = { admit: jest.fn().mockResolvedValue({ admitted: true }) };
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    // ── steer ──────────────────────────────────────────────────────
+
+    describe('steer', () => {
+        it('⭐ injects into a RUNNING run instead of starting a second one', async () => {
+            const result = await makeSvc().steer({ runId, userId, message: 'use fixture data' });
+            expect(result.dispatched).toBe('injected');
+            expect(result.runId).toBe(runId);
+            expect(runs.appendPendingInput).toHaveBeenCalledWith(runId, 'use fixture data');
+            expect(runs.createQueued).not.toHaveBeenCalled();
+        });
+
+        it('injects into a QUEUED run too — a run that has not started yet still takes input', async () => {
+            runs.findByIdAndUser.mockResolvedValue(makeRun({ status: 'queued' }));
+            const result = await makeSvc().steer({ runId, userId, message: 'wait for me' });
+            expect(result.dispatched).toBe('injected');
+            expect(runs.appendPendingInput).toHaveBeenCalled();
+        });
+
+        it('⭐ answers new-run for a TERMINAL run and injects nothing', async () => {
+            // THE ROUTING RULE. Injecting into a finished run would silently
+            // swallow the user's message: nothing is left to read the queue.
+            runs.findByIdAndUser.mockResolvedValue(makeRun({ status: 'completed' }));
+            const result = await makeSvc().steer({ runId, userId, message: 'and now deploy' });
+            expect(result.dispatched).toBe('new-run');
+            expect(runs.appendPendingInput).not.toHaveBeenCalled();
+        });
+
+        it('answers new-run when the append loses the race with a terminal write', async () => {
+            runs.appendPendingInput.mockResolvedValue(false);
+            const result = await makeSvc().steer({ runId, userId, message: 'ping' });
+            expect(result.dispatched).toBe('new-run');
+        });
+
+        it('404s a run owned by another user (no existence oracle)', async () => {
+            runs.findByIdAndUser.mockResolvedValue(null);
+            await expect(
+                makeSvc().steer({ runId, userId: 'someone-else', message: 'ping' }),
+            ).rejects.toBeInstanceOf(NotFoundException);
+        });
+
+        it('rejects an empty message rather than queueing whitespace', async () => {
+            await expect(makeSvc().steer({ runId, userId, message: '   ' })).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+            expect(runs.appendPendingInput).not.toHaveBeenCalled();
+        });
+
+        it('stamps the acting user on the run (executor stamping)', async () => {
+            await makeSvc().steer({ runId, userId, message: 'ping' });
+            expect(runLogs.append).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    runId,
+                    step: 'steering',
+                    metadata: expect.objectContaining({ action: 'steer', actorUserId: userId }),
+                }),
+            );
+        });
+    });
+
+    // ── interrupt ──────────────────────────────────────────────────
+
+    describe('interrupt', () => {
+        it('⭐ records the cooperative stop flag on a live run', async () => {
+            const result = await makeSvc().interrupt(runId, userId);
+            expect(result).toEqual({ interrupted: true, runId });
+            expect(runs.requestInterrupt).toHaveBeenCalledWith(runId);
+        });
+
+        it('409s on an already-terminal run (no meaningful fallback action)', async () => {
+            runs.findByIdAndUser.mockResolvedValue(makeRun({ status: 'completed' }));
+            await expect(makeSvc().interrupt(runId, userId)).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+            expect(runs.requestInterrupt).not.toHaveBeenCalled();
+        });
+
+        it('409s when the CAS loses to a terminal write mid-flight', async () => {
+            runs.requestInterrupt.mockResolvedValue(false);
+            await expect(makeSvc().interrupt(runId, userId)).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+        });
+
+        it('404s a run owned by another user', async () => {
+            runs.findByIdAndUser.mockResolvedValue(null);
+            await expect(makeSvc().interrupt(runId, userId)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+        });
+    });
+
+    // ── resume ─────────────────────────────────────────────────────
+
+    describe('resume', () => {
+        const parked = () =>
+            makeRun({
+                status: 'completed',
+                terminalEndedReason: 'parked',
+                cliSessionId: 'cli-session-abc',
+            });
+
+        it('⭐ carries cliSessionId onto the NEW run — that is what makes it a resume', async () => {
+            runs.findByIdAndUser.mockResolvedValue(parked());
+            const result = await makeSvc().resume(runId, userId, 'yes, ship it');
+            expect(result).toEqual(
+                expect.objectContaining({
+                    dispatched: 'new-run',
+                    runId: 'run-2',
+                    resumedFromRunId: runId,
+                    carriedCliSession: true,
+                    queued: false,
+                }),
+            );
+            expect(runs.seedResumeContext).toHaveBeenCalledWith('run-2', {
+                cliSessionId: 'cli-session-abc',
+                pendingInput: ['yes, ship it'],
+            });
+        });
+
+        it('resumes an awaiting-input run and clears its parked flag', async () => {
+            runs.findByIdAndUser.mockResolvedValue(
+                makeRun({ status: 'completed', awaitingInput: true }),
+            );
+            await makeSvc().resume(runId, userId, 'option B');
+            expect(runs.setAwaitingInput).toHaveBeenCalledWith(runId, false);
+        });
+
+        it('resumes with no message at all ("carry on")', async () => {
+            runs.findByIdAndUser.mockResolvedValue(parked());
+            await makeSvc().resume(runId, userId, null);
+            expect(runs.seedResumeContext).toHaveBeenCalledWith('run-2', {
+                cliSessionId: 'cli-session-abc',
+                pendingInput: null,
+            });
+        });
+
+        it('dispatches the new run with a run-scoped dedup key', async () => {
+            runs.findByIdAndUser.mockResolvedValue(parked());
+            await makeSvc().resume(runId, userId);
+            expect(dispatcher.enqueue).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    agentId: 'agent-1',
+                    taskId: 'task-1',
+                    runId: 'run-2',
+                    dedupKey: 'task-1:agent-1:resume:run-2',
+                }),
+            );
+            expect(runs.setTriggerRunId).toHaveBeenCalledWith('run-2', 'trigger-run-2');
+        });
+
+        it('parks the resumed run (and skips the enqueue) when the gate refuses admission', async () => {
+            runs.findByIdAndUser.mockResolvedValue(parked());
+            gate.admit.mockResolvedValue({ admitted: false, queuedReason: 'concurrency-limit' });
+            const result = await makeSvc().resume(runId, userId);
+            expect(result.queued).toBe(true);
+            expect(runs.createQueued).toHaveBeenCalledWith(
+                expect.objectContaining({ queuedReason: 'concurrency-limit' }),
+            );
+            expect(dispatcher.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('409s a run that is still live — resume is not a second dispatch button', async () => {
+            runs.findByIdAndUser.mockResolvedValue(makeRun({ status: 'running' }));
+            await expect(makeSvc().resume(runId, userId)).rejects.toBeInstanceOf(ConflictException);
+            expect(runs.createQueued).not.toHaveBeenCalled();
+        });
+
+        it('409s a run that ended for a non-parked reason', async () => {
+            runs.findByIdAndUser.mockResolvedValue(
+                makeRun({ status: 'failed', terminalEndedReason: 'crashed' }),
+            );
+            await expect(makeSvc().resume(runId, userId)).rejects.toBeInstanceOf(ConflictException);
+        });
+
+        it('409s a parked run with no Task — nothing to dispatch onto', async () => {
+            runs.findByIdAndUser.mockResolvedValue(parked());
+            runs.findByIdAndUser.mockResolvedValue({ ...parked(), taskId: null });
+            await expect(makeSvc().resume(runId, userId)).rejects.toBeInstanceOf(ConflictException);
+            expect(runs.createQueued).not.toHaveBeenCalled();
+        });
+
+        it('rolls the new run to dispatch-failed when the enqueue throws', async () => {
+            runs.findByIdAndUser.mockResolvedValue(parked());
+            dispatcher.enqueue.mockRejectedValue(new Error('runtime down'));
+            await expect(makeSvc().resume(runId, userId)).rejects.toBeInstanceOf(ConflictException);
+            expect(runs.markDispatchFailed).toHaveBeenCalledWith(
+                'run-2',
+                expect.stringContaining('dispatch-failed'),
+            );
+        });
+
+        it('404s a run owned by another user', async () => {
+            runs.findByIdAndUser.mockResolvedValue(null);
+            await expect(makeSvc().resume(runId, userId)).rejects.toBeInstanceOf(NotFoundException);
+        });
+    });
+});

--- a/packages/agent/src/agents/agent-run-post-processor.ts
+++ b/packages/agent/src/agents/agent-run-post-processor.ts
@@ -53,6 +53,13 @@ export const AGENT_RUN_TASK_FINISHER = 'AGENT_RUN_TASK_FINISHER' as const;
  * `force` — passed through to the transition call. Approver gate only.
  * `errored` — when true, the AgentRun row is marked failed instead of
  * completed and side-effects are skipped.
+ * `awaitingInput` — run steering (Wave 4 M5) lifecycle signal: the run
+ * ended without a definitive outcome because it needs a human (a
+ * question, an approval, an exhausted budget). `finalize()` stamps
+ * `agent_runs.awaitingInput`, which the Sessions view badges and the
+ * stale-run sweeper is forbidden to reap. A LIFECYCLE SIGNAL, never
+ * agent self-report prose — only the executor / pipeline plugin sets it,
+ * and it is not parsed out of the assistant's text.
  */
 export interface AgentRunOutcome {
     summary?: string | null;
@@ -61,4 +68,5 @@ export interface AgentRunOutcome {
     force?: boolean;
     errored?: boolean;
     errorMessage?: string;
+    awaitingInput?: boolean;
 }

--- a/packages/agent/src/agents/agent-run-sweeper.service.ts
+++ b/packages/agent/src/agents/agent-run-sweeper.service.ts
@@ -82,7 +82,22 @@ export class AgentRunSweeperService {
         const now = Date.now();
         const cutoff = new Date(now - cutoffMinutes * 60_000);
 
-        const stuck = await this.runs.findStuckNonTerminal(cutoff, limit);
+        const scanned = await this.runs.findStuckNonTerminal(cutoff, limit);
+        // Run steering (Wave 4 M5) — THE hard rule of this plan: a run parked
+        // on a human question must NEVER be reaped by a TTL sweep. It is not
+        // stuck, it is waiting, possibly for days, and killing it destroys
+        // work nobody can recover. The repository predicate already excludes
+        // these rows; re-asserting it here is deliberate belt-and-braces —
+        // this service is the last gate before `markStuckFailed`, and an
+        // older API replica (or a future second caller) handing back an
+        // awaiting row must still not reap it.
+        const stuck = scanned.filter((row) => row.awaitingInput !== true);
+        const skippedAwaiting = scanned.length - stuck.length;
+        if (skippedAwaiting > 0) {
+            this.logger.log(
+                `AgentRun sweep: skipped ${skippedAwaiting} run(s) awaiting human input (never reaped).`,
+            );
+        }
         if (stuck.length === 0) {
             // Logged even on zero so the ABSENCE of sweeps is positively
             // confirmed rather than inferred from silence.
@@ -103,7 +118,10 @@ export class AgentRunSweeperService {
             `${STUCK_SWEEP_PREFIX}: no worker checkpoint for ${cutoffMinutes}m`,
         );
 
-        const batchLimitReached = stuck.length >= limit;
+        // Measured on the RAW scan, not the awaiting-filtered set: the batch
+        // is what the query returned, so a page full of skipped rows still
+        // means "more remain, come back next tick".
+        const batchLimitReached = scanned.length >= limit;
         // Every non-zero sweep is an anomaly — a worker died. Loud on purpose:
         // a silent sweeper hides the upstream failure it is compensating for.
         // The per-kind breakdown is what separates "one node was evicted" from

--- a/packages/agent/src/agents/agent-run.service.ts
+++ b/packages/agent/src/agents/agent-run.service.ts
@@ -98,7 +98,16 @@ export interface AgentRunExecuteResult {
         | 'dispatched'
         | 'dispatch-failed'
         /** Cancelled mid-flight; the row is already 'cancelled' and no status was written. */
-        | 'cancelled';
+        | 'cancelled'
+        /**
+         * Run steering (Wave 4 M5) — a cooperative interrupt stopped the tool
+         * loop between iterations. Distinct from `cancelled` (the process was
+         * killed and every side effect skipped) and from `dispatched` (the
+         * agent finished its own work): the row IS marked `completed` with an
+         * honest summary, but downstream steps that grade completed work — the
+         * quality gate, the PR step — must not treat it as success.
+         */
+        | 'interrupted';
     prompt?: AssembledPrompt;
     budgetCheck?: AgentRunBudgetCheck;
     /** Set when the LLM-dispatch path ran end-to-end. */
@@ -441,6 +450,32 @@ export class AgentRunService {
         }
 
         const dispatchResult = await this.runToolLoop(context, agent, prompt);
+        if (dispatchResult.interrupted) {
+            // Run steering (Wave 4 M5) — a human asked the agent to stop. The
+            // run is COMPLETED (it did real work up to here and its workspace
+            // state is meaningful), with a summary that says why it ended.
+            // No replyBody / taskFinishStatus, so finalize applies no
+            // externally-visible side effect: an interrupted run must not
+            // silently flip the Task to done.
+            const summary =
+                dispatchResult.outcome.summary ??
+                `Interrupted by the user after ${dispatchResult.iterations} model round-trip(s).`;
+            const finalizeResult = await this.finalize(
+                context,
+                { errored: false, summary },
+                memorySessionId,
+                agent,
+            );
+            return {
+                runId: context.runId,
+                status: 'interrupted',
+                prompt,
+                budgetCheck,
+                outcome: { ...dispatchResult.outcome, summary },
+                finalizeResult,
+                toolLoopIterations: dispatchResult.iterations,
+            };
+        }
         if (dispatchResult.cancelled) {
             const finalizeResult = await this.finalize(
                 context,
@@ -526,6 +561,12 @@ export class AgentRunService {
          * every externally-visible side effect.
          */
         cancelled?: boolean;
+        /**
+         * Run steering (Wave 4 M5) — a cooperative interrupt stopped the loop
+         * between iterations. The row is still open, so the caller finalizes
+         * it `completed` with a summary.
+         */
+        interrupted?: boolean;
         errorMessage?: string;
         outcome: AgentRunOutcome;
         iterations: number;
@@ -583,6 +624,9 @@ export class AgentRunService {
         // partial outcome. Using the toolCalls.length signal directly is
         // provider-agnostic.
         let lastRoundHadToolCalls = false;
+        // Run steering (Wave 4 M5) — set when a cooperative interrupt landed
+        // between iterations; the caller finalizes the run `completed`.
+        let interrupted = false;
 
         try {
             while (iterations < TOOL_LOOP_MAX_ITERATIONS) {
@@ -590,6 +634,49 @@ export class AgentRunService {
                 // One checkpoint per model round-trip. Bounded at 10 by the cap
                 // above, and the DB is only read when the signal did not fire.
                 await abort.checkpoint();
+
+                // Run steering (Wave 4 M5) — the SAME checkpoint reads the two
+                // cooperative control signals: an interrupt request (stop
+                // between iterations, keeping the work done so far) and any
+                // steering messages a human queued while the agent was
+                // streaming. Deliberately adjacent to `abort.checkpoint()`:
+                // one place in the loop owns "should I keep going, and has
+                // anyone said anything?".
+                const steering = await this.takeSteeringSignals(context.runId);
+                if (steering.interruptRequested) {
+                    interrupted = true;
+                    await this.runLogs
+                        .append({
+                            runId: context.runId,
+                            level: 'WARN',
+                            step: 'steering',
+                            message: 'Interrupt requested — stopping between iterations.',
+                            metadata: { iteration: iterations, reason: 'interrupt' },
+                        })
+                        .catch(() => undefined);
+                    // Iterations counts round-trips PERFORMED; this one never
+                    // reached the model.
+                    iterations -= 1;
+                    break;
+                }
+                for (const injected of steering.pendingInput) {
+                    // Security (prompt-injection): a steering message is
+                    // authenticated human input from the run's owner, but it
+                    // still enters the same message list as untrusted tool
+                    // output, so it is framed explicitly as a user turn rather
+                    // than spliced into the system prompt.
+                    messages.push({ role: 'user', content: injected });
+                    await this.runLogs
+                        .append({
+                            runId: context.runId,
+                            level: 'INFO',
+                            step: 'steering',
+                            message: 'Injected a queued steering message into the live run.',
+                            metadata: { iteration: iterations, bytes: injected.length },
+                        })
+                        .catch(() => undefined);
+                }
+
                 const round = await this.aiDispatch!.dispatch({
                     abortSignal: abort.signal,
                     messages,
@@ -715,6 +802,22 @@ export class AgentRunService {
             };
         }
 
+        if (interrupted) {
+            // Honest summary: what the agent DID before it was told to stop.
+            // No `taskFinishStatus` / `replyBody` — an interrupted run must
+            // apply no externally-visible side effect.
+            const summary =
+                iterations > 0
+                    ? `Interrupted by the user after ${iterations} model round-trip(s).`
+                    : 'Interrupted by the user before the first model round-trip.';
+            return {
+                errored: false,
+                interrupted: true,
+                outcome: { errored: false, summary },
+                iterations,
+            };
+        }
+
         if (
             iterations >= TOOL_LOOP_MAX_ITERATIONS &&
             (lastFinishReason === 'tool_calls' || lastRoundHadToolCalls)
@@ -744,6 +847,69 @@ export class AgentRunService {
             capturedForce,
         );
         return { errored: false, outcome, iterations };
+    }
+
+    /**
+     * Run steering (Wave 4 M5) — read (and consume) this run's cooperative
+     * control signals.
+     *
+     * Feature-detected rather than called unconditionally: `this.runs` is
+     * stubbed with a partial mock in a large number of existing unit specs
+     * (and by the worker's RPC proxy shape when an older API replica is still
+     * rolling), and a missing method must degrade to "no steering" — never
+     * throw inside the tool loop and get misreported as a dispatch failure.
+     * Any read failure degrades the same way for the same reason: steering is
+     * an enhancement, the run is the product.
+     */
+    private async takeSteeringSignals(
+        runId: string,
+    ): Promise<{ pendingInput: string[]; interruptRequested: boolean }> {
+        const none = { pendingInput: [] as string[], interruptRequested: false };
+        const take = (this.runs as Partial<AgentRunRepository>).takeSteeringSignals;
+        if (typeof take !== 'function') return none;
+        try {
+            const signals = await take.call(this.runs, runId);
+            return {
+                pendingInput: Array.isArray(signals?.pendingInput) ? signals.pendingInput : [],
+                interruptRequested: signals?.interruptRequested === true,
+            };
+        } catch (err) {
+            this.logger.warn(`Run ${runId}: steering read failed (ignored): ${err}`);
+            return none;
+        }
+    }
+
+    /**
+     * Run steering (Wave 4 M5) — the awaiting-input lifecycle signal, exposed
+     * as a first-class method so the executor AND pipeline plugins (over the
+     * worker's existing RPC proxy of this service — no new transport) can park
+     * a run on a human without reaching into the repository.
+     *
+     * `awaitingInput` is a LIFECYCLE SIGNAL, never agent self-report prose:
+     * callers report a structured "I asked a question / I need an approval"
+     * event, nothing is parsed out of the assistant's text. A parked run is
+     * exempt from every TTL sweep (`AgentRunSweeperService`), so setting it
+     * from prose would let a chatty agent make itself immortal.
+     */
+    async markAwaitingInput(runId: string, awaitingInput = true): Promise<void> {
+        const set = (this.runs as Partial<AgentRunRepository>).setAwaitingInput;
+        if (typeof set !== 'function') return;
+        try {
+            await set.call(this.runs, runId, awaitingInput);
+            await this.runLogs
+                .append({
+                    runId,
+                    level: 'INFO',
+                    step: 'steering',
+                    message: awaitingInput
+                        ? 'Run parked awaiting human input.'
+                        : 'Run no longer awaiting human input.',
+                    metadata: { awaitingInput },
+                })
+                .catch(() => undefined);
+        } catch (err) {
+            this.logger.warn(`Run ${runId}: failed to set awaitingInput=${awaitingInput}: ${err}`);
+        }
     }
 
     /**
@@ -974,6 +1140,15 @@ export class AgentRunService {
         }
 
         await this.runs.markCompleted(context.runId, summary ?? undefined).catch(() => undefined);
+        // Run steering (Wave 4 M5) — a run that finished WITHOUT a definitive
+        // outcome because it needs a human is parked here, at the one place
+        // every completion path funnels through. Signal-driven only: the
+        // executor / pipeline plugin sets `outcome.awaitingInput`; nothing is
+        // inferred from the assistant's prose. The Sessions view badges it and
+        // the stale-run sweeper is forbidden to reap it.
+        if (outcome.awaitingInput === true) {
+            await this.markAwaitingInput(context.runId, true);
+        }
         await this.tryCloseMemorySession(memorySessionId, context, agent ?? null);
 
         // Schedules P2 — completed-heartbeat activity coverage (see the

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -27,6 +27,7 @@ import { AgentExportService } from './agent-export.service';
 import { PromptAssemblerService } from './prompt-assembler.service';
 import { AgentRunService } from './agent-run.service';
 import { RunDispatchGateService } from './run-dispatch-gate.service';
+import { RunSteeringService } from './run-steering.service';
 import { AgentToolService } from './agent-tool.service';
 import { VisionContextService } from '../services/vision-context.service';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
@@ -99,6 +100,9 @@ import { FacadesModule } from '../facades/facades.module';
         // AGENT_TASK_EXECUTE_DISPATCHER it drains through is @Optional()
         // and bound by the api-side @Global() TasksModule.
         RunDispatchGateService,
+        // Wave 4 M5 — steer / interrupt / resume. Reuses the gate for resume
+        // admission and the existing cancel path for stop.
+        RunSteeringService,
         AgentToolService,
     ],
     exports: [
@@ -117,6 +121,7 @@ import { FacadesModule } from '../facades/facades.module';
         PromptAssemblerService,
         AgentRunService,
         RunDispatchGateService,
+        RunSteeringService,
         AgentToolService,
     ],
 })

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -10,6 +10,7 @@ export * from './agent-export.service';
 export * from './prompt-assembler.service';
 export * from './agent-run.service';
 export * from './run-dispatch-gate.service';
+export * from './run-steering.service';
 export * from './run-credits-precheck';
 export * from './agent-run-canceller';
 export * from './agent-run-abort';

--- a/packages/agent/src/agents/run-steering.service.ts
+++ b/packages/agent/src/agents/run-steering.service.ts
@@ -1,0 +1,341 @@
+import {
+    ConflictException,
+    Inject,
+    Injectable,
+    Logger,
+    NotFoundException,
+    Optional,
+} from '@nestjs/common';
+import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import { AgentRunLogRepository } from '../database/repositories/agent-run-log.repository';
+import type { AgentRun } from '../entities/agent-run.entity';
+import {
+    AGENT_TASK_EXECUTE_DISPATCHER,
+    JOB_RUNTIME_NOT_CONFIGURED_REASON,
+    type AgentTaskExecuteDispatcher,
+} from '../tasks-domain/task-dispatcher';
+import type {
+    RunSteerInput,
+    RunSteerOutcome,
+    RunSteeringPort,
+} from '../tasks-domain/run-steering-port';
+import { RunDispatchGateService } from './run-dispatch-gate.service';
+
+/**
+ * `terminalEndedReason` values that make a finished run resumable: the
+ * process was parked (hibernated) rather than completed, so its
+ * conversation — identified by `cliSessionId` — is still valid.
+ */
+const RESUMABLE_ENDED_REASONS = ['parked'] as const;
+
+/** Longest steering message accepted. Matches the task-chat body cap. */
+const MAX_STEER_BYTES = 16 * 1024;
+
+export interface RunInterruptOutcome {
+    /** True when the flag was recorded on a live run. */
+    interrupted: boolean;
+    runId: string;
+}
+
+export interface RunResumeOutcome {
+    dispatched: 'new-run';
+    /** The NEW run's id. The source run stays terminal — runs are immutable. */
+    runId: string;
+    /** Source run this one resumes. */
+    resumedFromRunId: string;
+    /** Whether the pipeline's own conversation id was carried over. */
+    carriedCliSession: boolean;
+    /** True when the dispatch gate parked the new run instead of enqueuing it. */
+    queued: boolean;
+}
+
+/**
+ * Run steering (Wave 4 M5) — the four run controls, all owner-scoped and
+ * all executor-stamped.
+ *
+ *  - **steer**     — a message for a run. LIVE run (`queued`/`running`) ⇒ the
+ *                    message is appended to the run's persisted pending-input
+ *                    queue and the executing tool loop injects it between
+ *                    model round-trips (`dispatched: 'injected'`). TERMINAL
+ *                    run ⇒ nothing is injected and the caller is told to start
+ *                    a fresh run (`dispatched: 'new-run'`). Steering also
+ *                    clears `awaitingInput`: an answered question is no longer
+ *                    a question.
+ *  - **interrupt** — cooperative stop request. Sets `interruptRequested`; the
+ *                    tool loop honours it at its per-iteration checkpoint, so
+ *                    the run stops BETWEEN iterations and finishes `completed`
+ *                    with a summary rather than being killed mid-flight.
+ *  - **stop**      — deliberately NOT implemented here. Stop is cancel, and
+ *                    cancel already exists end-to-end
+ *                    (`AgentRunRepository.cancel` + `AGENT_RUN_CANCELLER` +
+ *                    `POST /api/agents/:id/runs/:runId/cancel`). Duplicating
+ *                    it would fork the CAS + remote-cancel + drain semantics.
+ *  - **resume**    — a parked or awaiting-input run gets a NEW run carrying
+ *                    its `cliSessionId` (the pipeline plugin's own conversation
+ *                    id) and, optionally, a first message. Runs are immutable:
+ *                    resume never revives the old row.
+ *
+ * Every method loads the run through `findByIdAndUser`, so a run belonging to
+ * another user is indistinguishable from a missing one (no existence oracle —
+ * architecture/security §9).
+ */
+@Injectable()
+export class RunSteeringService implements RunSteeringPort {
+    private readonly logger = new Logger(RunSteeringService.name);
+
+    constructor(
+        private readonly runs: AgentRunRepository,
+        // Executor stamping (this plan §3.4): every control action writes an
+        // audit row naming the acting user. @Optional() so unit-test
+        // constructors can omit it.
+        @Optional() private readonly runLogs?: AgentRunLogRepository,
+        // Bound by the api-side @Global() TasksModule; absent in unit tests
+        // and installs without a job runtime — resume reports honestly
+        // instead of pretending it dispatched.
+        @Optional()
+        @Inject(AGENT_TASK_EXECUTE_DISPATCHER)
+        private readonly dispatcher?: AgentTaskExecuteDispatcher,
+        // Resume goes through the same concurrency choke point as every
+        // other dispatch path — a resumed run is a run.
+        @Optional() private readonly dispatchGate?: RunDispatchGateService,
+    ) {}
+
+    /** A run that can still receive injected input. */
+    static isLive(run: Pick<AgentRun, 'status'>): boolean {
+        return run.status === 'queued' || run.status === 'running';
+    }
+
+    /** A finished run whose conversation can still be resumed. */
+    static isResumable(run: Pick<AgentRun, 'status' | 'awaitingInput' | 'terminalEndedReason'>) {
+        if (run.awaitingInput === true) return true;
+        return (
+            !RunSteeringService.isLive(run) &&
+            RESUMABLE_ENDED_REASONS.includes(
+                (run.terminalEndedReason ?? '') as (typeof RESUMABLE_ENDED_REASONS)[number],
+            )
+        );
+    }
+
+    // ── steer ──────────────────────────────────────────────────────
+
+    async steer(input: RunSteerInput): Promise<RunSteerOutcome> {
+        const message = this.assertMessage(input.message);
+        const run = await this.requireOwnedRun(input.runId, input.userId);
+
+        if (!RunSteeringService.isLive(run)) {
+            // Terminal run — nothing to inject into. The caller (task chat,
+            // API, UI) starts a fresh run instead. NOT an error: "the run
+            // already finished" is a normal race with a human typing.
+            await this.stamp(run.id, input.userId, 'steer', {
+                dispatched: 'new-run',
+                runStatus: run.status,
+            });
+            return { dispatched: 'new-run', runId: run.id };
+        }
+
+        const appended = await this.runs.appendPendingInput(run.id, message);
+        if (!appended) {
+            // Lost the race with a terminal write between our read and the
+            // guarded UPDATE. Same answer as the terminal branch.
+            await this.stamp(run.id, input.userId, 'steer', {
+                dispatched: 'new-run',
+                reason: 'terminal-race',
+            });
+            return { dispatched: 'new-run', runId: run.id };
+        }
+
+        const queue = await this.peekQueueLength(run.id);
+        await this.stamp(run.id, input.userId, 'steer', {
+            dispatched: 'injected',
+            queuedCount: queue,
+        });
+        this.logger.log(`Run ${run.id}: steering message injected by user ${input.userId}.`);
+        return { dispatched: 'injected', runId: run.id, queuedCount: queue };
+    }
+
+    // ── interrupt ──────────────────────────────────────────────────
+
+    async interrupt(runId: string, userId: string): Promise<RunInterruptOutcome> {
+        const run = await this.requireOwnedRun(runId, userId);
+        if (!RunSteeringService.isLive(run)) {
+            throw new ConflictException(
+                `AgentRun ${runId} is ${run.status} — only a queued or running run can be interrupted.`,
+            );
+        }
+        const recorded = await this.runs.requestInterrupt(run.id);
+        if (!recorded) {
+            // Terminal between the read and the CAS.
+            throw new ConflictException(
+                `AgentRun ${runId} finished before the interrupt could be recorded.`,
+            );
+        }
+        await this.stamp(run.id, userId, 'interrupt', { previousStatus: run.status });
+        this.logger.log(`Run ${run.id}: interrupt requested by user ${userId}.`);
+        return { interrupted: true, runId: run.id };
+    }
+
+    // ── resume ─────────────────────────────────────────────────────
+
+    async resume(
+        runId: string,
+        userId: string,
+        message?: string | null,
+    ): Promise<RunResumeOutcome> {
+        const trimmed =
+            message == null || message.trim().length === 0 ? null : this.assertMessage(message);
+        const run = await this.requireOwnedRun(runId, userId);
+
+        if (!RunSteeringService.isResumable(run)) {
+            throw new ConflictException(
+                `AgentRun ${runId} is not resumable — resume applies to runs awaiting input or ` +
+                    `ended with reason '${RESUMABLE_ENDED_REASONS.join("' / '")}' ` +
+                    `(status=${run.status}, endedReason=${run.terminalEndedReason ?? 'none'}).`,
+            );
+        }
+        if (!run.taskId) {
+            // The only dispatch path a resumed run can take today is
+            // `agent-task-execute`, which is Task-keyed. A heartbeat run has
+            // no Task to resume onto — say so instead of half-dispatching.
+            throw new ConflictException(
+                `AgentRun ${runId} has no Task — only task-attached runs can be resumed.`,
+            );
+        }
+
+        // Same concurrency choke point as every other dispatch path.
+        const admission = this.dispatchGate
+            ? await this.dispatchGate.admit({
+                  userId,
+                  workId: run.workId ?? null,
+                  organizationId: run.organizationId ?? null,
+              })
+            : { admitted: true as const, queuedReason: undefined };
+
+        const next = await this.runs.createQueued({
+            agentId: run.agentId,
+            userId,
+            triggerKind: 'task',
+            taskId: run.taskId,
+            workId: run.workId ?? null,
+            organizationId: run.organizationId ?? null,
+            runnerKind: run.runnerKind ?? null,
+            queuedReason: admission.admitted ? null : (admission.queuedReason ?? null),
+        });
+
+        // The conversation lifetime survives the process lifetime: hand the
+        // pipeline plugin its own resume id, and seed the first message so
+        // the resumed loop starts from the human's answer.
+        await this.runs.seedResumeContext(next.id, {
+            cliSessionId: run.cliSessionId ?? null,
+            pendingInput: trimmed ? [trimmed] : null,
+        });
+
+        // The source run is answered — it must stop showing up in the
+        // needs-attention filter.
+        if (run.awaitingInput) {
+            await this.runs.setAwaitingInput(run.id, false).catch(() => undefined);
+        }
+
+        if (admission.admitted && this.dispatcher) {
+            try {
+                const handle = await this.dispatcher.enqueue({
+                    agentId: run.agentId,
+                    userId,
+                    taskId: run.taskId,
+                    // Run-scoped so a double resume dedups at the runner and
+                    // cannot collide with the original run's fan-out key.
+                    dedupKey: `${run.taskId}:${run.agentId}:resume:${next.id}`,
+                    runId: next.id,
+                });
+                if (handle?.runId) {
+                    await this.runs
+                        .setTriggerRunId(next.id, handle.runId)
+                        .catch((err) =>
+                            this.logger.warn(
+                                `Run ${next.id}: failed to stamp triggerRunId on resume: ${err}`,
+                            ),
+                        );
+                }
+            } catch (err) {
+                const detail = err instanceof Error ? err.message : String(err);
+                const notConfigured =
+                    err instanceof Error && err.name === 'JobRuntimeNotConfiguredError';
+                const reason = notConfigured
+                    ? `${JOB_RUNTIME_NOT_CONFIGURED_REASON}: ${detail}`
+                    : `dispatch-failed: ${detail}`;
+                this.logger.warn(`Run ${next.id}: resume enqueue failed: ${reason}`);
+                await this.runs.markDispatchFailed(next.id, reason).catch(() => undefined);
+                throw new ConflictException(`Resume could not be dispatched — ${reason}`);
+            }
+        }
+
+        await this.stamp(next.id, userId, 'resume', {
+            resumedFromRunId: run.id,
+            carriedCliSession: Boolean(run.cliSessionId),
+            hasMessage: Boolean(trimmed),
+            queued: !admission.admitted,
+        });
+        this.logger.log(`Run ${run.id}: resumed as ${next.id} by user ${userId}.`);
+
+        return {
+            dispatched: 'new-run',
+            runId: next.id,
+            resumedFromRunId: run.id,
+            carriedCliSession: Boolean(run.cliSessionId),
+            queued: !admission.admitted,
+        };
+    }
+
+    // ── internals ──────────────────────────────────────────────────
+
+    private async requireOwnedRun(runId: string, userId: string): Promise<AgentRun> {
+        const run = await this.runs.findByIdAndUser(runId, userId);
+        if (!run) throw new NotFoundException(`AgentRun ${runId} not found.`);
+        return run;
+    }
+
+    private assertMessage(message: string): string {
+        const trimmed = (message ?? '').trim();
+        if (trimmed.length === 0) {
+            throw new ConflictException('A steering message is required.');
+        }
+        if (trimmed.length > MAX_STEER_BYTES) {
+            throw new ConflictException(`Steering message exceeds max ${MAX_STEER_BYTES} bytes.`);
+        }
+        return trimmed;
+    }
+
+    private async peekQueueLength(runId: string): Promise<number> {
+        try {
+            const fresh = await this.runs.findById(runId);
+            return Array.isArray(fresh?.pendingInput) ? fresh.pendingInput.length : 0;
+        } catch {
+            return 0;
+        }
+    }
+
+    /**
+     * Executor stamp (this plan §3.4 — "all of them stamp the acting user").
+     * Best-effort: an audit-row failure must never fail the control action it
+     * describes, but every failure is logged so a silent audit gap is
+     * impossible.
+     */
+    private async stamp(
+        runId: string,
+        userId: string,
+        action: 'steer' | 'interrupt' | 'resume',
+        metadata: Record<string, unknown>,
+    ): Promise<void> {
+        if (!this.runLogs) return;
+        try {
+            await this.runLogs.append({
+                runId,
+                level: 'INFO',
+                step: 'steering',
+                message: `Run control '${action}' by user ${userId}.`,
+                metadata: { ...metadata, action, actorUserId: userId },
+            });
+        } catch (err) {
+            this.logger.warn(`Run ${runId}: failed to stamp '${action}' audit row: ${err}`);
+        }
+    }
+}

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -273,27 +273,47 @@ export class AgentRunRepository {
     ): Promise<
         Pick<
             AgentRun,
-            'id' | 'agentId' | 'triggerKind' | 'status' | 'startedAt' | 'createdAt' | 'workId'
+            | 'id'
+            | 'agentId'
+            | 'triggerKind'
+            | 'status'
+            | 'startedAt'
+            | 'createdAt'
+            | 'workId'
+            | 'awaitingInput'
         >[]
     > {
-        return this.repository
-            .createQueryBuilder('run')
-            .select([
-                'run.id',
-                'run.agentId',
-                'run.triggerKind',
-                'run.status',
-                'run.startedAt',
-                'run.createdAt',
-                // Wave 4 M2 — the sweeper drains the concurrency queue for
-                // every Work whose stuck run it just reaped.
-                'run.workId',
-            ])
-            .where('run.status IN (:...statuses)', { statuses: NON_TERMINAL })
-            .andWhere('COALESCE(run.startedAt, run.createdAt) <= :cutoff', { cutoff })
-            .orderBy('COALESCE(run.startedAt, run.createdAt)', 'ASC')
-            .limit(limit)
-            .getMany();
+        return (
+            this.repository
+                .createQueryBuilder('run')
+                .select([
+                    'run.id',
+                    'run.agentId',
+                    'run.triggerKind',
+                    'run.status',
+                    'run.startedAt',
+                    'run.createdAt',
+                    // Wave 4 M2 — the sweeper drains the concurrency queue for
+                    // every Work whose stuck run it just reaped.
+                    'run.workId',
+                    // Wave 4 M5 — selected so the sweeper can re-assert the
+                    // never-reap-awaiting_input rule in the service layer too.
+                    'run.awaitingInput',
+                ])
+                .where('run.status IN (:...statuses)', { statuses: NON_TERMINAL })
+                // Wave 4 M5 — a run parked on a human question is NOT stuck; it is
+                // waiting, possibly for days. Reaping it is the production bug this
+                // predicate exists to prevent, so the exemption lives in the SQL
+                // (and again in `AgentRunSweeperService`, belt-and-braces). The
+                // NULL arm covers rows written before the column existed.
+                .andWhere('(run.awaitingInput IS NULL OR run.awaitingInput = :notAwaiting)', {
+                    notAwaiting: false,
+                })
+                .andWhere('COALESCE(run.startedAt, run.createdAt) <= :cutoff', { cutoff })
+                .orderBy('COALESCE(run.startedAt, run.createdAt)', 'ASC')
+                .limit(limit)
+                .getMany()
+        );
     }
 
     /**
@@ -773,6 +793,114 @@ export class AgentRunRepository {
             .andWhere('status = :status', { status: 'queued' satisfies AgentRunStatus })
             .andWhere('queuedReason IS NULL')
             .execute();
+    }
+
+    // ── Run steering (Wave 4 M5) ───────────────────────────────────
+
+    /**
+     * Append one steering message to a LIVE run's pending-input queue.
+     *
+     * Read-modify-write rather than a SQL array append: `pendingInput` is a
+     * `simple-json` (text) column, and the two supported drivers (Postgres in
+     * prod, sqlite in e2e) have no portable JSON-append. The status re-check
+     * inside the UPDATE's WHERE is what makes it safe: a run that went terminal
+     * between the read and the write takes no message, and the caller is told
+     * so (`false`) and starts a new run instead. Two concurrent steers on the
+     * same live run can drop one message under a lost update — acceptable for a
+     * human-paced control channel, and strictly better than a terminal run
+     * silently swallowing input.
+     *
+     * `awaitingInput` is cleared in the SAME statement: an answered question is
+     * no longer a question, and doing it here means no window where the run is
+     * both parked and holding fresh input.
+     */
+    async appendPendingInput(runId: string, message: string): Promise<boolean> {
+        const run = await this.repository.findOne({
+            where: { id: runId },
+            select: ['id', 'status', 'pendingInput'],
+        });
+        if (!run) return false;
+        if (!NON_TERMINAL.includes(run.status)) return false;
+        const queue = Array.isArray(run.pendingInput) ? [...run.pendingInput] : [];
+        queue.push(message);
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({ pendingInput: queue, awaitingInput: false })
+            .where('id = :id', { id: runId })
+            .andWhere('status IN (:...statuses)', { statuses: NON_TERMINAL })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Drain the steering signals for the executing run: the queued input
+     * messages (cleared as they are handed over, so the same message is never
+     * injected twice) plus the cooperative interrupt flag.
+     *
+     * Called once per model round-trip by `AgentRunService.runToolLoop`, i.e.
+     * at most `TOOL_LOOP_MAX_ITERATIONS` times per run, and it only writes when
+     * there was actually something queued.
+     */
+    async takeSteeringSignals(runId: string): Promise<{
+        pendingInput: string[];
+        interruptRequested: boolean;
+    }> {
+        const run = await this.repository.findOne({
+            where: { id: runId },
+            select: ['id', 'pendingInput', 'interruptRequested'],
+        });
+        if (!run) return { pendingInput: [], interruptRequested: false };
+        const pendingInput = Array.isArray(run.pendingInput) ? run.pendingInput : [];
+        if (pendingInput.length > 0) {
+            await this.repository.update(runId, { pendingInput: null });
+        }
+        return { pendingInput, interruptRequested: run.interruptRequested === true };
+    }
+
+    /**
+     * Request a cooperative stop. CAS-guarded on `queued|running` so an
+     * interrupt racing a terminal write cannot resurrect a finished run's
+     * flag. Returns whether the request was recorded.
+     */
+    async requestInterrupt(runId: string): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({ interruptRequested: true })
+            .where('id = :id', { id: runId })
+            .andWhere('status IN (:...statuses)', { statuses: NON_TERMINAL })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Lifecycle signal: the run is (or is no longer) parked on a human.
+     *
+     * Deliberately NOT status-guarded — a run parks itself as its LAST act
+     * before finishing, so the write frequently lands on a row that is already
+     * terminal, and that is the correct state to record (the Sessions view
+     * shows "awaiting input" on a finished-but-parked run, and Resume is
+     * offered from exactly there).
+     */
+    async setAwaitingInput(runId: string, awaitingInput: boolean): Promise<void> {
+        await this.repository.update(runId, { awaitingInput });
+    }
+
+    /**
+     * Seed a freshly-created run with the conversation identity + first
+     * message it should resume from. Field-by-field whitelist, mirroring
+     * {@link updateTerminalColumns}.
+     */
+    async seedResumeContext(
+        runId: string,
+        patch: { cliSessionId?: string | null; pendingInput?: string[] | null },
+    ): Promise<void> {
+        const update: Record<string, unknown> = {};
+        if (patch.cliSessionId !== undefined) update.cliSessionId = patch.cliSessionId;
+        if (patch.pendingInput !== undefined) update.pendingInput = patch.pendingInput;
+        if (Object.keys(update).length === 0) return;
+        await this.repository.update(runId, update);
     }
 
     /**

--- a/packages/agent/src/entities/__tests__/agent-run.entity.spec.ts
+++ b/packages/agent/src/entities/__tests__/agent-run.entity.spec.ts
@@ -32,6 +32,16 @@ describe('AgentRun entity', () => {
         );
     });
 
+    it('declares the run-steering columns (Wave 4 M5)', () => {
+        // Pinned because the whole steering loop is invisible without them:
+        // the executing run reads `pendingInput` + `interruptRequested` on
+        // every tool-loop iteration, and a rename here degrades silently to
+        // "steering never arrives" rather than failing loudly.
+        expect(columnNames).toEqual(
+            expect.arrayContaining(['pendingInput', 'interruptRequested', 'awaitingInput']),
+        );
+    });
+
     it('declares timeline + status + task + chat indexes', () => {
         expect(indices.some((i) => i.name === 'idx_agent_runs_agent_started')).toBe(true);
         expect(indices.some((i) => i.name === 'idx_agent_runs_status')).toBe(true);

--- a/packages/agent/src/entities/agent-run.entity.ts
+++ b/packages/agent/src/entities/agent-run.entity.ts
@@ -265,6 +265,36 @@ export class AgentRun {
     @Column({ type: 'int', nullable: true })
     costCents?: number | null;
 
+    // ── Run steering (Wave 4 M5). Both additive; NULL/false on every
+    // pre-existing row. The steering service writes them, the executing
+    // run's tool loop reads them between iterations.
+
+    /**
+     * FIFO queue of steering messages waiting to be injected into the
+     * LIVE run. `RunSteeringService.steer()` appends while the run is
+     * `queued`/`running`; the tool loop drains the queue between model
+     * round-trips and appends each entry as a `user` turn, then clears
+     * the column. NULL = nothing pending (the overwhelmingly common
+     * case), so the column costs one text read per iteration and no
+     * write at all on an unsteered run.
+     *
+     * Deliberately a queue, not a single slot: the UX contract is
+     * "messages sent during an active stream are queued, never dropped".
+     */
+    @Column({ type: 'simple-json', nullable: true })
+    pendingInput?: string[] | null;
+
+    /**
+     * Cooperative stop request. Set by `RunSteeringService.interrupt()`;
+     * the tool loop checks it at the same checkpoint as the abort
+     * signal and stops BETWEEN iterations, so the run ends cleanly with
+     * a summary instead of being killed mid-round-trip. Distinct from
+     * cancel: cancel kills the process and skips every side effect,
+     * interrupt asks the agent to stop and completes the run honestly.
+     */
+    @Column({ type: 'boolean', default: false })
+    interruptRequested: boolean;
+
     @CreateDateColumn()
     createdAt: Date;
 }

--- a/packages/agent/src/tasks-domain/__tests__/task-chat.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-chat.service.spec.ts
@@ -274,6 +274,112 @@ describe('TaskChatService', () => {
         });
     });
 
+    /**
+     * Run steering (Wave 4 M5) — the live-run routing rule. ONE new branch in
+     * front of the existing fan-out: a mention aimed at an agent that already
+     * has a live run on this Task steers that run instead of spawning a second
+     * one. Everything else is unchanged, which is what the "no live run" test
+     * below exists to prove.
+     */
+    describe('post — live-run steering routing', () => {
+        function makeSteeringSvc(over: {
+            live?: { id: string } | null;
+            steerResult?: { dispatched: 'injected' | 'new-run'; runId: string };
+            steerImpl?: jest.Mock;
+        }) {
+            const runs = {
+                findInFlightForTaskAgent: jest.fn().mockResolvedValue(over.live ?? null),
+                createQueued: jest.fn().mockResolvedValue({ id: 'run-chat-1' }),
+                setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+                markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+            };
+            const chatDispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
+            const steering = {
+                steer:
+                    over.steerImpl ??
+                    jest
+                        .fn()
+                        .mockResolvedValue(
+                            over.steerResult ?? { dispatched: 'injected', runId: 'run-live-1' },
+                        ),
+            };
+            const svcUnderTest = new TaskChatService(
+                tasks,
+                messages,
+                kbMentions,
+                activity,
+                runs as any,
+                chatDispatcher,
+                steering as any,
+            );
+            return { svcUnderTest, runs, chatDispatcher, steering };
+        }
+
+        async function postMention(target: TaskChatService) {
+            tasks.findByIdAndUser.mockResolvedValueOnce({ id: 't1', workId: 'w1' });
+            messages.create.mockImplementationOnce((d: any) => Promise.resolve({ id: 'm1', ...d }));
+            await target.post(
+                'u1',
+                {
+                    taskId: 't1',
+                    authorType: 'user',
+                    authorId: 'u1',
+                    body: 'hey @ceo, use the staging bucket instead',
+                },
+                { ownedAgentSlugs: new Map([['ceo', 'agent-a1']]) },
+            );
+            await new Promise((resolve) => setImmediate(resolve));
+        }
+
+        it('⭐ steers the LIVE run instead of dispatching a second one', async () => {
+            const { svcUnderTest, runs, chatDispatcher, steering } = makeSteeringSvc({
+                live: { id: 'run-live-1' },
+            });
+            await postMention(svcUnderTest);
+
+            expect(steering.steer).toHaveBeenCalledWith({
+                runId: 'run-live-1',
+                userId: 'u1',
+                message: 'hey @ceo, use the staging bucket instead',
+            });
+            expect(runs.createQueued).not.toHaveBeenCalled();
+            expect(chatDispatcher.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('⭐ dispatches a new run as before when there is NO live run', async () => {
+            // THE NO-REGRESSION TEST. The routing rule is additive: the
+            // overwhelmingly common path must behave exactly as it did.
+            const { svcUnderTest, runs, chatDispatcher, steering } = makeSteeringSvc({
+                live: null,
+            });
+            await postMention(svcUnderTest);
+
+            expect(steering.steer).not.toHaveBeenCalled();
+            expect(runs.createQueued).toHaveBeenCalledWith(
+                expect.objectContaining({ agentId: 'agent-a1', triggerKind: 'chat' }),
+            );
+            expect(chatDispatcher.enqueue).toHaveBeenCalled();
+        });
+
+        it('falls back to a new run when the live run went terminal mid-flight', async () => {
+            const { svcUnderTest, runs } = makeSteeringSvc({
+                live: { id: 'run-live-1' },
+                steerResult: { dispatched: 'new-run', runId: 'run-live-1' },
+            });
+            await postMention(svcUnderTest);
+            expect(runs.createQueued).toHaveBeenCalled();
+        });
+
+        it('falls back to a new run when steering itself throws — a message is never swallowed', async () => {
+            const { svcUnderTest, runs } = makeSteeringSvc({
+                live: { id: 'run-live-1' },
+                steerImpl: jest.fn().mockRejectedValue(new Error('steer exploded')),
+            });
+            await postMention(svcUnderTest);
+            expect(runs.createQueued).toHaveBeenCalled();
+        });
+    });
+
     describe('edit', () => {
         it('404s for a non-existent message', async () => {
             messages.findById.mockResolvedValueOnce(null);

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -9,6 +9,7 @@ export * from './task-gate-runner.service';
 export * from './task-transition.service';
 export * from './task-chat.service';
 export * from './task-dispatcher';
+export * from './run-steering-port';
 export * from './task-isolation';
 export * from './task-run-denorm.service';
 export * from './task-workspace.service';

--- a/packages/agent/src/tasks-domain/run-steering-port.ts
+++ b/packages/agent/src/tasks-domain/run-steering-port.ts
@@ -1,0 +1,42 @@
+/**
+ * Run steering (Wave 4 M5) — the port `TaskChatService` reaches for when a
+ * chat message mentions an agent that ALREADY has a live run on the Task.
+ *
+ * Same posture as `task-dispatcher.ts` and `agent-run-post-processor.ts`:
+ * the interface + token live on the consumer's side of the boundary, the
+ * implementation (`RunSteeringService`, in `../agents/`) is bound to the
+ * token by the api-side `@Global()` AgentsModule. That keeps the direction of
+ * file imports one-way (agents → tasks-domain, never back) even though the
+ * runtime call goes the other way, so neither barrel can form a cycle.
+ *
+ * When the token is unbound — unit tests, installs without the api layer —
+ * `TaskChatService` falls back to today's behaviour (dispatch a new run) with
+ * no behavioural change. Extension, not replacement.
+ */
+
+export interface RunSteerInput {
+    runId: string;
+    /** Acting user. Every steering write is owner-scoped AND executor-stamped. */
+    userId: string;
+    message: string;
+}
+
+export interface RunSteerOutcome {
+    /**
+     * `injected` — the message was appended to the live run's pending-input
+     *   queue and the executing tool loop will pick it up between iterations.
+     * `new-run` — the run was already terminal, so nothing was injected and
+     *   the caller must dispatch a fresh run instead.
+     */
+    dispatched: 'injected' | 'new-run';
+    /** The run that received the message (`injected` only). */
+    runId: string;
+    /** Messages waiting in the queue after this append (`injected` only). */
+    queuedCount?: number;
+}
+
+export interface RunSteeringPort {
+    steer(input: RunSteerInput): Promise<RunSteerOutcome>;
+}
+
+export const RUN_STEERING_PORT = 'RUN_STEERING_PORT' as const;

--- a/packages/agent/src/tasks-domain/task-chat.service.ts
+++ b/packages/agent/src/tasks-domain/task-chat.service.ts
@@ -19,6 +19,7 @@ import { ActivityLogService } from '../activity-log/activity-log.service';
 import { ActivityActionType, ActivityStatus } from '../entities/activity-log.types';
 import { assertNoSecrets } from '../utils/secret-scan';
 import { AGENT_CHAT_REPLY_DISPATCHER, type AgentChatReplyDispatcher } from './task-dispatcher';
+import { RUN_STEERING_PORT, type RunSteeringPort } from './run-steering-port';
 
 /**
  * Tasks feature — Phase 13.2.
@@ -75,6 +76,13 @@ export class TaskChatService {
         @Optional()
         @Inject(AGENT_CHAT_REPLY_DISPATCHER)
         private readonly chatDispatcher?: AgentChatReplyDispatcher,
+        // Run steering (Wave 4 M5) — bound to `RunSteeringService` by the
+        // api-side @Global() AgentsModule. Appended LAST + @Optional() so
+        // every positional `new TaskChatService(...)` in the specs keeps
+        // compiling, and so an install without it behaves exactly as before.
+        @Optional()
+        @Inject(RUN_STEERING_PORT)
+        private readonly steering?: RunSteeringPort,
     ) {}
 
     async list(
@@ -131,6 +139,14 @@ export class TaskChatService {
         // key is `${taskId}:${agentId}:${messageId}` — T6 chat-dedup
         // posture also enforced inside the trigger via
         // findInFlightForTaskAgent.
+        //
+        // Run steering (Wave 4 M5) adds ONE routing rule ahead of that, and
+        // changes nothing else: if the mentioned agent already has a LIVE run
+        // on this Task, the message is injected into that run instead of
+        // spawning a second one — "queue user messages while the agent is
+        // streaming" is the UX contract, and a Task chat is the steering
+        // channel. No live run ⇒ today's behaviour, unchanged. Extension, not
+        // replacement.
         if (this.chatDispatcher) {
             const agentMentions = mentions.records.filter(
                 (m): m is { type: 'agent'; id: string; slug?: string } =>
@@ -139,6 +155,9 @@ export class TaskChatService {
             for (const mention of agentMentions) {
                 const dedupKey = `${task.id}:${mention.id}:${row.id}`;
                 void (async () => {
+                    if (await this.trySteerLiveRun(task.id, mention.id, userId, input.body)) {
+                        return;
+                    }
                     let run: { id: string } | null = null;
                     try {
                         run = this.runs
@@ -322,6 +341,40 @@ export class TaskChatService {
     }
 
     // ── internals ─────────────────────────────────────────────────
+
+    /**
+     * Run steering (Wave 4 M5) — the live-run routing rule.
+     *
+     * Returns `true` when the message was injected into an already-running
+     * session for this (task, agent) pair, i.e. the caller must NOT dispatch a
+     * second run. Returns `false` for every other outcome — no live run, no
+     * steering port bound, the run went terminal mid-flight, or the steer
+     * itself failed — so the fan-out falls through to today's dispatch and a
+     * steering hiccup can never swallow a user's message.
+     */
+    private async trySteerLiveRun(
+        taskId: string,
+        agentId: string,
+        userId: string,
+        body: string,
+    ): Promise<boolean> {
+        if (!this.steering || !this.runs) return false;
+        try {
+            const live = await this.runs.findInFlightForTaskAgent(taskId, agentId);
+            if (!live) return false;
+            const outcome = await this.steering.steer({ runId: live.id, userId, message: body });
+            if (outcome.dispatched !== 'injected') return false;
+            this.logger.log(
+                `Task ${taskId}: steered live run ${live.id} for agent ${agentId} instead of dispatching a second run.`,
+            );
+            return true;
+        } catch (err) {
+            this.logger.warn(
+                `Task ${taskId}: live-run steering for agent ${agentId} failed, falling back to a new run: ${err}`,
+            );
+            return false;
+        }
+    }
 
     private async requireOwnedTask(userId: string, taskId: string) {
         const task = await this.tasks.findByIdAndUser(taskId, userId);

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -613,6 +613,19 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                     runDenorm.recordTerminal(payload.taskId, claimedRunId, 'failed'),
                 );
                 await drainWork(taskRow.workId);
+            } else if (result.status === 'interrupted') {
+                // Run steering (Wave 4 M5) — a human stopped the loop between
+                // iterations. `AgentRunService.finalize` already marked the row
+                // `completed` with a summary, so NO status write here; what is
+                // still owed is the bookkeeping every other terminal path does:
+                // mirror the board chip off "running", and free the Work's
+                // concurrency slot. `runSucceeded` is false for this status, so
+                // the gate and the PR step below are skipped by construction —
+                // an interrupted run must not be graded or shipped.
+                await bestEffort(() =>
+                    runDenorm.recordTerminal(payload.taskId, claimedRunId, 'completed'),
+                );
+                await drainWork(taskRow.workId);
             }
 
             // Wave 2 M4 — green-path finalize of the isolated workspace:


### PR DESCRIPTION
Wave 4 **M5 (run steering)** + **M8 (attach-session action)** from the parallel-sessions orchestration plan. Additive throughout — every existing path behaves exactly as it did when the new controls are unused.

## What lands

### 1. Steering domain (`packages/agent`)

`RunSteeringService` (`src/agents/run-steering.service.ts`, barrel-exported, module-registered, entity + module pins updated) implements the plan's run verbs, all owner-scoped via `findByIdAndUser` (a run belonging to someone else is indistinguishable from a missing one) and all **executor-stamped** into `agent_run_logs` with the acting user id:

| verb | behaviour |
|---|---|
| `steer` | **live** run (`queued`/`running`) → message appended to a persisted queue, `awaitingInput` cleared in the same statement, `{ dispatched: 'injected' }`. **terminal** run → nothing injected, `{ dispatched: 'new-run' }` so the caller starts a fresh run. Not a 409: "the run finished while you typed" is a normal race with a defined next step. |
| `interrupt` | sets `interruptRequested`; the tool loop honours it **between iterations** and the run ends `completed` with a summary. 409 when already terminal. |
| `stop` | **deliberately not reimplemented** — stop is cancel, which already exists end-to-end (`AgentRunRepository.cancel` + `AGENT_RUN_CANCELLER` + `POST …/cancel` + gate drain). Duplicating it would fork the CAS + remote-cancel + drain semantics. |
| `resume` | for a run that is `awaitingInput` or ended `terminalEndedReason='parked'`: dispatches a **NEW** run carrying the source run's `cliSessionId` and an optional first message, admitted through the existing `RunDispatchGateService`. Runs stay immutable. 409 when not resumable / no Task. |

Schema (migration `1784100000000-AddRunSteeringColumns`, same commit, house guard pattern, forward-only):

- `agent_runs.pendingInput` — `simple-json` FIFO queue of steering messages.
- `agent_runs.interruptRequested` — `boolean NOT NULL DEFAULT false`.

### 2. Tool-loop guard + awaiting-input

The loop reads both signals at the **same per-iteration checkpoint** as the existing abort/cancel check, so one place answers "should I keep going, and has anyone said anything?". An interrupt stops before the model round-trip (no wasted call), finalizes `completed` with an honest summary, and applies **no externally-visible side effect** — an interrupted task run must not flip its Task to done. A new `AgentRunExecuteResult.status = 'interrupted'` keeps it out of `agent-task-execute`'s `runSucceeded` gate/PR path.

The read is feature-detected (`typeof …takeSteeringSignals === 'function'`) and failure-tolerant: an older API replica mid-rollout, or any of the many partial repository stubs in existing specs, degrades to today's behaviour instead of throwing inside the loop and being misreported as a dispatch failure.

`awaitingInput` is set from `AgentRunOutcome.awaitingInput` in `finalize()` and from the new public `AgentRunService.markAwaitingInput(runId)` helper that pipeline plugins can call. **Lifecycle signal only** — nothing is parsed out of the assistant's prose, because a parked run is exempt from every TTL sweep and prose-driven parking would let a chatty agent make itself immortal.

**The sweeper never reaps an awaiting-input run** — the plan's hard rule. Enforced twice: excluded in `findStuckNonTerminal`'s SQL predicate, and re-asserted per-row in `AgentRunSweeperService` (the last gate before `markStuckFailed`).

### 3. Chat routing rule

`TaskChatService.post` gains **one** branch ahead of the existing fan-out: a mention aimed at an agent that already has a live run on this Task steers that run instead of spawning a second one. No live run means today's dispatch, unchanged. Any failure (no port bound, run went terminal, steer threw) falls through to a new run, so a message is never silently swallowed.

Wired through a `RUN_STEERING_PORT` token declared in `tasks-domain` and bound to `RunSteeringService` by the api-side `@Global()` `AgentsModule` — same posture as `AGENT_RUN_CHAT_BACK_POSTER`, so file imports stay one-way (`agents` → `tasks-domain`) and no package cycle can form.

### 4. API

- `POST /api/agents/:id/runs/:runId/steer` — body `{ message }`
- `POST /api/agents/:id/runs/:runId/interrupt`
- `POST /api/agents/:id/runs/:runId/resume` — body `{ message? }`

Owner-scoped (`service.getOne` 404s a cross-user Agent, then the service scopes the run), throttled 30/min/user, 409 when the control does not apply to the run's state.

Sessions rows gain **`sessionAttachable`** — true only when the terminal is `starting`/`attached` **AND** the run is still open. A dead run's columns can keep reading `attached` for minutes until the terminal sweeper corrects them, so gating on `terminalState` alone offers a guaranteed dead-end link.

### 5. Web (M8 + controls)

- Sessions list Attach link gated on `sessionAttachable` (with a fallback for rows served by an API replica that predates the field).
- New `TaskRunControls` on Task detail (fed by the latest run the page already fetches — no extra round-trip): steer composer, Interrupt behind a `window.confirm`, Resume, awaiting-input badge, and the terminal-icon attach deep link. Renders nothing when there is no actionable run.
- i18n (`en.json`, matching the repo's en-only convention) + testids (`task-run-controls`, `task-run-steer-input`, `task-run-steer-submit`, `task-run-interrupt`, `task-run-resume`, `task-run-attach`, `task-run-notice`, `task-run-error`).

### Worker wiring

**No new proxied service, and none needed.** The `pendingInput` / `interruptRequested` reads happen inside `AgentRunService.execute`, which the worker already calls over the internal RPC proxy — so they execute API-side against the real repository. The new `AgentRunService` and `AgentRunRepository` methods land on those services' existing **auto-derived** RPC allow-lists (`trigger-internal.controller` derives callable methods from the class), so the 3-place trigger-internal wiring is untouched by design.

## Tests — 55 added, all green

| suite | tests |
|---|---|
| `run-steering.service.spec.ts` (new) | 18 — steer live/queued/terminal/append-race/404/empty/stamp; interrupt live/terminal/CAS-race/404; resume cliSessionId carry, awaiting clear, no-message, dedup key, gate-parked, 409 live, 409 non-parked, 409 no-Task, enqueue rollback, 404 |
| `agent-run-steering-loop.spec.ts` (new) | 13 — interrupt before first round (model never called), completed-with-summary not failed/cancelled, no side effects, single + multi message injection in order, missing-method + throwing-read degradation, awaiting-input finalize signal |
| `AddRunSteeringColumns.spec.ts` (new) | 4 — columns added, `interruptRequested=false` / `pendingInput=NULL` backfill, idempotent `up()`, `down()` |
| `agent-run-sweeper.service.spec.ts` | +3 — skips a parked run, still reaps the non-awaiting rows in the same batch, pre-migration rows stay reapable |
| `task-chat.service.spec.ts` | +4 — steers the live run (no second dispatch), dispatches as before with no live run, falls back on `new-run`, falls back when steering throws |
| `agents.controller.runtime.spec.ts` | +12 — `sessionAttachable` true/starting/false-on-terminal/false-on-ended/false-no-terminal; steer auth-user forwarding, cross-user 404, `new-run` passthrough; interrupt 409 + activity row; resume message/null/409; unbound-service 500 |
| `agent-run.entity.spec.ts` | +1 — steering column pin |

## Verification (real output)

```
$ packages/agent: pnpm build
>  TSC  Found 0 issues.
>  SWC  Running...
Successfully compiled: 1057 files with swc (380.7ms)

$ packages/agent: npx jest --testPathPattern="steering|agent-run|task-chat"
Test Suites: 13 passed, 13 total
Tests:       166 passed, 166 total

$ pnpm build --filter=ever-works-api --filter=@ever-works/trigger-tasks
@ever-works/trigger-tasks:build: > tsc -p tsconfig.json
ever-works-api:build: >  TSC  Found 0 issues.
ever-works-api:build: Successfully compiled: 682 files with swc
 Tasks:    14 successful, 14 total

$ apps/api: pnpm generate:openapi
Wrote OpenAPI spec (438 paths) to apps/api/openapi.json
  /api/agents/{id}/runs/{runId}/steer
  /api/agents/{id}/runs/{runId}/interrupt
  /api/agents/{id}/runs/{runId}/resume

$ apps/api: npx jest --testPathPattern="agents.controller|AddRunSteeringColumns|trigger-internal.module"
Test Suites: 3 passed, 3 total
Tests:       53 passed, 53 total

$ apps/web: rm tsconfig.tsbuildinfo && npx tsc --noEmit
EXIT=0

$ apps/web: npx eslint <touched files>
EXIT=0   (clean)

$ npx prettier --write <touched files>   # all formatted
```

`openapi.json` is gitignored and therefore not committed (verified with `git check-ignore`).

## Skips and why

- **`packages/agent` / `apps/api` eslint** — both fail to *start* on this branch (agent: no flat `eslint.config.js` for eslint 9; api: an eslint 8/9 plugin mismatch crashing `@typescript-eslint/no-unused-expressions`). Pre-existing and unrelated; `apps/web` eslint runs clean on every touched file.
- **e2e** — no branch dispatch run; the new surfaces ship with testids so specs can be added in the follow-up e2e wave.
- **`generate:openapi` is a preview-mode bootstrap** ("providers/controllers will not be instantiated"), so it validates routing/metadata, not DI. `RunSteeringService`'s only required dependency is `AgentRunRepository` (provided in the same module); everything else is `@Optional()`, and the new `TaskChatService` / `AgentsController` parameters are trailing + `@Optional()` so every positional spec constructor still compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
