### PR TITLE
fix(billing): map credit exhaustion to 402 instead of an unmapped 500 (B37)

### DIFF
--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -1,6 +1,7 @@
 import { Module, OnApplicationBootstrap } from '@nestjs/common';
 import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { FacadeExceptionFilter } from './common/filters/facade-exception.filter';
+import { InsufficientCreditsExceptionFilter } from './common/filters/insufficient-credits.filter';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AuthModule } from './auth/auth.module';
@@ -299,6 +300,17 @@ import { DatabaseModule } from '@ever-works/agent/database';
         {
             provide: APP_FILTER,
             useClass: FacadeExceptionFilter,
+        },
+        // Maps credit-balance exhaustion (`InsufficientCreditsError`, thrown
+        // by CreditLedgerService when a debit would cross zero and overdraft
+        // is off) to 402 Payment Required instead of the generic 500 Nest's
+        // default filter would emit — matching the 402 the budget cap already
+        // uses (BudgetExceededException). Body is a constant: the error's own
+        // message and fields carry the owner's userId and balance, which are
+        // never echoed. See insufficient-credits.filter.ts.
+        {
+            provide: APP_FILTER,
+            useClass: InsufficientCreditsExceptionFilter,
         },
     ],
     controllers: [APIController],

--- a/apps/api/src/common/filters/insufficient-credits.filter.spec.ts
+++ b/apps/api/src/common/filters/insufficient-credits.filter.spec.ts
@@ -1,0 +1,164 @@
+// Mock the agent subscriptions barrel so importing the filter doesn't pull
+// the real credits runtime (TypeORM repositories / NestJS wiring / the
+// whole billing money path). The filter only references
+// `InsufficientCreditsError` for its `@Catch()` decorator and reads
+// duck-typed fields off the thrown error, so a stand-in that reproduces
+// the real constructor's shape (stable `name`, the three public fields and
+// the interpolated message) is enough — and it is what lets us assert the
+// no-leak contract against the exact payload the real class carries.
+// Mirrors facade-exception.filter.spec.ts.
+jest.mock('@ever-works/agent/subscriptions', () => ({
+    InsufficientCreditsError: class InsufficientCreditsError extends Error {
+        constructor(
+            public readonly userId: string,
+            public readonly requestedCredits: number,
+            public readonly balanceCredits: number,
+        ) {
+            super(
+                `Insufficient credits: balance ${balanceCredits}, requested debit ${requestedCredits}`,
+            );
+            this.name = 'InsufficientCreditsError';
+        }
+    },
+}));
+
+import { HttpStatus, Logger } from '@nestjs/common';
+import type { ArgumentsHost } from '@nestjs/common';
+import type { HttpAdapterHost } from '@nestjs/core';
+import { InsufficientCreditsError } from '@ever-works/agent/subscriptions';
+import {
+    INSUFFICIENT_CREDITS_ERROR_CODE,
+    INSUFFICIENT_CREDITS_MESSAGE,
+    InsufficientCreditsExceptionFilter,
+} from './insufficient-credits.filter';
+
+/** The exact payload CreditLedgerService.record() throws on exhaustion. */
+const SECRET_USER_ID = '11111111-2222-3333-4444-555555555555';
+
+function exhausted(requested = 37, balance = 3) {
+    return new InsufficientCreditsError(SECRET_USER_ID, requested, balance);
+}
+
+describe('InsufficientCreditsExceptionFilter', () => {
+    let filter: InsufficientCreditsExceptionFilter;
+    let reply: jest.Mock;
+    let host: ArgumentsHost;
+
+    beforeEach(() => {
+        reply = jest.fn();
+        const httpAdapterHost = {
+            httpAdapter: {
+                reply,
+                getRequestMethod: () => 'POST',
+                getRequestUrl: () => '/internal/trigger/remote/call',
+            },
+        } as unknown as HttpAdapterHost;
+        filter = new InsufficientCreditsExceptionFilter(httpAdapterHost);
+
+        host = {
+            switchToHttp: () => ({
+                getRequest: () => ({}),
+                getResponse: () => ({ res: true }),
+            }),
+        } as unknown as ArgumentsHost;
+
+        // Silence the error-level log the 500 fall-through emits.
+        jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => jest.restoreAllMocks());
+
+    const lastBody = () => reply.mock.calls[0][1];
+    const lastStatus = () => reply.mock.calls[0][2];
+
+    it('maps credit exhaustion to 402 Payment Required (never an unmapped 500)', () => {
+        filter.catch(exhausted(), host);
+
+        expect(lastStatus()).toBe(HttpStatus.PAYMENT_REQUIRED);
+        expect(lastStatus()).toBe(402);
+    });
+
+    it('returns the stable, caller-facing body shape', () => {
+        filter.catch(exhausted(), host);
+
+        expect(lastBody()).toEqual({
+            statusCode: 402,
+            message: INSUFFICIENT_CREDITS_MESSAGE,
+            error: INSUFFICIENT_CREDITS_ERROR_CODE,
+        });
+        // Pin the machine-readable code: clients branch on it, and it
+        // matches the un-suffixed shape the sibling 402 (`BudgetExceeded`)
+        // already uses.
+        expect(INSUFFICIENT_CREDITS_ERROR_CODE).toBe('InsufficientCredits');
+    });
+
+    it('leaks NO internal detail — no userId, no balance, no raw message, no stack', () => {
+        const exception = exhausted(37, 3);
+        filter.catch(exception, host);
+
+        const serialized = JSON.stringify(lastBody());
+
+        // The owner's id is the sharpest leak: this filter also serves the
+        // signature-authenticated worker RPC route, where the HTTP caller
+        // is provably NOT the balance owner.
+        expect(serialized).not.toContain(SECRET_USER_ID);
+        // Balance / requested figures are account state — the owner reads
+        // them from the owner-scoped GET /api/credits/balance instead.
+        expect(serialized).not.toContain('37');
+        expect(serialized).not.toContain('"balanceCredits"');
+        expect(serialized).not.toContain('"requestedCredits"');
+        // The error's own interpolated message must not be echoed.
+        expect(serialized).not.toContain(exception.message);
+        expect(serialized).not.toContain('requested debit');
+        // No stack, and no extra keys beyond the pinned three.
+        expect(serialized).not.toContain('at ');
+        expect(Object.keys(lastBody()).sort()).toEqual(['error', 'message', 'statusCode']);
+    });
+
+    it('the constant body text names no identifier and no numeric state', () => {
+        // Guards the message itself against a future edit that helpfully
+        // interpolates the balance back in.
+        expect(INSUFFICIENT_CREDITS_MESSAGE).not.toMatch(/\d/);
+        expect(INSUFFICIENT_CREDITS_MESSAGE).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}/i);
+    });
+
+    it('does NOT log the mapped 402 (it is expected and caller-actionable)', () => {
+        const spy = jest.spyOn(Logger.prototype, 'error');
+        filter.catch(exhausted(), host);
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('falls through to a generic 500 for an unlisted subclass name', () => {
+        // Conservative default, identical to FacadeExceptionFilter: an
+        // error whose `.name` is not in the table is not silently promoted
+        // to a 4xx, and its message is hidden.
+        const rogue = exhausted();
+        rogue.name = 'SomeBrandNewCreditsError';
+        (rogue as Error).message = 'connection string postgres://user:pw@host/db';
+
+        filter.catch(rogue, host);
+
+        expect(lastStatus()).toBe(HttpStatus.INTERNAL_SERVER_ERROR);
+        expect(lastBody()).toEqual({
+            statusCode: 500,
+            message: 'Internal server error',
+            error: 'Internal Server Error',
+        });
+        expect(JSON.stringify(lastBody())).not.toContain('postgres://');
+    });
+
+    it('logs the unmapped fall-through with request context (no message echo)', () => {
+        const spy = jest.spyOn(Logger.prototype, 'error');
+        const rogue = exhausted();
+        rogue.name = 'SomeBrandNewCreditsError';
+        (rogue as Error).message = 'leak me';
+
+        filter.catch(rogue, host);
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        const logged = String(spy.mock.calls[0][0]);
+        expect(logged).toContain('SomeBrandNewCreditsError');
+        expect(logged).toContain('/internal/trigger/remote/call');
+        expect(logged).not.toContain('leak me');
+    });
+});

--- a/apps/api/src/common/filters/insufficient-credits.filter.ts
+++ b/apps/api/src/common/filters/insufficient-credits.filter.ts
@@ -1,0 +1,130 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpStatus, Logger } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import { InsufficientCreditsError } from '@ever-works/agent/subscriptions';
+
+/**
+ * Maps credit-balance exhaustion to HTTP **402 Payment Required** at the
+ * API boundary. Sibling of `FacadeExceptionFilter` — same shape, same
+ * map-by-stable-`.name` design, same no-leak posture.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `CreditLedgerService.record()` rejects a debit that would take the
+ * balance below zero (overdraft off — `CREDITS_ALLOW_OVERDRAFT`, default
+ * false) with `InsufficientCreditsError`, a plain `Error` — NOT a NestJS
+ * `HttpException`. Nothing in `apps/api` referenced that class, so any
+ * spend attempt that reached a controller UNCAUGHT became a generic HTTP
+ * 500 via Nest's `BaseExceptionFilter`. That mislabels the single most
+ * caller-actionable condition the billing surface has ("you are out of
+ * credits — top up") as a server fault, and the billing/usage PRD §6 is
+ * explicit that balance exhaustion must never surface as an unmapped 500.
+ *
+ * It also had a concrete cost on the worker RPC path: the Trigger.dev
+ * worker's `TriggerInternalApiClient` retries 5xx three times with
+ * exponential backoff. An exhausted balance is deterministic — retrying
+ * it is pure waste. A 402 is terminal for that client.
+ *
+ * WHY 402 AND NOT 409
+ * -------------------
+ * The codebase already has a spend-exhaustion status, and it is 402:
+ * `BudgetExceededException` (packages/agent/src/budgets) throws
+ * `HttpStatus.PAYMENT_REQUIRED` with `error: 'BudgetExceeded'` when a
+ * Work hits its monthly cap. Credit exhaustion is the same class of
+ * condition, so it takes the same status and the same `error` code shape
+ * (`'InsufficientCredits'`). 409 is spoken-for in the sibling filter with
+ * a DIFFERENT meaning — "a precondition you resolve by CONFIGURING
+ * something" (no provider enabled, no credentials connected) — and
+ * overloading it would make the two indistinguishable to a client.
+ * `apps/web` already treats 402 as the quota/credits signal (see the
+ * generation-enqueue and usage-quota e2e specs).
+ *
+ * DESIGN NOTES
+ * ------------
+ * - Map by stable `.name`, not by class identity. `InsufficientCreditsError`
+ *   assigns `this.name` explicitly in its constructor, so the mapping
+ *   survives minification and any future sibling/subclass. An unlisted
+ *   name falls through to a generic 500 — the conservative default,
+ *   identical to `FacadeExceptionFilter`.
+ * - HTTP-ONLY by construction: a global exception filter runs only in the
+ *   HTTP request pipeline. The same error thrown inside the run-cost
+ *   settlement hook, a BullMQ worker or a Trigger.dev task is handled by
+ *   that caller's own policy (settlement records a partial debit and
+ *   notifies — PRD §6) and never reaches here.
+ * - ADDITIVE: nothing catches `InsufficientCreditsError` in a controller
+ *   today, so this filter only nets previously-unmapped 500s. Any future
+ *   controller-local `try/catch` that converts it to an `HttpException`
+ *   wins, because an `HttpException` is not an `InsufficientCreditsError`.
+ *
+ * NO LEAK
+ * -------
+ * The thrown error carries `userId`, `requestedCredits`, `balanceCredits`
+ * and a message that interpolates the last two. NONE of it is echoed. The
+ * filter cannot prove the HTTP caller owns the balance — the
+ * signature-authenticated `/internal/trigger/remote/call` RPC route
+ * reaches this filter too — so the body is owner-agnostic and constant.
+ * The owner reads exact figures from the owner-scoped
+ * `GET /api/credits/balance`.
+ */
+
+/** Stable, caller-facing body text. Contains no identifiers and no state. */
+export const INSUFFICIENT_CREDITS_MESSAGE =
+    'Insufficient credits. Top up your balance in /settings/billing to continue.';
+
+/**
+ * Machine-readable `error` code. Matches the un-suffixed shape the other
+ * 402 in this codebase uses (`BudgetExceeded`) so clients can branch on
+ * one convention.
+ */
+export const INSUFFICIENT_CREDITS_ERROR_CODE = 'InsufficientCredits';
+
+/**
+ * `error.name` → HTTP status. Anything not listed falls through to 500
+ * with the generic body (unchanged Nest behaviour).
+ */
+const CREDITS_ERROR_STATUS: Readonly<Record<string, HttpStatus>> = {
+    InsufficientCreditsError: HttpStatus.PAYMENT_REQUIRED,
+};
+
+@Catch(InsufficientCreditsError)
+export class InsufficientCreditsExceptionFilter implements ExceptionFilter {
+    private readonly logger = new Logger(InsufficientCreditsExceptionFilter.name);
+
+    constructor(private readonly httpAdapterHost: HttpAdapterHost) {}
+
+    catch(exception: InsufficientCreditsError, host: ArgumentsHost): void {
+        const { httpAdapter } = this.httpAdapterHost;
+        const ctx = host.switchToHttp();
+        const request = ctx.getRequest();
+
+        const status = CREDITS_ERROR_STATUS[exception.name] ?? HttpStatus.INTERNAL_SERVER_ERROR;
+        const isClientError = status < HttpStatus.INTERNAL_SERVER_ERROR;
+
+        if (!isClientError) {
+            // An unlisted subclass reached the boundary — a signal that a
+            // new mapping is needed. Logged server-side only; the client
+            // still gets the generic 500 body.
+            this.logger.error(
+                `Unmapped credits error (${exception.name}) on ` +
+                    `${httpAdapter.getRequestMethod(request)} ${httpAdapter.getRequestUrl(request)}`,
+                exception.stack,
+            );
+        }
+
+        // Mirror Nest's HttpException JSON shape. The 402 body is a
+        // constant — the error's own message interpolates the balance, and
+        // its fields carry the owner's userId, so neither is surfaced.
+        const body = isClientError
+            ? {
+                  statusCode: status,
+                  message: INSUFFICIENT_CREDITS_MESSAGE,
+                  error: INSUFFICIENT_CREDITS_ERROR_CODE,
+              }
+            : {
+                  statusCode: status,
+                  message: 'Internal server error',
+                  error: 'Internal Server Error',
+              };
+
+        httpAdapter.reply(ctx.getResponse(), body, status);
+    }
+}

--- a/docs/architecture/error-handling-patterns.md
+++ b/docs/architecture/error-handling-patterns.md
@@ -47,6 +47,7 @@ flowchart TD
 | `packages/agent/src/facades/ai.facade.ts`                         | AI-specific error class (`AiFacadeError`)                             |
 | `packages/agent/src/pipeline/pipeline-builder.service.ts`         | Pipeline errors (`CircularDependencyError`, `MissingDependencyError`) |
 | `apps/api/src/common/filters/facade-exception.filter.ts`          | Global filter mapping the `FacadeError` hierarchy → HTTP status codes |
+| `apps/api/src/common/filters/insufficient-credits.filter.ts`      | Global filter mapping credit-balance exhaustion → HTTP 402            |
 
 ## HTTP boundary: the FacadeException filter
 
@@ -94,6 +95,50 @@ connected a git provider (`gitFacade.cloneOrPull` → `NoGitCredentialsError`)
 now returns **409** instead of a generic 500. This covers taxonomy writes
 (categories / tags / collections), comparison generation, community-PR
 processing, and `POST /api/templates/fork`.
+
+## HTTP boundary: credit exhaustion → 402
+
+`CreditLedgerService.record()` rejects a debit that would take the balance
+below zero (overdraft off — `CREDITS_ALLOW_OVERDRAFT`, default `false`) with
+`InsufficientCreditsError`. It is a plain `Error`, so before
+`InsufficientCreditsExceptionFilter` existed it reached the client as an
+unmapped **500**, which the billing/usage PRD §6 forbids.
+
+| Credits error (by `.name`)       | HTTP    | Body                                                                          |
+| -------------------------------- | ------- | ----------------------------------------------------------------------------- |
+| `InsufficientCreditsError`       | **402** | `{ statusCode: 402, error: 'InsufficientCredits', message: <constant> }`      |
+| any other name (future subclass) | **500** | Generic `"Internal server error"` — conservative default, **no message leak** |
+
+**Why 402, not 409.** The codebase already answers spend exhaustion with 402:
+`BudgetExceededException` (`packages/agent/src/budgets`) throws
+`HttpStatus.PAYMENT_REQUIRED` with `error: 'BudgetExceeded'` when a Work hits
+its monthly cap. Credit exhaustion is the same condition ("add money / raise
+the cap"), so it reuses that status and the same un-suffixed `error` code
+shape. In the sibling facade filter **409 already means something else** — "a
+precondition you resolve by CONFIGURING something" (no provider enabled, no
+credentials connected) — and overloading it would make the two
+indistinguishable to a client. `apps/web` already treats 402 as the
+credits/quota signal.
+
+**Why the body is a constant.** The thrown error carries `userId`,
+`requestedCredits`, `balanceCredits` and a message interpolating the last two.
+None of it is echoed: the filter cannot prove the HTTP caller owns the balance
+— the signature-authenticated `/internal/trigger/remote/call` worker RPC route
+reaches this filter too. Owners read exact figures from the owner-scoped
+`GET /api/credits/balance`.
+
+**Side benefit on the worker path.** `TriggerInternalApiClient` retries 5xx
+three times with exponential backoff. An exhausted balance is deterministic, so
+the old 500 bought three pointless round-trips; a 402 is terminal for that
+client.
+
+**Spend paths all raise the typed error.** Every credit debit in the platform
+funnels through `CreditLedgerService.record()` (directly, or via
+`consumeForRun`), the only caller of `CreditLedgerRepository.recordAtomic`.
+Both entrypoints are pinned by spec to reject with `InsufficientCreditsError`
+rather than a bare `Error`, because two consumers key off it: this filter (by
+`.name`) and `RunCostSettlementService` (by type — it converts exhaustion into
+a partial debit plus an `AI_CREDITS` notification instead of failing the run).
 
 ## Key Classes
 

--- a/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
+++ b/packages/agent/src/subscriptions/credits/credit-ledger.service.spec.ts
@@ -214,6 +214,34 @@ describe('CreditLedgerService', () => {
                 expect.anything(),
             );
         });
+
+        it('propagates the TYPED InsufficientCreditsError (not a bare Error)', async () => {
+            // `consumeForRun` is the second of the two spend entrypoints
+            // (the other is `record` with a negative amount — covered
+            // above). Both MUST reject with the stable-named class: the
+            // api-side InsufficientCreditsExceptionFilter keys its 402 off
+            // `.name`, and RunCostSettlementService keys its
+            // partial-debit + exhaustion-notification policy off the type.
+            // A bare Error here would silently become an unmapped 500 and
+            // a swallowed settlement.
+            const { service } = makeService({
+                recordAtomic: jest.fn().mockResolvedValue({ status: 'insufficient', balance: 4 }),
+            });
+
+            const attempt = service.consumeForRun({
+                userId: 'u1',
+                runId: 'run-5',
+                costCents: 900,
+            });
+
+            await expect(attempt).rejects.toThrow(InsufficientCreditsError);
+            await expect(attempt).rejects.toMatchObject({
+                name: 'InsufficientCreditsError',
+                userId: 'u1',
+                requestedCredits: 900,
+                balanceCredits: 4,
+            });
+        });
     });
 
     describe('getLedger — period/kind filters + pagination', () => {


### PR DESCRIPTION
## The problem

`InsufficientCreditsError` was referenced **nowhere** in `apps/api`.

`CreditLedgerService.record()` throws it — a plain `Error`, not a NestJS
`HttpException` — when a debit would take the balance below zero and overdraft
is off (`CREDITS_ALLOW_OVERDRAFT`, default false). Any spend that reached a
controller uncaught became a generic **500** via Nest's `BaseExceptionFilter`,
mislabelling the most caller-actionable condition the billing surface has
("you are out of credits — top up") as a server fault. The billing/usage PRD §6
is explicit that balance exhaustion must never surface as an unmapped 500.

## What changed

`InsufficientCreditsExceptionFilter`, registered as a global `APP_FILTER` in
`api.module.ts` alongside the existing `FacadeExceptionFilter`, and built the
same way — map by stable `.name` rather than class identity so the mapping
survives minification and any future sibling; an unlisted name falls through to
a generic 500, the conservative default.

## Why 402 and not 409

The codebase already has a spend-exhaustion status, and it is **402**:
`BudgetExceededException` (`packages/agent/src/budgets`) throws
`HttpStatus.PAYMENT_REQUIRED` with `error: 'BudgetExceeded'` when a Work hits
its monthly cap. Credit exhaustion is the same class of condition, so it takes
the same status and the same un-suffixed `error` code shape
(`'InsufficientCredits'`).

409 is spoken-for in the sibling filter with a **different** meaning — "a
precondition you resolve by *configuring* something" (no provider enabled, no
credentials connected). Overloading it would make the two indistinguishable to
a client. `apps/web` already treats 402 as the quota/credits signal (see the
generation-enqueue and usage-quota e2e specs).

## A second, concrete benefit

The Trigger.dev worker's `TriggerInternalApiClient` retries **5xx three times
with exponential backoff**. An exhausted balance is deterministic — those
retries were pure waste. A 402 is terminal for that client.

## Who calls this in production?

The filter is registered as a global `APP_FILTER` (`api.module.ts:313`), so it
is live for every HTTP request. `InsufficientCreditsError` is thrown at
`credit-ledger.service.ts:152`, and there is a real HTTP path that reaches the
ledger: the signature-authenticated `/internal/trigger/remote/call` RPC route
exposes `CreditLedgerService` (`trigger-internal.controller.ts:444`).

The same error thrown *outside* the HTTP pipeline — inside the run-cost
settlement hook, a BullMQ worker or a Trigger.dev task — is unaffected and
still handled by that caller's own policy, because a global exception filter
runs only in the HTTP request pipeline.

## No leak

The error carries `userId`, `requestedCredits` and `balanceCredits`, and its
message interpolates the last two. **None of it is echoed.** The filter cannot
prove the HTTP caller owns the balance, so the body is owner-agnostic and
constant. Owners read exact figures from the owner-scoped
`GET /api/credits/balance`.

## Additive

Nothing catches `InsufficientCreditsError` in a controller today, so this only
nets previously-unmapped 500s. Any future controller-local `try/catch` that
converts it to an `HttpException` still wins, because an `HttpException` is not
an `InsufficientCreditsError`. Spec changes are purely additive — no existing
test was modified or removed.

## Gates

| Gate | Result |
|---|---|
| `pnpm build --filter=ever-works-api` | green |
| `packages/agent` jest | green — 438 suites, 7910 tests |
| `apps/api` jest | green — 228 suites, 3688 tests |
| prettier | clean |

Not run: `apps/web` tsc and `apps/node` vitest (this branch touches neither).