### PR TITLE
chore: unblock the test gate on develop — format + the two suites it exposes

### DIFF
--- a/apps/api/src/billing/billing.controller.spec.ts
+++ b/apps/api/src/billing/billing.controller.spec.ts
@@ -60,17 +60,15 @@ const otherAuth: AuthenticatedUser = { ...auth, userId: 'user-2' } as Authentica
 
 function makeService(overrides: Record<string, unknown> = {}) {
     return {
-        getPacks: jest
-            .fn()
-            .mockReturnValue([
-                {
-                    id: 'credits-1000',
-                    priceCents: 1000,
-                    credits: 1000,
-                    currency: 'usd',
-                    label: 'a',
-                },
-            ]),
+        getPacks: jest.fn().mockReturnValue([
+            {
+                id: 'credits-1000',
+                priceCents: 1000,
+                credits: 1000,
+                currency: 'usd',
+                label: 'a',
+            },
+        ]),
         isProviderConfigured: jest.fn().mockReturnValue(true),
         startCreditCheckout: jest.fn().mockResolvedValue({
             url: 'https://pay.example/cs_1',

--- a/apps/desktop-node/vite.config.ts
+++ b/apps/desktop-node/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
 
 // Renderer build for the Desktop Node UI (setup wizard + status window).
 // This app is a thin shell — all enrollment/heartbeat logic lives in
@@ -15,6 +16,23 @@ export default defineConfig({
 	},
 	test: {
 		environment: 'node',
-		include: ['src/**/*.spec.ts']
+		include: ['src/**/*.spec.ts'],
+		// `ever-works-node` resolves through its package.json `exports`, which
+		// point at `dist/` — but the root build script deliberately excludes
+		// apps/node (and both desktop apps): they are packaged by
+		// electron-builder, not by `pnpm build`. `pnpm test` has no such
+		// filter, so in CI these specs ran against a package that is never
+		// built and died with "Failed to resolve entry for package
+		// ever-works-node" before a single assertion.
+		//
+		// Point vitest at the source entry instead. The unit specs only need
+		// the pure projections (`normalizeApiUrl`, `redactConfig`, the config
+		// types), so resolving from source is both correct and hermetic — it
+		// removes the build-order dependency rather than papering over it.
+		// Scoped to `test` so the electron/renderer build keeps resolving the
+		// compiled package exactly as it does today.
+		alias: {
+			'ever-works-node': fileURLToPath(new URL('../node/src/index.ts', import.meta.url))
+		}
 	}
 });

--- a/packages/agent/src/subscriptions/billing/auto-recharge.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/auto-recharge.service.spec.ts
@@ -209,13 +209,11 @@ describe('AutoRechargeService', () => {
 
     it('releases the guard and counts the failure when the provider declines', async () => {
         const provider = makeProvider({
-            chargeOffSession: jest
-                .fn()
-                .mockResolvedValue({
-                    paymentId: '',
-                    status: 'failed',
-                    failureCode: 'card_declined',
-                }),
+            chargeOffSession: jest.fn().mockResolvedValue({
+                paymentId: '',
+                status: 'failed',
+                failureCode: 'card_declined',
+            }),
         });
         const profiles = makeProfileRepository();
         const service = new AutoRechargeService(provider, profiles, makeLedgerService(0));

--- a/packages/agent/src/subscriptions/billing/billing.service.spec.ts
+++ b/packages/agent/src/subscriptions/billing/billing.service.spec.ts
@@ -298,15 +298,13 @@ describe('BillingService — webhook: purchases', () => {
     it('ignores a purchase carrying a pack id that is not in the table', async () => {
         const profiles = makeProfileRepository(PROFILE);
         const provider = makeProvider({
-            verifyAndParseWebhook: jest
-                .fn()
-                .mockResolvedValue(
-                    event({
-                        kind: 'credits.purchased',
-                        customerId: 'cus_1',
-                        packId: 'credits-hack',
-                    }),
-                ),
+            verifyAndParseWebhook: jest.fn().mockResolvedValue(
+                event({
+                    kind: 'credits.purchased',
+                    customerId: 'cus_1',
+                    packId: 'credits-hack',
+                }),
+            ),
         });
         const { service, ledgerService } = build({ provider, profiles });
 

--- a/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
+++ b/packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts
@@ -193,13 +193,11 @@ describe('StripeBillingProvider — checkout', () => {
     it('reports a declined charge as failed instead of throwing', async () => {
         const client = fakeClient({
             paymentIntents: {
-                create: jest
-                    .fn()
-                    .mockRejectedValue(
-                        Object.assign(new Error('Your card was declined'), {
-                            code: 'card_declined',
-                        }),
-                    ),
+                create: jest.fn().mockRejectedValue(
+                    Object.assign(new Error('Your card was declined'), {
+                        code: 'card_declined',
+                    }),
+                ),
             },
         });
         const { provider } = build(client);

--- a/packages/contracts/src/kb/__tests__/kb-memory-facets.spec.ts
+++ b/packages/contracts/src/kb/__tests__/kb-memory-facets.spec.ts
@@ -37,9 +37,7 @@ describe('deriveKbMemorySourceBadge', () => {
 	});
 
 	it('labels a consolidation-synthesized document as synthesized (via the tag)', () => {
-		expect(deriveKbMemorySourceBadge({ source: 'agent', tags: ['synthesis'] })).toBe(
-			'synthesized'
-		);
+		expect(deriveKbMemorySourceBadge({ source: 'agent', tags: ['synthesis'] })).toBe('synthesized');
 	});
 
 	it('labels a consolidation-synthesized document as synthesized (via the stable path)', () => {
@@ -87,9 +85,7 @@ describe('deriveKbMemorySourceBadge', () => {
 
 describe('readKbConnectorSource', () => {
 	it('reads the connector name the ingest spine stamped', () => {
-		expect(readKbConnectorSource({ metadata: { provenance: { source: 'linear' } } })).toBe(
-			'linear'
-		);
+		expect(readKbConnectorSource({ metadata: { provenance: { source: 'linear' } } })).toBe('linear');
 	});
 
 	it('returns null for a document with no provenance, a malformed one, or a blank source', () => {

--- a/packages/plugins/local-workspace/vitest.config.ts
+++ b/packages/plugins/local-workspace/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// Same reason as the sandbox-workspace plugin: this is a real-git
+		// harness (pool clone, worktree add/remove, commit, push, merge-tree)
+		// and every test spawns several `git` processes. Solo it is well
+		// inside the limit, but under the concurrent turbo test load the
+		// subprocesses are starved and 10 of 11 tests fail with "Test timed
+		// out in 5000ms". Matches the 30000ms every other plugin package
+		// already configures.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+			include: ['src/**/*.ts'],
+			exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/index.ts']
+		}
+	}
+});

--- a/packages/plugins/sandbox-workspace/vitest.config.ts
+++ b/packages/plugins/sandbox-workspace/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// This suite is a real-git loopback harness: every test shells out to
+		// `git` many times (clone, branch, commit, push, merge-tree) against a
+		// bare file:// origin. Solo that is ~1.7s per test, but under the
+		// concurrent turbo test load — 112 packages testing at once — each
+		// subprocess is starved and the suite blows past vitest's 5s default,
+		// failing 6 of 8 with "Test timed out in 5000ms". Matches the 30000ms
+		// every other plugin package already configures.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+			include: ['src/**/*.ts'],
+			exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/index.ts']
+		}
+	}
+});


### PR DESCRIPTION
## develop is running zero unit tests right now

`lint-and-test` on develop fails at **Check formatting**, and because that is the
first step, everything after it never executes:

```
success   Install dependencies
failure   Check formatting          <-- fails here
skipped   Build all packages
skipped   run test on all packages
skipped   Build Internal CLI / Build External CLI
skipped   Test Internal CLI  / Test External CLI
```

Run: https://github.com/ever-works/ever-works/actions/runs/30195783119

So no suite has run on develop since the drift appeared — a real regression
would look identical to today's red — and every PR into develop inherits the
same red gate.

## Two commits

**1. Format the 5 drifted files.** `pnpm format` output with the repo's pinned
prettier (3.8.3), nothing else — whitespace and line-wrapping, no logic:

- `apps/api/src/billing/billing.controller.spec.ts`
- `packages/agent/src/subscriptions/billing/auto-recharge.service.spec.ts`
- `packages/agent/src/subscriptions/billing/billing.service.spec.ts`
- `packages/agent/src/subscriptions/billing/stripe-billing.provider.spec.ts`
- `packages/contracts/src/kb/__tests__/kb-memory-facets.spec.ts`

**2. Fix the two suites that un-skipping exposes.** With the gate unblocked the
test step actually runs, and two packages fail immediately:

```
@ever-works/sandbox-workspace-plugin   6 of 8 failed
@ever-works/local-workspace-plugin    10 of 11 failed
Error: Test timed out in 5000ms.
```

Both are real-git loopback harnesses — a bare `file://` repo plays origin and
every test spawns several `git` processes. Solo, each test is ~1.7s; alongside
110 other package test tasks the subprocesses are starved and they exceed
vitest's 5s default. Neither package had a `vitest.config.ts`, so neither got
the 30000ms that `packages/plugin`, `packages/contracts`, `packages/cli-shared`
and every configured plugin already use. The suites pass in 14s solo either way
— the failure is process scheduling, not a slow assertion.

Shipping these together on purpose: merging the format fix alone would un-skip
the test step and turn develop red on these two packages.

## Verification

- `pnpm format:check` — clean
- `pnpm build --filter='!./apps/docs'` — passes (needed #1887, now on develop)
- `turbo run test --continue --force` — no cache, all 112 tasks executed,
  **112 successful / 112 total**

> An earlier revision of this PR touched 127 files. That was wrong: it was
> produced in a worktree without `node_modules`, so `npx` resolved prettier
> **3.9.6** from the registry instead of the pinned **3.8.3**, and most of the
> diff was version difference rather than drift. Force-pushed to the correct
> change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized billing, subscription, payment, and knowledge-base test fixtures and assertions without changing expected behavior.
  * Improved test execution by enabling direct source resolution and consistent Node-based test settings.
  * Added coverage reporting with text, JSON, and HTML output for workspace plugin tests.
* **Chores**
  * Increased test and setup timeouts to improve reliability during longer-running test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->