### PR TITLE
fix(agent): raw timestamp columns break the API boot on sqlite (e2e is 100% red)

### DIFF
--- a/packages/agent/src/entities/fleet-node.entity.ts
+++ b/packages/agent/src/entities/fleet-node.entity.ts
@@ -1,4 +1,5 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { PortableDateColumn } from './_types';
 
 /**
  * Fleet (Wave 12, slice 1) — one machine registered to execute the
@@ -78,7 +79,10 @@ export class FleetNode {
     enrollmentTokenHash?: string | null;
 
     /** Server-stamped on every accepted heartbeat (never client-trusted). */
-    @Column({ type: 'timestamp', nullable: true })
+    // Portable date: better-sqlite3 (the e2e/CI driver) has no `timestamp`
+    // type, so a raw one makes TypeORM metadata validation throw
+    // DataTypeNotSupportedError and the API cannot boot there at all.
+    @PortableDateColumn({ nullable: true })
     lastHeartbeatAt?: Date | null;
 
     /** Capability tags ('terminal', 'workspace', 'docker', ...). */

--- a/packages/agent/src/entities/ingest-cursor.entity.ts
+++ b/packages/agent/src/entities/ingest-cursor.entity.ts
@@ -6,6 +6,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { PortableDateColumn } from './_types';
 
 /**
  * Event-ingest spine (Wave 8) — per-(user, plugin) pull state for the
@@ -47,11 +48,17 @@ export class IngestCursor {
     cursor?: string | null;
 
     /** Completed-sweep high-water mark (passed as `since`). */
-    @Column({ type: 'timestamp', nullable: true })
+    // Portable date: better-sqlite3 (the e2e/CI driver) has no `timestamp`
+    // type, so a raw one makes TypeORM metadata validation throw
+    // DataTypeNotSupportedError and the API cannot boot there at all.
+    @PortableDateColumn({ nullable: true })
     watermark?: Date | null;
 
     /** When the in-flight sweep began (null when no sweep is running). */
-    @Column({ type: 'timestamp', nullable: true })
+    // Portable date: better-sqlite3 (the e2e/CI driver) has no `timestamp`
+    // type, so a raw one makes TypeORM metadata validation throw
+    // DataTypeNotSupportedError and the API cannot boot there at all.
+    @PortableDateColumn({ nullable: true })
     sweepStartedAt?: Date | null;
 
     @CreateDateColumn()

--- a/packages/agent/src/entities/ingested-event.entity.ts
+++ b/packages/agent/src/entities/ingested-event.entity.ts
@@ -1,4 +1,5 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { PortableDateColumn } from './_types';
 
 /**
  * Event-ingest spine (Wave 6) — one normalized external event, landed.
@@ -55,7 +56,10 @@ export class IngestedEvent {
     kind: string;
 
     /** When the event happened at the source. */
-    @Column({ type: 'timestamp' })
+    // Portable date: better-sqlite3 (the e2e/CI driver) has no `timestamp`
+    // type, so a raw one makes TypeORM metadata validation throw
+    // DataTypeNotSupportedError and the API cannot boot there at all.
+    @PortableDateColumn()
     occurredAt: Date;
 
     @Column({ type: 'varchar', length: 200, nullable: true })
@@ -79,7 +83,10 @@ export class IngestedEvent {
     payload: Record<string, unknown>;
 
     /** Set when the processor fan-out (Activity + Memory) has run. */
-    @Column({ type: 'timestamp', nullable: true })
+    // Portable date: better-sqlite3 (the e2e/CI driver) has no `timestamp`
+    // type, so a raw one makes TypeORM metadata validation throw
+    // DataTypeNotSupportedError and the API cannot boot there at all.
+    @PortableDateColumn({ nullable: true })
     processedAt?: Date | null;
 
     /** sha256 hex over (userId, source, sourceEventId). */

--- a/packages/agent/src/entities/meeting.entity.ts
+++ b/packages/agent/src/entities/meeting.entity.ts
@@ -1,4 +1,5 @@
 import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+import { PortableDateColumn } from './_types';
 
 /**
  * Meetings v1 (Wave 8, feature a) — one captured meeting, org-wide or
@@ -63,10 +64,16 @@ export class Meeting {
     @Column({ type: 'varchar', length: 500 })
     title: string;
 
-    @Column({ type: 'timestamp' })
+    // Portable date: better-sqlite3 (the e2e/CI driver) has no `timestamp`
+    // type, so a raw one makes TypeORM metadata validation throw
+    // DataTypeNotSupportedError and the API cannot boot there at all.
+    @PortableDateColumn()
     startedAt: Date;
 
-    @Column({ type: 'timestamp', nullable: true })
+    // Portable date: better-sqlite3 (the e2e/CI driver) has no `timestamp`
+    // type, so a raw one makes TypeORM metadata validation throw
+    // DataTypeNotSupportedError and the API cannot boot there at all.
+    @PortableDateColumn({ nullable: true })
     endedAt?: Date | null;
 
     /** Producing surface: 'zoom' | 'google-meet' | 'manual' | 'import'. */


### PR DESCRIPTION
## develop's e2e is currently 100% red — the API cannot boot

`better-sqlite3` (the e2e/CI database driver) has no `timestamp` type, so TypeORM's metadata validation throws and **the API never starts**:

```
DataTypeNotSupportedError: Data type "timestamp" in
"IngestedEvent.occurredAt" is not supported by "better-sqlite3" database.
```

Because that is the entire e2e environment, **every shard dies in `global-setup`** — Playwright exits 1 with *no test output at all*, and `e2e-prod-build` fails too. The failure signature is deliberately confusing: no failing test, no useful log, just exit 1 everywhere.

## Fix

Converted every raw `type: 'timestamp'` column to the repo's purpose-built `@PortableDateColumn` (adding the import where absent):

| Entity | Columns |
|---|---|
| `fleet-node` | `lastHeartbeatAt` |
| `ingest-cursor` | `watermark`, `sweepStartedAt` |
| `ingested-event` | `occurredAt` (NOT NULL), `processedAt` |
| `meeting` | `startedAt` (NOT NULL), `endedAt` |

(An earlier commit in this branch fixed the same thing on `AgentRun.lastHeartbeatAt`.)

**Verified:** the API boots in ~24s again on merged develop. A repo-wide grep now reports **zero** raw `type: 'timestamp'` columns in any entity.

## This trap keeps recurring

`agent`, `mission`, `organization`, `user`, and `work-budget-alert-state` entities all carry warning comments about it already ("H-17", "EW-602 fix"). It has now landed a fifth and sixth time. A lint rule or an entity-schema test would prevent a seventh — worth doing as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)