### PR TITLE
fix(terminal): session dispatch + PTY dependency reaches the worker

### DIFF
--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -11,7 +11,9 @@ import {
     AGENT_GIT_FACADE,
     AGENT_EMAIL_FACADE,
     AGENT_NOTIFY_CHANNEL_FACADE,
+    TERMINAL_SESSION_DISPATCHER,
     RunSteeringService,
+    TerminalSessionLauncher,
     type AgentRunChatBackPoster,
     type AgentRunTaskFinisher,
     type AgentPluginToolsFacade,
@@ -36,6 +38,7 @@ import {
 import {
     agentHeartbeatTriggerAdapter,
     createAgentRunCancellerAdapter,
+    terminalSessionTriggerAdapter,
     TriggerModule as TasksTriggerModule,
     TriggerService,
 } from '@ever-works/trigger-tasks';
@@ -54,6 +57,7 @@ import {
     TasksService,
     TaskStatus,
     RUN_STEERING_PORT,
+    TERMINAL_SESSION_STARTER,
 } from '@ever-works/agent/tasks-domain';
 import {
     FacadesModule,
@@ -182,6 +186,19 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
         // TasksDomainModule, and neither package gains a runtime import of
         // the other.
         { provide: RUN_STEERING_PORT, useExisting: RunSteeringService },
+        // Streaming terminal — the two halves of the session dispatch.
+        //
+        // TERMINAL_SESSION_DISPATCHER is the job-runtime producer for the
+        // `terminal-session` task (which shipped with NO producer at all,
+        // so no session was ever started). TERMINAL_SESSION_STARTER is the
+        // port `TaskTransitionService` reaches for after a successful
+        // fan-out; it points at the same launcher so the ownership check,
+        // the CAS duplicate refusal and the persistent gate are stated
+        // exactly once. Same @Global() token posture as RUN_STEERING_PORT:
+        // implementation in the imported agent-side AgentsModule, consumer
+        // in TasksDomainModule, neither package importing the other.
+        { provide: TERMINAL_SESSION_DISPATCHER, useValue: terminalSessionTriggerAdapter },
+        { provide: TERMINAL_SESSION_STARTER, useExisting: TerminalSessionLauncher },
         // Notifications v2 (EW-670) — INBOUND_EMAIL_TASK_SPAWNER binding.
         // The inbound-email dispatcher's `task-spawn` mode delegates here:
         // create a Task from the inbound email (scoped to the address
@@ -644,6 +661,8 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
         AGENT_NOTIFY_CHANNEL_FACADE,
         INBOUND_EMAIL_TASK_SPAWNER,
         RUN_STEERING_PORT,
+        TERMINAL_SESSION_DISPATCHER,
+        TERMINAL_SESSION_STARTER,
     ],
 })
 export class AgentsModule {}

--- a/apps/api/src/terminal/__tests__/terminal-attach.controller.spec.ts
+++ b/apps/api/src/terminal/__tests__/terminal-attach.controller.spec.ts
@@ -1,8 +1,8 @@
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException, ServiceUnavailableException } from '@nestjs/common';
 import { TerminalAttachController } from '../terminal-attach.controller';
 import { TerminalAttachService } from '../terminal-attach.service';
 import { TerminalRelayRegistry } from '../terminal-relay.registry';
-import type { AgentsService } from '@ever-works/agent/agents';
+import type { AgentsService, TerminalSessionLauncher } from '@ever-works/agent/agents';
 import type { AgentRunRepository } from '@ever-works/agent/database';
 import type { AuthenticatedUser } from '../../auth/types/auth.types';
 
@@ -64,5 +64,84 @@ describe('TerminalAttachController — run-scoped authorization', () => {
 
         runs.findByIdAndUser.mockResolvedValueOnce(null);
         await expect(controller.status(AUTH, AGENT, RUN)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    /**
+     * `POST …/terminal/start` is the user action that finally produces a
+     * `terminal-session` job — before it, the whole terminal stack pointed at
+     * a session nothing ever launched.
+     */
+    describe('POST start', () => {
+        let launcher: { startForRun: jest.Mock };
+
+        function makeController(withLauncher = true) {
+            return new TerminalAttachController(
+                agents as unknown as AgentsService,
+                runs as unknown as AgentRunRepository,
+                new TerminalAttachService(),
+                new TerminalRelayRegistry(),
+                withLauncher ? (launcher as unknown as TerminalSessionLauncher) : undefined,
+            );
+        }
+
+        beforeEach(() => {
+            launcher = {
+                startForRun: jest
+                    .fn()
+                    .mockResolvedValue({ started: true, runId: RUN, jobRunId: 'job_1' }),
+            };
+        });
+
+        it('starts a session for the run owner and flags the run persistent', async () => {
+            const result = await makeController().start(AUTH, AGENT, RUN);
+
+            expect(agents.getOne).toHaveBeenCalledWith('user-1', AGENT);
+            expect(launcher.startForRun).toHaveBeenCalledWith({
+                userId: 'user-1',
+                agentId: AGENT,
+                runId: RUN,
+                markPersistent: true,
+            });
+            expect(result).toEqual({ started: true, runId: RUN, state: 'starting' });
+        });
+
+        it('404s (no existence leak) before the launcher is ever consulted', async () => {
+            runs.findByIdAndUser.mockResolvedValueOnce(null);
+            await expect(makeController().start(AUTH, AGENT, RUN)).rejects.toBeInstanceOf(
+                NotFoundException,
+            );
+            expect(launcher.startForRun).not.toHaveBeenCalled();
+        });
+
+        it('409s when a session is already live for the run', async () => {
+            launcher.startForRun.mockResolvedValueOnce({
+                started: false,
+                reason: 'session-already-live',
+            });
+            await expect(makeController().start(AUTH, AGENT, RUN)).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+        });
+
+        it('409s when the run has already finished', async () => {
+            launcher.startForRun.mockResolvedValueOnce({ started: false, reason: 'run-not-live' });
+            await expect(makeController().start(AUTH, AGENT, RUN)).rejects.toBeInstanceOf(
+                ConflictException,
+            );
+        });
+
+        it('503s (not 500) when no job runtime is wired on this install', async () => {
+            await expect(makeController(false).start(AUTH, AGENT, RUN)).rejects.toBeInstanceOf(
+                ServiceUnavailableException,
+            );
+
+            launcher.startForRun.mockResolvedValueOnce({
+                started: false,
+                reason: 'dispatcher-unavailable',
+            });
+            await expect(makeController().start(AUTH, AGENT, RUN)).rejects.toBeInstanceOf(
+                ServiceUnavailableException,
+            );
+        });
     });
 });

--- a/apps/api/src/terminal/terminal-attach.controller.ts
+++ b/apps/api/src/terminal/terminal-attach.controller.ts
@@ -1,16 +1,19 @@
 import {
+    ConflictException,
     Controller,
     HttpCode,
     HttpStatus,
     NotFoundException,
+    Optional,
     Param,
     ParseUUIDPipe,
     Post,
+    ServiceUnavailableException,
     Get,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import { AgentsService } from '@ever-works/agent/agents';
+import { AgentsService, TerminalSessionLauncher } from '@ever-works/agent/agents';
 import { AgentRunRepository } from '@ever-works/agent/database';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
@@ -37,6 +40,11 @@ export class TerminalAttachController {
         private readonly runs: AgentRunRepository,
         private readonly attach: TerminalAttachService,
         private readonly registry: TerminalRelayRegistry,
+        // Appended LAST + @Optional() so every positional
+        // `new TerminalAttachController(...)` in the existing specs keeps
+        // compiling, and an install with no job runtime answers 503 on
+        // start instead of failing to boot the controller.
+        @Optional() private readonly launcher?: TerminalSessionLauncher,
     ) {}
 
     private async authorizeRun(userId: string, agentId: string, runId: string) {
@@ -68,6 +76,80 @@ export class TerminalAttachController {
             role: 'driver',
         });
         return { token, wsPath: `/ws/terminal/${runId}`, role: 'driver', expiresInSec };
+    }
+
+    /**
+     * Start a terminal session for this run.
+     *
+     * The explicit user affordance behind the Terminal tab: without it the
+     * `terminal-session` job had no producer anywhere in the platform, so a
+     * user could mint attach tokens and open a socket onto a channel that
+     * would never carry a single frame.
+     *
+     * The session argv is resolved SERVER-SIDE (operator configuration,
+     * Linux-shell default) and is deliberately not accepted from the body —
+     * this endpoint opens the user's own worker shell, it is not a generic
+     * remote-exec surface.
+     *
+     * 202 → dispatched. 409 → a session is already live for this run, or
+     * the run itself is finished (nothing left to attach a shell to). 404 →
+     * the same no-existence-leak answer every other run-scoped route gives.
+     */
+    @Post('start')
+    @ApiOperation({
+        summary:
+            'Start a terminal session for this run (dispatches the terminal-session job). ' +
+            '409 when a session is already live for the run.',
+    })
+    @HttpCode(HttpStatus.ACCEPTED)
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    async start(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) agentId: string,
+        @Param('runId', ParseUUIDPipe) runId: string,
+    ): Promise<{ started: true; runId: string; state: 'starting' }> {
+        await this.authorizeRun(auth.userId, agentId, runId);
+        if (!this.launcher) {
+            throw new ServiceUnavailableException(
+                'Terminal sessions are unavailable on this install — no background job runtime is wired.',
+            );
+        }
+
+        const outcome = await this.launcher.startForRun({
+            userId: auth.userId,
+            agentId,
+            runId,
+            // Asking for a terminal on a run IS the statement that the run
+            // wants a long-lived interactive session.
+            markPersistent: true,
+        });
+
+        // `in` narrowing, not `if (outcome.started)`: this app compiles with
+        // `strictNullChecks: false`, under which truthiness narrowing on a
+        // `true | false` discriminant does not split the union.
+        if (!('reason' in outcome)) {
+            return { started: true, runId: outcome.runId, state: 'starting' };
+        }
+        switch (outcome.reason) {
+            case 'run-not-found':
+                throw new NotFoundException(`AgentRun ${runId} not found.`);
+            case 'session-already-live':
+                throw new ConflictException(
+                    `AgentRun ${runId} already has a live terminal session — attach to it instead of starting another.`,
+                );
+            case 'run-not-live':
+                throw new ConflictException(
+                    `AgentRun ${runId} has finished — a terminal session can only be started for a queued or running run.`,
+                );
+            case 'dispatcher-unavailable':
+                throw new ServiceUnavailableException(
+                    'Terminal sessions are unavailable on this install — no background job runtime is wired.',
+                );
+            default:
+                throw new ConflictException(
+                    `Terminal session could not be started for AgentRun ${runId}.`,
+                );
+        }
     }
 
     @Get()

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6182,7 +6182,10 @@
             "reconnect": "Reconnect",
             "waitingForOutput": "Waiting for output…",
             "noRuns": "No runs yet — terminals attach to agent runs.",
-            "runPickerLabel": "Run"
+            "runPickerLabel": "Run",
+            "startSession": "Start session",
+            "startingSession": "Starting…",
+            "startFailed": "Could not start a terminal session for this run."
         },
         "jobRuntimeBanner": {
             "title": "Background job runtime is not configured.",

--- a/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/start/route.ts
+++ b/apps/web/src/app/api/agents/[id]/runs/[runId]/terminal/start/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_URL } from '@/lib/constants';
+import { getAuthAccessCookie } from '@/lib/auth/cookies';
+
+type RouteContext = { params: Promise<{ id: string; runId: string }> };
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Streaming-terminal — start-session proxy.
+ *
+ * Sibling of the attach-token proxy: the browser holds a web session
+ * cookie, not an API bearer, and does not know the API origin. This
+ * forwards the start with the session bearer and passes the upstream
+ * status through UNCHANGED — 409 ("a session is already live", "the run
+ * has finished") and 404 are the whole point of the endpoint, so they must
+ * reach the pane instead of being flattened into a generic failure.
+ *
+ * No request body is forwarded: the session argv is operator configuration
+ * resolved server-side, never something the browser gets to choose.
+ */
+export async function POST(_request: NextRequest, ctx: RouteContext) {
+    const { id, runId } = await ctx.params;
+    if (!UUID.test(id) || !UUID.test(runId)) {
+        return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+    }
+
+    const token = await getAuthAccessCookie();
+    if (!token) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const upstream = await fetch(`${API_URL}/agents/${id}/runs/${runId}/terminal/start`, {
+        method: 'POST',
+        headers: { Accept: 'application/json', Authorization: `Bearer ${token}` },
+        cache: 'no-store',
+    });
+
+    const text = await upstream.text().catch(() => '');
+    return new Response(text, {
+        status: upstream.status,
+        headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+    });
+}

--- a/apps/web/src/components/terminal/AgentTerminalClient.tsx
+++ b/apps/web/src/components/terminal/AgentTerminalClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { TerminalPane } from './TerminalPane';
 
@@ -33,6 +33,35 @@ export function AgentTerminalClient({
         return runs[0]?.id ?? null;
     }, [initialRunId, runs]);
     const [selected, setSelected] = useState<string | null>(defaultRun);
+    // `paneKey` remounts the pane after a successful start so the attach
+    // re-runs against the session that now exists (previously the pane could
+    // only ever attach to a channel nothing published to).
+    const [paneKey, setPaneKey] = useState(0);
+    const [starting, setStarting] = useState(false);
+    const [startError, setStartError] = useState<string | null>(null);
+
+    const startSession = useCallback(async () => {
+        if (!selected || starting) return;
+        setStarting(true);
+        setStartError(null);
+        try {
+            const res = await fetch(`/api/agents/${agentId}/runs/${selected}/terminal/start`, {
+                method: 'POST',
+            });
+            if (!res.ok) {
+                // The API's 409 messages ("already live", "run has finished")
+                // are the useful ones — surface them verbatim when present.
+                const body = (await res.json().catch(() => null)) as { message?: string } | null;
+                setStartError(body?.message ?? t('startFailed'));
+                return;
+            }
+            setPaneKey((k) => k + 1);
+        } catch {
+            setStartError(t('startFailed'));
+        } finally {
+            setStarting(false);
+        }
+    }, [agentId, selected, starting, t]);
 
     if (runs.length === 0) {
         return (
@@ -65,10 +94,32 @@ export function AgentTerminalClient({
                         </option>
                     ))}
                 </select>
+                <button
+                    type="button"
+                    onClick={() => void startSession()}
+                    disabled={!selected || starting}
+                    data-testid="terminal-start-session"
+                    className="ml-auto inline-flex items-center gap-1 rounded-md border border-border/60 dark:border-border-dark/60 px-2 h-8 text-xs text-text dark:text-text-dark hover:bg-card-hover dark:hover:bg-card-hover-dark disabled:opacity-50"
+                >
+                    {starting ? t('startingSession') : t('startSession')}
+                </button>
             </div>
+            {startError && (
+                <p
+                    role="alert"
+                    data-testid="terminal-start-error"
+                    className="text-xs text-red-600 dark:text-red-400"
+                >
+                    {startError}
+                </p>
+            )}
             {selected && (
                 <div className="flex-1 min-h-0">
-                    <TerminalPane key={selected} agentId={agentId} runId={selected} />
+                    <TerminalPane
+                        key={`${selected}:${paneKey}`}
+                        agentId={agentId}
+                        runId={selected}
+                    />
                 </div>
             )}
         </div>

--- a/packages/agent/src/agents/__tests__/terminal-session-launcher.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/terminal-session-launcher.service.spec.ts
@@ -1,0 +1,259 @@
+import { TerminalSessionLauncher } from '../terminal-session-launcher.service';
+import {
+    TERMINAL_SESSION_COMMAND_DEFAULT,
+    TERMINAL_SESSION_COMMAND_ENV,
+    resolveTerminalSessionCommand,
+} from '../terminal-session-dispatcher';
+import type { AgentRunRepository } from '../../database/repositories/agent-run.repository';
+import type { TerminalSessionDispatcher } from '../terminal-session-dispatcher';
+
+const USER = 'user-1';
+const AGENT = '11111111-2222-4333-8444-555555555555';
+const RUN = '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f';
+
+function makeRun(over: Record<string, unknown> = {}) {
+    return {
+        id: RUN,
+        userId: USER,
+        agentId: AGENT,
+        status: 'running',
+        persistent: false,
+        terminalState: null,
+        workspaceMeta: null,
+        ...over,
+    };
+}
+
+describe('TerminalSessionLauncher', () => {
+    let runs: {
+        findByIdAndUser: jest.Mock;
+        casClaimTerminalSession: jest.Mock;
+        releaseTerminalSessionClaim: jest.Mock;
+    };
+    let dispatcher: { enqueue: jest.Mock };
+
+    beforeEach(() => {
+        runs = {
+            findByIdAndUser: jest.fn().mockResolvedValue(makeRun()),
+            casClaimTerminalSession: jest.fn().mockResolvedValue(true),
+            releaseTerminalSessionClaim: jest.fn().mockResolvedValue(undefined),
+        };
+        dispatcher = { enqueue: jest.fn().mockResolvedValue({ jobRunId: 'job_run_1' }) };
+    });
+
+    function makeLauncher(withDispatcher = true) {
+        return new TerminalSessionLauncher(
+            runs as unknown as AgentRunRepository,
+            withDispatcher ? (dispatcher as unknown as TerminalSessionDispatcher) : undefined,
+        );
+    }
+
+    it('dispatches terminal-session with the payload the task contract expects', async () => {
+        const outcome = await makeLauncher().startForRun({
+            userId: USER,
+            agentId: AGENT,
+            runId: RUN,
+            markPersistent: true,
+        });
+
+        expect(outcome).toEqual({ started: true, runId: RUN, jobRunId: 'job_run_1' });
+        expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
+        expect(dispatcher.enqueue).toHaveBeenCalledWith({
+            runId: RUN,
+            userId: USER,
+            agentId: AGENT,
+            command: [...TERMINAL_SESSION_COMMAND_DEFAULT],
+            cwd: '.',
+            persistent: true,
+        });
+    });
+
+    it('claims the terminal slot (and flags the run persistent) BEFORE dispatching', async () => {
+        const order: string[] = [];
+        runs.casClaimTerminalSession.mockImplementation(async () => {
+            order.push('claim');
+            return true;
+        });
+        dispatcher.enqueue.mockImplementation(async () => {
+            order.push('enqueue');
+            return { jobRunId: 'job_run_1' };
+        });
+
+        await makeLauncher().startForRun({
+            userId: USER,
+            agentId: AGENT,
+            runId: RUN,
+            markPersistent: true,
+        });
+
+        expect(order).toEqual(['claim', 'enqueue']);
+        expect(runs.casClaimTerminalSession).toHaveBeenCalledWith(RUN, { persistent: true });
+    });
+
+    it('refuses a duplicate start when a session is already resident on the run', async () => {
+        runs.findByIdAndUser.mockResolvedValue(makeRun({ terminalState: 'attached' }));
+
+        const outcome = await makeLauncher().startForRun({
+            userId: USER,
+            agentId: AGENT,
+            runId: RUN,
+            markPersistent: true,
+        });
+
+        expect(outcome).toEqual({ started: false, reason: 'session-already-live' });
+        expect(runs.casClaimTerminalSession).not.toHaveBeenCalled();
+        expect(dispatcher.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('refuses the racing duplicate that loses the CAS claim', async () => {
+        // Both callers read `terminalState: null`; only one UPDATE lands.
+        runs.casClaimTerminalSession.mockResolvedValueOnce(false);
+
+        const outcome = await makeLauncher().startForRun({
+            userId: USER,
+            agentId: AGENT,
+            runId: RUN,
+            markPersistent: true,
+        });
+
+        expect(outcome).toEqual({ started: false, reason: 'session-already-live' });
+        expect(dispatcher.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('does NOT spawn a session for a non-persistent run on the automatic path', async () => {
+        runs.findByIdAndUser.mockResolvedValue(makeRun({ persistent: false }));
+
+        const outcome = await makeLauncher().startForRun({
+            userId: USER,
+            agentId: AGENT,
+            runId: RUN,
+            requirePersistent: true,
+        });
+
+        expect(outcome).toEqual({ started: false, reason: 'not-persistent' });
+        expect(runs.casClaimTerminalSession).not.toHaveBeenCalled();
+        expect(dispatcher.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('DOES spawn a session for a persistent run on the automatic path', async () => {
+        runs.findByIdAndUser.mockResolvedValue(makeRun({ persistent: true }));
+
+        const outcome = await makeLauncher().startForRun({
+            userId: USER,
+            agentId: AGENT,
+            runId: RUN,
+            requirePersistent: true,
+        });
+
+        expect(outcome).toMatchObject({ started: true });
+        expect(dispatcher.enqueue).toHaveBeenCalledWith(
+            expect.objectContaining({ persistent: true }),
+        );
+        // The automatic path does not re-flag the run — it only honours a
+        // flag that is already there.
+        expect(runs.casClaimTerminalSession).toHaveBeenCalledWith(RUN, { persistent: undefined });
+    });
+
+    it('reports run-not-found (no existence leak) for a foreign or cross-agent run', async () => {
+        runs.findByIdAndUser.mockResolvedValueOnce(null);
+        await expect(
+            makeLauncher().startForRun({ userId: USER, agentId: AGENT, runId: RUN }),
+        ).resolves.toEqual({ started: false, reason: 'run-not-found' });
+
+        runs.findByIdAndUser.mockResolvedValueOnce(makeRun({ agentId: 'another-agent' }));
+        await expect(
+            makeLauncher().startForRun({ userId: USER, agentId: AGENT, runId: RUN }),
+        ).resolves.toEqual({ started: false, reason: 'run-not-found' });
+
+        expect(dispatcher.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('refuses to attach a shell to a run that has already finished', async () => {
+        for (const status of ['completed', 'failed', 'cancelled']) {
+            runs.findByIdAndUser.mockResolvedValueOnce(makeRun({ status }));
+            await expect(
+                makeLauncher().startForRun({ userId: USER, agentId: AGENT, runId: RUN }),
+            ).resolves.toEqual({ started: false, reason: 'run-not-live' });
+        }
+        expect(runs.casClaimTerminalSession).not.toHaveBeenCalled();
+    });
+
+    it('reports dispatcher-unavailable (and claims nothing) with no job runtime bound', async () => {
+        const outcome = await makeLauncher(false).startForRun({
+            userId: USER,
+            agentId: AGENT,
+            runId: RUN,
+        });
+
+        expect(outcome).toEqual({ started: false, reason: 'dispatcher-unavailable' });
+        expect(runs.casClaimTerminalSession).not.toHaveBeenCalled();
+        expect(makeLauncher(false).isAvailable()).toBe(false);
+        expect(makeLauncher().isAvailable()).toBe(true);
+    });
+
+    it('releases the claim (and rethrows) when the enqueue fails', async () => {
+        dispatcher.enqueue.mockRejectedValueOnce(new Error('job runtime down'));
+
+        await expect(
+            makeLauncher().startForRun({ userId: USER, agentId: AGENT, runId: RUN }),
+        ).rejects.toThrow('job runtime down');
+
+        expect(runs.releaseTerminalSessionClaim).toHaveBeenCalledWith(RUN, 'crashed');
+    });
+
+    it('uses the run’s isolated worktree as cwd when it has one', async () => {
+        runs.findByIdAndUser.mockResolvedValue(
+            makeRun({
+                workspaceMeta: {
+                    provider: 'sandbox-workspace',
+                    path: '/work/task-42',
+                    baseSha: 'abc',
+                    branchRef: 'refs/heads/task-42',
+                    reused: false,
+                },
+            }),
+        );
+
+        await makeLauncher().startForRun({ userId: USER, agentId: AGENT, runId: RUN });
+
+        expect(dispatcher.enqueue).toHaveBeenCalledWith(
+            expect.objectContaining({ cwd: '/work/task-42' }),
+        );
+    });
+});
+
+describe('resolveTerminalSessionCommand', () => {
+    const saved = process.env[TERMINAL_SESSION_COMMAND_ENV];
+    afterEach(() => {
+        if (saved === undefined) delete process.env[TERMINAL_SESSION_COMMAND_ENV];
+        else process.env[TERMINAL_SESSION_COMMAND_ENV] = saved;
+    });
+
+    it('defaults to the Linux worker shell when unset or blank', () => {
+        expect(resolveTerminalSessionCommand(undefined)).toEqual([
+            ...TERMINAL_SESSION_COMMAND_DEFAULT,
+        ]);
+        expect(resolveTerminalSessionCommand('   ')).toEqual([...TERMINAL_SESSION_COMMAND_DEFAULT]);
+    });
+
+    it('accepts a JSON array or a whitespace-separated argv', () => {
+        expect(resolveTerminalSessionCommand('["/usr/bin/zsh","-l"]')).toEqual([
+            '/usr/bin/zsh',
+            '-l',
+        ]);
+        expect(resolveTerminalSessionCommand('/bin/sh -i')).toEqual(['/bin/sh', '-i']);
+    });
+
+    it('falls back to the default for unparseable or empty configuration', () => {
+        // A typo in an env var must not make the feature un-startable.
+        expect(resolveTerminalSessionCommand('[not json')).toEqual([
+            ...TERMINAL_SESSION_COMMAND_DEFAULT,
+        ]);
+        expect(resolveTerminalSessionCommand('[]')).toEqual([...TERMINAL_SESSION_COMMAND_DEFAULT]);
+    });
+
+    it('caps a pathological argv instead of forwarding a payload bomb', () => {
+        const huge = Array.from({ length: 200 }, (_, i) => `arg${i}`).join(' ');
+        expect(resolveTerminalSessionCommand(huge).length).toBe(32);
+    });
+});

--- a/packages/agent/src/agents/agents.module.ts
+++ b/packages/agent/src/agents/agents.module.ts
@@ -28,6 +28,7 @@ import { PromptAssemblerService } from './prompt-assembler.service';
 import { AgentRunService } from './agent-run.service';
 import { RunDispatchGateService } from './run-dispatch-gate.service';
 import { RunSteeringService } from './run-steering.service';
+import { TerminalSessionLauncher } from './terminal-session-launcher.service';
 import { AgentToolService } from './agent-tool.service';
 import { VisionContextService } from '../services/vision-context.service';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
@@ -103,6 +104,11 @@ import { FacadesModule } from '../facades/facades.module';
         // Wave 4 M5 — steer / interrupt / resume. Reuses the gate for resume
         // admission and the existing cancel path for stop.
         RunSteeringService,
+        // Streaming terminal — the single dispatch choke point for the
+        // `terminal-session` job. The TERMINAL_SESSION_DISPATCHER it
+        // enqueues through is @Optional() and bound by the api-side
+        // @Global() AgentsModule, exactly like RunDispatchGateService's.
+        TerminalSessionLauncher,
         AgentToolService,
     ],
     exports: [
@@ -122,6 +128,7 @@ import { FacadesModule } from '../facades/facades.module';
         AgentRunService,
         RunDispatchGateService,
         RunSteeringService,
+        TerminalSessionLauncher,
         AgentToolService,
     ],
 })

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -12,6 +12,8 @@ export * from './agent-run.service';
 export * from './run-dispatch-gate.service';
 export * from './run-steering.service';
 export * from './run-credits-precheck';
+export * from './terminal-session-dispatcher';
+export * from './terminal-session-launcher.service';
 export * from './agent-run-canceller';
 export * from './agent-run-abort';
 export * from './agent-run-sweeper.service';

--- a/packages/agent/src/agents/run-steering.service.ts
+++ b/packages/agent/src/agents/run-steering.service.ts
@@ -219,6 +219,11 @@ export class RunSteeringService implements RunSteeringPort {
             organizationId: run.organizationId ?? null,
             runnerKind: run.runnerKind ?? null,
             queuedReason: admission.admitted ? null : (admission.queuedReason ?? null),
+            // Streaming terminal — the conversation lifetime survives the
+            // process lifetime, and so does the SHAPE of the session. A
+            // resumed persistent run still wants an interactive terminal,
+            // which is what the fan-out's `requirePersistent` gate reads.
+            persistent: run.persistent === true,
         });
 
         // The conversation lifetime survives the process lifetime: hand the

--- a/packages/agent/src/agents/terminal-session-dispatcher.ts
+++ b/packages/agent/src/agents/terminal-session-dispatcher.ts
@@ -1,0 +1,78 @@
+/**
+ * Streaming-terminal — job-runtime dispatch port for the `terminal-session`
+ * task.
+ *
+ * Same posture as `AGENT_TASK_EXECUTE_DISPATCHER` /
+ * `AGENT_CHAT_REPLY_DISPATCHER` (see `tasks-domain/task-dispatcher.ts`):
+ * the agent package declares the contract, the platform's Trigger.dev
+ * wrapper supplies the real adapter, and unit tests stub a synchronous
+ * one — so `@trigger.dev/sdk` never enters this package's dependency
+ * graph. Consumers inject it `@Optional()`: with the token unbound (CLI,
+ * tests, an install without a job runtime) starting a session is a
+ * reported no-op rather than a crash.
+ */
+
+export interface TerminalSessionDispatchPayload {
+    /** The AgentRun whose id doubles as the relay channel id. */
+    runId: string;
+    userId: string;
+    agentId: string;
+    /** Argv to exec in the worker. Resolved server-side, never by the caller. */
+    command: string[];
+    cwd: string;
+    /** Extra env for the child. NEVER credentials — those resolve job-side. */
+    env?: Record<string, string>;
+    persistent?: boolean;
+}
+
+export interface TerminalSessionDispatcher {
+    /** Enqueue the session task; resolves with the job-runtime's own run id. */
+    enqueue(payload: TerminalSessionDispatchPayload): Promise<{ jobRunId: string }>;
+}
+
+export const TERMINAL_SESSION_DISPATCHER = 'TERMINAL_SESSION_DISPATCHER' as const;
+
+/**
+ * Operator override for the session argv. The worker image is Linux, so the
+ * default is a Linux login shell — this is NOT resolved from the API host's
+ * `process.platform`, which would be the wrong machine's answer.
+ */
+export const TERMINAL_SESSION_COMMAND_ENV = 'TERMINAL_SESSION_COMMAND';
+
+export const TERMINAL_SESSION_COMMAND_DEFAULT: readonly string[] = ['/bin/bash', '-i'];
+
+/** Hard cap on a configured argv — a misconfiguration must not become a payload bomb. */
+const MAX_ARGV = 32;
+
+/**
+ * Resolve the argv a terminal session execs.
+ *
+ * Deliberately NOT caller-supplied: `POST …/terminal/start` is an
+ * authenticated user action, but accepting arbitrary argv over the API
+ * would turn the terminal affordance into a general remote-exec endpoint.
+ * The command is operator configuration (`TERMINAL_SESSION_COMMAND`, a
+ * JSON array or a whitespace-separated string) with a Linux shell default.
+ * Anything unparseable falls back to the default rather than throwing —
+ * a typo in an env var must not make the feature un-startable.
+ */
+export function resolveTerminalSessionCommand(raw?: string | null): string[] {
+    const value = typeof raw === 'string' ? raw.trim() : '';
+    if (value.length === 0) return [...TERMINAL_SESSION_COMMAND_DEFAULT];
+
+    let parts: string[] = [];
+    if (value.startsWith('[')) {
+        try {
+            const parsed: unknown = JSON.parse(value);
+            if (Array.isArray(parsed)) {
+                parts = parsed.filter((p): p is string => typeof p === 'string' && p.length > 0);
+            }
+        } catch {
+            parts = [];
+        }
+    } else {
+        parts = value.split(/\s+/).filter((p) => p.length > 0);
+    }
+
+    if (parts.length === 0) return [...TERMINAL_SESSION_COMMAND_DEFAULT];
+    return parts.slice(0, MAX_ARGV);
+}

--- a/packages/agent/src/agents/terminal-session-launcher.service.ts
+++ b/packages/agent/src/agents/terminal-session-launcher.service.ts
@@ -1,0 +1,149 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { AgentRunRepository } from '../database/repositories/agent-run.repository';
+import {
+    TERMINAL_SESSION_COMMAND_ENV,
+    TERMINAL_SESSION_DISPATCHER,
+    resolveTerminalSessionCommand,
+    type TerminalSessionDispatcher,
+} from './terminal-session-dispatcher';
+
+/**
+ * Streaming-terminal — the ONE place a `terminal-session` job is started.
+ *
+ * Before this existed the task had no dispatcher at all: the gateway, the
+ * relay registry, the attach tokens, the plugin and the web pane were all
+ * wired to a session that nothing ever launched. Every caller now funnels
+ * through here so the ownership check, the duplicate refusal and the
+ * persistent gate are stated once:
+ *
+ *  - **Ownership** — the run must belong to `(userId, agentId)`. A
+ *    mismatch reports `run-not-found` with no existence leak, mirroring
+ *    `AgentRunRepository.findByIdAndUser` posture everywhere else.
+ *  - **Duplicate refusal** — the terminal slot is CAS-claimed
+ *    (`casClaimTerminalSession`), so concurrent starts resolve to exactly
+ *    one dispatch and the losers report `session-already-live`.
+ *  - **Persistent gate** — `requirePersistent` is what the automatic
+ *    dispatch path (task fan-out) passes: a run that never asked for a
+ *    long-lived interactive session must not spawn one, and must not pay
+ *    for a worker that sits on a shell nobody opened.
+ *
+ * Never throws for a refusal — refusals are values, so the automatic
+ * caller can ignore them and the HTTP caller can map them to statuses.
+ * A dispatcher that throws DOES bubble (after releasing the claim): the
+ * user pressed a button and deserves the real error.
+ */
+
+export type TerminalSessionRefusal =
+    | 'run-not-found'
+    | 'not-persistent'
+    | 'run-not-live'
+    | 'session-already-live'
+    | 'dispatcher-unavailable';
+
+export type StartTerminalSessionOutcome =
+    | { started: true; runId: string; jobRunId: string }
+    | { started: false; reason: TerminalSessionRefusal };
+
+export interface StartTerminalSessionInput {
+    userId: string;
+    agentId: string;
+    runId: string;
+    /**
+     * Start ONLY when the run is already flagged persistent. The automatic
+     * dispatch path passes this; the explicit user action does not.
+     */
+    requirePersistent?: boolean;
+    /**
+     * Flag the run persistent as part of starting. The explicit
+     * `POST …/terminal/start` passes this — asking for a terminal on a run
+     * IS the statement that the run wants a long-lived session.
+     */
+    markPersistent?: boolean;
+}
+
+/** Statuses a run may still be dispatched a live terminal for. */
+const LIVE_RUN_STATUSES = new Set(['queued', 'running']);
+
+/** Terminal lifecycle states that mean "a session is already resident". */
+const LIVE_TERMINAL_STATES = new Set(['starting', 'attached']);
+
+@Injectable()
+export class TerminalSessionLauncher {
+    private readonly logger = new Logger(TerminalSessionLauncher.name);
+
+    constructor(
+        private readonly runs: AgentRunRepository,
+        @Optional()
+        @Inject(TERMINAL_SESSION_DISPATCHER)
+        private readonly dispatcher?: TerminalSessionDispatcher,
+    ) {}
+
+    /** Whether a job runtime is wired at all (drives the 503 vs 409 split). */
+    isAvailable(): boolean {
+        return Boolean(this.dispatcher);
+    }
+
+    async startForRun(input: StartTerminalSessionInput): Promise<StartTerminalSessionOutcome> {
+        const run = await this.runs.findByIdAndUser(input.runId, input.userId);
+        if (!run || run.agentId !== input.agentId) {
+            return { started: false, reason: 'run-not-found' };
+        }
+
+        if (input.requirePersistent === true && run.persistent !== true) {
+            return { started: false, reason: 'not-persistent' };
+        }
+
+        // A finished run has no worker, no workspace and nothing to drive —
+        // spawning a shell "for" it would be a session pointing at a cwd
+        // that no longer exists. Refuse honestly instead.
+        if (!LIVE_RUN_STATUSES.has(run.status)) {
+            return { started: false, reason: 'run-not-live' };
+        }
+
+        // Cheap pre-check so the common duplicate never even touches the
+        // dispatcher; the CAS below is what actually makes it safe.
+        if (run.terminalState && LIVE_TERMINAL_STATES.has(run.terminalState)) {
+            return { started: false, reason: 'session-already-live' };
+        }
+
+        if (!this.dispatcher) {
+            return { started: false, reason: 'dispatcher-unavailable' };
+        }
+
+        const claimed = await this.runs.casClaimTerminalSession(input.runId, {
+            persistent: input.markPersistent === true ? true : undefined,
+        });
+        if (!claimed) {
+            return { started: false, reason: 'session-already-live' };
+        }
+
+        const command = resolveTerminalSessionCommand(process.env[TERMINAL_SESSION_COMMAND_ENV]);
+        // The isolated worktree when the run has one (Wave 2 M3), else the
+        // worker's own cwd — `.` resolves job-side, which is the only
+        // machine that can answer that question.
+        const cwd = run.workspaceMeta?.path ?? '.';
+
+        try {
+            const { jobRunId } = await this.dispatcher.enqueue({
+                runId: run.id,
+                userId: input.userId,
+                agentId: run.agentId,
+                command,
+                cwd,
+                persistent: input.markPersistent === true || run.persistent === true,
+            });
+            return { started: true, runId: run.id, jobRunId };
+        } catch (error) {
+            // The claim outlived its session — hand the slot back so the
+            // next start is not refused by a session that never existed.
+            await this.runs
+                .releaseTerminalSessionClaim(run.id, 'crashed')
+                .catch((releaseErr) =>
+                    this.logger.warn(
+                        `Failed to release terminal claim on AgentRun ${run.id}: ${releaseErr}`,
+                    ),
+                );
+            throw error;
+        }
+    }
+}

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -361,6 +361,15 @@ export class AgentRunRepository {
         /** Wave 4 M1 — pipeline plugin id when known at creation. */
         runnerKind?: string | null;
         organizationId?: string | null;
+        /**
+         * Streaming-terminal — this run wants a long-lived interactive
+         * session. Carried forward by `RunSteeringService.resume` so a
+         * resumed persistent run keeps its terminal, and settable by any
+         * caller that knows the run is interactive at creation time. The
+         * column already defaults false, so omitting it is unchanged
+         * behaviour for every existing call site.
+         */
+        persistent?: boolean;
     }): Promise<AgentRun> {
         const run = this.repository.create({
             agentId: args.agentId,
@@ -372,6 +381,7 @@ export class AgentRunRepository {
             workId: args.workId ?? null,
             queuedReason: args.queuedReason ?? null,
             runnerKind: args.runnerKind ?? null,
+            ...(args.persistent === true ? { persistent: true } : {}),
             // Only stamp when explicitly provided — the ambient scope
             // subscriber (EW-657) remains the default writer.
             ...(args.organizationId !== undefined ? { organizationId: args.organizationId } : {}),
@@ -592,6 +602,60 @@ export class AgentRunRepository {
         if (patch.lastFrameSeq !== undefined) update.lastFrameSeq = patch.lastFrameSeq;
         if (Object.keys(update).length === 0) return;
         await this.repository.update(runId, update);
+    }
+
+    /**
+     * Streaming-terminal — CAS claim of a run's terminal session slot.
+     *
+     * The whole point is the DUPLICATE-START refusal: two concurrent
+     * `POST …/terminal/start` calls (double-click, two tabs, a fan-out
+     * racing the button) must produce exactly ONE dispatched session. A
+     * read-then-write check cannot promise that, so the claim rides the
+     * same CAS shape as {@link markStarted}: the UPDATE only lands while
+     * no session is resident (`terminalState` NULL — never started — or
+     * `'ended'` — the previous one is over). The loser sees affected=0 and
+     * reports "already live" instead of enqueuing a second worker onto the
+     * same relay channel.
+     *
+     * `lastHeartbeatAt` is stamped here so the M6 sweeper's stale-terminal
+     * cutoff starts counting from the claim: a session whose worker never
+     * boots is reaped like any other heartbeat loss, rather than pinning
+     * the run at `starting` forever.
+     */
+    async casClaimTerminalSession(
+        runId: string,
+        opts: { persistent?: boolean } = {},
+    ): Promise<boolean> {
+        const result = await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({
+                terminalState: 'starting',
+                terminalEndedReason: null,
+                lastHeartbeatAt: new Date(),
+                ...(opts.persistent === true ? { persistent: true } : {}),
+            })
+            .where('id = :id', { id: runId })
+            .andWhere('(terminalState IS NULL OR terminalState = :endedState)', {
+                endedState: 'ended',
+            })
+            .execute();
+        return (result.affected ?? 0) > 0;
+    }
+
+    /**
+     * Release a claim that never became a session (the enqueue threw).
+     * Guarded on `starting` so it can never close a session a worker has
+     * already picked up and moved to `attached`.
+     */
+    async releaseTerminalSessionClaim(runId: string, endedReason: string): Promise<void> {
+        await this.repository
+            .createQueryBuilder()
+            .update(AgentRun)
+            .set({ terminalState: 'ended', terminalEndedReason: endedReason })
+            .where('id = :id', { id: runId })
+            .andWhere('terminalState = :startingState', { startingState: 'starting' })
+            .execute();
     }
 
     /**

--- a/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
@@ -337,4 +337,71 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
         );
         expect(runs.markDispatchFailed).not.toHaveBeenCalled();
     });
+
+    /**
+     * Streaming terminal — the automatic session dispatch. The persistent
+     * gate itself lives in the launcher (see
+     * `agents/__tests__/terminal-session-launcher.service.spec.ts`); what is
+     * pinned here is that the fan-out ASKS with `requirePersistent: true`,
+     * for the run it just dispatched, and that a terminal hiccup can never
+     * contaminate the run's own dispatch bookkeeping.
+     */
+    describe('terminal session start on fan-out', () => {
+        function makeTerminalSvc(terminalSessions: { startForRun: jest.Mock }) {
+            return new TaskTransitionService(
+                tasks,
+                blocks,
+                approvers,
+                assignees,
+                runs,
+                dispatcher,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                terminalSessions as never,
+            );
+        }
+
+        async function fanOut(svc: TaskTransitionService) {
+            const task = makeTask({ status: TaskStatus.TODO });
+            tasks.findById.mockResolvedValueOnce({ ...task, status: TaskStatus.IN_PROGRESS });
+            assignees.findAgentAssignees.mockResolvedValueOnce([
+                { assigneeType: 'agent', assigneeId: 'agent-a' },
+            ]);
+            await svc.transition(task, TaskStatus.IN_PROGRESS);
+            await new Promise((r) => setImmediate(r));
+        }
+
+        it('asks the starter for the dispatched run, gated on persistent', async () => {
+            const terminalSessions = {
+                startForRun: jest.fn().mockResolvedValue({ started: false }),
+            };
+            await fanOut(makeTerminalSvc(terminalSessions));
+
+            expect(terminalSessions.startForRun).toHaveBeenCalledTimes(1);
+            expect(terminalSessions.startForRun).toHaveBeenCalledWith({
+                userId: 'u1',
+                agentId: 'agent-a',
+                runId: 'r1',
+                requirePersistent: true,
+            });
+        });
+
+        it('never marks a live run dispatch-failed when starting its terminal throws', async () => {
+            const terminalSessions = {
+                startForRun: jest.fn().mockRejectedValue(new Error('terminal dispatch down')),
+            };
+            await fanOut(makeTerminalSvc(terminalSessions));
+
+            expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
+            expect(runs.markDispatchFailed).not.toHaveBeenCalled();
+        });
+
+        it('is a silent no-op when no starter is bound (installs without a job runtime)', async () => {
+            await fanOut(makeSvc());
+            expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
+            expect(runs.markDispatchFailed).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/packages/agent/src/tasks-domain/task-dispatcher.ts
+++ b/packages/agent/src/tasks-domain/task-dispatcher.ts
@@ -40,6 +40,32 @@ export const AGENT_TASK_EXECUTE_DISPATCHER = 'AGENT_TASK_EXECUTE_DISPATCHER' as 
 export const AGENT_CHAT_REPLY_DISPATCHER = 'AGENT_CHAT_REPLY_DISPATCHER' as const;
 
 /**
+ * Streaming-terminal — the seam `TaskTransitionService` reaches for when a
+ * freshly-dispatched run also wants a live interactive session.
+ *
+ * A PORT, not the launcher class: `TerminalSessionLauncher` lives in the
+ * agents module and this file must stay a leaf (it is imported by the
+ * dispatch gate). The api-side @Global() `AgentsModule` binds the token
+ * with `useExisting`, the same shape as `RUN_STEERING_PORT`.
+ *
+ * `requirePersistent` is the whole safety property of the automatic path:
+ * the implementation refuses any run not flagged persistent, so a normal
+ * one-shot task run never spawns (or pays for) a terminal session.
+ */
+export interface TerminalSessionStartRequest {
+    userId: string;
+    agentId: string;
+    runId: string;
+    requirePersistent?: boolean;
+}
+
+export interface TerminalSessionStarter {
+    startForRun(request: TerminalSessionStartRequest): Promise<{ started: boolean }>;
+}
+
+export const TERMINAL_SESSION_STARTER = 'TERMINAL_SESSION_STARTER' as const;
+
+/**
  * Stable, user-readable marker the run-failure UI keys on. Kept as an
  * exported constant so the producer (dispatcher adapters), the consumer
  * (TaskTransitionService's failure classification), and any UI matcher

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -20,7 +20,9 @@ import { AgentRunRepository } from '../database/repositories/agent-run.repositor
 import {
     AGENT_TASK_EXECUTE_DISPATCHER,
     JOB_RUNTIME_NOT_CONFIGURED_REASON,
+    TERMINAL_SESSION_STARTER,
     type AgentTaskExecuteDispatcher,
+    type TerminalSessionStarter,
 } from './task-dispatcher';
 import { TaskNotificationService } from './task-notification.service';
 import { TaskRunDenormService } from './task-run-denorm.service';
@@ -116,6 +118,13 @@ export class TaskTransitionService {
         // positional-constructor reasoning as above); Optional so fixtures
         // without it skip the rule entirely (fail toward the status quo).
         @Optional() private readonly works?: WorkRepository,
+        // Streaming terminal — starts the `terminal-session` job for a
+        // freshly-dispatched run that asked for one. Appended LAST (same
+        // positional-constructor reasoning as above); Optional so fixtures
+        // and installs without a job runtime simply never start a session.
+        @Optional()
+        @Inject(TERMINAL_SESSION_STARTER)
+        private readonly terminalSessions?: TerminalSessionStarter,
     ) {}
 
     /**
@@ -363,6 +372,39 @@ export class TaskTransitionService {
                     } catch (stampErr) {
                         this.logger.warn(
                             `Failed to stamp triggerRunId on AgentRun ${run.id}: ${stampErr}`,
+                        );
+                    }
+                }
+                // Streaming terminal — a run that asked for a long-lived
+                // interactive session gets one alongside its execution.
+                // `requirePersistent` means the starter refuses anything
+                // that did not ask, so the one-shot path is untouched.
+                //
+                // Its own try/catch, NOT the enqueue's: the dispatch has
+                // already succeeded here, and a terminal-session hiccup
+                // must never fall through to the rollback below and mark a
+                // live run dispatch-failed. Fire-and-forget for the same
+                // reason the fan-out itself is — the run does not wait on
+                // its terminal.
+                if (run && this.terminalSessions) {
+                    const terminalRunId = run.id;
+                    const terminalAgentId = assignee.assigneeId;
+                    try {
+                        void this.terminalSessions
+                            .startForRun({
+                                userId: task.userId,
+                                agentId: terminalAgentId,
+                                runId: terminalRunId,
+                                requirePersistent: true,
+                            })
+                            .catch((terminalErr) =>
+                                this.logger.warn(
+                                    `Terminal session start failed for AgentRun ${terminalRunId}: ${terminalErr}`,
+                                ),
+                            );
+                    } catch (terminalErr) {
+                        this.logger.warn(
+                            `Terminal session start threw for AgentRun ${terminalRunId}: ${terminalErr}`,
                         );
                     }
                 }

--- a/packages/plugins/pty-local/src/__tests__/pty-local.plugin.spec.ts
+++ b/packages/plugins/pty-local/src/__tests__/pty-local.plugin.spec.ts
@@ -210,4 +210,92 @@ describe('PtyLocalPlugin', () => {
 		expect(probe.ok).toBe(true);
 		expect(probe.detail).toMatch(/PTY|pipe floor/i);
 	});
+
+	/**
+	 * The node-pty prebuild is declared `optionalDependencies` precisely so a
+	 * platform without a binary still installs. That contract only holds if a
+	 * MISSING (or broken) addon degrades to the pipe floor instead of failing
+	 * the session — these three lock that in so a future dependency move can
+	 * never quietly turn "no PTY" into "no terminal".
+	 */
+	describe('graceful degradation when the node-pty prebuild is unavailable', () => {
+		it('spawns through the pipe floor when the addon cannot be loaded', async () => {
+			const plugin = new PtyLocalPlugin();
+			// Simulate the addon being absent from this runtime.
+			(plugin as unknown as { tryLoadPty: () => null }).tryLoadPty = () => null;
+			const h = makeTransport();
+
+			const handle = await plugin.spawn(
+				{
+					runId: '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f',
+					command: [NODE, '-e', 'process.stdout.write("floor-ok")'],
+					cwd: process.cwd(),
+					env: {}
+				},
+				h.transport
+			);
+
+			expect(handle.isPty).toBe(false);
+			const outcome = await handle.exited;
+			expect(outcome.reason).toBe('completed');
+			expect(decodeStdout(h.published)).toContain('floor-ok');
+		});
+
+		it('degrades to the pipe floor when a PRESENT prebuild throws on spawn', async () => {
+			const plugin = new PtyLocalPlugin();
+			const warnings: string[] = [];
+			await plugin.onLoad({
+				logger: {
+					log: () => {},
+					warn: (m: string) => warnings.push(String(m)),
+					error: () => {},
+					debug: () => {}
+				}
+			} as never);
+			// A JS library installed without its native binary: present, but
+			// every spawn throws. Must degrade, never fail the session.
+			(plugin as unknown as { tryLoadPty: () => unknown }).tryLoadPty = () => ({
+				spawn: () => {
+					throw new Error('node-pty native binding missing');
+				}
+			});
+			const h = makeTransport();
+
+			const handle = await plugin.spawn(
+				{
+					runId: '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f',
+					command: [NODE, '-e', 'process.stdout.write("degraded")'],
+					cwd: process.cwd(),
+					env: {}
+				},
+				h.transport
+			);
+
+			expect(handle.isPty).toBe(false);
+			await handle.exited;
+			expect(decodeStdout(h.published)).toContain('degraded');
+			expect(warnings.join('\n')).toMatch(/pipe floor/i);
+		});
+
+		it('onLoad succeeds and reports pipe-floor mode with no addon present', async () => {
+			const plugin = new PtyLocalPlugin();
+			(plugin as unknown as { tryLoadPty: () => null }).tryLoadPty = () => null;
+			const logs: string[] = [];
+
+			await expect(
+				plugin.onLoad({
+					logger: {
+						log: (m: string) => logs.push(String(m)),
+						warn: () => {},
+						error: () => {},
+						debug: () => {}
+					}
+				} as never)
+			).resolves.toBeUndefined();
+
+			expect(logs.join('\n')).toContain('pipe-floor');
+			const health = await plugin.healthCheck();
+			expect(health.status).toBe('healthy');
+		});
+	});
 });

--- a/packages/tasks/src/__tests__/collect-plugin-deps.spec.ts
+++ b/packages/tasks/src/__tests__/collect-plugin-deps.spec.ts
@@ -117,6 +117,65 @@ describe('collectPluginDependencies', () => {
         expect(result).toEqual(['axios@^1.0.0', 'date-fns@^3.0.0', 'lodash@^4.0.0']);
     });
 
+    it('collects optionalDependencies — a native prebuild must reach the worker image', () => {
+        fsMock.existsSync.mockReturnValue(true);
+        fsMock.readdirSync.mockReturnValue([{ name: 'pty-local', isDirectory: () => true }]);
+        fsMock.readFileSync.mockReturnValue(
+            JSON.stringify({
+                everworks: { plugin: { id: 'pty-local' } },
+                peerDependencies: { '@ever-works/plugin': 'workspace:*' },
+                optionalDependencies: {
+                    '@homebridge/node-pty-prebuilt-multiarch': '^0.13.1',
+                },
+            }),
+        );
+
+        const result = collectPluginDependencies();
+        expect(result).toEqual(['@homebridge/node-pty-prebuilt-multiarch@^0.13.1']);
+    });
+
+    it('applies the workspace: / @ever-works filters to optionalDependencies too', () => {
+        fsMock.existsSync.mockReturnValue(true);
+        fsMock.readdirSync.mockReturnValue([{ name: 'a', isDirectory: () => true }]);
+        fsMock.readFileSync.mockReturnValue(
+            JSON.stringify({
+                everworks: { plugin: { id: 'a' } },
+                optionalDependencies: {
+                    '@ever-works/contracts': '^1.0.0',
+                    '@some-vendor/sdk': 'workspace:^1.0.0',
+                    sharp: '^0.33.0',
+                },
+            }),
+        );
+
+        const result = collectPluginDependencies();
+        expect(result).toEqual(['sharp@^0.33.0']);
+    });
+
+    it('dedupes a package declared optional in one plugin and required in another', () => {
+        const pkgA = {
+            everworks: { plugin: { id: 'a' } },
+            optionalDependencies: { sharp: '^0.33.0' },
+        };
+        const pkgB = {
+            everworks: { plugin: { id: 'b' } },
+            dependencies: { sharp: '^0.33.0' },
+        };
+
+        fsMock.existsSync.mockReturnValue(true);
+        fsMock.readdirSync.mockReturnValue([
+            { name: 'a', isDirectory: () => true },
+            { name: 'b', isDirectory: () => true },
+        ]);
+        fsMock.readFileSync.mockImplementation((p: any) => {
+            const str = String(p).replace(/\\/g, '/');
+            if (str.endsWith('/a/package.json')) return JSON.stringify(pkgA);
+            return JSON.stringify(pkgB);
+        });
+
+        expect(collectPluginDependencies()).toEqual(['sharp@^0.33.0']);
+    });
+
     it('logs the dependency count via console.log', () => {
         fsMock.existsSync.mockReturnValue(true);
         fsMock.readdirSync.mockReturnValue([{ name: 'a', isDirectory: () => true }]);

--- a/packages/tasks/src/__tests__/pty-local-worker-dependency.spec.ts
+++ b/packages/tasks/src/__tests__/pty-local-worker-dependency.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { collectPluginDependencies } from '../build/collect-plugin-deps';
+
+/**
+ * Regression guard for the terminal streaming feature's cloud path.
+ *
+ * `pty-local` opens a REAL PTY only when
+ * `@homebridge/node-pty-prebuilt-multiarch` is present in the running
+ * process. In cloud that process is the Trigger.dev worker image, whose
+ * package set is exactly what `collectPluginDependencies()` hands to the
+ * `additionalPackages` build extension. The collector used to read only
+ * `dependencies` + `peerDependencies`, while the manifest declares the
+ * prebuild under `optionalDependencies` — so the addon was never shipped
+ * and every cloud session degraded to the pipe floor, permanently and
+ * silently.
+ *
+ * This spec runs against the REAL manifest on disk (no fs mock), so a
+ * future manifest edit that moves the dependency somewhere the collector
+ * does not read fails here instead of in production.
+ */
+const PTY_LOCAL_PKG = path.resolve(
+    __dirname,
+    '../../../../packages/plugins/pty-local/package.json',
+);
+const NODE_PTY = '@homebridge/node-pty-prebuilt-multiarch';
+
+describe('pty-local ships its PTY prebuild to the Trigger.dev worker', () => {
+    let logSpy: ReturnType<typeof vi.spyOn>;
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        logSpy.mockRestore();
+        warnSpy.mockRestore();
+    });
+
+    it('declares the node-pty prebuild in a field the collector reads', () => {
+        const pkg = JSON.parse(fs.readFileSync(PTY_LOCAL_PKG, 'utf-8'));
+        const declared = {
+            ...(pkg.dependencies ?? {}),
+            ...(pkg.peerDependencies ?? {}),
+            ...(pkg.optionalDependencies ?? {}),
+        };
+        expect(Object.keys(declared)).toContain(NODE_PTY);
+    });
+
+    it('collectPluginDependencies() includes the node-pty prebuild', () => {
+        const collected = collectPluginDependencies();
+        expect(collected.some((entry) => entry.startsWith(`${NODE_PTY}@`))).toBe(true);
+    });
+});

--- a/packages/tasks/src/build/collect-plugin-deps.ts
+++ b/packages/tasks/src/build/collect-plugin-deps.ts
@@ -1,6 +1,17 @@
 /**
  * Collects plugin dependencies for Trigger.dev additionalPackages extension.
  * Scans all plugins and extracts their non-workspace dependencies.
+ *
+ * `optionalDependencies` are collected too, deliberately. "Optional" in a
+ * plugin manifest means *optional to INSTALL* — a native prebuild that must
+ * not hard-fail `pnpm install` on a platform it has no binary for — it does
+ * NOT mean "not wanted in the deployed worker image". `pty-local`'s
+ * `@homebridge/node-pty-prebuilt-multiarch` is the case in point: skipping
+ * it here shipped a worker that could never open a real PTY, so the terminal
+ * plugin silently and permanently degraded to its pipe floor in cloud. The
+ * collector and the manifests have to agree, and this is the side of the
+ * disagreement that keeps a failed native install a *degradation* rather
+ * than a broken monorepo install for everyone.
  */
 import * as fs from 'fs';
 import * as path from 'path';
@@ -26,8 +37,8 @@ export function collectPluginDependencies(): string[] {
         const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
         if (!pkg.everworks?.plugin) continue;
 
-        // Collect dependencies and peerDependencies
-        for (const deps of [pkg.dependencies, pkg.peerDependencies]) {
+        // Collect dependencies, peerDependencies and optionalDependencies
+        for (const deps of [pkg.dependencies, pkg.peerDependencies, pkg.optionalDependencies]) {
             if (!deps) continue;
 
             for (const [name, version] of Object.entries(deps)) {

--- a/packages/tasks/src/dispatchers/agent-task-dispatchers.spec.ts
+++ b/packages/tasks/src/dispatchers/agent-task-dispatchers.spec.ts
@@ -8,6 +8,7 @@ import { tasks } from '@trigger.dev/sdk';
 import {
     agentChatReplyTriggerAdapter,
     agentTaskExecuteTriggerAdapter,
+    terminalSessionTriggerAdapter,
 } from './agent-task-dispatchers';
 
 const PAYLOAD = {
@@ -74,5 +75,56 @@ describe('dispatcher adapters — loud degradation gate', () => {
             expect.objectContaining({ taskId: 'task-1' }),
             { idempotencyKey: PAYLOAD.dedupKey },
         );
+    });
+});
+
+/**
+ * The `terminal-session` task shipped with NO producer: its id appeared
+ * only in its own definition and the barrel export, so no session was ever
+ * started. These pin the producer that closes the loop.
+ */
+describe('terminalSessionTriggerAdapter', () => {
+    const TERMINAL_PAYLOAD = {
+        runId: '2f9d1f2a-9c7e-4b1a-8f0d-0a1b2c3d4e5f',
+        userId: 'user-1',
+        agentId: 'agent-1',
+        command: ['/bin/bash', '-i'],
+        cwd: '/work/task-42',
+        persistent: true,
+    };
+
+    it('triggers the terminal-session task with the payload the task destructures', async () => {
+        configure();
+        const handle = await terminalSessionTriggerAdapter.enqueue(TERMINAL_PAYLOAD);
+
+        expect(handle).toEqual({ jobRunId: 'run_123' });
+        expect(tasks.trigger).toHaveBeenCalledWith(
+            'terminal-session',
+            expect.objectContaining({
+                runId: TERMINAL_PAYLOAD.runId,
+                userId: 'user-1',
+                agentId: 'agent-1',
+                command: ['/bin/bash', '-i'],
+                cwd: '/work/task-42',
+                persistent: true,
+            }),
+            expect.anything(),
+        );
+    });
+
+    it('keys idempotency on the run id — the relay channel IS the run', async () => {
+        configure();
+        await terminalSessionTriggerAdapter.enqueue(TERMINAL_PAYLOAD);
+        expect(tasks.trigger).toHaveBeenCalledWith('terminal-session', expect.anything(), {
+            idempotencyKey: `terminal-session:${TERMINAL_PAYLOAD.runId}`,
+        });
+    });
+
+    it('degrades loudly (never reaching the SDK) on an unconfigured install', async () => {
+        unconfigure();
+        await expect(terminalSessionTriggerAdapter.enqueue(TERMINAL_PAYLOAD)).rejects.toMatchObject(
+            { name: 'JobRuntimeNotConfiguredError' },
+        );
+        expect(tasks.trigger).not.toHaveBeenCalled();
     });
 });

--- a/packages/tasks/src/dispatchers/agent-task-dispatchers.ts
+++ b/packages/tasks/src/dispatchers/agent-task-dispatchers.ts
@@ -5,6 +5,8 @@ import type {
     AgentHeartbeatTrigger,
     AgentRunCanceller,
     AgentRunCancelOutcome,
+    TerminalSessionDispatcher,
+    TerminalSessionDispatchPayload,
 } from '@ever-works/agent/agents';
 import type { TriggerService } from '../trigger/trigger.service';
 import type {
@@ -16,6 +18,7 @@ import type {
 import type { AgentHeartbeatPayload } from '../tasks/trigger/agent-heartbeat.task';
 import type { AgentChatReplyPayload } from '../tasks/trigger/agent-chat-reply.task';
 import type { AgentTaskExecutePayload } from '../tasks/trigger/agent-task-execute.task';
+import type { TerminalSessionPayload } from '../tasks/trigger/terminal-session.task';
 
 /**
  * Loud-degradation gate (mirrors `TriggerService.ensureConfigured()`:
@@ -99,6 +102,43 @@ export const agentChatReplyTriggerAdapter: AgentChatReplyDispatcher = {
             { idempotencyKey: payload.dedupKey },
         );
         return { runId: handle.id };
+    },
+};
+
+/**
+ * Streaming-terminal — the missing dispatcher for the `terminal-session`
+ * task. The task has existed since M6 with no producer at all: nothing in
+ * the repo referenced its id outside its own definition and the barrel
+ * export, so the gateway, relay registry, attach tokens, plugin and web
+ * pane were all wired to a session that never launched. This is the
+ * producer; `TerminalSessionLauncher` is the only thing allowed to call it.
+ *
+ * `idempotencyKey` is the run id: the relay channel IS the run id, so two
+ * accepted sessions for one run would fight over the same scrollback and
+ * stdin. The launcher's DB CAS already refuses the common duplicate; this
+ * makes the runner refuse the racy one too (defence in depth across a
+ * multi-replica API, where two replicas can each win their own CAS only if
+ * the row write is lost — belt and braces, cheap).
+ */
+export const terminalSessionTriggerAdapter: TerminalSessionDispatcher = {
+    async enqueue(payload: TerminalSessionDispatchPayload) {
+        assertJobRuntimeConfigured();
+        const handle = await tasks.trigger<
+            typeof import('../tasks/trigger/terminal-session.task').terminalSessionTask
+        >(
+            'terminal-session',
+            {
+                runId: payload.runId,
+                userId: payload.userId,
+                agentId: payload.agentId,
+                command: payload.command,
+                cwd: payload.cwd,
+                env: payload.env,
+                persistent: payload.persistent,
+            } satisfies TerminalSessionPayload,
+            { idempotencyKey: `terminal-session:${payload.runId}` },
+        );
+        return { jobRunId: handle.id };
     },
 };
 


### PR DESCRIPTION
## P0: the terminal streaming feature could never actually run

Two independent defects, both verified on `main`, that together made the whole streaming-terminal stack inert.

### (A) `terminal-session` had no dispatcher — no session was ever started

`packages/tasks/src/tasks/trigger/terminal-session.task.ts` defines the task, but the id `terminal-session` appeared **only** in its own definition and the barrel export. Nothing enqueued it. So the WS gateway, the relay registry, the attach tokens, the `pty-local` plugin and the web Terminal pane were all wired to a channel that never carried a frame: a user could mint an attach token, open the socket, and stare at a black pane forever.

**Fixed by** adding the missing producer and one choke point in front of it:

- `terminalSessionTriggerAdapter` (`packages/tasks/src/dispatchers/agent-task-dispatchers.ts`) — the Trigger.dev producer, `idempotencyKey` keyed on the run id because the relay channel **is** the run id.
- `TerminalSessionLauncher` (`packages/agent/src/agents/terminal-session-launcher.service.ts`) — the only caller of that adapter. States the rules once: owner-scoped run lookup (no existence leak), CAS duplicate refusal, persistent gate, finished-run refusal, claim release on enqueue failure.
- `AgentRunRepository.casClaimTerminalSession` / `releaseTerminalSessionClaim` — the CAS is what makes the duplicate refusal real. A read-then-write check cannot promise "exactly one session per run" against a double-click or two tabs.
- `POST /api/agents/:id/runs/:runId/terminal/start` — the explicit affordance. `202` dispatched, `409` session already live / run already finished, `404` cross-user or cross-agent, `503` no job runtime wired. Plus its web proxy route and a **Start session** button on the Terminal tab, so the loop is reachable by a real user action.
- Automatic start on `TaskTransitionService.fanOutAgentExecutions`, gated `requirePersistent: true` — a normal one-shot run never spawns (or pays for) a session. `RunSteeringService.resume` now carries `persistent` forward, so a resumed persistent run keeps its terminal.

The session argv is resolved **server-side** (`TERMINAL_SESSION_COMMAND` operator config, Linux-shell default) and is deliberately *not* accepted from the request body — this endpoint opens a shell in the caller's own worker, it must not become a generic remote-exec surface.

### (B) the PTY prebuild could never reach the worker image

`packages/plugins/pty-local/package.json` declares `@homebridge/node-pty-prebuilt-multiarch` under `optionalDependencies`. `collectPluginDependencies()` — whose output *is* the `additionalPackages` list in `trigger.config.ts` — read only `dependencies` + `peerDependencies`. The addon was therefore never installed into the deployed worker, and every cloud session silently and permanently fell back to the pipe floor (no resize, no TUI).

**Choice made: teach the collector to read `optionalDependencies`, keep the manifest as-is.**

Both options were on the table. The deciding factor is the failure mode:

- Promoting the dep to `dependencies` makes a platform without a prebuild fail `pnpm install` **for the entire monorepo**, on every dev box and CI job — regressing exactly the platforms the pipe floor exists to serve. It would delete the graceful degradation this plugin is built around.
- `optionalDependencies` in a plugin manifest means *optional to INSTALL*, not "unwanted in the deployed image". Teaching the collector that is the side of the disagreement that keeps a failed native install a **degradation** rather than a broken install for everyone.

`pty-local` is the only plugin in the repo declaring `optionalDependencies`, so the blast radius today is exactly this one package. The graceful-degradation fallback is kept and now covered by three new tests (missing addon, present-but-broken addon, `onLoad` with no addon).

---

## Verification (real output)

**Collector before/after** — recomputed from the real manifests on disk:

```
BEFORE (dependencies+peerDependencies): 62 packages
AFTER  (+optionalDependencies):         63 packages
DELTA: [ '@homebridge/node-pty-prebuilt-multiarch@^0.13.1' ]
```

And from the compiled collector, i.e. the literal input to `additionalPackages`:

```
[collectPluginDeps] Found 63 plugin dependencies
TOTAL additionalPackages entries: 63
node-pty entries: [ '@homebridge/node-pty-prebuilt-multiarch@^0.13.1' ]
```

**`packages/agent` build (TSC gate):**

```
> nest build -b swc && tsc -p tsconfig.types.json
-  TSC  Initializing type checker...
>  TSC  Found 0 issues.
>  SWC  Running...
Successfully compiled: 1074 files with swc (91.15ms)
```

**`packages/agent` targeted jest:**

```
Test Suites: 7 passed, 7 total
Tests:       94 passed, 94 total
Ran all test suites matching /(terminal-session-launcher|task-transition|agent-run.terminal-columns|run-steering)/i.
```

**`packages/tasks` build + full vitest:**

```
> tsc -p tsconfig.json      (clean)

 Test Files  26 passed (26)
      Tests  402 passed (402)
   Duration  167.35s
```

**`packages/plugins/pty-local` build + vitest:**

```
DTS ⚡️ Build success in 11379ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

**`pnpm build --filter=ever-works-api`:**

```
ever-works-api:build: >  TSC  Found 0 issues.
ever-works-api:build: >  SWC  Running...
ever-works-api:build: Successfully compiled: 687 files with swc (446.82ms)
 Tasks:    14 successful, 14 total
```

**`apps/api` terminal jest:**

```
Test Suites: 6 passed, 6 total
Tests:       67 passed, 67 total
```

**`apps/api pnpm generate:openapi`** (full-app Nest bootstrap gate — catches DI boot crashes that `tsc` cannot):

```
Wrote OpenAPI spec (440 paths) to .../apps/api/openapi.json
```

...and the new route is registered (439 -> 440 paths):

```
/api/agents/{id}/runs/{runId}/terminal/attach-token
/api/agents/{id}/runs/{runId}/terminal/start
/api/agents/{id}/runs/{runId}/terminal
--- start methods ---
[ 'post' ]
```

`openapi.json` is `.gitignore`d (`.gitignore:79`) and is **not** in this commit.

**`apps/web`** — `npx tsc --noEmit` clean; `TerminalPane.unit.spec.tsx` 5 passed.

### Not provable locally

`trigger.dev@4.4.6 deploy --dry-run` **does** exist as a flag, but it requires a Trigger.dev login this environment does not have:

```
You must login to continue.
Failed to get access token
X Error: You must login first. Use the `login` CLI command.
```

So the deployed bundle's package set is proven only at its input — `collectPluginDependencies()` now emits the node-pty entry, and that list is what `additionalPackages({ packages: ... })` installs. The end-to-end proof (a cloud session reporting `isPty: true`) needs a real deploy.

Also unproven locally: a live `terminal-session` run end-to-end. There is no local Trigger.dev worker here, so the loop is verified up to the dispatch boundary — the adapter's `tasks.trigger` call shape is pinned by unit test against the task's own payload type.

---

## Tests

**34 new tests** across both fixes:

| File | New |
| --- | --- |
| `packages/agent/src/agents/__tests__/terminal-session-launcher.service.spec.ts` | 15 (new file) |
| `apps/api/src/terminal/__tests__/terminal-attach.controller.spec.ts` | 5 |
| `packages/tasks/src/dispatchers/agent-task-dispatchers.spec.ts` | 3 |
| `packages/tasks/src/__tests__/collect-plugin-deps.spec.ts` | 3 |
| `packages/tasks/src/__tests__/pty-local-worker-dependency.spec.ts` | 2 (new file) |
| `packages/plugins/pty-local/src/__tests__/pty-local.plugin.spec.ts` | 3 |
| `packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts` | 3 |

Covering exactly what was asked: the dispatcher is called with the right payload under the right conditions; a duplicate start is refused (both the read pre-check **and** the CAS race); and non-persistent runs do **not** spawn a session.

`packages/tasks/src/__tests__/pty-local-worker-dependency.spec.ts` runs against the **real** manifest with no fs mock, so a future edit that moves the dependency somewhere the collector does not read fails in CI instead of in production.

## Notes for review

- `strictNullChecks: false` in `apps/api` means truthiness narrowing on a `true | false` discriminant does not split a union — the controller uses `'reason' in outcome` instead. Flagged in a comment at the site.
- New i18n keys land in `en.json` only, matching the existing `dashboard.terminal` block (no other locale carries it yet).
- No new migration: `agent_runs.persistent` / `terminalState` / `terminalEndedReason` / `lastHeartbeatAt` are the existing M4 columns.
- Additive throughout: no existing surface removed, every new injection is `@Optional()` and appended last so existing positional constructors in specs keep compiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
