### PR TITLE
feat(tasks,ingest): board dispatch + workId routing (backlog 9, 10)

### DIFF
--- a/apps/api/src/ingest/dto/ingest-events.dto.spec.ts
+++ b/apps/api/src/ingest/dto/ingest-events.dto.spec.ts
@@ -73,4 +73,36 @@ describe('IngestEventsDto', () => {
         expect(errors).toHaveLength(1);
         expect(JSON.stringify(errors)).toContain('workId');
     });
+
+    it('accepts a well-formed workHint', async () => {
+        const errors = await validate(
+            build([
+                validEnvelope({
+                    workHint: { kind: 'chat-channel', externalId: 'C0123456789', label: 'general' },
+                }),
+            ]),
+        );
+        expect(errors).toHaveLength(0);
+    });
+
+    it('rejects a workHint of an unknown kind (the resolver must understand every kind it routes)', async () => {
+        const errors = await validate(
+            build([validEnvelope({ workHint: { kind: 'whatever', externalId: 'x' } })]),
+        );
+        expect(errors).toHaveLength(1);
+        expect(JSON.stringify(errors)).toContain('kind');
+    });
+
+    it('rejects a workHint with an empty or over-long externalId', async () => {
+        const empty = await validate(
+            build([validEnvelope({ workHint: { kind: 'repo', externalId: '' } })]),
+        );
+        expect(empty).toHaveLength(1);
+
+        const tooLong = await validate(
+            build([validEnvelope({ workHint: { kind: 'repo', externalId: 'x'.repeat(201) } })]),
+        );
+        expect(tooLong).toHaveLength(1);
+        expect(JSON.stringify(tooLong)).toContain('externalId');
+    });
 });

--- a/apps/api/src/ingest/dto/ingest-events.dto.ts
+++ b/apps/api/src/ingest/dto/ingest-events.dto.ts
@@ -2,6 +2,7 @@ import {
     ArrayMaxSize,
     ArrayNotEmpty,
     IsArray,
+    IsIn,
     IsISO8601,
     IsNotEmpty,
     IsObject,
@@ -16,7 +17,27 @@ import {
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { INGEST_EVENT_BATCH_MAX, INGEST_EVENT_PAYLOAD_MAX_BYTES } from '@ever-works/contracts';
+import {
+    INGEST_EVENT_BATCH_MAX,
+    INGEST_EVENT_PAYLOAD_MAX_BYTES,
+    INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS,
+    INGEST_WORK_HINT_LABEL_MAX_CHARS,
+    type IngestedEventWorkHintKind,
+} from '@ever-works/contracts';
+
+/**
+ * Every hint kind the platform resolver understands. Kept as a literal
+ * tuple (rather than derived at runtime) so `IsIn` rejects an unknown
+ * kind at the edge, and `satisfies` makes adding a kind to the contract
+ * without teaching this DTO a compile error.
+ */
+const WORK_HINT_KINDS = [
+    'repo',
+    'chat-channel',
+    'tracker-team',
+    'doc-database',
+    'meeting',
+] as const satisfies readonly IngestedEventWorkHintKind[];
 
 /**
  * Event-ingest spine (Wave 6) — request shape for
@@ -76,6 +97,34 @@ export class IngestedEventSubjectDto {
     @IsString()
     @MaxLength(500)
     title?: string;
+}
+
+export class IngestedEventWorkHintDto {
+    @ApiProperty({
+        description: 'External container kind the platform resolves to a Work',
+        enum: WORK_HINT_KINDS,
+    })
+    @IsIn(WORK_HINT_KINDS)
+    kind: IngestedEventWorkHintKind;
+
+    @ApiProperty({
+        description:
+            'Stable id of the container in the source system (owner/repo, channel id, team key, database id, meeting id)',
+        maxLength: INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS,
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS)
+    externalId: string;
+
+    @ApiPropertyOptional({
+        description: 'Human-readable label — diagnostics only, never matched on',
+        maxLength: INGEST_WORK_HINT_LABEL_MAX_CHARS,
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(INGEST_WORK_HINT_LABEL_MAX_CHARS)
+    label?: string;
 }
 
 export class IngestedEventEnvelopeDto {
@@ -143,6 +192,16 @@ export class IngestedEventEnvelopeDto {
     @IsOptional()
     @IsUUID()
     workId?: string;
+
+    @ApiPropertyOptional({
+        type: IngestedEventWorkHintDto,
+        description:
+            'External container this event belongs to. Resolved to a workId within the ingesting user’s own Works; unresolvable hints leave the event user-scoped. Ignored when workId is set.',
+    })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => IngestedEventWorkHintDto)
+    workHint?: IngestedEventWorkHintDto;
 
     @ApiPropertyOptional({ description: 'Organization scope hint' })
     @IsOptional()

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.spec.ts
@@ -174,6 +174,15 @@ describe('GitHubPrReviewBridgeService', () => {
             const [, envelopes] = eventIngestService.ingest.mock.calls[0];
             expect(envelopes[0].sourceEventId).toBe('pr:octo/site#7@def456');
         });
+
+        it('carries the repo workHint so the spine can route the event to a Work', async () => {
+            const { service, eventIngestService } = createService();
+            await service.handleEvent(BINDING, 'pull_request', prOpenedBody());
+            await flush();
+
+            const [, envelopes] = eventIngestService.ingest.mock.calls[0];
+            expect(envelopes[0].workHint).toEqual({ kind: 'repo', externalId: 'octo/site' });
+        });
     });
 
     describe('@ever-works mention loop', () => {
@@ -186,6 +195,7 @@ describe('GitHubPrReviewBridgeService', () => {
             expect(envelopes[0]).toMatchObject({
                 kind: 'github.mention',
                 sourceEventId: 'comment:octo/site:42',
+                workHint: { kind: 'repo', externalId: 'octo/site' },
             });
             expect(prReviewService.reviewPullRequest).toHaveBeenCalledWith({
                 userId: 'user-1',

--- a/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
+++ b/apps/api/src/ingest/github/github-pr-review-bridge.service.ts
@@ -194,6 +194,10 @@ export class GitHubPrReviewBridgeService {
                         externalId: `${fullName}#${prNumber}`,
                         ...(pr.title ? { title: pr.title } : {}),
                     },
+                    // Work routing: the repository is the container. The
+                    // spine resolves `owner/repo` against the ingesting
+                    // user's own Works via the shared repo matcher.
+                    workHint: { kind: 'repo', externalId: fullName },
                     ...(pr.html_url ? { sourceUrl: pr.html_url } : {}),
                     payload: {
                         action,
@@ -254,6 +258,7 @@ export class GitHubPrReviewBridgeService {
                         externalId: `${fullName}#${prNumber}`,
                         ...(title ? { title } : {}),
                     },
+                    workHint: { kind: 'repo', externalId: fullName },
                     ...(comment.html_url ? { sourceUrl: comment.html_url } : {}),
                     payload: {
                         repoFullName: fullName,

--- a/apps/api/src/ingest/ingest.controller.ts
+++ b/apps/api/src/ingest/ingest.controller.ts
@@ -1,7 +1,16 @@
-import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Get,
+    HttpCode,
+    HttpStatus,
+    ParseUUIDPipe,
+    Post,
+    Query,
+} from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
-import { EventIngestService } from '@ever-works/agent/ingest';
+import { EventIngestService, IngestedEventRepository } from '@ever-works/agent/ingest';
 import { CurrentUser } from '../auth/decorators/user.decorator';
 import type { AuthenticatedUser } from '../auth/types/auth.types';
 import { IngestEventsDto } from './dto/ingest-events.dto';
@@ -21,7 +30,49 @@ import { IngestEventsDto } from './dto/ingest-events.dto';
 @ApiTags('ingest')
 @Controller('api/ingest')
 export class IngestController {
-    constructor(private readonly eventIngestService: EventIngestService) {}
+    constructor(
+        private readonly eventIngestService: EventIngestService,
+        private readonly events: IngestedEventRepository,
+    ) {}
+
+    /**
+     * Owner-scoped recent ingested events, newest first.
+     *
+     * `workId` narrows to a single Work — this is the query the per-Work
+     * Activities feed reads. The owner scope is applied first and
+     * unconditionally, so passing a Work the caller does not own returns
+     * an empty page rather than someone else's events.
+     */
+    @Get('events')
+    @ApiOperation({
+        summary: 'List my recent ingested external events (optionally filtered by Work / source).',
+    })
+    @HttpCode(HttpStatus.OK)
+    async listEvents(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Query('workId', new ParseUUIDPipe({ optional: true })) workId?: string,
+        @Query('source') source?: string,
+        @Query('limit') limit?: string,
+    ) {
+        const rows = await this.events.findRecentByUser(auth.userId, {
+            limit: limit ? Math.min(100, Math.max(1, parseInt(limit, 10) || 20)) : 20,
+            ...(workId ? { workId } : {}),
+            ...(source ? { source } : {}),
+        });
+        return {
+            data: rows.map((row) => ({
+                id: row.id,
+                source: row.source,
+                kind: row.kind,
+                occurredAt: row.occurredAt,
+                actorName: row.actorName ?? null,
+                title: row.title ?? null,
+                sourceUrl: row.sourceUrl ?? null,
+                workId: row.workId ?? null,
+                processed: !!row.processedAt,
+            })),
+        };
+    }
 
     @Post('events')
     @ApiOperation({

--- a/apps/api/src/ingest/slack/slack-chat-bridge.service.spec.ts
+++ b/apps/api/src/ingest/slack/slack-chat-bridge.service.spec.ts
@@ -148,6 +148,14 @@ describe('SlackChatBridgeService', () => {
             ).toBeNull();
             expect(service.toEnvelope({ type: 'url_verification' } as any)).toBeNull();
         });
+
+        it('carries the chat-channel workHint so the spine can route the event to a Work', () => {
+            const { service } = createService();
+            expect(service.toEnvelope(mentionBody() as any)?.workHint).toEqual({
+                kind: 'chat-channel',
+                externalId: 'C1',
+            });
+        });
     });
 
     describe('handleEventCallback', () => {

--- a/apps/api/src/ingest/slack/slack-chat-bridge.service.ts
+++ b/apps/api/src/ingest/slack/slack-chat-bridge.service.ts
@@ -163,6 +163,10 @@ export class SlackChatBridgeService {
                 ...(event.user ? { externalId: event.user } : {}),
             },
             subject: { type: 'channel', externalId: channel },
+            // Work routing: the channel is the container. Resolved
+            // against the bound user's own Works only — a channel two
+            // users both connect routes independently for each of them.
+            workHint: { kind: 'chat-channel', externalId: channel },
             payload: {
                 channel,
                 ts,

--- a/apps/api/src/migrations/1784200000000-AddWorkExternalRefs.ts
+++ b/apps/api/src/migrations/1784200000000-AddWorkExternalRefs.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * `workId` routing for ingested events — one additive, nullable
+ * `externalRefs` column on `works`.
+ *
+ * Stores the external containers a Work claims (chat channel ids,
+ * tracker team keys, doc database ids, meeting ids) as `simple-json`,
+ * i.e. a TEXT column at the DB level, matching the existing
+ * `works.mergePolicy` / `works.checkDefaults` storage pattern.
+ *
+ * NULL means "this Work claims nothing", which is what every existing
+ * row keeps meaning: an ingested event whose `workHint` matches no
+ * Work stays user-scoped exactly as it does today. Repo hints are NOT
+ * stored here — they resolve against the repositories a Work already
+ * declares (`matchWorkByRepo`).
+ *
+ * Forward-only, idempotent per-step guards (house pattern) so a
+ * partially-applied run and a fresh DB converge on the same shape.
+ */
+export class AddWorkExternalRefs1784200000000 implements MigrationInterface {
+    name = 'AddWorkExternalRefs1784200000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('works');
+        if (!table) return;
+        if (table.findColumnByName('externalRefs')) return;
+        await queryRunner.query(`ALTER TABLE "works" ADD COLUMN "externalRefs" text`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        const table = await queryRunner.getTable('works');
+        if (!table) return;
+        if (!table.findColumnByName('externalRefs')) return;
+        await queryRunner.query(`ALTER TABLE "works" DROP COLUMN "externalRefs"`);
+    }
+}

--- a/apps/api/src/tasks/tasks.controller.ts
+++ b/apps/api/src/tasks/tasks.controller.ts
@@ -21,6 +21,7 @@ import {
     TaskChatService,
     TaskStatus,
     TaskPriority,
+    RUN_BATCH_MAX_TASKS,
     type TaskActorType,
     type ListTasksFilter,
 } from '@ever-works/agent/tasks-domain';
@@ -44,6 +45,8 @@ import {
     AddReviewerDto,
     CreateTaskDto,
     PostTaskChatDto,
+    RunTaskDto,
+    RunTasksBatchDto,
     SetTaskRecurringDto,
     TransitionTaskDto,
     UpdateTaskDto,
@@ -177,6 +180,24 @@ export class TasksController {
         });
     }
 
+    // Declared BEFORE every `:id` route: `run-batch` is a single path
+    // segment, so a future `@Post(':id')` would otherwise shadow it.
+    @Post('run-batch')
+    @ApiOperation({
+        summary: `Run up to ${RUN_BATCH_MAX_TASKS} Tasks in one call. Per-item results — one Task failing (no agent, run already in flight) never fails the others.`,
+    })
+    @HttpCode(HttpStatus.OK)
+    @Throttle({ long: { limit: 20, ttl: 60_000 } })
+    async runBatch(@CurrentUser() auth: AuthenticatedUser, @Body() body: RunTasksBatchDto) {
+        if (!Array.isArray(body?.items)) {
+            throw new BadRequestException('items must be an array.');
+        }
+        return this.service.runTasksBatch(
+            auth.userId,
+            body.items.map((item) => ({ taskId: item.taskId, agentId: item.agentId ?? null })),
+        );
+    }
+
     @Get(':id')
     @ApiOperation({ summary: 'Get one Task.' })
     @HttpCode(HttpStatus.OK)
@@ -252,6 +273,36 @@ export class TasksController {
             throw new BadRequestException(`Invalid target status: ${body?.to}`);
         }
         return this.service.transition(auth.userId, id, body.to, { force: body.force === true });
+    }
+
+    // ── Board dispatch (kanban M3 / M4) ───────────────────────────
+
+    @Get(':id/run-candidates')
+    @ApiOperation({
+        summary:
+            'Agents that can run this Task (assignees, then its own agent, then the Work default) — the board agent picker.',
+    })
+    @HttpCode(HttpStatus.OK)
+    async runCandidates(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+    ) {
+        return { data: await this.service.listRunCandidates(auth.userId, id) };
+    }
+
+    @Post(':id/run')
+    @ApiOperation({
+        summary:
+            'Run this Task now. Resolves the Agent (explicit agentId → assigned Agent → the Work default), then dispatches through the same gated path a status transition uses. 409 RUN_ALREADY_IN_FLIGHT when a run for that (task, agent) is still queued/running.',
+    })
+    @HttpCode(HttpStatus.ACCEPTED)
+    @Throttle({ long: { limit: 60, ttl: 60_000 } })
+    async run(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Param('id', ParseUUIDPipe) id: string,
+        @Body() body: RunTaskDto,
+    ) {
+        return this.service.runTask(auth.userId, id, { agentId: body?.agentId ?? null });
     }
 
     @Post(':id/resolve-conflicts')

--- a/apps/api/src/tasks/tasks.dto.ts
+++ b/apps/api/src/tasks/tasks.dto.ts
@@ -1,6 +1,7 @@
 import { Type } from 'class-transformer';
 import {
     ArrayMaxSize,
+    ArrayNotEmpty,
     IsArray,
     IsBoolean,
     IsDateString,
@@ -16,6 +17,7 @@ import {
     ValidateNested,
 } from 'class-validator';
 import {
+    RUN_BATCH_MAX_TASKS,
     TaskPriority,
     TaskStatus,
     type TaskActorType,
@@ -282,4 +284,36 @@ export class PostTaskChatDto {
     @ValidateNested({ each: true })
     @Type(() => TaskChatAttachmentDto)
     attachments?: TaskChatAttachmentDto[];
+}
+
+// ── Board dispatch (kanban M3 / M4) ───────────────────────────────
+
+export class RunTaskDto {
+    /**
+     * Which Agent to run. Omit to let the server resolve it (the Task's
+     * assigned Agent, then the Work's default Agent) — an ambiguous or
+     * empty resolution comes back as a 400 carrying the candidate list,
+     * which is what the board's agent picker renders.
+     */
+    @IsOptional()
+    @IsUUID()
+    agentId?: string;
+}
+
+export class RunTaskBatchItemDto {
+    @IsUUID()
+    taskId: string;
+
+    @IsOptional()
+    @IsUUID()
+    agentId?: string;
+}
+
+export class RunTasksBatchDto {
+    @IsArray()
+    @ArrayNotEmpty()
+    @ArrayMaxSize(RUN_BATCH_MAX_TASKS)
+    @ValidateNested({ each: true })
+    @Type(() => RunTaskBatchItemDto)
+    items: RunTaskBatchItemDto[];
 }

--- a/apps/web/src/app/actions/tasks.ts
+++ b/apps/web/src/app/actions/tasks.ts
@@ -6,11 +6,15 @@ import type { TaskAcceptanceCheck } from '@ever-works/contracts';
 import {
     tasksAPI,
     type ListTasksQuery,
+    type RunBatchItemResult,
+    type RunCandidateAgent,
+    type RunTaskResult,
     type Task,
     type TaskChatMessage,
     type TaskPriority,
     type TaskStatus,
 } from '@/lib/api/tasks';
+import { ApiResponseError } from '@/lib/api/server-api';
 import { getAuthFromCookie } from '@/lib/auth';
 import { ROUTES } from '@/lib/constants';
 
@@ -108,6 +112,118 @@ export async function listTasksWithRunsAction(
         includeRun: true,
     });
     return result.data;
+}
+
+// ── Board dispatch (kanban M3 / M4) ───────────────────────────────
+
+/**
+ * Result of a board "Run".
+ *
+ * A DISCRIMINATED UNION rather than a thrown error on purpose: Next
+ * redacts thrown Server-Action messages in production, so a UI that
+ * branched on `err.message` would work in dev and silently do nothing in
+ * prod. Every outcome the board reacts to — pick an agent, point at the
+ * live run, report a park — travels in the return value.
+ */
+export type RunTaskActionResult =
+    | { ok: true; run: RunTaskResult }
+    | {
+          ok: false;
+          /** Machine code; `RUN_*` for the handled cases, `RUN_FAILED` otherwise. */
+          code: string;
+          message: string;
+          /** Present on RUN_AGENT_AMBIGUOUS / RUN_NO_AGENT — feeds the picker. */
+          candidates?: RunCandidateAgent[];
+          /** Present on RUN_ALREADY_IN_FLIGHT. */
+          runId?: string;
+      };
+
+function toRunFailure(err: unknown): RunTaskActionResult {
+    if (err instanceof ApiResponseError) {
+        const details = (err.details ?? {}) as {
+            candidates?: RunCandidateAgent[];
+            runId?: string;
+        };
+        return {
+            ok: false,
+            code: err.code ?? 'RUN_FAILED',
+            message: err.message,
+            ...(Array.isArray(details.candidates) ? { candidates: details.candidates } : {}),
+            ...(typeof details.runId === 'string' ? { runId: details.runId } : {}),
+        };
+    }
+    return {
+        ok: false,
+        code: 'RUN_FAILED',
+        message: err instanceof Error ? err.message : String(err),
+    };
+}
+
+/**
+ * Board dispatch (kanban M3) — run a Task now. `agentId` omitted lets
+ * the server resolve it; an ambiguous or empty resolution comes back as
+ * `RUN_AGENT_AMBIGUOUS` / `RUN_NO_AGENT` with the candidate list, which
+ * is what opens the agent picker.
+ */
+export async function runTaskAction(
+    id: string,
+    agentId?: string | null,
+): Promise<RunTaskActionResult> {
+    // Security: verify session server-side before mutating data
+    const user = await getAuthFromCookie();
+    if (!user) redirect(ROUTES.AUTH_LOGIN);
+
+    try {
+        const run = await tasksAPI.run(id, agentId ?? null);
+        revalidatePath('/tasks');
+        revalidatePath(`/tasks/${id}`);
+        return { ok: true, run };
+    } catch (err) {
+        return toRunFailure(err);
+    }
+}
+
+/** Board dispatch — the agent picker's option list for one Task. */
+export async function listTaskRunCandidatesAction(id: string): Promise<RunCandidateAgent[]> {
+    // Security: verify session server-side before reading data
+    const user = await getAuthFromCookie();
+    if (!user) redirect(ROUTES.AUTH_LOGIN);
+
+    const result = await tasksAPI.listRunCandidates(id);
+    return result.data ?? [];
+}
+
+/**
+ * Board dispatch (kanban M4) — the column "Run all" affordance. Per-item
+ * results: one Task without an agent never stops the rest of the column.
+ */
+export async function runTasksBatchAction(
+    items: { taskId: string; agentId?: string | null }[],
+): Promise<{ results: RunBatchItemResult[] }> {
+    // Security: verify session server-side before mutating data
+    const user = await getAuthFromCookie();
+    if (!user) redirect(ROUTES.AUTH_LOGIN);
+
+    if (items.length === 0) return { results: [] };
+    try {
+        const result = await tasksAPI.runBatch(items);
+        revalidatePath('/tasks');
+        return result;
+    } catch (err) {
+        // A whole-request failure (validation, auth, transport) is
+        // reported per item so the caller has exactly one result shape.
+        const failure = toRunFailure(err);
+        return {
+            results: items.map((item) => ({
+                taskId: item.taskId,
+                ok: false as const,
+                error: {
+                    code: failure.ok ? 'RUN_FAILED' : failure.code,
+                    message: failure.ok ? '' : failure.message,
+                },
+            })),
+        };
+    }
 }
 
 /**

--- a/apps/web/src/components/tasks/RunWithAgentMenu.tsx
+++ b/apps/web/src/components/tasks/RunWithAgentMenu.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Loader2, Play } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+import {
+    listTaskRunCandidatesAction,
+    runTaskAction,
+    type RunTaskActionResult,
+} from '@/app/actions/tasks';
+import {
+    RUN_AGENT_AMBIGUOUS,
+    RUN_ALREADY_IN_FLIGHT,
+    RUN_NO_AGENT,
+    type RunCandidateAgent,
+} from '@/lib/api/tasks';
+
+/**
+ * Board dispatch (kanban M3) — the "Run" affordance and its agent picker.
+ *
+ * One component serves three entry points so they can never disagree
+ * about what running a Task means:
+ *
+ *   - the Run button on a kanban card,
+ *   - the Run button on Task detail,
+ *   - the board opening the picker on its own (`open` / `onOpenChange`),
+ *     which is how a drag into In Progress with no Agent assigned stops
+ *     being a silent no-op.
+ *
+ * It never branches on an error MESSAGE — production redacts thrown
+ * Server-Action messages — only on the stable `code` the action returns.
+ */
+
+const SOURCE_LABELS: Record<RunCandidateAgent['source'], string> = {
+    assignee: 'Assigned',
+    task: 'Task agent',
+    'work-default': 'Work default',
+};
+
+export interface RunWithAgentMenuProps {
+    taskId: string;
+    /** `compact` renders the card-sized icon button; default is the detail button. */
+    compact?: boolean;
+    /** Controlled picker state — the board uses this for the drag case. */
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    /** Fired after a run is accepted (dispatched or parked). */
+    onRunStarted?: (result: Extract<RunTaskActionResult, { ok: true }>) => void;
+    className?: string;
+}
+
+export function RunWithAgentMenu({
+    taskId,
+    compact = false,
+    open,
+    onOpenChange,
+    onRunStarted,
+    className,
+}: RunWithAgentMenuProps) {
+    const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+    const isControlled = open !== undefined;
+    const pickerOpen = isControlled ? open : uncontrolledOpen;
+
+    const [candidates, setCandidates] = useState<RunCandidateAgent[] | null>(null);
+    const [busy, setBusy] = useState(false);
+    const [message, setMessage] = useState<string | null>(null);
+    const [tone, setTone] = useState<'ok' | 'error'>('ok');
+    const containerRef = useRef<HTMLDivElement | null>(null);
+
+    const setOpen = useCallback(
+        (next: boolean) => {
+            if (!isControlled) setUncontrolledOpen(next);
+            onOpenChange?.(next);
+        },
+        [isControlled, onOpenChange],
+    );
+
+    // Load the picker's options the first time it opens. Best-effort:
+    // a failed lookup still shows the panel, just with an empty list and
+    // the reason, rather than leaving the user with a dead button.
+    useEffect(() => {
+        if (!pickerOpen || candidates !== null) return;
+        let cancelled = false;
+        void (async () => {
+            try {
+                const rows = await listTaskRunCandidatesAction(taskId);
+                if (!cancelled) setCandidates(rows);
+            } catch {
+                if (!cancelled) setCandidates([]);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [pickerOpen, candidates, taskId]);
+
+    // Close on outside click / Escape — the picker is a popover, not a
+    // modal, so it must never trap the board's own `r` shortcut.
+    useEffect(() => {
+        if (!pickerOpen) return;
+        const onPointerDown = (event: MouseEvent) => {
+            if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+        };
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') setOpen(false);
+        };
+        document.addEventListener('mousedown', onPointerDown);
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.removeEventListener('mousedown', onPointerDown);
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [pickerOpen, setOpen]);
+
+    const dispatch = useCallback(
+        async (agentId?: string | null) => {
+            setBusy(true);
+            setMessage(null);
+            try {
+                const result = await runTaskAction(taskId, agentId ?? null);
+                if (result.ok) {
+                    setOpen(false);
+                    setTone('ok');
+                    setMessage(
+                        result.run.parked
+                            ? `Queued — waiting for capacity (${result.run.queuedReason ?? 'queued'}).`
+                            : 'Run started.',
+                    );
+                    onRunStarted?.(result);
+                    return;
+                }
+                setTone('error');
+                if (result.code === RUN_AGENT_AMBIGUOUS || result.code === RUN_NO_AGENT) {
+                    // The server already told us who the options are —
+                    // trust that list over a second round trip.
+                    setCandidates(result.candidates ?? []);
+                    setOpen(true);
+                    setMessage(
+                        result.code === RUN_NO_AGENT
+                            ? 'No Agent is assigned to this Task and its Work has no default Agent.'
+                            : 'Pick which Agent should run this Task.',
+                    );
+                    return;
+                }
+                if (result.code === RUN_ALREADY_IN_FLIGHT) {
+                    setMessage('A run is already in flight for this Agent.');
+                    return;
+                }
+                setMessage(result.message || 'Run failed.');
+            } finally {
+                setBusy(false);
+            }
+        },
+        [taskId, setOpen, onRunStarted],
+    );
+
+    return (
+        <div ref={containerRef} className={cn('relative inline-flex flex-col', className)}>
+            <button
+                type="button"
+                disabled={busy}
+                onClick={() => void dispatch(null)}
+                aria-label="Run this Task"
+                title="Run this Task (r)"
+                data-testid="task-run-button"
+                className={cn(
+                    'inline-flex items-center gap-1 rounded font-medium transition-colors disabled:opacity-50',
+                    compact
+                        ? 'text-[10px] px-1.5 py-0.5 text-text-muted hover:text-primary'
+                        : 'text-xs px-2.5 py-1.5 border border-border dark:border-border-dark hover:border-primary hover:text-primary',
+                )}
+            >
+                {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Play className="w-3 h-3" />}
+                Run
+            </button>
+
+            {pickerOpen && (
+                <div
+                    role="dialog"
+                    aria-label="Choose an Agent to run this Task"
+                    data-testid="task-run-agent-picker"
+                    className={cn(
+                        'absolute top-full right-0 mt-1 z-20 min-w-[200px] max-w-[280px]',
+                        'rounded-md border border-border/60 dark:border-border-dark/60',
+                        'bg-card dark:bg-card-primary-dark p-1.5 shadow-md',
+                    )}
+                >
+                    <p className="px-1.5 pb-1 text-[10px] uppercase tracking-wide text-text-muted">
+                        Run with
+                    </p>
+                    {candidates === null ? (
+                        <p className="px-1.5 py-1 text-[11px] text-text-muted">Loading…</p>
+                    ) : candidates.length === 0 ? (
+                        <p className="px-1.5 py-1 text-[11px] text-text-muted">
+                            No Agent available. Assign one to this Task (or to its Work) first.
+                        </p>
+                    ) : (
+                        <ul className="flex flex-col gap-0.5">
+                            {candidates.map((agent) => (
+                                <li key={agent.id}>
+                                    <button
+                                        type="button"
+                                        disabled={busy}
+                                        onClick={() => void dispatch(agent.id)}
+                                        data-testid="task-run-agent-option"
+                                        className="w-full flex items-center justify-between gap-2 text-left text-[11px] px-2 py-1 rounded hover:bg-surface-secondary dark:hover:bg-surface-secondary-dark hover:text-primary disabled:opacity-50"
+                                    >
+                                        <span className="truncate">{agent.name}</span>
+                                        <span className="text-[9px] text-text-muted shrink-0">
+                                            {SOURCE_LABELS[agent.source]}
+                                        </span>
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            )}
+
+            {message && (
+                <p
+                    className={cn(
+                        'mt-1 text-[10px]',
+                        tone === 'error' ? 'text-danger' : 'text-text-muted',
+                    )}
+                    role={tone === 'error' ? 'alert' : 'status'}
+                >
+                    {message}
+                </p>
+            )}
+        </div>
+    );
+}

--- a/apps/web/src/components/tasks/RunWithAgentMenu.unit.spec.tsx
+++ b/apps/web/src/components/tasks/RunWithAgentMenu.unit.spec.tsx
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { RunWithAgentMenu } from './RunWithAgentMenu';
+
+/**
+ * Board dispatch (kanban M3) — the Run affordance and its agent picker.
+ *
+ * The load-bearing behaviour is that the component branches on the
+ * action's stable `code`, NEVER on a message: production redacts thrown
+ * Server-Action messages, so a message-driven UI silently does nothing
+ * once deployed.
+ */
+
+const runTaskAction = vi.fn();
+const listTaskRunCandidatesAction = vi.fn();
+
+vi.mock('@/app/actions/tasks', () => ({
+    runTaskAction: (...args: unknown[]) => runTaskAction(...args),
+    listTaskRunCandidatesAction: (...args: unknown[]) => listTaskRunCandidatesAction(...args),
+}));
+
+describe('RunWithAgentMenu', () => {
+    beforeEach(() => {
+        runTaskAction.mockReset();
+        listTaskRunCandidatesAction.mockReset();
+        listTaskRunCandidatesAction.mockResolvedValue([]);
+    });
+
+    it('runs with the server-resolved Agent when there is no ambiguity', async () => {
+        runTaskAction.mockResolvedValue({
+            ok: true,
+            run: { taskId: 't1', agentId: 'a1', runId: 'r1', dispatched: true, parked: false },
+        });
+        render(<RunWithAgentMenu taskId="t1" />);
+        fireEvent.click(screen.getByTestId('task-run-button'));
+        await waitFor(() => expect(runTaskAction).toHaveBeenCalledWith('t1', null));
+        expect(await screen.findByText('Run started.')).toBeTruthy();
+        expect(screen.queryByTestId('task-run-agent-picker')).toBeNull();
+    });
+
+    it('opens the picker with the server-supplied candidates on RUN_AGENT_AMBIGUOUS', async () => {
+        runTaskAction.mockResolvedValue({
+            ok: false,
+            code: 'RUN_AGENT_AMBIGUOUS',
+            message: 'pick one',
+            candidates: [
+                { id: 'a1', name: 'Builder', source: 'assignee' },
+                { id: 'a2', name: 'Reviewer', source: 'work-default' },
+            ],
+        });
+        render(<RunWithAgentMenu taskId="t1" />);
+        fireEvent.click(screen.getByTestId('task-run-button'));
+        const picker = await screen.findByTestId('task-run-agent-picker');
+        expect(picker).toBeTruthy();
+        expect(screen.getAllByTestId('task-run-agent-option')).toHaveLength(2);
+        // The candidates came off the failure body — no second round trip.
+        expect(listTaskRunCandidatesAction).not.toHaveBeenCalled();
+    });
+
+    it('re-dispatches with the chosen Agent when the user picks one', async () => {
+        runTaskAction.mockResolvedValueOnce({
+            ok: false,
+            code: 'RUN_AGENT_AMBIGUOUS',
+            message: 'pick one',
+            candidates: [
+                { id: 'a1', name: 'Builder', source: 'assignee' },
+                { id: 'a2', name: 'Reviewer', source: 'work-default' },
+            ],
+        });
+        runTaskAction.mockResolvedValueOnce({
+            ok: true,
+            run: { taskId: 't1', agentId: 'a2', runId: 'r2', dispatched: true, parked: false },
+        });
+        render(<RunWithAgentMenu taskId="t1" />);
+        fireEvent.click(screen.getByTestId('task-run-button'));
+        await screen.findByTestId('task-run-agent-picker');
+        fireEvent.click(screen.getAllByTestId('task-run-agent-option')[1]);
+        await waitFor(() => expect(runTaskAction).toHaveBeenLastCalledWith('t1', 'a2'));
+    });
+
+    it('explains RUN_NO_AGENT instead of failing silently', async () => {
+        runTaskAction.mockResolvedValue({
+            ok: false,
+            code: 'RUN_NO_AGENT',
+            message: 'no agent',
+            candidates: [],
+        });
+        render(<RunWithAgentMenu taskId="t1" />);
+        fireEvent.click(screen.getByTestId('task-run-button'));
+        expect(await screen.findByText(/No Agent is assigned to this Task/i)).toBeTruthy();
+    });
+
+    it('points at the live run on RUN_ALREADY_IN_FLIGHT rather than racing a second one', async () => {
+        runTaskAction.mockResolvedValue({
+            ok: false,
+            code: 'RUN_ALREADY_IN_FLIGHT',
+            message: 'already running',
+            runId: 'r-live',
+        });
+        render(<RunWithAgentMenu taskId="t1" />);
+        fireEvent.click(screen.getByTestId('task-run-button'));
+        expect(await screen.findByText(/already in flight/i)).toBeTruthy();
+        expect(screen.queryByTestId('task-run-agent-picker')).toBeNull();
+    });
+
+    it('reports a parked run as queued-for-capacity, not as a failure', async () => {
+        runTaskAction.mockResolvedValue({
+            ok: true,
+            run: {
+                taskId: 't1',
+                agentId: 'a1',
+                runId: 'r1',
+                dispatched: false,
+                parked: true,
+                queuedReason: 'concurrency-limit',
+            },
+        });
+        render(<RunWithAgentMenu taskId="t1" />);
+        fireEvent.click(screen.getByTestId('task-run-button'));
+        expect(await screen.findByText(/waiting for capacity/i)).toBeTruthy();
+    });
+
+    it('loads candidates lazily when the board opens the picker itself (the drag fallback)', async () => {
+        listTaskRunCandidatesAction.mockResolvedValue([
+            { id: 'a1', name: 'Builder', source: 'work-default' },
+        ]);
+        render(<RunWithAgentMenu taskId="t1" open onOpenChange={() => undefined} />);
+        await waitFor(() => expect(listTaskRunCandidatesAction).toHaveBeenCalledWith('t1'));
+        expect(await screen.findByText('Builder')).toBeTruthy();
+    });
+
+    it('surfaces an unknown failure code with its message instead of swallowing it', async () => {
+        runTaskAction.mockResolvedValue({
+            ok: false,
+            code: 'RUN_FAILED',
+            message: 'job runtime not configured',
+        });
+        render(<RunWithAgentMenu taskId="t1" />);
+        fireEvent.click(screen.getByTestId('task-run-button'));
+        expect(await screen.findByText('job runtime not configured')).toBeTruthy();
+    });
+});

--- a/apps/web/src/components/tasks/TaskDetailClient.tsx
+++ b/apps/web/src/components/tasks/TaskDetailClient.tsx
@@ -21,6 +21,7 @@ import { TaskAttachmentsSection } from './TaskAttachmentsSection';
 import { TaskBranchSection } from './TaskBranchSection';
 import { TaskChecksSection } from './TaskChecksSection';
 import { TaskRunControls } from './TaskRunControls';
+import { RunWithAgentMenu } from './RunWithAgentMenu';
 
 // Status tones + dots mirror /tasks (TasksList) so colours stay
 // consistent across the list filter and the detail workflow buttons.
@@ -212,9 +213,16 @@ export function TaskDetailClient({
                         <div className="text-[11px] font-mono text-text-muted mb-1.5">
                             {task.slug}
                         </div>
-                        <h1 className="text-2xl font-semibold leading-tight text-text dark:text-text-dark">
-                            {task.title}
-                        </h1>
+                        <div className="flex items-start justify-between gap-3">
+                            <h1 className="text-2xl font-semibold leading-tight text-text dark:text-text-dark">
+                                {task.title}
+                            </h1>
+                            {/* Board dispatch (kanban M3) — run this Task
+                                from its detail page, through the same
+                                gated path the board and a status
+                                transition use. */}
+                            <RunWithAgentMenu taskId={task.id} className="shrink-0" />
+                        </div>
                         {/* JIRA-style workflow buttons — mirrors the status
                             pills on /tasks. Current status shows active in its
                             own colour; allowed transitions are clickable; the

--- a/apps/web/src/components/tasks/TasksKanbanView.tsx
+++ b/apps/web/src/components/tasks/TasksKanbanView.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import { cn } from '@/lib/utils/cn';
 import { Link } from '@/i18n/navigation';
 import { ROUTES } from '@/lib/constants';
 import type { Task, TaskStatus, TaskPriority } from '@/lib/api/tasks';
-import { transitionTaskAction } from '@/app/actions/tasks';
+import {
+    listTaskRunCandidatesAction,
+    runTasksBatchAction,
+    transitionTaskAction,
+} from '@/app/actions/tasks';
 import { useTaskRunPolling } from '@/lib/hooks/use-task-run-polling';
 import { TaskBranchChip } from './TaskBranchChip';
 import { TaskRunChip } from './TaskRunChip';
 import { GateChip } from './GateChip';
+import { RunWithAgentMenu } from './RunWithAgentMenu';
 import {
     Inbox,
     Circle,
@@ -19,10 +24,18 @@ import {
     CheckCircle2,
     XCircle,
     ChevronDown,
+    Play,
     type LucideIcon,
 } from 'lucide-react';
 
 const MAX_VISIBLE = 15;
+
+/**
+ * Board dispatch (kanban M4) — hard cap on the column "Run all" action,
+ * mirroring the API's `RUN_BATCH_MAX_TASKS`. The button labels itself
+ * with the real count so a 40-card column never silently runs 20.
+ */
+const RUN_ALL_MAX = 20;
 
 // ─── Column definitions ────────────────────────────────────────────────────
 
@@ -158,6 +171,8 @@ function TaskKanbanCard({
     error,
     onDragStart,
     onDragEnd,
+    pickerOpen,
+    onPickerOpenChange,
 }: {
     task: Task;
     col: ColumnDef;
@@ -165,15 +180,41 @@ function TaskKanbanCard({
     error: string | null;
     onDragStart?: () => void;
     onDragEnd?: () => void;
+    /** Board-driven picker state — set when a drag landed with no Agent. */
+    pickerOpen: boolean;
+    onPickerOpenChange: (open: boolean) => void;
 }) {
     const [menuOpen, setMenuOpen] = useState(false);
     const [pending, startTransition] = useTransition();
     const [dragging, setDragging] = useState(false);
     const targets = NEXT_STATUS[task.status] ?? [];
+    const runButtonRef = useRef<HTMLDivElement | null>(null);
 
     return (
         <div
             draggable
+            // Board dispatch (kanban M3) — the card is focusable so `r`
+            // has something to act on. `tabIndex={0}` + a role keeps it
+            // reachable by keyboard without turning the whole card into
+            // a button (it still holds links and its own menus).
+            tabIndex={0}
+            role="group"
+            aria-label={`${task.slug} — ${task.title}`}
+            data-testid="task-kanban-card"
+            onKeyDown={(e) => {
+                // `r` runs the focused card. Ignore it while a modifier
+                // is held (browser shortcuts) or while focus sits in a
+                // text field, and ignore repeats from a held key.
+                if (e.key !== 'r' && e.key !== 'R') return;
+                if (e.metaKey || e.ctrlKey || e.altKey || e.repeat) return;
+                const target = e.target as HTMLElement | null;
+                const tag = target?.tagName;
+                if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+                e.preventDefault();
+                runButtonRef.current
+                    ?.querySelector<HTMLButtonElement>('[data-testid="task-run-button"]')
+                    ?.click();
+            }}
             onDragStart={(e) => {
                 e.dataTransfer.setData('text/x-task-id', task.id);
                 e.dataTransfer.effectAllowed = 'move';
@@ -188,6 +229,7 @@ function TaskKanbanCard({
                 'group flex flex-col gap-2 p-3.5 rounded-lg border',
                 'bg-card dark:bg-card-primary-dark/70',
                 'transition-all duration-150 cursor-grab active:cursor-grabbing',
+                'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50',
                 col.cardBorderClass,
                 dragging && 'opacity-50',
             )}
@@ -278,12 +320,25 @@ function TaskKanbanCard({
                 ) : (
                     <span />
                 )}
-                <span className="text-[10px] text-text-muted dark:text-text-muted-dark shrink-0 ml-2">
-                    {new Date(task.updatedAt).toLocaleDateString(undefined, {
-                        month: 'short',
-                        day: 'numeric',
-                    })}
-                </span>
+                <div className="flex items-center gap-2 shrink-0 ml-2">
+                    {/* Board dispatch (kanban M3) — run this Task without
+                        leaving the board. Also the target of the `r`
+                        shortcut and of the board's drag fallback. */}
+                    <div ref={runButtonRef}>
+                        <RunWithAgentMenu
+                            taskId={task.id}
+                            compact
+                            open={pickerOpen}
+                            onOpenChange={onPickerOpenChange}
+                        />
+                    </div>
+                    <span className="text-[10px] text-text-muted dark:text-text-muted-dark">
+                        {new Date(task.updatedAt).toLocaleDateString(undefined, {
+                            month: 'short',
+                            day: 'numeric',
+                        })}
+                    </span>
+                </div>
             </div>
 
             {error && (
@@ -303,6 +358,8 @@ function TaskKanbanColumn({
     errors,
     draggingTaskId,
     dropTargetStatus,
+    pickerTaskId,
+    onPickerTaskChange,
     onMove,
     onDragStart,
     onDragEnd,
@@ -315,6 +372,8 @@ function TaskKanbanColumn({
     errors: Record<string, string | null>;
     draggingTaskId: string | null;
     dropTargetStatus: TaskStatus | null;
+    pickerTaskId: string | null;
+    onPickerTaskChange: (taskId: string | null) => void;
     onMove: (taskId: string, to: TaskStatus) => void;
     onDragStart: (taskId: string) => void;
     onDragEnd: () => void;
@@ -323,12 +382,35 @@ function TaskKanbanColumn({
     onDrop: (e: React.DragEvent, status: TaskStatus) => void;
 }) {
     const [visibleCount, setVisibleCount] = useState(MAX_VISIBLE);
+    const [batchBusy, setBatchBusy] = useState(false);
+    const [batchSummary, setBatchSummary] = useState<string | null>(null);
     const Icon = col.icon;
 
     const visibleTasks = tasks.slice(0, visibleCount);
     const remaining = tasks.length - visibleCount;
     const hasMore = remaining > 0;
     const isDropActive = dropTargetStatus === col.key && draggingTaskId !== null;
+
+    // Board dispatch (kanban M4) — "Run all" is offered only where it
+    // means something: columns holding work that has not been handed to
+    // an agent yet. Running a done/cancelled column is not a feature.
+    const runAllEligible = col.key === 'todo' || col.key === 'backlog' || col.key === 'in_progress';
+    const runAllTargets = tasks.slice(0, RUN_ALL_MAX);
+
+    const handleRunAll = async () => {
+        if (runAllTargets.length === 0) return;
+        setBatchBusy(true);
+        setBatchSummary(null);
+        try {
+            const { results } = await runTasksBatchAction(
+                runAllTargets.map((task) => ({ taskId: task.id })),
+            );
+            const started = results.filter((row) => row.ok).length;
+            setBatchSummary(`${started}/${results.length} started`);
+        } finally {
+            setBatchBusy(false);
+        }
+    };
 
     return (
         <div className="flex flex-col min-w-[220px] w-full flex-1">
@@ -344,6 +426,23 @@ function TaskKanbanColumn({
                 <span className="text-xs font-semibold text-text dark:text-text-dark flex-1 truncate">
                     {col.label}
                 </span>
+                {runAllEligible && runAllTargets.length > 0 && (
+                    <button
+                        type="button"
+                        disabled={batchBusy}
+                        onClick={() => void handleRunAll()}
+                        data-testid="task-run-all-button"
+                        title={`Run ${runAllTargets.length} Task(s) in ${col.label}`}
+                        className="inline-flex items-center gap-1 text-[10px] text-text-muted hover:text-primary disabled:opacity-50"
+                    >
+                        {batchBusy ? (
+                            <Loader2 className="w-3 h-3 animate-spin" />
+                        ) : (
+                            <Play className="w-3 h-3" />
+                        )}
+                        Run all
+                    </button>
+                )}
                 <span
                     className={cn(
                         'min-w-5 text-center text-[10px] font-semibold px-1.5 py-0.5 rounded-full',
@@ -353,6 +452,15 @@ function TaskKanbanColumn({
                     {tasks.length}
                 </span>
             </div>
+
+            {batchSummary && (
+                <p
+                    className="px-3 py-1 text-[10px] text-text-muted border-x border-slate-200/60 dark:border-white/8"
+                    role="status"
+                >
+                    {batchSummary}
+                </p>
+            )}
 
             {/* Card list — fixed height, scrollable */}
             <div
@@ -384,6 +492,8 @@ function TaskKanbanColumn({
                             error={errors[task.id] ?? null}
                             onDragStart={() => onDragStart(task.id)}
                             onDragEnd={onDragEnd}
+                            pickerOpen={pickerTaskId === task.id}
+                            onPickerOpenChange={(open) => onPickerTaskChange(open ? task.id : null)}
                         />
                     ))
                 )}
@@ -417,6 +527,10 @@ export function TasksKanbanView({ tasks: initialTasks }: { tasks: Task[] }) {
     const [errors, setErrors] = useState<Record<string, string | null>>({});
     const [draggingTaskId, setDraggingTaskId] = useState<string | null>(null);
     const [dropTargetStatus, setDropTargetStatus] = useState<TaskStatus | null>(null);
+    // Board dispatch (kanban M3) — at most ONE agent picker open at a
+    // time, owned here so a drag-into-In-Progress can open the picker on
+    // a card the user is not currently focused on.
+    const [pickerTaskId, setPickerTaskId] = useState<string | null>(null);
 
     // `useState(initialTasks)` only seeds on the first render, so any later
     // change to the `tasks` prop (filter swap, parent refetch) would never
@@ -463,6 +577,17 @@ export function TasksKanbanView({ tasks: initialTasks }: { tasks: Task[] }) {
                 setTasks((prev) =>
                     prev.map((t) => (t.id === taskId ? { ...t, status: updated.status } : t)),
                 );
+                // Board dispatch (kanban M3) — a drag into In Progress
+                // fans out to the Task's AGENT ASSIGNEES. With none, the
+                // move used to be a silent no-op: the card changes column
+                // and nothing runs. Open the picker instead so the drag
+                // still ends in a running agent.
+                if (to === 'in_progress') {
+                    const candidates = await listTaskRunCandidatesAction(taskId).catch(() => []);
+                    if (!candidates.some((agent) => agent.source === 'assignee')) {
+                        setPickerTaskId(taskId);
+                    }
+                }
             } catch (err) {
                 setTasks((prev) =>
                     prev.map((t) => (t.id === taskId ? { ...t, status: before.status } : t)),
@@ -519,6 +644,8 @@ export function TasksKanbanView({ tasks: initialTasks }: { tasks: Task[] }) {
                         errors={errors}
                         draggingTaskId={draggingTaskId}
                         dropTargetStatus={dropTargetStatus}
+                        pickerTaskId={pickerTaskId}
+                        onPickerTaskChange={setPickerTaskId}
                         onMove={handleMove}
                         onDragStart={setDraggingTaskId}
                         onDragEnd={() => {

--- a/apps/web/src/lib/api/tasks.ts
+++ b/apps/web/src/lib/api/tasks.ts
@@ -48,6 +48,41 @@ export interface TaskRun {
     gateStatus?: GateStatus | null;
 }
 
+// ── Board dispatch (kanban M3 / M4) ───────────────────────────────
+
+/**
+ * Stable machine codes the board keys its behaviour off — mirrored from
+ * `@ever-works/agent/tasks-domain`. Never branch on the message: the
+ * production build redacts thrown Server-Action messages.
+ */
+export const RUN_ALREADY_IN_FLIGHT = 'RUN_ALREADY_IN_FLIGHT';
+export const RUN_AGENT_AMBIGUOUS = 'RUN_AGENT_AMBIGUOUS';
+export const RUN_NO_AGENT = 'RUN_NO_AGENT';
+export const RUN_AGENT_NOT_FOUND = 'RUN_AGENT_NOT_FOUND';
+
+/** One row of the board's agent picker. */
+export interface RunCandidateAgent {
+    id: string;
+    name: string;
+    slug?: string;
+    status?: string;
+    source: 'assignee' | 'task' | 'work-default';
+}
+
+export interface RunTaskResult {
+    taskId: string;
+    agentId: string;
+    runId: string | null;
+    dispatched: boolean;
+    parked: boolean;
+    queuedReason?: string;
+    error?: string;
+}
+
+export type RunBatchItemResult =
+    | { taskId: string; ok: true; run: RunTaskResult }
+    | { taskId: string; ok: false; error: { code: string; message: string } };
+
 export interface Task {
     id: string;
     userId: string;
@@ -228,6 +263,44 @@ export const tasksAPI = {
         return serverMutation<{ ok: true }>({
             endpoint: `/tasks/${id}/discard-branch`,
             data: {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    // ── Board dispatch (kanban M3 / M4) ───────────────────────────
+
+    /** Agents the board's picker offers for this Task. */
+    async listRunCandidates(id: string) {
+        return serverFetch<{ data: RunCandidateAgent[] }>(`/tasks/${id}/run-candidates`, {
+            method: 'GET',
+        });
+    },
+
+    /**
+     * Run the Task now. `agentId` omitted lets the server resolve it;
+     * an ambiguous / empty resolution answers 400 with a `code` +
+     * `candidates` body the caller turns into the picker.
+     */
+    async run(id: string, agentId?: string | null) {
+        return serverMutation<RunTaskResult>({
+            endpoint: `/tasks/${id}/run`,
+            data: agentId ? { agentId } : {},
+            method: 'POST',
+            wrapInData: false,
+        });
+    },
+
+    /** Run several Tasks at once — per-item results, never all-or-nothing. */
+    async runBatch(items: { taskId: string; agentId?: string | null }[]) {
+        return serverMutation<{ results: RunBatchItemResult[] }>({
+            endpoint: `/tasks/run-batch`,
+            data: {
+                items: items.map((item) => ({
+                    taskId: item.taskId,
+                    ...(item.agentId ? { agentId: item.agentId } : {}),
+                })),
+            },
             method: 'POST',
             wrapInData: false,
         });

--- a/packages/agent/src/account-transfer/account-export.service.ts
+++ b/packages/agent/src/account-transfer/account-export.service.ts
@@ -196,6 +196,11 @@ export class AccountExportService {
             // deliberate `false` must round-trip; see ExportedWork).
             memoryRecallEnabled:
                 typeof dir.memoryRecallEnabled === 'boolean' ? dir.memoryRecallEnabled : undefined,
+            // Ingest routing claims (chat channels / teams / databases /
+            // meetings). Serialize the object as-is when present; an
+            // absent column exports as undefined so old importers and
+            // old payloads both stay happy.
+            externalRefs: dir.externalRefs ?? undefined,
             gitProvider: dir.gitProvider,
             deployProvider: dir.deployProvider || undefined,
             readmeConfig: dir.readmeConfig || undefined,

--- a/packages/agent/src/account-transfer/account-import.service.ts
+++ b/packages/agent/src/account-transfer/account-import.service.ts
@@ -23,7 +23,14 @@ import type {
 import { containsMaskedSecrets, MASKED_SECRET_PREFIX } from './types';
 import { sanitizePrompt } from '../utils/sanitize.util';
 import { normalizeCreateWorkKind, type Work, type WorkKind } from '../entities/work.entity';
-import { WORK_CHECKS_POLICIES, WORK_KINDS, type WorkChecksPolicy } from '@ever-works/contracts';
+import {
+    WORK_CHECKS_POLICIES,
+    WORK_EXTERNAL_REF_KINDS,
+    WORK_EXTERNAL_REFS_MAX_PER_KIND,
+    WORK_KINDS,
+    type WorkChecksPolicy,
+    type WorkExternalRefs,
+} from '@ever-works/contracts';
 
 /**
  * Canonical slug shape (matches the work/item DTO `@Matches` rule and
@@ -74,6 +81,37 @@ function normalizeImportedMaxGateAttempts(value: unknown): number | undefined {
     return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 5
         ? value
         : undefined;
+}
+
+/**
+ * Ingest routing claims: keep only the KNOWN hint kinds, and under each
+ * only non-empty strings, deduped and capped. Same drop-if-unrecognized
+ * posture as the rest — an unknown key in a hand-edited payload must not
+ * survive into a column the resolver iterates. Returns undefined when
+ * nothing survives, so the caller leaves the existing value untouched.
+ */
+function normalizeImportedExternalRefs(value: unknown): WorkExternalRefs | undefined {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+    const source = value as Record<string, unknown>;
+    const out: WorkExternalRefs = {};
+    let kept = 0;
+    for (const kind of WORK_EXTERNAL_REF_KINDS) {
+        const raw = source[kind];
+        if (!Array.isArray(raw)) continue;
+        const ids = Array.from(
+            new Set(
+                raw
+                    .filter((entry): entry is string => typeof entry === 'string')
+                    .map((entry) => entry.trim())
+                    .filter((entry) => entry.length > 0 && entry.length <= 200),
+            ),
+        ).slice(0, WORK_EXTERNAL_REFS_MAX_PER_KIND);
+        if (ids.length > 0) {
+            out[kind] = ids;
+            kept += ids.length;
+        }
+    }
+    return kept > 0 ? out : undefined;
 }
 
 /**
@@ -579,6 +617,12 @@ export class AccountImportService {
                 if (typeof dir.memoryRecallEnabled === 'boolean') {
                     updateData.memoryRecallEnabled = dir.memoryRecallEnabled;
                 }
+                // Ingest routing claims — sanitized to known kinds only;
+                // absent/empty leaves the existing Work's claims alone.
+                const importedExternalRefs = normalizeImportedExternalRefs(dir.externalRefs);
+                if (importedExternalRefs) {
+                    updateData.externalRefs = importedExternalRefs;
+                }
                 // Quality-gate fields: arrays only ever import as arrays;
                 // enum/int values are drop-if-unrecognized (see the
                 // normalizeImported* helpers above). Absent → existing
@@ -651,6 +695,10 @@ export class AccountImportService {
         }
         if (typeof dir.memoryRecallEnabled === 'boolean') {
             createData.memoryRecallEnabled = dir.memoryRecallEnabled;
+        }
+        const importedExternalRefs = normalizeImportedExternalRefs(dir.externalRefs);
+        if (importedExternalRefs) {
+            createData.externalRefs = importedExternalRefs;
         }
         if (
             typeof dir.taskIsolationBaseBranch === 'string' &&

--- a/packages/agent/src/account-transfer/types.ts
+++ b/packages/agent/src/account-transfer/types.ts
@@ -3,7 +3,7 @@
  * Supports versioned JSON export (v1) with full work data including
  * items, comparisons, site config, schedules, and advanced prompts.
  */
-import type { TaskAcceptanceCheck } from '@ever-works/contracts';
+import type { TaskAcceptanceCheck, WorkExternalRefs } from '@ever-works/contracts';
 
 // ─── Export Types ────────────────────────────────────────────────
 
@@ -153,6 +153,13 @@ export interface ExportedWork {
      *  would silently re-enable recall on the imported work. Absent in
      *  old payloads = leave defaults. */
     memoryRecallEnabled?: boolean;
+    /** External containers this Work claims for ingested-event routing
+     *  (chat channels, tracker teams, doc databases, meetings). A
+     *  user-visible Work setting, so it must round-trip. Payloads are
+     *  user-supplied JSON — import sanitizes to string arrays under the
+     *  known kinds and drops everything else. Repo identity is NOT here:
+     *  repo routing resolves off the Work's own repositories. */
+    externalRefs?: WorkExternalRefs | null;
     gitProvider: string;
     deployProvider?: string;
     readmeConfig?: any;

--- a/packages/agent/src/entities/work.entity.ts
+++ b/packages/agent/src/entities/work.entity.ts
@@ -67,6 +67,7 @@ import {
     type TaskAcceptanceCheck,
     type UserSelectableWorkKind,
     type WorkChecksPolicy,
+    type WorkExternalRefs,
     type WorkKind,
 } from '@ever-works/contracts';
 
@@ -480,6 +481,28 @@ export class Work {
      */
     @Column('simple-json', { nullable: true })
     mergePolicy?: MergePolicyOverride | null;
+
+    // ── External routing refs (ingest workId routing) ────────────────
+
+    /**
+     * External containers whose events belong to this Work, keyed by
+     * {@link IngestedEventWorkHintKind}. NULL / absent key = this Work
+     * claims nothing of that kind.
+     *
+     * This is the storage behind `IngestedEventEnvelope.workHint`
+     * resolution for the kinds that have no other home: a Slack channel
+     * id, a tracker team key, a doc database id, a meeting id. The
+     * `repo` kind deliberately does NOT live here — a Work already
+     * declares its repositories (`getRepoOwner`/`getMainRepo`/…) and
+     * `matchWorkByRepo` is the single matcher for them, so duplicating
+     * repo identity into this map would create a second source of truth.
+     *
+     * Matching is case-insensitive + trimmed and always scoped to the
+     * owning user, so two users may claim the same external id without
+     * ever seeing each other's events.
+     */
+    @Column('simple-json', { nullable: true })
+    externalRefs?: WorkExternalRefs | null;
 
     /**
      * Whether to generate the browsable repository published to the git

--- a/packages/agent/src/ingest/__tests__/agent-ingest-tools.spec.ts
+++ b/packages/agent/src/ingest/__tests__/agent-ingest-tools.spec.ts
@@ -40,7 +40,7 @@ describe('buildIngestEventTools — list_recent_events', () => {
     it('reads owner-scoped rows and maps them with the sourceUrl provenance', async () => {
         const result = (await tool().invoke({})) as { events: Array<Record<string, unknown>> };
 
-        expect(findRecentByUser).toHaveBeenCalledWith('user-1', 20);
+        expect(findRecentByUser).toHaveBeenCalledWith('user-1', { limit: 20 });
         expect(result.events).toEqual([
             expect.objectContaining({
                 id: 'row-1',
@@ -55,26 +55,37 @@ describe('buildIngestEventTools — list_recent_events', () => {
         ]);
     });
 
-    it('filters by source when asked (over-fetching so the filter does not starve the page)', async () => {
-        findRecentByUser.mockResolvedValue([
-            row({ id: 'a', source: 'other-source' }),
-            row({ id: 'b' }),
-        ]);
+    it('pushes the source filter into the query so the page is never starved', async () => {
+        findRecentByUser.mockResolvedValue([row({ id: 'b' })]);
 
         const result = (await tool().invoke({ source: 'slack-connector', limit: 5 })) as {
             events: Array<{ id: string }>;
         };
 
-        expect(findRecentByUser).toHaveBeenCalledWith('user-1', 15);
+        expect(findRecentByUser).toHaveBeenCalledWith('user-1', {
+            limit: 5,
+            source: 'slack-connector',
+        });
         expect(result.events.map((e) => e.id)).toEqual(['b']);
+    });
+
+    it('pushes the workId filter into the query — the per-Work activity feed', async () => {
+        findRecentByUser.mockResolvedValue([row({ id: 'w', workId: 'work-1' })]);
+
+        const result = (await tool().invoke({ workId: 'work-1' })) as {
+            events: Array<{ id: string; workId?: string }>;
+        };
+
+        expect(findRecentByUser).toHaveBeenCalledWith('user-1', { limit: 20, workId: 'work-1' });
+        expect(result.events[0].workId).toBe('work-1');
     });
 
     it('caps the limit at 50 and floors it at 1', async () => {
         await tool().invoke({ limit: 500 });
-        expect(findRecentByUser).toHaveBeenLastCalledWith('user-1', 50);
+        expect(findRecentByUser).toHaveBeenLastCalledWith('user-1', { limit: 50 });
 
         await tool().invoke({ limit: -3 });
-        expect(findRecentByUser).toHaveBeenLastCalledWith('user-1', 1);
+        expect(findRecentByUser).toHaveBeenLastCalledWith('user-1', { limit: 1 });
     });
 
     it('returns a tool-shaped error instead of throwing', async () => {

--- a/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/event-ingest.service.spec.ts
@@ -281,3 +281,91 @@ describe('EventIngestService', () => {
         });
     });
 });
+
+/**
+ * `workId` routing — the resolver seam. The spine's pre-routing
+ * behaviour (`envelope.workId ?? null`) is the contract when no resolver
+ * is bound; with one bound, a `workHint` becomes a real Work and a
+ * caller-supplied `workId` is verified against its owner.
+ */
+describe('EventIngestService — workId routing', () => {
+    let repository: { createIfNew: jest.Mock };
+    let activityLog: { log: jest.Mock };
+    let workHints: { resolve: jest.Mock; verifyOwnedWorkId: jest.Mock };
+
+    const build = (withResolver = true) =>
+        new EventIngestService(
+            repository as never,
+            activityLog as never,
+            undefined,
+            withResolver ? (workHints as never) : undefined,
+        );
+
+    beforeEach(() => {
+        repository = {
+            createIfNew: jest.fn(async () => ({ event: storedEvent(), created: true })),
+        };
+        activityLog = { log: jest.fn(async () => ({ id: 'activity-1' })) };
+        workHints = {
+            resolve: jest.fn(async () => 'work-resolved'),
+            verifyOwnedWorkId: jest.fn(async (_u: string, id: string) => id),
+        };
+    });
+
+    it('resolves a workHint into the stored workId', async () => {
+        await build().ingest('user-1', [
+            envelope({ workHint: { kind: 'chat-channel', externalId: 'C123' } }),
+        ]);
+        expect(workHints.resolve).toHaveBeenCalledWith('user-1', {
+            kind: 'chat-channel',
+            externalId: 'C123',
+        });
+        expect(repository.createIfNew).toHaveBeenCalledWith(
+            expect.objectContaining({ workId: 'work-resolved' }),
+        );
+    });
+
+    it('stores null when the hint resolves to nothing (routing is an upgrade, not a gate)', async () => {
+        workHints.resolve.mockResolvedValue(null);
+        await build().ingest('user-1', [
+            envelope({ workHint: { kind: 'meeting', externalId: 'nobody-claims-this' } }),
+        ]);
+        expect(repository.createIfNew).toHaveBeenCalledWith(
+            expect.objectContaining({ workId: null }),
+        );
+    });
+
+    it('prefers an explicit workId over the hint, after verifying ownership', async () => {
+        await build().ingest('user-1', [
+            envelope({
+                workId: 'work-explicit',
+                workHint: { kind: 'chat-channel', externalId: 'C123' },
+            }),
+        ]);
+        expect(workHints.verifyOwnedWorkId).toHaveBeenCalledWith('user-1', 'work-explicit');
+        expect(workHints.resolve).not.toHaveBeenCalled();
+        expect(repository.createIfNew).toHaveBeenCalledWith(
+            expect.objectContaining({ workId: 'work-explicit' }),
+        );
+    });
+
+    it('drops a workId the ingesting user does not own', async () => {
+        workHints.verifyOwnedWorkId.mockResolvedValue(null);
+        await build().ingest('user-1', [envelope({ workId: 'someone-elses-work' })]);
+        expect(repository.createIfNew).toHaveBeenCalledWith(
+            expect.objectContaining({ workId: null }),
+        );
+    });
+
+    it('keeps the pre-routing behaviour byte-for-byte when no resolver is bound', async () => {
+        await build(false).ingest('user-1', [
+            envelope({
+                workId: 'work-explicit',
+                workHint: { kind: 'chat-channel', externalId: 'C123' },
+            }),
+        ]);
+        expect(repository.createIfNew).toHaveBeenCalledWith(
+            expect.objectContaining({ workId: 'work-explicit' }),
+        );
+    });
+});

--- a/packages/agent/src/ingest/__tests__/ingest.module.spec.ts
+++ b/packages/agent/src/ingest/__tests__/ingest.module.spec.ts
@@ -37,6 +37,15 @@ jest.mock('../ingest-cursor.repository', () => ({
 jest.mock('../event-source-pull.service', () => ({
     EventSourcePullService: class EventSourcePullService {},
 }));
+jest.mock('../../entities/work.entity', () => ({
+    Work: class Work {},
+}));
+jest.mock('../../database/repositories/work.repository', () => ({
+    WorkRepository: class WorkRepository {},
+}));
+jest.mock('../work-hint-resolver.service', () => ({
+    WorkHintResolverService: class WorkHintResolverService {},
+}));
 
 import 'reflect-metadata';
 import { EventIngestModule } from '../ingest.module';
@@ -44,27 +53,33 @@ import { IngestedEventRepository } from '../ingested-event.repository';
 import { EventIngestService } from '../event-ingest.service';
 import { IngestCursorRepository } from '../ingest-cursor.repository';
 import { EventSourcePullService } from '../event-source-pull.service';
+import { WorkRepository } from '../../database/repositories/work.repository';
+import { WorkHintResolverService } from '../work-hint-resolver.service';
 import { ActivityLogModule } from '../../activity-log/activity-log.module';
 import { FacadesModule } from '../../facades/facades.module';
 
 describe('EventIngestModule', () => {
     const meta = (key: string): unknown[] => Reflect.getMetadata(key, EventIngestModule) ?? [];
 
-    it('provides the repositories, the ingest service and the pull service', () => {
+    it('provides the repositories, the ingest service, the pull service and the workId router', () => {
         expect(meta('providers')).toEqual([
             IngestedEventRepository,
             EventIngestService,
             IngestCursorRepository,
             EventSourcePullService,
+            WorkRepository,
+            WorkHintResolverService,
         ]);
     });
 
-    it('exports all four for the API surface + trigger-internal RPC wiring', () => {
+    it('exports every provider for the API surface + trigger-internal RPC wiring', () => {
         expect(meta('exports')).toEqual([
             IngestedEventRepository,
             EventIngestService,
             IngestCursorRepository,
             EventSourcePullService,
+            WorkRepository,
+            WorkHintResolverService,
         ]);
     });
 
@@ -87,5 +102,6 @@ describe('ingest barrel', () => {
         expect(barrel.EventSourcePullService).toBe(EventSourcePullService);
         expect(barrel.IngestCursorRepository).toBe(IngestCursorRepository);
         expect(typeof barrel.buildIngestEventTools).toBe('function');
+        expect(barrel.WorkHintResolverService).toBe(WorkHintResolverService);
     });
 });

--- a/packages/agent/src/ingest/__tests__/ingested-event.repository.spec.ts
+++ b/packages/agent/src/ingest/__tests__/ingested-event.repository.spec.ts
@@ -29,22 +29,33 @@ describe('IngestedEventRepository', () => {
         payload: { text: 'hello' },
     };
 
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    let qb: any;
     let typeormRepo: {
         findOne: jest.Mock;
         create: jest.Mock;
         save: jest.Mock;
         find: jest.Mock;
         update: jest.Mock;
+        createQueryBuilder: jest.Mock;
     };
     let repository: IngestedEventRepository;
 
     beforeEach(() => {
+        qb = {
+            where: jest.fn(() => qb),
+            andWhere: jest.fn(() => qb),
+            orderBy: jest.fn(() => qb),
+            take: jest.fn(() => qb),
+            getMany: jest.fn(async () => []),
+        };
         typeormRepo = {
             findOne: jest.fn(),
             create: jest.fn((data) => data),
             save: jest.fn(async (data) => ({ id: 'row-1', ...data })),
             find: jest.fn(async () => []),
             update: jest.fn(async () => undefined),
+            createQueryBuilder: jest.fn(() => qb),
         };
         repository = new IngestedEventRepository(typeormRepo as never);
     });
@@ -108,5 +119,51 @@ describe('IngestedEventRepository', () => {
         await repository.markProcessed('row-1', at);
 
         expect(typeormRepo.update).toHaveBeenCalledWith('row-1', { processedAt: at });
+    });
+
+    // ── `workId` routing — the per-Work activity feed query ──────────
+
+    it('findRecentByUser scopes to the owner and applies no extra filter by default', async () => {
+        await repository.findRecentByUser('user-1');
+
+        expect(qb.where).toHaveBeenCalledWith('event.userId = :userId', { userId: 'user-1' });
+        expect(qb.andWhere).not.toHaveBeenCalled();
+        expect(qb.take).toHaveBeenCalledWith(20);
+    });
+
+    it('findRecentByUser keeps accepting a bare limit (the pre-filter call shape)', async () => {
+        await repository.findRecentByUser('user-1', 5);
+        expect(qb.take).toHaveBeenCalledWith(5);
+    });
+
+    it('findRecentByUser pushes the workId and source filters into SQL', async () => {
+        await repository.findRecentByUser('user-1', {
+            workId: 'work-1',
+            source: 'slack-connector',
+            limit: 10,
+        });
+
+        expect(qb.andWhere).toHaveBeenCalledWith('event.workId = :workId', { workId: 'work-1' });
+        expect(qb.andWhere).toHaveBeenCalledWith('event.source = :source', {
+            source: 'slack-connector',
+        });
+        expect(qb.take).toHaveBeenCalledWith(10);
+    });
+
+    it('findRecentByWork applies the owner scope FIRST — another tenant Work returns an empty page, never their rows', async () => {
+        await repository.findRecentByWork('user-1', 'not-my-work');
+
+        expect(qb.where).toHaveBeenCalledWith('event.userId = :userId', { userId: 'user-1' });
+        expect(qb.andWhere).toHaveBeenCalledWith('event.workId = :workId', {
+            workId: 'not-my-work',
+        });
+    });
+
+    it('findRecentByUser clamps the page size to 1..200', async () => {
+        await repository.findRecentByUser('user-1', { limit: 5000 });
+        expect(qb.take).toHaveBeenLastCalledWith(200);
+
+        await repository.findRecentByUser('user-1', { limit: -1 });
+        expect(qb.take).toHaveBeenLastCalledWith(1);
     });
 });

--- a/packages/agent/src/ingest/__tests__/work-hint-resolver.service.spec.ts
+++ b/packages/agent/src/ingest/__tests__/work-hint-resolver.service.spec.ts
@@ -1,0 +1,186 @@
+import { WorkHintResolverService } from '../work-hint-resolver.service';
+import type { WorkRepository } from '../../database/repositories/work.repository';
+import type { Work } from '../../entities/work.entity';
+
+/**
+ * `workId` routing for ingested events — the resolver that turns a
+ * connector's `workHint` into a real Work.
+ *
+ * The invariants under test are the three the service promises: always
+ * owner-scoped, null is a normal outcome, never throws.
+ */
+
+function makeWork(
+    id: string,
+    opts: {
+        userId?: string;
+        repo?: { owner: string; name: string };
+        externalRefs?: Work['externalRefs'];
+    } = {},
+): Work {
+    return {
+        id,
+        userId: opts.userId ?? 'user-1',
+        externalRefs: opts.externalRefs ?? null,
+        getRepoOwner: () => opts.repo?.owner,
+        getMainRepo: () => opts.repo?.name,
+        getWebsiteRepo: () => undefined,
+        getDataRepo: () => undefined,
+    } as unknown as Work;
+}
+
+function makeService(works: {
+    findByUser?: jest.Mock;
+    findById?: jest.Mock;
+}): WorkHintResolverService {
+    return new WorkHintResolverService(works as unknown as WorkRepository);
+}
+
+describe('WorkHintResolverService.resolve', () => {
+    it('resolves a repo hint through the shared repo matcher', async () => {
+        const service = makeService({
+            findByUser: jest
+                .fn()
+                .mockResolvedValue([
+                    makeWork('w-other', { repo: { owner: 'acme', name: 'other' } }),
+                    makeWork('w-hit', { repo: { owner: 'acme', name: 'site' } }),
+                ]),
+        });
+        await expect(
+            service.resolve('user-1', { kind: 'repo', externalId: 'acme/site' }),
+        ).resolves.toBe('w-hit');
+    });
+
+    it('returns null for a malformed repo hint instead of guessing', async () => {
+        const findByUser = jest
+            .fn()
+            .mockResolvedValue([makeWork('w1', { repo: { owner: 'acme', name: 'site' } })]);
+        const service = makeService({ findByUser });
+        await expect(service.resolve('user-1', { kind: 'repo', externalId: 'acme' })).resolves.toBe(
+            null,
+        );
+    });
+
+    it('resolves a chat-channel hint from the Work externalRefs claim map', async () => {
+        const service = makeService({
+            findByUser: jest
+                .fn()
+                .mockResolvedValue([
+                    makeWork('w-noclaim'),
+                    makeWork('w-claim', { externalRefs: { 'chat-channel': ['C0123456789'] } }),
+                ]),
+        });
+        await expect(
+            service.resolve('user-1', { kind: 'chat-channel', externalId: 'C0123456789' }),
+        ).resolves.toBe('w-claim');
+    });
+
+    it('matches claims case-insensitively and ignoring surrounding whitespace', async () => {
+        const service = makeService({
+            findByUser: jest
+                .fn()
+                .mockResolvedValue([makeWork('w1', { externalRefs: { 'tracker-team': ['ENG'] } })]),
+        });
+        await expect(
+            service.resolve('user-1', { kind: 'tracker-team', externalId: '  eng  ' }),
+        ).resolves.toBe('w1');
+    });
+
+    it('resolves doc-database and meeting kinds off the same map', async () => {
+        const service = makeService({
+            findByUser: jest
+                .fn()
+                .mockResolvedValue([
+                    makeWork('w-db', { externalRefs: { 'doc-database': ['db-1'] } }),
+                    makeWork('w-meet', { externalRefs: { meeting: ['888'] } }),
+                ]),
+        });
+        await expect(
+            service.resolve('user-1', { kind: 'doc-database', externalId: 'db-1' }),
+        ).resolves.toBe('w-db');
+        await expect(
+            service.resolve('user-1', { kind: 'meeting', externalId: '888' }),
+        ).resolves.toBe('w-meet');
+    });
+
+    it('returns null when no Work claims the container', async () => {
+        const service = makeService({
+            findByUser: jest
+                .fn()
+                .mockResolvedValue([
+                    makeWork('w1', { externalRefs: { 'chat-channel': ['CAAA'] } }),
+                ]),
+        });
+        await expect(
+            service.resolve('user-1', { kind: 'chat-channel', externalId: 'CBBB' }),
+        ).resolves.toBeNull();
+    });
+
+    it('never queries at all for an absent, empty or non-object hint', async () => {
+        const findByUser = jest.fn();
+        const service = makeService({ findByUser });
+        await expect(service.resolve('user-1', undefined)).resolves.toBeNull();
+        await expect(service.resolve('user-1', null)).resolves.toBeNull();
+        await expect(
+            service.resolve('user-1', { kind: 'chat-channel', externalId: '   ' }),
+        ).resolves.toBeNull();
+        expect(findByUser).not.toHaveBeenCalled();
+    });
+
+    it('scopes the lookup to the ingesting user — never a global scan', async () => {
+        const findByUser = jest.fn().mockResolvedValue([]);
+        const service = makeService({ findByUser });
+        await service.resolve('user-42', { kind: 'chat-channel', externalId: 'C1' });
+        expect(findByUser).toHaveBeenCalledWith('user-42');
+    });
+
+    it('degrades to null (never throws) when the Work lookup fails', async () => {
+        const service = makeService({
+            findByUser: jest.fn().mockRejectedValue(new Error('db down')),
+        });
+        await expect(
+            service.resolve('user-1', { kind: 'chat-channel', externalId: 'C1' }),
+        ).resolves.toBeNull();
+    });
+
+    it('tolerates a hand-edited claim map holding non-strings', async () => {
+        const service = makeService({
+            findByUser: jest.fn().mockResolvedValue([
+                makeWork('w1', {
+                    externalRefs: { 'chat-channel': [42 as unknown as string, 'C1'] },
+                }),
+            ]),
+        });
+        await expect(
+            service.resolve('user-1', { kind: 'chat-channel', externalId: 'C1' }),
+        ).resolves.toBe('w1');
+    });
+});
+
+describe('WorkHintResolverService.verifyOwnedWorkId', () => {
+    it('keeps a workId the ingesting user owns', async () => {
+        const service = makeService({
+            findById: jest.fn().mockResolvedValue(makeWork('w1', { userId: 'user-1' })),
+        });
+        await expect(service.verifyOwnedWorkId('user-1', 'w1')).resolves.toBe('w1');
+    });
+
+    it('drops a workId belonging to another user (cross-tenant event injection)', async () => {
+        const service = makeService({
+            findById: jest.fn().mockResolvedValue(makeWork('w1', { userId: 'someone-else' })),
+        });
+        await expect(service.verifyOwnedWorkId('user-1', 'w1')).resolves.toBeNull();
+    });
+
+    it('drops a workId that does not exist', async () => {
+        const service = makeService({ findById: jest.fn().mockResolvedValue(null) });
+        await expect(service.verifyOwnedWorkId('user-1', 'ghost')).resolves.toBeNull();
+    });
+
+    it('fails OPEN on an infrastructure error — a flaky DB must not silently unroute events', async () => {
+        const service = makeService({
+            findById: jest.fn().mockRejectedValue(new Error('timeout')),
+        });
+        await expect(service.verifyOwnedWorkId('user-1', 'w1')).resolves.toBe('w1');
+    });
+});

--- a/packages/agent/src/ingest/agent-ingest-tools.ts
+++ b/packages/agent/src/ingest/agent-ingest-tools.ts
@@ -19,6 +19,12 @@ import type { IngestedEventRepository } from './ingested-event.repository';
 export interface ListRecentEventsArgs {
     /** Optional producing plugin id filter, e.g. `slack-connector`. */
     source?: string;
+    /**
+     * Optional Work filter — "what happened on this Work" (the per-Work
+     * Activities feed). Applied on top of the owner scope, so an id the
+     * caller does not own simply returns nothing.
+     */
+    workId?: string;
     /** Max rows (default 20, capped at 50). */
     limit?: number;
 }
@@ -53,6 +59,11 @@ export function buildIngestEventTools(args: {
                     type: 'string',
                     description: 'Optional plugin id to filter by (e.g. a connector id).',
                 },
+                workId: {
+                    type: 'string',
+                    description:
+                        'Optional Work id — return only events routed to that Work (per-Work activity feed).',
+                },
                 limit: {
                     type: 'integer',
                     description: 'Max events to return (default 20, capped at 50).',
@@ -64,14 +75,15 @@ export function buildIngestEventTools(args: {
             const a = (raw ?? {}) as ListRecentEventsArgs;
             const limit = Math.min(Math.max(Number(a.limit) || 20, 1), 50);
             try {
-                // Owner-scoped read; over-fetch when a source filter is
-                // applied so the filter does not starve the page.
-                const rows = await args.repository.findRecentByUser(
-                    args.userId,
-                    a.source ? limit * 3 : limit,
-                );
-                const filtered = a.source ? rows.filter((row) => row.source === a.source) : rows;
-                const events: RecentEventSummary[] = filtered.slice(0, limit).map((row) => ({
+                // Owner-scoped read. The source + workId filters are
+                // pushed into SQL so the page is never starved by rows
+                // the caller did not ask for.
+                const rows = await args.repository.findRecentByUser(args.userId, {
+                    limit,
+                    ...(a.source ? { source: a.source } : {}),
+                    ...(a.workId ? { workId: a.workId } : {}),
+                });
+                const events: RecentEventSummary[] = rows.slice(0, limit).map((row) => ({
                     id: row.id,
                     source: row.source,
                     kind: row.kind,

--- a/packages/agent/src/ingest/event-ingest.service.ts
+++ b/packages/agent/src/ingest/event-ingest.service.ts
@@ -6,6 +6,7 @@ import { AgentMemoryFacadeService } from '../facades/agent-memory.facade';
 import { ActivityActionType, ActivityStatus } from '../entities/activity-log.types';
 import type { IngestedEvent } from '../entities/ingested-event.entity';
 import { IngestedEventRepository } from './ingested-event.repository';
+import { WorkHintResolverService } from './work-hint-resolver.service';
 
 export interface IngestResult {
     /** New rows written. */
@@ -82,6 +83,12 @@ export class EventIngestService {
         private readonly repository: IngestedEventRepository,
         private readonly activityLogService: ActivityLogService,
         @Optional() private readonly agentMemory?: AgentMemoryFacadeService,
+        // `workId` routing — turns a connector's `workHint` into a real
+        // Work for the owning user (and verifies a caller-supplied
+        // `workId` actually belongs to them). Appended LAST + @Optional()
+        // so every positional `new EventIngestService(...)` fixture keeps
+        // compiling and ingests exactly as it did before.
+        @Optional() private readonly workHints?: WorkHintResolverService,
     ) {}
 
     /**
@@ -114,7 +121,7 @@ export class EventIngestService {
             const { created } = await this.repository.createIfNew({
                 userId,
                 organizationId: envelope.organizationId ?? null,
-                workId: envelope.workId ?? null,
+                workId: await this.resolveWorkId(userId, envelope),
                 source: envelope.source,
                 sourceEventId: envelope.sourceEventId,
                 kind: envelope.kind,
@@ -135,6 +142,32 @@ export class EventIngestService {
         }
 
         return result;
+    }
+
+    /**
+     * Decide which Work (if any) this envelope belongs to.
+     *
+     * Precedence: an explicit `workId` wins (verified to belong to the
+     * ingesting user), then the connector's `workHint`, then null.
+     * Without the resolver bound the behaviour is byte-for-byte the
+     * pre-routing one — `envelope.workId ?? null`.
+     */
+    private async resolveWorkId(
+        userId: string,
+        envelope: IngestedEventEnvelope,
+    ): Promise<string | null> {
+        if (!this.workHints) return envelope.workId ?? null;
+        if (envelope.workId) {
+            const owned = await this.workHints.verifyOwnedWorkId(userId, envelope.workId);
+            if (!owned) {
+                this.logger.warn(
+                    `Ingest: dropping workId ${envelope.workId} on ${envelope.source}/` +
+                        `${envelope.sourceEventId} — not owned by user ${userId}.`,
+                );
+            }
+            return owned;
+        }
+        return this.workHints.resolve(userId, envelope.workHint);
     }
 
     /**

--- a/packages/agent/src/ingest/index.ts
+++ b/packages/agent/src/ingest/index.ts
@@ -6,6 +6,7 @@ export * from './event-ingest.service';
 export * from './ingested-event.repository';
 export * from './event-source-pull.service';
 export * from './ingest-cursor.repository';
+export * from './work-hint-resolver.service';
 export * from './agent-ingest-tools';
 export { IngestedEvent } from '../entities/ingested-event.entity';
 export { IngestCursor } from '../entities/ingest-cursor.entity';

--- a/packages/agent/src/ingest/ingest.module.ts
+++ b/packages/agent/src/ingest/ingest.module.ts
@@ -2,12 +2,15 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { IngestedEvent } from '../entities/ingested-event.entity';
 import { IngestCursor } from '../entities/ingest-cursor.entity';
+import { Work } from '../entities/work.entity';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { FacadesModule } from '../facades/facades.module';
+import { WorkRepository } from '../database/repositories/work.repository';
 import { IngestedEventRepository } from './ingested-event.repository';
 import { EventIngestService } from './event-ingest.service';
 import { IngestCursorRepository } from './ingest-cursor.repository';
 import { EventSourcePullService } from './event-source-pull.service';
+import { WorkHintResolverService } from './work-hint-resolver.service';
 
 /**
  * Event-ingest spine (Wave 6, pull path Wave 8) — agent-side module
@@ -28,7 +31,11 @@ import { EventSourcePullService } from './event-source-pull.service';
  */
 @Module({
     imports: [
-        TypeOrmModule.forFeature([IngestedEvent, IngestCursor]),
+        // `Work` backs the `workHint` → `workId` resolver. It MUST also
+        // be present in the DataSource ENTITIES array (it already is) —
+        // a forFeature'd-but-unregistered entity throws
+        // EntityMetadataNotFoundError on first query.
+        TypeOrmModule.forFeature([IngestedEvent, IngestCursor, Work]),
         // Processor 1 — Activity-log rows with sourceUrl provenance.
         ActivityLogModule,
         // Processor 2 — best-effort Memory observations via
@@ -40,12 +47,16 @@ import { EventSourcePullService } from './event-source-pull.service';
         EventIngestService,
         IngestCursorRepository,
         EventSourcePullService,
+        WorkRepository,
+        WorkHintResolverService,
     ],
     exports: [
         IngestedEventRepository,
         EventIngestService,
         IngestCursorRepository,
         EventSourcePullService,
+        WorkRepository,
+        WorkHintResolverService,
     ],
 })
 export class EventIngestModule {}

--- a/packages/agent/src/ingest/ingested-event.repository.ts
+++ b/packages/agent/src/ingest/ingested-event.repository.ts
@@ -39,6 +39,16 @@ export interface CreateIngestedEventData {
     payload: Record<string, unknown>;
 }
 
+/** Filters for the owner-scoped recent-events page (chat tool + Work feed). */
+export interface ListRecentEventsFilter {
+    /** Narrow to one Work — the per-Work Activities feed. */
+    workId?: string;
+    /** Narrow to one producing plugin id. */
+    source?: string;
+    /** Page size; clamped to 1..200. */
+    limit?: number;
+}
+
 /**
  * Feature-owned repository (provided by `EventIngestModule`, not
  * `DatabaseModule` — same split as `WorkProposalRepository`).
@@ -95,13 +105,40 @@ export class IngestedEventRepository {
         await this.repository.update(id, { processedAt });
     }
 
-    /** Owner-scoped recent events (chat tool + future feed surfaces). */
-    async findRecentByUser(userId: string, limit = 20): Promise<IngestedEvent[]> {
-        return this.repository.find({
-            where: { userId },
-            order: { occurredAt: 'DESC' },
-            take: limit,
-        });
+    /**
+     * Owner-scoped recent events (chat tool + Work feed surfaces).
+     *
+     * `filter.workId` narrows to a single Work — the per-Work Activities
+     * feed. It is applied ON TOP of the owner scope, never instead of
+     * it, so passing another tenant's Work id yields an empty page
+     * rather than their events. `filter.source` narrows to one connector.
+     */
+    async findRecentByUser(
+        userId: string,
+        limitOrFilter: number | ListRecentEventsFilter = 20,
+    ): Promise<IngestedEvent[]> {
+        const filter: ListRecentEventsFilter =
+            typeof limitOrFilter === 'number' ? { limit: limitOrFilter } : limitOrFilter;
+        const limit = Math.min(Math.max(filter.limit ?? 20, 1), 200);
+        const qb = this.repository
+            .createQueryBuilder('event')
+            .where('event.userId = :userId', { userId });
+        if (filter.workId) {
+            qb.andWhere('event.workId = :workId', { workId: filter.workId });
+        }
+        if (filter.source) {
+            qb.andWhere('event.source = :source', { source: filter.source });
+        }
+        return qb.orderBy('event.occurredAt', 'DESC').take(limit).getMany();
+    }
+
+    /**
+     * Per-Work feed page — owner-scoped by construction. Thin alias so
+     * feed callers read as what they are and can never forget the owner
+     * argument.
+     */
+    async findRecentByWork(userId: string, workId: string, limit = 20): Promise<IngestedEvent[]> {
+        return this.findRecentByUser(userId, { workId, limit });
     }
 
     async findById(id: string): Promise<IngestedEvent | null> {

--- a/packages/agent/src/ingest/work-hint-resolver.service.ts
+++ b/packages/agent/src/ingest/work-hint-resolver.service.ts
@@ -1,0 +1,121 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { IngestedEventWorkHint, WorkExternalRefKind } from '@ever-works/contracts';
+import { WORK_EXTERNAL_REFS_MAX_PER_KIND } from '@ever-works/contracts';
+import { WorkRepository } from '../database/repositories/work.repository';
+import type { Work } from '../entities/work.entity';
+import { matchWorkByRepo, parseRepoFullName } from '../works/work-repo-match';
+
+/** Normalize an external id the same way on both sides of every compare. */
+function normalizeRef(value: string): string {
+    return value.trim().toLowerCase();
+}
+
+/**
+ * `workId` routing for ingested events — turns the connector-supplied
+ * {@link IngestedEventWorkHint} (a Slack channel, a GitHub repo, a
+ * Linear team, a Notion database, a Zoom meeting) into a real platform
+ * `workId`.
+ *
+ * Three rules define the whole service:
+ *
+ *   1. **Owner-scoped, always.** Every lookup starts from
+ *      `WorkRepository.findByUser(userId)`. Two users may claim the same
+ *      Slack channel; neither ever sees the other's events, and a hint
+ *      can never route an event into a Work its owner does not own.
+ *   2. **Null is a normal outcome.** An unmatched (or malformed, or
+ *      absent) hint leaves the event user-scoped exactly as it is today.
+ *      Routing is an upgrade, never a precondition.
+ *   3. **Never throws.** A repository failure logs and returns null —
+ *      the ingest spine must not lose an event because the router had a
+ *      bad day.
+ *
+ * `repo` hints resolve through the repositories a Work already declares
+ * (the shared `matchWorkByRepo`); every other kind resolves through the
+ * `works.externalRefs` claim map.
+ */
+@Injectable()
+export class WorkHintResolverService {
+    private readonly logger = new Logger(WorkHintResolverService.name);
+
+    constructor(private readonly works: WorkRepository) {}
+
+    /**
+     * Resolve a hint to a `workId` owned by `userId`, or null.
+     *
+     * @param hint the connector's hint; `undefined`/`null` short-circuits
+     *             to null without touching the database.
+     */
+    async resolve(userId: string, hint?: IngestedEventWorkHint | null): Promise<string | null> {
+        if (!hint || typeof hint !== 'object') return null;
+        const externalId = typeof hint.externalId === 'string' ? hint.externalId.trim() : '';
+        if (!externalId) return null;
+
+        let works: Work[];
+        try {
+            works = await this.works.findByUser(userId);
+        } catch (error) {
+            this.logger.warn(
+                `workHint resolution failed for user ${userId} (${hint.kind}) — leaving the ` +
+                    `event user-scoped: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            return null;
+        }
+
+        if (hint.kind === 'repo') {
+            const parsed = parseRepoFullName(externalId);
+            if (!parsed) return null;
+            return matchWorkByRepo(works, parsed.owner, parsed.repo)?.id ?? null;
+        }
+
+        return this.matchByExternalRef(works, hint.kind, externalId);
+    }
+
+    /**
+     * Verify that a connector-supplied `workId` really belongs to this
+     * user. The push endpoint (`POST /api/ingest/events`) accepts a
+     * caller-chosen `workId`, so without this an authenticated user
+     * could stamp another tenant's Work onto their own events and have
+     * the spine write Activity rows + Memory observations against it.
+     *
+     * Returns the id when it checks out, null when it provably does not.
+     * A lookup FAILURE keeps the id (fail-open on infrastructure, closed
+     * on identity) — same posture as the rest of the spine.
+     */
+    async verifyOwnedWorkId(userId: string, workId: string): Promise<string | null> {
+        try {
+            const work = await this.works.findById(workId);
+            if (!work) return null;
+            return work.userId === userId ? workId : null;
+        } catch (error) {
+            this.logger.warn(
+                `workId ownership check failed for ${workId} — keeping the caller's value: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+            return workId;
+        }
+    }
+
+    /** Claim-map match: first Work whose `externalRefs[kind]` contains the id. */
+    private matchByExternalRef(
+        works: readonly Work[],
+        kind: WorkExternalRefKind,
+        externalId: string,
+    ): string | null {
+        const target = normalizeRef(externalId);
+        for (const work of works) {
+            const claimed = work.externalRefs?.[kind];
+            if (!Array.isArray(claimed) || claimed.length === 0) continue;
+            // Bounded scan: the column is capped per kind at write time,
+            // and a hand-edited row must not turn routing into an
+            // unbounded loop over one Work.
+            const bounded = claimed.slice(0, WORK_EXTERNAL_REFS_MAX_PER_KIND);
+            for (const ref of bounded) {
+                if (typeof ref === 'string' && normalizeRef(ref) === target) {
+                    return work.id;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/packages/agent/src/pr-review/pr-review.service.ts
+++ b/packages/agent/src/pr-review/pr-review.service.ts
@@ -21,8 +21,10 @@ import {
     type PrStructuredReview,
 } from './pr-review.types';
 
-/** Repo roles a Work can own — checked in this order for repo→Work matching. */
-const WORK_REPO_ROLES = ['work', 'website', 'data'] as const;
+// Repo→Work matching lives in ONE place (`works/work-repo-match.ts`) so
+// the ingest `workHint` resolver and this reviewer can never drift apart
+// on what "this repository belongs to that Work" means.
+import { matchWorkByRepo } from '../works/work-repo-match';
 
 /**
  * GitHub PR review loop (Wave 7, feature g) — the Work-aware reviewer.
@@ -218,27 +220,9 @@ export class PrReviewService {
      * without Work context). Never throws.
      */
     async matchWorkForRepo(userId: string, owner: string, repo: string): Promise<Work | null> {
-        const target = `${owner}/${repo}`.toLowerCase();
         try {
             const works = await this.workRepository.findByUser(userId);
-            for (const work of works) {
-                for (const role of WORK_REPO_ROLES) {
-                    const repoOwner = work.getRepoOwner?.(role);
-                    const repoName =
-                        role === 'data'
-                            ? work.getDataRepo?.()
-                            : role === 'website'
-                              ? work.getWebsiteRepo?.()
-                              : work.getMainRepo?.();
-                    if (
-                        repoOwner &&
-                        repoName &&
-                        `${repoOwner}/${repoName}`.toLowerCase() === target
-                    ) {
-                        return work;
-                    }
-                }
-            }
+            return matchWorkByRepo(works, owner, repo);
         } catch (error) {
             this.logger.warn(
                 `repo→Work matching failed for ${owner}/${repo}: ${this.messageOf(error)}`,
@@ -525,6 +509,12 @@ export class PrReviewService {
                 commentCount: input.review.comments.length,
             },
             ...(input.work ? { workId: input.work.id } : {}),
+            // Work routing: even when this reviewer could not match the
+            // repo itself (no `work`), the repository IS the hint, so the
+            // spine gets a second, independent chance to route the event
+            // through `matchWorkByRepo` — the same matcher this service
+            // uses, never a second one.
+            workHint: { kind: 'repo', externalId: `${owner}/${repo}` },
         };
         try {
             await this.eventIngest.ingest(input.userId, [envelope]);

--- a/packages/agent/src/tasks-domain/__tests__/task-board-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-board-dispatch.spec.ts
@@ -1,0 +1,417 @@
+import { BadRequestException, ConflictException } from '@nestjs/common';
+import { TaskTransitionService } from '../task-transition.service';
+import {
+    TasksService,
+    RUN_AGENT_AMBIGUOUS,
+    RUN_AGENT_NOT_FOUND,
+    RUN_ALREADY_IN_FLIGHT,
+    RUN_BATCH_MAX_TASKS,
+    RUN_NO_AGENT,
+} from '../tasks.service';
+import { TaskStatus, TaskPriority } from '../../entities/task.entity';
+import type { Task } from '../../entities/task.entity';
+
+/**
+ * Board dispatch (kanban M3 / M4).
+ *
+ * Two things are pinned here:
+ *   - `TaskTransitionService.dispatchAgentRun` is THE dispatch path
+ *     (gate → queued row → denorm → enqueue → stamp), and the
+ *     transition fan-out is just a loop over it;
+ *   - `TasksService.runTask` resolves the agent the way the board's
+ *     picker expects and refuses a duplicate in-flight run.
+ */
+
+function makeTask(over: Partial<Task> = {}): Task {
+    return {
+        id: 't1',
+        userId: 'u1',
+        slug: 'T-1',
+        title: 'Ship the thing',
+        description: null,
+        status: TaskStatus.TODO,
+        previousStatus: null,
+        priority: TaskPriority.P3,
+        labels: null,
+        missionId: null,
+        ideaId: null,
+        workId: null,
+        agentId: null,
+        parentTaskId: null,
+        createdByType: 'user',
+        createdById: 'u1',
+        requireAllApprovers: false,
+        startedAt: null,
+        completedAt: null,
+        isRecurring: false,
+        recurrenceOccurredCount: 0,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+        ...over,
+    } as Task;
+}
+
+describe('TaskTransitionService.dispatchAgentRun — the one dispatch path', () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    let tasks: any;
+    let blocks: any;
+    let approvers: any;
+    let assignees: any;
+    let runs: any;
+    let dispatcher: any;
+    let runDenorm: any;
+    let dispatchGate: any;
+
+    beforeEach(() => {
+        tasks = { casUpdateStatus: jest.fn().mockResolvedValue(true), findById: jest.fn() };
+        blocks = { findByTaskId: jest.fn().mockResolvedValue([]) };
+        approvers = { allApproved: jest.fn().mockResolvedValue(true) };
+        assignees = { findAgentAssignees: jest.fn().mockResolvedValue([]) };
+        runs = {
+            createQueued: jest.fn().mockResolvedValue({ id: 'r1' }),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+        };
+        dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
+        runDenorm = {
+            recordQueued: jest.fn().mockResolvedValue(undefined),
+            recordTerminal: jest.fn().mockResolvedValue(undefined),
+        };
+        dispatchGate = { admit: jest.fn().mockResolvedValue({ admitted: true }) };
+    });
+
+    const makeSvc = () =>
+        new TaskTransitionService(
+            tasks,
+            blocks,
+            approvers,
+            assignees,
+            runs,
+            dispatcher,
+            undefined,
+            runDenorm,
+            dispatchGate,
+        );
+
+    it('consults the dispatch gate, creates the queued run, mirrors it on the board and enqueues', async () => {
+        const result = await makeSvc().dispatchAgentRun(makeTask({ workId: 'w1' }), 'agent-1');
+        expect(dispatchGate.admit).toHaveBeenCalledWith({
+            userId: 'u1',
+            workId: 'w1',
+            organizationId: null,
+        });
+        expect(runs.createQueued).toHaveBeenCalledWith(
+            expect.objectContaining({ agentId: 'agent-1', taskId: 't1', workId: 'w1' }),
+        );
+        expect(runDenorm.recordQueued).toHaveBeenCalledWith('t1', 'r1');
+        expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
+        expect(runs.setTriggerRunId).toHaveBeenCalledWith('r1', 'trd-1');
+        expect(result).toEqual({ runId: 'r1', dispatched: true, parked: false });
+    });
+
+    it('parks the run WITHOUT enqueuing when the concurrency gate refuses', async () => {
+        dispatchGate.admit.mockResolvedValue({
+            admitted: false,
+            queuedReason: 'concurrency-limit',
+        });
+        const result = await makeSvc().dispatchAgentRun(makeTask({ workId: 'w1' }), 'agent-1');
+        expect(runs.createQueued).toHaveBeenCalledWith(
+            expect.objectContaining({ queuedReason: 'concurrency-limit' }),
+        );
+        expect(dispatcher.enqueue).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            runId: 'r1',
+            dispatched: false,
+            parked: true,
+            queuedReason: 'concurrency-limit',
+        });
+    });
+
+    it('marks the run dispatch-failed (and clears the board chip) when the enqueue throws', async () => {
+        dispatcher.enqueue.mockRejectedValue(new Error('runtime unreachable'));
+        const result = await makeSvc().dispatchAgentRun(makeTask(), 'agent-1');
+        expect(runs.markDispatchFailed).toHaveBeenCalledWith(
+            'r1',
+            expect.stringContaining('dispatch-failed'),
+        );
+        expect(runDenorm.recordTerminal).toHaveBeenCalledWith('t1', 'r1', 'failed');
+        expect(result.dispatched).toBe(false);
+        expect(result.error).toContain('runtime unreachable');
+    });
+
+    it('reports no-dispatcher instead of throwing when no job runtime is wired', async () => {
+        const svc = new TaskTransitionService(tasks, blocks, approvers, assignees, runs);
+        await expect(svc.dispatchAgentRun(makeTask(), 'agent-1')).resolves.toEqual({
+            runId: null,
+            dispatched: false,
+            parked: false,
+            error: 'no-dispatcher',
+        });
+    });
+
+    it('fails OPEN when the gate itself throws — a broken valve never stops work', async () => {
+        dispatchGate.admit.mockRejectedValue(new Error('count query exploded'));
+        const result = await makeSvc().dispatchAgentRun(makeTask({ workId: 'w1' }), 'agent-1');
+        expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
+        expect(result.dispatched).toBe(true);
+    });
+
+    it('still fans a status transition out over every Agent assignee (one call per pair)', async () => {
+        const svc = makeSvc();
+        const task = makeTask({ status: TaskStatus.TODO });
+        tasks.findById.mockResolvedValue({ ...task, status: TaskStatus.IN_PROGRESS });
+        assignees.findAgentAssignees.mockResolvedValue([
+            { assigneeId: 'agent-1' },
+            { assigneeId: 'agent-2' },
+        ]);
+        await svc.transition(task, TaskStatus.IN_PROGRESS);
+        await new Promise((r) => setImmediate(r));
+        expect(dispatcher.enqueue).toHaveBeenCalledTimes(2);
+        expect(dispatcher.enqueue.mock.calls.map((c: any[]) => c[0].agentId)).toEqual([
+            'agent-1',
+            'agent-2',
+        ]);
+    });
+});
+
+describe('TasksService.runTask — board dispatch', () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    let taskRepo: any;
+    let assignees: any;
+    let transitions: any;
+    let agents: any;
+    let agentRuns: any;
+
+    const build = () =>
+        new TasksService(
+            taskRepo,
+            assignees,
+            {} as any, // reviewers
+            {} as any, // approvers
+            {} as any, // blocks
+            {} as any, // relations
+            {} as any, // counter
+            transitions,
+            undefined, // activityLog
+            undefined, // attachments
+            agents,
+            undefined, // notifications
+            undefined, // workUploads
+            undefined, // works
+            undefined, // missions
+            undefined, // ideas
+            undefined, // teams
+            undefined, // goals
+            agentRuns,
+        );
+
+    beforeEach(() => {
+        taskRepo = { findByIdAndUser: jest.fn().mockResolvedValue(makeTask()) };
+        assignees = { findAgentAssignees: jest.fn().mockResolvedValue([]) };
+        transitions = {
+            dispatchAgentRun: jest
+                .fn()
+                .mockResolvedValue({ runId: 'r1', dispatched: true, parked: false }),
+        };
+        agents = {
+            findByIdAndUser: jest.fn(async (id: string) => ({ id, name: `Agent ${id}` })),
+            findByUserIdScoped: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
+        };
+        agentRuns = { findInFlightForTaskAgent: jest.fn().mockResolvedValue(null) };
+    });
+
+    it('dispatches through TaskTransitionService — never its own copy of the dispatch logic', async () => {
+        const result = await build().runTask('u1', 't1', { agentId: 'agent-x' });
+        expect(transitions.dispatchAgentRun).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 't1' }),
+            'agent-x',
+            expect.objectContaining({ dedupKey: expect.stringContaining('t1:agent-x:manual:') }),
+        );
+        expect(result).toMatchObject({ taskId: 't1', agentId: 'agent-x', dispatched: true });
+    });
+
+    it('refuses with 409 RUN_ALREADY_IN_FLIGHT when that (task, agent) pair is already running', async () => {
+        agentRuns.findInFlightForTaskAgent.mockResolvedValue({ id: 'run-live', status: 'running' });
+        const error = await build()
+            .runTask('u1', 't1', { agentId: 'agent-x' })
+            .catch((e) => e);
+        expect(error).toBeInstanceOf(ConflictException);
+        expect(error.getResponse()).toMatchObject({
+            code: RUN_ALREADY_IN_FLIGHT,
+            runId: 'run-live',
+        });
+        expect(transitions.dispatchAgentRun).not.toHaveBeenCalled();
+    });
+
+    it('rejects an agentId the caller does not own, without leaking whether it exists', async () => {
+        agents.findByIdAndUser.mockResolvedValue(null);
+        const error = await build()
+            .runTask('u1', 't1', { agentId: 'not-mine' })
+            .catch((e) => e);
+        expect(error).toBeInstanceOf(BadRequestException);
+        expect(error.getResponse()).toMatchObject({ code: RUN_AGENT_NOT_FOUND });
+    });
+
+    it('falls back to the single Agent assignee when no agentId is given', async () => {
+        assignees.findAgentAssignees.mockResolvedValue([{ assigneeId: 'agent-assigned' }]);
+        const result = await build().runTask('u1', 't1');
+        expect(result.agentId).toBe('agent-assigned');
+    });
+
+    it("falls back to the Work's default Agent when the Task itself has none", async () => {
+        taskRepo.findByIdAndUser.mockResolvedValue(makeTask({ workId: 'w1' }));
+        agents.findByUserIdScoped.mockResolvedValue({
+            rows: [{ id: 'agent-work', name: 'Work agent' }],
+            total: 1,
+        });
+        const result = await build().runTask('u1', 't1');
+        expect(agents.findByUserIdScoped).toHaveBeenCalledWith(
+            'u1',
+            expect.objectContaining({ workId: 'w1' }),
+        );
+        expect(result.agentId).toBe('agent-work');
+    });
+
+    it('answers RUN_AGENT_AMBIGUOUS with the candidate list when several Agents could run it', async () => {
+        assignees.findAgentAssignees.mockResolvedValue([
+            { assigneeId: 'agent-1' },
+            { assigneeId: 'agent-2' },
+        ]);
+        const error = await build()
+            .runTask('u1', 't1')
+            .catch((e) => e);
+        expect(error.getResponse()).toMatchObject({ code: RUN_AGENT_AMBIGUOUS });
+        expect(error.getResponse().candidates).toHaveLength(2);
+    });
+
+    it('answers RUN_NO_AGENT with an empty candidate list when nothing can run it', async () => {
+        const error = await build()
+            .runTask('u1', 't1')
+            .catch((e) => e);
+        expect(error.getResponse()).toMatchObject({ code: RUN_NO_AGENT, candidates: [] });
+    });
+
+    it('reports a parked run as a success — the run exists, it is just waiting for capacity', async () => {
+        transitions.dispatchAgentRun.mockResolvedValue({
+            runId: 'r1',
+            dispatched: false,
+            parked: true,
+            queuedReason: 'concurrency-limit',
+        });
+        const result = await build().runTask('u1', 't1', { agentId: 'agent-x' });
+        expect(result).toMatchObject({ parked: true, queuedReason: 'concurrency-limit' });
+    });
+});
+
+describe('TasksService.listRunCandidates', () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const build = (taskRepo: any, assignees: any, agents: any) =>
+        new TasksService(
+            taskRepo,
+            assignees,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            agents,
+        );
+
+    it('labels each candidate with WHY it is offered and dedupes across sources', async () => {
+        const taskRepo = {
+            findByIdAndUser: jest
+                .fn()
+                .mockResolvedValue(makeTask({ workId: 'w1', agentId: 'agent-1' })),
+        };
+        const assignees = {
+            findAgentAssignees: jest.fn().mockResolvedValue([{ assigneeId: 'agent-1' }]),
+        };
+        const agents = {
+            findByIdAndUser: jest.fn(async (id: string) => ({ id, name: `Agent ${id}` })),
+            findByUserIdScoped: jest
+                .fn()
+                .mockResolvedValue({ rows: [{ id: 'agent-2', name: 'Work agent' }], total: 1 }),
+        };
+        const rows = await build(taskRepo, assignees, agents).listRunCandidates('u1', 't1');
+        expect(rows).toEqual([
+            expect.objectContaining({ id: 'agent-1', source: 'assignee' }),
+            expect.objectContaining({ id: 'agent-2', source: 'work-default' }),
+        ]);
+    });
+
+    it('drops an assignee row whose Agent no longer resolves for this owner', async () => {
+        const taskRepo = { findByIdAndUser: jest.fn().mockResolvedValue(makeTask()) };
+        const assignees = {
+            findAgentAssignees: jest.fn().mockResolvedValue([{ assigneeId: 'ghost' }]),
+        };
+        const agents = {
+            findByIdAndUser: jest.fn().mockResolvedValue(null),
+            findByUserIdScoped: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
+        };
+        await expect(
+            build(taskRepo, assignees, agents).listRunCandidates('u1', 't1'),
+        ).resolves.toEqual([]);
+    });
+});
+
+describe('TasksService.runTasksBatch', () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const build = () =>
+        new TasksService(
+            { findByIdAndUser: jest.fn().mockResolvedValue(makeTask()) } as any,
+            { findAgentAssignees: jest.fn().mockResolvedValue([]) } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {
+                dispatchAgentRun: jest
+                    .fn()
+                    .mockResolvedValue({ runId: 'r1', dispatched: true, parked: false }),
+            } as any,
+            undefined,
+            undefined,
+            {
+                findByIdAndUser: jest.fn(async (id: string) => ({ id, name: id })),
+                findByUserIdScoped: jest.fn().mockResolvedValue({ rows: [], total: 0 }),
+            } as any,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            { findInFlightForTaskAgent: jest.fn().mockResolvedValue(null) } as any,
+        );
+
+    it('returns one result per item and never lets a failure abort the rest', async () => {
+        const service = build();
+        const { results } = await service.runTasksBatch('u1', [
+            { taskId: 't1', agentId: 'agent-1' },
+            { taskId: 't2' }, // no agent → per-item failure, not a thrown batch
+            { taskId: 't3', agentId: 'agent-3' },
+        ]);
+        expect(results).toHaveLength(3);
+        expect(results[0]).toMatchObject({ taskId: 't1', ok: true });
+        expect(results[1]).toMatchObject({ taskId: 't2', ok: false });
+        expect((results[1] as any).error.code).toBe(RUN_NO_AGENT);
+        expect(results[2]).toMatchObject({ taskId: 't3', ok: true });
+    });
+
+    it('rejects an empty batch and one over the cap', async () => {
+        const service = build();
+        await expect(service.runTasksBatch('u1', [])).rejects.toBeInstanceOf(BadRequestException);
+        const tooMany = Array.from({ length: RUN_BATCH_MAX_TASKS + 1 }, (_, i) => ({
+            taskId: `t${i}`,
+            agentId: 'a',
+        }));
+        await expect(service.runTasksBatch('u1', tooMany)).rejects.toBeInstanceOf(
+            BadRequestException,
+        );
+    });
+});

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -285,7 +285,51 @@ export class TaskTransitionService {
         if (agentAssignees.length === 0) return;
         const generation = (task.recurrenceOccurredCount ?? 0) + 1;
         for (const assignee of agentAssignees) {
-            const dedupKey = `${task.id}:${assignee.assigneeId}:${generation}`;
+            await this.dispatchAgentRun(task, assignee.assigneeId, { generation });
+        }
+    }
+
+    /**
+     * THE dispatch path for one (Task, Agent) pair — gate admit →
+     * pre-created queued run → board denorm → job-runtime enqueue →
+     * triggerRunId stamp, with the loud-degradation error handling.
+     *
+     * Extracted from {@link fanOutAgentExecutions} (which is now a loop
+     * over it) so that board dispatch — "Run" on a kanban card — enters
+     * exactly the same path a drag-to-in-progress does. There is
+     * deliberately ONE implementation: a second one would be a second
+     * place for the concurrency valve, the credits precheck, the denorm
+     * mirror and the dispatch-failed bookkeeping to drift.
+     *
+     * Never throws: every failure is recorded on the run row and
+     * reported in the result, because the transition that hosts this
+     * call must not be rolled back by a dispatch hiccup.
+     *
+     * @param opts.generation dedup generation for the runtime key. The
+     *        transition path passes the recurrence generation so a rapid
+     *        status flip-flop cannot double-fire; explicit callers pass
+     *        their own discriminator.
+     */
+    async dispatchAgentRun(
+        task: Task,
+        agentId: string,
+        opts: { generation?: number; dedupKey?: string } = {},
+    ): Promise<{
+        runId: string | null;
+        /** True when the job runtime accepted the run this call. */
+        dispatched: boolean;
+        /** True when the run row exists but was parked by the gate. */
+        parked: boolean;
+        queuedReason?: string;
+        /** Set when the enqueue failed; the run is marked failed. */
+        error?: string;
+    }> {
+        if (!this.dispatcher) {
+            return { runId: null, dispatched: false, parked: false, error: 'no-dispatcher' };
+        }
+        const generation = opts.generation ?? (task.recurrenceOccurredCount ?? 0) + 1;
+        const dedupKey = opts.dedupKey ?? `${task.id}:${agentId}:${generation}`;
+        {
             let run: { id: string } | null = null;
             try {
                 // Run orchestration (Wave 4 M2) — consult the concurrency
@@ -315,7 +359,7 @@ export class TaskTransitionService {
                 // concurrency counts + the Sessions view need no join.
                 run = this.runs
                     ? await this.runs.createQueued({
-                          agentId: assignee.assigneeId,
+                          agentId,
                           userId: task.userId,
                           triggerKind: 'task',
                           taskId: task.id,
@@ -337,12 +381,17 @@ export class TaskTransitionService {
                 // terminal transitions promotes it when a slot frees.
                 if (!admission.admitted) {
                     this.logger.log(
-                        `Run for agent ${assignee.assigneeId} on task ${task.id} parked by dispatch gate (${admission.queuedReason}).`,
+                        `Run for agent ${agentId} on task ${task.id} parked by dispatch gate (${admission.queuedReason}).`,
                     );
-                    continue;
+                    return {
+                        runId: run?.id ?? null,
+                        dispatched: false,
+                        parked: true,
+                        queuedReason: admission.queuedReason ?? 'concurrency-limit',
+                    };
                 }
                 const handle = await this.dispatcher.enqueue({
-                    agentId: assignee.assigneeId,
+                    agentId,
                     userId: task.userId,
                     taskId: task.id,
                     dedupKey,
@@ -366,6 +415,7 @@ export class TaskTransitionService {
                         );
                     }
                 }
+                return { runId: run?.id ?? null, dispatched: true, parked: false };
             } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
                 // Loud degradation: an unconfigured job runtime is a distinct,
@@ -377,9 +427,7 @@ export class TaskTransitionService {
                 const reason = notConfigured
                     ? `${JOB_RUNTIME_NOT_CONFIGURED_REASON}: ${message}`
                     : `dispatch-failed: ${message}`;
-                this.logger.warn(
-                    `Failed to dispatch agent-task-execute for ${assignee.assigneeId}: ${reason}`,
-                );
+                this.logger.warn(`Failed to dispatch agent-task-execute for ${agentId}: ${reason}`);
                 if (run) {
                     try {
                         await this.runs?.markDispatchFailed(run.id, reason);
@@ -392,6 +440,12 @@ export class TaskTransitionService {
                     // board chip doesn't show a phantom queued run forever.
                     await this.runDenorm?.recordTerminal(task.id, run.id, 'failed');
                 }
+                return {
+                    runId: run?.id ?? null,
+                    dispatched: false,
+                    parked: false,
+                    error: reason,
+                };
             }
         }
     }

--- a/packages/agent/src/tasks-domain/tasks.service.ts
+++ b/packages/agent/src/tasks-domain/tasks.service.ts
@@ -30,6 +30,7 @@ import { ActivityActionType, ActivityStatus } from '../entities/activity-log.typ
 import { assertNoSecrets } from '../utils/secret-scan';
 import { computeNextOccurrence, validateRecurrenceRule } from './recurrence';
 import { AgentRepository } from '../database/repositories/agent.repository';
+import type { Agent } from '../entities/agent.entity';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
 import type { AgentRunStatus } from '../entities/agent-run.entity';
 import { TaskNotificationService } from './task-notification.service';
@@ -118,6 +119,61 @@ export interface TaskRunEmbed {
 }
 
 export type TaskWithRun = Task & { run?: TaskRunEmbed | null };
+
+// ── Board dispatch (kanban M3 / M4) ───────────────────────────────
+
+/**
+ * Stable machine codes on the board-dispatch failures. The board keys
+ * its behaviour off these, never off the message: `RUN_AGENT_AMBIGUOUS`
+ * and `RUN_NO_AGENT` open the agent picker, `RUN_ALREADY_IN_FLIGHT`
+ * points at the live run instead.
+ */
+export const RUN_ALREADY_IN_FLIGHT = 'RUN_ALREADY_IN_FLIGHT' as const;
+export const RUN_AGENT_AMBIGUOUS = 'RUN_AGENT_AMBIGUOUS' as const;
+export const RUN_NO_AGENT = 'RUN_NO_AGENT' as const;
+export const RUN_AGENT_NOT_FOUND = 'RUN_AGENT_NOT_FOUND' as const;
+
+/** Hard cap on `runTasksBatch` — a board action, not a bulk job runner. */
+export const RUN_BATCH_MAX_TASKS = 20;
+
+/** One row of the board's agent picker. */
+export interface RunCandidateAgent {
+    id: string;
+    name: string;
+    slug?: string;
+    status?: string;
+    /** Why this Agent is offered — drives the picker's grouping/labels. */
+    source: 'assignee' | 'task' | 'work-default';
+}
+
+export interface RunTaskResult {
+    taskId: string;
+    agentId: string;
+    runId: string | null;
+    dispatched: boolean;
+    parked: boolean;
+    queuedReason?: string;
+    error?: string;
+}
+
+export type RunBatchItemResult =
+    | { taskId: string; ok: true; run: RunTaskResult }
+    | { taskId: string; ok: false; error: { code: string; message: string } };
+
+/**
+ * Pull the machine code out of a thrown Nest exception whose response
+ * body we shaped ourselves; anything else reports as `RUN_FAILED`. Used
+ * only by the batch path, where per-item failures are DATA rather than
+ * an aborted request.
+ */
+function extractErrorCode(err: unknown): string {
+    const response = (err as { getResponse?: () => unknown })?.getResponse?.();
+    if (response && typeof response === 'object') {
+        const code = (response as { code?: unknown }).code;
+        if (typeof code === 'string') return code;
+    }
+    return 'RUN_FAILED';
+}
 
 @Injectable()
 export class TasksService {
@@ -541,6 +597,212 @@ export class TasksService {
             recurrenceMaxOccurrences: null,
         });
         return (await this.tasks.findById(id)) as Task;
+    }
+
+    // ── Board dispatch (kanban M3/M4) ─────────────────────────────
+
+    /**
+     * Agents that could run this Task, most-specific first:
+     *
+     *   1. its Agent assignees (the fan-out set a drag-to-in-progress
+     *      would dispatch), then
+     *   2. its own `agentId` column, then
+     *   3. the Works's Work-scoped Agents — "the Work's default agent".
+     *
+     * Deduped by id, owner-scoped throughout, never throws (a lookup
+     * failure degrades to the candidates gathered so far, so the picker
+     * still opens with whatever is knowable).
+     */
+    async listRunCandidates(userId: string, taskId: string): Promise<RunCandidateAgent[]> {
+        const task = await this.getOne(userId, taskId);
+        const out = new Map<string, RunCandidateAgent>();
+
+        const push = (id: string, source: RunCandidateAgent['source'], agent?: Agent | null) => {
+            if (!id || out.has(id)) return;
+            out.set(id, {
+                id,
+                name: agent?.name ?? agent?.slug ?? id,
+                ...(agent?.slug ? { slug: agent.slug } : {}),
+                ...(agent?.status ? { status: agent.status } : {}),
+                source,
+            });
+        };
+
+        try {
+            const assigned = await this.assignees.findAgentAssignees(taskId);
+            for (const row of assigned) {
+                const agent = this.agents
+                    ? await this.agents.findByIdAndUser(row.assigneeId, userId).catch(() => null)
+                    : null;
+                // An assignee row whose Agent is gone (or belongs to
+                // someone else) is not a candidate — the picker must
+                // never offer something dispatch would reject.
+                if (agent) push(row.assigneeId, 'assignee', agent);
+            }
+        } catch (err) {
+            this.logger.warn(`Run candidates: assignee lookup failed for task ${taskId}: ${err}`);
+        }
+
+        if (task.agentId && this.agents) {
+            const agent = await this.agents.findByIdAndUser(task.agentId, userId).catch(() => null);
+            if (agent) push(task.agentId, 'task', agent);
+        }
+
+        if (task.workId && this.agents) {
+            try {
+                const { rows } = await this.agents.findByUserIdScoped(userId, {
+                    workId: task.workId,
+                    limit: 25,
+                });
+                for (const agent of rows) push(agent.id, 'work-default', agent);
+            } catch (err) {
+                this.logger.warn(`Run candidates: Work-agent lookup failed for ${taskId}: ${err}`);
+            }
+        }
+
+        return [...out.values()];
+    }
+
+    /**
+     * Board dispatch (kanban M3) — run this Task now.
+     *
+     * Resolution order is `agentId` (explicit) → the Task's assigned
+     * Agent → the Work's default Agent, and an AMBIGUOUS or EMPTY
+     * resolution is a 400 carrying the candidate list, which is exactly
+     * what the board's agent picker renders. Dispatch itself goes
+     * through `TaskTransitionService.dispatchAgentRun` — the same path
+     * the drag-to-in-progress fan-out uses — so the concurrency valve,
+     * the credits precheck and the board denorm all apply unchanged.
+     *
+     * 409 `RUN_ALREADY_IN_FLIGHT` when this (Task, Agent) pair already
+     * has a queued/running run: the answer to "run it again" while it is
+     * still running is to steer the live run, never to race a second one.
+     */
+    async runTask(
+        userId: string,
+        taskId: string,
+        opts: { agentId?: string | null } = {},
+    ): Promise<RunTaskResult> {
+        const task = await this.getOne(userId, taskId);
+        const agentId = await this.resolveRunAgentId(userId, taskId, opts.agentId ?? null);
+
+        if (this.agentRuns) {
+            const inFlight = await this.agentRuns
+                .findInFlightForTaskAgent(taskId, agentId)
+                .catch(() => null);
+            if (inFlight) {
+                throw new ConflictException({
+                    code: RUN_ALREADY_IN_FLIGHT,
+                    message:
+                        'This Task already has a run in flight for that Agent. Steer or cancel it before starting another.',
+                    runId: inFlight.id,
+                    agentId,
+                    status: inFlight.status,
+                });
+            }
+        }
+
+        // Board dispatch is an explicit, human "go" — discriminate the
+        // dedup key by time so it can never collide with the generation
+        // key a status transition would use for the same pair.
+        const dispatch = await this.transitions.dispatchAgentRun(task, agentId, {
+            dedupKey: `${taskId}:${agentId}:manual:${Date.now()}`,
+        });
+
+        await this.logActivity({
+            userId,
+            taskId,
+            actionType: ActivityActionType.TASK_TRANSITIONED,
+            details: {
+                action: 'run',
+                agentId,
+                runId: dispatch.runId,
+                dispatched: dispatch.dispatched,
+                parked: dispatch.parked,
+            },
+        });
+
+        return { taskId, agentId, ...dispatch };
+    }
+
+    /**
+     * Board dispatch (kanban M4) — run up to
+     * {@link RUN_BATCH_MAX_TASKS} Tasks in one call, each independently.
+     *
+     * Per-item results, never all-or-nothing: a Task with no agent, one
+     * already running, and one that dispatches cleanly must all report
+     * their own outcome. Nothing here bypasses `runTask`, so the
+     * conflict rule and the dispatch gate hold identically per item.
+     */
+    async runTasksBatch(
+        userId: string,
+        items: { taskId: string; agentId?: string | null }[],
+    ): Promise<{ results: RunBatchItemResult[] }> {
+        if (!Array.isArray(items) || items.length === 0) {
+            throw new BadRequestException('At least one task is required.');
+        }
+        if (items.length > RUN_BATCH_MAX_TASKS) {
+            throw new BadRequestException(
+                `At most ${RUN_BATCH_MAX_TASKS} tasks can be run in one batch (received ${items.length}).`,
+            );
+        }
+        const results: RunBatchItemResult[] = [];
+        for (const item of items) {
+            try {
+                const run = await this.runTask(userId, item.taskId, { agentId: item.agentId });
+                results.push({ taskId: item.taskId, ok: true, run });
+            } catch (err) {
+                results.push({
+                    taskId: item.taskId,
+                    ok: false,
+                    error: {
+                        code: extractErrorCode(err),
+                        message: err instanceof Error ? err.message : String(err),
+                    },
+                });
+            }
+        }
+        return { results };
+    }
+
+    /** Explicit → assignee → Work default, with the picker-shaped 400s. */
+    private async resolveRunAgentId(
+        userId: string,
+        taskId: string,
+        explicitAgentId: string | null,
+    ): Promise<string> {
+        if (explicitAgentId) {
+            if (!this.agents) {
+                throw new BadRequestException('Agent repository not wired in this context.');
+            }
+            const agent = await this.agents.findByIdAndUser(explicitAgentId, userId);
+            if (!agent) {
+                // 400 (not 404) and no existence leak: from the caller's
+                // side an id they do not own and an id that never existed
+                // are the same unusable input.
+                throw new BadRequestException({
+                    code: RUN_AGENT_NOT_FOUND,
+                    message: `Agent ${explicitAgentId} not found.`,
+                });
+            }
+            return explicitAgentId;
+        }
+
+        const candidates = await this.listRunCandidates(userId, taskId);
+        if (candidates.length === 1) return candidates[0].id;
+        if (candidates.length === 0) {
+            throw new BadRequestException({
+                code: RUN_NO_AGENT,
+                message:
+                    'This Task has no Agent assigned and its Work has no Agent to fall back on. Assign an Agent, or pass agentId.',
+                candidates,
+            });
+        }
+        throw new BadRequestException({
+            code: RUN_AGENT_AMBIGUOUS,
+            message: `This Task has ${candidates.length} possible Agents — pass agentId to choose one.`,
+            candidates,
+        });
     }
 
     async transition(

--- a/packages/agent/src/works/work-repo-match.spec.ts
+++ b/packages/agent/src/works/work-repo-match.spec.ts
@@ -1,0 +1,76 @@
+import { getWorkRepoFullName, matchWorkByRepo, parseRepoFullName } from './work-repo-match';
+import type { Work } from '../entities/work.entity';
+
+/**
+ * The single repo→Work matcher. Both the PR reviewer and the ingest
+ * `workHint` resolver route through this, so its edge cases are pinned
+ * here once rather than duplicated in each caller's spec.
+ */
+
+function makeWork(
+    id: string,
+    repos: Partial<Record<'work' | 'website' | 'data', { owner: string; name: string }>>,
+): Work {
+    return {
+        id,
+        getRepoOwner: (role: 'work' | 'website' | 'data') => repos[role]?.owner,
+        getMainRepo: () => repos.work?.name,
+        getWebsiteRepo: () => repos.website?.name,
+        getDataRepo: () => repos.data?.name,
+    } as unknown as Work;
+}
+
+describe('matchWorkByRepo', () => {
+    it('matches the main (work) repo role', () => {
+        const work = makeWork('w1', { work: { owner: 'acme', name: 'site' } });
+        expect(matchWorkByRepo([work], 'acme', 'site')?.id).toBe('w1');
+    });
+
+    it('matches the website and data repo roles too', () => {
+        const website = makeWork('w-site', { website: { owner: 'acme', name: 'www' } });
+        const data = makeWork('w-data', { data: { owner: 'acme', name: 'content' } });
+        expect(matchWorkByRepo([website, data], 'acme', 'www')?.id).toBe('w-site');
+        expect(matchWorkByRepo([website, data], 'acme', 'content')?.id).toBe('w-data');
+    });
+
+    it('compares case-insensitively (GitHub owners/repos are case-preserving, not case-sensitive)', () => {
+        const work = makeWork('w1', { work: { owner: 'Acme', name: 'Site' } });
+        expect(matchWorkByRepo([work], 'acme', 'SITE')?.id).toBe('w1');
+    });
+
+    it('returns null when nothing claims the repo', () => {
+        const work = makeWork('w1', { work: { owner: 'acme', name: 'site' } });
+        expect(matchWorkByRepo([work], 'other', 'thing')).toBeNull();
+    });
+
+    it('returns null for an empty target rather than matching a half-declared Work', () => {
+        const work = makeWork('w1', { work: { owner: 'acme', name: 'site' } });
+        expect(matchWorkByRepo([work], '', '')).toBeNull();
+    });
+
+    it('first match wins when two Works claim the same repo', () => {
+        const first = makeWork('first', { work: { owner: 'acme', name: 'site' } });
+        const second = makeWork('second', { work: { owner: 'acme', name: 'site' } });
+        expect(matchWorkByRepo([first, second], 'acme', 'site')?.id).toBe('first');
+    });
+
+    it('ignores a role with an owner but no repo name (and vice versa)', () => {
+        const partial = makeWork('w1', {});
+        expect(getWorkRepoFullName(partial, 'work')).toBeNull();
+        expect(matchWorkByRepo([partial], 'acme', 'site')).toBeNull();
+    });
+});
+
+describe('parseRepoFullName', () => {
+    it('splits owner/repo', () => {
+        expect(parseRepoFullName('acme/site')).toEqual({ owner: 'acme', repo: 'site' });
+    });
+
+    it('rejects anything that is not exactly two non-empty segments', () => {
+        expect(parseRepoFullName('acme')).toBeNull();
+        expect(parseRepoFullName('acme/')).toBeNull();
+        expect(parseRepoFullName('/site')).toBeNull();
+        expect(parseRepoFullName('a/b/c')).toBeNull();
+        expect(parseRepoFullName('   ')).toBeNull();
+    });
+});

--- a/packages/agent/src/works/work-repo-match.ts
+++ b/packages/agent/src/works/work-repo-match.ts
@@ -1,0 +1,62 @@
+import type { Work } from '../entities/work.entity';
+
+/**
+ * Repo roles a Work can own, checked in this order for repo→Work
+ * matching. `work` is the browsable provider repository, `website` the
+ * generated site, `data` the content repo.
+ */
+export const WORK_REPO_ROLES = ['work', 'website', 'data'] as const;
+
+export type WorkRepoRole = (typeof WORK_REPO_ROLES)[number];
+
+/** The `owner/name` a Work declares for one repo role, or null. */
+export function getWorkRepoFullName(work: Work, role: WorkRepoRole): string | null {
+    const owner = work.getRepoOwner?.(role);
+    const name =
+        role === 'data'
+            ? work.getDataRepo?.()
+            : role === 'website'
+              ? work.getWebsiteRepo?.()
+              : work.getMainRepo?.();
+    if (!owner || !name) return null;
+    return `${owner}/${name}`.toLowerCase();
+}
+
+/**
+ * THE repo→Work matcher. Pure, dependency-free and synchronous so every
+ * caller (the PR reviewer, the ingest `workHint` resolver, anything
+ * later) shares one definition of "this repository belongs to that
+ * Work" instead of growing a second, subtly different one.
+ *
+ * `works` MUST already be owner-scoped by the caller — this function has
+ * no notion of users and will happily match whatever it is handed. First
+ * match wins; an unmatched repo returns null (never an exception).
+ */
+export function matchWorkByRepo<T extends Work>(
+    works: readonly T[],
+    owner: string,
+    repo: string,
+): T | null {
+    const target = `${owner}/${repo}`.trim().toLowerCase();
+    if (!target || target === '/') return null;
+    for (const work of works) {
+        for (const role of WORK_REPO_ROLES) {
+            if (getWorkRepoFullName(work, role) === target) return work;
+        }
+    }
+    return null;
+}
+
+/**
+ * Split an `owner/repo` string as it arrives on an
+ * `IngestedEventWorkHint` of kind `repo`. Returns null for anything that
+ * is not exactly two non-empty segments — a malformed hint must resolve
+ * to "no Work", never to a partial match.
+ */
+export function parseRepoFullName(value: string): { owner: string; repo: string } | null {
+    const parts = value.trim().split('/');
+    if (parts.length !== 2) return null;
+    const [owner, repo] = parts.map((part) => part.trim());
+    if (!owner || !repo) return null;
+    return { owner, repo };
+}

--- a/packages/contracts/src/ingest/ingest.types.ts
+++ b/packages/contracts/src/ingest/ingest.types.ts
@@ -33,6 +33,79 @@ export interface IngestedEventSubject {
 }
 
 /**
+ * The external containers a connector can name when it does NOT know the
+ * platform `workId` (which is almost always — a connector sees Slack
+ * channels and GitHub repos, never Ever Works ids).
+ *
+ * Deliberately a closed union: the platform resolver has to understand
+ * every kind it routes, so a connector inventing `kind: 'whatever'`
+ * must fail to compile rather than silently resolve to `null` forever.
+ */
+export type IngestedEventWorkHintKind =
+	/** Git host repository. `externalId` = `owner/repo`, lowercase-compared. */
+	| 'repo'
+	/** Chat channel. `externalId` = the channel's stable id (e.g. `C0123456789`). */
+	| 'chat-channel'
+	/** Issue-tracker team / project. `externalId` = team key or id. */
+	| 'tracker-team'
+	/** Doc-suite database / collection. `externalId` = database id. */
+	| 'doc-database'
+	/** Meeting room / recurring meeting. `externalId` = meeting id. */
+	| 'meeting';
+
+/**
+ * `workId` routing hint — what external container this event belongs to,
+ * in the SOURCE system's own vocabulary.
+ *
+ * Connectors populate this; the platform's ingest pipeline resolves it to
+ * a real `workId` **within the owning user's Works only** (never across
+ * users) and falls back to `null` when nothing matches. A hint is a hint:
+ * an unresolvable one is not an error, it just leaves the event
+ * user-scoped exactly as before.
+ */
+export interface IngestedEventWorkHint {
+	kind: IngestedEventWorkHintKind;
+	/**
+	 * Stable identifier of the container in the source system. Matching
+	 * is case-insensitive and whitespace-trimmed on both sides.
+	 */
+	externalId: string;
+	/** Human-readable label (channel name, repo name, team name) — diagnostics only. */
+	label?: string;
+}
+
+/** Serialized-hint caps, enforced at the API edge (DTO) and by the resolver. */
+export const INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS = 200;
+export const INGEST_WORK_HINT_LABEL_MAX_CHARS = 200;
+
+/**
+ * Hint kinds a Work stores claims for in `works.externalRefs`.
+ *
+ * `repo` is excluded on purpose: a Work already declares its
+ * repositories, and repo hints resolve through that existing identity
+ * (one matcher, one source of truth) rather than a second hand-kept map.
+ */
+export type WorkExternalRefKind = Exclude<IngestedEventWorkHintKind, 'repo'>;
+
+/** Ordered for stable UI rendering + exhaustive iteration in the resolver. */
+export const WORK_EXTERNAL_REF_KINDS = [
+	'chat-channel',
+	'tracker-team',
+	'doc-database',
+	'meeting'
+] as const satisfies readonly WorkExternalRefKind[];
+
+/**
+ * The external containers a Work claims, keyed by hint kind. Values are
+ * the SOURCE system's ids (channel id, team key, database id, meeting
+ * id), compared case-insensitively and trimmed.
+ */
+export type WorkExternalRefs = Partial<Record<WorkExternalRefKind, string[]>>;
+
+/** Per-kind cap on claimed ids — bounds both the column and the resolver scan. */
+export const WORK_EXTERNAL_REFS_MAX_PER_KIND = 50;
+
+/**
  * One normalized external event.
  *
  * Identity: `(source, sourceEventId)` — the ingest pipeline dedupes on
@@ -65,6 +138,12 @@ export interface IngestedEventEnvelope {
 	payload: Record<string, unknown>;
 	/** Optional Work routing hint resolved by the connector. */
 	workId?: string;
+	/**
+	 * Optional external-container hint the platform resolves to a
+	 * `workId` when `workId` itself is unknown to the connector. Ignored
+	 * when `workId` is present.
+	 */
+	workHint?: IngestedEventWorkHint;
 	/** Optional Organization scope hint. */
 	organizationId?: string;
 }

--- a/packages/plugins/linear-connector/src/linear-connector-plugin.ts
+++ b/packages/plugins/linear-connector/src/linear-connector-plugin.ts
@@ -47,6 +47,21 @@ function truncateText(text: string): string {
 	return text.length > LINEAR_EVENT_TEXT_MAX_CHARS ? text.slice(0, LINEAR_EVENT_TEXT_MAX_CHARS) : text;
 }
 
+/**
+ * Team key out of an issue identifier (`ENG-123` → `ENG`).
+ *
+ * The issue/comment nodes this connector pulls carry the identifier but
+ * not the team object, and resolving the team would cost one lazy fetch
+ * per node. The identifier prefix IS the team key by Linear's own
+ * construction, so it is both free and exact. Returns undefined for
+ * anything that is not `<KEY>-<number>`.
+ */
+function teamKeyFromIdentifier(identifier: string | undefined): string | undefined {
+	if (!identifier) return undefined;
+	const match = /^([A-Za-z0-9]+)-\d+$/.exec(identifier.trim());
+	return match ? match[1] : undefined;
+}
+
 /** Parse the team filter list: comma/space separated ids → array. */
 function resolveTeamIds(settings: PluginSettings | undefined): string[] {
 	const raw = settings?.teamIds;
@@ -410,6 +425,7 @@ export class LinearConnectorPlugin implements IConnectorPlugin, IEventSourcePlug
 		const updatedAt = toIso(issue.updatedAt ?? issue.createdAt);
 		const createdAt = toIso(issue.createdAt);
 		const changeType = Date.parse(createdAt) >= Date.parse(since) ? 'created' : 'updated';
+		const teamKey = teamKeyFromIdentifier(issue.identifier);
 		return {
 			id: randomUUID(),
 			source: this.id,
@@ -421,6 +437,10 @@ export class LinearConnectorPlugin implements IConnectorPlugin, IEventSourcePlug
 				externalId: issue.id,
 				...(issue.title ? { title: issue.title } : {})
 			},
+			// Work routing: the team is the container an Ever Works Work
+			// maps onto. Issues with an unparseable identifier carry no
+			// hint and stay user-scoped.
+			...(teamKey ? { workHint: { kind: 'tracker-team' as const, externalId: teamKey } } : {}),
 			...(issue.url ? { sourceUrl: issue.url } : {}),
 			payload: {
 				issueId: issue.id,
@@ -449,6 +469,7 @@ export class LinearConnectorPlugin implements IConnectorPlugin, IEventSourcePlug
 			issue = undefined;
 		}
 		const sourceUrl = comment.url ?? issue?.url;
+		const teamKey = teamKeyFromIdentifier(issue?.identifier);
 		return {
 			id: randomUUID(),
 			source: this.id,
@@ -460,6 +481,9 @@ export class LinearConnectorPlugin implements IConnectorPlugin, IEventSourcePlug
 				externalId: issue?.id ?? 'unknown',
 				...(issue?.title ? { title: issue.title } : {})
 			},
+			// Same team-as-container routing as issues; the parent-issue
+			// fetch is best-effort, so a failed one simply means no hint.
+			...(teamKey ? { workHint: { kind: 'tracker-team' as const, externalId: teamKey } } : {}),
 			...(sourceUrl ? { sourceUrl } : {}),
 			payload: {
 				commentId: comment.id,

--- a/packages/plugins/notion-connector/src/notion-connector-plugin.ts
+++ b/packages/plugins/notion-connector/src/notion-connector-plugin.ts
@@ -473,6 +473,7 @@ export class NotionConnectorPlugin implements IConnectorPlugin, IEventSourcePlug
 		const createdMs = Date.parse(page.created_time ?? '');
 		const changeType = Number.isFinite(createdMs) && createdMs >= Date.parse(since) ? 'created' : 'edited';
 		const title = extractPageTitle(page);
+		const resolvedDatabaseId = databaseId ?? page.parent?.database_id;
 
 		return {
 			id: randomUUID(),
@@ -485,6 +486,18 @@ export class NotionConnectorPlugin implements IConnectorPlugin, IEventSourcePlug
 				externalId: page.id,
 				...(title ? { title } : {})
 			},
+			// Work routing: the owning database is the container. Pages
+			// outside any database (workspace-root pages) carry no hint
+			// and stay user-scoped.
+			...(resolvedDatabaseId
+				? {
+						workHint: {
+							kind: 'doc-database' as const,
+							externalId: resolvedDatabaseId,
+							...(title ? { label: title } : {})
+						}
+					}
+				: {}),
 			...(page.url ? { sourceUrl: page.url } : {}),
 			payload: {
 				pageId: page.id,
@@ -492,11 +505,7 @@ export class NotionConnectorPlugin implements IConnectorPlugin, IEventSourcePlug
 				changeType,
 				...(page.created_time ? { createdTime: page.created_time } : {}),
 				lastEditedTime: occurredAt,
-				...(databaseId
-					? { databaseId }
-					: page.parent?.database_id
-						? { databaseId: page.parent.database_id }
-						: {})
+				...(resolvedDatabaseId ? { databaseId: resolvedDatabaseId } : {})
 			}
 		};
 	}

--- a/packages/plugins/slack-connector/src/slack-connector-plugin.ts
+++ b/packages/plugins/slack-connector/src/slack-connector-plugin.ts
@@ -466,6 +466,11 @@ export class SlackConnectorPlugin implements IConnectorPlugin, IEventSourcePlugi
 				...(message.user ? { externalId: message.user } : {})
 			},
 			subject: { type: 'channel', externalId: channel },
+			// Work routing: the channel is the only container this
+			// connector knows. The platform resolves it against the
+			// ingesting user's own Works (`works.externalRefs`) and falls
+			// back to a user-scoped event when nothing claims it.
+			workHint: { kind: 'chat-channel', externalId: channel },
 			...(sourceUrl ? { sourceUrl } : {}),
 			payload: {
 				channel,

--- a/packages/plugins/zoom-connector/src/zoom-connector-plugin.ts
+++ b/packages/plugins/zoom-connector/src/zoom-connector-plugin.ts
@@ -513,6 +513,14 @@ export class ZoomConnectorPlugin implements IConnectorPlugin, IEventSourcePlugin
 				externalId,
 				...(meeting.topic ? { title: meeting.topic } : {})
 			},
+			// Work routing: the meeting is the container. A Work that
+			// claims this meeting id gets the recording on its feed;
+			// otherwise the event stays user-scoped.
+			workHint: {
+				kind: 'meeting',
+				externalId,
+				...(meeting.topic ? { label: meeting.topic } : {})
+			},
 			...(playUrl ? { sourceUrl: playUrl } : {}),
 			payload: {
 				meetingExternalId: externalId,


### PR DESCRIPTION
Closes backlog items **9** and **10** from the consolidated audit (`00-STATUS.md` §E).

---

## Item 9 — Board dispatch (plan 04 M3 + M4)

> *"the board still describes work rather than running it"*

Dispatch logic was **not** duplicated. The per-pair body of
`TaskTransitionService.fanOutAgentExecutions` is extracted into a public
`dispatchAgentRun(task, agentId, opts)`; the fan-out is now a loop over it and
board dispatch calls the same method. So the concurrency valve
(`RunDispatchGateService.admit`), the credits precheck, the pre-created queued
`AgentRun`, the board denorm mirror and the loud dispatch-failed bookkeeping all
apply identically whether a run starts from a drag or from the Run button.

**API**

| Endpoint | Behaviour |
|---|---|
| `POST /api/tasks/:id/run` | Resolves the Agent: explicit `agentId` -> the Task's assigned Agent -> the Work's default (Work-scoped) Agent. Owner-scoped throughout. |
| `GET /api/tasks/:id/run-candidates` | The agent picker's option list, each row labelled with *why* it is offered (`assignee` / `task` / `work-default`). |
| `POST /api/tasks/run-batch` | 20 tasks max, **per-item results** — one Task without an Agent never aborts the rest. |

Stable machine codes (the UI never branches on a message — prod redacts thrown
Server-Action messages):

- `409 RUN_ALREADY_IN_FLIGHT` — that `(task, agent)` pair already has a
  queued/running run. The answer to "run it again" while it is running is to
  steer the live run, not race a second one. Body carries `runId`.
- `400 RUN_AGENT_AMBIGUOUS` / `400 RUN_NO_AGENT` — body carries `candidates`,
  which is exactly what opens the picker.
- `400 RUN_AGENT_NOT_FOUND` — an `agentId` the caller does not own, with no
  existence leak.

**Web** — `RunWithAgentMenu` serves all three entry points so they cannot
disagree: the Run button on the kanban card, the Run button on Task detail, and
the board opening the picker itself. Plus the `r` shortcut on a focused card,
a column **Run all**, and the drag case: dragging into *In Progress* with no
Agent assignee used to change the column and silently run nothing — it now opens
the picker.

## Item 10 — `workId` routing for ingested events (plan 08 k / j / e)

Nothing wrote `IngestedEvent.workId`, so no ingested event ever reached a Work
feed and the memory facets had nothing to filter on. One fix, three unblocked.

- **(a) contracts** — `IngestedEventWorkHint` (`repo` | `chat-channel` |
  `tracker-team` | `doc-database` | `meeting`) and `workHint?` on the envelope.
  Closed union on purpose: a connector inventing a kind the resolver does not
  understand is a compile error, not a silent permanent null.
- **(b) resolver** — `WorkHintResolverService`. Owner-scoped always
  (`findByUser` first, every time), null is a normal outcome, never throws.
- **(c) connectors** — Slack (channel), GitHub PR + mention receivers and the PR
  reviewer's own envelope (repo), Linear (team key off the issue identifier —
  free and exact, no extra fetch), Notion (owning database), Zoom (meeting).
- **(d) surfacing** — `findRecentByUser` gained `workId` + `source` filters
  pushed into SQL, `findRecentByWork` names the per-Work feed query,
  `GET /api/ingest/events?workId=` exposes it, and the `list_recent_events` chat
  tool takes the same filter. Feature (j) per-repo Activities now has data.

**Reuse, not a second matcher.** `PrReviewService.matchWorkForRepo` held the only
repo-to-Work logic; it is extracted to a pure `matchWorkByRepo` in
`works/work-repo-match.ts` that both the reviewer and the resolver now call.

**Storage.** Non-repo hints resolve against a new nullable
`works.externalRefs` claim map (migration `1784200000000-AddWorkExternalRefs` in
this commit). Repo identity deliberately does **not** live there — a Work
already declares its repositories, and a second copy would be a second source of
truth.

**Security fix found on the way.** `POST /api/ingest/events` accepted a
caller-chosen `workId`, so any authenticated user could stamp another tenant's
Work onto their events and have the spine write Activity rows + Memory
observations against it. The id is now verified against its owner
(fail-open on an infrastructure error, closed on identity).

---

## House rules

- **Additive** — 0 files deleted, 0 routes removed, 0 chat tools removed.
- **Migration in the same commit** as the entity change.
- **Account-transfer whitelist** — the standing repeat bug class. `externalRefs`
  added in all three places (`types.ts`, the export literal, **both** import
  paths) with a drop-if-unrecognized normalizer.
- **Pin specs same commit** — `ingest.module.spec.ts` updated for the two new
  providers/exports.
- **e2e whitelist sweep** — swept `apps/web/e2e` for the changed POST bodies:
  **zero specs** reference `/api/ingest/events`, `/tasks/:id/run` or
  `run-batch`, so no `forbidNonWhitelisted` reconciliation was needed. The one
  changed existing body is `IngestedEventEnvelopeDto` (new optional `workHint`);
  nothing asserts rejection against it.
- Prettier clean, conventional commit.

---

## Verification (real output)

**`packages/agent` build — TSC 0 issues**

```
> @ever-works/agent@0.1.0 build
> nest build -b swc && tsc -p tsconfig.types.json
OK  TSC  Initializing type checker...
>   TSC  Found 0 issues.
>   SWC  Running...
Successfully compiled: 1073 files with swc (835.71ms)
```

**`packages/agent` jest — `tasks-domain|ingest|pr-review|account-transfer|works`**

```
Test Suites: 54 passed, 54 total
Tests:       2 skipped, 734 passed, 736 total
Time:        261.581 s
```

**`pnpm build --filter=ever-works-api --filter=@ever-works/trigger-tasks`**

```
@ever-works/trigger-tasks:build: > tsc -p tsconfig.json
ever-works-api:build: OK  TSC  Initializing type checker...
ever-works-api:build: >   TSC  Found 0 issues.
ever-works-api:build: Successfully compiled: 688 files with swc (388.19ms)
 Tasks:    14 successful, 14 total
```

**`apps/api` `pnpm generate:openapi` (bootstrap gate)**

```
> node dist/openapi/generate-openapi.js
Wrote OpenAPI spec (442 paths) to ...\apps\api\openapi.json
```

`apps/api/openapi.json` is gitignored — not in this commit.

**`apps/api` jest — touched suites**

```
Test Suites: 7 passed, 7 total
Tests:       64 passed, 64 total
Time:        109.867 s
```

**`apps/web` `npx tsc --noEmit`** (after removing `tsconfig.tsbuildinfo`) — clean, no output.

**`apps/web` vitest — `src/components/tasks`**

```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

**Connector plugin suites (all four touched)**

```
slack-connector   27 passed (27)
linear-connector  19 passed (19)
notion-connector  18 passed (18)
zoom-connector    14 passed (14)
```

**Prettier**

```
Checking formatting...
All matched files use Prettier code style!
```

### New tests: 76

| Suite | Tests |
|---|---|
| `works/work-repo-match.spec.ts` | 9 |
| `ingest/__tests__/work-hint-resolver.service.spec.ts` | 16 |
| `ingest/__tests__/event-ingest.service.spec.ts` (routing block) | 5 |
| `ingest/__tests__/ingested-event.repository.spec.ts` (filter block) | 5 |
| `ingest/__tests__/agent-ingest-tools.spec.ts` (workId filter) | 1 |
| `tasks-domain/__tests__/task-board-dispatch.spec.ts` | 17 |
| `apps/api` ingest DTO + Slack/GitHub bridge `workHint` | 6 |
| `apps/web` `RunWithAgentMenu.unit.spec.tsx` | 8 |
| pin-spec updates (`ingest.module.spec.ts`) | 3 rewritten |

## Not in scope / follow-ups

- **No UI to edit `works.externalRefs` yet.** The column, the resolver and every
  connector hint ship here; until a Work-settings editor lands, `repo` hints
  route out of the box (they read the Work's existing repositories) and the
  other four kinds route once the map is populated. That editor is the natural
  next PR.
- **No e2e specs.** Consistent with the audit's standing finding for this
  program; the audit's own item 13 is the dedicated e2e + docs sweep.
- Batch run shipped (M4) — the single-run path was completed and tested first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task running from task details and Kanban boards, including agent selection, keyboard shortcuts, drag-and-drop support, and batch “Run all” actions.
  * Added recent ingest event browsing with filters for work and source.
  * Added automatic routing of GitHub, Slack, Linear, Notion, and Zoom events to related work items.
  * Added support for preserving external work references during account export and import.

* **Bug Fixes**
  * Improved task dispatch handling for missing, ambiguous, unavailable, duplicate, or capacity-limited agent runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->