### PR TITLE
test(pty-local): the 5s default is failing develop's test step — third package in this class

### DIFF
--- a/packages/plugins/pty-local/vitest.config.ts
+++ b/packages/plugins/pty-local/vitest.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		// This suite spawns REAL processes through the PTY plugin and asserts
+		// on the frames they stream back, so its wall-clock is the OS process
+		// scheduler's, not the assertions'. Alongside 110 other package test
+		// tasks under turbo those spawns are starved, and the streaming test
+		// blows vitest's 5s default ("Test timed out in 5000ms") — while the
+		// same run reports `tests 7.31s` against a 58.9s total, which is the
+		// signature of contention rather than a slow test.
+		//
+		// This package had no config at all, so it never got the 30000ms that
+		// `packages/plugin`, `packages/contracts`, `packages/cli-shared` and
+		// every configured plugin already use.
+		testTimeout: 30000,
+		hookTimeout: 30000,
+		globals: true,
+		environment: 'node',
+		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json', 'html'],
+			include: ['src/**/*.ts'],
+			exclude: ['src/**/*.spec.ts', 'src/**/*.test.ts', 'src/index.ts']
+		}
+	}
+});


### PR DESCRIPTION
develop `c3561dec` fails `run test on all packages`:

```
FAIL src/__tests__/pty-local.plugin.spec.ts > PtyLocalPlugin >
     streams stdout as sequenced frames and publishes the exit frame BEFORE resolving
Error: Test timed out in 5000ms.
```

## Why

`pty-local` spawns **real processes** and asserts on the frames they stream
back, so its wall-clock belongs to the OS process scheduler rather than to the
assertions. Running alongside 110 other package test tasks under turbo, those
spawns are starved.

The run's own numbers say contention rather than a slow test: `tests 7.31s`
against a `58.92s` total. Solo, the suite finishes in **1.4s**.

The package had no `vitest.config.ts` at all, so it never picked up the
`testTimeout: 30000` that `packages/plugin`, `packages/contracts`,
`packages/cli-shared` and every configured plugin already use.

## Third in a class — so I swept for the rest

This is the same failure as `sandbox-workspace` (6/8 failed) and
`local-workspace` (10/11 failed), both fixed in #1889. Rather than fix this one
and wait for a fourth, I checked every remaining config-less package for specs
that spawn processes or touch the filesystem.

Only one other came up — `secret-store-k8s` — and it `vi.mock`s
`node:fs/promises`, so it never does real I/O and is not at risk.
**`pty-local` was the last one.**

## Verification

- `pnpm test` in the package: 10 passed (1.4s)
- `prettier --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added dedicated test configuration for local terminal process functionality.
  * Improved reliability of streaming tests by allowing more time for process startup and execution.
  * Added V8-based code coverage reporting in text, JSON, and HTML formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->