### PR TITLE
fix(agents): wire chat tools into the tool loop + write run telemetry

### DIFF
--- a/apps/api/src/agents/agents.module.spec.ts
+++ b/apps/api/src/agents/agents.module.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * api-side AgentsModule — module-shape pin.
+ *
+ * This module is where the agent-side `@Optional() @Inject(TOKEN)` seams
+ * are actually bound. An unbound token is invisible to `tsc`, invisible
+ * to every unit test (the optional injection just resolves to
+ * `undefined`), and invisible to `generate:openapi` — which runs Nest in
+ * PREVIEW mode and never instantiates a provider. The chat-tool
+ * assembly this pin guards spent an entire program dead for exactly that
+ * reason: six descriptor factories existed, were unit-tested, and were
+ * never handed their services.
+ *
+ * Pattern (and mocking posture) mirrors
+ * `trigger/trigger-internal.module.spec.ts`: stub the heavy workspace
+ * barrels at module scope so the decorator metadata can be asserted
+ * without dragging the entity/zod graph through Jest's CJS transformer.
+ * Injection tokens are plain strings, so the stubs re-declare their real
+ * values and the assertions stay honest.
+ */
+
+jest.mock('@ever-works/agent/agents', () => ({
+    AgentsModule: class AgentsModule {},
+    AgentRepository: class AgentRepository {},
+    RunSteeringService: class RunSteeringService {},
+    AGENT_HEARTBEAT_TRIGGER: 'AGENT_HEARTBEAT_TRIGGER',
+    AGENT_RUN_CANCELLER: 'AGENT_RUN_CANCELLER',
+    AGENT_RUN_CHAT_BACK_POSTER: 'AGENT_RUN_CHAT_BACK_POSTER',
+    AGENT_RUN_TASK_FINISHER: 'AGENT_RUN_TASK_FINISHER',
+    AGENT_PLUGIN_TOOLS_FACADE: 'AGENT_PLUGIN_TOOLS_FACADE',
+    AGENT_AI_DISPATCH_FACADE: 'AGENT_AI_DISPATCH_FACADE',
+    AGENT_GIT_FACADE: 'AGENT_GIT_FACADE',
+    AGENT_EMAIL_FACADE: 'AGENT_EMAIL_FACADE',
+    AGENT_NOTIFY_CHANNEL_FACADE: 'AGENT_NOTIFY_CHANNEL_FACADE',
+    AGENT_DOMAIN_TOOL_SOURCES: 'AGENT_DOMAIN_TOOL_SOURCES',
+}));
+jest.mock('@ever-works/agent/database', () => ({
+    DatabaseModule: class DatabaseModule {},
+    AgentEmailAssignmentRepository: class AgentEmailAssignmentRepository {},
+    TenantEmailAddressRepository: class TenantEmailAddressRepository {},
+    NotificationChannelRepository: class NotificationChannelRepository {},
+}));
+jest.mock('@ever-works/agent/facades', () => ({
+    FacadesModule: class FacadesModule {},
+    NotificationChannelFacadeService: class NotificationChannelFacadeService {},
+    SearchFacadeService: class SearchFacadeService {},
+    ScreenshotFacadeService: class ScreenshotFacadeService {},
+    ContentExtractorFacadeService: class ContentExtractorFacadeService {},
+    AiFacadeService: class AiFacadeService {},
+    GitFacadeService: class GitFacadeService {},
+}));
+jest.mock('@ever-works/agent/notifications', () => ({
+    INBOUND_EMAIL_TASK_SPAWNER: 'INBOUND_EMAIL_TASK_SPAWNER',
+}));
+jest.mock('@ever-works/agent/tasks-domain', () => ({
+    TasksDomainModule: class TasksDomainModule {},
+    TaskChatService: class TaskChatService {},
+    TasksService: class TasksService {},
+    TaskAssigneeRepository: class TaskAssigneeRepository {},
+    TaskReviewerRepository: class TaskReviewerRepository {},
+    TaskApproverRepository: class TaskApproverRepository {},
+    TaskStatus: {},
+    RUN_STEERING_PORT: 'RUN_STEERING_PORT',
+}));
+jest.mock('@ever-works/agent/ingest', () => ({
+    EventIngestModule: class EventIngestModule {},
+    IngestedEventRepository: class IngestedEventRepository {},
+}));
+jest.mock('@ever-works/agent/digest', () => ({
+    DigestModule: class DigestModule {},
+    DigestService: class DigestService {},
+}));
+jest.mock('@ever-works/agent/meetings', () => ({
+    MeetingsModule: class MeetingsModule {},
+    MeetingRepository: class MeetingRepository {},
+}));
+jest.mock('@ever-works/agent/fleet', () => ({
+    FleetModule: class FleetModule {},
+    FleetService: class FleetService {},
+}));
+jest.mock('@ever-works/agent/pr-review', () => ({
+    PrReviewModule: class PrReviewModule {},
+    PrReviewService: class PrReviewService {},
+}));
+jest.mock('@ever-works/agent/policy', () => ({
+    PolicyModule: class PolicyModule {},
+    MergePolicyService: class MergePolicyService {},
+}));
+jest.mock('@ever-works/agent/services', () => ({
+    WorkOwnershipService: class WorkOwnershipService {},
+}));
+jest.mock('@ever-works/agent/skills', () => ({
+    SkillsModule: class SkillsModule {},
+}));
+jest.mock('@ever-works/agent/activity-log', () => ({
+    ActivityLogModule: class ActivityLogModule {},
+}));
+jest.mock('@ever-works/trigger-tasks', () => ({
+    TriggerModule: class TriggerModule {},
+    TriggerService: class TriggerService {},
+    agentHeartbeatTriggerAdapter: {},
+    createAgentRunCancellerAdapter: () => ({}),
+}));
+jest.mock('../email/email.module', () => ({ EmailModule: class EmailModule {} }));
+jest.mock('../email/email.service', () => ({ EmailService: class EmailService {} }));
+jest.mock('../auth/auth.module', () => ({ AuthModule: class AuthModule {} }));
+jest.mock('./agents.controller', () => ({ AgentsController: class AgentsController {} }));
+jest.mock('./agent-templates.controller', () => ({
+    AgentTemplatesController: class AgentTemplatesController {},
+}));
+jest.mock('./agent-template-catalog.service', () => ({
+    AgentTemplateCatalogService: class AgentTemplateCatalogService {},
+}));
+
+import 'reflect-metadata';
+import { AgentsModule } from './agents.module';
+import { EventIngestModule, IngestedEventRepository } from '@ever-works/agent/ingest';
+import { DigestModule, DigestService } from '@ever-works/agent/digest';
+import { MeetingsModule, MeetingRepository } from '@ever-works/agent/meetings';
+import { FleetModule, FleetService } from '@ever-works/agent/fleet';
+import { PrReviewModule, PrReviewService } from '@ever-works/agent/pr-review';
+import { PolicyModule, MergePolicyService } from '@ever-works/agent/policy';
+import { WorkOwnershipService } from '@ever-works/agent/services';
+import {
+    TasksService,
+    TaskChatService,
+    TaskAssigneeRepository,
+    TaskReviewerRepository,
+    TaskApproverRepository,
+} from '@ever-works/agent/tasks-domain';
+import { AgentRepository, AGENT_DOMAIN_TOOL_SOURCES } from '@ever-works/agent/agents';
+
+type FactoryProvider = {
+    provide?: unknown;
+    inject?: unknown[];
+    useFactory?: (...args: unknown[]) => unknown;
+};
+
+const meta = (key: string): unknown[] => Reflect.getMetadata(key, AgentsModule) ?? [];
+
+const findProvider = (token: unknown): FactoryProvider | undefined =>
+    (meta('providers') as FactoryProvider[]).find(
+        (provider) => provider && typeof provider === 'object' && provider.provide === token,
+    );
+
+describe('api-side AgentsModule — domain chat-tool wiring', () => {
+    it('imports every module that backs a domain chat tool', () => {
+        const imports = meta('imports');
+        expect(imports).toContain(EventIngestModule);
+        expect(imports).toContain(DigestModule);
+        expect(imports).toContain(MeetingsModule);
+        expect(imports).toContain(FleetModule);
+        expect(imports).toContain(PrReviewModule);
+        expect(imports).toContain(PolicyModule);
+    });
+
+    it('binds AGENT_DOMAIN_TOOL_SOURCES — without it every domain tool is dead code', () => {
+        expect(findProvider(AGENT_DOMAIN_TOOL_SOURCES)).toBeDefined();
+    });
+
+    it('injects exactly the services the six descriptor factories need', () => {
+        expect(findProvider(AGENT_DOMAIN_TOOL_SOURCES)?.inject).toEqual([
+            TasksService,
+            TaskChatService,
+            TaskAssigneeRepository,
+            TaskReviewerRepository,
+            TaskApproverRepository,
+            IngestedEventRepository,
+            DigestService,
+            MeetingRepository,
+            FleetService,
+            PrReviewService,
+            MergePolicyService,
+            WorkOwnershipService,
+            AgentRepository,
+        ]);
+    });
+
+    it('provides WorkOwnershipService locally but does NOT export it from this @Global module', () => {
+        expect(meta('providers')).toContain(WorkOwnershipService);
+        expect(meta('exports')).not.toContain(WorkOwnershipService);
+    });
+
+    it('exports the token so the agent-side @Optional() injection resolves', () => {
+        expect(meta('exports')).toContain(AGENT_DOMAIN_TOOL_SOURCES);
+    });
+
+    it('binds all three Task membership repositories (the commentOnTask gate is fail-closed)', () => {
+        const factory = findProvider(AGENT_DOMAIN_TOOL_SOURCES);
+        const bundle = factory?.useFactory?.(
+            ...(factory.inject ?? []).map((_, index) => ({ stub: index })),
+        ) as { tasks?: Record<string, unknown> };
+        expect(bundle?.tasks?.assignees).toBeDefined();
+        expect(bundle?.tasks?.reviewers).toBeDefined();
+        expect(bundle?.tasks?.approvers).toBeDefined();
+    });
+
+    it('carries every domain in the assembled bundle', () => {
+        const factory = findProvider(AGENT_DOMAIN_TOOL_SOURCES);
+        const bundle = factory?.useFactory?.(
+            ...(factory.inject ?? []).map((_, index) => ({ stub: index })),
+        ) as Record<string, unknown>;
+        expect(Object.keys(bundle)).toEqual([
+            'tasks',
+            'ingest',
+            'digest',
+            'meetings',
+            'fleet',
+            'prReview',
+            'mergePolicy',
+        ]);
+    });
+});

--- a/apps/api/src/agents/agents.module.ts
+++ b/apps/api/src/agents/agents.module.ts
@@ -11,7 +11,9 @@ import {
     AGENT_GIT_FACADE,
     AGENT_EMAIL_FACADE,
     AGENT_NOTIFY_CHANNEL_FACADE,
+    AGENT_DOMAIN_TOOL_SOURCES,
     RunSteeringService,
+    type AgentDomainToolSources,
     type AgentRunChatBackPoster,
     type AgentRunTaskFinisher,
     type AgentPluginToolsFacade,
@@ -53,8 +55,23 @@ import {
     TaskChatService,
     TasksService,
     TaskStatus,
+    TaskAssigneeRepository,
+    TaskReviewerRepository,
+    TaskApproverRepository,
     RUN_STEERING_PORT,
 } from '@ever-works/agent/tasks-domain';
+// Domain chat-tool sources (AGENT_DOMAIN_TOOL_SOURCES binding below).
+// Each module contributes the ONE service/repository its descriptor
+// factory needs; the descriptors themselves are assembled inside
+// `AgentToolService.resolveAllowedTools` — the tool loop's single
+// assembly point.
+import { EventIngestModule, IngestedEventRepository } from '@ever-works/agent/ingest';
+import { DigestModule, DigestService } from '@ever-works/agent/digest';
+import { MeetingsModule, MeetingRepository } from '@ever-works/agent/meetings';
+import { FleetModule, FleetService } from '@ever-works/agent/fleet';
+import { PrReviewModule, PrReviewService } from '@ever-works/agent/pr-review';
+import { PolicyModule, MergePolicyService } from '@ever-works/agent/policy';
+import { WorkOwnershipService } from '@ever-works/agent/services';
 import {
     FacadesModule,
     SearchFacadeService,
@@ -131,10 +148,24 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
         // Provides TriggerService, which backs the AGENT_RUN_CANCELLER factory
         // below. Same alias works.module.ts / webhooks.module.ts already use.
         TasksTriggerModule,
+        // Domain chat tools — the services the AGENT_DOMAIN_TOOL_SOURCES
+        // binding hands to `AgentToolService`. None of these modules
+        // imports anything api-side, so no cycle is introduced.
+        EventIngestModule,
+        DigestModule,
+        MeetingsModule,
+        FleetModule,
+        PrReviewModule,
+        PolicyModule,
     ],
     controllers: [AgentsController, AgentTemplatesController],
     providers: [
         AgentTemplateCatalogService,
+        // Security: provided LOCALLY (not exported) so the merge-policy
+        // chat tool's owner check runs the same `ensureAccess` gate the
+        // HTTP surface does. Its deps (WorkRepository / WorkMemberRepository)
+        // come from the DatabaseModule import above.
+        WorkOwnershipService,
         { provide: AGENT_HEARTBEAT_TRIGGER, useValue: agentHeartbeatTriggerAdapter },
         {
             provide: AGENT_RUN_CANCELLER,
@@ -632,6 +663,87 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
                 },
             }),
         },
+        // Domain chat tools — AGENT_DOMAIN_TOOL_SOURCES binding.
+        //
+        // Six descriptor factories shipped with their domains (Waves 3,
+        // 6, 7, 8, 12) but nothing ever handed them their services, so
+        // no agent run could call them. This is the binding that closes
+        // that gap: it carries ONLY the backing services, and
+        // `AgentToolService.resolveAllowedTools` builds + permission-gates
+        // the descriptors — the single tool-assembly point the run loop
+        // already reads from. Same @Global() token posture as the facade
+        // bindings above, so the @Optional() injection in the agent-side
+        // AgentsModule actually resolves in production.
+        {
+            provide: AGENT_DOMAIN_TOOL_SOURCES,
+            inject: [
+                TasksService,
+                TaskChatService,
+                TaskAssigneeRepository,
+                TaskReviewerRepository,
+                TaskApproverRepository,
+                IngestedEventRepository,
+                DigestService,
+                MeetingRepository,
+                FleetService,
+                PrReviewService,
+                MergePolicyService,
+                WorkOwnershipService,
+                AgentRepository,
+            ],
+            useFactory: (
+                tasksService: TasksService,
+                chatService: TaskChatService,
+                assignees: TaskAssigneeRepository,
+                reviewers: TaskReviewerRepository,
+                approvers: TaskApproverRepository,
+                ingestedEvents: IngestedEventRepository,
+                digest: DigestService,
+                meetings: MeetingRepository,
+                fleet: FleetService,
+                prReview: PrReviewService,
+                mergePolicy: MergePolicyService,
+                workOwnership: WorkOwnershipService,
+                agents: AgentRepository,
+            ): AgentDomainToolSources => ({
+                // All three membership repositories are bound: the
+                // commentOnTask gate is fail-closed and DENIES every call
+                // when any of them is missing.
+                tasks: { tasksService, chatService, assignees, reviewers, approvers },
+                ingest: { repository: ingestedEvents },
+                digest: { digestService: digest },
+                meetings: { repository: meetings },
+                fleet: { service: fleet },
+                prReview: { prReviewService: prReview },
+                mergePolicy: {
+                    service: mergePolicy,
+                    // Security: the model supplies workId/agentId, so both
+                    // are owner-checked BEFORE any resolution runs —
+                    // otherwise the tool is a cross-tenant policy oracle.
+                    // Mirrors `MergePolicyController.resolve` exactly;
+                    // returning null (rather than throwing) lets the tool
+                    // answer "not found or not accessible" with no
+                    // existence leak.
+                    async authorize(userId, input) {
+                        if (input.workId) {
+                            try {
+                                await workOwnership.ensureAccess(input.workId, userId);
+                            } catch {
+                                return null;
+                            }
+                        }
+                        if (input.agentId) {
+                            const agent = await agents.findByIdAndUser(input.agentId, userId);
+                            if (!agent) return null;
+                        }
+                        return {
+                            workId: input.workId ?? null,
+                            agentId: input.agentId ?? null,
+                        };
+                    },
+                },
+            }),
+        },
     ],
     exports: [
         AGENT_HEARTBEAT_TRIGGER,
@@ -642,6 +754,7 @@ import { AgentTemplateCatalogService } from './agent-template-catalog.service';
         AGENT_GIT_FACADE,
         AGENT_EMAIL_FACADE,
         AGENT_NOTIFY_CHANNEL_FACADE,
+        AGENT_DOMAIN_TOOL_SOURCES,
         INBOUND_EMAIL_TASK_SPAWNER,
         RUN_STEERING_PORT,
     ],

--- a/packages/agent/src/agents/__tests__/agent-run-telemetry.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-run-telemetry.spec.ts
@@ -1,0 +1,280 @@
+import { AgentRunService } from '../agent-run.service';
+import { AgentToolService } from '../agent-tool.service';
+import { PromptAssemblerService } from '../prompt-assembler.service';
+import {
+    AgentAvatarMode,
+    AgentIdleBehavior,
+    AgentScope,
+    AgentStatus,
+} from '../../entities/agent.entity';
+import type { Agent, AgentPermissions } from '../../entities/agent.entity';
+import type { AgentAiDispatchFacade, AgentAiDispatchResult } from '../agent-ai-dispatch-facade';
+import type { AgentDomainToolSources } from '../agent-domain-tool-sources';
+
+/**
+ * Run telemetry + end-to-end tool assembly for the agent tool loop.
+ *
+ * Two previously-dead paths are pinned here:
+ *
+ *  1. `agent_runs.totalTokens` had columns, an API embed and UI, but no
+ *     writer — the Sessions cockpit and the board run chip always showed
+ *     a blank counter. The loop now folds each round-trip's usage in.
+ *  2. The domain chat tools were never assembled, so a `task` run's tool
+ *     list only ever carried the built-ins. It now carries them.
+ */
+
+function makePerms(over: Partial<AgentPermissions> = {}): AgentPermissions {
+    return {
+        canCreateAgents: false,
+        canAssignTasks: false,
+        canEditSkills: false,
+        canEditAgentFiles: false,
+        canSpend: false,
+        canCommitToRepo: false,
+        canOpenPullRequests: false,
+        canCallExternalTools: false,
+        ...over,
+    };
+}
+
+function makeAgent(over: Partial<Agent> = {}): Agent {
+    return {
+        id: 'a1',
+        userId: 'u1',
+        scope: AgentScope.TENANT,
+        missionId: null,
+        ideaId: null,
+        workId: null,
+        name: 'CEO',
+        slug: 'ceo',
+        title: null,
+        capabilities: null,
+        aiProviderId: null,
+        modelId: 'gpt-4o-mini',
+        maxSkillContextTokens: 4000,
+        status: AgentStatus.ACTIVE,
+        permissions: makePerms(),
+        targets: null,
+        heartbeatCadence: null,
+        idleBehavior: AgentIdleBehavior.PROPOSE,
+        nextHeartbeatAt: null,
+        lastRunAt: null,
+        lastRunStatus: null,
+        errorCount: 0,
+        pauseAfterFailures: 3,
+        avatarMode: AgentAvatarMode.INITIALS,
+        avatarIcon: null,
+        avatarImageUploadId: null,
+        soulMd: '# Who I am\nThe boss.',
+        agentsMd: null,
+        heartbeatMd: '# Each tick\nLook at recent activity.',
+        toolsMd: null,
+        agentYml: null,
+        contentHash: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+        ...over,
+    } as Agent;
+}
+
+describe('AgentRunService — run telemetry + assembled tool list', () => {
+    let agents: any;
+    let runs: any;
+    let runLogs: any;
+    let budgets: any;
+    let assembler: PromptAssemblerService;
+    let ai: jest.Mocked<AgentAiDispatchFacade>;
+    let toolService: AgentToolService;
+    let sources: AgentDomainToolSources;
+
+    const baseContext = {
+        runId: 'r1',
+        agentId: 'a1',
+        userId: 'u1',
+        kind: 'chat' as const,
+        taskId: 't1',
+        chatMessageId: 'm1',
+    };
+
+    beforeEach(() => {
+        agents = { findById: jest.fn().mockResolvedValue(makeAgent()) };
+        runs = {
+            findByAgent: jest.fn().mockResolvedValue([]),
+            markFailed: jest.fn().mockResolvedValue(undefined),
+            markCompleted: jest.fn().mockResolvedValue(undefined),
+            addTokens: jest.fn().mockResolvedValue(undefined),
+        };
+        runLogs = { append: jest.fn().mockResolvedValue(undefined) };
+        budgets = { findByAgentId: jest.fn().mockResolvedValue(null) };
+        assembler = new PromptAssemblerService();
+        ai = { dispatch: jest.fn() };
+        sources = {
+            ingest: {
+                repository: { findRecentByUser: jest.fn().mockResolvedValue([]) } as any,
+            },
+            digest: {
+                digestService: { composeDigest: jest.fn().mockResolvedValue({}) } as any,
+            },
+            meetings: {
+                repository: {
+                    findByUser: jest.fn().mockResolvedValue([]),
+                    findById: jest.fn().mockResolvedValue(null),
+                } as any,
+            },
+            fleet: { service: { listForUser: jest.fn().mockResolvedValue([]) } as any },
+            mergePolicy: {
+                service: { resolve: jest.fn().mockResolvedValue({}) } as any,
+                authorize: jest.fn().mockResolvedValue(null) as any,
+            },
+        };
+        toolService = new AgentToolService(
+            { create: jest.fn(), findByIdAndUser: jest.fn() } as any,
+            { create: jest.fn() } as any,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            sources,
+        );
+    });
+
+    function makeSvc(): AgentRunService {
+        return new AgentRunService(
+            agents,
+            runs,
+            runLogs,
+            budgets,
+            assembler,
+            undefined,
+            undefined,
+            { postReply: jest.fn().mockResolvedValue({ messageId: 'msg' }) } as any,
+            { finishTask: jest.fn().mockResolvedValue({ status: 'done' }) } as any,
+            toolService,
+            ai,
+        );
+    }
+
+    function aiResponse(over: Partial<AgentAiDispatchResult> = {}): AgentAiDispatchResult {
+        return {
+            text: 'ok',
+            toolCalls: [],
+            finishReason: 'stop',
+            usage: { promptTokens: 100, completionTokens: 20, totalTokens: 120 },
+            model: 'gpt-4o-mini',
+            ...over,
+        };
+    }
+
+    // ── assembled tool list ──────────────────────────────────────────
+
+    it('a task-kind run dispatches with the domain tools in its tool list', async () => {
+        ai.dispatch.mockResolvedValue(aiResponse());
+
+        await makeSvc().execute({ ...baseContext, kind: 'task', immediateInput: 'go' });
+
+        const toolNames = (ai.dispatch.mock.calls[0][0].tools ?? []).map((t) => t.name);
+        expect(toolNames).toEqual(
+            expect.arrayContaining([
+                'list_recent_events',
+                'get_digest',
+                'list_meetings',
+                'get_meeting_summary',
+                'list_fleet_nodes',
+                'resolve_merge_policy',
+            ]),
+        );
+        // The virtual task-only tool and the built-ins are still there.
+        expect(toolNames).toContain('transitionTask');
+        expect(toolNames).toContain('getActivity');
+    });
+
+    it('the dispatched tool definitions carry a JSON-schema parameter block', async () => {
+        ai.dispatch.mockResolvedValue(aiResponse());
+
+        await makeSvc().execute({ ...baseContext, kind: 'task', immediateInput: 'go' });
+
+        const defs = ai.dispatch.mock.calls[0][0].tools ?? [];
+        const digest = defs.find((d) => d.name === 'get_digest');
+        expect(digest).toBeDefined();
+        expect((digest!.parameters as { type?: string }).type).toBe('object');
+        expect(digest!.description.length).toBeGreaterThan(0);
+    });
+
+    it('still gates permissioned domain tools inside a real run', async () => {
+        ai.dispatch.mockResolvedValue(aiResponse());
+        agents.findById.mockResolvedValue(makeAgent({ permissions: makePerms() }));
+
+        await makeSvc().execute({ ...baseContext, kind: 'task', immediateInput: 'go' });
+
+        const toolNames = (ai.dispatch.mock.calls[0][0].tools ?? []).map((t) => t.name);
+        expect(toolNames).not.toContain('createTask');
+        expect(toolNames).not.toContain('review_pull_request');
+    });
+
+    // ── token telemetry ──────────────────────────────────────────────
+
+    it('accumulates the token counter across every model round-trip', async () => {
+        ai.dispatch
+            .mockResolvedValueOnce(
+                aiResponse({
+                    toolCalls: [{ id: 'tc1', name: 'getActivity', args: {} }],
+                    finishReason: 'tool_calls',
+                    usage: { promptTokens: 100, completionTokens: 20, totalTokens: 120 },
+                }),
+            )
+            .mockResolvedValueOnce(
+                aiResponse({
+                    usage: { promptTokens: 40, completionTokens: 5, totalTokens: 45 },
+                }),
+            );
+
+        await makeSvc().execute(baseContext);
+
+        expect(runs.addTokens).toHaveBeenCalledTimes(2);
+        expect(runs.addTokens).toHaveBeenNthCalledWith(1, 'r1', 120);
+        expect(runs.addTokens).toHaveBeenNthCalledWith(2, 'r1', 45);
+    });
+
+    it('falls back to promptTokens + completionTokens when totalTokens is absent', async () => {
+        ai.dispatch.mockResolvedValue(
+            aiResponse({ usage: { promptTokens: 7, completionTokens: 3 } as never }),
+        );
+
+        await makeSvc().execute(baseContext);
+
+        expect(runs.addTokens).toHaveBeenCalledWith('r1', 10);
+    });
+
+    it('writes nothing when the provider reports no usage at all', async () => {
+        ai.dispatch.mockResolvedValue(aiResponse({ usage: undefined }));
+
+        await makeSvc().execute(baseContext);
+
+        expect(runs.addTokens).not.toHaveBeenCalled();
+    });
+
+    it('a rejecting token writer never fails the run', async () => {
+        runs.addTokens.mockRejectedValue(new Error('db down'));
+        ai.dispatch.mockResolvedValue(aiResponse());
+
+        const result = await makeSvc().execute(baseContext);
+
+        expect(result.status).toBe('dispatched');
+        expect(runs.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('a repository with no addTokens method at all never fails the run', async () => {
+        // Older RPC proxies / partial doubles throw SYNCHRONOUSLY here,
+        // which a bare `.catch()` would not absorb.
+        delete runs.addTokens;
+        ai.dispatch.mockResolvedValue(aiResponse());
+
+        const result = await makeSvc().execute(baseContext);
+
+        expect(result.status).toBe('dispatched');
+        expect(runs.markFailed).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/agents/__tests__/agent-tool-domain.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool-domain.spec.ts
@@ -1,0 +1,318 @@
+import { AgentToolService } from '../agent-tool.service';
+import {
+    AgentScope,
+    AgentStatus,
+    AgentAvatarMode,
+    AgentIdleBehavior,
+} from '../../entities/agent.entity';
+import type { Agent, AgentPermissions } from '../../entities/agent.entity';
+import type { AgentDomainToolSources } from '../agent-domain-tool-sources';
+
+/**
+ * Domain chat tools — assembly into the ONE tool-resolution point.
+ *
+ * Six descriptor factories shipped alongside their domains (Waves 3, 6,
+ * 7, 8, 12) but nothing ever called them, so no agent run could reach
+ * any of those tools. These tests pin the fix: the factories are now
+ * assembled by `AgentToolService.resolveAllowedTools` — the same list
+ * `AgentRunService.runToolLoop` turns into the model's tool definitions
+ * — with the same owner/permission scoping as the built-in tools.
+ */
+
+function makePerms(over: Partial<AgentPermissions> = {}): AgentPermissions {
+    return {
+        canCreateAgents: false,
+        canAssignTasks: false,
+        canEditSkills: false,
+        canEditAgentFiles: false,
+        canSpend: false,
+        canCommitToRepo: false,
+        canOpenPullRequests: false,
+        canCallExternalTools: false,
+        ...over,
+    };
+}
+
+function makeAgent(over: Partial<Agent> = {}): Agent {
+    return {
+        id: 'a1',
+        userId: 'u1',
+        scope: AgentScope.WORK,
+        missionId: null,
+        ideaId: null,
+        workId: 'w1',
+        name: 'Operator',
+        slug: 'operator',
+        title: null,
+        capabilities: null,
+        aiProviderId: null,
+        modelId: null,
+        maxSkillContextTokens: 4000,
+        status: AgentStatus.ACTIVE,
+        permissions: makePerms(),
+        targets: null,
+        heartbeatCadence: null,
+        idleBehavior: AgentIdleBehavior.PROPOSE,
+        nextHeartbeatAt: null,
+        lastRunAt: null,
+        lastRunStatus: null,
+        errorCount: 0,
+        pauseAfterFailures: 3,
+        avatarMode: AgentAvatarMode.INITIALS,
+        avatarIcon: null,
+        avatarImageUploadId: null,
+        soulMd: '# Soul',
+        agentsMd: null,
+        heartbeatMd: null,
+        toolsMd: null,
+        agentYml: null,
+        contentHash: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-01'),
+        ...over,
+    } as Agent;
+}
+
+/** Every domain tool the six previously-dead factories produce. */
+const DOMAIN_TOOL_NAMES = [
+    'commentOnTask',
+    'list_recent_events',
+    'get_digest',
+    'list_meetings',
+    'get_meeting_summary',
+    'list_fleet_nodes',
+    'resolve_merge_policy',
+];
+
+describe('AgentToolService — domain chat tool assembly', () => {
+    let agentsRepo: any;
+    let agentsService: any;
+    let sources: AgentDomainToolSources;
+    let authorize: jest.Mock;
+
+    beforeEach(() => {
+        agentsRepo = { create: jest.fn(), findByIdAndUser: jest.fn() };
+        agentsService = { create: jest.fn() };
+        authorize = jest.fn().mockResolvedValue({ workId: 'w1', agentId: null });
+        sources = {
+            tasks: {
+                tasksService: {
+                    create: jest.fn().mockResolvedValue({ id: 't-new', slug: 'task-new' }),
+                    transition: jest.fn().mockResolvedValue({ id: 't1', status: 'done' }),
+                } as any,
+                chatService: {
+                    post: jest
+                        .fn()
+                        .mockResolvedValue({ id: 'msg1', createdAt: new Date('2026-01-01') }),
+                } as any,
+                assignees: {
+                    findByTaskId: jest
+                        .fn()
+                        .mockResolvedValue([{ assigneeType: 'agent', assigneeId: 'a1' }]),
+                } as any,
+                reviewers: { findByTaskId: jest.fn().mockResolvedValue([]) } as any,
+                approvers: { findByTaskId: jest.fn().mockResolvedValue([]) } as any,
+            },
+            ingest: {
+                repository: { findRecentByUser: jest.fn().mockResolvedValue([]) } as any,
+            },
+            digest: {
+                digestService: {
+                    composeDigest: jest.fn().mockResolvedValue({ counts: {} }),
+                } as any,
+            },
+            meetings: {
+                repository: {
+                    findByUser: jest.fn().mockResolvedValue([]),
+                    findById: jest.fn().mockResolvedValue(null),
+                } as any,
+            },
+            fleet: { service: { listForUser: jest.fn().mockResolvedValue([]) } as any },
+            prReview: {
+                prReviewService: {
+                    reviewPullRequest: jest.fn().mockResolvedValue({ status: 'reviewed' }),
+                } as any,
+            },
+            mergePolicy: {
+                service: { resolve: jest.fn().mockResolvedValue({ source: 'work' }) } as any,
+                authorize: authorize as any,
+            },
+        };
+    });
+
+    /** `null` = the token is unbound (an explicit `undefined` would hit the default). */
+    function makeSvc(bundle: AgentDomainToolSources | null = sources): AgentToolService {
+        return new AgentToolService(
+            agentsRepo,
+            agentsService,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            bundle ?? undefined,
+        );
+    }
+
+    it('registers every domain tool the factories produce when the sources token is bound', () => {
+        const names = makeSvc()
+            .resolveAllowedTools(makeAgent())
+            .map((tool) => tool.name);
+        for (const expected of DOMAIN_TOOL_NAMES) {
+            expect(names).toContain(expected);
+        }
+    });
+
+    it('registers NO domain tools when the sources token is unbound (the pre-fix state)', () => {
+        const names = makeSvc(null)
+            .resolveAllowedTools(makeAgent())
+            .map((tool) => tool.name);
+        for (const notExpected of DOMAIN_TOOL_NAMES) {
+            expect(names).not.toContain(notExpected);
+        }
+        // …but the built-in tools are untouched.
+        expect(names).toContain('getActivity');
+        expect(names).toContain('getKbDocument');
+    });
+
+    it('keeps the built-in tools alongside the domain tools (additive, not a replacement)', () => {
+        const names = makeSvc()
+            .resolveAllowedTools(makeAgent())
+            .map((tool) => tool.name);
+        expect(names).toContain('getActivity');
+        expect(names).toContain('getKbDocument');
+        expect(new Set(names).size).toBe(names.length);
+    });
+
+    it('gates createTask / transitionTask behind canAssignTasks', () => {
+        const without = makeSvc()
+            .resolveAllowedTools(makeAgent())
+            .map((tool) => tool.name);
+        expect(without).not.toContain('createTask');
+        expect(without).not.toContain('transitionTask');
+
+        const withPerm = makeSvc()
+            .resolveAllowedTools(makeAgent({ permissions: makePerms({ canAssignTasks: true }) }))
+            .map((tool) => tool.name);
+        expect(withPerm).toContain('createTask');
+        expect(withPerm).toContain('transitionTask');
+    });
+
+    it('gates review_pull_request behind canCallExternalTools (outbound risk class)', () => {
+        const without = makeSvc()
+            .resolveAllowedTools(makeAgent())
+            .map((tool) => tool.name);
+        expect(without).not.toContain('review_pull_request');
+
+        const withPerm = makeSvc()
+            .resolveAllowedTools(
+                makeAgent({ permissions: makePerms({ canCallExternalTools: true }) }),
+            )
+            .map((tool) => tool.name);
+        expect(withPerm).toContain('review_pull_request');
+    });
+
+    it('registers only the domains the bundle actually carries', () => {
+        const names = makeSvc({ fleet: sources.fleet })
+            .resolveAllowedTools(makeAgent())
+            .map((tool) => tool.name);
+        expect(names).toContain('list_fleet_nodes');
+        expect(names).not.toContain('list_meetings');
+        expect(names).not.toContain('get_digest');
+        expect(names).not.toContain('commentOnTask');
+    });
+
+    it('scopes every read tool to the AGENT OWNER, never a model-supplied user', async () => {
+        const tools = makeSvc().resolveAllowedTools(makeAgent({ userId: 'owner-9' }));
+        const byName = new Map(tools.map((tool) => [tool.name, tool]));
+
+        await byName.get('list_recent_events')!.invoke({ limit: 5 });
+        expect((sources.ingest!.repository as any).findRecentByUser).toHaveBeenCalledWith(
+            'owner-9',
+            5,
+        );
+
+        await byName.get('list_meetings')!.invoke({});
+        expect((sources.meetings!.repository as any).findByUser).toHaveBeenCalledWith(
+            'owner-9',
+            expect.any(Object),
+        );
+
+        await byName.get('list_fleet_nodes')!.invoke({});
+        expect((sources.fleet!.service as any).listForUser).toHaveBeenCalledWith('owner-9');
+
+        await byName.get('get_digest')!.invoke({ period: 'weekly' });
+        expect((sources.digest!.digestService as any).composeDigest).toHaveBeenCalledWith(
+            'owner-9',
+            { period: 'weekly' },
+        );
+    });
+
+    it('authorizes resolve_merge_policy against the agent owner before resolving', async () => {
+        const tools = makeSvc().resolveAllowedTools(makeAgent({ userId: 'owner-9' }));
+        const tool = tools.find((t) => t.name === 'resolve_merge_policy')!;
+
+        await tool.invoke({ workId: 'w1' });
+
+        expect(authorize).toHaveBeenCalledWith('owner-9', { workId: 'w1' });
+        expect((sources.mergePolicy!.service as any).resolve).toHaveBeenCalled();
+    });
+
+    it('refuses resolve_merge_policy for a scope the owner may not reach (no existence leak)', async () => {
+        authorize.mockResolvedValue(null);
+        const tools = makeSvc().resolveAllowedTools(makeAgent());
+        const tool = tools.find((t) => t.name === 'resolve_merge_policy')!;
+
+        const result = await tool.invoke({ workId: 'someone-elses-work' });
+
+        expect(result).toEqual({ error: 'Not found or not accessible to the current user.' });
+        expect((sources.mergePolicy!.service as any).resolve).not.toHaveBeenCalled();
+    });
+
+    it('keeps commentOnTask fail-closed on membership', async () => {
+        (sources.tasks!.assignees as any).findByTaskId.mockResolvedValue([]);
+        const tools = makeSvc().resolveAllowedTools(makeAgent());
+        const tool = tools.find((t) => t.name === 'commentOnTask')!;
+
+        const result = (await tool.invoke({ taskId: 't1', body: 'hi' })) as { error?: string };
+
+        expect(result.error).toContain('not a member of the Task');
+        expect((sources.tasks!.chatService as any).post).not.toHaveBeenCalled();
+    });
+
+    it('skips a domain whose factory throws instead of failing tool resolution', () => {
+        // A source object that makes `buildFleetTools` throw at build time.
+        const exploding = {
+            ...sources,
+            fleet: {
+                get service(): never {
+                    throw new Error('fleet wiring exploded');
+                },
+            },
+        } as unknown as AgentDomainToolSources;
+
+        const names = makeSvc(exploding)
+            .resolveAllowedTools(makeAgent())
+            .map((tool) => tool.name);
+
+        expect(names).not.toContain('list_fleet_nodes');
+        // Every other domain still resolved.
+        expect(names).toContain('list_meetings');
+        expect(names).toContain('get_digest');
+        expect(names).toContain('getActivity');
+    });
+
+    it('exposes a JSON-schema parameter block for every domain tool', () => {
+        const tools = makeSvc()
+            .resolveAllowedTools(makeAgent({ permissions: makePerms({ canAssignTasks: true }) }))
+            .filter((tool) => DOMAIN_TOOL_NAMES.includes(tool.name));
+        expect(tools.length).toBeGreaterThanOrEqual(DOMAIN_TOOL_NAMES.length);
+        for (const tool of tools) {
+            expect(tool.parameters.type).toBe('object');
+            expect(tool.description.length).toBeGreaterThan(0);
+            expect(typeof tool.invoke).toBe('function');
+        }
+    });
+});

--- a/packages/agent/src/agents/agent-domain-tool-sources.ts
+++ b/packages/agent/src/agents/agent-domain-tool-sources.ts
@@ -1,0 +1,108 @@
+import type { TasksService } from '../tasks-domain/tasks.service';
+import type { TaskChatService } from '../tasks-domain/task-chat.service';
+import type {
+    TaskAssigneeRepository,
+    TaskReviewerRepository,
+    TaskApproverRepository,
+} from '../database/repositories/task-side.repositories';
+import type { IngestedEventRepository } from '../ingest/ingested-event.repository';
+import type { DigestService } from '../digest/digest.service';
+import type { MeetingRepository } from '../meetings/meeting.repository';
+import type { FleetService } from '../fleet/fleet.service';
+import type { PrReviewToolService } from '../pr-review/agent-pr-review-tools';
+import type { MergePolicyResolveInput, MergePolicyService } from '../policy/merge-policy.service';
+import type { ResolveMergePolicyArgs } from '../policy/agent-merge-policy-tools';
+
+/**
+ * Domain chat-tool sources — the ONE injection seam that lets
+ * `AgentToolService.resolveAllowedTools()` (the single tool-assembly
+ * point of the agent tool loop) build the per-domain chat tools without
+ * the `agents/` subpath gaining a runtime import of the tasks / ingest /
+ * digest / meetings / fleet / pr-review / policy graphs.
+ *
+ * Why a "sources" bundle instead of one facade per domain:
+ *
+ *  - The descriptor FACTORIES already exist next to their domains
+ *    (`tasks-domain/agent-task-tools.ts`, `ingest/agent-ingest-tools.ts`,
+ *    `digest/agent-digest-tools.ts`, `meetings/agent-meeting-tools.ts`,
+ *    `fleet/agent-fleet-tools.ts`, `pr-review/agent-pr-review-tools.ts`,
+ *    `policy/agent-merge-policy-tools.ts`) and are type-only imports of
+ *    their services, so importing the factory FUNCTIONS into
+ *    `AgentToolService` pulls in zero runtime graph. What cannot be
+ *    imported there are the SERVICES themselves — which is exactly (and
+ *    only) what this token carries.
+ *  - Assembly therefore stays in `resolveAllowedTools`, next to the
+ *    permission gates for the built-in tools. No second tool mechanism.
+ *
+ * Same circular-dep dodge and posture as `AGENT_GIT_FACADE` /
+ * `AGENT_PLUGIN_TOOLS_FACADE` / `AGENT_EMAIL_FACADE`: bound by the
+ * api-side `@Global()` AgentsModule, `@Optional()` at the consumer, and
+ * every sub-bundle is individually optional so a runtime that only wires
+ * some domains exposes only those tools (the model never sees a tool
+ * whose backing service is absent).
+ */
+export const AGENT_DOMAIN_TOOL_SOURCES = 'AGENT_DOMAIN_TOOL_SOURCES' as const;
+
+/** Tasks surface — createTask / commentOnTask / transitionTask. */
+export interface AgentTaskToolSource {
+    tasksService: TasksService;
+    chatService: TaskChatService;
+    /**
+     * Security (fail-closed): `commentOnTask`'s membership gate DENIES
+     * every call unless all three are bound — see `buildAgentTaskTools`.
+     * Production wiring must supply all three.
+     */
+    assignees?: TaskAssigneeRepository;
+    reviewers?: TaskReviewerRepository;
+    approvers?: TaskApproverRepository;
+}
+
+export interface AgentIngestToolSource {
+    repository: IngestedEventRepository;
+}
+
+export interface AgentDigestToolSource {
+    digestService: Pick<DigestService, 'composeDigest'>;
+}
+
+export interface AgentMeetingToolSource {
+    repository: MeetingRepository;
+}
+
+export interface AgentFleetToolSource {
+    service: Pick<FleetService, 'listForUser'>;
+}
+
+export interface AgentPrReviewToolSource {
+    prReviewService: PrReviewToolService;
+}
+
+export interface AgentMergePolicyToolSource {
+    service: Pick<MergePolicyService, 'resolve'>;
+    /**
+     * Owner check for the model-supplied ids. Takes the acting `userId`
+     * explicitly (unlike the factory's closure form) because the binding
+     * is built once at module scope, not per agent. Returns the scope
+     * tuple the user may resolve, or null when they may not — mirroring
+     * `MergePolicyController.resolve`'s 404-on-foreign-id posture.
+     */
+    authorize(
+        userId: string,
+        input: ResolveMergePolicyArgs,
+    ): Promise<MergePolicyResolveInput | null>;
+}
+
+/**
+ * The bundle itself. Every member optional: a runtime binds what it can
+ * reach, and `resolveAllowedTools` registers exactly the corresponding
+ * tools.
+ */
+export interface AgentDomainToolSources {
+    tasks?: AgentTaskToolSource;
+    ingest?: AgentIngestToolSource;
+    digest?: AgentDigestToolSource;
+    meetings?: AgentMeetingToolSource;
+    fleet?: AgentFleetToolSource;
+    prReview?: AgentPrReviewToolSource;
+    mergePolicy?: AgentMergePolicyToolSource;
+}

--- a/packages/agent/src/agents/agent-run.service.ts
+++ b/packages/agent/src/agents/agent-run.service.ts
@@ -549,6 +549,28 @@ export class AgentRunService {
      * cap-hit (loop ran out without a stop) — the caller marks the
      * run failed and skips side effects.
      */
+    /**
+     * Run telemetry — fold one model round-trip's token usage into
+     * `agent_runs.totalTokens`.
+     *
+     * Best-effort BY CONTRACT and defensive on BOTH failure shapes: a
+     * rejected promise AND a repository that does not implement the
+     * method at all (older RPC proxies, partial unit-test doubles) —
+     * the latter throws synchronously, which a bare `.catch()` would
+     * not absorb. A telemetry counter must never fail a run.
+     */
+    private async addRunTokens(runId: string, delta: number): Promise<void> {
+        try {
+            await this.runs.addTokens(runId, delta);
+        } catch (err) {
+            this.logger.warn(
+                `Run ${runId}: token telemetry write failed (ignored): ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+        }
+    }
+
     private async runToolLoop(
         context: AgentRunContext,
         agent: Agent,
@@ -698,6 +720,26 @@ export class AgentRunService {
                 lastFinishReason = round.finishReason;
                 lastRoundHadToolCalls = round.toolCalls.length > 0;
                 assistantText = round.text;
+
+                // Run telemetry — fold this round's usage into
+                // `agent_runs.totalTokens`. Written INCREMENTALLY (once
+                // per model round-trip) rather than once at settlement,
+                // because the Sessions cockpit and the board run chip
+                // read this column WHILE the run is open: a
+                // settlement-time write would leave both blank for the
+                // entire life of the run and only fill in after it went
+                // terminal — precisely when nobody is watching it.
+                //
+                // `totalTokens` is preferred; providers that only report
+                // the split are summed. Best-effort: see addRunTokens.
+                const roundTokens =
+                    round.usage?.totalTokens ??
+                    (round.usage
+                        ? (round.usage.promptTokens ?? 0) + (round.usage.completionTokens ?? 0)
+                        : 0);
+                if (roundTokens > 0) {
+                    await this.addRunTokens(context.runId, roundTokens);
+                }
 
                 await this.runLogs
                     .append({

--- a/packages/agent/src/agents/agent-tool.service.ts
+++ b/packages/agent/src/agents/agent-tool.service.ts
@@ -31,6 +31,23 @@ import {
     type AgentNotifyChannelFacade,
     type AgentNotifyChannelResult,
 } from './agent-notify-channel-facade';
+import {
+    AGENT_DOMAIN_TOOL_SOURCES,
+    type AgentDomainToolSources,
+} from './agent-domain-tool-sources';
+// Domain chat-tool factories. VALUE imports on purpose — every one of
+// these modules imports its own domain only with `import type`, so
+// pulling the factory functions in here adds ZERO runtime graph to the
+// `agents/` subpath (that was the whole point of siting them next to
+// their domains). The services they need arrive through the
+// AGENT_DOMAIN_TOOL_SOURCES token instead.
+import { buildAgentTaskTools, type TaskToolDescriptor } from '../tasks-domain/agent-task-tools';
+import { buildIngestEventTools } from '../ingest/agent-ingest-tools';
+import { buildDigestTools } from '../digest/agent-digest-tools';
+import { buildMeetingTools } from '../meetings/agent-meeting-tools';
+import { buildFleetTools } from '../fleet/agent-fleet-tools';
+import { buildPrReviewTools } from '../pr-review/agent-pr-review-tools';
+import { buildMergePolicyTools } from '../policy/agent-merge-policy-tools';
 // Security: lexical SSRF guard reused by the model-controlled URL tools
 // (screenshot / extractContent). Blocks non-HTTP(S) schemes, literal
 // private/loopback/link-local IPs, and cloud-metadata hostnames before
@@ -132,6 +149,15 @@ export class AgentToolService {
         @Optional()
         @Inject(AGENT_NOTIFY_CHANNEL_FACADE)
         private readonly notifyChannelFacade?: AgentNotifyChannelFacade,
+        // Domain chat tools (tasks / ingest / digest / meetings / fleet /
+        // pr-review / merge-policy). Token-injected for the same
+        // circular-dep reason as the facades above — this bundle carries
+        // ONLY the backing services; the descriptors themselves are
+        // assembled below, in `resolveAllowedTools`, so the tool loop
+        // keeps exactly one assembly point.
+        @Optional()
+        @Inject(AGENT_DOMAIN_TOOL_SOURCES)
+        private readonly domainToolSources?: AgentDomainToolSources,
     ) {}
 
     /**
@@ -253,7 +279,121 @@ export class AgentToolService {
         tools.push(this.buildGetActivityTool(agent));
         tools.push(this.buildGetKbDocumentTool(agent));
 
+        // Domain chat tools — the per-entity surfaces the program's DoD
+        // requires every new entity to ship with. Appended LAST so the
+        // built-in tool ordering (and every existing index-based
+        // assertion) is unchanged.
+        tools.push(...this.buildDomainTools(agent));
+
         return tools;
+    }
+
+    /**
+     * Build the domain chat tools for one Agent from the injected
+     * `AGENT_DOMAIN_TOOL_SOURCES` bundle.
+     *
+     * Scoping rules — identical posture to the built-in tools above:
+     *
+     *  - EVERY tool is owner-scoped to `agent.userId`; the factories only
+     *    ever read/write rows for that user (cross-user ids resolve to a
+     *    "not found" with no existence leak).
+     *  - `createTask` / `transitionTask` are gated on
+     *    `permissions.canAssignTasks` INSIDE `buildAgentTaskTools`;
+     *    `commentOnTask` is gated fail-closed on Task membership.
+     *  - `review_pull_request` is gated on `permissions.canCallExternalTools`
+     *    here: it fetches a diff from, and posts a comment to, a remote
+     *    git host — the same "outbound network call" risk class as
+     *    searchWeb / screenshot / extractContent / sendEmail.
+     *  - The remaining tools are READ-ONLY owner-scoped lookups over the
+     *    user's own rows (same risk class as the getActivity /
+     *    getKbDocument reads), so they carry no extra permission flag.
+     *
+     * A failing factory must never take down tool resolution — a broken
+     * domain simply contributes no tools.
+     */
+    private buildDomainTools(agent: Agent): AgentToolDescriptor[] {
+        const sources = this.domainToolSources;
+        if (!sources) return [];
+
+        const out: AgentToolDescriptor[] = [];
+        const add = (domain: string, build: () => TaskToolDescriptor[]): void => {
+            try {
+                out.push(...(build() as AgentToolDescriptor[]));
+            } catch (err) {
+                this.logger.warn(
+                    `Agent ${agent.id}: ${domain} chat tools could not be assembled (skipped): ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            }
+        };
+
+        if (sources.tasks) {
+            const tasks = sources.tasks;
+            add('tasks', () =>
+                buildAgentTaskTools({
+                    agent,
+                    tasksService: tasks.tasksService,
+                    chatService: tasks.chatService,
+                    assignees: tasks.assignees,
+                    reviewers: tasks.reviewers,
+                    approvers: tasks.approvers,
+                }),
+            );
+        }
+
+        if (sources.ingest) {
+            const ingest = sources.ingest;
+            add('ingest', () =>
+                buildIngestEventTools({ userId: agent.userId, repository: ingest.repository }),
+            );
+        }
+
+        if (sources.digest) {
+            const digest = sources.digest;
+            add('digest', () =>
+                buildDigestTools({ userId: agent.userId, digestService: digest.digestService }),
+            );
+        }
+
+        if (sources.meetings) {
+            const meetings = sources.meetings;
+            add('meetings', () =>
+                buildMeetingTools({ userId: agent.userId, repository: meetings.repository }),
+            );
+        }
+
+        if (sources.fleet) {
+            const fleet = sources.fleet;
+            add('fleet', () => buildFleetTools({ userId: agent.userId, service: fleet.service }));
+        }
+
+        // Outbound network call + a comment posted on someone's PR —
+        // gated exactly like the other external-tool surfaces.
+        if (agent.permissions?.canCallExternalTools && sources.prReview) {
+            const prReview = sources.prReview;
+            add('pr-review', () =>
+                buildPrReviewTools({
+                    userId: agent.userId,
+                    prReviewService: prReview.prReviewService,
+                }),
+            );
+        }
+
+        if (sources.mergePolicy) {
+            const mergePolicy = sources.mergePolicy;
+            add('merge-policy', () =>
+                buildMergePolicyTools({
+                    userId: agent.userId,
+                    service: mergePolicy.service,
+                    // Owner check runs per invocation against THIS agent's
+                    // owner — never the model-supplied id alone.
+                    authorize: (input) => mergePolicy.authorize(agent.userId, input),
+                }),
+            );
+        }
+
+        return out;
     }
 
     // ── tool builders ─────────────────────────────────────────────

--- a/packages/agent/src/agents/index.ts
+++ b/packages/agent/src/agents/index.ts
@@ -23,6 +23,7 @@ export * from './agent-notify-channel-facade';
 export * from './agent-plugin-tools-facade';
 export * from './agent-tools-skill';
 export * from './agent-tool.service';
+export * from './agent-domain-tool-sources';
 export * from './budget-period';
 export * from './guardrails';
 export * from './heartbeat-cron';

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -101,6 +101,38 @@ export class AgentRunRepository {
     }
 
     /**
+     * Run telemetry — ACCUMULATE token usage onto `agent_runs.totalTokens`.
+     *
+     * Separate from {@link updateTelemetry} (which sets an absolute value)
+     * because the caller — `AgentRunService.runToolLoop` — only ever knows
+     * ONE round-trip's usage, and the same run's loop can be re-entered
+     * (the Wave 3 M5 red-gate iterate loop calls `execute()` again on the
+     * same run). Folding the delta in here keeps the counter monotonic
+     * across attempts without the loop needing to read the row itself.
+     *
+     * Read-modify-write rather than a raw `SET col = col + :delta`: the
+     * three supported drivers (postgres / better-sqlite3 / mysql) do not
+     * share an identifier-quoting style, and a single run's tool loop is
+     * the only writer of this column. NULL (pre-column rows, runs that
+     * never reported) is treated as 0.
+     *
+     * Best-effort by contract: a missing row is a no-op and a non-positive
+     * / non-finite delta writes nothing. Callers additionally guard —
+     * telemetry must never fail a run.
+     */
+    async addTokens(runId: string, delta: number): Promise<void> {
+        if (!Number.isFinite(delta) || delta <= 0) return;
+        const row = await this.repository.findOne({
+            where: { id: runId },
+            select: { id: true, totalTokens: true },
+        });
+        if (!row) return;
+        await this.repository.update(runId, {
+            totalTokens: (row.totalTokens ?? 0) + Math.trunc(delta),
+        });
+    }
+
+    /**
      * @internal Background workers and internal services that have already
      * verified agent ownership through another path (e.g. agent-run.service
      * receives an `Agent` entity from an ownership-checked query) may use

--- a/packages/agent/src/database/repositories/agent-run.telemetry.spec.ts
+++ b/packages/agent/src/database/repositories/agent-run.telemetry.spec.ts
@@ -1,0 +1,61 @@
+import { AgentRunRepository } from './agent-run.repository';
+
+/**
+ * Run telemetry — `AgentRunRepository.addTokens`.
+ *
+ * The accumulator behind `agent_runs.totalTokens`. Deliberately a
+ * read-modify-write rather than a raw `SET col = col + :delta`: the
+ * three supported drivers (postgres / better-sqlite3 / mysql) do not
+ * share an identifier-quoting style for a camelCase column, and a
+ * single run's tool loop is the only writer.
+ */
+describe('AgentRunRepository.addTokens', () => {
+    let repository: { findOne: jest.Mock; update: jest.Mock };
+    let runs: AgentRunRepository;
+
+    beforeEach(() => {
+        repository = {
+            findOne: jest.fn().mockResolvedValue({ id: 'r1', totalTokens: null }),
+            update: jest.fn().mockResolvedValue(undefined),
+        };
+        runs = new AgentRunRepository(repository as never);
+    });
+
+    it('treats a NULL counter as zero so the first round-trip lands', async () => {
+        await runs.addTokens('r1', 120);
+        expect(repository.update).toHaveBeenCalledWith('r1', { totalTokens: 120 });
+    });
+
+    it('accumulates onto an existing counter (re-entering the loop keeps counting)', async () => {
+        repository.findOne.mockResolvedValue({ id: 'r1', totalTokens: 120 });
+        await runs.addTokens('r1', 45);
+        expect(repository.update).toHaveBeenCalledWith('r1', { totalTokens: 165 });
+    });
+
+    it('reads the run owner-agnostically by id and selects only what it needs', async () => {
+        await runs.addTokens('r1', 5);
+        expect(repository.findOne).toHaveBeenCalledWith({
+            where: { id: 'r1' },
+            select: { id: true, totalTokens: true },
+        });
+    });
+
+    it('is a no-op for a missing row', async () => {
+        repository.findOne.mockResolvedValue(null);
+        await runs.addTokens('gone', 10);
+        expect(repository.update).not.toHaveBeenCalled();
+    });
+
+    it('ignores non-positive and non-finite deltas without touching the DB', async () => {
+        await runs.addTokens('r1', 0);
+        await runs.addTokens('r1', -5);
+        await runs.addTokens('r1', Number.NaN);
+        expect(repository.findOne).not.toHaveBeenCalled();
+        expect(repository.update).not.toHaveBeenCalled();
+    });
+
+    it('truncates a fractional delta to keep the int column honest', async () => {
+        await runs.addTokens('r1', 12.9);
+        expect(repository.update).toHaveBeenCalledWith('r1', { totalTokens: 12 });
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-workspace-telemetry.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-workspace-telemetry.spec.ts
@@ -1,0 +1,196 @@
+import { TaskWorkspaceService } from '../task-workspace.service';
+
+/**
+ * Run telemetry — `agent_runs.changedFilesCount`.
+ *
+ * The column, the API embed and the board/Sessions UI all shipped, but
+ * nothing ever wrote it. The workspace provider is the only component
+ * that knows the checkout, so it now reports `changedFiles` from
+ * `git diff --name-only <baseSha>..HEAD` and finalize stamps it.
+ *
+ * Every assertion here is also a statement about the failure posture:
+ * the stamp is best-effort on three independent axes (no runId, no
+ * provider number, a throwing repository) and must never fail a
+ * finalize that already pushed a branch or opened a real pull request.
+ */
+describe('TaskWorkspaceService.finalizeRun — changed-files telemetry', () => {
+    const makeWork = (overrides: Record<string, unknown> = {}) => ({
+        id: 'work-1',
+        gitProvider: 'github',
+        taskIsolation: 'worktree',
+        taskIsolationBaseBranch: null,
+        taskIsolationTargetRepo: 'work-output',
+        taskBranchCleanup: 'on-merge',
+        getRepoOwner: () => 'acme',
+        getDataRepo: () => 'site-data',
+        ...overrides,
+    });
+
+    const makeTask = (overrides: Record<string, unknown> = {}) =>
+        ({
+            id: '123e4567-e89b-12d3-a456-426614174000',
+            slug: 't-42',
+            workId: 'work-1',
+            isolationMode: null,
+            branchRef: null,
+            branchState: null,
+            ...overrides,
+        }) as any;
+
+    const workspace = {
+        cwd: '/ws/task',
+        branch: 'task/t-42-123e4567',
+        baseSha: 'abc123def456',
+        reused: false,
+        provider: 'workspace',
+    };
+
+    let works: { findById: jest.Mock };
+    let tasks: { updateById: jest.Mock; findById: jest.Mock };
+    let runs: { setWorkspaceMeta: jest.Mock; updateTelemetry: jest.Mock };
+    let facade: { provision: jest.Mock; finalize: jest.Mock; simulateMerge: jest.Mock };
+    let git: {
+        getAccessToken: jest.Mock;
+        getRepository: jest.Mock;
+        createPullRequest: jest.Mock;
+    };
+    let transitions: { transition: jest.Mock };
+    let taskChat: { post: jest.Mock };
+
+    beforeEach(() => {
+        works = { findById: jest.fn().mockResolvedValue(makeWork()) };
+        tasks = {
+            updateById: jest.fn().mockResolvedValue(undefined),
+            findById: jest.fn().mockResolvedValue(makeTask()),
+        };
+        runs = {
+            setWorkspaceMeta: jest.fn().mockResolvedValue(undefined),
+            updateTelemetry: jest.fn().mockResolvedValue(undefined),
+        };
+        facade = {
+            provision: jest.fn().mockResolvedValue(workspace),
+            finalize: jest.fn().mockResolvedValue({
+                pushed: true,
+                headSha: 'ff00',
+                empty: false,
+                changedFiles: 7,
+            }),
+            simulateMerge: jest.fn().mockResolvedValue({ clean: true, conflictPaths: [] }),
+        };
+        git = {
+            getAccessToken: jest.fn().mockResolvedValue('tok-123'),
+            getRepository: jest.fn().mockResolvedValue({
+                defaultBranch: 'main',
+                cloneUrl: 'https://github.com/acme/site-data.git',
+            }),
+            createPullRequest: jest.fn().mockResolvedValue({
+                number: 7,
+                url: 'https://github.com/acme/site-data/pull/7',
+            }),
+        };
+        transitions = { transition: jest.fn().mockResolvedValue(undefined) };
+        taskChat = { post: jest.fn().mockResolvedValue(undefined) };
+    });
+
+    const build = () =>
+        new TaskWorkspaceService(
+            works as any,
+            tasks as any,
+            runs as any,
+            facade as any,
+            git as any,
+            transitions as any,
+            taskChat as any,
+        );
+
+    const finalizeInput = (over: Record<string, unknown> = {}) => ({
+        task: makeTask(),
+        userId: 'user-1',
+        agentId: 'agent-1',
+        agentCanOpenPullRequests: true,
+        workspace,
+        runId: 'run-1',
+        ...over,
+    });
+
+    it('stamps changedFilesCount on the run when the provider reports it', async () => {
+        const result = await build().finalizeRun(finalizeInput());
+
+        expect(result.outcome).toBe('pr-opened');
+        expect(runs.updateTelemetry).toHaveBeenCalledWith('run-1', { changedFilesCount: 7 });
+    });
+
+    it('stamps an honest 0 on an empty run', async () => {
+        facade.finalize.mockResolvedValue({
+            pushed: false,
+            headSha: null,
+            empty: true,
+            changedFiles: 0,
+        });
+
+        const result = await build().finalizeRun(finalizeInput());
+
+        expect(result.outcome).toBe('no-changes');
+        expect(runs.updateTelemetry).toHaveBeenCalledWith('run-1', { changedFilesCount: 0 });
+    });
+
+    it('stamps on the conflict path too — the branch changed files either way', async () => {
+        facade.simulateMerge.mockResolvedValue({ clean: false, conflictPaths: ['src/app.ts'] });
+
+        const result = await build().finalizeRun(finalizeInput());
+
+        expect(result.outcome).toBe('conflict');
+        expect(runs.updateTelemetry).toHaveBeenCalledWith('run-1', { changedFilesCount: 7 });
+    });
+
+    it('writes nothing when the provider omits changedFiles (never a misleading 0)', async () => {
+        facade.finalize.mockResolvedValue({ pushed: true, headSha: 'ff00', empty: false });
+
+        const result = await build().finalizeRun(finalizeInput());
+
+        expect(result.outcome).toBe('pr-opened');
+        expect(runs.updateTelemetry).not.toHaveBeenCalled();
+    });
+
+    it('writes nothing when the caller has no run context', async () => {
+        const result = await build().finalizeRun(finalizeInput({ runId: undefined }));
+
+        expect(result.outcome).toBe('pr-opened');
+        expect(runs.updateTelemetry).not.toHaveBeenCalled();
+    });
+
+    it('a throwing telemetry write never fails a finalize that already opened a PR', async () => {
+        runs.updateTelemetry.mockRejectedValue(new Error('db down'));
+
+        const result = await build().finalizeRun(finalizeInput());
+
+        expect(result).toEqual(expect.objectContaining({ outcome: 'pr-opened', prNumber: 7 }));
+        expect(git.createPullRequest).toHaveBeenCalled();
+    });
+
+    it('clamps a nonsense provider value instead of writing it verbatim', async () => {
+        facade.finalize.mockResolvedValue({
+            pushed: true,
+            headSha: 'ff00',
+            empty: false,
+            changedFiles: -3.7,
+        });
+
+        await build().finalizeRun(finalizeInput());
+
+        expect(runs.updateTelemetry).toHaveBeenCalledWith('run-1', { changedFilesCount: 0 });
+    });
+
+    it('ignores a non-numeric provider value', async () => {
+        facade.finalize.mockResolvedValue({
+            pushed: true,
+            headSha: 'ff00',
+            empty: false,
+            changedFiles: Number.NaN,
+        });
+
+        await build().finalizeRun(finalizeInput());
+
+        expect(runs.updateTelemetry).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/tasks-domain/task-workspace.service.ts
+++ b/packages/agent/src/tasks-domain/task-workspace.service.ts
@@ -189,6 +189,15 @@ export class TaskWorkspaceService {
         agentCanOpenPullRequests: boolean;
         workspace: ProvisionedTaskWorkspace;
         /**
+         * Run telemetry — the AgentRun this finalize belongs to. When
+         * supplied, the workspace's changed-file count is stamped onto
+         * `agent_runs.changedFilesCount` so the Sessions cockpit and the
+         * board run chip can show it. Optional (and best-effort) so
+         * callers that have no run context — and every existing unit
+         * test — keep working unchanged.
+         */
+        runId?: string;
+        /**
          * Wave 3 M3 — optional note that a green quality gate preceded this
          * finalize; surfaces on the PR body. The gate DECISION stays in the
          * worker step (a red gate never reaches finalizeRun at all) — this
@@ -232,6 +241,11 @@ export class TaskWorkspaceService {
             { commitMessage: `feat(task): ${task.slug} agent run output`, push: true },
             facadeOptions,
         );
+        // Run telemetry — stamp the changed-file count as soon as the
+        // workspace reports it, BEFORE the empty/conflict/PR branches, so
+        // every finalize outcome (including "no changes") leaves an
+        // honest counter behind.
+        await this.stampChangedFiles(input.runId, finalize.changedFiles);
         if (finalize.empty) {
             this.logger.log(`Task ${task.id} run produced no changes — nothing to push.`);
             return { outcome: 'no-changes' };
@@ -294,6 +308,37 @@ export class TaskWorkspaceService {
                 `${await this.describeMergePolicy(input.agentId, work.id)}.`,
         );
         return { outcome: 'pr-opened', prNumber: pr.number, prUrl: pr.url };
+    }
+
+    /**
+     * Run telemetry — write `agent_runs.changedFilesCount` from the
+     * workspace provider's finalize report.
+     *
+     * Best-effort BY CONTRACT, on three separate axes:
+     *   - no `runId` (caller has no run context)   → no write;
+     *   - provider omitted `changedFiles`          → no write, so a
+     *     provider that cannot diff never stamps a misleading 0;
+     *   - the update itself threw                  → logged, swallowed.
+     * A telemetry counter must never fail a finalize that already
+     * pushed a branch or opened a real pull request.
+     */
+    private async stampChangedFiles(
+        runId: string | undefined,
+        changedFiles: number | undefined,
+    ): Promise<void> {
+        if (!runId) return;
+        if (typeof changedFiles !== 'number' || !Number.isFinite(changedFiles)) return;
+        try {
+            await this.runs.updateTelemetry(runId, {
+                changedFilesCount: Math.max(0, Math.trunc(changedFiles)),
+            });
+        } catch (error) {
+            this.logger.warn(
+                `changedFilesCount telemetry write failed for run ${runId} (ignored): ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            );
+        }
     }
 
     /**

--- a/packages/plugin/src/contracts/capabilities/workspace.interface.ts
+++ b/packages/plugin/src/contracts/capabilities/workspace.interface.ts
@@ -59,6 +59,18 @@ export interface WorkspaceFinalizeResult {
 	headSha: string | null;
 	/** True when there was nothing to commit (clean tree). */
 	empty: boolean;
+	/**
+	 * How many distinct files the branch changed relative to the base it
+	 * was cut from (`git diff --name-only <baseSha>..HEAD`), i.e. the
+	 * whole branch's footprint — not just this finalize's commit — so a
+	 * re-run on a reused workspace reports the cumulative total.
+	 *
+	 * OPTIONAL and best-effort: providers that cannot compute it (or
+	 * whose diff call fails) omit it, and the caller leaves
+	 * `agent_runs.changedFilesCount` untouched rather than writing a
+	 * wrong 0. Never a reason to fail a finalize.
+	 */
+	changedFiles?: number;
 }
 
 export interface WorkspaceMergeSimulation {

--- a/packages/plugins/local-workspace/src/__tests__/local-workspace.spec.ts
+++ b/packages/plugins/local-workspace/src/__tests__/local-workspace.spec.ts
@@ -174,6 +174,8 @@ describe('finalize', () => {
 		const fin = await plugin.finalize(handle, { commitMessage: 'agent: nothing', push: true });
 		expect(fin.empty).toBe(true);
 		expect(fin.pushed).toBe(false);
+		// Run telemetry — an empty run honestly reports zero changed files.
+		expect(fin.changedFiles).toBe(0);
 	});
 
 	it('commits and pushes changes to the task branch, never the base', async () => {
@@ -183,6 +185,9 @@ describe('finalize', () => {
 		const fin = await plugin.finalize(handle, { commitMessage: 'agent: feature', push: true });
 		expect(fin.pushed).toBe(true);
 		expect(fin.headSha).not.toBe(handle.baseSha);
+		// Run telemetry — the branch's file footprint vs the base it was
+		// cut from, which is what `agent_runs.changedFilesCount` shows.
+		expect(fin.changedFiles).toBe(1);
 
 		// Remote task branch has the commit; remote main is untouched.
 		const remoteBranch = git(originDir, 'rev-parse', 'refs/heads/task/push-77778888');

--- a/packages/plugins/local-workspace/src/local-workspace.plugin.ts
+++ b/packages/plugins/local-workspace/src/local-workspace.plugin.ts
@@ -301,8 +301,14 @@ export class LocalWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 		// Empty run: no new commit AND the branch has nothing beyond the
 		// base — there is nothing worth pushing or PR-ing.
 		if (!dirty && (headSha === null || headSha === handle.baseSha)) {
-			return { pushed: false, headSha, empty: true };
+			return { pushed: false, headSha, empty: true, changedFiles: 0 };
 		}
+
+		// Run telemetry — the branch's file footprint vs the base it was
+		// cut from. Best-effort: a failed diff omits the field entirely
+		// (the caller then leaves the run's counter untouched rather
+		// than stamping a wrong 0) and never fails the finalize.
+		const changedFiles = await this.countChangedFiles(dir, handle.baseSha, opts.auth);
 
 		let pushed = false;
 		if (opts.push) {
@@ -318,7 +324,36 @@ export class LocalWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 			pushed = true;
 		}
 
-		return { pushed, headSha, empty: false };
+		return {
+			pushed,
+			headSha,
+			empty: false,
+			...(changedFiles === null ? {} : { changedFiles })
+		};
+	}
+
+	/**
+	 * `git diff --name-only <baseSha>..HEAD` → distinct changed-file
+	 * count for the run-telemetry counter. Returns null when the diff
+	 * cannot be taken (unknown base, git failure), so the caller can
+	 * tell "no data" apart from "zero files".
+	 */
+	private async countChangedFiles(
+		dir: string,
+		baseSha: string,
+		auth?: WorkspaceProvisionSpec['auth']
+	): Promise<number | null> {
+		try {
+			const diff = await this.git(['diff', '--name-only', `${baseSha}..HEAD`], dir, auth);
+			if (diff.code !== 0) return null;
+			const files = diff.stdout
+				.split('\n')
+				.map((line) => line.trim())
+				.filter((line) => line.length > 0);
+			return new Set(files).size;
+		} catch {
+			return null;
+		}
 	}
 
 	async simulateMerge(

--- a/packages/plugins/sandbox-workspace/src/__tests__/sandbox-workspace.spec.ts
+++ b/packages/plugins/sandbox-workspace/src/__tests__/sandbox-workspace.spec.ts
@@ -139,6 +139,8 @@ describe('finalize', () => {
 		const fin = await plugin.finalize(handle, { commitMessage: 'agent: nothing', push: true });
 		expect(fin.empty).toBe(true);
 		expect(fin.pushed).toBe(false);
+		// Run telemetry — an empty run honestly reports zero changed files.
+		expect(fin.changedFiles).toBe(0);
 		await plugin.teardown(handle);
 	});
 
@@ -155,6 +157,9 @@ describe('finalize', () => {
 		const fin = await plugin.finalize(handle, { commitMessage: 'agent: feature', push: true });
 		expect(fin.pushed).toBe(true);
 		expect(fin.headSha).not.toBe(handle.baseSha);
+		// Run telemetry — the branch's file footprint vs the base it was
+		// cut from, which is what `agent_runs.changedFilesCount` shows.
+		expect(fin.changedFiles).toBe(1);
 
 		// Remote task branch has the commit; remote main is untouched.
 		const remoteBranch = git(originDir, 'rev-parse', 'refs/heads/task/push-eeee5555');

--- a/packages/plugins/sandbox-workspace/src/sandbox-workspace.plugin.ts
+++ b/packages/plugins/sandbox-workspace/src/sandbox-workspace.plugin.ts
@@ -204,8 +204,14 @@ export class SandboxWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 		// Empty run: no new commit AND the branch has nothing beyond the
 		// base — there is nothing worth pushing or PR-ing.
 		if (!dirty && (headSha === null || headSha === handle.baseSha)) {
-			return { pushed: false, headSha, empty: true };
+			return { pushed: false, headSha, empty: true, changedFiles: 0 };
 		}
+
+		// Run telemetry — the branch's file footprint vs the base it was
+		// cut from. Best-effort: a failed diff omits the field entirely
+		// (the caller then leaves the run's counter untouched rather
+		// than stamping a wrong 0) and never fails the finalize.
+		const changedFiles = await this.countChangedFiles(dir, handle.baseSha, opts.auth);
 
 		let pushed = false;
 		if (opts.push) {
@@ -221,7 +227,36 @@ export class SandboxWorkspacePlugin implements IPlugin, IWorkspacePlugin {
 			pushed = true;
 		}
 
-		return { pushed, headSha, empty: false };
+		return {
+			pushed,
+			headSha,
+			empty: false,
+			...(changedFiles === null ? {} : { changedFiles })
+		};
+	}
+
+	/**
+	 * `git diff --name-only <baseSha>..HEAD` → distinct changed-file
+	 * count for the run-telemetry counter. Returns null when the diff
+	 * cannot be taken (unknown base after a shallow fetch, git failure),
+	 * so the caller can tell "no data" apart from "zero files".
+	 */
+	private async countChangedFiles(
+		dir: string,
+		baseSha: string,
+		auth?: WorkspaceProvisionSpec['auth']
+	): Promise<number | null> {
+		try {
+			const diff = await this.git(['diff', '--name-only', `${baseSha}..HEAD`], dir, auth);
+			if (diff.code !== 0) return null;
+			const files = diff.stdout
+				.split('\n')
+				.map((line) => line.trim())
+				.filter((line) => line.length > 0);
+			return new Set(files).size;
+		} catch {
+			return null;
+		}
 	}
 
 	async simulateMerge(

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -649,6 +649,10 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                         task: taskRow,
                         userId: payload.userId,
                         agentId: agent.id,
+                        // Run telemetry — lets finalize stamp
+                        // `agent_runs.changedFilesCount` for the board chip
+                        // + Sessions cockpit (best-effort inside).
+                        runId: claimedRunId,
                         agentCanOpenPullRequests:
                             (agent as { permissions?: { canOpenPullRequests?: boolean } })
                                 .permissions?.canOpenPullRequests !== false,


### PR DESCRIPTION
## Two "shipped" features were dead code paths

### Defect 1 — agent chat tools were never assembled

`git grep assembleTools` on `develop` found **only a comment**. Six descriptor factories shipped alongside their domains and were unit-tested, but nothing ever called them, so **no agent run could reach any of those tools**:

| factory | tools |
| --- | --- |
| `tasks-domain/agent-task-tools.ts` | `createTask`, `commentOnTask`, `transitionTask` |
| `ingest/agent-ingest-tools.ts` | `list_recent_events` |
| `digest/agent-digest-tools.ts` | `get_digest` |
| `meetings/agent-meeting-tools.ts` | `list_meetings`, `get_meeting_summary` |
| `fleet/agent-fleet-tools.ts` | `list_fleet_nodes` |
| `pr-review/agent-pr-review-tools.ts` | `review_pull_request` |
| `policy/agent-merge-policy-tools.ts` | `resolve_merge_policy` |

**The real assembly point** is `AgentToolService.resolveAllowedTools()` (`packages/agent/src/agents/agent-tool.service.ts`) — `AgentRunService.runToolLoop()` calls it and maps the result straight into the model's `tools` payload on every dispatch. The factories are now assembled **there**, appended after the built-ins. No second mechanism.

The blocker was never the factories, it was that `agents/` cannot import the tasks/ingest/digest/meetings/fleet/pr-review/policy runtime graphs. Every factory module is `import type`-only, so importing the factory **functions** costs nothing; only the **services** needed a seam. New token `AGENT_DOMAIN_TOOL_SOURCES` carries exactly those, bound by the api-side `@Global()` `AgentsModule` — the same posture as `AGENT_GIT_FACADE` / `AGENT_EMAIL_FACADE` / `AGENT_PLUGIN_TOOLS_FACADE`.

**Scoping is identical to the built-in tools:**

- every tool is owner-scoped to `agent.userId` — a model-supplied user id is never honored;
- `createTask` / `transitionTask` stay behind `canAssignTasks` (inside the factory);
- `commentOnTask` stays fail-closed on Task membership;
- `review_pull_request` is gated on `canCallExternalTools` — it fetches a diff from and posts a comment to a remote git host, the same outbound risk class as `searchWeb` / `screenshot` / `extractContent` / `sendEmail`;
- `resolve_merge_policy` owner-checks **both** model-supplied ids (`WorkOwnershipService.ensureAccess` plus an owner-filtered agent lookup, mirroring `MergePolicyController.resolve`) before resolving, so it cannot become a cross-tenant policy oracle;
- a factory that throws is skipped and logged — it can never take down tool resolution.

### Defect 2 — run telemetry had columns, an API embed and UI, but no writer

`agent_runs.totalTokens` and `agent_runs.changedFilesCount` were never written (only `currentActivity` got a claim-time write), so the Sessions cockpit and the board run chips always showed blank counters.

**Tokens — incremental, not at settlement.** The tool loop folds each round-trip's usage in through a new best-effort `AgentRunRepository.addTokens`. Incremental **because the UI reads this column while the run is open**: a settlement-time write would leave the counter blank for the entire life of the run and only fill it in after the run went terminal — precisely when nobody is watching it. `addTokens` accumulates (read-modify-write, NULL treated as 0) rather than setting an absolute value, so the Wave 3 M5 red-gate iterate loop re-entering `execute()` on the same run keeps counting up instead of resetting. Read-modify-write rather than a raw increment expression because postgres / better-sqlite3 / mysql do not share an identifier-quoting style for a camelCase column, and one run's tool loop is the only writer.

**Changed files — at finalize.** `WorkspaceFinalizeResult` gains an **optional** `changedFiles`; both workspace providers compute it from `git diff --name-only <baseSha>..HEAD` (the branch's whole footprint, so a re-run on a reused workspace reports the cumulative total), and `TaskWorkspaceService.finalizeRun` stamps it. Optional on purpose: a provider that cannot diff omits the field and the caller leaves the column untouched rather than writing a misleading `0`.

Both writers are best-effort on every axis — no `runId`, no provider number, a rejecting repository, or a repository with no such method at all (older RPC proxies throw *synchronously*, which a bare `.catch()` would not absorb). **Neither can fail a run.**

Additive throughout: no existing tool, column, or signature changed.

## Platform / web tool-list disagreement (reported, not papered over)

`apps/web/src/lib/ai/tools/generated/registry.ts` is manifest-driven over REST operations. Comparing its 329 tool names to the platform-side list:

- **Present on both:** `list_meetings`, `get_meeting_summary`, `list_fleet_nodes`, `resolve_merge_policy`, and the Tasks trio (web uses `create_task` / `transition_task` / `post_task_chat`).
- **Platform-only, and the web registry structurally cannot add them:** `list_recent_events`, `get_digest`, `review_pull_request`. There is **no REST endpoint** for any of the three — `apps/api/src/ingest` exposes only `POST /api/ingest/events` (inbound webhooks, not an owner-scoped read), and there is no `api/digest` or `api/pr-review` controller at all. Digest runs off the `digest-dispatcher` cron and PR review off the GitHub ingest bridge.
- **Naming convention split** (pre-existing): platform built-ins plus the Tasks trio are camelCase (`createTask`, `commentOnTask`, `transitionTask`); the newer domain tools are snake_case (`list_meetings`, `get_digest`). Web is uniformly snake_case.

Nothing was silently reconciled. Closing the first gap needs three new read endpoints, which is a separate change.

## Verification (real output)

**`packages/agent` build — TSC 0**

```
> nest build -b swc && tsc -p tsconfig.types.json
>  TSC  Found 0 issues.
Successfully compiled: 1076 files with swc
```

**Required suites — `packages/agent` `tasks-domain|agents`**

```
Test Suites: 43 passed, 43 total
Tests:       544 passed, 544 total
```

**Full `packages/agent` suite**

```
Test Suites: 394 passed, 394 total
Tests:       2 skipped, 7244 passed, 7246 total
```

**Full `apps/api` suite** (includes the new module-shape pin)

```
Test Suites: 1 skipped, 214 passed, 214 of 215 total
Tests:       9 skipped, 3488 passed, 3497 total
```

**`packages/tasks`**

```
Test Files  25 passed (25)
Tests       394 passed (394)
```

**Workspace plugins** (real-git integration; local Windows needs a `--testTimeout` above the 5s default, unrelated to this change)

```
sandbox-workspace   Test Files 1 passed (1)   Tests 8 passed (8)
local-workspace     Test Files 1 passed (1)   Tests 11 passed (11)
```

**`ever-works-api` + `@ever-works/trigger-tasks` build**

```
ever-works-api:build: >  TSC  Found 0 issues.
ever-works-api:build: Successfully compiled: 688 files with swc
 Tasks:    14 successful, 14 total
```

**`apps/api pnpm generate:openapi`** (`openapi.json` excluded from the commit)

```
Wrote OpenAPI spec (439 paths) to .../apps/api/openapi.json
```

**Real DI boot** — `generate:openapi` runs Nest in **PREVIEW mode** (`Providers/controllers will not be instantiated`), so it cannot catch a missing provider. A throwaway `NestFactory.createApplicationContext(ApiModule)` against a real Postgres — which *does* instantiate every provider — was used as the actual gate:

```
DI-OK: AGENT_DOMAIN_TOOL_SOURCES domains = tasks,ingest,digest,meetings,fleet,prReview,mergePolicy
DI-OK: resolveAllowedTools = getSkillBody,searchWeb,screenshot,extractContent,sendEmail,
       messageAgent,notifyChannel,getActivity,getKbDocument,createTask,commentOnTask,
       transitionTask,list_recent_events,get_digest,list_meetings,get_meeting_summary,
       list_fleet_nodes,review_pull_request,resolve_merge_policy
```

That last line is the fix, end to end: every previously-dead tool now reaches a real agent's tool list. Because preview mode makes this class of regression invisible to CI, the wiring is pinned by a new `apps/api/src/agents/agents.module.spec.ts` module-shape spec (imports / provider / exact `inject` list / exports).

**Prettier** — `All matched files use Prettier code style!`

**Known pre-existing issues found in passing (NOT touched here):**

- `IngestedEvent.occurredAt` uses a raw `timestamp` column instead of `PortableDateColumn`, so a sqlite boot fails with `DataTypeNotSupportedError` — the same bug class as `4940d4ec` (`AgentRun.lastHeartbeatAt`).
- Local ESLint is broken repo-wide on `develop` (`eslint@8.57.1` loading an `eslint@9` rule, `Cannot read properties of undefined (reading 'allowShortCircuit')`), reproducible on untouched files.

## Tests: 41 new

| suite | count |
| --- | --- |
| `agents/__tests__/agent-tool-domain.spec.ts` — assembly, permission gating, owner scoping, fail-closed membership, factory-throw isolation | 12 |
| `agents/__tests__/agent-run-telemetry.spec.ts` — a **task run's dispatched tool list contains each new tool**, token counter increases across dispatches, usage fallbacks, writer failures never fail the run | 8 |
| `tasks-domain/__tests__/task-workspace-telemetry.spec.ts` — changed-files stamped at finalize on every outcome, omitted/clamped/ignored values, throwing writer never fails a finalize that opened a PR | 8 |
| `database/repositories/agent-run.telemetry.spec.ts` — accumulator semantics | 6 |
| `apps/api/src/agents/agents.module.spec.ts` — module-shape pin for the binding | 7 |

Plus 4 assertions added to the existing workspace-plugin specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
