### PR TITLE
test(e2e): contract + journey specs + docs for the feature program (backlog 13)

### DIFF
--- a/apps/docs/sidebarsPlatform.ts
+++ b/apps/docs/sidebarsPlatform.ts
@@ -60,13 +60,27 @@ const sidebars: SidebarsConfig = {
 				'features/skills-catalog',
 				'features/agent-email',
 				'features/mission-templates',
+				// 2026-07 feature program — how agent work is isolated,
+				// verified, landed and steered. These four read as one
+				// chain (branch → checks → merge → live control), so they
+				// are listed together and before the money/ops pages.
+				'features/task-isolation',
+				'features/quality-gates',
+				'features/merge-policy',
+				'features/sessions-and-steering',
+				'features/memory-decisions',
 				'features/budgets-and-usage',
+				'features/credits-and-billing',
 				'features/knowledge-base',
 				'features/autonomous-operation',
 				'features/workers',
 				'features/store-builder',
 				'features/company-builder',
 				'features/desktop-app',
+				// Fleet is the registry the Desktop App enrolls into —
+				// keep it adjacent so the two read together.
+				'features/fleet',
+				'features/integrations',
 				'features/community-pr-processing',
 				'features/work-changelog',
 				'features/collections',

--- a/apps/web/e2e/api-public-contract.spec.ts
+++ b/apps/web/e2e/api-public-contract.spec.ts
@@ -64,6 +64,27 @@ const protectedEndpoints = [
     '/api/credits/ledger',
     '/api/credits/usage-summary',
     '/api/plugins',
+    // ── 2026-07 feature program ──────────────────────────────────────
+    // Every read surface the program added is owner-scoped behind the
+    // global auth guard. These rows are the tripwire: a controller that
+    // loses its guard (or gains an accidental @Public()) flips one of
+    // these from 401 to 200 and fails here first.
+    // Meetings v1 (Wave 8 a).
+    '/api/meetings',
+    // Fleet registry (Wave 12) — the OWNER half; enroll/heartbeat are
+    // deliberately @Public() and asserted separately below.
+    '/api/fleet/nodes',
+    // Sessions list (Wave 4 M3) — literal `runs` segment, declared
+    // before `:id` so it never reaches ParseUUIDPipe.
+    '/api/agents/runs',
+    // Prebuilt agent templates (Wave 10) — the AGENTS-scoped catalog.
+    // (`/api/agent-templates`, the repo-backed metadata catalog, is
+    // @Public() by design and is asserted separately below.)
+    '/api/agents/templates',
+    // Merge-policy resolution preview (Wave 3, D4). Auth is checked by
+    // the guard before the controller's "provide workId and/or agentId"
+    // 400, so an unauthenticated call is 401, never 400.
+    '/api/merge-policy/resolve',
 ];
 
 test.describe('Public API — protected endpoints reject unauth (401)', () => {
@@ -90,6 +111,93 @@ test.describe('Public API — non-existent routes 404 cleanly', () => {
             expect(res.status(), `${path} returned ${res.status()}`).toBe(404);
         });
     }
+});
+
+test.describe('Public API — 2026-07 program write surfaces reject unauth (401)', () => {
+    // Same tripwire as the GET table, on the verbs that mutate. A POST
+    // that answers 400 (validation) instead of 401 would mean the guard
+    // never ran — the DTO must never be reachable without a session.
+    const protectedWrites: Array<{ path: string; data: unknown }> = [
+        // Event-ingest push surface (Wave 6 k) — owner-scoped.
+        { path: '/api/ingest/events', data: { events: [] } },
+        // Meetings create (Wave 8 a).
+        { path: '/api/meetings', data: { title: 'anon', startedAt: new Date().toISOString() } },
+        // Fleet enrollment-token mint (Wave 12) — the OWNER half.
+        { path: '/api/fleet/nodes/enrollment-token', data: { name: 'anon', kind: 'node' } },
+    ];
+
+    for (const { path, data } of protectedWrites) {
+        test(`POST ${path} → 401 (no auth)`, async ({ request }) => {
+            const res = await request.post(`${API_BASE}${path}`, { data });
+            expect(res.status(), `${path} returned ${res.status()}`).toBe(401);
+        });
+    }
+});
+
+test.describe('Public API — self-authenticating public routes never accept an unsigned call', () => {
+    // These four are @Public() on purpose: the caller is a node app or a
+    // third-party webhook, so the CREDENTIAL is in the payload/signature
+    // rather than a platform session. The invariant under test is that
+    // they all still fail closed — an anonymous, unsigned call must
+    // never come back 2xx, whatever the install's configuration is.
+
+    test('POST /api/fleet/enroll with a bogus token → 4xx, never 2xx', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/fleet/enroll`, {
+            // 16-char floor satisfied so the DTO passes and the
+            // constant-time hash check is what rejects us.
+            data: { token: 'not-a-real-enrollment-token' },
+        });
+        expect(res.status(), `enroll returned ${res.status()}`).toBe(401);
+    });
+
+    test('POST /api/fleet/heartbeat with a bogus node credential → 401', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/fleet/heartbeat`, {
+            data: {
+                nodeId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+                secret: 'not-a-real-node-secret-value',
+            },
+        });
+        expect(res.status(), `heartbeat returned ${res.status()}`).toBe(401);
+    });
+
+    test('POST /api/ingest/slack/events without a valid signature → 4xx, never 2xx', async ({
+        request,
+    }) => {
+        // Slack signs the url_verification handshake too, so even the
+        // challenge echo must be rejected without a valid v0 signature.
+        const res = await request.post(`${API_BASE}/api/ingest/slack/events`, {
+            data: { type: 'url_verification', challenge: 'e2e-challenge' },
+        });
+        expect(res.status(), `slack returned ${res.status()}`).toBeGreaterThanOrEqual(400);
+        expect(res.status()).toBeLessThan(500);
+        // The challenge must NOT be echoed back to an unsigned caller.
+        expect(await res.text()).not.toContain('e2e-challenge');
+    });
+
+    test('POST /api/ingest/github/events without the event header → 400; with it but unsigned → 4xx', async ({
+        request,
+    }) => {
+        const noHeader = await request.post(`${API_BASE}/api/ingest/github/events`, {
+            data: { zen: 'e2e' },
+        });
+        expect(noHeader.status(), `github (no header) returned ${noHeader.status()}`).toBe(400);
+
+        const unsigned = await request.post(`${API_BASE}/api/ingest/github/events`, {
+            headers: { 'x-github-event': 'ping' },
+            data: { zen: 'e2e' },
+        });
+        expect(unsigned.status(), `github (unsigned) returned ${unsigned.status()}`).toBe(401);
+    });
+});
+
+test.describe('Public API — deliberately public catalogs stay public', () => {
+    test('GET /api/agent-templates → 200 for an anonymous caller', async ({ request }) => {
+        // The repo-backed agent-template metadata catalog is @Public() by
+        // design (the marketing/onboarding surfaces read it before login).
+        const res = await request.get(`${API_BASE}/api/agent-templates`);
+        expect(res.status(), `agent-templates returned ${res.status()}`).toBe(200);
+        expect(Array.isArray(await res.json())).toBe(true);
+    });
 });
 
 test.describe('Public API — POST without body returns 4xx (not 5xx)', () => {

--- a/apps/web/e2e/flow-agent-templates-digest-contract.spec.ts
+++ b/apps/web/e2e/flow-agent-templates-digest-contract.spec.ts
@@ -1,0 +1,230 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Prebuilt agent templates (Wave 10) + the digest-briefing preference
+ * (Wave 7) — API CONTRACT. Both shipped without e2e.
+ *
+ * ── Routes ─────────────────────────────────────────────────────────
+ *   GET  /api/agent-templates            @Public repo-backed METADATA
+ *        catalog (optionally ?entity=…). Public on purpose — the
+ *        pre-login surfaces read it.
+ *   GET  /api/agents/templates           auth-gated in-code catalog of
+ *        fully-specified presets (prompt + safe defaults).
+ *   POST /api/agents/from-template/:slug 201 — creates MY Agent from a
+ *        preset: owner-scoped, DRAFT, template prompt as SOUL.md,
+ *        conservative permissions. 404 on an unknown slug.
+ *   PUT  /api/auth/profile { digestFrequency: 'off'|'daily'|'weekly' }
+ *        — the digest cadence, default 'off'.
+ *
+ * The two catalogs are deliberately DIFFERENT surfaces with different
+ * auth postures; a regression that merges them (or makes the presets
+ * public) shows up here first.
+ */
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function errText(body: unknown): string {
+    const m = (body as { message?: unknown })?.message;
+    if (Array.isArray(m)) return m.join(' | ');
+    return String(m ?? '');
+}
+
+function get(request: APIRequestContext, token: string, path: string) {
+    return request.get(`${API_BASE}${path}`, { headers: authedHeaders(token) });
+}
+
+test.describe('GET /api/agent-templates — the public metadata catalog', () => {
+    test('is readable without a session and returns an array', async ({ request }) => {
+        const res = await request.get(`${API_BASE}/api/agent-templates`);
+        expect(res.status(), `templates body=${await res.text().catch(() => '')}`).toBe(200);
+        expect(Array.isArray(await res.json())).toBe(true);
+    });
+
+    test('an entity filter never 500s and never widens the result set', async ({ request }) => {
+        const all = await request.get(`${API_BASE}/api/agent-templates`);
+        expect(all.status()).toBe(200);
+        const allRows = (await all.json()) as unknown[];
+
+        for (const entity of ['agent', 'work', 'not-a-real-entity']) {
+            const res = await request.get(`${API_BASE}/api/agent-templates?entity=${entity}`);
+            expect(res.status(), `entity=${entity}`).toBe(200);
+            const rows = (await res.json()) as unknown[];
+            expect(rows.length, `entity=${entity} cannot widen the catalog`).toBeLessThanOrEqual(
+                allRows.length,
+            );
+        }
+    });
+});
+
+test.describe('GET /api/agents/templates — the auth-gated preset catalog', () => {
+    test('lists the prebuilt presets with their prompts and safe defaults', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await get(request, u.access_token, '/api/agents/templates');
+        expect(res.status(), `presets body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+        expect(Array.isArray(body.data)).toBe(true);
+        expect(body.data.length).toBeGreaterThan(0);
+
+        const slugs = (body.data as Array<{ slug: string }>).map((t) => t.slug);
+        // Pin a couple of first-party slugs — the /from-template route is
+        // keyed on them, so silently renaming one breaks every deep link.
+        expect(slugs).toContain('content-marketer');
+        expect(slugs).toContain('seo-auditor');
+
+        for (const template of body.data as Array<Record<string, unknown>>) {
+            expect(typeof template.slug).toBe('string');
+            expect(typeof template.name).toBe('string');
+            expect(typeof template.category).toBe('string');
+        }
+    });
+
+    test('the preset catalog is NOT public (unlike /api/agent-templates)', async ({ request }) => {
+        const res = await request.get(`${API_BASE}/api/agents/templates`);
+        expect(res.status()).toBe(401);
+    });
+
+    test('the literal `templates` segment resolves before the :id route', async ({ request }) => {
+        // If `@Get(':id')` were declared first, `templates` would hit
+        // ParseUUIDPipe and this would be a 400.
+        const u = await registerUserViaAPI(request);
+        const res = await get(request, u.access_token, '/api/agents/templates');
+        expect(res.status()).toBe(200);
+    });
+});
+
+test.describe('POST /api/agents/from-template/:slug', () => {
+    test('creates MY agent in DRAFT from the template, with the template’s identity', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const name = `Content Marketer ${uniq()}`;
+
+        const res = await request.post(`${API_BASE}/api/agents/from-template/content-marketer`, {
+            headers: authedHeaders(u.access_token),
+            data: { name },
+        });
+        expect(res.status(), `from-template body=${await res.text().catch(() => '')}`).toBe(201);
+        const agent = await res.json();
+        expect(agent.name).toBe(name);
+        expect(agent.status, 'a templated agent starts as a draft, never live').toBe('draft');
+        expect(typeof agent.id).toBe('string');
+
+        // It is genuinely MINE — it shows up in my own agents list.
+        const list = await get(request, u.access_token, '/api/agents');
+        expect(list.status()).toBe(200);
+        const rows = (await list.json()).data as Array<{ id: string }>;
+        expect(rows.some((r) => r.id === agent.id)).toBe(true);
+    });
+
+    test('an unknown slug is a truthful 404; the body overrides are validated', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        const unknown = await request.post(`${API_BASE}/api/agents/from-template/not-a-template`, {
+            headers: authedHeaders(u.access_token),
+            data: {},
+        });
+        expect(unknown.status()).toBe(404);
+        expect(errText(await unknown.json())).toContain('not-a-template');
+
+        const badScope = await request.post(
+            `${API_BASE}/api/agents/from-template/content-marketer`,
+            { headers: authedHeaders(u.access_token), data: { scope: 'galaxy' } },
+        );
+        expect(badScope.status()).toBe(400);
+
+        const badWork = await request.post(
+            `${API_BASE}/api/agents/from-template/content-marketer`,
+            {
+                headers: authedHeaders(u.access_token),
+                data: { workId: 'not-a-uuid' },
+            },
+        );
+        expect(badWork.status()).toBe(400);
+
+        const extra = await request.post(`${API_BASE}/api/agents/from-template/content-marketer`, {
+            headers: authedHeaders(u.access_token),
+            data: { name: `x-${uniq()}`, bogusField: 1 },
+        });
+        expect(extra.status()).toBe(400);
+        expect(errText(await extra.json())).toContain('property bogusField should not exist');
+    });
+
+    test('anonymous activation is 401 — templates are not a public factory', async ({
+        request,
+    }) => {
+        const res = await request.post(`${API_BASE}/api/agents/from-template/content-marketer`, {
+            data: { name: `anon-${uniq()}` },
+        });
+        expect(res.status()).toBe(401);
+    });
+
+    test('two accounts activating the same template get two independent agents', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const b = await registerUserViaAPI(request);
+
+        const resA = await request.post(`${API_BASE}/api/agents/from-template/seo-auditor`, {
+            headers: authedHeaders(a.access_token),
+            data: { name: `SEO ${uniq()}` },
+        });
+        expect(resA.status()).toBe(201);
+        const agentA = await resA.json();
+
+        const resB = await request.post(`${API_BASE}/api/agents/from-template/seo-auditor`, {
+            headers: authedHeaders(b.access_token),
+            data: { name: `SEO ${uniq()}` },
+        });
+        expect(resB.status()).toBe(201);
+        const agentB = await resB.json();
+
+        expect(agentA.id).not.toBe(agentB.id);
+        // …and neither can read the other's.
+        const cross = await get(request, b.access_token, `/api/agents/${agentA.id}`);
+        expect(cross.status()).toBe(404);
+    });
+});
+
+test.describe('PUT /api/auth/profile — digest briefing preference', () => {
+    test('defaults to off and accepts exactly off | daily | weekly', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+
+        for (const digestFrequency of ['daily', 'weekly', 'off']) {
+            const res = await request.put(`${API_BASE}/api/auth/profile`, {
+                headers: authedHeaders(u.access_token),
+                data: { digestFrequency },
+            });
+            expect(
+                res.status(),
+                `digestFrequency=${digestFrequency} body=${await res.text().catch(() => '')}`,
+            ).toBeLessThan(300);
+        }
+    });
+
+    test('an out-of-enum cadence is rejected, never silently defaulted', async ({ request }) => {
+        // Silently defaulting would mean a user who asked for digests
+        // quietly gets none — the failure mode this assertion prevents.
+        const u = await registerUserViaAPI(request);
+
+        for (const bad of ['hourly', 'never', '', 1]) {
+            const res = await request.put(`${API_BASE}/api/auth/profile`, {
+                headers: authedHeaders(u.access_token),
+                data: { digestFrequency: bad },
+            });
+            expect(res.status(), `digestFrequency=${String(bad)}`).toBe(400);
+            expect(errText(await res.json())).toContain('digestFrequency');
+        }
+    });
+
+    test('anonymous profile writes are 401', async ({ request }) => {
+        const res = await request.put(`${API_BASE}/api/auth/profile`, {
+            data: { digestFrequency: 'daily' },
+        });
+        expect(res.status()).toBe(401);
+    });
+});

--- a/apps/web/e2e/flow-billing-usage-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-billing-usage-ui-journey.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * `/settings/billing` + `/settings/usage` — the Wave 13 money surfaces.
+ *
+ * Both pages are SERVER components that fan out to
+ * `/api/credits/{balance,ledger,usage-summary}` and
+ * `/api/subscriptions/{plan,plans}` with a `.catch(() => null)` per
+ * call, so every fetch degrades independently. That design means a
+ * broken API call does NOT throw — it silently renders an empty
+ * section. Exactly the class of regression that ships unnoticed, and
+ * exactly what this journey pins.
+ *
+ * Runs as the seeded storageState user; no fixtures are needed because
+ * both pages render for an account with zero spend (that is the state
+ * the assertions target — a fresh account must see real empty states,
+ * never the load-error banner).
+ *
+ * Note on flag-gated sections: purchase / payment-method / auto-recharge
+ * ship behind the server-side `PAYMENTS_ENABLED` flag (default OFF), so
+ * the spec accepts either arm — the top-up controls OR the
+ * "coming soon" card — and only insists that exactly one is present.
+ */
+
+async function gotoSettings(page: Page, path: string, anchorTestId: string): Promise<void> {
+    await page.goto(`/en/settings/${path}`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/\/login/);
+    await expect(page.getByTestId(anchorTestId)).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe('/settings/billing', () => {
+    test('renders the shell, the current plan and the credits balance — not the load-error banner', async ({
+        page,
+    }) => {
+        await gotoSettings(page, 'billing', 'billing-settings');
+
+        // The load-error banner only appears when EVERY upstream call
+        // failed; seeing it here means the credits/subscriptions proxies
+        // are broken, which is the silent-failure mode we care about.
+        await expect(page.getByTestId('billing-load-error')).toHaveCount(0);
+
+        await expect(page.getByTestId('billing-current-plan')).toBeVisible();
+        const balance = page.getByTestId('billing-balance');
+        await expect(balance).toBeVisible();
+        // Either a formatted amount or the explicit em-dash placeholder —
+        // never an empty node.
+        await expect(balance).not.toBeEmpty();
+    });
+
+    test('the credits ledger renders a table or its empty state, never nothing', async ({
+        page,
+    }) => {
+        await gotoSettings(page, 'billing', 'billing-settings');
+
+        const table = page.getByTestId('billing-ledger-table');
+        const empty = page.getByTestId('billing-ledger-empty');
+        const error = page.getByTestId('billing-ledger-error');
+
+        // A fresh account has no movements, so the empty state is the
+        // expected arm — but a seeded account with a daily-free grant
+        // legitimately shows the table. Both are correct; an ERROR is not.
+        await expect(error).toHaveCount(0);
+        await expect(table.or(empty).first()).toBeVisible();
+
+        if (await table.isVisible().catch(() => false)) {
+            await expect(page.getByTestId('billing-ledger-row').first()).toBeVisible();
+        }
+    });
+
+    test('the purchase surface is present in exactly one of its two flag arms', async ({
+        page,
+    }) => {
+        await gotoSettings(page, 'billing', 'billing-settings');
+
+        const comingSoon = page.getByTestId('billing-payments-coming-soon');
+        const topupPreset = page.locator('[data-testid^="billing-topup-"]').first();
+
+        await expect(comingSoon.or(topupPreset).first()).toBeVisible();
+
+        // The two arms are mutually exclusive: showing both would mean the
+        // PAYMENTS_ENABLED branch leaked.
+        const comingSoonCount = await comingSoon.count();
+        const topupCount = await topupPreset.count();
+        expect(comingSoonCount === 0 || topupCount === 0).toBe(true);
+    });
+});
+
+test.describe('/settings/usage', () => {
+    test('renders the summary tiles with real numbers, not the load-error banner', async ({
+        page,
+    }) => {
+        await gotoSettings(page, 'usage', 'usage-credits-settings');
+
+        await expect(page.getByTestId('usage-load-error')).toHaveCount(0);
+        await expect(page.getByTestId('usage-summary-tiles')).toBeVisible();
+
+        // All seven §4.1/§4.2 tiles, each with a rendered value.
+        for (const tile of [
+            'usage-tile-balance',
+            'usage-tile-consumed',
+            'usage-tile-added',
+            'usage-tile-spend',
+            'usage-tile-tasks',
+            'usage-tile-works',
+            'usage-tile-runs',
+        ]) {
+            const node = page.getByTestId(tile);
+            await expect(node, `${tile} renders`).toBeVisible();
+            await expect(node, `${tile} has a value`).not.toBeEmpty();
+        }
+    });
+
+    test('the three breakdown charts mount (with their empty labels when there is no spend)', async ({
+        page,
+    }) => {
+        await gotoSettings(page, 'usage', 'usage-credits-settings');
+
+        // `UsageBreakdownChart` swaps its own testid for `<testId>-empty`
+        // when it has no rows, so a zero-spend account is the `-empty`
+        // arm. Either is a MOUNT; neither being present is the regression.
+        for (const chart of [
+            'usage-by-model-chart',
+            'usage-by-agent-chart',
+            'usage-by-work-chart',
+        ]) {
+            const mounted = page.getByTestId(chart);
+            const empty = page.getByTestId(`${chart}-empty`);
+            await expect(mounted.or(empty).first(), `${chart} mounts`).toBeVisible();
+        }
+    });
+
+    test('the 7d / 30d toggle refetches the by-day chart without erroring', async ({ page }) => {
+        await gotoSettings(page, 'usage', 'usage-credits-settings');
+
+        const sevenDay = page.getByTestId('usage-range-7d');
+        const thirtyDay = page.getByTestId('usage-range-30d');
+        await expect(sevenDay).toBeVisible();
+        await expect(thirtyDay).toBeVisible();
+
+        await sevenDay.click();
+        // The client refetches through the `/api/credits/usage-summary`
+        // proxy; the loading state is transient, the ERROR state is not.
+        await expect(page.getByTestId('usage-by-day-loading')).toHaveCount(0, { timeout: 20_000 });
+        await expect(page.getByTestId('usage-by-day-error')).toHaveCount(0);
+
+        await thirtyDay.click();
+        await expect(page.getByTestId('usage-by-day-loading')).toHaveCount(0, { timeout: 20_000 });
+        await expect(page.getByTestId('usage-by-day-error')).toHaveCount(0);
+    });
+});

--- a/apps/web/e2e/flow-credits-billing-contract.spec.ts
+++ b/apps/web/e2e/flow-credits-billing-contract.spec.ts
@@ -1,0 +1,241 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Credits & billing read surface (pricing Wave 9 M1 / Wave 13) — API
+ * CONTRACT. `api-public-contract` already pins the three 401 postures;
+ * this file pins the SHAPES and the filter semantics behind them.
+ *
+ * ── Routes (apps/api/src/subscriptions/credits.controller.ts) ───────
+ *   GET /api/credits/balance
+ *       → 200 { status:'success', balanceCredits:number }  (SUM over the
+ *         ledger — there is deliberately no credit_accounts table)
+ *   GET /api/credits/ledger?period=YYYY-MM&kinds=…&page=&pageSize=
+ *       → 200 { status:'success', entries:[…], total, page, pageSize }
+ *       → 400 on a malformed period or an unknown ledger kind
+ *   GET /api/credits/usage-summary?groupBy=day|model|agent|work&period=
+ *       → 200 totals (no groupBy) or grouped rows (with groupBy)
+ *       → 400 on an unknown groupBy or a period outside YYYY-MM|7d|30d
+ *
+ * Writes never happen over public HTTP — purchases arrive via the
+ * billing-provider webhook and consumption via the metering debit hook.
+ * The "no write verb exists" assertion below is the guard on that rule.
+ */
+
+function errText(body: unknown): string {
+    const m = (body as { message?: unknown })?.message;
+    if (Array.isArray(m)) return m.join(' | ');
+    return String(m ?? '');
+}
+
+function get(request: APIRequestContext, token: string, path: string) {
+    return request.get(`${API_BASE}${path}`, { headers: authedHeaders(token) });
+}
+
+const LEDGER_KINDS = ['purchase', 'grant', 'daily-free', 'consumption', 'adjustment', 'expiry'];
+
+test.describe('GET /api/credits/balance', () => {
+    test('a fresh account has a numeric balance and the success envelope', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await get(request, u.access_token, '/api/credits/balance');
+        expect(res.status(), `balance body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+        expect(body.status).toBe('success');
+        expect(typeof body.balanceCredits).toBe('number');
+    });
+
+    test('two accounts never see each other’s balance movements', async ({ request }) => {
+        // Owner scoping is a SUM over the caller's ledger rows; a fresh
+        // second account must not inherit anything from the first.
+        const a = await registerUserViaAPI(request);
+        const b = await registerUserViaAPI(request);
+
+        const resA = await get(request, a.access_token, '/api/credits/ledger');
+        const resB = await get(request, b.access_token, '/api/credits/ledger');
+        expect(resA.status()).toBe(200);
+        expect(resB.status()).toBe(200);
+
+        const idsA = new Set(
+            ((await resA.json()).entries as Array<{ id: string }>).map((e) => e.id),
+        );
+        const entriesB = (await resB.json()).entries as Array<{ id: string }>;
+        for (const entry of entriesB) {
+            expect(idsA.has(entry.id), 'ledger rows must never cross accounts').toBe(false);
+        }
+    });
+});
+
+test.describe('GET /api/credits/ledger', () => {
+    test('returns the paginated envelope with a projected row shape (no scope columns)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await get(request, u.access_token, '/api/credits/ledger?pageSize=5');
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+        expect(body.status).toBe('success');
+        expect(Array.isArray(body.entries)).toBe(true);
+        expect(typeof body.total).toBe('number');
+        expect(body.pageSize).toBe(5);
+
+        for (const entry of body.entries as Array<Record<string, unknown>>) {
+            // Explicit projection — these are the only fields that leave.
+            expect(Object.keys(entry).sort()).toEqual(
+                [
+                    'amountCredits',
+                    'balanceAfter',
+                    'costCentsRef',
+                    'createdAt',
+                    'description',
+                    'id',
+                    'kind',
+                    'refId',
+                    'refType',
+                ].sort(),
+            );
+            expect(entry).not.toHaveProperty('userId');
+            expect(entry).not.toHaveProperty('organizationId');
+            expect(entry).not.toHaveProperty('tenantId');
+        }
+    });
+
+    test('every documented kind is accepted; an unknown kind is a truthful 400', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        const all = await get(
+            request,
+            u.access_token,
+            `/api/credits/ledger?kinds=${LEDGER_KINDS.join(',')}`,
+        );
+        expect(all.status(), 'all six kinds are valid filters').toBe(200);
+
+        const bogus = await get(request, u.access_token, '/api/credits/ledger?kinds=free-money');
+        expect(bogus.status()).toBe(400);
+        expect(errText(await bogus.json())).toContain('Unknown ledger kind: free-money');
+
+        // One bad kind in an otherwise-valid list still rejects the call —
+        // silently dropping it would under-report spend.
+        const mixed = await get(
+            request,
+            u.access_token,
+            '/api/credits/ledger?kinds=purchase,free-money',
+        );
+        expect(mixed.status()).toBe(400);
+    });
+
+    test('period must be YYYY-MM; page/pageSize are bounded', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+
+        const okPeriod = await get(request, u.access_token, '/api/credits/ledger?period=2026-07');
+        expect(okPeriod.status()).toBe(200);
+
+        for (const period of ['2026-13', '2026-7', 'july', '7d']) {
+            const res = await get(request, u.access_token, `/api/credits/ledger?period=${period}`);
+            expect(res.status(), `period=${period}`).toBe(400);
+            expect(errText(await res.json())).toContain('period must be YYYY-MM');
+        }
+
+        const zeroPage = await get(request, u.access_token, '/api/credits/ledger?page=0');
+        expect(zeroPage.status()).toBe(400);
+
+        const hugePage = await get(request, u.access_token, '/api/credits/ledger?pageSize=101');
+        expect(hugePage.status()).toBe(400);
+
+        const maxPage = await get(request, u.access_token, '/api/credits/ledger?pageSize=100');
+        expect(maxPage.status(), 'pageSize=100 is the documented ceiling').toBe(200);
+    });
+});
+
+test.describe('GET /api/credits/usage-summary', () => {
+    test('without groupBy: the stat-tile totals the Usage page renders', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await get(request, u.access_token, '/api/credits/usage-summary');
+        expect(res.status(), `totals body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+        expect(body.status).toBe('success');
+        for (const key of [
+            'balanceCredits',
+            'creditsConsumed',
+            'creditsAdded',
+            'spendCents',
+            'tasksCompleted',
+            'worksActive',
+            'agentRuns',
+        ]) {
+            expect(typeof body[key], `${key} must be a number`).toBe('number');
+        }
+        expect(typeof body.period).toBe('string');
+    });
+
+    test('every documented groupBy returns rows; an unknown one is 400', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+
+        for (const groupBy of ['day', 'model', 'agent', 'work']) {
+            const res = await get(
+                request,
+                u.access_token,
+                `/api/credits/usage-summary?groupBy=${groupBy}`,
+            );
+            expect(res.status(), `groupBy=${groupBy}`).toBe(200);
+            const body = await res.json();
+            expect(Array.isArray(body.rows), `groupBy=${groupBy} rows`).toBe(true);
+        }
+
+        const bad = await get(request, u.access_token, '/api/credits/usage-summary?groupBy=galaxy');
+        expect(bad.status()).toBe(400);
+        expect(errText(await bad.json())).toContain('groupBy');
+    });
+
+    test('period accepts YYYY-MM / 7d / 30d and nothing else (never an unmapped 500)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        for (const period of ['2026-07', '7d', '30d']) {
+            const res = await get(
+                request,
+                u.access_token,
+                `/api/credits/usage-summary?period=${period}`,
+            );
+            expect(res.status(), `period=${period}`).toBe(200);
+        }
+
+        for (const period of ['2026-13', '90d', 'last-month', '2026-7']) {
+            const res = await get(
+                request,
+                u.access_token,
+                `/api/credits/usage-summary?period=${period}`,
+            );
+            expect(res.status(), `period=${period}`).toBe(400);
+            expect(errText(await res.json())).toContain('period must be YYYY-MM, 7d, or 30d');
+        }
+    });
+});
+
+test.describe('credits surface is read-only over HTTP', () => {
+    test('POST / PATCH / DELETE on the credits routes are never 2xx', async ({ request }) => {
+        // Purchases arrive via the billing-provider webhook and consumption
+        // via the metering debit hook — a write verb appearing here would be
+        // a way to mint credits over the public API.
+        const u = await registerUserViaAPI(request);
+        const headers = authedHeaders(u.access_token);
+
+        const writes = [
+            request.post(`${API_BASE}/api/credits/balance`, { headers, data: { balance: 1000 } }),
+            request.post(`${API_BASE}/api/credits/ledger`, {
+                headers,
+                data: { kind: 'grant', amountCredits: 1000 },
+            }),
+            request.patch(`${API_BASE}/api/credits/balance`, { headers, data: { balance: 1000 } }),
+            request.delete(`${API_BASE}/api/credits/ledger`, { headers }),
+        ];
+
+        for (const promise of writes) {
+            const res = await promise;
+            expect(res.status(), `write verb returned ${res.status()}`).toBeGreaterThanOrEqual(400);
+            expect(res.status()).toBeLessThan(500);
+        }
+    });
+});

--- a/apps/web/e2e/flow-fleet-enrollment-contract.spec.ts
+++ b/apps/web/e2e/flow-fleet-enrollment-contract.spec.ts
@@ -1,0 +1,323 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Fleet node registry (Wave 12, slice 1) — API CONTRACT plus the REAL
+ * enrollment protocol walked end to end. Shipped with no e2e.
+ *
+ * ── Routes (apps/api/src/fleet/fleet.controller.ts) ─────────────────
+ *   Owner-scoped (platform session):
+ *     GET    /api/fleet/nodes                  200 FleetNodeView[]
+ *     POST   /api/fleet/nodes/enrollment-token 201 { node, token,
+ *                                                    expiresInSec }
+ *     PATCH  /api/fleet/nodes/:id              200 (name and/or disabled)
+ *     DELETE /api/fleet/nodes/:id              204
+ *   Public, self-authenticating (called by the node apps):
+ *     POST   /api/fleet/enroll     201 { nodeId, secret, node } | 401
+ *     POST   /api/fleet/heartbeat  200 { ok:true, node }        | 401
+ *
+ * The protocol invariants asserted here are the ones a silent
+ * regression would break without any unit test noticing:
+ *   - the enrollment token is returned EXACTLY ONCE and is SINGLE-USE
+ *     (a replay is 401, not a second node);
+ *   - every invalid credential path is ONE undifferentiated 401 — the
+ *     response must never say which check failed;
+ *   - the heartbeat secret is minted at enroll, and a DISABLED node
+ *     stops being able to report (drain actually drains).
+ */
+
+const UNKNOWN_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function errText(body: unknown): string {
+    const m = (body as { message?: unknown })?.message;
+    if (Array.isArray(m)) return m.join(' | ');
+    return String(m ?? '');
+}
+
+async function mintToken(
+    request: APIRequestContext,
+    token: string,
+    overrides: Record<string, unknown> = {},
+): Promise<{ node: { id: string; name: string; status: string }; token: string }> {
+    const res = await request.post(`${API_BASE}/api/fleet/nodes/enrollment-token`, {
+        headers: authedHeaders(token),
+        data: { name: `node-${uniq()}`, kind: 'node', ...overrides },
+    });
+    expect(res.status(), `mintToken body=${await res.text().catch(() => '')}`).toBe(201);
+    return res.json();
+}
+
+test.describe('GET /api/fleet/nodes', () => {
+    test('a fresh account has an empty (or at least own-only) registry', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/fleet/nodes`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status(), `nodes body=${await res.text().catch(() => '')}`).toBe(200);
+        expect(Array.isArray(await res.json())).toBe(true);
+    });
+
+    test('the registry is owner-scoped — a stranger never sees my node', async ({ request }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const { node } = await mintToken(request, owner.access_token);
+
+        const mine = await request.get(`${API_BASE}/api/fleet/nodes`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        const mineRows = (await mine.json()) as Array<{ id: string }>;
+        expect(mineRows.some((r) => r.id === node.id)).toBe(true);
+
+        const theirs = await request.get(`${API_BASE}/api/fleet/nodes`, {
+            headers: authedHeaders(stranger.access_token),
+        });
+        const theirRows = (await theirs.json()) as Array<{ id: string }>;
+        expect(theirRows.some((r) => r.id === node.id)).toBe(false);
+    });
+});
+
+test.describe('POST /api/fleet/nodes/enrollment-token', () => {
+    test('mints a node in `enrolling` state and returns the token exactly once', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const minted = await mintToken(request, u.access_token, { name: `Mac mini ${uniq()}` });
+
+        expect(minted.node.status).toBe('enrolling');
+        expect(typeof minted.token).toBe('string');
+        expect(minted.token.length).toBeGreaterThanOrEqual(16);
+
+        // The token is hashed at rest — re-reading the registry must not
+        // hand it back a second time.
+        const list = await request.get(`${API_BASE}/api/fleet/nodes`, {
+            headers: authedHeaders(u.access_token),
+        });
+        const raw = await list.text();
+        expect(raw).not.toContain(minted.token);
+        expect(raw).not.toContain('enrollmentTokenHash');
+    });
+
+    test('name and kind are validated (kind is a closed, enrollable set)', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const url = `${API_BASE}/api/fleet/nodes/enrollment-token`;
+        const headers = authedHeaders(u.access_token);
+
+        const noName = await request.post(url, { headers, data: { kind: 'node' } });
+        expect(noName.status()).toBe(400);
+
+        const emptyName = await request.post(url, { headers, data: { name: '', kind: 'node' } });
+        expect(emptyName.status()).toBe(400);
+
+        const badKind = await request.post(url, {
+            headers,
+            data: { name: `n-${uniq()}`, kind: 'toaster' },
+        });
+        expect(badKind.status()).toBe(400);
+
+        for (const kind of ['node', 'desktop-node']) {
+            const ok = await request.post(url, {
+                headers,
+                data: { name: `n-${kind}-${uniq()}`, kind },
+            });
+            expect(ok.status(), `kind=${kind}`).toBe(201);
+        }
+
+        const extra = await request.post(url, {
+            headers,
+            data: { name: `n-${uniq()}`, kind: 'node', bogusField: 1 },
+        });
+        expect(extra.status()).toBe(400);
+        expect(errText(await extra.json())).toContain('property bogusField should not exist');
+    });
+});
+
+test.describe('the enrollment protocol, end to end', () => {
+    test('mint → enroll → heartbeat, with the token single-use and the secret minted once', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const minted = await mintToken(request, u.access_token, { name: `Node ${uniq()}` });
+
+        // 1) Enroll with the one-time token (PUBLIC route — the token IS
+        //    the credential; no platform session is presented).
+        const enrolled = await request.post(`${API_BASE}/api/fleet/enroll`, {
+            data: {
+                token: minted.token,
+                platform: 'linux/x64',
+                version: '1.0.0',
+                capabilities: ['terminal', 'workspace'],
+            },
+        });
+        expect(enrolled.status(), `enroll body=${await enrolled.text().catch(() => '')}`).toBe(201);
+        const enrollBody = await enrolled.json();
+        expect(enrollBody.nodeId).toBe(minted.node.id);
+        expect(typeof enrollBody.secret).toBe('string');
+        expect(enrollBody.secret.length).toBeGreaterThanOrEqual(16);
+        expect(enrollBody.secret).not.toBe(minted.token);
+
+        // 2) The token is SINGLE-USE — a replay is one undifferentiated 401.
+        const replay = await request.post(`${API_BASE}/api/fleet/enroll`, {
+            data: { token: minted.token },
+        });
+        expect(replay.status(), 'an enrollment token can only be consumed once').toBe(401);
+        expect(errText(await replay.json())).toContain('Invalid or expired enrollment token');
+
+        // 3) Heartbeat with the minted secret — the server stamps last-seen.
+        const beat = await request.post(`${API_BASE}/api/fleet/heartbeat`, {
+            data: {
+                nodeId: enrollBody.nodeId,
+                secret: enrollBody.secret,
+                capabilities: ['terminal'],
+            },
+        });
+        expect(beat.status(), `heartbeat body=${await beat.text().catch(() => '')}`).toBe(200);
+        const beatBody = await beat.json();
+        expect(beatBody.ok).toBe(true);
+        expect(beatBody.node.status).toBe('online');
+        expect(beatBody.node.lastHeartbeatAt, 'last-seen is server-stamped').toBeTruthy();
+        // Credentials never come back on a heartbeat.
+        expect(JSON.stringify(beatBody)).not.toContain(enrollBody.secret);
+
+        // 4) The owner sees the node as online in their registry.
+        const list = await request.get(`${API_BASE}/api/fleet/nodes`, {
+            headers: authedHeaders(u.access_token),
+        });
+        const rows = (await list.json()) as Array<{ id: string; status: string }>;
+        expect(rows.find((r) => r.id === enrollBody.nodeId)?.status).toBe('online');
+    });
+
+    test('every invalid credential path is one undifferentiated 401', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const minted = await mintToken(request, u.access_token);
+        const enrolled = await request.post(`${API_BASE}/api/fleet/enroll`, {
+            data: { token: minted.token },
+        });
+        expect(enrolled.status()).toBe(201);
+        const { nodeId, secret } = await enrolled.json();
+
+        // Unknown token / unknown node / wrong secret all answer the same,
+        // so nothing can be probed by comparing responses.
+        const badToken = await request.post(`${API_BASE}/api/fleet/enroll`, {
+            data: { token: 'a'.repeat(43) },
+        });
+        expect(badToken.status()).toBe(401);
+
+        const unknownNode = await request.post(`${API_BASE}/api/fleet/heartbeat`, {
+            data: { nodeId: UNKNOWN_UUID, secret },
+        });
+        expect(unknownNode.status()).toBe(401);
+
+        const wrongSecret = await request.post(`${API_BASE}/api/fleet/heartbeat`, {
+            data: { nodeId, secret: 'b'.repeat(43) },
+        });
+        expect(wrongSecret.status()).toBe(401);
+
+        // Identical message on both heartbeat failure modes — "unknown
+        // node" and "wrong secret" must be indistinguishable.
+        const unknownNodeMessage = errText(await unknownNode.json());
+        const wrongSecretMessage = errText(await wrongSecret.json());
+        expect(wrongSecretMessage).toBe(unknownNodeMessage);
+        expect(wrongSecretMessage).toContain('Invalid node credential');
+    });
+
+    test('disabling a node actually drains it — its heartbeat stops being accepted', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const minted = await mintToken(request, u.access_token);
+        const enrolled = await request.post(`${API_BASE}/api/fleet/enroll`, {
+            data: { token: minted.token },
+        });
+        expect(enrolled.status()).toBe(201);
+        const { nodeId, secret } = await enrolled.json();
+
+        const before = await request.post(`${API_BASE}/api/fleet/heartbeat`, {
+            data: { nodeId, secret },
+        });
+        expect(before.status(), 'the node reports fine before draining').toBe(200);
+
+        const drained = await request.patch(`${API_BASE}/api/fleet/nodes/${nodeId}`, {
+            headers: authedHeaders(u.access_token),
+            data: { disabled: true },
+        });
+        expect(drained.status()).toBe(200);
+        expect((await drained.json()).status).toBe('disabled');
+
+        const after = await request.post(`${API_BASE}/api/fleet/heartbeat`, {
+            data: { nodeId, secret },
+        });
+        expect(after.status(), 'a drained node must not be able to report').toBe(401);
+    });
+});
+
+test.describe('PATCH / DELETE /api/fleet/nodes/:id', () => {
+    test('rename works; an empty patch body is a truthful 400', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const { node } = await mintToken(request, u.access_token);
+
+        const renamed = await request.patch(`${API_BASE}/api/fleet/nodes/${node.id}`, {
+            headers: authedHeaders(u.access_token),
+            data: { name: `renamed-${uniq()}` },
+        });
+        expect(renamed.status()).toBe(200);
+        expect(String((await renamed.json()).name)).toContain('renamed-');
+
+        const empty = await request.patch(`${API_BASE}/api/fleet/nodes/${node.id}`, {
+            headers: authedHeaders(u.access_token),
+            data: {},
+        });
+        expect(empty.status()).toBe(400);
+        expect(errText(await empty.json())).toContain('Provide name and/or disabled');
+    });
+
+    test('authz: stranger 404, unknown 404, malformed 400, anon 401; delete is 204', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const { node } = await mintToken(request, owner.access_token);
+        const path = `/api/fleet/nodes/${node.id}`;
+
+        const cross = await request.patch(`${API_BASE}${path}`, {
+            headers: authedHeaders(stranger.access_token),
+            data: { name: 'hijack' },
+        });
+        expect(cross.status()).toBe(404);
+
+        const crossDelete = await request.delete(`${API_BASE}${path}`, {
+            headers: authedHeaders(stranger.access_token),
+        });
+        expect(crossDelete.status()).toBe(404);
+
+        const unknown = await request.patch(`${API_BASE}/api/fleet/nodes/${UNKNOWN_UUID}`, {
+            headers: authedHeaders(owner.access_token),
+            data: { name: 'x' },
+        });
+        expect(unknown.status()).toBe(404);
+
+        const malformed = await request.patch(`${API_BASE}/api/fleet/nodes/not-a-uuid`, {
+            headers: authedHeaders(owner.access_token),
+            data: { name: 'x' },
+        });
+        expect(malformed.status()).toBe(400);
+
+        const anon = await request.delete(`${API_BASE}${path}`);
+        expect(anon.status()).toBe(401);
+
+        // The owner's node survived every refused attempt, then deletes.
+        const removed = await request.delete(`${API_BASE}${path}`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(removed.status()).toBe(204);
+
+        const list = await request.get(`${API_BASE}/api/fleet/nodes`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        const rows = (await list.json()) as Array<{ id: string }>;
+        expect(rows.some((r) => r.id === node.id)).toBe(false);
+    });
+});

--- a/apps/web/e2e/flow-ingest-spine-receivers-contract.spec.ts
+++ b/apps/web/e2e/flow-ingest-spine-receivers-contract.spec.ts
@@ -1,0 +1,255 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Event-ingest spine (Wave 6, feature k) + the Slack / GitHub receivers
+ * (Wave 6 f, Wave 7 g) — API CONTRACT. All three shipped without e2e.
+ *
+ * ── Routes ─────────────────────────────────────────────────────────
+ *   POST /api/ingest/events        (auth) 202 { inserted, duplicates,
+ *                                              rejected }
+ *        Dedupe identity is (owner, source, sourceEventId) — a retry is
+ *        a no-op and the `duplicates` counter says so. Caps: ≤100
+ *        envelopes per call, ≤32 KB serialized payload each.
+ *   POST /api/ingest/slack/events  (@Public) signature-verified, FAILS
+ *        CLOSED — with no configured install everything is 401,
+ *        INCLUDING the url_verification handshake (Slack signs it too).
+ *   POST /api/ingest/github/events (@Public) signature-verified, fails
+ *        closed the same way; a missing `x-github-event` header is 400.
+ *
+ * The receivers are the highest-risk surface the program shipped: they
+ * are public, they take third-party payloads, and their only guard is
+ * an HMAC. The invariant asserted here is that no unsigned or
+ * wrongly-signed delivery is ever ACCEPTED, whatever the install's
+ * configuration state is.
+ */
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function errText(body: unknown): string {
+    const m = (body as { message?: unknown })?.message;
+    if (Array.isArray(m)) return m.join(' | ');
+    return String(m ?? '');
+}
+
+function ingest(request: APIRequestContext, token: string, events: unknown[]) {
+    return request.post(`${API_BASE}/api/ingest/events`, {
+        headers: authedHeaders(token),
+        data: { events },
+    });
+}
+
+/** A minimal VALID envelope (every required field, nothing else). */
+function envelope(overrides: Record<string, unknown> = {}) {
+    const id = uniq();
+    return {
+        id: `env-${id}`,
+        source: 'slack-connector',
+        sourceEventId: `evt-${id}`,
+        kind: 'slack.message',
+        occurredAt: new Date().toISOString(),
+        payload: { text: 'hello from e2e' },
+        ...overrides,
+    };
+}
+
+test.describe('POST /api/ingest/events', () => {
+    test('accepts a batch with 202 and reports inserted / duplicates / rejected', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const one = envelope();
+
+        const first = await ingest(request, u.access_token, [one]);
+        expect(first.status(), `ingest body=${await first.text().catch(() => '')}`).toBe(202);
+        const firstBody = await first.json();
+        expect(firstBody.inserted).toBe(1);
+        expect(firstBody.duplicates).toBe(0);
+        expect(firstBody.rejected).toBe(0);
+    });
+
+    test('re-posting the same (source, sourceEventId) is a no-op counted as a duplicate', async ({
+        request,
+    }) => {
+        // Retries are the normal case for connectors — the dedupe identity
+        // must absorb them instead of doubling a user's feed.
+        const u = await registerUserViaAPI(request);
+        const one = envelope();
+
+        const first = await ingest(request, u.access_token, [one]);
+        expect(first.status()).toBe(202);
+        expect((await first.json()).inserted).toBe(1);
+
+        // A DIFFERENT envelope id, same dedupe identity — still a duplicate.
+        const retry = await ingest(request, u.access_token, [
+            { ...one, id: `env-retry-${uniq()}` },
+        ]);
+        expect(retry.status()).toBe(202);
+        const retryBody = await retry.json();
+        expect(retryBody.inserted).toBe(0);
+        expect(retryBody.duplicates).toBe(1);
+    });
+
+    test('dedupe is PER OWNER — the same source event may land for two accounts', async ({
+        request,
+    }) => {
+        const a = await registerUserViaAPI(request);
+        const b = await registerUserViaAPI(request);
+        const shared = envelope();
+
+        const forA = await ingest(request, a.access_token, [shared]);
+        expect(forA.status()).toBe(202);
+        expect((await forA.json()).inserted).toBe(1);
+
+        const forB = await ingest(request, b.access_token, [shared]);
+        expect(forB.status()).toBe(202);
+        expect(
+            (await forB.json()).inserted,
+            'a second owner is not blocked by the first owner’s dedupe row',
+        ).toBe(1);
+    });
+
+    test('the envelope DTO is validated field by field', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+
+        const empty = await ingest(request, u.access_token, []);
+        expect(empty.status(), 'an empty batch is rejected (ArrayNotEmpty)').toBe(400);
+
+        const cases: Array<[string, Record<string, unknown>]> = [
+            ['id', envelope({ id: '' })],
+            ['source', envelope({ source: '' })],
+            ['sourceEventId', envelope({ sourceEventId: '' })],
+            ['kind', envelope({ kind: '' })],
+            ['occurredAt', envelope({ occurredAt: 'yesterday' })],
+            ['payload', envelope({ payload: 'not-an-object' })],
+            ['workId', envelope({ workId: 'not-a-uuid' })],
+            ['sourceUrl', envelope({ sourceUrl: 'x'.repeat(2049) })],
+        ];
+        for (const [field, bad] of cases) {
+            const res = await ingest(request, u.access_token, [bad]);
+            expect(res.status(), `envelope.${field}`).toBe(400);
+            expect(errText(await res.json()), `envelope.${field} message`).toContain(field);
+        }
+
+        const unknownKey = await ingest(request, u.access_token, [
+            { ...envelope(), bogusField: 1 },
+        ]);
+        expect(unknownKey.status()).toBe(400);
+        expect(errText(await unknownKey.json())).toContain('should not exist');
+    });
+
+    test('the batch (100) and payload (32 KB) caps are enforced at the edge', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        const hundred = Array.from({ length: 100 }, () => envelope());
+        const atCap = await ingest(request, u.access_token, hundred);
+        expect(atCap.status(), 'exactly 100 envelopes is accepted').toBe(202);
+
+        const overCap = await ingest(request, u.access_token, [...hundred, envelope()]);
+        expect(overCap.status(), '101 envelopes is rejected').toBe(400);
+
+        const oversizedPayload = await ingest(request, u.access_token, [
+            envelope({ payload: { blob: 'x'.repeat(33 * 1024) } }),
+        ]);
+        expect(oversizedPayload.status(), 'a >32 KB payload is rejected').toBe(400);
+        expect(errText(await oversizedPayload.json())).toContain('payload');
+    });
+
+    test('anonymous ingest is 401 — events are always owner-scoped', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/ingest/events`, {
+            data: { events: [envelope()] },
+        });
+        expect(res.status()).toBe(401);
+    });
+});
+
+test.describe('POST /api/ingest/slack/events — fail-closed signature verification', () => {
+    const slackBody = { type: 'url_verification', challenge: `e2e-${Date.now()}` };
+
+    test('an unsigned url_verification handshake is refused and the challenge is NOT echoed', async ({
+        request,
+    }) => {
+        const res = await request.post(`${API_BASE}/api/ingest/slack/events`, { data: slackBody });
+        expect(res.status(), `slack returned ${res.status()}`).toBeGreaterThanOrEqual(400);
+        expect(res.status()).toBeLessThan(500);
+        expect(await res.text()).not.toContain(slackBody.challenge);
+    });
+
+    test('a garbage signature + timestamp is refused (never 2xx)', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/ingest/slack/events`, {
+            headers: {
+                'x-slack-signature': 'v0=deadbeef',
+                'x-slack-request-timestamp': String(Math.floor(Date.now() / 1000)),
+            },
+            data: { type: 'event_callback', event: { type: 'app_mention', text: '@works hi' } },
+        });
+        expect(res.status()).toBeGreaterThanOrEqual(400);
+        expect(res.status()).toBeLessThan(500);
+    });
+
+    test('a STALE timestamp is refused even with a signature header present', async ({
+        request,
+    }) => {
+        // ±300s tolerance — a replayed delivery from an hour ago must not
+        // be accepted regardless of what the signature says.
+        const res = await request.post(`${API_BASE}/api/ingest/slack/events`, {
+            headers: {
+                'x-slack-signature': 'v0=deadbeef',
+                'x-slack-request-timestamp': String(Math.floor(Date.now() / 1000) - 3600),
+            },
+            data: { type: 'event_callback', event: { type: 'app_mention', text: '@works hi' } },
+        });
+        expect(res.status()).toBeGreaterThanOrEqual(400);
+        expect(res.status()).toBeLessThan(500);
+    });
+});
+
+test.describe('POST /api/ingest/github/events — fail-closed signature verification', () => {
+    test('a missing x-github-event header is a 400 before anything else runs', async ({
+        request,
+    }) => {
+        const res = await request.post(`${API_BASE}/api/ingest/github/events`, {
+            data: { zen: 'e2e' },
+        });
+        expect(res.status()).toBe(400);
+        expect(errText(await res.json())).toContain('GitHub event header');
+    });
+
+    test('an unsigned ping is refused — the handshake is signed too', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/ingest/github/events`, {
+            headers: { 'x-github-event': 'ping' },
+            data: { zen: 'e2e' },
+        });
+        expect(res.status()).toBe(401);
+    });
+
+    test('a wrongly-signed pull_request delivery is refused (never 2xx)', async ({ request }) => {
+        const res = await request.post(`${API_BASE}/api/ingest/github/events`, {
+            headers: {
+                'x-github-event': 'pull_request',
+                'x-hub-signature-256': 'sha256=deadbeef',
+            },
+            data: { action: 'opened', pull_request: { number: 1 } },
+        });
+        expect(res.status()).toBe(401);
+        expect(errText(await res.json())).toMatch(/signature|not configured/i);
+    });
+
+    test('the receiver is not reachable with a platform session either — it is signature-only', async ({
+        request,
+    }) => {
+        // Presenting a valid user token must NOT substitute for a valid
+        // webhook signature: the route is @Public() and its ONLY credential
+        // is the HMAC.
+        const u = await registerUserViaAPI(request);
+        const res = await request.post(`${API_BASE}/api/ingest/github/events`, {
+            headers: { ...authedHeaders(u.access_token), 'x-github-event': 'ping' },
+            data: { zen: 'e2e' },
+        });
+        expect(res.status()).toBe(401);
+    });
+});

--- a/apps/web/e2e/flow-meetings-crud-contract.spec.ts
+++ b/apps/web/e2e/flow-meetings-crud-contract.spec.ts
@@ -1,0 +1,341 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Meetings v1 (Wave 8, feature a) — owner-scoped CRUD + transcript
+ * capture API CONTRACT. Shipped with no e2e.
+ *
+ * ── Routes (apps/api/src/meetings/meetings.controller.ts) ───────────
+ *   GET    /api/meetings                 200 MeetingView[] (no transcript
+ *                                            body in list rows)
+ *   POST   /api/meetings                 201 MeetingView
+ *   GET    /api/meetings/:id             200 (INCLUDES transcriptText)
+ *   PATCH  /api/meetings/:id             200
+ *   DELETE /api/meetings/:id             204
+ *   POST   /api/meetings/:id/transcript  200 { meeting, summary?,
+ *                                            memorySaved, envelopeEmitted }
+ *
+ * Ownership is enforced in `MeetingsService.getForUser`, which 404s for
+ * missing AND for other owners' rows — no existence leak. `dedupeKey`
+ * never leaves the API (the view is an explicit projection).
+ *
+ * Environment note: the transcript pipeline's enrichment half (AI
+ * summary → memory observation → ingest envelope) is BEST EFFORT by
+ * design, so on a key-less CI stack `summary` is absent and both
+ * booleans are false. Only the transcript WRITE can fail the call, and
+ * that is what is asserted.
+ */
+
+const UNKNOWN_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const MEETING_SOURCES = ['zoom', 'google-meet', 'manual', 'import'];
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function errText(body: unknown): string {
+    const m = (body as { message?: unknown })?.message;
+    if (Array.isArray(m)) return m.join(' | ');
+    return String(m ?? '');
+}
+
+function post(request: APIRequestContext, token: string, path: string, data: unknown) {
+    return request.post(`${API_BASE}${path}`, { headers: authedHeaders(token), data });
+}
+
+async function createMeeting(
+    request: APIRequestContext,
+    token: string,
+    overrides: Record<string, unknown> = {},
+): Promise<Record<string, unknown>> {
+    const res = await post(request, token, '/api/meetings', {
+        title: `Standup ${uniq()}`,
+        startedAt: new Date().toISOString(),
+        ...overrides,
+    });
+    expect(res.status(), `setup createMeeting body=${await res.text().catch(() => '')}`).toBe(201);
+    return res.json();
+}
+
+test.describe('POST /api/meetings — CreateMeetingDto', () => {
+    test('creates with the documented view shape and never leaks dedupeKey', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const startedAt = new Date('2026-07-20T09:00:00.000Z').toISOString();
+
+        const meeting = await createMeeting(request, u.access_token, {
+            title: `Roadmap review ${uniq()}`,
+            startedAt,
+            endedAt: new Date('2026-07-20T09:45:00.000Z').toISOString(),
+            source: 'manual',
+            participants: [{ name: 'Ada Lovelace', email: 'ada@example.com' }, { name: 'Grace' }],
+            sourceUrl: 'https://example.com/recording/1',
+        });
+
+        expect(typeof meeting.id).toBe('string');
+        expect(meeting.startedAt).toBe(startedAt);
+        expect(meeting.source).toBe('manual');
+        expect(meeting.hasTranscript).toBe(false);
+        expect(Array.isArray(meeting.participants)).toBe(true);
+        expect((meeting.participants as unknown[]).length).toBe(2);
+        expect(meeting).not.toHaveProperty('dedupeKey');
+        expect(JSON.stringify(meeting)).not.toContain('dedupeKey');
+    });
+
+    test('title and startedAt are required and validated at both layers', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+
+        const noTitle = await post(request, u.access_token, '/api/meetings', {
+            startedAt: new Date().toISOString(),
+        });
+        expect(noTitle.status()).toBe(400);
+        expect(errText(await noTitle.json())).toContain('title');
+
+        // Whitespace passes the DTO's MinLength(1) and is caught by the
+        // SERVICE trim guard — a distinct code path, same 400.
+        const wsTitle = await post(request, u.access_token, '/api/meetings', {
+            title: '   ',
+            startedAt: new Date().toISOString(),
+        });
+        expect(wsTitle.status()).toBe(400);
+        expect(errText(await wsTitle.json())).toContain('title is required');
+
+        const noStart = await post(request, u.access_token, '/api/meetings', {
+            title: `no-start-${uniq()}`,
+        });
+        expect(noStart.status()).toBe(400);
+        expect(errText(await noStart.json())).toContain('startedAt');
+
+        const badStart = await post(request, u.access_token, '/api/meetings', {
+            title: `bad-start-${uniq()}`,
+            startedAt: 'yesterday',
+        });
+        expect(badStart.status()).toBe(400);
+    });
+
+    test('source is a closed set; workId must be a uuid; unknown fields are forbidden', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const base = { title: `src-${uniq()}`, startedAt: new Date().toISOString() };
+
+        for (const source of MEETING_SOURCES) {
+            const res = await post(request, u.access_token, '/api/meetings', {
+                ...base,
+                title: `src-${source}-${uniq()}`,
+                source,
+            });
+            expect(res.status(), `source=${source}`).toBe(201);
+            expect((await res.json()).source).toBe(source);
+        }
+
+        const badSource = await post(request, u.access_token, '/api/meetings', {
+            ...base,
+            source: 'telepathy',
+        });
+        expect(badSource.status()).toBe(400);
+
+        const badWork = await post(request, u.access_token, '/api/meetings', {
+            ...base,
+            workId: 'not-a-uuid',
+        });
+        expect(badWork.status()).toBe(400);
+        expect(errText(await badWork.json())).toContain('workId must be a UUID');
+
+        const extra = await post(request, u.access_token, '/api/meetings', {
+            ...base,
+            bogusField: 'x',
+        });
+        expect(extra.status()).toBe(400);
+        expect(errText(await extra.json())).toContain('property bogusField should not exist');
+    });
+
+    test('a participant entry is validated field-by-field (nested DTO)', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const base = { title: `p-${uniq()}`, startedAt: new Date().toISOString() };
+
+        const emptyName = await post(request, u.access_token, '/api/meetings', {
+            ...base,
+            participants: [{ name: '' }],
+        });
+        expect(emptyName.status()).toBe(400);
+        expect(errText(await emptyName.json())).toContain('name');
+
+        const notArray = await post(request, u.access_token, '/api/meetings', {
+            ...base,
+            participants: 'ada',
+        });
+        expect(notArray.status()).toBe(400);
+    });
+});
+
+test.describe('GET /api/meetings — list vs. detail projection', () => {
+    test('list omits the transcript body; detail includes it', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const meeting = await createMeeting(request, u.access_token, {
+            transcriptText: 'Ada: shipping the gate. Grace: reviewing the branch.',
+        });
+
+        const list = await request.get(`${API_BASE}/api/meetings`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(list.status()).toBe(200);
+        const rows = (await list.json()) as Array<Record<string, unknown>>;
+        const row = rows.find((r) => r.id === meeting.id);
+        expect(row, 'the created meeting appears in my list').toBeTruthy();
+        expect(row).not.toHaveProperty('transcriptText');
+        expect(row?.hasTranscript).toBe(true);
+
+        const detail = await request.get(`${API_BASE}/api/meetings/${meeting.id}`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(detail.status()).toBe(200);
+        const body = await detail.json();
+        expect(body).toHaveProperty('transcriptText');
+        expect(String(body.transcriptText)).toContain('shipping the gate');
+    });
+
+    test('the list is owner-scoped — another account never sees my meetings', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const meeting = await createMeeting(request, owner.access_token);
+
+        const theirs = await request.get(`${API_BASE}/api/meetings`, {
+            headers: authedHeaders(stranger.access_token),
+        });
+        expect(theirs.status()).toBe(200);
+        const rows = (await theirs.json()) as Array<{ id: string }>;
+        expect(rows.some((r) => r.id === meeting.id)).toBe(false);
+    });
+});
+
+test.describe('PATCH / DELETE /api/meetings/:id', () => {
+    test('partial update round-trips; an empty title is rejected by the service', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const meeting = await createMeeting(request, u.access_token);
+
+        const renamed = await request.patch(`${API_BASE}/api/meetings/${meeting.id}`, {
+            headers: authedHeaders(u.access_token),
+            data: { title: `Renamed ${uniq()}` },
+        });
+        expect(renamed.status(), `patch body=${await renamed.text().catch(() => '')}`).toBe(200);
+        expect(String((await renamed.json()).title)).toContain('Renamed');
+
+        const emptied = await request.patch(`${API_BASE}/api/meetings/${meeting.id}`, {
+            headers: authedHeaders(u.access_token),
+            data: { title: '   ' },
+        });
+        expect(emptied.status()).toBe(400);
+        expect(errText(await emptied.json())).toContain('title cannot be empty');
+    });
+
+    test('delete is 204 and the row is then gone (404 on re-read)', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const meeting = await createMeeting(request, u.access_token);
+
+        const removed = await request.delete(`${API_BASE}/api/meetings/${meeting.id}`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(removed.status()).toBe(204);
+
+        const reread = await request.get(`${API_BASE}/api/meetings/${meeting.id}`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(reread.status()).toBe(404);
+    });
+
+    test('authz closure on every verb: stranger 404, unknown 404, malformed 400, anon 401', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const meeting = await createMeeting(request, owner.access_token);
+        const path = `/api/meetings/${meeting.id}`;
+        const strangerHeaders = authedHeaders(stranger.access_token);
+
+        expect(
+            (await request.get(`${API_BASE}${path}`, { headers: strangerHeaders })).status(),
+        ).toBe(404);
+        expect(
+            (
+                await request.patch(`${API_BASE}${path}`, {
+                    headers: strangerHeaders,
+                    data: { title: 'hijack' },
+                })
+            ).status(),
+        ).toBe(404);
+        expect(
+            (await request.delete(`${API_BASE}${path}`, { headers: strangerHeaders })).status(),
+        ).toBe(404);
+
+        // …and the owner's row survived every refused attempt.
+        const survived = await request.get(`${API_BASE}${path}`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(survived.status()).toBe(200);
+
+        const unknown = await request.get(`${API_BASE}/api/meetings/${UNKNOWN_UUID}`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(unknown.status()).toBe(404);
+
+        const malformed = await request.get(`${API_BASE}/api/meetings/not-a-uuid`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(malformed.status()).toBe(400);
+
+        expect((await request.get(`${API_BASE}${path}`)).status()).toBe(401);
+    });
+});
+
+test.describe('POST /api/meetings/:id/transcript', () => {
+    test('stores the transcript and reports the best-effort fan-out flags', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const meeting = await createMeeting(request, u.access_token);
+
+        const res = await post(request, u.access_token, `/api/meetings/${meeting.id}/transcript`, {
+            transcriptText: 'Ada: the gate is green. Grace: merging the task branch.',
+        });
+        expect(res.status(), `transcript body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+
+        // The WRITE is the only part that can fail the call.
+        expect(body.meeting.hasTranscript).toBe(true);
+        expect(String(body.meeting.transcriptText)).toContain('the gate is green');
+        // Enrichment is best effort — booleans are always present, the
+        // summary only when an AI provider answered.
+        expect(typeof body.memorySaved).toBe('boolean');
+        expect(typeof body.envelopeEmitted).toBe('boolean');
+    });
+
+    test('an empty transcript is rejected; authz closes the same way as the rest', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const meeting = await createMeeting(request, owner.access_token);
+        const path = `/api/meetings/${meeting.id}/transcript`;
+
+        const empty = await post(request, owner.access_token, path, { transcriptText: '' });
+        expect(empty.status()).toBe(400);
+
+        const whitespace = await post(request, owner.access_token, path, { transcriptText: '   ' });
+        expect(whitespace.status()).toBe(400);
+        expect(errText(await whitespace.json())).toContain('Transcript text is required');
+
+        const cross = await post(request, stranger.access_token, path, {
+            transcriptText: 'not mine',
+        });
+        expect(cross.status()).toBe(404);
+
+        const anon = await request.post(`${API_BASE}${path}`, {
+            data: { transcriptText: 'anon' },
+        });
+        expect(anon.status()).toBe(401);
+    });
+});

--- a/apps/web/e2e/flow-merge-policy-resolve-contract.spec.ts
+++ b/apps/web/e2e/flow-merge-policy-resolve-contract.spec.ts
@@ -1,0 +1,237 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, createWorkViaAPI, registerUserViaAPI } from './helpers/api';
+import { createAgentViaAPI } from './helpers/agents-tasks';
+
+/**
+ * Merge-policy matrix (Wave 3, founder decision D4) — API CONTRACT for
+ * the resolution preview and the additive write path it reads.
+ *
+ * ── Routes ─────────────────────────────────────────────────────────
+ *   GET   /api/merge-policy/resolve?workId=&agentId=
+ *         → 200 { policy, source, chain }
+ *         → 400 when NEITHER workId nor agentId is given
+ *         → 404 for a Work/Agent the caller cannot reach (this endpoint
+ *              would otherwise be a cross-tenant policy oracle)
+ *   Writes ride the existing entity PATCHes — `PATCH /api/works/:id`
+ *   and `PATCH /api/agents/:id` each accept an additive optional
+ *   `mergePolicy` object; resolution is FIELD-BY-FIELD, so a Work that
+ *   sets one field inherits the other four.
+ *
+ * Platform default (conservative, and deliberately overridable):
+ *   allowAgentMerge:false, requireGreenGate:true, requireHumanApproval:true,
+ *   allowedMergeMethods:['squash'],
+ *   protectedBranches:['main','master','develop','stage']
+ */
+
+const UNKNOWN_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+const POLICY_FIELDS = [
+    'allowAgentMerge',
+    'requireGreenGate',
+    'requireHumanApproval',
+    'allowedMergeMethods',
+    'protectedBranches',
+] as const;
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function errText(body: unknown): string {
+    const m = (body as { message?: unknown })?.message;
+    if (Array.isArray(m)) return m.join(' | ');
+    return String(m ?? '');
+}
+
+function resolve(request: APIRequestContext, token: string, query: string) {
+    return request.get(`${API_BASE}/api/merge-policy/resolve?${query}`, {
+        headers: authedHeaders(token),
+    });
+}
+
+test.describe('GET /api/merge-policy/resolve', () => {
+    test('a bare call with no scope is a truthful 400', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const res = await request.get(`${API_BASE}/api/merge-policy/resolve`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(res.status()).toBe(400);
+        expect(errText(await res.json())).toContain('Provide workId and/or agentId');
+    });
+
+    test('an untouched Work resolves to the conservative platform default', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const work = await createWorkViaAPI(request, u.access_token, {
+            name: `Policy Work ${uniq()}`,
+        });
+
+        const res = await resolve(request, u.access_token, `workId=${work.id}`);
+        expect(res.status(), `resolve body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+
+        // A resolved policy is ALWAYS complete — unset fields fall through.
+        for (const field of POLICY_FIELDS) {
+            expect(body.policy, `policy.${field} is present`).toHaveProperty(field);
+        }
+        expect(body.policy.allowAgentMerge).toBe(false);
+        expect(body.policy.requireGreenGate).toBe(true);
+        expect(body.policy.requireHumanApproval).toBe(true);
+        expect(body.policy.allowedMergeMethods).toEqual(['squash']);
+        expect(body.policy.protectedBranches).toEqual(['main', 'master', 'develop', 'stage']);
+        expect(body.source, 'nothing declared anything → default').toBe('default');
+
+        // The chain is self-explaining and always starts at the platform
+        // default — "agents may not merge here" is only usable if the UI
+        // can also say WHERE that came from.
+        expect(Array.isArray(body.chain)).toBe(true);
+        expect(body.chain.length).toBeGreaterThan(0);
+        expect(body.chain[0].scope).toBe('default');
+        expect(body.chain[0].id).toBeNull();
+        expect(body.chain[0].fields).toEqual(expect.arrayContaining([...POLICY_FIELDS]));
+    });
+
+    test('a Work-scoped override is a FIELD-BY-FIELD merge, not a whole-object replace', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const work = await createWorkViaAPI(request, u.access_token, {
+            name: `Policy Work ${uniq()}`,
+        });
+
+        // Declare ONE field at the Work scope.
+        const patched = await request.patch(`${API_BASE}/api/works/${work.id}`, {
+            headers: authedHeaders(u.access_token),
+            data: { mergePolicy: { allowAgentMerge: true } },
+        });
+        expect(patched.status(), `patch body=${await patched.text().catch(() => '')}`).toBe(200);
+
+        const res = await resolve(request, u.access_token, `workId=${work.id}`);
+        expect(res.status()).toBe(200);
+        const body = await res.json();
+
+        expect(body.policy.allowAgentMerge, 'the declared field wins').toBe(true);
+        // …and the other four still come from the platform default.
+        expect(body.policy.requireGreenGate).toBe(true);
+        expect(body.policy.requireHumanApproval).toBe(true);
+        expect(body.policy.allowedMergeMethods).toEqual(['squash']);
+        expect(body.source).toBe('work');
+
+        const workLink = (body.chain as Array<{ scope: string; fields: string[] }>).find(
+            (link) => link.scope === 'work',
+        );
+        expect(workLink, 'the Work link appears in the chain').toBeTruthy();
+        expect(workLink?.fields).toEqual(['allowAgentMerge']);
+    });
+
+    test('the mergePolicy write DTO is validated (bad method, oversized list, unknown key)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const work = await createWorkViaAPI(request, u.access_token, {
+            name: `Policy Work ${uniq()}`,
+        });
+        const url = `${API_BASE}/api/works/${work.id}`;
+        const headers = authedHeaders(u.access_token);
+
+        const badMethod = await request.patch(url, {
+            headers,
+            data: { mergePolicy: { allowedMergeMethods: ['fast-forward'] } },
+        });
+        expect(badMethod.status()).toBe(400);
+
+        const badBool = await request.patch(url, {
+            headers,
+            data: { mergePolicy: { allowAgentMerge: 'yes' } },
+        });
+        expect(badBool.status()).toBe(400);
+
+        const unknownKey = await request.patch(url, {
+            headers,
+            data: { mergePolicy: { allowEverything: true } },
+        });
+        expect(unknownKey.status()).toBe(400);
+        expect(errText(await unknownKey.json())).toContain('should not exist');
+
+        // An explicitly EMPTY method list is legal and means "refuse every
+        // agent merge" — it must NOT be confused with "inherit".
+        const emptyList = await request.patch(url, {
+            headers,
+            data: { mergePolicy: { allowedMergeMethods: [] } },
+        });
+        expect(emptyList.status()).toBe(200);
+        const resolved = await resolve(request, u.access_token, `workId=${work.id}`);
+        expect((await resolved.json()).policy.allowedMergeMethods).toEqual([]);
+    });
+
+    test('resolving by agentId works and is owner-scoped', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const agent = await createAgentViaAPI(request, u.access_token, {
+            name: `policy-agent-${uniq()}`,
+        });
+
+        const res = await resolve(request, u.access_token, `agentId=${agent.id}`);
+        expect(res.status(), `agent resolve body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+        for (const field of POLICY_FIELDS) {
+            expect(body.policy).toHaveProperty(field);
+        }
+    });
+
+    test('a stranger is refused on BOTH inputs — the endpoint is never a cross-tenant policy oracle', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const work = await createWorkViaAPI(request, owner.access_token, {
+            name: `Policy Work ${uniq()}`,
+        });
+        const agent = await createAgentViaAPI(request, owner.access_token, {
+            name: `policy-agent-${uniq()}`,
+        });
+
+        // NOTE — the two inputs refuse with DIFFERENT codes, and that
+        // asymmetry is the platform's, not this endpoint's:
+        //   workId  → `WorkOwnershipService.ensureAccess`, which is 404
+        //             only for a Work that does not exist and 403 for one
+        //             that exists but has no membership row for the caller.
+        //             That is the shared Work-access contract used by
+        //             dozens of endpoints; the controller's own comment
+        //             saying "404 with no existence leak" overstates it.
+        //   agentId → an owner-filtered repository lookup, which cannot
+        //             distinguish the two cases at all → always 404.
+        // What matters for security is identical either way: a stranger
+        // never receives a resolved policy.
+        const crossWork = await resolve(request, stranger.access_token, `workId=${work.id}`);
+        expect(crossWork.status(), 'a stranger never gets a policy for my Work').toBe(403);
+        expect(await crossWork.text()).not.toContain('allowAgentMerge');
+
+        const crossAgent = await resolve(request, stranger.access_token, `agentId=${agent.id}`);
+        expect(crossAgent.status(), 'a stranger never gets a policy for my Agent').toBe(404);
+        expect(await crossAgent.text()).not.toContain('allowAgentMerge');
+
+        const unknownWork = await resolve(request, owner.access_token, `workId=${UNKNOWN_UUID}`);
+        expect(unknownWork.status()).toBe(404);
+
+        const unknownAgent = await resolve(request, owner.access_token, `agentId=${UNKNOWN_UUID}`);
+        expect(unknownAgent.status()).toBe(404);
+    });
+
+    test('malformed uuids are DTO 400s; anonymous is 401', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+
+        const badWork = await resolve(request, u.access_token, 'workId=not-a-uuid');
+        expect(badWork.status()).toBe(400);
+        expect(errText(await badWork.json())).toContain('workId must be a UUID');
+
+        const badAgent = await resolve(request, u.access_token, 'agentId=not-a-uuid');
+        expect(badAgent.status()).toBe(400);
+
+        const unknownParam = await resolve(request, u.access_token, 'tenantId=x');
+        expect(unknownParam.status(), 'the query DTO is whitelisted too').toBe(400);
+
+        const anon = await request.get(
+            `${API_BASE}/api/merge-policy/resolve?workId=${UNKNOWN_UUID}`,
+        );
+        expect(anon.status(), 'auth is checked before the 400/404 branches').toBe(401);
+    });
+});

--- a/apps/web/e2e/flow-run-sessions-steering-contract.spec.ts
+++ b/apps/web/e2e/flow-run-sessions-steering-contract.spec.ts
@@ -1,0 +1,374 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import {
+    API_BASE,
+    authedHeaders,
+    createWorkViaAPI,
+    registerUserViaAPI,
+    type RegisteredUser,
+} from './helpers/api';
+import {
+    assignTaskToAgent,
+    createAgentViaAPI,
+    createTaskViaAPI,
+    listAgentRuns,
+} from './helpers/agents-tasks';
+
+/**
+ * Run orchestration (Wave 4 M3) + run steering (Wave 4 M5) — API
+ * CONTRACT. Both shipped without a single e2e.
+ *
+ * ── Routes ─────────────────────────────────────────────────────────
+ *   GET  /api/agents/runs                  Sessions list — MY runs across
+ *        every Agent. Filters: status / workId / agentId / taskId / kind /
+ *        limit(1..200) / offset(>=0). Declared BEFORE `:id`, so the
+ *        literal `runs` segment never reaches ParseUUIDPipe.
+ *        → 200 { data: [...], meta: { total, limit, offset } }
+ *   GET  /api/works/:id/runs-summary       → 200 { running, queued,
+ *        awaiting, failedLast24h }; the Work is ownership-gated first.
+ *   POST /api/agents/:id/runs/:runId/steer      200 injected|new-run
+ *   POST /api/agents/:id/runs/:runId/interrupt  200; 409 when terminal
+ *   POST /api/agents/:id/runs/:runId/resume     202; 409 when not resumable
+ *
+ * The security property under test throughout: `listSessionsForUser`
+ * applies `userId = auth.userId` at the REPOSITORY layer, so filters can
+ * only ever narrow the caller's own set — passing another user's
+ * agentId/workId must return an empty page, never their rows.
+ */
+
+const UNKNOWN_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function errText(body: unknown): string {
+    const m = (body as { message?: unknown })?.message;
+    if (Array.isArray(m)) return m.join(' | ');
+    return String(m ?? '');
+}
+
+function get(request: APIRequestContext, token: string, path: string) {
+    return request.get(`${API_BASE}${path}`, { headers: authedHeaders(token) });
+}
+
+function post(request: APIRequestContext, token: string, path: string, data?: unknown) {
+    return request.post(`${API_BASE}${path}`, {
+        headers: authedHeaders(token),
+        ...(data === undefined ? {} : { data }),
+    });
+}
+
+/** Agent + Task + dispatch → the newest run id (null if none appeared). */
+async function seedRun(
+    request: APIRequestContext,
+    user: RegisteredUser,
+): Promise<{ agentId: string; taskId: string; runId: string | null }> {
+    const agent = await createAgentViaAPI(request, user.access_token, {
+        name: `session-agent-${uniq()}`,
+    });
+    const task = await createTaskViaAPI(request, user.access_token, {
+        title: `session-task-${uniq()}`,
+    });
+    await assignTaskToAgent(request, user.access_token, agent.id, task.id);
+    const runs = await listAgentRuns(request, user.access_token, agent.id);
+    return { agentId: agent.id, taskId: task.id, runId: runs[0]?.id ?? null };
+}
+
+test.describe('GET /api/agents/runs — the Sessions list', () => {
+    test('returns a paginated envelope for a fresh user and honours limit/offset', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        const res = await get(request, u.access_token, '/api/agents/runs');
+        expect(res.status(), `sessions body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+        expect(Array.isArray(body.data)).toBe(true);
+        expect(body.meta).toBeTruthy();
+        expect(typeof body.meta.total).toBe('number');
+        expect(typeof body.meta.limit).toBe('number');
+        expect(typeof body.meta.offset).toBe('number');
+
+        const paged = await get(request, u.access_token, '/api/agents/runs?limit=1&offset=0');
+        expect(paged.status()).toBe(200);
+        expect((await paged.json()).meta.limit).toBe(1);
+    });
+
+    test('the literal `runs` segment resolves to the sessions route, not to :id', async ({
+        request,
+    }) => {
+        // Regression guard for the route-ordering rule the controller
+        // documents: if `@Get(':id')` were declared first, `runs` would hit
+        // ParseUUIDPipe and this would be a 400 instead of a 200 envelope.
+        const u = await registerUserViaAPI(request);
+        const res = await get(request, u.access_token, '/api/agents/runs');
+        expect(res.status()).toBe(200);
+        expect(await res.json()).toHaveProperty('data');
+    });
+
+    test('rejects out-of-contract filters (bad status / kind / uuid / limit)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        const cases: Array<[string, string]> = [
+            ['status=nope', 'status'],
+            ['kind=telepathy', 'kind'],
+            ['workId=not-a-uuid', 'workId'],
+            ['agentId=not-a-uuid', 'agentId'],
+            ['taskId=not-a-uuid', 'taskId'],
+            ['limit=201', 'limit'],
+            ['limit=0', 'limit'],
+            ['offset=-1', 'offset'],
+        ];
+        for (const [query, field] of cases) {
+            const res = await get(request, u.access_token, `/api/agents/runs?${query}`);
+            expect(res.status(), `?${query}`).toBe(400);
+            expect(errText(await res.json()), `?${query} message`).toContain(field);
+        }
+    });
+
+    test('a filter can only narrow MY set — another user’s agentId returns an empty page', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const { agentId, runId } = await seedRun(request, owner);
+
+        // The owner sees their own runs (when the environment produced one).
+        const mine = await get(request, owner.access_token, `/api/agents/runs?agentId=${agentId}`);
+        expect(mine.status()).toBe(200);
+        const mineBody = await mine.json();
+        if (runId) {
+            expect(
+                mineBody.data.some((r: { id: string }) => r.id === runId),
+                'the owner sees their own run',
+            ).toBe(true);
+        }
+
+        // The stranger passes the SAME agentId — the repository-level
+        // userId clamp makes it an empty page, never a leak, never a 403.
+        const theirs = await get(
+            request,
+            stranger.access_token,
+            `/api/agents/runs?agentId=${agentId}`,
+        );
+        expect(theirs.status(), 'filtering by a foreign agentId is not an error').toBe(200);
+        const theirsBody = await theirs.json();
+        expect(theirsBody.data).toEqual([]);
+        expect(theirsBody.meta.total).toBe(0);
+    });
+
+    test('anonymous → 401', async ({ request }) => {
+        const res = await request.get(`${API_BASE}/api/agents/runs`);
+        expect(res.status()).toBe(401);
+    });
+});
+
+test.describe('GET /api/works/:id/runs-summary', () => {
+    test('returns the four counters for an owned Work, all zero when nothing ran', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const work = await createWorkViaAPI(request, u.access_token, {
+            name: `Summary Work ${uniq()}`,
+        });
+
+        const res = await get(request, u.access_token, `/api/works/${work.id}/runs-summary`);
+        expect(res.status(), `summary body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+        for (const key of ['running', 'queued', 'awaiting', 'failedLast24h']) {
+            expect(typeof body[key], `${key} is a number`).toBe('number');
+            expect(body[key], `${key} is non-negative`).toBeGreaterThanOrEqual(0);
+        }
+    });
+
+    test('authz: stranger refused (403), unknown work 404, malformed 400, anon 401', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const work = await createWorkViaAPI(request, owner.access_token, {
+            name: `Summary Work ${uniq()}`,
+        });
+        const path = `/api/works/${work.id}/runs-summary`;
+
+        // The Work gate is the shared `WorkOwnershipService.ensureAccess`,
+        // whose contract is 404 only for a Work that does NOT exist and
+        // 403 for one that exists without a membership row for the caller.
+        // (The controller's comment claims 404-with-no-existence-leak;
+        // that overstates the shared service, which dozens of endpoints
+        // share.) The counters themselves never reach a non-member.
+        const cross = await get(request, stranger.access_token, path);
+        expect(cross.status(), 'a non-member never gets another Work’s counters').toBe(403);
+        expect(await cross.text()).not.toContain('failedLast24h');
+
+        const unknown = await get(
+            request,
+            owner.access_token,
+            `/api/works/${UNKNOWN_UUID}/runs-summary`,
+        );
+        expect(unknown.status()).toBe(404);
+
+        const malformed = await get(
+            request,
+            owner.access_token,
+            `/api/works/not-a-uuid/runs-summary`,
+        );
+        expect(malformed.status()).toBe(400);
+
+        const anon = await request.get(`${API_BASE}${path}`);
+        expect(anon.status()).toBe(401);
+    });
+});
+
+test.describe('run steering — steer / interrupt / resume', () => {
+    test('steer: empty message is a DTO 400, whitespace-only is a 409, oversized is rejected', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const agent = await createAgentViaAPI(request, u.access_token, {
+            name: `steer-agent-${uniq()}`,
+        });
+        const path = `/api/agents/${agent.id}/runs/${UNKNOWN_UUID}/steer`;
+
+        // `@IsNotEmpty()` on the DTO fires before the service is reached.
+        const empty = await post(request, u.access_token, path, { message: '' });
+        expect(empty.status()).toBe(400);
+        expect(errText(await empty.json())).toContain('message');
+
+        // Whitespace passes the DTO; the service's own trim guard rejects
+        // it — and does so BEFORE the run lookup, so this is 409 not 404.
+        const whitespace = await post(request, u.access_token, path, { message: '   ' });
+        expect(whitespace.status()).toBe(409);
+        expect(errText(await whitespace.json())).toContain('steering message is required');
+
+        const oversized = await post(request, u.access_token, path, {
+            message: 'a'.repeat(16_385),
+        });
+        expect(oversized.status()).toBe(400);
+    });
+
+    test('steer: a real message against an unknown run → 404; anon → 401', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const agent = await createAgentViaAPI(request, u.access_token, {
+            name: `steer-agent-${uniq()}`,
+        });
+        const path = `/api/agents/${agent.id}/runs/${UNKNOWN_UUID}/steer`;
+
+        const unknown = await post(request, u.access_token, path, { message: 'keep going' });
+        expect(unknown.status()).toBe(404);
+
+        const anon = await request.post(`${API_BASE}${path}`, { data: { message: 'keep going' } });
+        expect(anon.status()).toBe(401);
+    });
+
+    test('steer on a FINISHED run answers new-run (a normal race), never an error', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const { agentId, runId } = await seedRun(request, u);
+        test.skip(!runId, 'no AgentRun row was produced by this environment');
+
+        const res = await post(
+            request,
+            u.access_token,
+            `/api/agents/${agentId}/runs/${runId}/steer`,
+            { message: 'please continue' },
+        );
+        expect(res.status(), `steer body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+        // "The run finished while you were typing" is a defined outcome
+        // with a defined next step — deliberately NOT a 409.
+        expect(['injected', 'new-run']).toContain(body.dispatched);
+        expect(body.runId).toBe(runId);
+    });
+
+    test('interrupt on a terminal run → 409; unknown run → 404; anon → 401', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const { agentId, runId } = await seedRun(request, u);
+
+        const unknown = await post(
+            request,
+            u.access_token,
+            `/api/agents/${agentId}/runs/${UNKNOWN_UUID}/interrupt`,
+        );
+        expect(unknown.status()).toBe(404);
+
+        const anon = await request.post(
+            `${API_BASE}/api/agents/${agentId}/runs/${UNKNOWN_UUID}/interrupt`,
+        );
+        expect(anon.status()).toBe(401);
+
+        test.skip(!runId, 'no AgentRun row was produced by this environment');
+        const terminal = await post(
+            request,
+            u.access_token,
+            `/api/agents/${agentId}/runs/${runId}/interrupt`,
+        );
+        // Unlike steer, interrupt has no meaningful fallback — 409.
+        expect([200, 409], `interrupt returned ${terminal.status()}`).toContain(terminal.status());
+        if (terminal.status() === 409) {
+            expect(errText(await terminal.json())).toContain('interrupted');
+        }
+    });
+
+    test('resume: unknown run → 404, non-resumable run → 409, anon → 401', async ({ request }) => {
+        const u = await registerUserViaAPI(request);
+        const { agentId, runId } = await seedRun(request, u);
+
+        const unknown = await post(
+            request,
+            u.access_token,
+            `/api/agents/${agentId}/runs/${UNKNOWN_UUID}/resume`,
+            {},
+        );
+        expect(unknown.status()).toBe(404);
+
+        const anon = await request.post(
+            `${API_BASE}/api/agents/${agentId}/runs/${UNKNOWN_UUID}/resume`,
+            { data: {} },
+        );
+        expect(anon.status()).toBe(401);
+
+        test.skip(!runId, 'no AgentRun row was produced by this environment');
+        const notResumable = await post(
+            request,
+            u.access_token,
+            `/api/agents/${agentId}/runs/${runId}/resume`,
+            {},
+        );
+        // Resume applies to runs awaiting input or parked for a resumable
+        // reason; a plain failed run is not one, so 409 with an explanation.
+        expect([202, 409], `resume returned ${notResumable.status()}`).toContain(
+            notResumable.status(),
+        );
+        if (notResumable.status() === 409) {
+            expect(errText(await notResumable.json())).toContain('not resumable');
+        }
+    });
+
+    test('all three controls reject a cross-user agent with 404, never 403', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const agent = await createAgentViaAPI(request, owner.access_token, {
+            name: `steer-agent-${uniq()}`,
+        });
+
+        const base = `/api/agents/${agent.id}/runs/${UNKNOWN_UUID}`;
+        const steer = await post(request, stranger.access_token, `${base}/steer`, {
+            message: 'hello',
+        });
+        expect(steer.status()).toBe(404);
+
+        const interrupt = await post(request, stranger.access_token, `${base}/interrupt`);
+        expect(interrupt.status()).toBe(404);
+
+        const resume = await post(request, stranger.access_token, `${base}/resume`, {});
+        expect(resume.status()).toBe(404);
+    });
+});

--- a/apps/web/e2e/flow-task-branch-gate-ui-journey.spec.ts
+++ b/apps/web/e2e/flow-task-branch-gate-ui-journey.spec.ts
@@ -1,0 +1,273 @@
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+import { API_BASE, authedHeaders, loginViaAPI } from './helpers/api';
+import { loadSeededTestUser } from './helpers/seeded-test-user';
+
+/**
+ * `/tasks/:id` — the Branch + Checks cockpit (Wave 2 M7 + Wave 3 M6).
+ *
+ * The two panels this program added to the Task detail page had zero UI
+ * coverage. They are also the surfaces most likely to regress SILENTLY:
+ * they render conditionally on server-owned columns, so a broken prop
+ * chain shows up as "the panel simply isn't there" rather than an error.
+ *
+ * Seeding is API-first and navigation is direct (no click-chains) — the
+ * house pattern for data-backed detail pages.
+ *
+ * ── What renders when (components/tasks/TaskBranchSection.tsx) ──────
+ *   task.branchRef set   → BranchPanel        [task-branch-section]
+ *                          + [task-conflict-banner] when
+ *                            branchState === 'conflict'
+ *   task.branchRef null  → IsolationOverridePanel
+ *                          [task-isolation-override-section]
+ *                          with the [task-isolation-override] select
+ *                          (inherit / on / off → isolationMode
+ *                           null / 'on' / 'off')
+ *
+ *   Checks section [task-checks-section] ALWAYS renders; it shows the
+ *   dispatch-frozen `resolvedChecks` when a run exists, otherwise the
+ *   Task's declared `acceptanceChecks`, one [task-check-row] each.
+ *
+ * `branchRef` / `branchState` are written only by the worker's workspace
+ * finalize path and are rejected by the Task PATCH DTO
+ * (forbidNonWhitelisted), so the branch/conflict arm is not reachable
+ * from a black-box e2e. This spec therefore proves the INHERIT arm, the
+ * checks rendering, and the round-trip of both editors — and explicitly
+ * pins that the conflict banner is ABSENT for a branchless Task, which
+ * is the regression that would otherwise ship unnoticed.
+ */
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+async function seededToken(request: APIRequestContext): Promise<string> {
+    const seeded = loadSeededTestUser();
+    const { access_token } = await loginViaAPI(request, {
+        email: seeded.email,
+        password: seeded.password,
+    });
+    expect(access_token, 'seeded login returns a bearer token').toBeTruthy();
+    return access_token;
+}
+
+async function createTask(
+    request: APIRequestContext,
+    token: string,
+    body: Record<string, unknown>,
+): Promise<{ id: string; slug: string }> {
+    const res = await request.post(`${API_BASE}/api/tasks`, {
+        headers: authedHeaders(token),
+        data: { title: `branch-ui-${uniq()}`, ...body },
+    });
+    expect(res.status(), `seed task body=${await res.text().catch(() => '')}`).toBe(201);
+    return res.json();
+}
+
+async function readTask(
+    request: APIRequestContext,
+    token: string,
+    id: string,
+): Promise<Record<string, unknown>> {
+    const res = await request.get(`${API_BASE}/api/tasks/${id}`, {
+        headers: authedHeaders(token),
+    });
+    expect(res.status()).toBe(200);
+    return res.json();
+}
+
+/** Land on the detail page and wait for a stable server-rendered anchor. */
+async function gotoTask(page: Page, id: string): Promise<void> {
+    await page.goto(`/en/tasks/${id}`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/\/login/);
+    await expect(page.getByTestId('task-checks-section')).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * `components/ui/select` is a CUSTOM dropdown, not a native `<select>`:
+ * `data-testid` lands on a trigger `<button>` whose text is the selected
+ * option's label, and the options are `role="option"` rows in a
+ * body-portalled `role="listbox"`. So "read the value" is a text
+ * assertion on the trigger and "set the value" is click-then-click.
+ * Retry-guarded for the prod-build hydration race (the CI web app is a
+ * production build — the trigger is in the DOM before it is wired).
+ */
+async function chooseOption(page: Page, testId: string, option: RegExp): Promise<void> {
+    const trigger = page.getByTestId(testId);
+    await expect(trigger).toBeVisible({ timeout: 30_000 });
+    await expect(async () => {
+        if (
+            !(await page
+                .getByRole('option')
+                .first()
+                .isVisible()
+                .catch(() => false))
+        ) {
+            await trigger.click({ timeout: 5_000 }).catch(() => undefined);
+        }
+        await page.getByRole('option', { name: option }).first().click({ timeout: 4_000 });
+    }).toPass({ timeout: 30_000 });
+}
+
+test.describe('Task detail — isolation override panel', () => {
+    test('a branchless Task shows the isolation select (not the branch panel) and no conflict banner', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const task = await createTask(request, token, {});
+
+        await gotoTask(page, task.id);
+
+        await expect(page.getByTestId('task-isolation-override-section')).toBeVisible();
+        await expect(page.getByTestId('task-isolation-override')).toBeVisible();
+        // The branch cockpit and its conflict banner belong to the OTHER
+        // arm — their presence here would mean the branchRef guard broke.
+        await expect(page.getByTestId('task-branch-section')).toHaveCount(0);
+        await expect(page.getByTestId('task-conflict-banner')).toHaveCount(0);
+        await expect(page.getByTestId('task-resolve-conflicts')).toHaveCount(0);
+        await expect(page.getByTestId('task-discard-branch')).toHaveCount(0);
+    });
+
+    test('the select reflects the persisted isolationMode', async ({ page, request }) => {
+        const token = await seededToken(request);
+        const inherited = await createTask(request, token, {});
+        const forced = await createTask(request, token, { isolationMode: 'on' });
+
+        await gotoTask(page, inherited.id);
+        await expect(page.getByTestId('task-isolation-override')).toContainText(
+            /Inherit from Work/i,
+        );
+
+        await gotoTask(page, forced.id);
+        await expect(page.getByTestId('task-isolation-override')).toContainText(/isolated branch/i);
+    });
+
+    test('changing the select persists through the server action to the API', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const task = await createTask(request, token, {});
+
+        await gotoTask(page, task.id);
+        await expect(page.getByTestId('task-isolation-override')).toContainText(
+            /Inherit from Work/i,
+        );
+
+        await chooseOption(page, 'task-isolation-override', /work directly/i);
+
+        // The server action PATCHes the Task — assert the API, not the DOM,
+        // so a purely optimistic UI cannot make this pass.
+        await expect
+            .poll(async () => (await readTask(request, token, task.id)).isolationMode ?? null, {
+                timeout: 20_000,
+                message: 'isolationMode is persisted by the isolation select',
+            })
+            .toBe('off');
+
+        // …and it survives a reload (the select is hydrated from the row).
+        await gotoTask(page, task.id);
+        await expect(page.getByTestId('task-isolation-override')).toContainText(/work directly/i);
+    });
+});
+
+test.describe('Task detail — checks (quality gate) section', () => {
+    test('renders one row per declared acceptance check', async ({ page, request }) => {
+        const token = await seededToken(request);
+        const task = await createTask(request, token, {
+            acceptanceChecks: [
+                {
+                    id: 'build',
+                    name: 'Build',
+                    kind: 'build',
+                    command: 'pnpm build',
+                    required: true,
+                },
+                {
+                    id: 'unit-tests',
+                    name: 'Unit tests',
+                    kind: 'test',
+                    command: 'pnpm test',
+                    required: false,
+                },
+            ],
+            maxGateAttempts: 3,
+        });
+
+        await gotoTask(page, task.id);
+
+        const section = page.getByTestId('task-checks-section');
+        await expect(section).toBeVisible();
+        await expect(page.getByTestId('task-check-row')).toHaveCount(2);
+        await expect(section).toContainText('Build');
+        await expect(section).toContainText('Unit tests');
+    });
+
+    test('a Task with no checks renders the section in its empty state, not a crash', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const task = await createTask(request, token, {});
+
+        await gotoTask(page, task.id);
+        await expect(page.getByTestId('task-checks-section')).toBeVisible();
+        await expect(page.getByTestId('task-check-row')).toHaveCount(0);
+        // No run exists, so neither the gate chip nor the attempts counter
+        // should be fabricated.
+        await expect(page.getByTestId('task-gate-chip')).toHaveCount(0);
+        await expect(page.getByTestId('task-gate-attempts')).toHaveCount(0);
+    });
+
+    test('the inline editor round-trips the gate-attempt budget to the API', async ({
+        page,
+        request,
+    }) => {
+        const token = await seededToken(request);
+        const task = await createTask(request, token, {
+            acceptanceChecks: [
+                { id: 'lint', name: 'Lint', kind: 'lint', command: 'pnpm lint', required: true },
+            ],
+        });
+
+        await gotoTask(page, task.id);
+
+        // "Edit" is a client-state toggle, so the button exists in the
+        // server-rendered HTML before React has attached its handler. On
+        // the PRODUCTION build the e2e suite runs against, a single click
+        // can land in that window and do nothing — retry until the editor
+        // actually opens (house pattern for the hydration race).
+        const editor = page.getByTestId('task-checks-editor');
+        await expect(async () => {
+            if (!(await editor.isVisible().catch(() => false))) {
+                await page
+                    .getByTestId('task-checks-edit')
+                    .click({ timeout: 5_000 })
+                    .catch(() => undefined);
+            }
+            await expect(editor).toBeVisible({ timeout: 3_000 });
+        }).toPass({ timeout: 30_000 });
+
+        await expect(page.getByTestId('task-checks-editor-row')).toHaveCount(1);
+        await expect(page.getByTestId('task-checks-editor-id')).toHaveValue('lint');
+
+        await expect(page.getByTestId('task-checks-max-attempts')).toContainText(
+            /Inherit from Work/i,
+        );
+        await chooseOption(page, 'task-checks-max-attempts', /^4$/);
+        await page.getByTestId('task-checks-save').click();
+
+        await expect
+            .poll(async () => (await readTask(request, token, task.id)).maxGateAttempts ?? null, {
+                timeout: 20_000,
+                message: 'the checks editor persists maxGateAttempts',
+            })
+            .toBe(4);
+
+        // The declared check survived the save (the editor replaces the set
+        // wholesale — dropping it silently would be the bug).
+        const stored = await readTask(request, token, task.id);
+        expect(Array.isArray(stored.acceptanceChecks)).toBe(true);
+        expect((stored.acceptanceChecks as Array<{ id: string }>)[0].id).toBe('lint');
+    });
+});

--- a/apps/web/e2e/flow-task-isolation-gates-contract.spec.ts
+++ b/apps/web/e2e/flow-task-isolation-gates-contract.spec.ts
@@ -1,0 +1,412 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI } from './helpers/api';
+
+/**
+ * Worktree-per-Task isolation + quality gates — API CONTRACT matrix.
+ *
+ * The 2026-07 feature program added three optional fields to the Task
+ * create/patch DTOs and two branch-lifecycle endpoints, and shipped ZERO
+ * e2e coverage for any of it. This file is the contract tripwire.
+ *
+ * Deliberately NOT re-walking `flow-tasks-validation-authz-matrix`
+ * (title/status/priority/labels/scope/actor DTOs) — only the NEW surface.
+ *
+ * ── Contract under test (read from the source of truth) ─────────────
+ *
+ *   CreateTaskDto / UpdateTaskDto (apps/api/src/tasks/tasks.dto.ts) —
+ *   global ValidationPipe: whitelist + forbidNonWhitelisted.
+ *     isolationMode      @IsOptional @IsIn('on','off')   — null inherits
+ *                        the Work's `taskIsolation` setting.
+ *     acceptanceChecks   @IsOptional @IsArray @ArrayMaxSize(20)
+ *                        @ValidateNested(each) → AcceptanceCheckDto
+ *                          id       slug-safe `^[a-z0-9][a-z0-9-_]{0,40}$`
+ *                          name     1..120
+ *                          kind     build|test|lint|typecheck|custom
+ *                          command  1..2000
+ *                          required boolean
+ *                          cwd? timeoutSec?(1..3600) disabled? envPassthrough?
+ *     maxGateAttempts    @IsOptional @IsInt @Min(1) @Max(5) — null inherits
+ *
+ *   POST /api/tasks/:id/resolve-conflicts
+ *     200 when the Task branch is in `conflict`
+ *     409 "Task branch is not in a conflict state" otherwise
+ *     404 unknown / cross-user   400 malformed uuid   401 anon
+ *
+ *   POST /api/tasks/:id/discard-branch
+ *     200 { ok: true } — IDEMPOTENT: a Task with no branch is a no-op
+ *     404 unknown / cross-user   400 malformed uuid   401 anon
+ *
+ * `branchState = 'conflict'` is only ever written by the worker's
+ * workspace finalize path, so the 200-arm of resolve-conflicts is not
+ * reachable from the public API. This spec therefore pins the REFUSAL
+ * arm (409) and the authz closure, which is exactly the half a silent
+ * prod regression would break.
+ */
+
+const UNKNOWN_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+/** class-validator returns message:string[]; thrown HttpExceptions a string. */
+function errText(body: unknown): string {
+    const m = (body as { message?: unknown })?.message;
+    if (Array.isArray(m)) return m.join(' | ');
+    return String(m ?? '');
+}
+
+function post(request: APIRequestContext, token: string, path: string, data: unknown) {
+    return request.post(`${API_BASE}${path}`, { headers: authedHeaders(token), data });
+}
+
+function patch(request: APIRequestContext, token: string, path: string, data: unknown) {
+    return request.patch(`${API_BASE}${path}`, { headers: authedHeaders(token), data });
+}
+
+/** A minimal VALID acceptance check (every required field, nothing else). */
+function validCheck(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'build',
+        name: 'Build',
+        kind: 'build',
+        command: 'pnpm build',
+        required: true,
+        ...overrides,
+    };
+}
+
+async function makeTask(
+    request: APIRequestContext,
+    token: string,
+    body: Record<string, unknown> = {},
+): Promise<{ id: string }> {
+    const res = await post(request, token, '/api/tasks', { title: `gate-${uniq()}`, ...body });
+    expect(res.status(), `setup makeTask body=${await res.text().catch(() => '')}`).toBe(201);
+    return res.json();
+}
+
+test.describe('CreateTaskDto — isolationMode / acceptanceChecks / maxGateAttempts', () => {
+    test('isolationMode accepts on|off and explicit null (inherit), rejects anything else', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        for (const mode of ['on', 'off']) {
+            const res = await post(request, u.access_token, '/api/tasks', {
+                title: `iso-${uniq()}`,
+                isolationMode: mode,
+            });
+            expect(res.status(), `isolationMode=${mode}`).toBe(201);
+            expect((await res.json()).isolationMode).toBe(mode);
+        }
+
+        // null is the documented "inherit the Work's taskIsolation" value.
+        const inherit = await post(request, u.access_token, '/api/tasks', {
+            title: `iso-${uniq()}`,
+            isolationMode: null,
+        });
+        expect(inherit.status()).toBe(201);
+        expect((await inherit.json()).isolationMode ?? null).toBeNull();
+
+        const bad = await post(request, u.access_token, '/api/tasks', {
+            title: `iso-${uniq()}`,
+            isolationMode: 'worktree', // that is the WORK-level value, not the Task's
+        });
+        expect(bad.status()).toBe(400);
+        expect(errText(await bad.json())).toContain('isolationMode');
+    });
+
+    test('maxGateAttempts is an int clamped to 1..5; 0 / 6 / non-int are rejected', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        const ok = await post(request, u.access_token, '/api/tasks', {
+            title: `gate-${uniq()}`,
+            maxGateAttempts: 3,
+        });
+        expect(ok.status()).toBe(201);
+        expect((await ok.json()).maxGateAttempts).toBe(3);
+
+        for (const value of [0, 6, 2.5, 'three']) {
+            const res = await post(request, u.access_token, '/api/tasks', {
+                title: `gate-${uniq()}`,
+                maxGateAttempts: value,
+            });
+            expect(res.status(), `maxGateAttempts=${String(value)}`).toBe(400);
+            expect(errText(await res.json())).toContain('maxGateAttempts');
+        }
+
+        // The boundaries themselves are legal.
+        for (const value of [1, 5]) {
+            const res = await post(request, u.access_token, '/api/tasks', {
+                title: `gate-${uniq()}`,
+                maxGateAttempts: value,
+            });
+            expect(res.status(), `boundary maxGateAttempts=${value}`).toBe(201);
+        }
+    });
+
+    test('acceptanceChecks: a well-formed array persists; each nested field is validated', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        const ok = await post(request, u.access_token, '/api/tasks', {
+            title: `checks-${uniq()}`,
+            acceptanceChecks: [
+                validCheck(),
+                validCheck({
+                    id: 'unit-tests',
+                    name: 'Unit tests',
+                    kind: 'test',
+                    command: 'pnpm test',
+                    required: false,
+                    timeoutSec: 600,
+                }),
+            ],
+        });
+        expect(ok.status(), `checks body=${await ok.text().catch(() => '')}`).toBe(201);
+        const created = await ok.json();
+        expect(Array.isArray(created.acceptanceChecks)).toBe(true);
+        expect(created.acceptanceChecks).toHaveLength(2);
+        expect(created.acceptanceChecks[0].id).toBe('build');
+        expect(created.acceptanceChecks[1].required).toBe(false);
+
+        // Nested validation fires per field.
+        const cases: Array<[string, Record<string, unknown>]> = [
+            ['id', validCheck({ id: 'NOT SLUG SAFE' })],
+            ['name', validCheck({ name: '' })],
+            ['kind', validCheck({ kind: 'deploy' })],
+            ['command', validCheck({ command: '' })],
+            ['required', validCheck({ required: 'yes' })],
+            ['timeoutSec', validCheck({ timeoutSec: 0 })],
+        ];
+        for (const [field, check] of cases) {
+            const res = await post(request, u.access_token, '/api/tasks', {
+                title: `checks-${uniq()}`,
+                acceptanceChecks: [check],
+            });
+            expect(res.status(), `nested ${field}`).toBe(400);
+            expect(errText(await res.json()), `nested ${field} message`).toContain(field);
+        }
+    });
+
+    test('acceptanceChecks is capped at 20 entries and rejects a non-array', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+
+        const twenty = Array.from({ length: 20 }, (_, i) => validCheck({ id: `check-${i}` }));
+        const atCap = await post(request, u.access_token, '/api/tasks', {
+            title: `cap-${uniq()}`,
+            acceptanceChecks: twenty,
+        });
+        expect(atCap.status(), 'exactly 20 checks is accepted').toBe(201);
+
+        const overCap = await post(request, u.access_token, '/api/tasks', {
+            title: `cap-${uniq()}`,
+            acceptanceChecks: [...twenty, validCheck({ id: 'check-20' })],
+        });
+        expect(overCap.status(), '21 checks is rejected').toBe(400);
+
+        const notArray = await post(request, u.access_token, '/api/tasks', {
+            title: `cap-${uniq()}`,
+            acceptanceChecks: 'nope',
+        });
+        expect(notArray.status()).toBe(400);
+        expect(errText(await notArray.json())).toContain('acceptanceChecks');
+    });
+
+    test('envPassthrough takes NAMES only — a `NAME=value` pair is rejected', async ({
+        request,
+    }) => {
+        // Security-relevant: checks run with a scrubbed environment and
+        // listing a name is a deliberate grant. Accepting `FOO=bar` would
+        // let a check smuggle a literal value past the scrubber.
+        const u = await registerUserViaAPI(request);
+
+        const ok = await post(request, u.access_token, '/api/tasks', {
+            title: `env-${uniq()}`,
+            acceptanceChecks: [validCheck({ envPassthrough: ['CI', 'NODE_ENV'] })],
+        });
+        expect(ok.status(), `env body=${await ok.text().catch(() => '')}`).toBe(201);
+
+        const bad = await post(request, u.access_token, '/api/tasks', {
+            title: `env-${uniq()}`,
+            acceptanceChecks: [validCheck({ envPassthrough: ['SECRET=hunter2'] })],
+        });
+        expect(bad.status()).toBe(400);
+        expect(errText(await bad.json())).toContain('envPassthrough');
+    });
+});
+
+test.describe('UpdateTaskDto — the same three fields on PATCH', () => {
+    test('PATCH round-trips isolationMode / maxGateAttempts / acceptanceChecks and null reverts to inherit', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const task = await makeTask(request, u.access_token, {
+            isolationMode: 'on',
+            maxGateAttempts: 2,
+            acceptanceChecks: [validCheck()],
+        });
+
+        const updated = await patch(request, u.access_token, `/api/tasks/${task.id}`, {
+            isolationMode: 'off',
+            maxGateAttempts: 5,
+            acceptanceChecks: [validCheck({ id: 'lint', name: 'Lint', kind: 'lint' })],
+        });
+        expect(updated.status(), `patch body=${await updated.text().catch(() => '')}`).toBe(200);
+        const body = await updated.json();
+        expect(body.isolationMode).toBe('off');
+        expect(body.maxGateAttempts).toBe(5);
+        expect(body.acceptanceChecks).toHaveLength(1);
+        expect(body.acceptanceChecks[0].id).toBe('lint');
+
+        // Explicit null on all three = revert to inheriting the Work.
+        const reverted = await patch(request, u.access_token, `/api/tasks/${task.id}`, {
+            isolationMode: null,
+            maxGateAttempts: null,
+            acceptanceChecks: null,
+        });
+        expect(reverted.status()).toBe(200);
+        const rb = await reverted.json();
+        expect(rb.isolationMode ?? null).toBeNull();
+        expect(rb.maxGateAttempts ?? null).toBeNull();
+        expect(rb.acceptanceChecks ?? null).toBeNull();
+    });
+
+    test('PATCH still rejects bad values and unknown fields (forbidNonWhitelisted intact)', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const task = await makeTask(request, u.access_token);
+
+        const badMode = await patch(request, u.access_token, `/api/tasks/${task.id}`, {
+            isolationMode: 'sometimes',
+        });
+        expect(badMode.status()).toBe(400);
+
+        const badAttempts = await patch(request, u.access_token, `/api/tasks/${task.id}`, {
+            maxGateAttempts: 99,
+        });
+        expect(badAttempts.status()).toBe(400);
+
+        // The neighbouring branch columns are SERVER-owned — a client must
+        // not be able to declare its own branch state.
+        for (const field of ['branchRef', 'branchState', 'conflictPaths', 'prUrl']) {
+            const res = await patch(request, u.access_token, `/api/tasks/${task.id}`, {
+                [field]: 'x',
+            });
+            expect(res.status(), `${field} is not client-writable`).toBe(400);
+            expect(errText(await res.json())).toContain(`property ${field} should not exist`);
+        }
+    });
+});
+
+test.describe('POST /api/tasks/:id/resolve-conflicts', () => {
+    test('a Task that is not in conflict → 409 with the documented message', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const task = await makeTask(request, u.access_token);
+
+        const res = await post(
+            request,
+            u.access_token,
+            `/api/tasks/${task.id}/resolve-conflicts`,
+            {},
+        );
+        expect(res.status(), `body=${await res.text().catch(() => '')}`).toBe(409);
+        expect(errText(await res.json())).toContain('not in a conflict state');
+    });
+
+    test('authz closure: cross-user 404, unknown uuid 404, malformed 400, anon 401', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const task = await makeTask(request, owner.access_token);
+        const path = `/api/tasks/${task.id}/resolve-conflicts`;
+
+        // A stranger must be unable to tell "exists but not yours" (409)
+        // from "does not exist" (404) — both answer 404.
+        const cross = await post(request, stranger.access_token, path, {});
+        expect(cross.status()).toBe(404);
+
+        const unknown = await post(
+            request,
+            owner.access_token,
+            `/api/tasks/${UNKNOWN_UUID}/resolve-conflicts`,
+            {},
+        );
+        expect(unknown.status()).toBe(404);
+
+        const malformed = await post(
+            request,
+            owner.access_token,
+            `/api/tasks/not-a-uuid/resolve-conflicts`,
+            {},
+        );
+        expect(malformed.status()).toBe(400);
+        expect(errText(await malformed.json())).toContain('uuid is expected');
+
+        const anon = await request.post(`${API_BASE}${path}`, { data: {} });
+        expect(anon.status()).toBe(401);
+    });
+});
+
+test.describe('POST /api/tasks/:id/discard-branch', () => {
+    test('is idempotent on a Task with no branch → 200 { ok: true }, twice', async ({
+        request,
+    }) => {
+        const u = await registerUserViaAPI(request);
+        const task = await makeTask(request, u.access_token);
+        const path = `/api/tasks/${task.id}/discard-branch`;
+
+        const first = await post(request, u.access_token, path, {});
+        expect(first.status(), `body=${await first.text().catch(() => '')}`).toBe(200);
+        expect((await first.json()).ok).toBe(true);
+
+        const second = await post(request, u.access_token, path, {});
+        expect(second.status(), 'discard is idempotent').toBe(200);
+        expect((await second.json()).ok).toBe(true);
+
+        // A no-branch discard must NOT invent a branchState on the row.
+        const after = await request.get(`${API_BASE}/api/tasks/${task.id}`, {
+            headers: authedHeaders(u.access_token),
+        });
+        expect(after.status()).toBe(200);
+        expect((await after.json()).branchRef ?? null).toBeNull();
+    });
+
+    test('authz closure: cross-user 404 and the row survives, malformed 400, anon 401', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const task = await makeTask(request, owner.access_token);
+        const path = `/api/tasks/${task.id}/discard-branch`;
+
+        const cross = await post(request, stranger.access_token, path, {});
+        expect(cross.status()).toBe(404);
+
+        const stillThere = await request.get(`${API_BASE}/api/tasks/${task.id}`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(stillThere.status(), 'a refused discard must not touch the Task').toBe(200);
+
+        const malformed = await post(
+            request,
+            owner.access_token,
+            `/api/tasks/not-a-uuid/discard-branch`,
+            {},
+        );
+        expect(malformed.status()).toBe(400);
+
+        const anon = await request.post(`${API_BASE}${path}`, { data: {} });
+        expect(anon.status()).toBe(401);
+    });
+});

--- a/apps/web/e2e/flow-terminal-attach-contract.spec.ts
+++ b/apps/web/e2e/flow-terminal-attach-contract.spec.ts
@@ -1,0 +1,256 @@
+import { test, expect, type APIRequestContext } from '@playwright/test';
+import { API_BASE, authedHeaders, registerUserViaAPI, type RegisteredUser } from './helpers/api';
+import {
+    assignTaskToAgent,
+    createAgentViaAPI,
+    createTaskViaAPI,
+    listAgentRuns,
+} from './helpers/agents-tasks';
+
+/**
+ * Streaming terminal (Wave 1 M3/M6) — attach-token, start and status
+ * API CONTRACT. Zero e2e existed for ~2,600 lines of tested machinery.
+ *
+ * ── Routes (apps/api/src/terminal/terminal-attach.controller.ts) ────
+ *   POST /api/agents/:id/runs/:runId/terminal/attach-token → 201
+ *        { token, wsPath:'/ws/terminal/<runId>', role:'driver', expiresInSec }
+ *        503 when neither TERMINAL_ATTACH_SECRET nor BETTER_AUTH_SECRET
+ *        is set (fail-closed: an unsecured relay refuses attaches).
+ *   POST /api/agents/:id/runs/:runId/terminal/start        → 202
+ *        409 session already live / run already finished
+ *        503 no background job runtime wired
+ *   GET  /api/agents/:id/runs/:runId/terminal              → 200
+ *        live relay view merged with the persisted run terminal columns
+ *
+ * Authorization is identical on all three: agent ownership
+ * (`AgentsService.getOne`) + user-scoped run lookup + agentId match, so
+ * a cross-user or cross-agent runId 404s with NO existence leak. That
+ * closure is the security property this file pins.
+ *
+ * Environment note: the e2e stack has no Trigger.dev key, so a run
+ * created through `assign-task` lands `failed` and `start` legitimately
+ * answers 409 (run not live) or 503 (no dispatcher). The spec asserts
+ * the SET of legal answers rather than pretending a worker exists —
+ * what must never happen is a 2xx "started" for a dead run.
+ */
+
+const UNKNOWN_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function uniq(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+}
+
+function terminalBase(agentId: string, runId: string): string {
+    return `/api/agents/${agentId}/runs/${runId}/terminal`;
+}
+
+/**
+ * Create an Agent + Task and dispatch, then return the newest run id.
+ * Returns null when no run row materialised — callers skip the
+ * run-dependent assertions rather than assert on a fixture that the
+ * environment could not produce.
+ */
+async function seedRun(
+    request: APIRequestContext,
+    user: RegisteredUser,
+): Promise<{ agentId: string; runId: string | null }> {
+    const agent = await createAgentViaAPI(request, user.access_token, {
+        name: `terminal-agent-${uniq()}`,
+    });
+    const task = await createTaskViaAPI(request, user.access_token, {
+        title: `terminal-task-${uniq()}`,
+    });
+    // Returns null on the expected enqueue failure — the run row is still
+    // persisted, which is what we are after.
+    await assignTaskToAgent(request, user.access_token, agent.id, task.id);
+    const runs = await listAgentRuns(request, user.access_token, agent.id);
+    return { agentId: agent.id, runId: runs[0]?.id ?? null };
+}
+
+test.describe('terminal attach-token', () => {
+    test('mints a driver token for the run owner (or fails closed with 503 when unconfigured)', async ({
+        request,
+    }) => {
+        const user = await registerUserViaAPI(request);
+        const { agentId, runId } = await seedRun(request, user);
+        test.skip(!runId, 'no AgentRun row was produced by this environment');
+
+        const res = await request.post(
+            `${API_BASE}${terminalBase(agentId, runId as string)}/attach-token`,
+            { headers: authedHeaders(user.access_token) },
+        );
+        expect([201, 503], `attach-token returned ${res.status()}`).toContain(res.status());
+
+        if (res.status() === 503) {
+            // Fail-closed arm: no signing secret on this install.
+            expect(String((await res.json()).message)).toContain('not configured');
+            return;
+        }
+
+        const body = await res.json();
+        expect(typeof body.token).toBe('string');
+        expect(body.token.length).toBeGreaterThan(0);
+        // The token is presented in the FIRST WebSocket message, never in
+        // the URL — so wsPath must carry the run id and nothing secret.
+        expect(body.wsPath).toBe(`/ws/terminal/${runId}`);
+        expect(body.wsPath).not.toContain(body.token);
+        expect(body.role).toBe('driver');
+        expect(typeof body.expiresInSec).toBe('number');
+        expect(body.expiresInSec).toBeGreaterThan(0);
+        // Short-lived by construction — a leak must have a small blast radius.
+        expect(body.expiresInSec).toBeLessThanOrEqual(300);
+    });
+
+    test('cross-user and cross-agent run ids 404 with no existence leak; anon is 401', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const { agentId, runId } = await seedRun(request, owner);
+        test.skip(!runId, 'no AgentRun row was produced by this environment');
+
+        const path = `${terminalBase(agentId, runId as string)}/attach-token`;
+
+        // Stranger: the AGENT lookup 404s first — same answer either way.
+        const cross = await request.post(`${API_BASE}${path}`, {
+            headers: authedHeaders(stranger.access_token),
+        });
+        expect(cross.status(), 'a stranger must never mint a token').toBe(404);
+
+        // Owner, but the run belongs to a DIFFERENT agent of theirs.
+        const otherAgent = await createAgentViaAPI(request, owner.access_token, {
+            name: `other-agent-${uniq()}`,
+        });
+        const mismatched = await request.post(
+            `${API_BASE}${terminalBase(otherAgent.id, runId as string)}/attach-token`,
+            { headers: authedHeaders(owner.access_token) },
+        );
+        expect(mismatched.status(), 'agentId/runId must match').toBe(404);
+
+        const anon = await request.post(`${API_BASE}${path}`);
+        expect(anon.status()).toBe(401);
+    });
+
+    test('unknown run uuid → 404, malformed uuid → 400 (ParseUUIDPipe before the handler)', async ({
+        request,
+    }) => {
+        const user = await registerUserViaAPI(request);
+        const agent = await createAgentViaAPI(request, user.access_token, {
+            name: `terminal-agent-${uniq()}`,
+        });
+
+        const unknown = await request.post(
+            `${API_BASE}${terminalBase(agent.id, UNKNOWN_UUID)}/attach-token`,
+            { headers: authedHeaders(user.access_token) },
+        );
+        expect(unknown.status()).toBe(404);
+
+        const malformed = await request.post(
+            `${API_BASE}${terminalBase(agent.id, 'not-a-uuid')}/attach-token`,
+            { headers: authedHeaders(user.access_token) },
+        );
+        expect(malformed.status()).toBe(400);
+        expect(String((await malformed.json()).message)).toContain('uuid is expected');
+    });
+});
+
+test.describe('terminal start', () => {
+    test('never reports "started" for a run that is not live — 409 or 503, never 2xx', async ({
+        request,
+    }) => {
+        const user = await registerUserViaAPI(request);
+        const { agentId, runId } = await seedRun(request, user);
+        test.skip(!runId, 'no AgentRun row was produced by this environment');
+
+        const res = await request.post(
+            `${API_BASE}${terminalBase(agentId, runId as string)}/start`,
+            { headers: authedHeaders(user.access_token) },
+        );
+        // 409 = run finished / session already live. 503 = no job runtime
+        // wired on this install. Both are correct refusals; a 202 here
+        // would mean the launcher dispatched a shell onto a dead run.
+        expect([409, 503], `start returned ${res.status()}`).toContain(res.status());
+        expect(res.status(), 'a dead run must never report "started"').not.toBe(202);
+    });
+
+    test('start authz: stranger 404, unknown run 404, malformed 400, anon 401', async ({
+        request,
+    }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const agent = await createAgentViaAPI(request, owner.access_token, {
+            name: `terminal-agent-${uniq()}`,
+        });
+
+        const unknown = await request.post(
+            `${API_BASE}${terminalBase(agent.id, UNKNOWN_UUID)}/start`,
+            { headers: authedHeaders(owner.access_token) },
+        );
+        expect(unknown.status()).toBe(404);
+
+        const cross = await request.post(
+            `${API_BASE}${terminalBase(agent.id, UNKNOWN_UUID)}/start`,
+            {
+                headers: authedHeaders(stranger.access_token),
+            },
+        );
+        expect(cross.status()).toBe(404);
+
+        const malformed = await request.post(
+            `${API_BASE}${terminalBase(agent.id, 'not-a-uuid')}/start`,
+            { headers: authedHeaders(owner.access_token) },
+        );
+        expect(malformed.status()).toBe(400);
+
+        const anon = await request.post(`${API_BASE}${terminalBase(agent.id, UNKNOWN_UUID)}/start`);
+        expect(anon.status()).toBe(401);
+    });
+});
+
+test.describe('terminal status', () => {
+    test('returns the merged relay + persisted view, and never leaks the resume id', async ({
+        request,
+    }) => {
+        const user = await registerUserViaAPI(request);
+        const { agentId, runId } = await seedRun(request, user);
+        test.skip(!runId, 'no AgentRun row was produced by this environment');
+
+        const res = await request.get(`${API_BASE}${terminalBase(agentId, runId as string)}`, {
+            headers: authedHeaders(user.access_token),
+        });
+        expect(res.status(), `status body=${await res.text().catch(() => '')}`).toBe(200);
+        const body = await res.json();
+
+        // Persisted half is always present (it survives replica restarts).
+        expect(body.run).toBeTruthy();
+        expect(typeof body.run.persistent).toBe('boolean');
+        expect(body.run).toHaveProperty('terminalState');
+        expect(body.run).toHaveProperty('terminalEndedReason');
+        expect(body.run).toHaveProperty('lastFrameSeq');
+        // PRESENCE only — the pipeline resume id must stay server-side.
+        expect(typeof body.run.hasCliSession).toBe('boolean');
+        expect(body.run).not.toHaveProperty('cliSessionId');
+        expect(JSON.stringify(body)).not.toContain('cliSessionId');
+    });
+
+    test('status authz: stranger 404, malformed run uuid 400, anon 401', async ({ request }) => {
+        const owner = await registerUserViaAPI(request);
+        const stranger = await registerUserViaAPI(request);
+        const agent = await createAgentViaAPI(request, owner.access_token, {
+            name: `terminal-agent-${uniq()}`,
+        });
+
+        const cross = await request.get(`${API_BASE}${terminalBase(agent.id, UNKNOWN_UUID)}`, {
+            headers: authedHeaders(stranger.access_token),
+        });
+        expect(cross.status()).toBe(404);
+
+        const malformed = await request.get(`${API_BASE}${terminalBase(agent.id, 'not-a-uuid')}`, {
+            headers: authedHeaders(owner.access_token),
+        });
+        expect(malformed.status()).toBe(400);
+
+        const anon = await request.get(`${API_BASE}${terminalBase(agent.id, UNKNOWN_UUID)}`);
+        expect(anon.status()).toBe(401);
+    });
+});

--- a/docs/features/credits-and-billing.md
+++ b/docs/features/credits-and-billing.md
@@ -1,0 +1,76 @@
+---
+id: credits-and-billing
+title: Credits & Billing
+sidebar_label: Credits & Billing
+---
+
+# Credits & Billing
+
+**Credits** are the platform's unit of consumption. Agent runs, pipelines and AI calls debit them; grants, plan inclusions and (once payments are wired) purchases add them. Two settings pages read this data: **Billing** for the plan, the balance and the ledger, and **Usage & Credits** for where the money went.
+
+Credits are complementary to [Budgets](./budgets-and-usage.md), not a replacement: budgets cap _spend at a scope before a call runs_; credits are the account-level balance the platform meters against.
+
+## The ledger is the source of truth
+
+There is no separate balance column. Your balance is the **sum of your ledger movements**, so the number and its explanation can never disagree.
+
+| Entry kind    | Sign | What it is                                                   |
+| ------------- | ---- | ------------------------------------------------------------ |
+| `purchase`    | +    | A top-up or auto-recharge confirmed by the billing provider. |
+| `grant`       | +    | Plan-included, promotional or admin grant.                   |
+| `daily-free`  | +    | The small daily allowance granted by a scheduled job.        |
+| `consumption` | −    | Metered usage, rolled up per run / Task.                     |
+| `adjustment`  | ±    | Platform correction.                                         |
+| `expiry`      | −    | Expiring promotional or daily grants, where configured.      |
+
+```
+GET /api/credits/balance                    → { balanceCredits }
+GET /api/credits/ledger?period=YYYY-MM&kinds=purchase,consumption&page=&pageSize=
+GET /api/credits/usage-summary[?groupBy=day|model|agent|work][&period=YYYY-MM|7d|30d]
+```
+
+All three are read-only and owner-scoped. Credits are **never written over public HTTP** — purchases arrive through the billing-provider webhook and consumption through the metering debit hook.
+
+## The Billing page
+
+**Settings → Billing** shows:
+
+- your **current plan** and a credits-forward plan switcher,
+- your **credits balance**,
+- **invoice history**,
+- the **credits ledger**, filterable by entry kind and paged.
+
+The purchase, payment-method and auto-recharge surfaces are flag-gated behind `PAYMENTS_ENABLED` (default off) until a payment provider is wired in; with the flag off, the page shows a "coming soon" card in their place. Preset top-up amounts are $10 / $25 / $100 at 100 credits per dollar.
+
+## The Usage & Credits page
+
+**Settings → Usage** shows the period totals and four spend breakdowns:
+
+| Tile            | Meaning                                            |
+| --------------- | -------------------------------------------------- |
+| Balance         | Live balance (not window-bound).                   |
+| Consumed        | Credits debited inside the window.                 |
+| Added           | Purchases + grants + daily-free inside the window. |
+| Spend           | Metered provider spend in cents for the window.    |
+| Tasks completed | Count for the window.                              |
+| Works active    | Count for the window.                              |
+| Agent runs      | Count for the window.                              |
+
+Charts break the same window down **per day** (with a 7d / 30d toggle), **per model**, **per agent** and **per Work**. `period` accepts a calendar month (`YYYY-MM`, default the current month) or a rolling `7d` / `30d`.
+
+## Plan entitlements
+
+Plans carry additive entitlement keys. A missing row always means "use the platform default", never an error:
+
+| Key                   | Effect                                                  |
+| --------------------- | ------------------------------------------------------- |
+| `daily-free-credits`  | Size of the daily free grant.                           |
+| `max-concurrent-runs` | Concurrency ceiling consulted by the run dispatch gate. |
+| `works-limit`         | How many Works the plan allows.                         |
+| `credit-limited`      | Whether the plan's runs are billed against the balance. |
+
+Credit enforcement is deliberately conservative: only a `credit-limited` plan with a balance at or below zero parks new runs, and only when `CREDITS_ENFORCEMENT=on`. Today no plan seeds that row, so enforcement stays dark and a zero balance never blocks work unexpectedly.
+
+## Related
+
+- [Budgets & Usage](./budgets-and-usage.md) · [Sessions & Steering](./sessions-and-steering.md)

--- a/docs/features/fleet.md
+++ b/docs/features/fleet.md
@@ -1,0 +1,77 @@
+---
+id: fleet
+title: Fleet (your own machines)
+sidebar_label: Fleet
+---
+
+# Fleet
+
+**Fleet** is the registry of machines that belong to you — the [Desktop App](./desktop-app.md) on your laptop, a headless node on a box you own, or the nodes of a Kubernetes cluster you configured. It is how the platform knows what compute you have, without you opening a port.
+
+## Two kinds of node
+
+| Kind           | How it appears                                                           | `persisted` |
+| -------------- | ------------------------------------------------------------------------ | ----------- |
+| `desktop-node` | The Desktop App, enrolled with a one-time token.                         | `true`      |
+| `node`         | A headless node app, enrolled the same way.                              | `true`      |
+| Cluster nodes  | Nodes of _your own_ configured cluster, merged in live and never stored. | `false`     |
+
+Cluster nodes are read live from the cluster you configured; the platform's own managed cluster is excluded by a sentinel so you never see infrastructure that is not yours.
+
+Enrolled nodes go **offline** after five minutes without a heartbeat.
+
+## Enrolling a node
+
+Enrollment is outbound-only: the node calls the platform, never the other way round. Nothing needs to be reachable from the internet.
+
+1. **Mint a token** — **Settings → Fleet → Add node**, or
+
+    ```
+    POST /api/fleet/nodes/enrollment-token   { "name": "Mac mini", "kind": "node" }
+    → { node, token, expiresInSec }
+    ```
+
+    The token is shown **exactly once** and only its SHA-256 is stored. It is single-use and expires in 15 minutes.
+
+2. **Hand it to the node** — the node app calls the public route with the token as its credential:
+
+    ```
+    POST /api/fleet/enroll   { "token": "…", "platform": "linux/x64",
+                               "version": "1.0.0", "capabilities": ["terminal","workspace"] }
+    → { nodeId, secret, node }
+    ```
+
+    The heartbeat `secret` is likewise returned exactly once and stored only as a hash.
+
+3. **The node reports in** — periodically:
+
+    ```
+    POST /api/fleet/heartbeat   { "nodeId": "…", "secret": "…", "capabilities": [...] }
+    → { ok: true, node }
+    ```
+
+    Last-seen is **server-stamped**; a node never supplies its own clock.
+
+Every invalid credential path — unknown token, expired token, already-consumed token, unknown node, wrong secret — answers one undifferentiated `401`. The response never says which check failed.
+
+## Managing nodes
+
+```
+GET    /api/fleet/nodes        list mine (enrolled + live own-cluster)
+PATCH  /api/fleet/nodes/:id    { name?, disabled? }
+DELETE /api/fleet/nodes/:id    remove the registration
+```
+
+**Disabling drains.** A disabled node's heartbeats stop being accepted, so it goes quiet immediately rather than at the next sweep. Re-enabling puts it back to `offline` until its next accepted heartbeat proves it alive. Disabling a node that is still `enrolling` revokes its unused token.
+
+Everything here is owner-scoped: another account's node id is indistinguishable from one that does not exist.
+
+## Capabilities
+
+A node advertises capability tags (up to 16) such as `terminal`, `workspace` or `docker`. These describe what the node can host.
+
+> **Status.** Enrollment, heartbeats, the registry and the Fleet settings page are shipped. Scheduling Tasks _onto_ an enrolled node needs the node worker host, which is on the roadmap — until it lands, Fleet is an accurate inventory of your machines rather than a scheduling target.
+
+## Related
+
+- [Desktop App](./desktop-app.md) · [Workers](./workers.md) · [Kubernetes Deployment](./k8s-deployment.md)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -35,12 +35,20 @@ This section covers the individual capabilities that make that possible, beyond 
 | [Store Builder](./store-builder)         | _(Coming soon)_ eCommerce storefronts an AI team researches, stocks, writes, and optimizes                       |
 | [Company Builder](./company-builder)     | _(Coming soon)_ Register and run a whole company, staffed by AI Agents, on top of the platform                   |
 | [Desktop App](./desktop-app)             | _(Coming soon)_ Run the full stack locally as a single application                                               |
+| [Fleet](./fleet)                         | The registry of machines that are yours — enroll a node, watch it heartbeat, drain it when you want it quiet     |
 
 ## Operating a Work
 
 | Feature                                              | Description                                                                                                  |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| [Task Isolation](./task-isolation)                   | A branch and a private checkout per Task, so parallel Agents never overwrite each other                      |
+| [Quality Gates](./quality-gates)                     | Acceptance checks that decide whether an Agent's work is done — red sends it back instead of to you          |
+| [Merge Policy](./merge-policy)                       | Whether an Agent may land its own pull request, configurable per tenant / org / Work / Agent                 |
+| [Sessions & Steering](./sessions-and-steering)       | Watch every agent run, and talk to one that is already in flight — steer, interrupt, resume                  |
+| [Decisions & Review](./memory-decisions)             | First-class decision documents plus a review queue that keeps agent-authored memory out of context           |
 | [Budgets & Usage](./budgets-and-usage)               | Per-Mission / per-Idea / per-Work / per-Agent / account-wide caps that gate AI spend before the bill arrives |
+| [Credits & Billing](./credits-and-billing)           | The credits ledger, the balance it sums to, and the plan / usage surfaces that read it                       |
+| [Integrations](./integrations)                       | Slack, GitHub PR review, native connectors and Meetings — outside activity as one normalized event stream    |
 | [Scheduled Updates](./scheduled-updates)             | Re-run the AI generation pipeline on a recurring cadence to keep content fresh                               |
 | [Generation Cancellation](./generation-cancellation) | Cancel an in-flight generation and roll back to a clean state from the dashboard or API                      |
 | [Community PR Processing](./community-pr-processing) | Automatically process community-submitted GitHub PRs to extract work items using AI                          |

--- a/docs/features/integrations.md
+++ b/docs/features/integrations.md
@@ -1,0 +1,90 @@
+---
+id: integrations
+title: Integrations (Slack, GitHub, connectors, meetings)
+sidebar_label: Integrations
+---
+
+# Integrations
+
+Your AI team should see the same things your human team sees. Integrations bring outside activity — chat, pull requests, issues, docs, recordings — into the platform as a normalized stream, and let Agents act back through the same channels.
+
+## The event spine
+
+Every integration produces the same shape: an **event envelope**.
+
+| Field           | Notes                                                                        |
+| --------------- | ---------------------------------------------------------------------------- |
+| `id`            | Connector-assigned envelope id.                                              |
+| `source`        | Producing plugin id, e.g. `slack-connector`.                                 |
+| `sourceEventId` | Stable id in the source system. `(source, sourceEventId)` is the dedupe key. |
+| `kind`          | Source-namespaced event kind, e.g. `slack.message`.                          |
+| `occurredAt`    | ISO 8601, when it happened at the source.                                    |
+| `actor`         | `{ name, externalId? }`                                                      |
+| `subject`       | `{ type, externalId, title? }`                                               |
+| `sourceUrl`     | Deep link back to the original message / PR / page / recording.              |
+| `payload`       | Source-specific detail (≤ 32 KB serialized).                                 |
+
+Events arrive two ways:
+
+- **Pull** — the `event-ingest-tick` cron drives every enabled `event-source` plugin with a resumable per-(plugin, user) cursor and a page budget.
+- **Push** — `POST /api/ingest/events` accepts up to 100 envelopes per call.
+
+Ingest is a **dedupe-insert**, so retries are free: the response reports `{ inserted, duplicates, rejected }`. Events land owner-scoped, and dedupe is per owner — the same source event may legitimately land for two different accounts.
+
+Ingested events fan out to your Activity feed and, where relevant, to memory.
+
+## Slack
+
+The **slack-connector** plugin is bidirectional:
+
+- **Outbound** — Agents post messages to channels.
+- **Inbound** — the Slack Events API points at `POST /api/ingest/slack/events`.
+
+Mention `@works` in a channel and the message is routed to the same platform chat the web app uses; the reply is posted back into the thread.
+
+Security: every delivery is verified with the app's signing secret (HMAC v0 over `v0:{timestamp}:{rawBody}`, ±300s timestamp tolerance, constant-time compare) and the endpoint **fails closed** — with no configured install, everything is rejected, including Slack's own `url_verification` handshake.
+
+## GitHub pull-request review
+
+Point a repository webhook at `POST /api/ingest/github/events` and Agents review your pull requests.
+
+On `pull_request` opened/synchronize — and on `@ever-works` mentions in PR comments — the reviewer matches the repository to a Work (across all three repo roles), builds a byte-capped diff, adds Knowledge-Base context and memory recall, makes one structured AI call, and posts the review. The review is keyed on the head SHA, so each pushed revision is reviewed exactly once and bot comments are never re-ingested.
+
+Deliveries are verified with the configured webhook secret (HMAC SHA-256 over the raw body, constant-time compare) and the endpoint fails closed the same way. A missing `x-github-event` header is rejected outright.
+
+> This per-repository receiver is distinct from the platform **GitHub App** webhook (`/api/github-app/webhooks`), which handles installation and push sync.
+
+## Native connectors
+
+| Connector   | Direction          | Brings in                                 |
+| ----------- | ------------------ | ----------------------------------------- |
+| **Slack**   | inbound + outbound | Channel messages, mentions; posts replies |
+| **Discord** | inbound + outbound | Channel messages; posts replies           |
+| **Linear**  | inbound + outbound | Issue activity; posts comments            |
+| **Notion**  | inbound + outbound | Page activity; appends comments           |
+| **Zoom**    | inbound            | Completed cloud recordings → Meetings     |
+
+Enable them like any other [plugin](../plugin-system/index.md), under **Settings → Integrations**.
+
+## Meetings
+
+A **Meeting** is a first-class record: title, start/end, source, participants, a deep link, and optionally a transcript.
+
+| Endpoint                            | What it does                                                 |
+| ----------------------------------- | ------------------------------------------------------------ |
+| `GET /api/meetings`                 | Your meetings, newest first. Filter by `workId` or `source`. |
+| `POST /api/meetings`                | Create one manually or by import.                            |
+| `GET /api/meetings/:id`             | One meeting, including the transcript body.                  |
+| `PATCH /api/meetings/:id`           | Partial update.                                              |
+| `DELETE /api/meetings/:id`          | Remove it.                                                   |
+| `POST /api/meetings/:id/transcript` | Attach a transcript (size-capped at 200,000 characters).     |
+
+Sources are `zoom`, `google-meet`, `manual` and `import`. Zoom recordings arrive through the ingest spine rather than this API.
+
+Attaching a transcript stores it and then runs a **best-effort** fan-out: an AI summary, a memory observation, and a `meeting.transcript` envelope that lands on your Activity feed with the recording link. Only the transcript write can fail the call — every enrichment degrades gracefully, so a missing AI key costs you the summary, not the transcript.
+
+List rows omit the transcript body; the detail endpoint includes it.
+
+## Related
+
+- [Plugin System](../plugin-system/index.md) · [Knowledge Base & Memory](./knowledge-base.md) · [Agents](./agents.md)

--- a/docs/features/memory-decisions.md
+++ b/docs/features/memory-decisions.md
@@ -1,0 +1,59 @@
+---
+id: memory-decisions
+title: Decisions & the Memory Review Queue
+sidebar_label: Decisions & Review
+---
+
+# Decisions & the Memory Review Queue
+
+Your [Knowledge Base](./knowledge-base.md) is what every Agent run reads before it acts. Two features keep it trustworthy as Agents start writing to it themselves: a first-class **decision** document class, and a **review state** that keeps agent-authored material out of Agent context until a human has looked at it.
+
+## Decisions
+
+A KB document with `class: decision` records a choice — what was decided, why, and whether it still holds. Decisions carry their own lifecycle, separate from the document's publish status:
+
+```
+proposed  →  accepted  →  superseded  →  archived
+```
+
+`archived` is reachable from any non-terminal state. Illegal moves are rejected with `409`.
+
+```
+POST /api/works/:id/kb/documents/:docId/decision-status
+     { "status": "superseded", "supersededByDocId": "…", "rationale": "…" }
+```
+
+Transitioning to `superseded` with a `supersededByDocId` records the replacement chain on **both** documents, so a reader always lands on the decision that is currently in force rather than a stale one. When a superseded decision is later archived, its survivor is promoted so the chain never dead-ends.
+
+Retrieval is decision-aware: accepted decisions rank ahead of general notes for the same query, and they render with their status so an Agent (and you) can see at a glance whether a rule is current.
+
+## Review state
+
+Anything an Agent writes or synthesizes lands as `reviewState: proposed`. Proposed documents are **excluded from context injection** at all three retrieval paths — an Agent cannot bootstrap its own claims into its own future context.
+
+Absent or `null` review state is treated as `accepted`, so everything written before this feature (and everything a human writes) keeps feeding context exactly as before.
+
+### Acting on a proposal
+
+| Action           | Endpoint                                          | Effect                                                                                                                                                        |
+| ---------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Accept           | `POST /api/works/:id/kb/documents/:docId/accept`  | Flips `reviewState` to `accepted` so the document starts feeding context. A decision still in `proposed` is accepted as current in the same call. Idempotent. |
+| Edit then accept | `PATCH` the document, then Accept                 | Fix the wording first, then admit it.                                                                                                                         |
+| Supersede        | `POST …/decision-status` with `superseded`        | Keeps the history and points readers at the replacement.                                                                                                      |
+| Archive          | `POST /api/works/:id/kb/documents/:docId/archive` | Kept readable, dropped from default listings and from context injection. Never a physical delete. Idempotent.                                                 |
+
+Archive is deliberately not a delete: a decision you reversed is itself part of the record.
+
+## Recall injection
+
+Agent runs and all four self-managed pipelines pull recall from the same helper, so what an Agent "remembers" is consistent no matter which path invoked it. You can turn recall off for a Work:
+
+```
+PATCH /api/works/:id   { "memoryRecallEnabled": false }
+```
+
+With it off, self-managed pipeline runs for that Work skip the fenced memory block in their session preamble. It is on by default.
+
+## Related
+
+- [Knowledge Base & Memory](./knowledge-base.md) · [Agents](./agents.md) · [Autonomous Operation](./autonomous-operation.md)

--- a/docs/features/merge-policy.md
+++ b/docs/features/merge-policy.md
@@ -1,0 +1,85 @@
+---
+id: merge-policy
+title: Merge Policy
+sidebar_label: Merge Policy
+---
+
+# Merge Policy
+
+Whether an Agent may **land** its own pull request is a policy you configure, not something the platform hardcodes. The default is conservative — Agents open pull requests, humans merge them — and you can loosen it, per Work or per Agent, as far as you are comfortable.
+
+Note the distinction: _opening_ a pull request is an Agent permission (`canOpenPullRequests`). _Merging_ one is this policy.
+
+## The five knobs
+
+| Field                  | Platform default                      | Meaning                                                                 |
+| ---------------------- | ------------------------------------- | ----------------------------------------------------------------------- |
+| `allowAgentMerge`      | `false`                               | May an Agent land a pull request at all?                                |
+| `requireGreenGate`     | `true`                                | The run's [quality gate](./quality-gates.md) must be green first.       |
+| `requireHumanApproval` | `true`                                | A recorded human approval must exist first.                             |
+| `allowedMergeMethods`  | `['squash']`                          | Strategies an Agent may use. An **empty list refuses every merge**.     |
+| `protectedBranches`    | `['main','master','develop','stage']` | Branches an Agent may never merge **into**. Matched case-insensitively. |
+
+## Four scopes, resolved field by field
+
+A policy can be stored at four scopes. Least specific first:
+
+```
+platform default  <  tenant  <  organization  <  Work  <  Agent
+```
+
+Resolution is a **deep merge, not a replace**: the most specific scope that declares a field wins _for that field_. A Work that sets only `allowAgentMerge: true` still inherits `requireGreenGate`, `requireHumanApproval`, `allowedMergeMethods` and `protectedBranches` from the organization, then the tenant, then the platform default. An omitted or `null` key means "inherit" — never "false".
+
+### Writing a policy
+
+Each scope accepts an additive optional `mergePolicy` object on its existing update endpoint:
+
+- `PATCH /api/works/:id` — the Work scope
+- `PATCH /api/agents/:id` — the Agent scope (most specific)
+- `PATCH /api/organizations/:id` — the organization scope
+
+Pass `null` to clear a scope's override entirely and inherit everything. The tenant scope is resolvable and storable but has no HTTP write surface today — an operator-level ceiling there is set out of band.
+
+### Previewing a policy
+
+```
+GET /api/merge-policy/resolve?workId=…&agentId=…
+```
+
+returns the complete effective `policy`, the `source` (the most specific scope that contributed anything, or `default`), and the full `chain` — least to most specific, starting at the platform default, with the fields each link actually contributed.
+
+The chain matters: _"Agents may not merge here"_ is only actionable if the answer also says **where** that came from and which knob to change.
+
+## Refusals
+
+When a merge is refused, the decision carries a stable machine-readable code alongside the human explanation:
+
+| Code                       | Meaning                                                                       |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `agent-merge-disabled`     | `allowAgentMerge` is false at the winning scope.                              |
+| `protected-branch`         | The pull request's base branch is protected.                                  |
+| `target-branch-unknown`    | Branches are protected but the target could not be determined — fails closed. |
+| `merge-method-not-allowed` | The requested strategy is not in `allowedMergeMethods`.                       |
+| `gate-not-green`           | `requireGreenGate` is on and the gate is not green.                           |
+| `human-approval-required`  | `requireHumanApproval` is on and no approval is on record.                    |
+
+Every path that could land a pull request on an Agent's behalf routes through one decision point, so the answer is the same wherever it is asked.
+
+## A worked example
+
+You want Agents to land their own work on a Work, but only when the tests pass and never onto `main`:
+
+```json
+{
+	"mergePolicy": {
+		"allowAgentMerge": true,
+		"requireHumanApproval": false
+	}
+}
+```
+
+`requireGreenGate` and `protectedBranches` are left out, so they keep the platform defaults — green gate required, `main` still protected.
+
+## Related
+
+- [Quality Gates](./quality-gates.md) · [Task Isolation](./task-isolation.md) · [Agents](./agents.md)

--- a/docs/features/quality-gates.md
+++ b/docs/features/quality-gates.md
@@ -1,0 +1,76 @@
+---
+id: quality-gates
+title: Quality Gates (acceptance checks)
+sidebar_label: Quality Gates
+---
+
+# Quality Gates
+
+A **quality gate** is the set of commands that decide whether an Agent's work on a [Task](../api/tasks.md) is actually done. Each command runs after the Agent finishes; exit code `0` is green, anything else is red. Red work goes back to the Agent instead of to you.
+
+Without gates, "the Agent said it was finished" is the only signal you get. With them, "the build passes, the tests pass and the types check" is.
+
+## Declaring checks
+
+A check is a small object:
+
+| Field            | Required | Notes                                                                           |
+| ---------------- | -------- | ------------------------------------------------------------------------------- |
+| `id`             | yes      | Slug (`^[a-z0-9][a-z0-9-_]{0,40}$`). Also the merge key against a Work default. |
+| `name`           | yes      | Human label shown in run reports (≤ 120 chars).                                 |
+| `kind`           | yes      | `build` · `test` · `lint` · `typecheck` · `custom` — display grouping only.     |
+| `command`        | yes      | What to run (≤ 2000 chars). Exit `0` = green.                                   |
+| `required`       | yes      | Required checks decide the gate. Non-required ones only report.                 |
+| `cwd`            | no       | Working directory relative to the checkout root.                                |
+| `timeoutSec`     | no       | 1–3600. Exceeding it reports `timeout`, which is distinct from `red`.           |
+| `disabled`       | no       | On a Task entry, suppresses the same-id inherited Work default.                 |
+| `envPassthrough` | no       | Environment variable **names** (never values) this check is allowed to see.     |
+
+Checks run with a **scrubbed environment**. Listing a name in `envPassthrough` is a deliberate grant of that one value; platform-owned configuration (database, auth, job-runtime and plugin credentials) is never granted even if you list it.
+
+## Work defaults and Task overrides
+
+Set `checkDefaults` on the Work (**Work → Settings → Checks**) and every agent-executed Task under it inherits them. A Task's own `acceptanceChecks` are merged over the defaults **by `id`**:
+
+- same `id` → the Task's entry replaces the Work default,
+- same `id` with `disabled: true` → the Work default is suppressed for this Task,
+- new `id` → added on top,
+- `acceptanceChecks: null` → inherit the Work defaults untouched.
+
+Both lists are capped at 20 entries.
+
+## Enforcement policy
+
+`checksPolicy` on the Work decides what a red gate means:
+
+| Policy     | Behaviour                                                             |
+| ---------- | --------------------------------------------------------------------- |
+| `off`      | Checks never run.                                                     |
+| `warn`     | Checks run and report; red does not block the Task.                   |
+| `required` | Red blocks Task completion — the Agent iterates instead of finishing. |
+
+## The red → iterate loop
+
+When a required check is red, the run does not fail; the Agent is handed the failing check's name, exit code and log tail and asked to fix it. That repeats up to a **gate-attempt budget**:
+
+- `maxGateAttempts` on the Work is the default (1–5),
+- `maxGateAttempts` on a Task overrides it; `null` inherits.
+
+When the budget is spent, the Task stops with the gate red and the failure recorded, rather than looping forever. The budget is also consulted against the Task's spend guardrails, so an expensive iterate loop stops when the budget does.
+
+## Reading the result
+
+The Task detail page's **Checks** section shows:
+
+- one row per check, with its verdict (`Passed` / `Failed` / `Timeout` / `Error`) and exit code,
+- an expandable **log tail** per row,
+- a gate chip (`green` / `red` / …) and an "Attempt _n_ of _m_" counter once a run exists,
+- an inline editor for the checks and the attempt budget.
+
+Before a run exists, the section shows the Task's _declared_ checks. Once a run has happened it shows the **dispatch-frozen** set that actually ran — so editing a check later never rewrites the history of what was executed.
+
+## Related
+
+- [Task Isolation](./task-isolation.md) — the branch the checks run against.
+- [Merge Policy](./merge-policy.md) — `requireGreenGate` makes a green gate a precondition for an agent merge.
+- [Budgets & Usage](./budgets-and-usage.md) — the spend guardrails the iterate loop consults.

--- a/docs/features/sessions-and-steering.md
+++ b/docs/features/sessions-and-steering.md
@@ -1,0 +1,85 @@
+---
+id: sessions-and-steering
+title: Sessions & Run Steering
+sidebar_label: Sessions & Steering
+---
+
+# Sessions & Run Steering
+
+Every time an Agent runs — on a schedule, from a Task, from chat, from an inbound event — the platform records a **session** (an agent run). The Sessions view is where you watch them, and **steering** is how you talk to one that is already in flight instead of waiting for it to finish and starting another.
+
+## The Sessions list
+
+```
+GET /api/agents/runs
+```
+
+returns _your_ runs across every Agent and every Work, newest first, with `{ data, meta: { total, limit, offset } }`.
+
+Filters (each one only ever narrows your own set — you cannot widen it to somebody else's runs):
+
+| Filter    | Values                                                      |
+| --------- | ----------------------------------------------------------- |
+| `status`  | `queued` · `running` · `completed` · `failed` · `cancelled` |
+| `kind`    | `heartbeat` · `manual` · `task` · `chat` · `event`          |
+| `workId`  | uuid                                                        |
+| `agentId` | uuid                                                        |
+| `taskId`  | uuid                                                        |
+| `limit`   | 1–200 (default 50)                                          |
+| `offset`  | ≥ 0                                                         |
+
+Each row carries what the run cost and changed — duration, tokens, changed files, spend — plus its gate status and attempt count, whether it is `awaitingInput`, and why it is queued if it is.
+
+A Work's header polls a cheaper summary of the same data:
+
+```
+GET /api/works/:id/runs-summary
+→ { running, queued, awaiting, failedLast24h }
+```
+
+## Steering a live run
+
+```
+POST /api/agents/:id/runs/:runId/steer   { "message": "…" }
+```
+
+The message is appended to the run's pending-input queue and drained **between tool round-trips**, so the Agent picks it up at the next clean boundary rather than mid-call.
+
+The response tells you which of two things happened:
+
+| `dispatched` | Meaning                                                                            |
+| ------------ | ---------------------------------------------------------------------------------- |
+| `injected`   | The run is live; your message is queued into it. `queuedCount` is the queue depth. |
+| `new-run`    | The run already finished while you were typing — start a fresh run instead.        |
+
+`new-run` is deliberately **not** an error: "the run ended while a human was typing" is a normal race with a defined next step.
+
+In Task chat, posting a message while a run is live steers that run rather than dispatching a second one.
+
+## Interrupting
+
+```
+POST /api/agents/:id/runs/:runId/interrupt
+```
+
+asks for a **cooperative stop**. The tool loop honours it at its next per-iteration checkpoint, so the run halts _between_ iterations and completes with a summary instead of being killed mid-call. If the run is already terminal you get a `409` — unlike steering, there is no meaningful fallback.
+
+To kill a run outright, use the existing `POST /api/agents/:id/runs/:runId/cancel`.
+
+## Resuming a parked run
+
+A run that asked you a question sets `awaitingInput` and parks. It is **never reaped** by the idle sweeper while it is waiting — that guarantee is enforced both in the sweeper and in SQL.
+
+```
+POST /api/agents/:id/runs/:runId/resume   { "message": "…" }   (message optional)
+```
+
+dispatches a **new** run that carries the original's pipeline session id, so the Agent keeps its conversation and its context rather than starting cold. Runs are immutable: the source row stays terminal and the answer is recorded as a new run linked back to it. `409` when the run is not resumable (still live, or ended for a non-parkable reason).
+
+## Ownership
+
+All four surfaces are owner-scoped twice over — the Agent lookup and the run lookup are both user-filtered — so somebody else's run id is indistinguishable from one that does not exist (`404`, never `403`).
+
+## Related
+
+- [Agents](./agents.md) · [Autonomous Operation](./autonomous-operation.md) · [Quality Gates](./quality-gates.md)

--- a/docs/features/task-isolation.md
+++ b/docs/features/task-isolation.md
@@ -1,0 +1,73 @@
+---
+id: task-isolation
+title: Task Isolation (worktree per Task)
+sidebar_label: Task Isolation
+---
+
+# Task Isolation
+
+When an Agent works on a [Task](../api/tasks.md), it changes files in your Work's repository. **Task isolation** gives every Task its own branch and its own checkout, so two Agents working at the same time never overwrite each other, and nothing lands on your main branch until you say so.
+
+Turn it on and each agent-executed Task gets:
+
+- a dedicated **branch** (`task/<slug>`) cut from a base branch you choose,
+- a **private working copy** of the repository — the Agent's edits are invisible to every other Task until the branch is pushed,
+- a **pull request** when the Task finishes, instead of a direct commit,
+- an explicit **conflict** state when the branch can no longer merge cleanly.
+
+## Turning it on
+
+Isolation is a Work setting under **Work → Settings → Tasks & Branches**.
+
+| Setting                   | Values                              | What it does                                                                      |
+| ------------------------- | ----------------------------------- | --------------------------------------------------------------------------------- |
+| `taskIsolation`           | `off` (default) · `worktree`        | Whether agent-executed Tasks under this Work get their own branch + checkout.     |
+| `taskIsolationBaseBranch` | branch name                         | What each Task branch is cut from. Defaults to the repository's default branch.   |
+| `taskIsolationTargetRepo` | `work-output` · `data` · `provider` | Which of the Work's repositories the branch is created in.                        |
+| `taskBranchCleanup`       | `on-merge` (default) · `manual`     | Whether the nightly sweep deletes branches of finished Tasks, or you delete them. |
+
+The same fields are writable over the API with `PATCH /api/works/:id`.
+
+## Per-Task override
+
+A single Task can opt in or out regardless of the Work setting. On the Task detail page, the **Branch** panel shows an isolation selector while the Task has no branch yet:
+
+| Selection            | Stored `isolationMode` | Effect                                              |
+| -------------------- | ---------------------- | --------------------------------------------------- |
+| Inherit from Work    | `null`                 | Follows the Work's `taskIsolation` setting.         |
+| On — isolated branch | `on`                   | This Task always gets its own branch.               |
+| Off — work directly  | `off`                  | This Task writes straight to the Work repositories. |
+
+Over the API the same field is `isolationMode` on `POST /api/tasks` and `PATCH /api/tasks/:id`.
+
+## The Branch panel
+
+Once a Task has a branch, the panel replaces the selector with the branch cockpit:
+
+- the **branch name** with a copy button, and the short **base SHA** it was cut from,
+- a **state** pill — `created` → `pushed` → `pr-open` → `merged`, plus `conflict`, `discarded` and `cleaned`,
+- a link to the **pull request** when one is open,
+- **Discard branch**, which deletes the remote branch and resets the Task's workspace identity so the next run starts clean. This is irreversible and asks for confirmation.
+
+The same branch state appears as a chip on the Task's card on the [board](../api/tasks.md).
+
+## When a branch conflicts
+
+If the base branch moves on and the Task branch can no longer merge, the branch state becomes `conflict` and the panel shows a banner listing the exact conflicting paths.
+
+**Resolve conflicts** re-runs the Task's Agent against the conflicted branch — the Agent sees the named paths and resolves them, and the Task moves back to _In progress_. If you would rather start over, **Discard branch** throws the branch away and the next run cuts a fresh one.
+
+| Action            | API                                     | Result                                                                                         |
+| ----------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Resolve conflicts | `POST /api/tasks/:id/resolve-conflicts` | 200 — branch back to `pushed`, Task back to `in_progress`. 409 if the Task is not in conflict. |
+| Discard branch    | `POST /api/tasks/:id/discard-branch`    | 200 — branch deleted, workspace identity reset. Idempotent.                                    |
+
+## Cleanup
+
+With `taskBranchCleanup: on-merge`, a nightly sweep deletes the remote branches of Tasks that reached a terminal state (done or cancelled), plus any abandoned branch past a hard staleness cutoff. With `manual`, branches are never auto-deleted — use **Discard branch**.
+
+## Related
+
+- [Quality Gates](./quality-gates.md) — the checks a Task branch must pass before it is accepted.
+- [Merge Policy](./merge-policy.md) — whether an Agent may land its own pull request.
+- [Git Operations](./git-operations.md) — how the platform talks to your Git provider.

--- a/packages/agent/src/plugins/repositories/user-plugin.repository.spec.ts
+++ b/packages/agent/src/plugins/repositories/user-plugin.repository.spec.ts
@@ -156,10 +156,15 @@ describe('UserPluginRepository', () => {
     });
 
     describe('findByPlugin', () => {
-        it('queries `find` with pluginId + `user` relation (NOT pluginEntity)', async () => {
-            // The `user` relation here is the inverse — given a pluginId,
-            // load all users who have a record. Pinned so a future swap
-            // to `pluginEntity` (which would be redundant) is deliberate.
+        it('queries `find` by pluginId ONLY — it must never ask for a relation the entity lacks', async () => {
+            // `UserPluginEntity` declares exactly one relation
+            // (`pluginEntity`); the owner is a loosely-coupled `userId`
+            // STRING column, deliberately not a `user` relation. This
+            // query used to pass `relations: ['user']`, which TypeORM
+            // rejects at RUNTIME with `EntityPropertyNotFoundError` —
+            // a failure this very mock used to hide, and which reached
+            // production as a 500 on both public ingest receivers.
+            // Pinned so nobody "restores" the relation.
             const rows = [{ id: 'up-1', userId: 'u-1' }];
             const { repo, typeormRepo } = makeService({
                 find: jest.fn().mockResolvedValue(rows),
@@ -167,10 +172,8 @@ describe('UserPluginRepository', () => {
 
             await repo.findByPlugin('p-1');
 
-            expect(typeormRepo.find).toHaveBeenCalledWith({
-                where: { pluginId: 'p-1' },
-                relations: ['user'],
-            });
+            expect(typeormRepo.find).toHaveBeenCalledWith({ where: { pluginId: 'p-1' } });
+            expect(typeormRepo.find.mock.calls[0][0]).not.toHaveProperty('relations');
         });
     });
 

--- a/packages/agent/src/plugins/repositories/user-plugin.repository.ts
+++ b/packages/agent/src/plugins/repositories/user-plugin.repository.ts
@@ -64,12 +64,25 @@ export class UserPluginRepository {
     }
 
     /**
-     * Find all user records for a specific plugin
+     * Find all user records for a specific plugin.
+     *
+     * NOTE: `UserPluginEntity` deliberately has NO `user` relation — the
+     * owner is a loosely-coupled `userId` string column (see the entity's
+     * own comment), and the only relation it declares is `pluginEntity`.
+     * This method used to ask TypeORM for `relations: ['user']`, which
+     * throws `EntityPropertyNotFoundError` at QUERY time — invisible to
+     * unit tests (they mock the repository) and to `tsc`. It went
+     * unnoticed while the method had no callers; the 2026-07 program
+     * wired it into three live paths (the Slack + GitHub webhook
+     * receivers, which then 500'd on EVERY delivery instead of failing
+     * closed with a 401, and the `event-source` pull tick, whose
+     * catch-and-continue turned it into a silently dead pull half).
+     * Callers only ever read `userId` / `enabled` / `createdAt`, so the
+     * fix is simply not to ask for a relation that does not exist.
      */
     async findByPlugin(pluginId: string): Promise<UserPluginEntity[]> {
         return this.repository.find({
             where: { pluginId },
-            relations: ['user'],
         });
     }
 


### PR DESCRIPTION
Closes backlog item **13** from `Research/audit/00-STATUS.md` §E — *"E2E + docs sweep for terminal attach, isolation, gates, billing, usage, fleet, credits — plus the `forbidNonWhitelisted` reconciliation"*.

The 2026-07 program shipped ~15 features and **zero** Playwright specs. This adds **117 test cases** across 11 new spec files (+13 rows on the existing `api-public-contract` tripwire), **8 user-facing docs pages** registered in the sidebar, and fixes **one production bug** the new specs uncovered.

---

## 1. The bug the specs found

`UserPluginRepository.findByPlugin` asked TypeORM for `relations: ['user']`, but `UserPluginEntity` deliberately has **no `user` relation** — the owner is a loosely-coupled `userId` string column (the entity says so in its own header comment), and the only relation it declares is `pluginEntity`.

The query therefore throws `EntityPropertyNotFoundError: Property "user" was not found in "UserPluginEntity"` at **query** time. Invisible to `tsc`, and invisible to the unit test — which mocked the repository and *pinned the broken shape*.

It was dead code from the 2023 plugin-system PR until this program wired it into three live paths:

| Caller | Consequence before this PR |
| --- | --- |
| `SlackChatBridgeService.resolveBinding` | `POST /api/ingest/slack/events` answered **500 on every delivery** instead of failing closed with 401 |
| `GitHubPrReviewBridgeService.resolveBinding` | `POST /api/ingest/github/events` — same, so the PR-review loop could never run |
| `EventSourcePullService` | catch-and-continue, so **the entire pull half of the ingest spine was silently dead** (zero sources, every tick) |

The fix is one line (drop the non-existent relation); no caller ever read `row.user`. The unit test now pins the corrected query and asserts no `relations` key at all.

**Verified live** — before the fix:

```
Error: github (unsigned) returned 500
Expected: 401   Received: 500
```

```
ERROR [ExceptionsHandler] EntityPropertyNotFoundError: Property "user" was not found in "UserPluginEntity".
  at SlackChatBridgeService.resolveBinding (dist/ingest/slack/slack-chat-bridge.service.js:45:58)
  at GitHubPrReviewBridgeService.resolveBinding (dist/ingest/github/github-pr-review-bridge.service.js:48:58)
```

after the fix:

```
github-unsigned=401
slack-unsigned=401
```

## 2. Two contract claims corrected (behaviour left alone)

Two controllers' doc comments claim *"cross-user Works 404 with no existence leak"*. They do not: they gate on the shared `WorkOwnershipService.ensureAccess`, whose contract is **404 only for a Work that does not exist** and **403 for one that exists without a membership row**. That is the platform-wide Work-access contract dozens of endpoints share, so the specs assert the truth (403) and explain the discrepancy inline rather than flipping a broad semantic.

Notably `GET /api/merge-policy/resolve` is asymmetric — `workId` gives 403, `agentId` gives 404 — because the two inputs use different gates. Both specs pin that, plus the security property that actually matters: a stranger never receives a resolved policy or another Work's counters.

## 3. What was added

### API-contract specs — auth posture, owner scoping, documented status codes

| File | Tests | Covers |
| --- | ---: | --- |
| `flow-task-isolation-gates-contract.spec.ts` | 11 | `isolationMode` / `acceptanceChecks` (nested DTO, 20-cap, `envPassthrough` names-only) / `maxGateAttempts` (1..5) on create **and** patch; `resolve-conflicts` 409/404/400/401; `discard-branch` idempotency + authz; server-owned branch columns stay non-writable |
| `flow-terminal-attach-contract.spec.ts` | 7 | attach-token mint (or fail-closed 503), `wsPath` never carries the token, start never reports "started" for a dead run, status never leaks `cliSessionId`, full 404/400/401 closure |
| `flow-run-sessions-steering-contract.spec.ts` | 13 | Sessions list envelope + every filter's rejection, repository-level owner clamp (a foreign `agentId` returns an empty page, not a leak), `runs-summary`, steer/interrupt/resume including the `new-run` race arm and the whitespace-409-before-404 ordering |
| `flow-credits-billing-contract.spec.ts` | 9 | balance / ledger (exact projected row key-set, all six kinds, period + page bounds) / usage-summary (every `groupBy`, `YYYY-MM` or `7d` or `30d`), and that **no write verb exists** on the credits surface |
| `flow-meetings-crud-contract.spec.ts` | 11 | full CRUD + transcript, list-vs-detail projection, `dedupeKey` never leaves the API, best-effort fan-out flags, authz closure on every verb |
| `flow-fleet-enrollment-contract.spec.ts` | 9 | the **enrollment protocol end to end** — mint, enroll, heartbeat; token single-use (replay = 401), secret minted once, every invalid credential path one *undifferentiated* 401, and disabling actually drains |
| `flow-merge-policy-resolve-contract.spec.ts` | 7 | platform default, the self-explaining `chain`, field-by-field merge over a Work override, `mergePolicy` write-DTO validation, empty-method-list is not "inherit" |
| `flow-ingest-spine-receivers-contract.spec.ts` | 13 | envelope DTO field by field, batch/payload caps, dedupe (retry = duplicate; dedupe is **per owner**), Slack + GitHub fail-closed including stale timestamps and "a user token is not a substitute for a signature" |
| `flow-agent-templates-digest-contract.spec.ts` | 12 | the two catalogs' *different* auth postures, `from-template` gives a DRAFT owner-scoped agent, unknown slug 404, digest cadence enum never silently defaulted |

### UI journeys — API-seeded, direct navigation, no click-chains

| File | Tests | Covers |
| --- | ---: | --- |
| `flow-task-branch-gate-ui-journey.spec.ts` | 6 | isolation chip arm renders (and the branch panel + conflict banner are *absent* for a branchless Task), checks rows, empty state without a fabricated gate chip, and both editors round-tripping through the server action to the API |
| `flow-billing-usage-ui-journey.spec.ts` | 6 | both pages render without the load-error banner, ledger table-or-empty, the flag-gated purchase surface in exactly one arm, all seven usage tiles, three breakdown charts mounting, 7d/30d refetch |

Both handle the custom `components/ui/select` (a trigger `<button>` plus a portalled `role="listbox"`, not a native `<select>`) and are retry-guarded for the production-build hydration race, per the house rule that CI web is a prod build.

### `api-public-contract` extended in place (not duplicated)

+5 protected GETs, +3 protected writes, +4 self-authenticating public routes (fleet enroll/heartbeat, Slack, GitHub), +1 "the deliberately public catalog stays public".

### Docs — 8 pages, all registered in `apps/docs/sidebarsPlatform.ts`

`task-isolation`, `quality-gates`, `merge-policy`, `sessions-and-steering`, `memory-decisions`, `integrations`, `credits-and-billing`, `fleet` — plus rows in `docs/features/index.md`. Unlisted files become orphan pages, so each one is in the sidebar and cross-linked.

## 4. `forbidNonWhitelisted` reconciliation — **no broken specs found**

Swept `apps/web/e2e` for every field this program made real (`isolationMode`, `acceptanceChecks`, `maxGateAttempts`, `taskIsolation*`, `taskBranchCleanup`, `memoryRecallEnabled`, `checkDefaults`, `checksPolicy`, `mergePolicy`, `digestFrequency`, onboarding `profile.roles` / `teamSize`) and extracted every `property <x> should not exist` assertion in the suite. **Zero** of the 60 asserted field names is a now-real field — the two near-misses (`reviewState`, `disabled`) are on unrelated endpoints (task reviewers, notification channels) where they remain correctly forbidden. Also checked for exact-key-set assertions on Task / Work / Run bodies that new columns could break: none.

No specs needed fixing. The new specs positively assert that the new fields are *accepted*, so a future regression fails loudly instead of silently.

---

## Verification (real output, run locally)

Full local stack: prebuilt API (`node dist/main`, sqlite in-memory, port 3100) plus **prebuilt** web (`next start`, port 3010 — 3000 was occupied by another worktree), matching the CI recipe.

**`cd apps/web && rm -f tsconfig.tsbuildinfo && npx tsc --noEmit`** — e2e specs are inside this config's `**/*.ts` include (confirmed with `--listFilesOnly`: all 11 new spec files listed, 776 e2e files total):

```
WEB_TSC_EXIT=0
```

**Playwright — every new/changed spec, two consecutive green runs:**

```
$ npx playwright test --project=chromium-no-auth api-public-contract
  44 passed (4.2s)

$ npx playwright test --project=chromium \
    flow-task-isolation-gates-contract flow-terminal-attach-contract \
    flow-run-sessions-steering-contract flow-credits-billing-contract \
    flow-meetings-crud-contract flow-fleet-enrollment-contract \
    flow-merge-policy-resolve-contract flow-ingest-spine-receivers-contract \
    flow-agent-templates-digest-contract flow-task-branch-gate-ui-journey \
    flow-billing-usage-ui-journey
  105 passed (2.0m)
  105 passed (3.2m)      # second consecutive run
```

105 = 104 test cases + the `setup` project. 44 = `api-public-contract`, of which 13 are new.

**Agent unit test for the fixed repository:**

```
$ cd packages/agent && npx jest src/plugins/repositories/user-plugin.repository.spec.ts
PASS src/plugins/repositories/user-plugin.repository.spec.ts (60.861 s)
Tests:       33 passed, 33 total
```

**Prettier:** all 24 changed files pass `--check`.

### Ran locally vs not

| | |
| --- | --- |
| **Ran, green twice** | All 11 new spec files (104 cases) and `api-public-contract` (44 cases) — i.e. **every test this PR adds or touches** |
| **Not run** | The rest of the ~6000-test suite (unchanged by this PR); the agent package's other Jest suites; and the intentionally-unreachable arms noted in each spec's header — `branchState = 'conflict'` and a *live* terminal session are only ever written by the worker's finalize path, so the specs pin the refusal arms and the authz closure instead of pretending a worker exists |

CI e2e was **not** dispatched, per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
