### PR TITLE
style: fix format:check drift from the wave program

### DIFF
--- a/packages/agent/src/services/__tests__/memory-recall.spec.ts
+++ b/packages/agent/src/services/__tests__/memory-recall.spec.ts
@@ -172,21 +172,19 @@ describe('memory-recall helper', () => {
 
         it('times out a stalled backend instead of holding up the run (best-effort contract)', async () => {
             const source: MemoryRecallContextSource = {
-                buildContextWithProvider: jest
-                    .fn()
-                    .mockImplementation(
-                        () =>
-                            new Promise((resolve) =>
-                                setTimeout(
-                                    () =>
-                                        resolve({
-                                            context: { content: 'too late' },
-                                            providerId: 'slow',
-                                        }),
-                                    5_000,
-                                ).unref?.(),
-                            ),
-                    ),
+                buildContextWithProvider: jest.fn().mockImplementation(
+                    () =>
+                        new Promise((resolve) =>
+                            setTimeout(
+                                () =>
+                                    resolve({
+                                        context: { content: 'too late' },
+                                        providerId: 'slow',
+                                    }),
+                                5_000,
+                            ).unref?.(),
+                        ),
+                ),
             };
 
             const result = await resolveMemoryRecall(source, { timeoutMs: 25 }, { userId: 'u1' });

--- a/packages/plugins/sandbox-workspace/src/sandbox-workspace.plugin.ts
+++ b/packages/plugins/sandbox-workspace/src/sandbox-workspace.plugin.ts
@@ -163,15 +163,8 @@ export class SandboxWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 			)
 		).stdout.trim();
 
-		const startPoint = reused
-			? `refs/remotes/origin/${spec.branch}`
-			: `refs/remotes/origin/${spec.baseRef}`;
-		await this.gitOrThrow(
-			['checkout', '-B', spec.branch, startPoint],
-			dir,
-			spec.auth,
-			'branch checkout failed'
-		);
+		const startPoint = reused ? `refs/remotes/origin/${spec.branch}` : `refs/remotes/origin/${spec.baseRef}`;
+		await this.gitOrThrow(['checkout', '-B', spec.branch, startPoint], dir, spec.auth, 'branch checkout failed');
 
 		await this.writeStamp(dir, { bindingKey: spec.bindingKey, branch: spec.branch });
 
@@ -186,12 +179,7 @@ export class SandboxWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 		const dir = handle.path;
 		await this.gitOrThrow(['add', '-A'], dir, opts.auth, 'git add failed');
 
-		const status = await this.gitOrThrow(
-			['status', '--porcelain'],
-			dir,
-			opts.auth,
-			'git status failed'
-		);
+		const status = await this.gitOrThrow(['status', '--porcelain'], dir, opts.auth, 'git status failed');
 		const dirty = status.stdout.trim().length > 0;
 		if (dirty) {
 			await this.gitOrThrow(
@@ -222,12 +210,7 @@ export class SandboxWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 		let pushed = false;
 		if (opts.push) {
 			const repoUrl = (
-				await this.gitOrThrow(
-					['remote', 'get-url', 'origin'],
-					dir,
-					opts.auth,
-					'origin remote missing'
-				)
+				await this.gitOrThrow(['remote', 'get-url', 'origin'], dir, opts.auth, 'origin remote missing')
 			).stdout.trim();
 			await this.gitOrThrow(
 				['push', this.authedUrl(repoUrl, opts.auth), `HEAD:refs/heads/${handle.branch}`],
@@ -324,9 +307,7 @@ export class SandboxWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 	// ── internals ────────────────────────────────────────────────────
 
 	private baseDir(settings: WorkspaceProvisionSpec['settings']): string {
-		const configured =
-			(typeof settings?.baseDir === 'string' && settings.baseDir) ||
-			process.env.EW_WORKSPACES_DIR;
+		const configured = (typeof settings?.baseDir === 'string' && settings.baseDir) || process.env.EW_WORKSPACES_DIR;
 		return configured || join(tmpdir(), 'ew-workspaces');
 	}
 
@@ -364,11 +345,7 @@ export class SandboxWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 		return out;
 	}
 
-	private git(
-		args: string[],
-		cwd: string | undefined,
-		auth: WorkspaceProvisionSpec['auth']
-	): Promise<GitResult> {
+	private git(args: string[], cwd: string | undefined, auth: WorkspaceProvisionSpec['auth']): Promise<GitResult> {
 		return new Promise((resolve) => {
 			execFile(
 				'git',


### PR DESCRIPTION
`pnpm format:check` on main flagged two files: `packages/agent/src/services/__tests__/memory-recall.spec.ts` and `packages/plugins/sandbox-workspace/src/sandbox-workspace.plugin.ts`. Both were written against a package-local prettier config rather than the root config that `format:check` enforces.

Formatting only. Verified after the reformat: sandbox-workspace vitest 8/8, agent `memory-recall` jest 27/27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal workspace provisioning and finalization code without changing behavior.
  * Simplified formatting and command construction for workspace Git operations.

* **Tests**
  * Restructured the timeout test mock while preserving coverage for failed, timed-out memory recall responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->