### PR TITLE
test(e2e): tenant allow-list toggles still lose pre-hydration clicks (3 failures on develop)

### DIFF
--- a/apps/web/e2e/admin-tenant-runtime-allowlist.spec.ts
+++ b/apps/web/e2e/admin-tenant-runtime-allowlist.spec.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { loadSeed } from './helpers/seed';
 import { API_BASE } from './helpers/api';
+import { clickUntil } from './helpers/nav';
 
 /**
  * EW-742 P5.1 (#1516) — Operator admin UI for the per-tenant runtime
@@ -336,8 +337,14 @@ test.describe('Operator tenant runtime allow-list — admin UI (#1516)', () => {
             // intermittently fails to dispatch the onChange the React
             // listener picks up, so the `draft` set never gains the provider
             // and `isDirty` stays false → Save stays disabled.
-            await page.locator('label[for="runtime-allowlist-temporal"]').click();
-            await expect(target).toBeChecked({ timeout: 5_000 });
+            // The label capture is necessary but NOT sufficient: a click that
+            // lands before the client component wires its onChange is dropped
+            // outright, so `draft` never updates and Save stays disabled.
+            // Re-click until the box is actually checked (a landed click is
+            // never undone, because the retry stops as soon as it is true).
+            await clickUntil(page.locator('label[for="runtime-allowlist-temporal"]'), () =>
+                target.isChecked(),
+            );
             await expect(saveBtn).toBeEnabled({ timeout: 5_000 });
             await saveBtn.click();
             // Wait for the post-save UI to settle: when the action returns
@@ -375,8 +382,10 @@ test.describe('Operator tenant runtime allow-list — admin UI (#1516)', () => {
             // Click the label rather than the bare input — React onChange is
             // unreliable on direct input clicks pre-hydration (see the
             // "check a provider" case for the full rationale).
-            await page.locator('label[for="runtime-allowlist-temporal"]').click();
-            await expect(target).not.toBeChecked({ timeout: 5_000 });
+            await clickUntil(
+                page.locator('label[for="runtime-allowlist-temporal"]'),
+                async () => !(await target.isChecked()),
+            );
             const saveBtn = page.getByRole('button', { name: /Save allow-list/i });
             await expect(saveBtn).toBeEnabled({ timeout: 5_000 });
             await saveBtn.click();
@@ -408,8 +417,9 @@ test.describe('Operator tenant runtime allow-list — admin UI (#1516)', () => {
                 // Click the label rather than the bare input — same reason
                 // as the "check a provider" case (React onChange is
                 // unreliable on direct input clicks).
-                await page.locator('label[for="runtime-allowlist-bullmq"]').click();
-                await expect(bullmq).toBeChecked({ timeout: 5_000 });
+                await clickUntil(page.locator('label[for="runtime-allowlist-bullmq"]'), () =>
+                    bullmq.isChecked(),
+                );
                 const saveBtn = page.getByRole('button', { name: /Save allow-list/i });
                 await expect(saveBtn).toBeEnabled({ timeout: 5_000 });
                 // The Save action is a Next.js Server Action → POST to the
@@ -511,7 +521,9 @@ test.describe('Operator tenant runtime allow-list — admin UI (#1516)', () => {
             // Force a dirty state we can save — click the label so the
             // onChange propagates reliably to React (see check-a-provider
             // for the rationale).
-            await page.locator('label[for="runtime-allowlist-inngest"]').click();
+            await clickUntil(page.locator('label[for="runtime-allowlist-inngest"]'), () =>
+                target.isChecked(),
+            );
             const saveBtn = page.getByRole('button', { name: /Save allow-list/i });
             await expect(saveBtn).toBeEnabled({ timeout: 5_000 });
             // The Save action is a Next.js Server Action → POST to the page


### PR DESCRIPTION
develop's e2e run on `c3561dec` failed three tests in
`admin-tenant-runtime-allowlist.spec.ts`, all with the checkbox in the **wrong
state** rather than a timeout:

```
:364  expect(temporal).not.toBeChecked  → received checked
:400  expect(bullmq).toBeChecked        → received unchecked
:504  expect(saveBtn).toBeEnabled       → received disabled
```

## Not what it looks like

It reads like cross-test interference, but every test mints a fresh random
tenant UUID (`freshTenantId()`) and is fully isolated — the operator endpoints
don't require the tenant to exist, so each test owns its own allow-list.

It's the swallowed pre-hydration click. The click lands before the client
component wires its `onChange`, gets dropped outright, `draft` never updates,
and `isDirty` stays false — which is why `:504` fails on the **button** rather
than on a checkbox: no dirty state, so Save never enables.

## Why the existing mitigations weren't enough

The file already knew about this class — it clicks the `<label>` rather than the
bare input, and `gotoAllowlist` waits for network idle before interacting. Both
help. Neither is sufficient under CI load, because a one-shot click has no
recovery if it lands a frame early.

All four toggle sites now use `clickUntil`, which re-clicks **only while** the
checkbox has not reached the wanted state. That's safe for a toggle precisely
because the retry stops the moment the state is right, so a click that did land
is never undone.

## Verification

- `admin-tenant-runtime-allowlist`: 12 passed / 4 skipped locally against a PROD-web
  stack (the 4 skips are unrelated gating-dependent cases, not these three)
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved runtime allow-list test reliability by ensuring checkbox states are fully synchronized before save, delete, and concurrent-update scenarios.
  * Reduced test flakiness caused by delayed interface updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->