### PR TITLE
feat(works): campaign activation + external-refs editor

### DIFF
--- a/apps/api/src/works/dto/create-campaign-work.dto.ts
+++ b/apps/api/src/works/dto/create-campaign-work.dto.ts
@@ -1,0 +1,109 @@
+import { Type, Transform } from 'class-transformer';
+import {
+    ArrayMaxSize,
+    IsArray,
+    IsIn,
+    IsNotEmpty,
+    IsNumber,
+    IsOptional,
+    IsPositive,
+    IsString,
+    Matches,
+    MaxLength,
+    ValidateNested,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+const GOAL_WINDOWS = ['day', 'week', 'month', 'total', 'point'] as const;
+
+/** Optional measurable target carried on a campaign brief. */
+export class CampaignTargetDto {
+    @ApiPropertyOptional({
+        description:
+            'Metric id the campaign Goal targets. Constrained to the campaign Work kind’s own metric vocabulary (defaults to `conversions`).',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(64)
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+    metricId?: string;
+
+    @ApiPropertyOptional({ description: 'Target value (must be positive).', example: 25 })
+    @IsOptional()
+    @IsNumber()
+    @IsPositive()
+    value?: number;
+
+    @ApiPropertyOptional({ description: 'Unit label for the target.', example: 'signups' })
+    @IsOptional()
+    @IsString()
+    @MaxLength(32)
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+    unit?: string;
+
+    @ApiPropertyOptional({
+        description: 'Evaluation window for the Goal.',
+        enum: GOAL_WINDOWS,
+    })
+    @IsOptional()
+    @IsIn(GOAL_WINDOWS)
+    window?: (typeof GOAL_WINDOWS)[number];
+}
+
+/**
+ * Body of `POST /api/works/from-campaign-template`.
+ *
+ * A brief, not a Work payload: the activation service derives the Work,
+ * the Goal, the go-to-market Agents, the seeded pipeline Tasks and the
+ * pipeline preference from these few fields.
+ */
+export class CreateCampaignWorkDto {
+    @ApiProperty({ description: 'Campaign name.', maxLength: 100, example: 'Q3 developer launch' })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(100)
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+    name: string;
+
+    @ApiProperty({
+        description: 'What the campaign is trying to achieve — becomes the campaign Goal.',
+        maxLength: 500,
+        example: 'Book 25 qualified demos with platform engineering teams',
+    })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(500)
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+    objective: string;
+
+    @ApiPropertyOptional({
+        description:
+            'Explicit slug for the campaign Work. Derived from `name` (and de-duplicated) when omitted.',
+    })
+    @IsOptional()
+    @IsString()
+    @MaxLength(100)
+    @Matches(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, {
+        message: 'Slug can only contain lowercase letters, numbers, and hyphens',
+    })
+    @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+    slug?: string;
+
+    @ApiPropertyOptional({ description: 'Optional measurable target.', type: CampaignTargetDto })
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => CampaignTargetDto)
+    target?: CampaignTargetDto;
+
+    @ApiPropertyOptional({
+        description:
+            'Channels the campaign runs on (email, linkedin, newsletter…). Recorded as labels on the seeded pipeline Tasks. Max 10.',
+        type: [String],
+    })
+    @IsOptional()
+    @IsArray()
+    @ArrayMaxSize(10)
+    @IsString({ each: true })
+    @MaxLength(40, { each: true })
+    channels?: string[];
+}

--- a/apps/api/src/works/work-campaigns.controller.spec.ts
+++ b/apps/api/src/works/work-campaigns.controller.spec.ts
@@ -1,0 +1,123 @@
+// Short-circuit the transitive `@ever-works/agent/*` import chains so the
+// test doesn't pull `@src/entities` (which only resolves inside apps/api)
+// through the agent-package barrels. House pattern — mirrors
+// work-runs.controller.spec.ts. The campaign catalog is re-declared here
+// with the real shape so the preview assertions stay meaningful.
+jest.mock('@ever-works/agent/campaigns', () => ({
+    __esModule: true,
+    CampaignActivationService: class {},
+    CAMPAIGN_PIPELINE_ID: 'gtm-pipeline',
+    CAMPAIGN_GOAL_METRIC_IDS: ['agents', 'open-tasks', 'conversions', 'days-active'],
+    CAMPAIGN_GOAL_DEFAULTS: {
+        metricId: 'conversions',
+        comparator: 'gte',
+        targetValue: 10,
+        unit: 'conversions',
+        window: 'month',
+    },
+    CAMPAIGN_SEED_STAGES: [
+        { stageId: 'research', title: 'Research', description: 'collect' },
+        { stageId: 'qualify', title: 'Qualify', description: 'score' },
+    ],
+    listCampaignAgentTemplates: () => [
+        {
+            slug: 'lead-researcher',
+            name: 'Lead Researcher',
+            title: 'Lead research',
+            category: 'sales',
+        },
+    ],
+}));
+jest.mock('../auth', () => ({
+    __esModule: true,
+    AuthService: class {},
+    AuthSessionGuard: class {},
+    CurrentUser: () => () => undefined,
+}));
+
+import { WorkCampaignsController } from './work-campaigns.controller';
+
+/**
+ * `POST /api/works/from-campaign-template` — the only path that mints a
+ * `campaign` Work. The controller is deliberately thin: resolve the
+ * authenticated user, hand the brief to the activation service. The
+ * load-bearing assertions are that it resolves the ACTING user (never a
+ * client-supplied id) and that the brief is forwarded verbatim.
+ */
+describe('WorkCampaignsController', () => {
+    const auth = { userId: 'u1' } as never;
+    const user = { id: 'u1', username: 'founder' };
+
+    let authService: { getUser: jest.Mock };
+    let activation: { activate: jest.Mock };
+    let controller: WorkCampaignsController;
+
+    beforeEach(() => {
+        authService = { getUser: jest.fn().mockResolvedValue(user) };
+        activation = {
+            activate: jest.fn().mockResolvedValue({
+                work: { id: 'w1', slug: 'q3-launch', name: 'Q3 launch', kind: 'campaign' },
+                goal: { id: 'g1', title: 'Q3 launch', metricId: 'conversions', targetValue: 10 },
+                agents: [],
+                tasks: [],
+                pipeline: { id: 'gtm-pipeline', applied: true },
+            }),
+        };
+        controller = new WorkCampaignsController(authService as never, activation as never);
+    });
+
+    it('activates a brief for the ACTING user and returns the provisioning summary', async () => {
+        const result = await controller.createFromCampaignTemplate(auth, {
+            name: 'Q3 launch',
+            objective: 'Book 25 demos',
+            channels: ['email'],
+        } as never);
+
+        expect(authService.getUser).toHaveBeenCalledWith('u1');
+        expect(activation.activate).toHaveBeenCalledWith(user, {
+            name: 'Q3 launch',
+            objective: 'Book 25 demos',
+            slug: null,
+            target: null,
+            channels: ['email'],
+        });
+        expect(result.work.kind).toBe('campaign');
+    });
+
+    it('forwards an explicit slug and target instead of defaulting them', async () => {
+        await controller.createFromCampaignTemplate(auth, {
+            name: 'Q3 launch',
+            objective: 'Book 25 demos',
+            slug: 'q3-launch',
+            target: { metricId: 'conversions', value: 25, unit: 'demos', window: 'month' },
+        } as never);
+
+        expect(activation.activate.mock.calls[0][1]).toMatchObject({
+            slug: 'q3-launch',
+            target: { metricId: 'conversions', value: 25, unit: 'demos', window: 'month' },
+        });
+    });
+
+    it('previews what activation will provision (agents, stages, metric vocabulary)', () => {
+        const preview = controller.getCampaignTemplate();
+
+        expect(preview.pipelineId).toBe('gtm-pipeline');
+        expect(preview.metricIds).toContain('conversions');
+        expect(preview.defaults.metricId).toBe('conversions');
+        expect(preview.agents).toEqual([
+            {
+                slug: 'lead-researcher',
+                name: 'Lead Researcher',
+                title: 'Lead research',
+                category: 'sales',
+            },
+        ]);
+        expect(preview.stages.map((s) => s.stageId)).toEqual(['research', 'qualify']);
+    });
+
+    it('does not touch the activation service just to render the preview', () => {
+        controller.getCampaignTemplate();
+        expect(activation.activate).not.toHaveBeenCalled();
+        expect(authService.getUser).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/works/work-campaigns.controller.ts
+++ b/apps/api/src/works/work-campaigns.controller.ts
@@ -1,0 +1,104 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, UseGuards } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+    CampaignActivationService,
+    CAMPAIGN_GOAL_DEFAULTS,
+    CAMPAIGN_GOAL_METRIC_IDS,
+    CAMPAIGN_PIPELINE_ID,
+    CAMPAIGN_SEED_STAGES,
+    listCampaignAgentTemplates,
+    type CampaignActivationResult,
+} from '@ever-works/agent/campaigns';
+import { AuthService, AuthSessionGuard, CurrentUser } from '../auth';
+import { AuthenticatedUser } from '@src/auth/types/auth.types';
+import { CreateCampaignWorkDto } from './dto/create-campaign-work.dto';
+
+/** Shape returned by `GET /api/works/campaign-template`. */
+interface CampaignTemplatePreview {
+    pipelineId: string;
+    metricIds: readonly string[];
+    defaults: typeof CAMPAIGN_GOAL_DEFAULTS;
+    agents: Array<{ slug: string; name: string; title: string; category: string }>;
+    stages: Array<{ stageId: string; title: string; description: string }>;
+}
+
+/**
+ * Campaign activation (roadmap 14.1 / audit G20).
+ *
+ * The `campaign` Work kind shipped with capabilities + metrics but nothing
+ * minted one — it is deliberately absent from `USER_SELECTABLE_WORK_KINDS`,
+ * so the general create path cannot produce it. These two routes are the
+ * dedicated activation path:
+ *
+ *   - `GET  /api/works/campaign-template` — what activation will provision
+ *     (agents, stages, metric vocabulary), so the UI can preview it;
+ *   - `POST /api/works/from-campaign-template` — activate a brief.
+ *
+ * Kept in its own controller (the `WorkTemplatesController` / `KbController`
+ * idiom) rather than bolted onto the 30-dependency `WorksController`.
+ */
+@ApiTags('Works')
+@ApiBearerAuth('JWT-auth')
+@Controller('api')
+@UseGuards(AuthSessionGuard)
+export class WorkCampaignsController {
+    constructor(
+        private readonly authService: AuthService,
+        private readonly campaignActivation: CampaignActivationService,
+    ) {}
+
+    @Get('works/campaign-template')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({
+        summary: 'Preview the campaign template',
+        description:
+            'Returns the prebuilt go-to-market agents, the seeded pipeline stages and the metric vocabulary a campaign activation provisions.',
+    })
+    @ApiResponse({ status: 200, description: 'Campaign template preview' })
+    getCampaignTemplate(): CampaignTemplatePreview {
+        return {
+            pipelineId: CAMPAIGN_PIPELINE_ID,
+            metricIds: CAMPAIGN_GOAL_METRIC_IDS,
+            defaults: CAMPAIGN_GOAL_DEFAULTS,
+            agents: listCampaignAgentTemplates().map((template) => ({
+                slug: template.slug,
+                name: template.name,
+                title: template.title,
+                category: template.category,
+            })),
+            stages: CAMPAIGN_SEED_STAGES.map((stage) => ({
+                stageId: stage.stageId,
+                title: stage.title,
+                description: stage.description,
+            })),
+        };
+    }
+
+    @Post('works/from-campaign-template')
+    @HttpCode(HttpStatus.CREATED)
+    // Activation writes a Work + a Goal + N agents + N tasks in one call,
+    // so it carries the same per-IP envelope as the other create paths.
+    @Throttle({ long: { limit: 10, ttl: 60_000 } })
+    @ApiOperation({
+        summary: 'Start a campaign',
+        description:
+            'Provisions a campaign Work from a brief: a Work of kind `campaign`, a Goal capturing the objective, the prebuilt go-to-market Agents, seeded Tasks for the first pipeline stages, and `gtm-pipeline` as the Work’s pipeline preference. Owner-scoped and atomic — a failure at any step removes everything it already created.',
+    })
+    @ApiResponse({ status: 201, description: 'Campaign activated' })
+    @ApiResponse({ status: 400, description: 'Invalid brief' })
+    @ApiResponse({ status: 409, description: 'Slug already taken' })
+    async createFromCampaignTemplate(
+        @CurrentUser() auth: AuthenticatedUser,
+        @Body() dto: CreateCampaignWorkDto,
+    ): Promise<CampaignActivationResult> {
+        const user = await this.authService.getUser(auth.userId);
+        return this.campaignActivation.activate(user, {
+            name: dto.name,
+            objective: dto.objective,
+            slug: dto.slug ?? null,
+            target: dto.target ?? null,
+            channels: dto.channels ?? null,
+        });
+    }
+}

--- a/apps/api/src/works/works.module.ts
+++ b/apps/api/src/works/works.module.ts
@@ -15,6 +15,9 @@ import { OrganizationsModule } from '../organizations/organizations.module';
 // Run orchestration (Wave 4 M3) — AgentsModule exports AgentRunRepository
 // for the per-Work runs-summary endpoint (DatabaseModule does not provide it).
 import { AgentsModule } from '@ever-works/agent/agents';
+// Campaign activation (roadmap 14.1) — composition module over Works,
+// Goals, Agent templates and Tasks; provides CampaignActivationService.
+import { CampaignsModule } from '@ever-works/agent/campaigns';
 
 // Controllers
 import { WorksController } from './works.controller';
@@ -27,6 +30,7 @@ import { KbController } from './kb.controller';
 import { OrgKbController } from './org-kb.controller';
 import { OrgMemoryController } from './org-memory.controller';
 import { WorkTemplatesController } from './work-templates.controller';
+import { WorkCampaignsController } from './work-campaigns.controller';
 
 // Services
 import { WorksTemplateCatalogService } from './works-template-catalog.service';
@@ -60,6 +64,9 @@ import { WorkScheduleDispatcherCronService } from './tasks/work-schedule-dispatc
         // Run orchestration (Wave 4 M3) — AgentRunRepository for the
         // per-Work runs-summary endpoint.
         AgentsModule,
+        // Campaign activation (roadmap 14.1) — CampaignActivationService
+        // for POST /api/works/from-campaign-template.
+        CampaignsModule,
     ],
     providers: [
         CacheEntryRepository,
@@ -122,6 +129,8 @@ import { WorkScheduleDispatcherCronService } from './tasks/work-schedule-dispatc
         // KnowledgeBaseModule + OrganizationsModule (membership guard) wiring.
         OrgMemoryController,
         WorkTemplatesController,
+        // Roadmap 14.1 — the only path that mints a `campaign` Work.
+        WorkCampaignsController,
     ],
 })
 export class WorksModule {}

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -4185,6 +4185,42 @@
                     "defaultsLabel": "Default checks",
                     "defaultsDescription": "Inherited by every Task under this Work. A Task check with the same id overrides its default.",
                     "defaultsSave": "Save default checks"
+                },
+                "externalRefs": {
+                    "title": "Ingest routing claims",
+                    "subtitle": "Claim the external containers whose events belong to this Work. Ingested events carrying one of these identifiers are routed here instead of staying account-wide. Repositories are not listed — repository events already route through the repositories this Work declares.",
+                    "add": "Add",
+                    "save": "Save claims",
+                    "saved": "Routing claims saved",
+                    "saveFailed": "Could not save the routing claims",
+                    "remove": "Remove {id}",
+                    "kinds": {
+                        "chat-channel": {
+                            "label": "Chat channels",
+                            "helper": "Chat channel IDs whose messages belong to this Work (for example a Slack channel id like C0123456789).",
+                            "placeholder": "C0123456789"
+                        },
+                        "tracker-team": {
+                            "label": "Tracker teams",
+                            "helper": "Issue-tracker team keys whose issues belong to this Work (for example the team identifier ENG).",
+                            "placeholder": "ENG"
+                        },
+                        "doc-database": {
+                            "label": "Doc databases",
+                            "helper": "Document database IDs whose pages belong to this Work (for example a wiki or docs database id).",
+                            "placeholder": "db_2f19c4a7"
+                        },
+                        "meeting": {
+                            "label": "Meetings",
+                            "helper": "Recurring meeting IDs whose transcripts and notes belong to this Work.",
+                            "placeholder": "meeting-8891"
+                        }
+                    },
+                    "errors": {
+                        "duplicate": "That identifier is already claimed under this kind.",
+                        "tooLong": "Identifiers can be at most {max} characters.",
+                        "tooMany": "At most {max} identifiers per kind."
+                    }
                 }
             },
             "deploy": {
@@ -5195,6 +5231,34 @@
                     "description": "Repositories with this name already exist in your account. You can use a different name or accept the suggestion.",
                     "useSuggestion": "Use \"{slug}\" instead"
                 }
+            },
+            "campaign": {
+                "chip": "Start a campaign",
+                "title": "Start a campaign",
+                "subtitle": "Describe the campaign and we provision the whole go-to-market setup: a campaign Work, a goal for the objective, the prebuilt go-to-market agents, and tasks for the first pipeline stages.",
+                "nameLabel": "Campaign name",
+                "namePlaceholder": "Q3 developer launch",
+                "objectiveLabel": "Objective",
+                "objectivePlaceholder": "Book 25 qualified demos with platform engineering teams",
+                "targetLabel": "Target (optional)",
+                "targetValuePlaceholder": "25",
+                "targetUnitPlaceholder": "demos",
+                "channelsLabel": "Channels (optional)",
+                "channelsPlaceholder": "email, linkedin, newsletter",
+                "channelsHelper": "Comma-separated. Recorded as labels on the seeded pipeline tasks.",
+                "submit": "Start campaign",
+                "submitting": "Provisioning your campaign…",
+                "success": "Campaign \"{name}\" is ready",
+                "failed": "Could not start the campaign",
+                "provisions": {
+                    "title": "What this provisions",
+                    "work": "A Work of kind campaign",
+                    "goal": "A goal capturing the objective",
+                    "agents": "The prebuilt go-to-market agents",
+                    "tasks": "Tasks for the first pipeline stages",
+                    "pipeline": "The go-to-market pipeline as this Work's pipeline preference"
+                },
+                "pipelineNotPinned": "The go-to-market pipeline could not be pinned to this Work; runs will auto-detect a pipeline instead."
             }
         },
         "gitProvider": {

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/campaign/campaign-form-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/campaign/campaign-form-client.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { Loader2, Megaphone } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { PageHeader } from '@/components/common/PageHeader';
+import { useRouter } from '@/i18n/navigation';
+import { createCampaignWork } from '@/app/actions/dashboard/works';
+
+/** Split a comma-separated channel list into trimmed, deduped entries. */
+export function parseChannels(raw: string): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const part of raw.split(',')) {
+        const trimmed = part.trim().slice(0, 40);
+        if (!trimmed) continue;
+        const key = trimmed.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(trimmed);
+        if (out.length >= 10) break;
+    }
+    return out;
+}
+
+/**
+ * Campaign brief form — name + objective (+ optional target and channels).
+ *
+ * Submits to the single activation endpoint, which provisions the Work,
+ * the Goal, the go-to-market Agents, the seeded pipeline Tasks and the
+ * pipeline preference in one owner-scoped, all-or-nothing call.
+ */
+export default function CampaignFormClient() {
+    const t = useTranslations('dashboard.workCreation.campaign');
+    const router = useRouter();
+
+    const [name, setName] = useState('');
+    const [objective, setObjective] = useState('');
+    const [targetValue, setTargetValue] = useState('');
+    const [targetUnit, setTargetUnit] = useState('');
+    const [channels, setChannels] = useState('');
+    const [pending, startTransition] = useTransition();
+
+    const canSubmit = name.trim().length > 0 && objective.trim().length > 0 && !pending;
+
+    const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        if (!canSubmit) return;
+
+        const parsedTarget = Number(targetValue);
+        const target =
+            targetValue.trim() && Number.isFinite(parsedTarget) && parsedTarget > 0
+                ? {
+                      value: parsedTarget,
+                      ...(targetUnit.trim() ? { unit: targetUnit.trim() } : {}),
+                  }
+                : undefined;
+
+        startTransition(async () => {
+            const result = await createCampaignWork({
+                name: name.trim(),
+                objective: objective.trim(),
+                target,
+                channels: parseChannels(channels),
+            });
+
+            if (!result.success) {
+                toast.error(result.error || t('failed'));
+                return;
+            }
+
+            toast.success(t('success', { name: result.campaign.work.name }));
+            if (!result.campaign.pipeline.applied) {
+                toast.warning(t('pipelineNotPinned'));
+            }
+            router.push(`/works/${result.campaign.work.id}`);
+        });
+    };
+
+    return (
+        <div className="w-full space-y-6">
+            <PageHeader icon={Megaphone} title={t('title')} subtitle={t('subtitle')} tone="work" />
+
+            <form
+                onSubmit={handleSubmit}
+                className={cn(
+                    'rounded-lg border overflow-hidden',
+                    'bg-card dark:bg-card-primary-dark/30',
+                    'border-card-border dark:border-border-secondary-dark',
+                )}
+                data-testid="campaign-brief-form"
+            >
+                <div className="px-5 py-4 space-y-4">
+                    <div className="space-y-1.5">
+                        <label
+                            htmlFor="campaign-name"
+                            className="text-xs font-medium text-text dark:text-text-dark"
+                        >
+                            {t('nameLabel')}
+                        </label>
+                        <Input
+                            id="campaign-name"
+                            value={name}
+                            onChange={(event) => setName(event.target.value)}
+                            placeholder={t('namePlaceholder')}
+                            maxLength={100}
+                            disabled={pending}
+                            required
+                        />
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <label
+                            htmlFor="campaign-objective"
+                            className="text-xs font-medium text-text dark:text-text-dark"
+                        >
+                            {t('objectiveLabel')}
+                        </label>
+                        <Textarea
+                            id="campaign-objective"
+                            value={objective}
+                            onChange={(event) => setObjective(event.target.value)}
+                            placeholder={t('objectivePlaceholder')}
+                            maxLength={500}
+                            rows={3}
+                            disabled={pending}
+                            required
+                        />
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <span className="text-xs font-medium text-text dark:text-text-dark">
+                            {t('targetLabel')}
+                        </span>
+                        <div className="flex items-center gap-2">
+                            <Input
+                                aria-label={t('targetLabel')}
+                                type="number"
+                                min={1}
+                                value={targetValue}
+                                onChange={(event) => setTargetValue(event.target.value)}
+                                placeholder={t('targetValuePlaceholder')}
+                                disabled={pending}
+                            />
+                            <Input
+                                aria-label={t('targetUnitPlaceholder')}
+                                value={targetUnit}
+                                onChange={(event) => setTargetUnit(event.target.value)}
+                                placeholder={t('targetUnitPlaceholder')}
+                                maxLength={32}
+                                disabled={pending}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <label
+                            htmlFor="campaign-channels"
+                            className="text-xs font-medium text-text dark:text-text-dark"
+                        >
+                            {t('channelsLabel')}
+                        </label>
+                        <Input
+                            id="campaign-channels"
+                            value={channels}
+                            onChange={(event) => setChannels(event.target.value)}
+                            placeholder={t('channelsPlaceholder')}
+                            disabled={pending}
+                        />
+                        <p className="text-xs text-text-muted dark:text-text-muted-dark">
+                            {t('channelsHelper')}
+                        </p>
+                    </div>
+
+                    <div className="rounded-md border border-border dark:border-border-dark px-4 py-3">
+                        <h3 className="text-xs font-semibold text-text dark:text-text-dark">
+                            {t('provisions.title')}
+                        </h3>
+                        <ul className="mt-1.5 space-y-1 text-xs text-text-muted dark:text-text-muted-dark list-disc pl-4">
+                            <li>{t('provisions.work')}</li>
+                            <li>{t('provisions.goal')}</li>
+                            <li>{t('provisions.agents')}</li>
+                            <li>{t('provisions.tasks')}</li>
+                            <li>{t('provisions.pipeline')}</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <div className="flex items-center justify-end gap-2 border-t border-card-border dark:border-border-secondary-dark px-5 py-3.5">
+                    <Button type="submit" disabled={!canSubmit} data-testid="campaign-submit">
+                        {pending && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+                        {pending ? t('submitting') : t('submit')}
+                    </Button>
+                </div>
+            </form>
+        </div>
+    );
+}

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/campaign/campaign-form-client.unit.spec.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/campaign/campaign-form-client.unit.spec.tsx
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, vars?: Record<string, unknown>) =>
+        vars ? `${key}:${JSON.stringify(vars)}` : key,
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+const toastWarning = vi.fn();
+vi.mock('sonner', () => ({
+    toast: {
+        success: (...args: unknown[]) => toastSuccess(...args),
+        error: (...args: unknown[]) => toastError(...args),
+        warning: (...args: unknown[]) => toastWarning(...args),
+    },
+}));
+
+const push = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ push, refresh: vi.fn() }),
+    Link: ({ children }: { children?: React.ReactNode }) => <a>{children}</a>,
+}));
+
+const createCampaignWork = vi.fn();
+vi.mock('@/app/actions/dashboard/works', () => ({
+    createCampaignWork: (...args: unknown[]) => createCampaignWork(...args),
+}));
+
+import CampaignFormClient, { parseChannels } from './campaign-form-client';
+
+const OK = {
+    success: true,
+    campaign: {
+        work: { id: 'w1', slug: 'q3-launch', name: 'Q3 launch', kind: 'campaign' },
+        goal: { id: 'g1', title: 'Q3 launch', metricId: 'conversions', targetValue: 25 },
+        agents: [],
+        tasks: [],
+        pipeline: { id: 'gtm-pipeline', applied: true },
+    },
+};
+
+/**
+ * "Start a campaign" — the activation surface for the `campaign` Work
+ * kind. One brief in; the API provisions Work + Goal + Agents + Tasks +
+ * pipeline preference atomically.
+ */
+describe('CampaignFormClient', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        createCampaignWork.mockResolvedValue(OK);
+    });
+
+    it('lists what activation provisions so the brief is not a black box', () => {
+        render(<CampaignFormClient />);
+        const form = screen.getByTestId('campaign-brief-form');
+
+        for (const key of ['work', 'goal', 'agents', 'tasks', 'pipeline']) {
+            expect(form.textContent).toContain(`provisions.${key}`);
+        }
+    });
+
+    it('keeps submit disabled until both name and objective are filled', async () => {
+        const user = userEvent.setup();
+        render(<CampaignFormClient />);
+
+        const submit = screen.getByTestId('campaign-submit') as HTMLButtonElement;
+        expect(submit.disabled).toBe(true);
+
+        await user.type(screen.getByLabelText('nameLabel'), 'Q3 launch');
+        expect((screen.getByTestId('campaign-submit') as HTMLButtonElement).disabled).toBe(true);
+
+        await user.type(screen.getByLabelText('objectiveLabel'), 'Book 25 demos');
+        expect((screen.getByTestId('campaign-submit') as HTMLButtonElement).disabled).toBe(false);
+    });
+
+    it('submits the brief, then routes to the new campaign Work', async () => {
+        const user = userEvent.setup();
+        render(<CampaignFormClient />);
+
+        await user.type(screen.getByLabelText('nameLabel'), 'Q3 launch');
+        await user.type(screen.getByLabelText('objectiveLabel'), 'Book 25 demos');
+        await user.type(screen.getByLabelText('targetLabel'), '25');
+        await user.type(screen.getByLabelText('targetUnitPlaceholder'), 'demos');
+        await user.type(screen.getByLabelText('channelsLabel'), 'email, LinkedIn, email');
+        await user.click(screen.getByTestId('campaign-submit'));
+
+        expect(createCampaignWork).toHaveBeenCalledWith({
+            name: 'Q3 launch',
+            objective: 'Book 25 demos',
+            target: { value: 25, unit: 'demos' },
+            // Comma-separated, trimmed, de-duplicated.
+            channels: ['email', 'LinkedIn'],
+        });
+        expect(toastSuccess).toHaveBeenCalledWith('success:{"name":"Q3 launch"}');
+        expect(push).toHaveBeenCalledWith('/works/w1');
+    });
+
+    it('omits the target entirely when no positive value was entered', async () => {
+        const user = userEvent.setup();
+        render(<CampaignFormClient />);
+
+        await user.type(screen.getByLabelText('nameLabel'), 'Q3 launch');
+        await user.type(screen.getByLabelText('objectiveLabel'), 'Book demos');
+        await user.click(screen.getByTestId('campaign-submit'));
+
+        expect(createCampaignWork.mock.calls[0][0].target).toBeUndefined();
+    });
+
+    it('warns (but still navigates) when the pipeline preference could not be pinned', async () => {
+        const user = userEvent.setup();
+        createCampaignWork.mockResolvedValue({
+            ...OK,
+            campaign: {
+                ...OK.campaign,
+                pipeline: { id: 'gtm-pipeline', applied: false, reason: 'plugin not found' },
+            },
+        });
+        render(<CampaignFormClient />);
+
+        await user.type(screen.getByLabelText('nameLabel'), 'Q3 launch');
+        await user.type(screen.getByLabelText('objectiveLabel'), 'Book demos');
+        await user.click(screen.getByTestId('campaign-submit'));
+
+        expect(toastWarning).toHaveBeenCalledWith('pipelineNotPinned');
+        expect(push).toHaveBeenCalledWith('/works/w1');
+    });
+
+    it('surfaces an activation failure and stays on the form', async () => {
+        const user = userEvent.setup();
+        createCampaignWork.mockResolvedValue({ success: false, error: 'slug already taken' });
+        render(<CampaignFormClient />);
+
+        await user.type(screen.getByLabelText('nameLabel'), 'Q3 launch');
+        await user.type(screen.getByLabelText('objectiveLabel'), 'Book demos');
+        await user.click(screen.getByTestId('campaign-submit'));
+
+        expect(toastError).toHaveBeenCalledWith('slug already taken');
+        expect(push).not.toHaveBeenCalled();
+    });
+});
+
+describe('parseChannels', () => {
+    it('trims, drops blanks and de-duplicates case-insensitively', () => {
+        expect(parseChannels(' email , LinkedIn ,, email,')).toEqual(['email', 'LinkedIn']);
+    });
+
+    it('caps the list at ten channels', () => {
+        const many = Array.from({ length: 15 }, (_, i) => `ch${i}`).join(',');
+        expect(parseChannels(many)).toHaveLength(10);
+    });
+});

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/campaign/page.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/campaign/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import { getTranslations } from 'next-intl/server';
+import { redirect } from 'next/navigation';
+import { getAuthFromCookie } from '@/lib/auth';
+import CampaignFormClient from './campaign-form-client';
+
+export async function generateMetadata(): Promise<Metadata> {
+    const t = await getTranslations('dashboard.workCreation.campaign');
+    return { title: t('title') };
+}
+
+/**
+ * "Start a campaign" — the activation surface for the `campaign` Work kind
+ * (roadmap 14.1). Deliberately a separate route from `/works/new`: a
+ * campaign is not a website, so none of the git/deploy provider selection
+ * on that page applies. One brief in, a whole go-to-market setup out.
+ */
+export default async function NewCampaignPage() {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect('/login');
+    }
+
+    return <CampaignFormClient />;
+}

--- a/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
+++ b/apps/web/src/app/[locale]/(dashboard)/works/new/new-work-client.tsx
@@ -8,6 +8,7 @@ import { WorkImportForm } from '@/components/works/WorkImportForm';
 import { GitProviderSelector } from './git-provider-selector';
 import { DeployProviderSelector, type DeployProvider } from './deploy-provider-selector';
 import { useTranslations } from 'next-intl';
+import { useRouter } from '@/i18n/navigation';
 import { toast } from 'sonner';
 import {
     BookOpen,
@@ -17,6 +18,7 @@ import {
     FolderKanban,
     FolderOpen,
     Globe,
+    Megaphone,
     PenLine,
     Star,
     Store,
@@ -151,6 +153,7 @@ export default function NewWorkClient({
             null,
     );
     const t = useTranslations('dashboard.workCreation');
+    const router = useRouter();
 
     // Composer state used by the entry view (creationMode === null).
     const [prompt, setPrompt] = useState(initialPrompt ?? '');
@@ -328,6 +331,21 @@ export default function NewWorkClient({
                         >
                             <FolderInput className="w-3.5 h-3.5" />
                             {t('buttons.import')}
+                        </Button>
+                        {/* Roadmap 14.1 — campaigns are not websites, so they
+                            get their own activation surface instead of a kind
+                            chip: one brief provisions the Work, the goal, the
+                            go-to-market agents and the first pipeline tasks. */}
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            className="gap-1.5"
+                            onClick={() => router.push('/works/new/campaign')}
+                            data-testid="start-campaign"
+                        >
+                            <Megaphone className="w-3.5 h-3.5" />
+                            {t('campaign.chip')}
                         </Button>
                     </div>
                 </div>

--- a/apps/web/src/app/actions/dashboard/works.ts
+++ b/apps/web/src/app/actions/dashboard/works.ts
@@ -20,6 +20,12 @@ import type {
     MergePolicyOverride,
     TaskAcceptanceCheck,
     WorkChecksPolicy,
+    WorkExternalRefs,
+} from '@ever-works/contracts';
+import {
+    INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS,
+    WORK_EXTERNAL_REFS_MAX_PER_KIND,
+    WORK_EXTERNAL_REF_KINDS,
 } from '@ever-works/contracts';
 // Security: server actions are reachable as POST endpoints via the
 // `Next-Action` header, so every exported action must independently verify
@@ -1579,6 +1585,137 @@ export async function updateCommitterSettings(
         return {
             success: false,
             error: error instanceof Error ? error.message : 'Failed to update committer settings',
+        };
+    }
+}
+
+/**
+ * Save the Work's ingest routing claims (`works.externalRefs`).
+ *
+ * Mirrors the server-side rules so a bad map never leaves the browser:
+ * only the known kinds, non-empty ids capped at
+ * `INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS`, at most
+ * `WORK_EXTERNAL_REFS_MAX_PER_KIND` per kind. The API re-validates and
+ * additionally rejects a claim another Work of the same owner already
+ * holds (409) — that error message is surfaced verbatim.
+ */
+export async function updateWorkExternalRefs(
+    workId: string,
+    externalRefs: WorkExternalRefs | null,
+) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    const refsSchema = z
+        .object(
+            Object.fromEntries(
+                WORK_EXTERNAL_REF_KINDS.map((kind) => [
+                    kind,
+                    z
+                        .array(z.string().trim().min(1).max(INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS))
+                        .max(WORK_EXTERNAL_REFS_MAX_PER_KIND)
+                        .optional(),
+                ]),
+            ) as Record<string, z.ZodTypeAny>,
+        )
+        .strict()
+        .nullable();
+
+    try {
+        const validation = refsSchema.safeParse(externalRefs);
+        if (!validation.success) {
+            return {
+                success: false,
+                error: validation.error.errors[0].message,
+            };
+        }
+
+        const response = await workAPI.update(workId, {
+            externalRefs: validation.data as WorkExternalRefs | null,
+        });
+        revalidatePath(`/works/${workId}/settings`);
+
+        return {
+            success: response.status === 'success',
+        };
+    } catch (error) {
+        console.error('Failed to update external references:', error);
+        return {
+            success: false,
+            error: error instanceof Error ? error.message : 'Failed to update external references',
+        };
+    }
+}
+
+/** One artifact set provisioned by `POST /api/works/from-campaign-template`. */
+export interface CampaignActivationSummary {
+    work: { id: string; slug: string; name: string; kind: string };
+    goal: { id: string; title: string; metricId: string; targetValue: number };
+    agents: Array<{ id: string; name: string; templateSlug: string }>;
+    tasks: Array<{ id: string; slug: string; title: string; stageId: string }>;
+    pipeline: { id: string; applied: boolean; reason?: string };
+}
+
+const campaignBriefSchema = z.object({
+    name: z.string().trim().min(1).max(100),
+    objective: z.string().trim().min(1).max(500),
+    target: z
+        .object({
+            metricId: z.string().trim().max(64).optional(),
+            value: z.number().positive().optional(),
+            unit: z.string().trim().max(32).optional(),
+            window: z.enum(['day', 'week', 'month', 'total', 'point']).optional(),
+        })
+        .optional(),
+    channels: z.array(z.string().trim().min(1).max(40)).max(10).optional(),
+});
+
+/**
+ * Start a campaign — the ONLY path that mints a `campaign` Work.
+ *
+ * One call provisions the Work, a Goal capturing the objective, the
+ * prebuilt go-to-market Agents, Tasks for the first pipeline stages and
+ * the `gtm-pipeline` preference. The API runs it as a compensating
+ * transaction, so a failure here means nothing was left behind.
+ */
+export async function createCampaignWork(input: {
+    name: string;
+    objective: string;
+    target?: { metricId?: string; value?: number; unit?: string; window?: string };
+    channels?: string[];
+}) {
+    const user = await getAuthFromCookie();
+    if (!user) {
+        redirect(ROUTES.AUTH_LOGIN);
+    }
+
+    const validation = campaignBriefSchema.safeParse(input);
+    if (!validation.success) {
+        return { success: false as const, error: validation.error.errors[0].message };
+    }
+
+    try {
+        const response = await serverMutation<CampaignActivationSummary>({
+            endpoint: '/works/from-campaign-template',
+            data: {
+                name: sanitizeName(validation.data.name, 100),
+                objective: sanitizeDescription(validation.data.objective, 500),
+                target: validation.data.target,
+                channels: validation.data.channels,
+            },
+            method: 'POST',
+            wrapInData: false,
+        });
+
+        revalidatePath('/works');
+        return { success: true as const, campaign: response };
+    } catch (error) {
+        console.error('Failed to start campaign:', error);
+        return {
+            success: false as const,
+            error: error instanceof Error ? error.message : 'Failed to start campaign',
         };
     }
 }

--- a/apps/web/src/components/works/detail/settings/ExternalRefsSettings.tsx
+++ b/apps/web/src/components/works/detail/settings/ExternalRefsSettings.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useMemo, useState, useTransition } from 'react';
+import { useTranslations } from 'next-intl';
+import { Loader2, Plus, X } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+    INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS,
+    WORK_EXTERNAL_REFS_MAX_PER_KIND,
+    WORK_EXTERNAL_REF_KINDS,
+    type WorkExternalRefKind,
+    type WorkExternalRefs,
+} from '@ever-works/contracts';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useRouter } from '@/i18n/navigation';
+import { updateWorkExternalRefs } from '@/app/actions/dashboard/works';
+import { useSettings } from './SettingsContext';
+
+/** Editor state: one row list per kind, always present (possibly empty). */
+type RefRows = Record<WorkExternalRefKind, string[]>;
+
+function toRows(refs?: WorkExternalRefs | null): RefRows {
+    return WORK_EXTERNAL_REF_KINDS.reduce((acc, kind) => {
+        const claimed = refs?.[kind];
+        acc[kind] = Array.isArray(claimed) ? [...claimed] : [];
+        return acc;
+    }, {} as RefRows);
+}
+
+/** Drop blanks + case-insensitive duplicates; `null` when nothing is left. */
+export function rowsToExternalRefs(rows: RefRows): WorkExternalRefs | null {
+    const out: WorkExternalRefs = {};
+    let kept = 0;
+    for (const kind of WORK_EXTERNAL_REF_KINDS) {
+        const seen = new Set<string>();
+        const ids: string[] = [];
+        for (const raw of rows[kind] ?? []) {
+            const trimmed = raw.trim();
+            if (!trimmed) continue;
+            const key = trimmed.toLowerCase();
+            if (seen.has(key)) continue;
+            seen.add(key);
+            ids.push(trimmed);
+        }
+        if (ids.length > 0) {
+            out[kind] = ids;
+            kept += ids.length;
+        }
+    }
+    return kept > 0 ? out : null;
+}
+
+/**
+ * Ingest routing claims editor (`works.externalRefs`).
+ *
+ * `works.externalRefs` is the claim map the ingest spine reads to route an
+ * ingested event to a Work: a Slack channel id, a tracker team key, a doc
+ * database id, a meeting id. Repositories are deliberately absent — repo
+ * hints already resolve through the repositories the Work declares.
+ *
+ * Saves through the existing Work update path. The server re-validates and
+ * rejects an identifier another Work you own already claims (two Works
+ * claiming one channel is ambiguous); that message is surfaced as-is.
+ */
+export function ExternalRefsSettings() {
+    const t = useTranslations('dashboard.workDetail.settings.externalRefs');
+    const router = useRouter();
+    const { context } = useSettings();
+    const { work } = context;
+
+    const [rows, setRows] = useState<RefRows>(() => toRows(work.externalRefs));
+    const [drafts, setDrafts] = useState<Record<string, string>>({});
+    const [pending, startTransition] = useTransition();
+
+    const initial = useMemo(() => JSON.stringify(toRows(work.externalRefs)), [work.externalRefs]);
+    const dirty = JSON.stringify(rows) !== initial;
+
+    const addRow = (kind: WorkExternalRefKind) => {
+        const value = (drafts[kind] ?? '').trim();
+        if (!value) return;
+        if (value.length > INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS) {
+            toast.error(t('errors.tooLong', { max: INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS }));
+            return;
+        }
+        const existing = rows[kind] ?? [];
+        if (existing.length >= WORK_EXTERNAL_REFS_MAX_PER_KIND) {
+            toast.error(t('errors.tooMany', { max: WORK_EXTERNAL_REFS_MAX_PER_KIND }));
+            return;
+        }
+        if (existing.some((entry) => entry.trim().toLowerCase() === value.toLowerCase())) {
+            toast.error(t('errors.duplicate'));
+            return;
+        }
+        setRows({ ...rows, [kind]: [...existing, value] });
+        setDrafts({ ...drafts, [kind]: '' });
+    };
+
+    const removeRow = (kind: WorkExternalRefKind, index: number) => {
+        setRows({ ...rows, [kind]: (rows[kind] ?? []).filter((_, i) => i !== index) });
+    };
+
+    const handleSave = () => {
+        startTransition(async () => {
+            const result = await updateWorkExternalRefs(work.id, rowsToExternalRefs(rows));
+            if (result.success) {
+                toast.success(t('saved'));
+                router.refresh();
+            } else {
+                toast.error(result.error || t('saveFailed'));
+            }
+        });
+    };
+
+    return (
+        <div
+            className={cn(
+                'rounded-lg border overflow-hidden',
+                'bg-card dark:bg-card-primary-dark/30',
+                'border-card-border dark:border-border-secondary-dark',
+            )}
+            data-testid="work-external-refs-card"
+        >
+            <div className="px-5 py-3.5 border-b border-card-border dark:border-border-secondary-dark">
+                <h3 className="text-sm font-semibold text-text dark:text-text-dark">
+                    {t('title')}
+                </h3>
+                <p className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark">
+                    {t('subtitle')}
+                </p>
+            </div>
+
+            <div className="px-5 py-4 space-y-5">
+                {WORK_EXTERNAL_REF_KINDS.map((kind) => {
+                    const entries = rows[kind] ?? [];
+                    const atCap = entries.length >= WORK_EXTERNAL_REFS_MAX_PER_KIND;
+                    return (
+                        <div key={kind} className="space-y-2" data-testid={`external-ref-${kind}`}>
+                            <div>
+                                <h4 className="text-xs font-medium text-text dark:text-text-dark">
+                                    {t(`kinds.${kind}.label`)}
+                                </h4>
+                                <p className="mt-0.5 text-xs text-text-muted dark:text-text-muted-dark">
+                                    {t(`kinds.${kind}.helper`)}
+                                </p>
+                            </div>
+
+                            {entries.length > 0 && (
+                                <ul className="space-y-1.5">
+                                    {entries.map((entry, index) => (
+                                        <li
+                                            key={`${kind}-${entry}-${index}`}
+                                            className={cn(
+                                                'flex items-center justify-between gap-2 rounded-md border px-3 py-1.5',
+                                                'border-border dark:border-border-dark',
+                                            )}
+                                        >
+                                            <span className="truncate font-mono text-xs text-text dark:text-text-dark">
+                                                {entry}
+                                            </span>
+                                            <button
+                                                type="button"
+                                                onClick={() => removeRow(kind, index)}
+                                                disabled={pending}
+                                                aria-label={t('remove', { id: entry })}
+                                                className="shrink-0 rounded p-1 text-text-muted hover:text-error disabled:opacity-50"
+                                            >
+                                                <X className="h-3.5 w-3.5" />
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+
+                            <div className="flex items-center gap-2">
+                                <Input
+                                    value={drafts[kind] ?? ''}
+                                    onChange={(event) =>
+                                        setDrafts({ ...drafts, [kind]: event.target.value })
+                                    }
+                                    onKeyDown={(event) => {
+                                        if (event.key === 'Enter') {
+                                            event.preventDefault();
+                                            addRow(kind);
+                                        }
+                                    }}
+                                    placeholder={t(`kinds.${kind}.placeholder`)}
+                                    aria-label={t(`kinds.${kind}.label`)}
+                                    disabled={pending || atCap}
+                                    maxLength={INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS}
+                                />
+                                <Button
+                                    type="button"
+                                    variant="secondary"
+                                    size="sm"
+                                    className="gap-1.5 shrink-0"
+                                    onClick={() => addRow(kind)}
+                                    disabled={pending || atCap}
+                                >
+                                    <Plus className="h-3.5 w-3.5" />
+                                    {t('add')}
+                                </Button>
+                            </div>
+
+                            {atCap && (
+                                <p className="text-xs text-warning">
+                                    {t('errors.tooMany', { max: WORK_EXTERNAL_REFS_MAX_PER_KIND })}
+                                </p>
+                            )}
+                        </div>
+                    );
+                })}
+
+                <div className="flex items-center justify-end gap-2 pt-1">
+                    <Button
+                        type="button"
+                        size="sm"
+                        onClick={handleSave}
+                        disabled={pending || !dirty}
+                        data-testid="external-refs-save"
+                    >
+                        {pending && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+                        {t('save')}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/components/works/detail/settings/ExternalRefsSettings.unit.spec.tsx
+++ b/apps/web/src/components/works/detail/settings/ExternalRefsSettings.unit.spec.tsx
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+    INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS,
+    WORK_EXTERNAL_REFS_MAX_PER_KIND,
+    WORK_EXTERNAL_REF_KINDS,
+} from '@ever-works/contracts';
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string, vars?: Record<string, unknown>) =>
+        vars ? `${key}:${JSON.stringify(vars)}` : key,
+}));
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+vi.mock('sonner', () => ({
+    toast: {
+        success: (...args: unknown[]) => toastSuccess(...args),
+        error: (...args: unknown[]) => toastError(...args),
+    },
+}));
+
+const refresh = vi.fn();
+vi.mock('@/i18n/navigation', () => ({
+    useRouter: () => ({ refresh, push: vi.fn() }),
+    // `@/components/ui/button` re-wraps `Link` from the same module.
+    Link: ({ children }: { children?: React.ReactNode }) => <a>{children}</a>,
+}));
+
+const updateWorkExternalRefs = vi.fn();
+vi.mock('@/app/actions/dashboard/works', () => ({
+    updateWorkExternalRefs: (...args: unknown[]) => updateWorkExternalRefs(...args),
+}));
+
+let work: Record<string, unknown> = { id: 'work-1', externalRefs: null };
+vi.mock('./SettingsContext', () => ({
+    useSettings: () => ({ context: { work } }),
+}));
+
+import { ExternalRefsSettings, rowsToExternalRefs } from './ExternalRefsSettings';
+
+/**
+ * The Work external-refs editor — the missing half of workId routing.
+ * `works.externalRefs` routes ingested events to a Work; this card is the
+ * only surface that populates it.
+ */
+describe('ExternalRefsSettings', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        work = { id: 'work-1', externalRefs: null };
+        updateWorkExternalRefs.mockResolvedValue({ success: true });
+    });
+
+    it('renders one section per claimable ref kind, each with helper copy', () => {
+        render(<ExternalRefsSettings />);
+
+        for (const kind of WORK_EXTERNAL_REF_KINDS) {
+            expect(screen.getByTestId(`external-ref-${kind}`)).toBeTruthy();
+            expect(screen.getByTestId(`external-ref-${kind}`).textContent).toContain(
+                `kinds.${kind}.helper`,
+            );
+        }
+        // `repo` is deliberately not claimable — repo hints resolve through
+        // the repositories the Work already declares.
+        expect(screen.queryByTestId('external-ref-repo')).toBeNull();
+    });
+
+    it('adds a claim and saves the normalized map through the Work update path', async () => {
+        const user = userEvent.setup();
+        render(<ExternalRefsSettings />);
+
+        const input = screen.getByLabelText('kinds.chat-channel.label');
+        await user.type(input, 'C0123456789');
+        await user.click(screen.getAllByText('add')[0]);
+        await user.click(screen.getByTestId('external-refs-save'));
+
+        expect(updateWorkExternalRefs).toHaveBeenCalledWith('work-1', {
+            'chat-channel': ['C0123456789'],
+        });
+        expect(toastSuccess).toHaveBeenCalledWith('saved');
+        expect(refresh).toHaveBeenCalled();
+    });
+
+    it('rejects a duplicate claim under the same kind (case-insensitive) without adding a row', async () => {
+        const user = userEvent.setup();
+        work = { id: 'work-1', externalRefs: { 'chat-channel': ['C-Support'] } };
+        render(<ExternalRefsSettings />);
+
+        const input = screen.getByLabelText('kinds.chat-channel.label');
+        await user.type(input, 'c-support');
+        await user.click(screen.getAllByText('add')[0]);
+
+        expect(toastError).toHaveBeenCalledWith('errors.duplicate');
+        expect(screen.getByTestId('external-ref-chat-channel').querySelectorAll('li')).toHaveLength(
+            1,
+        );
+    });
+
+    it('refuses an identifier longer than the ingest cap', async () => {
+        const user = userEvent.setup();
+        render(<ExternalRefsSettings />);
+
+        const input = screen.getByLabelText('kinds.meeting.label') as HTMLInputElement;
+        // The input carries the cap as `maxLength` (typing/pasting is
+        // clamped by the browser), so assert that bound AND drive the
+        // programmatic path that can still exceed it.
+        expect(input.maxLength).toBe(INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS);
+        fireEvent.change(input, {
+            target: { value: 'm'.repeat(INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS + 5) },
+        });
+        await user.click(screen.getAllByText('add')[3]);
+
+        expect(toastError).toHaveBeenCalledWith(
+            `errors.tooLong:{"max":${INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS}}`,
+        );
+        expect(updateWorkExternalRefs).not.toHaveBeenCalled();
+    });
+
+    it('locks a kind that is already at the per-kind cap', () => {
+        work = {
+            id: 'work-1',
+            externalRefs: {
+                'chat-channel': Array.from(
+                    { length: WORK_EXTERNAL_REFS_MAX_PER_KIND },
+                    (_, i) => `C${i}`,
+                ),
+            },
+        };
+        render(<ExternalRefsSettings />);
+
+        const section = screen.getByTestId('external-ref-chat-channel');
+        expect(section.textContent).toContain(
+            `errors.tooMany:{"max":${WORK_EXTERNAL_REFS_MAX_PER_KIND}}`,
+        );
+        expect((section.querySelector('input') as HTMLInputElement).disabled).toBe(true);
+    });
+
+    it('removes a claim row and persists the shorter list', async () => {
+        const user = userEvent.setup();
+        work = { id: 'work-1', externalRefs: { 'tracker-team': ['ENG', 'OPS'] } };
+        render(<ExternalRefsSettings />);
+
+        await user.click(screen.getByLabelText('remove:{"id":"OPS"}'));
+        await user.click(screen.getByTestId('external-refs-save'));
+
+        expect(updateWorkExternalRefs).toHaveBeenCalledWith('work-1', { 'tracker-team': ['ENG'] });
+    });
+
+    it('sends null when the last claim is removed (clears the column)', async () => {
+        const user = userEvent.setup();
+        work = { id: 'work-1', externalRefs: { meeting: ['zoom-1'] } };
+        render(<ExternalRefsSettings />);
+
+        await user.click(screen.getByLabelText('remove:{"id":"zoom-1"}'));
+        await user.click(screen.getByTestId('external-refs-save'));
+
+        expect(updateWorkExternalRefs).toHaveBeenCalledWith('work-1', null);
+    });
+
+    it('surfaces the server-side duplicate-claim rejection verbatim', async () => {
+        const user = userEvent.setup();
+        updateWorkExternalRefs.mockResolvedValue({
+            success: false,
+            error: 'External reference already claimed by another Work you own: "C-1" (chat-channel) is already claimed by "Support Work".',
+        });
+        render(<ExternalRefsSettings />);
+
+        await user.type(screen.getByLabelText('kinds.chat-channel.label'), 'C-1');
+        await user.click(screen.getAllByText('add')[0]);
+        await user.click(screen.getByTestId('external-refs-save'));
+
+        expect(toastError).toHaveBeenCalledWith(
+            expect.stringContaining('already claimed by "Support Work"'),
+        );
+        expect(toastSuccess).not.toHaveBeenCalled();
+    });
+
+    it('keeps save disabled until something actually changes', async () => {
+        const user = userEvent.setup();
+        work = { id: 'work-1', externalRefs: { 'tracker-team': ['ENG'] } };
+        render(<ExternalRefsSettings />);
+
+        const save = screen.getByTestId('external-refs-save') as HTMLButtonElement;
+        expect(save.disabled).toBe(true);
+
+        await user.type(screen.getByLabelText('kinds.tracker-team.label'), 'OPS');
+        await user.click(screen.getAllByText('add')[1]);
+        expect((screen.getByTestId('external-refs-save') as HTMLButtonElement).disabled).toBe(
+            false,
+        );
+    });
+});
+
+describe('rowsToExternalRefs', () => {
+    const empty = WORK_EXTERNAL_REF_KINDS.reduce(
+        (acc, kind) => ({ ...acc, [kind]: [] }),
+        {} as Record<string, string[]>,
+    );
+
+    it('returns null when every kind is empty or blank-only', () => {
+        expect(rowsToExternalRefs(empty as never)).toBeNull();
+        expect(rowsToExternalRefs({ ...empty, meeting: ['   '] } as never)).toBeNull();
+    });
+
+    it('trims, drops blanks and dedupes case-insensitively', () => {
+        expect(
+            rowsToExternalRefs({
+                ...empty,
+                'chat-channel': [' C1 ', 'c1', '', 'C2'],
+            } as never),
+        ).toEqual({ 'chat-channel': ['C1', 'C2'] });
+    });
+});

--- a/apps/web/src/components/works/detail/settings/SettingsForm.tsx
+++ b/apps/web/src/components/works/detail/settings/SettingsForm.tsx
@@ -19,6 +19,7 @@ import { ActivitySyncSettings } from './ActivitySyncSettings';
 import { TaskIsolationSettings } from './TaskIsolationSettings';
 import { QualityGatesSettings } from './QualityGatesSettings';
 import { MergePolicySettings } from './MergePolicySettings';
+import { ExternalRefsSettings } from './ExternalRefsSettings';
 interface SettingsFormProps {
     work: Work;
     user: AuthUser;
@@ -67,6 +68,11 @@ export function SettingsForm({ work, user, initialRepositories }: SettingsFormPr
 
                 {/* Activity Feed sync mode (EW-120 dual-mode) */}
                 <ActivitySyncSettings />
+
+                {/* Ingest routing claims — which external containers
+                    (chat channels, tracker teams, doc databases, meetings)
+                    route their events to this Work. */}
+                <ExternalRefsSettings />
 
                 {/* Git Committer Settings */}
                 <CommitterSettings />

--- a/apps/web/src/lib/api/tasks.ts
+++ b/apps/web/src/lib/api/tasks.ts
@@ -277,6 +277,10 @@ export const tasksAPI = {
     /** Agents the board's picker offers for this Task. */
     async listRunCandidates(id: string) {
         return serverFetch<{ data: RunCandidateAgent[] }>(`/tasks/${id}/run-candidates`, {
+            method: 'GET',
+        });
+    },
+
     /**
      * Re-litigation guard (memory upgrades M6) — settled decisions this
      * Task appears to re-open. Deterministic term-overlap check on the

--- a/apps/web/src/lib/api/work.ts
+++ b/apps/web/src/lib/api/work.ts
@@ -29,6 +29,7 @@ import type {
     MergePolicyOverride,
     TaskAcceptanceCheck,
     WorkChecksPolicy,
+    WorkExternalRefs,
 } from '@ever-works/contracts';
 import { APIResponse, ItemData, Category, Tag, Collection } from './types';
 import { CreateItemsGeneratorDto, ItemsGeneratorResponse } from './items-generator';
@@ -128,6 +129,11 @@ export interface UpdateWorkDto {
      *  Omitted fields inherit organization → tenant → platform default;
      *  `null` clears the Work override entirely. */
     mergePolicy?: MergePolicyOverride | null;
+    /** Ingest routing claims: the external containers (chat channels,
+     *  tracker teams, doc databases, meetings) whose events belong to this
+     *  Work. `null` clears every claim. Rejected server-side when another
+     *  Work you own already claims one of the identifiers. */
+    externalRefs?: WorkExternalRefs | null;
 }
 
 /** Wave 2 M7 — Work-level worktree-per-Task isolation settings. */
@@ -313,6 +319,11 @@ export interface Work {
     // Merge-policy matrix (Wave 3, D4). Absent/null means the Work
     // declares nothing and inherits organization → tenant → default.
     mergePolicy?: MergePolicyOverride | null;
+    // Ingest routing claims — which external containers (chat channels,
+    // tracker teams, doc databases, meetings) route their events to this
+    // Work. Absent/null means the Work claims nothing and only its
+    // repositories route events.
+    externalRefs?: WorkExternalRefs | null;
 }
 
 /** Wave 4 M3 — per-Work AgentRun summary counts

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -149,6 +149,10 @@
             "types": "./dist/agents/index.d.ts",
             "default": "./dist/agents/index.js"
         },
+        "./campaigns": {
+            "types": "./dist/campaigns/index.d.ts",
+            "default": "./dist/campaigns/index.js"
+        },
         "./agent-approvals": {
             "types": "./dist/agent-approvals/index.d.ts",
             "default": "./dist/agent-approvals/index.js"

--- a/packages/agent/src/campaigns/__tests__/campaign-activation.service.spec.ts
+++ b/packages/agent/src/campaigns/__tests__/campaign-activation.service.spec.ts
@@ -1,0 +1,371 @@
+// `github-slugger` is ESM-only and reaches this spec transitively through
+// `WorkLifecycleService -> MarkdownGeneratorService -> readme-builder`
+// (a TYPE-only import here, but ts-jest still loads the module graph).
+// Same stub the other work-lifecycle specs use.
+jest.mock('github-slugger', () => ({
+    __esModule: true,
+    default: class {
+        slug(s: string) {
+            return s;
+        }
+    },
+}));
+
+import { BadRequestException } from '@nestjs/common';
+import { AgentScope } from '../../entities/agent.entity';
+import { TaskStatus } from '../../entities/task.entity';
+import type { User } from '../../entities/user.entity';
+import { CampaignActivationService } from '../campaign-activation.service';
+import {
+    CAMPAIGN_GOAL_DEFAULTS,
+    CAMPAIGN_PIPELINE_ID,
+    CAMPAIGN_SEED_STAGES,
+    listCampaignAgentTemplateSlugs,
+} from '../campaign-template';
+
+/**
+ * Campaign activation is pure orchestration over five owning services, so
+ * the spec drives it with hand-rolled doubles and asserts on the calls:
+ * what gets provisioned, that everything is owner-scoped, and that a
+ * failure at any step leaves nothing behind.
+ */
+
+const USER = { id: 'user-1', username: 'founder' } as unknown as User;
+const WORK_ID = 'work-1';
+
+type Doubles = ReturnType<typeof buildDoubles>;
+
+function buildDoubles() {
+    let taskCounter = 0;
+    let agentCounter = 0;
+
+    const workLifecycle = {
+        createCampaignWork: jest
+            .fn()
+            .mockImplementation(async (_user: User, params: Record<string, string>) => ({
+                id: WORK_ID,
+                slug: params.slug,
+                name: params.name,
+                kind: 'campaign',
+                description: params.description,
+            })),
+    };
+    const workQuery = {
+        checkSlugAvailability: jest
+            .fn()
+            .mockImplementation(async (raw: string) => ({ available: true, slug: raw })),
+    };
+    const workRepository = { delete: jest.fn().mockResolvedValue(true) };
+    const goals = {
+        create: jest
+            .fn()
+            .mockImplementation(async (_userId: string, input: Record<string, unknown>) => ({
+                id: 'goal-1',
+                title: input.title,
+                targetValue: input.targetValue,
+                metricSource: input.metricSource,
+                description: input.description,
+                unit: input.unit,
+                window: input.window,
+            })),
+        delete: jest.fn().mockResolvedValue({ deleted: true }),
+    };
+    const agentTemplates = {
+        createFromTemplate: jest.fn().mockImplementation(async (_userId: string, slug: string) => ({
+            id: `agent-${++agentCounter}`,
+            name: slug,
+        })),
+    };
+    const agents = { deleteHard: jest.fn().mockResolvedValue({ deleted: true }) };
+    const tasks = {
+        create: jest
+            .fn()
+            .mockImplementation(async (_userId: string, input: Record<string, unknown>) => ({
+                id: `task-${++taskCounter}`,
+                slug: `T-${taskCounter}`,
+                title: input.title,
+            })),
+        remove: jest.fn().mockResolvedValue({ deleted: true }),
+    };
+    const pluginOperations = { enablePluginForWork: jest.fn().mockResolvedValue({}) };
+
+    return {
+        workLifecycle,
+        workQuery,
+        workRepository,
+        goals,
+        agentTemplates,
+        agents,
+        tasks,
+        pluginOperations,
+    };
+}
+
+function buildService(doubles: Doubles): CampaignActivationService {
+    return new CampaignActivationService(
+        doubles.workLifecycle as never,
+        doubles.workQuery as never,
+        doubles.workRepository as never,
+        doubles.goals as never,
+        doubles.agentTemplates as never,
+        doubles.agents as never,
+        doubles.tasks as never,
+        doubles.pluginOperations as never,
+    );
+}
+
+const BRIEF = {
+    name: 'Q3 developer launch',
+    objective: 'Book 25 qualified demos with platform engineering teams',
+};
+
+describe('CampaignActivationService — provisioning', () => {
+    let doubles: Doubles;
+    let service: CampaignActivationService;
+
+    beforeEach(() => {
+        doubles = buildDoubles();
+        service = buildService(doubles);
+    });
+
+    it('provisions the Work, the Goal, the agents, the seeded tasks and the pipeline preference', async () => {
+        const result = await service.activate(USER, {
+            ...BRIEF,
+            channels: ['email', 'LinkedIn'],
+        });
+
+        // 1. A campaign Work (repo-free, kind-pinned).
+        expect(doubles.workLifecycle.createCampaignWork).toHaveBeenCalledTimes(1);
+        expect(result.work).toMatchObject({ id: WORK_ID, kind: 'campaign' });
+
+        // 2. A Goal capturing the objective, targeting a campaign metric.
+        expect(doubles.goals.create).toHaveBeenCalledTimes(1);
+        const goalInput = doubles.goals.create.mock.calls[0][1];
+        expect(goalInput.title).toContain(BRIEF.objective);
+        expect(goalInput.metricSource).toMatchObject({
+            metricId: CAMPAIGN_GOAL_DEFAULTS.metricId,
+            params: { workId: WORK_ID },
+        });
+        expect(goalInput.targetValue).toBe(CAMPAIGN_GOAL_DEFAULTS.targetValue);
+        expect(goalInput.description).toContain('email');
+
+        // 3. Every go-to-market template, scoped to the new Work.
+        const expectedSlugs = listCampaignAgentTemplateSlugs();
+        expect(result.agents.map((a) => a.templateSlug)).toEqual([...expectedSlugs]);
+        for (const call of doubles.agentTemplates.createFromTemplate.mock.calls) {
+            expect(call[2]).toMatchObject({ scope: AgentScope.WORK, workId: WORK_ID });
+        }
+
+        // 4. One Task per seeded stage, carrying BOTH owners (work + goal).
+        expect(result.tasks.map((t) => t.stageId)).toEqual(
+            CAMPAIGN_SEED_STAGES.map((s) => s.stageId),
+        );
+        const firstTask = doubles.tasks.create.mock.calls[0][1];
+        expect(firstTask).toMatchObject({
+            workId: WORK_ID,
+            goalId: 'goal-1',
+            status: TaskStatus.TODO,
+            createdByType: 'user',
+            createdById: USER.id,
+        });
+        expect(firstTask.labels).toEqual(
+            expect.arrayContaining([CAMPAIGN_PIPELINE_ID, 'stage:research', 'email', 'LinkedIn']),
+        );
+
+        // 5. The pipeline preference.
+        expect(doubles.pluginOperations.enablePluginForWork).toHaveBeenCalledWith(
+            WORK_ID,
+            CAMPAIGN_PIPELINE_ID,
+            USER.id,
+            { activeCapability: 'pipeline' },
+        );
+        expect(result.pipeline).toEqual({ id: CAMPAIGN_PIPELINE_ID, applied: true });
+    });
+
+    it('passes the activating user id to every owner-scoped service (no cross-account writes)', async () => {
+        await service.activate(USER, BRIEF);
+
+        expect(doubles.workLifecycle.createCampaignWork.mock.calls[0][0]).toBe(USER);
+        expect(doubles.goals.create.mock.calls[0][0]).toBe(USER.id);
+        for (const call of doubles.agentTemplates.createFromTemplate.mock.calls) {
+            expect(call[0]).toBe(USER.id);
+        }
+        for (const call of doubles.tasks.create.mock.calls) {
+            expect(call[0]).toBe(USER.id);
+        }
+        expect(doubles.pluginOperations.enablePluginForWork.mock.calls[0][2]).toBe(USER.id);
+    });
+
+    it('de-duplicates the slug through the existing availability check', async () => {
+        doubles.workQuery.checkSlugAvailability.mockResolvedValue({
+            available: false,
+            slug: 'q3-developer-launch',
+            suggestion: 'q3-developer-launch-2',
+        });
+
+        const result = await service.activate(USER, BRIEF);
+
+        expect(result.work.slug).toBe('q3-developer-launch-2');
+        expect(doubles.workLifecycle.createCampaignWork.mock.calls[0][1]).toMatchObject({
+            slug: 'q3-developer-launch-2',
+        });
+    });
+
+    it('honors an explicit target (metric, value, unit, window)', async () => {
+        const result = await service.activate(USER, {
+            ...BRIEF,
+            target: { metricId: 'open-tasks', value: 42, unit: 'tasks', window: 'week' },
+        });
+
+        const goalInput = doubles.goals.create.mock.calls[0][1];
+        expect(goalInput.metricSource.metricId).toBe('open-tasks');
+        expect(goalInput.targetValue).toBe(42);
+        expect(goalInput.unit).toBe('tasks');
+        expect(goalInput.window).toBe('week');
+        expect(result.goal.metricId).toBe('open-tasks');
+    });
+
+    it('rejects a metric outside the campaign kind’s vocabulary before writing anything', async () => {
+        await expect(
+            service.activate(USER, { ...BRIEF, target: { metricId: 'posts' } }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+
+        expect(doubles.workLifecycle.createCampaignWork).not.toHaveBeenCalled();
+    });
+
+    it('rejects a blank name / objective / non-positive target', async () => {
+        await expect(service.activate(USER, { name: '  ', objective: 'x' })).rejects.toBeInstanceOf(
+            BadRequestException,
+        );
+        await expect(service.activate(USER, { name: 'x', objective: ' ' })).rejects.toBeInstanceOf(
+            BadRequestException,
+        );
+        await expect(
+            service.activate(USER, { ...BRIEF, target: { value: 0 } }),
+        ).rejects.toBeInstanceOf(BadRequestException);
+
+        expect(doubles.workLifecycle.createCampaignWork).not.toHaveBeenCalled();
+    });
+
+    it('keeps the campaign when the pipeline plugin cannot be pinned (best-effort preference)', async () => {
+        doubles.pluginOperations.enablePluginForWork.mockRejectedValue(
+            new Error('Plugin "gtm-pipeline" not found'),
+        );
+
+        const result = await service.activate(USER, BRIEF);
+
+        expect(result.work.id).toBe(WORK_ID);
+        expect(result.pipeline.applied).toBe(false);
+        expect(result.pipeline.reason).toContain('gtm-pipeline');
+        // Nothing was rolled back — the campaign itself is complete.
+        expect(doubles.workRepository.delete).not.toHaveBeenCalled();
+        expect(doubles.tasks.remove).not.toHaveBeenCalled();
+    });
+
+    it('reports the preference as not applied when plugin operations are unavailable', async () => {
+        const withoutPlugins = new CampaignActivationService(
+            doubles.workLifecycle as never,
+            doubles.workQuery as never,
+            doubles.workRepository as never,
+            doubles.goals as never,
+            doubles.agentTemplates as never,
+            doubles.agents as never,
+            doubles.tasks as never,
+        );
+
+        const result = await withoutPlugins.activate(USER, BRIEF);
+
+        expect(result.pipeline).toMatchObject({ id: CAMPAIGN_PIPELINE_ID, applied: false });
+        expect(result.tasks).toHaveLength(CAMPAIGN_SEED_STAGES.length);
+    });
+});
+
+describe('CampaignActivationService — atomicity', () => {
+    let doubles: Doubles;
+    let service: CampaignActivationService;
+
+    beforeEach(() => {
+        doubles = buildDoubles();
+        service = buildService(doubles);
+    });
+
+    it('removes the Work and the Goal when agent creation fails', async () => {
+        doubles.agentTemplates.createFromTemplate.mockRejectedValueOnce(
+            new Error('template blew up'),
+        );
+
+        await expect(service.activate(USER, BRIEF)).rejects.toThrow('template blew up');
+
+        expect(doubles.goals.delete).toHaveBeenCalledWith(USER.id, 'goal-1');
+        expect(doubles.workRepository.delete).toHaveBeenCalledWith(WORK_ID);
+        expect(doubles.tasks.remove).not.toHaveBeenCalled();
+    });
+
+    it('removes every artifact — tasks, agents, goal, work — when a later task fails', async () => {
+        doubles.tasks.create
+            .mockImplementationOnce(async () => ({ id: 'task-1', slug: 'T-1', title: 'first' }))
+            .mockRejectedValueOnce(new Error('task blew up'));
+
+        await expect(service.activate(USER, BRIEF)).rejects.toThrow('task blew up');
+
+        expect(doubles.tasks.remove).toHaveBeenCalledWith(USER.id, 'task-1');
+        expect(doubles.agents.deleteHard).toHaveBeenCalledTimes(
+            listCampaignAgentTemplateSlugs().length,
+        );
+        expect(doubles.goals.delete).toHaveBeenCalledWith(USER.id, 'goal-1');
+        expect(doubles.workRepository.delete).toHaveBeenCalledWith(WORK_ID);
+        // Nothing partial survives: the pipeline pin never ran either.
+        expect(doubles.pluginOperations.enablePluginForWork).not.toHaveBeenCalled();
+    });
+
+    it('rolls back in reverse creation order (tasks → agents → goal → work)', async () => {
+        const order: string[] = [];
+        doubles.tasks.remove.mockImplementation(async () => {
+            order.push('task');
+            return { deleted: true } as never;
+        });
+        doubles.agents.deleteHard.mockImplementation(async () => {
+            order.push('agent');
+            return { deleted: true } as never;
+        });
+        doubles.goals.delete.mockImplementation(async () => {
+            order.push('goal');
+            return { deleted: true } as never;
+        });
+        doubles.workRepository.delete.mockImplementation(async () => {
+            order.push('work');
+            return true as never;
+        });
+        doubles.tasks.create
+            .mockImplementationOnce(async () => ({ id: 'task-1', slug: 'T-1', title: 'first' }))
+            .mockRejectedValueOnce(new Error('boom'));
+
+        await expect(service.activate(USER, BRIEF)).rejects.toThrow('boom');
+
+        expect(order[0]).toBe('task');
+        expect(order[order.length - 2]).toBe('goal');
+        expect(order[order.length - 1]).toBe('work');
+    });
+
+    it('surfaces the original failure even when a cleanup step also fails', async () => {
+        doubles.tasks.create.mockRejectedValueOnce(new Error('task blew up'));
+        doubles.workRepository.delete.mockRejectedValue(new Error('cleanup blew up'));
+
+        await expect(service.activate(USER, BRIEF)).rejects.toThrow('task blew up');
+
+        // Cleanup was still attempted for the rest of the ledger.
+        expect(doubles.goals.delete).toHaveBeenCalledWith(USER.id, 'goal-1');
+        expect(doubles.agents.deleteHard).toHaveBeenCalled();
+    });
+
+    it('does not create anything when the Work itself cannot be created', async () => {
+        doubles.workLifecycle.createCampaignWork.mockRejectedValue(new Error('slug taken'));
+
+        await expect(service.activate(USER, BRIEF)).rejects.toThrow('slug taken');
+
+        expect(doubles.goals.create).not.toHaveBeenCalled();
+        expect(doubles.agentTemplates.createFromTemplate).not.toHaveBeenCalled();
+        expect(doubles.tasks.create).not.toHaveBeenCalled();
+        expect(doubles.workRepository.delete).not.toHaveBeenCalled();
+    });
+});

--- a/packages/agent/src/campaigns/__tests__/campaign-template.spec.ts
+++ b/packages/agent/src/campaigns/__tests__/campaign-template.spec.ts
@@ -1,0 +1,62 @@
+import { WORK_KINDS, WORK_KIND_CAPABILITIES, WORK_METRIC_IDS } from '@ever-works/contracts';
+import { getAgentTemplate } from '../../agents/agent-templates';
+import { TaskStatus } from '../../entities/task.entity';
+import {
+    CAMPAIGN_GOAL_DEFAULTS,
+    CAMPAIGN_GOAL_METRIC_IDS,
+    CAMPAIGN_PIPELINE_ID,
+    CAMPAIGN_SEED_STAGES,
+    CAMPAIGN_WORK_KIND,
+    listCampaignAgentTemplates,
+    listCampaignAgentTemplateSlugs,
+} from '../campaign-template';
+
+describe('campaign template catalog', () => {
+    it('targets the shipped `campaign` Work kind', () => {
+        expect(WORK_KINDS).toContain(CAMPAIGN_WORK_KIND);
+        expect(WORK_KIND_CAPABILITIES[CAMPAIGN_WORK_KIND]).toBeDefined();
+    });
+
+    it('resolves the go-to-market agent templates from the prebuilt catalog', () => {
+        const templates = listCampaignAgentTemplates();
+
+        expect(templates.length).toBeGreaterThan(0);
+        for (const template of templates) {
+            // Every activated template must actually exist in the shipped
+            // catalog (createFromTemplate 404s on an unknown slug).
+            expect(getAgentTemplate(template.slug)).toBeDefined();
+            expect(template.suggestedPipeline).toBe(CAMPAIGN_PIPELINE_ID);
+        }
+        expect(listCampaignAgentTemplateSlugs()).toEqual(templates.map((t) => t.slug));
+        // The set is derived, never hand-listed: no duplicates.
+        expect(new Set(listCampaignAgentTemplateSlugs()).size).toBe(templates.length);
+    });
+
+    it('draws its goal metric vocabulary from the campaign kind, not a new list', () => {
+        expect(CAMPAIGN_GOAL_METRIC_IDS).toEqual(WORK_KIND_CAPABILITIES.campaign.metrics);
+        for (const metricId of CAMPAIGN_GOAL_METRIC_IDS) {
+            expect(WORK_METRIC_IDS).toContain(metricId);
+        }
+        expect(CAMPAIGN_GOAL_METRIC_IDS).toContain(CAMPAIGN_GOAL_DEFAULTS.metricId);
+        expect(CAMPAIGN_GOAL_DEFAULTS.targetValue).toBeGreaterThan(0);
+    });
+
+    it('seeds the first gtm-pipeline stages up to and including the human review gate', () => {
+        expect(CAMPAIGN_SEED_STAGES.map((stage) => stage.stageId)).toEqual([
+            'research',
+            'qualify',
+            'draft',
+            'review',
+        ]);
+        // The first stage is the only actionable one; the rest wait in the
+        // backlog so the board reads as a pipeline, not a pile.
+        expect(CAMPAIGN_SEED_STAGES[0].status).toBe(TaskStatus.TODO);
+        for (const stage of CAMPAIGN_SEED_STAGES.slice(1)) {
+            expect(stage.status).toBe(TaskStatus.BACKLOG);
+        }
+        for (const stage of CAMPAIGN_SEED_STAGES) {
+            expect(stage.title.length).toBeGreaterThan(0);
+            expect(stage.description.length).toBeGreaterThan(0);
+        }
+    });
+});

--- a/packages/agent/src/campaigns/campaign-activation.service.ts
+++ b/packages/agent/src/campaigns/campaign-activation.service.ts
@@ -1,0 +1,362 @@
+import { BadRequestException, Injectable, Logger, Optional } from '@nestjs/common';
+import type { WorkMetricId } from '@ever-works/contracts';
+import { AgentScope } from '../entities/agent.entity';
+import type { GoalWindow } from '../entities/goal.entity';
+import type { User } from '../entities/user.entity';
+import type { Work } from '../entities/work.entity';
+import { AgentsService } from '../agents/agents.service';
+import { AgentTemplatesService } from '../agents/agent-templates.service';
+import { GoalsService } from '../goals/goals.service';
+import { TasksService } from '../tasks-domain/tasks.service';
+import { WorkLifecycleService } from '../services/work-lifecycle.service';
+import { WorkQueryService } from '../services/work-query.service';
+import { WorkRepository } from '../database/repositories/work.repository';
+import { PluginOperationsService } from '../plugins/services/plugin-operations.service';
+import { PLUGIN_CAPABILITIES } from '@ever-works/plugin';
+import {
+    CAMPAIGN_GOAL_DEFAULTS,
+    CAMPAIGN_GOAL_METRIC_IDS,
+    CAMPAIGN_GOAL_METRIC_PLUGIN_ID,
+    CAMPAIGN_PIPELINE_ID,
+    CAMPAIGN_SEED_STAGES,
+    listCampaignAgentTemplates,
+} from './campaign-template';
+
+/** Campaign brief accepted by {@link CampaignActivationService.activate}. */
+export interface CampaignBrief {
+    /** Display name of the campaign — also seeds the Work slug. */
+    name: string;
+    /** What the campaign is trying to achieve; becomes the Goal. */
+    objective: string;
+    /** Optional explicit slug; derived from `name` when omitted. */
+    slug?: string | null;
+    /** Optional measurable target for the Goal. */
+    target?: {
+        /** One of the campaign kind's metric ids (default `conversions`). */
+        metricId?: string | null;
+        value?: number | null;
+        unit?: string | null;
+        window?: GoalWindow | null;
+    } | null;
+    /** Channels the campaign runs on (labels on the drafting stages). */
+    channels?: string[] | null;
+}
+
+/** Everything one activation provisioned. */
+export interface CampaignActivationResult {
+    work: { id: string; slug: string; name: string; kind: string };
+    goal: { id: string; title: string; metricId: string; targetValue: number };
+    agents: Array<{ id: string; name: string; templateSlug: string }>;
+    tasks: Array<{ id: string; slug: string; title: string; stageId: string }>;
+    pipeline: { id: string; applied: boolean; reason?: string };
+}
+
+/** Max channels accepted on a brief (labels are a bounded column). */
+const MAX_CAMPAIGN_CHANNELS = 10;
+const MAX_CHANNEL_LENGTH = 40;
+
+/**
+ * Campaign activation (roadmap 14.1 / audit G20).
+ *
+ * The `campaign` Work kind shipped with capabilities and metrics but
+ * nothing minted one: it is not user-selectable, and no flow provisioned
+ * its contents. This service is that flow — pure wiring over surfaces that
+ * already exist:
+ *
+ *   1. `WorkLifecycleService.createCampaignWork` — a repo-free Work row of
+ *      kind `campaign` (the `createCompanyWork` idiom);
+ *   2. `GoalsService.create` — the objective as an ordinary DRAFT Goal,
+ *      targeting a metric id from the campaign kind's own metric list;
+ *   3. `AgentTemplatesService.createFromTemplate` — the prebuilt
+ *      go-to-market agents, scoped to the new Work;
+ *   4. `TasksService.create` — one Task per seeded `gtm-pipeline` stage,
+ *      each carrying both `workId` and `goalId` (which is how a Goal and a
+ *      Work relate today — there is no Work→Goal column to invent);
+ *   5. `PluginOperationsService.enablePluginForWork` — the Work's pipeline
+ *      preference, i.e. `gtm-pipeline` as the active `pipeline` capability
+ *      provider for this Work.
+ *
+ * **Atomicity.** The five services own five different repositories and
+ * there is no shared transaction to enlist them in, so activation runs as
+ * a compensating transaction: every artifact is recorded as it is created
+ * and, on ANY failure, they are removed in reverse order before the error
+ * is rethrown. A caller therefore sees either a complete campaign or none
+ * of it — never a half-provisioned Work.
+ *
+ * **Owner scope.** Every call is made with the activating user's id and
+ * every service re-checks ownership itself, so activation can only ever
+ * write into the caller's own account.
+ */
+@Injectable()
+export class CampaignActivationService {
+    private readonly logger = new Logger(CampaignActivationService.name);
+
+    constructor(
+        private readonly workLifecycle: WorkLifecycleService,
+        private readonly workQuery: WorkQueryService,
+        private readonly workRepository: WorkRepository,
+        private readonly goals: GoalsService,
+        private readonly agentTemplates: AgentTemplatesService,
+        private readonly agents: AgentsService,
+        private readonly tasks: TasksService,
+        // Optional: the pipeline preference is a nice-to-have that depends
+        // on plugin discovery being wired in this deployment. A missing
+        // registration must not cost the user their campaign.
+        @Optional() private readonly pluginOperations?: PluginOperationsService,
+    ) {}
+
+    async activate(user: User, brief: CampaignBrief): Promise<CampaignActivationResult> {
+        const name = (brief?.name ?? '').trim();
+        if (!name) {
+            throw new BadRequestException('Campaign name is required.');
+        }
+        const objective = (brief?.objective ?? '').trim();
+        if (!objective) {
+            throw new BadRequestException('Campaign objective is required.');
+        }
+
+        const channels = this.normalizeChannels(brief.channels);
+        const metricId = this.resolveMetricId(brief.target?.metricId);
+        const targetValue = this.resolveTargetValue(brief.target?.value);
+        const slug = await this.resolveSlug(brief.slug ?? name, user);
+
+        // Rollback ledger — reverse order on failure.
+        const createdTaskIds: string[] = [];
+        const createdAgentIds: string[] = [];
+        let createdGoalId: string | null = null;
+        let work: Work | null = null;
+
+        try {
+            work = await this.workLifecycle.createCampaignWork(user, {
+                name,
+                slug,
+                description: objective,
+            });
+
+            const goal = await this.goals.create(user.id, {
+                title: `${name} — ${objective}`.slice(0, 200),
+                description: this.buildGoalDescription(objective, channels),
+                metricSource: {
+                    pluginId: CAMPAIGN_GOAL_METRIC_PLUGIN_ID,
+                    metricId,
+                    params: { workId: work.id },
+                },
+                comparator: CAMPAIGN_GOAL_DEFAULTS.comparator,
+                targetValue,
+                unit: (brief.target?.unit ?? CAMPAIGN_GOAL_DEFAULTS.unit).trim(),
+                window: brief.target?.window ?? CAMPAIGN_GOAL_DEFAULTS.window,
+            });
+            createdGoalId = goal.id;
+
+            const agents: CampaignActivationResult['agents'] = [];
+            for (const template of listCampaignAgentTemplates()) {
+                const agent = await this.agentTemplates.createFromTemplate(user.id, template.slug, {
+                    // Scoped to the campaign Work so activating a second
+                    // campaign can reuse the same template names without
+                    // tripping the per-scope name-uniqueness 409.
+                    scope: AgentScope.WORK,
+                    workId: work.id,
+                });
+                createdAgentIds.push(agent.id);
+                agents.push({ id: agent.id, name: agent.name, templateSlug: template.slug });
+            }
+
+            const tasks: CampaignActivationResult['tasks'] = [];
+            for (const stage of CAMPAIGN_SEED_STAGES) {
+                const task = await this.tasks.create(user.id, {
+                    title: `${stage.title}`,
+                    description: this.buildTaskDescription(stage.description, objective, channels),
+                    status: stage.status,
+                    priority: stage.priority,
+                    labels: [CAMPAIGN_PIPELINE_ID, `stage:${stage.stageId}`, ...channels],
+                    workId: work.id,
+                    // The Goal ↔ Work relation today IS the Task row: a Task
+                    // may carry both owners at once (TASK_OWNER_KEYS).
+                    goalId: goal.id,
+                    createdByType: 'user',
+                    createdById: user.id,
+                });
+                createdTaskIds.push(task.id);
+                tasks.push({
+                    id: task.id,
+                    slug: task.slug,
+                    title: task.title,
+                    stageId: stage.stageId,
+                });
+            }
+
+            const pipeline = await this.applyPipelinePreference(work.id, user.id);
+
+            this.logger.log(
+                `Activated campaign "${slug}" for user ${user.id}: work=${work.id} goal=${goal.id} ` +
+                    `agents=${agents.length} tasks=${tasks.length} pipeline=${pipeline.applied}`,
+            );
+
+            return {
+                work: { id: work.id, slug: work.slug, name: work.name, kind: work.kind },
+                goal: {
+                    id: goal.id,
+                    title: goal.title,
+                    metricId,
+                    targetValue: goal.targetValue,
+                },
+                agents,
+                tasks,
+                pipeline,
+            };
+        } catch (error) {
+            await this.rollback(user, {
+                workId: work?.id ?? null,
+                goalId: createdGoalId,
+                agentIds: createdAgentIds,
+                taskIds: createdTaskIds,
+            });
+            throw error;
+        }
+    }
+
+    /**
+     * Set `gtm-pipeline` as the Work's active pipeline provider.
+     *
+     * Best-effort on purpose: plugin availability is a deployment
+     * property (the plugin must be discovered AND enabled at user level),
+     * and a campaign without a pinned pipeline still works — the
+     * orchestrator falls back to auto-detect. The outcome is reported back
+     * so the caller/UI can surface "pipeline not pinned" instead of
+     * pretending it was.
+     */
+    private async applyPipelinePreference(
+        workId: string,
+        userId: string,
+    ): Promise<CampaignActivationResult['pipeline']> {
+        if (!this.pluginOperations) {
+            return {
+                id: CAMPAIGN_PIPELINE_ID,
+                applied: false,
+                reason: 'Plugin operations unavailable in this deployment.',
+            };
+        }
+        try {
+            await this.pluginOperations.enablePluginForWork(workId, CAMPAIGN_PIPELINE_ID, userId, {
+                activeCapability: PLUGIN_CAPABILITIES.PIPELINE,
+            });
+            return { id: CAMPAIGN_PIPELINE_ID, applied: true };
+        } catch (error) {
+            const reason = error instanceof Error ? error.message : String(error);
+            this.logger.warn(
+                `Campaign work ${workId}: could not pin the "${CAMPAIGN_PIPELINE_ID}" pipeline — ` +
+                    `the orchestrator will auto-detect instead (${reason}).`,
+            );
+            return { id: CAMPAIGN_PIPELINE_ID, applied: false, reason };
+        }
+    }
+
+    /**
+     * Compensating rollback. Every step is individually guarded: a failing
+     * cleanup is logged and the rest still runs, because the caller's
+     * original error is the one worth surfacing.
+     */
+    private async rollback(
+        user: User,
+        created: {
+            workId: string | null;
+            goalId: string | null;
+            agentIds: readonly string[];
+            taskIds: readonly string[];
+        },
+    ): Promise<void> {
+        for (const taskId of [...created.taskIds].reverse()) {
+            await this.safely('task', taskId, () => this.tasks.remove(user.id, taskId));
+        }
+        for (const agentId of [...created.agentIds].reverse()) {
+            await this.safely('agent', agentId, () => this.agents.deleteHard(user.id, agentId));
+        }
+        if (created.goalId) {
+            await this.safely('goal', created.goalId, () =>
+                this.goals.delete(user.id, created.goalId as string),
+            );
+        }
+        if (created.workId) {
+            await this.safely('work', created.workId, () =>
+                this.workRepository.delete(created.workId as string),
+            );
+        }
+    }
+
+    private async safely(kind: string, id: string, fn: () => Promise<unknown>): Promise<void> {
+        try {
+            await fn();
+        } catch (error) {
+            this.logger.error(
+                `Campaign activation rollback: failed to remove ${kind} ${id} — ` +
+                    `${error instanceof Error ? error.message : String(error)}`,
+            );
+        }
+    }
+
+    /** Metric ids are constrained to the campaign kind's own vocabulary. */
+    private resolveMetricId(value?: string | null): WorkMetricId {
+        if (value === undefined || value === null || value === '') {
+            return CAMPAIGN_GOAL_DEFAULTS.metricId;
+        }
+        const match = CAMPAIGN_GOAL_METRIC_IDS.find((id) => id === value);
+        if (!match) {
+            throw new BadRequestException(
+                `Unsupported campaign metric "${value}". Allowed: ${CAMPAIGN_GOAL_METRIC_IDS.join(', ')}.`,
+            );
+        }
+        return match;
+    }
+
+    private resolveTargetValue(value?: number | null): number {
+        if (value === undefined || value === null) return CAMPAIGN_GOAL_DEFAULTS.targetValue;
+        if (!Number.isFinite(value) || value <= 0) {
+            throw new BadRequestException('Campaign target value must be a positive number.');
+        }
+        return value;
+    }
+
+    private normalizeChannels(channels?: string[] | null): string[] {
+        if (!Array.isArray(channels)) return [];
+        const seen = new Set<string>();
+        const out: string[] = [];
+        for (const channel of channels) {
+            if (typeof channel !== 'string') continue;
+            const trimmed = channel.trim().slice(0, MAX_CHANNEL_LENGTH);
+            if (!trimmed) continue;
+            const key = trimmed.toLowerCase();
+            if (seen.has(key)) continue;
+            seen.add(key);
+            out.push(trimmed);
+            if (out.length >= MAX_CAMPAIGN_CHANNELS) break;
+        }
+        return out;
+    }
+
+    /** First free `<slug>` / `<slug>-N` for this user, via the existing check. */
+    private async resolveSlug(source: string, user: User): Promise<string> {
+        const availability = await this.workQuery.checkSlugAvailability(source, user);
+        if (availability.available) return availability.slug;
+        if (availability.suggestion) return availability.suggestion;
+        throw new BadRequestException(
+            'Could not derive a free slug for this campaign. Pass an explicit slug.',
+        );
+    }
+
+    private buildGoalDescription(objective: string, channels: readonly string[]): string {
+        const base = `Campaign objective: ${objective}`;
+        return channels.length > 0 ? `${base}\n\nChannels: ${channels.join(', ')}` : base;
+    }
+
+    private buildTaskDescription(
+        stageDescription: string,
+        objective: string,
+        channels: readonly string[],
+    ): string {
+        const lines = [stageDescription, '', `Campaign objective: ${objective}`];
+        if (channels.length > 0) {
+            lines.push(`Channels: ${channels.join(', ')}`);
+        }
+        return lines.join('\n');
+    }
+}

--- a/packages/agent/src/campaigns/campaign-template.ts
+++ b/packages/agent/src/campaigns/campaign-template.ts
@@ -1,0 +1,122 @@
+import { WORK_KIND_CAPABILITIES, type WorkMetricId } from '@ever-works/contracts';
+import { TaskPriority, TaskStatus } from '../entities/task.entity';
+import { listAgentTemplates, type AgentTemplate } from '../agents/agent-templates';
+
+/**
+ * Campaign activation catalog — the data half of "start a campaign".
+ *
+ * Everything here is a POINTER at something that already shipped:
+ *
+ *   - the Work kind (`campaign`) and its metric vocabulary come from
+ *     `WORK_KIND_CAPABILITIES` in `@ever-works/contracts`;
+ *   - the agents come from the prebuilt `AGENT_TEMPLATES` catalog —
+ *     selected by the pipeline they already declare, never re-listed here;
+ *   - the seed stages mirror the first four stages of the `gtm-pipeline`
+ *     plugin (research → qualify → draft → review), i.e. everything up to
+ *     and including the human gate that precedes any outbound action.
+ *
+ * No new concepts: the activation service turns this catalog into ordinary
+ * Work / Goal / Agent / Task rows through the services that own them.
+ */
+
+/** Pipeline plugin a campaign Work runs on. */
+export const CAMPAIGN_PIPELINE_ID = 'gtm-pipeline';
+
+/** Work kind minted by campaign activation. */
+export const CAMPAIGN_WORK_KIND = 'campaign';
+
+/**
+ * Metric-source namespace for a campaign Goal.
+ *
+ * The Goal's `metricSource.metricId` is drawn from the campaign kind's own
+ * metric list (`WORK_KIND_CAPABILITIES.campaign.metrics`) so the Goal and
+ * the Work's stat tiles speak the same vocabulary. Provider-backed metrics
+ * (`conversions`) report `not_configured` until an analytics provider is
+ * connected to the Work — which is exactly why the Goal is created in
+ * DRAFT and only becomes evaluable once the user activates it.
+ */
+export const CAMPAIGN_GOAL_METRIC_PLUGIN_ID = 'work-metrics';
+
+/** Metric ids a campaign Goal may target — the campaign kind's own set. */
+export const CAMPAIGN_GOAL_METRIC_IDS: readonly WorkMetricId[] =
+    WORK_KIND_CAPABILITIES.campaign.metrics;
+
+/** Default target when the brief does not carry one. */
+export const CAMPAIGN_GOAL_DEFAULTS = {
+    metricId: 'conversions' as WorkMetricId,
+    comparator: 'gte' as const,
+    targetValue: 10,
+    unit: 'conversions',
+    window: 'month' as const,
+};
+
+/** One seeded Task, pinned to a `gtm-pipeline` stage id. */
+export interface CampaignSeedStage {
+    /** Stage id in the `gtm-pipeline` plugin. */
+    readonly stageId: string;
+    /** Task title (the campaign name is appended by the activation service). */
+    readonly title: string;
+    readonly description: string;
+    readonly priority: TaskPriority;
+    readonly status: TaskStatus;
+}
+
+/**
+ * The first `gtm-pipeline` stages, seeded as Tasks so a fresh campaign has
+ * a runnable board instead of an empty one. Stops at `review` — the human
+ * gate before anything goes out (`act` and beyond are queued by the
+ * pipeline once drafts are approved).
+ */
+export const CAMPAIGN_SEED_STAGES: readonly CampaignSeedStage[] = [
+    {
+        stageId: 'research',
+        title: 'Research: collect seed contacts and market signals',
+        description:
+            'Collect the seed contact list and the fresh market signals the campaign will work from. Output feeds the qualify stage.',
+        priority: TaskPriority.P1,
+        status: TaskStatus.TODO,
+    },
+    {
+        stageId: 'qualify',
+        title: 'Qualify: score and risk-filter the collected contacts',
+        description:
+            'Deterministic-first scoring plus risk filtering over the researched contacts, so drafting only runs against contacts worth contacting.',
+        priority: TaskPriority.P2,
+        status: TaskStatus.BACKLOG,
+    },
+    {
+        stageId: 'draft',
+        title: 'Draft: write the campaign messaging',
+        description:
+            'Personalized drafting for the campaign channels and tone. Drafts are staged for review — nothing is sent from this stage.',
+        priority: TaskPriority.P2,
+        status: TaskStatus.BACKLOG,
+    },
+    {
+        stageId: 'review',
+        title: 'Review: approve drafts before anything goes out',
+        description:
+            'The human gate. Approve, edit or reject the drafts; only approved drafts are handed to the act stage for delivery.',
+        priority: TaskPriority.P2,
+        status: TaskStatus.BACKLOG,
+    },
+];
+
+/**
+ * The go-to-market agent templates activated with a campaign.
+ *
+ * Derived from the prebuilt catalog by the pipeline each template already
+ * declares (`suggestedPipeline === 'gtm-pipeline'`), so adding a GTM
+ * template to `agent-templates.ts` automatically ships it with the next
+ * campaign — no second list to keep in sync.
+ */
+export function listCampaignAgentTemplates(): readonly AgentTemplate[] {
+    return listAgentTemplates().filter(
+        (template) => template.suggestedPipeline === CAMPAIGN_PIPELINE_ID,
+    );
+}
+
+/** Slugs of the templates {@link listCampaignAgentTemplates} resolves. */
+export function listCampaignAgentTemplateSlugs(): readonly string[] {
+    return listCampaignAgentTemplates().map((template) => template.slug);
+}

--- a/packages/agent/src/campaigns/campaigns.module.ts
+++ b/packages/agent/src/campaigns/campaigns.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { AgentsModule } from '../agents/agents.module';
+import { GoalsModule } from '../goals/goals.module';
+import { TasksDomainModule } from '../tasks-domain/tasks.module';
+import { WorkModule } from '../services/work.module';
+import { CampaignActivationService } from './campaign-activation.service';
+
+/**
+ * Campaign activation (roadmap 14.1 / audit G20).
+ *
+ * A pure composition module: it owns exactly one service and imports the
+ * four modules that already own the artifacts a campaign is made of —
+ * Works (+ the plugin-operations provider that pins the pipeline), Goals,
+ * Agents (templates) and Tasks. Nothing new is provided here, so any
+ * consumer that imports this module gets campaign activation without
+ * re-declaring a single existing provider.
+ */
+@Module({
+    imports: [WorkModule, GoalsModule, AgentsModule, TasksDomainModule],
+    providers: [CampaignActivationService],
+    exports: [CampaignActivationService],
+})
+export class CampaignsModule {}

--- a/packages/agent/src/campaigns/index.ts
+++ b/packages/agent/src/campaigns/index.ts
@@ -1,0 +1,3 @@
+export * from './campaign-template';
+export * from './campaign-activation.service';
+export * from './campaigns.module';

--- a/packages/agent/src/dto/update-work.dto.ts
+++ b/packages/agent/src/dto/update-work.dto.ts
@@ -15,7 +15,13 @@ import {
     Min,
 } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { WORK_CHECKS_POLICIES, type WorkChecksPolicy } from '@ever-works/contracts';
+import {
+    WORK_CHECKS_POLICIES,
+    WORK_EXTERNAL_REFS_MAX_PER_KIND,
+    WORK_EXTERNAL_REF_KINDS,
+    type WorkChecksPolicy,
+    type WorkExternalRefs,
+} from '@ever-works/contracts';
 import { AcceptanceCheckDto } from './acceptance-check.dto';
 import { MergePolicyDto } from './merge-policy.dto';
 import { MarkdownReadmeConfigDto } from './create-work.dto';
@@ -215,4 +221,25 @@ export class UpdateWorkDto {
         value === null || value === '' ? null : typeof value === 'string' ? value.trim() : value,
     )
     organizationId?: string | null;
+
+    @ApiPropertyOptional({
+        description:
+            'External containers this Work claims, keyed by ingest hint kind (' +
+            `${WORK_EXTERNAL_REF_KINDS.join(' | ')}). Ingested events carrying one of these ` +
+            'identifiers route to this Work. At most ' +
+            `${WORK_EXTERNAL_REFS_MAX_PER_KIND} identifiers per kind; matching is ` +
+            'case-insensitive and trimmed. Pass `null` (or an object whose kinds are all ' +
+            'empty) to clear every claim. `repo` is intentionally absent — repository ' +
+            'hints resolve through the repositories the Work already declares.',
+        example: { 'chat-channel': ['C0123456789'], 'tracker-team': ['ENG'] },
+        nullable: true,
+    })
+    @IsOptional()
+    // Shape validation (known kinds, per-kind cap, id length) and the
+    // cross-Work duplicate-claim check both live in the service layer
+    // (`validateWorkExternalRefs` / `findExternalRefConflicts`), which is
+    // the single source of truth shared with the campaign-activation and
+    // account-import paths. The DTO only declares the property so
+    // `forbidNonWhitelisted` lets it through.
+    externalRefs?: WorkExternalRefs | null;
 }

--- a/packages/agent/src/services/__tests__/work-lifecycle.external-refs.spec.ts
+++ b/packages/agent/src/services/__tests__/work-lifecycle.external-refs.spec.ts
@@ -1,0 +1,212 @@
+// `github-slugger` is an ESM-only dependency pulled in transitively via
+// `MarkdownGeneratorService -> readme-builder`. ts-jest cannot parse its
+// `import` syntax, so stub it out — this spec never touches slug building.
+jest.mock('github-slugger', () => ({
+    __esModule: true,
+    default: class {
+        slug(s: string) {
+            return s;
+        }
+    },
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ConflictException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { WORK_EXTERNAL_REFS_MAX_PER_KIND } from '@ever-works/contracts';
+import { WorkLifecycleService } from '../work-lifecycle.service';
+import { WorkRepository } from '@src/database/repositories/work.repository';
+import { UserRepository } from '@src/database/repositories/user.repository';
+import { OrganizationRepository } from '@src/database/repositories/organization.repository';
+import { DataGeneratorService } from '@src/generators/data-generator/data-generator.service';
+import { MarkdownGeneratorService } from '@src/generators/markdown-generator/markdown-generator.service';
+import { WebsiteGeneratorService } from '@src/generators/website-generator/website-generator.service';
+import { WebsiteUpdateService } from '@src/generators/website-generator/website-update.service';
+import { WorkOwnershipService } from '../work-ownership.service';
+import { DeployFacadeService } from '@src/facades/deploy.facade';
+import { TemplateCatalogService } from '@src/template-catalog/template-catalog.service';
+import { WorkWebsiteRepositoryStateService } from '../work-website-repository-state.service';
+import {
+    EverWorksDeployQuotaService,
+    EverWorksGitProvider,
+    EverWorksDnsService,
+} from '@src/ever-works-providers';
+import { ZeroFrictionFunnelService } from '../zero-friction-funnel.service';
+import type { Work } from '@src/entities/work.entity';
+import type { User } from '@src/entities/user.entity';
+
+/**
+ * `works.externalRefs` write path (the missing half of workId routing).
+ *
+ * The column routes ingested events to a Work; until now only the account
+ * import path could populate it. `PATCH /api/works/:id` now carries it,
+ * gated by shape validation and an owner-scoped duplicate-claim check.
+ */
+
+const WORK_ID = '00000000-0000-0000-0000-000000000001';
+const OTHER_WORK_ID = '00000000-0000-0000-0000-000000000002';
+
+function buildWork(overrides: Partial<Work> = {}): Work {
+    return {
+        id: WORK_ID,
+        name: 'Acme',
+        description: 'Acme directory',
+        owner: 'acme',
+        organization: false,
+        readmeConfig: null,
+        userId: 'user-1',
+        tenantId: null,
+        organizationId: null,
+        websiteTemplateId: null,
+        deployProvider: 'vercel',
+        externalRefs: null,
+        getRepoOwner: () => 'acme',
+        ...overrides,
+    } as unknown as Work;
+}
+
+describe('WorkLifecycleService — externalRefs claim map', () => {
+    let service: WorkLifecycleService;
+    let workRepository: { update: jest.Mock; findByUser: jest.Mock };
+    let work: Work;
+
+    const user = { id: 'user-1', username: 'user-1' } as unknown as User;
+
+    beforeEach(async () => {
+        work = buildWork();
+
+        workRepository = {
+            update: jest
+                .fn()
+                .mockImplementation(async (_id: string, data: Record<string, unknown>) => ({
+                    ...work,
+                    ...data,
+                    getRepoOwner: () => 'acme',
+                })),
+            findByUser: jest.fn().mockResolvedValue([work]),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                WorkLifecycleService,
+                { provide: WorkRepository, useValue: workRepository },
+                { provide: UserRepository, useValue: {} },
+                { provide: OrganizationRepository, useValue: {} },
+                { provide: DataGeneratorService, useValue: {} },
+                { provide: MarkdownGeneratorService, useValue: {} },
+                { provide: WebsiteGeneratorService, useValue: {} },
+                { provide: WebsiteUpdateService, useValue: {} },
+                {
+                    provide: WorkOwnershipService,
+                    useValue: {
+                        ensureCanEdit: jest
+                            .fn()
+                            .mockImplementation(async () => ({ work, role: 'owner' })),
+                    },
+                },
+                { provide: DeployFacadeService, useValue: { getAvailableProviders: () => [] } },
+                { provide: TemplateCatalogService, useValue: {} },
+                { provide: WorkWebsiteRepositoryStateService, useValue: {} },
+                { provide: EverWorksDeployQuotaService, useValue: {} },
+                { provide: EverWorksGitProvider, useValue: {} },
+                { provide: EverWorksDnsService, useValue: {} },
+                { provide: ZeroFrictionFunnelService, useValue: {} },
+                { provide: EventEmitter2, useValue: { emit: jest.fn(), emitAsync: jest.fn() } },
+            ],
+        }).compile();
+
+        service = module.get(WorkLifecycleService);
+    });
+
+    it('round-trips a claim map through the update path', async () => {
+        const result = await service.updateWork(
+            WORK_ID,
+            { externalRefs: { 'chat-channel': ['C0123456789'], meeting: ['zoom-9981'] } },
+            user,
+        );
+
+        expect(result.status).toBe('success');
+        expect(workRepository.update.mock.calls[0][1]).toMatchObject({
+            externalRefs: { 'chat-channel': ['C0123456789'], meeting: ['zoom-9981'] },
+        });
+        expect(result.work.externalRefs).toEqual({
+            'chat-channel': ['C0123456789'],
+            meeting: ['zoom-9981'],
+        });
+    });
+
+    it('clears every claim when the map is null (and skips the duplicate scan)', async () => {
+        const result = await service.updateWork(WORK_ID, { externalRefs: null }, user);
+
+        expect(result.status).toBe('success');
+        expect(workRepository.findByUser).not.toHaveBeenCalled();
+        expect(workRepository.update.mock.calls[0][1]).toMatchObject({ externalRefs: null });
+    });
+
+    it('rejects an unknown ref kind with a 400 and never writes', async () => {
+        await expect(
+            service.updateWork(WORK_ID, { externalRefs: { repo: ['acme/site'] } } as never, user),
+        ).rejects.toBeInstanceOf(BadRequestException);
+
+        expect(workRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects going over the per-kind cap with a 400 and never writes', async () => {
+        const overCap = Array.from(
+            { length: WORK_EXTERNAL_REFS_MAX_PER_KIND + 1 },
+            (_, i) => `C${i}`,
+        );
+
+        await expect(
+            service.updateWork(WORK_ID, { externalRefs: { 'chat-channel': overCap } }, user),
+        ).rejects.toBeInstanceOf(BadRequestException);
+
+        expect(workRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a claim another Work of the SAME owner already holds (409, named)', async () => {
+        workRepository.findByUser.mockResolvedValue([
+            work,
+            buildWork({
+                id: OTHER_WORK_ID,
+                name: 'Support Work',
+                externalRefs: { 'chat-channel': ['c-support'] },
+            }),
+        ]);
+
+        // Case-insensitive: the stored claim is lowercase, the submitted one is not.
+        const failure = service.updateWork(
+            WORK_ID,
+            { externalRefs: { 'chat-channel': ['C-SUPPORT'] } },
+            user,
+        );
+
+        await expect(failure).rejects.toBeInstanceOf(ConflictException);
+        await expect(failure).rejects.toThrow(/Support Work/);
+        expect(workRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('allows re-saving the Work’s OWN existing claims (self is excluded from the scan)', async () => {
+        work.externalRefs = { 'chat-channel': ['C-MINE'] };
+        workRepository.findByUser.mockResolvedValue([work]);
+
+        const result = await service.updateWork(
+            WORK_ID,
+            { externalRefs: { 'chat-channel': ['C-MINE', 'C-NEW'] } },
+            user,
+        );
+
+        expect(result.status).toBe('success');
+        expect(workRepository.update.mock.calls[0][1]).toMatchObject({
+            externalRefs: { 'chat-channel': ['C-MINE', 'C-NEW'] },
+        });
+    });
+
+    it('leaves externalRefs untouched when the field is omitted', async () => {
+        const result = await service.updateWork(WORK_ID, { name: 'Renamed' }, user);
+
+        expect(result.status).toBe('success');
+        expect(workRepository.findByUser).not.toHaveBeenCalled();
+        expect(workRepository.update.mock.calls[0][1]).not.toHaveProperty('externalRefs');
+    });
+});

--- a/packages/agent/src/services/work-lifecycle.service.ts
+++ b/packages/agent/src/services/work-lifecycle.service.ts
@@ -1,5 +1,6 @@
 import {
     BadRequestException,
+    ConflictException,
     HttpException,
     Injectable,
     Logger,
@@ -41,6 +42,12 @@ import {
 } from '@src/generators/website-generator';
 import { WebsiteRepositoryCreationMethod } from '@src/items-generator/dto/create-items-generator.dto';
 import { TemplateCatalogService } from '../template-catalog/template-catalog.service';
+import {
+    describeExternalRefConflicts,
+    findExternalRefConflicts,
+    validateWorkExternalRefs,
+    WorkExternalRefsValidationError,
+} from '../works/work-external-refs';
 import { WorkWebsiteRepositoryStateService } from './work-website-repository-state.service';
 import {
     EverWorksDeployQuotaService,
@@ -456,6 +463,48 @@ export class WorkLifecycleService {
     }
 
     /**
+     * Campaign activation (roadmap 14.1) — a `campaign` Work row without
+     * the repo/git side-effects `createWork` triggers.
+     *
+     * A campaign Work is where a go-to-market pipeline's output lives
+     * (lead lists, drafts awaiting the review gate, period reports); it
+     * produces no deployable site, so `WORK_KIND_CAPABILITIES.campaign`
+     * turns `deploy` and the website repo off. Same posture as
+     * {@link createCompanyWork}: minimal row, quota-safe
+     * `deployProvider: null`, no generators.
+     *
+     * `campaign` is deliberately absent from `USER_SELECTABLE_WORK_KINDS`
+     * — this method (driven by {@link CampaignActivationService}) is the
+     * only way one gets minted, so the general create path can never
+     * produce a campaign Work with none of its contents.
+     */
+    async createCampaignWork(
+        user: User,
+        params: {
+            name: string;
+            slug: string;
+            description?: string;
+            status?: WorkStatus;
+        },
+    ): Promise<Work> {
+        const workData: Partial<Work> = {
+            slug: params.slug,
+            name: params.name,
+            description: params.description ?? params.name,
+            userId: user.id,
+            kind: 'campaign',
+            status: params.status ?? 'active',
+            deployProvider: null,
+        };
+
+        try {
+            return await this.workRepository.create(workData, user);
+        } catch (error) {
+            rethrowAsNormalized(error, this.logger, 'creating campaign work');
+        }
+    }
+
+    /**
      * Teams & Prebuilt Companies (spec §6.2) — bare DRAFT Work row with
      * zero repo/git/generation side-effects. The company-template importer
      * maps each `PROJECT.md` in a package onto one of these; a later
@@ -741,6 +790,19 @@ export class WorkLifecycleService {
                 updateData.organizationId = updateDto.organizationId;
             }
 
+            // Ingest routing claims (`works.externalRefs`). Two gates before
+            // the write: shape validation against the closed kind set + the
+            // per-kind cap, then an owner-scoped duplicate scan — two Works
+            // owned by the same user claiming one channel is ambiguous, and
+            // the resolver would silently pick whichever it saw first.
+            if (updateDto.externalRefs !== undefined) {
+                updateData.externalRefs = await this.resolveExternalRefsUpdate(
+                    id,
+                    user.id,
+                    updateDto.externalRefs,
+                );
+            }
+
             const updatedWork = await this.workRepository.update(id, updateData);
 
             if (!updatedWork) {
@@ -776,6 +838,45 @@ export class WorkLifecycleService {
         } catch (error) {
             rethrowAsNormalized(error, this.logger, 'updating work');
         }
+    }
+
+    /**
+     * Validate a claim map and prove no sibling Work of the same owner
+     * already claims any of its identifiers.
+     *
+     * Returns the normalized map, or `null` when the caller cleared every
+     * claim (`null` is the column's canonical "claims nothing" value).
+     *
+     * @throws BadRequestException on a malformed map (unknown kind,
+     *   non-string / empty / oversized id, over the per-kind cap).
+     * @throws ConflictException when another Work owned by the same user
+     *   already claims one of the identifiers — the message names both
+     *   the identifier and the Work holding it.
+     */
+    private async resolveExternalRefsUpdate(workId: string, userId: string, value: unknown) {
+        let normalized: ReturnType<typeof validateWorkExternalRefs>;
+        try {
+            normalized = validateWorkExternalRefs(value);
+        } catch (error) {
+            if (error instanceof WorkExternalRefsValidationError) {
+                throw new BadRequestException({ status: 'error', message: error.message });
+            }
+            throw error;
+        }
+
+        if (normalized) {
+            const siblings = await this.workRepository.findByUser(userId);
+            const conflicts = findExternalRefConflicts(normalized, siblings, workId);
+            if (conflicts.length > 0) {
+                throw new ConflictException({
+                    status: 'error',
+                    message: describeExternalRefConflicts(conflicts),
+                    conflicts,
+                });
+            }
+        }
+
+        return normalized;
     }
 
     async switchWebsiteTemplate(

--- a/packages/agent/src/services/work.module.spec.ts
+++ b/packages/agent/src/services/work.module.spec.ts
@@ -282,9 +282,10 @@ describe('WorkModule', () => {
             // Pinned: WorksConfigSyncListener is NOT exported (Nest doesn't
             // export listeners, they're internal) and SettingsSchemaValidatorService
             // is NOT exported (consumers go through PluginOperationsService).
-            // PluginOperationsService IS a provider but NOT exported either —
-            // current behaviour pinned (downstream services that need it would
-            // import the plugins module directly).
+            // PluginOperationsService IS now exported (campaign activation pins
+            // the Work's pipeline provider through it from CampaignsModule);
+            // the global PluginsModule does not export it, so WorkModule is the
+            // single reachable instance.
             for (const provider of providers) {
                 // Skip non-class providers (the EVER_WORKS_DEPLOY_QUOTA_COUNTER
                 // factory is an object, not a class).
@@ -294,7 +295,6 @@ describe('WorkModule', () => {
                 if (
                     provider === WorksConfigSyncListener ||
                     provider === SettingsSchemaValidatorService ||
-                    provider === PluginOperationsService ||
                     provider === EverWorksDeployQuotaService ||
                     provider === EverWorksGitProvider ||
                     provider === EverWorksK8sDeployProvider ||
@@ -320,7 +320,7 @@ describe('WorkModule', () => {
             expect(exports).toContain(TemplateCatalogModule);
         });
 
-        it('keeps the exports list at the documented 33-entry shape (30 services + 3 re-exported modules)', () => {
+        it('keeps the exports list at the documented 35-entry shape (32 services + 3 re-exported modules)', () => {
             // Bumped to 28 with the PlatformSyncSecretService resurrection for
             // EW-120 dual-mode (pull/push/disabled) Activity Feed sync.
             // Bumped to 29 with AnonymousUserCleanupService for EW-617 G2
@@ -333,7 +333,9 @@ describe('WorkModule', () => {
             // DATABASE_URL surface (#1315).
             // Bumped to 34 with WorkMemoryService (scheduled-run learnings
             // written into shared Memory).
-            expect(meta('exports')).toHaveLength(34);
+            // Bumped to 35 with PluginOperationsService, now exported so
+            // CampaignsModule can pin `gtm-pipeline` on a campaign Work.
+            expect(meta('exports')).toHaveLength(35);
         });
 
         it('does NOT re-export DatabaseModule (callers must import it explicitly when they need entities/repositories)', () => {

--- a/packages/agent/src/services/work.module.ts
+++ b/packages/agent/src/services/work.module.ts
@@ -171,6 +171,13 @@ import { WorkRepository } from '@src/database/repositories/work.repository';
         WorksConfigWriterService,
         WorksConfigProjectionService,
         WorksConfigRepositorySyncService,
+        // Campaign activation (roadmap 14.1) pins `gtm-pipeline` as the
+        // campaign Work's active pipeline provider through this service.
+        // It is the only work-scoped plugin write surface, and the global
+        // PluginsModule does not export it — so WorkModule (which already
+        // owns the instance) is what makes it reachable to
+        // `CampaignsModule` without spawning a second copy.
+        PluginOperationsService,
         PlatformSyncSecretService,
         WebhookSecretService,
         WorkRuntimeEnvService,

--- a/packages/agent/src/works/work-external-refs.spec.ts
+++ b/packages/agent/src/works/work-external-refs.spec.ts
@@ -1,0 +1,164 @@
+import {
+    WORK_EXTERNAL_REFS_MAX_PER_KIND,
+    WORK_EXTERNAL_REF_KINDS,
+    INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS,
+} from '@ever-works/contracts';
+import {
+    describeExternalRefConflicts,
+    findExternalRefConflicts,
+    isWorkExternalRefKind,
+    normalizeExternalRefValue,
+    validateWorkExternalRefs,
+    WorkExternalRefsValidationError,
+    type ExternalRefClaimant,
+} from './work-external-refs';
+
+describe('work external refs — write-path validation', () => {
+    it('accepts a well-formed claim map and preserves the caller casing', () => {
+        const refs = validateWorkExternalRefs({
+            'chat-channel': ['C0123456789'],
+            'tracker-team': ['ENG'],
+        });
+
+        expect(refs).toEqual({ 'chat-channel': ['C0123456789'], 'tracker-team': ['ENG'] });
+    });
+
+    it('returns null for null/undefined and for a map whose kinds are all empty (clear the column)', () => {
+        expect(validateWorkExternalRefs(null)).toBeNull();
+        expect(validateWorkExternalRefs(undefined)).toBeNull();
+        expect(validateWorkExternalRefs({})).toBeNull();
+        expect(validateWorkExternalRefs({ 'chat-channel': [] })).toBeNull();
+    });
+
+    it('rejects an unknown ref kind by name and lists the allowed kinds', () => {
+        expect(() => validateWorkExternalRefs({ repo: ['acme/site'] })).toThrow(
+            WorkExternalRefsValidationError,
+        );
+        try {
+            validateWorkExternalRefs({ 'slack-thread': ['x'] });
+            throw new Error('expected a validation error');
+        } catch (error) {
+            expect((error as Error).message).toContain('slack-thread');
+            for (const kind of WORK_EXTERNAL_REF_KINDS) {
+                expect((error as Error).message).toContain(kind);
+            }
+        }
+    });
+
+    it('rejects a non-object payload and a non-array kind value', () => {
+        expect(() => validateWorkExternalRefs(['C1'])).toThrow(WorkExternalRefsValidationError);
+        expect(() => validateWorkExternalRefs('C1')).toThrow(WorkExternalRefsValidationError);
+        expect(() => validateWorkExternalRefs({ 'chat-channel': 'C1' })).toThrow(
+            /must be an array/,
+        );
+    });
+
+    it('rejects empty, non-string and oversized identifiers', () => {
+        expect(() => validateWorkExternalRefs({ 'chat-channel': ['   '] })).toThrow(
+            /must not be empty/,
+        );
+        expect(() => validateWorkExternalRefs({ 'chat-channel': [42] })).toThrow(/must be strings/);
+        const tooLong = 'c'.repeat(INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS + 1);
+        expect(() => validateWorkExternalRefs({ meeting: [tooLong] })).toThrow(
+            new RegExp(`${INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS} characters`),
+        );
+    });
+
+    it(`rejects more than ${WORK_EXTERNAL_REFS_MAX_PER_KIND} identifiers under one kind`, () => {
+        const overCap = Array.from(
+            { length: WORK_EXTERNAL_REFS_MAX_PER_KIND + 1 },
+            (_, i) => `C${i}`,
+        );
+        expect(() => validateWorkExternalRefs({ 'chat-channel': overCap })).toThrow(
+            new RegExp(`at most ${WORK_EXTERNAL_REFS_MAX_PER_KIND}`),
+        );
+
+        // Exactly at the cap is fine.
+        const atCap = overCap.slice(0, WORK_EXTERNAL_REFS_MAX_PER_KIND);
+        expect(validateWorkExternalRefs({ 'chat-channel': atCap })).toEqual({
+            'chat-channel': atCap,
+        });
+    });
+
+    it('dedupes case-insensitively within one kind instead of rejecting the resubmit', () => {
+        const refs = validateWorkExternalRefs({ 'chat-channel': [' C123 ', 'c123', 'C999'] });
+        expect(refs).toEqual({ 'chat-channel': ['C123', 'C999'] });
+    });
+
+    it('normalizes and guards kinds the same way the ingest resolver does', () => {
+        expect(normalizeExternalRefValue(' C123 ')).toBe('c123');
+        expect(isWorkExternalRefKind('chat-channel')).toBe(true);
+        // `repo` is deliberately NOT a claimable kind — repo hints resolve
+        // through the repositories a Work already declares.
+        expect(isWorkExternalRefKind('repo')).toBe(false);
+        expect(isWorkExternalRefKind(7)).toBe(false);
+    });
+});
+
+describe('work external refs — duplicate-claim scan', () => {
+    const siblings: ExternalRefClaimant[] = [
+        { id: 'work-self', name: 'This Work', externalRefs: { 'chat-channel': ['C-SELF'] } },
+        { id: 'work-other', name: 'Other Work', externalRefs: { 'chat-channel': ['c-taken'] } },
+        { id: 'work-empty', name: 'Empty Work', externalRefs: null },
+    ];
+
+    it('flags an identifier already claimed by another Work of the same owner', () => {
+        const conflicts = findExternalRefConflicts(
+            { 'chat-channel': ['C-TAKEN'] },
+            siblings,
+            'work-self',
+        );
+
+        expect(conflicts).toEqual([
+            {
+                kind: 'chat-channel',
+                externalId: 'C-TAKEN',
+                workId: 'work-other',
+                workName: 'Other Work',
+            },
+        ]);
+        expect(describeExternalRefConflicts(conflicts)).toContain('Other Work');
+        expect(describeExternalRefConflicts(conflicts)).toContain('C-TAKEN');
+    });
+
+    it('ignores the Work being edited (re-saving your own claims is not a conflict)', () => {
+        expect(
+            findExternalRefConflicts({ 'chat-channel': ['C-SELF'] }, siblings, 'work-self'),
+        ).toEqual([]);
+    });
+
+    it('does not cross ref kinds — the same string under a different kind is free', () => {
+        expect(
+            findExternalRefConflicts({ 'tracker-team': ['c-taken'] }, siblings, 'work-self'),
+        ).toEqual([]);
+    });
+
+    it('returns nothing for a cleared claim map or a sibling set with no claims', () => {
+        expect(findExternalRefConflicts(null, siblings, 'work-self')).toEqual([]);
+        expect(
+            findExternalRefConflicts({ 'chat-channel': ['C-NEW'] }, [siblings[2]], 'work-self'),
+        ).toEqual([]);
+    });
+
+    it('bounds the scan of a hand-edited over-cap sibling row', () => {
+        const bloated: ExternalRefClaimant = {
+            id: 'work-bloated',
+            name: 'Bloated',
+            externalRefs: {
+                'chat-channel': [
+                    ...Array.from({ length: WORK_EXTERNAL_REFS_MAX_PER_KIND }, (_, i) => `C${i}`),
+                    'C-BEYOND-CAP',
+                ],
+            },
+        };
+
+        // Inside the cap → seen.
+        expect(
+            findExternalRefConflicts({ 'chat-channel': ['C0'] }, [bloated], 'work-self'),
+        ).toHaveLength(1);
+        // Past the cap → not scanned (same bound the resolver applies).
+        expect(
+            findExternalRefConflicts({ 'chat-channel': ['C-BEYOND-CAP'] }, [bloated], 'work-self'),
+        ).toEqual([]);
+    });
+});

--- a/packages/agent/src/works/work-external-refs.ts
+++ b/packages/agent/src/works/work-external-refs.ts
@@ -1,0 +1,199 @@
+import {
+    INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS,
+    WORK_EXTERNAL_REFS_MAX_PER_KIND,
+    WORK_EXTERNAL_REF_KINDS,
+    type WorkExternalRefKind,
+    type WorkExternalRefs,
+} from '@ever-works/contracts';
+
+/**
+ * Write-path rules for `works.externalRefs` — the claim map the ingest
+ * spine reads to route an ingested event to a Work
+ * (`WorkHintResolverService.matchByExternalRef`).
+ *
+ * Two deliberately different postures share this vocabulary:
+ *
+ *   - the account-IMPORT path (`normalizeImportedExternalRefs`) is
+ *     drop-if-unrecognized: a hand-edited archive must never fail a
+ *     restore, so unknown kinds/entries are silently discarded;
+ *   - this module is the USER write path (`PATCH /api/works/:id`), where
+ *     silently discarding a claim would look like "the editor lost my
+ *     Slack channel". Unknown kinds, over-cap lists and oversized ids are
+ *     rejected with an explicit message instead.
+ *
+ * Matching is case-insensitive + trimmed on both sides, exactly like the
+ * resolver, so `#C123` and ` c123 ` are the same claim.
+ */
+
+/** Same normalization the resolver applies before comparing. */
+export function normalizeExternalRefValue(value: string): string {
+    return value.trim().toLowerCase();
+}
+
+/** Thrown for a malformed claim map; callers map it to a 400. */
+export class WorkExternalRefsValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'WorkExternalRefsValidationError';
+    }
+}
+
+/** One duplicate claim: `externalId` under `kind` is already taken by `workId`. */
+export interface WorkExternalRefConflict {
+    kind: WorkExternalRefKind;
+    externalId: string;
+    workId: string;
+    workName: string;
+}
+
+/** Type guard for the closed kind set (also usable from DTO validation). */
+export function isWorkExternalRefKind(value: unknown): value is WorkExternalRefKind {
+    return (
+        typeof value === 'string' && (WORK_EXTERNAL_REF_KINDS as readonly string[]).includes(value)
+    );
+}
+
+/**
+ * Validate + normalize a user-supplied claim map.
+ *
+ * Returns `null` when nothing survives (every kind empty) so the caller
+ * can clear the column — `null` is the canonical "claims nothing" value
+ * the resolver already tolerates.
+ *
+ * Throws {@link WorkExternalRefsValidationError} on: a non-object payload,
+ * an unknown kind, a non-array kind value, a non-string / empty / oversized
+ * entry, or more than {@link WORK_EXTERNAL_REFS_MAX_PER_KIND} entries under
+ * one kind. Duplicates WITHIN one kind are deduped (case-insensitively)
+ * rather than rejected — re-submitting the same editor rows is not an error.
+ */
+export function validateWorkExternalRefs(value: unknown): WorkExternalRefs | null {
+    if (value === null || value === undefined) return null;
+    if (typeof value !== 'object' || Array.isArray(value)) {
+        throw new WorkExternalRefsValidationError(
+            'externalRefs must be an object keyed by ref kind.',
+        );
+    }
+
+    const source = value as Record<string, unknown>;
+
+    for (const key of Object.keys(source)) {
+        if (!isWorkExternalRefKind(key)) {
+            throw new WorkExternalRefsValidationError(
+                `Unknown external ref kind "${key}". Allowed: ${WORK_EXTERNAL_REF_KINDS.join(', ')}.`,
+            );
+        }
+    }
+
+    const out: WorkExternalRefs = {};
+    let kept = 0;
+
+    for (const kind of WORK_EXTERNAL_REF_KINDS) {
+        const raw = source[kind];
+        if (raw === undefined || raw === null) continue;
+        if (!Array.isArray(raw)) {
+            throw new WorkExternalRefsValidationError(
+                `externalRefs.${kind} must be an array of identifiers.`,
+            );
+        }
+
+        const seen = new Set<string>();
+        const ids: string[] = [];
+        for (const entry of raw) {
+            if (typeof entry !== 'string') {
+                throw new WorkExternalRefsValidationError(
+                    `externalRefs.${kind} entries must be strings.`,
+                );
+            }
+            const trimmed = entry.trim();
+            if (trimmed.length === 0) {
+                throw new WorkExternalRefsValidationError(
+                    `externalRefs.${kind} entries must not be empty.`,
+                );
+            }
+            if (trimmed.length > INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS) {
+                throw new WorkExternalRefsValidationError(
+                    `externalRefs.${kind} entries must be at most ${INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS} characters.`,
+                );
+            }
+            const normalized = normalizeExternalRefValue(trimmed);
+            if (seen.has(normalized)) continue;
+            seen.add(normalized);
+            ids.push(trimmed);
+        }
+
+        if (ids.length > WORK_EXTERNAL_REFS_MAX_PER_KIND) {
+            throw new WorkExternalRefsValidationError(
+                `externalRefs.${kind} accepts at most ${WORK_EXTERNAL_REFS_MAX_PER_KIND} identifiers (received ${ids.length}).`,
+            );
+        }
+
+        if (ids.length > 0) {
+            out[kind] = ids;
+            kept += ids.length;
+        }
+    }
+
+    return kept > 0 ? out : null;
+}
+
+/** The minimum shape the duplicate scan needs from a sibling Work. */
+export interface ExternalRefClaimant {
+    id: string;
+    name?: string | null;
+    externalRefs?: WorkExternalRefs | null;
+}
+
+/**
+ * Find claims in `refs` that another Work already owns.
+ *
+ * Owner-scoped by construction: the caller passes only Works owned by the
+ * same user (`WorkRepository.findByUser`), so two different users may
+ * still claim the same Slack channel — their events never cross. Within
+ * one owner a shared claim IS ambiguous (the resolver returns the first
+ * match), so the write path rejects it.
+ */
+export function findExternalRefConflicts(
+    refs: WorkExternalRefs | null,
+    siblings: readonly ExternalRefClaimant[],
+    excludeWorkId: string,
+): WorkExternalRefConflict[] {
+    if (!refs) return [];
+
+    const conflicts: WorkExternalRefConflict[] = [];
+    for (const kind of WORK_EXTERNAL_REF_KINDS) {
+        const claimed = refs[kind];
+        if (!claimed || claimed.length === 0) continue;
+        const wanted = new Map(claimed.map((id) => [normalizeExternalRefValue(id), id]));
+
+        for (const sibling of siblings) {
+            if (!sibling || sibling.id === excludeWorkId) continue;
+            const existing = sibling.externalRefs?.[kind];
+            if (!Array.isArray(existing) || existing.length === 0) continue;
+            // Bounded scan — mirrors the resolver, so a hand-edited row
+            // can never turn this check into an unbounded loop.
+            for (const ref of existing.slice(0, WORK_EXTERNAL_REFS_MAX_PER_KIND)) {
+                if (typeof ref !== 'string') continue;
+                const hit = wanted.get(normalizeExternalRefValue(ref));
+                if (hit !== undefined) {
+                    conflicts.push({
+                        kind,
+                        externalId: hit,
+                        workId: sibling.id,
+                        workName: sibling.name ?? sibling.id,
+                    });
+                }
+            }
+        }
+    }
+    return conflicts;
+}
+
+/** Human-readable summary used as the 409 message. */
+export function describeExternalRefConflicts(
+    conflicts: readonly WorkExternalRefConflict[],
+): string {
+    const details = conflicts
+        .map((c) => `"${c.externalId}" (${c.kind}) is already claimed by "${c.workName}"`)
+        .join('; ');
+    return `External reference already claimed by another Work you own: ${details}. Remove the claim there first — one identifier can only route to one Work.`;
+}


### PR DESCRIPTION
Two runner-up items, both pure wiring over surfaces that already shipped.

## ITEM A — campaign Work activation (roadmap 14.1 / audit G20)

The `campaign` Work kind shipped with capabilities + metrics but **nothing minted one** — it is deliberately absent from `USER_SELECTABLE_WORK_KINDS` and no flow provisioned its contents.

`CampaignActivationService` (`packages/agent/src/campaigns/`) turns a brief (name + objective + optional target/channels) into a whole go-to-market setup in **one owner-scoped call**, reusing the services that own each artifact:

| # | Artifact | Reused surface |
|---|----------|----------------|
| 1 | Work of kind `campaign` (repo-free, quota-safe `deployProvider: null`) | new `WorkLifecycleService.createCampaignWork` — the existing `createCompanyWork` idiom |
| 2 | Goal capturing the objective (DRAFT) | `GoalsService.create`; `metricId` drawn from `WORK_KIND_CAPABILITIES.campaign.metrics` (default `conversions`) |
| 3 | The prebuilt go-to-market Agents, scoped to the new Work | `AgentTemplatesService.createFromTemplate` — templates selected by `suggestedPipeline === 'gtm-pipeline'`, never re-listed |
| 4 | One Task per seeded `gtm-pipeline` stage (research → qualify → draft → **review** human gate) | `TasksService.create`, each Task carrying BOTH `workId` and `goalId` (that *is* the Goal↔Work relation today) |
| 5 | Pipeline preference: `gtm-pipeline` as the Work's active `pipeline` capability provider | `PluginOperationsService.enablePluginForWork` (best-effort: a deployment without the plugin still gets a working campaign, reported as `pipeline.applied: false`) |

**Atomicity.** The five services own five repositories with no shared transaction to enlist, so activation runs as a **compensating transaction**: every artifact is recorded as created and removed in reverse order (tasks → agents → goal → work) on any failure, then the original error is rethrown. A caller sees a complete campaign or none of it.

**Surface** — checked `template-catalog` first: `TemplateCatalogService` (repo forks) and `WorksTemplateCatalogService` (blueprint list) exist, but **no Work activation flow did**, so this adds one rather than extending a non-existent path:

- `POST /api/works/from-campaign-template` — activate a brief (throttled like the other create paths)
- `GET  /api/works/campaign-template` — preview what activation provisions (agents, stages, metric vocabulary)
- Web: **"Start a campaign"** affordance on `/works/new` → `/works/new/campaign` brief form

## ITEM B — Work external-refs editor (missing half of workId routing, PR #1872)

`works.externalRefs` routes ingested events to a Work, but nothing except account-import could write it — so only repo hints routed out of the box.

- **Settings card** (`ExternalRefsSettings`) — one section per `WORK_EXTERNAL_REF_KINDS` entry with add/remove rows and short helper copy ("Chat channel IDs whose messages belong to this Work…"). `repo` is deliberately not claimable: repo hints resolve through the repositories a Work already declares.
- **Saved through the existing Work update path** — `externalRefs` added to `UpdateWorkDto`.
- **Server-side validation** (`packages/agent/src/works/work-external-refs.ts`): closed kind set, `WORK_EXTERNAL_REFS_MAX_PER_KIND` cap, `INGEST_WORK_HINT_EXTERNAL_ID_MAX_CHARS` id length, case-insensitive dedupe within a kind → 400 with a named message. The account-IMPORT path keeps its drop-if-unrecognized posture; this write path rejects loudly instead (silently dropping a claim would read as "the editor lost my Slack channel").
- **Duplicate-claim guard** — an owner-scoped scan over `WorkRepository.findByUser`: if another Work you own already claims the identifier, the save 409s naming both the identifier and the holding Work (two Works claiming one channel is ambiguous — the resolver returns the first match).

## Drive-by fix

`origin/develop` carries a **truncated `listRunCandidates`** in `apps/web/src/lib/api/tasks.ts` (bad merge in 6bd78d10) — an unterminated call that makes `apps/web npx tsc --noEmit` fail with `TS1005` for everyone. Restored the three missing lines so the web typecheck gate is green again.

## Verification (real output)

**packages/agent build**
```
> nest build -b swc && tsc -p tsconfig.types.json
>  TSC  Found 0 issues.
Successfully compiled: 1104 files with swc
```

**packages/agent jest (new + touched suites)**
```
Test Suites: 10 passed, 10 total
Tests:       312 passed, 312 total
Ran all test suites matching /(campaign|work-external-refs|work-lifecycle|work.module|dto)/i
```

**pnpm build --filter=ever-works-api**
```
ever-works-api:build: >  TSC  Found 0 issues.
ever-works-api:build: Successfully compiled: 698 files with swc
 Tasks:    14 successful, 14 total
```

**apps/api pnpm generate:openapi** (openapi.json excluded from the commit via .gitignore)
```
Wrote OpenAPI spec (447 paths) to apps/api/openapi.json
/api/works/campaign-template        ['get']
/api/works/from-campaign-template   ['post']
```

**apps/api jest (works)**
```
Test Suites: 31 passed, 31 total
Tests:       420 passed, 420 total
```

**apps/web npx tsc --noEmit** (after `rm tsconfig.tsbuildinfo`)
```
(no output — 0 errors)
```

**apps/web vitest run (full unit suite)**
```
Test Files  120 passed (120)
     Tests  1156 passed (1156)
```

## Tests added — 55

| Suite | Tests |
|---|---|
| `packages/agent/src/works/work-external-refs.spec.ts` | 13 |
| `packages/agent/src/services/__tests__/work-lifecycle.external-refs.spec.ts` | 7 |
| `packages/agent/src/campaigns/__tests__/campaign-activation.service.spec.ts` | 13 |
| `packages/agent/src/campaigns/__tests__/campaign-template.spec.ts` | 4 |
| `apps/api/src/works/work-campaigns.controller.spec.ts` | 4 |
| `apps/web/.../ExternalRefsSettings.unit.spec.tsx` | 11 |
| `apps/web/.../campaign-form-client.unit.spec.tsx` | 8 |

Covering: activation creates every artifact; activation is atomic on failure (per-step rollback, reverse order, cleanup failure never masks the original error); activation is owner-scoped (every service gets the acting user id); templates resolve against the shipped catalog; refs editor validation (kind, count cap, id length, dedupe) and duplicate-claim rejection; refs round-trip through the Work update path.

Pin specs updated in the same commit: `work.module.spec.ts` (exports 34 → 35 — `PluginOperationsService` is now exported so `CampaignsModule` can pin the pipeline without spawning a second instance).

No migrations: the pipeline preference reuses the existing `work_plugins` active-capability mechanism, and `works.externalRefs` already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
