### PR TITLE
fix(agents): resume restarts the terminal for persistent runs

### DIFF
--- a/packages/agent/src/agents/run-steering.service.ts
+++ b/packages/agent/src/agents/run-steering.service.ts
@@ -20,6 +20,7 @@ import type {
     RunSteeringPort,
 } from '../tasks-domain/run-steering-port';
 import { RunDispatchGateService } from './run-dispatch-gate.service';
+import { TerminalSessionLauncher } from './terminal-session-launcher.service';
 
 /**
  * `terminalEndedReason` values that make a finished run resumable: the
@@ -98,6 +99,9 @@ export class RunSteeringService implements RunSteeringPort {
         // Resume goes through the same concurrency choke point as every
         // other dispatch path — a resumed run is a run.
         @Optional() private readonly dispatchGate?: RunDispatchGateService,
+        // A resumed persistent run wants its terminal back. Appended last +
+        // @Optional() so existing positional test constructions keep working.
+        @Optional() private readonly terminalLauncher?: TerminalSessionLauncher,
     ) {}
 
     /** A run that can still receive injected input. */
@@ -279,6 +283,33 @@ export class RunSteeringService implements RunSteeringPort {
             hasMessage: Boolean(trimmed),
             queued: !admission.admitted,
         });
+        // Streaming terminal: the fan-out path gates on `requirePersistent`,
+        // but resume dispatches `agent-task-execute` directly, so without this
+        // a resumed persistent run comes back with no session attached.
+        // Best-effort — a terminal is an affordance, never a reason to fail a
+        // resume that already dispatched.
+        if (admission.admitted && run.persistent === true && this.terminalLauncher) {
+            try {
+                const outcome = await this.terminalLauncher.startForRun({
+                    runId: next.id,
+                    agentId: run.agentId,
+                    userId,
+                    requirePersistent: true,
+                });
+                if (outcome.started === false) {
+                    this.logger.warn(
+                        `Run ${next.id}: terminal not restarted on resume (${outcome.reason}).`,
+                    );
+                }
+            } catch (err) {
+                this.logger.warn(
+                    `Run ${next.id}: terminal relaunch failed on resume: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            }
+        }
+
         this.logger.log(`Run ${run.id}: resumed as ${next.id} by user ${userId}.`);
 
         return {


### PR DESCRIPTION
Closes the gap flagged in #1868's own report.

The automatic fan-out path gates terminal launch on `requirePersistent`, but `RunSteeringService.resume` dispatches `agent-task-execute` directly — so a resumed persistent run came back with no session attached, even though it carries `persistent: true` and its `cliSessionId`.

Relaunches through the same `TerminalSessionLauncher` the explicit start endpoint uses, after a successful resume dispatch, best-effort: a terminal is an affordance, never a reason to fail a resume that already dispatched. Injected `@Optional()` and appended last, so existing positional test constructions are unaffected.

**Verified:** `packages/agent` TSC 0; `jest 'run-steering|terminal-session|agents.module'` → **46 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)