### PR TITLE
fix: develop repairs — web build, cross-wave pins, portable dates

### DIFF
--- a/apps/web/src/lib/api/tasks.ts
+++ b/apps/web/src/lib/api/tasks.ts
@@ -277,6 +277,10 @@ export const tasksAPI = {
     /** Agents the board's picker offers for this Task. */
     async listRunCandidates(id: string) {
         return serverFetch<{ data: RunCandidateAgent[] }>(`/tasks/${id}/run-candidates`, {
+            method: 'GET',
+        });
+    },
+
     /**
      * Re-litigation guard (memory upgrades M6) — settled decisions this
      * Task appears to re-open. Deterministic term-overlap check on the

--- a/packages/agent/src/agents/__tests__/agent-tool-domain.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-tool-domain.spec.ts
@@ -229,9 +229,11 @@ describe('AgentToolService — domain chat tool assembly', () => {
         const byName = new Map(tools.map((tool) => [tool.name, tool]));
 
         await byName.get('list_recent_events')!.invoke({ limit: 5 });
+        // #1872 gave findRecentByUser a filter object (workId/source support);
+        // the owner stays the first positional arg — that is what this pins.
         expect((sources.ingest!.repository as any).findRecentByUser).toHaveBeenCalledWith(
             'owner-9',
-            5,
+            { limit: 5 },
         );
 
         await byName.get('list_meetings')!.invoke({});


### PR DESCRIPTION
Three repairs to develop found while integrating the overnight branches.

1. **`apps/web` was unbuildable.** An earlier union merge truncated `tasksAPI.listRunCandidates`, leaving an unterminated call (`TS1005` ×2) — so `tsc --noEmit` and `next build` both failed on develop. Restored. Three separate agents independently reported this; I introduced it, and web tsc now runs after every union-resolved merge.
2. **Cross-wave pin drift**: `ActivityActionType` count and `findRecentByUser`'s filter-object shape.
3. **Nine raw `timestamp` columns** (billing profiles, invoices, fleet jobs, task run window) converted to `PortableDateColumn` — the sqlite boot-guard added by the dispatch-gating work caught them. Postgres normalizes both to the same type, so no migration; only sqlite installs change (they stop crashing).

Verified on the full integration: agent 7,907 tests, API 3,681, web 1,270, web tsc clean, openapi 468 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving available task run candidates.

* **Tests**
  * Updated coverage for owner-scoped recent-source queries to reflect the current filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->