### PR TITLE
fix(agents,entities): dispatch gating everywhere + portable dates

### DIFF
--- a/apps/api/src/agents/agents.controller.runtime.spec.ts
+++ b/apps/api/src/agents/agents.controller.runtime.spec.ts
@@ -939,4 +939,110 @@ describe('AgentsController — runtime endpoints (FU-2)', () => {
             );
         });
     });
+
+    /**
+     * Run orchestration — `assign-task` used to enqueue straight past the
+     * concurrency valve every other dispatch path respects, so an
+     * assign-task loop could put unbounded runs on a Work the board and
+     * fan-out paths would have parked. It now goes through the SAME
+     * `RunDispatchGateService.admit`, with the run row created inside the
+     * admission critical section.
+     */
+    describe('POST /:id/assign-task — dispatch gating', () => {
+        const workId = 'work-1';
+        const gatedController = (gate: unknown) =>
+            new AgentsController(
+                service,
+                files,
+                exportService,
+                dispatcher,
+                agentRuns,
+                agentRunLogs,
+                skillBindings,
+                pluginUsage,
+                tasks,
+                activityLog,
+                heartbeatTrigger,
+                taskExecuteDispatcher,
+                runCanceller,
+                gate as never,
+            );
+
+        beforeEach(() => {
+            tasks.getOne.mockResolvedValue({ id: taskId, workId, organizationId: 'org-1' });
+            agentRuns.createQueued.mockResolvedValue({ id: runId });
+        });
+
+        it('consults the gate with the Task scope', async () => {
+            const gate = { admit: jest.fn().mockResolvedValue({ admitted: true }) };
+            await gatedController(gate).assignTask(auth, agentId, { taskId });
+            expect(gate.admit).toHaveBeenCalledWith(
+                { userId: 'u1', workId, organizationId: 'org-1' },
+                expect.any(Function),
+            );
+        });
+
+        it('denormalizes workId so the run counts toward its Work valve', async () => {
+            const gate = {
+                admit: jest.fn(async (_i: unknown, reserve: (v: unknown) => Promise<void>) => {
+                    await reserve({ admitted: true });
+                    return { admitted: true };
+                }),
+            };
+            await gatedController(gate).assignTask(auth, agentId, { taskId });
+            expect(agentRuns.createQueued).toHaveBeenCalledWith(
+                expect.objectContaining({ workId, queuedReason: null }),
+            );
+        });
+
+        it('PARKS the run and SKIPS the enqueue when over the valve', async () => {
+            const gate = {
+                admit: jest.fn(async (_i: unknown, reserve: (v: unknown) => Promise<void>) => {
+                    await reserve({ admitted: false, queuedReason: 'concurrency-limit' });
+                    return { admitted: false, queuedReason: 'concurrency-limit' };
+                }),
+            };
+            const result = await gatedController(gate).assignTask(auth, agentId, { taskId });
+            expect(result).toEqual({
+                runId,
+                queued: true,
+                queuedReason: 'concurrency-limit',
+            });
+            expect(agentRuns.createQueued).toHaveBeenCalledWith(
+                expect.objectContaining({ queuedReason: 'concurrency-limit' }),
+            );
+            // The row exists and is drainable — it must NOT be enqueued or
+            // rolled to failed.
+            expect(taskExecuteDispatcher.enqueue).not.toHaveBeenCalled();
+            expect(agentRuns.markDispatchFailed).not.toHaveBeenCalled();
+        });
+
+        it('FAILS OPEN — a gate that throws never 500s a legitimate assignment', async () => {
+            const gate = { admit: jest.fn().mockRejectedValue(new Error('gate exploded')) };
+            const result = await gatedController(gate).assignTask(auth, agentId, { taskId });
+            expect(result.runId).toBe(runId);
+            expect(taskExecuteDispatcher.enqueue).toHaveBeenCalledTimes(1);
+        });
+
+        it('creates the run itself when a gate stub ignores the reserve callback', async () => {
+            const gate = { admit: jest.fn().mockResolvedValue({ admitted: true }) };
+            const result = await gatedController(gate).assignTask(auth, agentId, { taskId });
+            expect(result.runId).toBe(runId);
+            expect(agentRuns.createQueued).toHaveBeenCalledTimes(1);
+        });
+
+        it('behaves exactly as before when no gate is bound', async () => {
+            const result = await controller.assignTask(auth, agentId, { taskId });
+            expect(result.runId).toBe(runId);
+            expect(taskExecuteDispatcher.enqueue).toHaveBeenCalledTimes(1);
+        });
+
+        it('still short-circuits on an in-flight run WITHOUT consulting the gate', async () => {
+            agentRuns.findInFlightForTaskAgent.mockResolvedValueOnce({ id: runId });
+            const gate = { admit: jest.fn() };
+            const result = await gatedController(gate).assignTask(auth, agentId, { taskId });
+            expect(result).toEqual({ runId });
+            expect(gate.admit).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/apps/api/src/agents/agents.controller.ts
+++ b/apps/api/src/agents/agents.controller.ts
@@ -1094,7 +1094,7 @@ export class AgentsController {
     @Post(':id/assign-task')
     @ApiOperation({
         summary:
-            'Assign a Task to this Agent — pre-creates an AgentRun for the (taskId, agentId) pair and enqueues `agent-task-execute`.',
+            'Assign a Task to this Agent — pre-creates an AgentRun for the (taskId, agentId) pair and enqueues `agent-task-execute`. Over the concurrency valve the run is created parked (`queued: true`) and promoted by the drain when a slot frees.',
     })
     @HttpCode(HttpStatus.ACCEPTED)
     @Throttle({ long: { limit: 30, ttl: 60_000 } })
@@ -1102,7 +1102,7 @@ export class AgentsController {
         @CurrentUser() auth: AuthenticatedUser,
         @Param('id', ParseUUIDPipe) id: string,
         @Body() body: AssignTaskToAgentDto,
-    ): Promise<{ runId: string }> {
+    ): Promise<{ runId: string; queued?: boolean; queuedReason?: string }> {
         await this.service.getOne(auth.userId, id);
         // Cross-user 404 on the Task too — surfaces via TasksService.
         const task = await this.tasks.getOne(auth.userId, body.taskId);
@@ -1120,12 +1120,69 @@ export class AgentsController {
         if (inflight) {
             return { runId: inflight.id };
         }
-        const run = await this.agentRuns.createQueued({
-            agentId: id,
-            userId: auth.userId,
-            triggerKind: 'task',
-            taskId: body.taskId,
-        });
+        // Run orchestration — this endpoint used to enqueue straight past
+        // the concurrency valve, so an assign-task loop could put
+        // unbounded runs on a Work that the board / fan-out paths would
+        // have parked. It now goes through the SAME gate, with the row
+        // created inside the admission critical section.
+        //
+        // `workId` is denormalized here for the same reason the fan-out
+        // does it: without it this run counts toward nothing, and the
+        // per-Work valve cannot see it.
+        let created: { id: string } | undefined;
+        const reserve = async (verdict: {
+            admitted: boolean;
+            queuedReason?: string;
+        }): Promise<void> => {
+            created = await this.agentRuns.createQueued({
+                agentId: id,
+                userId: auth.userId,
+                triggerKind: 'task',
+                taskId: body.taskId,
+                workId: task.workId ?? null,
+                queuedReason: verdict.admitted ? null : (verdict.queuedReason ?? null),
+            });
+        };
+        let admission: { admitted: boolean; queuedReason?: string } = { admitted: true };
+        if (this.dispatchGate) {
+            try {
+                admission = await this.dispatchGate.admit(
+                    {
+                        userId: auth.userId,
+                        workId: task.workId ?? null,
+                        organizationId: task.organizationId ?? null,
+                    },
+                    reserve,
+                );
+            } catch (gateErr) {
+                // Fail-open — a broken safety valve must never 500 a
+                // legitimate assignment.
+                this.logger.warn(
+                    `Dispatch gate admit failed for task ${body.taskId} — failing open: ${gateErr}`,
+                );
+            }
+            if (!created) await reserve(admission);
+        } else {
+            await reserve(admission);
+        }
+        const run = created!;
+        if (!admission.admitted) {
+            // Parked: the row exists with its `queuedReason`, the enqueue
+            // is SKIPPED, and `RunDispatchGateService.drainForWork`
+            // promotes it on the next terminal transition for this Work.
+            void this.tryLog({
+                userId: auth.userId,
+                agentId: id,
+                actionType: ActivityActionType.AGENT_TASK_ASSIGNED,
+                details: {
+                    runId: run.id,
+                    taskId: body.taskId,
+                    queued: true,
+                    queuedReason: admission.queuedReason,
+                },
+            });
+            return { runId: run.id, queued: true, queuedReason: admission.queuedReason };
+        }
         let handle: { runId: string } | undefined;
         try {
             handle = await this.taskExecuteDispatcher.enqueue({

--- a/packages/agent/src/agents/__tests__/agent-schedule-dispatcher-gating.spec.ts
+++ b/packages/agent/src/agents/__tests__/agent-schedule-dispatcher-gating.spec.ts
@@ -1,0 +1,185 @@
+import { AgentScheduleDispatcherService } from '../agent-schedule-dispatcher.service';
+import { AgentStatus } from '../../entities/agent.entity';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Run orchestration — the heartbeat cron and "Run now" are dispatch
+ * paths too, and they used to walk straight past the concurrency valve
+ * that every Task-keyed path respects.
+ *
+ * They DEFER rather than park. `RunDispatchGateService.drainForWork`
+ * promotes concurrency-parked rows through the Task-keyed dispatchers,
+ * and a heartbeat run has no Task — a parked one would sit `queued`
+ * forever with nothing able to drain it (the drain says exactly that:
+ * "parked run has no taskId — cannot drain"). Deferring is self-healing
+ * instead: the cron re-offers the Agent next tick, and run-now returns a
+ * `skipped` reason the caller can retry on.
+ */
+describe('AgentScheduleDispatcherService — heartbeat dispatch is gated', () => {
+    const ENV_KEYS = ['AGENTS_DISPATCHER_ENABLED'] as const;
+    const savedEnv: Record<string, string | undefined> = {};
+
+    let agentRepository: any;
+    let agentRunRepository: any;
+    let trigger: any;
+
+    const agent = (over: Record<string, unknown> = {}) => ({
+        id: 'agent-1',
+        userId: 'user-1',
+        organizationId: 'org-1',
+        scope: 'global',
+        status: AgentStatus.ACTIVE,
+        heartbeatCadence: 'manual',
+        nextHeartbeatAt: new Date('2026-01-01'),
+        ...over,
+    });
+
+    beforeEach(() => {
+        for (const key of ENV_KEYS) {
+            savedEnv[key] = process.env[key];
+            delete process.env[key];
+        }
+        agentRepository = {
+            findDueForHeartbeat: jest.fn().mockResolvedValue([agent()]),
+            findStuckRunning: jest.fn().mockResolvedValue([]),
+            findById: jest.fn().mockResolvedValue(agent()),
+            tryClaimForRun: jest.fn().mockResolvedValue(new Date('2026-01-02')),
+            tryClaimForManualRun: jest
+                .fn()
+                .mockResolvedValue({ priorNextHeartbeatAt: new Date('2026-01-02') }),
+            releaseAfterRun: jest.fn().mockResolvedValue(undefined),
+            releaseAfterManualRunFailure: jest.fn().mockResolvedValue(undefined),
+            updateById: jest.fn().mockResolvedValue(undefined),
+        };
+        agentRunRepository = {
+            createQueued: jest.fn().mockResolvedValue({ id: 'run-hb-1' }),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+        };
+        trigger = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
+    });
+
+    afterEach(() => {
+        for (const key of ENV_KEYS) {
+            if (savedEnv[key] === undefined) delete process.env[key];
+            else process.env[key] = savedEnv[key];
+        }
+    });
+
+    const makeSvc = (dispatchGate?: any) =>
+        new AgentScheduleDispatcherService(agentRepository, agentRunRepository, dispatchGate);
+
+    const gateAdmitting = (admitted: boolean) => ({
+        admit: jest
+            .fn()
+            .mockResolvedValue(
+                admitted
+                    ? { admitted: true }
+                    : { admitted: false, queuedReason: 'concurrency-limit' },
+            ),
+    });
+
+    describe('dispatchDue (cron)', () => {
+        it('consults the gate on the org/user scope (heartbeats are not Work-scoped)', async () => {
+            const gate = gateAdmitting(true);
+            await makeSvc(gate).dispatchDue(trigger);
+            expect(gate.admit).toHaveBeenCalledWith({
+                userId: 'user-1',
+                workId: null,
+                organizationId: 'org-1',
+            });
+        });
+
+        it('dispatches normally when admitted', async () => {
+            const summary = await makeSvc(gateAdmitting(true)).dispatchDue(trigger);
+            expect(summary.dispatched).toBe(1);
+            expect(trigger.enqueue).toHaveBeenCalledTimes(1);
+        });
+
+        it('DEFERS over the valve: no claim, no run row, no enqueue', async () => {
+            const summary = await makeSvc(gateAdmitting(false)).dispatchDue(trigger);
+            expect(summary.dispatched).toBe(0);
+            expect(summary.skipped).toBe(1);
+            expect(summary.entries[0]).toEqual(
+                expect.objectContaining({ outcome: 'skipped', message: 'concurrency-limit' }),
+            );
+            // Nothing to unwind — the Agent keeps its schedule and comes
+            // back on the next tick.
+            expect(agentRepository.tryClaimForRun).not.toHaveBeenCalled();
+            expect(agentRunRepository.createQueued).not.toHaveBeenCalled();
+            expect(trigger.enqueue).not.toHaveBeenCalled();
+            expect(agentRepository.releaseAfterRun).not.toHaveBeenCalled();
+        });
+
+        it('never PARKS a heartbeat run (nothing could ever drain it)', async () => {
+            await makeSvc(gateAdmitting(false)).dispatchDue(trigger);
+            expect(agentRunRepository.createQueued).not.toHaveBeenCalled();
+        });
+
+        it('FAILS OPEN when the gate throws — a broken valve must not stop the sweep', async () => {
+            const gate = { admit: jest.fn().mockRejectedValue(new Error('gate exploded')) };
+            const summary = await makeSvc(gate).dispatchDue(trigger);
+            expect(summary.dispatched).toBe(1);
+            expect(trigger.enqueue).toHaveBeenCalledTimes(1);
+        });
+
+        it('behaves exactly as before when no gate is bound', async () => {
+            const summary = await makeSvc(undefined).dispatchDue(trigger);
+            expect(summary.dispatched).toBe(1);
+        });
+
+        it('defers only the saturated Agent — the rest of the batch still goes', async () => {
+            agentRepository.findDueForHeartbeat.mockResolvedValueOnce([
+                agent({ id: 'agent-hot', userId: 'user-hot' }),
+                agent({ id: 'agent-cold', userId: 'user-cold' }),
+            ]);
+            const gate = {
+                admit: jest.fn(async (input: { userId: string }) => ({
+                    admitted: input.userId !== 'user-hot',
+                })),
+            };
+            const summary = await makeSvc(gate).dispatchDue(trigger);
+            expect(summary.dispatched).toBe(1);
+            expect(summary.skipped).toBe(1);
+            expect(trigger.enqueue).toHaveBeenCalledWith(
+                expect.objectContaining({ agentId: 'agent-cold' }),
+            );
+        });
+    });
+
+    describe('dispatchOne (run-now)', () => {
+        it('dispatches when admitted', async () => {
+            const result = await makeSvc(gateAdmitting(true)).dispatchOne(trigger, 'agent-1');
+            expect(result).toEqual({ outcome: 'dispatched', runId: 'run-hb-1' });
+        });
+
+        it('reports a retryable `concurrency-limit` skip over the valve', async () => {
+            const result = await makeSvc(gateAdmitting(false)).dispatchOne(trigger, 'agent-1');
+            expect(result).toEqual({ outcome: 'skipped', reason: 'concurrency-limit' });
+            // Checked before the CAS claim ⇒ nothing to unwind.
+            expect(agentRepository.tryClaimForManualRun).not.toHaveBeenCalled();
+            expect(agentRunRepository.createQueued).not.toHaveBeenCalled();
+            expect(trigger.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('checks ownership/status BEFORE the valve (a missing Agent is still a 404)', async () => {
+            agentRepository.findById.mockResolvedValueOnce(null);
+            const gate = gateAdmitting(false);
+            const result = await makeSvc(gate).dispatchOne(trigger, 'nope');
+            expect(result).toEqual({ outcome: 'skipped', reason: 'agent-missing' });
+            expect(gate.admit).not.toHaveBeenCalled();
+        });
+
+        it('FAILS OPEN when the gate throws', async () => {
+            const gate = { admit: jest.fn().mockRejectedValue(new Error('gate exploded')) };
+            const result = await makeSvc(gate).dispatchOne(trigger, 'agent-1');
+            expect(result).toEqual({ outcome: 'dispatched', runId: 'run-hb-1' });
+        });
+
+        it('behaves exactly as before when no gate is bound', async () => {
+            const result = await makeSvc(undefined).dispatchOne(trigger, 'agent-1');
+            expect(result).toEqual({ outcome: 'dispatched', runId: 'run-hb-1' });
+        });
+    });
+});

--- a/packages/agent/src/agents/__tests__/dispatch-paths-gated.spec.ts
+++ b/packages/agent/src/agents/__tests__/dispatch-paths-gated.spec.ts
@@ -1,0 +1,213 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+/**
+ * Run orchestration — the DURABLE guard that every AgentRun dispatch
+ * path stays behind `RunDispatchGateService`.
+ *
+ * The concurrency valve was consulted on the task fan-out and nowhere
+ * else: chat replies, the heartbeat cron, run-now and
+ * `POST /agents/:id/assign-task` all created runs and enqueued them
+ * straight past it, so the limit held on one path and was decorative on
+ * four. Fixing the four is a point-in-time repair; this spec is what
+ * stops a FIFTH from landing unnoticed.
+ *
+ * Rule: every `createQueued(` call site is either
+ *   - GATED   — a `dispatchGate` / `admit(` appears in its neighbourhood, or
+ *   - BYPASS  — it carries the literal marker `DOCUMENTED dispatch-gate
+ *               bypass`, which forces the author to say WHY in the same
+ *               breath (see the worker-side trigger tasks: the runtime has
+ *               already accepted that job, so the row is bookkeeping for
+ *               work in flight, not a new admission).
+ *
+ * Anything else fails here, in a fast unit test, naming the file and line.
+ */
+
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..', '..');
+
+/** Package sources that may contain an AgentRun dispatch path. */
+const SCAN_ROOTS = [
+    join(REPO_ROOT, 'packages', 'agent', 'src'),
+    join(REPO_ROOT, 'packages', 'tasks', 'src'),
+    join(REPO_ROOT, 'apps', 'api', 'src'),
+];
+
+/** Lines of context searched around a call site for the gate. */
+const CONTEXT_LINES = 30;
+
+const BYPASS_MARKER = 'DOCUMENTED dispatch-gate bypass';
+/**
+ * Evidence that a call site sits behind the gate. `admit\w*` also covers
+ * the thin per-path wrappers (e.g. the heartbeat dispatcher's
+ * `admitHeartbeat`, which defers instead of parking).
+ */
+const GATE_HINTS = [/dispatchGate/, /\.admit\w*\s*\(/, /RunDispatchGate/];
+
+interface CallSite {
+    file: string;
+    line: number;
+    snippet: string;
+    gated: boolean;
+    documented: boolean;
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+    if (!existsSync(dir)) return out;
+    for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+            if (entry === 'node_modules' || entry === 'dist' || entry === '__tests__') continue;
+            walk(full, out);
+            continue;
+        }
+        if (!entry.endsWith('.ts') || entry.endsWith('.d.ts') || entry.endsWith('.spec.ts')) {
+            continue;
+        }
+        out.push(full);
+    }
+    return out;
+}
+
+/**
+ * Locate every `createQueued(` call site and classify it. Exported so the
+ * spec can exercise it against synthetic sources — a guard nobody has
+ * seen fail is not a guard.
+ */
+export function classifyDispatchSites(source: string, file = '<memory>'): CallSite[] {
+    const lines = source.split(/\r?\n/);
+    const sites: CallSite[] = [];
+    for (let i = 0; i < lines.length; i += 1) {
+        if (!/\.createQueued\s*\(/.test(lines[i])) continue;
+        const from = Math.max(0, i - CONTEXT_LINES);
+        const to = Math.min(lines.length, i + CONTEXT_LINES);
+        const context = lines.slice(from, to).join('\n');
+        sites.push({
+            file,
+            line: i + 1,
+            snippet: lines[i].trim(),
+            gated: GATE_HINTS.some((hint) => hint.test(context)),
+            documented: context.includes(BYPASS_MARKER),
+        });
+    }
+    return sites;
+}
+
+describe('every AgentRun dispatch path is gated or documented', () => {
+    const files = SCAN_ROOTS.flatMap((root) => walk(root));
+
+    const allSites: CallSite[] = files.flatMap((file) =>
+        classifyDispatchSites(
+            readFileSync(file, 'utf8'),
+            relative(REPO_ROOT, file).split(sep).join('/'),
+        ),
+    );
+    // The repository's own definition of `createQueued` is not a call site.
+    const callSites = allSites.filter(
+        (s) => !s.file.endsWith('database/repositories/agent-run.repository.ts'),
+    );
+
+    it('finds the dispatch call sites to check (a scan over zero files proves nothing)', () => {
+        expect(files.length).toBeGreaterThan(100);
+        expect(callSites.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('NO call site is both ungated and undocumented', () => {
+        const offenders = callSites
+            .filter((s) => !s.gated && !s.documented)
+            .map((s) => `${s.file}:${s.line}  ${s.snippet}`);
+        expect(offenders).toEqual([]);
+    });
+
+    it.each([
+        ['packages/agent/src/tasks-domain/task-transition.service.ts', 'task fan-out + board run'],
+        ['packages/agent/src/tasks-domain/task-chat.service.ts', 'agent-mention chat reply'],
+        ['packages/agent/src/agents/run-steering.service.ts', 'resume'],
+        ['apps/api/src/agents/agents.controller.ts', 'assign-task endpoint'],
+    ])('%s (%s) dispatches through the gate', (file) => {
+        const sites = callSites.filter((s) => s.file === file);
+        expect(sites.length).toBeGreaterThan(0);
+        for (const site of sites) {
+            expect({ file: site.file, line: site.line, gated: site.gated }).toEqual({
+                file: site.file,
+                line: site.line,
+                gated: true,
+            });
+        }
+    });
+
+    it.each([
+        'packages/tasks/src/tasks/trigger/agent-task-execute.task.ts',
+        'packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts',
+        'packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts',
+    ])('%s stays a DOCUMENTED bypass (worker-side, job already accepted)', (file) => {
+        const sites = callSites.filter((s) => s.file === file);
+        expect(sites.length).toBeGreaterThan(0);
+        for (const site of sites) {
+            expect(site.documented).toBe(true);
+        }
+    });
+
+    it('the heartbeat dispatcher gates without creating a row when refused', () => {
+        // `AgentScheduleDispatcherService` defers rather than parks, so its
+        // gate call has no `reserve` callback — but it MUST still be gated.
+        const source = readFileSync(
+            join(REPO_ROOT, 'packages/agent/src/agents/agent-schedule-dispatcher.service.ts'),
+            'utf8',
+        );
+        const sites = classifyDispatchSites(source, 'agent-schedule-dispatcher.service.ts');
+        expect(sites.length).toBe(2); // dispatchDue + dispatchOne
+        for (const site of sites) {
+            expect(site.gated).toBe(true);
+        }
+    });
+
+    describe('the classifier itself', () => {
+        it('CATCHES an ungated, undocumented dispatch', () => {
+            const bad = [
+                'async function rogueDispatch() {',
+                '    const run = await this.runs.createQueued({ agentId, userId });',
+                '    await dispatcher.enqueue({ runId: run.id });',
+                '}',
+            ].join('\n');
+            const sites = classifyDispatchSites(bad);
+            expect(sites).toHaveLength(1);
+            expect(sites[0].gated).toBe(false);
+            expect(sites[0].documented).toBe(false);
+        });
+
+        it('ACCEPTS a gated dispatch', () => {
+            const good = [
+                'const admission = await this.dispatchGate.admit(input, reserve);',
+                'const run = await this.runs.createQueued({ agentId, userId });',
+            ].join('\n');
+            expect(classifyDispatchSites(good)[0].gated).toBe(true);
+        });
+
+        it('ACCEPTS a documented bypass', () => {
+            const good = [
+                '// DOCUMENTED dispatch-gate bypass: the runtime already accepted this job.',
+                'run = await runs.createQueued({ agentId, userId, triggerKind: "task" });',
+            ].join('\n');
+            const site = classifyDispatchSites(good)[0];
+            expect(site.gated).toBe(false);
+            expect(site.documented).toBe(true);
+        });
+
+        it('ACCEPTS a thin per-path admission wrapper (e.g. `admitHeartbeat`)', () => {
+            const good = [
+                'if (!(await this.admitHeartbeat(agent))) continue;',
+                'const run = await this.agentRunRepository.createQueued({ agentId });',
+            ].join('\n');
+            expect(classifyDispatchSites(good)[0].gated).toBe(true);
+        });
+
+        it('does NOT reach past its context window for the gate', () => {
+            const far = [
+                'await this.someGate.admit(input);',
+                ...Array.from({ length: CONTEXT_LINES + 5 }, () => '// filler'),
+                'const run = await this.runs.createQueued({ agentId });',
+            ].join('\n');
+            expect(classifyDispatchSites(far)[0].gated).toBe(false);
+        });
+    });
+});

--- a/packages/agent/src/agents/__tests__/run-dispatch-gating.spec.ts
+++ b/packages/agent/src/agents/__tests__/run-dispatch-gating.spec.ts
@@ -1,0 +1,334 @@
+import {
+    AgentRunRepository,
+    RUN_ADMISSION_LOCK_CLASS_ID,
+    advisoryLockObjectId,
+} from '../../database/repositories/agent-run.repository';
+import {
+    QUEUED_REASON_CONCURRENCY,
+    RunDispatchGateService,
+    runAdmissionLockScope,
+} from '../run-dispatch-gate.service';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Run orchestration — the admission CRITICAL SECTION and the advisory
+ * lock behind it.
+ *
+ * `admit(input, reserve)` is what makes the concurrency valve hold: the
+ * count and the `agent_runs` insert that consumes the counted slot run
+ * as one unit, serialized per admission scope by `pg_advisory_xact_lock`
+ * on Postgres and — documented, deliberate — unlocked everywhere else,
+ * because better-sqlite3 (the whole e2e stack) has no advisory locks.
+ * The CAS claim in `claimQueuedForDispatch` stays the correctness floor
+ * on every driver.
+ */
+describe('RunDispatchGateService — admit + reserve critical section', () => {
+    const ENV_KEYS = [
+        'AGENT_MAX_CONCURRENT_RUNS_PER_WORK',
+        'AGENT_MAX_CONCURRENT_RUNS_PER_ORG',
+        'CREDITS_ENFORCEMENT',
+    ] as const;
+    const savedEnv: Record<string, string | undefined> = {};
+
+    let runs: any;
+    let dispatcher: any;
+    let chatDispatcher: any;
+
+    beforeEach(() => {
+        for (const key of ENV_KEYS) {
+            savedEnv[key] = process.env[key];
+            delete process.env[key];
+        }
+        runs = {
+            countInFlightForWork: jest.fn().mockResolvedValue(0),
+            countInFlightForUser: jest.fn().mockResolvedValue(0),
+            countInFlightForOrganization: jest.fn().mockResolvedValue(0),
+            findOldestQueuedForConcurrency: jest.fn().mockResolvedValue(null),
+            claimQueuedForDispatch: jest.fn().mockResolvedValue(true),
+            restoreQueuedReason: jest.fn().mockResolvedValue(undefined),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+            // Default: the real Postgres-or-nothing helper, stubbed as a
+            // pass-through so the ordering assertions below stay readable.
+            withAdmissionLock: jest.fn(async (_key: string, fn: () => Promise<unknown>) => fn()),
+        };
+        dispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
+        chatDispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-chat-1' }) };
+    });
+
+    afterEach(() => {
+        for (const key of ENV_KEYS) {
+            if (savedEnv[key] === undefined) delete process.env[key];
+            else process.env[key] = savedEnv[key];
+        }
+    });
+
+    const makeGate = () => new RunDispatchGateService(runs, dispatcher, undefined, chatDispatcher);
+
+    describe('reserve callback', () => {
+        it('runs the reservation exactly once, with the ADMITTED verdict', async () => {
+            const reserve = jest.fn().mockResolvedValue(undefined);
+            const result = await makeGate().admit({ userId: 'u1', workId: 'w1' }, reserve);
+            expect(result).toEqual({ admitted: true });
+            expect(reserve).toHaveBeenCalledTimes(1);
+            expect(reserve).toHaveBeenCalledWith({ admitted: true });
+        });
+
+        it('runs the reservation with the PARKED verdict when over the valve', async () => {
+            runs.countInFlightForWork.mockResolvedValueOnce(10); // default limit 10
+            const reserve = jest.fn().mockResolvedValue(undefined);
+            const result = await makeGate().admit({ userId: 'u1', workId: 'w1' }, reserve);
+            expect(result).toEqual({
+                admitted: false,
+                queuedReason: QUEUED_REASON_CONCURRENCY,
+            });
+            expect(reserve).toHaveBeenCalledTimes(1);
+            expect(reserve).toHaveBeenCalledWith({
+                admitted: false,
+                queuedReason: QUEUED_REASON_CONCURRENCY,
+            });
+        });
+
+        it('FAILS OPEN and still reserves when the counting query explodes', async () => {
+            runs.countInFlightForWork.mockRejectedValueOnce(new Error('count query exploded'));
+            const reserve = jest.fn().mockResolvedValue(undefined);
+            const result = await makeGate().admit({ userId: 'u1', workId: 'w1' }, reserve);
+            // A broken safety valve must never stop legitimate work, and
+            // must never leave the caller with no run row either.
+            expect(result).toEqual({ admitted: true });
+            expect(reserve).toHaveBeenCalledTimes(1);
+            expect(reserve).toHaveBeenCalledWith({ admitted: true });
+        });
+
+        it('propagates an error thrown BY the reservation (that one is real)', async () => {
+            const reserve = jest.fn().mockRejectedValue(new Error('insert failed'));
+            await expect(makeGate().admit({ userId: 'u1', workId: 'w1' }, reserve)).rejects.toThrow(
+                'insert failed',
+            );
+        });
+
+        it('counts BEFORE it reserves — the insert must not inflate its own count', async () => {
+            const order: string[] = [];
+            runs.countInFlightForWork.mockImplementation(async () => {
+                order.push('count');
+                return 0;
+            });
+            const reserve = jest.fn(async () => {
+                order.push('reserve');
+            });
+            await makeGate().admit({ userId: 'u1', workId: 'w1' }, reserve);
+            expect(order).toEqual(['count', 'reserve']);
+        });
+
+        it('holds the admission lock across BOTH the count and the reservation', async () => {
+            const order: string[] = [];
+            runs.withAdmissionLock.mockImplementation(
+                async (_key: string, fn: () => Promise<unknown>) => {
+                    order.push('lock-acquired');
+                    const out = await fn();
+                    order.push('lock-released');
+                    return out;
+                },
+            );
+            runs.countInFlightForWork.mockImplementation(async () => {
+                order.push('count');
+                return 0;
+            });
+            await makeGate().admit({ userId: 'u1', workId: 'w1' }, async () => {
+                order.push('reserve');
+            });
+            expect(order).toEqual(['lock-acquired', 'count', 'reserve', 'lock-released']);
+        });
+
+        it('locks on the Work scope when the run has one', async () => {
+            await makeGate().admit(
+                { userId: 'u1', workId: 'w1', organizationId: 'o1' },
+                async () => undefined,
+            );
+            expect(runs.withAdmissionLock).toHaveBeenCalledWith('work:w1', expect.any(Function));
+        });
+
+        it('falls back to the org, then the user, for Work-less runs', async () => {
+            const gate = makeGate();
+            await gate.admit({ userId: 'u1', organizationId: 'o1' }, async () => undefined);
+            expect(runs.withAdmissionLock).toHaveBeenLastCalledWith('org:o1', expect.any(Function));
+            await gate.admit({ userId: 'u1' }, async () => undefined);
+            expect(runs.withAdmissionLock).toHaveBeenLastCalledWith(
+                'user:u1',
+                expect.any(Function),
+            );
+        });
+
+        it('works against a repository stub that has no lock helper (unit tests, old drivers)', async () => {
+            delete runs.withAdmissionLock;
+            const reserve = jest.fn().mockResolvedValue(undefined);
+            const result = await makeGate().admit({ userId: 'u1', workId: 'w1' }, reserve);
+            expect(result).toEqual({ admitted: true });
+            expect(reserve).toHaveBeenCalledTimes(1);
+        });
+
+        it('takes NO lock when the caller only wants a verdict (drain, probes)', async () => {
+            const result = await makeGate().admit({ userId: 'u1', workId: 'w1' });
+            expect(result).toEqual({ admitted: true });
+            expect(runs.withAdmissionLock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('runAdmissionLockScope', () => {
+        it.each([
+            [{ userId: 'u1', workId: 'w1', organizationId: 'o1' }, 'work:w1'],
+            [{ userId: 'u1', workId: null, organizationId: 'o1' }, 'org:o1'],
+            [{ userId: 'u1', workId: null, organizationId: null }, 'user:u1'],
+            [{ userId: 'u1' }, 'user:u1'],
+        ])('%j → %s', (input, expected) => {
+            expect(runAdmissionLockScope(input as any)).toBe(expected);
+        });
+    });
+
+    describe('drain — parked CHAT runs go back out on the chat path', () => {
+        const parkedChatRun = (over: Record<string, unknown> = {}) => ({
+            id: 'run-chat',
+            agentId: 'agent-1',
+            userId: 'user-1',
+            taskId: 'task-1',
+            chatMessageId: 'msg-1',
+            triggerKind: 'chat',
+            workId: 'work-1',
+            organizationId: null,
+            status: 'queued',
+            queuedReason: QUEUED_REASON_CONCURRENCY,
+            ...over,
+        });
+
+        it('re-dispatches through agent-chat-reply, carrying the triggering message', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedChatRun());
+            const result = await makeGate().drainForWork('work-1');
+            expect(result).toEqual({ dispatched: true, runId: 'run-chat' });
+            expect(chatDispatcher.enqueue).toHaveBeenCalledWith({
+                agentId: 'agent-1',
+                userId: 'user-1',
+                taskId: 'task-1',
+                triggeringMessageId: 'msg-1',
+                dedupKey: 'task-1:agent-1:drain:run-chat',
+                runId: 'run-chat',
+            });
+            // The task path must NOT be used — it would drop the message
+            // the agent was mentioned in.
+            expect(dispatcher.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('still uses the TASK path for task-triggered parked runs', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(
+                parkedChatRun({ triggerKind: 'task', chatMessageId: null }),
+            );
+            await makeGate().drainForWork('work-1');
+            expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
+            expect(chatDispatcher.enqueue).not.toHaveBeenCalled();
+        });
+
+        it('leaves a parked chat run alone when no chat dispatcher is bound', async () => {
+            runs.findOldestQueuedForConcurrency.mockResolvedValueOnce(parkedChatRun());
+            const gate = new RunDispatchGateService(runs, dispatcher, undefined, undefined);
+            const result = await gate.drainForWork('work-1');
+            expect(result).toEqual({ dispatched: false, reason: 'no-dispatcher' });
+            // Never claimed ⇒ still parked ⇒ still drainable later.
+            expect(runs.claimQueuedForDispatch).not.toHaveBeenCalled();
+        });
+    });
+});
+
+describe('AgentRunRepository.withAdmissionLock — pg advisory lock', () => {
+    /**
+     * The gate hands its whole critical section to this helper. On
+     * Postgres it must open a transaction, take
+     * `pg_advisory_xact_lock(classid, objid)` and only THEN run the
+     * section (the lock is released by the transaction commit). On every
+     * other driver it must be a straight pass-through — better-sqlite3
+     * has no advisory locks at all, and pretending otherwise would throw
+     * on every dispatch in the e2e stack.
+     */
+    const makeRepo = (driverType: string, transaction?: jest.Mock) => {
+        const repository = {
+            manager: {
+                connection: {
+                    options: { type: driverType },
+                    transaction:
+                        transaction ??
+                        jest.fn(async (cb: (m: unknown) => Promise<unknown>) =>
+                            cb({ query: jest.fn().mockResolvedValue(undefined) }),
+                        ),
+                },
+            },
+        };
+        return {
+            repo: new AgentRunRepository(repository as any),
+            repository,
+        };
+    };
+
+    it('POSTGRES: opens a transaction, takes the advisory lock, then runs the section', async () => {
+        const query = jest.fn().mockResolvedValue(undefined);
+        const transaction = jest.fn(async (cb: (m: unknown) => Promise<unknown>) => cb({ query }));
+        const { repo } = makeRepo('postgres', transaction);
+
+        const order: string[] = [];
+        query.mockImplementation(async () => {
+            order.push('lock');
+        });
+        const result = await repo.withAdmissionLock('work:w1', async () => {
+            order.push('section');
+            return 'done';
+        });
+
+        expect(result).toBe('done');
+        expect(transaction).toHaveBeenCalledTimes(1);
+        expect(query).toHaveBeenCalledWith('SELECT pg_advisory_xact_lock($1, $2)', [
+            RUN_ADMISSION_LOCK_CLASS_ID,
+            advisoryLockObjectId('work:w1'),
+        ]);
+        expect(order).toEqual(['lock', 'section']);
+    });
+
+    it('SQLITE: documented no-op — runs the section directly, no transaction', async () => {
+        const transaction = jest.fn();
+        const { repo } = makeRepo('better-sqlite3', transaction);
+        const section = jest.fn().mockResolvedValue('done');
+        await expect(repo.withAdmissionLock('work:w1', section)).resolves.toBe('done');
+        expect(transaction).not.toHaveBeenCalled();
+        expect(section).toHaveBeenCalledTimes(1);
+    });
+
+    it('degrades to UNLOCKED when the lock itself cannot be taken', async () => {
+        const transaction = jest.fn(async () => {
+            throw new Error('no connections available');
+        });
+        const { repo } = makeRepo('postgres', transaction);
+        const section = jest.fn().mockResolvedValue('done');
+        // A broken safety valve must never stop legitimate work.
+        await expect(repo.withAdmissionLock('work:w1', section)).resolves.toBe('done');
+        expect(section).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-raises an error thrown by the SECTION (never re-runs it)', async () => {
+        const query = jest.fn().mockResolvedValue(undefined);
+        const transaction = jest.fn(async (cb: (m: unknown) => Promise<unknown>) => cb({ query }));
+        const { repo } = makeRepo('postgres', transaction);
+        const section = jest.fn().mockRejectedValue(new Error('insert failed'));
+        await expect(repo.withAdmissionLock('work:w1', section)).rejects.toThrow('insert failed');
+        // Re-running would double-create the run row it reserves.
+        expect(section).toHaveBeenCalledTimes(1);
+    });
+
+    it('derives a STABLE int4 lock id per scope, distinct across scopes', () => {
+        const a = advisoryLockObjectId('work:w1');
+        const b = advisoryLockObjectId('work:w2');
+        expect(a).toBe(advisoryLockObjectId('work:w1'));
+        expect(a).not.toBe(b);
+        for (const id of [a, b, advisoryLockObjectId('user:u1'), advisoryLockObjectId('')]) {
+            expect(Number.isInteger(id)).toBe(true);
+            expect(id).toBeGreaterThanOrEqual(-(2 ** 31));
+            expect(id).toBeLessThanOrEqual(2 ** 31 - 1);
+        }
+    });
+});

--- a/packages/agent/src/agents/agent-schedule-dispatcher.service.ts
+++ b/packages/agent/src/agents/agent-schedule-dispatcher.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { config } from '../config';
 import { AgentRepository } from '../database/repositories/agent.repository';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
 import { AgentStatus } from '../entities/agent.entity';
 import type { Agent } from '../entities/agent.entity';
 import { computeNextHeartbeat } from './heartbeat-cron';
+import { RunDispatchGateService } from './run-dispatch-gate.service';
 
 export interface AgentDispatchEntry {
     agentId: string;
@@ -65,7 +66,48 @@ export class AgentScheduleDispatcherService {
     constructor(
         private readonly agentRepository: AgentRepository,
         private readonly agentRunRepository: AgentRunRepository,
+        // Run orchestration — the same concurrency choke point every
+        // other dispatch path uses. Heartbeat runs DEFER rather than
+        // park (see {@link admitHeartbeat}). Appended LAST + @Optional()
+        // per the positional-spec arity rule; without it the dispatcher
+        // behaves exactly as it did before.
+        @Optional() private readonly dispatchGate?: RunDispatchGateService,
     ) {}
+
+    /**
+     * Heartbeat admission.
+     *
+     * Heartbeat runs DEFER instead of parking: `drainForWork` promotes
+     * concurrency-parked rows through the Task-keyed dispatch paths, and
+     * a heartbeat run has no Task — a parked one would sit in `queued`
+     * forever with nothing able to drain it (the drain says so out loud:
+     * "parked run has no taskId — cannot drain"). Skipping is both
+     * correct and self-healing: the cron re-offers the Agent on its next
+     * tick, and run-now tells the caller to try again.
+     *
+     * Never throws: a broken valve must not stop the sweep, so a
+     * counting failure admits.
+     */
+    private async admitHeartbeat(agent: Agent): Promise<boolean> {
+        if (!this.dispatchGate) return true;
+        try {
+            // No `reserve` callback: nothing is created when a heartbeat
+            // is refused, so there is no count+insert window to close.
+            const admission = await this.dispatchGate.admit({
+                userId: agent.userId,
+                // Heartbeats are Agent-scoped, not Work-scoped — the
+                // org/user valve is the one that applies.
+                workId: null,
+                organizationId: agent.organizationId ?? null,
+            });
+            return admission.admitted;
+        } catch (err) {
+            this.logger.warn(
+                `Dispatch gate admit failed for Agent ${agent.id} — failing open: ${err}`,
+            );
+            return true;
+        }
+    }
 
     /**
      * Caller is the Trigger.dev cron wrapper, which knows how to enqueue
@@ -116,6 +158,24 @@ export class AgentScheduleDispatcherService {
             // did not, leaving the run orphaned in `queued`.
             let createdRun: { id: string } | null = null;
             try {
+                // Run orchestration — the concurrency valve applies to the
+                // heartbeat cron too. Checked BEFORE the CAS claim so a
+                // refusal costs nothing to undo: the Agent keeps its
+                // `nextHeartbeatAt` and is simply re-offered next tick.
+                if (!(await this.admitHeartbeat(agent))) {
+                    this.logger.log(
+                        `Agent ${agent.id} deferred by the dispatch gate — retrying next tick.`,
+                    );
+                    summary.skipped += 1;
+                    summary.entries.push(
+                        this.entry(agent, {
+                            outcome: 'skipped',
+                            message: 'concurrency-limit',
+                        }),
+                    );
+                    continue;
+                }
+
                 originalNext = await this.agentRepository.tryClaimForRun(agent.id);
                 if (!originalNext) {
                     this.logger.warn(
@@ -220,7 +280,10 @@ export class AgentScheduleDispatcherService {
         agentId: string,
     ): Promise<
         | { outcome: 'dispatched'; runId: string }
-        | { outcome: 'skipped'; reason: 'already-claimed' | 'agent-missing' | 'inactive' }
+        | {
+              outcome: 'skipped';
+              reason: 'already-claimed' | 'agent-missing' | 'inactive' | 'concurrency-limit';
+          }
         | { outcome: 'failed'; message: string }
     > {
         const agent = await this.agentRepository.findById(agentId);
@@ -229,6 +292,13 @@ export class AgentScheduleDispatcherService {
         }
         if (agent.status !== AgentStatus.ACTIVE && agent.status !== AgentStatus.ERROR) {
             return { outcome: 'skipped', reason: 'inactive' };
+        }
+        // Run orchestration — run-now is a dispatch like any other. Checked
+        // before the CAS claim so a refusal leaves no state to unwind, and
+        // reported as a `skipped` reason the caller can retry on (a
+        // heartbeat run cannot be parked — nothing could ever drain it).
+        if (!(await this.admitHeartbeat(agent))) {
+            return { outcome: 'skipped', reason: 'concurrency-limit' };
         }
 
         // FU-2 review fix (codex P1): manual run-now must work for

--- a/packages/agent/src/agents/run-dispatch-gate.service.ts
+++ b/packages/agent/src/agents/run-dispatch-gate.service.ts
@@ -2,8 +2,10 @@ import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { config } from '../config';
 import { AgentRunRepository } from '../database/repositories/agent-run.repository';
 import {
+    AGENT_CHAT_REPLY_DISPATCHER,
     AGENT_TASK_EXECUTE_DISPATCHER,
     JOB_RUNTIME_NOT_CONFIGURED_REASON,
+    type AgentChatReplyDispatcher,
     type AgentTaskExecuteDispatcher,
 } from '../tasks-domain/task-dispatcher';
 import { RUN_CREDITS_PRECHECK, type RunCreditsPrecheck } from './run-credits-precheck';
@@ -45,6 +47,34 @@ export interface RunDispatchDrainResult {
 }
 
 /**
+ * Persist-the-run half of an admission. Runs INSIDE the advisory lock
+ * (Postgres) so the valve's count and the row that consumes a slot are
+ * one critical section instead of a check-then-insert race.
+ *
+ * Contract: exactly one call per `admit()` that supplies it, and it must
+ * be the thing that creates the `agent_runs` row (parked or not).
+ */
+export type RunDispatchReserve = (admission: RunDispatchAdmitResult) => Promise<void>;
+
+/**
+ * The scope a burst is serialized on. Narrowest-wins: a Work when the
+ * run has one (that is the valve that actually saturates, and it keeps
+ * two Works in one org from serializing against each other), else the
+ * org, else the user.
+ *
+ * Consequence, stated plainly: with a Work-scoped lock the per-ORG valve
+ * is still check-then-insert across different Works of the same org. It
+ * is a safety valve with a burst-width tolerance, not a quota — and
+ * locking every dispatch in an org behind one key would be a far worse
+ * trade.
+ */
+export function runAdmissionLockScope(input: RunDispatchAdmitInput): string {
+    if (input.workId) return `work:${input.workId}`;
+    if (input.organizationId) return `org:${input.organizationId}`;
+    return `user:${input.userId}`;
+}
+
+/**
  * Run orchestration (Wave 4 M2) — the single concurrency choke point for
  * agent-run dispatch.
  *
@@ -63,11 +93,29 @@ export interface RunDispatchDrainResult {
  * terminal transitions (worker terminal writes, user cancel) and from the
  * stuck-run sweeper as the safety net.
  *
- * Races: the count is check-then-insert without an advisory lock (the
- * e2e suite runs on sqlite, which has none), so a parallel burst can
- * transiently exceed a valve by the burst width. Acceptable for a safety
- * valve; the CAS claim in `claimQueuedForDispatch` is what prevents the
- * harmful race — two drains double-dispatching one run.
+ * Races: pass a `reserve` callback to `admit()` and the count + the
+ * caller's row insert become ONE critical section, serialized per
+ * admission scope by `pg_advisory_xact_lock` when the driver is Postgres
+ * (`AgentRunRepository.withAdmissionLock`). On sqlite — the entire e2e
+ * stack — advisory locks do not exist, so that degrades to a documented
+ * no-op and a parallel burst can still transiently exceed a valve by the
+ * burst width. Acceptable for a safety valve; the CAS claim in
+ * `claimQueuedForDispatch` remains the correctness floor either way — it
+ * is what prevents the harmful race, two drains double-dispatching one
+ * run.
+ *
+ * EVERY path that enqueues an AgentRun goes through `admit()`: the task
+ * fan-out and board/batch run (`TaskTransitionService.dispatchAgentRun`),
+ * resume (`RunSteeringService`), agent-mention chat replies
+ * (`TaskChatService`), the heartbeat cron + run-now
+ * (`AgentScheduleDispatcherService`) and `POST /agents/:id/assign-task`.
+ * The DOCUMENTED bypasses, which must stay bypassed, are:
+ *   - this service's own `drainForWork` (it IS the gate, and re-admits);
+ *   - the worker-side `createQueued` fallbacks in `@ever-works/tasks`
+ *     trigger tasks — the job runtime has already accepted that job, so
+ *     the row is bookkeeping for work in flight, not a new admission;
+ *   - `TerminalSessionLauncher` — attaches a shell to an ALREADY-admitted
+ *     live run; it enqueues no AgentRun.
  */
 @Injectable()
 export class RunDispatchGateService {
@@ -89,6 +137,14 @@ export class RunDispatchGateService {
         @Optional()
         @Inject(RUN_CREDITS_PRECHECK)
         private readonly creditsPrecheck?: RunCreditsPrecheck,
+        // Chat-triggered runs are now gated too, so the drain must be
+        // able to put one back on the path it came from. Same @Optional()
+        // + appended-LAST posture as every other seam here (the
+        // positional-spec arity rule): unit tests and chat-less installs
+        // simply report `no-dispatcher` for a parked chat run.
+        @Optional()
+        @Inject(AGENT_CHAT_REPLY_DISPATCHER)
+        private readonly chatDispatcher?: AgentChatReplyDispatcher,
     ) {}
 
     /** Env default today; per-Work override column when it lands. */
@@ -104,8 +160,47 @@ export class RunDispatchGateService {
      * Decide whether a new run may be handed to the job runtime NOW.
      * Never throws on its own account — callers treat a thrown counting
      * failure as fail-open (a broken safety valve must not stop work).
+     *
+     * `reserve` (optional) turns the call into a critical section: the
+     * count AND the caller's `agent_runs` insert run under one
+     * `pg_advisory_xact_lock` on Postgres, closing the check-then-insert
+     * window that let a parallel burst walk past the valve. On every
+     * other driver the lock is a documented no-op (see
+     * {@link AgentRunRepository.withAdmissionLock}). When `reserve` is
+     * supplied it is called EXACTLY ONCE — including on the fail-open
+     * path, so a broken valve still produces a run — and errors it
+     * raises propagate to the caller unchanged.
+     *
+     * Callers that only need the verdict (the drain, admission probes)
+     * omit `reserve` and get the pre-existing behaviour byte for byte.
      */
-    async admit(input: RunDispatchAdmitInput): Promise<RunDispatchAdmitResult> {
+    async admit(
+        input: RunDispatchAdmitInput,
+        reserve?: RunDispatchReserve,
+    ): Promise<RunDispatchAdmitResult> {
+        if (!reserve) return this.evaluate(input);
+        // `withAdmissionLock` is optional on the repository so hand-built
+        // stubs in unit tests (and any partial mock) keep working — they
+        // simply run unlocked, which is what sqlite does anyway.
+        const run = async (): Promise<RunDispatchAdmitResult> => {
+            let admission: RunDispatchAdmitResult;
+            try {
+                admission = await this.evaluate(input);
+            } catch (err) {
+                // Fail-open: a broken counting query must never stop
+                // legitimate dispatch. The caller still gets its row.
+                this.logger.warn(`Dispatch gate: admission evaluation failed (fail-open): ${err}`);
+                admission = { admitted: true };
+            }
+            await reserve(admission);
+            return admission;
+        };
+        return typeof this.runs.withAdmissionLock === 'function'
+            ? this.runs.withAdmissionLock(runAdmissionLockScope(input), run)
+            : run();
+    }
+
+    private async evaluate(input: RunDispatchAdmitInput): Promise<RunDispatchAdmitResult> {
         const workLimit = this.resolveWorkLimit();
         if (input.workId && workLimit > 0) {
             const inFlight = await this.runs.countInFlightForWork(input.workId);
@@ -178,14 +273,20 @@ export class RunDispatchGateService {
             );
             if (!candidate) return { dispatched: false, reason: 'no-candidate' };
             if (!candidate.taskId) {
-                // Only the task dispatch path parks runs today; a parked
-                // run without a Task cannot be re-dispatched through the
-                // agent-task-execute path. Surface loudly.
+                // Every parking path is Task-keyed (task fan-out, board
+                // run, resume, chat reply); a parked run without a Task
+                // cannot be re-dispatched through either runtime path.
+                // Surface loudly.
                 this.logger.warn(
                     `Dispatch gate: parked run ${candidate.id} has no taskId — cannot drain.`,
                 );
                 return { dispatched: false, reason: 'no-candidate' };
             }
+            // A chat-triggered run must go back out as `agent-chat-reply`
+            // with its triggering message, NOT as `agent-task-execute` —
+            // re-dispatching it on the task path would drop the message
+            // the agent is supposed to be replying to.
+            const viaChat = candidate.triggerKind === 'chat' && Boolean(candidate.chatMessageId);
 
             const admission = await this.admit({
                 userId: candidate.userId,
@@ -194,7 +295,7 @@ export class RunDispatchGateService {
             });
             if (!admission.admitted) return { dispatched: false, reason: 'over-limit' };
 
-            if (!this.dispatcher) {
+            if (viaChat ? !this.chatDispatcher : !this.dispatcher) {
                 // Nothing to dispatch through — leave the row parked (it
                 // was never claimed) and tell the caller why.
                 return { dispatched: false, reason: 'no-dispatcher' };
@@ -207,18 +308,28 @@ export class RunDispatchGateService {
             if (!claimed) return { dispatched: false, reason: 'claim-lost' };
 
             try {
-                const handle = await this.dispatcher.enqueue({
-                    agentId: candidate.agentId,
-                    userId: candidate.userId,
-                    taskId: candidate.taskId,
-                    // Unique per parked row — the original generation-based
-                    // key is unknowable here, and this run was never handed
-                    // to the runtime, so a run-scoped key both dedups a
-                    // double drain at the runner AND cannot collide with the
-                    // fan-out key of the run that was admitted immediately.
-                    dedupKey: `${candidate.taskId}:${candidate.agentId}:drain:${candidate.id}`,
-                    runId: candidate.id,
-                });
+                // Unique per parked row — the original generation-based
+                // key is unknowable here, and this run was never handed
+                // to the runtime, so a run-scoped key both dedups a
+                // double drain at the runner AND cannot collide with the
+                // fan-out key of the run that was admitted immediately.
+                const dedupKey = `${candidate.taskId}:${candidate.agentId}:drain:${candidate.id}`;
+                const handle = viaChat
+                    ? await this.chatDispatcher!.enqueue({
+                          agentId: candidate.agentId,
+                          userId: candidate.userId,
+                          taskId: candidate.taskId,
+                          triggeringMessageId: candidate.chatMessageId!,
+                          dedupKey,
+                          runId: candidate.id,
+                      })
+                    : await this.dispatcher!.enqueue({
+                          agentId: candidate.agentId,
+                          userId: candidate.userId,
+                          taskId: candidate.taskId,
+                          dedupKey,
+                          runId: candidate.id,
+                      });
                 if (handle?.runId) {
                     try {
                         await this.runs.setTriggerRunId(candidate.id, handle.runId);

--- a/packages/agent/src/agents/run-steering.service.ts
+++ b/packages/agent/src/agents/run-steering.service.ts
@@ -205,30 +205,46 @@ export class RunSteeringService implements RunSteeringPort {
             );
         }
 
-        // Same concurrency choke point as every other dispatch path.
-        const admission = this.dispatchGate
-            ? await this.dispatchGate.admit({
-                  userId,
-                  workId: run.workId ?? null,
-                  organizationId: run.organizationId ?? null,
-              })
-            : { admitted: true as const, queuedReason: undefined };
-
-        const next = await this.runs.createQueued({
-            agentId: run.agentId,
-            userId,
-            triggerKind: 'task',
-            taskId: run.taskId,
-            workId: run.workId ?? null,
-            organizationId: run.organizationId ?? null,
-            runnerKind: run.runnerKind ?? null,
-            queuedReason: admission.admitted ? null : (admission.queuedReason ?? null),
-            // Streaming terminal — the conversation lifetime survives the
-            // process lifetime, and so does the SHAPE of the session. A
-            // resumed persistent run still wants an interactive terminal,
-            // which is what the fan-out's `requirePersistent` gate reads.
-            persistent: run.persistent === true,
-        });
+        // Same concurrency choke point as every other dispatch path — and
+        // the row that consumes the admitted slot is created INSIDE it, so
+        // count + insert are one critical section (advisory-locked on
+        // Postgres, documented no-op elsewhere).
+        let created: AgentRun | undefined;
+        const reserve = async (verdict: {
+            admitted: boolean;
+            queuedReason?: string;
+        }): Promise<void> => {
+            created = await this.runs.createQueued({
+                agentId: run.agentId,
+                userId,
+                triggerKind: 'task',
+                taskId: run.taskId!,
+                workId: run.workId ?? null,
+                organizationId: run.organizationId ?? null,
+                runnerKind: run.runnerKind ?? null,
+                queuedReason: verdict.admitted ? null : (verdict.queuedReason ?? null),
+                // Streaming terminal — the conversation lifetime survives
+                // the process lifetime, and so does the SHAPE of the
+                // session. A resumed persistent run still wants an
+                // interactive terminal, which is what the fan-out's
+                // `requirePersistent` gate reads.
+                persistent: run.persistent === true,
+            });
+        };
+        const admission: { admitted: boolean; queuedReason?: string } = this.dispatchGate
+            ? await this.dispatchGate.admit(
+                  {
+                      userId,
+                      workId: run.workId ?? null,
+                      organizationId: run.organizationId ?? null,
+                  },
+                  reserve,
+              )
+            : { admitted: true, queuedReason: undefined };
+        // Gate absent, or a gate stub that ignored the callback.
+        if (!created) await reserve(admission);
+        // Non-null from here: `reserve` either ran above or threw.
+        const next = created!;
 
         // The conversation lifetime survives the process lifetime: hand the
         // pipeline plugin its own resume id, and seed the first message so

--- a/packages/agent/src/agents/terminal-session-launcher.service.ts
+++ b/packages/agent/src/agents/terminal-session-launcher.service.ts
@@ -31,6 +31,12 @@ import {
  * caller can ignore them and the HTTP caller can map them to statuses.
  * A dispatcher that throws DOES bubble (after releasing the claim): the
  * user pressed a button and deserves the real error.
+ *
+ * DOCUMENTED `RunDispatchGateService` bypass, and it must stay one: this
+ * attaches a shell to an AgentRun that the gate ALREADY admitted and
+ * that is already live (`LIVE_RUN_STATUSES`). It creates no AgentRun and
+ * consumes no run slot, so re-admitting here would only be able to
+ * refuse a terminal for work that is running regardless.
  */
 
 export type TerminalSessionRefusal =

--- a/packages/agent/src/database/repositories/agent-run.repository.ts
+++ b/packages/agent/src/database/repositories/agent-run.repository.ts
@@ -21,6 +21,31 @@ const NON_TERMINAL: AgentRunStatus[] = ['queued', 'running'];
  */
 const QUEUED_ONLY: AgentRunStatus[] = ['queued'];
 
+/**
+ * Namespace (`classid`) for every run-admission advisory lock, so this
+ * subsystem can never collide with another feature's advisory locks in
+ * the same Postgres database. Arbitrary but STABLE — changing it would
+ * make an old deploy and a new one lock on different keys during a
+ * rolling restart, which is exactly the window the lock exists for.
+ */
+export const RUN_ADMISSION_LOCK_CLASS_ID = 0x6577_0001 | 0; // 'ew' + subsystem 1
+
+/**
+ * FNV-1a over the scope key, coerced into Postgres' signed `int4` range
+ * (`pg_advisory_xact_lock(int4, int4)`). A hash collision costs only
+ * some extra serialization between two unrelated scopes — never
+ * correctness — which is why a 32-bit digest is enough here.
+ */
+export function advisoryLockObjectId(scopeKey: string): number {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < scopeKey.length; i += 1) {
+        hash ^= scopeKey.charCodeAt(i);
+        // FNV prime 16777619, kept in 32-bit space via Math.imul.
+        hash = Math.imul(hash, 0x01000193);
+    }
+    return hash | 0;
+}
+
 @Injectable()
 export class AgentRunRepository {
     private readonly logger = new Logger(AgentRunRepository.name);
@@ -806,6 +831,64 @@ export class AgentRunRepository {
     }
 
     // ── Run orchestration (Wave 4 M2/M3) ───────────────────────────
+
+    /**
+     * Serialize one admission scope's count-then-create against other
+     * dispatchers, so the concurrency valve cannot be walked past by a
+     * parallel burst.
+     *
+     * POSTGRES: takes `pg_advisory_xact_lock(classid, objid)` inside a
+     * throwaway transaction and holds it for the whole of `fn`. Two
+     * dispatchers admitting into the SAME scope now queue behind each
+     * other: the second one's count sees the first one's freshly
+     * committed run row instead of the pre-burst number. `fn` runs on
+     * the pool's normal connection (auto-commit), so its writes are
+     * visible the moment this transaction releases the lock.
+     *
+     * EVERY OTHER DRIVER (better-sqlite3 — the whole e2e/CI stack —
+     * plus mysql/mssql): advisory locks do not exist, so this is a
+     * DOCUMENTED no-op that calls `fn` directly. Behaviour there is
+     * exactly what it was before this method existed: a burst may
+     * transiently exceed a valve by the burst width. That is acceptable
+     * because the valve is a safety valve, and because the CAS claim in
+     * {@link claimQueuedForDispatch} — not this lock — is the
+     * correctness floor that stops two drains double-dispatching one
+     * run.
+     *
+     * Never fails the caller on account of the lock itself: a lock
+     * acquisition error degrades to running `fn` unlocked (same posture
+     * as the gate's fail-open counting), because a broken safety valve
+     * must never stop legitimate work.
+     */
+    async withAdmissionLock<T>(scopeKey: string, fn: () => Promise<T>): Promise<T> {
+        const driver = this.repository.manager.connection.options.type;
+        if (driver !== 'postgres') {
+            return fn();
+        }
+        const objId = advisoryLockObjectId(scopeKey);
+        // Distinguishes "the lock plumbing broke" (swallow, retry
+        // unlocked) from "`fn` threw" (re-raise). Re-running `fn` after
+        // it already ran would double-create the run row it reserves.
+        let entered = false;
+        try {
+            return await this.repository.manager.connection.transaction(async (manager) => {
+                await manager.query('SELECT pg_advisory_xact_lock($1, $2)', [
+                    RUN_ADMISSION_LOCK_CLASS_ID,
+                    objId,
+                ]);
+                entered = true;
+                return fn();
+            });
+        } catch (err) {
+            if (entered) throw err;
+            this.logger.warn(
+                `Admission advisory lock unavailable for scope ${scopeKey} — admitting unlocked: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            return fn();
+        }
+    }
 
     /**
      * In-flight = `running`, plus `queued` rows that were actually handed

--- a/packages/agent/src/entities/__tests__/portable-date-columns.spec.ts
+++ b/packages/agent/src/entities/__tests__/portable-date-columns.spec.ts
@@ -1,0 +1,229 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Portable date columns — the durable guard for a bug class that has now
+ * landed FIVE separate times.
+ *
+ * better-sqlite3 (the driver behind the entire e2e/CI stack and several
+ * integration specs) has no `timestamp` type. A raw `@Column({ type:
+ * 'timestamp' })` therefore makes TypeORM's metadata validation throw at
+ * BOOT — not at query time:
+ *
+ *     DataTypeNotSupportedError: Data type "timestamp" in
+ *     "IngestedEvent.occurredAt" is not supported by "better-sqlite3".
+ *
+ * That is total: the API cannot start at all, so every e2e shard dies in
+ * global-setup with an error that names one column and looks nothing like
+ * "somebody added an entity". The repo's answer is `PortableDateColumn`
+ * (`type: Date`), which lets TypeORM pick the dialect's own type —
+ * Postgres still gets `timestamp`, sqlite gets `datetime` — or a bare
+ * `@Column()` on a `Date`-typed property, which resolves identically via
+ * reflected metadata.
+ *
+ * Every previous fix was a one-off (agent, mission, organization, user,
+ * work-budget-alert-state, and most recently the whole Wave 6–9 entity
+ * batch), each leaving only a warning comment behind. This spec is the
+ * fix that scales: it scans the entity sources, so the SIXTH occurrence
+ * fails here, in a fast unit test, instead of in an e2e global-setup.
+ */
+
+const ENTITIES_DIR = join(__dirname, '..');
+
+/**
+ * Column types that exist on one driver and not the other. `date`, `time`
+ * and the `timestamp` family are all Postgres/MySQL spellings that
+ * better-sqlite3 rejects outright.
+ */
+const BANNED_COLUMN_TYPES = [
+    'timestamp',
+    'timestamptz',
+    'timestamp with time zone',
+    'timestamp without time zone',
+    'datetime',
+    'datetime2',
+    'datetimeoffset',
+    'smalldatetime',
+    'date',
+    'time',
+    'timetz',
+    'time with time zone',
+    'time without time zone',
+];
+
+export interface RawDateColumnFinding {
+    line: number;
+    snippet: string;
+}
+
+/**
+ * Strip line + block comments so the many `// H-17: \`type: 'timestamp'\`
+ * is Postgres-only` warning comments already in these files are not
+ * reported as violations. Replaces comment bodies with spaces so line
+ * numbers stay exact.
+ */
+function stripComments(source: string): string {
+    return source
+        .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+        .replace(/\/\/[^\n]*/g, (m) => ' '.repeat(m.length));
+}
+
+/**
+ * Find raw driver-specific date/time column declarations in one entity
+ * source. Matches both decorator spellings TypeORM accepts:
+ *   - `@Column({ type: 'timestamp' })` / `@Column({ type: "datetime" })`
+ *   - `@Column('timestamp', { ... })` (positional type)
+ *
+ * Exported so the spec can feed it a deliberately-bad fixture — a scanner
+ * nobody has ever seen fail is not a guard.
+ */
+export function findRawDateColumns(source: string): RawDateColumnFinding[] {
+    const code = stripComments(source);
+    const lines = code.split(/\r?\n/);
+    const originalLines = source.split(/\r?\n/);
+    const banned = BANNED_COLUMN_TYPES.map((t) => t.toLowerCase());
+    const findings: RawDateColumnFinding[] = [];
+
+    // `type:` option form, e.g. `type: 'timestamp'`.
+    const optionRe = /\btype\s*:\s*(['"])([^'"]+)\1/g;
+    // Positional form, e.g. `@Column('timestamp'` / `@CreateDateColumn('datetime'`.
+    const positionalRe = /@\w*Column\s*\(\s*(['"])([^'"]+)\1/g;
+
+    for (let i = 0; i < lines.length; i += 1) {
+        for (const re of [optionRe, positionalRe]) {
+            re.lastIndex = 0;
+            let match: RegExpExecArray | null;
+            while ((match = re.exec(lines[i])) !== null) {
+                if (banned.includes(match[2].trim().toLowerCase())) {
+                    findings.push({ line: i + 1, snippet: originalLines[i].trim() });
+                }
+            }
+        }
+    }
+    return findings;
+}
+
+function entitySourceFiles(): string[] {
+    return readdirSync(ENTITIES_DIR)
+        .filter((f) => f.endsWith('.ts') && !f.endsWith('.spec.ts') && !f.endsWith('.d.ts'))
+        .sort();
+}
+
+describe('entities — portable date columns (sqlite boot guard)', () => {
+    const files = entitySourceFiles();
+
+    it('finds entity sources to scan (a scanner over zero files proves nothing)', () => {
+        expect(files.length).toBeGreaterThan(50);
+        expect(files).toContain('ingested-event.entity.ts');
+    });
+
+    it('NO entity declares a raw driver-specific date/time column', () => {
+        const offenders: string[] = [];
+        for (const file of files) {
+            const source = readFileSync(join(ENTITIES_DIR, file), 'utf8');
+            for (const finding of findRawDateColumns(source)) {
+                offenders.push(`${file}:${finding.line}  ${finding.snippet}`);
+            }
+        }
+        expect(offenders).toEqual([]);
+    });
+
+    // The entities named in the 2026-07 feature-program audit. Pinned by
+    // name so deleting one is a deliberate act, and so a regression in
+    // any of them points at the right file immediately.
+    it.each([
+        'ingested-event.entity.ts',
+        'ingest-cursor.entity.ts',
+        'ingest-install-binding.entity.ts',
+        'meeting.entity.ts',
+        'fleet-node.entity.ts',
+        'credit-ledger-entry.entity.ts',
+        'plan-entitlement.entity.ts',
+    ])('%s (2026-07 wave) uses portable date columns only', (file) => {
+        expect(files).toContain(file);
+        const source = readFileSync(join(ENTITIES_DIR, file), 'utf8');
+        expect(findRawDateColumns(source)).toEqual([]);
+    });
+
+    describe('the scanner itself', () => {
+        it('CATCHES a deliberately-bad fixture (option form)', () => {
+            const bad = `
+                @Entity({ name: 'bad_things' })
+                export class BadThing {
+                    @Column({ type: 'timestamp' })
+                    occurredAt: Date;
+                }
+            `;
+            const found = findRawDateColumns(bad);
+            expect(found).toHaveLength(1);
+            expect(found[0].snippet).toContain("type: 'timestamp'");
+        });
+
+        it('CATCHES the positional decorator form', () => {
+            const bad = `@Column('timestamptz', { nullable: true })\nendedAt?: Date | null;`;
+            expect(findRawDateColumns(bad)).toHaveLength(1);
+        });
+
+        it.each(BANNED_COLUMN_TYPES)('CATCHES the banned type `%s`', (type) => {
+            expect(findRawDateColumns(`@Column({ type: '${type}' })`)).toHaveLength(1);
+        });
+
+        it('CATCHES several offenders in one file and reports each line', () => {
+            const bad = [
+                "@Column({ type: 'timestamp' })",
+                'startedAt: Date;',
+                "@Column({ type: 'datetime', nullable: true })",
+                'endedAt?: Date | null;',
+            ].join('\n');
+            expect(findRawDateColumns(bad).map((f) => f.line)).toEqual([1, 3]);
+        });
+
+        it('ACCEPTS PortableDateColumn / TimestampColumn / bare @Column', () => {
+            const good = [
+                '@PortableDateColumn()',
+                'occurredAt: Date;',
+                '@PortableDateColumn({ nullable: true })',
+                'processedAt?: Date | null;',
+                "@TimestampColumn({ nullable: true, name: 'last_used_at' })",
+                'lastUsedAt: Date;',
+                '@Column({ nullable: true })',
+                'revokedAt: Date;',
+                '@CreateDateColumn()',
+                'createdAt: Date;',
+            ].join('\n');
+            expect(findRawDateColumns(good)).toEqual([]);
+        });
+
+        it('does NOT flag unrelated column types', () => {
+            const good = [
+                "@Column({ type: 'varchar', length: 200 })",
+                "@Column({ type: 'uuid', nullable: true })",
+                "@Column({ type: 'simple-json' })",
+                "@Column({ type: 'bigint', nullable: true })",
+                "@Column({ type: 'int', default: 0 })",
+            ].join('\n');
+            expect(findRawDateColumns(good)).toEqual([]);
+        });
+
+        it('does NOT flag the warning COMMENTS the previous fixes left behind', () => {
+            // Every earlier one-off fix left a comment quoting the banned
+            // literal. A scanner that flagged those would be permanently red.
+            const commented = [
+                "// H-17: `type: 'timestamp'` is Postgres-only and breaks integration specs",
+                '/**',
+                " *  PortableDateColumn: raw `type: 'timestamp'` breaks the better-sqlite3",
+                ' *  stack at BOOT, not at query time.',
+                ' */',
+                '@PortableDateColumn({ nullable: true })',
+                'lockedUntil?: Date | null;',
+            ].join('\n');
+            expect(findRawDateColumns(commented)).toEqual([]);
+        });
+
+        it('flags a banned type that follows a comment on the SAME line', () => {
+            // Comment stripping must not swallow real code before it.
+            const bad = "@Column({ type: 'timestamp' }) // portable? no.";
+            expect(findRawDateColumns(bad)).toHaveLength(1);
+        });
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-board-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-board-dispatch.spec.ts
@@ -95,11 +95,18 @@ describe('TaskTransitionService.dispatchAgentRun — the one dispatch path', () 
 
     it('consults the dispatch gate, creates the queued run, mirrors it on the board and enqueues', async () => {
         const result = await makeSvc().dispatchAgentRun(makeTask({ workId: 'w1' }), 'agent-1');
-        expect(dispatchGate.admit).toHaveBeenCalledWith({
-            userId: 'u1',
-            workId: 'w1',
-            organizationId: null,
-        });
+        // The second argument is the `reserve` half of the admission: the
+        // gate runs the `createQueued` insert INSIDE its critical section
+        // so the count and the row that consumes the counted slot cannot
+        // be split by a parallel burst.
+        expect(dispatchGate.admit).toHaveBeenCalledWith(
+            {
+                userId: 'u1',
+                workId: 'w1',
+                organizationId: null,
+            },
+            expect.any(Function),
+        );
         expect(runs.createQueued).toHaveBeenCalledWith(
             expect.objectContaining({ agentId: 'agent-1', taskId: 't1', workId: 'w1' }),
         );

--- a/packages/agent/src/tasks-domain/__tests__/task-chat-dispatch-gating.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-chat-dispatch-gating.spec.ts
@@ -1,0 +1,151 @@
+import { TaskChatService } from '../task-chat.service';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Run orchestration — an `@agent` mention is a DISPATCH, and it now goes
+ * through the same concurrency choke point as the task fan-out, the
+ * board run and resume.
+ *
+ * Before this, a chat storm on a saturated Work put unbounded runs on the
+ * job runtime while the board path politely parked its own: the valve
+ * held on one path and was invisible on the other. Over-limit now parks
+ * the row (`queuedReason`, no enqueue) with `chatMessageId` intact, which
+ * is what lets `RunDispatchGateService.drainForWork` put it back on the
+ * CHAT path rather than the task path.
+ */
+describe('TaskChatService — agent-mention dispatch is gated', () => {
+    let tasks: any;
+    let messages: any;
+    let kbMentions: any;
+    let activity: any;
+    let runs: any;
+    let chatDispatcher: any;
+
+    beforeEach(() => {
+        tasks = { findByIdAndUser: jest.fn() };
+        messages = {
+            findByTaskId: jest.fn().mockResolvedValue([]),
+            findById: jest.fn(),
+            create: jest.fn(),
+            updateBody: jest.fn().mockResolvedValue(undefined),
+            updateBodyAndMentions: jest.fn().mockResolvedValue(undefined),
+        };
+        kbMentions = { add: jest.fn().mockResolvedValue({}) };
+        activity = { log: jest.fn().mockResolvedValue(undefined) };
+        runs = {
+            createQueued: jest.fn().mockResolvedValue({ id: 'run-chat-1' }),
+            setTriggerRunId: jest.fn().mockResolvedValue(undefined),
+            markDispatchFailed: jest.fn().mockResolvedValue(undefined),
+        };
+        chatDispatcher = { enqueue: jest.fn().mockResolvedValue({ runId: 'trd-1' }) };
+    });
+
+    const makeSvc = (dispatchGate?: any) =>
+        new TaskChatService(
+            tasks,
+            messages,
+            kbMentions,
+            activity,
+            runs as any,
+            chatDispatcher,
+            undefined,
+            dispatchGate,
+        );
+
+    /** The fan-out is fire-and-forget; let the IIFE settle. */
+    const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+    const postMention = async (svc: TaskChatService, task: Record<string, unknown> = {}) => {
+        tasks.findByIdAndUser.mockResolvedValueOnce({ id: 't1', workId: 'w1', ...task });
+        messages.create.mockImplementationOnce((d: any) => Promise.resolve({ id: 'm1', ...d }));
+        await svc.post(
+            'u1',
+            { taskId: 't1', authorType: 'user', authorId: 'u1', body: 'hey @ceo, look' },
+            { ownedAgentSlugs: new Map([['ceo', 'agent-a1']]) },
+        );
+        await settle();
+    };
+
+    it('consults the gate with the Task scope before enqueuing', async () => {
+        const gate = { admit: jest.fn().mockResolvedValue({ admitted: true }) };
+        await postMention(makeSvc(gate), { workId: 'w1', organizationId: 'o1' });
+        expect(gate.admit).toHaveBeenCalledWith(
+            { userId: 'u1', workId: 'w1', organizationId: 'o1' },
+            expect.any(Function),
+        );
+    });
+
+    it('dispatches normally when admitted', async () => {
+        const gate = {
+            admit: jest.fn(async (_i: unknown, reserve: any) => {
+                await reserve({ admitted: true });
+                return { admitted: true };
+            }),
+        };
+        await postMention(makeSvc(gate));
+        expect(runs.createQueued).toHaveBeenCalledWith(
+            expect.objectContaining({ triggerKind: 'chat', queuedReason: null }),
+        );
+        expect(chatDispatcher.enqueue).toHaveBeenCalledWith(
+            expect.objectContaining({ runId: 'run-chat-1', triggeringMessageId: 'm1' }),
+        );
+    });
+
+    it('PARKS the run and SKIPS the enqueue when over the valve', async () => {
+        const gate = {
+            admit: jest.fn(async (_i: unknown, reserve: any) => {
+                await reserve({ admitted: false, queuedReason: 'concurrency-limit' });
+                return { admitted: false, queuedReason: 'concurrency-limit' };
+            }),
+        };
+        await postMention(makeSvc(gate));
+        expect(runs.createQueued).toHaveBeenCalledWith(
+            expect.objectContaining({
+                triggerKind: 'chat',
+                queuedReason: 'concurrency-limit',
+                // Kept so the drain can put it back on the CHAT path.
+                chatMessageId: 'm1',
+                workId: 'w1',
+            }),
+        );
+        expect(chatDispatcher.enqueue).not.toHaveBeenCalled();
+        // Parked, NOT failed — it is waiting for capacity.
+        expect(runs.markDispatchFailed).not.toHaveBeenCalled();
+    });
+
+    it('FAILS OPEN — a gate that throws never swallows a user mention', async () => {
+        const gate = { admit: jest.fn().mockRejectedValue(new Error('gate exploded')) };
+        await postMention(makeSvc(gate));
+        expect(runs.createQueued).toHaveBeenCalledTimes(1);
+        expect(chatDispatcher.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates the run itself when a gate stub ignores the reserve callback', async () => {
+        const gate = { admit: jest.fn().mockResolvedValue({ admitted: true }) };
+        await postMention(makeSvc(gate));
+        expect(runs.createQueued).toHaveBeenCalledTimes(1);
+        expect(chatDispatcher.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('behaves exactly as before when no gate is bound at all', async () => {
+        await postMention(makeSvc(undefined));
+        expect(runs.createQueued).toHaveBeenCalledTimes(1);
+        expect(chatDispatcher.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    it('still rolls the run to dispatch-failed when the enqueue throws', async () => {
+        chatDispatcher.enqueue.mockRejectedValueOnce(new Error('Trigger.dev down'));
+        const gate = {
+            admit: jest.fn(async (_i: unknown, reserve: any) => {
+                await reserve({ admitted: true });
+                return { admitted: true };
+            }),
+        };
+        await postMention(makeSvc(gate));
+        expect(runs.markDispatchFailed).toHaveBeenCalledWith(
+            'run-chat-1',
+            expect.stringContaining('dispatch-failed: Trigger.dev down'),
+        );
+    });
+});

--- a/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
+++ b/packages/agent/src/tasks-domain/__tests__/task-transition-dispatch.spec.ts
@@ -261,11 +261,18 @@ describe('TaskTransitionService — Phase 15.3 agent dispatch hook', () => {
                 workId: 'work-1',
                 organizationId: 'org-1',
             } as Partial<Task>);
-            expect(gate.admit).toHaveBeenCalledWith({
-                userId: 'u1',
-                workId: 'work-1',
-                organizationId: 'org-1',
-            });
+            // The second argument is the `reserve` half of the admission:
+            // the gate runs the `createQueued` insert INSIDE its critical
+            // section so the count and the row that consumes the counted
+            // slot cannot be split by a parallel burst.
+            expect(gate.admit).toHaveBeenCalledWith(
+                {
+                    userId: 'u1',
+                    workId: 'work-1',
+                    organizationId: 'org-1',
+                },
+                expect.any(Function),
+            );
             expect(dispatcher.enqueue).toHaveBeenCalledTimes(1);
         });
 

--- a/packages/agent/src/tasks-domain/task-chat.service.ts
+++ b/packages/agent/src/tasks-domain/task-chat.service.ts
@@ -20,6 +20,7 @@ import { ActivityActionType, ActivityStatus } from '../entities/activity-log.typ
 import { assertNoSecrets } from '../utils/secret-scan';
 import { AGENT_CHAT_REPLY_DISPATCHER, type AgentChatReplyDispatcher } from './task-dispatcher';
 import { RUN_STEERING_PORT, type RunSteeringPort } from './run-steering-port';
+import { RunDispatchGateService } from '../agents/run-dispatch-gate.service';
 
 /**
  * Tasks feature — Phase 13.2.
@@ -83,6 +84,13 @@ export class TaskChatService {
         @Optional()
         @Inject(RUN_STEERING_PORT)
         private readonly steering?: RunSteeringPort,
+        // Run orchestration — the SAME concurrency choke point the task
+        // fan-out, board run and resume go through. An @agent mention is
+        // a dispatch like any other: before this, a chat storm could put
+        // unbounded runs on a Work that the board path would have parked.
+        // Appended LAST + @Optional() per the positional-spec arity rule;
+        // without it the path behaves exactly as it did before.
+        @Optional() private readonly dispatchGate?: RunDispatchGateService,
     ) {}
 
     async list(
@@ -160,19 +168,69 @@ export class TaskChatService {
                     }
                     let run: { id: string } | null = null;
                     try {
-                        run = this.runs
-                            ? await this.runs.createQueued({
-                                  agentId: mention.id,
-                                  userId,
-                                  triggerKind: 'chat',
-                                  taskId: task.id,
-                                  chatMessageId: row.id,
-                                  // Wave 4 M1 — workId denorm at creation so
-                                  // chat-triggered runs count toward (and show
-                                  // under) their Work like task runs do.
-                                  workId: task.workId ?? null,
-                              })
-                            : null;
+                        // Run orchestration — admit + reserve as ONE
+                        // critical section, exactly like the task fan-out.
+                        // Over-limit parks the row (queuedReason set, no
+                        // enqueue); `RunDispatchGateService.drainForWork`
+                        // promotes it back onto the CHAT path when a slot
+                        // frees, carrying `chatMessageId` so the agent
+                        // still replies to the message it was mentioned in.
+                        const reserve = async (verdict: {
+                            admitted: boolean;
+                            queuedReason?: string;
+                        }): Promise<void> => {
+                            run = this.runs
+                                ? await this.runs.createQueued({
+                                      agentId: mention.id,
+                                      userId,
+                                      triggerKind: 'chat',
+                                      taskId: task.id,
+                                      chatMessageId: row.id,
+                                      // Wave 4 M1 — workId denorm at creation so
+                                      // chat-triggered runs count toward (and show
+                                      // under) their Work like task runs do.
+                                      workId: task.workId ?? null,
+                                      queuedReason: verdict.admitted
+                                          ? null
+                                          : (verdict.queuedReason ?? null),
+                                  })
+                                : null;
+                        };
+                        let admission: { admitted: boolean; queuedReason?: string } = {
+                            admitted: true,
+                        };
+                        if (this.dispatchGate) {
+                            try {
+                                admission = await this.dispatchGate.admit(
+                                    {
+                                        userId,
+                                        workId: task.workId ?? null,
+                                        organizationId: task.organizationId ?? null,
+                                    },
+                                    reserve,
+                                );
+                            } catch (gateErr) {
+                                // Fail-open: a broken safety valve must
+                                // never swallow a user's @mention.
+                                this.logger.warn(
+                                    `Dispatch gate admit failed for chat message ${row.id} — failing open: ${gateErr}`,
+                                );
+                            }
+                            if (!run) await reserve(admission);
+                        } else {
+                            await reserve(admission);
+                        }
+                        // TypeScript's control-flow analysis cannot see the
+                        // assignment that happens inside `reserve`, so it
+                        // still believes `run` is the `null` it was
+                        // initialised to. Re-widen to the declared type.
+                        run = run as { id: string } | null;
+                        if (!admission.admitted) {
+                            this.logger.log(
+                                `Chat reply for agent ${mention.id} on task ${task.id} parked by dispatch gate (${admission.queuedReason}).`,
+                            );
+                            return;
+                        }
                         const handle = await this.chatDispatcher!.enqueue({
                             agentId: mention.id,
                             userId,

--- a/packages/agent/src/tasks-domain/task-transition.service.ts
+++ b/packages/agent/src/tasks-domain/task-transition.service.ts
@@ -349,35 +349,59 @@ export class TaskTransitionService {
                 let admission: { admitted: boolean; queuedReason?: string } = {
                     admitted: true,
                 };
+                // Pre-create a queued AgentRun row so the worker can find
+                // it via findInFlightForTaskAgent (T6 chat-dedup posture).
+                // `workId` is denormalized here (Wave 4 M1) so per-Work
+                // concurrency counts + the Sessions view need no join.
+                //
+                // Handed to the gate as the `reserve` half of admission so
+                // the count and this insert are one critical section under
+                // the advisory lock (no-op off Postgres).
+                const reserve = async (verdict: {
+                    admitted: boolean;
+                    queuedReason?: string;
+                }): Promise<void> => {
+                    run = this.runs
+                        ? await this.runs.createQueued({
+                              agentId,
+                              userId: task.userId,
+                              triggerKind: 'task',
+                              taskId: task.id,
+                              workId: task.workId ?? null,
+                              queuedReason: verdict.admitted
+                                  ? null
+                                  : (verdict.queuedReason ?? 'concurrency-limit'),
+                          })
+                        : null;
+                };
                 if (this.dispatchGate) {
                     try {
-                        admission = await this.dispatchGate.admit({
-                            userId: task.userId,
-                            workId: task.workId ?? null,
-                            organizationId: task.organizationId ?? null,
-                        });
+                        admission = await this.dispatchGate.admit(
+                            {
+                                userId: task.userId,
+                                workId: task.workId ?? null,
+                                organizationId: task.organizationId ?? null,
+                            },
+                            reserve,
+                        );
                     } catch (gateErr) {
                         this.logger.warn(
                             `Dispatch gate admit failed for task ${task.id} — failing open: ${gateErr}`,
                         );
                     }
+                    // Defence in depth: the gate calls `reserve` on every
+                    // path INCLUDING its own fail-open, but a gate stub
+                    // that ignores the callback must not silently produce a
+                    // dispatch with no run row behind it.
+                    if (!run) await reserve(admission);
+                } else {
+                    await reserve(admission);
                 }
-                // Pre-create a queued AgentRun row so the worker can find
-                // it via findInFlightForTaskAgent (T6 chat-dedup posture).
-                // `workId` is denormalized here (Wave 4 M1) so per-Work
-                // concurrency counts + the Sessions view need no join.
-                run = this.runs
-                    ? await this.runs.createQueued({
-                          agentId,
-                          userId: task.userId,
-                          triggerKind: 'task',
-                          taskId: task.id,
-                          workId: task.workId ?? null,
-                          queuedReason: admission.admitted
-                              ? null
-                              : (admission.queuedReason ?? 'concurrency-limit'),
-                      })
-                    : null;
+                // TypeScript's control-flow analysis cannot see the
+                // assignment that happens inside `reserve`, so it still
+                // believes `run` is the `null` it was initialised to.
+                // Re-widen to the declared type.
+                run = run as { id: string } | null;
                 // Kanban run cockpit — mirror the freshly-queued run onto the
                 // Task row so the board chip appears before the worker even
                 // claims it. The service is best-effort by contract (logs +

--- a/packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-chat-reply.task.ts
@@ -134,6 +134,12 @@ export const agentChatReplyTask = task<'agent-chat-reply', AgentChatReplyPayload
                 // are equal, but using payload.userId keeps this fallback row consistent
                 // with the dispatcher's pre-created row and avoids attributing the run to
                 // a different owner should the lookup ever resolve a foreign agent.
+                //
+                // DOCUMENTED dispatch-gate bypass: worker-side bookkeeping
+                // for a job the runtime has ALREADY accepted and started.
+                // The gate ran at dispatch time (`TaskChatService.post`);
+                // re-admitting here could only refuse work already in
+                // flight and strand it with no run row.
                 run = await runs.createQueued({
                     agentId: agent.id,
                     userId: payload.userId,

--- a/packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-heartbeat.task.ts
@@ -130,6 +130,12 @@ export const agentHeartbeatTask = task<'agent-heartbeat', AgentHeartbeatPayload>
                 run = await runs.findInFlightForAgent(agent.id);
             }
             if (!run) {
+                // DOCUMENTED dispatch-gate bypass: this is worker-side
+                // bookkeeping for a job the runtime has ALREADY accepted
+                // and started, not a new admission. The gate ran at
+                // dispatch time (`AgentScheduleDispatcherService`); asking
+                // it again here could only refuse work that is already
+                // executing, which would strand the job with no run row.
                 run = await runs.createQueued({
                     agentId: agent.id,
                     userId: payload.userId,

--- a/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
+++ b/packages/tasks/src/tasks/trigger/agent-task-execute.task.ts
@@ -280,6 +280,12 @@ export const agentTaskExecuteTask = task<'agent-task-execute', AgentTaskExecuteP
                 run = await runs.findInFlightForTaskAgent(payload.taskId, payload.agentId);
             }
             if (!run) {
+                // DOCUMENTED dispatch-gate bypass: worker-side bookkeeping
+                // for a job the runtime has ALREADY accepted and started.
+                // The gate ran at dispatch time
+                // (`TaskTransitionService.dispatchAgentRun`, the drain, or
+                // assign-task); re-admitting here could only refuse work
+                // already in flight and strand it with no run row.
                 run = await runs.createQueued({
                     agentId: agent.id,
                     userId: agent.userId,


### PR DESCRIPTION
Closes the audit 08(g) runner-up and the platform/web tool-surface gap #1873 reported.

## 1. There were two GitHub webhook receivers

Installing the GitHub App did **not** turn PR review on. The user had to configure a *second* webhook, with a *second* secret, pointing at a *different* URL.

| | `POST /api/github-app/webhooks` | `POST /api/ingest/github/events` |
| --- | --- | --- |
| Origin | pre-existing GitHub App integration | Wave 7 feature (g) |
| Secret | app-level `GITHUB_APP_WEBHOOK_SECRET` | per-user `github` plugin install `webhookSecret` |
| Verifier | `verifyGitHubWebhookSignature` (`@ever-works/agent/utils`) | `verifyGitHubSignature` (`ingest/github/github-signature.util.ts`) |
| Owner resolution | none | `ingest_install_bindings` |
| Consumers | `GitHubAppSyncService` (installation/repo sync) only | `GitHubPrReviewBridgeService` (ingest envelopes + AI review) only |

The Wave 7 receiver's own header named the split and called consolidating it a documented follow-up.

### The merge

New `GitHubWebhookDispatcherService` (`apps/api/src/ingest/github/github-webhook-dispatcher.service.ts`) owns the whole inbound path. Both routes now call it and nothing else.

**One signature verification.** One helper, one place, accepting either configured credential. Two secrets exist because GitHub signs with whichever secret is on the webhook that fired — a single receiver must accept both or it regresses one of the two surfaces. The app secret is tried first (no DB round-trip); when it is unset — self-hosted, no GitHub App — the flow is byte-for-byte the pre-existing per-install path.

**One install binding.** `ingest_install_bindings` stays the single source of install ownership. `IngestBindingMatch` gains an additive `'app-install'` member: a delivery verified by the platform App secret resolves its owner through an existing binding row → `github_app_installations.createdByUserId` → the `github_app_user_links` row behind `createdByGithubUserId`, and the result is **written back into that same table** so later deliveries resolve exactly. No second binding store. An App delivery with no resolvable owner skips the review leg (logged) rather than guessing — the sync leg is user-agnostic and still runs.

**One fan-out, to every consumer.** Every verified delivery, on either route, reaches both `GitHubAppSyncService.handleWebhook` and `GitHubPrReviewBridgeService.handleEvent`. That is what makes installing the App enough.

**Legacy route preserved as a thin forwarder.** `POST /api/github-app/webhooks` is baked into the App's settings on github.com and into every existing installation, so it cannot move. The class moved from `integrations/github-app/` to `ingest/github/` so the receiver files sit together and the module edge points one way (`IngestModule` → `GitHubAppModule`, never back — no cycle). Route, status codes and response body are unchanged; `GitHubAppModule` simply stops registering a webhook controller, which is what stops the two from shadowing each other.

### Preserving behaviour: failure contracts stay per-route

Fanning out to a second consumer must not invent a new way for an existing route to fail. `dispatch()` therefore **reports** both legs' errors instead of throwing, and each controller rethrows only the leg it has always been able to fail on:

- `/api/github-app/webhooks` rethrows a **sync**-leg failure (it always 500'd on those, and GitHub's redelivery is load-bearing for installation sync) and logs a review-leg failure;
- `/api/ingest/github/events` rethrows a **review**-leg failure (its historical behaviour; the spine's `(source, sourceEventId)` dedupe makes the retry free) and logs a sync-leg failure.

Status codes likewise keep their route's meaning: an unattributable delivery is a 200 no-op on the canonical route (so GitHub stops retrying something that can never be routed) and a 401 on the legacy route, because on that URL "no credential verified it" is exactly the case that has always been a 401 there. `not-configured` → 401 and bad-signature → 401 are shared and unchanged.

## 2. Three chat tools had no REST endpoint

`apps/web/src/lib/ai/tools/generated/registry.ts` is manifest-driven over REST operations, so `list_recent_events`, `get_digest` and `review_pull_request` could not be registered on the web side **at all** — the platform and web agents disagreed about which tools exist.

- **`GET /api/ingest/events`** — already shipped in #1872. Verified live (`openapi.json` reports `get,post`) and registered.
- **`GET /api/digest?period=daily|weekly`** — new. Composes for `auth.userId` and nothing else: there is deliberately **no `userId` parameter**, since a digest aggregates the caller's runs, tasks, PRs, ingested events and goals and an accepted "compose for user X" would be a ready-made cross-tenant activity oracle. Read-only — `deliverDigest` (which mutates delivery state) is not exposed; cadence stays the existing profile preference and delivery stays on the cron.
- **`POST /api/pr-review`** — new.

### Why `POST /api/pr-review` is top-level

A review is addressed by a **provider** coordinate (`owner/repo#number`), not a platform entity id. A Work declares several repos (main / website / data) and a repo may match no Work at all, so `POST /api/works/:id/pull-requests/:n/review` would demand a Work id the caller — chat model, PR-list row, webhook — usually does not have, and would be undefined for the repo-without-a-Work case the reviewer explicitly supports. `GET /api/works/:id/pull-requests` stays Work-nested because it *enumerates one Work's repos*, a genuinely Work-shaped question. Precedent for a top-level verb resource over a cross-cutting service: `GET /api/merge-policy/resolve`.

**It refuses cross-user PRs.** The endpoint pulls a diff with the caller's git credentials and posts a comment back, so an unscoped trigger would be a fetch-and-post primitive aimed at any repository. Ownership is established *before* anything runs: an explicit `workId` goes through `WorkOwnershipService.ensureAccess` (cross-user Works 404 with no existence leak), **and** `matchWorkForRepo(auth.userId, owner, repo)` — which only ever searches the caller's own Works — must match. A repo connected to someone else's Work and a repo connected to no Work 404 identically, leaking nothing about which. Deliberately stricter than the chat tool, which runs inside an already owner-scoped agent; a REST endpoint takes its coordinates straight from the client and has to prove the link itself. Throttled to 20/min (each call spends model credits).

Both endpoints carry no `@Public()`, so the global `AuthSessionGuard` 401s an unauthenticated call — pinned by spec.

### Naming convention (decided)

**New tools are `snake_case`: action verb + singular noun.** It is already the majority on both sides — all 334 raw web manifest entries (332 unique after dedupe; the spec pins that zero are camelCase) and every newer platform domain tool (`list_meetings`, `get_meeting_summary`, `list_fleet_nodes`, `resolve_merge_policy`) follow it.

**Existing camelCase tools are NOT renamed** — the platform built-ins (`searchWeb`, `sendEmail`, `createTask`, …) and the hand-written web tools (`listWorks`, `createMission`, …). A tool name is part of a live contract with the model *and* appears in stored conversation histories, so renaming breaks replay of past conversations and every prompt/spec/test that names them, for zero user-visible gain. Documented in `docs/specs/features/chat-everything/README.md` §4.1, in the registry header, and in `AgentToolService.buildDomainTools`.

Keyword slots ship in the same change (`tool-selection.ts`: new `events` / `digest` / `prreview` domains + `deriveDomain` entries) — the program DoD rule, and a registry entry with no slot is gated out of every turn.

## Two pre-existing breakages fixed in passing

- **`apps/web` does not typecheck on `develop`.** Merge `6bd78d10` truncated `tasksApi.listRunCandidates` in `apps/web/src/lib/api/tasks.ts`, dropping its closing three lines — `npx tsc --noEmit` fails with `TS1005` and `next build` would too. Restored verbatim from `60eda30c`.
- **`packages/agent` `agent-tool-domain.spec.ts` was red on `develop`** — a stale positional-argument assertion for `findRecentByUser`, which now takes a filter object. Confirmed pre-existing by stashing this branch's changes and re-running.

## Verification (real output)

**`packages/agent` build — TSC 0**

```
> nest build -b swc && tsc -p tsconfig.types.json
>  TSC  Found 0 issues.
Successfully compiled: 1100 files with swc
```

**`packages/agent` touched suites** (`agents|digest|pr-review|ingest`)

```
Test Suites: 43 passed, 43 total
Tests:       506 passed, 506 total
```

**`ever-works-api` build**

```
ever-works-api:build: >  TSC  Found 0 issues.
ever-works-api:build: Successfully compiled: 710 files with swc
 Tasks:    14 successful, 14 total
```

**`apps/api pnpm generate:openapi`** (`openapi.json` excluded from the commit — it is gitignored)

```
Wrote OpenAPI spec (450 paths) to .../apps/api/openapi.json

/api/digest              -> get
/api/pr-review           -> post
/api/ingest/events       -> get,post
/api/ingest/github/events-> post
/api/github-app/webhooks -> post      <- legacy route still answering
```

**Real DI instantiation.** `generate:openapi` runs Nest in PREVIEW mode (`Providers/controllers will not be instantiated`), so it cannot catch an unbound provider — the trap that hid the InboundTriggersModule regression. A throwaway `Test.createTestingModule({ imports: [ApiModule] }).compile()` against a real Postgres *does* instantiate the whole graph, and `compile()` (rather than `init()`) means no bootstrap query can mask a DI failure:

```
DI-OK: GitHubWebhookDispatcherService.dispatch = function
DI-OK: GitHubEventsController -> receiveEvents
DI-OK: GitHubAppWebhookController -> handleWebhook
DI-OK: DigestController -> getDigest
DI-OK: PrReviewController -> reviewPullRequest
```

**`apps/api` receiver + new controller suites**

```
PASS src/ingest/github/github-webhook-dispatcher.service.spec.ts
PASS src/ingest/github/github-events.controller.spec.ts
PASS src/ingest/github/github-app-webhook.controller.spec.ts
PASS src/ingest/github/github-pr-review-bridge.service.spec.ts
PASS src/ingest/github/github-signature.util.spec.ts
PASS src/ingest/ingest.module.spec.ts
PASS src/digest/digest.controller.spec.ts
PASS src/pr-review/pr-review.controller.spec.ts
PASS src/integrations/github-app/*.spec.ts (5 suites)
Test Suites: 16 passed, 16 total
Tests:       191 passed, 191 total
```

**Full `apps/api` suite**

```
Test Suites: 1 skipped, 221 passed, 221 of 222 total
Tests:       9 skipped, 3600 passed, 3609 total
```

**`apps/web npx tsc --noEmit`** (`tsconfig.tsbuildinfo` removed first)

```
TSC EXIT=0
```

**`apps/web` tool-registry unit tests**

```
 Test Files  8 passed (8)
      Tests  96 passed (96)
```

**Prettier**

```
Checking formatting...
All matched files use Prettier code style!
```

## Tests: 45 new

| suite | count |
| --- | --- |
| `ingest/github/github-webhook-dispatcher.service.spec.ts` — one verification / two credentials, fan-out to both consumers, one install binding (row → `createdByUserId` → user link → record-back), fail-closed 401s, 200 no-op refusal, isolated consumer failures | 17 |
| `ingest/github/github-events.controller.spec.ts` — every pre-consolidation assertion re-run through the real dispatcher, plus the new sync leg and this route's failure contract | +3 (13 total) |
| `ingest/github/github-app-webhook.controller.spec.ts` — legacy route still answers: 400s, 401, `{ ok: true }`, rethrown sync failure, AND it now drives the review loop | 7 |
| `ingest/ingest.module.spec.ts` — module-shape pin: both routes registered here over one dispatcher, provided exactly once, `GitHubAppModule` imported, App module registers no webhook controller | 6 |
| `digest/digest.controller.spec.ts` — composed shape, session-user-only scoping, period default/forwarding, not `@Public()`, DTO validation | 7 |
| `pr-review/pr-review.controller.spec.ts` — owner-scoped run, cross-user repo 404 before any provider call, `workId` ownership check, own-Work-id + stranger-repo refused, not `@Public()`, DTO validation | 12 |
| `web/.../generated/registry-parity.unit.spec.ts` — all three entries resolve to the endpoints that now exist, no duplicate `toolName`, keyword slots reach each tool, no leakage into unrelated turns, snake_case convention | 12 |

Additive throughout: no existing route, status code, response body, secret or binding semantic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
