### PR TITLE
fix(transfer,ingest): account-transfer sweep + per-install inbound binding

### DIFF
--- a/apps/api/src/ingest/github/github-events.controller.spec.ts
+++ b/apps/api/src/ingest/github/github-events.controller.spec.ts
@@ -1,6 +1,9 @@
 import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 
-jest.mock('@ever-works/agent/ingest', () => ({ EventIngestService: class {} }));
+jest.mock('@ever-works/agent/ingest', () => ({
+    EventIngestService: class {},
+    IngestInstallBindingRepository: class {},
+}));
 jest.mock('@ever-works/agent/pr-review', () => ({ PrReviewService: class {} }));
 jest.mock('@ever-works/agent/plugins', () => ({
     PluginSettingsService: class {},
@@ -14,12 +17,13 @@ import { GitHubEventsController } from './github-events.controller';
 import { computeGitHubSignature } from './github-signature.util';
 
 const SECRET = 'test-webhook-secret';
-const BINDING = { userId: 'user-1', webhookSecret: SECRET };
+const BINDING = { userId: 'user-1', webhookSecret: SECRET, matchedBy: 'binding' as const };
 
 describe('GitHubEventsController (POST /api/ingest/github/events)', () => {
     function createController() {
         const bridge = {
-            resolveBinding: jest.fn().mockResolvedValue(BINDING),
+            resolveBinding: jest.fn().mockResolvedValue({ status: 'resolved', binding: BINDING }),
+            recordBinding: jest.fn().mockResolvedValue(undefined),
             handleEvent: jest.fn().mockResolvedValue({ ingested: null }),
         };
         const controller = new GitHubEventsController(bridge as any);
@@ -55,7 +59,7 @@ describe('GitHubEventsController (POST /api/ingest/github/events)', () => {
 
     it('fails closed with 401 when no binding is configured — even for ping', async () => {
         const { controller, bridge } = createController();
-        bridge.resolveBinding.mockResolvedValue(null);
+        bridge.resolveBinding.mockResolvedValue({ status: 'not-configured' });
         const { req, signature } = signedRequest({ zen: 'Keep it logically awesome.' });
         await expect(controller.receiveEvents(req as any, signature, 'ping')).rejects.toThrow(
             UnauthorizedException,
@@ -94,5 +98,65 @@ describe('GitHubEventsController (POST /api/ingest/github/events)', () => {
         const result = await controller.receiveEvents(req as any, signature, 'pull_request');
         expect(result).toEqual({ ok: true });
         expect(bridge.handleEvent).toHaveBeenCalledWith(BINDING, 'pull_request', body);
+    });
+
+    /**
+     * Per-installation routing: the delivery's `installation.id` (or
+     * repository owner) selects WHICH install's webhook secret verifies
+     * it, and an unresolvable installation is a clean no-op rather than a
+     * guess or a 500.
+     */
+    describe('per-installation binding', () => {
+        it('passes the delivery installation + a signature probe to the resolver', async () => {
+            const { controller, bridge } = createController();
+            const { req, signature } = signedRequest({
+                action: 'opened',
+                installation: { id: 99 },
+                repository: { full_name: 'octo/site' },
+            });
+
+            await controller.receiveEvents(req as any, signature, 'pull_request');
+
+            const lookup = bridge.resolveBinding.mock.calls[0][0];
+            expect(lookup.workspace).toEqual({
+                keys: ['installation:99', 'owner:octo'],
+                label: 'octo',
+            });
+            expect(lookup.verifySignature(SECRET)).toBe(true);
+            expect(lookup.verifySignature('someone-elses-secret')).toBe(false);
+        });
+
+        it('refuses an unresolvable installation as a 200 no-op — never a 500, never a guess', async () => {
+            const { controller, bridge } = createController();
+            bridge.resolveBinding.mockResolvedValue({
+                status: 'unresolved',
+                reason: 'unknown-workspace',
+            });
+            const { req, signature } = signedRequest({
+                action: 'opened',
+                repository: { full_name: 'stranger/site' },
+            });
+
+            const result = await controller.receiveEvents(req as any, signature, 'pull_request');
+
+            expect(result).toEqual({ ok: true, ignored: 'unknown-workspace' });
+            expect(bridge.handleEvent).not.toHaveBeenCalled();
+            expect(bridge.recordBinding).not.toHaveBeenCalled();
+        });
+
+        it('records the binding only after the signature verified', async () => {
+            const { controller, bridge } = createController();
+            const body = { action: 'opened', repository: { full_name: 'octo/site' } };
+
+            const bad = signedRequest(body);
+            await expect(
+                controller.receiveEvents(bad.req as any, 'sha256=deadbeef', 'pull_request'),
+            ).rejects.toThrow(UnauthorizedException);
+            expect(bridge.recordBinding).not.toHaveBeenCalled();
+
+            const good = signedRequest(body);
+            await controller.receiveEvents(good.req as any, good.signature, 'pull_request');
+            expect(bridge.recordBinding).toHaveBeenCalledWith(BINDING);
+        });
     });
 });

--- a/apps/api/src/ingest/github/github-events.controller.ts
+++ b/apps/api/src/ingest/github/github-events.controller.ts
@@ -13,6 +13,7 @@ import { Throttle } from '@nestjs/throttler';
 import { Public } from '../../auth/decorators/public.decorator';
 import {
     GitHubPrReviewBridgeService,
+    extractGitHubWorkspaceRef,
     type GitHubWebhookBody,
 } from './github-pr-review-bridge.service';
 import { verifyGitHubSignature } from './github-signature.util';
@@ -35,6 +36,19 @@ import { verifyGitHubSignature } from './github-signature.util';
  * signature verification; the parsed body is consumed as-is,
  * bypassing the global whitelist ValidationPipe (GitHub's event
  * schema is theirs, not ours).
+ *
+ * Per-user resolution is PER INSTALLATION: the delivery's
+ * `installation.id` (or, for a user-configured repo/org webhook, the
+ * repository owner) selects the platform user bound to it, so two
+ * customers' repositories never cross-attribute. The identity is read
+ * from the not-yet-verified body, which is safe because it only SELECTS
+ * which install's webhook secret to verify against — a forged id picks a
+ * secret that fails the HMAC.
+ *
+ * An unknown or ambiguous installation is REFUSED rather than guessed,
+ * and the refusal is a clean no-op (warn log, 200, nothing ingested) —
+ * never a 500. Only "no install configured at all" and "bad signature"
+ * are 401s, preserving the fail-closed posture.
  *
  * Distinct from the platform GitHub App webhook
  * (`/api/github-app/webhooks`, app-level secret, install/push sync):
@@ -66,15 +80,35 @@ export class GitHubEventsController {
             throw new BadRequestException('Missing raw request payload');
         }
 
-        // Fail-closed: no configured binding → no secret → reject,
-        // including the initial `ping` (GitHub signs that too).
-        const binding = await this.bridge.resolveBinding();
-        if (!binding) {
+        const rawBody = req.rawBody;
+        const body = (req.body ?? {}) as GitHubWebhookBody;
+
+        // Resolve WHICH install owns this installation/repository before
+        // verifying, so the right webhook secret is used. The workspace
+        // ref comes from the unverified body and only selects a candidate
+        // secret — a forged id picks a secret that fails the HMAC below.
+        const resolution = await this.bridge.resolveBinding({
+            workspace: extractGitHubWorkspaceRef(body),
+            verifySignature: (webhookSecret) =>
+                verifyGitHubSignature({ rawBody, signature, webhookSecret }).valid,
+        });
+
+        // Fail-closed: nothing configured → reject, including the initial
+        // `ping` (GitHub signs that too).
+        if (resolution.status === 'not-configured') {
             throw new UnauthorizedException('GitHub events receiver is not configured');
         }
+        // Unknown/ambiguous installation → clean no-op. The bridge already
+        // logged the refusal; 200 so GitHub does not retry a delivery we
+        // will never be able to attribute.
+        if (resolution.status === 'unresolved') {
+            return { ok: true, ignored: resolution.reason };
+        }
+
+        const binding = resolution.binding;
 
         const verdict = verifyGitHubSignature({
-            rawBody: req.rawBody,
+            rawBody,
             signature,
             webhookSecret: binding.webhookSecret,
         });
@@ -82,12 +116,16 @@ export class GitHubEventsController {
             throw new UnauthorizedException('Invalid GitHub webhook signature');
         }
 
+        // Verified — persist the installation→user binding so subsequent
+        // deliveries resolve exactly instead of through the fallback.
+        await this.bridge.recordBinding(binding);
+
         // Webhook-creation handshake — acknowledge without dispatching.
         if (eventName === 'ping') {
             return { ok: true };
         }
 
-        await this.bridge.handleEvent(binding, eventName, (req.body ?? {}) as GitHubWebhookBody);
+        await this.bridge.handleEvent(binding, eventName, body);
 
         return { ok: true };
     }

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
@@ -1,18 +1,24 @@
-jest.mock('@ever-works/agent/ingest', () => ({ EventIngestService: class {} }));
+jest.mock('@ever-works/agent/ingest', () => ({
+    EventIngestService: class {},
+    IngestInstallBindingRepository: class {},
+}));
 jest.mock('@ever-works/agent/pr-review', () => ({ PrReviewService: class {} }));
 jest.mock('@ever-works/agent/plugins', () => ({
     PluginSettingsService: class {},
     UserPluginRepository: class {},
 }));
 
-import { GitHubPrReviewBridgeService } from './github-pr-review-bridge.service';
+import {
+    GitHubPrReviewBridgeService,
+    extractGitHubWorkspaceRef,
+} from './github-pr-review-bridge.service';
 
 /** Flush the fire-and-forget review promise chain. */
 function flush(): Promise<void> {
     return new Promise((resolve) => setImmediate(resolve));
 }
 
-const BINDING = { userId: 'user-1', webhookSecret: 'sec' };
+const BINDING = { userId: 'user-1', webhookSecret: 'sec', matchedBy: 'binding' as const };
 
 function prOpenedBody(overrides: Record<string, unknown> = {}) {
     return {
@@ -69,11 +75,16 @@ describe('GitHubPrReviewBridgeService', () => {
                 context: { work: false, kb: false, memory: false },
             }),
         };
+        const installBindings = {
+            findByWorkspace: jest.fn().mockResolvedValue(null),
+            record: jest.fn().mockResolvedValue(null),
+        };
         const service = new GitHubPrReviewBridgeService(
             userPluginRepository as any,
             pluginSettingsService as any,
             eventIngestService as any,
             prReviewService as any,
+            installBindings as any,
         );
         return {
             service,
@@ -81,11 +92,110 @@ describe('GitHubPrReviewBridgeService', () => {
             pluginSettingsService,
             eventIngestService,
             prReviewService,
+            installBindings,
         };
     }
 
+    /**
+     * Per-installation binding.
+     *
+     * The receiver used to resolve "the oldest enabled install
+     * platform-wide" and attribute EVERY inbound delivery to that one
+     * platform user — a multi-tenant data-isolation defect (a second
+     * customer's repository had its diffs reviewed under, and billed to,
+     * the first customer's account). These cases pin the replacement.
+     */
     describe('resolveBinding', () => {
-        it('returns the oldest enabled install with a webhookSecret', async () => {
+        function twoInstalls(overrides: { sharedSecret?: boolean } = {}) {
+            const ctx = createService();
+            ctx.userPluginRepository.findByPlugin.mockResolvedValue([
+                { userId: 'u-a', enabled: true, createdAt: new Date('2026-01-01') },
+                { userId: 'u-disabled', enabled: false, createdAt: new Date('2025-01-01') },
+                { userId: 'u-b', enabled: true, createdAt: new Date('2026-02-01') },
+            ]);
+            ctx.pluginSettingsService.getSettings.mockImplementation(
+                async (_pluginId: string, opts: { userId: string }) => ({
+                    webhookSecret: overrides.sharedSecret ? 'shared' : `sec-${opts.userId}`,
+                }),
+            );
+            return ctx;
+        }
+
+        it('routes each installation to its OWN owner when two installs exist', async () => {
+            const { service, installBindings } = twoInstalls();
+            installBindings.findByWorkspace.mockImplementation(
+                async (_provider: string, key: string) =>
+                    key === 'owner:octo'
+                        ? { userId: 'u-a' }
+                        : key === 'owner:acme'
+                          ? { userId: 'u-b' }
+                          : null,
+            );
+
+            await expect(
+                service.resolveBinding({ workspace: { keys: ['owner:octo'] } }),
+            ).resolves.toMatchObject({
+                status: 'resolved',
+                binding: { userId: 'u-a', webhookSecret: 'sec-u-a', matchedBy: 'binding' },
+            });
+            await expect(
+                service.resolveBinding({ workspace: { keys: ['owner:acme'] } }),
+            ).resolves.toMatchObject({
+                status: 'resolved',
+                binding: { userId: 'u-b', webhookSecret: 'sec-u-b', matchedBy: 'binding' },
+            });
+        });
+
+        it('prefers the installation id over the repository owner key', async () => {
+            const { service, installBindings } = twoInstalls();
+            installBindings.findByWorkspace.mockImplementation(
+                async (_provider: string, key: string) =>
+                    key === 'installation:99' ? { userId: 'u-b' } : { userId: 'u-a' },
+            );
+
+            const result = await service.resolveBinding({
+                workspace: { keys: ['installation:99', 'owner:octo'] },
+            });
+            expect(result).toMatchObject({ status: 'resolved', binding: { userId: 'u-b' } });
+        });
+
+        it('REFUSES an unknown installation instead of guessing an owner', async () => {
+            const { service } = twoInstalls();
+            await expect(
+                service.resolveBinding({ workspace: { keys: ['owner:stranger'] } }),
+            ).resolves.toEqual({ status: 'unresolved', reason: 'unknown-workspace' });
+        });
+
+        it('REFUSES when the bound install is disabled — never re-points at another tenant', async () => {
+            const { service, installBindings } = twoInstalls();
+            installBindings.findByWorkspace.mockResolvedValue({ userId: 'u-disabled' });
+            await expect(
+                service.resolveBinding({ workspace: { keys: ['owner:octo'] } }),
+            ).resolves.toEqual({ status: 'unresolved', reason: 'bound-install-unavailable' });
+        });
+
+        it('resolves by unique signature proof — each install has its own webhook secret', async () => {
+            const { service } = twoInstalls();
+            const result = await service.resolveBinding({
+                workspace: { keys: ['owner:stranger'] },
+                verifySignature: (secret) => secret === 'sec-u-b',
+            });
+            expect(result).toMatchObject({
+                status: 'resolved',
+                binding: { userId: 'u-b', matchedBy: 'signature' },
+            });
+        });
+
+        it('REFUSES when several installs share a webhook secret', async () => {
+            const { service } = twoInstalls({ sharedSecret: true });
+            const result = await service.resolveBinding({
+                workspace: { keys: ['owner:stranger'] },
+                verifySignature: () => true,
+            });
+            expect(result).toEqual({ status: 'unresolved', reason: 'ambiguous-install' });
+        });
+
+        it('legacy single-install path still works (and is flagged as the fallback)', async () => {
             const { service, userPluginRepository, pluginSettingsService } = createService();
             userPluginRepository.findByPlugin.mockResolvedValue([
                 { userId: 'u-newer', enabled: true, createdAt: new Date('2026-02-01') },
@@ -96,16 +206,98 @@ describe('GitHubPrReviewBridgeService', () => {
                 async (_pluginId: string, opts: { userId: string }) =>
                     opts.userId === 'u-older' ? { webhookSecret: 's3cr3t' } : {},
             );
-            const binding = await service.resolveBinding();
-            expect(binding).toEqual({ userId: 'u-older', webhookSecret: 's3cr3t' });
+
+            const result = await service.resolveBinding({
+                workspace: { keys: ['owner:octo'], label: 'octo' },
+            });
+            expect(result).toMatchObject({
+                status: 'resolved',
+                binding: {
+                    userId: 'u-older',
+                    webhookSecret: 's3cr3t',
+                    matchedBy: 'single-install',
+                },
+            });
         });
 
-        it('returns null when no enabled install carries a secret (fail-closed input)', async () => {
+        it('reports not-configured (fail-closed 401 upstream) when no install carries a secret', async () => {
             const { service, userPluginRepository } = createService();
             userPluginRepository.findByPlugin.mockResolvedValue([
                 { userId: 'u1', enabled: true, createdAt: new Date() },
             ]);
-            await expect(service.resolveBinding()).resolves.toBeNull();
+            await expect(service.resolveBinding()).resolves.toEqual({ status: 'not-configured' });
+        });
+    });
+
+    describe('recordBinding', () => {
+        it('persists the installation→user binding after a fallback match', async () => {
+            const { service, installBindings } = createService();
+            await service.recordBinding({
+                userId: 'u-older',
+                webhookSecret: 's',
+                matchedBy: 'single-install',
+                workspace: { keys: ['owner:octo'], label: 'octo' },
+            });
+            expect(installBindings.record).toHaveBeenCalledWith({
+                provider: 'github',
+                externalWorkspaceId: 'owner:octo',
+                userId: 'u-older',
+                pluginId: 'github',
+                externalWorkspaceName: 'octo',
+            });
+        });
+
+        it('is a no-op when the binding already came from the table', async () => {
+            const { service, installBindings } = createService();
+            await service.recordBinding({
+                userId: 'u-a',
+                webhookSecret: 's',
+                matchedBy: 'binding',
+                workspace: { keys: ['owner:octo'] },
+            });
+            expect(installBindings.record).not.toHaveBeenCalled();
+        });
+
+        it('swallows a repository failure (a verified webhook must not 500)', async () => {
+            const { service, installBindings } = createService();
+            installBindings.record.mockRejectedValue(new Error('db down'));
+            await expect(
+                service.recordBinding({
+                    userId: 'u-a',
+                    webhookSecret: 's',
+                    matchedBy: 'single-install',
+                    workspace: { keys: ['owner:octo'] },
+                }),
+            ).resolves.toBeUndefined();
+        });
+    });
+
+    describe('extractGitHubWorkspaceRef', () => {
+        it('prefers the App installation id, then the repository owner', () => {
+            expect(
+                extractGitHubWorkspaceRef({
+                    installation: { id: 99 },
+                    repository: { full_name: 'Octo/site' },
+                } as any),
+            ).toEqual({ keys: ['installation:99', 'owner:octo'], label: 'Octo' });
+        });
+
+        it('falls back to the repository owner for a user-configured webhook', () => {
+            expect(
+                extractGitHubWorkspaceRef({ repository: { full_name: 'octo/site' } } as any),
+            ).toEqual({ keys: ['owner:octo'], label: 'octo' });
+        });
+
+        it('falls back to the organization login (org-level webhook / ping)', () => {
+            expect(extractGitHubWorkspaceRef({ organization: { login: 'Acme' } } as any)).toEqual({
+                keys: ['owner:acme'],
+                label: 'Acme',
+            });
+        });
+
+        it('returns undefined when the delivery names no installation at all', () => {
+            expect(extractGitHubWorkspaceRef({ zen: 'x' } as any)).toBeUndefined();
+            expect(extractGitHubWorkspaceRef(undefined)).toBeUndefined();
         });
     });
 

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
@@ -1,11 +1,19 @@
 import { randomUUID } from 'node:crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import type { IngestedEventEnvelope } from '@ever-works/contracts';
-import { EventIngestService, type IngestResult } from '@ever-works/agent/ingest';
+import {
+    EventIngestService,
+    IngestInstallBindingRepository,
+    type IngestResult,
+} from '@ever-works/agent/ingest';
 import { PrReviewService } from '@ever-works/agent/pr-review';
 import { PluginSettingsService, UserPluginRepository } from '@ever-works/agent/plugins';
+import type { IngestBindingMatch, IngestBindingResolution } from '../install-binding.types';
 
 export const GITHUB_PLUGIN_ID = 'github';
+
+/** Binding-table namespace for GitHub installations / repo owners. */
+export const GITHUB_BINDING_PROVIDER = 'github';
 
 /** The mention token that routes a PR comment into the review loop. */
 export const EVER_WORKS_MENTION = '@ever-works';
@@ -14,22 +22,65 @@ export const EVER_WORKS_MENTION = '@ever-works';
 export const GITHUB_EVENT_TEXT_MAX_CHARS = 4000;
 
 /**
- * v1 install→user binding (same posture as `SlackEventsBinding`): the
- * events land under the platform user who configured the github
- * plugin's `webhookSecret` (oldest enabled install wins). Per-repo /
- * per-installation user mapping is a documented follow-up.
+ * The external installation identity a GitHub delivery carries, as an
+ * ORDERED list of binding keys (most specific first):
+ *
+ *   * `installation:<id>` — the GitHub App installation, when present;
+ *   * `owner:<login>`     — the repository/organization owner, which is
+ *                           what a user-configured repo or org webhook
+ *                           carries.
+ *
+ * Both live in the same `externalWorkspaceId` column under distinct
+ * prefixes, so the two namespaces can never collide.
+ */
+export interface GitHubWorkspaceRef {
+    readonly keys: readonly string[];
+    /** Human-readable label persisted alongside the binding. */
+    readonly label?: string;
+}
+
+/**
+ * Per-installation binding: the platform user that OWNS the GitHub
+ * installation / repository owner a delivery came from, plus the webhook
+ * secret the receiver verifies it with.
+ *
+ * Resolution order and the refusal posture live in
+ * `../install-binding.types`. `matchedBy` records which path produced
+ * this binding so the receiver knows whether to persist it after
+ * signature verification.
  */
 export interface GitHubEventsBinding {
     readonly userId: string;
     readonly webhookSecret: string;
+    readonly matchedBy: IngestBindingMatch;
+    /** The installation/owner this delivery named, when it carried one. */
+    readonly workspace?: GitHubWorkspaceRef;
+}
+
+/** Inputs the receiver passes when resolving a delivery to its owner. */
+export interface GitHubBindingLookup {
+    readonly workspace?: GitHubWorkspaceRef;
+    /**
+     * Verifies the raw delivery against a candidate's webhook secret.
+     * Decisive for GitHub, where each install configures its OWN secret:
+     * a unique match is cryptographic proof of ownership, not a guess.
+     */
+    readonly verifySignature?: (webhookSecret: string) => boolean;
 }
 
 /** The subset of GitHub webhook payloads the bridge consumes. */
 export interface GitHubWebhookBody {
     action?: string;
+    installation?: {
+        id?: number;
+    };
+    organization?: {
+        login?: string;
+    };
     repository?: {
         full_name?: string;
         html_url?: string;
+        owner?: { login?: string };
     };
     sender?: {
         login?: string;
@@ -59,12 +110,42 @@ export interface GitHubWebhookBody {
 }
 
 /**
+ * Read the installation identity off a delivery body.
+ *
+ * The body is NOT yet signature-verified here, and that is safe: the
+ * value only SELECTS which install's webhook secret to verify against, so
+ * a forged installation id or owner login picks a secret that fails the
+ * HMAC and the delivery is rejected.
+ */
+export function extractGitHubWorkspaceRef(
+    body: GitHubWebhookBody | undefined,
+): GitHubWorkspaceRef | undefined {
+    const keys: string[] = [];
+    const installationId = body?.installation?.id;
+    if (typeof installationId === 'number' && Number.isFinite(installationId)) {
+        keys.push(`installation:${installationId}`);
+    }
+    const owner =
+        body?.repository?.owner?.login ??
+        body?.repository?.full_name?.split('/')[0] ??
+        body?.organization?.login;
+    if (typeof owner === 'string' && owner.length > 0) {
+        keys.push(`owner:${owner.toLowerCase()}`);
+    }
+    if (keys.length === 0) return undefined;
+    return { keys, ...(typeof owner === 'string' && owner ? { label: owner } : {}) };
+}
+
+/**
  * GitHub PR review loop (Wave 7, feature g) — ONE service bridging
  * GitHub webhook deliveries into the platform:
  *
- * 1. `resolveBinding()` — the v1 install→user binding plus the webhook
- *    secret the receiver verifies deliveries with. Fail-closed: no
- *    configured install → no binding → the endpoint 401s.
+ * 1. `resolveBinding()` — the PER-INSTALLATION binding plus the webhook
+ *    secret the receiver verifies deliveries with. Deliveries are
+ *    attributed to the platform user that owns the installation /
+ *    repository owner they came from, never to "the oldest install".
+ *    Fail-closed: no configured install → the endpoint 401s; an
+ *    unknown/ambiguous installation is refused as a clean no-op.
  * 2. `handleEvent()` — normalizes `pull_request` (opened/synchronize)
  *    and `@ever-works`-mentioning `issue_comment` /
  *    `pull_request_review_comment` deliveries into
@@ -89,30 +170,148 @@ export class GitHubPrReviewBridgeService {
         private readonly pluginSettingsService: PluginSettingsService,
         private readonly eventIngestService: EventIngestService,
         private readonly prReviewService: PrReviewService,
+        private readonly installBindings: IngestInstallBindingRepository,
     ) {}
 
     /**
-     * Resolve the v1 events binding: the OLDEST enabled github-plugin
-     * install whose resolved settings carry a webhook secret. Returns
-     * null when nothing is configured — callers must fail closed.
+     * Resolve one delivery to the platform user that OWNS the GitHub
+     * installation / repository owner it came from.
+     *
+     * Order (see `../install-binding.types`): exact binding → single
+     * install (warn, then recorded once verified) → unique signature
+     * match → refuse. Never falls back to "some other install": with two
+     * repositories configured by two users, each one's events reach
+     * exactly its own owner.
      */
-    async resolveBinding(): Promise<GitHubEventsBinding | null> {
+    async resolveBinding(
+        lookup: GitHubBindingLookup = {},
+    ): Promise<IngestBindingResolution<GitHubEventsBinding>> {
+        const candidates = await this.loadCandidates();
+        if (candidates.length === 0) {
+            return { status: 'not-configured' };
+        }
+
+        const workspace = lookup.workspace;
+        const label = workspace?.keys[0] ?? 'unknown installation';
+
+        // 1. Exact binding — most specific key first (installation id
+        //    before repository owner).
+        for (const key of workspace?.keys ?? []) {
+            const bound = await this.installBindings
+                .findByWorkspace(GITHUB_BINDING_PROVIDER, key)
+                .catch(() => null);
+            if (!bound) continue;
+            const owner = candidates.find((c) => c.userId === bound.userId);
+            if (owner) {
+                return {
+                    status: 'resolved',
+                    binding: { ...owner, matchedBy: 'binding', workspace },
+                };
+            }
+            // The bound install was removed or lost its webhook secret.
+            // Attributing its events to ANOTHER user is exactly the defect
+            // this replaces, so refuse instead.
+            this.logger.warn(
+                `Refusing GitHub delivery for ${key}: the bound install is disabled or unconfigured`,
+            );
+            return { status: 'unresolved', reason: 'bound-install-unavailable' };
+        }
+
+        // 2. Single-install legacy path — nothing to disambiguate.
+        if (candidates.length === 1) {
+            this.logger.warn(
+                `GitHub delivery for ${label} has no installation binding; attributing it to the single configured install (legacy path)`,
+            );
+            return {
+                status: 'resolved',
+                binding: {
+                    ...candidates[0],
+                    matchedBy: 'single-install',
+                    ...(workspace ? { workspace } : {}),
+                },
+            };
+        }
+
+        // 3. Signature proof. Each GitHub install configures its OWN
+        //    webhook secret, so a unique HMAC match is evidence of
+        //    ownership rather than a guess.
+        if (lookup.verifySignature) {
+            const matches = candidates.filter((c) => lookup.verifySignature!(c.webhookSecret));
+            if (matches.length === 1) {
+                return {
+                    status: 'resolved',
+                    binding: {
+                        ...matches[0],
+                        matchedBy: 'signature',
+                        ...(workspace ? { workspace } : {}),
+                    },
+                };
+            }
+            if (matches.length > 1) {
+                this.logger.warn(
+                    `Refusing GitHub delivery for ${label}: ${matches.length} installs share a webhook secret and nothing distinguishes them`,
+                );
+                return { status: 'unresolved', reason: 'ambiguous-install' };
+            }
+        }
+
+        this.logger.warn(
+            `Refusing GitHub delivery for ${label}: no install is bound to this installation`,
+        );
+        return { status: 'unresolved', reason: 'unknown-workspace' };
+    }
+
+    /**
+     * Persist the installation→user binding after a delivery has passed
+     * signature verification, so the deployment self-migrates off the
+     * legacy single-install path onto exact resolution.
+     *
+     * Best-effort: a failure here must never break a webhook that has
+     * already been verified and handled.
+     */
+    async recordBinding(binding: GitHubEventsBinding): Promise<void> {
+        const key = binding.workspace?.keys[0];
+        if (binding.matchedBy === 'binding' || !key) return;
+        try {
+            await this.installBindings.record({
+                provider: GITHUB_BINDING_PROVIDER,
+                externalWorkspaceId: key,
+                userId: binding.userId,
+                pluginId: GITHUB_PLUGIN_ID,
+                externalWorkspaceName: binding.workspace?.label ?? null,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Failed to record GitHub installation binding for ${key}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /**
+     * Enabled github-plugin installs whose resolved settings carry a
+     * webhook secret, oldest first (stable ordering keeps the
+     * single-install path deterministic).
+     */
+    private async loadCandidates(): Promise<Array<{ userId: string; webhookSecret: string }>> {
         const installs = await this.userPluginRepository.findByPlugin(GITHUB_PLUGIN_ID);
-        const candidates = installs
+        const enabled = installs
             .filter((row) => row.enabled)
             .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
-        for (const row of candidates) {
+        const candidates: Array<{ userId: string; webhookSecret: string }> = [];
+        for (const row of enabled) {
             const settings = await this.pluginSettingsService.getSettings(GITHUB_PLUGIN_ID, {
                 userId: row.userId,
                 includeSecrets: true,
             });
             const webhookSecret = settings?.webhookSecret;
             if (typeof webhookSecret === 'string' && webhookSecret.length > 0) {
-                return { userId: row.userId, webhookSecret };
+                candidates.push({ userId: row.userId, webhookSecret });
             }
         }
-        return null;
+        return candidates;
     }
 
     /**

--- a/apps/api/src/ingest/install-binding.types.ts
+++ b/apps/api/src/ingest/install-binding.types.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared shapes for per-workspace / per-installation resolution on the
+ * INBOUND receivers (Slack Events, GitHub webhooks).
+ *
+ * Both receivers used to resolve "the oldest enabled install
+ * platform-wide" and attribute every delivery to that one platform user.
+ * In a hosted multi-tenant deployment that is a data-isolation defect:
+ * a second customer's Slack workspace or GitHub repository would have its
+ * messages, diffs and AI replies executed under — and billed to — the
+ * first customer's account.
+ *
+ * The replacement resolves the owner from the external workspace /
+ * installation identity carried ON the delivery, in a fixed order:
+ *
+ *   1. **exact binding** — an `ingest_install_bindings` row for this
+ *      workspace names the owner;
+ *   2. **single-install fallback** — exactly ONE install is configured, so
+ *      there is nothing to disambiguate. Logged as a warning, and the
+ *      binding is recorded once the delivery passes signature verification
+ *      so the deployment self-migrates onto path 1;
+ *   3. **signature proof** — with several installs and no binding, the
+ *      raw payload is verified against each candidate's secret. A UNIQUE
+ *      cryptographic match is evidence of ownership, not a guess (it does
+ *      not help for Slack, where installs of the same app share one
+ *      signing secret — those deliveries fall through to 4);
+ *   4. **refuse** — anything ambiguous or unknown. Refusal is a clean
+ *      no-op: warn log, HTTP 200, nothing ingested, nothing dispatched.
+ *      Never a 500, and never a guess.
+ */
+
+/** Outcome of resolving an inbound delivery to an owning install. */
+export type IngestBindingResolution<TBinding> =
+    | { readonly status: 'resolved'; readonly binding: TBinding }
+    /** No install is configured at all — the receiver fails closed (401). */
+    | { readonly status: 'not-configured' }
+    /** Installs exist but none can be attributed to this delivery. */
+    | { readonly status: 'unresolved'; readonly reason: IngestBindingRefusal };
+
+/** Stable refusal codes — surfaced in warn logs and asserted by tests. */
+export type IngestBindingRefusal =
+    /** The delivery names a workspace nothing is bound to. */
+    | 'unknown-workspace'
+    /** Bound, but the owning install is gone or disabled. */
+    | 'bound-install-unavailable'
+    /** Bound to a different Slack enterprise than the delivery carries. */
+    | 'enterprise-mismatch'
+    /** Several installs matched and nothing distinguishes them. */
+    | 'ambiguous-install';
+
+/** How the owning install was determined (drives the warn/record logic). */
+export type IngestBindingMatch = 'binding' | 'single-install' | 'signature';

--- a/apps/api/src/ingest/slack/slack-chat-bridge.service.spec.ts
+++ b/apps/api/src/ingest/slack/slack-chat-bridge.service.spec.ts
@@ -1,4 +1,7 @@
-jest.mock('@ever-works/agent/ingest', () => ({ EventIngestService: class {} }));
+jest.mock('@ever-works/agent/ingest', () => ({
+    EventIngestService: class {},
+    IngestInstallBindingRepository: class {},
+}));
 jest.mock('@ever-works/agent/plugins', () => ({
     PluginRegistryService: class {},
     PluginSettingsService: class {},
@@ -8,7 +11,7 @@ jest.mock('../../ai-conversation/openai-compat.service', () => ({
     OpenAiCompatService: class {},
 }));
 
-import { SlackChatBridgeService } from './slack-chat-bridge.service';
+import { SlackChatBridgeService, extractSlackWorkspaceRef } from './slack-chat-bridge.service';
 
 /** Flush the fire-and-forget bridge promise chain. */
 function flush(): Promise<void> {
@@ -19,6 +22,7 @@ const BINDING = {
     userId: 'user-1',
     signingSecret: 'sec',
     settings: { botToken: 'xoxb-test' },
+    matchedBy: 'binding' as const,
 };
 
 function mentionBody(overrides: Record<string, unknown> = {}) {
@@ -58,12 +62,17 @@ describe('SlackChatBridgeService', () => {
                 choices: [{ index: 0, message: { role: 'assistant', content: 'All green.' } }],
             }),
         };
+        const installBindings = {
+            findByWorkspace: jest.fn().mockResolvedValue(null),
+            record: jest.fn().mockResolvedValue(null),
+        };
         const service = new SlackChatBridgeService(
             userPluginRepository as any,
             pluginSettingsService as any,
             pluginRegistry as any,
             eventIngestService as any,
             openAiCompatService as any,
+            installBindings as any,
         );
         return {
             service,
@@ -72,27 +81,140 @@ describe('SlackChatBridgeService', () => {
             pluginRegistry,
             eventIngestService,
             openAiCompatService,
+            installBindings,
             slackPlugin,
         };
     }
 
+    /**
+     * Per-workspace binding.
+     *
+     * The receiver used to resolve "the oldest enabled install
+     * platform-wide" and attribute EVERY inbound event to that one
+     * platform user — a multi-tenant data-isolation defect. These cases
+     * pin the replacement: exact binding → single-install fallback →
+     * signature proof → refuse, and NEVER a fallback to another tenant.
+     */
     describe('resolveBinding', () => {
-        it('binds to the OLDEST enabled install whose settings carry a signing secret', async () => {
+        /** Two configured installs with distinct owners. */
+        function twoInstalls(overrides: { sharedSecret?: boolean } = {}) {
+            const ctx = createService();
+            ctx.userPluginRepository.findByPlugin.mockResolvedValue([
+                { userId: 'u-a', enabled: true, createdAt: new Date('2026-01-15') },
+                { userId: 'u-disabled', enabled: false, createdAt: new Date('2026-01-01') },
+                { userId: 'u-b', enabled: true, createdAt: new Date('2026-02-01') },
+            ]);
+            ctx.pluginSettingsService.getSettings.mockImplementation(
+                async (_pluginId: string, options: { userId: string }) => ({
+                    botToken: `xoxb-${options.userId}`,
+                    signingSecret: overrides.sharedSecret ? 'app-secret' : `sec-${options.userId}`,
+                }),
+            );
+            return ctx;
+        }
+
+        it('routes each workspace to its OWN owner when two installs exist', async () => {
+            const { service, installBindings } = twoInstalls();
+            installBindings.findByWorkspace.mockImplementation(
+                async (_provider: string, teamId: string) =>
+                    teamId === 'T-AAA'
+                        ? { userId: 'u-a', externalEnterpriseId: null }
+                        : teamId === 'T-BBB'
+                          ? { userId: 'u-b', externalEnterpriseId: null }
+                          : null,
+            );
+
+            const a = await service.resolveBinding({ workspace: { teamId: 'T-AAA' } });
+            expect(a).toMatchObject({
+                status: 'resolved',
+                binding: { userId: 'u-a', signingSecret: 'sec-u-a', matchedBy: 'binding' },
+            });
+
+            const b = await service.resolveBinding({ workspace: { teamId: 'T-BBB' } });
+            expect(b).toMatchObject({
+                status: 'resolved',
+                binding: { userId: 'u-b', signingSecret: 'sec-u-b', matchedBy: 'binding' },
+            });
+        });
+
+        it('REFUSES an unknown workspace instead of guessing an owner', async () => {
+            const { service } = twoInstalls({ sharedSecret: true });
+
+            const result = await service.resolveBinding({
+                workspace: { teamId: 'T-STRANGER' },
+                // Both installs share the app-level signing secret, so the
+                // signature cannot disambiguate them either.
+                verifySignature: () => true,
+            });
+
+            expect(result).toEqual({ status: 'unresolved', reason: 'ambiguous-install' });
+        });
+
+        it('REFUSES when nothing is bound and no signature proof is available', async () => {
+            const { service } = twoInstalls();
+            const result = await service.resolveBinding({ workspace: { teamId: 'T-STRANGER' } });
+            expect(result).toEqual({ status: 'unresolved', reason: 'unknown-workspace' });
+        });
+
+        it('REFUSES when the bound install is disabled — never re-points at another tenant', async () => {
+            const { service, installBindings } = twoInstalls();
+            installBindings.findByWorkspace.mockResolvedValue({
+                userId: 'u-disabled',
+                externalEnterpriseId: null,
+            });
+
+            const result = await service.resolveBinding({ workspace: { teamId: 'T-AAA' } });
+            expect(result).toEqual({ status: 'unresolved', reason: 'bound-install-unavailable' });
+        });
+
+        it('REFUSES when the binding names a different Slack enterprise', async () => {
+            const { service, installBindings } = twoInstalls();
+            installBindings.findByWorkspace.mockResolvedValue({
+                userId: 'u-a',
+                externalEnterpriseId: 'E-ONE',
+            });
+
+            const result = await service.resolveBinding({
+                workspace: { teamId: 'T-AAA', enterpriseId: 'E-TWO' },
+            });
+            expect(result).toEqual({ status: 'unresolved', reason: 'enterprise-mismatch' });
+        });
+
+        it('resolves by unique signature proof when the installs use different secrets', async () => {
+            const { service } = twoInstalls();
+            const result = await service.resolveBinding({
+                workspace: { teamId: 'T-STRANGER' },
+                verifySignature: (secret) => secret === 'sec-u-b',
+            });
+            expect(result).toMatchObject({
+                status: 'resolved',
+                binding: { userId: 'u-b', matchedBy: 'signature' },
+            });
+        });
+
+        it('legacy single-install path still works (and is flagged as the fallback)', async () => {
             const { service, userPluginRepository, pluginSettingsService } = createService();
             userPluginRepository.findByPlugin.mockResolvedValue([
-                { userId: 'u-newer', enabled: true, createdAt: new Date('2026-02-01') },
                 { userId: 'u-disabled', enabled: false, createdAt: new Date('2026-01-01') },
-                { userId: 'u-oldest', enabled: true, createdAt: new Date('2026-01-15') },
+                { userId: 'u-only', enabled: true, createdAt: new Date('2026-01-15') },
             ]);
             pluginSettingsService.getSettings.mockImplementation(
                 async (_pluginId: string, options: { userId: string }) =>
-                    options.userId === 'u-oldest'
+                    options.userId === 'u-only'
                         ? { signingSecret: 'shhh', botToken: 'xoxb' }
                         : { botToken: 'xoxb' },
             );
 
-            const binding = await service.resolveBinding();
-            expect(binding).toMatchObject({ userId: 'u-oldest', signingSecret: 'shhh' });
+            const result = await service.resolveBinding({ workspace: { teamId: 'T-AAA' } });
+            expect(result).toMatchObject({
+                status: 'resolved',
+                binding: {
+                    userId: 'u-only',
+                    signingSecret: 'shhh',
+                    matchedBy: 'single-install',
+                    workspace: { teamId: 'T-AAA' },
+                },
+            });
             // Disabled installs are never consulted.
             const consulted = pluginSettingsService.getSettings.mock.calls.map(
                 (c: any[]) => c[1].userId,
@@ -105,12 +227,85 @@ describe('SlackChatBridgeService', () => {
             );
         });
 
-        it('returns null (fail-closed) when no enabled install has a signing secret', async () => {
+        it('reports not-configured (fail-closed 401 upstream) when no install has a signing secret', async () => {
             const { service, userPluginRepository } = createService();
             userPluginRepository.findByPlugin.mockResolvedValue([
                 { userId: 'u1', enabled: true, createdAt: new Date('2026-01-01') },
             ]);
-            expect(await service.resolveBinding()).toBeNull();
+            expect(await service.resolveBinding()).toEqual({ status: 'not-configured' });
+        });
+    });
+
+    describe('recordBinding', () => {
+        it('persists the workspace→user binding after a fallback match', async () => {
+            const { service, installBindings } = createService();
+            await service.recordBinding({
+                userId: 'u-only',
+                signingSecret: 's',
+                settings: {},
+                matchedBy: 'single-install',
+                workspace: { teamId: 'T-AAA', enterpriseId: 'E-ONE' },
+            });
+            expect(installBindings.record).toHaveBeenCalledWith({
+                provider: 'slack',
+                externalWorkspaceId: 'T-AAA',
+                externalEnterpriseId: 'E-ONE',
+                userId: 'u-only',
+                pluginId: 'slack-connector',
+            });
+        });
+
+        it('is a no-op when the binding already came from the table, or carries no workspace', async () => {
+            const { service, installBindings } = createService();
+            await service.recordBinding({
+                userId: 'u-a',
+                signingSecret: 's',
+                settings: {},
+                matchedBy: 'binding',
+                workspace: { teamId: 'T-AAA' },
+            });
+            await service.recordBinding({
+                userId: 'u-a',
+                signingSecret: 's',
+                settings: {},
+                matchedBy: 'single-install',
+            });
+            expect(installBindings.record).not.toHaveBeenCalled();
+        });
+
+        it('swallows a repository failure (a verified webhook must not 500)', async () => {
+            const { service, installBindings } = createService();
+            installBindings.record.mockRejectedValue(new Error('db down'));
+            await expect(
+                service.recordBinding({
+                    userId: 'u-a',
+                    signingSecret: 's',
+                    settings: {},
+                    matchedBy: 'single-install',
+                    workspace: { teamId: 'T-AAA' },
+                }),
+            ).resolves.toBeUndefined();
+        });
+    });
+
+    describe('extractSlackWorkspaceRef', () => {
+        it('reads team_id and enterprise_id off the delivery', () => {
+            expect(extractSlackWorkspaceRef({ team_id: 'T1', enterprise_id: 'E1' } as any)).toEqual(
+                { teamId: 'T1', enterpriseId: 'E1' },
+            );
+        });
+
+        it('falls back to the authorizations entry (Enterprise Grid deliveries)', () => {
+            expect(
+                extractSlackWorkspaceRef({
+                    authorizations: [{ team_id: 'T2', enterprise_id: 'E2' }],
+                } as any),
+            ).toEqual({ teamId: 'T2', enterpriseId: 'E2' });
+        });
+
+        it('returns undefined when the delivery names no workspace (e.g. the handshake)', () => {
+            expect(extractSlackWorkspaceRef({ type: 'url_verification' } as any)).toBeUndefined();
+            expect(extractSlackWorkspaceRef(undefined)).toBeUndefined();
         });
     });
 

--- a/apps/api/src/ingest/slack/slack-chat-bridge.service.ts
+++ b/apps/api/src/ingest/slack/slack-chat-bridge.service.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import type { IngestedEventEnvelope } from '@ever-works/contracts';
-import { EventIngestService, type IngestResult } from '@ever-works/agent/ingest';
+import {
+    EventIngestService,
+    IngestInstallBindingRepository,
+    type IngestResult,
+} from '@ever-works/agent/ingest';
 import {
     PluginRegistryService,
     PluginSettingsService,
@@ -11,23 +15,57 @@ import { PLUGIN_CAPABILITIES, isConnectorPlugin } from '@ever-works/plugin';
 import type { ChannelTargetConfig, IConnectorPlugin } from '@ever-works/plugin';
 import { OpenAiCompatService } from '../../ai-conversation/openai-compat.service';
 import type { OpenAiChatCompletionRequestDto } from '../../ai-conversation/dto/openai-compat.dto';
+import type { IngestBindingMatch, IngestBindingResolution } from '../install-binding.types';
 
 export const SLACK_CONNECTOR_PLUGIN_ID = 'slack-connector';
+
+/** Binding-table namespace for Slack workspaces. */
+export const SLACK_BINDING_PROVIDER = 'slack';
 
 /** Payload text cap for envelopes built from webhook deliveries. */
 export const SLACK_EVENT_TEXT_MAX_CHARS = 4000;
 
 /**
- * v1 workspace→user binding: the events land under the platform user who
- * configured the slack-connector plugin (first enabled install with a
- * signing secret). Multi-user / per-workspace `team_id` mapping is a
- * documented follow-up (a pairing table keyed by Slack team + user id).
+ * The external workspace identity a Slack delivery carries. `teamId` is
+ * the discriminator (unique per workspace, including inside an Enterprise
+ * Grid); `enterpriseId` is an extra guard applied when both the delivery
+ * and the stored binding carry one.
+ */
+export interface SlackWorkspaceRef {
+    readonly teamId: string;
+    readonly enterpriseId?: string;
+}
+
+/**
+ * Per-workspace binding: the platform user that OWNS the Slack workspace
+ * a delivery came from, plus the signing secret the receiver verifies it
+ * with and the resolved settings used to post the reply back.
+ *
+ * Resolution order and the refusal posture live in
+ * `../install-binding.types`. `matchedBy` records which path produced
+ * this binding so the receiver knows whether to persist it after
+ * signature verification.
  */
 export interface SlackEventsBinding {
     readonly userId: string;
     readonly signingSecret: string;
     /** Resolved plugin settings (secrets included) for outbound replies. */
     readonly settings: Record<string, unknown>;
+    readonly matchedBy: IngestBindingMatch;
+    /** The workspace this delivery named, when it carried one. */
+    readonly workspace?: SlackWorkspaceRef;
+}
+
+/** Inputs the receiver passes when resolving a delivery to its owner. */
+export interface SlackBindingLookup {
+    /** Workspace identity read off the (not yet verified) delivery body. */
+    readonly workspace?: SlackWorkspaceRef;
+    /**
+     * Verifies the raw delivery against a candidate's signing secret.
+     * Only consulted when the workspace is unknown AND several installs
+     * exist — a unique match is cryptographic proof of ownership.
+     */
+    readonly verifySignature?: (signingSecret: string) => boolean;
 }
 
 /** The subset of a Slack Events API `event_callback` we consume. */
@@ -35,6 +73,9 @@ export interface SlackEventCallbackBody {
     type?: string;
     event_id?: string;
     team_id?: string;
+    enterprise_id?: string;
+    /** Grid deliveries carry the installing team/enterprise here. */
+    authorizations?: Array<{ team_id?: string | null; enterprise_id?: string | null }>;
     event?: {
         type?: string;
         subtype?: string;
@@ -50,13 +91,36 @@ export interface SlackEventCallbackBody {
 }
 
 /**
+ * Read the workspace identity off a delivery body.
+ *
+ * The body is NOT yet signature-verified at this point, and that is safe:
+ * the value is used only to SELECT which install's secret to verify
+ * against. A forged `team_id` therefore picks a secret that will not
+ * validate the HMAC, and the delivery is rejected — it can never be used
+ * to attribute an event to someone else.
+ */
+export function extractSlackWorkspaceRef(
+    body: SlackEventCallbackBody | undefined,
+): SlackWorkspaceRef | undefined {
+    const auth = body?.authorizations?.[0];
+    const teamId = body?.team_id ?? auth?.team_id ?? undefined;
+    if (typeof teamId !== 'string' || teamId.length === 0) return undefined;
+    const enterpriseId = body?.enterprise_id ?? auth?.enterprise_id ?? undefined;
+    return typeof enterpriseId === 'string' && enterpriseId.length > 0
+        ? { teamId, enterpriseId }
+        : { teamId };
+}
+
+/**
  * Slack app surface (Wave 6, feature f) — ONE service bridging the Slack
  * Events API into the platform:
  *
- * 1. `resolveBinding()` — the v1 workspace→user binding (see
+ * 1. `resolveBinding()` — the PER-WORKSPACE binding (see
  *    {@link SlackEventsBinding}) plus the signing secret the receiver
- *    verifies deliveries with. Fail-closed: no configured install → no
- *    binding → the endpoint 401s.
+ *    verifies deliveries with. Deliveries are attributed to the platform
+ *    user that owns the Slack workspace they came from — never to "the
+ *    oldest install". Fail-closed: no configured install → the endpoint
+ *    401s; an unknown/ambiguous workspace is refused as a clean no-op.
  * 2. `handleEventCallback()` — normalizes `app_mention` / `message`
  *    events into `IngestedEventEnvelope`s and dedupe-inserts them
  *    through the event-ingest spine (`slack.mention` / `slack.message`,
@@ -79,30 +143,168 @@ export class SlackChatBridgeService {
         private readonly pluginRegistry: PluginRegistryService,
         private readonly eventIngestService: EventIngestService,
         private readonly openAiCompatService: OpenAiCompatService,
+        private readonly installBindings: IngestInstallBindingRepository,
     ) {}
 
     /**
-     * Resolve the v1 events binding: the OLDEST enabled slack-connector
-     * install whose resolved settings carry a signing secret. Returns
-     * null when nothing is configured — callers must fail closed.
+     * Resolve one delivery to the platform user that OWNS the Slack
+     * workspace it came from.
+     *
+     * Order (see `../install-binding.types`): exact binding → single
+     * install (warn, then recorded once verified) → unique signature
+     * match → refuse. Never falls back to "some other install": with two
+     * workspaces configured, each one's events reach exactly its own
+     * owner, and an unrecognized workspace is refused rather than guessed.
      */
-    async resolveBinding(): Promise<SlackEventsBinding | null> {
+    async resolveBinding(
+        lookup: SlackBindingLookup = {},
+    ): Promise<IngestBindingResolution<SlackEventsBinding>> {
+        const candidates = await this.loadCandidates();
+        if (candidates.length === 0) {
+            return { status: 'not-configured' };
+        }
+
+        const workspace = lookup.workspace;
+
+        // 1. Exact binding — the authoritative path.
+        if (workspace) {
+            const bound = await this.installBindings
+                .findByWorkspace(SLACK_BINDING_PROVIDER, workspace.teamId)
+                .catch(() => null);
+            if (bound) {
+                if (
+                    bound.externalEnterpriseId &&
+                    workspace.enterpriseId &&
+                    bound.externalEnterpriseId !== workspace.enterpriseId
+                ) {
+                    this.logger.warn(
+                        `Refusing Slack delivery for team ${workspace.teamId}: bound to a different enterprise`,
+                    );
+                    return { status: 'unresolved', reason: 'enterprise-mismatch' };
+                }
+                const owner = candidates.find((c) => c.userId === bound.userId);
+                if (owner) {
+                    return {
+                        status: 'resolved',
+                        binding: { ...owner, matchedBy: 'binding', workspace },
+                    };
+                }
+                // The bound install was removed or lost its signing secret.
+                // Attributing its events to ANOTHER user is exactly the
+                // defect this replaces, so refuse instead.
+                this.logger.warn(
+                    `Refusing Slack delivery for team ${workspace.teamId}: the bound install is disabled or unconfigured`,
+                );
+                return { status: 'unresolved', reason: 'bound-install-unavailable' };
+            }
+        }
+
+        // 2. Single-install legacy path — nothing to disambiguate.
+        if (candidates.length === 1) {
+            this.logger.warn(
+                `Slack delivery${
+                    workspace ? ` for team ${workspace.teamId}` : ''
+                } has no workspace binding; attributing it to the single configured install (legacy path)`,
+            );
+            return {
+                status: 'resolved',
+                binding: {
+                    ...candidates[0],
+                    matchedBy: 'single-install',
+                    ...(workspace ? { workspace } : {}),
+                },
+            };
+        }
+
+        // 3. Signature proof. Only decisive when the installs carry
+        //    DIFFERENT signing secrets — installs of the same Slack app
+        //    share one, so those deliveries fall through to the refusal.
+        if (lookup.verifySignature) {
+            const matches = candidates.filter((c) => lookup.verifySignature!(c.signingSecret));
+            if (matches.length === 1) {
+                return {
+                    status: 'resolved',
+                    binding: {
+                        ...matches[0],
+                        matchedBy: 'signature',
+                        ...(workspace ? { workspace } : {}),
+                    },
+                };
+            }
+            if (matches.length > 1) {
+                this.logger.warn(
+                    `Refusing Slack delivery${
+                        workspace ? ` for team ${workspace.teamId}` : ''
+                    }: ${matches.length} installs share a signing secret and nothing distinguishes them`,
+                );
+                return { status: 'unresolved', reason: 'ambiguous-install' };
+            }
+        }
+
+        this.logger.warn(
+            `Refusing Slack delivery${
+                workspace ? ` for team ${workspace.teamId}` : ' with no team_id'
+            }: no install is bound to this workspace`,
+        );
+        return { status: 'unresolved', reason: 'unknown-workspace' };
+    }
+
+    /**
+     * Persist the workspace→user binding after a delivery has passed
+     * signature verification, so the deployment self-migrates off the
+     * legacy single-install path onto exact resolution.
+     *
+     * Best-effort: a failure here must never break a webhook that has
+     * already been verified and handled.
+     */
+    async recordBinding(binding: SlackEventsBinding): Promise<void> {
+        if (binding.matchedBy === 'binding' || !binding.workspace) return;
+        try {
+            await this.installBindings.record({
+                provider: SLACK_BINDING_PROVIDER,
+                externalWorkspaceId: binding.workspace.teamId,
+                externalEnterpriseId: binding.workspace.enterpriseId ?? null,
+                userId: binding.userId,
+                pluginId: SLACK_CONNECTOR_PLUGIN_ID,
+            });
+        } catch (error) {
+            this.logger.warn(
+                `Failed to record Slack workspace binding for team ${binding.workspace.teamId}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
+    }
+
+    /**
+     * Enabled slack-connector installs whose resolved settings carry a
+     * signing secret, oldest first (stable ordering keeps the
+     * single-install path deterministic).
+     */
+    private async loadCandidates(): Promise<
+        Array<{ userId: string; signingSecret: string; settings: Record<string, unknown> }>
+    > {
         const installs = await this.userPluginRepository.findByPlugin(SLACK_CONNECTOR_PLUGIN_ID);
-        const candidates = installs
+        const enabled = installs
             .filter((row) => row.enabled)
             .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
-        for (const row of candidates) {
+        const candidates: Array<{
+            userId: string;
+            signingSecret: string;
+            settings: Record<string, unknown>;
+        }> = [];
+        for (const row of enabled) {
             const settings = await this.pluginSettingsService.getSettings(
                 SLACK_CONNECTOR_PLUGIN_ID,
                 { userId: row.userId, includeSecrets: true },
             );
             const signingSecret = settings?.signingSecret;
             if (typeof signingSecret === 'string' && signingSecret.length > 0) {
-                return { userId: row.userId, signingSecret, settings: settings ?? {} };
+                candidates.push({ userId: row.userId, signingSecret, settings: settings ?? {} });
             }
         }
-        return null;
+        return candidates;
     }
 
     /**

--- a/apps/api/src/ingest/slack/slack-events.controller.spec.ts
+++ b/apps/api/src/ingest/slack/slack-events.controller.spec.ts
@@ -1,6 +1,9 @@
 import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 
-jest.mock('@ever-works/agent/ingest', () => ({ EventIngestService: class {} }));
+jest.mock('@ever-works/agent/ingest', () => ({
+    EventIngestService: class {},
+    IngestInstallBindingRepository: class {},
+}));
 jest.mock('@ever-works/agent/plugins', () => ({
     PluginRegistryService: class {},
     PluginSettingsService: class {},
@@ -21,12 +24,14 @@ const BINDING = {
     userId: 'user-1',
     signingSecret: SECRET,
     settings: { botToken: 'xoxb-test' },
+    matchedBy: 'binding' as const,
 };
 
 describe('SlackEventsController (POST /api/ingest/slack/events)', () => {
     function createController() {
         const bridge = {
-            resolveBinding: jest.fn().mockResolvedValue(BINDING),
+            resolveBinding: jest.fn().mockResolvedValue({ status: 'resolved', binding: BINDING }),
+            recordBinding: jest.fn().mockResolvedValue(undefined),
             handleEventCallback: jest.fn().mockResolvedValue({ ingested: null }),
         };
         const controller = new SlackEventsController(bridge as any);
@@ -51,7 +56,7 @@ describe('SlackEventsController (POST /api/ingest/slack/events)', () => {
 
     it('fails closed with 401 when no binding is configured — even for url_verification', async () => {
         const { controller, bridge } = createController();
-        bridge.resolveBinding.mockResolvedValue(null);
+        bridge.resolveBinding.mockResolvedValue({ status: 'not-configured' });
         const { req, timestamp, signature } = signedRequest({
             type: 'url_verification',
             challenge: 'abc',
@@ -123,5 +128,70 @@ describe('SlackEventsController (POST /api/ingest/slack/events)', () => {
         const result = await controller.receiveEvents(req as any, signature, timestamp);
         expect(result).toEqual({ ok: true });
         expect(bridge.handleEventCallback).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Per-workspace routing: the delivery's `team_id` selects WHICH
+     * install's signing secret verifies it, and an unresolvable workspace
+     * is a clean no-op rather than a guess or a 500.
+     */
+    describe('per-workspace binding', () => {
+        it('passes the delivery workspace + a signature probe to the resolver', async () => {
+            const { controller, bridge } = createController();
+            const { req, timestamp, signature } = signedRequest({
+                type: 'event_callback',
+                team_id: 'T-AAA',
+                enterprise_id: 'E-ONE',
+                event: { type: 'message', channel: 'C1', ts: '1.0' },
+            });
+
+            await controller.receiveEvents(req as any, signature, timestamp);
+
+            const lookup = bridge.resolveBinding.mock.calls[0][0];
+            expect(lookup.workspace).toEqual({ teamId: 'T-AAA', enterpriseId: 'E-ONE' });
+            // The probe must accept the real secret and reject any other.
+            expect(lookup.verifySignature(SECRET)).toBe(true);
+            expect(lookup.verifySignature('someone-elses-secret')).toBe(false);
+        });
+
+        it('refuses an unresolvable workspace as a 200 no-op — never a 500, never a guess', async () => {
+            const { controller, bridge } = createController();
+            bridge.resolveBinding.mockResolvedValue({
+                status: 'unresolved',
+                reason: 'unknown-workspace',
+            });
+            const { req, timestamp, signature } = signedRequest({
+                type: 'event_callback',
+                team_id: 'T-STRANGER',
+                event: { type: 'app_mention', channel: 'C1', ts: '1.0' },
+            });
+
+            const result = await controller.receiveEvents(req as any, signature, timestamp);
+
+            expect(result).toEqual({ ok: true, ignored: 'unknown-workspace' });
+            expect(bridge.handleEventCallback).not.toHaveBeenCalled();
+            expect(bridge.recordBinding).not.toHaveBeenCalled();
+        });
+
+        it('records the binding only after the signature verified', async () => {
+            const { controller, bridge } = createController();
+            const body = {
+                type: 'event_callback',
+                team_id: 'T-AAA',
+                event: { type: 'message', channel: 'C1', ts: '1.0' },
+            };
+
+            // Bad signature → 401 and nothing recorded.
+            const bad = signedRequest(body);
+            await expect(
+                controller.receiveEvents(bad.req as any, 'v0=deadbeef', bad.timestamp),
+            ).rejects.toThrow(UnauthorizedException);
+            expect(bridge.recordBinding).not.toHaveBeenCalled();
+
+            // Good signature → recorded.
+            const good = signedRequest(body);
+            await controller.receiveEvents(good.req as any, good.signature, good.timestamp);
+            expect(bridge.recordBinding).toHaveBeenCalledWith(BINDING);
+        });
     });
 });

--- a/apps/api/src/ingest/slack/slack-events.controller.ts
+++ b/apps/api/src/ingest/slack/slack-events.controller.ts
@@ -11,7 +11,11 @@ import {
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
 import { Public } from '../../auth/decorators/public.decorator';
-import { SlackChatBridgeService, type SlackEventCallbackBody } from './slack-chat-bridge.service';
+import {
+    SlackChatBridgeService,
+    extractSlackWorkspaceRef,
+    type SlackEventCallbackBody,
+} from './slack-chat-bridge.service';
 import { verifySlackSignature } from './slack-signature.util';
 
 /**
@@ -30,9 +34,17 @@ import { verifySlackSignature } from './slack-signature.util';
  * verification; the parsed body is consumed as-is, bypassing the global
  * whitelist ValidationPipe (Slack's event schema is theirs, not ours).
  *
- * Per-user resolution is the v1 binding — the user who configured the
- * plugin owns the events (multi-workspace mapping is a documented
- * follow-up on `SlackEventsBinding`).
+ * Per-user resolution is PER WORKSPACE: the delivery's `team_id` (plus
+ * `enterprise_id` on Grid) selects the platform user bound to that Slack
+ * workspace, so two customers' workspaces never cross-attribute. The
+ * workspace id is read from the not-yet-verified body, which is safe
+ * because it only SELECTS which install's signing secret to verify
+ * against — a forged `team_id` picks a secret that fails the HMAC.
+ *
+ * An unknown or ambiguous workspace is REFUSED rather than guessed, and
+ * the refusal is a clean no-op (warn log, 200, nothing ingested) — never
+ * a 500. Only "no install configured at all" and "bad signature" are
+ * 401s, preserving the fail-closed posture.
  */
 @ApiTags('ingest')
 @Controller('api/ingest')
@@ -56,15 +68,35 @@ export class SlackEventsController {
             throw new BadRequestException('Missing raw request payload');
         }
 
-        // Fail-closed: no configured binding → no secret → reject, including
+        const rawBody = req.rawBody;
+        const body = (req.body ?? {}) as SlackEventCallbackBody & { challenge?: string };
+
+        // Resolve WHICH install owns this workspace before verifying, so
+        // the right signing secret is used. The workspace ref comes from
+        // the unverified body and only selects a candidate secret — a
+        // forged team_id picks a secret that fails the HMAC below.
+        const resolution = await this.slackChatBridge.resolveBinding({
+            workspace: extractSlackWorkspaceRef(body),
+            verifySignature: (signingSecret) =>
+                verifySlackSignature({ rawBody, timestamp, signature, signingSecret }).valid,
+        });
+
+        // Fail-closed: nothing configured → reject, including
         // url_verification (Slack signs the handshake too).
-        const binding = await this.slackChatBridge.resolveBinding();
-        if (!binding) {
+        if (resolution.status === 'not-configured') {
             throw new UnauthorizedException('Slack events receiver is not configured');
         }
+        // Unknown/ambiguous workspace → clean no-op. The bridge already
+        // logged the refusal; 200 so Slack does not retry a delivery we
+        // will never be able to attribute.
+        if (resolution.status === 'unresolved') {
+            return { ok: true, ignored: resolution.reason };
+        }
+
+        const binding = resolution.binding;
 
         const verdict = verifySlackSignature({
-            rawBody: req.rawBody,
+            rawBody,
             timestamp,
             signature,
             signingSecret: binding.signingSecret,
@@ -73,7 +105,9 @@ export class SlackEventsController {
             throw new UnauthorizedException('Invalid Slack request signature');
         }
 
-        const body = (req.body ?? {}) as SlackEventCallbackBody & { challenge?: string };
+        // Verified — persist the workspace→user binding so subsequent
+        // deliveries resolve exactly instead of through the fallback.
+        await this.slackChatBridge.recordBinding(binding);
 
         // Events API URL-verification handshake — echo the challenge.
         if (body.type === 'url_verification' && typeof body.challenge === 'string') {

--- a/apps/api/src/migrations/1784200000000-CreateIngestInstallBindings.ts
+++ b/apps/api/src/migrations/1784200000000-CreateIngestInstallBindings.ts
@@ -1,0 +1,118 @@
+import { MigrationInterface, QueryRunner, Table, TableForeignKey, TableIndex } from 'typeorm';
+
+/**
+ * Inbound receivers — creates `ingest_install_bindings`, the external
+ * workspace/installation → platform user binding that the Slack Events
+ * receiver and the GitHub webhook receiver resolve deliveries through.
+ *
+ * Before this table both receivers resolved "the oldest enabled install
+ * platform-wide" and attributed EVERY inbound event to that one user — a
+ * multi-tenant data-isolation defect (a second customer's Slack workspace
+ * or GitHub repository had its messages and diffs executed under, and
+ * billed to, the first customer's account).
+ *
+ * Entity: `packages/agent/src/entities/ingest-install-binding.entity.ts`
+ * Repository: `packages/agent/src/ingest/ingest-install-binding.repository.ts`
+ *
+ * **Schema notes:**
+ *   - `provider` is a deliberate varchar(32) (not an enum) so a new
+ *     inbound surface ships without a schema change — same convention as
+ *     `fleet_nodes.kind`.
+ *   - `externalWorkspaceId` holds the identity carried on the webhook:
+ *     Slack's raw `team_id`, or — for GitHub — `installation:<id>` /
+ *     `owner:<login>` under a disambiguating prefix so the two GitHub
+ *     namespaces can never collide.
+ *   - UNIQUE `(provider, externalWorkspaceId)` — one external workspace
+ *     has exactly one owning platform user. The uniqueness is what makes
+ *     resolution exact rather than a guess; it also resolves the
+ *     concurrent-first-delivery race in the repository's `record()`.
+ *   - `externalEnterpriseId` (nullable) carries Slack's `enterprise_id`
+ *     when a delivery has one (Enterprise Grid). A stored value must
+ *     match the incoming delivery or the binding does not apply.
+ *   - FK `userId` → `users.id` ON DELETE CASCADE (a binding is
+ *     meaningless without the account it attributes events to; deleting
+ *     the account must not leave inbound events pointing at a ghost).
+ *
+ * Forward-only + idempotent (`hasTable` guard) — same shape as
+ * `1783900000000-CreateFleetNodes`.
+ */
+export class CreateIngestInstallBindings1784200000000 implements MigrationInterface {
+    name = 'CreateIngestInstallBindings1784200000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('ingest_install_bindings')) {
+            return;
+        }
+
+        await queryRunner.createTable(
+            new Table({
+                name: 'ingest_install_bindings',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    { name: 'provider', type: 'varchar', length: '32' },
+                    { name: 'externalWorkspaceId', type: 'varchar', length: '200' },
+                    {
+                        name: 'externalEnterpriseId',
+                        type: 'varchar',
+                        length: '200',
+                        isNullable: true,
+                    },
+                    { name: 'userId', type: 'uuid' },
+                    { name: 'pluginId', type: 'varchar', length: '64' },
+                    {
+                        name: 'externalWorkspaceName',
+                        type: 'varchar',
+                        length: '200',
+                        isNullable: true,
+                    },
+                    { name: 'createdAt', type: 'timestamp', default: 'now()' },
+                    { name: 'updatedAt', type: 'timestamp', default: 'now()' },
+                ],
+            }),
+            true,
+        );
+
+        // Exact workspace → owner lookup on every inbound delivery. Unique
+        // so two platform users can never claim the same workspace.
+        await queryRunner.createIndex(
+            'ingest_install_bindings',
+            new TableIndex({
+                name: 'idx_ingest_install_bindings_workspace',
+                columnNames: ['provider', 'externalWorkspaceId'],
+                isUnique: true,
+            }),
+        );
+
+        // Owner-scoped list reads (settings UI / diagnostics).
+        await queryRunner.createIndex(
+            'ingest_install_bindings',
+            new TableIndex({
+                name: 'idx_ingest_install_bindings_user',
+                columnNames: ['userId'],
+            }),
+        );
+
+        await queryRunner.createForeignKey(
+            'ingest_install_bindings',
+            new TableForeignKey({
+                name: 'fk_ingest_install_bindings_user',
+                columnNames: ['userId'],
+                referencedTableName: 'users',
+                referencedColumnNames: ['id'],
+                onDelete: 'CASCADE',
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (await queryRunner.hasTable('ingest_install_bindings')) {
+            await queryRunner.dropTable('ingest_install_bindings', true);
+        }
+    }
+}

--- a/apps/api/src/migrations/__tests__/CreateIngestInstallBindings.spec.ts
+++ b/apps/api/src/migrations/__tests__/CreateIngestInstallBindings.spec.ts
@@ -1,0 +1,119 @@
+import { DataSource } from 'typeorm';
+import { CreateIngestInstallBindings1784200000000 } from '../1784200000000-CreateIngestInstallBindings';
+
+/**
+ * Inbound receivers — migration test for `ingest_install_bindings`, run
+ * against an in-memory better-sqlite3 DataSource (same harness as
+ * `AddRunSteeringColumns.spec.ts`).
+ *
+ * The load-bearing assertion is the UNIQUE `(provider,
+ * externalWorkspaceId)` index: uniqueness is what makes workspace→owner
+ * resolution EXACT rather than a guess. Without it two platform users
+ * could claim the same Slack workspace or GitHub installation and the
+ * multi-tenancy defect this table fixes would come straight back.
+ *
+ * The inserts below pass `createdAt`/`updatedAt` explicitly: the table's
+ * `now()` / `uuid_generate_v4()` defaults are Postgres functions (the
+ * shape every migration in this folder ships), and sqlite is used here
+ * only as a cheap DDL harness.
+ */
+describe('CreateIngestInstallBindings1784200000000', () => {
+    let dataSource: DataSource;
+    const migration = new CreateIngestInstallBindings1784200000000();
+
+    beforeEach(async () => {
+        dataSource = new DataSource({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [],
+            synchronize: false,
+        });
+        await dataSource.initialize();
+        await dataSource.query(`CREATE TABLE "users" ("id" varchar PRIMARY KEY NOT NULL)`);
+        await dataSource.query(`INSERT INTO "users" ("id") VALUES ('u-a'), ('u-b')`);
+    });
+
+    afterEach(async () => {
+        await dataSource.destroy();
+    });
+
+    async function up(): Promise<void> {
+        const runner = dataSource.createQueryRunner();
+        await migration.up(runner);
+        await runner.release();
+    }
+
+    async function columnNames(): Promise<string[]> {
+        const rows: Array<{ name: string }> = await dataSource.query(
+            `PRAGMA table_info("ingest_install_bindings")`,
+        );
+        return rows.map((r) => r.name);
+    }
+
+    it('creates the table with the binding columns', async () => {
+        await up();
+        expect(await columnNames()).toEqual(
+            expect.arrayContaining([
+                'id',
+                'provider',
+                'externalWorkspaceId',
+                'externalEnterpriseId',
+                'userId',
+                'pluginId',
+                'externalWorkspaceName',
+                'createdAt',
+                'updatedAt',
+            ]),
+        );
+    });
+
+    const COLUMNS =
+        '"id", "provider", "externalWorkspaceId", "userId", "pluginId", "createdAt", "updatedAt"';
+    const STAMPS = `'2026-07-26 00:00:00', '2026-07-26 00:00:00'`;
+
+    it('⭐ enforces one owner per (provider, workspace) — two tenants cannot claim the same workspace', async () => {
+        await up();
+        await dataSource.query(
+            `INSERT INTO "ingest_install_bindings" (${COLUMNS})
+             VALUES ('b-1', 'slack', 'T-AAA', 'u-a', 'slack-connector', ${STAMPS})`,
+        );
+
+        await expect(
+            dataSource.query(
+                `INSERT INTO "ingest_install_bindings" (${COLUMNS})
+                 VALUES ('b-2', 'slack', 'T-AAA', 'u-b', 'slack-connector', ${STAMPS})`,
+            ),
+        ).rejects.toThrow();
+    });
+
+    it('keeps the slack and github namespaces independent', async () => {
+        await up();
+        await dataSource.query(
+            `INSERT INTO "ingest_install_bindings" (${COLUMNS})
+             VALUES ('b-1', 'slack', 'shared-id', 'u-a', 'slack-connector', ${STAMPS}),
+                    ('b-2', 'github', 'shared-id', 'u-b', 'github', ${STAMPS})`,
+        );
+        const rows = await dataSource.query(`SELECT COUNT(*) AS n FROM "ingest_install_bindings"`);
+        expect(Number(rows[0].n)).toBe(2);
+    });
+
+    it('is idempotent — running up() twice does not throw', async () => {
+        await up();
+        const runner = dataSource.createQueryRunner();
+        await expect(migration.up(runner)).resolves.toBeUndefined();
+        await runner.release();
+        expect(await columnNames()).toContain('externalWorkspaceId');
+    });
+
+    it('down() drops the table', async () => {
+        await up();
+        const runner = dataSource.createQueryRunner();
+        await migration.down(runner);
+        await runner.release();
+
+        const tables: Array<{ name: string }> = await dataSource.query(
+            `SELECT name FROM sqlite_master WHERE type='table' AND name='ingest_install_bindings'`,
+        );
+        expect(tables).toHaveLength(0);
+    });
+});

--- a/apps/web/src/lib/api/account-transfer.types.ts
+++ b/apps/web/src/lib/api/account-transfer.types.ts
@@ -1,9 +1,33 @@
+/**
+ * Mirrors `ExportedProfile` in
+ * `packages/agent/src/account-transfer/types.ts`. The onboarding answers
+ * and account preferences are user-authored settings that must survive an
+ * export/import round trip; every field is optional so pre-sweep payloads
+ * still parse.
+ */
+export interface ExportedProfile {
+    username: string;
+    email: string;
+    avatar?: string;
+    onboarding?: {
+        roles?: string[];
+        teamSize?: string;
+    };
+    preferences?: {
+        digestFrequency?: string;
+        emailAgentAlerts?: boolean;
+        emailTaskNotifications?: boolean;
+        emailBudgetAlerts?: boolean;
+        userResearchOptOut?: boolean;
+    };
+}
+
 export interface AccountExportPayload {
     version: number;
     exportedAt: string;
     includesSecrets: boolean;
     data: {
-        profile: { username: string; email: string; avatar?: string };
+        profile: ExportedProfile;
         works: any[];
         userPlugins: any[];
     };
@@ -21,7 +45,7 @@ export interface ImportPreview {
     version: number;
     includesSecrets: boolean;
     hasMaskedSecrets: boolean;
-    profile: { username: string; email: string; avatar?: string };
+    profile: ExportedProfile;
     workCount: number;
     totalItemCount: number;
     userPluginCount: number;
@@ -41,6 +65,8 @@ export interface ImportResult {
     worksUpdated: number;
     worksSkipped: number;
     userPluginsImported: number;
+    /** True when the payload's onboarding answers / preferences were applied. */
+    profileImported?: boolean;
     errors: string[];
     warnings: string[];
 }

--- a/packages/agent/src/account-transfer/account-export.service.spec.ts
+++ b/packages/agent/src/account-transfer/account-export.service.spec.ts
@@ -173,6 +173,78 @@ describe('AccountExportService', () => {
             });
         });
 
+        it('exports the onboarding answers + account preferences (whitelist sweep)', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({
+                username: 'octo',
+                email: 'o@e.com',
+                onboardingState: {
+                    version: 2,
+                    lastStep: 4,
+                    profile: { roles: ['engineering', 'product'], teamSize: 'small-2-10' },
+                },
+                digestFrequency: 'weekly',
+                emailAgentAlerts: true,
+                // A deliberate opt-OUT is exactly the value that must survive
+                // the round trip, so `false` has to be serialized, not dropped.
+                emailTaskNotifications: false,
+                emailBudgetAlerts: false,
+                userResearchOptOut: true,
+            });
+
+            const result = await service.exportAccountData('user-1');
+
+            expect(result.data.profile.onboarding).toEqual({
+                roles: ['engineering', 'product'],
+                teamSize: 'small-2-10',
+            });
+            expect(result.data.profile.preferences).toEqual({
+                digestFrequency: 'weekly',
+                emailAgentAlerts: true,
+                emailTaskNotifications: false,
+                emailBudgetAlerts: false,
+                userResearchOptOut: true,
+            });
+        });
+
+        it('omits onboarding/preferences entirely when the user has none', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({
+                username: 'octo',
+                email: 'o@e.com',
+            });
+
+            const result = await service.exportAccountData('user-1');
+
+            expect(result.data.profile).toEqual({
+                username: 'octo',
+                email: 'o@e.com',
+                avatar: undefined,
+            });
+        });
+
+        it('never exports privileged or money columns on the profile', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({
+                username: 'octo',
+                email: 'o@e.com',
+                isPlatformAdmin: true,
+                tenantId: 't-1',
+                organizationId: 'o-1',
+                defaultPlanId: 'plan-pro',
+                digestFrequency: 'daily',
+            });
+
+            const result = await service.exportAccountData('user-1');
+            const serialized = JSON.stringify(result.data.profile);
+
+            expect(serialized).not.toContain('isPlatformAdmin');
+            expect(serialized).not.toContain('tenantId');
+            expect(serialized).not.toContain('organizationId');
+            expect(serialized).not.toContain('defaultPlanId');
+            expect(result.data.profile.preferences).toEqual({ digestFrequency: 'daily' });
+        });
+
         it('preserves a real avatar URL', async () => {
             const { service, mocks } = makeService();
             mocks.userRepository.findById.mockResolvedValue({

--- a/packages/agent/src/account-transfer/account-export.service.ts
+++ b/packages/agent/src/account-transfer/account-export.service.ts
@@ -11,6 +11,9 @@ import { GitFacadeService } from '../facades/git.facade';
 import { DataRepository } from '../generators/data-generator/data-repository';
 import type {
     AccountExportPayload,
+    ExportedProfile,
+    ExportedOnboardingProfile,
+    ExportedUserPreferences,
     ExportedWork,
     ExportedAdvancedPrompts,
     ExportedSchedule,
@@ -118,11 +121,7 @@ export class AccountExportService {
             exportedAt: new Date().toISOString(),
             includesSecrets: includeSecrets,
             data: {
-                profile: {
-                    username: user.username,
-                    email: user.email,
-                    avatar: user.avatar || undefined,
-                },
+                profile: this.exportProfile(user),
                 works: exportedWorks,
                 userPlugins: exportedUserPlugins,
                 ...(tailAgents ? { agents: tailAgents } : {}),
@@ -130,6 +129,63 @@ export class AccountExportService {
                 ...(tailTasks ? { tasks: tailTasks } : {}),
             },
         };
+    }
+
+    /**
+     * Serialize the account-level profile. Onboarding answers and account
+     * preferences are user-authored settings, so they must round-trip —
+     * without them an export/import silently resets the "What do you do"
+     * answers (and every suggestion surface built on them) plus the digest
+     * cadence and the notification/privacy opt-outs.
+     *
+     * Explicit `false` booleans are serialized (an opt-OUT is exactly the
+     * value that must survive); only genuinely absent values are omitted so
+     * the importing account keeps its own.
+     */
+    private exportProfile(user: any): ExportedProfile {
+        const profile: ExportedProfile = {
+            username: user.username,
+            email: user.email,
+            avatar: user.avatar || undefined,
+        };
+
+        const answers = user.onboardingState?.profile;
+        if (answers && typeof answers === 'object') {
+            const onboarding: ExportedOnboardingProfile = {};
+            if (Array.isArray(answers.roles)) {
+                onboarding.roles = answers.roles.filter(
+                    (role: unknown): role is string => typeof role === 'string',
+                );
+            }
+            if (typeof answers.teamSize === 'string' && answers.teamSize.length > 0) {
+                onboarding.teamSize = answers.teamSize;
+            }
+            if (Object.keys(onboarding).length > 0) {
+                profile.onboarding = onboarding;
+            }
+        }
+
+        const preferences: ExportedUserPreferences = {};
+        if (typeof user.digestFrequency === 'string' && user.digestFrequency.length > 0) {
+            preferences.digestFrequency = user.digestFrequency;
+        }
+        if (typeof user.emailAgentAlerts === 'boolean') {
+            preferences.emailAgentAlerts = user.emailAgentAlerts;
+        }
+        if (typeof user.emailTaskNotifications === 'boolean') {
+            preferences.emailTaskNotifications = user.emailTaskNotifications;
+        }
+        if (typeof user.emailBudgetAlerts === 'boolean') {
+            preferences.emailBudgetAlerts = user.emailBudgetAlerts;
+        }
+        if (typeof user.userResearchOptOut === 'boolean') {
+            preferences.userResearchOptOut = user.userResearchOptOut;
+        }
+        if (Object.keys(preferences).length > 0) {
+            profile.preferences = preferences;
+        }
+
+        return profile;
     }
 
     private async exportWork(

--- a/packages/agent/src/account-transfer/account-import.service.spec.ts
+++ b/packages/agent/src/account-transfer/account-import.service.spec.ts
@@ -62,6 +62,7 @@ describe('AccountImportService', () => {
 
         const userRepository = {
             findById: jest.fn(),
+            update: jest.fn().mockResolvedValue(undefined),
         };
         const workRepository = {
             findByUser: jest.fn().mockResolvedValue([]),
@@ -1375,6 +1376,211 @@ describe('AccountImportService', () => {
                 expect.objectContaining({ owner: 'someoneelse' }),
                 expect.anything(),
             );
+        });
+    });
+
+    /**
+     * Account-transfer whitelist sweep — the account-level profile.
+     *
+     * Onboarding answers ("What do you do") and account preferences are
+     * user-authored settings that previously did NOT round-trip: the
+     * whitelist only carried `{username, email, avatar}`, so an
+     * export/import silently reset the roles/team-size answers (and every
+     * suggestion surface built on them), the digest cadence and the
+     * notification/privacy opt-outs.
+     *
+     * One case per added field, plus the standing posture rules: enum
+     * values are drop-if-unrecognized on BOTH import paths, arrays only
+     * apply when they really are arrays, and a deliberate `false` must
+     * survive the round-trip.
+     */
+    describe('applyImport — account profile round-trip', () => {
+        function payloadWithProfile(profile: Record<string, unknown>): AccountExportPayload {
+            const payload = makePayload([]);
+            payload.data.profile = { username: 'octocat', email: 'o@e.com', ...profile } as any;
+            return payload;
+        }
+
+        it('round-trips onboarding roles + teamSize, merged into the existing wizard state', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({
+                id: 'user-1',
+                username: 'octocat',
+                onboardingState: {
+                    version: 2,
+                    lastStep: 3,
+                    ai: { choice: 'openrouter' },
+                    storage: { choice: 'user-github' },
+                    db: { choice: 'custom' },
+                    deploy: { choice: 'vercel' },
+                    skippedSteps: ['plugins'],
+                    pluginsReviewed: true,
+                },
+            });
+
+            const result = await service.applyImport(
+                'user-1',
+                payloadWithProfile({
+                    onboarding: { roles: ['engineering', 'product'], teamSize: 'small-2-10' },
+                }),
+                [],
+            );
+
+            expect(result.profileImported).toBe(true);
+            const [id, patch] = mocks.userRepository.update.mock.calls[0];
+            expect(id).toBe('user-1');
+            expect(patch.onboardingState.profile).toEqual({
+                roles: ['engineering', 'product'],
+                teamSize: 'small-2-10',
+            });
+            // The importer's own wizard progress must survive untouched.
+            expect(patch.onboardingState).toMatchObject({
+                lastStep: 3,
+                ai: { choice: 'openrouter' },
+                storage: { choice: 'user-github' },
+                pluginsReviewed: true,
+            });
+        });
+
+        it('drops unrecognized role ids and an unrecognized teamSize instead of defaulting them', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+
+            await service.applyImport(
+                'user-1',
+                payloadWithProfile({
+                    onboarding: {
+                        roles: ['engineering', 'wizard-of-the-coast', 42],
+                        teamSize: 'galactic',
+                    },
+                }),
+                [],
+            );
+
+            const patch = mocks.userRepository.update.mock.calls[0][1];
+            expect(patch.onboardingState.profile.roles).toEqual(['engineering']);
+            expect('teamSize' in patch.onboardingState.profile).toBe(false);
+        });
+
+        it('ignores a non-array roles value rather than writing it', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+
+            const result = await service.applyImport(
+                'user-1',
+                payloadWithProfile({ onboarding: { roles: 'engineering' } }),
+                [],
+            );
+
+            expect(result.profileImported).toBe(false);
+            expect(mocks.userRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('round-trips the digest cadence', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+
+            await service.applyImport(
+                'user-1',
+                payloadWithProfile({ preferences: { digestFrequency: 'weekly' } }),
+                [],
+            );
+
+            expect(mocks.userRepository.update).toHaveBeenCalledWith(
+                'user-1',
+                expect.objectContaining({ digestFrequency: 'weekly' }),
+            );
+        });
+
+        it('drops an unrecognized digest cadence instead of resetting it to off', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+
+            const result = await service.applyImport(
+                'user-1',
+                payloadWithProfile({ preferences: { digestFrequency: 'hourly' } }),
+                [],
+            );
+
+            expect(result.profileImported).toBe(false);
+            expect(mocks.userRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('round-trips every notification/privacy preference, including deliberate false values', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+
+            await service.applyImport(
+                'user-1',
+                payloadWithProfile({
+                    preferences: {
+                        emailAgentAlerts: true,
+                        emailTaskNotifications: false,
+                        emailBudgetAlerts: false,
+                        userResearchOptOut: true,
+                    },
+                }),
+                [],
+            );
+
+            // An opt-OUT is exactly the value that has to survive — these can
+            // never be applied through a truthiness check.
+            expect(mocks.userRepository.update).toHaveBeenCalledWith(
+                'user-1',
+                expect.objectContaining({
+                    emailAgentAlerts: true,
+                    emailTaskNotifications: false,
+                    emailBudgetAlerts: false,
+                    userResearchOptOut: true,
+                }),
+            );
+        });
+
+        it('never applies identity or privileged columns from the payload', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+
+            await service.applyImport(
+                'user-1',
+                payloadWithProfile({
+                    username: 'attacker',
+                    email: 'attacker@example.com',
+                    avatar: 'https://example.invalid/a.png',
+                    isPlatformAdmin: true,
+                    preferences: { digestFrequency: 'daily', isPlatformAdmin: true },
+                } as any),
+                [],
+            );
+
+            const patch = mocks.userRepository.update.mock.calls[0][1];
+            expect(patch).toEqual({ digestFrequency: 'daily' });
+        });
+
+        it('is a no-op for a pre-profile payload (no onboarding / preferences keys)', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+
+            const result = await service.applyImport('user-1', makePayload([]), []);
+
+            expect(result.profileImported).toBe(false);
+            expect(mocks.userRepository.update).not.toHaveBeenCalled();
+        });
+
+        it('a profile write failure is a warning, not a failed import', async () => {
+            const { service, mocks } = makeService();
+            mocks.userRepository.findById.mockResolvedValue({ id: 'user-1', username: 'octocat' });
+            mocks.userRepository.update.mockRejectedValue(new Error('db down'));
+
+            const result = await service.applyImport(
+                'user-1',
+                payloadWithProfile({ preferences: { digestFrequency: 'daily' } }),
+                [],
+            );
+
+            expect(result.success).toBe(true);
+            expect(
+                result.warnings.some((w) => w.includes('Failed to import profile settings')),
+            ).toBe(true);
         });
     });
 });

--- a/packages/agent/src/account-transfer/account-import.service.ts
+++ b/packages/agent/src/account-transfer/account-import.service.ts
@@ -23,7 +23,14 @@ import type {
 import { containsMaskedSecrets, MASKED_SECRET_PREFIX } from './types';
 import { sanitizePrompt } from '../utils/sanitize.util';
 import { normalizeCreateWorkKind, type Work, type WorkKind } from '../entities/work.entity';
+import type { User } from '../entities/user.entity';
 import { WORK_CHECKS_POLICIES, WORK_KINDS, type WorkChecksPolicy } from '@ever-works/contracts';
+import {
+    ONBOARDING_DEFAULT_STATE,
+    ROLE_OPTIONS,
+    TEAM_SIZE_OPTIONS,
+    type OnboardingWizardStateV2,
+} from '@ever-works/contracts/api';
 
 /**
  * Canonical slug shape (matches the work/item DTO `@Matches` rule and
@@ -73,6 +80,41 @@ function normalizeImportedChecksPolicy(value: unknown): WorkChecksPolicy | undef
 function normalizeImportedMaxGateAttempts(value: unknown): number | undefined {
     return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 5
         ? value
+        : undefined;
+}
+
+/** Cadences accepted for `users.digestFrequency` (drop-if-unrecognized). */
+const DIGEST_FREQUENCIES: readonly string[] = ['off', 'daily', 'weekly'];
+
+const ROLE_IDS: readonly string[] = ROLE_OPTIONS.map((option) => option.id);
+const TEAM_SIZE_IDS: readonly string[] = TEAM_SIZE_OPTIONS.map((option) => option.id);
+
+/**
+ * Onboarding roles from an untrusted payload. Arrays only ever import as
+ * arrays; entries outside `ROLE_OPTIONS` are DROPPED (never defaulted, never
+ * stored verbatim) so a hand-edited export can't plant unknown ids into the
+ * suggestion surfaces that read this list. An array that survives filtering
+ * with zero entries is still meaningful — it means "the user cleared their
+ * answers" — so it is kept; a non-array is treated as absent.
+ */
+function normalizeImportedRoles(value: unknown): string[] | undefined {
+    if (!Array.isArray(value)) return undefined;
+    const seen = new Set<string>();
+    for (const entry of value) {
+        if (typeof entry === 'string' && ROLE_IDS.includes(entry)) seen.add(entry);
+    }
+    return [...seen];
+}
+
+/** Team size: a single known id, or absent. Drop-if-unrecognized. */
+function normalizeImportedTeamSize(value: unknown): string | undefined {
+    return typeof value === 'string' && TEAM_SIZE_IDS.includes(value) ? value : undefined;
+}
+
+/** Digest cadence: a single known value, or absent. Drop-if-unrecognized. */
+function normalizeImportedDigestFrequency(value: unknown): 'off' | 'daily' | 'weekly' | undefined {
+    return typeof value === 'string' && DIGEST_FREQUENCIES.includes(value)
+        ? (value as 'off' | 'daily' | 'weekly')
         : undefined;
 }
 
@@ -401,6 +443,23 @@ export class AccountImportService {
         await queryRunner.startTransaction();
 
         try {
+            // Import the account-level profile (onboarding answers +
+            // preferences) BEFORE the works, so a failure there still
+            // rolls back with everything else in the same transaction.
+            try {
+                result.profileImported = await this.importProfile(
+                    userId,
+                    user,
+                    payload.data?.profile,
+                );
+            } catch (error) {
+                result.warnings.push(
+                    `Failed to import profile settings: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                );
+            }
+
             // Import works
             for (const dir of payload.data.works) {
                 try {
@@ -470,6 +529,90 @@ export class AccountImportService {
         }
 
         return result;
+    }
+
+    /**
+     * Apply the account-level profile from an imported payload: the
+     * onboarding "What do you do" answers and the account preferences.
+     *
+     * Posture (identical to every other imported field): the payload is
+     * attacker-editable JSON, so enum values are DROP-if-unrecognized
+     * rather than default-if-unrecognized, arrays only apply when they
+     * really are arrays, and an absent field leaves the importing
+     * account's own value untouched. Identity columns (`username`,
+     * `email`, `avatar`) are deliberately NOT applied — they identify the
+     * importing account, not the exporting one.
+     *
+     * The onboarding answers are deep-merged into the existing wizard
+     * state so importing a profile never wipes the importer's own AI /
+     * storage / deploy choices or step progress.
+     *
+     * Returns true when at least one column was written.
+     */
+    private async importProfile(userId: string, user: any, profile: unknown): Promise<boolean> {
+        if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+            return false;
+        }
+        const source = profile as {
+            onboarding?: unknown;
+            preferences?: unknown;
+        };
+        const update: Partial<User> = {};
+
+        const onboarding =
+            source.onboarding && typeof source.onboarding === 'object'
+                ? (source.onboarding as { roles?: unknown; teamSize?: unknown })
+                : null;
+        if (onboarding) {
+            const roles = normalizeImportedRoles(onboarding.roles);
+            const teamSize = normalizeImportedTeamSize(onboarding.teamSize);
+            if (roles !== undefined || teamSize !== undefined) {
+                const current: OnboardingWizardStateV2 =
+                    user.onboardingState && typeof user.onboardingState === 'object'
+                        ? (user.onboardingState as OnboardingWizardStateV2)
+                        : ONBOARDING_DEFAULT_STATE;
+                update.onboardingState = {
+                    ...current,
+                    profile: {
+                        ...(current.profile ?? {}),
+                        ...(roles !== undefined ? { roles } : {}),
+                        ...(teamSize !== undefined ? { teamSize } : {}),
+                    },
+                };
+            }
+        }
+
+        const preferences =
+            source.preferences && typeof source.preferences === 'object'
+                ? (source.preferences as Record<string, unknown>)
+                : null;
+        if (preferences) {
+            const digestFrequency = normalizeImportedDigestFrequency(preferences.digestFrequency);
+            if (digestFrequency !== undefined) {
+                update.digestFrequency = digestFrequency;
+            }
+            // Explicit booleans only — a deliberate `false` (an opt-out) is
+            // exactly the value that has to survive the round-trip, so these
+            // can never be written through a truthiness check.
+            if (typeof preferences.emailAgentAlerts === 'boolean') {
+                update.emailAgentAlerts = preferences.emailAgentAlerts;
+            }
+            if (typeof preferences.emailTaskNotifications === 'boolean') {
+                update.emailTaskNotifications = preferences.emailTaskNotifications;
+            }
+            if (typeof preferences.emailBudgetAlerts === 'boolean') {
+                update.emailBudgetAlerts = preferences.emailBudgetAlerts;
+            }
+            if (typeof preferences.userResearchOptOut === 'boolean') {
+                update.userResearchOptOut = preferences.userResearchOptOut;
+            }
+        }
+
+        if (Object.keys(update).length === 0) {
+            return false;
+        }
+        await this.userRepository.update(userId, update);
+        return true;
     }
 
     private async importWork(

--- a/packages/agent/src/account-transfer/agents-skills-tasks-export.service.spec.ts
+++ b/packages/agent/src/account-transfer/agents-skills-tasks-export.service.spec.ts
@@ -173,6 +173,121 @@ describe('AgentsSkillsTasksExportService.exportTail', () => {
         expect(child.parentTaskSlug).toBe('T-1');
     });
 
+    /**
+     * Account-transfer whitelist sweep — Task isolation + quality-gate
+     * settings. These are user-authored settings and previously did NOT
+     * round-trip, so an export/import silently reset a Task that opted
+     * into isolation or curated its own acceptance checks.
+     *
+     * The BRANCH columns are the deliberate counterpart: they name a git
+     * ref, base commit and PR inside the exporting account's repository,
+     * so replaying them would point the imported Task at someone else's
+     * branch. They must stay out of the envelope.
+     */
+    it('exports Task isolation + gate settings, and never the branch/run state', async () => {
+        const { svc, tasks } = makeSvc();
+        const checks = [
+            { id: 'build', name: 'Build', kind: 'build', command: 'pnpm build', required: true },
+        ];
+        tasks.findByUserIdFiltered.mockResolvedValueOnce({
+            rows: [
+                {
+                    id: 't1',
+                    slug: 'T-1',
+                    title: 'gated',
+                    description: null,
+                    status: 'todo',
+                    priority: 'p3',
+                    labels: null,
+                    missionId: null,
+                    ideaId: null,
+                    workId: null,
+                    parentTaskId: null,
+                    isRecurring: false,
+                    recurrenceRule: null,
+                    recurrenceTimezone: null,
+                    recurrenceEndsAt: null,
+                    recurrenceMaxOccurrences: null,
+                    parentRecurringTaskId: null,
+                    requireAllApprovers: true,
+                    isolationMode: 'on',
+                    acceptanceChecks: checks,
+                    maxGateAttempts: 4,
+                    branchRef: 'task/t-1-9f3c1a2b',
+                    branchState: 'pr-open',
+                    baseSha: 'a'.repeat(40),
+                    prNumber: 42,
+                    prUrl: 'https://example.invalid/pr/42',
+                    conflictPaths: ['src/a.ts'],
+                    latestRunId: 'run-1',
+                    latestRunStatus: 'completed',
+                    createdAt: new Date(),
+                    startedAt: null,
+                    completedAt: null,
+                },
+            ],
+            total: 1,
+        });
+
+        const tail = await svc.exportTail('u1', { includeTasks: true });
+        const task = tail.tasks![0];
+
+        expect(task.isolationMode).toBe('on');
+        expect(task.acceptanceChecks).toEqual(checks);
+        expect(task.maxGateAttempts).toBe(4);
+
+        const serialized = JSON.stringify(task);
+        for (const excluded of [
+            'branchRef',
+            'branchState',
+            'baseSha',
+            'prNumber',
+            'prUrl',
+            'conflictPaths',
+            'latestRunId',
+            'latestRunStatus',
+        ]) {
+            expect(serialized).not.toContain(excluded);
+        }
+    });
+
+    it('serializes absent Task isolation/gate settings as explicit null (= inherit)', async () => {
+        const { svc, tasks } = makeSvc();
+        tasks.findByUserIdFiltered.mockResolvedValueOnce({
+            rows: [
+                {
+                    id: 't1',
+                    slug: 'T-1',
+                    title: 'plain',
+                    description: null,
+                    status: 'todo',
+                    priority: 'p3',
+                    labels: null,
+                    missionId: null,
+                    ideaId: null,
+                    workId: null,
+                    parentTaskId: null,
+                    isRecurring: false,
+                    recurrenceRule: null,
+                    recurrenceTimezone: null,
+                    recurrenceEndsAt: null,
+                    recurrenceMaxOccurrences: null,
+                    parentRecurringTaskId: null,
+                    requireAllApprovers: true,
+                    createdAt: new Date(),
+                    startedAt: null,
+                    completedAt: null,
+                },
+            ],
+            total: 1,
+        });
+
+        const task = (await svc.exportTail('u1', { includeTasks: true })).tasks![0];
+        expect(task.isolationMode).toBeNull();
+        expect(task.acceptanceChecks).toBeNull();
+        expect(task.maxGateAttempts).toBeNull();
+    });
+
     it('omits chat by default; includes it when toggle set', async () => {
         const { svc, tasks, chat } = makeSvc();
         tasks.findByUserIdFiltered.mockResolvedValue({

--- a/packages/agent/src/account-transfer/agents-skills-tasks-export.service.ts
+++ b/packages/agent/src/account-transfer/agents-skills-tasks-export.service.ts
@@ -171,6 +171,17 @@ export class AgentsSkillsTasksExportService {
                     identifier: row.approverId,
                 })),
                 requireAllApprovers: task.requireAllApprovers,
+                // User-authored Task settings — isolation override + quality
+                // gates. Without these an export/import silently resets a
+                // Task that opted into isolation or curated its own checks.
+                // (Branch/PR/run state is deliberately excluded — see the
+                // note on `ExportedTask`.)
+                isolationMode: task.isolationMode ?? null,
+                acceptanceChecks: Array.isArray(task.acceptanceChecks)
+                    ? task.acceptanceChecks
+                    : null,
+                maxGateAttempts:
+                    typeof task.maxGateAttempts === 'number' ? task.maxGateAttempts : null,
                 createdAt: task.createdAt.toISOString(),
                 startedAt: task.startedAt?.toISOString() ?? null,
                 completedAt: task.completedAt?.toISOString() ?? null,

--- a/packages/agent/src/account-transfer/agents-skills-tasks-import.service.spec.ts
+++ b/packages/agent/src/account-transfer/agents-skills-tasks-import.service.spec.ts
@@ -1,0 +1,169 @@
+import { AgentsSkillsTasksImportService } from './agents-skills-tasks-import.service';
+import type { ExportedTask } from './agents-skills-tasks-types';
+
+/**
+ * Account-transfer whitelist sweep — the v2 payload tail's Task side.
+ *
+ * Task isolation (`isolationMode`) and the quality-gate settings
+ * (`acceptanceChecks`, `maxGateAttempts`) are user-authored settings that
+ * previously did NOT round-trip: the tail carried title/status/priority
+ * and the recurrence block only, so importing a Task silently reset the
+ * isolation override and every curated acceptance check back to
+ * "inherit".
+ *
+ * Import posture, identical to every other imported field:
+ *   * `null` is MEANINGFUL (= inherit the Work's value) and is preserved;
+ *   * arrays only ever apply when they really are arrays;
+ *   * unrecognized enum values and out-of-range budgets are DROPPED —
+ *     never defaulted, never clamped — so a hand-edited payload cannot
+ *     launder a bogus value into a legitimate-looking setting.
+ */
+describe('AgentsSkillsTasksImportService — Task settings round-trip', () => {
+    function makeSvc() {
+        const agentExport = { importOne: jest.fn().mockResolvedValue({}) };
+        const skillsService = { create: jest.fn().mockResolvedValue({}) };
+        const tasksService = { create: jest.fn().mockResolvedValue({ id: 't-new' }) };
+        const svc = new AgentsSkillsTasksImportService(
+            agentExport as any,
+            skillsService as any,
+            tasksService as any,
+        );
+        return { svc, agentExport, skillsService, tasksService };
+    }
+
+    function makeTask(overrides: Partial<ExportedTask> = {}): ExportedTask {
+        return {
+            __kind: 'task',
+            slug: 'T-1',
+            title: 'Ship it',
+            description: null,
+            status: 'todo',
+            priority: 'p3',
+            labels: null,
+            missionSourceId: null,
+            ideaSourceId: null,
+            workSourceId: null,
+            parentTaskSlug: null,
+            isRecurring: false,
+            recurrenceRule: null,
+            recurrenceTimezone: null,
+            recurrenceEndsAt: null,
+            recurrenceMaxOccurrences: null,
+            parentRecurringTaskSlug: null,
+            assignees: [],
+            reviewers: [],
+            approvers: [],
+            requireAllApprovers: true,
+            createdAt: '2026-07-01T00:00:00.000Z',
+            ...overrides,
+        };
+    }
+
+    const CHECKS = [
+        {
+            id: 'build',
+            name: 'Build',
+            kind: 'build' as const,
+            command: 'pnpm build',
+            required: true,
+        },
+    ];
+
+    it('applies isolationMode, acceptanceChecks and maxGateAttempts', async () => {
+        const { svc, tasksService } = makeSvc();
+
+        const summary = await svc.importTail(
+            'u1',
+            {
+                tasks: [
+                    makeTask({
+                        isolationMode: 'on',
+                        acceptanceChecks: CHECKS,
+                        maxGateAttempts: 4,
+                    }),
+                ],
+            },
+            { importTasks: true },
+        );
+
+        expect(summary.tasks.imported).toBe(1);
+        expect(tasksService.create).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({
+                isolationMode: 'on',
+                acceptanceChecks: CHECKS,
+                maxGateAttempts: 4,
+            }),
+        );
+    });
+
+    it('preserves an explicit null (= inherit the Work setting)', async () => {
+        const { svc, tasksService } = makeSvc();
+
+        await svc.importTail(
+            'u1',
+            {
+                tasks: [
+                    makeTask({
+                        isolationMode: null,
+                        acceptanceChecks: null,
+                        maxGateAttempts: null,
+                    }),
+                ],
+            },
+            { importTasks: true },
+        );
+
+        const input = tasksService.create.mock.calls[0][1];
+        expect(input.isolationMode).toBeNull();
+        expect(input.acceptanceChecks).toBeNull();
+        expect(input.maxGateAttempts).toBeNull();
+    });
+
+    it('drops an unrecognized isolationMode instead of defaulting it', async () => {
+        const { svc, tasksService } = makeSvc();
+
+        await svc.importTail(
+            'u1',
+            { tasks: [makeTask({ isolationMode: 'always-on' as any })] },
+            { importTasks: true },
+        );
+
+        expect('isolationMode' in tasksService.create.mock.calls[0][1]).toBe(false);
+    });
+
+    it('drops a non-array acceptanceChecks value', async () => {
+        const { svc, tasksService } = makeSvc();
+
+        await svc.importTail(
+            'u1',
+            { tasks: [makeTask({ acceptanceChecks: 'pnpm build' as any })] },
+            { importTasks: true },
+        );
+
+        expect('acceptanceChecks' in tasksService.create.mock.calls[0][1]).toBe(false);
+    });
+
+    it('drops an out-of-range maxGateAttempts rather than clamping it', async () => {
+        const { svc, tasksService } = makeSvc();
+
+        await svc.importTail(
+            'u1',
+            { tasks: [makeTask({ maxGateAttempts: 99 })] },
+            { importTasks: true },
+        );
+
+        expect('maxGateAttempts' in tasksService.create.mock.calls[0][1]).toBe(false);
+    });
+
+    it('omits all three for a pre-sweep payload that never carried them', async () => {
+        const { svc, tasksService } = makeSvc();
+
+        await svc.importTail('u1', { tasks: [makeTask()] }, { importTasks: true });
+
+        const input = tasksService.create.mock.calls[0][1];
+        expect('isolationMode' in input).toBe(false);
+        expect('acceptanceChecks' in input).toBe(false);
+        expect('maxGateAttempts' in input).toBe(false);
+    });
+});

--- a/packages/agent/src/account-transfer/agents-skills-tasks-import.service.ts
+++ b/packages/agent/src/account-transfer/agents-skills-tasks-import.service.ts
@@ -2,10 +2,46 @@ import { Injectable, Logger } from '@nestjs/common';
 import { AgentExportService } from '../agents/agent-export.service';
 import { SkillsService } from '../skills/skills.service';
 import { TasksService } from '../tasks-domain/tasks.service';
+import type { TaskAcceptanceCheck } from '@ever-works/contracts';
 import {
     type AccountExportV2Tail,
     type AgentsSkillsTasksImportOptions,
 } from './agents-skills-tasks-types';
+
+/** Per-Task isolation override values (drop-if-unrecognized on import). */
+const TASK_ISOLATION_MODES: readonly string[] = ['on', 'off'];
+
+/**
+ * Task isolation override from an untrusted payload. `null` is MEANINGFUL
+ * (= inherit the Work's setting) and is preserved; an unrecognized string
+ * is dropped (treated as absent) rather than defaulted.
+ */
+function normalizeImportedIsolationMode(value: unknown): 'on' | 'off' | null | undefined {
+    if (value === null) return null;
+    return typeof value === 'string' && TASK_ISOLATION_MODES.includes(value)
+        ? (value as 'on' | 'off')
+        : undefined;
+}
+
+/** Task acceptance checks: arrays only ever import as arrays; `null` = inherit. */
+function normalizeImportedAcceptanceChecks(
+    value: unknown,
+): TaskAcceptanceCheck[] | null | undefined {
+    if (value === null) return null;
+    return Array.isArray(value) ? (value as TaskAcceptanceCheck[]) : undefined;
+}
+
+/**
+ * Task gate-attempt budget: integers inside the resolve-time clamp range
+ * only. `null` = inherit the Work's value and is preserved; out-of-range
+ * values are dropped, never clamped.
+ */
+function normalizeImportedMaxGateAttempts(value: unknown): number | null | undefined {
+    if (value === null) return null;
+    return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 5
+        ? value
+        : undefined;
+}
 
 export interface AgentsSkillsTasksImportSummary {
     agents: { imported: number; skipped: number; errors: string[] };
@@ -107,6 +143,18 @@ export class AgentsSkillsTasksImportService {
             // missionId/ideaId/workId).
             for (const task of tail.tasks) {
                 try {
+                    // User-authored Task settings round-trip with the same
+                    // posture as every other imported field: `null` means
+                    // "inherit" and is preserved, arrays only apply when
+                    // they really are arrays, and unrecognized enum / out
+                    // of range values are DROPPED (never defaulted, never
+                    // clamped) so a hand-edited payload cannot reset an
+                    // isolation or gate setting into something plausible.
+                    const isolationMode = normalizeImportedIsolationMode(task.isolationMode);
+                    const acceptanceChecks = normalizeImportedAcceptanceChecks(
+                        task.acceptanceChecks,
+                    );
+                    const maxGateAttempts = normalizeImportedMaxGateAttempts(task.maxGateAttempts);
                     await this.tasksService.create(userId, {
                         title: task.title,
                         description: task.description ?? null,
@@ -119,6 +167,9 @@ export class AgentsSkillsTasksImportService {
                         createdByType: 'user',
                         createdById: userId,
                         requireAllApprovers: task.requireAllApprovers,
+                        ...(isolationMode !== undefined ? { isolationMode } : {}),
+                        ...(acceptanceChecks !== undefined ? { acceptanceChecks } : {}),
+                        ...(maxGateAttempts !== undefined ? { maxGateAttempts } : {}),
                     });
                     summary.tasks.imported += 1;
                 } catch (err) {

--- a/packages/agent/src/account-transfer/agents-skills-tasks-types.ts
+++ b/packages/agent/src/account-transfer/agents-skills-tasks-types.ts
@@ -1,3 +1,4 @@
+import type { TaskAcceptanceCheck } from '@ever-works/contracts';
 import type { AgentExportEnvelope } from '../agents/agent-export.service';
 
 /**
@@ -93,10 +94,40 @@ export interface ExportedTask {
     reviewers: Array<{ type: 'user' | 'agent'; identifier: string }>;
     approvers: Array<{ type: 'user' | 'agent'; identifier: string }>;
     requireAllApprovers: boolean;
+    /**
+     * Per-Task override of the Work's isolation setting: `'on' | 'off'`,
+     * `null` = inherit. A user-authored setting, so it round-trips;
+     * drop-if-unrecognized on import.
+     */
+    isolationMode?: string | null;
+    /**
+     * Task-level acceptance checks (quality gates). `null` = inherit the
+     * Work's `checkDefaults`. Arrays only ever import as arrays.
+     */
+    acceptanceChecks?: TaskAcceptanceCheck[] | null;
+    /**
+     * Task-level gate-attempt budget. `null` = inherit the Work's value.
+     * Out-of-range values are dropped on import, never clamped — clamping
+     * would launder a bogus payload value into a legitimate-looking setting.
+     */
+    maxGateAttempts?: number | null;
     createdAt: string;
     startedAt?: string | null;
     completedAt?: string | null;
     chat?: ExportedTaskChatMessage[];
+    // NOTE — the Task BRANCH columns (`branchRef`, `branchState`,
+    // `baseSha`, `prNumber`, `prUrl`, `conflictPaths`) and the latest-run
+    // denorm (`latestRunId`, `latestRunStatus`) are DELIBERATELY absent,
+    // and that omission is correct rather than the usual "new column
+    // forgotten in the transfer whitelist" bug. They are not settings —
+    // they are live runtime state naming a git ref, a base commit and a
+    // pull request inside the EXPORTING account's repository, plus a
+    // pointer to an AgentRun row that is not part of this envelope.
+    // Replaying them would give the imported Task a branch/PR/run identity
+    // it does not own, so the importer's isolation flow would resume
+    // against someone else's branch instead of provisioning its own. An
+    // imported Task therefore starts with clean branch state and engages
+    // isolation from scratch on its first run.
 }
 
 /**

--- a/packages/agent/src/account-transfer/types.ts
+++ b/packages/agent/src/account-transfer/types.ts
@@ -7,10 +7,64 @@ import type { TaskAcceptanceCheck } from '@ever-works/contracts';
 
 // ─── Export Types ────────────────────────────────────────────────
 
+/**
+ * The "What do you do" onboarding answers (`users.onboardingState.profile`).
+ * Values are plain strings — never the narrowed id unions — so a payload
+ * written by a newer build still parses here; both import paths validate
+ * against `ROLE_OPTIONS` / `TEAM_SIZE_OPTIONS` and DROP unrecognised
+ * values (never default them).
+ */
+export interface ExportedOnboardingProfile {
+    roles?: string[];
+    teamSize?: string;
+}
+
+/**
+ * Account-level preferences the user authored explicitly. Every field is
+ * optional so pre-preferences payloads keep importing; absent = leave the
+ * importing account's own value alone.
+ *
+ * `digestFrequency` is an enum on the wire and is drop-if-unrecognized on
+ * both import paths; the booleans are applied only when they really are
+ * booleans (a deliberate `false` — e.g. an email opt-out — must survive the
+ * round-trip, so these can never be collapsed to "truthy means set").
+ */
+export interface ExportedUserPreferences {
+    /** 'off' | 'daily' | 'weekly' — drop-if-unrecognized on import. */
+    digestFrequency?: string;
+    emailAgentAlerts?: boolean;
+    emailTaskNotifications?: boolean;
+    emailBudgetAlerts?: boolean;
+    /** Privacy opt-out — a deliberate `true` must survive the round-trip. */
+    userResearchOptOut?: boolean;
+}
+
 export interface ExportedProfile {
     username: string;
     email: string;
     avatar?: string;
+    /** Onboarding "What do you do" answers (roles + team size). */
+    onboarding?: ExportedOnboardingProfile;
+    /** Digest cadence + notification/privacy opt-ins. */
+    preferences?: ExportedUserPreferences;
+    // NOTE — the following user columns are DELIBERATELY absent from this
+    // envelope, and their omission is correct behaviour, not the usual
+    // "new column forgotten in the transfer whitelist" bug:
+    //   * `isPlatformAdmin` — the envelope is an attacker-editable JSON
+    //     file; carrying an admin flag across accounts would be a
+    //     straight privilege escalation on import (same reasoning that
+    //     clamps `AgentExportEnvelope.runtime.permissions` and omits
+    //     `works.mergePolicy`, below).
+    //   * Credits ledger + plan entitlements — money. Balances are earned
+    //     or bought in ONE account and must never be minted by importing
+    //     a JSON file into another.
+    //   * Fleet nodes — machine identity. A node row is a hashed
+    //     credential bound to a physical machine that enrolled against
+    //     THIS deployment; re-materialising it elsewhere would hand the
+    //     importer a registration it never performed.
+    //   * `tenantId` / `organizationId` / `defaultPlanId` — scope and
+    //     billing pointers that only mean anything inside the exporting
+    //     deployment. The importing account resolves its own.
 }
 
 export interface ExportedWorkMember {
@@ -271,6 +325,12 @@ export interface ImportResult {
     worksUpdated: number;
     worksSkipped: number;
     userPluginsImported: number;
+    /**
+     * True when the payload's account-level profile (onboarding answers /
+     * preferences) wrote at least one column. Optional so pre-existing
+     * callers constructing an `ImportResult` literal keep compiling.
+     */
+    profileImported?: boolean;
     errors: string[];
     warnings: string[];
 }

--- a/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-export.service.spec.ts
@@ -106,6 +106,24 @@ describe('AgentExportService', () => {
                 expect.objectContaining({ actionType: ActivityActionType.AGENT_EXPORTED }),
             );
         });
+
+        // Account-transfer whitelist sweep: `memoryRecallEnabled` is a
+        // user-authored Agent setting and previously did NOT round-trip, so
+        // an export/import silently re-enabled recall on an Agent whose
+        // owner had deliberately turned it off.
+        it('carries memoryRecallEnabled, including a deliberate false', async () => {
+            agents.findByIdAndUser.mockResolvedValueOnce(
+                makeAgent({ memoryRecallEnabled: false } as any),
+            );
+            const env = await svc.exportOne('u1', 'src-a');
+            expect(env.model.memoryRecallEnabled).toBe(false);
+        });
+
+        it('omits memoryRecallEnabled when the column is absent (legacy row)', async () => {
+            agents.findByIdAndUser.mockResolvedValueOnce(makeAgent());
+            const env = await svc.exportOne('u1', 'src-a');
+            expect('memoryRecallEnabled' in env.model).toBe(false);
+        });
     });
 
     describe('importOne', () => {
@@ -183,6 +201,48 @@ describe('AgentExportService', () => {
             expect(activity.log).toHaveBeenCalledWith(
                 expect.objectContaining({ actionType: ActivityActionType.AGENT_IMPORTED }),
             );
+        });
+
+        // Whitelist sweep — BOTH import paths must honour an explicit
+        // boolean and must leave the setting alone when it is absent.
+        it('applies an explicit memoryRecallEnabled:false on create', async () => {
+            agents.findByUserIdAndSlug.mockResolvedValue(null);
+            agents.create.mockResolvedValueOnce(makeAgent({ id: 'new-a' }));
+            const env = baseEnvelope();
+            env.model.memoryRecallEnabled = false;
+
+            await svc.importOne('u1', env);
+            expect(agents.create).toHaveBeenCalledWith(
+                expect.objectContaining({ memoryRecallEnabled: false }),
+            );
+        });
+
+        it('omits memoryRecallEnabled on create for a pre-recall envelope', async () => {
+            agents.findByUserIdAndSlug.mockResolvedValue(null);
+            agents.create.mockResolvedValueOnce(makeAgent({ id: 'new-a' }));
+
+            await svc.importOne('u1', baseEnvelope());
+            expect('memoryRecallEnabled' in agents.create.mock.calls[0][0]).toBe(false);
+        });
+
+        it('applies memoryRecallEnabled on the overwrite path, and omits it when absent', async () => {
+            const existing = makeAgent({ id: 'existing-ceo' });
+            agents.findByUserIdAndSlug.mockResolvedValueOnce(existing);
+            agents.findById.mockResolvedValueOnce(existing);
+            const env = baseEnvelope();
+            env.model.memoryRecallEnabled = false;
+
+            await svc.importOne('u1', env, { onConflict: 'overwrite' });
+            expect(agents.updateById).toHaveBeenCalledWith(
+                'existing-ceo',
+                expect.objectContaining({ memoryRecallEnabled: false }),
+            );
+
+            agents.updateById.mockClear();
+            agents.findByUserIdAndSlug.mockResolvedValueOnce(existing);
+            agents.findById.mockResolvedValueOnce(existing);
+            await svc.importOne('u1', baseEnvelope(), { onConflict: 'overwrite' });
+            expect('memoryRecallEnabled' in agents.updateById.mock.calls[0][1]).toBe(false);
         });
 
         it('conflict skip — throws ConflictException', async () => {

--- a/packages/agent/src/agents/agent-export.service.ts
+++ b/packages/agent/src/agents/agent-export.service.ts
@@ -117,6 +117,14 @@ export interface AgentExportEnvelope {
         aiProviderId: string | null;
         modelId: string | null;
         maxSkillContextTokens: number;
+        /**
+         * Memory-recall injection toggle. Optional so pre-recall envelopes
+         * keep importing; absent = leave the target Agent's own setting
+         * alone. A deliberate `false` must survive an export/import round
+         * trip — omitting it would silently re-enable recall on the
+         * imported Agent. Applied only when it really is a boolean.
+         */
+        memoryRecallEnabled?: boolean;
     };
     runtime: {
         permissions: AgentPermissions;
@@ -262,6 +270,9 @@ export class AgentExportService {
                 aiProviderId: agent.aiProviderId ?? null,
                 modelId: agent.modelId ?? null,
                 maxSkillContextTokens: agent.maxSkillContextTokens,
+                ...(typeof agent.memoryRecallEnabled === 'boolean'
+                    ? { memoryRecallEnabled: agent.memoryRecallEnabled }
+                    : {}),
             },
             runtime: {
                 permissions: agent.permissions ?? AGENT_PERMISSIONS_DEFAULT,
@@ -451,6 +462,11 @@ export class AgentExportService {
             aiProviderId: envelope.model.aiProviderId,
             modelId: envelope.model.modelId,
             maxSkillContextTokens: envelope.model.maxSkillContextTokens,
+            // Recall toggle: apply only an explicit boolean (notably
+            // `false`); absent in pre-recall envelopes → the column default.
+            ...(typeof envelope.model.memoryRecallEnabled === 'boolean'
+                ? { memoryRecallEnabled: envelope.model.memoryRecallEnabled }
+                : {}),
             status: AgentStatus.DRAFT, // imported Agents always start in DRAFT — user vets before activating
             permissions,
             targets: envelope.runtime.targets,
@@ -614,6 +630,12 @@ export class AgentExportService {
             aiProviderId: envelope.model.aiProviderId,
             modelId: envelope.model.modelId,
             maxSkillContextTokens: envelope.model.maxSkillContextTokens,
+            // Recall toggle on the overwrite path too — explicit boolean
+            // only, so an old envelope can't silently re-enable recall on
+            // an existing Agent that deliberately turned it off.
+            ...(typeof envelope.model.memoryRecallEnabled === 'boolean'
+                ? { memoryRecallEnabled: envelope.model.memoryRecallEnabled }
+                : {}),
             // Security (D9): clamp imported permissions to least-privilege
             // on the overwrite path too — the envelope is attacker-editable,
             // so an overwrite import must NOT silently elevate an existing

--- a/packages/agent/src/database/_entities-inventory.ts
+++ b/packages/agent/src/database/_entities-inventory.ts
@@ -115,6 +115,7 @@ import { TenantCredentialSnapshot } from '../entities/tenant-credential-snapshot
 import { InboundTrigger } from '../entities/inbound-trigger.entity';
 import { IngestedEvent } from '../entities/ingested-event.entity';
 import { IngestCursor } from '../entities/ingest-cursor.entity';
+import { IngestInstallBinding } from '../entities/ingest-install-binding.entity';
 import { Meeting } from '../entities/meeting.entity';
 import { CreditLedgerEntry } from '../entities/credit-ledger-entry.entity';
 import { PlanEntitlement } from '../entities/plan-entitlement.entity';
@@ -261,6 +262,10 @@ export const ENTITIES = [
     // Event-ingest pull path (Wave 8) — per-(user, plugin) event-source
     // pull watermarks + continuation cursors.
     IngestCursor,
+    // Inbound receivers — external workspace/installation → platform user
+    // binding, so Slack/GitHub deliveries are attributed to the account
+    // that actually owns the workspace instead of the oldest install.
+    IngestInstallBinding,
     // Meetings v1 (Wave 8, feature a) — captured meetings with
     // transcripts, summaries and provider dedupe.
     Meeting,

--- a/packages/agent/src/database/_entity-names.ts
+++ b/packages/agent/src/database/_entity-names.ts
@@ -75,6 +75,8 @@ export const AGENT_ENTITY_NAMES: ReadonlyArray<string> = [
     'InboundTrigger',
     // Event-ingest pull path (Wave 8) — per-(user, plugin) pull cursors
     'IngestCursor',
+    // Inbound receivers — workspace/installation → platform user binding
+    'IngestInstallBinding',
     // Event-ingest spine (Wave 6) — normalized external events
     'IngestedEvent',
     // Meetings v1 (Wave 8, feature a) — captured meetings w/ transcripts

--- a/packages/agent/src/entities/index.ts
+++ b/packages/agent/src/entities/index.ts
@@ -118,6 +118,8 @@ export * from './inbound-trigger.entity';
 export * from './ingested-event.entity';
 // Event-ingest pull path (Wave 8) — per-(user, plugin) pull watermarks/cursors
 export * from './ingest-cursor.entity';
+// Inbound receivers — external workspace/installation → platform user binding
+export * from './ingest-install-binding.entity';
 // Meetings v1 (Wave 8, feature a) — captured meetings with transcripts
 export * from './meeting.entity';
 // Credits ledger + plan entitlements (pricing Wave 9 M1)

--- a/packages/agent/src/entities/ingest-install-binding.entity.ts
+++ b/packages/agent/src/entities/ingest-install-binding.entity.ts
@@ -1,0 +1,114 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Per-workspace / per-installation binding for INBOUND event receivers.
+ *
+ * Problem it fixes: both `SlackChatBridgeService` and
+ * `GitHubPrReviewBridgeService` used to resolve "the oldest enabled
+ * install platform-wide" and attribute EVERY inbound delivery to that one
+ * platform user. In a hosted multi-tenant deployment that is a
+ * data-isolation defect, not a limitation: a second customer's Slack
+ * workspace or GitHub repository would have its messages, diffs and AI
+ * replies executed under — and billed to — the first customer's account.
+ *
+ * The fix binds each external workspace/installation identity carried on
+ * the webhook to exactly one platform user:
+ *
+ *   * Slack    — `team_id` (plus `enterprise_id` when the delivery
+ *                carries one, for Enterprise Grid).
+ *   * GitHub   — the App `installation.id` when present, otherwise the
+ *                repository owner login. Both are stored in
+ *                `externalWorkspaceId` under a disambiguating prefix
+ *                (`installation:123` / `owner:acme`) so the two
+ *                namespaces can never collide.
+ *
+ * ## Why a table rather than a plugin-settings field
+ *
+ *  1. **Cardinality.** One platform user may legitimately own several
+ *     Slack workspaces or GitHub installations. Plugin settings are a
+ *     single row per (user, plugin), so a scalar `teamId` field cannot
+ *     express the relation without inventing an array-in-JSON.
+ *  2. **Direction of the lookup.** Resolution runs workspace → user, the
+ *     REVERSE of how settings are keyed. Over settings, every inbound
+ *     webhook would have to load and DECRYPT the secret settings of every
+ *     install just to find the owner — O(installs) decryptions per
+ *     request on a public, unauthenticated endpoint. Here it is one
+ *     indexed row.
+ *  3. **Trust.** Plugin settings are user-editable, so a user could type
+ *     another tenant's `team_id` into their own settings and hijack that
+ *     tenant's events. Rows in this table are written by the SERVER only,
+ *     and only after a delivery has passed signature verification — the
+ *     binding is a record of proven ownership, never a user claim.
+ *
+ * Rows are additive and self-healing: a deployment that predates this
+ * table keeps working through the single-install fallback in the bridges,
+ * which records the binding on the first signature-verified delivery.
+ *
+ * NOTE: also registered in `database/_entities-inventory.ts` — this repo
+ * has no `autoLoadEntities`, so a forFeature'd-but-unregistered entity
+ * throws EntityMetadataNotFoundError on first query.
+ */
+
+/** Inbound receiver this binding belongs to. */
+export type IngestInstallProvider = 'slack' | 'github';
+
+@Entity({ name: 'ingest_install_bindings' })
+@Index('idx_ingest_install_bindings_workspace', ['provider', 'externalWorkspaceId'], {
+    unique: true,
+})
+@Index('idx_ingest_install_bindings_user', ['userId'])
+export class IngestInstallBinding {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    /**
+     * Receiver namespace. Deliberately a varchar (not an enum) so a new
+     * inbound surface ships without a schema change — same convention as
+     * `fleet_nodes.kind`.
+     */
+    @Column({ type: 'varchar', length: 32 })
+    provider: string;
+
+    /**
+     * The external workspace / installation identity carried on the
+     * webhook. Slack: the raw `team_id`. GitHub: `installation:<id>` or
+     * `owner:<login>`. Unique per provider — one workspace has exactly one
+     * owning platform user.
+     */
+    @Column({ type: 'varchar', length: 200 })
+    externalWorkspaceId: string;
+
+    /**
+     * Slack `enterprise_id` when the delivery carries one (Enterprise
+     * Grid). NULL for ordinary workspaces and for GitHub. When a stored
+     * value is present it must match the incoming delivery, otherwise the
+     * binding does NOT apply and the receiver refuses rather than guesses.
+     */
+    @Column({ type: 'varchar', length: 200, nullable: true })
+    externalEnterpriseId?: string | null;
+
+    /** Platform user every event from this workspace is attributed to. */
+    @Column({ type: 'uuid' })
+    userId: string;
+
+    /** Plugin install the binding resolves through ('slack-connector' / 'github'). */
+    @Column({ type: 'varchar', length: 64 })
+    pluginId: string;
+
+    /** Human-readable workspace/repo-owner label, for the settings UI. */
+    @Column({ type: 'varchar', length: 200, nullable: true })
+    externalWorkspaceName?: string | null;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+}

--- a/packages/agent/src/ingest/__tests__/ingest-install-binding.repository.spec.ts
+++ b/packages/agent/src/ingest/__tests__/ingest-install-binding.repository.spec.ts
@@ -1,0 +1,120 @@
+jest.mock('@nestjs/typeorm', () => ({
+    InjectRepository: () => () => undefined,
+}));
+jest.mock('../../entities/ingest-install-binding.entity', () => ({
+    IngestInstallBinding: class IngestInstallBinding {},
+}));
+
+import { IngestInstallBindingRepository } from '../ingest-install-binding.repository';
+
+/**
+ * Workspace/installation → platform user bindings for the inbound
+ * receivers. Every method runs on a PUBLIC webhook hot path, so the
+ * contract is: exact indexed reads, and a write that resolves the
+ * UNIQUE-index race by adopting the winner rather than throwing.
+ */
+describe('IngestInstallBindingRepository', () => {
+    function makeRepo() {
+        const repository = {
+            findOne: jest.fn().mockResolvedValue(null),
+            find: jest.fn().mockResolvedValue([]),
+            count: jest.fn().mockResolvedValue(0),
+            create: jest.fn((data: unknown) => data),
+            save: jest.fn(async (row: unknown) => row),
+        };
+        return { repo: new IngestInstallBindingRepository(repository as any), repository };
+    }
+
+    it('looks a workspace up by (provider, externalWorkspaceId)', async () => {
+        const { repo, repository } = makeRepo();
+        await repo.findByWorkspace('slack', 'T-AAA');
+        expect(repository.findOne).toHaveBeenCalledWith({
+            where: { provider: 'slack', externalWorkspaceId: 'T-AAA' },
+        });
+    });
+
+    it('never queries for an empty workspace id', async () => {
+        const { repo, repository } = makeRepo();
+        expect(await repo.findByWorkspace('slack', '')).toBeNull();
+        expect(repository.findOne).not.toHaveBeenCalled();
+    });
+
+    it('inserts a new binding with the enterprise id normalized to null', async () => {
+        const { repo, repository } = makeRepo();
+        await repo.record({
+            provider: 'github',
+            externalWorkspaceId: 'owner:octo',
+            userId: 'u-a',
+            pluginId: 'github',
+        });
+        expect(repository.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+                provider: 'github',
+                externalWorkspaceId: 'owner:octo',
+                externalEnterpriseId: null,
+                userId: 'u-a',
+                pluginId: 'github',
+            }),
+        );
+    });
+
+    it('re-points an existing binding instead of inserting a duplicate', async () => {
+        const { repo, repository } = makeRepo();
+        const existing = {
+            id: 'b-1',
+            provider: 'slack',
+            externalWorkspaceId: 'T-AAA',
+            externalEnterpriseId: null,
+            userId: 'u-old',
+            pluginId: 'slack-connector',
+        };
+        repository.findOne.mockResolvedValue(existing);
+
+        await repo.record({
+            provider: 'slack',
+            externalWorkspaceId: 'T-AAA',
+            externalEnterpriseId: 'E-ONE',
+            userId: 'u-new',
+            pluginId: 'slack-connector',
+        });
+
+        expect(repository.create).not.toHaveBeenCalled();
+        expect(repository.save).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: 'b-1',
+                userId: 'u-new',
+                externalEnterpriseId: 'E-ONE',
+            }),
+        );
+    });
+
+    it('adopts the winner when a concurrent first delivery lost the UNIQUE race', async () => {
+        const { repo, repository } = makeRepo();
+        const winner = { id: 'b-winner', userId: 'u-a' };
+        repository.save.mockRejectedValueOnce(new Error('UNIQUE constraint failed'));
+        repository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(winner);
+
+        const result = await repo.record({
+            provider: 'slack',
+            externalWorkspaceId: 'T-AAA',
+            userId: 'u-a',
+            pluginId: 'slack-connector',
+        });
+
+        expect(result).toBe(winner);
+    });
+
+    it('returns null (never throws) when the insert fails and no winner exists', async () => {
+        const { repo, repository } = makeRepo();
+        repository.save.mockRejectedValue(new Error('db down'));
+
+        await expect(
+            repo.record({
+                provider: 'slack',
+                externalWorkspaceId: 'T-AAA',
+                userId: 'u-a',
+                pluginId: 'slack-connector',
+            }),
+        ).resolves.toBeNull();
+    });
+});

--- a/packages/agent/src/ingest/__tests__/ingest.module.spec.ts
+++ b/packages/agent/src/ingest/__tests__/ingest.module.spec.ts
@@ -19,6 +19,9 @@ jest.mock('../../entities/ingested-event.entity', () => ({
 jest.mock('../../entities/ingest-cursor.entity', () => ({
     IngestCursor: class IngestCursor {},
 }));
+jest.mock('../../entities/ingest-install-binding.entity', () => ({
+    IngestInstallBinding: class IngestInstallBinding {},
+}));
 jest.mock('../../activity-log/activity-log.module', () => ({
     ActivityLogModule: class ActivityLogModule {},
 }));
@@ -37,6 +40,9 @@ jest.mock('../ingest-cursor.repository', () => ({
 jest.mock('../event-source-pull.service', () => ({
     EventSourcePullService: class EventSourcePullService {},
 }));
+jest.mock('../ingest-install-binding.repository', () => ({
+    IngestInstallBindingRepository: class IngestInstallBindingRepository {},
+}));
 
 import 'reflect-metadata';
 import { EventIngestModule } from '../ingest.module';
@@ -44,6 +50,7 @@ import { IngestedEventRepository } from '../ingested-event.repository';
 import { EventIngestService } from '../event-ingest.service';
 import { IngestCursorRepository } from '../ingest-cursor.repository';
 import { EventSourcePullService } from '../event-source-pull.service';
+import { IngestInstallBindingRepository } from '../ingest-install-binding.repository';
 import { ActivityLogModule } from '../../activity-log/activity-log.module';
 import { FacadesModule } from '../../facades/facades.module';
 
@@ -56,15 +63,17 @@ describe('EventIngestModule', () => {
             EventIngestService,
             IngestCursorRepository,
             EventSourcePullService,
+            IngestInstallBindingRepository,
         ]);
     });
 
-    it('exports all four for the API surface + trigger-internal RPC wiring', () => {
+    it('exports all five for the API surface + trigger-internal RPC wiring', () => {
         expect(meta('exports')).toEqual([
             IngestedEventRepository,
             EventIngestService,
             IngestCursorRepository,
             EventSourcePullService,
+            IngestInstallBindingRepository,
         ]);
     });
 
@@ -86,6 +95,7 @@ describe('ingest barrel', () => {
         expect(barrel.IngestedEventRepository).toBe(IngestedEventRepository);
         expect(barrel.EventSourcePullService).toBe(EventSourcePullService);
         expect(barrel.IngestCursorRepository).toBe(IngestCursorRepository);
+        expect(barrel.IngestInstallBindingRepository).toBe(IngestInstallBindingRepository);
         expect(typeof barrel.buildIngestEventTools).toBe('function');
     });
 });

--- a/packages/agent/src/ingest/index.ts
+++ b/packages/agent/src/ingest/index.ts
@@ -6,6 +6,11 @@ export * from './event-ingest.service';
 export * from './ingested-event.repository';
 export * from './event-source-pull.service';
 export * from './ingest-cursor.repository';
+export * from './ingest-install-binding.repository';
 export * from './agent-ingest-tools';
 export { IngestedEvent } from '../entities/ingested-event.entity';
 export { IngestCursor } from '../entities/ingest-cursor.entity';
+export {
+    IngestInstallBinding,
+    type IngestInstallProvider,
+} from '../entities/ingest-install-binding.entity';

--- a/packages/agent/src/ingest/ingest-install-binding.repository.ts
+++ b/packages/agent/src/ingest/ingest-install-binding.repository.ts
@@ -1,0 +1,101 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+    IngestInstallBinding,
+    type IngestInstallProvider,
+} from '../entities/ingest-install-binding.entity';
+
+export interface RecordIngestBindingData {
+    provider: IngestInstallProvider;
+    externalWorkspaceId: string;
+    externalEnterpriseId?: string | null;
+    userId: string;
+    pluginId: string;
+    externalWorkspaceName?: string | null;
+}
+
+/**
+ * Per-workspace / per-installation bindings for the inbound receivers
+ * (see `IngestInstallBinding`). Feature-owned repository provided by
+ * `EventIngestModule` — same split as `IngestedEventRepository` and
+ * `IngestCursorRepository`.
+ *
+ * Every method is safe to call on the webhook hot path: reads are a
+ * single indexed lookup and the write is check-then-insert with the
+ * UNIQUE-index race resolved by retrying as an update (same convention
+ * as `IngestCursorRepository.save`).
+ */
+@Injectable()
+export class IngestInstallBindingRepository {
+    private readonly logger = new Logger(IngestInstallBindingRepository.name);
+
+    constructor(
+        @InjectRepository(IngestInstallBinding)
+        private readonly repository: Repository<IngestInstallBinding>,
+    ) {}
+
+    /** Exact binding for one external workspace, or null. */
+    async findByWorkspace(
+        provider: IngestInstallProvider,
+        externalWorkspaceId: string,
+    ): Promise<IngestInstallBinding | null> {
+        if (!externalWorkspaceId) return null;
+        return this.repository.findOne({ where: { provider, externalWorkspaceId } });
+    }
+
+    /** Every binding owned by one platform user (settings UI / diagnostics). */
+    async findByUser(userId: string): Promise<IngestInstallBinding[]> {
+        return this.repository.find({ where: { userId }, order: { createdAt: 'ASC' } });
+    }
+
+    /** Count of bindings for a provider — used to reason about ambiguity. */
+    async countByProvider(provider: IngestInstallProvider): Promise<number> {
+        return this.repository.count({ where: { provider } });
+    }
+
+    /**
+     * Record (or re-point) the binding for one external workspace.
+     *
+     * Callers MUST only invoke this after a delivery has passed signature
+     * verification — the row is a record of proven ownership, never a
+     * user-supplied claim.
+     */
+    async record(data: RecordIngestBindingData): Promise<IngestInstallBinding | null> {
+        if (!data.externalWorkspaceId) return null;
+        const existing = await this.findByWorkspace(data.provider, data.externalWorkspaceId);
+        if (existing) {
+            existing.userId = data.userId;
+            existing.pluginId = data.pluginId;
+            existing.externalEnterpriseId = data.externalEnterpriseId ?? null;
+            if (data.externalWorkspaceName) {
+                existing.externalWorkspaceName = data.externalWorkspaceName;
+            }
+            return this.repository.save(existing);
+        }
+        try {
+            return await this.repository.save(
+                this.repository.create({
+                    provider: data.provider,
+                    externalWorkspaceId: data.externalWorkspaceId,
+                    externalEnterpriseId: data.externalEnterpriseId ?? null,
+                    userId: data.userId,
+                    pluginId: data.pluginId,
+                    externalWorkspaceName: data.externalWorkspaceName ?? null,
+                }),
+            );
+        } catch (error) {
+            // Concurrent first-delivery from the same workspace — the
+            // UNIQUE index picked a winner; adopt it rather than throw on
+            // a public webhook path.
+            const winner = await this.findByWorkspace(data.provider, data.externalWorkspaceId);
+            if (winner) return winner;
+            this.logger.warn(
+                `Failed to record ${data.provider} install binding for "${data.externalWorkspaceId}": ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return null;
+        }
+    }
+}

--- a/packages/agent/src/ingest/ingest.module.ts
+++ b/packages/agent/src/ingest/ingest.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { IngestedEvent } from '../entities/ingested-event.entity';
 import { IngestCursor } from '../entities/ingest-cursor.entity';
+import { IngestInstallBinding } from '../entities/ingest-install-binding.entity';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { FacadesModule } from '../facades/facades.module';
 import { IngestedEventRepository } from './ingested-event.repository';
 import { EventIngestService } from './event-ingest.service';
 import { IngestCursorRepository } from './ingest-cursor.repository';
 import { EventSourcePullService } from './event-source-pull.service';
+import { IngestInstallBindingRepository } from './ingest-install-binding.repository';
 
 /**
  * Event-ingest spine (Wave 6, pull path Wave 8) — agent-side module
@@ -21,14 +23,21 @@ import { EventSourcePullService } from './event-source-pull.service';
  * pull path needs (registry / settings / user-plugin rows) are
  * `@Global` providers in the API process and injected `@Optional()`.
  *
- * `IngestedEvent` + `IngestCursor` MUST also stay registered in the
- * DataSource ENTITIES array (`database/_entities-inventory.ts`) — this
- * repo has no `autoLoadEntities`, so a forFeature'd-but-unregistered
- * entity throws EntityMetadataNotFoundError on first query.
+ * Also owns `IngestInstallBindingRepository` — the external
+ * workspace/installation → platform user binding the INBOUND receivers
+ * (Slack events, GitHub webhooks) resolve deliveries through, so an
+ * event is attributed to the account that actually owns the workspace
+ * instead of "the oldest enabled install platform-wide".
+ *
+ * `IngestedEvent` + `IngestCursor` + `IngestInstallBinding` MUST also
+ * stay registered in the DataSource ENTITIES array
+ * (`database/_entities-inventory.ts`) — this repo has no
+ * `autoLoadEntities`, so a forFeature'd-but-unregistered entity throws
+ * EntityMetadataNotFoundError on first query.
  */
 @Module({
     imports: [
-        TypeOrmModule.forFeature([IngestedEvent, IngestCursor]),
+        TypeOrmModule.forFeature([IngestedEvent, IngestCursor, IngestInstallBinding]),
         // Processor 1 — Activity-log rows with sourceUrl provenance.
         ActivityLogModule,
         // Processor 2 — best-effort Memory observations via
@@ -40,12 +49,14 @@ import { EventSourcePullService } from './event-source-pull.service';
         EventIngestService,
         IngestCursorRepository,
         EventSourcePullService,
+        IngestInstallBindingRepository,
     ],
     exports: [
         IngestedEventRepository,
         EventIngestService,
         IngestCursorRepository,
         EventSourcePullService,
+        IngestInstallBindingRepository,
     ],
 })
 export class EventIngestModule {}


### PR DESCRIPTION
Closes backlog items **5** and **6** from the consolidated audit (`00-STATUS.md` §E).

---

## Item 5 — account-transfer whitelist sweep

Export/import is an explicit three-place field whitelist (`types.ts` + `account-export.service.ts` + **both** import paths in `account-import.service.ts`). Data added over the recent waves silently did not round-trip. Fixed, with the standing posture applied on **both** import paths: enum values are **drop-if-unrecognized** (never default-if-unrecognized, never clamped), arrays only apply when they really are arrays, and an explicit `false`/`null` is preserved because an opt-out is exactly the value that has to survive.

### Fields added to the whitelist

| Field | Backing column | Import rule |
|---|---|---|
| `profile.onboarding.roles` | `users.onboardingState.profile` | array-only; entries validated against `ROLE_OPTIONS`, unknown ids dropped; deep-merged so the importer's own wizard progress survives |
| `profile.onboarding.teamSize` | same | validated against `TEAM_SIZE_OPTIONS`, drop-if-unrecognized |
| `profile.preferences.digestFrequency` | `users.digestFrequency` | `off\|daily\|weekly`, drop-if-unrecognized |
| `profile.preferences.emailAgentAlerts` | `users` | explicit boolean only |
| `profile.preferences.emailTaskNotifications` | `users` | explicit boolean only |
| `profile.preferences.emailBudgetAlerts` | `users` | explicit boolean only |
| `profile.preferences.userResearchOptOut` | `users` | explicit boolean only (privacy opt-out) |
| `model.memoryRecallEnabled` | `agents.memoryRecallEnabled` | explicit boolean only; applied on **create and overwrite** import paths |
| `isolationMode` | `tasks.isolationMode` (v2 tail) | `on\|off`; `null` = inherit is preserved; drop-if-unrecognized |
| `acceptanceChecks` | `tasks.acceptanceChecks` | array-only; `null` = inherit is preserved |
| `maxGateAttempts` | `tasks.maxGateAttempts` | integer 1..5; `null` = inherit is preserved; out-of-range **dropped, not clamped** |

`applyImport` previously never touched the profile at all — it now does, inside the same transaction, with a failure downgraded to a warning rather than a failed import. Identity columns (`username`, `email`, `avatar`) are deliberately **not** applied: they identify the importing account.

### Deliberate exclusions (kept, and now documented in the envelope)

- **Credits ledger + plan entitlements** — money. Balances are earned or bought in one account and must never be minted by importing a JSON file into another.
- **Fleet nodes** — machine identity. A node row is a hashed credential bound to a machine that enrolled against *this* deployment.
- **`works.mergePolicy`** — already documented; privilege escalation on import.
- **`users.isPlatformAdmin`** — same class, newly documented. Likewise `tenantId` / `organizationId` / `defaultPlanId` (scope and billing pointers meaningful only inside the exporting deployment).
- **Task branch/PR/run state** (`branchRef`, `branchState`, `baseSha`, `prNumber`, `prUrl`, `conflictPaths`, `latestRunId`, `latestRunStatus`) — not settings but live runtime state naming a git ref, a base commit and a pull request inside the *exporting* account's repository. Replaying them would resume the imported Task's isolation flow against someone else's branch. An imported Task starts with clean branch state and provisions its own on the first run.

---

## Item 6 — per-workspace/install binding for the inbound receivers

Both `slack-chat-bridge.service.ts` and `github-pr-review-bridge.service.ts` resolved *"the oldest enabled install platform-wide"* and attributed **every** inbound event to that one platform user. In a hosted multi-tenant deployment a second customer's Slack workspace or GitHub repository had its messages, diffs and AI replies executed under — and billed to — the first customer's account.

### Storage choice: a new table (`ingest_install_bindings`), not a plugin-settings field

Justification (also recorded on the entity):

1. **Cardinality** — one platform user may legitimately own several Slack workspaces or GitHub installations. Plugin settings are a single row per `(user, plugin)`, so a scalar `teamId` field cannot express the relation without inventing an array-in-JSON.
2. **Direction of the lookup** — resolution runs *workspace to user*, the reverse of how settings are keyed. Over settings, every inbound webhook would have to load and **decrypt** the secret settings of every install just to find the owner: O(installs) decryptions per request on a public, unauthenticated endpoint. The table makes it one indexed row.
3. **Trust** — plugin settings are user-editable, so a user could type another tenant's `team_id` into their own settings and hijack that tenant's events. Rows here are written by the **server only**, and only after a delivery has passed signature verification. The binding is a record of proven ownership, never a user claim.

Entity + guarded, idempotent migration (`1784200000000`, the next free timestamp after `1784100000000`) ship in the same commit, with `_entities-inventory` / `_entity-names` / barrel registration and the `EventIngestModule` pin spec updated.

### Resolution order

1. **Exact binding** — an `ingest_install_bindings` row for this workspace names the owner. Slack keys on `team_id` (with `enterprise_id` compared when both sides carry one); GitHub keys on `installation:<id>` first, then `owner:<login>`, under distinct prefixes so the two namespaces cannot collide.
2. **Single-install fallback** — exactly one install exists, so there is nothing to disambiguate. Logged as a **warning**, and the binding is recorded once the delivery verifies, so existing deployments self-migrate onto path 1.
3. **Signature proof** — with several installs and no binding, the raw payload is verified against each candidate's secret; a *unique* cryptographic match is evidence of ownership, not a guess. (Decisive for GitHub, where each install configures its own secret. Slack installs of the same app share one signing secret, so those fall through to 4.)
4. **Refuse** — anything unknown or ambiguous. A **clean no-op**: warn log, HTTP 200, nothing ingested, nothing dispatched. Never a 500 and never a guess. Refusal codes are stable (`unknown-workspace`, `bound-install-unavailable`, `enterprise-mismatch`, `ambiguous-install`).

A bound-but-now-disabled install **refuses** rather than re-pointing at another tenant — re-pointing is precisely the defect being removed. `not-configured` still 401s and a bad signature still 401s, preserving the fail-closed posture.

The workspace id is read from the not-yet-verified body. That is safe because it only *selects* which install's secret to verify against: a forged `team_id` / `installation.id` picks a secret that fails the HMAC.

---

## Verification (real output)

**`packages/agent` build — TSC 0 issues**

```
> @ever-works/agent@0.1.0 build
> nest build -b swc && tsc -p tsconfig.types.json

-  TSC  Initializing type checker...
✔  TSC  Initializing type checker...
>  TSC  Found 0 issues.
>  SWC  Running...
Successfully compiled: 1075 files with swc (611.85ms)
```

**`packages/agent` jest — account-transfer + agent-export + ingest + entity registration**

```
PASS src/database/database.config.spec.ts (75.008 s)
PASS src/ingest/__tests__/ingested-event.repository.spec.ts (84.187 s)
PASS src/ingest/__tests__/event-source-pull.service.spec.ts (89.343 s)
PASS src/database/database.module.spec.ts (95.675 s)
PASS src/ingest/__tests__/ingest.module.spec.ts (9.022 s)
PASS src/ingest/__tests__/ingest-install-binding.repository.spec.ts (13.437 s)
PASS src/ingest/__tests__/agent-ingest-tools.spec.ts
PASS src/database/database-config.factory.spec.ts
PASS src/account-transfer/account-export.service.spec.ts (106.218 s)
PASS src/account-transfer/agents-skills-tasks-import.service.spec.ts (106.037 s)
PASS src/ingest/__tests__/event-ingest.service.spec.ts (110.432 s)
PASS src/agents/__tests__/agent-export.service.spec.ts (20.693 s)
PASS src/account-transfer/agents-skills-tasks-export.service.spec.ts (23.33 s)
PASS src/account-transfer/account-import.service.spec.ts (47.655 s)
Test Suites: 14 passed, 14 total
Tests:       268 passed, 268 total
```

**`pnpm build --filter=ever-works-api` — TSC 0 issues**

```
ever-works-api:build: > nest build -b swc
ever-works-api:build: -  TSC  Initializing type checker...
ever-works-api:build: ✔  TSC  Initializing type checker...
ever-works-api:build: >  TSC  Found 0 issues.
ever-works-api:build: >  SWC  Running...
ever-works-api:build: Successfully compiled: 690 files with swc (317.43ms)

 Tasks:    14 successful, 14 total
```

**`apps/api` jest — both bridge suites, both controllers, the new migration spec**

```
PASS src/ingest/slack/slack-events.controller.spec.ts (81.102 s)
PASS src/migrations/__tests__/AddAgentScopeTargetIdForDurableSlugCas.spec.ts (86.888 s)
PASS src/ingest/github/github-pr-review-bridge.service.spec.ts (90.394 s)
PASS src/migrations/__tests__/CreateIngestInstallBindings.spec.ts (96.304 s)
PASS src/migrations/__tests__/AddUniqueIndexToUsername.spec.ts (98.25 s)
PASS src/activity-log/dto/ingest-event.dto.spec.ts (19.009 s)
PASS src/ingest/github/github-signature.util.spec.ts
PASS src/migrations/__tests__/AddWorkKindAndStatus.spec.ts (11.086 s)
PASS src/ingest/github/github-events.controller.spec.ts (103.985 s)
PASS src/ingest/slack/slack-chat-bridge.service.spec.ts (103.776 s)
PASS src/migrations/__tests__/AddRunSteeringColumns.spec.ts (7.283 s)
PASS src/ingest/dto/ingest-events.dto.spec.ts (21.326 s)
Test Suites: 12 passed, 12 total
Tests:       113 passed, 113 total
```

**`apps/api` `pnpm generate:openapi` — full-app bootstrap gate (DI wiring for the new repository provider)**

```
> node dist/openapi/generate-openapi.js
Wrote OpenAPI spec (439 paths) to apps/api/openapi.json
```

`openapi.json` is deliberately not part of this commit.

---

## Test coverage added

**Transfer** — one case per added field, on export and on both import paths: onboarding merge into an existing wizard state, unknown role ids dropped, non-array roles ignored, digest cadence round-trip, unknown cadence dropped, every notification/privacy boolean including deliberate `false`, identity and privileged columns never applied, pre-profile payload is a no-op, profile write failure is a warning not a failure. Task isolation/gate settings applied, `null` preserved, unknown enum dropped, non-array checks dropped, out-of-range budget dropped not clamped. Agent `memoryRecallEnabled` on create + overwrite and omitted for legacy envelopes. Export-side assertions that branch/PR/run state and privileged columns never reach the envelope.

**Ingest** — two installs route to the right owner each time (Slack and GitHub), unknown workspace refused, bound-but-disabled install refused (never re-pointed), Slack enterprise mismatch refused, ambiguous shared-secret refused, unique signature proof resolves, **single-install legacy path still works** and is flagged as the fallback, `not-configured` still 401s, binding recorded only after the signature verified, repository failures swallowed so a verified webhook never 500s, workspace-ref extraction for both providers, and a migration spec pinning the UNIQUE `(provider, externalWorkspaceId)` index that makes resolution exact rather than a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
