### PR TITLE
feat(agent): configurable merge-policy matrix (Wave 3 D4)

### DIFF
--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -410,6 +410,8 @@ export class AgentsController {
             committerEmail: body.committerEmail,
             reportsToAgentId: body.reportsToAgentId,
             scorecard: body.scorecard as AgentScorecardMetric[] | null | undefined,
+            // Merge-policy matrix (Wave 3, D4) — the Agent-scoped slice.
+            mergePolicy: body.mergePolicy,
         });
     }
 

--- a/apps/api/src/agents/dto/agent.dto.ts
+++ b/apps/api/src/agents/dto/agent.dto.ts
@@ -32,6 +32,9 @@ import {
     AGENT_ACTION_PROPOSAL_ACTION_TYPES,
     type AgentActionProposalActionType,
 } from '@ever-works/agent/agent-approvals';
+// Entity-free validation subpath on purpose — see the docstring on
+// `@ever-works/agent/validation`.
+import { MergePolicyDto } from '@ever-works/agent/validation';
 
 /**
  * Permissions partial sent on create/update — every flag optional;
@@ -370,6 +373,17 @@ export class UpdateAgentDto {
     @ValidateNested({ each: true })
     @Type(() => AgentScorecardMetricDto)
     scorecard?: AgentScorecardMetricDto[] | null;
+
+    /**
+     * Merge-policy matrix (Wave 3, D4) — this Agent's slice, the MOST
+     * specific scope. Every field inside is optional and inherits when
+     * omitted; `null` clears the Agent override entirely.
+     */
+    @ApiProperty({ required: false, type: MergePolicyDto, nullable: true })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => MergePolicyDto)
+    mergePolicy?: MergePolicyDto | null;
 }
 
 /**

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -55,6 +55,7 @@ import { InboundTriggersModule } from './triggers/inbound-triggers.module';
 import { IngestModule } from './ingest/ingest.module';
 import { MeetingsApiModule } from './meetings/meetings.module';
 import { FleetApiModule } from './fleet/fleet.module';
+import { MergePolicyApiModule } from './merge-policy/merge-policy.module';
 import { TelemetryModule } from './telemetry/telemetry.module';
 import { UsersModule } from './users/users.module';
 import { ScopeModule } from './scope/scope.module';
@@ -204,6 +205,11 @@ import { DatabaseModule } from '@ever-works/agent/database';
         // CRUD-lite + public token-authenticated enroll/heartbeat) over
         // the agent-side FleetModule.
         FleetApiModule,
+        // Merge-policy matrix (Wave 3, founder decision D4) —
+        // GET /api/merge-policy/resolve owner-scoped preview over the
+        // agent-side PolicyModule. Writes ride the existing Work / Agent /
+        // organization PATCH endpoints.
+        MergePolicyApiModule,
         TelemetryModule,
         FunnelAnalyticsBindingModule,
         UploadsModule,

--- a/apps/api/src/common/filters/facade-exception.filter.ts
+++ b/apps/api/src/common/filters/facade-exception.filter.ts
@@ -71,6 +71,13 @@ const FACADE_ERROR_STATUS: Readonly<Record<string, HttpStatus>> = {
     NoDeployCredentialsError: HttpStatus.CONFLICT,
     // "the resolved plugin does not implement this operation".
     OAuthNotSupportedError: HttpStatus.BAD_REQUEST,
+    // Merge-policy matrix (Wave 3, D4) — an agent-driven merge the
+    // effective policy refuses. Not a fault: the caller resolves it by
+    // changing the policy at the tenant / org / Work / Agent scope, or by
+    // satisfying the condition (green gate, human approval, allowed
+    // method, non-protected branch). The refusal reason is safe to
+    // surface — it names the offending value on purpose.
+    MergePolicyRefusedError: HttpStatus.FORBIDDEN,
 };
 
 @Catch(FacadeError)

--- a/apps/api/src/merge-policy/dto/resolve-merge-policy.dto.ts
+++ b/apps/api/src/merge-policy/dto/resolve-merge-policy.dto.ts
@@ -1,0 +1,26 @@
+import { IsOptional, IsUUID } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Query for `GET /api/merge-policy/resolve` (Wave 3, D4).
+ *
+ * At least one of `workId` / `agentId` must be present — the controller
+ * enforces that (a bare "resolve nothing" call would only ever echo the
+ * platform default and would tell the caller nothing about their setup).
+ */
+export class ResolveMergePolicyQueryDto {
+    @ApiPropertyOptional({
+        description: 'Resolve the policy as it applies to this Work. Must be owned/accessible.',
+    })
+    @IsOptional()
+    @IsUUID()
+    workId?: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Resolve the policy as it applies to this Agent (most specific scope; its Work, organization and tenant are discovered from the row). Must be owned.',
+    })
+    @IsOptional()
+    @IsUUID()
+    agentId?: string;
+}

--- a/apps/api/src/merge-policy/merge-policy.controller.spec.ts
+++ b/apps/api/src/merge-policy/merge-policy.controller.spec.ts
@@ -1,0 +1,81 @@
+// The controller's DI types come from three `@ever-works/agent` barrels
+// whose runtime graphs (entities → items-generator DTOs) do not load under
+// this app's jest module mapping. Every dependency is injected here as a
+// stub anyway, so stub the barrels at module scope — the same posture the
+// agent package's module-shape pins use. Nothing about the controller's
+// behaviour is mocked.
+jest.mock('@ever-works/agent/policy', () => ({ MergePolicyService: class {} }));
+jest.mock('@ever-works/agent/services', () => ({ WorkOwnershipService: class {} }));
+jest.mock('@ever-works/agent/database', () => ({ AgentRepository: class {} }));
+
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PLATFORM_DEFAULT_MERGE_POLICY } from '@ever-works/contracts';
+import { MergePolicyController } from './merge-policy.controller';
+
+/**
+ * Merge-policy matrix (Wave 3, D4) — the preview endpoint's OWNER
+ * SCOPING. Both ids are checked before anything is resolved; without
+ * that, `GET /api/merge-policy/resolve` would be a cross-tenant policy
+ * oracle (it reports the tenant/org/Work/Agent chain by design).
+ */
+describe('MergePolicyController.resolve', () => {
+    const auth = { userId: 'user-1' } as never;
+    const resolved = {
+        policy: PLATFORM_DEFAULT_MERGE_POLICY,
+        source: 'default' as const,
+        chain: [],
+    };
+
+    function make(overrides?: {
+        ensureAccess?: jest.Mock;
+        findByIdAndUser?: jest.Mock;
+        resolve?: jest.Mock;
+    }) {
+        const resolve = overrides?.resolve ?? jest.fn().mockResolvedValue(resolved);
+        const ensureAccess = overrides?.ensureAccess ?? jest.fn().mockResolvedValue({});
+        const findByIdAndUser =
+            overrides?.findByIdAndUser ?? jest.fn().mockResolvedValue({ id: 'agent-1' });
+        const controller = new MergePolicyController(
+            { resolve } as never,
+            { ensureAccess } as never,
+            { findByIdAndUser } as never,
+        );
+        return { controller, resolve, ensureAccess, findByIdAndUser };
+    }
+
+    it('rejects a call with neither workId nor agentId', async () => {
+        const { controller, resolve } = make();
+        await expect(controller.resolve(auth, {})).rejects.toBeInstanceOf(BadRequestException);
+        expect(resolve).not.toHaveBeenCalled();
+    });
+
+    it('gates the Work through WorkOwnershipService before resolving', async () => {
+        const ensureAccess = jest.fn().mockRejectedValue(new NotFoundException('nope'));
+        const { controller, resolve } = make({ ensureAccess });
+        await expect(controller.resolve(auth, { workId: 'work-9' })).rejects.toBeInstanceOf(
+            NotFoundException,
+        );
+        expect(ensureAccess).toHaveBeenCalledWith('work-9', 'user-1');
+        expect(resolve).not.toHaveBeenCalled();
+    });
+
+    it("404s an Agent the caller does not own, without resolving anyone's policy", async () => {
+        const { controller, resolve } = make({
+            findByIdAndUser: jest.fn().mockResolvedValue(null),
+        });
+        await expect(controller.resolve(auth, { agentId: 'agent-9' })).rejects.toBeInstanceOf(
+            NotFoundException,
+        );
+        expect(resolve).not.toHaveBeenCalled();
+    });
+
+    it('resolves the owner-scoped tuple and returns policy + source + chain', async () => {
+        const { controller, resolve, ensureAccess, findByIdAndUser } = make();
+        await expect(
+            controller.resolve(auth, { workId: 'work-1', agentId: 'agent-1' }),
+        ).resolves.toEqual(resolved);
+        expect(ensureAccess).toHaveBeenCalledWith('work-1', 'user-1');
+        expect(findByIdAndUser).toHaveBeenCalledWith('agent-1', 'user-1');
+        expect(resolve).toHaveBeenCalledWith({ workId: 'work-1', agentId: 'agent-1' });
+    });
+});

--- a/apps/api/src/merge-policy/merge-policy.controller.ts
+++ b/apps/api/src/merge-policy/merge-policy.controller.ts
@@ -1,0 +1,84 @@
+import {
+    BadRequestException,
+    Controller,
+    Get,
+    HttpCode,
+    HttpStatus,
+    NotFoundException,
+    Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { ResolvedMergePolicy } from '@ever-works/contracts';
+import { MergePolicyService } from '@ever-works/agent/policy';
+import { AgentRepository } from '@ever-works/agent/database';
+import { WorkOwnershipService } from '@ever-works/agent/services';
+import { CurrentUser } from '../auth/decorators/user.decorator';
+import type { AuthenticatedUser } from '../auth/types/auth.types';
+import { ResolveMergePolicyQueryDto } from './dto/resolve-merge-policy.dto';
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — read-only preview
+ * of the EFFECTIVE policy:
+ *
+ *   GET /api/merge-policy/resolve?workId=&agentId=
+ *     → { policy, source, chain }
+ *
+ * The response deliberately includes the whole `chain` (least → most
+ * specific, starting at the platform default) with the fields each scope
+ * contributed. "Agents may not merge here" is only a usable answer if the
+ * UI can also say WHERE that came from and which knob to change.
+ *
+ * WRITES live on the existing entity surfaces — `PATCH /api/works/:id`,
+ * `PATCH /api/agents/:id` and `PATCH /api/organizations/:id` each accept
+ * an additive optional `mergePolicy` object. The Tenant scope is
+ * resolvable and storable (`tenants.mergePolicy`) but has no HTTP write
+ * surface: Tenants are internal-only and never rendered in the UI, so an
+ * operator-level ceiling there is set out-of-band today. That is a
+ * documented gap, not an oversight.
+ *
+ * Security: owner-scoped on BOTH inputs before any resolution runs —
+ * `WorkOwnershipService.ensureAccess` for the Work (cross-user Works 404
+ * with no existence leak) and an owner-filtered lookup for the Agent.
+ * Without this the endpoint would be a cross-tenant policy oracle.
+ */
+@ApiTags('merge-policy')
+@Controller('api/merge-policy')
+export class MergePolicyController {
+    constructor(
+        private readonly mergePolicy: MergePolicyService,
+        private readonly ownership: WorkOwnershipService,
+        private readonly agents: AgentRepository,
+    ) {}
+
+    @Get('resolve')
+    @ApiOperation({
+        summary:
+            'Preview the effective merge policy for a Work and/or Agent, with the resolution chain (tenant → organization → Work → Agent over the platform default).',
+    })
+    @HttpCode(HttpStatus.OK)
+    async resolve(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query() query: ResolveMergePolicyQueryDto,
+    ): Promise<ResolvedMergePolicy> {
+        if (!query.workId && !query.agentId) {
+            throw new BadRequestException('Provide workId and/or agentId.');
+        }
+
+        if (query.workId) {
+            // Throws 404 for a Work the caller cannot reach.
+            await this.ownership.ensureAccess(query.workId, auth.userId);
+        }
+
+        if (query.agentId) {
+            const agent = await this.agents.findByIdAndUser(query.agentId, auth.userId);
+            if (!agent) {
+                throw new NotFoundException(`Agent with id '${query.agentId}' not found`);
+            }
+        }
+
+        return this.mergePolicy.resolve({
+            workId: query.workId ?? null,
+            agentId: query.agentId ?? null,
+        });
+    }
+}

--- a/apps/api/src/merge-policy/merge-policy.module.ts
+++ b/apps/api/src/merge-policy/merge-policy.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { PolicyModule } from '@ever-works/agent/policy';
+import { AgentsModule } from '@ever-works/agent/agents';
+import { WorkModule } from '@ever-works/agent/services';
+import { MergePolicyController } from './merge-policy.controller';
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — thin API module
+ * exposing the read-only `GET /api/merge-policy/resolve` preview over the
+ * agent-side `PolicyModule` (resolution, deep merge and the single
+ * decision point all live there).
+ *
+ * `WorkModule` supplies `WorkOwnershipService` and `AgentsModule` supplies
+ * `AgentRepository` — the two owner-scope checks the controller runs
+ * BEFORE resolving anything, so this endpoint can never become a
+ * cross-tenant policy oracle.
+ *
+ * There is no controller for WRITES here on purpose: a policy is a field
+ * on an existing entity, so it is set through that entity's existing
+ * PATCH endpoint (Work / Agent / organization) with that entity's
+ * existing permission checks — extension, not a parallel surface.
+ */
+@Module({
+    imports: [PolicyModule, WorkModule, AgentsModule],
+    controllers: [MergePolicyController],
+    exports: [PolicyModule],
+})
+export class MergePolicyApiModule {}

--- a/apps/api/src/migrations/1784000000000-AddMergePolicyColumns.ts
+++ b/apps/api/src/migrations/1784000000000-AddMergePolicyColumns.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — one additive,
+ * nullable `mergePolicy` column on each of the four policy scopes:
+ * `tenants`, `organizations`, `works`, `agents`.
+ *
+ * The column stores a PARTIAL policy (`MergePolicyOverride`) as
+ * `simple-json`, i.e. a TEXT column at the DB level, matching the
+ * existing `agents.permissions` / `agents.guardrails` /
+ * `works.checkDefaults` storage pattern.
+ *
+ * NULL means INHERIT — never "deny". Every existing row therefore keeps
+ * resolving to the platform default
+ * (`PLATFORM_DEFAULT_MERGE_POLICY`: agents do not merge, green gate and
+ * human approval required, squash only, main/master/develop/stage
+ * protected) until someone deliberately sets a policy at some scope.
+ *
+ * Forward-only, idempotent per-step guards (house pattern) so a
+ * partially-applied run and a fresh DB converge on the same shape.
+ */
+export class AddMergePolicyColumns1784000000000 implements MigrationInterface {
+    name = 'AddMergePolicyColumns1784000000000';
+
+    private static readonly TABLES = ['tenants', 'organizations', 'works', 'agents'] as const;
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const tableName of AddMergePolicyColumns1784000000000.TABLES) {
+            const table = await queryRunner.getTable(tableName);
+            if (!table) continue;
+            if (table.findColumnByName('mergePolicy')) continue;
+            await queryRunner.query(`ALTER TABLE "${tableName}" ADD COLUMN "mergePolicy" text`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (const tableName of [...AddMergePolicyColumns1784000000000.TABLES].reverse()) {
+            const table = await queryRunner.getTable(tableName);
+            if (!table) continue;
+            if (!table.findColumnByName('mergePolicy')) continue;
+            await queryRunner.query(`ALTER TABLE "${tableName}" DROP COLUMN "mergePolicy"`);
+        }
+    }
+}

--- a/apps/api/src/organizations/dto/update-organization.dto.ts
+++ b/apps/api/src/organizations/dto/update-organization.dto.ts
@@ -1,5 +1,17 @@
-import { IsOptional, IsString, Length, MaxLength, ValidateIf } from 'class-validator';
+import {
+    IsOptional,
+    IsString,
+    Length,
+    MaxLength,
+    ValidateIf,
+    ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+// Entity-free validation subpath on purpose — see the docstring on
+// `@ever-works/agent/validation`. Importing the general `/dto` barrel here
+// would pull the whole entity graph into every consumer of this DTO.
+import { MergePolicyDto } from '@ever-works/agent/validation';
 
 /**
  * EW-658 — body for `PATCH /api/organizations/:id`. Mirrors
@@ -48,4 +60,20 @@ export class UpdateOrganizationDto {
     @IsString()
     @MaxLength(5000)
     vision?: string | null;
+
+    @ApiPropertyOptional({
+        description:
+            'Merge-policy matrix (Wave 3, D4) — the organization-scoped slice. PARTIAL by design: a field ' +
+            'omitted inside the object inherits from the Tenant, then the platform default. Pass `null` to ' +
+            'clear the organization override entirely. Works and Agents under this organization can still ' +
+            'override individual fields.',
+        type: MergePolicyDto,
+        nullable: true,
+    })
+    // Nullable column, so `@IsOptional()` is right: an explicit null is a
+    // valid "clear this override" operation (same posture as vision above).
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => MergePolicyDto)
+    mergePolicy?: MergePolicyDto | null;
 }

--- a/apps/api/src/organizations/organization.service.ts
+++ b/apps/api/src/organizations/organization.service.ts
@@ -14,6 +14,11 @@ import type {
     OrganizationRegistrationStatus,
 } from '@ever-works/agent/entities';
 import { UPGRADE_NOT_AVAILABLE_AFTER_MULTIPLE_ORGS } from '@ever-works/contracts/api';
+// Merge-policy matrix (Wave 3, D4). Imported from CONTRACTS, not from
+// `@ever-works/agent/policy`: the sanitizer is pure and the contracts
+// package is dependency-free, so this file does not drag the agent
+// package's entity graph into every consumer of the org service.
+import { sanitizeMergePolicyOverride, type MergePolicyOverride } from '@ever-works/contracts';
 import { UsernameAllocatorService } from '../users/services/username-allocator.service';
 import { TenantBootstrapService } from '../scope/tenant-bootstrap.service';
 
@@ -988,6 +993,11 @@ export class OrganizationService {
             legalName?: string;
             countryCode?: string;
             vision?: string | null;
+            /**
+             * Merge-policy matrix (Wave 3, D4) — organization-scoped slice.
+             * `null` clears the override (inherit Tenant / platform default).
+             */
+            mergePolicy?: MergePolicyOverride | null;
         },
     ): Promise<Organization> {
         const user = await this.userRepository.findById(userId);
@@ -998,11 +1008,23 @@ export class OrganizationService {
         if (!org || org.tenantId !== user.tenantId) {
             throw new NotFoundException(`Organization ${organizationId} not found`);
         }
-        const { vision, ...rest } = patch;
+        const { vision, mergePolicy, ...rest } = patch;
         let updatePayload: Partial<Organization> = { ...rest };
         if (vision !== undefined) {
             updatePayload.vision = this.normalizeVision(vision);
             updatePayload.visionUpdatedAt = new Date();
+        }
+        // Merge-policy matrix (Wave 3, D4). Sanitized defense-in-depth
+        // behind the DTO (drop-if-unrecognized, never coerce); an override
+        // that survives as `{}` is stored as NULL so "inherit" has exactly
+        // one representation at rest.
+        if (mergePolicy !== undefined) {
+            if (mergePolicy === null) {
+                updatePayload.mergePolicy = null;
+            } else {
+                const sanitized = sanitizeMergePolicyOverride(mergePolicy);
+                updatePayload.mergePolicy = Object.keys(sanitized).length > 0 ? sanitized : null;
+            }
         }
         await this.organizationRepository.update(organizationId, updatePayload);
         const updated = await this.organizationRepository.findById(organizationId);

--- a/apps/web/src/lib/ai/tools/generated/registry.ts
+++ b/apps/web/src/lib/ai/tools/generated/registry.ts
@@ -257,6 +257,31 @@ export const OPERATION_REGISTRY: OperationSpec[] = [
         params: [],
     },
 
+    // ── Merge policy (Wave 3, founder decision D4) ───────────────
+    {
+        toolName: 'resolve_merge_policy',
+        method: 'GET',
+        path: '/api/merge-policy/resolve',
+        summary:
+            'Resolve the effective merge policy for a Work and/or Agent — whether agents may merge their own pull requests, whether a green quality gate and/or a human approval is required, which merge methods are allowed and which branches are protected. Also reports which scope (tenant, organization, Work, Agent or the platform default) each setting came from. Use when the user asks who may merge, why a merge was refused, or what the current policy is.',
+        kind: 'read',
+        params: [
+            {
+                name: 'workId',
+                in: 'query',
+                type: 'string',
+                description: 'Resolve the policy as it applies to this Work.',
+            },
+            {
+                name: 'agentId',
+                in: 'query',
+                type: 'string',
+                description:
+                    'Resolve the policy as it applies to this Agent (most specific scope; its Work, organization and tenant are discovered automatically).',
+            },
+        ],
+    },
+
     // ── Tasks ────────────────────────────────────────────────────
     {
         toolName: 'list_tasks',

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -196,6 +196,14 @@
         "./pr-review": {
             "types": "./dist/pr-review/index.d.ts",
             "default": "./dist/pr-review/index.js"
+        },
+        "./policy": {
+            "types": "./dist/policy/index.d.ts",
+            "default": "./dist/policy/index.js"
+        },
+        "./validation": {
+            "types": "./dist/validation/index.d.ts",
+            "default": "./dist/validation/index.js"
         }
     },
     "scripts": {

--- a/packages/agent/src/account-transfer/types.ts
+++ b/packages/agent/src/account-transfer/types.ts
@@ -174,6 +174,18 @@ export interface ExportedWork {
     /** Gate-attempt budget (1..5). Out-of-range values are dropped on
      *  import, not clamped. */
     maxGateAttempts?: number;
+    // NOTE — `works.mergePolicy` (Wave 3, D4) is DELIBERATELY absent from
+    // this envelope, and that omission is the correct behaviour, not the
+    // usual "new Work column forgotten in the transfer whitelist" bug.
+    // A merge policy can only LOOSEN enforcement (`allowAgentMerge: true`,
+    // `requireHumanApproval: false`), and the envelope is an
+    // attacker-editable JSON file. Carrying it across accounts would let
+    // an import grant agents merge rights in the importing account —
+    // exactly the privilege-escalation-across-import that made
+    // `AgentExportService` clamp `permissions` to the all-false default.
+    // An imported Work therefore starts with `mergePolicy = NULL`, i.e.
+    // INHERIT, and resolves against the importing owner's own
+    // organization / tenant / platform default.
     members: ExportedWorkMember[];
     customDomains: ExportedCustomDomain[];
     workPlugins: ExportedWorkPlugin[];

--- a/packages/agent/src/agents/agents.service.ts
+++ b/packages/agent/src/agents/agents.service.ts
@@ -35,6 +35,10 @@ import { toAgentDto, type AgentDto } from './types';
 import { computeNextHeartbeat } from './heartbeat-cron';
 import { validateScorecard } from './scorecard';
 import { validateGuardrails, type AgentGuardrails } from './guardrails';
+// Merge-policy matrix (Wave 3, D4). The sanitizer is a pure contracts
+// helper (no Nest graph, no DB), so the agents module gains no runtime
+// dependency on the policy module.
+import { sanitizeMergePolicyOverride, type MergePolicyOverride } from '@ever-works/contracts';
 
 // Upload IDs are SHA-256 hex strings (the `id` field returned by
 // POST /api/uploads/file). 64 lowercase hex chars — NOT UUID-shaped
@@ -124,6 +128,16 @@ export interface UpdateAgentInput {
      * (null clears it). Validated via `validateScorecard`.
      */
     scorecard?: AgentScorecardMetric[] | null;
+    /**
+     * Merge-policy matrix (Wave 3, D4) — this Agent's slice, the MOST
+     * specific scope. A PARTIAL object is normal (resolution is
+     * field-by-field); `null` clears the Agent override so it inherits
+     * the Work / organization / tenant / platform default.
+     *
+     * Distinct from `permissions.canOpenPullRequests`, which governs
+     * OPENING a PR; this governs LANDING one.
+     */
+    mergePolicy?: MergePolicyOverride | null;
 }
 
 /**
@@ -429,6 +443,22 @@ export class AgentsService {
             }
             patch.scorecard =
                 input.scorecard && input.scorecard.length > 0 ? input.scorecard : null;
+        }
+
+        // Merge-policy matrix (Wave 3, D4) — whole-object replace at THIS
+        // scope; `null` (or an empty object) clears the Agent override so
+        // resolution falls through to the Work / org / tenant / platform
+        // default. `sanitizeMergePolicyOverride` is the defense-in-depth
+        // check behind the DTO layer (tool/import callers reach this
+        // service without class-validator) and drops unknown values rather
+        // than coercing them to something permissive.
+        if (input.mergePolicy !== undefined) {
+            if (input.mergePolicy === null) {
+                patch.mergePolicy = null;
+            } else {
+                const sanitized = sanitizeMergePolicyOverride(input.mergePolicy);
+                patch.mergePolicy = Object.keys(sanitized).length > 0 ? sanitized : null;
+            }
         }
 
         await this.agents.updateById(id, patch);

--- a/packages/agent/src/config/index.ts
+++ b/packages/agent/src/config/index.ts
@@ -661,6 +661,19 @@ export const config = {
             const raw = parseInt(process.env.AGENT_MAX_CONCURRENT_RUNS_PER_ORG || '25', 10);
             return Number.isFinite(raw) ? raw : 25;
         },
+        /**
+         * Merge-policy matrix (Wave 3, D4) — operator kill-switch for
+         * enforcement at the git facade. Default ON: an agent-driven merge
+         * consults the resolved policy and is refused when the policy says
+         * no. Set `AGENT_MERGE_POLICY_ENFORCEMENT=off` to fall back to the
+         * pre-feature behavior (no policy consult at all) if enforcement
+         * ever misfires in production — a rollback valve, not a product
+         * knob. The POLICY itself is configured per tenant / org / Work /
+         * Agent, never by env.
+         */
+        isMergePolicyEnforcementEnabled() {
+            return (process.env.AGENT_MERGE_POLICY_ENFORCEMENT || 'on').toLowerCase() !== 'off';
+        },
     },
 
     /**

--- a/packages/agent/src/dto/index.ts
+++ b/packages/agent/src/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './acceptance-check.dto';
+export * from './merge-policy.dto';
 export * from './create-work.dto';
 export * from './quick-create-work.dto';
 export * from './generate-data.dto';

--- a/packages/agent/src/dto/merge-policy.dto.ts
+++ b/packages/agent/src/dto/merge-policy.dto.ts
@@ -1,0 +1,79 @@
+import {
+    ArrayMaxSize,
+    IsArray,
+    IsBoolean,
+    IsIn,
+    IsOptional,
+    IsString,
+    MaxLength,
+    MinLength,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { MERGE_METHODS, type MergeMethod, type MergePolicyOverride } from '@ever-works/contracts';
+
+/**
+ * Validated body shape for one scope's slice of the merge-policy matrix
+ * (Wave 3, founder decision D4).
+ *
+ * EVERY FIELD IS OPTIONAL — and that is the point. A stored policy is a
+ * PARTIAL: an omitted field means "inherit from the next scope up"
+ * (Agent → Work → organization → tenant → platform default), never
+ * "false". Sending `{ "allowAgentMerge": true }` on a Work grants that one
+ * knob and leaves gate/approval/method/branch rules inherited.
+ *
+ * Shared by the Work update path (`update-work.dto.ts`), the Agent update
+ * path (`apps/api/src/agents/dto/agent.dto.ts`) and the organization
+ * update path, so all three surfaces enforce identical constraints on
+ * what is, at rest, the same `simple-json` shape.
+ */
+export class MergePolicyDto implements MergePolicyOverride {
+    @ApiPropertyOptional({
+        description:
+            'Whether an agent may LAND a pull request (distinct from opening one, which is the Agent permission `canOpenPullRequests`). Omit to inherit.',
+    })
+    @IsOptional()
+    @IsBoolean()
+    allowAgentMerge?: boolean;
+
+    @ApiPropertyOptional({
+        description:
+            'Require the run’s quality gate to be green before an agent may merge. Omit to inherit.',
+    })
+    @IsOptional()
+    @IsBoolean()
+    requireGreenGate?: boolean;
+
+    @ApiPropertyOptional({
+        description:
+            'Require a recorded human approval before an agent may merge. Omit to inherit.',
+    })
+    @IsOptional()
+    @IsBoolean()
+    requireHumanApproval?: boolean;
+
+    @ApiPropertyOptional({
+        description:
+            'Merge strategies an agent may use. An explicitly EMPTY array refuses every agent merge; omit the field to inherit.',
+        enum: MERGE_METHODS,
+        isArray: true,
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(3)
+    @IsIn(MERGE_METHODS, { each: true })
+    allowedMergeMethods?: MergeMethod[];
+
+    @ApiPropertyOptional({
+        description:
+            'Branch names an agent may never merge INTO (case-insensitive; a leading refs/heads/ is stripped). An explicitly EMPTY array protects nothing; omit the field to inherit.',
+        isArray: true,
+        type: String,
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(50)
+    @IsString({ each: true })
+    @MinLength(1, { each: true })
+    @MaxLength(255, { each: true })
+    protectedBranches?: string[];
+}

--- a/packages/agent/src/dto/update-work.dto.ts
+++ b/packages/agent/src/dto/update-work.dto.ts
@@ -17,6 +17,7 @@ import {
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { WORK_CHECKS_POLICIES, type WorkChecksPolicy } from '@ever-works/contracts';
 import { AcceptanceCheckDto } from './acceptance-check.dto';
+import { MergePolicyDto } from './merge-policy.dto';
 import { MarkdownReadmeConfigDto } from './create-work.dto';
 import { sanitizeName, sanitizeDescription } from '../utils/sanitize.util';
 
@@ -146,6 +147,19 @@ export class UpdateWorkDto {
     @Min(1)
     @Max(5)
     maxGateAttempts?: number;
+
+    @ApiPropertyOptional({
+        description:
+            'Work-scoped slice of the merge-policy matrix (Wave 3, D4). PARTIAL by design: every field ' +
+            'omitted inside the object inherits from the organization, then the tenant, then the platform ' +
+            'default. Pass `null` to clear the Work override entirely and inherit everything.',
+        type: MergePolicyDto,
+        nullable: true,
+    })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => MergePolicyDto)
+    mergePolicy?: MergePolicyDto | null;
 
     @ApiPropertyOptional({ description: 'Whether community PR processing is enabled' })
     @IsOptional()

--- a/packages/agent/src/entities/agent.entity.ts
+++ b/packages/agent/src/entities/agent.entity.ts
@@ -10,6 +10,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import type { MergePolicyOverride } from '@ever-works/contracts';
 import { User } from './user.entity';
 import { PortableDateColumn } from './_types';
 // Type-only import (erased at compile time) — no runtime cycle with the
@@ -412,6 +413,21 @@ export class Agent {
 
     @Column('simple-json', { nullable: true })
     scorecard?: AgentScorecardMetric[] | null;
+
+    // ── Merge policy (Wave 3, founder decision D4) ──
+    // The MOST SPECIFIC scope of the merge-policy matrix. NULL = inherit
+    // the Work's policy, then the organization's, then the tenant's, then
+    // the platform default. A PARTIAL object is the normal case:
+    // resolution is field-by-field, so one Agent can be granted
+    // `allowAgentMerge` without restating the rest of the matrix.
+    //
+    // Distinct from `permissions.canOpenPullRequests`: that decides
+    // whether this Agent may OPEN a PR; this decides who may LAND it.
+    // Resolve through `MergePolicyService` (`@ever-works/agent/policy`) —
+    // never read this column directly to decide a merge.
+
+    @Column('simple-json', { nullable: true })
+    mergePolicy?: MergePolicyOverride | null;
 
     // EW-655 (Tenants & Organizations Phase 3) — Tier A scope FKs.
     // Both NULL until the owning user creates their first Organization

--- a/packages/agent/src/entities/organization.entity.ts
+++ b/packages/agent/src/entities/organization.entity.ts
@@ -6,6 +6,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import type { MergePolicyOverride } from '@ever-works/contracts';
 import { PortableDateColumn } from './_types';
 
 /**
@@ -161,6 +162,19 @@ export class Organization {
      */
     @Column({ type: 'uuid', nullable: true })
     linkedWorkId?: string | null;
+
+    /**
+     * Merge policy (Wave 3, founder decision D4) — organization-scoped
+     * slice of the matrix. NULL = inherit the Tenant's policy, then the
+     * platform default (`PLATFORM_DEFAULT_MERGE_POLICY`). Partial objects
+     * are normal: resolution is field-by-field, so an org can require
+     * human approval while inheriting everything else.
+     *
+     * Resolve through `MergePolicyService` (`@ever-works/agent/policy`) —
+     * never read this column directly to decide a merge.
+     */
+    @Column('simple-json', { nullable: true })
+    mergePolicy?: MergePolicyOverride | null;
 
     @CreateDateColumn()
     createdAt: Date;

--- a/packages/agent/src/entities/tenant.entity.ts
+++ b/packages/agent/src/entities/tenant.entity.ts
@@ -5,6 +5,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import type { MergePolicyOverride } from '@ever-works/contracts';
 
 /**
  * EW-653 (Tenants & Organizations Phase 1) — internal-only scope
@@ -71,6 +72,21 @@ export class Tenant {
      */
     @Column({ type: 'varchar', length: 200 })
     displayName: string;
+
+    /**
+     * Merge policy (Wave 3, founder decision D4) — the LEAST specific
+     * scope of the matrix, one step above the platform default. NULL =
+     * inherit `PLATFORM_DEFAULT_MERGE_POLICY`. Partial objects are
+     * normal: resolution is field-by-field.
+     *
+     * The Tenant is internal-only (never rendered in the UI), so this
+     * column has no self-service HTTP write surface yet — it is read on
+     * every resolution and is the natural home for an operator-level
+     * ceiling. Resolve through `MergePolicyService`
+     * (`@ever-works/agent/policy`), never read it directly.
+     */
+    @Column('simple-json', { nullable: true })
+    mergePolicy?: MergePolicyOverride | null;
 
     @CreateDateColumn()
     createdAt: Date;

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -63,6 +63,7 @@ import {
     USER_SELECTABLE_WORK_KINDS,
     getWorkCapabilities,
     normalizeWorkKind,
+    type MergePolicyOverride,
     type TaskAcceptanceCheck,
     type UserSelectableWorkKind,
     type WorkChecksPolicy,
@@ -463,6 +464,22 @@ export class Work {
      */
     @Column({ type: 'int', default: 2 })
     maxGateAttempts: number;
+
+    // ── Merge policy (Wave 3, founder decision D4) ───────────────────
+
+    /**
+     * Work-scoped slice of the merge-policy matrix. NULL = inherit the
+     * organization's policy, then the tenant's, then the platform default
+     * (`PLATFORM_DEFAULT_MERGE_POLICY`). A PARTIAL object is the normal
+     * case: resolution is field-by-field, so a Work can override just
+     * `allowAgentMerge` and inherit the rest.
+     *
+     * Never read this column directly to decide a merge — resolve through
+     * `MergePolicyService` (`@ever-works/agent/policy`), the single decision
+     * point.
+     */
+    @Column('simple-json', { nullable: true })
+    mergePolicy?: MergePolicyOverride | null;
 
     /**
      * Whether to generate the browsable repository published to the git

--- a/packages/agent/src/facades/__tests__/facades.module.spec.ts
+++ b/packages/agent/src/facades/__tests__/facades.module.spec.ts
@@ -154,6 +154,8 @@ describe('FacadesModule + barrel re-exports', () => {
             expect(typeof facadesBarrel.NoGitProviderError).toBe('function');
             expect(typeof facadesBarrel.GitProviderNotFoundError).toBe('function');
             expect(typeof facadesBarrel.NoGitCredentialsError).toBe('function');
+            // Merge-policy matrix (Wave 3, D4) — agent merge refused by policy.
+            expect(typeof facadesBarrel.MergePolicyRefusedError).toBe('function');
             // oauth
             expect(typeof facadesBarrel.OAuthFacadeError).toBe('function');
             expect(typeof facadesBarrel.NoOAuthProviderError).toBe('function');
@@ -249,6 +251,9 @@ describe('FacadesModule + barrel re-exports', () => {
                     // Goals feature PR-7 — metrics-provider capability facade.
                     'MetricsFacadeError',
                     'MetricsFacadeService',
+                    // Merge-policy matrix (Wave 3, D4). `AgentMergeActor` is
+                    // type-only and correctly absent from this runtime list.
+                    'MergePolicyRefusedError',
                 ].sort(),
             );
         });

--- a/packages/agent/src/facades/__tests__/git.facade.merge-policy.spec.ts
+++ b/packages/agent/src/facades/__tests__/git.facade.merge-policy.spec.ts
@@ -1,0 +1,160 @@
+import type { MergeDecision } from '@ever-works/contracts';
+import { GitFacadeService, MergePolicyRefusedError } from '../git.facade';
+import type { MergePolicyEnforcer } from '../../policy/merge-policy.enforcer';
+
+/**
+ * Merge-policy matrix (Wave 3, D4) — enforcement at the ONE place a
+ * pull request can actually be landed.
+ *
+ * The load-bearing assertions here are the negative ones: on a refusal
+ * the provider plugin must never be called at all. A gate that merges
+ * first and complains second is not a gate.
+ */
+
+const ALLOW: MergeDecision = { allowed: true, source: 'work' };
+const REFUSE: MergeDecision = {
+    allowed: false,
+    code: 'agent-merge-disabled',
+    reason: 'Agent merges are disabled by the effective merge policy (from work scope).',
+    source: 'work',
+};
+
+function makeFacade(decision?: MergeDecision) {
+    const plugin = {
+        id: 'github',
+        state: 'loaded',
+        mergePullRequest: jest.fn().mockResolvedValue({ merged: true, sha: 'deadbeef' }),
+        getPullRequest: jest.fn().mockResolvedValue({
+            number: 7,
+            base: 'main',
+            head: 'task/x',
+            state: 'open',
+            title: 't',
+            url: 'u',
+            createdAt: '',
+            updatedAt: '',
+        }),
+    };
+    const enforcer: MergePolicyEnforcer = {
+        canAgentMerge: jest.fn().mockResolvedValue(decision ?? ALLOW),
+    };
+    const facade = new GitFacadeService(
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        {} as never,
+        enforcer,
+    );
+    // The token/plugin resolution path is exercised by git.facade.spec.ts;
+    // here we stub it so the test is about the policy decision only.
+    (
+        facade as unknown as {
+            resolvePluginAndToken: () => Promise<{ plugin: unknown; token: string }>;
+        }
+    ).resolvePluginAndToken = jest.fn().mockResolvedValue({ plugin, token: 'tok' });
+    return { facade, plugin, enforcer };
+}
+
+const OPTIONS = { providerId: 'github', userId: 'user-1', workId: 'work-1' } as const;
+
+describe('GitFacadeService.mergePullRequest — merge policy', () => {
+    afterEach(() => {
+        delete process.env.AGENT_MERGE_POLICY_ENFORCEMENT;
+    });
+
+    it('does NOT consult the policy for a human-driven merge (no agent actor)', async () => {
+        const { facade, plugin, enforcer } = makeFacade();
+        await facade.mergePullRequest('o', 'r', 7, { mergeMethod: 'squash' }, OPTIONS);
+        expect(enforcer.canAgentMerge).not.toHaveBeenCalled();
+        expect(plugin.mergePullRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('consults the policy for an agent-driven merge and proceeds when allowed', async () => {
+        const { facade, plugin, enforcer } = makeFacade(ALLOW);
+        const result = await facade.mergePullRequest(
+            'o',
+            'r',
+            7,
+            { mergeMethod: 'squash' },
+            OPTIONS,
+            {
+                agentId: 'agent-1',
+                gateStatus: 'green',
+                humanApproved: true,
+                targetBranch: 'feature/x',
+            },
+        );
+        expect(enforcer.canAgentMerge).toHaveBeenCalledWith(
+            expect.objectContaining({
+                agentId: 'agent-1',
+                workId: 'work-1',
+                gateStatus: 'green',
+                humanApproved: true,
+                targetBranch: 'feature/x',
+                mergeMethod: 'squash',
+            }),
+        );
+        expect(plugin.mergePullRequest).toHaveBeenCalledTimes(1);
+        expect(result.merged).toBe(true);
+    });
+
+    it('REFUSES with the policy reason and never calls the provider', async () => {
+        const { facade, plugin } = makeFacade(REFUSE);
+        await expect(
+            facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' }),
+        ).rejects.toMatchObject({
+            name: 'MergePolicyRefusedError',
+            message: REFUSE.reason,
+        });
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('carries the refusal code + policy source on the thrown error (403 mapping input)', async () => {
+        const { facade } = makeFacade(REFUSE);
+        const error = await facade
+            .mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' })
+            .catch((e: unknown) => e);
+        expect(error).toBeInstanceOf(MergePolicyRefusedError);
+        expect((error as MergePolicyRefusedError).code).toBe('agent-merge-disabled');
+        expect((error as MergePolicyRefusedError).policySource).toBe('work');
+    });
+
+    it('looks the base branch up through the provider when the caller did not supply it', async () => {
+        const { facade, plugin, enforcer } = makeFacade(ALLOW);
+        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' });
+        expect(plugin.getPullRequest).toHaveBeenCalledWith('o', 'r', 7, 'tok');
+        expect(enforcer.canAgentMerge).toHaveBeenCalledWith(
+            expect.objectContaining({ targetBranch: 'main' }),
+        );
+    });
+
+    it('fails CLOSED when the enforcer is not bound at all', async () => {
+        const facade = new GitFacadeService(
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+            {} as never,
+        );
+        const plugin = { mergePullRequest: jest.fn() };
+        (
+            facade as unknown as {
+                resolvePluginAndToken: () => Promise<{ plugin: unknown; token: string }>;
+            }
+        ).resolvePluginAndToken = jest.fn().mockResolvedValue({ plugin, token: 'tok' });
+
+        await expect(
+            facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' }),
+        ).rejects.toBeInstanceOf(MergePolicyRefusedError);
+        expect(plugin.mergePullRequest).not.toHaveBeenCalled();
+    });
+
+    it('honours the operator kill-switch (AGENT_MERGE_POLICY_ENFORCEMENT=off)', async () => {
+        process.env.AGENT_MERGE_POLICY_ENFORCEMENT = 'off';
+        const { facade, plugin, enforcer } = makeFacade(REFUSE);
+        await facade.mergePullRequest('o', 'r', 7, undefined, OPTIONS, { agentId: 'agent-1' });
+        expect(enforcer.canAgentMerge).not.toHaveBeenCalled();
+        expect(plugin.mergePullRequest).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/agent/src/facades/facades.module.ts
+++ b/packages/agent/src/facades/facades.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../database/database.module';
 import { UsageModule } from '../usage/usage.module';
 import { BudgetsModule } from '../budgets/budgets.module';
+import { PolicyModule } from '../policy/policy.module';
 
 import { AiFacadeService } from './ai.facade';
 import { SearchFacadeService } from './search.facade';
@@ -77,7 +78,11 @@ const FACADES = [
  * at the application root level. Do not import PluginsModule directly here.
  */
 @Module({
-    imports: [DatabaseModule, UsageModule, BudgetsModule],
+    // PolicyModule is a leaf (four scope entities, no facade imports), so
+    // importing it here cannot cycle. It binds MERGE_POLICY_ENFORCER,
+    // which GitFacadeService consumes @Optional() to enforce the
+    // merge-policy matrix on agent-driven merges (Wave 3, D4).
+    imports: [DatabaseModule, UsageModule, BudgetsModule, PolicyModule],
     providers: FACADES,
     exports: FACADES,
 })

--- a/packages/agent/src/facades/git.facade.ts
+++ b/packages/agent/src/facades/git.facade.ts
@@ -1,4 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import type {
+    GateStatus,
+    MergeDecision,
+    MergeRefusalCode,
+    MergePolicySource,
+} from '@ever-works/contracts';
 import type {
     IGitProviderPlugin,
     GitRepository,
@@ -33,6 +39,7 @@ import {
 } from '../database/repositories/auth-account.repository';
 import { WorkRepository } from '../database/repositories/work.repository';
 import { GitHubAppInstallationRepository } from '../database/repositories/github-app-installation.repository';
+import { MERGE_POLICY_ENFORCER, type MergePolicyEnforcer } from '../policy/merge-policy.enforcer';
 import type { AuthAccount } from '../entities/auth-account.entity';
 import { FacadeError } from './base.facade';
 import { config } from '@src/config';
@@ -74,6 +81,32 @@ export class GitProviderNotFoundError extends GitFacadeError {
     }
 }
 
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — an agent-driven
+ * merge that the EFFECTIVE policy refuses. Carries the machine-readable
+ * refusal `code`, the scope the policy came from, and a human `reason`
+ * that names the offending value.
+ *
+ * Mapped to HTTP 403 by `FacadeExceptionFilter` (by this exact `name`):
+ * it is not a fault, it is a policy the caller can change at the tenant,
+ * organization, Work or Agent scope.
+ */
+export class MergePolicyRefusedError extends GitFacadeError {
+    readonly code?: MergeRefusalCode;
+    readonly policySource?: MergePolicySource;
+
+    constructor(decision: MergeDecision, providerId?: string) {
+        super(
+            decision.reason ?? 'Merge refused by the effective merge policy.',
+            'mergePullRequest',
+            providerId,
+        );
+        this.name = 'MergePolicyRefusedError';
+        this.code = decision.code;
+        this.policySource = decision.source;
+    }
+}
+
 export class NoGitCredentialsError extends GitFacadeError {
     constructor(providerId: string, userId: string) {
         super(
@@ -105,6 +138,37 @@ export interface GitFacadeUserAuth extends GitFacadeBaseOptions {
 
 /** Git facade options: must provide at least token OR userId */
 export type GitFacadeOptions = GitFacadeTokenAuth | GitFacadeUserAuth;
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — the "who is asking"
+ * for {@link GitFacadeService.mergePullRequest}.
+ *
+ * PRESENT  ⇒ the merge is AGENT-DRIVEN and is routed through the single
+ *            decision point (`MergePolicyService.canAgentMerge`) before
+ *            the provider is called at all.
+ * ABSENT   ⇒ the merge is human-driven; behaviour is exactly as it was
+ *            before this feature landed. Human merges are governed by the
+ *            git provider's own branch protection, not by this matrix.
+ */
+export interface AgentMergeActor {
+    /** The Agent asking to merge. Required — it is what makes this agent-driven. */
+    agentId: string;
+    /** Narrows the policy chain when the Agent is not itself Work-scoped. */
+    workId?: string | null;
+    organizationId?: string | null;
+    tenantId?: string | null;
+    /** Latest quality-gate verdict for the run behind this pull request. */
+    gateStatus?: GateStatus | null;
+    /** Whether a human approval is on record for this merge. */
+    humanApproved?: boolean;
+    /**
+     * Base branch of the pull request. Optional: when omitted the facade
+     * looks it up through the provider. If it still cannot be determined
+     * and the policy protects any branch, the merge is REFUSED rather than
+     * performed blind.
+     */
+    targetBranch?: string | null;
+}
 
 export type { GitProviderInfo };
 
@@ -159,6 +223,15 @@ export class GitFacadeService implements IGitFacade {
         private readonly settingsService: PluginSettingsService,
         private readonly workRepository: WorkRepository,
         private readonly gitHubAppInstallationRepository: GitHubAppInstallationRepository,
+        // Merge-policy matrix (Wave 3, D4) — bound to MergePolicyService by
+        // the agent-side PolicyModule (imported by FacadesModule). Appended
+        // LAST + @Optional() per the positional-spec arity rule; consumed
+        // via the token so the facade never imports the concrete service.
+        // Unbound, an AGENT-DRIVEN merge fails CLOSED (see mergePullRequest);
+        // human-driven merges are untouched.
+        @Optional()
+        @Inject(MERGE_POLICY_ENFORCER)
+        private readonly mergePolicy?: MergePolicyEnforcer,
     ) {}
 
     private getRequiredOAuthScopes(providerId: string): readonly string[] {
@@ -670,15 +743,118 @@ export class GitFacadeService implements IGitFacade {
         return null;
     }
 
+    /**
+     * Land a pull request.
+     *
+     * Merge-policy matrix (Wave 3, founder decision D4): when `agentActor`
+     * is supplied the merge is AGENT-DRIVEN and is routed through the
+     * single decision point before the provider is touched. A refusal
+     * throws {@link MergePolicyRefusedError} carrying the reason — the
+     * provider call never happens, so a policy violation cannot land even
+     * partially. Without `agentActor` (human-driven merges) nothing
+     * changes.
+     */
     async mergePullRequest(
         owner: string,
         repo: string,
         prNumber: number,
         mergeOptions: MergeOptions | undefined,
         options: GitFacadeOptions,
+        agentActor?: AgentMergeActor,
     ): Promise<MergeResult> {
+        if (agentActor?.agentId) {
+            await this.assertAgentMayMerge(
+                owner,
+                repo,
+                prNumber,
+                mergeOptions,
+                options,
+                agentActor,
+            );
+        }
         const { plugin, token } = await this.resolvePluginAndToken(options);
         return plugin.mergePullRequest(owner, repo, prNumber, mergeOptions, token);
+    }
+
+    /**
+     * The enforcement half of the merge-policy matrix. Throws
+     * {@link MergePolicyRefusedError} when the effective policy refuses.
+     *
+     * Fail-CLOSED by design (the opposite posture from the concurrency
+     * valve in `RunDispatchGateService`, and deliberately so): a merge is
+     * irreversible, so an unavailable enforcer or an undeterminable target
+     * branch refuses instead of proceeding. The only bypass is the
+     * operator kill-switch `AGENT_MERGE_POLICY_ENFORCEMENT=off`, which
+     * restores the pre-feature behaviour wholesale.
+     */
+    private async assertAgentMayMerge(
+        owner: string,
+        repo: string,
+        prNumber: number,
+        mergeOptions: MergeOptions | undefined,
+        options: GitFacadeOptions,
+        agentActor: AgentMergeActor,
+    ): Promise<void> {
+        if (!config.agents.isMergePolicyEnforcementEnabled()) {
+            this.logger.warn(
+                `Merge-policy enforcement is DISABLED (AGENT_MERGE_POLICY_ENFORCEMENT=off) — ` +
+                    `agent ${agentActor.agentId} merging ${owner}/${repo}#${prNumber} unchecked.`,
+            );
+            return;
+        }
+
+        if (!this.mergePolicy) {
+            throw new MergePolicyRefusedError(
+                {
+                    allowed: false,
+                    code: 'agent-merge-disabled',
+                    reason:
+                        'Agent-driven merges are unavailable in this runtime: the merge-policy ' +
+                        'enforcer is not bound, and an unevaluated policy is never a satisfied policy.',
+                },
+                options.providerId,
+            );
+        }
+
+        // Resolve the base branch when the caller did not supply it — the
+        // protected-branch rule is worthless without it, and the decision
+        // point refuses on an unknown target rather than guessing.
+        let targetBranch = agentActor.targetBranch ?? null;
+        if (!targetBranch) {
+            try {
+                const pr = await this.getPullRequest(owner, repo, prNumber, options);
+                targetBranch = pr?.base ?? null;
+            } catch (error) {
+                this.logger.warn(
+                    `Merge policy: could not read ${owner}/${repo}#${prNumber} to determine its ` +
+                        `base branch: ${error instanceof Error ? error.message : String(error)}`,
+                );
+            }
+        }
+
+        const decision = await this.mergePolicy.canAgentMerge({
+            agentId: agentActor.agentId,
+            workId: agentActor.workId ?? options.workId ?? null,
+            organizationId: agentActor.organizationId ?? null,
+            tenantId: agentActor.tenantId ?? null,
+            gateStatus: agentActor.gateStatus ?? null,
+            humanApproved: agentActor.humanApproved ?? false,
+            targetBranch,
+            mergeMethod: mergeOptions?.mergeMethod ?? null,
+        });
+
+        if (!decision.allowed) {
+            this.logger.log(
+                `Merge policy REFUSED agent ${agentActor.agentId} on ${owner}/${repo}#${prNumber} ` +
+                    `(${decision.code ?? 'refused'}, policy source: ${decision.source ?? 'default'}).`,
+            );
+            throw new MergePolicyRefusedError(decision, options.providerId);
+        }
+
+        this.logger.log(
+            `Merge policy ALLOWED agent ${agentActor.agentId} on ${owner}/${repo}#${prNumber} ` +
+                `(policy source: ${decision.source ?? 'default'}).`,
+        );
     }
 
     async listPullRequests(

--- a/packages/agent/src/facades/index.ts
+++ b/packages/agent/src/facades/index.ts
@@ -51,6 +51,11 @@ export {
     NoGitProviderError,
     GitProviderNotFoundError,
     NoGitCredentialsError,
+    // Merge-policy matrix (Wave 3, D4) — refusal error + the actor shape
+    // that marks a merge agent-driven. Both cross package boundaries
+    // (apps/api maps the error to 403), so both must be barrel-exported.
+    MergePolicyRefusedError,
+    type AgentMergeActor,
     type GitFacadeOptions,
     type GitProviderInfo,
     type FacadeCloneOptions,

--- a/packages/agent/src/policy/__tests__/agent-merge-policy-tools.spec.ts
+++ b/packages/agent/src/policy/__tests__/agent-merge-policy-tools.spec.ts
@@ -1,0 +1,75 @@
+import { PLATFORM_DEFAULT_MERGE_POLICY } from '@ever-works/contracts';
+import { buildMergePolicyTools } from '../agent-merge-policy-tools';
+
+/**
+ * Merge-policy matrix (Wave 3, D4) — the `resolve_merge_policy` chat
+ * tool. Read-only and owner-scoped: an agent asking about a scope its
+ * user cannot reach gets a flat "not found", never a policy leak.
+ */
+describe('buildMergePolicyTools', () => {
+    const resolved = {
+        policy: PLATFORM_DEFAULT_MERGE_POLICY,
+        source: 'default' as const,
+        chain: [],
+    };
+
+    it('exposes exactly the resolve_merge_policy read tool', () => {
+        const tools = buildMergePolicyTools({
+            userId: 'user-1',
+            service: { resolve: jest.fn() },
+            authorize: jest.fn(),
+        });
+        expect(tools).toHaveLength(1);
+        expect(tools[0].name).toBe('resolve_merge_policy');
+        expect(tools[0].parameters.required).toEqual([]);
+        expect(Object.keys(tools[0].parameters.properties).sort()).toEqual(['agentId', 'workId']);
+    });
+
+    it('refuses a call with neither workId nor agentId', async () => {
+        const resolve = jest.fn();
+        const [tool] = buildMergePolicyTools({
+            userId: 'user-1',
+            service: { resolve },
+            authorize: jest.fn(),
+        });
+        await expect(tool.invoke({})).resolves.toEqual({
+            error: 'Provide workId or agentId to resolve a merge policy.',
+        });
+        expect(resolve).not.toHaveBeenCalled();
+    });
+
+    it('never resolves a scope the authorizer rejects (owner scoping)', async () => {
+        const resolve = jest.fn();
+        const [tool] = buildMergePolicyTools({
+            userId: 'user-1',
+            service: { resolve },
+            authorize: jest.fn().mockResolvedValue(null),
+        });
+        await expect(tool.invoke({ workId: 'someone-elses-work' })).resolves.toEqual({
+            error: 'Not found or not accessible to the current user.',
+        });
+        expect(resolve).not.toHaveBeenCalled();
+    });
+
+    it('resolves the authorized scope tuple and returns policy + source + chain', async () => {
+        const resolve = jest.fn().mockResolvedValue(resolved);
+        const [tool] = buildMergePolicyTools({
+            userId: 'user-1',
+            service: { resolve },
+            authorize: jest.fn().mockResolvedValue({ workId: 'work-1', agentId: 'agent-1' }),
+        });
+        await expect(tool.invoke({ workId: 'work-1', agentId: 'agent-1' })).resolves.toEqual(
+            resolved,
+        );
+        expect(resolve).toHaveBeenCalledWith({ workId: 'work-1', agentId: 'agent-1' });
+    });
+
+    it('reports a resolution failure as a tool error instead of throwing', async () => {
+        const [tool] = buildMergePolicyTools({
+            userId: 'user-1',
+            service: { resolve: jest.fn().mockRejectedValue(new Error('boom')) },
+            authorize: jest.fn().mockResolvedValue({ workId: 'work-1' }),
+        });
+        await expect(tool.invoke({ workId: 'work-1' })).resolves.toEqual({ error: 'boom' });
+    });
+});

--- a/packages/agent/src/policy/__tests__/merge-policy.service.spec.ts
+++ b/packages/agent/src/policy/__tests__/merge-policy.service.spec.ts
@@ -1,0 +1,180 @@
+import { PLATFORM_DEFAULT_MERGE_POLICY } from '@ever-works/contracts';
+import { MergePolicyService } from '../merge-policy.service';
+import type { MergePolicyScopeRepository, MergePolicyScopeRow } from '../merge-policy.repository';
+
+/**
+ * Merge-policy matrix (Wave 3, D4) — the I/O half: scope discovery,
+ * the chain it hands the pure resolver, and the fail-safe posture.
+ */
+
+interface Fixture {
+    agents?: Record<string, MergePolicyScopeRow>;
+    works?: Record<string, MergePolicyScopeRow>;
+    organizations?: Record<string, MergePolicyScopeRow>;
+    tenants?: Record<string, MergePolicyScopeRow>;
+}
+
+function makeService(fixture: Fixture): {
+    service: MergePolicyService;
+    repo: jest.Mocked<MergePolicyScopeRepository>;
+} {
+    const repo = {
+        findAgent: jest.fn(async (id: string) => fixture.agents?.[id] ?? null),
+        findWork: jest.fn(async (id: string) => fixture.works?.[id] ?? null),
+        findOrganization: jest.fn(async (id: string) => fixture.organizations?.[id] ?? null),
+        findTenant: jest.fn(async (id: string) => fixture.tenants?.[id] ?? null),
+    } as unknown as jest.Mocked<MergePolicyScopeRepository>;
+    return { service: new MergePolicyService(repo), repo };
+}
+
+describe('MergePolicyService.resolve', () => {
+    it('discovers Work, organization and tenant from the Agent row', async () => {
+        const { service, repo } = makeService({
+            agents: {
+                'agent-1': {
+                    id: 'agent-1',
+                    mergePolicy: { requireHumanApproval: false },
+                    workId: 'work-1',
+                    organizationId: null,
+                    tenantId: null,
+                },
+            },
+            works: {
+                'work-1': {
+                    id: 'work-1',
+                    mergePolicy: { allowAgentMerge: true },
+                    organizationId: 'org-1',
+                    tenantId: null,
+                },
+            },
+            organizations: {
+                'org-1': {
+                    id: 'org-1',
+                    mergePolicy: { allowedMergeMethods: ['merge'] },
+                    tenantId: 'tenant-1',
+                },
+            },
+            tenants: {
+                'tenant-1': { id: 'tenant-1', mergePolicy: { protectedBranches: ['trunk'] } },
+            },
+        });
+
+        const resolved = await service.resolve({ agentId: 'agent-1' });
+
+        expect(resolved.policy).toEqual({
+            allowAgentMerge: true,
+            requireGreenGate: true,
+            requireHumanApproval: false,
+            allowedMergeMethods: ['merge'],
+            protectedBranches: ['trunk'],
+        });
+        expect(resolved.source).toBe('agent');
+        expect(resolved.chain.map((c) => c.scope)).toEqual([
+            'default',
+            'tenant',
+            'organization',
+            'work',
+            'agent',
+        ]);
+        expect(repo.findTenant).toHaveBeenCalledWith('tenant-1');
+    });
+
+    it('lets an explicit id win over the one discovered from the Agent row', async () => {
+        const { service, repo } = makeService({
+            agents: {
+                'agent-1': { id: 'agent-1', mergePolicy: null, workId: 'work-own' },
+            },
+            works: {
+                'work-other': { id: 'work-other', mergePolicy: { allowAgentMerge: true } },
+            },
+        });
+
+        const resolved = await service.resolve({ agentId: 'agent-1', workId: 'work-other' });
+
+        expect(repo.findWork).toHaveBeenCalledWith('work-other');
+        expect(repo.findWork).not.toHaveBeenCalledWith('work-own');
+        expect(resolved.policy.allowAgentMerge).toBe(true);
+        expect(resolved.source).toBe('work');
+    });
+
+    it('resolves to the platform default when nothing in the chain declares anything', async () => {
+        const { service } = makeService({
+            works: { 'work-1': { id: 'work-1', mergePolicy: null } },
+        });
+        const resolved = await service.resolve({ workId: 'work-1' });
+        expect(resolved.policy).toEqual(PLATFORM_DEFAULT_MERGE_POLICY);
+        expect(resolved.source).toBe('default');
+    });
+
+    it('skips scopes whose row no longer exists instead of throwing', async () => {
+        const { service } = makeService({});
+        const resolved = await service.resolve({ agentId: 'ghost', workId: 'ghost' });
+        expect(resolved.policy).toEqual(PLATFORM_DEFAULT_MERGE_POLICY);
+        expect(resolved.chain.map((c) => c.scope)).toEqual(['default']);
+    });
+
+    it('falls back to the platform default (never to a permissive policy) when a lookup throws', async () => {
+        const repo = {
+            findAgent: jest.fn().mockRejectedValue(new Error('db down')),
+            findWork: jest.fn(),
+            findOrganization: jest.fn(),
+            findTenant: jest.fn(),
+        } as unknown as jest.Mocked<MergePolicyScopeRepository>;
+        const service = new MergePolicyService(repo);
+
+        const resolved = await service.resolve({ agentId: 'agent-1' });
+
+        expect(resolved.policy).toEqual(PLATFORM_DEFAULT_MERGE_POLICY);
+        expect(resolved.policy.allowAgentMerge).toBe(false);
+        expect(resolved.source).toBe('default');
+    });
+});
+
+describe('MergePolicyService.canAgentMerge', () => {
+    it('refuses under the platform default and names the reason', async () => {
+        const { service } = makeService({
+            works: { 'work-1': { id: 'work-1', mergePolicy: null } },
+        });
+        const decision = await service.canAgentMerge({
+            workId: 'work-1',
+            gateStatus: 'green',
+            humanApproved: true,
+            targetBranch: 'feature/x',
+            mergeMethod: 'squash',
+        });
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('agent-merge-disabled');
+    });
+
+    it('allows once a scope opts in and every condition is met', async () => {
+        const { service } = makeService({
+            works: {
+                'work-1': {
+                    id: 'work-1',
+                    mergePolicy: { allowAgentMerge: true, requireHumanApproval: false },
+                },
+            },
+        });
+        const decision = await service.canAgentMerge({
+            workId: 'work-1',
+            gateStatus: 'green',
+            targetBranch: 'feature/x',
+            mergeMethod: 'squash',
+        });
+        expect(decision.allowed).toBe(true);
+        expect(decision.source).toBe('work');
+    });
+
+    it('treats missing decision inputs conservatively (no gate status, no approval)', async () => {
+        const { service } = makeService({
+            works: { 'work-1': { id: 'work-1', mergePolicy: { allowAgentMerge: true } } },
+        });
+        const decision = await service.canAgentMerge({
+            workId: 'work-1',
+            targetBranch: 'feature/x',
+            mergeMethod: 'squash',
+        });
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('gate-not-green');
+    });
+});

--- a/packages/agent/src/policy/__tests__/merge-policy.spec.ts
+++ b/packages/agent/src/policy/__tests__/merge-policy.spec.ts
@@ -1,0 +1,324 @@
+import { PLATFORM_DEFAULT_MERGE_POLICY, type MergePolicy } from '@ever-works/contracts';
+import {
+    evaluateAgentMerge,
+    resolveMergePolicyChain,
+    sanitizeMergePolicyOverride,
+    type MergePolicyLayer,
+} from '../merge-policy';
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — the pure half.
+ *
+ * These tests are the executable statement of the founder's rule: the
+ * platform must NEVER hardcode "agents do not merge". The default is
+ * conservative, but every field is overridable at every scope, and the
+ * merge is refused only for reasons a user can act on.
+ */
+
+const layer = (
+    scope: MergePolicyLayer['scope'],
+    policy: MergePolicyLayer['policy'],
+): MergePolicyLayer => ({ scope, id: `${scope}-1`, policy });
+
+describe('resolveMergePolicyChain — precedence', () => {
+    it('returns the platform default when there are no layers at all', () => {
+        const resolved = resolveMergePolicyChain([]);
+        expect(resolved.policy).toEqual(PLATFORM_DEFAULT_MERGE_POLICY);
+        expect(resolved.source).toBe('default');
+    });
+
+    it('returns the platform default when every scope stores null (NULL = inherit)', () => {
+        const resolved = resolveMergePolicyChain([
+            layer('tenant', null),
+            layer('organization', null),
+            layer('work', null),
+            layer('agent', null),
+        ]);
+        expect(resolved.policy).toEqual(PLATFORM_DEFAULT_MERGE_POLICY);
+        expect(resolved.source).toBe('default');
+        // The chain still lists the scopes it walked — with no contributions.
+        expect(resolved.chain.map((c) => c.scope)).toEqual([
+            'default',
+            'tenant',
+            'organization',
+            'work',
+            'agent',
+        ]);
+    });
+
+    it('tenant overrides the platform default', () => {
+        const resolved = resolveMergePolicyChain([layer('tenant', { allowAgentMerge: true })]);
+        expect(resolved.policy.allowAgentMerge).toBe(true);
+        expect(resolved.source).toBe('tenant');
+    });
+
+    it('organization overrides tenant', () => {
+        const resolved = resolveMergePolicyChain([
+            layer('tenant', { allowAgentMerge: true }),
+            layer('organization', { allowAgentMerge: false }),
+        ]);
+        expect(resolved.policy.allowAgentMerge).toBe(false);
+        expect(resolved.source).toBe('organization');
+    });
+
+    it('Work overrides organization', () => {
+        const resolved = resolveMergePolicyChain([
+            layer('organization', { requireHumanApproval: true }),
+            layer('work', { requireHumanApproval: false }),
+        ]);
+        expect(resolved.policy.requireHumanApproval).toBe(false);
+        expect(resolved.source).toBe('work');
+    });
+
+    it('Agent overrides Work — the most specific scope wins', () => {
+        const resolved = resolveMergePolicyChain([
+            layer('work', { allowAgentMerge: false }),
+            layer('agent', { allowAgentMerge: true }),
+        ]);
+        expect(resolved.policy.allowAgentMerge).toBe(true);
+        expect(resolved.source).toBe('agent');
+    });
+
+    it('sorts layers into the documented precedence regardless of input order', () => {
+        const resolved = resolveMergePolicyChain([
+            layer('agent', { allowAgentMerge: true }),
+            layer('tenant', { allowAgentMerge: false }),
+            layer('work', { allowAgentMerge: false }),
+        ]);
+        // Agent still wins even though it was passed first.
+        expect(resolved.policy.allowAgentMerge).toBe(true);
+        expect(resolved.chain.map((c) => c.scope)).toEqual(['default', 'tenant', 'work', 'agent']);
+    });
+});
+
+describe('resolveMergePolicyChain — field-level deep merge', () => {
+    it('lets a Work override ONE field and inherit the other four', () => {
+        const resolved = resolveMergePolicyChain([
+            layer('tenant', {
+                allowedMergeMethods: ['merge', 'squash'],
+                protectedBranches: ['main'],
+            }),
+            layer('work', { allowAgentMerge: true }),
+        ]);
+        expect(resolved.policy).toEqual({
+            allowAgentMerge: true, // from Work
+            requireGreenGate: true, // platform default
+            requireHumanApproval: true, // platform default
+            allowedMergeMethods: ['merge', 'squash'], // from tenant
+            protectedBranches: ['main'], // from tenant
+        } satisfies MergePolicy);
+    });
+
+    it('reports which scope contributed which field in the chain', () => {
+        const resolved = resolveMergePolicyChain([
+            layer('tenant', { requireGreenGate: false }),
+            layer('work', { allowAgentMerge: true }),
+            layer('agent', { requireHumanApproval: false }),
+        ]);
+        const byScope = Object.fromEntries(resolved.chain.map((c) => [c.scope, c.fields]));
+        expect(byScope.tenant).toEqual(['requireGreenGate']);
+        expect(byScope.work).toEqual(['allowAgentMerge']);
+        expect(byScope.agent).toEqual(['requireHumanApproval']);
+        // The two fields nobody claimed still come from the platform default.
+        expect(byScope.default).toEqual(['allowedMergeMethods', 'protectedBranches']);
+    });
+
+    it('marks a fully-shadowed layer as contributing nothing', () => {
+        const resolved = resolveMergePolicyChain([
+            layer('organization', { allowAgentMerge: false }),
+            layer('agent', { allowAgentMerge: true }),
+        ]);
+        const org = resolved.chain.find((c) => c.scope === 'organization');
+        expect(org?.fields).toEqual([]);
+        expect(resolved.source).toBe('agent');
+    });
+
+    it('never mutates the frozen platform default', () => {
+        const resolved = resolveMergePolicyChain([layer('work', { protectedBranches: ['trunk'] })]);
+        resolved.policy.protectedBranches.push('sneaky');
+        expect(PLATFORM_DEFAULT_MERGE_POLICY.protectedBranches).toEqual([
+            'main',
+            'master',
+            'develop',
+            'stage',
+        ]);
+    });
+});
+
+describe('sanitizeMergePolicyOverride', () => {
+    it('drops non-boolean flags instead of coercing them', () => {
+        const out = sanitizeMergePolicyOverride({
+            allowAgentMerge: 'yes',
+            requireGreenGate: 1,
+        } as never);
+        expect(out).toEqual({});
+    });
+
+    it('drops unknown merge methods but keeps the valid ones', () => {
+        const out = sanitizeMergePolicyOverride({
+            allowedMergeMethods: ['squash', 'fast-forward', 'rebase'],
+        } as never);
+        expect(out.allowedMergeMethods).toEqual(['squash', 'rebase']);
+    });
+
+    it('keeps an explicitly EMPTY list (it means "none allowed", not "inherit")', () => {
+        expect(
+            sanitizeMergePolicyOverride({ allowedMergeMethods: [] }).allowedMergeMethods,
+        ).toEqual([]);
+        expect(sanitizeMergePolicyOverride({ protectedBranches: [] }).protectedBranches).toEqual(
+            [],
+        );
+    });
+
+    it('trims, de-dupes and drops blank protected branches', () => {
+        const out = sanitizeMergePolicyOverride({
+            protectedBranches: ['  main ', 'main', '', '   ', 'release'],
+        });
+        expect(out.protectedBranches).toEqual(['main', 'release']);
+    });
+});
+
+describe('evaluateAgentMerge — the single decision point', () => {
+    /** Everything satisfied, so each test can flip exactly one thing. */
+    const permissive: MergePolicy = {
+        allowAgentMerge: true,
+        requireGreenGate: true,
+        requireHumanApproval: true,
+        allowedMergeMethods: ['squash'],
+        protectedBranches: ['main'],
+    };
+    const okCtx = {
+        policy: permissive,
+        gateStatus: 'green' as const,
+        humanApproved: true,
+        targetBranch: 'feature/x',
+        mergeMethod: 'squash' as const,
+    };
+
+    it('allows when every condition is satisfied', () => {
+        expect(evaluateAgentMerge(okCtx)).toEqual({ allowed: true, source: undefined });
+    });
+
+    it('refuses when allowAgentMerge is false (the platform default posture)', () => {
+        const decision = evaluateAgentMerge({
+            ...okCtx,
+            policy: { ...permissive, allowAgentMerge: false },
+            source: 'organization',
+        });
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('agent-merge-disabled');
+        // The refusal names WHERE the policy came from, so the user knows
+        // which scope to change.
+        expect(decision.reason).toContain('organization');
+        expect(decision.source).toBe('organization');
+    });
+
+    it('refuses a red gate when requireGreenGate is on', () => {
+        const decision = evaluateAgentMerge({ ...okCtx, gateStatus: 'red' });
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('gate-not-green');
+        expect(decision.reason).toContain('red');
+    });
+
+    it('allows a red gate when requireGreenGate is configured off', () => {
+        const decision = evaluateAgentMerge({
+            ...okCtx,
+            policy: { ...permissive, requireGreenGate: false },
+            gateStatus: 'red',
+        });
+        expect(decision.allowed).toBe(true);
+    });
+
+    it('refuses a protected target branch, case-insensitively and through refs/heads/', () => {
+        for (const target of ['main', 'MAIN', 'refs/heads/main']) {
+            const decision = evaluateAgentMerge({ ...okCtx, targetBranch: target });
+            expect(decision.allowed).toBe(false);
+            expect(decision.code).toBe('protected-branch');
+            expect(decision.reason).toContain('main');
+        }
+    });
+
+    it('fails CLOSED when the target branch is unknown and branches are protected', () => {
+        const decision = evaluateAgentMerge({ ...okCtx, targetBranch: null });
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('target-branch-unknown');
+    });
+
+    it('allows an unknown target branch when the policy protects nothing', () => {
+        const decision = evaluateAgentMerge({
+            ...okCtx,
+            policy: { ...permissive, protectedBranches: [] },
+            targetBranch: null,
+        });
+        expect(decision.allowed).toBe(true);
+    });
+
+    it('refuses a merge method the policy does not allow', () => {
+        const decision = evaluateAgentMerge({ ...okCtx, mergeMethod: 'rebase' });
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('merge-method-not-allowed');
+        expect(decision.reason).toContain('rebase');
+        expect(decision.reason).toContain('squash');
+    });
+
+    it('evaluates an unspecified method as the provider default (merge), never as a bypass', () => {
+        const decision = evaluateAgentMerge({ ...okCtx, mergeMethod: null });
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('merge-method-not-allowed');
+        expect(decision.reason).toContain("'merge'");
+    });
+
+    it('refuses when human approval is required and absent', () => {
+        const decision = evaluateAgentMerge({ ...okCtx, humanApproved: false });
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('human-approval-required');
+    });
+
+    it('allows without approval once the policy stops requiring it', () => {
+        const decision = evaluateAgentMerge({
+            ...okCtx,
+            policy: { ...permissive, requireHumanApproval: false },
+            humanApproved: false,
+        });
+        expect(decision.allowed).toBe(true);
+    });
+
+    it('refuses everything when the policy allows no merge method at all', () => {
+        const decision = evaluateAgentMerge({
+            ...okCtx,
+            policy: { ...permissive, allowedMergeMethods: [] },
+        });
+        expect(decision.allowed).toBe(false);
+        expect(decision.code).toBe('merge-method-not-allowed');
+        expect(decision.reason).toContain('none');
+    });
+
+    it('resolves + decides end-to-end: an org that opts agents into merging green work', () => {
+        const resolved = resolveMergePolicyChain([
+            layer('organization', {
+                allowAgentMerge: true,
+                requireHumanApproval: false,
+            }),
+            layer('work', { allowedMergeMethods: ['squash', 'rebase'] }),
+        ]);
+        const decision = evaluateAgentMerge({
+            policy: resolved.policy,
+            source: resolved.source,
+            gateStatus: 'green',
+            humanApproved: false,
+            targetBranch: 'feature/agent-work',
+            mergeMethod: 'rebase',
+        });
+        expect(decision.allowed).toBe(true);
+        // …and the same setup still refuses a merge into a protected branch.
+        expect(
+            evaluateAgentMerge({
+                policy: resolved.policy,
+                gateStatus: 'green',
+                humanApproved: false,
+                targetBranch: 'develop',
+                mergeMethod: 'rebase',
+            }).code,
+        ).toBe('protected-branch');
+    });
+});

--- a/packages/agent/src/policy/__tests__/policy.module.spec.ts
+++ b/packages/agent/src/policy/__tests__/policy.module.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Merge-policy matrix (Wave 3, D4) — module-shape pin for PolicyModule.
+ *
+ * Pattern mirrors `fleet/__tests__/fleet.module.spec.ts`: heavy runtime
+ * trees (TypeORM, the entity graph) are mocked at module scope so the
+ * decorator metadata can be asserted without loading them under Jest's
+ * CJS transformer.
+ */
+
+jest.mock('@nestjs/typeorm', () => ({
+    TypeOrmModule: { forFeature: () => class TypeOrmFeatureStub {} },
+    InjectRepository: () => () => undefined,
+    InjectDataSource: () => () => undefined,
+}));
+jest.mock('../../entities/agent.entity', () => ({ Agent: class Agent {} }));
+jest.mock('../../entities/work.entity', () => ({ Work: class Work {} }));
+jest.mock('../../entities/organization.entity', () => ({ Organization: class Organization {} }));
+jest.mock('../../entities/tenant.entity', () => ({ Tenant: class Tenant {} }));
+jest.mock('../merge-policy.repository', () => ({
+    MergePolicyScopeRepository: class MergePolicyScopeRepository {},
+}));
+jest.mock('../merge-policy.service', () => ({
+    MergePolicyService: class MergePolicyService {},
+}));
+
+import 'reflect-metadata';
+import { PolicyModule } from '../policy.module';
+import { MERGE_POLICY_ENFORCER } from '../merge-policy.enforcer';
+import { MergePolicyScopeRepository } from '../merge-policy.repository';
+import { MergePolicyService } from '../merge-policy.service';
+
+describe('PolicyModule', () => {
+    const meta = (key: string): unknown[] => Reflect.getMetadata(key, PolicyModule) ?? [];
+
+    it('provides the scope repository, the service and the enforcer binding', () => {
+        expect(meta('providers')).toEqual([
+            MergePolicyScopeRepository,
+            MergePolicyService,
+            { provide: MERGE_POLICY_ENFORCER, useExisting: MergePolicyService },
+        ]);
+    });
+
+    it('exports all three so the facade can consume the TOKEN, not the class', () => {
+        expect(meta('exports')).toEqual([
+            MergePolicyScopeRepository,
+            MergePolicyService,
+            MERGE_POLICY_ENFORCER,
+        ]);
+    });
+
+    it('imports only the four scope entities — a leaf module cannot cycle', () => {
+        expect(meta('imports')).toHaveLength(1);
+    });
+});
+
+describe('policy barrel', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const barrel = require('../index');
+
+    it('re-exports the module, service, repository, token and tool factory', () => {
+        expect(barrel.PolicyModule).toBe(PolicyModule);
+        expect(barrel.MergePolicyService).toBe(MergePolicyService);
+        expect(barrel.MergePolicyScopeRepository).toBe(MergePolicyScopeRepository);
+        expect(barrel.MERGE_POLICY_ENFORCER).toBe(MERGE_POLICY_ENFORCER);
+        expect(typeof barrel.buildMergePolicyTools).toBe('function');
+    });
+
+    it('re-exports the pure resolution + decision functions (cross-package consumers)', () => {
+        expect(typeof barrel.resolveMergePolicyChain).toBe('function');
+        expect(typeof barrel.evaluateAgentMerge).toBe('function');
+        expect(typeof barrel.sanitizeMergePolicyOverride).toBe('function');
+    });
+});

--- a/packages/agent/src/policy/agent-merge-policy-tools.ts
+++ b/packages/agent/src/policy/agent-merge-policy-tools.ts
@@ -1,0 +1,87 @@
+import type { ResolvedMergePolicy } from '@ever-works/contracts';
+import type { TaskToolDescriptor } from '../tasks-domain/agent-task-tools';
+import type { MergePolicyResolveInput, MergePolicyService } from './merge-policy.service';
+
+/**
+ * Merge-policy matrix (Wave 3, D4) — chat tool for the policy surface,
+ * per the program DoD rule that every new entity ships with chat tools +
+ * keyword slots.
+ *
+ * Mirrors `fleet/agent-fleet-tools.ts`: a descriptor-factory the tool
+ * assembly concatenates at run time (type-only import of
+ * `TaskToolDescriptor`, so the Tasks runtime graph is NOT pulled into the
+ * policy subpath).
+ *
+ * READ-ONLY by design — the tool explains the effective policy and where
+ * each field came from; changing a policy goes through the Work / Agent /
+ * organization update endpoints with their own permission checks.
+ *
+ * Keyword slots: "merge policy", "can the agent merge", "who merges",
+ * "why was the merge refused", "is human approval required", "which
+ * branches are protected".
+ */
+
+export interface ResolveMergePolicyArgs {
+    /** Resolve as it would apply to this Work. */
+    workId?: string;
+    /** Resolve as it would apply to this Agent (most specific scope). */
+    agentId?: string;
+}
+
+export function buildMergePolicyTools(args: {
+    /**
+     * Owner scope. The caller (API/chat runtime) has already established
+     * this user; the tool only ever resolves scopes it is handed.
+     */
+    userId: string;
+    service: Pick<MergePolicyService, 'resolve'>;
+    /**
+     * Owner check for the ids the model supplies — the tool must not
+     * become a cross-tenant policy oracle. Returns the scope tuple the
+     * user may resolve, or null when they may not.
+     */
+    authorize: (input: ResolveMergePolicyArgs) => Promise<MergePolicyResolveInput | null>;
+}): TaskToolDescriptor[] {
+    const out: TaskToolDescriptor[] = [];
+
+    out.push({
+        name: 'resolve_merge_policy',
+        description:
+            'Resolve the effective merge policy for a Work or Agent — whether agents may merge their own pull requests, whether a green quality gate and/or a human approval is required, which merge methods are allowed and which branches are protected. Also reports which scope (tenant, organization, Work, Agent or the platform default) each setting came from. Use when the user asks who may merge, why a merge was refused, or what the current policy is.',
+        parameters: {
+            type: 'object',
+            properties: {
+                workId: {
+                    type: 'string',
+                    description: 'Resolve the policy as it applies to this Work.',
+                },
+                agentId: {
+                    type: 'string',
+                    description:
+                        'Resolve the policy as it applies to this Agent (the most specific scope; its Work, organization and tenant are discovered automatically).',
+                },
+            },
+            required: [],
+        },
+        invoke: async (raw) => {
+            const a = (raw ?? {}) as ResolveMergePolicyArgs;
+            if (!a.workId && !a.agentId) {
+                return { error: 'Provide workId or agentId to resolve a merge policy.' };
+            }
+            try {
+                const scope = await args.authorize(a);
+                if (!scope) {
+                    return { error: 'Not found or not accessible to the current user.' };
+                }
+                return await args.service.resolve(scope);
+            } catch (err) {
+                return { error: err instanceof Error ? err.message : String(err) };
+            }
+        },
+    } satisfies TaskToolDescriptor<
+        ResolveMergePolicyArgs,
+        ResolvedMergePolicy | { error: string }
+    >);
+
+    return out;
+}

--- a/packages/agent/src/policy/index.ts
+++ b/packages/agent/src/policy/index.ts
@@ -1,0 +1,11 @@
+// Public surface of the merge-policy matrix (Wave 3, founder decision
+// D4): the pure resolution + decision functions, the read-only scope
+// repository, the Nest service that is BOTH the one resolution function
+// and the one decision point, the `MERGE_POLICY_ENFORCER` token the git
+// facade consumes, and the `resolve_merge_policy` chat-tool factory.
+export * from './merge-policy';
+export * from './merge-policy.enforcer';
+export * from './merge-policy.repository';
+export * from './merge-policy.service';
+export * from './agent-merge-policy-tools';
+export * from './policy.module';

--- a/packages/agent/src/policy/merge-policy.enforcer.ts
+++ b/packages/agent/src/policy/merge-policy.enforcer.ts
@@ -1,0 +1,41 @@
+import type { GateStatus, MergeDecision, MergeMethod } from '@ever-works/contracts';
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — injection token +
+ * contract for the enforcement half.
+ *
+ * Token + contract only (leaf file, type-only imports — the same
+ * circular-dep dodge as the other agent injection tokens, see
+ * `docs/architecture/agent-injection-tokens.md`). `GitFacadeService`
+ * consumes it via `@Optional() @Inject(...)`; `PolicyModule` binds it to
+ * `MergePolicyService`. Left unbound (unit tests, runtimes without the
+ * policy module) the facade behaves exactly as before the feature landed.
+ */
+
+/** Everything the decision point needs, in one call. */
+export interface MergePolicyDecisionInput {
+    /** Most specific scope. Its Work/org/tenant are discovered from the row. */
+    agentId?: string | null;
+    workId?: string | null;
+    organizationId?: string | null;
+    tenantId?: string | null;
+    /** Latest quality-gate verdict for the work being merged. */
+    gateStatus?: GateStatus | null;
+    /** Whether a human approval is on record for this merge. */
+    humanApproved?: boolean;
+    /** Base branch of the pull request; unknown fails closed when branches are protected. */
+    targetBranch?: string | null;
+    /** Requested strategy; `undefined` evaluates as the provider default (`merge`). */
+    mergeMethod?: MergeMethod | null;
+}
+
+export interface MergePolicyEnforcer {
+    /**
+     * The single decision point: may THIS agent land THIS pull request?
+     * Implementations resolve the policy chain themselves and must never
+     * throw for policy reasons — a refusal is `{ allowed: false, reason }`.
+     */
+    canAgentMerge(input: MergePolicyDecisionInput): Promise<MergeDecision>;
+}
+
+export const MERGE_POLICY_ENFORCER = 'MERGE_POLICY_ENFORCER' as const;

--- a/packages/agent/src/policy/merge-policy.repository.ts
+++ b/packages/agent/src/policy/merge-policy.repository.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { MergePolicyOverride } from '@ever-works/contracts';
+import { Agent } from '../entities/agent.entity';
+import { Organization } from '../entities/organization.entity';
+import { Tenant } from '../entities/tenant.entity';
+import { Work } from '../entities/work.entity';
+
+/**
+ * One scope row, reduced to what policy resolution needs: its stored
+ * override plus the parent ids that continue the chain upward.
+ */
+export interface MergePolicyScopeRow {
+    id: string;
+    mergePolicy?: MergePolicyOverride | null;
+    workId?: string | null;
+    organizationId?: string | null;
+    tenantId?: string | null;
+}
+
+/**
+ * Feature-owned, READ-ONLY repository for the merge-policy matrix
+ * (provided by `PolicyModule`, not `DatabaseModule` — same split as
+ * `FleetNodeRepository` / `MeetingRepository`).
+ *
+ * Deliberately projects only the columns resolution needs. Writes go
+ * through the owning services (`AgentService.update`,
+ * `WorkLifecycleService.updateWork`, `OrganizationService.update`), which
+ * already own validation and ownership checks for their entity — this
+ * feature adds one field to each, not a second write path.
+ */
+@Injectable()
+export class MergePolicyScopeRepository {
+    constructor(
+        @InjectRepository(Agent)
+        private readonly agents: Repository<Agent>,
+        @InjectRepository(Work)
+        private readonly works: Repository<Work>,
+        @InjectRepository(Organization)
+        private readonly organizations: Repository<Organization>,
+        @InjectRepository(Tenant)
+        private readonly tenants: Repository<Tenant>,
+    ) {}
+
+    async findAgent(id: string): Promise<MergePolicyScopeRow | null> {
+        const row = await this.agents.findOne({
+            where: { id },
+            select: ['id', 'mergePolicy', 'workId', 'organizationId', 'tenantId'],
+        });
+        return row ?? null;
+    }
+
+    async findWork(id: string): Promise<MergePolicyScopeRow | null> {
+        const row = await this.works.findOne({
+            where: { id },
+            select: ['id', 'mergePolicy', 'organizationId', 'tenantId'],
+        });
+        return row ?? null;
+    }
+
+    async findOrganization(id: string): Promise<MergePolicyScopeRow | null> {
+        const row = await this.organizations.findOne({
+            where: { id },
+            select: ['id', 'mergePolicy', 'tenantId'],
+        });
+        return row ?? null;
+    }
+
+    async findTenant(id: string): Promise<MergePolicyScopeRow | null> {
+        const row = await this.tenants.findOne({
+            where: { id },
+            select: ['id', 'mergePolicy'],
+        });
+        return row ?? null;
+    }
+}

--- a/packages/agent/src/policy/merge-policy.service.ts
+++ b/packages/agent/src/policy/merge-policy.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { MergeDecision, ResolvedMergePolicy } from '@ever-works/contracts';
+import { PLATFORM_DEFAULT_MERGE_POLICY } from '@ever-works/contracts';
+import { evaluateAgentMerge, resolveMergePolicyChain, type MergePolicyLayer } from './merge-policy';
+import type { MergePolicyDecisionInput, MergePolicyEnforcer } from './merge-policy.enforcer';
+import { MergePolicyScopeRepository } from './merge-policy.repository';
+
+/** Where a resolution starts. Any subset; more specific ids win. */
+export interface MergePolicyResolveInput {
+    agentId?: string | null;
+    workId?: string | null;
+    organizationId?: string | null;
+    tenantId?: string | null;
+}
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — the I/O half.
+ *
+ * ONE resolution function (`resolve`) and ONE decision point
+ * (`canAgentMerge`). Every path that could land a pull request on an
+ * agent's behalf routes through the latter, so "may an agent merge?" is
+ * answered in exactly one place and is answered by CONFIGURATION, never
+ * by a hardcoded invariant.
+ *
+ * Scope discovery walks upward from whatever the caller knows: an
+ * `agentId` yields the Agent's `workId` / `organizationId` / `tenantId`,
+ * a Work yields its org + tenant, an org yields its tenant. Explicit ids
+ * passed by the caller win over discovered ones (a preview can ask "what
+ * would this Agent's policy be under that Work?").
+ *
+ * Modelled on `RunDispatchGateService`: a small resolution service in
+ * front of a policy decision, with an operator kill-switch
+ * (`AGENT_MERGE_POLICY_ENFORCEMENT`) consulted at the enforcement site
+ * rather than here — this service always tells the truth about the
+ * policy.
+ */
+@Injectable()
+export class MergePolicyService implements MergePolicyEnforcer {
+    private readonly logger = new Logger(MergePolicyService.name);
+
+    constructor(private readonly scopes: MergePolicyScopeRepository) {}
+
+    /**
+     * Resolve the effective policy for a scope tuple.
+     *
+     * Returns the complete policy, the most specific scope that
+     * contributed a field (`source`), and the full `chain` least → most
+     * specific so a preview can explain *why* — the difference between a
+     * policy surface people trust and one they work around.
+     *
+     * Never throws: a lookup failure degrades to the platform default with
+     * a warning, because a broken policy read must not become a merge that
+     * bypasses policy (the default is the safe posture).
+     */
+    async resolve(input: MergePolicyResolveInput): Promise<ResolvedMergePolicy> {
+        try {
+            const layers: MergePolicyLayer[] = [];
+            let workId = input.workId ?? null;
+            let organizationId = input.organizationId ?? null;
+            let tenantId = input.tenantId ?? null;
+
+            if (input.agentId) {
+                const agent = await this.scopes.findAgent(input.agentId);
+                if (agent) {
+                    layers.push({ scope: 'agent', id: agent.id, policy: agent.mergePolicy });
+                    workId = workId ?? agent.workId ?? null;
+                    organizationId = organizationId ?? agent.organizationId ?? null;
+                    tenantId = tenantId ?? agent.tenantId ?? null;
+                }
+            }
+
+            if (workId) {
+                const work = await this.scopes.findWork(workId);
+                if (work) {
+                    layers.push({ scope: 'work', id: work.id, policy: work.mergePolicy });
+                    organizationId = organizationId ?? work.organizationId ?? null;
+                    tenantId = tenantId ?? work.tenantId ?? null;
+                }
+            }
+
+            if (organizationId) {
+                const org = await this.scopes.findOrganization(organizationId);
+                if (org) {
+                    layers.push({
+                        scope: 'organization',
+                        id: org.id,
+                        policy: org.mergePolicy,
+                    });
+                    tenantId = tenantId ?? org.tenantId ?? null;
+                }
+            }
+
+            if (tenantId) {
+                const tenant = await this.scopes.findTenant(tenantId);
+                if (tenant) {
+                    layers.push({ scope: 'tenant', id: tenant.id, policy: tenant.mergePolicy });
+                }
+            }
+
+            return resolveMergePolicyChain(layers);
+        } catch (error) {
+            this.logger.warn(
+                `Merge-policy resolution failed (falling back to the platform default): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return {
+                policy: {
+                    ...PLATFORM_DEFAULT_MERGE_POLICY,
+                    allowedMergeMethods: [...PLATFORM_DEFAULT_MERGE_POLICY.allowedMergeMethods],
+                    protectedBranches: [...PLATFORM_DEFAULT_MERGE_POLICY.protectedBranches],
+                },
+                source: 'default',
+                chain: [],
+            };
+        }
+    }
+
+    /**
+     * THE decision point for agent-driven merges. Resolves the policy for
+     * the scope tuple, then evaluates the request against it.
+     *
+     * Refusals carry a stable `code` and a human `reason` naming the
+     * offending value, so a caller can both branch on the code and show
+     * the user something actionable.
+     */
+    async canAgentMerge(input: MergePolicyDecisionInput): Promise<MergeDecision> {
+        const resolved = await this.resolve(input);
+        return evaluateAgentMerge({
+            policy: resolved.policy,
+            source: resolved.source,
+            gateStatus: input.gateStatus ?? null,
+            humanApproved: input.humanApproved ?? false,
+            targetBranch: input.targetBranch ?? null,
+            mergeMethod: input.mergeMethod ?? null,
+        });
+    }
+}

--- a/packages/agent/src/policy/merge-policy.ts
+++ b/packages/agent/src/policy/merge-policy.ts
@@ -1,0 +1,222 @@
+import {
+    MERGE_POLICY_FIELDS,
+    MERGE_POLICY_SCOPE_PRECEDENCE,
+    PLATFORM_DEFAULT_MERGE_POLICY,
+    sanitizeMergePolicyOverride,
+    type GateStatus,
+    type MergeDecision,
+    type MergeMethod,
+    type MergePolicy,
+    type MergePolicyChainEntry,
+    type MergePolicyOverride,
+    type MergePolicyScope,
+    type MergePolicySource,
+    type ResolvedMergePolicy,
+} from '@ever-works/contracts';
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — the PURE half.
+ *
+ * The platform never hardcodes "agents do not merge". It ships a
+ * conservative DEFAULT (`PLATFORM_DEFAULT_MERGE_POLICY`) that any of the
+ * four scopes can override, field by field:
+ *
+ *     platform default  <  tenant  <  organization  <  Work  <  Agent
+ *
+ * Everything in this file is side-effect free so the precedence rules and
+ * the merge decision can be unit-tested without a database, and so the
+ * same functions can run in the API, the worker, or a future edge caller.
+ * The I/O half (loading the four rows) lives in `merge-policy.service.ts`.
+ */
+
+/** One layer of the resolution chain, least specific first. */
+export interface MergePolicyLayer {
+    scope: MergePolicyScope;
+    /** Row id of the scope entity; kept for the reported chain. */
+    id: string;
+    /** What the row stores. `null`/`undefined`/`{}` all mean "inherit". */
+    policy?: MergePolicyOverride | null;
+}
+
+/**
+ * The stored-override shape guard lives in `@ever-works/contracts`
+ * (zero-dependency, next to the type) so writers that only touch the
+ * contract — the API's organization update path, importers — do not have
+ * to pull the agent package's entity graph in just to validate five
+ * fields. Re-exported here so `@ever-works/agent/policy` remains the one
+ * import site for everything merge-policy inside this package.
+ */
+export { sanitizeMergePolicyOverride };
+
+/** Defensive copy so callers can never mutate the frozen platform default. */
+function clonePolicy(policy: MergePolicy): MergePolicy {
+    return {
+        ...policy,
+        allowedMergeMethods: [...policy.allowedMergeMethods],
+        protectedBranches: [...policy.protectedBranches],
+    };
+}
+
+/**
+ * THE resolution function. Folds the layers over the platform default,
+ * FIELD BY FIELD (a deep merge, not a whole-object override) so a Work can
+ * change exactly one knob and inherit the other four.
+ *
+ * Layers may be passed in any order — they are sorted into the documented
+ * precedence (`MERGE_POLICY_SCOPE_PRECEDENCE`) here, so no caller can
+ * accidentally invert it.
+ */
+export function resolveMergePolicyChain(layers: MergePolicyLayer[]): ResolvedMergePolicy {
+    const ordered = [...layers].sort(
+        (a, b) =>
+            MERGE_POLICY_SCOPE_PRECEDENCE.indexOf(a.scope) -
+            MERGE_POLICY_SCOPE_PRECEDENCE.indexOf(b.scope),
+    );
+
+    const policy = clonePolicy(PLATFORM_DEFAULT_MERGE_POLICY);
+    // Which layer index (or -1 for the platform default) owns each field.
+    const owner = new Map<keyof MergePolicy, number>();
+    for (const field of MERGE_POLICY_FIELDS) owner.set(field, -1);
+
+    ordered.forEach((layer, index) => {
+        const override = sanitizeMergePolicyOverride(layer.policy);
+        for (const field of MERGE_POLICY_FIELDS) {
+            const value = override[field];
+            if (value === undefined) continue;
+            // Field-level assignment: later (more specific) layers win only
+            // for the fields they actually declare.
+            (policy as unknown as Record<string, unknown>)[field] = Array.isArray(value)
+                ? [...value]
+                : value;
+            owner.set(field, index);
+        }
+    });
+
+    const fieldsOwnedBy = (index: number): (keyof MergePolicy)[] =>
+        MERGE_POLICY_FIELDS.filter((field) => owner.get(field) === index);
+
+    const chain: MergePolicyChainEntry[] = [
+        { scope: 'default', id: null, fields: fieldsOwnedBy(-1) },
+        ...ordered.map((layer, index) => ({
+            scope: layer.scope as MergePolicySource,
+            id: layer.id,
+            fields: fieldsOwnedBy(index),
+        })),
+    ];
+
+    // The most specific layer that contributed anything; 'default' when the
+    // whole chain was silent.
+    let source: MergePolicySource = 'default';
+    for (const entry of chain) {
+        if (entry.fields.length > 0) source = entry.scope;
+    }
+
+    return { policy, source, chain };
+}
+
+/** Context the single decision point evaluates against. */
+export interface MergeDecisionContext {
+    /** The already-resolved policy (from `resolveMergePolicyChain`). */
+    policy: MergePolicy;
+    /** Where the policy came from; echoed into the decision for logs/UI. */
+    source?: MergePolicySource;
+    /** Latest quality-gate verdict for the work being merged. */
+    gateStatus?: GateStatus | null;
+    /** Whether a human approval is on record for this merge. */
+    humanApproved?: boolean;
+    /**
+     * The pull request's BASE branch. `refs/heads/` prefixes are stripped
+     * and comparison is case-insensitive. When the policy protects at least
+     * one branch and the target is unknown, the decision FAILS CLOSED — a
+     * policy that cannot be evaluated is never satisfied.
+     */
+    targetBranch?: string | null;
+    /**
+     * Requested merge strategy. `undefined` means "provider default", which
+     * every supported provider treats as a merge commit — so it is
+     * evaluated as `'merge'` rather than waved through.
+     */
+    mergeMethod?: MergeMethod | null;
+}
+
+function normalizeBranch(ref: string): string {
+    return ref
+        .trim()
+        .replace(/^refs\/heads\//i, '')
+        .toLowerCase();
+}
+
+/**
+ * THE decision point. Every agent-driven merge path routes through this
+ * one function so there is exactly one place where "may this agent land
+ * this pull request" is answered.
+ *
+ * Refusals are ordered from most to least fundamental, and each carries a
+ * stable `code` plus a human `reason` that names the offending value — a
+ * refusal a user cannot act on is a bug report waiting to happen.
+ */
+export function evaluateAgentMerge(ctx: MergeDecisionContext): MergeDecision {
+    const { policy, source } = ctx;
+    const deny = (code: NonNullable<MergeDecision['code']>, reason: string): MergeDecision => ({
+        allowed: false,
+        code,
+        reason,
+        source,
+    });
+
+    if (!policy.allowAgentMerge) {
+        return deny(
+            'agent-merge-disabled',
+            'Agent merges are disabled by the effective merge policy' +
+                `${source ? ` (from ${source} scope)` : ''}. Enable allowAgentMerge at the tenant, organization, Work or Agent scope to allow it.`,
+        );
+    }
+
+    if (policy.protectedBranches.length > 0) {
+        if (!ctx.targetBranch || !ctx.targetBranch.trim()) {
+            return deny(
+                'target-branch-unknown',
+                'The pull request target branch could not be determined, and the merge policy protects ' +
+                    `${policy.protectedBranches.length} branch(es) — refusing rather than merging blind.`,
+            );
+        }
+        const target = normalizeBranch(ctx.targetBranch);
+        const protectedMatch = policy.protectedBranches.find(
+            (branch) => normalizeBranch(branch) === target,
+        );
+        if (protectedMatch) {
+            return deny(
+                'protected-branch',
+                `Branch '${protectedMatch}' is protected by the effective merge policy — an agent may not merge into it.`,
+            );
+        }
+    }
+
+    const method: MergeMethod = ctx.mergeMethod ?? 'merge';
+    if (!policy.allowedMergeMethods.includes(method)) {
+        return deny(
+            'merge-method-not-allowed',
+            `Merge method '${method}' is not allowed by the effective merge policy (allowed: ${
+                policy.allowedMergeMethods.join(', ') || 'none'
+            }).`,
+        );
+    }
+
+    if (policy.requireGreenGate && ctx.gateStatus !== 'green') {
+        return deny(
+            'gate-not-green',
+            `The effective merge policy requires a green quality gate; the current gate status is '${
+                ctx.gateStatus ?? 'unknown'
+            }'.`,
+        );
+    }
+
+    if (policy.requireHumanApproval && !ctx.humanApproved) {
+        return deny(
+            'human-approval-required',
+            'The effective merge policy requires a human approval before an agent may merge.',
+        );
+    }
+
+    return { allowed: true, source };
+}

--- a/packages/agent/src/policy/policy.module.ts
+++ b/packages/agent/src/policy/policy.module.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Agent } from '../entities/agent.entity';
+import { Organization } from '../entities/organization.entity';
+import { Tenant } from '../entities/tenant.entity';
+import { Work } from '../entities/work.entity';
+import { MERGE_POLICY_ENFORCER } from './merge-policy.enforcer';
+import { MergePolicyScopeRepository } from './merge-policy.repository';
+import { MergePolicyService } from './merge-policy.service';
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — agent-side module
+ * owning policy RESOLUTION and the single merge decision point.
+ *
+ * Deliberately a leaf: it imports only the four scope entities, so
+ * `FacadesModule` (and anything else that has to ask "may this agent
+ * merge?") can depend on it without creating a cycle. It binds
+ * `MERGE_POLICY_ENFORCER` to `MergePolicyService` via `useExisting`, so
+ * `GitFacadeService` consumes the contract, never the concrete class.
+ *
+ * The four entities MUST also stay registered in the DataSource ENTITIES
+ * array (`database/database.config.ts`) — this repo has no
+ * `autoLoadEntities`, so a forFeature'd-but-unregistered entity throws
+ * EntityMetadataNotFoundError on first query. All four have been
+ * registered since their own features landed; this module adds no new
+ * entity.
+ */
+@Module({
+    imports: [TypeOrmModule.forFeature([Agent, Work, Organization, Tenant])],
+    providers: [
+        MergePolicyScopeRepository,
+        MergePolicyService,
+        { provide: MERGE_POLICY_ENFORCER, useExisting: MergePolicyService },
+    ],
+    exports: [MergePolicyScopeRepository, MergePolicyService, MERGE_POLICY_ENFORCER],
+})
+export class PolicyModule {}

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -678,6 +678,15 @@ export class WorkLifecycleService {
                 updateData.maxGateAttempts = updateDto.maxGateAttempts;
             }
 
+            // Merge-policy matrix (Wave 3, D4). A PARTIAL object is normal —
+            // resolution is field-by-field, so a Work can set one knob and
+            // inherit the rest. `null` clears the Work override entirely
+            // (back to inheriting the org / tenant / platform default);
+            // the column is nullable precisely so NULL can mean INHERIT.
+            if (updateDto.mergePolicy !== undefined) {
+                updateData.mergePolicy = updateDto.mergePolicy;
+            }
+
             // Handle community PR processing settings
             if (updateDto.communityPrEnabled !== undefined) {
                 updateData.communityPrEnabled = updateDto.communityPrEnabled;

--- a/packages/agent/src/tasks-domain/task-workspace.service.ts
+++ b/packages/agent/src/tasks-domain/task-workspace.service.ts
@@ -7,6 +7,7 @@ import { WorkspaceFacadeService } from '../facades/workspace.facade';
 import { GitFacadeService } from '../facades/git.facade';
 import { TaskTransitionService } from './task-transition.service';
 import { TaskChatService } from './task-chat.service';
+import { MergePolicyService } from '../policy/merge-policy.service';
 import { resolveTaskIsolation, taskBranchName } from './task-isolation';
 
 export interface ProvisionedTaskWorkspace {
@@ -58,6 +59,13 @@ export class TaskWorkspaceService {
         @Optional()
         @Inject(forwardRef(() => TaskChatService))
         private readonly taskChat?: TaskChatService,
+        // Merge-policy matrix (Wave 3, D4) — read-only here: finalize
+        // OPENS the PR, it never lands one, so the policy is RECORDED
+        // (which scope governs this Work's merges) rather than enforced.
+        // Enforcement lives at the one place a merge can happen,
+        // `GitFacadeService.mergePullRequest`. Appended LAST + @Optional()
+        // per the positional-spec arity rule.
+        @Optional() private readonly mergePolicy?: MergePolicyService,
     ) {}
 
     /**
@@ -281,8 +289,40 @@ export class TaskWorkspaceService {
             prUrl: pr.url,
         });
         await this.transitionTask(task, TaskStatus.IN_REVIEW);
-        this.logger.log(`Task ${task.id} opened PR #${pr.number} (${pr.url}).`);
+        this.logger.log(
+            `Task ${task.id} opened PR #${pr.number} (${pr.url})` +
+                `${await this.describeMergePolicy(input.agentId, work.id)}.`,
+        );
         return { outcome: 'pr-opened', prNumber: pr.number, prUrl: pr.url };
+    }
+
+    /**
+     * Merge-policy matrix (Wave 3, D4) — the audit half. The PR-opened log
+     * line names the SCOPE that governs who may land this PR (agent /
+     * work / organization / tenant / default) plus whether agent merges
+     * are allowed at all, so "why did/didn't the agent merge this?" is
+     * answerable from the run log alone.
+     *
+     * Best-effort by contract: returns an empty suffix when the policy
+     * service is unbound or the lookup fails. A logging concern must never
+     * fail a finalize that already opened a real pull request.
+     */
+    private async describeMergePolicy(agentId: string, workId: string): Promise<string> {
+        if (!this.mergePolicy) return '';
+        try {
+            const resolved = await this.mergePolicy.resolve({ agentId, workId });
+            return (
+                ` — merge policy from ${resolved.source} scope ` +
+                `(allowAgentMerge=${resolved.policy.allowAgentMerge})`
+            );
+        } catch (error) {
+            this.logger.warn(
+                `Task merge-policy lookup failed (continuing): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return '';
+        }
     }
 
     private async transitionTask(task: Task, to: TaskStatus): Promise<void> {

--- a/packages/agent/src/tasks-domain/tasks.module.ts
+++ b/packages/agent/src/tasks-domain/tasks.module.ts
@@ -42,6 +42,7 @@ import { TaskNotificationService } from './task-notification.service';
 import { TaskRunDenormService } from './task-run-denorm.service';
 import { TaskWorkspaceService } from './task-workspace.service';
 import { FacadesModule } from '../facades/facades.module';
+import { PolicyModule } from '../policy/policy.module';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { AgentsModule } from '../agents/agents.module';
 import { NotificationsModule } from '../notifications/notifications.module';
@@ -91,6 +92,9 @@ import { NotificationsModule } from '../notifications/notifications.module';
         // Wave 2 M3 — TaskWorkspaceService resolves + provisions the
         // per-Task isolated workspace through the workspace/git facades.
         FacadesModule,
+        // Wave 3 D4 — TaskWorkspaceService.finalizeRun records the scope
+        // that governs this Work's merges in its PR-opened log line.
+        PolicyModule,
     ],
     providers: [
         TaskRepository,

--- a/packages/agent/src/validation/index.ts
+++ b/packages/agent/src/validation/index.ts
@@ -1,0 +1,18 @@
+/**
+ * ENTITY-FREE validation DTOs — shared request-body shapes that carry
+ * class-validator / Swagger decorators and import NOTHING from the entity
+ * graph.
+ *
+ * Why this subpath exists: `@ever-works/agent/dto` is the general DTO
+ * barrel, and it transitively loads `work.entity` → `user.entity` →
+ * `work-generation-history.entity` → the items-generator DTOs. That is
+ * fine for API modules that already live in the entity world, but an
+ * `apps/api` DTO file that only needs ONE small shared body shape should
+ * not have to drag the whole graph in with it (under the api test runner
+ * that import order resolves a pre-existing entity import cycle to
+ * `undefined` and fails the suite before a single test runs).
+ *
+ * Rule for anything added here: no entity imports, no Nest modules, no
+ * repositories — decorators plus `@ever-works/contracts` types only.
+ */
+export { MergePolicyDto } from '../dto/merge-policy.dto';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -5,4 +5,5 @@ export * from './github/index.js';
 export * from './kb/index.js';
 export * from './terminal/index.js';
 export * from './tasks/index.js';
+export * from './policy/index.js';
 export * from './ingest/index.js';

--- a/packages/contracts/src/policy/index.ts
+++ b/packages/contracts/src/policy/index.ts
@@ -1,0 +1,2 @@
+export * from './merge-policy.types.js';
+export * from './merge-policy.sanitize.js';

--- a/packages/contracts/src/policy/merge-policy.sanitize.ts
+++ b/packages/contracts/src/policy/merge-policy.sanitize.ts
@@ -1,0 +1,52 @@
+import type { MergeMethod, MergePolicyOverride } from './merge-policy.types.js';
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — the shape guard for
+ * a stored override.
+ *
+ * It lives HERE, next to the type, rather than in `@ever-works/agent`,
+ * because it is a property of the WIRE SHAPE and every writer needs it:
+ * the Work/Agent update paths in the agent package, the organization
+ * update path in the API, and any future importer. Reaching for the agent
+ * package just to validate a five-field JSON object would drag the whole
+ * entity graph into callers that only ever touch the contract.
+ *
+ * `simple-json` columns round-trip whatever was written, and API bodies /
+ * import payloads can carry junk, so every field is validated on the way
+ * IN to resolution. An invalid value is DROPPED (which means "inherit"),
+ * never coerced to a permissive default — the same drop-if-unrecognized
+ * posture the account import uses for enums, and the only safe one for a
+ * field that can loosen enforcement.
+ */
+export function sanitizeMergePolicyOverride(raw: MergePolicyOverride | null | undefined): MergePolicyOverride {
+	if (!raw || typeof raw !== 'object') return {};
+	const out: MergePolicyOverride = {};
+
+	for (const key of ['allowAgentMerge', 'requireGreenGate', 'requireHumanApproval'] as const) {
+		if (typeof raw[key] === 'boolean') out[key] = raw[key];
+	}
+
+	if (Array.isArray(raw.allowedMergeMethods)) {
+		const methods = raw.allowedMergeMethods.filter(
+			(m): m is MergeMethod => m === 'merge' || m === 'squash' || m === 'rebase'
+		);
+		// A declared-but-fully-invalid list is dropped; a declared EMPTY
+		// list is meaningful ("no method is allowed") and kept.
+		if (methods.length > 0 || raw.allowedMergeMethods.length === 0) {
+			out.allowedMergeMethods = Array.from(new Set(methods));
+		}
+	}
+
+	if (Array.isArray(raw.protectedBranches)) {
+		const branches = raw.protectedBranches
+			.filter((b): b is string => typeof b === 'string')
+			.map((b) => b.trim())
+			.filter((b) => b.length > 0);
+		// Same rule: an explicitly empty list means "protect nothing".
+		if (branches.length > 0 || raw.protectedBranches.length === 0) {
+			out.protectedBranches = Array.from(new Set(branches));
+		}
+	}
+
+	return out;
+}

--- a/packages/contracts/src/policy/merge-policy.types.ts
+++ b/packages/contracts/src/policy/merge-policy.types.ts
@@ -1,0 +1,157 @@
+/**
+ * Merge policy — the configurable enforcement matrix for agent-driven merges
+ * (Wave 3, founder decision D4).
+ *
+ * The platform does NOT hardcode whether an agent may merge its own pull
+ * request. Whether it may is a POLICY, resolvable at four scopes
+ * (tenant → organization → Work → Agent) and layered over a conservative
+ * platform DEFAULT. Operators keep the safe posture by doing nothing and can
+ * opt into "agents merge when green" — or anything in between — per scope.
+ *
+ * This package holds the zero-dependency storage/wire shapes only. The
+ * resolution algorithm, the deep merge and the single decision point
+ * (`canAgentMerge`) live in `@ever-works/agent` (`policy/`), and enforcement
+ * lives at the git facade + the Task finalize path.
+ */
+
+/** Merge strategy a provider can be asked to use when landing a pull request. */
+export type MergeMethod = 'merge' | 'squash' | 'rebase';
+
+/**
+ * Canonical list of merge methods. Kept as a const so validators (DTO
+ * `@IsIn`, import sanitizers) share one source of truth with the type.
+ */
+export const MERGE_METHODS: readonly MergeMethod[] = ['merge', 'squash', 'rebase'];
+
+/**
+ * The fully-resolved policy. Every field is REQUIRED here — a resolved policy
+ * is always complete, because unset fields fall through to the next scope and
+ * ultimately to {@link PLATFORM_DEFAULT_MERGE_POLICY}.
+ */
+export interface MergePolicy {
+	/**
+	 * May an agent land a pull request at all? `false` does not stop the agent
+	 * from OPENING one (that is `AgentPermissions.canOpenPullRequests`) — it
+	 * stops the merge itself.
+	 */
+	allowAgentMerge: boolean;
+	/** Require the run's quality gate to be green before an agent may merge. */
+	requireGreenGate: boolean;
+	/** Require a recorded human approval before an agent may merge. */
+	requireHumanApproval: boolean;
+	/** Merge strategies an agent may use. An empty list refuses every merge. */
+	allowedMergeMethods: MergeMethod[];
+	/**
+	 * Branch names an agent may never merge INTO, matched case-insensitively
+	 * against the pull request's base branch (a leading `refs/heads/` is
+	 * stripped before comparison).
+	 */
+	protectedBranches: string[];
+}
+
+/**
+ * The scopes a policy can be stored at, from least to most specific. The
+ * most specific scope that declares a field wins for THAT field
+ * (see {@link MERGE_POLICY_SCOPE_PRECEDENCE}).
+ */
+export type MergePolicyScope = 'tenant' | 'organization' | 'work' | 'agent';
+
+/**
+ * Documented precedence, least specific first:
+ *
+ *   platform default  <  tenant  <  organization  <  Work  <  Agent
+ *
+ * Resolution is FIELD-BY-FIELD (a deep merge, not a whole-object override):
+ * a Work that sets only `allowAgentMerge` inherits the other four fields from
+ * its organization / tenant / the platform default. `null` or an omitted key
+ * at any scope means "inherit", never "false".
+ */
+export const MERGE_POLICY_SCOPE_PRECEDENCE: readonly MergePolicyScope[] = ['tenant', 'organization', 'work', 'agent'];
+
+/**
+ * What a scope actually stores: a PARTIAL policy. Absent/`null` fields
+ * inherit from the next-least-specific scope. This is the shape of the
+ * additive `mergePolicy` `simple-json` column on `tenants`, `organizations`,
+ * `works` and `agents`.
+ */
+export type MergePolicyOverride = Partial<MergePolicy>;
+
+/**
+ * Which scope a resolved policy (or one of its fields) came from. `'default'`
+ * means no scope in the chain declared it and the platform default applies.
+ */
+export type MergePolicySource = MergePolicyScope | 'default';
+
+/**
+ * The platform DEFAULT — deliberately conservative, and deliberately NOT a
+ * hardcode: every field is overridable at any of the four scopes. An operator
+ * who wants agents to land their own green work sets
+ * `{ allowAgentMerge: true, requireHumanApproval: false }` at the scope of
+ * their choosing.
+ */
+export const PLATFORM_DEFAULT_MERGE_POLICY: MergePolicy = Object.freeze({
+	allowAgentMerge: false,
+	requireGreenGate: true,
+	requireHumanApproval: true,
+	allowedMergeMethods: ['squash'],
+	protectedBranches: ['main', 'master', 'develop', 'stage']
+}) as MergePolicy;
+
+/** Every field name of {@link MergePolicy}; the deep-merge iterates this. */
+export const MERGE_POLICY_FIELDS: readonly (keyof MergePolicy)[] = [
+	'allowAgentMerge',
+	'requireGreenGate',
+	'requireHumanApproval',
+	'allowedMergeMethods',
+	'protectedBranches'
+];
+
+/** One link of the resolution chain, reported so a preview can explain itself. */
+export interface MergePolicyChainEntry {
+	/** The scope this link represents (`'default'` is always the first link). */
+	scope: MergePolicySource;
+	/** Row id of the scope entity; `null` for the platform default. */
+	id: string | null;
+	/**
+	 * Fields this link CONTRIBUTED to the final policy — i.e. it declared them
+	 * and no more specific link overrode them. An empty array means the link
+	 * exists in the ancestry but was fully shadowed (or declared nothing).
+	 */
+	fields: (keyof MergePolicy)[];
+}
+
+/** Result of one policy resolution. */
+export interface ResolvedMergePolicy {
+	/** The complete, effective policy. */
+	policy: MergePolicy;
+	/**
+	 * The MOST SPECIFIC scope that contributed at least one field, or
+	 * `'default'` when nothing in the chain declared anything.
+	 */
+	source: MergePolicySource;
+	/** Least → most specific, starting at the platform default. */
+	chain: MergePolicyChainEntry[];
+}
+
+/**
+ * Stable refusal codes from the single decision point. Kept machine-readable
+ * so callers (facade, worker, UI) can branch without string-matching prose.
+ */
+export type MergeRefusalCode =
+	| 'agent-merge-disabled'
+	| 'protected-branch'
+	| 'target-branch-unknown'
+	| 'merge-method-not-allowed'
+	| 'gate-not-green'
+	| 'human-approval-required';
+
+/** Outcome of the single decision point (`canAgentMerge`). */
+export interface MergeDecision {
+	allowed: boolean;
+	/** Human-readable explanation; present only when `allowed === false`. */
+	reason?: string;
+	/** Machine-readable counterpart of `reason`. */
+	code?: MergeRefusalCode;
+	/** The policy the decision was made against, and where it came from. */
+	source?: MergePolicySource;
+}


### PR DESCRIPTION
## What

The platform must never hardcode "agents do not merge" (Wave 3, founder decision D4). Whether an agent may land its own pull request is now a **configurable policy**, resolvable at **tenant → organization → Work → Agent** over a conservative platform default, and enforced at the one place a merge can actually happen.

The differentiator this ships: **enforcement is real and the policy is yours.**

## Policy model — `packages/contracts/src/policy`

```ts
MergePolicy = {
  allowAgentMerge: boolean;
  requireGreenGate: boolean;
  requireHumanApproval: boolean;
  allowedMergeMethods: ('merge'|'squash'|'rebase')[];
  protectedBranches: string[];
}
MergePolicyScope = 'tenant' | 'organization' | 'work' | 'agent'
```

**Precedence (documented, and enforced by sorting inside the resolver):**

```
platform default  <  tenant  <  organization  <  Work  <  Agent
```

Resolution is **field by field**, not whole-object: a Work that sets only `allowAgentMerge` inherits the other four from its org / tenant / the default. `NULL` or an omitted key always means **inherit**, never "deny".

`PLATFORM_DEFAULT_MERGE_POLICY` = `{ allowAgentMerge: false, requireGreenGate: true, requireHumanApproval: true, allowedMergeMethods: ['squash'], protectedBranches: ['main','master','develop','stage'] }` — a **default**, not a hardcode. Every field is overridable at every scope; an org that wants agents landing their own green work sets two booleans.

## Storage

Additive nullable `mergePolicy` `simple-json` column on **all four** scope entities — `tenants`, `organizations`, `works`, `agents` (each verified to exist; none skipped) — plus one guarded, forward-only migration `1784000000000-AddMergePolicyColumns`, following the per-step guard pattern of `1782700000000-AddTaskIsolationColumns`. Every existing row keeps resolving to the platform default.

## Resolution + decision — `packages/agent/src/policy` (new leaf `PolicyModule`)

- **`resolve({agentId?, workId?, organizationId?, tenantId?})`** — ONE resolution function. Walks the chain upward (an Agent yields its Work → org → tenant), returns `{ policy, source, chain }`. The `chain` reports *which scope contributed which field*, because "agents may not merge here" is only actionable if the UI can say where that came from. Never throws: a lookup failure degrades to the platform default, never to something permissive.
- **`canAgentMerge({...ctx, gateStatus, humanApproved, targetBranch, mergeMethod})`** — THE decision point, returning `{ allowed, reason, code, source }` with stable refusal codes (`agent-merge-disabled`, `protected-branch`, `target-branch-unknown`, `merge-method-not-allowed`, `gate-not-green`, `human-approval-required`).

Modelled on `RunDispatchGateService` (resolution service + env valve), but **fail-closed** where that one fails open — a merge is irreversible, so an undeterminable target branch or an unbound enforcer refuses rather than proceeds.

## Enforcement

1. **`GitFacadeService.mergePullRequest`** — the only merge site in the repo — takes an optional `AgentMergeActor`. Present ⇒ agent-driven ⇒ routed through `canAgentMerge` **before the provider is called at all**; a refusal throws `MergePolicyRefusedError`, mapped to **403** by `FacadeExceptionFilter`. Absent ⇒ human-driven, behaviour unchanged. The base branch is looked up through the provider when the caller does not supply it. Operator rollback valve: `AGENT_MERGE_POLICY_ENFORCEMENT=off`.
2. **`TaskWorkspaceService.finalizeRun`** records the resolved policy source in its PR-opened log line (`— merge policy from work scope (allowAgentMerge=false)`). Read-only there: finalize opens PRs, it never lands one.

## API + chat

- **`GET /api/merge-policy/resolve?workId=&agentId=`** — owner-scoped preview returning `{ policy, source, chain }`. Both ids are authorized (`WorkOwnershipService.ensureAccess`, owner-filtered Agent lookup) **before** anything resolves, so it cannot become a cross-tenant policy oracle.
- Additive optional `mergePolicy` on the existing **Work**, **Agent** and **organization** update DTOs, nested class-validator (`MergePolicyDto`; every field optional = inherit, `null` clears the override).
- **Tenant scope: documented gap.** `tenants.mergePolicy` is resolvable and storable, but Tenants are internal-only and have no user-facing settings surface, so there is no HTTP write path for it yet. Noted on the entity and the controller.
- Chat tool **`resolve_merge_policy`** — agent-side factory (mirrors `buildFleetTools`) + web generated registry entry.

## Verification — all foreground, real output

**`packages/agent` build (TSC 0):**

```
> nest build -b swc && tsc -p tsconfig.types.json
✔  TSC  Initializing type checker...
>  TSC  Found 0 issues.
Successfully compiled: 1067 files with swc (432.52ms)
```

**`packages/agent` jest `merge-policy`:**

```
PASS src/policy/__tests__/merge-policy.spec.ts
PASS src/policy/__tests__/agent-merge-policy-tools.spec.ts
PASS src/policy/__tests__/merge-policy.service.spec.ts
PASS src/facades/__tests__/git.facade.merge-policy.spec.ts
Test Suites: 4 passed, 4 total
Tests:       48 passed, 48 total
```

**`packages/agent` full suite (no regressions):**

```
Test Suites: 388 passed, 388 total
Tests:       2 skipped, 7164 passed, 7166 total
```

**`pnpm build --filter=ever-works-api`:**

```
ever-works-api:build: >  TSC  Found 0 issues.
ever-works-api:build: Successfully compiled: 685 files with swc (924.71ms)
 Tasks:    14 successful, 14 total
```

**`apps/api pnpm generate:openapi` (full-app bootstrap gate):**

```
Wrote OpenAPI spec (436 paths) to .../apps/api/openapi.json
merge-policy paths: [ '/api/merge-policy/resolve' ]
UpdateWorkDto.mergePolicy present: true
UpdateAgentDto.mergePolicy present: true
UpdateOrganizationDto.mergePolicy present: true
```

`openapi.json` is gitignored and is not part of this commit.

**`apps/api` jest on touched suites:**

```
PASS src/merge-policy/merge-policy.controller.spec.ts
PASS src/common/filters/facade-exception.filter.spec.ts
PASS src/organizations/__tests__/organization.service.spec.ts
PASS src/organizations/__tests__/organizations.controller.register-company.spec.ts
PASS src/agents/agents.controller.runtime.spec.ts
...
Test Suites: 10 passed, 10 total
Tests:       120 passed, 120 total
```

**`apps/web npx tsc --noEmit`** (after deleting `tsconfig.tsbuildinfo` — stale-cache trap): exit 0, no output.

## Tests — 52 new

Precedence (each scope wins over its parent), field-level deep merge, chain attribution, default-when-all-null, override sanitization (drop-if-unrecognized), the full `canAgentMerge` refusal matrix (red gate + `requireGreenGate`, protected branch including case and `refs/heads/` forms, unknown target fails closed, disallowed method, unspecified method evaluated as the provider default, missing approval), refusal reasons naming the offending value, facade enforcement (refusal ⇒ provider never called; kill-switch; unbound enforcer fails closed), and endpoint owner scoping.

## Notes for review

- **New `@ever-works/agent/validation` subpath.** `MergePolicyDto` is shared by three update surfaces, but importing it through the general `/dto` barrel drags the entity graph in and trips a pre-existing entity import cycle under the api test runner. The new subpath re-exports entity-free validation DTOs only. `sanitizeMergePolicyOverride` lives in `@ever-works/contracts` for the same reason — it validates a wire shape, so it should not require the agent package.
- **Account export/import deliberately does NOT carry `mergePolicy`.** A policy can only loosen enforcement and the envelope is hand-editable, so round-tripping it would be privilege escalation across import — the same reasoning that makes `AgentExportService` clamp `permissions` to the all-false default. Imported Works/Agents start at `NULL` (inherit). Commented in `account-transfer/types.ts` so it is not later "fixed" as a missing-whitelist bug.
- **e2e whitelist sweep:** `grep mergePolicy apps/web/e2e` → 0 hits. No spec asserts these DTO fields are rejected, so the additive DTO change breaks nothing.
- Module-shape pins updated in the same commit: `facades.module.spec.ts` (new runtime symbol) plus the new `policy.module.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
