### PR TITLE
fix(plugins): export plugin classes as default (loader materialization)

### DIFF
--- a/packages/plugins/linear-connector/src/index.ts
+++ b/packages/plugins/linear-connector/src/index.ts
@@ -12,3 +12,11 @@ export {
 	LINEAR_PULL_PAGE_SIZE,
 	LINEAR_BACKFILL_MAX_PAGES
 } from './linear-connector-plugin.js';
+
+// The plugin loader resolves `module.default` first. Without a default
+// export, `import()` of the CJS build hands back the whole namespace
+// object (no __esModule marker), which fails the plugin-class check at
+// materialization time — the plugin registers from its manifest and then
+// dies on first use. Every loadable first-party plugin re-exports its
+// class as default; keep this in sync with the class above.
+export { LinearConnectorPlugin as default } from './linear-connector-plugin.js';

--- a/packages/plugins/notion-connector/src/index.ts
+++ b/packages/plugins/notion-connector/src/index.ts
@@ -13,3 +13,11 @@ export {
 	NOTION_PULL_PAGE_SIZE,
 	NOTION_BACKFILL_MAX_PAGES
 } from './notion-connector-plugin.js';
+
+// The plugin loader resolves `module.default` first. Without a default
+// export, `import()` of the CJS build hands back the whole namespace
+// object (no __esModule marker), which fails the plugin-class check at
+// materialization time — the plugin registers from its manifest and then
+// dies on first use. Every loadable first-party plugin re-exports its
+// class as default; keep this in sync with the class above.
+export { NotionConnectorPlugin as default } from './notion-connector-plugin.js';

--- a/packages/plugins/slack-connector/src/index.ts
+++ b/packages/plugins/slack-connector/src/index.ts
@@ -19,3 +19,11 @@ export {
 	type SlackSignatureInput,
 	type SlackSignatureResult
 } from './slack-signature.js';
+
+// The plugin loader resolves `module.default` first. Without a default
+// export, `import()` of the CJS build hands back the whole namespace
+// object (no __esModule marker), which fails the plugin-class check at
+// materialization time — the plugin registers from its manifest and then
+// dies on first use. Every loadable first-party plugin re-exports its
+// class as default; keep this in sync with the class above.
+export { SlackConnectorPlugin as default } from './slack-connector-plugin.js';

--- a/packages/plugins/zoom-connector/src/index.ts
+++ b/packages/plugins/zoom-connector/src/index.ts
@@ -22,3 +22,11 @@ export type {
 	ZoomRecordingMeetingNode,
 	ZoomRecordingFileNode
 } from './zoom-connector-plugin.js';
+
+// The plugin loader resolves `module.default` first. Without a default
+// export, `import()` of the CJS build hands back the whole namespace
+// object (no __esModule marker), which fails the plugin-class check at
+// materialization time — the plugin registers from its manifest and then
+// dies on first use. Every loadable first-party plugin re-exports its
+// class as default; keep this in sync with the class above.
+export { ZoomConnectorPlugin as default } from './zoom-connector-plugin.js';


### PR DESCRIPTION
Found by booting the API against a real database as part of the wave-program finale.

The plugin loader resolves `module.default` first. Without a default export, `import()` of the tsup CJS build hands back the whole namespace object (no `__esModule` marker) — truthy, so the loader accepts it, then fails both `isPluginClass` and `isPlugin` and logs *Exported value is not a valid plugin*. The plugin registers from its manifest and dies on first use.

Affected: `linear-connector`, `notion-connector`, `zoom-connector` (all failed `onLoad` at boot) and `slack-connector` (same latent defect — it just had not been materialized yet). `sandbox-workspace`, `local-workspace` and `gtm-pipeline` already exported a default and loaded fine.

**Verified:** after the fix, a fresh API boot shows **zero** `not a valid plugin` / `Failed to load plugin module` errors, and `onLoad` runs for all four connectors plus both workspace providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dynamic loading for Linear, Notion, Slack, and Zoom integrations.
  - Prevented connector loading failures in environments using CommonJS module builds.
  - Ensured each connector is recognized and initialized correctly when first used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->