### PR TITLE
feat(memory): review queue + re-litigation guard (backlog 7, 12)

### DIFF
--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -33,6 +33,9 @@ import { PluginUsageRepository } from '@ever-works/agent/database';
 // agents barrel re-exports services + module only).
 import { AgentRepository } from '@ever-works/agent/database';
 import { TaskWorkspaceService } from '@ever-works/agent/tasks-domain';
+// Re-litigation guard (memory upgrades M6) — provided + exported by
+// `KnowledgeBaseModule`, which the api-side TasksModule imports.
+import { DecisionConflictService } from '@ever-works/agent/services';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 import {
@@ -81,6 +84,8 @@ export class TasksController {
         private readonly agents: AgentRepository,
         // Wave 2 M5/M6 — workspace conflict-resolve + discard actions.
         private readonly taskWorkspace: TaskWorkspaceService,
+        // Memory upgrades M6 — deterministic re-litigation guard.
+        private readonly decisionConflicts: DecisionConflictService,
     ) {}
 
     /**
@@ -182,6 +187,29 @@ export class TasksController {
     @HttpCode(HttpStatus.OK)
     async getOne(@CurrentUser() auth: AuthenticatedUser, @Param('id', ParseUUIDPipe) id: string) {
         return this.service.getOne(auth.userId, id);
+    }
+
+    @Get(':id/decision-conflicts')
+    @ApiOperation({
+        summary:
+            'Re-litigation guard — settled decisions this Task appears to re-open (advisory, never blocking).',
+        description:
+            "Deterministic term-overlap check (`term-overlap/v1`, no LLM) of the Task's title + description against the `class=decision, status=accepted` documents in the Task's Work Knowledge Base. Owner-scoped: a Task the caller does not own 404s, and every candidate read goes through the KB service's own view gate. Returns `{ conflicts, scanned, heuristic }`; an empty `conflicts` array is the normal case.",
+    })
+    @HttpCode(HttpStatus.OK)
+    async decisionConflictsForTask(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ) {
+        // Owner scope + existence: `getOne` throws NotFound for a Task
+        // the caller doesn't own (no 403 existence leak).
+        const task = await this.service.getOne(auth.userId, id);
+        return this.decisionConflicts.checkIntent({
+            workId: task.workId ?? null,
+            userId: auth.userId,
+            title: task.title,
+            description: task.description ?? null,
+        });
     }
 
     @Patch(':id')

--- a/apps/api/src/tasks/tasks.module.ts
+++ b/apps/api/src/tasks/tasks.module.ts
@@ -11,6 +11,13 @@ import { DatabaseModule } from '@ever-works/agent/database';
 // controllers would fail to instantiate at boot with an "argument
 // AgentRepository is not available" Nest error.
 import { AgentsModule } from '@ever-works/agent/agents';
+// Memory upgrades M6 — `DecisionConflictService` (the re-litigation
+// guard behind `GET /api/tasks/:id/decision-conflicts`) is provided and
+// exported by `KnowledgeBaseModule`. NestJS only resolves a controller's
+// deps against its own module's imports, so this import is load-bearing:
+// without it the API fails to boot with an
+// `UnknownDependenciesException: TasksController (..., ?)`.
+import { KnowledgeBaseModule } from '@ever-works/agent/services';
 import {
     agentTaskExecuteTriggerAdapter,
     agentChatReplyTriggerAdapter,
@@ -40,7 +47,7 @@ import { TaskChatController } from './task-chat.controller';
 // breaking the entire Phase 15.3 / 15.4 dispatch fan-out.
 @Global()
 @Module({
-    imports: [TasksDomainModule, DatabaseModule, AgentsModule],
+    imports: [TasksDomainModule, DatabaseModule, AgentsModule, KnowledgeBaseModule],
     controllers: [TasksController, TaskChatController],
     providers: [
         { provide: AGENT_TASK_EXECUTE_DISPATCHER, useValue: agentTaskExecuteTriggerAdapter },

--- a/apps/api/src/works/kb.controller.ts
+++ b/apps/api/src/works/kb.controller.ts
@@ -46,6 +46,7 @@ import type {
     KbDocumentClass,
     KbDocumentStatus,
     KbLockMode,
+    KbReviewState,
     KbUploadExtractionStatus,
 } from '@ever-works/agent/entities';
 
@@ -91,6 +92,13 @@ export class KbController {
     @ApiQuery({ name: 'status', required: false })
     @ApiQuery({ name: 'tag', required: false })
     @ApiQuery({ name: 'locked', required: false })
+    @ApiQuery({
+        name: 'reviewState',
+        required: false,
+        enum: ['proposed', 'accepted'],
+        description:
+            'Memory upgrades M8 — review-queue filter. `proposed` lists only agent-authored / synthesized documents awaiting human review (excluded from context injection until accepted); `accepted` lists the reviewed set including pre-M7 rows whose column is NULL. Omit to list everything.',
+    })
     @ApiQuery({ name: 'q', required: false })
     @ApiQuery({ name: 'limit', required: false })
     @ApiQuery({ name: 'offset', required: false })
@@ -113,6 +121,7 @@ export class KbController {
             tag: query.tag,
             locked: query.locked,
             language: query.language,
+            reviewState: query.reviewState as KbReviewState | undefined,
             q: query.q,
             limit: query.limit,
             offset: query.offset,

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1215,6 +1215,16 @@
                 "skipped": "Gate skipped",
                 "none": "No checks"
             },
+            "decisionConflicts": {
+                "title": "This may re-open {count} settled decision(s)",
+                "subtitle": "Your organization already recorded a call on this subject.",
+                "overlap": "Shared terms: {terms}",
+                "advisory": "Advisory only — nothing is blocked. Open a decision to read the rationale, or supersede it if the call has changed.",
+                "signal": {
+                    "strong": "Strong match",
+                    "moderate": "Possible match"
+                }
+            },
             "checks": {
                 "title": "Checks",
                 "edit": "Edit",
@@ -4583,6 +4593,29 @@
                     "errorFallback": "Could not delete. Please try again.",
                     "errorBusy": "Deleting…",
                     "errorPartial": "Deleted {ok}, failed {failed}."
+                },
+                "review": {
+                    "nav": "Review",
+                    "navAria": "Review queue — {count} documents awaiting review",
+                    "metaTitle": "Knowledge Base review queue",
+                    "title": "Review queue",
+                    "subtitle": "Agent-written notes stay out of agent context until you accept them.",
+                    "empty": "Nothing to review. New agent-written documents will appear here.",
+                    "loading": "Loading the review queue…",
+                    "retry": "Try again",
+                    "source": "From {source}",
+                    "accept": "Accept",
+                    "editThenAccept": "Edit & accept",
+                    "supersede": "Supersede",
+                    "supersedePrompt": "Replaced by",
+                    "supersedePlaceholder": "Pick the surviving decision…",
+                    "supersedeConfirm": "Supersede",
+                    "archive": "Archive",
+                    "cancel": "Cancel",
+                    "preview": "Toggle content preview",
+                    "previewLoading": "Loading preview…",
+                    "previewEmpty": "This document has no body yet.",
+                    "bannerMessage": "This document is awaiting review — it is not feeding agent context yet. Edit it if needed, then accept."
                 },
                 "workbench": {
                     "title": "Knowledge Base workbench",

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/[...path]/page.tsx
@@ -11,6 +11,7 @@ import { TiptapEditor } from '@/components/kb/workbench/TiptapEditor';
 import { KbMetadataPanel } from '@/components/kb/workbench/KbMetadataPanel';
 import { KbDocumentViewerSwitch } from '@/components/kb/workbench/KbDocumentViewerSwitch';
 import { KbSearchPalette } from '@/components/kb/workbench/KbSearchPalette';
+import { KbReviewBanner } from '@/components/kb/workbench/KbReviewBanner';
 import type { KbUploadDto } from '@ever-works/contracts';
 
 type Params = {
@@ -127,6 +128,10 @@ export default async function WorkKnowledgeBaseDocumentPage({ params }: Params) 
                 left={<WorkbenchUploadCoordinator workId={id} currentDocPath={doc.path} />}
                 center={
                     <div className="flex h-full flex-col">
+                        {/* Memory upgrades M8 — renders only while the doc
+                            is still `proposed`; completes the review
+                            queue's "Edit & accept" flow in place. */}
+                        <KbReviewBanner workId={id} document={doc} />
                         <KbDocumentHeader workId={id} document={doc} />
                         {useInlineViewer && upload ? (
                             <div className="flex-1 overflow-auto p-4">

--- a/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/review/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/[id]/kb/review/page.tsx
@@ -1,0 +1,64 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+import { workAPI } from '@/lib/api';
+import { kbAPI } from '@/lib/api/kb';
+import { WorkbenchShell } from '@/components/kb/workbench/WorkbenchShell';
+import { WorkbenchUploadCoordinator } from '@/components/kb/workbench/WorkbenchUploadCoordinator';
+import { KbSearchPalette } from '@/components/kb/workbench/KbSearchPalette';
+import { KbReviewQueue } from '@/components/kb/workbench/KbReviewQueue';
+import type { KbDocumentDto } from '@ever-works/contracts';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.workDetail.kb');
+    return { title: t('review.metaTitle') };
+}
+
+type Params = { params: Promise<{ id: string; locale: string }> };
+
+/**
+ * Memory upgrades M8 — the KB review queue route.
+ *
+ * Lives inside the existing three-pane workbench (same tree pane on the
+ * left, queue in the center) so the review step is part of the KB
+ * surface rather than a detached screen. The static `review` segment
+ * takes precedence over the sibling `[...path]` catch-all in Next's
+ * routing, and no KB document path can collide with it: canonical doc
+ * paths are always `<class>/<slug>.md`, i.e. at least two segments.
+ *
+ * The first page of proposed documents is fetched server-side so the
+ * queue renders real content on first paint; `KbReviewQueue` owns every
+ * subsequent refresh after an Accept / Supersede / Archive.
+ */
+export default async function WorkKnowledgeBaseReviewPage({ params }: Params) {
+    const { id } = await params;
+
+    try {
+        const workResponse = await workAPI.get(id);
+        if (!workResponse?.work) notFound();
+    } catch {
+        notFound();
+    }
+
+    let documents: KbDocumentDto[] = [];
+    let error: string | null = null;
+    try {
+        const result = await kbAPI.listDocuments(id, { reviewState: 'proposed', limit: 100 });
+        documents = result.items ?? [];
+    } catch (err) {
+        console.error('[kb-review] failed to pre-fetch proposed KB documents:', err);
+        error = err instanceof Error ? err.message : 'Failed to load the review queue';
+    }
+
+    return (
+        <>
+            <KbSearchPalette workId={id} />
+            <WorkbenchShell
+                left={<WorkbenchUploadCoordinator workId={id} />}
+                center={
+                    <KbReviewQueue workId={id} initialDocuments={documents} initialError={error} />
+                }
+            />
+        </>
+    );
+}

--- a/apps/web/src/app/actions/tasks.ts
+++ b/apps/web/src/app/actions/tasks.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
-import type { TaskAcceptanceCheck } from '@ever-works/contracts';
+import type { DecisionConflictReportDto, TaskAcceptanceCheck } from '@ever-works/contracts';
 import {
     tasksAPI,
     type ListTasksQuery,
@@ -108,6 +108,29 @@ export async function listTasksWithRunsAction(
         includeRun: true,
     });
     return result.data;
+}
+
+/**
+ * Re-litigation guard (memory upgrades M6) — fetch the settled decisions
+ * this Task appears to re-open.
+ *
+ * Read-only, so no `revalidatePath`. Deliberately NEVER throws: the guard
+ * is advisory and a failure to compute it must not degrade the Task
+ * surface, so a failed read degrades to "no conflicts".
+ */
+export async function getTaskDecisionConflictsAction(
+    id: string,
+): Promise<DecisionConflictReportDto> {
+    // Security: verify session server-side before reading data
+    const user = await getAuthFromCookie();
+    if (!user) redirect(ROUTES.AUTH_LOGIN);
+
+    try {
+        return await tasksAPI.decisionConflicts(id);
+    } catch (error) {
+        console.error('[tasks] decision-conflict check failed:', error);
+        return { conflicts: [], scanned: 0, heuristic: 'unavailable' };
+    }
 }
 
 /**

--- a/apps/web/src/app/actions/works/kb-review.ts
+++ b/apps/web/src/app/actions/works/kb-review.ts
@@ -1,0 +1,160 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { kbAPI, type KbDocumentListResponse } from '@/lib/api/kb';
+import type { ActionResult } from '@/app/actions/plugins';
+import type { KbDocumentBodyDto, KbDocumentDto } from '@ever-works/contracts';
+
+/**
+ * Memory upgrades M8 — server actions behind the KB **review queue**.
+ *
+ * The M7 backend lands every agent-authored / consolidation-synthesized
+ * document as `reviewState='proposed'` and excludes it from context
+ * injection at all three retrieval paths. Until this queue shipped those
+ * endpoints had ZERO web callers, which made the circuit breaker a
+ * discard: captured learning was never routed anywhere a human could see
+ * it. These actions are the missing half.
+ *
+ * All four review actions are thin wrappers over endpoints that already
+ * existed (`/accept`, `/archive`, `/decision-status`) — nothing new is
+ * introduced on the API surface here. Each revalidates the KB index and
+ * the review route so the server-rendered tree + queue reflect the new
+ * state without a hard reload.
+ */
+
+function kbPaths(workId: string): string[] {
+    return [`/works/${workId}/kb`, `/works/${workId}/kb/review`];
+}
+
+function revalidateKb(workId: string, docPath?: string): void {
+    for (const path of kbPaths(workId)) revalidatePath(path);
+    if (docPath) revalidatePath(`/works/${workId}/kb/${docPath}`);
+}
+
+function toMessage(error: unknown, fallback: string): string {
+    return error instanceof Error && error.message ? error.message : fallback;
+}
+
+/**
+ * List the documents awaiting review for a Work — the queue's data
+ * source. Uses the existing `GET /works/:id/kb/documents` list with the
+ * additive `reviewState=proposed` filter (owner-scoped server-side via
+ * `ensureCanView`), so no bespoke endpoint was needed.
+ */
+export async function listProposedKbDocumentsAction(
+    workId: string,
+    opts: { limit?: number } = {},
+): Promise<ActionResult<KbDocumentListResponse>> {
+    try {
+        const data = await kbAPI.listDocuments(workId, {
+            reviewState: 'proposed',
+            limit: opts.limit ?? 100,
+        });
+        return { success: true, data };
+    } catch (error) {
+        console.error('[kb-review] failed to list proposed KB documents:', error);
+        return { success: false, error: toMessage(error, 'Failed to load the review queue') };
+    }
+}
+
+/**
+ * Fetch one document's body so the queue can show a real content
+ * preview. Deliberately lazy (per-row, on expand) — the list endpoint is
+ * metadata-only and fetching every body up front would be a needless
+ * fan-out on a queue that is usually skimmed, not read end to end.
+ */
+export async function getKbDocumentBodyAction(
+    workId: string,
+    docId: string,
+): Promise<ActionResult<KbDocumentBodyDto>> {
+    try {
+        const data = await kbAPI.getDocument(workId, docId);
+        return { success: true, data };
+    } catch (error) {
+        console.error('[kb-review] failed to load KB document body:', error);
+        return { success: false, error: toMessage(error, 'Failed to load the document') };
+    }
+}
+
+/** Accept — the document starts feeding agent context. Idempotent. */
+export async function acceptKbDocumentAction(args: {
+    workId: string;
+    docId: string;
+    path?: string;
+}): Promise<ActionResult<KbDocumentDto>> {
+    try {
+        const doc = await kbAPI.acceptDocument(args.workId, args.docId);
+        revalidateKb(args.workId, args.path);
+        return { success: true, data: doc };
+    } catch (error) {
+        console.error('[kb-review] failed to accept KB document:', error);
+        return { success: false, error: toMessage(error, 'Failed to accept the document') };
+    }
+}
+
+/** Archive — status flip, never a physical delete. Idempotent. */
+export async function archiveKbDocumentAction(args: {
+    workId: string;
+    docId: string;
+    path?: string;
+}): Promise<ActionResult<KbDocumentDto>> {
+    try {
+        const doc = await kbAPI.archiveDocument(args.workId, args.docId);
+        revalidateKb(args.workId, args.path);
+        return { success: true, data: doc };
+    } catch (error) {
+        console.error('[kb-review] failed to archive KB document:', error);
+        return { success: false, error: toMessage(error, 'Failed to archive the document') };
+    }
+}
+
+/**
+ * Supersede — pick the survivor. Reuses the M4 decision status machine:
+ * `superseded` with `supersededByDocId` writes the chain link on BOTH
+ * documents, so the demoted decision keeps rendering as
+ * "historical — replaced by kb:decision/<slug>" in agent context instead
+ * of vanishing.
+ *
+ * Only meaningful for `class=decision` documents; the API returns 400 for
+ * anything else and the UI hides the action accordingly.
+ */
+export async function supersedeKbDecisionAction(args: {
+    workId: string;
+    docId: string;
+    supersededByDocId: string;
+    rationale?: string;
+    path?: string;
+}): Promise<ActionResult<KbDocumentDto>> {
+    try {
+        const doc = await kbAPI.transitionDecisionStatus(args.workId, args.docId, {
+            status: 'superseded',
+            supersededByDocId: args.supersededByDocId,
+            ...(args.rationale ? { rationale: args.rationale } : {}),
+        });
+        revalidateKb(args.workId, args.path);
+        return { success: true, data: doc };
+    } catch (error) {
+        console.error('[kb-review] failed to supersede KB decision:', error);
+        return { success: false, error: toMessage(error, 'Failed to supersede the decision') };
+    }
+}
+
+/**
+ * Candidate survivors for the supersede picker: the Work's accepted
+ * decision documents, minus the one being superseded.
+ */
+export async function listSupersedeCandidatesAction(
+    workId: string,
+    excludeDocId: string,
+): Promise<ActionResult<KbDocumentDto[]>> {
+    try {
+        const { items } = await kbAPI.listDocuments(workId, { class: 'decision', limit: 100 });
+        const candidates = items.filter(
+            (doc) => doc.id !== excludeDocId && doc.decision?.status === 'accepted',
+        );
+        return { success: true, data: candidates };
+    } catch (error) {
+        console.error('[kb-review] failed to list supersede candidates:', error);
+        return { success: false, error: toMessage(error, 'Failed to load decisions') };
+    }
+}

--- a/apps/web/src/components/kb/workbench/KbReviewBanner.tsx
+++ b/apps/web/src/components/kb/workbench/KbReviewBanner.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { useRouter } from '@/i18n/navigation';
+import { Archive, Check, Loader2, ShieldQuestion } from 'lucide-react';
+import type { KbDocumentDto } from '@ever-works/contracts';
+import { acceptKbDocumentAction, archiveKbDocumentAction } from '@/app/actions/works/kb-review';
+
+/**
+ * Memory upgrades M8 — the "edit then accept" half of the review queue.
+ *
+ * The queue's **Edit & accept** action links to this document in the
+ * existing workbench editor; this banner is what makes that flow
+ * complete. It renders only while the document is still `proposed`, so
+ * the operator can fix the wording first and then accept in place — no
+ * second editor, no duplicated save logic.
+ *
+ * It also does double duty as a standing signal: any `proposed` document
+ * opened from the tree now says out loud that it is NOT feeding agent
+ * context yet, which was previously invisible everywhere in the UI.
+ */
+
+export interface KbReviewBannerProps {
+    readonly workId: string;
+    readonly document: Pick<KbDocumentDto, 'id' | 'path' | 'reviewState'>;
+}
+
+export function KbReviewBanner({ workId, document: doc }: KbReviewBannerProps) {
+    const t = useTranslations('dashboard.workDetail.kb');
+    const router = useRouter();
+    const [resolved, setResolved] = useState(false);
+    const [busy, setBusy] = useState<'accept' | 'archive' | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const act = useCallback(
+        (kind: 'accept' | 'archive') => {
+            setBusy(kind);
+            setError(null);
+            void (async () => {
+                const args = { workId, docId: doc.id, path: doc.path };
+                const result =
+                    kind === 'accept'
+                        ? await acceptKbDocumentAction(args)
+                        : await archiveKbDocumentAction(args);
+                if (result.success) {
+                    setResolved(true);
+                    try {
+                        router.refresh();
+                    } catch {
+                        /* the unit specs stub useRouter */
+                    }
+                    return;
+                }
+                setError(result.error ?? 'Action failed');
+                setBusy(null);
+            })();
+        },
+        [workId, doc.id, doc.path, router],
+    );
+
+    // Additive by construction: `null` / `accepted` renders nothing, so
+    // dropping the banner into the document page changes nothing for the
+    // overwhelming majority of documents.
+    if (doc.reviewState !== 'proposed' || resolved) return null;
+
+    return (
+        <div
+            data-testid="kb-review-banner"
+            role="status"
+            className="flex flex-wrap items-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-xs text-amber-800 dark:text-amber-200"
+        >
+            <ShieldQuestion className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <p className="min-w-0 flex-1">{t('review.bannerMessage')}</p>
+            <button
+                type="button"
+                data-testid="kb-review-banner-accept"
+                disabled={busy !== null}
+                onClick={() => act('accept')}
+                className="inline-flex items-center gap-1 rounded-md border border-amber-500/40 px-2 py-1 font-medium disabled:opacity-50 hover:bg-amber-500/20"
+            >
+                {busy === 'accept' ? (
+                    <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                ) : (
+                    <Check className="h-3 w-3" aria-hidden="true" />
+                )}
+                {t('review.accept')}
+            </button>
+            <button
+                type="button"
+                data-testid="kb-review-banner-archive"
+                disabled={busy !== null}
+                onClick={() => act('archive')}
+                className="inline-flex items-center gap-1 rounded-md border border-amber-500/40 px-2 py-1 font-medium disabled:opacity-50 hover:bg-amber-500/20"
+            >
+                {busy === 'archive' ? (
+                    <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                ) : (
+                    <Archive className="h-3 w-3" aria-hidden="true" />
+                )}
+                {t('review.archive')}
+            </button>
+            {error ? (
+                <p role="alert" data-testid="kb-review-banner-error" className="w-full text-danger">
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/web/src/components/kb/workbench/KbReviewBanner.unit.spec.tsx
+++ b/apps/web/src/components/kb/workbench/KbReviewBanner.unit.spec.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) =>
+        React.createElement('a', { href, ...rest }, children),
+    useRouter: () => ({
+        push: vi.fn(),
+        refresh: vi.fn(),
+        back: vi.fn(),
+        replace: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    usePathname: () => '/',
+}));
+
+const acceptMock = vi.fn();
+const archiveMock = vi.fn();
+vi.mock('@/app/actions/works/kb-review', () => ({
+    acceptKbDocumentAction: (...args: unknown[]) => acceptMock(...args),
+    archiveKbDocumentAction: (...args: unknown[]) => archiveMock(...args),
+}));
+
+import { KbReviewBanner } from './KbReviewBanner';
+
+describe('KbReviewBanner', () => {
+    beforeEach(() => vi.clearAllMocks());
+    afterEach(() => vi.clearAllMocks());
+
+    it('renders nothing for an accepted document (additive by construction)', () => {
+        const { container } = render(
+            <KbReviewBanner
+                workId="work-1"
+                document={{ id: 'doc-1', path: 'output/n.md', reviewState: 'accepted' }}
+            />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders nothing for a pre-M7 document whose review state is null', () => {
+        const { container } = render(
+            <KbReviewBanner
+                workId="work-1"
+                document={{ id: 'doc-1', path: 'output/n.md', reviewState: null }}
+            />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders for a proposed document with both review actions', () => {
+        render(
+            <KbReviewBanner
+                workId="work-1"
+                document={{ id: 'doc-1', path: 'output/n.md', reviewState: 'proposed' }}
+            />,
+        );
+        expect(screen.getByTestId('kb-review-banner')).toBeTruthy();
+        expect(screen.getByTestId('kb-review-banner-accept')).toBeTruthy();
+        expect(screen.getByTestId('kb-review-banner-archive')).toBeTruthy();
+    });
+
+    it('accepts in place and then hides itself (edit-then-accept completion)', async () => {
+        acceptMock.mockResolvedValue({ success: true, data: {} });
+        render(
+            <KbReviewBanner
+                workId="work-1"
+                document={{ id: 'doc-1', path: 'output/n.md', reviewState: 'proposed' }}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('kb-review-banner-accept'));
+        await waitFor(() => expect(screen.queryByTestId('kb-review-banner')).toBeNull());
+        expect(acceptMock).toHaveBeenCalledWith({
+            workId: 'work-1',
+            docId: 'doc-1',
+            path: 'output/n.md',
+        });
+    });
+
+    it('keeps the banner and shows the error when the action fails', async () => {
+        archiveMock.mockResolvedValue({ success: false, error: 'denied' });
+        render(
+            <KbReviewBanner
+                workId="work-1"
+                document={{ id: 'doc-1', path: 'output/n.md', reviewState: 'proposed' }}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('kb-review-banner-archive'));
+        await waitFor(() =>
+            expect(screen.getByTestId('kb-review-banner-error').textContent).toBe('denied'),
+        );
+        expect(screen.getByTestId('kb-review-banner')).toBeTruthy();
+    });
+});

--- a/apps/web/src/components/kb/workbench/KbReviewQueue.tsx
+++ b/apps/web/src/components/kb/workbench/KbReviewQueue.tsx
@@ -1,0 +1,478 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { Link, useRouter } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
+import { Archive, Check, ChevronDown, ChevronRight, Loader2, Pencil, Replace } from 'lucide-react';
+import type { KbDocumentDto } from '@ever-works/contracts';
+import {
+    acceptKbDocumentAction,
+    archiveKbDocumentAction,
+    getKbDocumentBodyAction,
+    listProposedKbDocumentsAction,
+    listSupersedeCandidatesAction,
+    supersedeKbDecisionAction,
+} from '@/app/actions/works/kb-review';
+
+/**
+ * Memory upgrades M8 — the KB **review queue**.
+ *
+ * Agent-authored and consolidation-synthesized documents land as
+ * `reviewState='proposed'` and are excluded from context injection until
+ * a human accepts them (M7). Before this component that circuit breaker
+ * had no UI: captured learning went into a state nothing surfaced, which
+ * made the feature a discard rather than a review step.
+ *
+ * Every action here calls an endpoint that already existed:
+ *   - **Accept**          → `POST …/documents/:docId/accept`
+ *   - **Edit & accept**   → opens the existing workbench editor; the
+ *                           `KbReviewBanner` on that page carries the
+ *                           Accept button so the operator edits first and
+ *                           accepts in place.
+ *   - **Supersede**       → `POST …/documents/:docId/decision-status`
+ *                           with `superseded` + the chosen survivor
+ *                           (decision-class documents only — the status
+ *                           machine is decision-scoped).
+ *   - **Archive**         → `POST …/documents/:docId/archive`
+ *
+ * Content preview is lazy per row: the list endpoint is metadata-only, so
+ * expanding a row fetches that one document's body.
+ */
+
+export interface KbReviewQueueProps {
+    readonly workId: string;
+    /**
+     * Server-fetched first page. When omitted the component fetches on
+     * mount — used by the unit specs and any future client-only mount.
+     */
+    readonly initialDocuments?: KbDocumentDto[];
+    /** Server-side load error, rendered instead of an empty state. */
+    readonly initialError?: string | null;
+}
+
+/** Chars of the body shown in an expanded preview. */
+const PREVIEW_CHARS = 600;
+
+type RowBusy = 'accept' | 'archive' | 'supersede' | null;
+
+export function KbReviewQueue({
+    workId,
+    initialDocuments,
+    initialError = null,
+}: KbReviewQueueProps) {
+    const t = useTranslations('dashboard.workDetail.kb');
+    const router = useRouter();
+    const [documents, setDocuments] = useState<KbDocumentDto[]>(initialDocuments ?? []);
+    const [loading, setLoading] = useState(initialDocuments === undefined);
+    const [error, setError] = useState<string | null>(initialError);
+
+    const applyResult = useCallback(
+        (result: Awaited<ReturnType<typeof listProposedKbDocumentsAction>>) => {
+            if (result.success && result.data) {
+                setDocuments(result.data.items ?? []);
+                setError(null);
+            } else {
+                setError(result.error ?? 'Failed to load');
+            }
+            setLoading(false);
+        },
+        [],
+    );
+
+    /** Event-handler refresh (the error state's retry button). */
+    const refresh = useCallback(async () => {
+        setLoading(true);
+        applyResult(await listProposedKbDocumentsAction(workId));
+    }, [workId, applyResult]);
+
+    useEffect(() => {
+        // Client-only mount (no server-rendered first page). `loading` is
+        // already seeded true from `initialDocuments === undefined`, and
+        // every setState below happens AFTER the await — never
+        // synchronously inside the effect body (react-hooks/set-state-in-effect).
+        if (initialDocuments !== undefined) return;
+        let cancelled = false;
+        void (async () => {
+            const result = await listProposedKbDocumentsAction(workId);
+            if (cancelled) return;
+            applyResult(result);
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [initialDocuments, workId, applyResult]);
+
+    // Optimistic removal — an accepted / archived / superseded document is
+    // no longer `proposed`, so it leaves the queue immediately instead of
+    // waiting for a round-trip.
+    const removeRow = useCallback(
+        (docId: string) => {
+            setDocuments((prev) => prev.filter((doc) => doc.id !== docId));
+            try {
+                router.refresh();
+            } catch {
+                /* the unit specs stub useRouter */
+            }
+        },
+        [router],
+    );
+
+    if (loading) {
+        return (
+            <div
+                data-testid="kb-review-queue-loading"
+                className="flex flex-1 items-center justify-center gap-2 p-8 text-sm text-text-muted dark:text-text-muted-dark/70"
+            >
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                {t('review.loading')}
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div
+                data-testid="kb-review-queue-error"
+                role="alert"
+                className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center"
+            >
+                <p className="text-sm text-danger">{error}</p>
+                <button
+                    type="button"
+                    data-testid="kb-review-queue-retry"
+                    onClick={() => void refresh()}
+                    className="rounded-md border border-border px-3 py-1.5 text-xs font-medium hover:bg-card-hover dark:border-border-dark dark:hover:bg-card-primary-dark/40"
+                >
+                    {t('review.retry')}
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div data-testid="kb-review-queue" className="flex h-full flex-col">
+            <header className="flex items-center gap-2 border-b border-border px-4 py-3 dark:border-border-dark">
+                <h2 className="text-sm font-medium text-text dark:text-text-dark">
+                    {t('review.title')}
+                </h2>
+                <span
+                    data-testid="kb-review-queue-count"
+                    className="rounded-full bg-card-hover px-2 py-0.5 text-[11px] font-medium text-text-muted dark:bg-card-primary-dark/40 dark:text-text-muted-dark/80"
+                >
+                    {documents.length}
+                </span>
+                <p className="ml-auto max-w-md text-right text-[11px] text-text-muted dark:text-text-muted-dark/60">
+                    {t('review.subtitle')}
+                </p>
+            </header>
+
+            {documents.length === 0 ? (
+                <div
+                    data-testid="kb-review-queue-empty"
+                    className="flex flex-1 items-center justify-center p-8 text-center text-sm text-text-muted dark:text-text-muted-dark/70"
+                >
+                    <p className="max-w-md">{t('review.empty')}</p>
+                </div>
+            ) : (
+                <ul className="flex-1 divide-y divide-border overflow-y-auto dark:divide-border-dark">
+                    {documents.map((doc) => (
+                        <KbReviewRow
+                            key={doc.id}
+                            workId={workId}
+                            document={doc}
+                            onResolved={() => removeRow(doc.id)}
+                        />
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}
+
+interface KbReviewRowProps {
+    readonly workId: string;
+    readonly document: KbDocumentDto;
+    readonly onResolved: () => void;
+}
+
+function KbReviewRow({ workId, document: doc, onResolved }: KbReviewRowProps) {
+    const t = useTranslations('dashboard.workDetail.kb');
+    const [expanded, setExpanded] = useState(false);
+    const [preview, setPreview] = useState<string | null>(null);
+    const [previewLoading, setPreviewLoading] = useState(false);
+    const [busy, setBusy] = useState<RowBusy>(null);
+    const [rowError, setRowError] = useState<string | null>(null);
+    const [picking, setPicking] = useState(false);
+    const [candidates, setCandidates] = useState<KbDocumentDto[] | null>(null);
+    const [survivorId, setSurvivorId] = useState('');
+    const [, startAction] = useTransition();
+
+    const isDecision = doc.class === 'decision';
+    const createdAt = useMemo(() => formatTimestamp(doc.createdAt), [doc.createdAt]);
+
+    const toggleExpanded = useCallback(() => {
+        const next = !expanded;
+        setExpanded(next);
+        if (!next || preview !== null || previewLoading) return;
+        setPreviewLoading(true);
+        void (async () => {
+            const result = await getKbDocumentBodyAction(workId, doc.id);
+            setPreview(
+                result.success && result.data ? (result.data.body ?? '') : (result.error ?? ''),
+            );
+            setPreviewLoading(false);
+        })();
+    }, [expanded, preview, previewLoading, workId, doc.id]);
+
+    const run = useCallback(
+        (kind: Exclude<RowBusy, null>, fn: () => Promise<{ success: boolean; error?: string }>) => {
+            setRowError(null);
+            setBusy(kind);
+            startAction(() => {
+                void (async () => {
+                    const result = await fn();
+                    if (result.success) {
+                        onResolved();
+                        return;
+                    }
+                    setRowError(result.error ?? 'Action failed');
+                    setBusy(null);
+                })();
+            });
+        },
+        [onResolved],
+    );
+
+    const openPicker = useCallback(() => {
+        setPicking(true);
+        setRowError(null);
+        if (candidates !== null) return;
+        void (async () => {
+            const result = await listSupersedeCandidatesAction(workId, doc.id);
+            if (result.success && result.data) {
+                setCandidates(result.data);
+            } else {
+                setCandidates([]);
+                setRowError(result.error ?? 'Failed to load decisions');
+            }
+        })();
+    }, [candidates, workId, doc.id]);
+
+    return (
+        <li data-testid={`kb-review-row-${doc.id}`} data-kb-class={doc.class} className="px-4 py-3">
+            <div className="flex items-start gap-2">
+                <button
+                    type="button"
+                    onClick={toggleExpanded}
+                    aria-expanded={expanded}
+                    data-testid={`kb-review-row-${doc.id}-toggle`}
+                    aria-label={t('review.preview')}
+                    className="mt-0.5 rounded p-0.5 text-text-muted hover:bg-card-hover dark:hover:bg-card-primary-dark/40"
+                >
+                    {expanded ? (
+                        <ChevronDown className="h-4 w-4" aria-hidden="true" />
+                    ) : (
+                        <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                    )}
+                </button>
+
+                <div className="min-w-0 flex-1">
+                    <Link
+                        href={`${ROUTES.DASHBOARD_WORK_KB(workId)}/${doc.path}`}
+                        data-testid={`kb-review-row-${doc.id}-title`}
+                        className="block truncate text-sm font-medium text-text hover:underline dark:text-text-dark"
+                    >
+                        {doc.title || doc.path}
+                    </Link>
+                    <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-text-muted dark:text-text-muted-dark/70">
+                        <span
+                            data-testid={`kb-review-row-${doc.id}-class`}
+                            className="rounded-full bg-card-hover px-1.5 py-0.5 uppercase tracking-wide dark:bg-card-primary-dark/40"
+                        >
+                            {t(`classes.${doc.class}`)}
+                        </span>
+                        <span data-testid={`kb-review-row-${doc.id}-source`}>
+                            {t('review.source', { source: doc.source })}
+                        </span>
+                        <span data-testid={`kb-review-row-${doc.id}-created`}>{createdAt}</span>
+                    </div>
+                    {doc.description ? (
+                        <p className="mt-1 line-clamp-2 text-xs text-text-secondary dark:text-text-secondary-dark/80">
+                            {doc.description}
+                        </p>
+                    ) : null}
+                </div>
+
+                <div className="flex shrink-0 flex-wrap items-center justify-end gap-1.5">
+                    <RowAction
+                        testId={`kb-review-row-${doc.id}-accept`}
+                        label={t('review.accept')}
+                        icon={Check}
+                        busy={busy === 'accept'}
+                        disabled={busy !== null}
+                        onClick={() =>
+                            run('accept', () =>
+                                acceptKbDocumentAction({ workId, docId: doc.id, path: doc.path }),
+                            )
+                        }
+                    />
+                    <Link
+                        href={`${ROUTES.DASHBOARD_WORK_KB(workId)}/${doc.path}`}
+                        data-testid={`kb-review-row-${doc.id}-edit`}
+                        className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium text-text-secondary hover:bg-card-hover dark:border-border-dark dark:text-text-secondary-dark/80 dark:hover:bg-card-primary-dark/40"
+                    >
+                        <Pencil className="h-3 w-3" aria-hidden="true" />
+                        {t('review.editThenAccept')}
+                    </Link>
+                    {isDecision ? (
+                        <RowAction
+                            testId={`kb-review-row-${doc.id}-supersede`}
+                            label={t('review.supersede')}
+                            icon={Replace}
+                            busy={busy === 'supersede'}
+                            disabled={busy !== null}
+                            onClick={openPicker}
+                        />
+                    ) : null}
+                    <RowAction
+                        testId={`kb-review-row-${doc.id}-archive`}
+                        label={t('review.archive')}
+                        icon={Archive}
+                        busy={busy === 'archive'}
+                        disabled={busy !== null}
+                        onClick={() =>
+                            run('archive', () =>
+                                archiveKbDocumentAction({ workId, docId: doc.id, path: doc.path }),
+                            )
+                        }
+                    />
+                </div>
+            </div>
+
+            {picking ? (
+                <div
+                    data-testid={`kb-review-row-${doc.id}-supersede-picker`}
+                    className="mt-2 flex flex-wrap items-center gap-2 rounded-md border border-border bg-card-hover/40 p-2 dark:border-border-dark dark:bg-card-primary-dark/30"
+                >
+                    <label
+                        htmlFor={`kb-review-survivor-${doc.id}`}
+                        className="text-[11px] text-text-muted dark:text-text-muted-dark/70"
+                    >
+                        {t('review.supersedePrompt')}
+                    </label>
+                    <select
+                        id={`kb-review-survivor-${doc.id}`}
+                        data-testid={`kb-review-row-${doc.id}-survivor-select`}
+                        value={survivorId}
+                        onChange={(e) => setSurvivorId(e.target.value)}
+                        className="rounded border border-border bg-transparent px-2 py-1 text-xs dark:border-border-dark"
+                    >
+                        <option value="">{t('review.supersedePlaceholder')}</option>
+                        {(candidates ?? []).map((candidate) => (
+                            <option key={candidate.id} value={candidate.id}>
+                                {candidate.title || candidate.path}
+                            </option>
+                        ))}
+                    </select>
+                    <button
+                        type="button"
+                        data-testid={`kb-review-row-${doc.id}-supersede-confirm`}
+                        disabled={!survivorId || busy !== null}
+                        onClick={() =>
+                            run('supersede', () =>
+                                supersedeKbDecisionAction({
+                                    workId,
+                                    docId: doc.id,
+                                    supersededByDocId: survivorId,
+                                    path: doc.path,
+                                }),
+                            )
+                        }
+                        className="rounded-md border border-border px-2 py-1 text-xs font-medium disabled:opacity-50 dark:border-border-dark"
+                    >
+                        {t('review.supersedeConfirm')}
+                    </button>
+                    <button
+                        type="button"
+                        data-testid={`kb-review-row-${doc.id}-supersede-cancel`}
+                        onClick={() => setPicking(false)}
+                        className="rounded-md px-2 py-1 text-xs text-text-muted hover:bg-card-hover dark:hover:bg-card-primary-dark/40"
+                    >
+                        {t('review.cancel')}
+                    </button>
+                </div>
+            ) : null}
+
+            {expanded ? (
+                <div
+                    data-testid={`kb-review-row-${doc.id}-preview`}
+                    className="mt-2 whitespace-pre-wrap rounded-md bg-card-hover/50 p-2 text-xs text-text-secondary dark:bg-card-primary-dark/30 dark:text-text-secondary-dark/80"
+                >
+                    {previewLoading
+                        ? t('review.previewLoading')
+                        : truncate(preview ?? '', PREVIEW_CHARS) || t('review.previewEmpty')}
+                </div>
+            ) : null}
+
+            {rowError ? (
+                <p
+                    role="alert"
+                    data-testid={`kb-review-row-${doc.id}-error`}
+                    className="mt-2 text-xs text-danger"
+                >
+                    {rowError}
+                </p>
+            ) : null}
+        </li>
+    );
+}
+
+interface RowActionProps {
+    readonly testId: string;
+    readonly label: string;
+    readonly icon: React.ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+    readonly busy: boolean;
+    readonly disabled: boolean;
+    readonly onClick: () => void;
+}
+
+function RowAction({ testId, label, icon: Icon, busy, disabled, onClick }: RowActionProps) {
+    return (
+        <button
+            type="button"
+            data-testid={testId}
+            disabled={disabled}
+            onClick={onClick}
+            className={cn(
+                'inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs font-medium',
+                'text-text-secondary hover:bg-card-hover disabled:opacity-50',
+                'dark:border-border-dark dark:text-text-secondary-dark/80 dark:hover:bg-card-primary-dark/40',
+            )}
+        >
+            {busy ? (
+                <Loader2 className="h-3 w-3 animate-spin" aria-hidden={true} />
+            ) : (
+                <Icon className="h-3 w-3" aria-hidden={true} />
+            )}
+            {label}
+        </button>
+    );
+}
+
+/** Trim a body preview at a character budget without splitting mid-word. */
+export function truncate(text: string, max: number): string {
+    const trimmed = text.trim();
+    if (trimmed.length <= max) return trimmed;
+    const cut = trimmed.slice(0, max);
+    const lastSpace = cut.lastIndexOf(' ');
+    return `${(lastSpace > max * 0.6 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+}
+
+function formatTimestamp(iso: string): string {
+    const date = new Date(iso);
+    return Number.isNaN(date.getTime())
+        ? '—'
+        : date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}

--- a/apps/web/src/components/kb/workbench/KbReviewQueue.unit.spec.tsx
+++ b/apps/web/src/components/kb/workbench/KbReviewQueue.unit.spec.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, vars?: Record<string, unknown>) => {
+        if (!vars) return key;
+        // The real messages interpolate `{source}` etc; the mock appends
+        // the values so specs can assert on them without duplicating copy.
+        return `${key} ${Object.values(vars).join(' ')}`;
+    },
+}));
+
+const routerRefreshMock = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) =>
+        React.createElement('a', { href, ...rest }, children),
+    useRouter: () => ({
+        push: vi.fn(),
+        refresh: routerRefreshMock,
+        back: vi.fn(),
+        replace: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    usePathname: () => '/',
+}));
+
+const listProposedMock = vi.fn();
+const acceptMock = vi.fn();
+const archiveMock = vi.fn();
+const supersedeMock = vi.fn();
+const bodyMock = vi.fn();
+const candidatesMock = vi.fn();
+
+vi.mock('@/app/actions/works/kb-review', () => ({
+    listProposedKbDocumentsAction: (...args: unknown[]) => listProposedMock(...args),
+    acceptKbDocumentAction: (...args: unknown[]) => acceptMock(...args),
+    archiveKbDocumentAction: (...args: unknown[]) => archiveMock(...args),
+    supersedeKbDecisionAction: (...args: unknown[]) => supersedeMock(...args),
+    getKbDocumentBodyAction: (...args: unknown[]) => bodyMock(...args),
+    listSupersedeCandidatesAction: (...args: unknown[]) => candidatesMock(...args),
+}));
+
+import { KbReviewQueue, truncate } from './KbReviewQueue';
+import type { KbDocumentDto } from '@ever-works/contracts';
+
+function doc(overrides: Partial<KbDocumentDto> = {}): KbDocumentDto {
+    return {
+        id: 'doc-1',
+        workId: 'work-1',
+        organizationId: null,
+        path: 'output/agent-note.md',
+        slug: 'agent-note',
+        title: 'Agent note',
+        description: 'What the agent learned.',
+        class: 'output',
+        tags: [],
+        categories: [],
+        status: 'active',
+        locked: false,
+        lockMode: null,
+        language: 'en',
+        wordCount: null,
+        tokenCount: null,
+        source: 'agent',
+        sourceUploadId: null,
+        sourceUrl: null,
+        generatedByAgentRunId: null,
+        createdById: null,
+        updatedById: null,
+        createdAt: '2026-07-02T09:00:00.000Z',
+        updatedAt: '2026-07-02T09:00:00.000Z',
+        lastCommitSha: null,
+        lastIndexedAt: null,
+        reviewState: 'proposed',
+        ...overrides,
+    };
+}
+
+describe('truncate', () => {
+    it('returns short text unchanged', () => {
+        expect(truncate('hello world', 100)).toBe('hello world');
+    });
+
+    it('cuts on a word boundary and appends an ellipsis', () => {
+        const out = truncate('alpha beta gamma delta epsilon', 20);
+        expect(out.endsWith('…')).toBe(true);
+        expect(out.length).toBeLessThanOrEqual(21);
+    });
+});
+
+describe('KbReviewQueue', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders the empty state when nothing is awaiting review', () => {
+        render(<KbReviewQueue workId="work-1" initialDocuments={[]} />);
+        expect(screen.getByTestId('kb-review-queue-empty')).toBeTruthy();
+        expect(listProposedMock).not.toHaveBeenCalled();
+    });
+
+    it('renders the error state with a retry that re-fetches', async () => {
+        listProposedMock.mockResolvedValue({ success: true, data: { items: [], total: 0 } });
+        render(<KbReviewQueue workId="work-1" initialDocuments={[]} initialError="boom" />);
+        expect(screen.getByTestId('kb-review-queue-error').textContent).toContain('boom');
+        fireEvent.click(screen.getByTestId('kb-review-queue-retry'));
+        await waitFor(() => expect(listProposedMock).toHaveBeenCalledWith('work-1'));
+    });
+
+    it('fetches on mount when no server-rendered page was supplied', async () => {
+        listProposedMock.mockResolvedValue({
+            success: true,
+            data: { items: [doc()], total: 1 },
+        });
+        render(<KbReviewQueue workId="work-1" />);
+        await waitFor(() => expect(screen.getByTestId('kb-review-row-doc-1')).toBeTruthy());
+    });
+
+    it('shows source, created-at and the count badge for each row', () => {
+        render(<KbReviewQueue workId="work-1" initialDocuments={[doc()]} />);
+        expect(screen.getByTestId('kb-review-queue-count').textContent).toBe('1');
+        expect(screen.getByTestId('kb-review-row-doc-1-source').textContent).toContain('agent');
+        expect(screen.getByTestId('kb-review-row-doc-1-created').textContent).not.toBe('—');
+    });
+
+    it('lazily loads a content preview when a row is expanded', async () => {
+        bodyMock.mockResolvedValue({ success: true, data: { body: 'the note body' } });
+        render(<KbReviewQueue workId="work-1" initialDocuments={[doc()]} />);
+        expect(screen.queryByTestId('kb-review-row-doc-1-preview')).toBeNull();
+
+        fireEvent.click(screen.getByTestId('kb-review-row-doc-1-toggle'));
+        await waitFor(() =>
+            expect(screen.getByTestId('kb-review-row-doc-1-preview').textContent).toContain(
+                'the note body',
+            ),
+        );
+        expect(bodyMock).toHaveBeenCalledWith('work-1', 'doc-1');
+    });
+
+    it('accepts a document and drops it from the queue', async () => {
+        acceptMock.mockResolvedValue({ success: true, data: doc({ reviewState: 'accepted' }) });
+        render(<KbReviewQueue workId="work-1" initialDocuments={[doc()]} />);
+
+        fireEvent.click(screen.getByTestId('kb-review-row-doc-1-accept'));
+        await waitFor(() => expect(screen.queryByTestId('kb-review-row-doc-1')).toBeNull());
+        expect(acceptMock).toHaveBeenCalledWith({
+            workId: 'work-1',
+            docId: 'doc-1',
+            path: 'output/agent-note.md',
+        });
+    });
+
+    it('archives a document via the existing archive endpoint', async () => {
+        archiveMock.mockResolvedValue({ success: true, data: doc({ status: 'archived' }) });
+        render(<KbReviewQueue workId="work-1" initialDocuments={[doc()]} />);
+
+        fireEvent.click(screen.getByTestId('kb-review-row-doc-1-archive'));
+        await waitFor(() => expect(archiveMock).toHaveBeenCalled());
+    });
+
+    it('surfaces a per-row error and keeps the row when an action fails', async () => {
+        acceptMock.mockResolvedValue({ success: false, error: 'nope' });
+        render(<KbReviewQueue workId="work-1" initialDocuments={[doc()]} />);
+
+        fireEvent.click(screen.getByTestId('kb-review-row-doc-1-accept'));
+        await waitFor(() =>
+            expect(screen.getByTestId('kb-review-row-doc-1-error').textContent).toBe('nope'),
+        );
+        expect(screen.getByTestId('kb-review-row-doc-1')).toBeTruthy();
+    });
+
+    it('offers Edit & accept as a link into the existing editor', () => {
+        render(<KbReviewQueue workId="work-1" initialDocuments={[doc()]} />);
+        expect(screen.getByTestId('kb-review-row-doc-1-edit').getAttribute('href')).toBe(
+            '/works/work-1/kb/output/agent-note.md',
+        );
+    });
+
+    it('hides Supersede for non-decision documents (the status machine is decision-scoped)', () => {
+        render(<KbReviewQueue workId="work-1" initialDocuments={[doc()]} />);
+        expect(screen.queryByTestId('kb-review-row-doc-1-supersede')).toBeNull();
+    });
+
+    it('offers Supersede for decision-class documents', () => {
+        render(
+            <KbReviewQueue
+                workId="work-1"
+                initialDocuments={[doc({ class: 'decision', path: 'decision/db.md' })]}
+            />,
+        );
+        expect(screen.getByTestId('kb-review-row-doc-1-supersede')).toBeTruthy();
+    });
+
+    it('supersedes a decision through the decision-status transition with the chosen survivor', async () => {
+        candidatesMock.mockResolvedValue({
+            success: true,
+            data: [doc({ id: 'survivor-1', title: 'New call', class: 'decision' })],
+        });
+        supersedeMock.mockResolvedValue({ success: true, data: doc() });
+        render(
+            <KbReviewQueue
+                workId="work-1"
+                initialDocuments={[doc({ class: 'decision', path: 'decision/db.md' })]}
+            />,
+        );
+
+        fireEvent.click(screen.getByTestId('kb-review-row-doc-1-supersede'));
+        await waitFor(() =>
+            expect(screen.getByTestId('kb-review-row-doc-1-survivor-select')).toBeTruthy(),
+        );
+        await waitFor(() => expect(candidatesMock).toHaveBeenCalledWith('work-1', 'doc-1'));
+
+        fireEvent.change(screen.getByTestId('kb-review-row-doc-1-survivor-select'), {
+            target: { value: 'survivor-1' },
+        });
+        fireEvent.click(screen.getByTestId('kb-review-row-doc-1-supersede-confirm'));
+
+        await waitFor(() =>
+            expect(supersedeMock).toHaveBeenCalledWith({
+                workId: 'work-1',
+                docId: 'doc-1',
+                supersededByDocId: 'survivor-1',
+                path: 'decision/db.md',
+            }),
+        );
+    });
+});

--- a/apps/web/src/components/kb/workbench/KbTreePanel.tsx
+++ b/apps/web/src/components/kb/workbench/KbTreePanel.tsx
@@ -17,6 +17,7 @@ import {
     Milestone,
     Palette,
     Search,
+    ShieldQuestion,
     Sparkles,
     UploadCloud,
     Users,
@@ -120,6 +121,13 @@ export function KbTreePanel({ workId, currentDocPath, refreshKey }: KbTreePanelP
     }, [workId, refreshKey]);
 
     const grouped = useMemo(() => groupByClass(documents), [documents]);
+    // Memory upgrades M8 — how many documents are waiting for review.
+    // Derived from the list this panel already fetched (the KB list is
+    // unfiltered, so `proposed` docs are in it) — zero extra requests.
+    const proposedCount = useMemo(
+        () => documents.filter((doc) => doc.reviewState === 'proposed').length,
+        [documents],
+    );
     // Pre-compute which class contains the active doc so it opens by
     // default on first render (without overriding subsequent user
     // toggles — see `expandedDefaults`).
@@ -145,6 +153,33 @@ export function KbTreePanel({ workId, currentDocPath, refreshKey }: KbTreePanelP
                     onClick={() => setTab('originals')}
                     testId="kb-workbench-tab-originals"
                 />
+                {/* Memory upgrades M8 — the review queue's entry point.
+                    A link (not a tab) because the queue is its own route
+                    inside the same workbench shell. The count badge is
+                    what makes the queue discoverable at all: without it
+                    `proposed` documents are captured and never surfaced. */}
+                <Link
+                    href={`${ROUTES.DASHBOARD_WORK_KB(workId)}/review`}
+                    data-testid="kb-workbench-review-link"
+                    aria-label={t('review.navAria', { count: proposedCount })}
+                    className={cn(
+                        'ml-auto inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors',
+                        proposedCount > 0
+                            ? 'text-amber-700 hover:bg-amber-500/10 dark:text-amber-300'
+                            : 'text-text-muted hover:bg-card-hover hover:text-text dark:text-text-muted-dark/70 dark:hover:bg-card-primary-dark/40',
+                    )}
+                >
+                    <ShieldQuestion className="h-3.5 w-3.5" aria-hidden="true" />
+                    <span>{t('review.nav')}</span>
+                    {proposedCount > 0 ? (
+                        <span
+                            data-testid="kb-workbench-review-badge"
+                            className="rounded-full bg-amber-500/20 px-1.5 text-[10px] font-semibold text-amber-800 dark:text-amber-200"
+                        >
+                            {proposedCount}
+                        </span>
+                    ) : null}
+                </Link>
             </header>
 
             <div className="flex-1 overflow-y-auto p-2">

--- a/apps/web/src/components/kb/workbench/KbTreePanel.unit.spec.tsx
+++ b/apps/web/src/components/kb/workbench/KbTreePanel.unit.spec.tsx
@@ -151,4 +151,41 @@ describe('workbench KbTreePanel', () => {
             expect(screen.getByTestId('kb-workbench-row-d1-lock')).toBeTruthy();
         });
     });
+
+    // ─── Memory upgrades M8 — review-queue discoverability ────────────
+
+    it('links to the review queue route', async () => {
+        mockFetchOnce([doc({ id: 'd1' })]);
+        render(<KbTreePanel workId="work-1" />);
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-workbench-review-link')).toBeTruthy();
+        });
+        expect(screen.getByTestId('kb-workbench-review-link').getAttribute('href')).toBe(
+            '/works/work-1/kb/review',
+        );
+    });
+
+    it('badges the count of documents awaiting review', async () => {
+        mockFetchOnce([
+            doc({ id: 'd1', reviewState: 'proposed', source: 'agent' }),
+            doc({ id: 'd2', reviewState: 'proposed', source: 'agent' }),
+            doc({ id: 'd3', reviewState: 'accepted' }),
+            // Pre-M7 rows carry a null column and must NOT count as work.
+            doc({ id: 'd4', reviewState: null }),
+        ]);
+        render(<KbTreePanel workId="work-1" />);
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-workbench-review-badge')).toBeTruthy();
+        });
+        expect(screen.getByTestId('kb-workbench-review-badge').textContent).toBe('2');
+    });
+
+    it('hides the badge when nothing is awaiting review', async () => {
+        mockFetchOnce([doc({ id: 'd1', reviewState: 'accepted' }), doc({ id: 'd2' })]);
+        render(<KbTreePanel workId="work-1" />);
+        await waitFor(() => {
+            expect(screen.getByTestId('kb-workbench-review-link')).toBeTruthy();
+        });
+        expect(screen.queryByTestId('kb-workbench-review-badge')).toBeNull();
+    });
 });

--- a/apps/web/src/components/tasks/TaskDecisionConflicts.tsx
+++ b/apps/web/src/components/tasks/TaskDecisionConflicts.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/navigation';
+import { ROUTES } from '@/lib/constants';
+import { cn } from '@/lib/utils/cn';
+import { ExternalLink, ScrollText } from 'lucide-react';
+import type { DecisionConflictDto } from '@ever-works/contracts';
+import { getTaskDecisionConflictsAction } from '@/app/actions/tasks';
+
+/**
+ * Re-litigation guard (memory upgrades M6) — the Task-side surface.
+ *
+ * Lists the `class=decision, status=accepted` Knowledge Base documents
+ * that this Task's title + description appear to re-open, as computed by
+ * the API's deterministic `term-overlap/v1` heuristic (no LLM, no
+ * embeddings — see `DecisionConflictService`).
+ *
+ * **Informational only.** Nothing here blocks, disables, or gates any
+ * Task action; the banner exists so the operator finds out that the
+ * question is already settled BEFORE spending a run on it, and can click
+ * straight through to the decision to read the rationale.
+ *
+ * It re-checks whenever `refreshKey` changes — the Task detail client
+ * bumps that after a description save, which is exactly the "or its
+ * description is edited" half of the requirement.
+ */
+
+export interface TaskDecisionConflictsProps {
+    readonly taskId: string;
+    /** Bump to re-run the check (e.g. after the description is saved). */
+    readonly refreshKey?: number;
+    /**
+     * Pre-computed conflicts. When provided the component renders them
+     * directly and skips the initial fetch — used by the unit specs.
+     */
+    readonly initialConflicts?: DecisionConflictDto[];
+}
+
+export function TaskDecisionConflicts({
+    taskId,
+    refreshKey = 0,
+    initialConflicts,
+}: TaskDecisionConflictsProps) {
+    const t = useTranslations('dashboard.tasksPage.decisionConflicts');
+    const [conflicts, setConflicts] = useState<DecisionConflictDto[]>(initialConflicts ?? []);
+
+    useEffect(() => {
+        // The very first render uses `initialConflicts` when supplied;
+        // every explicit refresh still re-fetches.
+        if (initialConflicts !== undefined && refreshKey === 0) return;
+        let cancelled = false;
+        void (async () => {
+            const report = await getTaskDecisionConflictsAction(taskId);
+            if (cancelled) return;
+            setConflicts(report.conflicts ?? []);
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [taskId, refreshKey, initialConflicts]);
+
+    // Silent by default — the overwhelmingly common case is "no settled
+    // decision touches this Task", and a banner that renders an empty
+    // state would be pure noise on every Task page.
+    if (conflicts.length === 0) return null;
+
+    return (
+        <section
+            data-testid="task-decision-conflicts"
+            role="status"
+            className="rounded-xl border border-amber-500/40 bg-amber-500/10 p-4"
+        >
+            <div className="flex items-center gap-2">
+                <ScrollText
+                    className="h-4 w-4 shrink-0 text-amber-700 dark:text-amber-300"
+                    aria-hidden="true"
+                />
+                <h2 className="text-sm font-medium text-amber-900 dark:text-amber-200">
+                    {t('title', { count: conflicts.length })}
+                </h2>
+            </div>
+            <p className="mt-1 text-xs text-amber-800/90 dark:text-amber-200/80">{t('subtitle')}</p>
+            <ul className="mt-3 space-y-2">
+                {conflicts.map((conflict) => (
+                    <li
+                        key={conflict.documentId}
+                        data-testid={`task-decision-conflict-${conflict.documentId}`}
+                        data-signal={conflict.signal}
+                        className="rounded-lg border border-amber-500/30 bg-card/60 p-2.5 dark:bg-card-primary-dark/40"
+                    >
+                        <div className="flex items-start gap-2">
+                            <span
+                                className={cn(
+                                    'mt-0.5 rounded-full px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+                                    conflict.signal === 'strong'
+                                        ? 'bg-amber-500/25 text-amber-900 dark:text-amber-200'
+                                        : 'bg-amber-500/10 text-amber-800 dark:text-amber-300/90',
+                                )}
+                            >
+                                {t(`signal.${conflict.signal}`)}
+                            </span>
+                            <div className="min-w-0 flex-1">
+                                {conflict.workId ? (
+                                    <Link
+                                        href={`${ROUTES.DASHBOARD_WORK_KB(conflict.workId)}/${conflict.path}`}
+                                        data-testid={`task-decision-conflict-${conflict.documentId}-link`}
+                                        className="inline-flex items-center gap-1 text-sm font-medium text-text hover:underline dark:text-text-dark"
+                                    >
+                                        {conflict.title}
+                                        <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                                    </Link>
+                                ) : (
+                                    <span className="text-sm font-medium text-text dark:text-text-dark">
+                                        {conflict.title}
+                                    </span>
+                                )}
+                                {conflict.rationale ? (
+                                    <p className="mt-0.5 text-xs text-text-secondary dark:text-text-secondary-dark/80">
+                                        {conflict.rationale}
+                                    </p>
+                                ) : null}
+                                {conflict.overlapTerms.length > 0 ? (
+                                    <p className="mt-0.5 text-[11px] text-text-muted dark:text-text-muted-dark/70">
+                                        {t('overlap', {
+                                            terms: conflict.overlapTerms.slice(0, 6).join(', '),
+                                        })}
+                                    </p>
+                                ) : null}
+                            </div>
+                        </div>
+                    </li>
+                ))}
+            </ul>
+            <p className="mt-3 text-[11px] text-amber-800/80 dark:text-amber-200/70">
+                {t('advisory')}
+            </p>
+        </section>
+    );
+}

--- a/apps/web/src/components/tasks/TaskDecisionConflicts.unit.spec.tsx
+++ b/apps/web/src/components/tasks/TaskDecisionConflicts.unit.spec.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, vars?: Record<string, unknown>) => {
+        if (!vars) return key;
+        // The real messages interpolate `{count}` / `{terms}`; the mock
+        // appends the values so specs can assert on them directly.
+        return `${key} ${Object.values(vars).join(' ')}`;
+    },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+    Link: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) =>
+        React.createElement('a', { href, ...rest }, children),
+    useRouter: () => ({
+        push: vi.fn(),
+        refresh: vi.fn(),
+        back: vi.fn(),
+        replace: vi.fn(),
+        forward: vi.fn(),
+        prefetch: vi.fn(),
+    }),
+    usePathname: () => '/',
+}));
+
+const conflictsMock = vi.fn();
+vi.mock('@/app/actions/tasks', () => ({
+    getTaskDecisionConflictsAction: (...args: unknown[]) => conflictsMock(...args),
+}));
+
+import { TaskDecisionConflicts } from './TaskDecisionConflicts';
+import type { DecisionConflictDto } from '@ever-works/contracts';
+
+function conflict(overrides: Partial<DecisionConflictDto> = {}): DecisionConflictDto {
+    return {
+        documentId: 'dec-1',
+        path: 'decision/database-engine.md',
+        slug: 'database-engine',
+        title: 'Use PostgreSQL as the primary database engine',
+        workId: 'work-1',
+        rationale: 'JSONB + pgvector',
+        decidedAt: '2026-07-01T10:00:00.000Z',
+        score: 0.83,
+        overlapTerms: ['database', 'engine', 'postgresql'],
+        signal: 'strong',
+        ...overrides,
+    };
+}
+
+describe('TaskDecisionConflicts', () => {
+    beforeEach(() => vi.clearAllMocks());
+    afterEach(() => vi.clearAllMocks());
+
+    it('renders nothing when there are no conflicts (silent by default)', () => {
+        const { container } = render(
+            <TaskDecisionConflicts taskId="task-1" initialConflicts={[]} />,
+        );
+        expect(container.firstChild).toBeNull();
+        expect(conflictsMock).not.toHaveBeenCalled();
+    });
+
+    it('lists conflicting decisions with a link into the KB document', () => {
+        render(<TaskDecisionConflicts taskId="task-1" initialConflicts={[conflict()]} />);
+        expect(screen.getByTestId('task-decision-conflicts')).toBeTruthy();
+        expect(screen.getByTestId('task-decision-conflict-dec-1-link').getAttribute('href')).toBe(
+            '/works/work-1/kb/decision/database-engine.md',
+        );
+    });
+
+    it('renders the rationale and the shared terms that produced the flag', () => {
+        render(<TaskDecisionConflicts taskId="task-1" initialConflicts={[conflict()]} />);
+        const row = screen.getByTestId('task-decision-conflict-dec-1');
+        expect(row.textContent).toContain('JSONB + pgvector');
+        expect(row.textContent).toContain('database, engine, postgresql');
+    });
+
+    it('distinguishes strong from moderate signals', () => {
+        render(
+            <TaskDecisionConflicts
+                taskId="task-1"
+                initialConflicts={[
+                    conflict(),
+                    conflict({ documentId: 'dec-2', signal: 'moderate', workId: null }),
+                ]}
+            />,
+        );
+        expect(screen.getByTestId('task-decision-conflict-dec-1').dataset.signal).toBe('strong');
+        expect(screen.getByTestId('task-decision-conflict-dec-2').dataset.signal).toBe('moderate');
+        // No workId ⇒ no KB link (nothing to point at), but the row still renders.
+        expect(screen.queryByTestId('task-decision-conflict-dec-2-link')).toBeNull();
+    });
+
+    it('fetches on mount when no pre-computed conflicts are supplied', async () => {
+        conflictsMock.mockResolvedValue({
+            conflicts: [conflict()],
+            scanned: 3,
+            heuristic: 'term-overlap/v1',
+        });
+        render(<TaskDecisionConflicts taskId="task-1" />);
+        await waitFor(() => expect(screen.getByTestId('task-decision-conflicts')).toBeTruthy());
+        expect(conflictsMock).toHaveBeenCalledWith('task-1');
+    });
+
+    it('re-checks when the refresh key changes (description edited)', async () => {
+        conflictsMock.mockResolvedValue({
+            conflicts: [],
+            scanned: 0,
+            heuristic: 'term-overlap/v1',
+        });
+        const { rerender } = render(
+            <TaskDecisionConflicts taskId="task-1" initialConflicts={[]} refreshKey={0} />,
+        );
+        expect(conflictsMock).not.toHaveBeenCalled();
+
+        rerender(<TaskDecisionConflicts taskId="task-1" initialConflicts={[]} refreshKey={1} />);
+        await waitFor(() => expect(conflictsMock).toHaveBeenCalledWith('task-1'));
+    });
+
+    it('stays silent when the re-check comes back empty', async () => {
+        conflictsMock.mockResolvedValue({
+            conflicts: [],
+            scanned: 5,
+            heuristic: 'term-overlap/v1',
+        });
+        const { container } = render(<TaskDecisionConflicts taskId="task-1" />);
+        await waitFor(() => expect(conflictsMock).toHaveBeenCalled());
+        expect(container.firstChild).toBeNull();
+    });
+});

--- a/apps/web/src/components/tasks/TaskDetailClient.tsx
+++ b/apps/web/src/components/tasks/TaskDetailClient.tsx
@@ -21,6 +21,7 @@ import { TaskAttachmentsSection } from './TaskAttachmentsSection';
 import { TaskBranchSection } from './TaskBranchSection';
 import { TaskChecksSection } from './TaskChecksSection';
 import { TaskRunControls } from './TaskRunControls';
+import { TaskDecisionConflicts } from './TaskDecisionConflicts';
 
 // Status tones + dots mirror /tasks (TasksList) so colours stay
 // consistent across the list filter and the detail workflow buttons.
@@ -129,6 +130,10 @@ export function TaskDetailClient({
     const [descDraft, setDescDraft] = useState(task.description ?? '');
     const [pendingDesc, startDesc] = useTransition();
     const [descError, setDescError] = useState<string | null>(null);
+    // Re-litigation guard (memory upgrades M6). Bumped after a
+    // description save so the conflict check re-runs against the new
+    // intent — "created OR its description is edited".
+    const [conflictKey, setConflictKey] = useState(0);
 
     const handlePost = (e: React.FormEvent) => {
         e.preventDefault();
@@ -172,6 +177,7 @@ export function TaskDetailClient({
                     });
                     setDescription(updated.description ?? '');
                     setEditingDesc(false);
+                    setConflictKey((prev) => prev + 1);
                 } catch (err) {
                     setDescError(err instanceof Error ? err.message : t('saveDescriptionError'));
                 }
@@ -266,6 +272,11 @@ export function TaskDetailClient({
                             </p>
                         )}
                     </div>
+
+                    {/* Re-litigation guard (memory upgrades M6) — settled
+                        decisions this Task appears to re-open. Renders
+                        nothing when there are none; never blocks. */}
+                    <TaskDecisionConflicts taskId={task.id} refreshKey={conflictKey} />
 
                     {/* Description — inline editable, saves via updateTaskAction. */}
                     <section className="rounded-xl border border-border/60 dark:border-border-dark/60 bg-card dark:bg-card-primary-dark p-5">

--- a/apps/web/src/lib/api/kb.ts
+++ b/apps/web/src/lib/api/kb.ts
@@ -2,6 +2,7 @@ import 'server-only';
 import { serverFetch, serverMutation } from './server-api';
 import type {
     CreateKbDocumentInput,
+    KbDecisionStatus,
     KbDocumentBodyDto,
     KbDocumentDto,
     KbDocumentHistoryResult,
@@ -41,6 +42,9 @@ export const kbAPI = {
         if (opts.tag && !Array.isArray(opts.tag)) params.append('tag', opts.tag);
         if (typeof opts.locked === 'boolean') params.append('locked', String(opts.locked));
         if (opts.language) params.append('language', opts.language);
+        // Memory upgrades M8 — review-queue filter (`proposed` = the
+        // agent-authored docs excluded from injection until accepted).
+        if (opts.reviewState) params.append('reviewState', opts.reviewState);
         if (opts.q) params.append('q', opts.q);
         if (typeof opts.limit === 'number') params.append('limit', String(opts.limit));
         if (opts.cursor) params.append('offset', opts.cursor);
@@ -253,6 +257,60 @@ export const kbAPI = {
         return serverFetch<KbDocumentHistoryResult>(
             `/works/${workId}/kb/documents/${encodeURIComponent(docId)}/history${query}`,
         );
+    },
+
+    /**
+     * `POST /api/works/:id/kb/documents/:docId/accept` — memory upgrades
+     * M7 review action. Flips `reviewState` to `accepted` so the document
+     * starts feeding agent context; a decision-class doc still in
+     * `proposed` decision status is accepted as current in the same call.
+     * Idempotent.
+     */
+    acceptDocument: async (workId: string, docId: string): Promise<KbDocumentDto> => {
+        return serverMutation<KbDocumentDto>({
+            endpoint: `/works/${workId}/kb/documents/${encodeURIComponent(docId)}/accept`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * `POST /api/works/:id/kb/documents/:docId/archive` — memory upgrades
+     * M7 review action. Status-flip to `archived` (kept readable, dropped
+     * from default listings + injection) — never a physical delete.
+     * Idempotent.
+     */
+    archiveDocument: async (workId: string, docId: string): Promise<KbDocumentDto> => {
+        return serverMutation<KbDocumentDto>({
+            endpoint: `/works/${workId}/kb/documents/${encodeURIComponent(docId)}/archive`,
+            data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /**
+     * `POST /api/works/:id/kb/documents/:docId/decision-status` — memory
+     * upgrades M4 decision status machine. The review queue's
+     * "Supersede" action uses it with `status: 'superseded'` plus the
+     * surviving decision's id, which records the chain on BOTH documents.
+     */
+    transitionDecisionStatus: async (
+        workId: string,
+        docId: string,
+        input: {
+            status: KbDecisionStatus;
+            supersededByDocId?: string;
+            rationale?: string;
+        },
+    ): Promise<KbDocumentDto> => {
+        return serverMutation<KbDocumentDto>({
+            endpoint: `/works/${workId}/kb/documents/${encodeURIComponent(docId)}/decision-status`,
+            data: input as unknown as Record<string, unknown>,
+            method: 'POST',
+            wrapInData: false,
+        });
     },
 
     /**

--- a/apps/web/src/lib/api/tasks.ts
+++ b/apps/web/src/lib/api/tasks.ts
@@ -1,5 +1,9 @@
 import 'server-only';
-import type { GateStatus, TaskAcceptanceCheck } from '@ever-works/contracts';
+import type {
+    DecisionConflictReportDto,
+    GateStatus,
+    TaskAcceptanceCheck,
+} from '@ever-works/contracts';
 import { ApiResponseError, serverFetch, serverMutation } from './server-api';
 
 export type TaskStatus =
@@ -230,6 +234,18 @@ export const tasksAPI = {
             data: {},
             method: 'POST',
             wrapInData: false,
+        });
+    },
+
+    /**
+     * Re-litigation guard (memory upgrades M6) — settled decisions this
+     * Task appears to re-open. Deterministic term-overlap check on the
+     * API side; advisory only, never blocking. Returns
+     * `{ conflicts, scanned, heuristic }`.
+     */
+    async decisionConflicts(id: string) {
+        return serverFetch<DecisionConflictReportDto>(`/tasks/${id}/decision-conflicts`, {
+            method: 'GET',
         });
     },
 

--- a/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
+++ b/packages/agent/src/database/repositories/work-knowledge-document.repository.ts
@@ -8,6 +8,7 @@ import {
     KbDocumentSource,
     KbDocumentStatus,
     KbLockMode,
+    KbReviewState,
 } from '../../entities/kb-types';
 import { sanitizeLikePattern } from '../utils';
 
@@ -20,6 +21,14 @@ export interface KbDocumentListOptions {
     locked?: boolean;
     language?: string;
     source?: KbDocumentSource;
+    /**
+     * Memory upgrades M8 — review-state filter powering the review
+     * queue. `proposed` matches the column exactly; `accepted` also
+     * matches `NULL` because a null `review_state` reads as accepted
+     * everywhere else in the system (the M7 feature is additive and
+     * never backfilled pre-existing rows).
+     */
+    reviewState?: KbReviewState;
     q?: string;
     limit?: number;
     offset?: number;
@@ -207,6 +216,19 @@ export class WorkKnowledgeDocumentRepository {
 
         if (opts.source) {
             qb.andWhere('doc.source = :source', { source: opts.source });
+        }
+
+        if (opts.reviewState === KbReviewState.PROPOSED) {
+            qb.andWhere('doc.reviewState = :reviewState', {
+                reviewState: KbReviewState.PROPOSED,
+            });
+        } else if (opts.reviewState === KbReviewState.ACCEPTED) {
+            // `NULL` reads as accepted (M7 is additive — no backfill),
+            // so the accepted filter must include the un-stamped rows or
+            // it would hide every document created before the feature.
+            qb.andWhere('(doc.reviewState = :reviewState OR doc.reviewState IS NULL)', {
+                reviewState: KbReviewState.ACCEPTED,
+            });
         }
 
         if (opts.q) {

--- a/packages/agent/src/dto/kb.dto.ts
+++ b/packages/agent/src/dto/kb.dto.ts
@@ -18,10 +18,12 @@ import {
     KB_DOCUMENT_CLASSES,
     KB_DOCUMENT_STATUSES,
     KB_LOCK_MODES,
+    KB_REVIEW_STATES,
     KbDecisionStatus,
     KbDocumentClass,
     KbDocumentStatus,
     KbLockMode,
+    KbReviewState,
 } from '@ever-works/contracts';
 
 /** Max body size per spec D9 — 1 MB Markdown. */
@@ -149,6 +151,18 @@ export class KbDocumentQueryDto {
     @IsString()
     @Length(2, 8)
     language?: string;
+
+    /**
+     * Memory upgrades M8 — review-queue filter. `proposed` returns only
+     * the agent-authored / synthesized documents awaiting human review
+     * (the ones excluded from context injection); `accepted` returns the
+     * reviewed set, including pre-M7 rows whose column is still NULL.
+     * Additive: omitting it preserves the original "list everything"
+     * behaviour every existing caller relies on.
+     */
+    @IsOptional()
+    @IsIn(KB_REVIEW_STATES as unknown as readonly string[])
+    reviewState?: KbReviewState;
 
     @IsOptional()
     @IsString()

--- a/packages/agent/src/services/__tests__/decision-conflict.service.spec.ts
+++ b/packages/agent/src/services/__tests__/decision-conflict.service.spec.ts
@@ -1,0 +1,218 @@
+import {
+    CANDIDATE_LIMIT,
+    DECISION_CONFLICT_HEURISTIC,
+    DecisionConflictService,
+    extractTerms,
+    scoreDecision,
+} from '../decision-conflict.service';
+import { KnowledgeBaseService } from '../knowledge-base.service';
+
+/**
+ * Re-litigation guard (memory upgrades M6) — unit coverage for the
+ * deterministic `term-overlap/v1` heuristic and its owner-scoped
+ * candidate fetch.
+ *
+ * The two properties that matter most are asserted explicitly:
+ *  - only `class=decision, status=accepted, reviewState != proposed`
+ *    documents are ever scored, and
+ *  - unrelated intents produce ZERO conflicts (false positives are the
+ *    failure mode that would make this feature unusable).
+ */
+
+type DecisionDoc = Parameters<typeof scoreDecision>[0] & {
+    decision?: { status?: string; rationale?: string | null } | null;
+    reviewState?: string | null;
+    class?: string;
+};
+
+function decisionDoc(overrides: Partial<DecisionDoc> = {}): DecisionDoc {
+    return {
+        id: 'doc-1',
+        path: 'decision/database-engine.md',
+        slug: 'database-engine',
+        title: 'Use PostgreSQL as the primary database engine',
+        description: 'Chosen over MySQL for JSONB and extension support.',
+        workId: 'work-1',
+        updatedAt: '2026-07-01T10:00:00.000Z',
+        class: 'decision',
+        reviewState: 'accepted',
+        decision: { status: 'accepted', rationale: 'JSONB + pgvector' },
+        ...overrides,
+    };
+}
+
+function makeService(items: DecisionDoc[]) {
+    const listDocuments = jest.fn().mockResolvedValue({ items, total: items.length });
+    const kb = { listDocuments } as unknown as KnowledgeBaseService;
+    return { service: new DecisionConflictService(kb), listDocuments };
+}
+
+describe('extractTerms', () => {
+    it('lowercases, drops short tokens and stop-words, and de-duplicates', () => {
+        const terms = extractTerms('The PostgreSQL database, the database and a DB');
+        expect(terms.has('postgresql')).toBe(true);
+        expect(terms.has('database')).toBe(true);
+        // stop-word + sub-3-char token
+        expect(terms.has('the')).toBe(false);
+        expect(terms.has('db')).toBe(false);
+    });
+
+    it('de-pluralizes only tokens longer than four characters', () => {
+        const terms = extractTerms('engines apis');
+        expect(terms.has('engine')).toBe(true);
+        // `apis` is 4 chars — left intact so short stems are not mangled.
+        expect(terms.has('apis')).toBe(true);
+    });
+
+    it('returns an empty set for empty input', () => {
+        expect(extractTerms('').size).toBe(0);
+    });
+});
+
+describe('scoreDecision — thresholds', () => {
+    it('flags a strong conflict when the intent restates the whole decision title', () => {
+        const intent = extractTerms(
+            'Switch the primary database engine away from PostgreSQL to MySQL',
+        );
+        const hit = scoreDecision(decisionDoc(), intent);
+        expect(hit).not.toBeNull();
+        expect(hit?.signal).toBe('strong');
+        expect(hit?.overlapTerms).toEqual(expect.arrayContaining(['postgresql', 'database']));
+        expect(hit?.score).toBeGreaterThanOrEqual(0.6);
+    });
+
+    it('returns null for an unrelated intent (no false positive)', () => {
+        const intent = extractTerms('Redesign the marketing landing page hero illustration');
+        expect(scoreDecision(decisionDoc(), intent)).toBeNull();
+    });
+
+    it('returns null when only ONE significant term is shared', () => {
+        // "database" alone is below the 2-term overlap floor.
+        const intent = extractTerms('Document the database backup runbook for on-call rotation');
+        const hit = scoreDecision(
+            decisionDoc({
+                title: 'Use PostgreSQL',
+                description: 'Primary engine decision.',
+            }),
+            intent,
+        );
+        expect(hit).toBeNull();
+    });
+
+    it('skips decisions whose subject has fewer than two significant terms', () => {
+        const intent = extractTerms('postgresql everywhere for every service we operate');
+        expect(
+            scoreDecision(decisionDoc({ title: 'PostgreSQL', description: null }), intent),
+        ).toBeNull();
+    });
+
+    it('reports a moderate signal for partial subject overlap', () => {
+        const doc = decisionDoc({
+            title: 'Adopt trunk-based development with short-lived feature branches',
+            description: null,
+        });
+        const intent = extractTerms('Adopt trunk based development for the mobile client');
+        const hit = scoreDecision(doc, intent);
+        expect(hit).not.toBeNull();
+        expect(['strong', 'moderate']).toContain(hit?.signal);
+    });
+
+    it('carries the decision rationale and a stable rounded score', () => {
+        const intent = extractTerms('Move the primary database engine off PostgreSQL');
+        const hit = scoreDecision(decisionDoc(), intent);
+        expect(hit?.rationale).toBe('JSONB + pgvector');
+        expect(hit?.documentId).toBe('doc-1');
+        expect(hit?.path).toBe('decision/database-engine.md');
+        expect(Number.isFinite(hit?.score)).toBe(true);
+        expect(String(hit?.score)).toMatch(/^\d(\.\d{1,2})?$/);
+    });
+});
+
+describe('DecisionConflictService.checkIntent', () => {
+    it('returns an empty report (and never queries) for a Task with no Work', async () => {
+        const { service, listDocuments } = makeService([decisionDoc()]);
+        const report = await service.checkIntent({
+            workId: null,
+            userId: 'user-1',
+            title: 'Switch the primary database engine to MySQL',
+        });
+        expect(report.conflicts).toEqual([]);
+        expect(report.scanned).toBe(0);
+        expect(report.heuristic).toBe(DECISION_CONFLICT_HEURISTIC);
+        expect(listDocuments).not.toHaveBeenCalled();
+    });
+
+    it('fetches decision-class candidates owner-scoped through the KB service', async () => {
+        const { service, listDocuments } = makeService([decisionDoc()]);
+        await service.checkIntent({
+            workId: 'work-1',
+            userId: 'user-1',
+            title: 'Replace the primary database engine, dropping PostgreSQL',
+        });
+        expect(listDocuments).toHaveBeenCalledWith('work-1', 'user-1', {
+            class: 'decision',
+            limit: CANDIDATE_LIMIT,
+        });
+    });
+
+    it('scores only accepted, non-proposed decisions', async () => {
+        const { service } = makeService([
+            decisionDoc({ id: 'accepted-1' }),
+            decisionDoc({ id: 'proposed-1', decision: { status: 'proposed' } }),
+            decisionDoc({ id: 'superseded-1', decision: { status: 'superseded' } }),
+            decisionDoc({ id: 'unreviewed-1', reviewState: 'proposed' }),
+        ]);
+        const report = await service.checkIntent({
+            workId: 'work-1',
+            userId: 'user-1',
+            title: 'Replace the primary database engine, dropping PostgreSQL',
+        });
+        expect(report.scanned).toBe(1);
+        expect(report.conflicts.map((c) => c.documentId)).toEqual(['accepted-1']);
+    });
+
+    it('sorts conflicts by descending score and honours maxConflicts', async () => {
+        const { service } = makeService([
+            decisionDoc({
+                id: 'weak',
+                title: 'Adopt trunk-based development with short-lived branches',
+                description: null,
+                decision: { status: 'accepted' },
+            }),
+            decisionDoc({ id: 'strong', decision: { status: 'accepted' } }),
+        ]);
+        const report = await service.checkIntent({
+            workId: 'work-1',
+            userId: 'user-1',
+            title: 'Move the primary database engine off PostgreSQL and adopt trunk based development',
+            maxConflicts: 1,
+        });
+        expect(report.conflicts).toHaveLength(1);
+        expect(report.scanned).toBe(2);
+    });
+
+    it('degrades to an empty report when the KB read fails (never breaks Task creation)', async () => {
+        const listDocuments = jest.fn().mockRejectedValue(new Error('db down'));
+        const service = new DecisionConflictService({
+            listDocuments,
+        } as unknown as KnowledgeBaseService);
+        const report = await service.checkIntent({
+            workId: 'work-1',
+            userId: 'user-1',
+            title: 'Replace the primary database engine, dropping PostgreSQL',
+        });
+        expect(report.conflicts).toEqual([]);
+        expect(report.scanned).toBe(0);
+    });
+
+    it('returns nothing for an intent too short to judge', async () => {
+        const { service, listDocuments } = makeService([decisionDoc()]);
+        const report = await service.checkIntent({
+            workId: 'work-1',
+            userId: 'user-1',
+            title: 'Fix',
+        });
+        expect(report.conflicts).toEqual([]);
+        expect(listDocuments).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/services/__tests__/kb-review-queue.spec.ts
+++ b/packages/agent/src/services/__tests__/kb-review-queue.spec.ts
@@ -1,0 +1,212 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { KB_STORAGE_PLUGIN, KnowledgeBaseService } from '../knowledge-base.service';
+import { KB_EMBED_DOCUMENT_DISPATCHER } from '../../tasks/kb-embed-document-dispatcher';
+import { WorkKnowledgeDocumentRepository } from '../../database/repositories/work-knowledge-document.repository';
+import { WorkKnowledgeUploadRepository } from '../../database/repositories/work-knowledge-upload.repository';
+import { WorkKnowledgeTagRepository } from '../../database/repositories/work-knowledge-tag.repository';
+import { WorkKnowledgeCitationRepository } from '../../database/repositories/work-knowledge-citation.repository';
+import { WorkOwnershipService } from '../work-ownership.service';
+import { ActivityLogService } from '../../activity-log/activity-log.service';
+import { WorkKnowledgeDocument } from '../../entities/work-knowledge-document.entity';
+import {
+    KbDocumentClass,
+    KbDocumentSource,
+    KbDocumentStatus,
+    KbReviewState,
+} from '../../entities/kb-types';
+
+/**
+ * Memory upgrades M8 — the review queue's data path.
+ *
+ * The queue is "list the documents the platform captured but excluded
+ * from injection". Two things must hold or the feature is a lie:
+ *  - the `reviewState` filter reaches the repository (service layer), and
+ *  - the repository turns it into a predicate that treats a NULL column
+ *    as `accepted` (so pre-M7 rows never show up as review work).
+ */
+
+const WORK_ID = '00000000-0000-0000-0000-0000000000a1';
+const USER_ID = '00000000-0000-0000-0000-0000000000a2';
+
+function buildDocument(overrides: Partial<WorkKnowledgeDocument> = {}): WorkKnowledgeDocument {
+    return {
+        id: '00000000-0000-0000-0000-0000000000b1',
+        workId: WORK_ID,
+        organizationId: null,
+        path: 'output/agent-note.md',
+        slug: 'agent-note',
+        title: 'Agent note',
+        description: null,
+        kbDocumentClass: KbDocumentClass.OUTPUT,
+        tags: null,
+        categories: null,
+        status: KbDocumentStatus.ACTIVE,
+        locked: false,
+        lockMode: null,
+        language: 'en',
+        wordCount: 0,
+        tokenCount: 0,
+        source: KbDocumentSource.AGENT,
+        sourceUploadId: null,
+        sourceUrl: null,
+        generatedByAgentRunId: null,
+        createdById: USER_ID,
+        updatedById: USER_ID,
+        lastIndexedAt: null,
+        lastCommitSha: null,
+        metadata: { body: 'note body' },
+        consolidation: null,
+        decision: null,
+        reviewState: KbReviewState.PROPOSED,
+        createdAt: new Date('2026-07-02T09:00:00Z'),
+        updatedAt: new Date('2026-07-02T09:00:00Z'),
+        ...overrides,
+    } as WorkKnowledgeDocument;
+}
+
+describe('KnowledgeBaseService.listDocuments — reviewState filter (M8)', () => {
+    let service: KnowledgeBaseService;
+    let docRepo: jest.Mocked<WorkKnowledgeDocumentRepository>;
+
+    beforeEach(async () => {
+        const docRepoMock: Partial<jest.Mocked<WorkKnowledgeDocumentRepository>> = {
+            list: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+            findById: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                KnowledgeBaseService,
+                { provide: WorkKnowledgeDocumentRepository, useValue: docRepoMock },
+                {
+                    provide: WorkKnowledgeUploadRepository,
+                    useValue: { findById: jest.fn(), create: jest.fn(), update: jest.fn() },
+                },
+                {
+                    provide: WorkKnowledgeTagRepository,
+                    useValue: { list: jest.fn().mockResolvedValue([]) },
+                },
+                {
+                    provide: WorkKnowledgeCitationRepository,
+                    useValue: { listForDocument: jest.fn().mockResolvedValue([]) },
+                },
+                {
+                    provide: WorkOwnershipService,
+                    useValue: {
+                        ensureCanView: jest.fn().mockResolvedValue({ role: 'editor' }),
+                        ensureCanEdit: jest.fn().mockResolvedValue({ role: 'editor' }),
+                    },
+                },
+                {
+                    provide: KB_STORAGE_PLUGIN,
+                    useValue: { isAvailable: jest.fn().mockResolvedValue(true) },
+                },
+                { provide: ActivityLogService, useValue: { log: jest.fn() } },
+                {
+                    provide: KB_EMBED_DOCUMENT_DISPATCHER,
+                    useValue: { dispatchKbEmbedDocument: jest.fn() },
+                },
+            ],
+        }).compile();
+
+        service = module.get(KnowledgeBaseService);
+        docRepo = module.get(WorkKnowledgeDocumentRepository);
+    });
+
+    it('forwards reviewState=proposed to the repository', async () => {
+        await service.listDocuments(WORK_ID, USER_ID, {
+            reviewState: KbReviewState.PROPOSED,
+            limit: 50,
+        });
+        expect(docRepo.list).toHaveBeenCalledWith(
+            expect.objectContaining({
+                workId: WORK_ID,
+                reviewState: KbReviewState.PROPOSED,
+                limit: 50,
+            }),
+        );
+    });
+
+    it('omits the filter entirely when reviewState is not supplied (additive)', async () => {
+        await service.listDocuments(WORK_ID, USER_ID, {});
+        expect(docRepo.list).toHaveBeenCalledWith(
+            expect.objectContaining({ reviewState: undefined }),
+        );
+    });
+
+    it('returns the proposed documents mapped through the DTO with reviewState carried', async () => {
+        docRepo.list.mockResolvedValue({ items: [buildDocument()], total: 1 });
+        const result = await service.listDocuments(WORK_ID, USER_ID, {
+            reviewState: KbReviewState.PROPOSED,
+        });
+        expect(result.total).toBe(1);
+        expect(result.items[0].reviewState).toBe('proposed');
+        expect(result.items[0].source).toBe('agent');
+    });
+});
+
+describe('WorkKnowledgeDocumentRepository.list — reviewState predicate (M8)', () => {
+    let repo: WorkKnowledgeDocumentRepository;
+    let qb: {
+        andWhere: jest.Mock;
+        orderBy: jest.Mock;
+        take: jest.Mock;
+        skip: jest.Mock;
+        getCount: jest.Mock;
+        getMany: jest.Mock;
+    };
+
+    beforeEach(async () => {
+        qb = {
+            andWhere: jest.fn().mockReturnThis(),
+            orderBy: jest.fn().mockReturnThis(),
+            take: jest.fn().mockReturnThis(),
+            skip: jest.fn().mockReturnThis(),
+            getCount: jest.fn().mockResolvedValue(0),
+            getMany: jest.fn().mockResolvedValue([]),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                WorkKnowledgeDocumentRepository,
+                {
+                    provide: getRepositoryToken(WorkKnowledgeDocument),
+                    useValue: { createQueryBuilder: jest.fn().mockReturnValue(qb) },
+                },
+            ],
+        }).compile();
+
+        repo = module.get(WorkKnowledgeDocumentRepository);
+    });
+
+    function predicates(): string[] {
+        return qb.andWhere.mock.calls.map((call) => String(call[0]));
+    }
+
+    it('matches the column exactly for proposed', async () => {
+        await repo.list({ workId: WORK_ID, reviewState: KbReviewState.PROPOSED });
+        expect(predicates()).toContain('doc.reviewState = :reviewState');
+        expect(qb.andWhere).toHaveBeenCalledWith('doc.reviewState = :reviewState', {
+            reviewState: 'proposed',
+        });
+    });
+
+    it('treats a NULL column as accepted', async () => {
+        await repo.list({ workId: WORK_ID, reviewState: KbReviewState.ACCEPTED });
+        expect(predicates()).toContain(
+            '(doc.reviewState = :reviewState OR doc.reviewState IS NULL)',
+        );
+    });
+
+    it('adds no review predicate when the filter is omitted', async () => {
+        await repo.list({ workId: WORK_ID });
+        expect(predicates().some((p) => p.includes('reviewState'))).toBe(false);
+    });
+
+    it('still enforces the mandatory tenant scope guard', async () => {
+        await expect(repo.list({ reviewState: KbReviewState.PROPOSED })).rejects.toThrow(
+            /requires workId or organizationId/,
+        );
+    });
+});

--- a/packages/agent/src/services/decision-conflict.service.ts
+++ b/packages/agent/src/services/decision-conflict.service.ts
@@ -1,0 +1,362 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type {
+    DecisionConflictDto,
+    DecisionConflictReportDto,
+    DecisionConflictSignal,
+} from '@ever-works/contracts';
+import { KbDecisionStatus, KbDocumentClass, KbReviewState } from '../entities/kb-types';
+import { KnowledgeBaseService } from './knowledge-base.service';
+
+/**
+ * Re-litigation guard — memory upgrades M6.
+ *
+ * When a Task is created (or its description is edited), the platform
+ * compares the Task's *intent* against the settled calls the org already
+ * recorded: Knowledge Base documents with `class=decision` and
+ * `decision.status=accepted`. Anything that looks like a restatement is
+ * surfaced to the user as an informational banner.
+ *
+ * ## The heuristic (`term-overlap/v1`)
+ *
+ * v1 is DETERMINISTIC on purpose — no LLM judgement, no embeddings, no
+ * network. The same input always produces the same flags, which is what
+ * makes the feature safe to put in front of a user who is mid-typing.
+ *
+ * 1. **Candidates** come from the existing KB retrieval
+ *    (`KnowledgeBaseService.listDocuments`, owner-scoped via
+ *    `ensureCanView`) filtered to `class=decision`. Only documents whose
+ *    `decision.status` is `accepted` AND whose `reviewState` is not
+ *    `proposed` are scored — a proposal is not a settled call, and an
+ *    unreviewed agent-authored doc is not yet part of the org's memory.
+ * 2. **Terms** are extracted from free text by lowercasing, splitting on
+ *    non-alphanumerics, dropping tokens shorter than
+ *    {@link MIN_TERM_LENGTH}, dropping a small English stop-word list,
+ *    and de-pluralizing a trailing `s` on tokens longer than 4 chars.
+ *    The result is a SET, so repetition never inflates a score.
+ * 3. **Scores** are two containment ratios, both in `0..1`:
+ *      - `subjectCoverage`  = |overlap| / |decision title ∪ description terms|
+ *      - `titleCoverage`    = |title overlap| / |decision title terms|
+ *    and `score = max(subjectCoverage, titleCoverage)`.
+ *    Containment (not Jaccard) is deliberate: a long Task description
+ *    should not dilute the signal that it restates a one-line decision.
+ * 4. **Thresholds** — a conflict needs at least
+ *    {@link MIN_OVERLAP_TERMS} shared significant terms in every case,
+ *    which is the single biggest false-positive suppressor:
+ *      - `strong`   — `titleCoverage === 1` (the intent contains every
+ *                     significant term of the decision's title) OR
+ *                     `score >= 0.6`
+ *      - `moderate` — `score >= 0.4`
+ *      - otherwise  — not reported at all.
+ *    Decisions or intents with fewer than {@link MIN_SUBJECT_TERMS}
+ *    significant terms are skipped entirely: there is not enough text to
+ *    judge, and guessing there is where noisy flags come from.
+ *
+ * The report is ADVISORY. This service never blocks, never mutates a
+ * Task, and never transitions a decision — the caller renders it and the
+ * user decides.
+ */
+
+/** Shortest token kept as a "significant" term. */
+export const MIN_TERM_LENGTH = 3;
+
+/** Minimum shared significant terms before anything is reported. */
+export const MIN_OVERLAP_TERMS = 2;
+
+/**
+ * Minimum significant terms on BOTH sides before a comparison is even
+ * attempted. Below this the ratios are dominated by a single token and
+ * the flag would be noise.
+ */
+export const MIN_SUBJECT_TERMS = 2;
+
+/** `score` at or above this (with the overlap floor) is a strong signal. */
+export const STRONG_SCORE_THRESHOLD = 0.6;
+
+/** `score` at or above this (with the overlap floor) is a moderate signal. */
+export const MODERATE_SCORE_THRESHOLD = 0.4;
+
+/** How many accepted decisions are pulled from KB retrieval and scored. */
+export const CANDIDATE_LIMIT = 200;
+
+/** How many conflicts are returned to the caller (highest score first). */
+export const DEFAULT_MAX_CONFLICTS = 5;
+
+/** Stable marker recorded on every report. */
+export const DECISION_CONFLICT_HEURISTIC = 'term-overlap/v1';
+
+/**
+ * Small, deliberately boring English stop-word list. Kept inline (not a
+ * dependency) so the heuristic has zero runtime surface and stays
+ * reviewable in one screen. Words here are the ones that would otherwise
+ * create overlap between two completely unrelated sentences.
+ */
+const STOP_WORDS: ReadonlySet<string> = new Set([
+    'the',
+    'and',
+    'for',
+    'with',
+    'that',
+    'this',
+    'from',
+    'into',
+    'onto',
+    'our',
+    'their',
+    'your',
+    'its',
+    'has',
+    'have',
+    'had',
+    'was',
+    'were',
+    'are',
+    'been',
+    'being',
+    'not',
+    'but',
+    'all',
+    'any',
+    'can',
+    'will',
+    'would',
+    'should',
+    'could',
+    'must',
+    'may',
+    'might',
+    'shall',
+    'about',
+    'after',
+    'before',
+    'when',
+    'while',
+    'where',
+    'which',
+    'what',
+    'why',
+    'how',
+    'who',
+    'whom',
+    'than',
+    'then',
+    'there',
+    'here',
+    'each',
+    'every',
+    'some',
+    'more',
+    'most',
+    'other',
+    'such',
+    'only',
+    'own',
+    'same',
+    'too',
+    'very',
+    'just',
+    'also',
+    'now',
+    'get',
+    'got',
+    'let',
+    'via',
+    'per',
+    'use',
+    'used',
+    'using',
+    'make',
+    'made',
+    'need',
+    'needs',
+    'want',
+    'add',
+    'new',
+    'old',
+    'task',
+    'tasks',
+    'work',
+    'works',
+    'please',
+    'todo',
+]);
+
+/** Input for a single conflict check. */
+export interface DecisionConflictInput {
+    /**
+     * Work whose Knowledge Base holds the candidate decisions. `null` /
+     * `undefined` (a Task with no Work scope) short-circuits to an empty
+     * report — decisions live in a Work's KB.
+     */
+    workId?: string | null;
+    /** Caller — every candidate read is owner-scoped through the KB service. */
+    userId: string;
+    /** The intent's title (Task title). */
+    title: string;
+    /** The intent's body (Task description). Optional. */
+    description?: string | null;
+    /** Cap on returned conflicts. Defaults to {@link DEFAULT_MAX_CONFLICTS}. */
+    maxConflicts?: number;
+}
+
+@Injectable()
+export class DecisionConflictService {
+    private readonly logger = new Logger(DecisionConflictService.name);
+
+    constructor(private readonly kb: KnowledgeBaseService) {}
+
+    /**
+     * Score an intent against the accepted decisions in a Work's KB.
+     *
+     * Never throws for the "no signal" cases — a Task without a Work, a
+     * Work without decisions, or a title too short to judge all return an
+     * empty report. A KB read failure is logged and degraded to an empty
+     * report too: the guard is advisory and must never break Task
+     * creation.
+     */
+    async checkIntent(input: DecisionConflictInput): Promise<DecisionConflictReportDto> {
+        const empty: DecisionConflictReportDto = {
+            conflicts: [],
+            scanned: 0,
+            heuristic: DECISION_CONFLICT_HEURISTIC,
+        };
+
+        if (!input.workId) return empty;
+
+        const intentTerms = extractTerms(`${input.title ?? ''} ${input.description ?? ''}`);
+        if (intentTerms.size < MIN_SUBJECT_TERMS) return empty;
+
+        let candidates: Awaited<ReturnType<KnowledgeBaseService['listDocuments']>>['items'];
+        try {
+            // Reuse the existing retrieval surface (owner-scoped via
+            // `ensureCanView`) rather than reaching into the repository:
+            // one authorization path, one place to change when the KB
+            // list grows new semantics.
+            const result = await this.kb.listDocuments(input.workId, input.userId, {
+                class: KbDocumentClass.DECISION,
+                limit: CANDIDATE_LIMIT,
+            });
+            candidates = result.items;
+        } catch (error) {
+            this.logger.warn(
+                `Decision-conflict check skipped for work ${input.workId}: ${(error as Error).message}`,
+            );
+            return empty;
+        }
+
+        const accepted = candidates.filter(
+            (doc) =>
+                doc.decision?.status === KbDecisionStatus.ACCEPTED &&
+                doc.reviewState !== KbReviewState.PROPOSED,
+        );
+
+        const conflicts: DecisionConflictDto[] = [];
+        for (const doc of accepted) {
+            const conflict = scoreDecision(doc, intentTerms);
+            if (conflict) conflicts.push(conflict);
+        }
+
+        conflicts.sort((a, b) => b.score - a.score || a.title.localeCompare(b.title));
+
+        const max = input.maxConflicts ?? DEFAULT_MAX_CONFLICTS;
+        return {
+            conflicts: conflicts.slice(0, Math.max(0, max)),
+            scanned: accepted.length,
+            heuristic: DECISION_CONFLICT_HEURISTIC,
+        };
+    }
+}
+
+/**
+ * Candidate shape the scorer needs. Declared structurally so the scoring
+ * helpers stay unit-testable without constructing a full `KbDocumentDto`.
+ */
+interface ScorableDecision {
+    id: string;
+    path: string;
+    slug: string;
+    title: string;
+    description: string | null;
+    workId: string | null;
+    updatedAt: string;
+    decision?: { rationale?: string | null } | null;
+}
+
+/**
+ * Split free text into the SET of significant terms used by the
+ * heuristic. Exported for the spec + for any future caller that wants to
+ * explain a flag to a user.
+ */
+export function extractTerms(text: string): Set<string> {
+    const out = new Set<string>();
+    if (!text) return out;
+    for (const raw of text.toLowerCase().split(/[^a-z0-9]+/)) {
+        if (raw.length < MIN_TERM_LENGTH) continue;
+        if (STOP_WORDS.has(raw)) continue;
+        // De-pluralize conservatively: only tokens long enough that the
+        // trailing `s` is unlikely to be part of the stem.
+        const stem = raw.length > 4 && raw.endsWith('s') ? raw.slice(0, -1) : raw;
+        if (stem.length < MIN_TERM_LENGTH) continue;
+        if (STOP_WORDS.has(stem)) continue;
+        out.add(stem);
+    }
+    return out;
+}
+
+function intersect(a: ReadonlySet<string>, b: ReadonlySet<string>): string[] {
+    const out: string[] = [];
+    for (const term of a) {
+        if (b.has(term)) out.push(term);
+    }
+    return out;
+}
+
+/**
+ * Apply `term-overlap/v1` to one accepted decision. Returns `null` when
+ * the signal is below the moderate threshold (i.e. not reported).
+ *
+ * Exported so the thresholds can be exercised directly in unit tests
+ * without a Nest DI container.
+ */
+export function scoreDecision(
+    doc: ScorableDecision,
+    intentTerms: ReadonlySet<string>,
+): DecisionConflictDto | null {
+    const titleTerms = extractTerms(doc.title ?? '');
+    const subjectTerms = extractTerms(`${doc.title ?? ''} ${doc.description ?? ''}`);
+
+    if (subjectTerms.size < MIN_SUBJECT_TERMS) return null;
+    if (intentTerms.size < MIN_SUBJECT_TERMS) return null;
+
+    const overlapTerms = intersect(subjectTerms, intentTerms);
+    if (overlapTerms.length < MIN_OVERLAP_TERMS) return null;
+
+    const subjectCoverage = overlapTerms.length / subjectTerms.size;
+    const titleOverlap = intersect(titleTerms, intentTerms);
+    const titleCoverage = titleTerms.size > 0 ? titleOverlap.length / titleTerms.size : 0;
+    const score = Math.max(subjectCoverage, titleCoverage);
+
+    let signal: DecisionConflictSignal | null = null;
+    if (
+        (titleCoverage === 1 && titleOverlap.length >= MIN_OVERLAP_TERMS) ||
+        score >= STRONG_SCORE_THRESHOLD
+    ) {
+        signal = 'strong';
+    } else if (score >= MODERATE_SCORE_THRESHOLD) {
+        signal = 'moderate';
+    }
+    if (!signal) return null;
+
+    return {
+        documentId: doc.id,
+        path: doc.path,
+        slug: doc.slug,
+        title: doc.title,
+        workId: doc.workId ?? null,
+        rationale: doc.decision?.rationale ?? null,
+        decidedAt: doc.updatedAt,
+        // Round so the wire value is stable across float noise.
+        score: Math.round(score * 100) / 100,
+        overlapTerms: overlapTerms.sort(),
+        signal,
+    };
+}

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -38,6 +38,7 @@ export * from './knowledge-base-transcribe.service';
 export * from './knowledge-base-reembed.service';
 export * from './knowledge-base-buffer-extractor.service';
 export * from './knowledge-base-reconcile.service';
+export * from './decision-conflict.service';
 export * from './knowledge-base.module';
 export * from './kb-chunker';
 export * from './kb-rrf';

--- a/packages/agent/src/services/knowledge-base.module.spec.ts
+++ b/packages/agent/src/services/knowledge-base.module.spec.ts
@@ -61,6 +61,7 @@ jest.mock('./knowledge-base-git-mirror.service', () => ({
 jest.mock('./knowledge-base-buffer-extractor.service', () => ({
     KnowledgeBaseBufferExtractorService: class {},
 }));
+jest.mock('./decision-conflict.service', () => ({ DecisionConflictService: class {} }));
 jest.mock('./kb-mention-resolver.service', () => ({ KbMentionResolverService: class {} }));
 jest.mock('./kb-agent-tools.service', () => ({ KbAgentToolsService: class {} }));
 jest.mock('./kb-tools-facade.adapter', () => ({ KbToolsFacadeAdapter: class {} }));
@@ -71,9 +72,12 @@ import { KnowledgeBaseModule } from './knowledge-base.module';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { DatabaseModule } from '../database/database.module';
 import { FacadesModule } from '../facades/facades.module';
+import { DecisionConflictService } from './decision-conflict.service';
 
 describe('KnowledgeBaseModule — static metadata', () => {
     const imports = Reflect.getMetadata('imports', KnowledgeBaseModule) as unknown[];
+    const providers = Reflect.getMetadata('providers', KnowledgeBaseModule) as unknown[];
+    const exports_ = Reflect.getMetadata('exports', KnowledgeBaseModule) as unknown[];
 
     it('declares its expected non-TypeORM imports', () => {
         // The TypeORM forFeature import is a dynamic shell from the
@@ -93,5 +97,17 @@ describe('KnowledgeBaseModule — static metadata', () => {
         // retry) that poll the activity-log endpoint for KB rows time
         // out after 30s. Lock this import in.
         expect(imports).toContain(ActivityLogModule);
+    });
+
+    it('provides AND exports DecisionConflictService (memory upgrades M6)', () => {
+        // The api-side `TasksModule` imports this module purely so
+        // `TasksController` can inject `DecisionConflictService` for
+        // `GET /api/tasks/:id/decision-conflicts`. A provider that is not
+        // ALSO in `exports` is invisible to the importing module, and
+        // NestJS fails the whole API boot with an
+        // `UnknownDependenciesException` — a class of break that neither
+        // tsc nor the unit suite would otherwise catch.
+        expect(providers).toContain(DecisionConflictService);
+        expect(exports_).toContain(DecisionConflictService);
     });
 });

--- a/packages/agent/src/services/knowledge-base.module.ts
+++ b/packages/agent/src/services/knowledge-base.module.ts
@@ -23,6 +23,7 @@ import { KnowledgeBaseMediaNormalizeService } from './knowledge-base-media-norma
 import { KnowledgeBaseTranscribeService } from './knowledge-base-transcribe.service';
 import { KnowledgeBaseReembedService } from './knowledge-base-reembed.service';
 import { KnowledgeBaseReconcileService } from './knowledge-base-reconcile.service';
+import { DecisionConflictService } from './decision-conflict.service';
 import { KbMentionResolverService } from './kb-mention-resolver.service';
 import { KbAgentToolsService } from './kb-agent-tools.service';
 import { KbToolsFacadeAdapter } from './kb-tools-facade.adapter';
@@ -109,6 +110,11 @@ import { WorkOwnershipService } from './work-ownership.service';
         // `WorkKnowledgeUploadRepository` below, and `KB_STORAGE_PLUGIN`
         // from the `@Global()` `KbStorageModule` in apps/api.
         KnowledgeBaseReconcileService,
+        // Re-litigation guard (memory upgrades M6) — deterministic
+        // conflict check of a Task's intent against the Work's accepted
+        // decisions. Depends only on `KnowledgeBaseService` (above), so
+        // it adds no new module imports.
+        DecisionConflictService,
         KbMentionResolverService,
         KbAgentToolsService,
         KbToolsFacadeAdapter,
@@ -128,6 +134,7 @@ import { WorkOwnershipService } from './work-ownership.service';
         KnowledgeBaseTranscribeService,
         KnowledgeBaseReembedService,
         KnowledgeBaseReconcileService,
+        DecisionConflictService,
         KbMentionResolverService,
         KbAgentToolsService,
         KbToolsFacadeAdapter,

--- a/packages/agent/src/services/knowledge-base.service.ts
+++ b/packages/agent/src/services/knowledge-base.service.ts
@@ -134,6 +134,14 @@ interface ListOptions {
     tag?: string;
     locked?: boolean;
     language?: string;
+    /**
+     * Memory upgrades M8 — review-state filter. `proposed` is the review
+     * queue's list call (agent-authored / synthesized documents that are
+     * excluded from context injection until a human accepts them);
+     * `accepted` returns the reviewed set including pre-M7 rows whose
+     * column is still NULL. Omit for the historical "everything" list.
+     */
+    reviewState?: KbReviewState;
     q?: string;
     limit?: number;
     offset?: number;
@@ -673,6 +681,7 @@ export class KnowledgeBaseService {
                 tag: opts.tag,
                 locked: opts.locked,
                 language: opts.language,
+                reviewState: opts.reviewState,
                 q: undefined,
                 limit: opts.limit,
                 offset: opts.offset,
@@ -696,6 +705,7 @@ export class KnowledgeBaseService {
                 tag: opts.tag,
                 locked: opts.locked,
                 language: opts.language,
+                reviewState: opts.reviewState,
                 q: trimmedQ,
                 limit: fusionLimit,
                 offset: 0,
@@ -748,8 +758,32 @@ export class KnowledgeBaseService {
             if (fetched) materialized.push(fetched);
         }
 
-        const sliced = materialized.slice(requestedOffset, requestedOffset + requestedLimit);
-        return { items: sliced.map((d) => this.toDto(d)), total: materialized.length };
+        // Memory upgrades M8 — the semantic leg of the blend is a
+        // chunk-level k-NN with no metadata predicate, so a doc that the
+        // lexical (filtered) leg excluded can still enter via the
+        // semantic ranking. Re-apply the review-state predicate on the
+        // merged list so `reviewState=proposed` never leaks an accepted
+        // document into the review queue (and vice versa).
+        const filtered = opts.reviewState
+            ? materialized.filter((d) => this.matchesReviewState(d, opts.reviewState))
+            : materialized;
+
+        const sliced = filtered.slice(requestedOffset, requestedOffset + requestedLimit);
+        return { items: sliced.map((d) => this.toDto(d)), total: filtered.length };
+    }
+
+    /**
+     * Memory upgrades M8 — in-memory mirror of the repository's
+     * review-state predicate. `null` reads as `accepted` because M7
+     * never backfilled the column.
+     */
+    private matchesReviewState(
+        doc: Pick<WorkKnowledgeDocument, 'reviewState'>,
+        wanted: KbReviewState | undefined,
+    ): boolean {
+        if (!wanted) return true;
+        if (wanted === KbReviewState.PROPOSED) return doc.reviewState === KbReviewState.PROPOSED;
+        return doc.reviewState !== KbReviewState.PROPOSED;
     }
 
     async getDocument(

--- a/packages/contracts/src/kb/decision-conflict.types.ts
+++ b/packages/contracts/src/kb/decision-conflict.types.ts
@@ -1,0 +1,51 @@
+/**
+ * Re-litigation guard (memory upgrades M6) — wire types.
+ *
+ * A "conflict" is a DETERMINISTIC signal that a new (or freshly edited)
+ * Task restates a subject the organization has already settled: an
+ * `class=decision`, `decision.status=accepted` Knowledge Base document.
+ * There is no LLM judgement in v1 — see
+ * `DecisionConflictService` in `@ever-works/agent/services` for the
+ * exact term-overlap heuristic and its thresholds.
+ *
+ * The report is ADVISORY. Nothing in the platform blocks, rejects, or
+ * auto-transitions a Task because of it; the UI renders an informational
+ * banner with links to the settled decisions and the user decides.
+ */
+
+/** Strength of a single deterministic conflict signal. */
+export type DecisionConflictSignal = 'strong' | 'moderate';
+
+/** One settled decision that the checked intent appears to re-open. */
+export interface DecisionConflictDto {
+	/** KB document id of the accepted decision. */
+	documentId: string;
+	/** Canonical `<class>/<slug>.md` path — used to build the KB link. */
+	path: string;
+	slug: string;
+	title: string;
+	/** Work that owns the decision (null for org-scope documents). */
+	workId: string | null;
+	/** One-line rationale recorded on the decision, when present. */
+	rationale: string | null;
+	/** ISO timestamp of the decision document's last update. */
+	decidedAt: string;
+	/** Normalized 0..1 overlap score (higher = more of the decision restated). */
+	score: number;
+	/** The significant terms shared by the intent and the decision. */
+	overlapTerms: string[];
+	signal: DecisionConflictSignal;
+}
+
+/**
+ * Result of a conflict check. `heuristic` is a stable version marker so
+ * a client (or a support conversation) can tell which rule produced a
+ * given flag after the thresholds are re-tuned.
+ */
+export interface DecisionConflictReportDto {
+	conflicts: DecisionConflictDto[];
+	/** How many accepted decisions were scored. */
+	scanned: number;
+	/** Heuristic identifier, e.g. `term-overlap/v1`. */
+	heuristic: string;
+}

--- a/packages/contracts/src/kb/index.ts
+++ b/packages/contracts/src/kb/index.ts
@@ -6,3 +6,4 @@ export * from './kb-citation.types.js';
 export * from './kb-search.types.js';
 export * from './kb-tree.types.js';
 export * from './kb-context-bundle.types.js';
+export * from './decision-conflict.types.js';

--- a/packages/contracts/src/kb/kb-document.types.ts
+++ b/packages/contracts/src/kb/kb-document.types.ts
@@ -135,6 +135,15 @@ export interface KbDocumentListFilter {
 	locked?: boolean;
 	language?: string;
 	source?: KbDocumentSource;
+	/**
+	 * Review-state filter (memory upgrades M7 / M8). `'proposed'` returns
+	 * only the agent-authored / synthesized documents awaiting review —
+	 * the review queue's list call. `'accepted'` returns the reviewed set
+	 * INCLUDING pre-existing rows whose `review_state` column is still
+	 * `NULL` (null reads as accepted). Omit for the historical
+	 * "everything" behaviour.
+	 */
+	reviewState?: KbReviewState;
 	/** Lexical search across title + description + body via Postgres FTS. */
 	q?: string;
 	limit?: number;


### PR DESCRIPTION
Closes backlog items **7** and **12** from `Research/audit/00-STATUS.md` §E (plan 05 **M8** + **M6**).

---

## Item 7 — Memory review queue UI (plan 05 M8)

The M7 backend already landed every agent-authored / consolidation-synthesized KB document as `reviewState='proposed'` and excluded it from context injection at all three retrieval paths — but `POST …/accept`, `POST …/archive` and the decision-status transition had **zero web callers**. As deployed the circuit breaker *discarded* agent learning instead of routing it to review. This PR is the missing half.

### (a) List endpoint — reused, not added
Checked first: no org-scoped proposed-doc endpoint existed (`org-memory.controller.ts` exposes only `GET memory` + `POST memory/consolidate`), and the per-Work list had no review filter. So the filter was added **additively** to the endpoint that already exists rather than minting a new route:

- `GET /api/works/:id/kb/documents?reviewState=proposed|accepted` — `KbDocumentQueryDto` (`@IsIn(KB_REVIEW_STATES)`), `KnowledgeBaseService.ListOptions`, and `WorkKnowledgeDocumentRepository.list`.
- `accepted` matches `review_state = 'accepted' OR review_state IS NULL` — M7 never backfilled, and a NULL column reads as accepted everywhere else. Without this, every pre-M7 row would have vanished from an `accepted` filter.
- The RRF (`q=`) branch re-applies the predicate on the merged list, because the semantic leg is a chunk-level k-NN with no metadata predicate and could otherwise leak an accepted doc into the queue.
- Owner-scoped through the existing `ensureCanView`; the web proxy forwards the query string verbatim, so no proxy change was needed.

### (b) The queue — `/works/:id/kb/review`
Rendered inside the existing three-pane `WorkbenchShell` (same tree pane on the left), first page server-fetched. Per row: title, class chip, **source**, **created-at**, description, and a **lazy body preview** (the list endpoint is metadata-only, so expanding a row fetches that one document). Actions:

| Action | Endpoint |
|---|---|
| **Accept** | `POST …/documents/:docId/accept` (already shipped) |
| **Edit & accept** | link into the existing workbench editor → `KbReviewBanner` carries Accept/Archive so the operator edits first and accepts *in place* |
| **Supersede** | `POST …/documents/:docId/decision-status` with `superseded` + the picked survivor — decision-class only, since the status machine is decision-scoped |
| **Archive** | `POST …/documents/:docId/archive` (already shipped) |

No new API endpoints were introduced for the review actions.

### (c) Discoverability
A **Review** link with a count badge in the KB tree-panel header (the KB navigation). The count is derived from the document list the panel already fetches — zero extra requests — and correctly ignores `reviewState: null` rows.

### (d) States, testids, i18n
Loading / empty / error (+ retry) states, per-row error that keeps the row, `data-testid` on every interactive element (`kb-review-queue`, `kb-review-row-<id>-{accept,edit,supersede,archive,preview,error}`, `kb-workbench-review-link`, `kb-workbench-review-badge`, `kb-review-banner*`). i18n added to `apps/web/messages/en.json` only.

---

## Item 12 — Re-litigation guard (plan 05 M6)

### The heuristic: `term-overlap/v1` — deterministic, no LLM

Documented in full on `DecisionConflictService`; thresholds are exported constants so they are tunable and directly unit-testable.

1. **Candidates** come from the existing retrieval (`KnowledgeBaseService.listDocuments`, `class=decision`, bounded at 200, owner-scoped via `ensureCanView`), then filtered to `decision.status === 'accepted'` **and** `reviewState !== 'proposed'` — a proposal is not a settled call, and an unreviewed doc is not yet org memory.
2. **Terms**: lowercase → split on non-alphanumerics → drop tokens `< 3` chars → drop a small inline English stop-word list (incl. generic platform nouns like `task`/`work`) → de-pluralize a trailing `s` only on tokens `> 4` chars → **Set** (repetition can't inflate a score).
3. **Scores** — two containment ratios, not Jaccard, so a long Task description can't dilute the signal that it restates a one-line decision:
   - `subjectCoverage = |overlap| / |decision title ∪ description terms|`
   - `titleCoverage   = |title overlap| / |decision title terms|`
   - `score = max(subjectCoverage, titleCoverage)`
4. **Thresholds** — every flag needs **≥ 2 shared significant terms** (the single biggest false-positive suppressor):
   - `strong` — `titleCoverage === 1` (the intent contains every significant term of the decision title) **or** `score ≥ 0.6`
   - `moderate` — `score ≥ 0.4`
   - anything else is not reported at all
   - either side with `< 2` significant terms is skipped entirely — too little text to judge, and guessing there is where noise comes from

Top 5 by score are returned with `{ conflicts, scanned, heuristic }`; `heuristic` is a stable version marker so a flag can be explained after the thresholds are re-tuned.

### Surface
- **Service**: `DecisionConflictService.checkIntent({ workId, userId, title, description })` in `@ever-works/agent/services`, provided + exported by `KnowledgeBaseModule`.
- **Endpoint**: `GET /api/tasks/:id/decision-conflicts` — owner-scoped (`TasksService.getOne` 404s a Task the caller doesn't own; no 403 existence leak).
- **UI**: `TaskDecisionConflicts` banner on the Task detail/edit surface, listing each conflicting decision with a **link into the KB document**, its rationale, the shared terms that produced the flag, and a strong/possible chip. It re-checks when the description is saved. `NewTaskForm` pushes to the Task detail route on create, so the "created" half is covered by the same banner.
- **Never blocks.** No gating, no disabled buttons, no auto-transition. A KB read failure degrades to "no conflicts" rather than breaking the Task surface, and the banner renders nothing when there is no conflict.

---

## e2e DTO-whitelist sweep

Swept `apps/web/e2e` for `forbidNonWhitelisted` / "property X should not exist" assertions against everything this PR touches:

- **No create/patch DTO was modified.** The only DTO change is an additive optional field on the **query** DTO `KbDocumentQueryDto`. `flow-kb-documents-validation-authz-matrix.spec.ts` exercises whitelisting on the **create** (`injected`) and **update** (`evil`) bodies only — both untouched.
- `flow-tasks-recurring-reviewers.spec.ts:483` asserts `reviewState: 'approved'` → 400 on `POST /api/tasks/:id/reviewers`. That is `AddReviewerDto` / the `TaskReviewer` entity's own `reviewState` — a **different field on a different DTO**, not modified here. No conflict.
- `GET /api/tasks/:id/decision-conflicts` is a new read-only route with no body and no query params; no existing spec asserts a 404 for it.

**Finding: no e2e reconciliation required.**

---

## Verification (real output)

**`packages/agent` build — TSC 0 issues**
```
> nest build -b swc && tsc -p tsconfig.types.json
✔  TSC  Initializing type checker...
>  TSC  Found 0 issues.
>  SWC  Running...
Successfully compiled: 1074 files with swc (416.24ms)
```

**`packages/agent` jest — new suites + `knowledge-base|kb-`**
```
PASS src/services/__tests__/kb-review-queue.spec.ts (64.983 s)
PASS src/services/__tests__/decision-conflict.service.spec.ts (77.115 s)
...
Test Suites: 25 passed, 25 total
Tests:       392 passed, 392 total
```
plus the updated module pin spec:
```
PASS src/services/knowledge-base.module.spec.ts
  KnowledgeBaseModule — static metadata
    √ declares its expected non-TypeORM imports
    √ imports ActivityLogModule so KnowledgeBaseService.activityLog actually resolves at runtime
    √ provides AND exports DecisionConflictService (memory upgrades M6)
Tests: 3 passed, 3 total
```

**`pnpm build --filter=ever-works-api`**
```
ever-works-api:build: >  TSC  Found 0 issues.
ever-works-api:build: >  SWC  Running...
ever-works-api:build: Successfully compiled: 687 files with swc (565.48ms)
 Tasks:    14 successful, 14 total
```

**`apps/api pnpm generate:openapi`** (excluded from the commit — gitignored at `.gitignore:79`)
```
Wrote OpenAPI spec (440 paths) to C:\...\apps\api\openapi.json
```
New surface present in the emitted spec:
```
/api/tasks/{id}/decision-conflicts
list query params: [ 'id', 'offset', 'limit', 'q', 'reviewState', 'locked', 'tag', 'status', 'class' ]
```

**`apps/web npx tsc --noEmit`** (after `rm apps/web/tsconfig.tsbuildinfo`)
```
web tsc exit=0
```

**`apps/web` vitest — `src/components/kb`, `src/components/tasks`, `src/app/actions`**
```
 Test Files  16 passed (16)
      Tests  154 passed (154)
```

**eslint** on every touched web file: `exit=0` (one `react-hooks/set-state-in-effect` error was found and fixed — the mount effect now sets state only after the await). **prettier**: clean.

### Test totals
| | new tests |
|---|---|
| `decision-conflict.service.spec.ts` | 15 |
| `kb-review-queue.spec.ts` | 7 |
| `knowledge-base.module.spec.ts` (added) | 1 |
| `KbReviewQueue.unit.spec.tsx` | 14 |
| `KbReviewBanner.unit.spec.tsx` | 5 |
| `TaskDecisionConflicts.unit.spec.tsx` | 7 |
| `KbTreePanel.unit.spec.tsx` (added) | 3 |
| **Total new** | **52** |

---

## Notes / not done

- The queue is **Work-scoped**, matching the review-action endpoints (which are all `works/:id/kb/documents/:docId/*`). An org-wide roll-up on the Memory page would need org-scoped accept/archive routes that do not exist; not added here.
- The static `review` segment shadows the sibling `[...path]` catch-all for that one name. No real KB document can collide: canonical doc paths are always `<class>/<slug>.md`, i.e. at least two segments.
- `generate:openapi` runs Nest in **preview mode**, so it validates route/metadata emission but not provider instantiation. The DI risk (`TasksController` → `DecisionConflictService`) is covered instead by the module pin spec asserting the service is in both `providers` **and** `exports` of `KnowledgeBaseModule`, plus the `KnowledgeBaseModule` import added to the api-side `TasksModule`.
- No e2e specs added (backlog item 13 owns the e2e sweep for this whole program).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
