### PR TITLE
fix(web): develop is red — client component value-imports the server-only tasks module

### DIFF
--- a/apps/web/src/components/tasks/RunWithAgentMenu.tsx
+++ b/apps/web/src/components/tasks/RunWithAgentMenu.tsx
@@ -13,7 +13,7 @@ import {
     RUN_ALREADY_IN_FLIGHT,
     RUN_NO_AGENT,
     type RunCandidateAgent,
-} from '@/lib/api/tasks';
+} from '@/lib/api/tasks.shared';
 
 /**
  * Board dispatch (kanban M3) — the "Run" affordance and its agent picker.

--- a/apps/web/src/lib/api/tasks.shared.ts
+++ b/apps/web/src/lib/api/tasks.shared.ts
@@ -1,0 +1,34 @@
+/**
+ * Board dispatch — client-safe contract values.
+ *
+ * These sentinels and the picker row shape carry NO server dependency,
+ * so they live apart from `tasks.ts` (which is `server-only`). The
+ * `'use client'` dispatch menu imports them from here directly;
+ * `tasks.ts` re-exports them so server-side callers keep a single
+ * import site.
+ *
+ * Importing a VALUE (not just a type) from `tasks.ts` in a client
+ * component pulls its `server-only` guard into the client bundle and
+ * fails `next build` — tsc stays clean, so only the production build
+ * catches it. This split avoids that while keeping one canonical
+ * definition.
+ */
+
+/**
+ * Stable machine codes the board keys its behaviour off — mirrored from
+ * `@ever-works/agent/tasks-domain`. Never branch on the message: the
+ * production build redacts thrown Server-Action messages.
+ */
+export const RUN_ALREADY_IN_FLIGHT = 'RUN_ALREADY_IN_FLIGHT';
+export const RUN_AGENT_AMBIGUOUS = 'RUN_AGENT_AMBIGUOUS';
+export const RUN_NO_AGENT = 'RUN_NO_AGENT';
+export const RUN_AGENT_NOT_FOUND = 'RUN_AGENT_NOT_FOUND';
+
+/** One row of the board's agent picker. */
+export interface RunCandidateAgent {
+    id: string;
+    name: string;
+    slug?: string;
+    status?: string;
+    source: 'assignee' | 'task' | 'work-default';
+}

--- a/apps/web/src/lib/api/tasks.ts
+++ b/apps/web/src/lib/api/tasks.ts
@@ -115,24 +115,18 @@ export interface TaskDiff {
 
 // ── Board dispatch (kanban M3 / M4) ───────────────────────────────
 
-/**
- * Stable machine codes the board keys its behaviour off — mirrored from
- * `@ever-works/agent/tasks-domain`. Never branch on the message: the
- * production build redacts thrown Server-Action messages.
- */
-export const RUN_ALREADY_IN_FLIGHT = 'RUN_ALREADY_IN_FLIGHT';
-export const RUN_AGENT_AMBIGUOUS = 'RUN_AGENT_AMBIGUOUS';
-export const RUN_NO_AGENT = 'RUN_NO_AGENT';
-export const RUN_AGENT_NOT_FOUND = 'RUN_AGENT_NOT_FOUND';
-
-/** One row of the board's agent picker. */
-export interface RunCandidateAgent {
-    id: string;
-    name: string;
-    slug?: string;
-    status?: string;
-    source: 'assignee' | 'task' | 'work-default';
-}
+// The dispatch sentinels and the picker row shape are consumed by a
+// `'use client'` component, so they live in a `server-only`-free module
+// (`tasks.shared.ts`). Re-exported here so server-side callers keep one
+// import site.
+export {
+    RUN_ALREADY_IN_FLIGHT,
+    RUN_AGENT_AMBIGUOUS,
+    RUN_NO_AGENT,
+    RUN_AGENT_NOT_FOUND,
+    type RunCandidateAgent,
+} from './tasks.shared';
+import type { RunCandidateAgent } from './tasks.shared';
 
 export interface RunTaskResult {
     taskId: string;


### PR DESCRIPTION
## develop HEAD cannot build the web image

`k8s-build` on develop `e64d3a12` fails, so **develop cannot deploy right now**:

```
ever-works-web:build: Failed to compile.
Error:   x You're importing a module that depends on "server-only".
  ./src/lib/api/tasks.ts
  ./src/components/tasks/RunWithAgentMenu.tsx
  ./src/components/tasks/TaskDetailClient.tsx
```

Run: https://github.com/ever-works/ever-works/actions/runs/30195783145

## Root cause

`RunWithAgentMenu` is a `'use client'` component and imports
`RUN_AGENT_AMBIGUOUS` / `RUN_ALREADY_IN_FLIGHT` / `RUN_NO_AGENT` as **values**
from `@/lib/api/tasks`, whose first line is `import 'server-only'`. That pulls
the server-only guard into the client bundle.

`tsc --noEmit` is clean — only a real `next build` catches this, which is why
it got past the originating PR's checks.

This is a known repeat bug class in this repo (same shape previously hit
`goals`, which is why `goals.shared.ts` exists).

## Fix

The house `.shared.ts` split, matching `goals.shared.ts` / `agents.shared.ts` /
`billing.shared.ts` / `credits.shared.ts`:

- the four `RUN_*` sentinels and `RunCandidateAgent` move to `tasks.shared.ts`
  (no server dependency),
- `tasks.ts` re-exports them so every server-side caller keeps one import site,
- `RunWithAgentMenu.tsx` imports from the shared module.

No behaviour change — same canonical definitions, one extra module.

## Verification

- `turbo build --filter=ever-works-web` — **passes** (this is the check that was failing)
- `tsc --noEmit` in `apps/web` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)